### PR TITLE
Add new function `arb_minmax`

### DIFF
--- a/doc/source/arb.rst
+++ b/doc/source/arb.rst
@@ -760,6 +760,10 @@ Arithmetic
 
     Sets *z* respectively to the minimum and the maximum of *x* and *y*.
 
+.. function:: void arb_minmax(arb_t z1, arb_t z2, const arb_t x, const arb_t y, slong prec)
+
+    Sets *z1* and *z2* respectively to the minimum and the maximum of *x* and *y*.
+
 .. function:: void arb_add(arb_t z, const arb_t x, const arb_t y, slong prec)
 
 .. function:: void arb_add_arf(arb_t z, const arb_t x, const arf_t y, slong prec)
@@ -999,7 +1003,7 @@ Powers and roots
 
 .. function:: void arb_sqr(arb_t y, const arb_t x, slong prec)
 
-    Sets *y* to be the square of *x*. 
+    Sets *y* to be the square of *x*.
 
 .. function:: void arb_pow_fmpz_binexp(arb_t y, const arb_t b, const fmpz_t e, slong prec)
 
@@ -1965,4 +1969,3 @@ Vector functions
     Calls :func:`arb_get_unique_fmpz` elementwise and returns nonzero if
     all entries can be rounded uniquely to integers. If any entry in *vec*
     cannot be rounded uniquely to an integer, returns zero.
-

--- a/src/arb.h
+++ b/src/arb.h
@@ -372,6 +372,7 @@ void arb_get_rand_fmpq(fmpq_t q, flint_rand_t state, const arb_t x, slong bits);
 
 void arb_min(arb_t z, const arb_t x, const arb_t y, slong prec);
 void arb_max(arb_t z, const arb_t x, const arb_t y, slong prec);
+void arb_minmax(arb_t z1, arb_t z2, const arb_t x, const arb_t y, slong prec);
 
 int arb_can_round_arf(const arb_t x, slong prec, arf_rnd_t rnd);
 #ifdef __MPFR_H

--- a/src/arb/max.c
+++ b/src/arb/max.c
@@ -22,6 +22,30 @@ arb_max(arb_t z, const arb_t x, const arb_t y, slong prec)
         return;
     }
 
+    if (!arb_is_finite(x) || !arb_is_finite(y))
+    {
+        if (
+	  (arf_is_pos_inf(arb_midref(x)) && mag_is_finite(arb_radref(x))) ||
+	  (arf_is_pos_inf(arb_midref(y)) && mag_is_finite(arb_radref(y)))
+	  )
+	{
+	    arb_pos_inf(z);
+	}
+	else if (!mag_is_finite(arb_radref(x)) || !mag_is_finite(arb_radref(y)))
+	{
+	    arb_zero_pm_inf(z);
+	}
+	else if (arf_is_neg_inf(arb_midref(x)))
+	{
+	    arb_set(z, y);
+	} else
+	{
+	    /* In this case must have y = -inf */
+	    arb_set(z, x);
+	}
+	return;
+    }
+
     arf_init(left);
     arf_init(right);
     arf_init(t);

--- a/src/arb/min.c
+++ b/src/arb/min.c
@@ -22,6 +22,30 @@ arb_min(arb_t z, const arb_t x, const arb_t y, slong prec)
         return;
     }
 
+    if (!arb_is_finite(x) || !arb_is_finite(y))
+    {
+        if (
+	    (arf_is_neg_inf(arb_midref(x)) && mag_is_finite(arb_radref(x))) ||
+	    (arf_is_neg_inf(arb_midref(y)) && mag_is_finite(arb_radref(y)))
+	    )
+	{
+	    arb_neg_inf(z);
+	}
+	else if (!mag_is_finite(arb_radref(x)) || !mag_is_finite(arb_radref(y)))
+	{
+	    arb_zero_pm_inf(z);
+	}
+	else if (arf_is_pos_inf(arb_midref(x)))
+	{
+	    arb_set(z, y);
+	} else
+	{
+	    /* In this case must have y = +inf */
+	    arb_set(z, x);
+	}
+	return;
+    }
+
     arf_init(left);
     arf_init(right);
     arf_init(t);

