### PR TITLE
Fix mp_limb_t/ulong discrepancies in var/func decls.

### DIFF
--- a/fmpz_factor/append_ui.c
+++ b/fmpz_factor/append_ui.c
@@ -31,7 +31,7 @@
 #include "fmpz_factor.h"
 
 void
-_fmpz_factor_append_ui(fmpz_factor_t factor, ulong p, ulong exp)
+_fmpz_factor_append_ui(fmpz_factor_t factor, mp_limb_t p, ulong exp)
 {
     _fmpz_factor_fit_length(factor, factor->num + 1);
     fmpz_set_ui(factor->p + factor->num, p);

--- a/ulong_extras.h
+++ b/ulong_extras.h
@@ -120,7 +120,7 @@ extern mp_limb_t * flint_primes;
 
 extern double * flint_prime_inverses;
 
-extern mp_limb_t flint_num_primes;
+extern ulong flint_num_primes;
 
 extern mp_limb_t flint_primes_cutoff;
 
@@ -328,7 +328,7 @@ mp_limb_t n_factor_trial_partial(n_factor_t * factors, mp_limb_t n,
                 mp_limb_t * prod, ulong num_primes, mp_limb_t limit);
 
 mp_limb_t n_factor_trial(n_factor_t * factors, 
-                                  mp_limb_t n, mp_limb_t num_primes);
+                                  mp_limb_t n, ulong num_primes);
 
 mp_limb_t n_factor_partial(n_factor_t * factors, 
                            mp_limb_t n, mp_limb_t limit, int proved);


### PR DESCRIPTION
These are needed to compile on MinGW64.
