### PR TITLE
Add some temporary configure output to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ src/flint-config.h
 build/
 config/
 config.log
+confdefs.h
+conftest.*
 /Makefile
 doc/build
 doc/latex/flint-manual.*


### PR DESCRIPTION
If one does 'git add .' while configure runs, these could be added by accident
