### PR TITLE
remove two self assignments

### DIFF
--- a/examples/complex_plot.c
+++ b/examples/complex_plot.c
@@ -423,7 +423,6 @@ void worker(slong x, work_t * work)
 
     xnum = work->xnum;
     ynum = work->ynum;
-    ynum = ynum; /* unused */
     y = work->y;
 
     for (prec = 30; prec < 500; prec *= 2)

--- a/examples/functions_benchmark.c
+++ b/examples/functions_benchmark.c
@@ -97,7 +97,7 @@ int main()
     arb_t x, y, res;
     slong n, prec;
     int function;
-    double tcpu, twall;
+    double __attribute__((unused)) tcpu, twall;
 
     arb_init(x);
     arb_init(y);
@@ -149,7 +149,6 @@ int main()
             printf("%12.3g", twall);
             fflush(stdout);
 
-            tcpu = tcpu; /* unused */
             printf("\n");
         }
     }


### PR DESCRIPTION
the `ynum` one is used a  few lines below,
the `tcpu` is used in the macro