### PR TITLE
Bernoulli(1) = +½

### DIFF
--- a/arith/bernoulli_number_vec_multi_mod.c
+++ b/arith/bernoulli_number_vec_multi_mod.c
@@ -99,7 +99,7 @@ void _arith_bernoulli_number_vec_multi_mod(fmpz * num, fmpz * den, slong n)
 
     /* Trivial entries */
     if (n > 1)
-        fmpz_set_si(num + 1, WORD(-1));
+        fmpz_set_si(num + 1, WORD(1));
     for (k = 3; k < n; k += 2)
         fmpz_zero(num + k);
 

--- a/arith/bernoulli_number_zeta.c
+++ b/arith/bernoulli_number_zeta.c
@@ -22,7 +22,7 @@ void _arith_bernoulli_number_zeta(fmpz_t num, fmpz_t den, ulong n)
 
     if (n % 2)
     {
-        fmpz_set_si(num, -(n == 1));
+        fmpz_set_si(num, (n == 1));
         return;
     }
 

--- a/arith/bernoulli_polynomial.c
+++ b/arith/bernoulli_polynomial.c
@@ -30,8 +30,9 @@ void arith_bernoulli_polynomial(fmpq_poly_t poly, ulong n)
 
     _arith_bernoulli_number_vec(poly->coeffs, den, n + 1);
 
-    /* Multiply the odd term by binomial(n,1) = n */
+    /* Multiply the odd term by -binomial(n,1) = -n */
     fmpz_mul_ui(poly->coeffs + 1, poly->coeffs + 1, n);
+    fmpz_neg(poly->coeffs + 1, poly->coeffs + 1);
 
     /* Multiply even terms by binomial coefficients */
     fmpz_one(t);

--- a/doc/source/arith.rst
+++ b/doc/source/arith.rst
@@ -201,17 +201,18 @@ Bell numbers
 Bernoulli numbers and polynomials
 --------------------------------------------------------------------------------
 
+The functions in this section use `B_1=+\frac{1}{2}`.
 
 .. function:: void _arith_bernoulli_number(fmpz_t num, fmpz_t den, ulong n)
 
     Sets ``(num, den)`` to the reduced numerator and denominator
     of the `n`-th Bernoulli number. As presently implemented,
-    this function simply calls\\ ``_arith_bernoulli_number_zeta``.
+    this function simply calls ``_arith_bernoulli_number_zeta``.
 
 .. function:: void arith_bernoulli_number(fmpq_t x, ulong n)
 
     Sets ``x`` to the `n`-th Bernoulli number. This function is
-    equivalent to\\ ``_arith_bernoulli_number`` apart from the output
+    equivalent to ``_arith_bernoulli_number`` apart from the output
     being a single ``fmpq_t`` variable.
 
     Warning: this function does not use proven precision bounds, and
@@ -253,7 +254,7 @@ Bernoulli numbers and polynomials
 .. function:: void arith_bernoulli_polynomial(fmpq_poly_t poly, ulong n)
 
     Sets ``poly`` to the Bernoulli polynomial of degree `n`,
-    `B_n(x) = \sum_{k=0}^n \binom{n}{k} B_k x^{n-k}` where `B_k`
+    `B_n(x) = \sum_{k=0}^n (-1)^k \binom{n}{k} B_k x^{n-k}` where `B_k`
     is a Bernoulli number. This function basically calls
     ``arith_bernoulli_number_vec`` and then rescales the coefficients
     efficiently.
@@ -290,14 +291,11 @@ Bernoulli numbers and polynomials
     say `n < 1000`. The common denominator is calculated directly
     as the primorial of `n + 1`.
 
-    %[1] https://en.wikipedia.org/w/index.php?
-    %    title=Bernoulli_number&oldid=405938876
-
 .. function:: void _arith_bernoulli_number_vec_zeta(fmpz * num, fmpz * den, slong n)
 
     Sets the elements of ``num`` and ``den`` to the reduced
     numerators and denominators of `B_0, B_1, B_2, \ldots, B_{n-1}`
-    inclusive. Uses repeated direct calls to\\
+    inclusive. Uses repeated direct calls to
     ``_arith_bernoulli_number_zeta``.
 
 .. function:: void _arith_bernoulli_number_vec_multi_mod(fmpz * num, fmpz * den, slong n)
@@ -315,7 +313,7 @@ Bernoulli numbers and polynomials
     arithmetic to yield the numerators of the Bernoulli numbers after
     multiplication by the denominators and CRT reconstruction. This formula,
     given (incorrectly) in [BuhlerCrandallSompolski1992]_, saves about
-    half of the time compared to the usual generating function `x/(e^x-1)`
+    half of the time compared to the usual generating function `x/(1-e^{-x})`
     since the odd terms vanish.
 
 


### PR DESCRIPTION
There was a discussion in SymPy at sympy/sympy#23866 on changing its value of $B_1$ (the first Bernoulli number) to $+\frac12$ from the old value of $-\frac12$. Using $+\frac12$ allows interpolating the Bernoulli numbers and polynomials with the **entire** Bernoulli function $B(s,a)=-s\zeta(1-s,a)$ [and confers several other advantages](http://luschny.de/math/zeta/The-Bernoulli-Manifesto.html) – in short, when considering the many appearances of the Bernoulli numbers across mathematics, $+\frac12$ is the most logical choice for $B_1$.

That discussion has been closed because **I have got PRs merged into SymPy changing its $B_1$ to $+\frac12$**; cf. sympy/sympy#23926. I thought that also changed the value in SageMath (which SymPy includes), but @oscarbenjamin [corrected me](https://github.com/sympy/sympy/pull/23926#issuecomment-1240477140), pointing out the ability of SageMath to use other libraries' Bernoulli number implementations, all of which still have $B_1=-\frac12$. I dug through Sage's code and found that it uses FLINT for the smaller arguments; in order to ensure consistency with mathematical truth as soon as possible, I have opened this PR.

----

The associated sage-devel mailing list thread is
https://groups.google.com/g/sage-devel/c/G4sbKoibXK4
The corresponding trac ticket is
https://trac.sagemath.org/ticket/34521