### PR TITLE
Limit concurrency of CI jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,6 +3,12 @@ name: CI
 
 on: [push, pull_request]
 
+concurrency:
+  # group by workflow and ref; the last slightly strange component ensures that for pull
+  # requests, we limit to 1 concurrent job, but for the trunk branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/trunk' || github.run_number }}
+  # Cancel intermediate builds, but only if it is a pull request build.
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   ##############################################################################


### PR DESCRIPTION
Right now I see multiple GH action jobs scheduled for my PR #1449 ; each time I push there, more jobs are scheduled.

But we really only care about the most recent one! All the others just waste time (and a lot of it).

This PR attempts to improve the situation by limiting each PR to one (set of) active GH workflow; when updates are pushed, then any already running workflows are cancelled.

For `trunk` this is relaxed, as there it may be useful to have test results for all intermediate commits, even if e.g. two PRs are merged in quick succession, we still want to see the outcome of both CI jobs.