### PR TITLE
Fix declusion of fq_zech_vec's tests

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -260,12 +260,14 @@ _PROF_SOURCES := $(wildcard $(SRC_DIR)/profile/*.c)
 $(foreach dir, $(DIRS), $(eval $(call xxx_PROF_SOURCES,$(dir))))
 PROF_SOURCES := $(foreach dir,$(DIRS),$($(dir)_PROF_SOURCES)) $(_PROF_SOURCES)
 
+# FIXME: De-hardcode fq_zech_vec from this.
+fq_zech_vec_TEST_SOURCES := $(wildcard $(SRC_DIR)/fq_zech_vec/test/*.c)
 define xxx_TEST_SOURCES
 $(1)_TEST_SOURCES := $(wildcard $(SRC_DIR)/$(1)/test/*.c)
 endef
 _TEST_SOURCES := $(wildcard $(SRC_DIR)/test/*.c)
 $(foreach dir, $(DIRS), $(eval $(call xxx_TEST_SOURCES,$(dir))))
-TEST_SOURCES := $(foreach dir,$(DIRS),$($(dir)_TEST_SOURCES)) $(_TEST_SOURCES)
+TEST_SOURCES := $(foreach dir,$(DIRS),$($(dir)_TEST_SOURCES)) $(_TEST_SOURCES) $(fq_zech_vec_TEST_SOURCES)
 ifneq ($(WANT_NTL), 0)
 interfaces_TEST_SOURCES := $(SRC_DIR)/interfaces/test/t-NTL-interface.cpp
 endif


### PR DESCRIPTION
Accidentally removed checks of `fq_zech_vec` when I merged #1453

Perhaps some more elegant solution could be found, but this should work for now.