### PR TITLE
Basic printing functions for nmod_vec

### DIFF
--- a/doc/source/nmod_mat.rst
+++ b/doc/source/nmod_mat.rst
@@ -140,15 +140,15 @@ Printing
 
 .. function:: int nmod_mat_fprint_pretty(FILE * file, const nmod_mat_t mat)
 
-    Same as `nmod_mat_print_pretty` but printing to `file`.
+    Same as ``nmod_mat_print_pretty`` but printing to `file`.
 
 .. function:: int nmod_mat_print(const nmod_mat_t mat)
 
-    Currently, same as `nmod_mat_print_pretty`.
+    Currently, same as ``nmod_mat_print_pretty``.
 
 .. function:: int nmod_mat_fprint(FILE * f, const nmod_mat_t mat)
 
-    Currently, same as `nmod_mat_fprint_pretty`.
+    Currently, same as ``nmod_mat_fprint_pretty``.
 
 
 Random matrix generation

--- a/doc/source/nmod_mat.rst
+++ b/doc/source/nmod_mat.rst
@@ -150,6 +150,7 @@ Printing
 
     Currently, same as `nmod_mat_fprint_pretty`.
 
+
 Random matrix generation
 --------------------------------------------------------------------------------
 

--- a/doc/source/nmod_mat.rst
+++ b/doc/source/nmod_mat.rst
@@ -140,7 +140,7 @@ Printing
 
 .. function:: int nmod_mat_fprint_pretty(FILE * file, const nmod_mat_t mat)
 
-    Same as ``nmod_mat_print_pretty`` but printing to `file`.
+    Same as ``nmod_mat_print_pretty`` but printing to ``file``.
 
 .. function:: int nmod_mat_print(const nmod_mat_t mat)
 

--- a/doc/source/nmod_mat.rst
+++ b/doc/source/nmod_mat.rst
@@ -138,6 +138,17 @@ Printing
         [   0    0 2607]
         [ 622    0    0]
 
+.. function:: int nmod_mat_fprint_pretty(FILE * file, const nmod_mat_t mat)
+
+    Same as `nmod_mat_print_pretty` but printing to `file`.
+
+.. function:: int nmod_mat_print(const nmod_mat_t mat)
+
+    Currently, same as `nmod_mat_print_pretty`.
+
+.. function:: int nmod_mat_fprint(FILE * f, const nmod_mat_t mat)
+
+    Currently, same as `nmod_mat_fprint_pretty`.
 
 Random matrix generation
 --------------------------------------------------------------------------------

--- a/doc/source/nmod_vec.rst
+++ b/doc/source/nmod_vec.rst
@@ -59,6 +59,33 @@ Basic manipulation and comparison
     otherwise returns~`0`.
 
 
+Printing
+--------------------------------------------------------------------------------
+
+
+.. function:: void _nmod_vec_print_pretty(mp_srcptr vec, slong len, nmod_t mod)
+
+    Pretty-prints ``vec`` to ``stdout``. A header is printed followed by the
+    vector enclosed in brackets. Each entry is right-aligned to the width of
+    the modulus written in decimal, and the entries are separated by spaces.
+    For example::
+
+        <length-12 integer vector mod 197>
+        [ 33 181 107  61  32  11  80 138  34 171  86 156]
+
+.. function:: int _nmod_vec_fprint_pretty(FILE * file, mp_srcptr vec, slong len, nmod_t mod)
+
+    Same as `_nmod_vec_print_pretty` but printing to `file`.
+
+.. function:: int _nmod_vec_print(mp_srcptr vec, slong len, nmod_t mod)
+
+    Currently, same as `_nmod_vec_print_pretty`.
+
+.. function:: int _nmod_vec_fprint(FILE * f, mp_srcptr vec, slong len, nmod_t mod)
+
+    Currently, same as `_nmod_vec_fprint_pretty`.
+
+
 Arithmetic operations
 --------------------------------------------------------------------------------
 

--- a/doc/source/nmod_vec.rst
+++ b/doc/source/nmod_vec.rst
@@ -75,7 +75,7 @@ Printing
 
 .. function:: int _nmod_vec_fprint_pretty(FILE * file, mp_srcptr vec, slong len, nmod_t mod)
 
-    Same as ``_nmod_vec_print_pretty`` but printing to `file`.
+    Same as ``_nmod_vec_print_pretty`` but printing to ``file``.
 
 .. function:: int _nmod_vec_print(mp_srcptr vec, slong len, nmod_t mod)
 

--- a/doc/source/nmod_vec.rst
+++ b/doc/source/nmod_vec.rst
@@ -75,15 +75,15 @@ Printing
 
 .. function:: int _nmod_vec_fprint_pretty(FILE * file, mp_srcptr vec, slong len, nmod_t mod)
 
-    Same as `_nmod_vec_print_pretty` but printing to `file`.
+    Same as ``_nmod_vec_print_pretty`` but printing to `file`.
 
 .. function:: int _nmod_vec_print(mp_srcptr vec, slong len, nmod_t mod)
 
