### PR TITLE
Add thread-local storage declaration for VC++

### DIFF
--- a/flint.h
+++ b/flint.h
@@ -131,7 +131,11 @@ void flint_cleanup(void);
 #define mp_bitcnt_t ulong
 
 #if HAVE_TLS
+#ifdef _MSC_VER
+#define FLINT_TLS_PREFIX __declspec(thread)
+#else
 #define FLINT_TLS_PREFIX __thread
+#endif
 #else
 #define FLINT_TLS_PREFIX
 #endif


### PR DESCRIPTION
just a very simple #ifdef for VC++

With this change, I can cross-compile in MinGW and then use the DLL to create a LIB, link the LIB and use flint from C++/CLI for easy access from the .net framework.

I still need to copy `sys/param.h` from MinGW imports, I still have to define `_WIN64` and `__MINGW64__`, but at least I can use the headers to access flint.
