### PR TITLE
[WIP] flint_mpn_sqrtrem2

### DIFF
--- a/doc/source/mpn_extras.rst
+++ b/doc/source/mpn_extras.rst
@@ -189,6 +189,23 @@ Division
 
     Note that this function is not always as fast as ordinary division.
 
+Square root
+--------------------------------------------------------------------------------
+
+.. function:: mp_size_t flint_mpn_sqrtrem2(mp_ptr sp, mp_ptr rp, mp_srcptr np)
+
+    Equivalent to ``mpn_sqrtrem2(sp, rp, np, 2)``.
+    Sets ``sp`` to the integer square root of ``(np, 2)`` and if
+    ``rp`` is not ``NULL``, writes the remainder (two words)
+    to ``rp``. If ``rp`` is ``NULL``, the return value is zero
+    if the square root is exact and nonzero (warning: not necessarily
+    one) otherwise. If ``rp`` is not ``NULL``, the return value
+    is the number of limbs in the remainder (0, 1 or 2).
+
+    This function computes a ``double`` floating-point approximation
+    of the square root, which is refined using a single Newton step if
+    the square root is larger than about 53 bits. The square root is
+    then adjusted until the remainder is correct.
 
 GCD
 --------------------------------------------------------------------------------

--- a/mpn_extras.h
+++ b/mpn_extras.h
@@ -160,6 +160,8 @@ FLINT_DLL void flint_mpn_mulmod_preinvn(mp_ptr r,
 FLINT_DLL int flint_mpn_mulmod_2expp1_basecase(mp_ptr xp, mp_srcptr yp, mp_srcptr zp, 
     int c, flint_bitcnt_t b, mp_ptr tp);
 
+FLINT_DLL mp_size_t flint_mpn_sqrtrem2(mp_ptr sp, mp_ptr rp, mp_srcptr np);
+
 MPN_EXTRAS_INLINE
 void flint_mpn_rrandom(mp_limb_t *rp, gmp_randstate_t state, mp_size_t n)
 {

--- a/mpn_extras/profile/p-sqrtrem2.c
+++ b/mpn_extras/profile/p-sqrtrem2.c
@@ -1,0 +1,115 @@
+/*
+    Copyright (C) 2021 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <gmp.h>
+#include <math.h>
+#include "profiler.h"
+#include "flint.h"
+#include "longlong.h"
+#include "mpn_extras.h"
+#include "ulong_extras.h"
+
+double clocktime()
+{
+    return (double) clock() / CLOCKS_PER_SEC;
+}
+
+int main()
+{
+    flint_rand_t state;
+    flint_randinit(state);
+    slong i;
+
+    slong N = 1000000;
+    slong bits;
+
+    printf("bits   mpn_sqrtrem   flint_mpn_sqrtrem2   speedup\n");
+
+    for (bits = 128; bits >= 65; bits--)
+    {
+        mp_ptr X, S1, S2, R1, R2;
+        int *L1, *L2;
+        double t1, t2;
+
+        X = flint_malloc(2 * N * sizeof(mp_limb_t));
+        S1 = flint_malloc(N * sizeof(mp_limb_t));
+        S2 = flint_malloc(N * sizeof(mp_limb_t));
+        R1 = flint_malloc(2 * N * sizeof(mp_limb_t));
+        R2 = flint_malloc(2 * N * sizeof(mp_limb_t));
+        L1 = flint_malloc(N * sizeof(int));
+        L2 = flint_malloc(N * sizeof(int));
+
+        for (i = 0; i < N; i++)
+        {
+#if 0
+            X[2 * i] = n_randtest(state);
+            X[2 * i + 1] = n_randtest(state);
+#else
+            X[2 * i] = n_randlimb(state);
+            X[2 * i + 1] = n_randlimb(state);
+#endif
+
+            X[2 * i + 1] |= (UWORD(1) << 63);
+            X[2 * i + 1] >>= (128 - bits);
+
+#if 0
+            /* test perfect squares, or +/- 1 */
+            if (n_randint(state, 2))
+            {
+                mpn_sqrtrem(S1, NULL, X + 2 * i, 2);
+                umul_ppmm(X[2 * i + 1], X[2 * i], S1[0], S1[0]);
+                if (n_randint(state, 2))
+                    add_ssaaaa(X[2 * i + 1], X[2 * i], X[2 * i + 1], X[2 * i], 0, 1);
+                if (n_randint(state, 2))
+                    sub_ddmmss(X[2 * i + 1], X[2 * i], X[2 * i + 1], X[2 * i], 0, 1);
+            }
+#endif
+        }
+
+        t1 = clocktime();
+        for (i = 0; i < N; i++)
+        {
+            L1[i] = mpn_sqrtrem(S1 + i, R1 + 2 * i, X + 2 * i, 2);
+        }
+        t1 = (clocktime() - t1) / N;
+
+        t2 = clocktime();
+        for (i = 0; i < N; i++)
+        {
+            L2[i] = flint_mpn_sqrtrem2(S2 + i, R2 + 2 * i, X + 2 * i);
+        }
+        t2 = (clocktime() - t2) / N;
+
+        for (i = 0; i < N; i++)
+        {
+            if (S1[i] != S2[i] || L1[i] != L2[i] || (L1[i] > 0 && R1[2 * i] != R2[2 * i]) || (L1[i] == 2 && R1[2 * i + 1] != R2[2 * i + 1]))
+            {
+                printf("FAIL X = %lu %lu  S = %lu %lu  Rhi = %lu %lu  Rlo = %lu %lu\n",
+                    X[2 * i], X[2 * i + 1], S1[i], S2[i], R1[2 * i + 1], R2[2 * i + 1], R1[2 * i], R2[2 * i]);
+                abort();
+            }
+        }
+
+        printf("%3ld   %g   %g   %f\n", bits, t1, t2, t1 / t2);
+
+        free(X);
+        free(S1);
+        free(S2);
+        free(R1);
+        free(R2);
+        free(L1);
+        free(L2);
+    }
+
+    return 0;
+}

