### PR TITLE
update cross-platform-action to improve reliability?

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -190,7 +190,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: "Run tests on FreeBSD"
-        uses: cross-platform-actions/action@v0.10.0
+        uses: cross-platform-actions/action@v0.19.1
         timeout-minutes: 25
         continue-on-error: true
         with:


### PR DESCRIPTION
because #1440 fails repeatedly on freebsd