### PR TITLE
Add some rules to regenerate parts of the build system if needed

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -795,6 +795,45 @@ endif
 	$(RM_RF) $(INCLUDEDIR)/flint
 
 ################################################################################
+# regenerate part of the build system of needed
+################################################################################
+
+ifneq ($(MAINTAINER_MODE),no)  # disable this for releases?
+ifneq ($(shell command -v autoconf 2> /dev/null),)
+configure: configure.ac
+	@echo "Running autoconf"
+	@autoconf
+else
+configure: configure.ac
+	$(warning autoconf not available, proceeding with stale configure)
+endif
+endif
+
+config.status: configure
+	./config.status --recheck
+
+Makefile: Makefile.in config.status
+	./config.status $@
+
+flint.pc: flint.pc.in config.status
+	./config.status $@
+
+src/flint.h: src/flint.h.in config.status
+	./config.status $@
+
+libtool: config.status
+	./config.status $@
+
+src/fft_tuning.h: @FFT_TUNING_IN@ config.status
+	./config.status $@
+
+src/fmpz/fmpz.c: @FMPZ_C_IN@ config.status
+	./config.status $@
+
+src/gmpcompat.h: src/@GMPCOMPAT_H_IN@ config.status
+	./config.status $@
+
+################################################################################
 # maintainer stuff
 ################################################################################
 

--- a/configure.ac
+++ b/configure.ac
@@ -572,6 +572,7 @@ case "$host_cpu" in
         ;;
 esac
 AC_CONFIG_FILES([src/fft_tuning.h:$fft_tuning_in],[],[fft_tuning_in="$fft_tuning_in"])
+AC_SUBST(FFT_TUNING_IN, $fft_tuning_in)
 
 if test -z "$LDCONFIG";
 then
@@ -643,6 +644,7 @@ AC_COMPILE_IFELSE(
     gmpcompat_h_in="gmpcompat.h.in")
 
 AC_CONFIG_FILES([src/gmpcompat.h:src/$gmpcompat_h_in],[],[gmpcompat_h_in="$gmpcompat_h_in"])
+AC_SUBST(GMPCOMPAT_H_IN, $gmpcompat_h_in)
 
 # Check that MPFR >= 4.1.0
 AC_MSG_CHECKING([if version of MPFR is greater than 4.1.0])
@@ -1102,6 +1104,7 @@ else
 fi
 
 AC_CONFIG_FILES([src/fmpz/fmpz.c:$fmpz_c],[],[fmpz_c="$fmpz_c"])
+AC_SUBST(FMPZ_C_IN, $fmpz_c)
 
 if test "$enable_shared" = "yes";
 then


### PR DESCRIPTION
This is useful when e.g. editing configure.ac and then switching branches.

This does not yet regenerate src/config.h because that is slightly more complicated. 

And of course it should cover `flint.h` once/if we generate it (see PR #1449).

There is also issue #1526 which I first need to figure out. But I thought I'd open it as a draft so people can comment before I invest more time :-).