--- a/mpn_extras/sqrtrem2.c
+++ b/mpn_extras/sqrtrem2.c
@@ -1,0 +1,129 @@
+/*
+    Copyright (C) 2021 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdlib.h>
+#include <math.h>
+#include <gmp.h>
+#include "flint.h"
+#include "mpn_extras.h"
+
+#if FLINT_BITS == 64
+
+/* Above NEWTON_CUTOFF, we need one Newton iteration. Shifting down
+   the numerator and denominator by MAGIC_BITS allows doing the
+   division using 32-bit unsigned ints. This constant can be changed
+   slightly, but not too much, since we have to avoid overflow in the
+   numerator and we simultaneously want to guarantee sufficiently
+   many accurate quotient bits. */
+#define NEWTON_CUTOFF (2 * 53)
+#define NEED_NEWTON_ABOVE_HIGH_LIMB (UWORD(1) << (NEWTON_CUTOFF - 64))
+#define MAGIC_BITS 45
+#define TWO_EXP_64 18446744073709551616.0
+#define MAX_LIMBIFYABLE_DOUBLE 1.844674407370955e+19
+#define UU_LE(ahi, alo, bhi, blo) ((ahi) < (bhi) || ((ahi) == (bhi) && (alo <= blo)))
+
+mp_size_t
+flint_mpn_sqrtrem2(mp_ptr sp, mp_ptr rp, mp_srcptr np)
+{
+    double x;
+    mp_limb_t s, rhi, rlo, thi, tlo, hi, lo;
+    unsigned int rm, sm;
+
+    hi = np[1];
+    lo = np[0];
+
+    FLINT_ASSERT(hi != 0);
+
+    if (hi > NEED_NEWTON_ABOVE_HIGH_LIMB)
+    {
+        x = sqrt(hi * TWO_EXP_64 + lo);
+        x = FLINT_MIN(x, MAX_LIMBIFYABLE_DOUBLE);
+        s = (mp_limb_t) x;
+
+        umul_ppmm(rhi, rlo, s, s);
+        if (UU_LE(rhi, rlo, hi, lo))
+        {
+            /* r = n - x^2 */
+            sub_ddmmss(rhi, rlo, hi, lo, rhi, rlo);
+            /* rm = r >> MAGIC_BITS */
+            rm = (rhi << (FLINT_BITS - MAGIC_BITS)) | (rlo >> MAGIC_BITS);
+            sm = s >> (MAGIC_BITS - 1);
+            s += rm / sm;
+            s -= (s == 0);  /* fix possible wraparound */
+        }
+        else
+        {
+            /* r = x^2 - n */
+            sub_ddmmss(rhi, rlo, rhi, rlo, hi, lo);
+            /* as above, but round up to get a better approximation of the integer square root */
+            rm = (rhi << (FLINT_BITS - MAGIC_BITS)) | (rlo >> MAGIC_BITS);
+            sm = s >> (MAGIC_BITS - 1);
+            s -= (rm + sm - 1) / sm;
+        }
+    }
+    else
+    {
+        s = (mp_limb_t) sqrt(hi * TWO_EXP_64 + lo);
+    }
+
+    /* The integer square root satisfies s^2 <= n < (s+1)^2,
+       or 0 <= r <= 2*s  where r = n - s^2. */
+
+    /* If s^2 > n, we need to decrement s. */
+    umul_ppmm(rhi, rlo, s, s);
+    while (!UU_LE(rhi, rlo, hi, lo))
+    {
+        /* s^2 > n; set s' = s - 1 and s'^2 = s^2 - (2s-1)  */
+        sub_ddmmss(thi, tlo, (s >> (FLINT_BITS - 1)), (s << 1), 0, 1);
+        sub_ddmmss(rhi, rlo, rhi, rlo, thi, tlo);
+        s -= 1;
+    }
+
+    /* rhi, rlo = n - s^2 */
+    sub_ddmmss(rhi, rlo, hi, lo, rhi, rlo);
+    /* thi, tlo = 2s */
+    thi = s >> (FLINT_BITS - 1);
+    tlo = s << 1;
+    while (!UU_LE(rhi, rlo, thi, tlo))
+    {
+        /* r > 2*s; set s' = s + 1 and r' = r - (2s+1)  */
+        add_ssaaaa(thi, tlo, thi, tlo, 0, 1);
+        sub_ddmmss(rhi, rlo, rhi, rlo, thi, tlo);
+        s += 1;
+        thi = s >> (FLINT_BITS - 1);
+        tlo = s << 1;
+    }
+
+    sp[0] = s;
+
+    if (rp != NULL)
+    {
+        rp[0] = rlo;
+        rp[1] = rhi;
+    }
+
+    if (rhi != 0)
+        return 2;
+    return (rlo != 0);
+}
+
+#else
+
+/* todo: could implement the algorithm of n_sqrtrem if we cared
+   about optimizing for 32-bit machines */
+mp_size_t
+flint_mpn_sqrtrem2(mp_ptr sp, mp_ptr rp, mp_srcptr np)
+{
+    return mpn_sqrtrem(sp, rp, np, 2);
+}
+
+#endif
+

