### PR TITLE
Change needed for ntl 6.2+, this is compatible with ntl 6.1

### DIFF
--- a/interfaces/NTL-interface.cpp
+++ b/interfaces/NTL-interface.cpp
@@ -32,9 +32,7 @@
 #include <NTL/ZZ.h>
 #include <NTL/ZZX.h>
 #include <NTL/mat_ZZ.h>
-#include <NTL/lip.h>
 #include <NTL/ctools.h>
-#include <NTL/g_lip.h>
 #include <gmp.h>
 
 #include "flint.h"


### PR DESCRIPTION
This was discussed on http://trac.sagemath.org/ticket/16882 and https://groups.google.com/forum/#!topic/flint-devel/YEsOO_lnQNs
The change is actually compatible with ntl 6.1 (flint 2.4.4 with that patch passes its test suite with ntl 6.1).