--- a/src/arb/minmax.c
+++ b/src/arb/minmax.c
@@ -1,0 +1,89 @@
+/*
+    Copyright (C) 2023 Arb authors
+
+    This file is part of Arb.
+
+    Arb is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "arb.h"
+
+void
+arb_minmax(arb_t z1, arb_t z2, const arb_t x, const arb_t y, slong prec)
+{
+    arf_t xleft, xright, yleft, yright, xr, yr;
+
+    if (arf_is_nan(arb_midref(x)) || arf_is_nan(arb_midref(y)))
+    {
+        arb_indeterminate(z1);
+	arb_indeterminate(z2);
+        return;
+    }
+
+    if (!arb_is_finite(x) || !arb_is_finite(y))
+    {
+	if (z1 != x && z1 != y)
+	{
+	    arb_min(z1, x, y, prec);
+	    arb_max(z2, x, y, prec);
+	}
+	else
+	{
+	    arb_t t;
+	    arb_init(t);
+	    arb_min(t, x, y, prec);
+	    arb_max(z2, x, y, prec);
+	    arb_swap(z1, t);
+	    arb_clear(t);
+	}
+	return;
+    }
+
+    arf_init(xleft);
+    arf_init(xright);
+    arf_init(yleft);
+    arf_init(yright);
+
+    arf_init_set_mag_shallow(xr, arb_radref(x));
+    arf_init_set_mag_shallow(yr, arb_radref(y));
+
+    arf_sub(xleft, arb_midref(x), xr, prec, ARF_RND_FLOOR);
+    arf_sub(yleft, arb_midref(y), yr, prec, ARF_RND_FLOOR);
+    arf_add(xright, arb_midref(x), xr, prec, ARF_RND_CEIL);
+    arf_add(yright, arb_midref(y), yr, prec, ARF_RND_CEIL);
+
+    if (arf_cmp(xleft, yleft) < 0)
+    {
+	/* xleft < yleft */
+	if (arf_cmp(xright, yright) < 0)
+	{
+	    /* xright < yright */
+	    arb_set_interval_arf(z1, xleft, xright, prec);
+	    arb_set_interval_arf(z2, yleft, yright, prec);
+	} else {
+	    /* xright >= yright */
+	    arb_set_interval_arf(z1, xleft, yright, prec);
+	    arb_set_interval_arf(z2, yleft, xright, prec);
+	}
+    } else {
+	/* xleft >= yleft */
+	if (arf_cmp(xright, yright) < 0)
+	{
+	    /* xright < yright */
+	    arb_set_interval_arf(z1, yleft, xright, prec);
+	    arb_set_interval_arf(z2, xleft, yright, prec);
+	} else {
+	    /* xright >= yright */
+	    arb_set_interval_arf(z1, yleft, yright, prec);
+	    arb_set_interval_arf(z2, xleft, xright, prec);
+	}
+    }
+
+    arf_clear(xleft);
+    arf_clear(xright);
+    arf_clear(yleft);
+    arf_clear(yright);
+}

--- a/src/arb/test/t-max.c
+++ b/src/arb/test/t-max.c
@@ -11,6 +11,8 @@
 
 #include "arb.h"
 
+#define ASSERT(cond) if (!(cond)) { flint_printf("FAIL: %d\n", __LINE__); flint_abort(); }
+
 /* sample (x, y) so that x /in y */
 void _sample_arf_in_arb(arf_t x, arb_t y, flint_rand_t state)
 {
@@ -119,6 +121,51 @@ int main(void)
         arb_clear(x);
         arb_clear(y);
         arb_clear(z);
+    }
+
+    /* test special cases with non-finite input */
+    {
+      slong prec;
+      arb_t zero, special, z;
+
+      prec = 64;
+      arb_init(zero);
+      arb_init(special);
+      arb_init(z);
+
+      /* -Inf +/- Inf */
+      mag_inf(arb_radref(special));
+      arf_neg_inf(arb_midref(special));
+      arb_max(z, zero, special, prec);
+      ASSERT(arf_is_zero(arb_midref(z)));
+      ASSERT(mag_is_inf(arb_radref(z)));
+      arb_max(z, special, zero, prec);
+      ASSERT(arf_is_zero(arb_midref(z)));
+      ASSERT(mag_is_inf(arb_radref(z)));
+
+      /* Inf +/- Inf */
+      mag_inf(arb_radref(special));
+      arf_pos_inf(arb_midref(special));
+      arb_max(z, zero, special, prec);
+      ASSERT(arf_is_zero(arb_midref(z)));
+      ASSERT(mag_is_inf(arb_radref(z)));
+      arb_max(z, special, zero, prec);
+      ASSERT(arf_is_zero(arb_midref(z)));
+      ASSERT(mag_is_inf(arb_radref(z)));
+
+      /* NaN +/- 1*/
+      mag_one(arb_radref(special));
+      arf_nan(arb_midref(special));
+      arb_max(z, zero, special, prec);
+      ASSERT(arf_is_nan(arb_midref(z)));
+      ASSERT(mag_is_inf(arb_radref(z)));
+      arb_max(z, special, zero, prec);
+      ASSERT(arf_is_nan(arb_midref(z)));
+      ASSERT(mag_is_inf(arb_radref(z)));
+
+      arb_clear(zero);
+      arb_clear(special);
+      arb_clear(z);
     }
 
     flint_randclear(state);

--- a/src/arb/test/t-min.c
+++ b/src/arb/test/t-min.c
@@ -11,6 +11,8 @@
 
 #include "arb.h"
 