--- a/mpn_extras/test/t-sqrtrem2.c
+++ b/mpn_extras/test/t-sqrtrem2.c
@@ -1,0 +1,78 @@
+/*
+    Copyright (C) 2021 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <gmp.h>
+#include "flint.h"
+#include "mpn_extras.h"
+#include "ulong_extras.h"
+
+int main(void)
+{
+    slong iter;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("sqrtrem2....");
+    fflush(stdout);
+
+    for (iter = 0; iter < 100000 * flint_test_multiplier(); iter++)
+    {
+        mp_limb_t X[2], S1[1], S2[1], R1[2], R2[2];
+        mp_size_t L1, L2;
+
+        X[0] = n_randtest(state);
+        X[1] = n_randtest_not_zero(state);
+
+        /* Generate perfect squares, or +/- 1 */
+        if (n_randint(state, 2))
+        {
+            mpn_sqrtrem(S1, NULL, X, 2);
+            umul_ppmm(X[1], X[0], S1[0], S1[0]);
+            if (n_randint(state, 2))
+                add_ssaaaa(X[1], X[0], X[1], X[0], 0, 1);
+            if (n_randint(state, 2))
+                sub_ddmmss(X[1], X[0], X[1], X[0], 0, 1);
+            if (X[1] == 0)
+                X[1] = n_randtest_not_zero(state);
+        }
+
+        L1 = mpn_sqrtrem(S1, R1, X, 2);
+        L2 = flint_mpn_sqrtrem2(S2, R2, X);
+
+        if (S1[0] != S2[0] || L1 != L2 || (L1 > 0 && R1[0] != R2[0]) || (L1 == 2 && R1[1] != R2[1]))
+        {
+            flint_printf("FAIL\n");
+            flint_printf("X = %wu, %wu\n", X[1], X[0]);
+            flint_printf("L1 = %wd, L2 = %wd\n", L1, L2);
+            flint_printf("S1 = %wu, S2 = %wu\n", S1[0], S2[0]);
+            flint_printf("R1[0] = %wd, R2[0] = %wu\n", R1[0], R2[0]);
+            flint_printf("R1[1] = %wd, R2[1] = %wu\n", R1[1], R2[1]);
+            flint_abort();
+        }
+
+        L1 = (mpn_sqrtrem(S1, NULL, X, 2) != 0);
+        L2 = (flint_mpn_sqrtrem2(S2, NULL, X) != 0);
+
+        if (S1[0] != S2[0] || L1 != L2)
+        {
+            flint_printf("FAIL\n");
+            flint_printf("X = %wu, %wu\n", X[1], X[0]);
+            flint_printf("L1 = %wd, L2 = %wd\n", L1, L2);
+            flint_printf("S1 = %wu, S2 = %wu\n", S1[0], S2[0]);
+            flint_abort();
+        }
+    }
+    FLINT_TEST_CLEANUP(state);
+    
+    flint_printf("PASS\n");
+    return 0;
+}


