### PR TITLE
Fix test for empty string in Makefile.in.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -178,7 +178,7 @@ install: library
 		cp libflint.a $(DESTDIR)$(PREFIX)/lib; \
 	fi
 	cp $(HEADERS) $(DESTDIR)$(PREFIX)/include/flint
-	$(AT)if [ ! -z $(EXT_HEADERS) ]; then \
+	$(AT)if [ ! -z "$(EXT_HEADERS)" ]; then \
 		cp $(EXT_HEADERS) $(DESTDIR)$(PREFIX)/include/flint; \
 	fi
 	mkdir -p $(DESTDIR)$(FLINT_CPIMPORT_DIR)


### PR DESCRIPTION
if [ -z ]; then echo "bla"; fi
fails on solaris.
Reported by Volker Braun at http://trac.sagemath.org/ticket/15574#comment:27.