+#define ASSERT(cond) if (!(cond)) { flint_printf("FAIL: %d\n", __LINE__); flint_abort(); }
+
 /* sample (x, y) so that x /in y */
 void _sample_arf_in_arb(arf_t x, arb_t y, flint_rand_t state)
 {
@@ -119,6 +121,51 @@ int main(void)
         arb_clear(x);
         arb_clear(y);
         arb_clear(z);
+    }
+
+    /* test special cases with non-finite input */
+    {
+      slong prec;
+      arb_t zero, special, z;
+
+      prec = 64;
+      arb_init(zero);
+      arb_init(special);
+      arb_init(z);
+
+      /* -Inf +/- Inf */
+      mag_inf(arb_radref(special));
+      arf_neg_inf(arb_midref(special));
+      arb_min(z, zero, special, prec);
+      ASSERT(arf_is_zero(arb_midref(z)));
+      ASSERT(mag_is_inf(arb_radref(z)));
+      arb_min(z, special, zero, prec);
+      ASSERT(arf_is_zero(arb_midref(z)));
+      ASSERT(mag_is_inf(arb_radref(z)));
+
+      /* Inf +/- Inf */
+      mag_inf(arb_radref(special));
+      arf_pos_inf(arb_midref(special));
+      arb_min(z, zero, special, prec);
+      ASSERT(arf_is_zero(arb_midref(z)));
+      ASSERT(mag_is_inf(arb_radref(z)));
+      arb_min(z, special, zero, prec);
+      ASSERT(arf_is_zero(arb_midref(z)));
+      ASSERT(mag_is_inf(arb_radref(z)));
+
+      /* NaN +/- 1*/
+      mag_one(arb_radref(special));
+      arf_nan(arb_midref(special));
+      arb_min(z, zero, special, prec);
+      ASSERT(arf_is_nan(arb_midref(z)));
+      ASSERT(mag_is_inf(arb_radref(z)));
+      arb_min(z, special, zero, prec);
+      ASSERT(arf_is_nan(arb_midref(z)));
+      ASSERT(mag_is_inf(arb_radref(z)));
+
+      arb_clear(zero);
+      arb_clear(special);
+      arb_clear(z);
     }
 
     flint_randclear(state);

--- a/src/arb/test/t-minmax.c
+++ b/src/arb/test/t-minmax.c
@@ -1,0 +1,94 @@
+/*
+    Copyright (C) 2023 Arb authors
+
+    This file is part of Arb.
+
+    Arb is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "arb.h"
+
+int main(void)
+{
+    slong iter;
+    flint_rand_t state;
+
+    flint_printf("minmax....");
+    fflush(stdout);
+    flint_randinit(state);
+
+    for (iter = 0; iter < 100000 * 0.1 * flint_test_multiplier(); iter++)
+    {
+        arb_t x, y, z1, z2, w1, w2;
+        slong prec;
+
+        arb_init(x);
+        arb_init(y);
+        arb_init(z1);
+	arb_init(z2);
+	arb_init(w1);
+	arb_init(w2);
+
+	prec = 2 + n_randint(state, 200);
+
+	arb_randtest_special(x, state, 1 + n_randint(state, 200), 10);
+        arb_randtest_special(y, state, 1 + n_randint(state, 200), 10);
+
+	arb_min(w1, x, y, prec);
+	arb_max(w2, x, y, prec);
+        arb_minmax(z1, z2, x, y, prec);
+
+        if (!arb_equal(w1, z1) || !arb_equal(w2, z2))
+        {
+            flint_printf("FAIL: same as min and max\n\n");
+            flint_printf("x = "); arb_print(x); flint_printf("\n\n");
+            flint_printf("y = "); arb_print(y); flint_printf("\n\n");
+            flint_printf("z1 = "); arb_print(z1); flint_printf("\n\n");
+	    flint_printf("z2 = "); arb_print(z2); flint_printf("\n\n");
+	    flint_printf("w1 = "); arb_print(w1); flint_printf("\n\n");
+	    flint_printf("w2 = "); arb_print(w2); flint_printf("\n\n");
+            flint_abort();
+        }
+
+        /* aliasing */
+        {
+            int alias;
+
+            if (n_randint(state, 2))
+            {
+		arb_minmax(x, y, x, y, prec);
+                alias = arb_equal(x, z1) && arb_equal(y, z2);
+            }
+            else
+            {
+                arb_minmax(y, x, x, y, prec);
+                alias = arb_equal(y, z1) && arb_equal(x, z2);
+            }
+
+            if (!alias)
+            {
+                flint_printf("FAIL: aliasing\n\n");
+                flint_printf("x = "); arb_print(x); flint_printf("\n\n");
+                flint_printf("y = "); arb_print(y); flint_printf("\n\n");
+                flint_printf("z1 = "); arb_print(z1); flint_printf("\n\n");
+		flint_printf("z2 = "); arb_print(z2); flint_printf("\n\n");
+                flint_abort();
+            }
+        }
+
+        arb_clear(x);
+        arb_clear(y);
+        arb_clear(z1);
+	arb_clear(z2);
+	arb_clear(w1);
+	arb_clear(w2);
+    }
+
+    flint_randclear(state);
+    flint_cleanup();
+    flint_printf("PASS\n");
+    return 0;
+}


### PR DESCRIPTION
I have wanted this for some time, see #1395. This PR only implements it for `arb` and not for any other type. For any time with `min` and `max` this function could of course be defined, but in most cases you can handle it in simple way using `cmp`. For `arb` it is however not possible to use `cmp` directly and this function is then helpful. It improves the performance and makes it easier to handle aliasing between input and output compared to using `arb_min` and `arb_max` directly.