### PR DESCRIPTION
This is an experimental two-limb square root function. It is about twice as fast as mpn_sqrtrem in GMP 6.2 up to 106 bits, about the same speed between 107 and 126 bits, and slightly slower at 127 and 128 bits. Before merging this, I'd be interested in a review of the code (@wbhart and @tthsqe12) as well as profiling data on a more modern machine (results on my laptop attached below).

I coded this defensively: the final adjustment loops ensure a correct square root and remainder even if the initial approximation is off by several units. In practice it is usually correct and never seems to be off by more than +/-1. With a careful rounding analysis, one could ensure that the approximation is correct or consistently 1 too large (or consistently 1 too small), allowing for a faster adjustment. However, pretending that this is the case and commenting out the adjustment loops seems to make a negligible difference.

It's a bit disappointing that the speedup isn't bigger, and especially that there is no speedup (possibly even some slowdown) in the 107-128 bits range. It's especially a mystery that the timings are 127 and 128 bits behave differently from 126 bits and below: GMP seemingly gets a little faster while flint_mpn_sqrtrem2 is a little slower. I believe GMP manages to avoid a shift in this case, but I really don't see why flint_mpn_sqrtrem2 would slow down.

If we can't find something to improve, it might be better to throw out the new code for >= 107 bits and just fall back to mpn_sqrtrem, but figuring out some way to go faster would be better :-)

This is not used anywhere right now, but it could be used in fmpz_sqrt / fmpz_sqrtrem and some other functions.

I'd also be interested in 3 and 4 limbs as well as sqrtexact and sqrtapprox, but it will be hard to beat GMP.


