### PR TITLE
Let cmake install flintxx/*.h header files into flintxx subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,8 +103,6 @@ set(HEADERS
 foreach (build_dir IN LISTS BUILD_DIRS TEMPLATE_DIRS)
     file(GLOB TEMP RELATIVE "${CMAKE_SOURCE_DIR}" "${build_dir}/*.c")
     list(APPEND SOURCES ${TEMP})
-    file(GLOB TEMP RELATIVE "${CMAKE_SOURCE_DIR}" "${build_dir}/*.h")
-    list(APPEND HEADERS ${TEMP})
 endforeach ()
 
 execute_process(
@@ -221,6 +219,7 @@ endforeach()
 
 file(GLOB TEMP "${CMAKE_SOURCE_DIR}/*.h")
 list(APPEND HEADERS ${TEMP})
+file(GLOB CXX_HEADERS "${CMAKE_SOURCE_DIR}/flintxx/*.h")
 
 add_library(flint ${SOURCES})
 target_link_libraries(flint PUBLIC
@@ -307,6 +306,7 @@ install(TARGETS flint
         )
 
 install(FILES ${HEADERS} DESTINATION include/flint)
+install(FILES ${CXX_HEADERS} DESTINATION include/flint/flintxx)
 
 set_target_properties(flint
     PROPERTIES


### PR DESCRIPTION
Fixes #462 on Flint 2.9. With cmake, the header files in `flintxx` were previously installed to `/usr/include/flint`, but they should go to `/usr/include/flint/flintxx`.