### PR TITLE
Fix `configure' helpstring for older version of bash

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1165,7 +1165,7 @@ Fine tuning of the installation directories:
   --includedir=DIR        C header files [PREFIX/include]
 _ACEOF
 
-    cat <<_ACEOF]
-    m4_divert_pop([HELP_BEGIN])dnl
+    cat <<\_ACEOF]
+m4_divert_pop([HELP_BEGIN])dnl
 
 dnl NOTE: There is supposed to be a missing `fi' here.


### PR DESCRIPTION
On Debian Buster the helpstring did not display all options. This commit fixes it.

Could someone with a newer version check that this prints the helpstring OK? So just do
```
$ ./bootstrap.sh
$ ./configure --help
```
and check that it looks ok.