### PR TITLE
Use `ulong` instead of `slong` for unsigned integer input in some cases

### DIFF
--- a/doc/source/gr_poly.rst
+++ b/doc/source/gr_poly.rst
@@ -114,7 +114,7 @@ Basic manipulation
 
 .. function:: int gr_poly_set_scalar(gr_poly_t poly, gr_srcptr c, gr_ctx_t ctx)
               int gr_poly_set_si(gr_poly_t poly, slong c, gr_ctx_t ctx)
-              int gr_poly_set_ui(gr_poly_t poly, slong c, gr_ctx_t ctx)
+              int gr_poly_set_ui(gr_poly_t poly, ulong c, gr_ctx_t ctx)
               int gr_poly_set_fmpz(gr_poly_t poly, const fmpz_t c, gr_ctx_t ctx)
               int gr_poly_set_fmpq(gr_poly_t poly, const fmpq_t c, gr_ctx_t ctx)
 

--- a/src/fmpq.h
+++ b/src/fmpq.h
@@ -123,7 +123,7 @@ void fmpq_set_ui(fmpq_t res, ulong p, ulong q);
 void _fmpq_set_si(fmpz_t rnum, fmpz_t rden, slong p, ulong q);
 void fmpq_set_si(fmpq_t res, slong p, ulong q);
 
-FMPQ_INLINE int fmpq_equal_ui(fmpq_t q, slong n)
+FMPQ_INLINE int fmpq_equal_ui(fmpq_t q, ulong n)
 {
     return fmpz_equal_ui(fmpq_numref(q), n) && q->den == WORD(1);
 }

--- a/src/gr_mpoly.h
+++ b/src/gr_mpoly.h
@@ -165,7 +165,7 @@ int gr_mpoly_print_pretty(const gr_mpoly_t A, const char ** x_in, const mpoly_ct
 /* Constants */
 
 WARN_UNUSED_RESULT int gr_mpoly_set_scalar(gr_mpoly_t A, gr_srcptr c, const mpoly_ctx_t mctx, gr_ctx_t cctx);
-WARN_UNUSED_RESULT int gr_mpoly_set_ui(gr_mpoly_t A, slong c, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+WARN_UNUSED_RESULT int gr_mpoly_set_ui(gr_mpoly_t A, ulong c, const mpoly_ctx_t mctx, gr_ctx_t cctx);
 WARN_UNUSED_RESULT int gr_mpoly_set_si(gr_mpoly_t A, slong c, const mpoly_ctx_t mctx, gr_ctx_t cctx);
 WARN_UNUSED_RESULT int gr_mpoly_set_fmpz(gr_mpoly_t A, const fmpz_t c, const mpoly_ctx_t mctx, gr_ctx_t cctx);
 WARN_UNUSED_RESULT int gr_mpoly_set_fmpq(gr_mpoly_t A, const fmpq_t c, const mpoly_ctx_t mctx, gr_ctx_t cctx);

--- a/src/gr_mpoly/set_scalar.c
+++ b/src/gr_mpoly/set_scalar.c
@@ -31,7 +31,7 @@ int gr_mpoly_set_scalar(gr_mpoly_t A,
 }
 
 int gr_mpoly_set_ui(gr_mpoly_t A,
-    slong c,
+    ulong c,
     const mpoly_ctx_t mctx, gr_ctx_t cctx)
 {
     int status;

--- a/src/gr_poly.h
+++ b/src/gr_poly.h
@@ -97,7 +97,7 @@ truth_t gr_poly_is_scalar(const gr_poly_t poly, gr_ctx_t ctx);
 
 WARN_UNUSED_RESULT int gr_poly_set_scalar(gr_poly_t poly, gr_srcptr x, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_set_si(gr_poly_t poly, slong x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_set_ui(gr_poly_t poly, slong x, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_poly_set_ui(gr_poly_t poly, ulong x, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_set_fmpz(gr_poly_t poly, const fmpz_t x, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_set_fmpq(gr_poly_t poly, const fmpq_t x, gr_ctx_t ctx);
 

--- a/src/gr_poly/set_scalar.c
+++ b/src/gr_poly/set_scalar.c
@@ -49,7 +49,7 @@ gr_poly_set_si(gr_poly_t poly, slong x, gr_ctx_t ctx)
 }
 
 int
-gr_poly_set_ui(gr_poly_t poly, slong x, gr_ctx_t ctx)
+gr_poly_set_ui(gr_poly_t poly, ulong x, gr_ctx_t ctx)
 {
     if (x == 0)
     {


### PR DESCRIPTION
Probably these are typos. Do these changes break compatibility? Maybe the PR is for `flint3` then.

- Fixes https://github.com/flintlib/flint/issues/1403

Note `fmpz_mod_mpoly_set_ui` was already fixed before this PR.