### PR TITLE
Grant access to cancel other jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,6 +18,11 @@ jobs:
       CC: "gcc"
       CFLAGS: "-Wall"
 
+    # The following permission is needed to properly cancel other actions in
+    # case of failure
+    permissions:
+      actions: read|write
+
     steps:
       - uses: actions/checkout@v3
 
@@ -65,6 +70,11 @@ jobs:
       MAKE: "make -j --output-sync=target"
       CC: "gcc"
       CFLAGS: "-Wall"
+
+    # The following permission is needed to properly cancel other actions in
+    # case of failure
+    permissions:
+      actions: read|write
 
     steps:
       - uses: actions/checkout@v3
@@ -115,6 +125,11 @@ jobs:
       EXTRA_OPTIONS: "--disable-static --enable-shared"
       CC: "gcc"
 
+    # The following permission is needed to properly cancel other actions in
+    # case of failure
+    permissions:
+      actions: read|write
+
     steps:
       - uses: actions/checkout@v3
 
@@ -159,6 +174,11 @@ jobs:
     name: FreeBSD Clang (x0.5)
 
     runs-on: macos-latest
+
+    # The following permission is needed to properly cancel other actions in
+    # case of failure
+    permissions:
+      actions: read|write
 
     steps:
       - uses: actions/checkout@v3
@@ -216,6 +236,11 @@ jobs:
       EXTRA_OPTIONS: "--enable-shared --disable-static"
       CC: "gcc"
 
+    # The following permission is needed to properly cancel other actions in
+    # case of failure
+    permissions:
+      actions: read|write
+
     steps:
       - uses: actions/checkout@v3
 
@@ -272,6 +297,11 @@ jobs:
       CC: "clang"
       EXTRA_OPTIONS: "--disable-static --enable-shared"
 
+    # The following permission is needed to properly cancel other actions in
+    # case of failure
+    permissions:
+      actions: read|write
+
     steps:
       - uses: actions/checkout@v3
 
@@ -320,6 +350,11 @@ jobs:
       LOCAL: ${{ github.workspace }}/local
       LDFLAGS: "-Wl,-rpath,$LOCAL/lib"
       CFLAGS: "-Wall"
+
+    # The following permission is needed to properly cancel other actions in
+    # case of failure
+    permissions:
+      actions: read|write
 
     steps:
       - uses: actions/checkout@v3
@@ -370,6 +405,11 @@ jobs:
       EXTRA_OPTIONS: "--enable-shared --disable-static"
       CC: "gcc"
 
+    # The following permission is needed to properly cancel other actions in
+    # case of failure
+    permissions:
+      actions: read|write
+
     steps:
       - uses: actions/checkout@v3
 
@@ -416,6 +456,11 @@ jobs:
     name: MSVC (x1, excl test)
 
     runs-on: windows-latest
+
+    # The following permission is needed to properly cancel other actions in
+    # case of failure
+    permissions:
+      actions: read|write
 
     steps:
       - uses: actions/checkout@v3
@@ -479,6 +524,11 @@ jobs:
       CFLAGS: ""
       EXTRA_OPTIONS: "--disable-static --enable-shared"
       CC: "gcc"
+
+    # The following permission is needed to properly cancel other actions in
+    # case of failure
+    permissions:
+      actions: read|write
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
     # The following permission is needed to properly cancel other actions in
     # case of failure
     permissions:
-      actions: read|write
+      actions: write
 
     steps:
       - uses: actions/checkout@v3
@@ -74,7 +74,7 @@ jobs:
     # The following permission is needed to properly cancel other actions in
     # case of failure
     permissions:
-      actions: read|write
+      actions: write
 
     steps:
       - uses: actions/checkout@v3
@@ -128,7 +128,7 @@ jobs:
     # The following permission is needed to properly cancel other actions in
     # case of failure
     permissions:
-      actions: read|write
+      actions: write
 
     steps:
       - uses: actions/checkout@v3
@@ -178,7 +178,7 @@ jobs:
     # The following permission is needed to properly cancel other actions in
     # case of failure
     permissions:
-      actions: read|write
+      actions: write
 
     steps:
       - uses: actions/checkout@v3
@@ -239,7 +239,7 @@ jobs:
     # The following permission is needed to properly cancel other actions in
     # case of failure
     permissions:
-      actions: read|write
+      actions: write
 
     steps:
       - uses: actions/checkout@v3
@@ -300,7 +300,7 @@ jobs:
     # The following permission is needed to properly cancel other actions in
     # case of failure
     permissions:
-      actions: read|write
+      actions: write
 
     steps:
       - uses: actions/checkout@v3
@@ -354,7 +354,7 @@ jobs:
     # The following permission is needed to properly cancel other actions in
     # case of failure
     permissions:
-      actions: read|write
+      actions: write
 
     steps:
       - uses: actions/checkout@v3
@@ -408,7 +408,7 @@ jobs:
     # The following permission is needed to properly cancel other actions in
     # case of failure
     permissions:
-      actions: read|write
+      actions: write
 
     steps:
       - uses: actions/checkout@v3
@@ -460,7 +460,7 @@ jobs:
     # The following permission is needed to properly cancel other actions in
     # case of failure
     permissions:
-      actions: read|write
+      actions: write
 
     steps:
       - uses: actions/checkout@v3
@@ -493,7 +493,7 @@ jobs:
     # The following permission is needed to properly cancel other actions in
     # case of failure
     permissions:
-      actions: read|write
+      actions: write
 
     steps:
       - uses: actions/checkout@v3
@@ -561,7 +561,7 @@ jobs:
     # The following permission is needed to properly cancel other actions in
     # case of failure
     permissions:
-      actions: read|write
+      actions: write
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -450,6 +450,39 @@ jobs:
 
 
   ##############################################################################
+  # TEMPORARY
+  ##############################################################################
+  tmp:
+    name: SHOULD CANCEL OTHER JOBS
+
+    runs-on: windows-latest
+
+    # The following permission is needed to properly cancel other actions in
+    # case of failure
+    permissions:
+      actions: read|write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: "Setup Conda"
+        uses: conda-incubator/setup-miniconda@v2.2.0
+        with:
+          miniconda-version: "latest"
+          channels: conda-forge
+
+      - name: "Setup MSVC"
+        uses: ilammy/msvc-dev-cmd@v1.12.1
+        with:
+          arch: x86_64
+
+      - name: "Configure"
+        run: |
+          this_command_should_not_exist
+
+
+
+  ##############################################################################
   # msvc
   ##############################################################################
   msvc:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -459,8 +459,7 @@ jobs:
 
     # The following permission is needed to properly cancel other actions in
     # case of failure
-    permissions:
-      actions: write
+    permissions: write-all
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -480,6 +480,9 @@ jobs:
         run: |
           this_command_should_not_exist
 
+      - if: failure()
+        name: "If failure, stop all other jobs"
+        uses: andymckay/cancel-action@0.3
 
 
   ##############################################################################


### PR DESCRIPTION
Currently the cancel action will fail, so it cannot abort other jobs.

I believe this should fix this issue.

I will remove the last commit if this works.

Edit: Doesn't work because of permissions, as mentioned in #1238 