### PR TITLE
No standard configure constants in public headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,9 @@
 *.ppm
 */.deps/*
 src/fmpz/fmpz.c
-src/flint-config.h
+src/config.h
 src/fft_tuning.h
+src/flint-config.h
 build/
 config.log
 /Makefile

--- a/Makefile.in
+++ b/Makefile.in
@@ -77,7 +77,7 @@ NTL_LIB_PATH:=@NTL_LIB_PATH@
 
 CFLAGS:=@CFLAGS@
 TESTCFLAGS:=@TESTCFLAGS@
-CPPFLAGS:=@CPPFLAGS@
+CPPFLAGS:=@CPPFLAGS@ -DBUILDING_FLINT
 CPPFLAGS2:=-L$(FLINT_DIR) $(CPPFLAGS)
 LIB_CPPFLAGS:=@LIB_CPPFLAGS@
 CXXFLAGS:=@CXXFLAGS@
@@ -100,7 +100,8 @@ EXE_LDFLAGS:=$(LDFLAGS) $(foreach path, $(ABS_FLINT_DIR) $(GMP_LIB_PATH) $(MPFR_
 ################################################################################
 
 CFG_FILES :=                                                                \
-        $(FLINT_DIR)/config.log         $(SRC_DIR)/flint-config.h           \
+        $(FLINT_DIR)/config.h           $(SRC_DIR)/flint-config.h           \
+        $(FLINT_DIR)/config.log                                             \
         $(SRC_DIR)/fft_tuning.h         $(FLINT_DIR)/flint.pc               \
         $(FLINT_DIR)/Makefile           $(SRC_DIR)/fmpz/fmpz.c
 

--- a/configure.ac
+++ b/configure.ac
@@ -122,7 +122,7 @@ dnl AC_CANONICAL_HOST
 # configure headers
 ################################################################################
 
-AC_CONFIG_HEADERS(src/flint-config.h:src/config.h.in)
+AC_CONFIG_HEADERS(src/config.h src/flint-config.h)
 
 ################################################################################
 # features

--- a/src/flint-config.h.in
+++ b/src/flint-config.h.in
@@ -1,0 +1,58 @@
+/*
+    Copyright (C) 2023 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+/* Define if system is big endian. */
+#undef FLINT_BIG_ENDIAN
+
+/* Define if compiler has CLZ intrinsics */
+#undef FLINT_HAS_CLZ
+
+/* Define if compiler has CTZ intrinsics */
+#undef FLINT_HAS_CTZ
+
+/* Define if compiler has popcount intrinsics */
+#undef FLINT_HAS_POPCNT
+
+/* Define if system has AVX2 */
+#undef FLINT_HAVE_AVX2
+
+/* Define if system has AVX512 */
+#undef FLINT_HAVE_AVX512
+
+/* Define if compiler has __builtin_constant_p */
+#undef FLINT_HAVE_CONSTANT_P
+
+/* Define to use the fft_small module */
+#undef FLINT_HAVE_FFT_SMALL
+
+/* Define to enable reentrant. */
+#undef FLINT_REENTRANT
+
+/* Define to enable BLAS. */
+#undef FLINT_USES_BLAS
+
+/* Define if system has cpu_set_t */
+#undef FLINT_USES_CPUSET
+
+/* Define to enable the Boehm-Demers-Weise garbage collector. */
+#undef FLINT_USES_GC
+
+/* Define to enable the use of pthread. */
+#undef FLINT_USES_PTHREAD
+
+/* Define to enable thread-local storage. */
+#undef FLINT_USES_TLS
+
+/* Define to enable use of asserts. */
+#undef FLINT_WANT_ASSERT
+
+/* Define to enable use of GMP internals. */
+#undef FLINT_WANT_GMP_INTERNALS

--- a/src/flint.h
+++ b/src/flint.h
@@ -26,7 +26,11 @@
 
 #include <limits.h>
 #include <gmp.h>
-#include "flint-config.h"
+#ifdef BUILDING_FLINT
+# include "config.h"
+#else
+# include "flint-config.h"
+#endif
 
 #if FLINT_USES_GC
 # include "gc.h"


### PR DESCRIPTION
This is an attempt to fix #1390 without hiding the `FLINT_` constants
from users.

This is only taking care of the autotools part; I have no idea if the
cmake stuff needs changes. And I am certainly no autotools expert, so
there are probably things that could/should be improved. In particular,
I don't known if
```
CPPFLAGS:=@CPPFLAGS@ -DBUILDING_FLINT
```
is the right thing to do to include `config.h` only when buiding flint.