```
fredrik@agm:~/src/flint2$ build/mpn_extras/profile/p-sqrtrem2 
bits   mpn_sqrtrem   flint_mpn_sqrtrem2   speedup
128   4.7367e-08   5.7808e-08   0.819385
127   4.7425e-08   5.1583e-08   0.919392
126   5.0509e-08   4.7342e-08   1.066896
125   5.2316e-08   4.6638e-08   1.121746
124   5.3065e-08   4.6385e-08   1.144012
123   5.2096e-08   4.5128e-08   1.154405
122   5.164e-08   4.5214e-08   1.142124
121   5.3442e-08   4.5463e-08   1.175505
120   5.0963e-08   4.386e-08   1.161947
119   5.2273e-08   5.0013e-08   1.045188
118   5.4118e-08   4.7073e-08   1.149661
117   5.3052e-08   4.4661e-08   1.187882
116   5.0893e-08   4.5696e-08   1.113730
115   5.3293e-08   4.326e-08   1.231923
114   5.1125e-08   4.3251e-08   1.182054
113   5.3052e-08   4.2777e-08   1.240199
112   5.1305e-08   4.2308e-08   1.212655
111   5.3077e-08   4.3209e-08   1.228378
110   5.1059e-08   4.2325e-08   1.206356
109   5.2315e-08   4.3399e-08   1.205443
108   5.063e-08   4.326e-08   1.170365
107   5.3812e-08   4.1941e-08   1.283040
106   5.0678e-08   3.3376e-08   1.518396
105   5.41e-08   3.4151e-08   1.584141
104   5.1846e-08   2.8721e-08   1.805160
103   5.9929e-08   2.8882e-08   2.074960
102   5.7809e-08   3.1015e-08   1.863905
101   5.4536e-08   2.609e-08   2.090303
100   5.0324e-08   2.5389e-08   1.982118
 99   5.2306e-08   2.6577e-08   1.968093
 98   5.0534e-08   2.5882e-08   1.952477
 97   5.216e-08   2.652e-08   1.966817
 96   5.1064e-08   2.3956e-08   2.131575
 95   5.2174e-08   2.5545e-08   2.042435
 94   5.5909e-08   2.3965e-08   2.332944
 93   5.2956e-08   2.3644e-08   2.239723
 92   5.1616e-08   2.37e-08   2.177890
 91   5.2554e-08   2.3847e-08   2.203799
 90   5.0104e-08   2.3909e-08   2.095613
 89   5.3237e-08   2.3675e-08   2.248659
 88   5.0948e-08   2.3654e-08   2.153885
 87   5.2765e-08   2.357e-08   2.238651
 86   5.0664e-08   2.3522e-08   2.153898
 85   5.2387e-08   2.3949e-08   2.187440
 84   5.0685e-08   2.3743e-08   2.134734
 83   5.4671e-08   2.3494e-08   2.327020
 82   5.046e-08   2.3591e-08   2.138951
 81   5.2798e-08   2.388e-08   2.210972
 80   5.0444e-08   2.3479e-08   2.148473
 79   5.5517e-08   2.4501e-08   2.265908
 78   5.1319e-08   2.4895e-08   2.061418
 77   5.4687e-08   2.3617e-08   2.315578
 76   5.08e-08   2.3502e-08   2.161518
 75   5.2428e-08   2.3848e-08   2.198423
 74   5.2108e-08   2.3963e-08   2.174519
 73   5.2953e-08   2.4372e-08   2.172698
 72   5.1019e-08   2.3823e-08   2.141586
 71   5.3212e-08   2.3619e-08   2.252932
 70   5.0984e-08   2.3491e-08   2.170363
 69   5.251e-08   2.4521e-08   2.141430
 68   5.1266e-08   2.3662e-08   2.166596
 67   5.242e-08   2.4784e-08   2.115074
 66   5.0664e-08   2.4935e-08   2.031843
 65   5.1985e-08   2.4038e-08   2.162618

```