### PR TITLE
Arguments to fmpz_CRT and fmpz_CRT_ui

### DIFF
--- a/doc/source/fmpz.rst
+++ b/doc/source/fmpz.rst
@@ -1261,7 +1261,7 @@ Chinese remaindering
 --------------------------------------------------------------------------------
 
 The following functions can be used to reconstruct an integer from its
-residues modulo a set of small (word-size) prime numbers. The first two
+residues modulo a set of prime numbers. The first two
 functions, :func:`fmpz_CRT_ui` and :func:`fmpz_CRT`, are easy
 to use and allow building the result one residue at a time, which is
 useful when the number of needed primes is not known in advance.

--- a/doc/source/fmpz.rst
+++ b/doc/source/fmpz.rst
@@ -1283,8 +1283,7 @@ The ``fmpz_multi_CRT`` class is similar to ``fmpz_multi_CRT_ui`` except that it 
     congruent to `r_1` modulo `m_1` and `r_2` modulo `m_2`,
     where `M = m_1 \times m_2`. The result `x` is stored in ``out``.
 
-    It is assumed that `m_1` and `m_2` are positive integers greater
-    than `1` and coprime.
+    It is assumed that `m_1` and `m_2` are positive coprime integers.
 
     If sign = 0, it is assumed that `0 \le r_1 < m_1` and `0 \le r_2 < m_2`.
     Otherwise, it is assumed that `-m_1 \le r_1 < m_1` and `0 \le r_2 < m_2`.
@@ -1296,8 +1295,7 @@ The ``fmpz_multi_CRT`` class is similar to ``fmpz_multi_CRT_ui`` except that it 
     congruent to `r_1` modulo `m_1` and `r_2` modulo `m_2`,
     where `M = m_1 \times m_2`.
 
-    It is assumed that `m_1` and `m_2` are positive integers greater
-    than `1` and coprime.
+    It is assumed that `m_1` and `m_2` are positive coprime integers.
 
     If sign = 0, it is assumed that `0 \le r_1 < m_1` and `0 \le r_2 < m_2`.
     Otherwise, it is assumed that `-m_1 \le r_1 < m_1` and `0 \le r_2 < m_2`.

--- a/doc/source/fmpz.rst
+++ b/doc/source/fmpz.rst
@@ -1288,7 +1288,7 @@ The ``fmpz_multi_CRT`` class is similar to ``fmpz_multi_CRT_ui`` except that it 
     If sign = 0, it is assumed that `0 \le r_1 < m_1` and `0 \le r_2 < m_2`.
     Otherwise, it is assumed that `-m_1 \le r_1 < m_1` and `0 \le r_2 < m_2`.
 
-.. function:: void fmpz_CRT(fmpz_t out, const fmpz_t r1, const fmpz_t m1, fmpz_t r2, fmpz_t m2, int sign)
+.. function:: void fmpz_CRT(fmpz_t out, const fmpz_t r1, const fmpz_t m1, const fmpz_t r2, const fmpz_t m2, int sign)
 
     Use the Chinese Remainder Theorem to set ``out`` to the unique value
     `0 \le x < M` (if sign = 0) or `-M/2 < x \le M/2` (if sign = 1)

--- a/src/fmpz.h
+++ b/src/fmpz.h
@@ -621,7 +621,7 @@ void fmpz_fib_ui(fmpz_t f, ulong n);
 
 void _fmpz_CRT_ui_precomp(fmpz_t out, const fmpz_t r1, const fmpz_t m1, ulong r2, ulong m2, mp_limb_t m2inv, const fmpz_t m1m2, mp_limb_t c, int sign);
 void fmpz_CRT_ui(fmpz_t out, const fmpz_t r1, const fmpz_t m1, ulong r2, ulong m2, int sign);
-void fmpz_CRT(fmpz_t out, const fmpz_t r1, const fmpz_t m1, fmpz_t r2, fmpz_t m2, int sign);
+void fmpz_CRT(fmpz_t out, const fmpz_t r1, const fmpz_t m1, const fmpz_t r2, const fmpz_t m2, int sign);
 
 /* multi CRT *****************************************************************/
 

--- a/src/fmpz/CRT.c
+++ b/src/fmpz/CRT.c
@@ -16,8 +16,8 @@
 #include "fmpz.h"
 
 void
-_fmpz_CRT(fmpz_t out, const fmpz_t r1, const fmpz_t m1, fmpz_t r2,
-                   fmpz_t m2, const fmpz_t m1m2, fmpz_t c, int sign)
+_fmpz_CRT(fmpz_t out, const fmpz_t r1, const fmpz_t m1, const fmpz_t r2,
+                   const fmpz_t m2, const fmpz_t m1m2, fmpz_t c, int sign)
 {
     fmpz_t r1normal, tmp, r1mod, s;
 
@@ -65,7 +65,7 @@ _fmpz_CRT(fmpz_t out, const fmpz_t r1, const fmpz_t m1, fmpz_t r2,
 }
 
 void fmpz_CRT(fmpz_t out, const fmpz_t r1, const fmpz_t m1,
-    fmpz_t r2, fmpz_t m2, int sign)
+    const fmpz_t r2, const fmpz_t m2, int sign)
 {
     fmpz_t m1m2, c;
 

--- a/src/fmpz/CRT.c
+++ b/src/fmpz/CRT.c
@@ -72,9 +72,7 @@ void fmpz_CRT(fmpz_t out, const fmpz_t r1, const fmpz_t m1,
     fmpz_init(c);
 
     fmpz_mod(c, m1, m2);
-    fmpz_invmod(c, c, m2);
-
-    if (fmpz_is_zero(c))
+    if (!fmpz_invmod(c, c, m2))
     {
         flint_printf("Exception (fmpz_CRT). m1 not invertible modulo m2.\n");
         flint_abort();

--- a/src/fmpz/CRT_ui.c
+++ b/src/fmpz/CRT_ui.c
@@ -61,12 +61,6 @@ void fmpz_CRT_ui(fmpz_t out, const fmpz_t r1, const fmpz_t m1,
     c = fmpz_fdiv_ui(m1, m2);
     c = n_invmod(c, m2);
 
-    if (c == 0)
-    {
-        flint_printf("Exception (fmpz_CRT_ui). m1 not invertible modulo m2.\n");
-        flint_abort();
-    }
-
     fmpz_init(m1m2);
     fmpz_mul_ui(m1m2, m1, m2);
 

--- a/src/ulong_extras/test/t-CRT.c
+++ b/src/ulong_extras/test/t-CRT.c
@@ -37,9 +37,7 @@ int main(void)
         fmpz_randtest_not_zero(m1, state, b1);
         fmpz_randtest_not_zero(m2, state, b2);
         fmpz_abs(m1, m1);
-        fmpz_add_ui(m1, m1, 1);
         fmpz_abs(m2, m2);
-        fmpz_add_ui(m2, m2, 1);
         fmpz_mul(m1m2, m1, m2);
 
         fmpz_gcd(r, m1, m2);


### PR DESCRIPTION
1. The documentation of `fmpz_CRT` requires that the arguments m1 and m2 are greater than 1. If you pass m2=1, it currently prints the confusing message `Exception (fmpz_CRT). m1 not invertible modulo m2.`.
I propose removing the requirement since it's not really used in the implementation anyways.
I haven't added any serious test with m1=1 or m2=1. (As far as I see, only the case where m2 is prime is currently tested, really...)

2. Maybe also make the parameters r2 and m2 const?