### PR TITLE
Remove inclusion of `gmpcompat.h` in `mpn extras.h`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -574,8 +574,6 @@ jobs:
       - name: "Setup"
         run: |
           sudo apt install -y sed
-          sudo apt install -y libgmp-dev
-          sudo apt install -y libmpfr-dev
           sudo apt install -y autoconf
           sudo apt install -y libtool-bin
           gcc --version
@@ -583,9 +581,16 @@ jobs:
           autoconf --version
           libtool --version
           julia --version
+          julia -e 'println(Base.BinaryPlatforms.HostPlatform())'
 
       - name: "Configure"
         run: |
+          # Find path to GMP and MPFR
+          gmp_path=$(julia -e 'include("dev/find_gmp_mpfr.jl"); print(gmp_artifact_dir())')
+          echo "Path to GMP: ${gmp_path}"
+          mpfr_path=$(julia -e 'include("dev/find_gmp_mpfr.jl"); print(mpfr_artifact_dir())')
+          echo "Path to MPFR: ${mpfr_path}"
+
           # Make sure that we output an soname which corresponds to FLINT_JLL's
           # soname
           wget https://raw.githubusercontent.com/JuliaPackaging/Yggdrasil/master/F/FLINT/build_tarballs.jl
@@ -598,9 +603,12 @@ jobs:
           sed -i "s/^\(FLINT_MINOR_SO=\)[0-9]\+/\1$FLINT_JLL_MINOR/" configure.ac
           sed -i "s/^\(FLINT_PATCH_SO=\)[0-9]\+/\1$FLINT_JLL_PATCH/" configure.ac
 
-          # Now we can create the makefile
+          # Now we can configure FLINT. However, recent versions of MPFR_jll has
+          # memory sanitation which messes with finding mpfr_init in the
+          # configure-script. Hence, we also omit the check for finding MPFR.
+          # FIXME: Probably want to fix this.
           ./bootstrap.sh
-          ./configure CC=${CC} CFLAGS="${CFLAGS}" --prefix=${LOCAL} ${EXTRA_OPTIONS}
+          ./configure CC=${CC} CFLAGS="${CFLAGS}" --prefix=${LOCAL} ${EXTRA_OPTIONS} --with-gmp=${gmp_path} --with-mpfr=${mpfr_path} --disable-mpfr-check
 
       - name: "Compile and install"
         run: |

--- a/configure.ac
+++ b/configure.ac
@@ -659,14 +659,14 @@ then
     [dummy_var="x"],
     [AC_MSG_ERROR([`mpn_gcd_11' was not found in the GMP library. It is needed to enable GMP
 internals.])])
+
     AC_CHECK_LIB([gmp],[__gmpn_div_q],
     [dummy_var="x"],
     [AC_MSG_ERROR([`mpn_div_q' was not found in the GMP library. It is needed to enable GMP
 internals.])])