-    Currently, same as `_nmod_vec_print_pretty`.
+    Currently, same as ``_nmod_vec_print_pretty``.
 
 .. function:: int _nmod_vec_fprint(FILE * f, mp_srcptr vec, slong len, nmod_t mod)
 
-    Currently, same as `_nmod_vec_fprint_pretty`.
+    Currently, same as ``_nmod_vec_fprint_pretty``.
 
 
 Arithmetic operations

--- a/src/nmod_vec.h
+++ b/src/nmod_vec.h
@@ -191,13 +191,14 @@ mp_limb_t _nmod_vec_dot_ptr(mp_srcptr vec1, const mp_ptr * vec2, slong offset,
     slong len, nmod_t mod, int nlimbs);
 
 /* some IO functions */
+#ifdef FLINT_HAVE_FILE
 int _nmod_vec_fprint_pretty(FILE * file, mp_srcptr vec, slong len, nmod_t mod);
+int _nmod_vec_fprint(FILE * f, mp_srcptr vec, slong len, nmod_t mod);
+#endif
 
 void _nmod_vec_print_pretty(mp_srcptr vec, slong len, nmod_t mod);
-
 int _nmod_vec_print(mp_srcptr vec, slong len, nmod_t mod);
 
-int _nmod_vec_fprint(FILE * f, mp_srcptr vec, slong len, nmod_t mod);
 
 
 #ifdef __cplusplus

--- a/src/nmod_vec.h
+++ b/src/nmod_vec.h
@@ -190,6 +190,15 @@ mp_limb_t _nmod_vec_dot_rev(mp_srcptr vec1, mp_srcptr vec2,
 mp_limb_t _nmod_vec_dot_ptr(mp_srcptr vec1, const mp_ptr * vec2, slong offset,
     slong len, nmod_t mod, int nlimbs);
 
+/* some IO functions */
+int _nmod_vec_fprint_pretty(FILE * file, mp_srcptr vec, slong len, nmod_t mod);
+
+void _nmod_vec_print_pretty(mp_srcptr vec, slong len, nmod_t mod);
+
+int _nmod_vec_print(mp_srcptr vec, slong len, nmod_t mod);
+
+int _nmod_vec_fprint(FILE * f, mp_srcptr vec, slong len, nmod_t mod);
+
 
 #ifdef __cplusplus
 }

--- a/src/nmod_vec/io.c
+++ b/src/nmod_vec/io.c
@@ -10,8 +10,8 @@
 */
 
 #include <stdio.h>
-#include "flint/ulong_extras.h"
-#include "flint/nmod_vec.h"
+#include "ulong_extras.h"
+#include "nmod_vec.h"
 
 int _nmod_vec_fprint_pretty(FILE * file, mp_srcptr vec, slong len, nmod_t mod)
 {

--- a/src/nmod_vec/io.c
+++ b/src/nmod_vec/io.c
@@ -1,0 +1,73 @@
+/*
+    Copyright (C) 2023 Vincent Neiger
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include "flint/ulong_extras.h"
+#include "flint/nmod_vec.h"
+
+int _nmod_vec_fprint_pretty(FILE * file, mp_srcptr vec, slong len, nmod_t mod)
+{
+    slong j;
+    int z, width;
+    char fmt[FLINT_BITS + 5];
+
+    z = flint_fprintf(file, "<length-%wd integer vector mod %wu>\n", len, mod.n);
+    if (z <= 0)
+        return z;
+
+    if (!len)
+        return z;
+
+    width = n_sizeinbase(mod.n, 10);
+
+    z = flint_sprintf(fmt, "%%%dwu", width);
+    if (z <= 0)
+        return z;
+
+    z = flint_printf("[");
+    if (z <= 0)
+        return z;
+
+    for (j = 0; j < len; j++)
+    {
+        z = flint_printf(fmt, vec[j]);
+        if (z <= 0)
+            return z;
+
+        if (j + 1 < len)
+        {
+            z = flint_printf(" ");
+            if (z <= 0)
+                return z;
+        }
+    }
+
+    z = flint_printf("]\n");
+
+    return z;
+}
+
+void _nmod_vec_print_pretty(mp_srcptr vec, slong len, nmod_t mod)
+{
+    _nmod_vec_fprint_pretty(stdout, vec, len, mod);
+}
+
+int _nmod_vec_print(mp_srcptr vec, slong len, nmod_t mod)
+{
+    return _nmod_vec_fprint_pretty(stdout, vec, len, mod);
+}
+
+int _nmod_vec_fprint(FILE * f, mp_srcptr vec, slong len, nmod_t mod)
+{
+    return _nmod_vec_fprint_pretty(f, vec, len, mod);
+}
+
+


### PR DESCRIPTION
This adds some basic IO functions for `nmod_vec`, mimicking those for `nmod_mat`.