### PR TITLE
CI: limit which branches run CI tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,11 @@
 name: CI
 
-
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - trunk
+      - flint-*
 
 concurrency:
   # group by workflow and ref; the last slightly strange component ensures that for pull


### PR DESCRIPTION
Right now when people make PRs from branches which live in the main
repository `flintlib/flint` (as opposed to in a branch), the CI will run
all tests *twice*: once for the branch HEAD, and once for the pull
request HEAD (which is a merge commit created from merging the branch
HEAD into trunk). This is mostly useless, so let's disable that to
conserve more CI resources. Only run those CI tests on trunk and on
release branches.