+
     AC_CHECK_LIB([gmp],[__gmpn_modexact_1_odd],
-    [dummy_var="x"],
-    [AC_MSG_ERROR([`mpn_modexact_1_odd' was not found in the GMP library. It is needed to
-enable GMP internals.])])
+    [AC_DEFINE(FLINT_HAVE_MPN_MODEXACT_1_ODD,1,Define if system has mpn_modexact_1_odd)])
 fi
 
 AC_CHECK_LIB(mpfr,mpfr_init,

--- a/configure.ac
+++ b/configure.ac
@@ -246,6 +246,17 @@ yes|no)
 esac],
 enable_avx512="no")
 
+# Note: This is maintainer level only. Currently only used for Nemo CI.
+AC_ARG_ENABLE(mpfr-check,[],
+[case $enableval in
+yes|no)
+    ;;
+*)
+    AC_MSG_ERROR([Bad value $enableval for --enable-mpfr-check. Need yes or no.])
+    ;;
+esac],
+enable_mpfr_check="yes")
+
 ################################################################################
 # packages
 ################################################################################
@@ -309,6 +320,7 @@ then
     LDFLAGS="$LDFLAGS -L$withval/lib"
     mpfr_include_path="$withval/include"
     mpfr_lib_path="$withval/lib"
+    with_mpfr="yes"
 else
     AC_MSG_FAILURE([Cannot use --with-mpfr along with --with-mpfr-include or --with-mpfr-lib.])
 fi,
@@ -543,8 +555,8 @@ case "$host_os" in
     cygwin|mingw*|msys)
         if test "$DLLTOOL" = "false";
         then
-            AC_MSG_ERROR("Couldn't find any dlltool that is required to create import libraries for
-Windows-type systems.")
+            AC_MSG_ERROR(["Couldn't find any dlltool that is required to create import libraries for
+Windows-type systems."])
         fi
         ;;
     *)
@@ -643,63 +655,67 @@ fi
 # check libraries
 ################################################################################
 
-AC_CHECK_LIB(m,fabs,
-[LIBS="-lm $LIBS"],
-[AC_MSG_ERROR([The C math library was not found!])])
+AC_SEARCH_LIBS([fabs],[m],
+   [],
+   [AC_MSG_ERROR(["The C math library was not found!"])])
 
-AC_CHECK_LIB(gmp,__gmpz_init,
-[LIBS="-lgmp $LIBS"],
-[AC_MSG_ERROR([GMP library was not found.  If you indeed have GMP installed, please
+AC_SEARCH_LIBS([__gmpz_init],[gmp],
+   [],
+   [AC_MSG_ERROR(["GMP library was not found.  If you indeed have GMP installed, please
 submit a bug report to <https://github.com/flintlib/flint/issues/> so
-that we can either fix the issue or give a more proper error message.])])
+that we can either fix the issue or give a more proper error message."])])
 
 if test "$enable_gmp_internals" = "yes";
 then
-    AC_CHECK_LIB([gmp],[__gmpn_gcd_11],
-    [dummy_var="x"],
-    [AC_MSG_ERROR([`mpn_gcd_11' was not found in the GMP library. It is needed to enable GMP
+    AC_SEARCH_LIBS([__gmpn_gcd_11],[gmp],
+        [],
+        [AC_MSG_ERROR(["`mpn_gcd_11' was not found in the GMP library. It is needed to enable GMP
+internals."])])
+
+    AC_SEARCH_LIBS([__gmpn_div_q],[gmp],
+        [],
+        [AC_MSG_ERROR([`mpn_div_q' was not found in the GMP library. It is needed to enable GMP
 internals.])])
 
-    AC_CHECK_LIB([gmp],[__gmpn_div_q],
-    [dummy_var="x"],
-    [AC_MSG_ERROR([`mpn_div_q' was not found in the GMP library. It is needed to enable GMP
-internals.])])
-
-    AC_CHECK_LIB([gmp],[__gmpn_modexact_1_odd],
-    [AC_DEFINE(FLINT_HAVE_MPN_MODEXACT_1_ODD,1,Define if system has mpn_modexact_1_odd)])
+    AC_SEARCH_LIBS([__gmpn_modexact_1_odd],[gmp],
+        [AC_DEFINE(FLINT_HAVE_MPN_MODEXACT_1_ODD,1,Define if system has mpn_modexact_1_odd)])
 fi
 
-AC_CHECK_LIB(mpfr,mpfr_init,
-[LIBS="-lmpfr $LIBS"],
-[AC_MSG_ERROR([MPFR library was not found.  If you indeed have MPFR installed, please
+if test "$enable_mpfr_check" = "yes";
+then
+    AC_SEARCH_LIBS([mpfr_init],[mpfr],
+        [],
+        [AC_MSG_ERROR([MPFR library was not found.  If you indeed have MPFR installed, please
 submit a bug report to <https://github.com/flintlib/flint/issues/> so
 that we can either fix the issue or give a more proper error message.])])
+else
+    LIBS="$LIBS -lmpfr"
+fi
 
 if test "$enable_pthread" = "yes";
 then
     # check if compiler accepts the preferred -pthread
-    AX_CHECK_COMPILE_FLAG(-pthread,
-    [LIBS="-pthread $LIBS"],
-    # check if the compiler can do -lpthread
-    AC_CHECK_LIB(pthread,pthread_create,
-    [LIBS="-lpthread $LIBS"],
-    [AC_MSG_ERROR([Couldn't link against POSIX threads via -pthread or -lpthread while
---enable-pthread was specified.])]))
+    AX_CHECK_COMPILE_FLAG([-pthread],
+        [LIBS="-pthread $LIBS"],
+        # check if the compiler can do -lpthread
+        AC_SEARCH_LIBS([pthread_create],[pthread],
+            [],
+            AC_MSG_ERROR([Couldn't link against POSIX threads via -pthread or -lpthread while
+--enable-pthread was specified.])
+        )
+    )
 fi
 
 if test "$with_blas" = "yes";
 then
-    AC_CHECK_LIB(cblas,cblas_dgemm,
-    [LIBS="-lcblas $LIBS"],
-    [AC_CHECK_LIB(openblas,cblas_dgemm,
-     [LIBS="-lopenblas $LIBS"],
-     [AC_CHECK_LIB(blas,cblas_dgemm,
-      [LIBS="-lblas $LIBS"],
-      [AC_MSG_ERROR([BLAS library was not found.  If you indeed have BLAS installed, please
+    AC_SEARCH_LIBS([cblas_dgemm],[cblas],[],
+        [AC_SEARCH_LIBS([cblas_dgemm],[openblas],[],
+            [AC_SEARCH_LIBS([cblas_dgemm],[blas],[],
+                [AC_MSG_ERROR([BLAS library was not found.  If you indeed have BLAS installed, please
 submit a bug report to <https://github.com/flintlib/flint/issues/> so
 that we can either fix the issue or give a more proper error message.])]
-      )]
-     )]
+            )]
+        )]
     )
 fi
 
@@ -711,19 +727,18 @@ then
     AC_LANG_PUSH([C++])
     dnl The following code snippet was taken from NTL's documentation
     AC_LINK_IFELSE(
-    [AC_LANG_PROGRAM(
-        [#include <NTL/ZZ.h>],
-        [NTL::ZZ a, b, c;
+        [AC_LANG_PROGRAM([[#include <NTL/ZZ.h>]],
+            [NTL::ZZ a, b, c;
 std::cin >> a;
 std::cin >> b;
 c = (a+1)*(b+1);
-std::cout << c << "\n";]
-    )],
-    [AC_MSG_RESULT([yes])],
-    [AC_MSG_RESULT([no])
-    AC_MSG_ERROR([NTL library was not found.  If you indeed have NTL installed, please
+std::cout << c << "\n";])],
+        AC_MSG_RESULT([yes]),
+        AC_MSG_RESULT([no])
+        [AC_MSG_ERROR([NTL library was not found.  If you indeed have NTL installed, please
 submit a bug report to <https://github.com/flintlib/flint/issues/> so
-that we can either fix the issue or give a more proper error message.])])
+that we can either fix the issue or give a more proper error message.])]
+    )
     AC_LANG_POP
     LIBS="$SAVE_libs"
 fi
@@ -737,10 +752,13 @@ AC_SUBST(PIC_FLAG,$pic_flag)
 if test "$enable_thread_safe" = "yes";
 then
     AC_MSG_CHECKING([if $CC supports TLS handle])
-    for tls_expression in "__thread" "_Thread_local" "__declspec(thread)"
+    for tls_expression in '__thread' '_Thread_local' '__declspec(thread)'
     do
-        AC_LINK_IFELSE([AC_LANG_PROGRAM([$tls_expression int myvariable = 0;],[])],
-        [flint_success="yes"],[flint_success="no"])
+        AC_LINK_IFELSE(
+            [AC_LANG_PROGRAM([$tls_expression int myvariable = 0;],[])],
+            [flint_success="yes"],
+            [flint_success="no"]
+        )
 
         if test "$flint_success" = "yes";
         then
@@ -912,7 +930,7 @@ then
     CFLAGS="$save_CFLAGS $DEFAULT_CFLAGS"
 else
     CFLAGS="$save_CFLAGS"
-    AX_CHECK_COMPILE_FLAG([$CFLAGS],[],AC_MSG_ERROR([Couldn't compile with given CFLAGS!]))
+    AX_CHECK_COMPILE_FLAG([$CFLAGS],[],AC_MSG_ERROR(["Couldn't compile with given CFLAGS!"]))
 fi
 
 if test "$testcflags_set" = "no";
@@ -1008,7 +1026,7 @@ if test "$with_gc" = "yes";
 then
     if test "$enable_thread_safe" = "yes";
     then
-        AC_MSG_ERROR([The Boehm-Demers-Weise garbage collector does not support thread-local storage!])
+        AC_MSG_ERROR(["The Boehm-Demers-Weise garbage collector does not support thread-local storage!"])
     fi
     fmpz_c="src/fmpz/link/fmpz_gc.c"
 else
@@ -1019,6 +1037,7 @@ else
         fmpz_c="src/fmpz/link/fmpz_single.c"
     fi
 fi
+
 AC_CONFIG_FILES([src/fmpz/fmpz.c:$fmpz_c])
 
 if test "$enable_shared" = "yes";

--- a/configure.ac
+++ b/configure.ac
@@ -655,7 +655,7 @@ fi
 # check libraries
 ################################################################################
 
-AC_SEARCH_LIBS([fabs],[m],
+AC_SEARCH_LIBS([atan2],[m],
    [],
    [AC_MSG_ERROR(["The C math library was not found!"])])
 

--- a/configure.ac
+++ b/configure.ac
@@ -663,6 +663,10 @@ internals.])])
     [dummy_var="x"],
     [AC_MSG_ERROR([`mpn_div_q' was not found in the GMP library. It is needed to enable GMP
 internals.])])
+    AC_CHECK_LIB([gmp],[__gmpn_modexact_1_odd],
+    [dummy_var="x"],
+    [AC_MSG_ERROR([`mpn_modexact_1_odd' was not found in the GMP library. It is needed to
+enable GMP internals.])])
 fi
 
 AC_CHECK_LIB(mpfr,mpfr_init,

--- a/dev/find_gmp_mpfr.jl
+++ b/dev/find_gmp_mpfr.jl
@@ -1,0 +1,38 @@
+using GMP_jll, MPFR_jll, Artifacts
+import Pkg
+
+function gmp_artifact_dir()
+    artifacts_toml = joinpath(dirname(dirname(Base.pathof(GMP_jll))), "StdlibArtifacts.toml")
+
+    # If this file exists, it's a stdlib JLL and we must download the artifact ourselves
+    if isfile(artifacts_toml)
+        meta = artifact_meta("GMP", artifacts_toml)
+        hash = Base.SHA1(meta["git-tree-sha1"])
+        if !artifact_exists(hash)
+            dl_info = first(meta["download"])
+            Pkg.Artifacts.download_artifact(hash, dl_info["url"], dl_info["sha256"])
+        end
+        return artifact_path(hash)
+    end
+
+    # Otherwise, we can just use the artifact directory given to us by GMP_jll
+    return GMP_jll.find_artifact_dir()
+end
+
+function mpfr_artifact_dir()
+    artifacts_toml = joinpath(dirname(dirname(Base.pathof(MPFR_jll))), "StdlibArtifacts.toml")
+
+    # If this file exists, it's a stdlib JLL and we must download the artifact ourselves
+    if isfile(artifacts_toml)
+        meta = artifact_meta("MPFR", artifacts_toml)
+        hash = Base.SHA1(meta["git-tree-sha1"])
+        if !artifact_exists(hash)
+            dl_info = first(meta["download"])
+            Pkg.Artifacts.download_artifact(hash, dl_info["url"], dl_info["sha256"])
+        end
+        return artifact_path(hash)
+    end
+
+    # Otherwise, we can just use the artifact directory given to us by MPFR_jll
+    return MPFR_jll.find_artifact_dir()
+end

--- a/doc/source/mpn_extras.rst
+++ b/doc/source/mpn_extras.rst
@@ -70,7 +70,7 @@ Divisibility
 --------------------------------------------------------------------------------
 
 
-.. function:: int flint_mpn_divisible_1_p(mp_srcptr x, mp_size_t xsize, mp_limb_t d)
+.. function:: int flint_mpn_divisible_1_odd(mp_srcptr x, mp_size_t xsize, mp_limb_t d)
 
     Expression determining whether ``(x, xsize)`` is divisible by the
     ``mp_limb_t d`` which is assumed to be odd-valued and at least `3`.

--- a/src/arith/test/t-harmonic.c
+++ b/src/arith/test/t-harmonic.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gmpcompat.h"
 #include "mpn_extras.h"
 #include "fmpq.h"
 #include "arith.h"

--- a/src/fft/test/t-adjust.c
+++ b/src/fft/test/t-adjust.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gmpcompat.h"
 #include "mpn_extras.h"
 #include "fft.h"
 

--- a/src/fft/test/t-adjust_sqrt2.c
+++ b/src/fft/test/t-adjust_sqrt2.c
@@ -9,9 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gmpcompat.h"
 #include "mpn_extras.h"
 #include "fft.h"
-
 
 /* set p = 2^wn + 1 */
 void set_p(mpz_t p, mp_size_t n, flint_bitcnt_t w)

--- a/src/fft/test/t-butterfly.c
+++ b/src/fft/test/t-butterfly.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gmpcompat.h"
 #include "mpn_extras.h"
 #include "fft.h"
 

--- a/src/fft/test/t-butterfly_lshB.c
+++ b/src/fft/test/t-butterfly_lshB.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gmpcompat.h"
 #include "mpn_extras.h"
 #include "fft.h"
 

--- a/src/fft/test/t-butterfly_rshB.c
+++ b/src/fft/test/t-butterfly_rshB.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gmpcompat.h"
 #include "mpn_extras.h"
 #include "fft.h"
 

--- a/src/fft/test/t-butterfly_sqrt2.c
+++ b/src/fft/test/t-butterfly_sqrt2.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gmpcompat.h"
 #include "mpn_extras.h"
 #include "fft.h"
 

--- a/src/fft/test/t-butterfly_twiddle.c
+++ b/src/fft/test/t-butterfly_twiddle.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gmpcompat.h"
 #include "mpn_extras.h"
 #include "fft.h"
 

--- a/src/fft/test/t-div_2expmod_2expp1.c
+++ b/src/fft/test/t-div_2expmod_2expp1.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gmpcompat.h"
 #include "mpn_extras.h"
 #include "fft.h"
 

--- a/src/fft/test/t-negmod_2expp1.c
+++ b/src/fft/test/t-negmod_2expp1.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gmpcompat.h"
 #include "mpn_extras.h"
 #include "fft.h"
 

--- a/src/fft/test/t-normmod_2expp1.c
+++ b/src/fft/test/t-normmod_2expp1.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gmpcompat.h"
 #include "mpn_extras.h"
 #include "fft.h"
 

--- a/src/fmpq/get_cfrac_helpers.c
+++ b/src/fmpq/get_cfrac_helpers.c
@@ -9,9 +9,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gmpcompat.h"
+#include "mpn_extras.h"
 #include "fmpq.h"
 #include "fmpz_poly.h"
-#include "mpn_extras.h"
 
 /* enable for debug printing of various types */
 #if 0

--- a/src/fmpq/reconstruct_fmpz_2.c
+++ b/src/fmpq/reconstruct_fmpz_2.c
@@ -10,8 +10,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "fmpq.h"
+#include "gmpcompat.h"
 #include "mpn_extras.h"
+#include "fmpq.h"
 
 #define FMPQ_RECONSTRUCT_ARRAY_LIMIT 12
 #define FMPQ_RECONSTRUCT_HGCD_CUTOFF 500

--- a/src/fmpz/mul.c
+++ b/src/fmpz/mul.c
@@ -11,6 +11,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gmpcompat.h"
 #include "fmpz.h"
 #include "mpn_extras.h"
 

--- a/src/fmpz/multi_CRT_ui.c
+++ b/src/fmpz/multi_CRT_ui.c
@@ -11,6 +11,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gmpcompat.h"
 #include "mpn_extras.h"
 #include "fmpz.h"
 #include "nmod.h"

--- a/src/fmpz_factor/factor.c
+++ b/src/fmpz_factor/factor.c
@@ -78,7 +78,7 @@ fmpz_factor(fmpz_factor_t factor, const fmpz_t n)
             xsize = flint_mpn_divexact_1(xd, xsize, p);
 
             /* Check if p^2 divides n */
-            if (flint_mpn_divisible_1_p(xd, xsize, p))
+            if (flint_mpn_divisible_1_odd(xd, xsize, p))
             {
                 /* TODO: when searching for squarefree numbers
                    (Moebius function, etc), we can abort here. */
@@ -87,7 +87,7 @@ fmpz_factor(fmpz_factor_t factor, const fmpz_t n)
             }
 
             /* If we're up to cubes, then maybe there are higher powers */
-            if (exp == 2 && flint_mpn_divisible_1_p(xd, xsize, p))
+            if (exp == 2 && flint_mpn_divisible_1_odd(xd, xsize, p))
             {
                 xsize = flint_mpn_divexact_1(xd, xsize, p);
                 xsize = flint_mpn_remove_power_ascending(xd, xsize, &p, 1, &exp);

--- a/src/fmpz_factor/factor_smooth.c
+++ b/src/fmpz_factor/factor_smooth.c
@@ -148,14 +148,14 @@ int fmpz_factor_smooth(fmpz_factor_t factor, const fmpz_t n,
             xsize = flint_mpn_divexact_1(xd, xsize, p);
 
             /* Check if p^2 divides n */
-            if (flint_mpn_divisible_1_p(xd, xsize, p))
+            if (flint_mpn_divisible_1_odd(xd, xsize, p))
             {
                 xsize = flint_mpn_divexact_1(xd, xsize, p);
                 exp = 2;
             }
 
             /* If we're up to cubes, then maybe there are higher powers */
-            if (exp == 2 && flint_mpn_divisible_1_p(xd, xsize, p))
+            if (exp == 2 && flint_mpn_divisible_1_odd(xd, xsize, p))
             {
                 xsize = flint_mpn_divexact_1(xd, xsize, p);
                 xsize = flint_mpn_remove_power_ascending(xd, xsize, &p, 1, &exp);

--- a/src/fmpz_factor/factor_smooth.c
+++ b/src/fmpz_factor/factor_smooth.c
@@ -141,6 +141,9 @@ int fmpz_factor_smooth(fmpz_factor_t factor, const fmpz_t n,
         {
             p = primes[idx[i]];
 
+            if (p == 2)
+                continue;
+
             exp = 1;
             xsize = flint_mpn_divexact_1(xd, xsize, p);
 

--- a/src/fmpz_factor/factor_trial.c
+++ b/src/fmpz_factor/factor_trial.c
@@ -85,7 +85,7 @@ fmpz_factor_trial(fmpz_factor_t factor, const fmpz_t n, slong num_primes)
             xsize = flint_mpn_divexact_1(xd, xsize, p);
 
             /* Check if p^2 divides n */
-            if (flint_mpn_divisible_1_p(xd, xsize, p))
+            if (flint_mpn_divisible_1_odd(xd, xsize, p))
             {
                 /* TODO: when searching for squarefree numbers
                    (Moebius function, etc), we can abort here. */
@@ -94,7 +94,7 @@ fmpz_factor_trial(fmpz_factor_t factor, const fmpz_t n, slong num_primes)
             }
 
             /* If we're up to cubes, then maybe there are higher powers */
-            if (exp == 2 && flint_mpn_divisible_1_p(xd, xsize, p))
+            if (exp == 2 && flint_mpn_divisible_1_odd(xd, xsize, p))
             {
                 xsize = flint_mpn_divexact_1(xd, xsize, p);
                 xsize = flint_mpn_remove_power_ascending(xd, xsize, &p, 1, &exp);

--- a/src/fmpz_factor/factor_trial.c
+++ b/src/fmpz_factor/factor_trial.c
@@ -78,6 +78,9 @@ fmpz_factor_trial(fmpz_factor_t factor, const fmpz_t n, slong num_primes)
         {
             p = primes[idx[i]];
 
+            if (p == 2)
+                continue;
+
             exp = 1;
             xsize = flint_mpn_divexact_1(xd, xsize, p);
 

--- a/src/fmpz_factor/factor_trial_range.c
+++ b/src/fmpz_factor/factor_trial_range.c
@@ -73,7 +73,7 @@ fmpz_factor_trial_range(fmpz_factor_t factor, const fmpz_t n, ulong start, ulong
             xsize = flint_mpn_divexact_1(xd, xsize, p);
 
             /* Check if p^2 divides n */
-            if (flint_mpn_divisible_1_p(xd, xsize, p))
+            if (flint_mpn_divisible_1_odd(xd, xsize, p))
             {
                 /* TODO: when searching for squarefree numbers
                    (Moebius function, etc), we can abort here. */
@@ -82,7 +82,7 @@ fmpz_factor_trial_range(fmpz_factor_t factor, const fmpz_t n, ulong start, ulong
             }
 
             /* If we're up to cubes, then maybe there are higher powers */
-            if (exp == 2 && flint_mpn_divisible_1_p(xd, xsize, p))
+            if (exp == 2 && flint_mpn_divisible_1_odd(xd, xsize, p))
             {
                 xsize = flint_mpn_divexact_1(xd, xsize, p);
                 xsize = flint_mpn_remove_power_ascending(xd, xsize, &p, 1, &exp);

--- a/src/fmpz_mod_mpoly/mul_johnson.c
+++ b/src/fmpz_mod_mpoly/mul_johnson.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gmpcompat.h"
 #include "mpn_extras.h"
 #include "fmpz_vec.h"
 #include "fmpz_mod_mpoly.h"

--- a/src/fmpz_mpoly/sqrt_heap.c
+++ b/src/fmpz_mpoly/sqrt_heap.c
@@ -10,15 +10,16 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "mpn_extras.h"
-#include "nmod_mpoly.h"
-#include "fmpz_mpoly.h"
-
 #ifdef __GNUC__
 # define sqrt __builtin_sqrt
 #else
 # include <math.h>
 #endif
+
+#include "gmpcompat.h"
+#include "mpn_extras.h"
+#include "nmod_mpoly.h"
+#include "fmpz_mpoly.h"
 
 /* try to prove that A is not a square */
 static int _is_proved_not_square(

--- a/src/mpn_extras.h
+++ b/src/mpn_extras.h
@@ -157,17 +157,20 @@ flint_mpn_sqr(mp_ptr z, mp_srcptr x, mp_size_t n)
     ((n) > 0 ? (((lo) >> (n)) | ((hi) << (GMP_LIMB_BITS - (n))))    \
              : (lo))
 
+#ifdef FLINT_WANT_GMP_INTERNALS
 
-/* Not defined in gmp.h
-mp_limb_t  __gmpn_modexact_1_odd(mp_srcptr src, mp_size_t size,
-                                 mp_limb_t divisor);
-#define mpn_modexact_1_odd __gmpn_modexact_1_odd
-*/
+# define mpn_modexact_1_odd __gmpn_modexact_1_odd
+mp_limb_t mpn_modexact_1_odd(mp_srcptr, mp_size_t, mp_limb_t);
 
-#ifdef mpn_modexact_1_odd
-#define flint_mpn_divisible_1_p(x, xsize, d) (mpn_modexact_1_odd(x, xsize, d) == 0)
+MPN_EXTRAS_INLINE int
+flint_mpn_divisible_1_p(mp_srcptr x, mp_size_t xsize, mp_limb_t d)
+{
+    return mpn_modexact_1_odd(x, xsize, d) == 0;
+}
+
 #else
-#include "gmpcompat.h"
+
+# include "gmpcompat.h"
 
 MPN_EXTRAS_INLINE int
 flint_mpn_divisible_1_p(mp_srcptr x, mp_size_t xsize, mp_limb_t d)
@@ -177,9 +180,9 @@ flint_mpn_divisible_1_p(mp_srcptr x, mp_size_t xsize, mp_limb_t d)
     s._mp_d = (mp_ptr) x;
     return flint_mpz_divisible_ui_p(&s, d);
 }
+
 #endif
 
-/* todo: figure out how to call GMP's actual division code instead of mpn_tdiv_qr here */
 #ifndef mpn_tdiv_q
 /* substitute for mpir's mpn_tdiv_q */
 static __inline__ void

--- a/src/mpn_extras.h
+++ b/src/mpn_extras.h
@@ -163,7 +163,7 @@ flint_mpn_sqr(mp_ptr z, mp_srcptr x, mp_size_t n)
 mp_limb_t mpn_modexact_1_odd(mp_srcptr, mp_size_t, mp_limb_t);
 
 MPN_EXTRAS_INLINE int
-flint_mpn_divisible_1_p(mp_srcptr x, mp_size_t xsize, mp_limb_t d)
+flint_mpn_divisible_1_odd(mp_srcptr x, mp_size_t xsize, mp_limb_t d)
 {
     return mpn_modexact_1_odd(x, xsize, d) == 0;
 }
@@ -173,7 +173,7 @@ flint_mpn_divisible_1_p(mp_srcptr x, mp_size_t xsize, mp_limb_t d)
 # include "gmpcompat.h"
 
 MPN_EXTRAS_INLINE int
-flint_mpn_divisible_1_p(mp_srcptr x, mp_size_t xsize, mp_limb_t d)
+flint_mpn_divisible_1_odd(mp_srcptr x, mp_size_t xsize, mp_limb_t d)
 {
     __mpz_struct s;
     s._mp_size = xsize;

--- a/src/mpn_extras.h
+++ b/src/mpn_extras.h
@@ -157,7 +157,7 @@ flint_mpn_sqr(mp_ptr z, mp_srcptr x, mp_size_t n)
     ((n) > 0 ? (((lo) >> (n)) | ((hi) << (GMP_LIMB_BITS - (n))))    \
              : (lo))
 
-#ifdef FLINT_WANT_GMP_INTERNALS
+#ifdef FLINT_HAVE_MPN_MODEXACT_1_ODD
 
 # define mpn_modexact_1_odd __gmpn_modexact_1_odd
 mp_limb_t mpn_modexact_1_odd(mp_srcptr, mp_size_t, mp_limb_t);

--- a/src/mpn_extras/factor_trial.c
+++ b/src/mpn_extras/factor_trial.c
@@ -25,7 +25,7 @@ int flint_mpn_factor_trial(mp_srcptr x, mp_size_t xsize, slong start, slong stop
 
     for (i = start; i < stop; i++)
     {
-        if (flint_mpn_divisible_1_p(x, xsize, primes[i]))
+        if (flint_mpn_divisible_1_odd(x, xsize, primes[i]))
             return i;
     }
     return 0;

--- a/src/mpn_extras/factor_trial_tree.c
+++ b/src/mpn_extras/factor_trial_tree.c
@@ -207,7 +207,7 @@ int flint_mpn_factor_trial_tree(slong * factors,
             {
 
                 /* check divisibility by primes with index 4*i + j */
-	            if (flint_mpn_divisible_1_p(x, xsize, primes[(FLINT_BITS/16)*i + j]))
+	            if (flint_mpn_divisible_1_odd(x, xsize, primes[(FLINT_BITS/16)*i + j]))
 	                factors[numfacs++] = (FLINT_BITS/16)*i + j;
 	        }
 	    }


### PR DESCRIPTION
As suggested by previous code in `mpn_extras.h`, use `mpn_modexact_1_odd` if one intends to use GMP internals.