### PR TITLE
make 3 casts explicit

### DIFF
--- a/src/calcium.h
+++ b/src/calcium.h
@@ -58,7 +58,7 @@ CALCIUM_INLINE
 void calcium_stream_init_str(calcium_stream_t out)
 {
     out->fp = NULL;
-    out->s = flint_malloc(16);
+    out->s = (char *) flint_malloc(16);
     out->s[0] = '\0';
     out->len = 0;
     out->alloc = 16;

--- a/src/fexpr.h
+++ b/src/fexpr.h
@@ -94,7 +94,7 @@ FEXPR_INLINE fexpr_ptr
 _fexpr_vec_init(slong len)
 {
     slong i;
-    fexpr_ptr vec = (fexpr_struct *) flint_malloc(sizeof(fexpr_struct) * len);
+    fexpr_ptr vec = (fexpr_ptr) flint_malloc(sizeof(fexpr_struct) * len);
     for (i = 0; i < len; i++)
         fexpr_init(vec + i);
     return vec;
@@ -456,7 +456,7 @@ fexpr_vec_init(fexpr_vec_t vec, slong len)
     else
     {
         slong i;
-        vec->entries = flint_malloc(sizeof(fexpr_struct) * len);
+        vec->entries = (fexpr_ptr) flint_malloc(sizeof(fexpr_struct) * len);
         for (i = 0; i < len; i++)
             fexpr_init(vec->entries + i);
         vec->length = vec->alloc = len;


### PR DESCRIPTION
Three explicit cast that allows compilation with strict C++ compilers.