### PR TITLE
Fix use of AC_SEARCH_LIBS to find cblas_dgemm

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -705,14 +705,10 @@ fi
 
 if test "$with_blas" = "yes";
 then
-    AC_SEARCH_LIBS([cblas_dgemm],[cblas],[],
-        [AC_SEARCH_LIBS([cblas_dgemm],[openblas],[],
-            [AC_SEARCH_LIBS([cblas_dgemm],[blas],[],
-                [AC_MSG_ERROR([BLAS library was not found.  If you indeed have BLAS installed, please
+    AC_SEARCH_LIBS([cblas_dgemm],[cblas openblas blas],[],
+        [AC_MSG_ERROR([BLAS library was not found.  If you indeed have BLAS installed, please
 submit a bug report to <https://github.com/flintlib/flint/issues/> so
 that we can either fix the issue or give a more proper error message.])]
-            )]
-        )]
     )
 fi
 


### PR DESCRIPTION
Without this change, configure only tries with `-lcblas` since `AC_SEARCH_LIBS` caches the result based on function name.

This is what happens without this change:
```
$ ./configure --with-blas-include=/usr/include/openblas
...
checking for library containing cblas_dgemm... no
checking for library containing cblas_dgemm... (cached) no
checking for library containing cblas_dgemm... (cached) no
configure: error: BLAS library was not found.  If you indeed have BLAS installed, please
submit a bug report to <https://github.com/flintlib/flint/issues/> so
that we can either fix the issue or give a more proper error message.
```

As you can see, it never tries with `-lopenblas` (2nd call) nor `-lblas` (3rd call).

With this change:
```
$ ./configure --with-blas-include=/usr/include/openblas
...
checking for library containing cblas_dgemm... -lopenblas
...
```

BTW, is `cblas` preferred over `openblas`?