### PR TITLE
Cleanup of fmpz tests

### DIFF
--- a/doc/source/fmpz.rst
+++ b/doc/source/fmpz.rst
@@ -174,6 +174,10 @@ Types, macros and constants
    preserve the value in `f` which we make to represent an ``slong``, and
    clear the ``mpz_t``.
 
+.. function:: int _fmpz_is_canonical(const fmpz_t f)
+
+   Returns 1 if the internal representation of `f` is correctly normalised
+   and demoted; 0 otherwise.
 
 Memory management
 --------------------------------------------------------------------------------

--- a/src/fmpz.h
+++ b/src/fmpz.h
@@ -119,6 +119,8 @@ void flint_mpz_clear_readonly(mpz_t z);
 void _fmpz_clear_readonly_mpz(mpz_t);
 void fmpz_clear_readonly(fmpz_t f);
 
+int _fmpz_is_canonical(const fmpz_t x);
+
 /* Randomisation *************************************************************/
 
 void fmpz_randbits(fmpz_t f, flint_rand_t state, flint_bitcnt_t bits);

--- a/src/fmpz/is_canonical.c
+++ b/src/fmpz/is_canonical.c
@@ -1,0 +1,32 @@
+/*
+    Copyright (C) 2023 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz.h"
+
+int _fmpz_is_canonical(const fmpz_t x)
+{
+    __mpz_struct * z;
+    mp_size_t n;
+
+    if (!COEFF_IS_MPZ(*x))
+        return 1;
+
+    z = COEFF_TO_PTR(*x);
+    n = FLINT_ABS(z->_mp_size);
+
+    if (n == 0)
+        return 0;
+
+    if (n == 1)
+        return z->_mp_d[0] > (mp_limb_t) COEFF_MAX;
+
+    return z->_mp_d[n - 1] != 0;
+}

--- a/src/fmpz/test/t-abs.c
+++ b/src/fmpz/test/t-abs.c
@@ -22,8 +22,6 @@ main(void)
     flint_printf("abs....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b;
@@ -38,12 +36,21 @@ main(void)
 
         fmpz_get_mpz(c, a);
 
-        fmpz_abs(b, a);
+        if (n_randint(state, 2)) /* test aliasing */
+        {
+            fmpz_set(b, a);
+            fmpz_abs(b, b);
+        }
+        else
+        {
+            fmpz_abs(b, a);
+        }
+
         mpz_abs(c, c);
 
         fmpz_get_mpz(d, b);
 
-        result = (mpz_cmp(c, d) == 0);
+        result = (mpz_cmp(c, d) == 0) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -54,39 +61,6 @@ main(void)
 
         fmpz_clear(a);
         fmpz_clear(b);
-        mpz_clear(c);
-        mpz_clear(d);
-    }
-
-    /* Check aliasing */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a;
-        mpz_t c, d;
-
-        fmpz_init(a);
-        mpz_init(c);
-        mpz_init(d);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(c, a);
-
-        fmpz_abs(a, a);
-        mpz_abs(c, c);
-
-        fmpz_get_mpz(d, a);
-
-        result = (mpz_cmp(c, d) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("c = %Zd, d = %Zd\n", c, d);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
         mpz_clear(c);
         mpz_clear(d);
     }

--- a/src/fmpz/test/t-add.c
+++ b/src/fmpz/test/t-add.c
@@ -22,12 +22,11 @@ main(void)
     flint_printf("add....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b, c;
         mpz_t d, e, f, g;
+        int aliasing;
 
         fmpz_init(a);
         fmpz_init(b);
@@ -44,13 +43,34 @@ main(void)
         fmpz_get_mpz(d, a);
         fmpz_get_mpz(e, b);
 
-        fmpz_add(c, a, b);
+        aliasing = n_randint(state, 4);
+
+        if (aliasing == 0)
+        {
+            fmpz_add(c, a, b);
+        }
+        else if (aliasing == 1)
+        {
+            fmpz_set(a, b);
+            mpz_set(d, e);
+            fmpz_add(c, a, a);
+        }
+        else if (aliasing == 2)
+        {
+            fmpz_set(c, a);
+            fmpz_add(c, c, b);
+        }
+        else
+        {
+            fmpz_set(c, b);
+            fmpz_add(c, a, c);
+        }
+
         mpz_add(f, d, e);
 
         fmpz_get_mpz(g, c);
 
-        result = (mpz_cmp(f, g) == 0);
-
+        result = (mpz_cmp(f, g) == 0) && _fmpz_is_canonical(c);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -62,134 +82,6 @@ main(void)
         fmpz_clear(a);
         fmpz_clear(b);
         fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, c;
-        mpz_t d, f, g;
-
-        fmpz_init(a);
-        fmpz_init(c);
-
-        mpz_init(d);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-
-        fmpz_add(c, a, a);
-        mpz_add(f, d, d);
-
-        fmpz_get_mpz(g, c);
-
-        result = (mpz_cmp(f, g) == 0);
-
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, f = %Zd, g = %Zd\n", d, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_add(a, a, b);
-        mpz_add(f, d, e);
-
-        fmpz_get_mpz(g, a);
-
-        result = (mpz_cmp(f, g) == 0);
-
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of b and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_add(b, a, b);
-        mpz_add(f, d, e);
-
-        fmpz_get_mpz(g, b);
-
-        result = (mpz_cmp(f, g) == 0);
-
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-add_ui.c
+++ b/src/fmpz/test/t-add_ui.c
@@ -23,8 +23,6 @@ main(void)
     flint_printf("add_ui....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t f, g, tst;
@@ -43,7 +41,16 @@ main(void)
         fmpz_get_mpz(mg, g);
         x = n_randtest(state);
 
-        fmpz_add_ui(f, g, x);
+        if (n_randint(state, 2))
+        {
+            fmpz_add_ui(f, g, x);
+        }
+        else /* test aliasing */
+        {
+            fmpz_set(f, g);
+            fmpz_add_ui(f, f, x);
+        }
+
         flint_mpz_add_ui(mf, mg, x);
 
         fmpz_set_mpz(tst, mf);
@@ -67,51 +74,6 @@ main(void)
 
         mpz_clear(mf);
         mpz_clear(mg);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t f, g, tst;
-        mpz_t mf;
-        ulong x;
-
-        fmpz_init(f);
-        fmpz_init(g);
-        fmpz_init(tst);
-
-        mpz_init(mf);
-
-        fmpz_randtest(g, state, 200);
-        fmpz_set(f, g);
-
-        fmpz_get_mpz(mf, f);
-        x = n_randtest(state);
-
-        fmpz_add_ui(f, f, x);
-        flint_mpz_add_ui(mf, mf, x);
-
-        fmpz_set_mpz(tst, mf);
-
-        result = fmpz_equal(f, tst);
-
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            flint_printf("(aliasing)\n");
-            flint_printf("f = "); fmpz_print(f); flint_printf(", ");
-            flint_printf("g = "); fmpz_print(g); flint_printf(", ");
-            flint_printf("x = %wu\n", x);
-            flint_printf("Correct result via GMP: "); fmpz_print(tst); flint_printf("\n");
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(f);
-        fmpz_clear(g);
-        fmpz_clear(tst);
-
-        mpz_clear(mf);
     }
 
     FLINT_TEST_CLEANUP(state);

--- a/src/fmpz/test/t-addmul_si.c
+++ b/src/fmpz/test/t-addmul_si.c
@@ -43,21 +43,23 @@ main(void)
         fmpz_get_mpz(e, b);
         x = z_randtest(state);
 
-        fmpz_addmul_si(b, a, x);
+        if (n_randint(state, 2))
+        {
+            fmpz_addmul_si(b, a, x);
+        }
+        else  /* test aliasing */
+        {
+            fmpz_set(b, a);
+            mpz_set(e, d);
+            fmpz_addmul_si(b, b, x);
+        }
+
         flint_mpz_init_set_si(xx, x);
         mpz_addmul(e, d, xx);
 
         fmpz_get_mpz(f, b);
 
-        result = (mpz_cmp(e, f) == 0);
-
-        if (COEFF_IS_MPZ(*b))
-        {
-            fmpz c = *b;
-            _fmpz_demote_val(b);
-            if (*b != c)
-                result = 0;
-        }
+        result = (mpz_cmp(e, f) == 0) && _fmpz_is_canonical(b);
 
         if (!result)
         {
@@ -74,46 +76,6 @@ main(void)
         mpz_clear(d);
         mpz_clear(e);
         mpz_clear(f);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a;
-        mpz_t d, e, xx;
-        slong x;
-
-        fmpz_init(a);
-
-        mpz_init(d);
-        mpz_init(e);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-        x = n_randtest(state);
-
-        fmpz_addmul_si(a, a, x);
-        flint_mpz_init_set_si(xx, x);
-        mpz_addmul(d, d, xx);
-
-        fmpz_get_mpz(e, a);
-
-        result = (mpz_cmp(d, e) == 0);
-
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, xx = %Zd\n", d, e, xx);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-
-        mpz_clear(xx);
-        mpz_clear(d);
-        mpz_clear(e);
     }
 
     FLINT_TEST_CLEANUP(state);

--- a/src/fmpz/test/t-addmul_ui.c
+++ b/src/fmpz/test/t-addmul_ui.c
@@ -23,8 +23,6 @@ main(void)
     flint_printf("addmul_ui....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b;
@@ -45,20 +43,22 @@ main(void)
         fmpz_get_mpz(e, b);
         x = n_randtest(state);
 
-        fmpz_addmul_ui(b, a, x);
+        if (n_randint(state, 2))
+        {
+            fmpz_addmul_ui(b, a, x);
+        }
+        else  /* test aliasing */
+        {
+            fmpz_set(b, a);
+            mpz_set(e, d);
+            fmpz_addmul_ui(b, b, x);
+        }
+
         flint_mpz_addmul_ui(e, d, x);
 
         fmpz_get_mpz(f, b);
 
-        result = (mpz_cmp(e, f) == 0);
-
-        if (COEFF_IS_MPZ(*b))
-        {
-            fmpz c = *b;
-            _fmpz_demote_val(b);
-            if (*b != c)
-                result = 0;
-        }
+        result = (mpz_cmp(e, f) == 0) && _fmpz_is_canonical(b);
 
         if (!result)
         {

--- a/src/fmpz/test/t-and.c
+++ b/src/fmpz/test/t-and.c
@@ -22,12 +22,11 @@ main(void)
     flint_printf("and....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b, c;
         mpz_t d, e, f, g;
+        int aliasing;
 
         fmpz_init(a);
         fmpz_init(b);
@@ -44,16 +43,38 @@ main(void)
         fmpz_get_mpz(d, a);
         fmpz_get_mpz(e, b);
 
-        fmpz_and(c, a, b);
+        aliasing = n_randint(state, 4);
+
+        if (aliasing == 0)
+        {
+            fmpz_and(c, a, b);
+        }
+        else if (aliasing == 1)
+        {
+            fmpz_set(c, a);
+            fmpz_and(c, c, b);
+        }
+        else if (aliasing == 2)
+        {
+            fmpz_set(c, b);
+            fmpz_and(c, a, c);
+        }
+        else if (aliasing == 3)
+        {
+            fmpz_set(c, a);
+            fmpz_and(c, a, a);
+            mpz_set(e, d);
+        }
+
         mpz_and(f, d, e);
 
         fmpz_get_mpz(g, c);
 
-        result = (mpz_cmp(f, g) == 0);
+        result = (mpz_cmp(f, g) == 0) && _fmpz_is_canonical(c);
 
         if (!result)
         {
-            flint_printf("FAIL (no aliasing):\n");
+            flint_printf("FAIL:\n");
             gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
             fflush(stdout);
             flint_abort();
@@ -62,134 +83,6 @@ main(void)
         fmpz_clear(a);
         fmpz_clear(b);
         fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, c;
-        mpz_t d, f, g;
-
-        fmpz_init(a);
-        fmpz_init(c);
-
-        mpz_init(d);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-
-        fmpz_and(c, a, a);
-        mpz_and(f, d, d);
-
-        fmpz_get_mpz(g, c);
-
-        result = (mpz_cmp(f, g) == 0);
-
-        if (!result)
-        {
-            flint_printf("FAIL (a/b alias):\n");
-            gmp_printf("d = %Zd, f = %Zd, g = %Zd\n", d, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_and(a, a, b);
-        mpz_and(f, d, e);
-
-        fmpz_get_mpz(g, a);
-
-        result = (mpz_cmp(f, g) == 0);
-
-        if (!result)
-        {
-            flint_printf("FAIL (a/c alias):\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of b and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_and(b, a, b);
-        mpz_and(f, d, e);
-
-        fmpz_get_mpz(g, b);
-
-        result = (mpz_cmp(f, g) == 0);
-
-        if (!result)
-        {
-            flint_printf("FAIL (b/c alias):\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-bin_uiui.c
+++ b/src/fmpz/test/t-bin_uiui.c
@@ -26,8 +26,6 @@ main(void)
     flint_printf("bin_uiui....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 1000 * flint_test_multiplier(); i++)
     {
         fmpz_init(x);
@@ -41,7 +39,7 @@ main(void)
         flint_mpz_bin_uiui(z, n, k);
         fmpz_set_mpz(y, z);
 
-        if (!fmpz_equal(x, y))
+        if (!fmpz_equal(x, y) || !_fmpz_is_canonical(x))
         {
             flint_printf("FAIL: n,k = %wu,%wu\n", n, k);
             fflush(stdout);
@@ -52,8 +50,6 @@ main(void)
         fmpz_clear(y);
         mpz_clear(z);
     }
-
-
 
     FLINT_TEST_CLEANUP(state);
     flint_printf("PASS\n");

--- a/src/fmpz/test/t-bit_pack.c
+++ b/src/fmpz/test/t-bit_pack.c
@@ -77,7 +77,7 @@ main(void)
         fmpz_bit_pack(arr, shift, bits, a, 0, 0);
         fmpz_bit_unpack_unsigned(b, arr, shift, bits);
 
-        result = (fmpz_cmp(a, b) == 0);
+        result = (fmpz_cmp(a, b) == 0) && _fmpz_is_canonical(b);
 
         if (!result)
         {

--- a/src/fmpz/test/t-bits.c
+++ b/src/fmpz/test/t-bits.c
@@ -22,8 +22,6 @@ main(void)
     flint_printf("bits....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a;

--- a/src/fmpz/test/t-cdiv_q.c
+++ b/src/fmpz/test/t-cdiv_q.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2009 William Hart
+    Copyright (C) 2010 Sebastian Pancratz
 
     This file is part of FLINT.
 
@@ -22,12 +23,11 @@ main(void)
     flint_printf("cdiv_q....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b, c;
         mpz_t d, e, f, g;
+        int aliasing;
 
         fmpz_init(a);
         fmpz_init(b);
@@ -44,16 +44,37 @@ main(void)
         fmpz_get_mpz(d, a);
         fmpz_get_mpz(e, b);
 
-        fmpz_cdiv_q(c, a, b);
+        aliasing = n_randint(state, 4);
+
+        if (aliasing == 0)
+        {
+            fmpz_cdiv_q(c, a, b);
+        }
+        else if (aliasing == 1)
+        {
+            fmpz_set(a, b);
+            mpz_set(d, e);
+            fmpz_cdiv_q(c, a, a);
+        }
+        else if (aliasing == 2)
+        {
+            fmpz_set(c, a);
+            fmpz_cdiv_q(c, c, b);
+        }
+        else
+        {
+            fmpz_set(c, b);
+            fmpz_cdiv_q(c, a, c);
+        }
+
         mpz_cdiv_q(f, d, e);
 
         fmpz_get_mpz(g, c);
 
-        result = (mpz_cmp(f, g) == 0);
-
+        result = (mpz_cmp(f, g) == 0) && _fmpz_is_canonical(c);
         if (!result)
         {
-            flint_printf("FAIL\n");
+            flint_printf("FAIL:\n");
             gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
             fflush(stdout);
             flint_abort();
@@ -62,134 +83,6 @@ main(void)
         fmpz_clear(a);
         fmpz_clear(b);
         fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, c;
-        mpz_t d, f, g;
-
-        fmpz_init(a);
-        fmpz_init(c);
-
-        mpz_init(d);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest_not_zero(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-
-        fmpz_cdiv_q(c, a, a);
-        mpz_cdiv_q(f, d, d);
-
-        fmpz_get_mpz(g, c);
-
-        result = (mpz_cmp(f, g) == 0);
-
-        if (!result)
-        {
-            flint_printf("FAIL\n");
-            gmp_printf("d = %Zd, f = %Zd, g = %Zd\n", d, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_cdiv_q(a, a, b);
-        mpz_cdiv_q(f, d, e);
-
-        fmpz_get_mpz(g, a);
-
-        result = (mpz_cmp(f, g) == 0);
-
-        if (!result)
-        {
-            flint_printf("FAIL\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of b and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_cdiv_q(b, a, b);
-        mpz_cdiv_q(f, d, e);
-
-        fmpz_get_mpz(g, b);
-
-        result = (mpz_cmp(f, g) == 0);
-
-        if (!result)
-        {
-            flint_printf("FAIL\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-cdiv_q_2exp.c
+++ b/src/fmpz/test/t-cdiv_q_2exp.c
@@ -22,8 +22,6 @@ main(void)
     flint_printf("cdiv_q_2exp....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b;
@@ -42,12 +40,21 @@ main(void)
         fmpz_get_mpz(d, a);
         x = n_randint(state, 200);
 
-        fmpz_cdiv_q_2exp(b, a, x);
+        if (n_randint(state, 2))
+        {
+            fmpz_cdiv_q_2exp(b, a, x);
+        }
+        else /* test aliasing */
+        {
+            fmpz_set(b, a);
+            fmpz_cdiv_q_2exp(b, b, x);
+        }
+
         mpz_cdiv_q_2exp(e, d, x);
 
         fmpz_get_mpz(f, b);
 
-        result = (mpz_cmp(e, f) == 0);
+        result = (mpz_cmp(e, f) == 0) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -58,45 +65,6 @@ main(void)
 
         fmpz_clear(a);
         fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a;
-        mpz_t d, e, f;
-        ulong x;
-
-        fmpz_init(a);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-        x = n_randint(state, 200);
-
-        fmpz_cdiv_q_2exp(a, a, x);
-        mpz_cdiv_q_2exp(e, d, x);
-
-        fmpz_get_mpz(f, a);
-
-        result = (mpz_cmp(e, f) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, exp = %Mu\n", d, e, f, x);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-cdiv_q_si.c
+++ b/src/fmpz/test/t-cdiv_q_si.c
@@ -23,8 +23,6 @@ main(void)
     flint_printf("cdiv_q_si....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         slong b;
@@ -45,12 +43,21 @@ main(void)
         fmpz_get_mpz(d, a);
         flint_mpz_set_si(e, b);
 
-        fmpz_cdiv_q_si(c, a, b);
+        if (n_randint(state, 2))
+        {
+            fmpz_cdiv_q_si(c, a, b);
+        }
+        else /* test aliasing */
+        {
+            fmpz_set(c, a);
+            fmpz_cdiv_q_si(c, c, b);
+        }
+
         mpz_cdiv_q(f, d, e);
 
         fmpz_get_mpz(g, c);
 
-        result = (mpz_cmp(f, g) == 0);
+        result = (mpz_cmp(f, g) == 0) && _fmpz_is_canonical(c);
         if (!result)
         {
             flint_printf("FAIL (1):\n");
@@ -61,48 +68,6 @@ main(void)
 
         fmpz_clear(a);
         fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        slong b;
-        fmpz_t a;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        b = z_randtest_not_zero(state);
-
-        fmpz_get_mpz(d, a);
-        flint_mpz_set_si(e, b);
-
-        fmpz_cdiv_q_si(a, a, b);
-        mpz_cdiv_q(f, d, e);
-
-        fmpz_get_mpz(g, a);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL (2):\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-cdiv_q_ui.c
+++ b/src/fmpz/test/t-cdiv_q_ui.c
@@ -23,8 +23,6 @@ main(void)
     flint_printf("cdiv_q_ui....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         ulong b;
@@ -45,12 +43,21 @@ main(void)
         fmpz_get_mpz(d, a);
         flint_mpz_set_ui(e, b);
 
-        fmpz_cdiv_q_ui(c, a, b);
+        if (n_randint(state, 2))
+        {
+            fmpz_cdiv_q_ui(c, a, b);
+        }
+        else /* test aliasing */
+        {
+            fmpz_set(c, a);
+            fmpz_cdiv_q_ui(c, c, b);
+        }
+
         mpz_cdiv_q(f, d, e);
 
         fmpz_get_mpz(g, c);
 
-        result = (mpz_cmp(f, g) == 0);
+        result = (mpz_cmp(f, g) == 0) && _fmpz_is_canonical(c);
         if (!result)
         {
             flint_printf("FAIL (1):\n");
@@ -61,48 +68,6 @@ main(void)
 
         fmpz_clear(a);
         fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        ulong b;
-        fmpz_t a;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        b = n_randtest_not_zero(state);
-
-        fmpz_get_mpz(d, a);
-        flint_mpz_set_ui(e, b);
-
-        fmpz_cdiv_q_ui(a, a, b);
-        mpz_cdiv_q(f, d, e);
-
-        fmpz_get_mpz(g, a);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL (2):\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-cdiv_qr.c
+++ b/src/fmpz/test/t-cdiv_qr.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020 Daniel Schultz
+    Copyright (C) 2009 William Hart
 
     This file is part of FLINT.
 
@@ -26,8 +26,7 @@ main(void)
     {
         fmpz_t a, b, c, r;
         mpz_t d, e, f, g, h, s;
-        slong j;
-
+        int aliasing;
 
         fmpz_init(a);
         fmpz_init(b);
@@ -41,241 +40,48 @@ main(void)
         mpz_init(h);
         mpz_init(s);
 
-        fmpz_randbits(a, state, 1000);
-        do {
-           fmpz_randbits(b, state, 500);
-        } while(fmpz_is_zero(b));
+        fmpz_randtest(a, state, 200);
+        fmpz_randtest_not_zero(b, state, 200);
 
         fmpz_get_mpz(d, a);
         fmpz_get_mpz(e, b);
 
-        for (j = 1; j < 100; j++)
-           fmpz_cdiv_qr(c, r, a, b);
+        aliasing = n_randint(state, 5);
+
+        if (aliasing == 0)
+        {
+            fmpz_cdiv_qr(c, r, a, b);
+        }
+        else if (aliasing == 1)
+        {
+            fmpz_set(c, a);
+            fmpz_cdiv_qr(c, r, c, b);
+        }
+        else if (aliasing == 2)
+        {
+            fmpz_set(c, b);
+            fmpz_cdiv_qr(c, r, a, c);
+        }
+        else if (aliasing == 3)
+        {
+            fmpz_set(r, a);
+            fmpz_cdiv_qr(c, r, r, b);
+        }
+        else
+        {
+            fmpz_set(r, b);
+            fmpz_cdiv_qr(c, r, a, r);
+        }
+
         mpz_cdiv_qr(f, s, d, e);
 
         fmpz_get_mpz(g, c);
         fmpz_get_mpz(h, r);
 
-        result = (mpz_cmp(f, g) == 0 && mpz_cmp(h, s) == 0);
+        result = (mpz_cmp(f, g) == 0 && mpz_cmp(h, s) == 0) && _fmpz_is_canonical(c) && _fmpz_is_canonical(r);
         if (!result)
         {
-            flint_printf("FAIL 1:\n");
-            gmp_printf
-                ("d = %Zd, e = %Zd, f = %Zd, g = %Zd, h = %Zd, s = %Zd\n", d,
-                 e, f, g, h, s);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-        fmpz_clear(r);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-        mpz_clear(h);
-        mpz_clear(s);
-    }
-
-    /* Check aliasing of c and a */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, c, r;
-        mpz_t d, e, f, g, h, s;
-
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-        fmpz_init(r);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-        mpz_init(h);
-        mpz_init(s);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_cdiv_qr(a, r, a, b);
-        mpz_cdiv_qr(f, s, d, e);
-
-        fmpz_get_mpz(g, a);
-        fmpz_get_mpz(h, r);
-
-        result = (mpz_cmp(f, g) == 0 && mpz_cmp(h, s) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL 2:\n");
-            gmp_printf
-                ("d = %Zd, e = %Zd, f = %Zd, g = %Zd, h = %Zd, s = %Zd\n", d,
-                 e, f, g, h, s);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-        fmpz_clear(r);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-        mpz_clear(h);
-        mpz_clear(s);
-    }
-
-    /* Check aliasing of c and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, c, r;
-        mpz_t d, e, f, g, h, s;
-
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-        fmpz_init(r);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-        mpz_init(h);
-        mpz_init(s);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_cdiv_qr(b, r, a, b);
-        mpz_cdiv_qr(f, s, d, e);
-
-        fmpz_get_mpz(g, b);
-        fmpz_get_mpz(h, r);
-
-        result = (mpz_cmp(f, g) == 0 && mpz_cmp(h, s) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL 3:\n");
-            gmp_printf
-                ("d = %Zd, e = %Zd, f = %Zd, g = %Zd, h = %Zd, s = %Zd\n", d,
-                 e, f, g, h, s);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-        fmpz_clear(r);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-        mpz_clear(h);
-        mpz_clear(s);
-    }
-
-    /* Check aliasing of r and a */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, c, r;
-        mpz_t d, e, f, g, h, s;
-
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-        fmpz_init(r);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-        mpz_init(h);
-        mpz_init(s);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_cdiv_qr(c, a, a, b);
-        mpz_cdiv_qr(f, s, d, e);
-
-        fmpz_get_mpz(g, c);
-        fmpz_get_mpz(h, a);
-
-        result = (mpz_cmp(f, g) == 0 && mpz_cmp(h, s) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL 4:\n");
-            gmp_printf
-                ("d = %Zd, e = %Zd, f = %Zd, g = %Zd, h = %Zd, s = %Zd\n", d,
-                 e, f, g, h, s);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-        fmpz_clear(r);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-        mpz_clear(h);
-        mpz_clear(s);
-    }
-
-    /* Check aliasing of r and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, c, r;
-        mpz_t d, e, f, g, h, s;
-
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-        fmpz_init(r);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-        mpz_init(h);
-        mpz_init(s);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_cdiv_qr(c, b, a, b);
-        mpz_cdiv_qr(f, s, d, e);
-
-        fmpz_get_mpz(g, c);
-        fmpz_get_mpz(h, b);
-
-        result = (mpz_cmp(f, g) == 0 && mpz_cmp(h, s) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL 5:\n");
+            flint_printf("FAIL:\n");
             gmp_printf
                 ("d = %Zd, e = %Zd, f = %Zd, g = %Zd, h = %Zd, s = %Zd\n", d,
                  e, f, g, h, s);

--- a/src/fmpz/test/t-cdiv_r_2exp.c
+++ b/src/fmpz/test/t-cdiv_r_2exp.c
@@ -40,12 +40,21 @@ main(void)
         fmpz_get_mpz(d, a);
         x = n_randint(state, 200);
 
-        fmpz_cdiv_r_2exp(b, a, x);
+        if (n_randint(state, 2))
+        {
+            fmpz_cdiv_r_2exp(b, a, x);
+        }
+        else
+        {
+            fmpz_set(b, a);
+            fmpz_cdiv_r_2exp(b, b, x);
+        }
+
         mpz_cdiv_r_2exp(e, d, x);
 
         fmpz_get_mpz(f, b);
 
-        result = (mpz_cmp(e, f) == 0);
+        result = (mpz_cmp(e, f) == 0) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL 1:\n");
@@ -56,45 +65,6 @@ main(void)
 
         fmpz_clear(a);
         fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a;
-        mpz_t d, e, f;
-        ulong x;
-
-        fmpz_init(a);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-        x = n_randint(state, 200);
-
-        fmpz_cdiv_r_2exp(a, a, x);
-        mpz_cdiv_r_2exp(e, d, x);
-
-        fmpz_get_mpz(f, a);
-
-        result = (mpz_cmp(e, f) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL 2:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, exp = %Mu\n", d, e, f, x);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-cdiv_ui.c
+++ b/src/fmpz/test/t-cdiv_ui.c
@@ -40,12 +40,12 @@ main(void)
         r1 = fmpz_cdiv_ui(a, x);
         r2 = flint_mpz_cdiv_ui(b, x);
 
-        result = (r1 == r2);
+        result = (r1 == r2) && _fmpz_is_canonical(a);
         if (!result)
         {
             flint_printf("FAIL:\n");
             gmp_printf
-                ("b = %Zd, x = %ld, r1 = %ld, r2 = %ld\n", b, x, r1, r2);
+                ("b = %Zd, x = %wu, r1 = %wu, r2 = %wu\n", b, x, r1, r2);
             fflush(stdout);
             flint_abort();
         }

--- a/src/fmpz/test/t-combit.c
+++ b/src/fmpz/test/t-combit.c
@@ -23,8 +23,6 @@ main(void)
     flint_printf("combit....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         ulong j;
@@ -43,7 +41,7 @@ main(void)
         mpz_combit(b, j);
         fmpz_get_mpz(c, a);
 
-        result = (mpz_cmp(b, c) == 0);
+        result = (mpz_cmp(b, c) == 0) && _fmpz_is_canonical(a);
 
         if (!result)
         {

--- a/src/fmpz/test/t-complement.c
+++ b/src/fmpz/test/t-complement.c
@@ -22,8 +22,6 @@ main(void)
     flint_printf("complement....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b;
@@ -39,12 +37,21 @@ main(void)
 
         fmpz_get_mpz(c, a);
 
-        fmpz_complement(b, a);
+        if (n_randint(state, 2))
+        {
+            fmpz_complement(b, a);
+        }
+        else
+        {
+            fmpz_set(b, a);
+            fmpz_complement(b, b);
+        }
+
         mpz_com(c, c);
 
         fmpz_get_mpz(d, b);
 
-        result = (mpz_cmp(c, d) == 0);
+        result = (mpz_cmp(c, d) == 0) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL (no alias):\n");
@@ -55,41 +62,6 @@ main(void)
 
         fmpz_clear(a);
         fmpz_clear(b);
-
-        mpz_clear(c);
-        mpz_clear(d);
-    }
-
-    /* Check aliasing */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a;
-        mpz_t c, d;
-
-        fmpz_init(a);
-
-        mpz_init(c);
-        mpz_init(d);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(c, a);
-
-        fmpz_complement(a, a);
-        mpz_com(c, c);
-
-        fmpz_get_mpz(d, a);
-
-        result = (mpz_cmp(c, d) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL (aliased):\n");
-            gmp_printf("c = %Zd, d = %Zd\n", c, d);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
 
         mpz_clear(c);
         mpz_clear(d);

--- a/src/fmpz/test/t-crt.c
+++ b/src/fmpz/test/t-crt.c
@@ -73,7 +73,7 @@ int main(void)
 
         fmpz_CRT(result, r1, m1, r2, m2, sign);
 
-        if (!fmpz_equal(result, input))
+        if (!fmpz_equal(result, input) || !_fmpz_is_canonical(result))
         {
             flint_printf("FAIL:\n");
             flint_printf("m1: "); fmpz_print(m1); flint_printf("\n");

--- a/src/fmpz/test/t-crt_ui.c
+++ b/src/fmpz/test/t-crt_ui.c
@@ -70,7 +70,7 @@ int main(void)
 
         fmpz_CRT_ui(result, r1, m1, r2, m2, sign);
 
-        if (!fmpz_equal(result, input))
+        if (!fmpz_equal(result, input) || !_fmpz_is_canonical(result))
         {
             flint_printf("FAIL:\n");
             flint_printf("m1: "); fmpz_print(m1); flint_printf("\n");

--- a/src/fmpz/test/t-div_newton.c
+++ b/src/fmpz/test/t-div_newton.c
@@ -68,7 +68,7 @@ test_div_q(void (*my_f)(fmpz_t, const fmpz_t, const fmpz_t),
 
     reference_f(q2, a, b);
 
-    if (!fmpz_equal(q, q2))
+    if (!fmpz_equal(q, q2) || !_fmpz_is_canonical(q))
     {
         flint_printf("FAIL: %s\n", descr);
         flint_printf("aliasing = %d\n", aliasing);
@@ -144,7 +144,7 @@ test_div_qr(void (*my_f)(fmpz_t, fmpz_t, const fmpz_t, const fmpz_t),
 
     reference_f(q2, r2, a, b);
 
-    if (!fmpz_equal(q, q2) || !fmpz_equal(r, r2))
+    if (!fmpz_equal(q, q2) || !fmpz_equal(r, r2) || !_fmpz_is_canonical(q) || !_fmpz_is_canonical(r))
     {
         flint_printf("FAIL: %s\n", descr);
         flint_printf("aliasing = %d\n", aliasing);

--- a/src/fmpz/test/t-divexact.c
+++ b/src/fmpz/test/t-divexact.c
@@ -22,12 +22,11 @@ main(void)
     flint_printf("divexact....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b, c;
         mpz_t d, e, f, g;
+        int aliasing;
 
         fmpz_init(a);
         fmpz_init(b);
@@ -45,146 +44,37 @@ main(void)
         fmpz_get_mpz(d, b);
         fmpz_get_mpz(e, c);
 
-        fmpz_divexact(a, c, b);
+        aliasing = n_randint(state, 4);
+
+        if (aliasing == 0)
+        {
+            fmpz_divexact(a, c, b);
+        }
+        else if (aliasing == 1)
+        {
+            fmpz_set(c, b);
+            mpz_set(e, d);
+            fmpz_divexact(a, c, c);
+        }
+        else if (aliasing == 2)
+        {
+            fmpz_set(a, c);
+            fmpz_divexact(a, a, b);
+        }
+        else
+        {
+            fmpz_set(a, b);
+            fmpz_divexact(a, c, a);
+        }
+
         mpz_divexact(f, e, d);
 
         fmpz_get_mpz(g, a);
 
-        result = (mpz_cmp(f, g) == 0);
+        result = (mpz_cmp(f, g) == 0) && _fmpz_is_canonical(a);
         if (!result)
         {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, c;
-        mpz_t d, f, g;
-
-        fmpz_init(a);
-        fmpz_init(c);
-
-        mpz_init(d);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest_not_zero(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-
-        fmpz_divexact(c, a, a);
-        mpz_divexact(f, d, d);
-
-        fmpz_get_mpz(g, c);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, f = %Zd, g = %Zd\n", d, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, c;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-        fmpz_mul(c, a, b);
-
-        fmpz_get_mpz(d, c);
-        fmpz_get_mpz(e, b);
-
-        fmpz_divexact(c, c, b);
-        mpz_divexact(f, d, e);
-
-        fmpz_get_mpz(g, c);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of b and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, c;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-        fmpz_mul(c, a, b);
-
-        fmpz_get_mpz(d, c);
-        fmpz_get_mpz(e, b);
-
-        fmpz_divexact(b, c, b);
-        mpz_divexact(f, d, e);
-
-        fmpz_get_mpz(g, b);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
+            flint_printf("FAIL %d:\n");
             gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
             fflush(stdout);
             flint_abort();

--- a/src/fmpz/test/t-divexact2_uiui.c
+++ b/src/fmpz/test/t-divexact2_uiui.c
@@ -25,8 +25,6 @@ main(void)
     flint_printf("divexact2_uiui....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, c;
@@ -48,14 +46,22 @@ main(void)
 
         fmpz_get_mpz(e, c);
 
-        fmpz_divexact2_uiui(a, c, n, m);
+        if (n_randint(state, 2))
+        {
+            fmpz_divexact2_uiui(a, c, n, m);
+        }
+        else
+        {
+            fmpz_set(a, c);
+            fmpz_divexact2_uiui(a, a, n, m);
+        }
 
         flint_mpz_divexact_ui(f, e, n);
         flint_mpz_divexact_ui(f, f, m);
 
         fmpz_get_mpz(g, a);
 
-        result = (mpz_cmp(f, g) == 0);
+        result = (mpz_cmp(f, g) == 0) && _fmpz_is_canonical(a);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -68,51 +74,6 @@ main(void)
         fmpz_clear(a);
         fmpz_clear(c);
         mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, c;
-        mpz_t d, f, g;
-        ulong n, m;
-
-        fmpz_init(a);
-        fmpz_init(c);
-        mpz_init(d);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        n = n_randtest_not_zero(state);
-        m = n_randtest_not_zero(state);
-        fmpz_mul_ui(c, a, n);
-        fmpz_mul_ui(c, c, m);
-
-        fmpz_get_mpz(d, c);
-
-        fmpz_divexact2_uiui(c, c, n, m);
-
-        flint_mpz_divexact_ui(f, d, n);
-        flint_mpz_divexact_ui(f, f, m);
-
-        fmpz_get_mpz(g, c);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, n = %Mu, m = %Mu, f = %Zd, g = %Zd\n",
-                d, n, m, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(c);
-        mpz_clear(d);
         mpz_clear(f);
         mpz_clear(g);
     }

--- a/src/fmpz/test/t-divexact_si.c
+++ b/src/fmpz/test/t-divexact_si.c
@@ -24,8 +24,6 @@ main(void)
     flint_printf("divexact_si....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, c;
@@ -44,14 +42,23 @@ main(void)
 
         fmpz_get_mpz(e, c);
 
-        fmpz_divexact_si(a, c, n);
+        if (n_randint(state, 2))
+        {
+            fmpz_divexact_si(a, c, n);
+        }
+        else
+        {
+            fmpz_set(a, c);
+            fmpz_divexact_si(a, a, n);
+        }
+
         flint_mpz_divexact_ui(f, e, FLINT_ABS(n));
         if (n < 0)
             mpz_neg(f, f);
 
         fmpz_get_mpz(g, a);
 
-        result = (mpz_cmp(f, g) == 0);
+        result = (mpz_cmp(f, g) == 0) && _fmpz_is_canonical(a);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -63,49 +70,6 @@ main(void)
         fmpz_clear(a);
         fmpz_clear(c);
         mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, c;
-        mpz_t d, f, g;
-        slong n;
-
-        fmpz_init(a);
-        fmpz_init(c);
-        mpz_init(d);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        n = z_randtest_not_zero(state);
-        fmpz_mul_si(c, a, n);
-
-        fmpz_get_mpz(d, c);
-
-        fmpz_divexact_si(c, c, n);
-        flint_mpz_divexact_ui(f, d, FLINT_ABS(n));
-        if (n < 0)
-            mpz_neg(f, f);
-
-        fmpz_get_mpz(g, c);
-
-        result = (mpz_cmp(f, g) == 0);
-
-        if (!result)
-        {
-            flint_printf("FAIL;\n");
-            gmp_printf("d = %Zd, n = %Md, f = %Zd, g = %Zd\n", d, n, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(c);
-        mpz_clear(d);
         mpz_clear(f);
         mpz_clear(g);
     }

--- a/src/fmpz/test/t-divexact_ui.c
+++ b/src/fmpz/test/t-divexact_ui.c
@@ -24,8 +24,6 @@ main(void)
     flint_printf("divexact_ui....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, c;
@@ -44,12 +42,21 @@ main(void)
 
         fmpz_get_mpz(e, c);
 
-        fmpz_divexact_ui(a, c, n);
+        if (n_randint(state, 2))
+        {
+            fmpz_divexact_ui(a, c, n);
+        }
+        else
+        {
+            fmpz_set(a, c);
+            fmpz_divexact_ui(a, a, n);
+        }
+
         flint_mpz_divexact_ui(f, e, n);
 
         fmpz_get_mpz(g, a);
 
-        result = (mpz_cmp(f, g) == 0);
+        result = (mpz_cmp(f, g) == 0) && _fmpz_is_canonical(a);
         if (!result)
         {
             flint_printf("FAIL1\n");
@@ -61,46 +68,6 @@ main(void)
         fmpz_clear(a);
         fmpz_clear(c);
         mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, c;
-        mpz_t d, f, g;
-        ulong n;
-
-        fmpz_init(a);
-        fmpz_init(c);
-        mpz_init(d);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        n = n_randtest_not_zero(state);
-        fmpz_mul_ui(c, a, n);
-
-        fmpz_get_mpz(d, c);
-
-        fmpz_divexact_ui(c, c, n);
-        flint_mpz_divexact_ui(f, d, n);
-
-        fmpz_get_mpz(g, c);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, n = %Mu, f = %Zd, g = %Zd\n", d, n, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(c);
-        mpz_clear(d);
         mpz_clear(f);
         mpz_clear(g);
     }

--- a/src/fmpz/test/t-divides.c
+++ b/src/fmpz/test/t-divides.c
@@ -27,25 +27,48 @@ main(void)
     {
         fmpz_t a, b, q, p;
         int divides;
+        int aliasing;
 
         fmpz_init(a);
         fmpz_init(b);
         fmpz_init(p);
-	fmpz_init(q);
+        fmpz_init(q);
 
         fmpz_randtest(a, state, 200);
         fmpz_randtest(b, state, 200);
 
-        divides = fmpz_divides(q, b, a);
+        aliasing = n_randint(state, 4);
+
+        if (aliasing == 0)
+        {
+            divides = fmpz_divides(q, b, a);
+        }
+        else if (aliasing == 1)
+        {
+            fmpz_set(b, a);
+            divides = fmpz_divides(q, b, b);
+        }
+        else if (aliasing == 2)
+        {
+            fmpz_set(q, b);
+            divides = fmpz_divides(q, q, a);
+        }
+        else
+        {
+            fmpz_set(q, a);
+            divides = fmpz_divides(q, b, q);
+        }
+
         fmpz_mul(p, a, q);
 
         result = ((divides && fmpz_equal(p, b)) ||
 	         (!divides && fmpz_is_zero(q) && !fmpz_equal(p, b)));
+        result = result && _fmpz_is_canonical(q);
         if (!result)
         {
             flint_printf("FAIL:\n");
             flint_printf("divides = %d\n", divides);
-	    flint_printf("a = "); fmpz_print(a); flint_printf("\n");
+            flint_printf("a = "); fmpz_print(a); flint_printf("\n");
             flint_printf("b = "); fmpz_print(b); flint_printf("\n");
             flint_printf("p = "); fmpz_print(p); flint_printf("\n");
             flint_printf("q = "); fmpz_print(q); flint_printf("\n");
@@ -68,7 +91,7 @@ main(void)
         fmpz_init(a);
         fmpz_init(b);
         fmpz_init(p);
-	fmpz_init(q);
+        fmpz_init(q);
 
         fmpz_randtest(a, state, 200);
         fmpz_randtest(b, state, 200);
@@ -82,7 +105,7 @@ main(void)
         {
             flint_printf("FAIL:\n");
             flint_printf("divides = %d\n", divides);
-	    flint_printf("a = "); fmpz_print(a); flint_printf("\n");
+            flint_printf("a = "); fmpz_print(a); flint_printf("\n");
             flint_printf("b = "); fmpz_print(b); flint_printf("\n");
             flint_printf("p = "); fmpz_print(p); flint_printf("\n");
             flint_printf("q = "); fmpz_print(q); flint_printf("\n");
@@ -92,73 +115,7 @@ main(void)
 
         fmpz_clear(a);
         fmpz_clear(b);
-	fmpz_clear(p);
-        fmpz_clear(q);
-    }
-
-    /* Check aliasing of q and a */
-    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, q;
-        int divides1, divides2;
-
-        fmpz_init(a);
-        fmpz_init(b);
-	fmpz_init(q);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest(b, state, 200);
-
-        divides1 = fmpz_divides(q, b, a);
-        divides2 = fmpz_divides(a, b, a);
-
-        result = (divides1 == divides2 && fmpz_equal(q, a));
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            flint_printf("divides1 = %d, divides2 = %d\n", divides1, divides2);
-	    flint_printf("a = "); fmpz_print(a); flint_printf("\n");
-            flint_printf("b = "); fmpz_print(b); flint_printf("\n");
-            flint_printf("q = "); fmpz_print(q); flint_printf("\n");
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(q);
-    }
-
-    /* Check aliasing of q and b */
-    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, q;
-        int divides1, divides2;
-
-        fmpz_init(a);
-        fmpz_init(b);
-	fmpz_init(q);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest(b, state, 200);
-
-        divides1 = fmpz_divides(q, b, a);
-        divides2 = fmpz_divides(b, b, a);
-
-        result = (divides1 == divides2 && fmpz_equal(q, b));
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            flint_printf("divides1 = %d, divides2 = %d\n", divides1, divides2);
-	    flint_printf("a = "); fmpz_print(a); flint_printf("\n");
-            flint_printf("b = "); fmpz_print(b); flint_printf("\n");
-            flint_printf("q = "); fmpz_print(q); flint_printf("\n");
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
+        fmpz_clear(p);
         fmpz_clear(q);
     }
 

--- a/src/fmpz/test/t-divisible.c
+++ b/src/fmpz/test/t-divisible.c
@@ -22,7 +22,7 @@ main(void)
     flint_printf("divisible....");
     fflush(stdout);
 
-    /* Compare with MPIR:  random */
+    /* Compare with GMP:  random */
     for (i = 0; i < 1000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b;
@@ -58,7 +58,7 @@ main(void)
         mpz_clear(d);
     }
 
-    /* Compare with MPIR:  b a multiple of a */
+    /* Compare with GMP:  b a multiple of a */
     for (i = 0; i < 1000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b;

--- a/src/fmpz/test/t-divisible_si.c
+++ b/src/fmpz/test/t-divisible_si.c
@@ -25,7 +25,7 @@ main(void)
 
 
 
-    /* Compare with MPIR:  random */
+    /* Compare with GMP:  random */
     for (i = 0; i < 1000 * flint_test_multiplier(); i++)
     {
         slong a;
@@ -57,7 +57,7 @@ main(void)
         mpz_clear(d);
     }
 
-    /* Compare with MPIR:  b a multiple of a */
+    /* Compare with GMP:  b a multiple of a */
     for (i = 0; i < 1000 * flint_test_multiplier(); i++)
     {
         slong a;

--- a/src/fmpz/test/t-divisor_sigma.c
+++ b/src/fmpz/test/t-divisor_sigma.c
@@ -60,7 +60,7 @@ int main(void)
             fmpz_set_ui(m, n);
             fmpz_divisor_sigma(a, k, m);
             fmpz_sigma_naive(b, k, n);
-            if (!fmpz_equal(a, b))
+            if (!fmpz_equal(a, b) || !_fmpz_is_canonical(a))
             {
                 flint_printf("FAIL:\n");
                 flint_printf("wrong value for n=%wd, k=%wd\n", n, k);

--- a/src/fmpz/test/t-euler_phi.c
+++ b/src/fmpz/test/t-euler_phi.c
@@ -75,7 +75,7 @@ int main(void)
         fmpz_set_ui(y, n_nth_prime(i+1));
         fmpz_pow_ui(y, y, n-1);
         fmpz_mul_ui(y, y, n_nth_prime(i+1)-1);
-        if (!fmpz_equal(x, y))
+        if (!fmpz_equal(x, y) || !_fmpz_is_canonical(x))
         {
             flint_printf("FAIL: %wu ^ %wu\n", n_nth_prime(i+1), n);
         }
@@ -85,7 +85,7 @@ int main(void)
     fmpz_set_str(x, "10426024348053113487152988625265848110501553295256578345594388516660144", 10);
     fmpz_set_str(y, "2265085829098571747262267425315881590169106756213617459200000000000000", 10);
     fmpz_euler_phi(x, x);
-    if (!fmpz_equal(x, y))
+    if (!fmpz_equal(x, y) || !_fmpz_is_canonical(x))
     {
         flint_printf("FAIL: special test value\n");
         fflush(stdout);

--- a/src/fmpz/test/t-fac_ui.c
+++ b/src/fmpz/test/t-fac_ui.c
@@ -38,7 +38,7 @@ main(void)
         {
             fmpz_fac_ui(x, i);
             fmpz_mul_ui(y, y, FLINT_MAX(1, i));
-            if (!fmpz_equal(x, y))
+            if (!fmpz_equal(x, y) || !_fmpz_is_canonical(x))
             {
                 flint_printf("FAIL: %wd\n", i);
                 fmpz_print(x);

--- a/src/fmpz/test/t-fdiv_q.c
+++ b/src/fmpz/test/t-fdiv_q.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2009 William Hart
+    Copyright (C) 2010 Sebastian Pancratz
 
     This file is part of FLINT.
 
@@ -22,12 +23,11 @@ main(void)
     flint_printf("fdiv_q....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b, c;
         mpz_t d, e, f, g;
+        int aliasing;
 
         fmpz_init(a);
         fmpz_init(b);
@@ -44,12 +44,34 @@ main(void)
         fmpz_get_mpz(d, a);
         fmpz_get_mpz(e, b);
 
-        fmpz_fdiv_q(c, a, b);
+        aliasing = n_randint(state, 4);
+
+        if (aliasing == 0)
+        {
+            fmpz_fdiv_q(c, a, b);
+        }
+        else if (aliasing == 1)
+        {
+            fmpz_set(a, b);
+            mpz_set(d, e);
+            fmpz_fdiv_q(c, a, a);
+        }
+        else if (aliasing == 2)
+        {
+            fmpz_set(c, a);
+            fmpz_fdiv_q(c, c, b);
+        }
+        else
+        {
+            fmpz_set(c, b);
+            fmpz_fdiv_q(c, a, c);
+        }
+
         mpz_fdiv_q(f, d, e);
 
         fmpz_get_mpz(g, c);
 
-        result = (mpz_cmp(f, g) == 0);
+        result = (mpz_cmp(f, g) == 0) && _fmpz_is_canonical(c);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -61,131 +83,6 @@ main(void)
         fmpz_clear(a);
         fmpz_clear(b);
         fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, c;
-        mpz_t d, f, g;
-
-        fmpz_init(a);
-        fmpz_init(c);
-
-        mpz_init(d);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest_not_zero(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-
-        fmpz_fdiv_q(c, a, a);
-        mpz_fdiv_q(f, d, d);
-
-        fmpz_get_mpz(g, c);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, f = %Zd, g = %Zd\n", d, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_fdiv_q(a, a, b);
-        mpz_fdiv_q(f, d, e);
-
-        fmpz_get_mpz(g, a);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of b and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_fdiv_q(b, a, b);
-        mpz_fdiv_q(f, d, e);
-
-        fmpz_get_mpz(g, b);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-fdiv_q_2exp.c
+++ b/src/fmpz/test/t-fdiv_q_2exp.c
@@ -22,8 +22,6 @@ main(void)
     flint_printf("fdiv_q_2exp....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b;
@@ -42,12 +40,21 @@ main(void)
         fmpz_get_mpz(d, a);
         x = n_randint(state, 200);
 
-        fmpz_fdiv_q_2exp(b, a, x);
+        if (n_randint(state, 2))
+        {
+            fmpz_fdiv_q_2exp(b, a, x);
+        }
+        else /* test aliasing */
+        {
+            fmpz_set(b, a);
+            fmpz_fdiv_q_2exp(b, b, x);
+        }
+
         mpz_fdiv_q_2exp(e, d, x);
 
         fmpz_get_mpz(f, b);
 
-        result = (mpz_cmp(e, f) == 0);
+        result = (mpz_cmp(e, f) == 0) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -58,45 +65,6 @@ main(void)
 
         fmpz_clear(a);
         fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a;
-        mpz_t d, e, f;
-        ulong x;
-
-        fmpz_init(a);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-        x = n_randint(state, 200);
-
-        fmpz_fdiv_q_2exp(a, a, x);
-        mpz_fdiv_q_2exp(e, d, x);
-
-        fmpz_get_mpz(f, a);
-
-        result = (mpz_cmp(e, f) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, exp = %Mu\n", d, e, f, x);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-fdiv_q_si.c
+++ b/src/fmpz/test/t-fdiv_q_si.c
@@ -23,8 +23,6 @@ main(void)
     flint_printf("fdiv_q_si....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         slong b;
@@ -45,12 +43,21 @@ main(void)
         fmpz_get_mpz(d, a);
         flint_mpz_set_si(e, b);
 
-        fmpz_fdiv_q_si(c, a, b);
+        if (n_randint(state, 2))
+        {
+            fmpz_fdiv_q_si(c, a, b);
+        }
+        else /* test aliasing */
+        {
+            fmpz_set(c, a);
+            fmpz_fdiv_q_si(c, c, b);
+        }
+
         mpz_fdiv_q(f, d, e);
 
         fmpz_get_mpz(g, c);
 
-        result = (mpz_cmp(f, g) == 0);
+        result = (mpz_cmp(f, g) == 0) && _fmpz_is_canonical(c);
         if (!result)
         {
             flint_printf("FAIL (1):\n");
@@ -61,48 +68,6 @@ main(void)
 
         fmpz_clear(a);
         fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        slong b;
-        fmpz_t a;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        b = z_randtest_not_zero(state);
-
-        fmpz_get_mpz(d, a);
-        flint_mpz_set_si(e, b);
-
-        fmpz_fdiv_q_si(a, a, b);
-        mpz_fdiv_q(f, d, e);
-
-        fmpz_get_mpz(g, a);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL (2):\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-fdiv_q_ui.c
+++ b/src/fmpz/test/t-fdiv_q_ui.c
@@ -23,8 +23,6 @@ main(void)
     flint_printf("fdiv_q_ui....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         ulong b;
@@ -45,12 +43,21 @@ main(void)
         fmpz_get_mpz(d, a);
         flint_mpz_set_ui(e, b);
 
-        fmpz_fdiv_q_ui(c, a, b);
+        if (n_randint(state, 2))
+        {
+            fmpz_fdiv_q_ui(c, a, b);
+        }
+        else /* test aliasing */
+        {
+            fmpz_set(c, a);
+            fmpz_fdiv_q_ui(c, c, b);
+        }
+
         mpz_fdiv_q(f, d, e);
 
         fmpz_get_mpz(g, c);
 
-        result = (mpz_cmp(f, g) == 0);
+        result = (mpz_cmp(f, g) == 0) && _fmpz_is_canonical(c);
         if (!result)
         {
             flint_printf("FAIL (1):\n");
@@ -61,48 +68,6 @@ main(void)
 
         fmpz_clear(a);
         fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        ulong b;
-        fmpz_t a;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        b = n_randtest_not_zero(state);
-
-        fmpz_get_mpz(d, a);
-        flint_mpz_set_ui(e, b);
-
-        fmpz_fdiv_q_ui(a, a, b);
-        mpz_fdiv_q(f, d, e);
-
-        fmpz_get_mpz(g, a);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL (2):\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-fdiv_qr.c
+++ b/src/fmpz/test/t-fdiv_qr.c
@@ -22,12 +22,11 @@ main(void)
     flint_printf("fdiv_qr....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b, c, r;
         mpz_t d, e, f, g, h, s;
+        int aliasing;
 
         fmpz_init(a);
         fmpz_init(b);
@@ -41,237 +40,45 @@ main(void)
         mpz_init(h);
         mpz_init(s);
 
-        fmpz_randbits(a, state, 1000);
-        do {
-           fmpz_randbits(b, state, 500);
-        } while(fmpz_is_zero(b));
+        fmpz_randtest(a, state, 200);
+        fmpz_randtest_not_zero(b, state, 200);
 
         fmpz_get_mpz(d, a);
         fmpz_get_mpz(e, b);
 
-        fmpz_fdiv_qr(c, r, a, b);
+        aliasing = n_randint(state, 5);
+
+        if (aliasing == 0)
+        {
+            fmpz_fdiv_qr(c, r, a, b);
+        }
+        else if (aliasing == 1)
+        {
+            fmpz_set(c, a);
+            fmpz_fdiv_qr(c, r, c, b);
+        }
+        else if (aliasing == 2)
+        {
+            fmpz_set(c, b);
+            fmpz_fdiv_qr(c, r, a, c);
+        }
+        else if (aliasing == 3)
+        {
+            fmpz_set(r, a);
+            fmpz_fdiv_qr(c, r, r, b);
+        }
+        else
+        {
+            fmpz_set(r, b);
+            fmpz_fdiv_qr(c, r, a, r);
+        }
+
         mpz_fdiv_qr(f, s, d, e);
 
         fmpz_get_mpz(g, c);
         fmpz_get_mpz(h, r);
 
-        result = (mpz_cmp(f, g) == 0 && mpz_cmp(h, s) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf
-                ("d = %Zd, e = %Zd, f = %Zd, g = %Zd, h = %Zd, s = %Zd\n", d,
-                 e, f, g, h, s);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-        fmpz_clear(r);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-        mpz_clear(h);
-        mpz_clear(s);
-    }
-
-    /* Check aliasing of c and a */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, c, r;
-        mpz_t d, e, f, g, h, s;
-
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-        fmpz_init(r);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-        mpz_init(h);
-        mpz_init(s);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_fdiv_qr(a, r, a, b);
-        mpz_fdiv_qr(f, s, d, e);
-
-        fmpz_get_mpz(g, a);
-        fmpz_get_mpz(h, r);
-
-        result = (mpz_cmp(f, g) == 0 && mpz_cmp(h, s) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf
-                ("d = %Zd, e = %Zd, f = %Zd, g = %Zd, h = %Zd, s = %Zd\n", d,
-                 e, f, g, h, s);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-        fmpz_clear(r);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-        mpz_clear(h);
-        mpz_clear(s);
-    }
-
-    /* Check aliasing of c and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, c, r;
-        mpz_t d, e, f, g, h, s;
-
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-        fmpz_init(r);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-        mpz_init(h);
-        mpz_init(s);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_fdiv_qr(b, r, a, b);
-        mpz_fdiv_qr(f, s, d, e);
-
-        fmpz_get_mpz(g, b);
-        fmpz_get_mpz(h, r);
-
-        result = (mpz_cmp(f, g) == 0 && mpz_cmp(h, s) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf
-                ("d = %Zd, e = %Zd, f = %Zd, g = %Zd, h = %Zd, s = %Zd\n", d,
-                 e, f, g, h, s);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-        fmpz_clear(r);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-        mpz_clear(h);
-        mpz_clear(s);
-    }
-
-    /* Check aliasing of r and a */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, c, r;
-        mpz_t d, e, f, g, h, s;
-
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-        fmpz_init(r);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-        mpz_init(h);
-        mpz_init(s);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_fdiv_qr(c, a, a, b);
-        mpz_fdiv_qr(f, s, d, e);
-
-        fmpz_get_mpz(g, c);
-        fmpz_get_mpz(h, a);
-
-        result = (mpz_cmp(f, g) == 0 && mpz_cmp(h, s) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf
-                ("d = %Zd, e = %Zd, f = %Zd, g = %Zd, h = %Zd, s = %Zd\n", d,
-                 e, f, g, h, s);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-        fmpz_clear(r);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-        mpz_clear(h);
-        mpz_clear(s);
-    }
-
-    /* Check aliasing of r and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, c, r;
-        mpz_t d, e, f, g, h, s;
-
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-        fmpz_init(r);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-        mpz_init(h);
-        mpz_init(s);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_fdiv_qr(c, b, a, b);
-        mpz_fdiv_qr(f, s, d, e);
-
-        fmpz_get_mpz(g, c);
-        fmpz_get_mpz(h, b);
-
-        result = (mpz_cmp(f, g) == 0 && mpz_cmp(h, s) == 0);
+        result = (mpz_cmp(f, g) == 0 && mpz_cmp(h, s) == 0) && _fmpz_is_canonical(c) && _fmpz_is_canonical(r);
         if (!result)
         {
             flint_printf("FAIL:\n");

--- a/src/fmpz/test/t-fdiv_qr_preinvn.c
+++ b/src/fmpz/test/t-fdiv_qr_preinvn.c
@@ -22,13 +22,12 @@ main(void)
     flint_printf("fdiv_qr_preinvn....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b, c, r;
         mpz_t d, e, f, g, h, s;
         fmpz_preinvn_t inv;
+        int aliasing;
 
         fmpz_init(a);
         fmpz_init(b);
@@ -49,239 +48,38 @@ main(void)
         fmpz_get_mpz(e, b);
 
         fmpz_preinvn_init(inv, b);
-        fmpz_fdiv_qr_preinvn(c, r, a, b, inv);
+
+        aliasing = n_randint(state, 5);
+
+        if (aliasing == 0)
+        {
+            fmpz_fdiv_qr_preinvn(c, r, a, b, inv);
+        }
+        else if (aliasing == 1)
+        {
+            fmpz_set(c, a);
+            fmpz_fdiv_qr_preinvn(c, r, c, b, inv);
+        }
+        else if (aliasing == 2)
+        {
+            fmpz_set(c, b);
+            fmpz_fdiv_qr_preinvn(c, r, a, c, inv);
+        }
+        else if (aliasing == 3)
+        {
+            fmpz_set(r, a);
+            fmpz_fdiv_qr_preinvn(c, r, r, b, inv);
+        }
+        else
+        {
+            fmpz_set(r, b);
+            fmpz_fdiv_qr_preinvn(c, r, a, r, inv);
+        }
+
         mpz_fdiv_qr(f, s, d, e);
 
         fmpz_get_mpz(g, c);
         fmpz_get_mpz(h, r);
-
-        result = (mpz_cmp(f, g) == 0 && mpz_cmp(h, s) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf
-                ("d = %Zd, e = %Zd, f = %Zd, g = %Zd, h = %Zd, s = %Zd\n", d,
-                 e, f, g, h, s);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_preinvn_clear(inv);
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-        fmpz_clear(r);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-        mpz_clear(h);
-        mpz_clear(s);
-    }
-
-    /* Check aliasing of c and a */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, c, r;
-        mpz_t d, e, f, g, h, s;
-        fmpz_preinvn_t inv;
-
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-        fmpz_init(r);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-        mpz_init(h);
-        mpz_init(s);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_preinvn_init(inv, b);
-        fmpz_fdiv_qr_preinvn(a, r, a, b, inv);
-        mpz_fdiv_qr(f, s, d, e);
-
-        fmpz_get_mpz(g, a);
-        fmpz_get_mpz(h, r);
-
-        result = (mpz_cmp(f, g) == 0 && mpz_cmp(h, s) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf
-                ("d = %Zd, e = %Zd, f = %Zd, g = %Zd, h = %Zd, s = %Zd\n", d,
-                 e, f, g, h, s);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_preinvn_clear(inv);
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-        fmpz_clear(r);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-        mpz_clear(h);
-        mpz_clear(s);
-    }
-
-    /* Check aliasing of c and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, c, r;
-        mpz_t d, e, f, g, h, s;
-        fmpz_preinvn_t inv;
-
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-        fmpz_init(r);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-        mpz_init(h);
-        mpz_init(s);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_preinvn_init(inv, b);
-        fmpz_fdiv_qr_preinvn(b, r, a, b, inv);
-        mpz_fdiv_qr(f, s, d, e);
-
-        fmpz_get_mpz(g, b);
-        fmpz_get_mpz(h, r);
-
-        result = (mpz_cmp(f, g) == 0 && mpz_cmp(h, s) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf
-                ("d = %Zd, e = %Zd, f = %Zd, g = %Zd, h = %Zd, s = %Zd\n", d,
-                 e, f, g, h, s);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_preinvn_clear(inv);
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-        fmpz_clear(r);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-        mpz_clear(h);
-        mpz_clear(s);
-    }
-
-    /* Check aliasing of r and a */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, c, r;
-        mpz_t d, e, f, g, h, s;
-        fmpz_preinvn_t inv;
-
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-        fmpz_init(r);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-        mpz_init(h);
-        mpz_init(s);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_preinvn_init(inv, b);
-        fmpz_fdiv_qr_preinvn(c, a, a, b, inv);
-        mpz_fdiv_qr(f, s, d, e);
-
-        fmpz_get_mpz(g, c);
-        fmpz_get_mpz(h, a);
-
-        result = (mpz_cmp(f, g) == 0 && mpz_cmp(h, s) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf
-                ("d = %Zd, e = %Zd, f = %Zd, g = %Zd, h = %Zd, s = %Zd\n", d,
-                 e, f, g, h, s);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_preinvn_clear(inv);
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-        fmpz_clear(r);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-        mpz_clear(h);
-        mpz_clear(s);
-    }
-
-    /* Check aliasing of r and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, c, r;
-        mpz_t d, e, f, g, h, s;
-        fmpz_preinvn_t inv;
-
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-        fmpz_init(r);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-        mpz_init(h);
-        mpz_init(s);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_preinvn_init(inv, b);
-        fmpz_fdiv_qr_preinvn(c, b, a, b, inv);
-        mpz_fdiv_qr(f, s, d, e);
-
-        fmpz_get_mpz(g, c);
-        fmpz_get_mpz(h, b);
 
         result = (mpz_cmp(f, g) == 0 && mpz_cmp(h, s) == 0);
         if (!result)

--- a/src/fmpz/test/t-fdiv_r.c
+++ b/src/fmpz/test/t-fdiv_r.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2009 William Hart
+    Copyright (C) 2010 Sebastian Pancratz
 
     This file is part of FLINT.
 
@@ -22,12 +23,11 @@ main(void)
     flint_printf("fdiv_r....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b, c;
         mpz_t d, e, f, g;
+        int aliasing;
 
         fmpz_init(a);
         fmpz_init(b);
@@ -44,12 +44,34 @@ main(void)
         fmpz_get_mpz(d, a);
         fmpz_get_mpz(e, b);
 
-        fmpz_fdiv_r(c, a, b);
+        aliasing = n_randint(state, 4);
+
+        if (aliasing == 0)
+        {
+            fmpz_fdiv_r(c, a, b);
+        }
+        else if (aliasing == 1)
+        {
+            fmpz_set(a, b);
+            mpz_set(d, e);
+            fmpz_fdiv_r(c, a, a);
+        }
+        else if (aliasing == 2)
+        {
+            fmpz_set(c, a);
+            fmpz_fdiv_r(c, c, b);
+        }
+        else
+        {
+            fmpz_set(c, b);
+            fmpz_fdiv_r(c, a, c);
+        }
+
         mpz_fdiv_r(f, d, e);
 
         fmpz_get_mpz(g, c);
 
-        result = (mpz_cmp(f, g) == 0);
+        result = (mpz_cmp(f, g) == 0) && _fmpz_is_canonical(c);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -61,131 +83,6 @@ main(void)
         fmpz_clear(a);
         fmpz_clear(b);
         fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, c;
-        mpz_t d, f, g;
-
-        fmpz_init(a);
-        fmpz_init(c);
-
-        mpz_init(d);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest_not_zero(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-
-        fmpz_fdiv_r(c, a, a);
-        mpz_fdiv_r(f, d, d);
-
-        fmpz_get_mpz(g, c);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, f = %Zd, g = %Zd\n", d, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_fdiv_r(a, a, b);
-        mpz_fdiv_r(f, d, e);
-
-        fmpz_get_mpz(g, a);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of b and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_fdiv_r(b, a, b);
-        mpz_fdiv_r(f, d, e);
-
-        fmpz_get_mpz(g, b);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-fdiv_r_2exp.c
+++ b/src/fmpz/test/t-fdiv_r_2exp.c
@@ -1,6 +1,5 @@
 /*
-    Copyright (C) 2009 William Hart
-    Copyright (C) 2011 Sebastian Pancratz
+    Copyright (C) 2020 Daniel Schultz
 
     This file is part of FLINT.
 
@@ -23,8 +22,6 @@ main(void)
     flint_printf("fdiv_r_2exp....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b;
@@ -43,15 +40,24 @@ main(void)
         fmpz_get_mpz(d, a);
         x = n_randint(state, 200);
 
-        fmpz_fdiv_r_2exp(b, a, x);
+        if (n_randint(state, 2))
+        {
+            fmpz_fdiv_r_2exp(b, a, x);
+        }
+        else
+        {
+            fmpz_set(b, a);
+            fmpz_fdiv_r_2exp(b, b, x);
+        }
+
         mpz_fdiv_r_2exp(e, d, x);
 
         fmpz_get_mpz(f, b);
 
-        result = (mpz_cmp(e, f) == 0);
+        result = (mpz_cmp(e, f) == 0) && _fmpz_is_canonical(b);
         if (!result)
         {
-            flint_printf("FAIL:\n");
+            flint_printf("FAIL 1:\n");
             gmp_printf("d = %Zd, e = %Zd, f = %Zd, exp = %Mu\n", d, e, f, x);
             fflush(stdout);
             flint_abort();
@@ -59,45 +65,6 @@ main(void)
 
         fmpz_clear(a);
         fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a;
-        mpz_t d, e, f;
-        ulong x;
-
-        fmpz_init(a);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-        x = n_randint(state, 200);
-
-        fmpz_fdiv_r_2exp(a, a, x);
-        mpz_fdiv_r_2exp(e, d, x);
-
-        fmpz_get_mpz(f, a);
-
-        result = (mpz_cmp(e, f) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, exp = %Mu\n", d, e, f, x);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-fdiv_ui.c
+++ b/src/fmpz/test/t-fdiv_ui.c
@@ -23,8 +23,6 @@ main(void)
     flint_printf("fdiv_ui....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a;
@@ -42,7 +40,7 @@ main(void)
         r1 = fmpz_fdiv_ui(a, x);
         r2 = flint_mpz_fdiv_ui(b, x);
 
-        result = (r1 == r2);
+        result = (r1 == r2) && _fmpz_is_canonical(a);
         if (!result)
         {
             flint_printf("FAIL:\n");

--- a/src/fmpz/test/t-fib_ui.c
+++ b/src/fmpz/test/t-fib_ui.c
@@ -40,7 +40,7 @@ main(void)
             fmpz_fib_ui(z, i+2);
             fmpz_add(w, x, y);
 
-            if (!fmpz_equal(w, z))
+            if (!fmpz_equal(w, z) || !_fmpz_is_canonical(x))
             {
                 flint_printf("FAIL: %wd\n", i);
                 fmpz_print(x);

--- a/src/fmpz/test/t-fmma.c
+++ b/src/fmpz/test/t-fmma.c
@@ -51,7 +51,7 @@ main(void)
         fmpz_mul(g, a, b);
         fmpz_addmul(g, c, d);
 
-        if (!fmpz_equal(f, g))
+        if (!fmpz_equal(f, g) || !_fmpz_is_canonical(f))
         {
             flint_printf("FAIL:\n");
             fmpz_print(a); flint_printf("\n");

--- a/src/fmpz/test/t-fmms.c
+++ b/src/fmpz/test/t-fmms.c
@@ -51,7 +51,7 @@ main(void)
         fmpz_mul(g, a, b);
         fmpz_submul(g, c, d);
 
-        if (!fmpz_equal(f, g))
+        if (!fmpz_equal(f, g) || !_fmpz_is_canonical(f))
         {
             flint_printf("FAIL:\n");
             fmpz_print(a); flint_printf("\n");

--- a/src/fmpz/test/t-fmpz_stress.c
+++ b/src/fmpz/test/t-fmpz_stress.c
@@ -147,7 +147,7 @@ main(void)
             fmpz_set_ui(check, n);
             fmpz_mul_ui(check, check, n - 1);
             fmpz_mul_2exp(check, check, 99);
-            if (!fmpz_equal(total, check))
+            if (!fmpz_equal(total, check) || !_fmpz_is_canonical(total))
             {
                 flint_printf("FAIL:\n");
                 flint_printf("total: "); fmpz_print(total); flint_printf("\n");

--- a/src/fmpz/test/t-gcd.c
+++ b/src/fmpz/test/t-gcd.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2009 William Hart
+    Copyright (C) 2011 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -22,12 +23,11 @@ main(void)
     flint_printf("gcd....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b, c;
         mpz_t d, e, f, g;
+        int aliasing;
 
         fmpz_init(a);
         fmpz_init(b);
@@ -46,148 +46,35 @@ main(void)
         fmpz_get_mpz(d, a);
         fmpz_get_mpz(e, b);
 
-        fmpz_gcd(c, a, b);
+        aliasing = n_randint(state, 4);
+
+        if (aliasing == 0)
+        {
+            fmpz_gcd(c, a, b);
+        }
+        else if (aliasing == 1)
+        {
+            fmpz_set(a, b);
+            mpz_set(d, e);
+            fmpz_gcd(c, a, a);
+        }
+        else if (aliasing == 2)
+        {
+            fmpz_set(c, a);
+            fmpz_gcd(c, c, b);
+        }
+        else
+        {
+            fmpz_set(c, b);
+            fmpz_gcd(c, a, c);
+        }
+
         mpz_gcd(f, d, e);
 
         fmpz_get_mpz(g, c);
 
         result = (mpz_cmp(f, g) == 0);
 
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, c;
-        mpz_t d, f, g;
-
-        fmpz_init(a);
-        fmpz_init(c);
-
-        mpz_init(d);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-
-        fmpz_gcd(c, a, a);
-        mpz_gcd(f, d, d);
-
-        fmpz_get_mpz(g, c);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, f = %Zd, g = %Zd\n", d, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, c;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest(b, state, 200);
-        fmpz_randtest(c, state, 200);
-        fmpz_mul(a, a, c);
-        fmpz_mul(b, b, c);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_gcd(a, a, b);
-        mpz_gcd(f, d, e);
-
-        fmpz_get_mpz(g, a);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of b and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, c;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest(b, state, 200);
-        fmpz_randtest(c, state, 200);
-        fmpz_mul(a, a, c);
-        fmpz_mul(b, b, c);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_gcd(b, a, b);
-        mpz_gcd(f, d, e);
-
-        fmpz_get_mpz(g, b);
-
-        result = (mpz_cmp(f, g) == 0);
         if (!result)
         {
             flint_printf("FAIL:\n");

--- a/src/fmpz/test/t-gcd_ui.c
+++ b/src/fmpz/test/t-gcd_ui.c
@@ -37,9 +37,18 @@ main(void)
         fmpz_set_ui(fb, b);
 
         fmpz_gcd(r1, a, fb);
-        fmpz_gcd_ui(r2, a, b);
 
-        result = (fmpz_cmp(r1, r2) == 0);
+        if (n_randint(state, 2))
+        {
+            fmpz_gcd_ui(r2, a, b);
+        }
+        else
+        {
+            fmpz_set(r2, a);
+            fmpz_gcd_ui(r2, r2, b);
+        }
+
+        result = (fmpz_cmp(r1, r2) == 0) && _fmpz_is_canonical(r2);
 
         if (!result)
         {
@@ -58,43 +67,6 @@ main(void)
 
         fmpz_clear(r1);
         fmpz_clear(r2);
-        fmpz_clear(a);
-        fmpz_clear(fb);
-    }
-
-    /* Check aliasing of res and a */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t r, a, fb;
-        ulong b;
-
-        fmpz_init(r);
-        fmpz_init(a);
-        fmpz_init(fb);
-
-        fmpz_randtest(a, state, 200);
-        b = n_randtest(state);
-        fmpz_set_ui(fb, b);
-
-        fmpz_gcd(r, a, fb);
-        fmpz_gcd_ui(a, a, b);
-
-        result = (fmpz_cmp(r, a) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            flint_printf("Aliasing with res and a.\n");
-            flint_printf("a = ");
-            fmpz_print(a);
-            flint_printf("\nb = %wu", b);
-            flint_printf("\nr = ");
-            fmpz_print(r);
-            flint_printf("\n");
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(r);
         fmpz_clear(a);
         fmpz_clear(fb);
     }

--- a/src/fmpz/test/t-gcdinv.c
+++ b/src/fmpz/test/t-gcdinv.c
@@ -21,137 +21,11 @@ int main(void)
    flint_printf("gcdinv....");
    fflush(stdout);
 
-   /* Test aliasing of d and f, a and g */
-   for (i = 0; i < 1000 * flint_test_multiplier(); i++)
-   {
-      fmpz_t d, a, f, g, F, G;
-
-      fmpz_init(d);
-      fmpz_init(a);
-      fmpz_init(f);
-      fmpz_init(g);
-      fmpz_init(F);
-      fmpz_init(G);
-
-      fmpz_randtest_unsigned(G, state, 200);
-      fmpz_add_ui(G, G, 1);
-      fmpz_randm(F, state, G);
-      fmpz_set(f, F);
-      fmpz_set(g, G);
-
-      fmpz_gcdinv(d, a, f, g);
-      fmpz_gcdinv(f, g, f, g);
-
-      result = (fmpz_equal(d, f) && (fmpz_equal(a, g) || fmpz_is_zero(F)));
-      if (!result)
-      {
-         flint_printf("FAIL:\n\n");
-         flint_printf("d = "), fmpz_print(d), flint_printf("\n");
-         flint_printf("a = "), fmpz_print(a), flint_printf("\n");
-         flint_printf("f = "), fmpz_print(f), flint_printf("\n");
-         flint_printf("g = "), fmpz_print(g), flint_printf("\n");
-         flint_printf("F = "), fmpz_print(F), flint_printf("\n");
-         flint_printf("G = "), fmpz_print(G), flint_printf("\n");
-         fflush(stdout);
-         flint_abort();
-      }
-
-      fmpz_clear(d);
-      fmpz_clear(a);
-      fmpz_clear(f);
-      fmpz_clear(g);
-      fmpz_clear(F);
-      fmpz_clear(G);
-   }
-
-   /* Test aliasing of a and f, d and g */
-   for (i = 0; i < 1000 * flint_test_multiplier(); i++)
-   {
-      fmpz_t d, a, f, g, F, G;
-
-      fmpz_init(d);
-      fmpz_init(a);
-      fmpz_init(f);
-      fmpz_init(g);
-      fmpz_init(F);
-      fmpz_init(G);
-
-      fmpz_randtest_unsigned(G, state, 200);
-      fmpz_add_ui(G, G, 1);
-      fmpz_randm(F, state, G);
-      fmpz_set(f, F);
-      fmpz_set(g, G);
-
-      fmpz_gcdinv(d, a, f, g);
-      fmpz_gcdinv(g, f, f, g);
-
-      result = (fmpz_equal(d, g) && (fmpz_equal(a, f) || fmpz_is_zero(F)));
-      if (!result)
-      {
-         flint_printf("FAIL:\n\n");
-         flint_printf("d = "), fmpz_print(d), flint_printf("\n");
-         flint_printf("a = "), fmpz_print(a), flint_printf("\n");
-         flint_printf("f = "), fmpz_print(f), flint_printf("\n");
-         flint_printf("g = "), fmpz_print(g), flint_printf("\n");
-         flint_printf("F = "), fmpz_print(F), flint_printf("\n");
-         flint_printf("G = "), fmpz_print(G), flint_printf("\n");
-         fflush(stdout);
-         flint_abort();
-      }
-
-      fmpz_clear(d);
-      fmpz_clear(a);
-      fmpz_clear(f);
-      fmpz_clear(g);
-      fmpz_clear(F);
-      fmpz_clear(G);
-   }
-
-   /* Test a f == d mod g (generically d == 1) */
-   for (i = 0; i < 1000 * flint_test_multiplier(); i++)
-   {
-      fmpz_t d, a, f, g, t;
-
-      fmpz_init(d);
-      fmpz_init(a);
-      fmpz_init(f);
-      fmpz_init(g);
-      fmpz_init(t);
-
-      fmpz_randtest_unsigned(g, state, 200);
-      fmpz_add_ui(g, g, 1);
-      fmpz_randm(f, state, g);
-
-      fmpz_gcdinv(d, a, f, g);
-
-      fmpz_mul(t, a, f);
-      fmpz_mod(t, t, g);
-
-      result = ((fmpz_equal(t, d) || fmpz_is_zero(f)) &&
-		fmpz_cmp_ui(a, 0) >= 0 && fmpz_cmp(a, g) < 0);
-      if (!result)
-      {
-         flint_printf("FAIL:\n\n");
-         flint_printf("d = "), fmpz_print(d), flint_printf("\n");
-         flint_printf("a = "), fmpz_print(a), flint_printf("\n");
-         flint_printf("f = "), fmpz_print(f), flint_printf("\n");
-         flint_printf("g = "), fmpz_print(g), flint_printf("\n");
-         flint_printf("t = "), fmpz_print(t), flint_printf("\n");
-         fflush(stdout);
-         flint_abort();
-      }
-
-      fmpz_clear(d);
-      fmpz_clear(a);
-      fmpz_clear(f);
-      fmpz_clear(g);
-      fmpz_clear(t);
-   }
-
    /* Test a f == d mod g (specifically d > 1) */
    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
    {
       fmpz_t d, a, f, g, t, x;
+      int aliasing = n_randint(state, 5);
 
       fmpz_init(d);
       fmpz_init(a);
@@ -168,13 +42,37 @@ int main(void)
       fmpz_mul(f, f, x);
       fmpz_mul(g, g, x);
 
-      fmpz_gcdinv(d, a, f, g);
+      if (aliasing == 0)
+      {
+          fmpz_gcdinv(d, a, f, g);
+      }
+      else if (aliasing == 1)
+      {
+          fmpz_set(d, f);
+          fmpz_gcdinv(d, a, d, g);
+      }
+      else if (aliasing == 2)
+      {
+          fmpz_set(a, g);
+          fmpz_gcdinv(d, a, f, a);
+      }
+      else if (aliasing == 3)
+      {
+          fmpz_set(a, f);
+          fmpz_gcdinv(d, a, a, g);
+      }
+      else
+      {
+          fmpz_set(d, g);
+          fmpz_gcdinv(d, a, f, d);
+      }
 
       fmpz_mul(t, a, f);
       fmpz_mod(t, t, g);
 
       result = ((fmpz_equal(t, d) || fmpz_is_zero(f)) &&
-	           fmpz_cmp_ui(a, 0) >= 0 && fmpz_cmp(a, g) < 0);
+	           fmpz_cmp_ui(a, 0) >= 0 && fmpz_cmp(a, g) < 0)
+                && _fmpz_is_canonical(d) && _fmpz_is_canonical(a);
       if (!result)
       {
          flint_printf("FAIL:\n\n");

--- a/src/fmpz/test/t-get_mpz.c
+++ b/src/fmpz/test/t-get_mpz.c
@@ -46,7 +46,7 @@ main(void)
         fmpz_set_mpz(a, b);
         fmpz_get_mpz(c, a);
 
-        result = (mpz_cmp(b, c) == 0);
+        result = (mpz_cmp(b, c) == 0) && _fmpz_is_canonical(a);
         if (!result)
         {
             flint_printf("FAIL:\n");

--- a/src/fmpz/test/t-get_set_ui_array.c
+++ b/src/fmpz/test/t-get_set_ui_array.c
@@ -54,7 +54,7 @@ main(void)
             fmpz_add_ui(c, c, limbs[j]);
         }
 
-        if (!fmpz_equal(a, b))
+        if (!fmpz_equal(a, b) || !_fmpz_is_canonical(b))
         {
             flint_printf("FAIL:\n");
             flint_printf("Check get and set are inverse\n");

--- a/src/fmpz/test/t-get_si.c
+++ b/src/fmpz/test/t-get_si.c
@@ -75,7 +75,7 @@ main(void)
         fmpz_set_si(a, b);
         c = fmpz_get_si(a);
 
-        result = (b == c);
+        result = (b == c) && _fmpz_is_canonical(a);
         if (!result)
         {
             flint_printf("FAIL:\n");

--- a/src/fmpz/test/t-get_ui.c
+++ b/src/fmpz/test/t-get_ui.c
@@ -35,7 +35,7 @@ main(void)
         fmpz_set_ui(a, b);
         c = fmpz_get_ui(a);
 
-        result = (b == c);
+        result = (b == c) && _fmpz_is_canonical(a);
 
         if (!result)
         {

--- a/src/fmpz/test/t-init_set.c
+++ b/src/fmpz/test/t-init_set.c
@@ -22,8 +22,6 @@ main(void)
     flint_printf("init_set....");
     fflush(stdout);
 
-
-
     /* Small integers */
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
@@ -33,7 +31,7 @@ main(void)
         fmpz_randtest(a, state, SMALL_FMPZ_BITCOUNT_MAX);
         fmpz_init_set(b, a);
 
-        result = fmpz_equal(a, b);
+        result = fmpz_equal(a, b) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL:\n\n");
@@ -56,7 +54,7 @@ main(void)
         fmpz_randtest(a, state, 2 * FLINT_BITS);
         fmpz_init_set(b, a);
 
-        result = fmpz_equal(a, b);
+        result = fmpz_equal(a, b) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL:\n\n");

--- a/src/fmpz/test/t-init_set_readonly.c
+++ b/src/fmpz/test/t-init_set_readonly.c
@@ -82,7 +82,7 @@ int main(void)
             fmpz_init(h);
             fmpz_set_mpz(h, z);
 
-            if (!fmpz_equal(g, h))
+            if (!fmpz_equal(g, h) || !_fmpz_is_canonical(h))
             {
                 flint_printf("FAIL:\n\n");
                 flint_printf("g = "), fmpz_print(g), flint_printf("\n");

--- a/src/fmpz/test/t-init_set_ui.c
+++ b/src/fmpz/test/t-init_set_ui.c
@@ -22,8 +22,6 @@ main(void)
     flint_printf("init_set_ui....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b;
@@ -33,7 +31,7 @@ main(void)
         fmpz_set_ui(a, x);
         fmpz_init_set_ui(b, x);
 
-        result = fmpz_equal(a, b);
+        result = fmpz_equal(a, b) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL:\n\n");

--- a/src/fmpz/test/t-invmod.c
+++ b/src/fmpz/test/t-invmod.c
@@ -35,13 +35,12 @@ main(void)
     flint_printf("invmod....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b, c;
         mpz_t d, e, f, g;
         int r1, r2;
+        int aliasing;
 
         fmpz_init(a);
         fmpz_init(b);
@@ -58,12 +57,35 @@ main(void)
         fmpz_get_mpz(d, a);
         fmpz_get_mpz(e, b);
 
-        r1 = fmpz_invmod(c, a, b);
+        aliasing = n_randint(state, 4);
+
+        if (aliasing == 0)
+        {
+            r1 = fmpz_invmod(c, a, b);
+        }
+        else if (aliasing == 1)
+        {
+            fmpz_set(a, b);
+            mpz_set(d, e);
+            r1 = fmpz_invmod(c, a, a);
+        }
+        else if (aliasing == 2)
+        {
+            fmpz_set(c, a);
+            r1 = fmpz_invmod(c, c, b);
+        }
+        else
+        {
+            fmpz_set(c, b);
+            r1 = fmpz_invmod(c, a, c);
+        }
+
         r2 = mpz_invert2(f, d, e);
 
         fmpz_get_mpz(g, c);
 
         result = (r1 != 0 && r2 != 0 && (mpz_cmp(f, g) == 0)) || (r1 == 0 && r2 == 0);
+        result = result && _fmpz_is_canonical(c);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -77,135 +99,6 @@ main(void)
         fmpz_clear(a);
         fmpz_clear(b);
         fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, c;
-        mpz_t d, f, g;
-        int r1, r2;
-
-        fmpz_init(a);
-        fmpz_init(c);
-
-        mpz_init(d);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest_not_zero(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-
-        r1 = fmpz_invmod(c, a, a);
-        r2 = mpz_invert2(f, d, d);
-
-        fmpz_get_mpz(g, c);
-
-        result = (r1 != 0 && r2 != 0 && (mpz_cmp(f, g) == 0)) || (r1 == 0 && r2 == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, f = %Zd, g = %Zd, r1 = %d, r2 = %d\n", d, f,
-                       g, r1, r2);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-        int r1, r2;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        r1 = fmpz_invmod(a, a, b);
-        r2 = mpz_invert2(f, d, e);
-
-        fmpz_get_mpz(g, a);
-
-        result = (r1 != 0 && r2 != 0 && (mpz_cmp(f, g) == 0)) || (r1 == 0 && r2 == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of b and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-        int r1, r2;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        r1 = fmpz_invmod(b, a, b);
-        r2 = mpz_invert2(f, d, e);
-
-        fmpz_get_mpz(g, b);
-
-        result = (r1 != 0 && r2 != 0 && (mpz_cmp(f, g) == 0)) || (r1 == 0 && r2 == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-lcm.c
+++ b/src/fmpz/test/t-lcm.c
@@ -23,12 +23,11 @@ main(void)
     flint_printf("lcm....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b, c;
         mpz_t d, e, f, g;
+        int aliasing;
 
         fmpz_init(a);
         fmpz_init(b);
@@ -47,148 +46,35 @@ main(void)
         fmpz_get_mpz(d, a);
         fmpz_get_mpz(e, b);
 
-        fmpz_lcm(c, a, b);
+        aliasing = n_randint(state, 4);
+
+        if (aliasing == 0)
+        {
+            fmpz_lcm(c, a, b);
+        }
+        else if (aliasing == 1)
+        {
+            fmpz_set(a, b);
+            mpz_set(d, e);
+            fmpz_lcm(c, a, a);
+        }
+        else if (aliasing == 2)
+        {
+            fmpz_set(c, a);
+            fmpz_lcm(c, c, b);
+        }
+        else
+        {
+            fmpz_set(c, b);
+            fmpz_lcm(c, a, c);
+        }
+
         mpz_lcm(f, d, e);
 
         fmpz_get_mpz(g, c);
 
         result = (mpz_cmp(f, g) == 0);
 
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, c;
-        mpz_t d, f, g;
-
-        fmpz_init(a);
-        fmpz_init(c);
-
-        mpz_init(d);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-
-        fmpz_lcm(c, a, a);
-        mpz_lcm(f, d, d);
-
-        fmpz_get_mpz(g, c);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, f = %Zd, g = %Zd\n", d, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, c;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest(b, state, 200);
-        fmpz_randtest(c, state, 200);
-        fmpz_mul(a, a, c);
-        fmpz_mul(b, b, c);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_lcm(a, a, b);
-        mpz_lcm(f, d, e);
-
-        fmpz_get_mpz(g, a);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of b and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, c;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest(b, state, 200);
-        fmpz_randtest(c, state, 200);
-        fmpz_mul(a, a, c);
-        fmpz_mul(b, b, c);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_lcm(b, a, b);
-        mpz_lcm(f, d, e);
-
-        fmpz_get_mpz(g, b);
-
-        result = (mpz_cmp(f, g) == 0);
         if (!result)
         {
             flint_printf("FAIL:\n");

--- a/src/fmpz/test/t-mod.c
+++ b/src/fmpz/test/t-mod.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2009 William Hart
+    Copyright (C) 2010 Sebastian Pancratz
 
     This file is part of FLINT.
 
@@ -22,12 +23,11 @@ main(void)
     flint_printf("mod....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b, c;
         mpz_t d, e, f, g;
+        int aliasing;
 
         fmpz_init(a);
         fmpz_init(b);
@@ -44,12 +44,34 @@ main(void)
         fmpz_get_mpz(d, a);
         fmpz_get_mpz(e, b);
 
-        fmpz_mod(c, a, b);
+        aliasing = n_randint(state, 4);
+
+        if (aliasing == 0)
+        {
+            fmpz_mod(c, a, b);
+        }
+        else if (aliasing == 1)
+        {
+            fmpz_set(a, b);
+            mpz_set(d, e);
+            fmpz_mod(c, a, a);
+        }
+        else if (aliasing == 2)
+        {
+            fmpz_set(c, a);
+            fmpz_mod(c, c, b);
+        }
+        else
+        {
+            fmpz_set(c, b);
+            fmpz_mod(c, a, c);
+        }
+
         mpz_mod(f, d, e);
 
         fmpz_get_mpz(g, c);
 
-        result = (mpz_cmp(f, g) == 0);
+        result = (mpz_cmp(f, g) == 0) && _fmpz_is_canonical(c);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -61,132 +83,6 @@ main(void)
         fmpz_clear(a);
         fmpz_clear(b);
         fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, c;
-        mpz_t d, f, g;
-
-        fmpz_init(a);
-        fmpz_init(c);
-
-        mpz_init(d);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest_not_zero(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-
-        fmpz_mod(c, a, a);
-        mpz_mod(f, d, d);
-
-        fmpz_get_mpz(g, c);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, f = %Zd, g = %Zd\n", d, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_mod(a, a, b);
-        mpz_mod(f, d, e);
-
-        fmpz_get_mpz(g, a);
-
-        result = (mpz_cmp(f, g) == 0);
-
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of b and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_mod(b, a, b);
-        mpz_mod(f, d, e);
-
-        fmpz_get_mpz(g, b);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-mod_ui.c
+++ b/src/fmpz/test/t-mod_ui.c
@@ -23,8 +23,6 @@ main(void)
     flint_printf("mod_ui....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b;
@@ -43,12 +41,21 @@ main(void)
         fmpz_get_mpz(d, a);
         x = n_randtest_not_zero(state);
 
-        r1 = fmpz_mod_ui(b, a, x);
+        if (n_randint(state, 2))
+        {
+            r1 = fmpz_mod_ui(b, a, x);
+        }
+        else
+        {
+            fmpz_set(b, a);
+            r1 = fmpz_mod_ui(b, b, x);
+        }
+
         r2 = flint_mpz_fdiv_r_ui(e, d, x);
 
         fmpz_get_mpz(f, b);
 
-        result = ((mpz_cmp(e, f) == 0) && (r1 == r2));
+        result = ((mpz_cmp(e, f) == 0) && (r1 == r2)) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -61,47 +68,6 @@ main(void)
 
         fmpz_clear(a);
         fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a;
-        mpz_t d, e, f;
-        ulong x, r1, r2;
-
-        fmpz_init(a);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-        x = n_randtest_not_zero(state);
-
-        r1 = fmpz_mod_ui(a, a, x);
-        r2 = flint_mpz_fdiv_r_ui(e, d, x);
-
-        fmpz_get_mpz(f, a);
-
-        result = ((mpz_cmp(e, f) == 0) && (r1 == r2));
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf
-                ("d = %Zd, e = %Zd, f = %Zd, x = %wu, r1 = %wu, r2 = %wu\n", d,
-                 e, f, x, r1, r2);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-mul.c
+++ b/src/fmpz/test/t-mul.c
@@ -22,12 +22,11 @@ main(void)
     flint_printf("mul....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b, c;
         mpz_t d, e, f, g;
+        int aliasing;
 
         fmpz_init(a);
         fmpz_init(b);
@@ -44,12 +43,34 @@ main(void)
         fmpz_get_mpz(d, a);
         fmpz_get_mpz(e, b);
 
-        fmpz_mul(c, a, b);
+        aliasing = n_randint(state, 4);
+
+        if (aliasing == 0)
+        {
+            fmpz_mul(c, a, b);
+        }
+        else if (aliasing == 1)
+        {
+            fmpz_set(a, b);
+            mpz_set(d, e);
+            fmpz_mul(c, a, a);
+        }
+        else if (aliasing == 2)
+        {
+            fmpz_set(c, a);
+            fmpz_mul(c, c, b);
+        }
+        else
+        {
+            fmpz_set(c, b);
+            fmpz_mul(c, a, c);
+        }
+
         mpz_mul(f, d, e);
 
         fmpz_get_mpz(g, c);
 
-        result = (mpz_cmp(f, g) == 0);
+        result = (mpz_cmp(f, g) == 0) && _fmpz_is_canonical(c);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -61,131 +82,6 @@ main(void)
         fmpz_clear(a);
         fmpz_clear(b);
         fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, c;
-        mpz_t d, f, g;
-
-        fmpz_init(a);
-        fmpz_init(c);
-
-        mpz_init(d);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-
-        fmpz_mul(c, a, a);
-        mpz_mul(f, d, d);
-
-        fmpz_get_mpz(g, c);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, f = %Zd, g = %Zd\n", d, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_mul(a, a, b);
-        mpz_mul(f, d, e);
-
-        fmpz_get_mpz(g, a);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of b and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_mul(b, a, b);
-        mpz_mul(f, d, e);
-
-        fmpz_get_mpz(g, b);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-mul2_uiui.c
+++ b/src/fmpz/test/t-mul2_uiui.c
@@ -24,8 +24,6 @@ main(void)
     flint_printf("mul2_uiui....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b;
@@ -45,13 +43,22 @@ main(void)
         x = n_randtest(state);
         y = n_randtest(state);
 
-        fmpz_mul2_uiui(b, a, x, y);
+        if (n_randint(state, 2))
+        {
+            fmpz_mul2_uiui(b, a, x, y);
+        }
+        else
+        {
+            fmpz_set(b, a);
+            fmpz_mul2_uiui(b, b, x, y);
+        }
+
         flint_mpz_mul_ui(e, d, x);
         flint_mpz_mul_ui(e, e, y);
 
         fmpz_get_mpz(f, b);
 
-        result = (mpz_cmp(e, f) == 0);
+        result = (mpz_cmp(e, f) == 0) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -63,48 +70,6 @@ main(void)
 
         fmpz_clear(a);
         fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a;
-        mpz_t d, e, f;
-        ulong x, y;
-
-        fmpz_init(a);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-        x = n_randtest(state);
-        y = n_randtest(state);
-
-        fmpz_mul2_uiui(a, a, x, y);
-        flint_mpz_mul_ui(e, d, x);
-        flint_mpz_mul_ui(e, e, y);
-
-        fmpz_get_mpz(f, a);
-
-        result = (mpz_cmp(e, f) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, x = %Mu, y = %Mu\n",
-                d, e, f, x, y);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-mul_2exp.c
+++ b/src/fmpz/test/t-mul_2exp.c
@@ -22,8 +22,6 @@ main(void)
     flint_printf("mul_2exp....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b;
@@ -42,12 +40,21 @@ main(void)
         fmpz_get_mpz(d, a);
         x = n_randint(state, 200);
 
-        fmpz_mul_2exp(b, a, x);
+        if (n_randint(state, 2))
+        {
+            fmpz_mul_2exp(b, a, x);
+        }
+        else
+        {
+            fmpz_set(b, a);
+            fmpz_mul_2exp(b, b, x);
+        }
+
         mpz_mul_2exp(e, d, x);
 
         fmpz_get_mpz(f, b);
 
-        result = (mpz_cmp(e, f) == 0);
+        result = (mpz_cmp(e, f) == 0) && _fmpz_is_canonical(b);
 
         if (!result)
         {
@@ -59,45 +66,6 @@ main(void)
 
         fmpz_clear(a);
         fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a;
-        mpz_t d, e, f;
-        ulong x;
-
-        fmpz_init(a);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-        x = n_randint(state, 200);
-
-        fmpz_mul_2exp(a, a, x);
-        mpz_mul_2exp(e, d, x);
-
-        fmpz_get_mpz(f, a);
-
-        result = (mpz_cmp(e, f) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, exp = %Mu\n", d, e, f, x);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-mul_si.c
+++ b/src/fmpz/test/t-mul_si.c
@@ -23,8 +23,6 @@ main(void)
     flint_printf("mul_si....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b;
@@ -43,12 +41,21 @@ main(void)
         fmpz_get_mpz(d, a);
         x = z_randtest(state);
 
-        fmpz_mul_si(b, a, x);
+        if (n_randint(state, 2))
+        {
+            fmpz_mul_si(b, a, x);
+        }
+        else
+        {
+            fmpz_set(b, a);
+            fmpz_mul_si(b, b, x);
+        }
+
         flint_mpz_mul_si(e, d, x);
 
         fmpz_get_mpz(f, b);
 
-        result = (mpz_cmp(e, f) == 0);
+        result = (mpz_cmp(e, f) == 0) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -59,45 +66,6 @@ main(void)
 
         fmpz_clear(a);
         fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a;
-        mpz_t d, e, f;
-        slong x;
-
-        fmpz_init(a);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-        x = z_randtest(state);
-
-        fmpz_mul_si(a, a, x);
-        flint_mpz_mul_si(e, d, x);
-
-        fmpz_get_mpz(f, a);
-
-        result = (mpz_cmp(e, f) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, x = %Md\n", d, e, f, x);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-mul_si_tdiv_q_2exp.c
+++ b/src/fmpz/test/t-mul_si_tdiv_q_2exp.c
@@ -24,8 +24,6 @@ main(void)
     flint_printf("mul_si_tdiv_q_2exp....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b;
@@ -46,13 +44,22 @@ main(void)
         x = z_randtest(state);
         exp = n_randint(state, 200);
 
-        fmpz_mul_si_tdiv_q_2exp(b, a, x, exp);
+        if (n_randint(state, 2))
+        {
+            fmpz_mul_si_tdiv_q_2exp(b, a, x, exp);
+        }
+        else
+        {
+            fmpz_set(b, a);
+            fmpz_mul_si_tdiv_q_2exp(b, b, x, exp);
+        }
+
         flint_mpz_mul_si(e, d, x);
         mpz_tdiv_q_2exp(e, e, exp);
 
         fmpz_get_mpz(f, b);
 
-        result = (mpz_cmp(e, f) == 0);
+        result = (mpz_cmp(e, f) == 0) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -64,49 +71,6 @@ main(void)
 
         fmpz_clear(a);
         fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a;
-        mpz_t d, e, f;
-        slong x;
-        ulong exp;
-
-        fmpz_init(a);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-        x = z_randtest(state);
-        exp = n_randint(state, 200);
-
-        fmpz_mul_si_tdiv_q_2exp(a, a, x, exp);
-        flint_mpz_mul_si(e, d, x);
-        mpz_tdiv_q_2exp(e, e, exp);
-
-        fmpz_get_mpz(f, a);
-
-        result = (mpz_cmp(e, f) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, x = %Md, exp = %Mu\n",
-                d, e, f, x, exp);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-mul_tdiv_q_2exp.c
+++ b/src/fmpz/test/t-mul_tdiv_q_2exp.c
@@ -23,13 +23,12 @@ main(void)
     flint_printf("mul_tdiv_q_2exp....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b, c;
         mpz_t d, e, f, g;
         ulong exp;
+        int aliasing;
 
         fmpz_init(a);
         fmpz_init(b);
@@ -47,13 +46,35 @@ main(void)
         fmpz_get_mpz(d, a);
         fmpz_get_mpz(e, b);
 
-        fmpz_mul_tdiv_q_2exp(c, a, b, exp);
+        aliasing = n_randint(state, 4);
+
+        if (aliasing == 0)
+        {
+            fmpz_mul_tdiv_q_2exp(c, a, b, exp);
+        }
+        else if (aliasing == 1)
+        {
+            fmpz_set(a, b);
+            mpz_set(d, e);
+            fmpz_mul_tdiv_q_2exp(c, a, a, exp);
+        }
+        else if (aliasing == 2)
+        {
+            fmpz_set(c, a);
+            fmpz_mul_tdiv_q_2exp(c, c, b, exp);
+        }
+        else
+        {
+            fmpz_set(c, b);
+            fmpz_mul_tdiv_q_2exp(c, a, c, exp);
+        }
+
         mpz_mul(f, d, e);
         mpz_tdiv_q_2exp(f, f, exp);
 
         fmpz_get_mpz(g, c);
 
-        result = (mpz_cmp(f, g) == 0);
+        result = (mpz_cmp(f, g) == 0) && _fmpz_is_canonical(c);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -66,139 +87,6 @@ main(void)
         fmpz_clear(a);
         fmpz_clear(b);
         fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, c;
-        mpz_t d, f, g;
-        ulong exp;
-
-        fmpz_init(a);
-        fmpz_init(c);
-
-        mpz_init(d);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        exp = n_randint(state, 200);
-        fmpz_get_mpz(d, a);
-
-        fmpz_mul_tdiv_q_2exp(c, a, a, exp);
-        mpz_mul(f, d, d);
-        mpz_tdiv_q_2exp(f, f, exp);
-
-        fmpz_get_mpz(g, c);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, f = %Zd, g = %Zd, exp = %Mu\n", d, f, g, exp);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-        ulong exp;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest(b, state, 200);
-        exp = n_randint(state, 200);
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_mul_tdiv_q_2exp(a, a, b, exp);
-        mpz_mul(f, d, e);
-        mpz_tdiv_q_2exp(f, f, exp);
-
-        fmpz_get_mpz(g, a);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd, exp = %Mu\n",
-                d, e, f, g, exp);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of b and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-        ulong exp;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest(b, state, 200);
-        exp = n_randint(state, 200);
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_mul_tdiv_q_2exp(b, a, b, exp);
-        mpz_mul(f, d, e);
-        mpz_tdiv_q_2exp(f, f, exp);
-
-        fmpz_get_mpz(g, b);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd, exp = %Mu\n",
-                d, e, f, g, exp);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-mul_ui.c
+++ b/src/fmpz/test/t-mul_ui.c
@@ -23,8 +23,6 @@ main(void)
     flint_printf("mul_ui....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b;
@@ -43,12 +41,21 @@ main(void)
         fmpz_get_mpz(d, a);
         x = n_randtest(state);
 
-        fmpz_mul_ui(b, a, x);
+        if (n_randint(state, 2))
+        {
+            fmpz_mul_ui(b, a, x);
+        }
+        else
+        {
+            fmpz_set(b, a);
+            fmpz_mul_ui(b, b, x);
+        }
+
         flint_mpz_mul_ui(e, d, x);
 
         fmpz_get_mpz(f, b);
 
-        result = (mpz_cmp(e, f) == 0);
+        result = (mpz_cmp(e, f) == 0) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -59,45 +66,6 @@ main(void)
 
         fmpz_clear(a);
         fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a;
-        mpz_t d, e, f;
-        ulong x;
-
-        fmpz_init(a);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-        x = n_randtest(state);
-
-        fmpz_mul_ui(a, a, x);
-        flint_mpz_mul_ui(e, d, x);
-
-        fmpz_get_mpz(f, a);
-
-        result = (mpz_cmp(e, f) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, x = %Mu\n", d, e, f, x);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-ndiv_qr.c
+++ b/src/fmpz/test/t-ndiv_qr.c
@@ -78,7 +78,8 @@ main(void)
         fmpz_addmul(tmp, b, nquo);
         result = ( fmpz_cmp(tmp, a) == 0
                 && fmpz_cmpabs(nrem, frem) <= 0
-                && fmpz_cmpabs(nrem, crem) <= 0);
+                && fmpz_cmpabs(nrem, crem) <= 0)
+                && _fmpz_is_canonical(nquo) && _fmpz_is_canonical(nrem);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -147,7 +148,8 @@ main(void)
         fmpz_addmul(tmp, b, nquo);
         result = ( fmpz_cmp(tmp, a) == 0
                 && fmpz_cmp(nquo, tquo) == 0
-                && fmpz_cmp(nrem, trem) == 0);
+                && fmpz_cmp(nrem, trem) == 0)
+                && _fmpz_is_canonical(nquo) && _fmpz_is_canonical(nrem);
         if (!result)
         {
             flint_printf("FAIL:\n");

--- a/src/fmpz/test/t-neg.c
+++ b/src/fmpz/test/t-neg.c
@@ -22,8 +22,6 @@ main(void)
     flint_printf("neg....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b;
@@ -39,12 +37,21 @@ main(void)
 
         fmpz_get_mpz(c, a);
 
-        fmpz_neg(b, a);
+        if (n_randint(state, 2))
+        {
+            fmpz_neg(b, a);
+        }
+        else
+        {
+            fmpz_set(b, a);
+            fmpz_neg(b, b);
+        }
+
         mpz_neg(c, c);
 
         fmpz_get_mpz(d, b);
 
-        result = (mpz_cmp(c, d) == 0);
+        result = (mpz_cmp(c, d) == 0) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -55,41 +62,6 @@ main(void)
 
         fmpz_clear(a);
         fmpz_clear(b);
-
-        mpz_clear(c);
-        mpz_clear(d);
-    }
-
-    /* Check aliasing */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a;
-        mpz_t c, d;
-
-        fmpz_init(a);
-
-        mpz_init(c);
-        mpz_init(d);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(c, a);
-
-        fmpz_neg(a, a);
-        mpz_neg(c, c);
-
-        fmpz_get_mpz(d, a);
-
-        result = (mpz_cmp(c, d) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("c = %Zd, d = %Zd\n", c, d);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
 
         mpz_clear(c);
         mpz_clear(d);

--- a/src/fmpz/test/t-neg_ui.c
+++ b/src/fmpz/test/t-neg_ui.c
@@ -39,7 +39,7 @@ main(void)
 
         fmpz_neg_ui(b, c);
 
-        result = fmpz_equal(a, b);
+        result = fmpz_equal(a, b) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL:\n");

--- a/src/fmpz/test/t-neg_uiui.c
+++ b/src/fmpz/test/t-neg_uiui.c
@@ -20,7 +20,6 @@ main(void)
 
     FLINT_TEST_INIT(state);
 
-
     flint_printf("neg_uiui....");
     fflush(stdout);
 
@@ -42,7 +41,7 @@ main(void)
 
         fmpz_neg_uiui(b, hi, lo);
 
-        result = fmpz_equal(a, b);
+        result = fmpz_equal(a, b) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL:\n");

--- a/src/fmpz/test/t-nextprime.c
+++ b/src/fmpz/test/t-nextprime.c
@@ -55,7 +55,7 @@ int main(void)
         fmpz_nextprime(actual, start, 0);
         fmpz_set_str(expected, manual_tests[i+1], 10);
 
-        if (!fmpz_equal(actual, expected))
+        if (!fmpz_equal(actual, expected) || !_fmpz_is_canonical(actual))
         {
             flint_printf("FAIL:\n");
             fmpz_print(start); flint_printf("\n");
@@ -83,7 +83,7 @@ int main(void)
         do fmpz_add_ui(iter, iter, UWORD(1));
         while (!fmpz_is_probabprime(iter));
 
-        if (!fmpz_equal(res, iter))
+        if (!fmpz_equal(res, iter) || !_fmpz_is_canonical(res))
         {
             flint_printf("FAIL:\n");
             fmpz_print(start); flint_printf("\n");

--- a/src/fmpz/test/t-or.c
+++ b/src/fmpz/test/t-or.c
@@ -22,21 +22,20 @@ main(void)
     flint_printf("or....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
-        fmpz_t a, b, c, g;
-        mpz_t d, e, f;
+        fmpz_t a, b, c;
+        mpz_t d, e, f, g;
+        int aliasing;
 
         fmpz_init(a);
         fmpz_init(b);
         fmpz_init(c);
-        fmpz_init(g);
 
         mpz_init(d);
         mpz_init(e);
         mpz_init(f);
+        mpz_init(g);
 
         fmpz_randtest(a, state, 200);
         fmpz_randtest(b, state, 200);
@@ -44,152 +43,46 @@ main(void)
         fmpz_get_mpz(d, a);
         fmpz_get_mpz(e, b);
 
-        fmpz_or(c, a, b);
-        mpz_ior(f, d, e);
+        aliasing = n_randint(state, 4);
 
-        fmpz_set_mpz(g, f);
-
-        result = (fmpz_equal(c, g));
-
-        if (!result)
+        if (aliasing == 0)
         {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = ", d, e, f); fmpz_print(g); flint_printf("\n");
-            fflush(stdout);
-            flint_abort();
+            fmpz_or(c, a, b);
+        }
+        else if (aliasing == 1)
+        {
+            fmpz_set(c, a);
+            fmpz_or(c, c, b);
+        }
+        else if (aliasing == 2)
+        {
+            fmpz_set(c, b);
+            fmpz_or(c, a, c);
+        }
+        else if (aliasing == 3)
+        {
+            fmpz_set(c, a);
+            fmpz_or(c, a, a);
+            mpz_set(e, d);
         }
 
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-        fmpz_clear(g);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, c;
-        mpz_t d, f, g;
-
-        fmpz_init(a);
-        fmpz_init(c);
-
-        mpz_init(d);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-
-        fmpz_or(c, a, a);
-        mpz_ior(f, d, d);
+        mpz_ior(f, d, e);
 
         fmpz_get_mpz(g, c);
 
-        result = (mpz_cmp(f, g) == 0);
+        result = (mpz_cmp(f, g) == 0) && _fmpz_is_canonical(c);
 
         if (!result)
         {
             flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, f = %Zd, g = %Zd\n", d, f, g);
+            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
             fflush(stdout);
             flint_abort();
         }
 
         fmpz_clear(a);
+        fmpz_clear(b);
         fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_or(a, a, b);
-        mpz_ior(f, d, e);
-
-        fmpz_get_mpz(g, a);
-
-        result = (mpz_cmp(f, g) == 0);
-
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of b and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_or(b, a, b);
-        mpz_ior(f, d, e);
-
-        fmpz_get_mpz(g, b);
-
-        result = (mpz_cmp(f, g) == 0);
-
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-out_inp_raw.c
+++ b/src/fmpz/test/t-out_inp_raw.c
@@ -116,7 +116,7 @@ int main(void)
             i = 0;
             while ( (r = fmpz_inp_raw(t, in)) != 0 )
             {
-                result = fmpz_equal(t, a + i);
+                result = fmpz_equal(t, a + i) && _fmpz_is_canonical(t);
                 if (!result)
                 {
                     printf("FAIL:\n");

--- a/src/fmpz/test/t-popcnt.c
+++ b/src/fmpz/test/t-popcnt.c
@@ -24,8 +24,6 @@ main(void)
     flint_printf("popcnt....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a;

--- a/src/fmpz/test/t-pow_ui.c
+++ b/src/fmpz/test/t-pow_ui.c
@@ -23,8 +23,6 @@ main(void)
     flint_printf("pow_ui....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b;
@@ -43,12 +41,21 @@ main(void)
         fmpz_get_mpz(d, a);
         x = n_randint(state, 20);
 
-        fmpz_pow_ui(b, a, x);
+        if (n_randint(state, 2))
+        {
+            fmpz_pow_ui(b, a, x);
+        }
+        else
+        {
+            fmpz_set(b, a);
+            fmpz_pow_ui(b, b, x);
+        }
+
         flint_mpz_pow_ui(e, d, x);
 
         fmpz_get_mpz(f, b);
 
-        result = (mpz_cmp(e, f) == 0);
+        result = (mpz_cmp(e, f) == 0) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -59,45 +66,6 @@ main(void)
 
         fmpz_clear(a);
         fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a;
-        mpz_t d, e, f;
-        ulong x;
-
-        fmpz_init(a);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-        x = n_randint(state, 20);
-
-        fmpz_pow_ui(a, a, x);
-        flint_mpz_pow_ui(e, d, x);
-
-        fmpz_get_mpz(f, a);
-
-        result = (mpz_cmp(e, f) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, x = %Mu\n", d, e, f, x);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-primorial.c
+++ b/src/fmpz/test/t-primorial.c
@@ -29,12 +29,12 @@ int main(void)
     fmpz_init(y);
     fmpz_set_ui(y, 1);
 
-    for (k = 0; k < 10000; k++)
+    for (k = 0; k < 2000; k++)
     {
        fmpz_primorial(x, k);
        if (n_is_prime(k))
           fmpz_mul_ui(y, y, k);
-       if (!fmpz_equal(x, y))
+       if (!fmpz_equal(x, y) || !_fmpz_is_canonical(x))
        {
           flint_printf("FAIL:\n");
           flint_printf("primorial of %wu disagrees with direct product\n", k);

--- a/src/fmpz/test/t-print_read.c
+++ b/src/fmpz/test/t-print_read.c
@@ -125,7 +125,7 @@ int main(void)
                     flint_abort();
                 }
 
-                result = fmpz_equal(t, a + i);
+                result = fmpz_equal(t, a + i) && _fmpz_is_canonical(t);
                 if (!result)
                 {
                     flint_printf("FAIL:\n");
@@ -222,7 +222,7 @@ int main(void)
             while (!feof(in))
             {
                 r = fmpz_fread(in, t);
-                if (r > 0)
+                if (r > 0 || !_fmpz_is_canonical(t))
                 {
                     flint_printf("FAIL:\n");
                     flint_printf("r = %d\n", r);

--- a/src/fmpz/test/t-randprime.c
+++ b/src/fmpz/test/t-randprime.c
@@ -32,7 +32,7 @@ int main(void)
 
             fmpz_randprime(p, state, bits, 1);
 
-            if (fmpz_bits(p) != bits)
+            if (fmpz_bits(p) != bits || !_fmpz_is_canonical(p))
             {
                 flint_printf("FAIL: not %wu bits\n", bits);
                 fmpz_print(p); flint_printf("\n");
@@ -70,7 +70,7 @@ int main(void)
             {
                 fmpz_randprime(p+j, state, bits, 0);
 
-                if (fmpz_bits(p+j) != bits)
+                if (fmpz_bits(p+j) != bits || !_fmpz_is_canonical(p+j))
                 {
                     flint_printf("FAIL: not %wu bits\n", bits);
                     fmpz_print(p+j); flint_printf("\n");

--- a/src/fmpz/test/t-rfac_ui.c
+++ b/src/fmpz/test/t-rfac_ui.c
@@ -22,39 +22,6 @@ main(void)
     flint_printf("rfac_ui... ");
     fflush(stdout);
 
-
-
-    /* Check aliasing */
-    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t x, r;
-        ulong a;
-
-        fmpz_init(x);
-        fmpz_init(r);
-
-        fmpz_randtest(x, state, 1 + n_randint(state, 200));
-        a = n_randint(state, 100);
-
-        fmpz_rfac_ui(r, x, a);
-        fmpz_rfac_ui(x, x, a);
-
-        result = fmpz_equal(r, x);
-
-        if (!result)
-        {
-            flint_printf("FAIL (aliasing)\n\n");
-            flint_printf("x: "); fmpz_print(x); flint_printf("\n\n");
-            flint_printf("a = %wu\n\n", a);
-            flint_printf("r: "); fmpz_print(r); flint_printf("\n\n");
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(x);
-        fmpz_clear(r);
-    }
-
     /* Check rf(x,a) * rf(x+a,b) = rf(x,a+b) */
     for (i = 0; i < 1000 * flint_test_multiplier(); i++)
     {
@@ -73,13 +40,22 @@ main(void)
         b = n_randint(state, 100);
         fmpz_add_ui(xa, x, a);
 
-        fmpz_rfac_ui(r1, x, a);
+        if (n_randint(state, 2))
+        {
+            fmpz_rfac_ui(r1, x, a);
+        }
+        else /* test aliasing */
+        {
+            fmpz_set(r1, x);
+            fmpz_rfac_ui(r1, r1, a);
+        }
+
         fmpz_rfac_ui(r2, xa, b);
         fmpz_rfac_ui(r3, x, a+b);
 
         fmpz_mul(r1r2, r1, r2);
 
-        result = fmpz_equal(r1r2, r3);
+        result = fmpz_equal(r1r2, r3) && _fmpz_is_canonical(r1) && _fmpz_is_canonical(r2) && _fmpz_is_canonical(r3);
 
         if (!result)
         {

--- a/src/fmpz/test/t-rfac_uiui.c
+++ b/src/fmpz/test/t-rfac_uiui.c
@@ -22,8 +22,6 @@ main(void)
     flint_printf("rfac_uiui... ");
     fflush(stdout);
 
-
-
     /* Check rf(x,a) * rf(x+a,b) = rf(x,a+b) */
     for (i = 0; i < 1000 * flint_test_multiplier(); i++)
     {
@@ -50,7 +48,7 @@ main(void)
 
         fmpz_mul(r1r2, r1, r2);
 
-        result = fmpz_equal(r1r2, r3);
+        result = fmpz_equal(r1r2, r3) && _fmpz_is_canonical(r1) && _fmpz_is_canonical(r2) && _fmpz_is_canonical(r3);
 
         if (!result)
         {

--- a/src/fmpz/test/t-root.c
+++ b/src/fmpz/test/t-root.c
@@ -44,12 +44,21 @@ main(void)
             fmpz_abs(g, g);
         fmpz_get_mpz(mg, g);
 
-        fmpz_root(f, g, n);
+        if (n_randint(state, 2))
+        {
+            fmpz_root(f, g, n);
+        }
+        else /* test aliasing */
+        {
+            fmpz_set(f, g);
+            fmpz_root(f, f, n);
+        }
+
         mpz_root(mf, mg, n);
 
         fmpz_get_mpz(mf2, f);
 
-        result = (mpz_cmp(mf2, mf) == 0);
+        result = (mpz_cmp(mf2, mf) == 0) && _fmpz_is_canonical(f);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -145,46 +154,6 @@ main(void)
         fmpz_clear(f);
         fmpz_clear(g);
         fmpz_clear(pow);
-    }
-
-    /* Check aliasing of f and g */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t f;
-        mpz_t mf, mf2;
-        slong n;
-
-        fmpz_init(f);
-
-        mpz_init(mf);
-        mpz_init(mf2);
-
-        n = n_randint(state, 20) + 1;
-
-        fmpz_randtest(f, state, 200);
-        if ((n & 1) == 0)
-            fmpz_abs(f, f);
-        fmpz_get_mpz(mf, f);
-
-        fmpz_root(f, f, n);
-        mpz_root(mf, mf, n);
-
-        fmpz_get_mpz(mf2, f);
-
-        result = (mpz_cmp(mf, mf2) == 0);
-
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("mf = %Zd, mf2 = %Zd, root = %Md\n", mf, mf2, n);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(f);
-
-        mpz_clear(mf);
-        mpz_clear(mf2);
     }
 
     FLINT_TEST_CLEANUP(state);

--- a/src/fmpz/test/t-set.c
+++ b/src/fmpz/test/t-set.c
@@ -48,7 +48,7 @@ main(void)
         fmpz_set(b, a);
         fmpz_get_mpz(d, b);
 
-        result = (mpz_cmp(c, d) == 0);
+        result = (mpz_cmp(c, d) == 0) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL:\n");

--- a/src/fmpz/test/t-set_d_2exp.c
+++ b/src/fmpz/test/t-set_d_2exp.c
@@ -39,7 +39,7 @@ main(void)
         fmpz_set_d_2exp(a, d, exp);
         d2 = fmpz_get_d_2exp(&exp2, a);
 
-        result = (d2 == d && exp == exp2);
+        result = (d2 == d && exp == exp2) && _fmpz_is_canonical(a);
         if (!result)
         {
             flint_printf("FAIL:\n");

--- a/src/fmpz/test/t-set_signed_ui_array.c
+++ b/src/fmpz/test/t-set_signed_ui_array.c
@@ -54,7 +54,7 @@ main(void)
         fmpz_one(c);
         fmpz_mul_2exp(c, c, n*FLINT_BITS);
 
-        if (!fmpz_divisible(a, c))
+        if (!fmpz_divisible(a, c) || !_fmpz_is_canonical(b))
         {
             flint_printf("FAIL: check answer mod 2^(n*FLINT_BITS)\n");
             fflush(stdout);

--- a/src/fmpz/test/t-set_signed_uiui.c
+++ b/src/fmpz/test/t-set_signed_uiui.c
@@ -48,7 +48,7 @@ main(void)
 
         fmpz_set_signed_uiui(b, hi, lo);
 
-        result = fmpz_equal(a, b);
+        result = fmpz_equal(a, b) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL:\n");

--- a/src/fmpz/test/t-set_signed_uiuiui.c
+++ b/src/fmpz/test/t-set_signed_uiuiui.c
@@ -51,7 +51,7 @@ main(void)
 
         fmpz_set_signed_uiuiui(b, hi, mid, lo);
 
-        result = fmpz_equal(a, b);
+        result = fmpz_equal(a, b) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL:\n");

--- a/src/fmpz/test/t-set_str.c
+++ b/src/fmpz/test/t-set_str.c
@@ -62,7 +62,7 @@ main(void)
         ret2 = mpz_set_str(b, str, base);
         fmpz_set_mpz(c, b);
 
-        if (ret1 != ret2 || (ret1 == 0 && !fmpz_equal(a, c)))
+        if (ret1 != ret2 || (ret1 == 0 && !fmpz_equal(a, c)) || !_fmpz_is_canonical(a))
         {
             flint_printf("FAIL:\n");
             flint_printf("base = %d\n", base);
@@ -108,7 +108,7 @@ main(void)
         ret2 = mpz_set_str(b, str, 10);
         fmpz_set_mpz(c, b);
 
-        if (ret1 != ret2 || !fmpz_equal(a, c))
+        if (ret1 != ret2 || !fmpz_equal(a, c) || !_fmpz_is_canonical(a))
         {
             flint_printf("FAIL:\n");
             flint_printf("str = %s\n", str);

--- a/src/fmpz/test/t-set_ui_smod.c
+++ b/src/fmpz/test/t-set_ui_smod.c
@@ -42,7 +42,7 @@ main(void)
 
         fmpz_set_ui_smod(b, r, m);
 
-        if (!fmpz_equal(a, b))
+        if (!fmpz_equal(a, b) || !_fmpz_is_canonical(b))
         {
             flint_printf("FAIL:\n");
             flint_printf("a: "); fmpz_print(a); flint_printf("\n");

--- a/src/fmpz/test/t-set_uiui.c
+++ b/src/fmpz/test/t-set_uiui.c
@@ -41,7 +41,7 @@ main(void)
 
         fmpz_set_uiui(b, hi, lo);
 
-        result = fmpz_equal(a, b);
+        result = fmpz_equal(a, b) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL:\n");

--- a/src/fmpz/test/t-setbit.c
+++ b/src/fmpz/test/t-setbit.c
@@ -25,7 +25,7 @@ main(void)
 
 
 
-    for (i = 0; i < 100000 * flint_test_multiplier(); i++)
+    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         ulong j;
         fmpz_t a, b, c;
@@ -45,7 +45,7 @@ main(void)
         mpz_setbit(z, j);
         fmpz_set_mpz(c, z);
 
-        result = (fmpz_equal(b, c));
+        result = (fmpz_equal(b, c)) && _fmpz_is_canonical(b);
 
         if (!result)
         {

--- a/src/fmpz/test/t-smod.c
+++ b/src/fmpz/test/t-smod.c
@@ -17,15 +17,16 @@
 int
 main(void)
 {
-    int i, result;
+    int i;
     FLINT_TEST_INIT(state);
 
     flint_printf("smod....");
     fflush(stdout);
 
-    for (i = 0; i < 200000 * flint_test_multiplier(); i++)
+    for (i = 0; i < 20000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b, c, d, e;
+        int aliasing;
 
         fmpz_init(a);
         fmpz_init(b);
@@ -47,11 +48,31 @@ main(void)
                 fmpz_add(a, b, b);
         }
 
-        fmpz_smod(c, a, b);
+        aliasing = n_randint(state, 4);
+
+        if (aliasing == 0)
+        {
+            fmpz_smod(c, a, b);
+        }
+        else if (aliasing == 1)
+        {
+            fmpz_set(a, b);
+            fmpz_smod(c, a, a);
+        }
+        else if (aliasing == 2)
+        {
+            fmpz_set(c, a);
+            fmpz_smod(c, c, b);
+        }
+        else
+        {
+            fmpz_set(c, b);
+            fmpz_smod(c, a, c);
+        }
 
         fmpz_sub(d, a, c);
         fmpz_mod(d, d, b);
-        if (!fmpz_is_zero(d))
+        if (!fmpz_is_zero(d) || !_fmpz_is_canonical(c))
         {
             flint_printf("FAIL: check b|(smod(a,b) - a)\n");
             flint_printf("a = "), fmpz_print(a), flint_printf("\n");
@@ -89,136 +110,6 @@ main(void)
         fmpz_clear(c);
         fmpz_clear(d);
         fmpz_clear(e);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, c, d;
-
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-        fmpz_init(d);
-
-        fmpz_randtest_not_zero(a, state, 200);
-        fmpz_set(b, a);
-
-        fmpz_smod(c, a, a);
-        fmpz_smod(d, a, b);
-
-        result = (fmpz_cmp(c, d) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            flint_printf("a = ");
-            fmpz_print(a);
-            flint_printf("\n");
-            flint_printf("b = ");
-            fmpz_print(b);
-            flint_printf("\n");
-            flint_printf("c = ");
-            fmpz_print(c);
-            flint_printf("\n");
-            flint_printf("d = ");
-            fmpz_print(d);
-            flint_printf("\n");
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-        fmpz_clear(d);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, c, d;
-
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-        fmpz_init(d);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-        fmpz_set(c, a);
-
-        fmpz_smod(a, a, b);
-        fmpz_smod(d, c, b);
-
-        result = (fmpz_cmp(a, d) == 0);
-
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            flint_printf("a = ");
-            fmpz_print(a);
-            flint_printf("\n");
-            flint_printf("b = ");
-            fmpz_print(b);
-            flint_printf("\n");
-            flint_printf("c = ");
-            fmpz_print(c);
-            flint_printf("\n");
-            flint_printf("d = ");
-            fmpz_print(d);
-            flint_printf("\n");
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-        fmpz_clear(d);
-    }
-
-    /* Test aliasing of b and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, c, d;
-
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-        fmpz_init(d);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-        fmpz_set(c, b);
-
-        fmpz_smod(b, a, b);
-        fmpz_smod(d, a, c);
-
-        result = (fmpz_cmp(b, d) == 0);
-
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            flint_printf("a = ");
-            fmpz_print(a);
-            flint_printf("\n");
-            flint_printf("b = ");
-            fmpz_print(b);
-            flint_printf("\n");
-            flint_printf("c = ");
-            fmpz_print(c);
-            flint_printf("\n");
-            flint_printf("d = ");
-            fmpz_print(d);
-            flint_printf("\n");
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-        fmpz_clear(d);
     }
 
     FLINT_TEST_CLEANUP(state);

--- a/src/fmpz/test/t-sqrt.c
+++ b/src/fmpz/test/t-sqrt.c
@@ -23,8 +23,6 @@ main(void)
     flint_printf("sqrt....");
     fflush(stdout);
 
-
-
     /* Comparison with mpz routines */
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
@@ -42,12 +40,22 @@ main(void)
         fmpz_abs(g, g);
         fmpz_get_mpz(mg, g);
 
+        if (n_randint(state, 2))
+        {
+            fmpz_sqrt(f, g);
+        }
+        else /* test aliasing */
+        {
+            fmpz_set(f, g);
+            fmpz_sqrt(f, f);
+        }
+
         fmpz_sqrt(f, g);
         mpz_sqrt(mf, mg);
 
         fmpz_get_mpz(mf2, f);
 
-        result = (mpz_cmp(mf2, mf) == 0);
+        result = (mpz_cmp(mf2, mf) == 0) && _fmpz_is_canonical(f);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -62,42 +70,6 @@ main(void)
         mpz_clear(mf);
         mpz_clear(mf2);
         mpz_clear(mg);
-    }
-
-    /* Check aliasing of f and g */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t f;
-        mpz_t mf, mf2;
-
-        fmpz_init(f);
-
-        mpz_init(mf);
-        mpz_init(mf2);
-
-        fmpz_randtest(f, state, 200);
-        fmpz_abs(f, f);
-        fmpz_get_mpz(mf, f);
-
-        fmpz_sqrt(f, f);
-        mpz_sqrt(mf, mf);
-
-        fmpz_get_mpz(mf2, f);
-
-        result = (mpz_cmp(mf, mf2) == 0);
-
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("mf = %Zd, mf2 = %Zd\n", mf, mf2);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(f);
-
-        mpz_clear(mf);
-        mpz_clear(mf2);
     }
 
     FLINT_TEST_CLEANUP(state);

--- a/src/fmpz/test/t-sqrtmod.c
+++ b/src/fmpz/test/t-sqrtmod.c
@@ -21,8 +21,6 @@ int main(void)
     flint_printf("sqrtmod....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 100 * flint_test_multiplier(); i++) /* Test random integers */
     {
         int ans;
@@ -45,7 +43,7 @@ int main(void)
         fmpz_mul(c, b, b);
         fmpz_mod(c, c, p);
 
-        result = (ans == 0 || fmpz_equal(a, c));
+        result = (ans == 0 || fmpz_equal(a, c)) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL (random):\n");
@@ -98,7 +96,7 @@ int main(void)
         fmpz_mul(d, c, c);
         fmpz_mod(d, d, p);
 
-        result = (ans && fmpz_equal(a, d));
+        result = (ans && fmpz_equal(a, d)) && _fmpz_is_canonical(c);
         if (!result)
         {
             flint_printf("FAIL (squares):\n");

--- a/src/fmpz/test/t-sqrtrem.c
+++ b/src/fmpz/test/t-sqrtrem.c
@@ -23,13 +23,12 @@ main(void)
     flint_printf("sqrtrem....");
     fflush(stdout);
 
-
-
     /* Comparison with mpz routines */
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t f, r, g;
         mpz_t mf, mf2, mr, mg;
+        int aliasing;
 
         fmpz_init(f);
         fmpz_init(r);
@@ -44,12 +43,28 @@ main(void)
         fmpz_abs(g, g);
         fmpz_get_mpz(mg, g);
 
-        fmpz_sqrtrem(f, r, g);
+        aliasing = n_randint(state, 3);
+
+        if (aliasing == 0)
+        {
+            fmpz_sqrtrem(f, r, g);
+        }
+        else if (aliasing == 1)
+        {
+            fmpz_set(f, g);
+            fmpz_sqrtrem(f, r, f);
+        }
+        else
+        {
+            fmpz_set(r, g);
+            fmpz_sqrtrem(f, r, r);
+        }
+
         mpz_sqrtrem(mf, mr, mg);
 
         fmpz_get_mpz(mf2, f);
 
-        result = (mpz_cmp(mf2, mf) == 0);
+        result = (mpz_cmp(mf2, mf) == 0) && _fmpz_is_canonical(f) && _fmpz_is_canonical(r);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -67,84 +82,6 @@ main(void)
         mpz_clear(mf2);
         mpz_clear(mr);
         mpz_clear(mg);
-    }
-
-    /* Check aliasing of r and g */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, f;
-        mpz_t ma, mf, mf2;
-
-        fmpz_init(a);
-        fmpz_init(f);
-
-        mpz_init(ma);
-        mpz_init(mf);
-        mpz_init(mf2);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_abs(a, a);
-        fmpz_get_mpz(ma, a);
-
-        fmpz_sqrtrem(f, a, a);
-        mpz_sqrtrem(mf, ma, ma);
-
-        fmpz_get_mpz(mf2, f);
-
-        result = (mpz_cmp(mf, mf2) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("ma = %Zd, mf = %Zd, mf2 = %Zd\n", ma, mf, mf2);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(f);
-
-        mpz_clear(ma);
-        mpz_clear(mf);
-        mpz_clear(mf2);
-    }
-
-    /* Check aliasing of f and g */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t r, f;
-        mpz_t mr, mf, mf2;
-
-        fmpz_init(r);
-        fmpz_init(f);
-
-        mpz_init(mr);
-        mpz_init(mf);
-        mpz_init(mf2);
-
-        fmpz_randtest(f, state, 200);
-        fmpz_abs(f, f);
-        fmpz_get_mpz(mf, f);
-
-        fmpz_sqrtrem(f, r, f);
-        mpz_sqrtrem(mf, mr, mf);
-
-        fmpz_get_mpz(mf2, f);
-
-        result = (mpz_cmp(mf, mf2) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("mr = %Zd, mf = %Zd, mf2 = %Zd\n", mr, mf, mf2);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(r);
-        fmpz_clear(f);
-
-        mpz_clear(mr);
-        mpz_clear(mf);
-        mpz_clear(mf2);
     }
 
     FLINT_TEST_CLEANUP(state);

--- a/src/fmpz/test/t-sub.c
+++ b/src/fmpz/test/t-sub.c
@@ -22,12 +22,11 @@ main(void)
     flint_printf("sub....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b, c;
         mpz_t d, e, f, g;
+        int aliasing;
 
         fmpz_init(a);
         fmpz_init(b);
@@ -44,12 +43,34 @@ main(void)
         fmpz_get_mpz(d, a);
         fmpz_get_mpz(e, b);
 
-        fmpz_sub(c, a, b);
+        aliasing = n_randint(state, 4);
+
+        if (aliasing == 0)
+        {
+            fmpz_sub(c, a, b);
+        }
+        else if (aliasing == 1)
+        {
+            fmpz_set(a, b);
+            mpz_set(d, e);
+            fmpz_sub(c, a, a);
+        }
+        else if (aliasing == 2)
+        {
+            fmpz_set(c, a);
+            fmpz_sub(c, c, b);
+        }
+        else
+        {
+            fmpz_set(c, b);
+            fmpz_sub(c, a, c);
+        }
+
         mpz_sub(f, d, e);
 
         fmpz_get_mpz(g, c);
 
-        result = (mpz_cmp(f, g) == 0);
+        result = (mpz_cmp(f, g) == 0) && _fmpz_is_canonical(c);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -61,131 +82,6 @@ main(void)
         fmpz_clear(a);
         fmpz_clear(b);
         fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, c;
-        mpz_t d, f, g;
-
-        fmpz_init(a);
-        fmpz_init(c);
-
-        mpz_init(d);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-
-        fmpz_sub(c, a, a);
-        mpz_sub(f, d, d);
-
-        fmpz_get_mpz(g, c);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, f = %Zd, g = %Zd\n", d, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_sub(a, a, b);
-        mpz_sub(f, d, e);
-
-        fmpz_get_mpz(g, a);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of b and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_sub(b, a, b);
-        mpz_sub(f, d, e);
-
-        fmpz_get_mpz(g, b);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-sub_ui.c
+++ b/src/fmpz/test/t-sub_ui.c
@@ -23,8 +23,6 @@ main(void)
     flint_printf("sub_ui....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t f, g, tst;
@@ -43,7 +41,16 @@ main(void)
         fmpz_get_mpz(mg, g);
         x = n_randtest(state);
 
-        fmpz_sub_ui(f, g, x);
+        if (n_randint(state, 2))
+        {
+            fmpz_sub_ui(f, g, x);
+        }
+        else /* test aliasing */
+        {
+            fmpz_set(f, g);
+            fmpz_sub_ui(f, f, x);
+        }
+
         flint_mpz_sub_ui(mf, mg, x);
 
         fmpz_set_mpz(tst, mf);
@@ -67,51 +74,6 @@ main(void)
 
         mpz_clear(mf);
         mpz_clear(mg);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t f, g, tst;
-        mpz_t mf;
-        ulong x;
-
-        fmpz_init(f);
-        fmpz_init(g);
-        fmpz_init(tst);
-
-        mpz_init(mf);
-
-        fmpz_randtest(g, state, 200);
-        fmpz_set(f, g);
-
-        fmpz_get_mpz(mf, f);
-        x = n_randtest(state);
-
-        fmpz_sub_ui(f, f, x);
-        flint_mpz_sub_ui(mf, mf, x);
-
-        fmpz_set_mpz(tst, mf);
-
-        result = fmpz_equal(f, tst);
-
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            flint_printf("(aliasing)\n");
-            flint_printf("f = "); fmpz_print(f); flint_printf(", ");
-            flint_printf("g = "); fmpz_print(g); flint_printf(", ");
-            flint_printf("x = %wu\n", x);
-            flint_printf("Correct result via GMP: "); fmpz_print(tst); flint_printf("\n");
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(f);
-        fmpz_clear(g);
-        fmpz_clear(tst);
-
-        mpz_clear(mf);
     }
 
     FLINT_TEST_CLEANUP(state);

--- a/src/fmpz/test/t-submul.c
+++ b/src/fmpz/test/t-submul.c
@@ -22,12 +22,11 @@ main(void)
     flint_printf("submul....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b, c;
         mpz_t d, e, f, g;
+        int aliasing;
 
         fmpz_init(a);
         fmpz_init(b);
@@ -49,12 +48,36 @@ main(void)
         fmpz_get_mpz(e, b);
         fmpz_get_mpz(f, c);
 
-        fmpz_submul(c, a, b);
+        aliasing = n_randint(state, 4);
+
+        if (aliasing == 0)
+        {
+            fmpz_submul(c, a, b);
+        }
+        else if (aliasing == 1)
+        {
+            fmpz_set(a, b);
+            mpz_set(d, e);
+            fmpz_submul(c, a, a);
+        }
+        else if (aliasing == 2)
+        {
+            fmpz_set(c, a);
+            mpz_set(f, d);
+            fmpz_submul(c, c, b);
+        }
+        else
+        {
+            fmpz_set(c, b);
+            mpz_set(f, e);
+            fmpz_submul(c, a, c);
+        }
+
         mpz_submul(f, d, e);
 
         fmpz_get_mpz(g, c);
 
-        result = (mpz_cmp(f, g) == 0);
+        result = (mpz_cmp(f, g) == 0) && _fmpz_is_canonical(c);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -71,130 +94,6 @@ main(void)
         mpz_clear(e);
         mpz_clear(f);
         mpz_clear(g);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, c;
-        mpz_t d, f, g;
-
-        fmpz_init(a);
-        fmpz_init(c);
-
-        mpz_init(d);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest(c, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(f, c);
-
-        fmpz_submul(c, a, a);
-        mpz_submul(f, d, d);
-
-        fmpz_get_mpz(g, c);
-
-        result = (mpz_cmp(f, g) == 0);
-
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, f = %Zd, g = %Zd\n", d, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_submul(a, a, b);
-        mpz_submul(d, d, e);
-
-        fmpz_get_mpz(f, a);
-
-        result = (mpz_cmp(d, f) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd\n", d, e, f);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-    }
-
-    /* Test aliasing of b and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_submul(b, a, b);
-        mpz_submul(e, d, e);
-
-        fmpz_get_mpz(f, b);
-
-        result = (mpz_cmp(f, e) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd\n", d, e, f);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
     }
 
     FLINT_TEST_CLEANUP(state);

--- a/src/fmpz/test/t-submul_si.c
+++ b/src/fmpz/test/t-submul_si.c
@@ -43,21 +43,24 @@ main(void)
         fmpz_get_mpz(e, b);
         x = z_randtest(state);
 
-        fmpz_submul_si(b, a, x);
+        if (n_randint(state, 2))
+        {
+            fmpz_submul_si(b, a, x);
+        }
+        else  /* test aliasing */
+        {
+            fmpz_set(b, a);
+            mpz_set(e, d);
+            fmpz_submul_si(b, b, x);
+        }
+
+
         flint_mpz_init_set_si(xx, x);
         mpz_submul(e, d, xx);
 
         fmpz_get_mpz(f, b);
 
-        result = (mpz_cmp(e, f) == 0);
-
-        if (COEFF_IS_MPZ(*b))
-        {
-            fmpz c = *b;
-            _fmpz_demote_val(b);
-            if (*b != c)
-                result = 0;
-        }
+        result = (mpz_cmp(e, f) == 0) && _fmpz_is_canonical(b);
 
         if (!result)
         {
@@ -74,46 +77,6 @@ main(void)
         mpz_clear(d);
         mpz_clear(e);
         mpz_clear(f);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a;
-        mpz_t d, e, xx;
-        slong x;
-
-        fmpz_init(a);
-
-        mpz_init(d);
-        mpz_init(e);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-        x = n_randtest(state);
-
-        fmpz_submul_si(a, a, x);
-        flint_mpz_init_set_si(xx, x);
-        mpz_submul(d, d, xx);
-
-        fmpz_get_mpz(e, a);
-
-        result = (mpz_cmp(d, e) == 0);
-
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, xx = %Zd\n", d, e, xx);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-
-        mpz_clear(xx);
-        mpz_clear(d);
-        mpz_clear(e);
     }
 
     FLINT_TEST_CLEANUP(state);

--- a/src/fmpz/test/t-submul_ui.c
+++ b/src/fmpz/test/t-submul_ui.c
@@ -23,8 +23,6 @@ main(void)
     flint_printf("submul_ui....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b;
@@ -45,20 +43,22 @@ main(void)
         fmpz_get_mpz(e, b);
         x = n_randtest(state);
 
-        fmpz_submul_ui(b, a, x);
+        if (n_randint(state, 2))
+        {
+            fmpz_submul_ui(b, a, x);
+        }
+        else  /* test aliasing */
+        {
+            fmpz_set(b, a);
+            mpz_set(e, d);
+            fmpz_submul_ui(b, b, x);
+        }
+
         flint_mpz_submul_ui(e, d, x);
 
         fmpz_get_mpz(f, b);
 
-        result = (mpz_cmp(e, f) == 0);
-
-        if (COEFF_IS_MPZ(*b))
-        {
-            fmpz c = *b;
-            _fmpz_demote_val(b);
-            if (*b != c)
-                result = 0;
-        }
+        result = (mpz_cmp(e, f) == 0) && _fmpz_is_canonical(b);
 
         if (!result)
         {
@@ -74,43 +74,6 @@ main(void)
         mpz_clear(d);
         mpz_clear(e);
         mpz_clear(f);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a;
-        mpz_t d, e;
-        ulong x;
-
-        fmpz_init(a);
-
-        mpz_init(d);
-        mpz_init(e);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-        x = n_randtest(state);
-
-        fmpz_submul_ui(a, a, x);
-        flint_mpz_submul_ui(d, d, x);
-
-        fmpz_get_mpz(e, a);
-
-        result = (mpz_cmp(d, e) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, x = %Mu\n", d, e, x);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-
-        mpz_clear(d);
-        mpz_clear(e);
     }
 
     FLINT_TEST_CLEANUP(state);

--- a/src/fmpz/test/t-swap.c
+++ b/src/fmpz/test/t-swap.c
@@ -22,8 +22,6 @@ main(void)
     flint_printf("swap....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b;
@@ -44,7 +42,7 @@ main(void)
 
         fmpz_get_mpz(d, b);
 
-        result = (mpz_cmp(c, d) == 0);
+        result = (mpz_cmp(c, d) == 0) && _fmpz_is_canonical(a) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL:\n");

--- a/src/fmpz/test/t-tdiv_q.c
+++ b/src/fmpz/test/t-tdiv_q.c
@@ -23,12 +23,11 @@ main(void)
     flint_printf("tdiv_q....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b, c;
         mpz_t d, e, f, g;
+        int aliasing;
 
         fmpz_init(a);
         fmpz_init(b);
@@ -45,12 +44,34 @@ main(void)
         fmpz_get_mpz(d, a);
         fmpz_get_mpz(e, b);
 
-        fmpz_tdiv_q(c, a, b);
+        aliasing = n_randint(state, 4);
+
+        if (aliasing == 0)
+        {
+            fmpz_tdiv_q(c, a, b);
+        }
+        else if (aliasing == 1)
+        {
+            fmpz_set(a, b);
+            mpz_set(d, e);
+            fmpz_tdiv_q(c, a, a);
+        }
+        else if (aliasing == 2)
+        {
+            fmpz_set(c, a);
+            fmpz_tdiv_q(c, c, b);
+        }
+        else
+        {
+            fmpz_set(c, b);
+            fmpz_tdiv_q(c, a, c);
+        }
+
         mpz_tdiv_q(f, d, e);
 
         fmpz_get_mpz(g, c);
 
-        result = (mpz_cmp(f, g) == 0);
+        result = (mpz_cmp(f, g) == 0) && _fmpz_is_canonical(c);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -62,131 +83,6 @@ main(void)
         fmpz_clear(a);
         fmpz_clear(b);
         fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, c;
-        mpz_t d, f, g;
-
-        fmpz_init(a);
-        fmpz_init(c);
-
-        mpz_init(d);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest_not_zero(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-
-        fmpz_tdiv_q(c, a, a);
-        mpz_tdiv_q(f, d, d);
-
-        fmpz_get_mpz(g, c);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, f = %Zd, g = %Zd\n", d, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_tdiv_q(a, a, b);
-        mpz_tdiv_q(f, d, e);
-
-        fmpz_get_mpz(g, a);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of b and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_tdiv_q(b, a, b);
-        mpz_tdiv_q(f, d, e);
-
-        fmpz_get_mpz(g, b);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-tdiv_q_2exp.c
+++ b/src/fmpz/test/t-tdiv_q_2exp.c
@@ -22,8 +22,6 @@ main(void)
     flint_printf("tdiv_q_2exp....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b;
@@ -42,12 +40,21 @@ main(void)
         fmpz_get_mpz(d, a);
         x = n_randint(state, 200);
 
-        fmpz_tdiv_q_2exp(b, a, x);
+        if (n_randint(state, 2))
+        {
+            fmpz_tdiv_q_2exp(b, a, x);
+        }
+        else /* test aliasing */
+        {
+            fmpz_set(b, a);
+            fmpz_tdiv_q_2exp(b, b, x);
+        }
+
         mpz_tdiv_q_2exp(e, d, x);
 
         fmpz_get_mpz(f, b);
 
-        result = (mpz_cmp(e, f) == 0);
+        result = (mpz_cmp(e, f) == 0) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL:\n");
@@ -58,45 +65,6 @@ main(void)
 
         fmpz_clear(a);
         fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a;
-        mpz_t d, e, f;
-        ulong x;
-
-        fmpz_init(a);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-        x = n_randint(state, 200);
-
-        fmpz_tdiv_q_2exp(a, a, x);
-        mpz_tdiv_q_2exp(e, d, x);
-
-        fmpz_get_mpz(f, a);
-
-        result = (mpz_cmp(e, f) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, exp = %Mu\n", d, e, f, x);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-tdiv_q_si.c
+++ b/src/fmpz/test/t-tdiv_q_si.c
@@ -23,8 +23,6 @@ main(void)
     flint_printf("tdiv_q_si....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         slong b;
@@ -45,12 +43,21 @@ main(void)
         fmpz_get_mpz(d, a);
         flint_mpz_set_si(e, b);
 
-        fmpz_tdiv_q_si(c, a, b);
+        if (n_randint(state, 2))
+        {
+            fmpz_tdiv_q_si(c, a, b);
+        }
+        else /* test aliasing */
+        {
+            fmpz_set(c, a);
+            fmpz_tdiv_q_si(c, c, b);
+        }
+
         mpz_tdiv_q(f, d, e);
 
         fmpz_get_mpz(g, c);
 
-        result = (mpz_cmp(f, g) == 0);
+        result = (mpz_cmp(f, g) == 0) && _fmpz_is_canonical(c);
         if (!result)
         {
             flint_printf("FAIL (1):\n");
@@ -61,48 +68,6 @@ main(void)
 
         fmpz_clear(a);
         fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        slong b;
-        fmpz_t a;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        b = z_randtest_not_zero(state);
-
-        fmpz_get_mpz(d, a);
-        flint_mpz_set_si(e, b);
-
-        fmpz_tdiv_q_si(a, a, b);
-        mpz_tdiv_q(f, d, e);
-
-        fmpz_get_mpz(g, a);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL (2):\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-tdiv_q_ui.c
+++ b/src/fmpz/test/t-tdiv_q_ui.c
@@ -23,8 +23,6 @@ main(void)
     flint_printf("tdiv_q_ui....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         ulong b;
@@ -45,12 +43,21 @@ main(void)
         fmpz_get_mpz(d, a);
         flint_mpz_set_ui(e, b);
 
-        fmpz_tdiv_q_ui(c, a, b);
+        if (n_randint(state, 2))
+        {
+            fmpz_tdiv_q_ui(c, a, b);
+        }
+        else /* test aliasing */
+        {
+            fmpz_set(c, a);
+            fmpz_tdiv_q_ui(c, c, b);
+        }
+
         mpz_tdiv_q(f, d, e);
 
         fmpz_get_mpz(g, c);
 
-        result = (mpz_cmp(f, g) == 0);
+        result = (mpz_cmp(f, g) == 0) && _fmpz_is_canonical(c);
         if (!result)
         {
             flint_printf("FAIL (1):\n");
@@ -61,48 +68,6 @@ main(void)
 
         fmpz_clear(a);
         fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        ulong b;
-        fmpz_t a;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        b = n_randtest_not_zero(state);
-
-        fmpz_get_mpz(d, a);
-        flint_mpz_set_ui(e, b);
-
-        fmpz_tdiv_q_ui(a, a, b);
-        mpz_tdiv_q(f, d, e);
-
-        fmpz_get_mpz(g, a);
-
-        result = (mpz_cmp(f, g) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL (2):\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-tdiv_qr.c
+++ b/src/fmpz/test/t-tdiv_qr.c
@@ -22,12 +22,11 @@ main(void)
     flint_printf("tdiv_qr....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b, c, r;
         mpz_t d, e, f, g, h, s;
+        int aliasing;
 
         fmpz_init(a);
         fmpz_init(b);
@@ -47,229 +46,39 @@ main(void)
         fmpz_get_mpz(d, a);
         fmpz_get_mpz(e, b);
 
-        fmpz_tdiv_qr(c, r, a, b);
+        aliasing = n_randint(state, 5);
+
+        if (aliasing == 0)
+        {
+            fmpz_tdiv_qr(c, r, a, b);
+        }
+        else if (aliasing == 1)
+        {
+            fmpz_set(c, a);
+            fmpz_tdiv_qr(c, r, c, b);
+        }
+        else if (aliasing == 2)
+        {
+            fmpz_set(c, b);
+            fmpz_tdiv_qr(c, r, a, c);
+        }
+        else if (aliasing == 3)
+        {
+            fmpz_set(r, a);
+            fmpz_tdiv_qr(c, r, r, b);
+        }
+        else
+        {
+            fmpz_set(r, b);
+            fmpz_tdiv_qr(c, r, a, r);
+        }
+
         mpz_tdiv_qr(f, s, d, e);
 
         fmpz_get_mpz(g, c);
         fmpz_get_mpz(h, r);
 
-        result = (mpz_cmp(f, g) == 0 && mpz_cmp(h, s) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf
-                ("d = %Zd, e = %Zd, f = %Zd, g = %Zd, h = %Zd, s = %Zd\n", d,
-                 e, f, g, h, s);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-        fmpz_clear(r);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-        mpz_clear(h);
-        mpz_clear(s);
-    }
-
-    /* Check aliasing of c and a */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, c, r;
-        mpz_t d, e, f, g, h, s;
-
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-        fmpz_init(r);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-        mpz_init(h);
-        mpz_init(s);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_tdiv_qr(a, r, a, b);
-        mpz_tdiv_qr(f, s, d, e);
-
-        fmpz_get_mpz(g, a);
-        fmpz_get_mpz(h, r);
-
-        result = (mpz_cmp(f, g) == 0 && mpz_cmp(h, s) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf
-                ("d = %Zd, e = %Zd, f = %Zd, g = %Zd, h = %Zd, s = %Zd\n", d,
-                 e, f, g, h, s);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-        fmpz_clear(r);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-        mpz_clear(h);
-        mpz_clear(s);
-    }
-
-    /* Check aliasing of c and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, c, r;
-        mpz_t d, e, f, g, h, s;
-
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-        fmpz_init(r);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-        mpz_init(h);
-        mpz_init(s);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_tdiv_qr(b, r, a, b);
-        mpz_tdiv_qr(f, s, d, e);
-
-        fmpz_get_mpz(g, b);
-        fmpz_get_mpz(h, r);
-
-        result = (mpz_cmp(f, g) == 0 && mpz_cmp(h, s) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf
-                ("d = %Zd, e = %Zd, f = %Zd, g = %Zd, h = %Zd, s = %Zd\n", d,
-                 e, f, g, h, s);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-        fmpz_clear(r);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-        mpz_clear(h);
-        mpz_clear(s);
-    }
-
-    /* Check aliasing of r and a */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, c, r;
-        mpz_t d, e, f, g, h, s;
-
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-        fmpz_init(r);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-        mpz_init(h);
-        mpz_init(s);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_tdiv_qr(c, a, a, b);
-        mpz_tdiv_qr(f, s, d, e);
-
-        fmpz_get_mpz(g, c);
-        fmpz_get_mpz(h, a);
-
-        result = (mpz_cmp(f, g) == 0 && mpz_cmp(h, s) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf
-                ("d = %Zd, e = %Zd, f = %Zd, g = %Zd, h = %Zd, s = %Zd\n", d,
-                 e, f, g, h, s);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-        fmpz_clear(r);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-        mpz_clear(h);
-        mpz_clear(s);
-    }
-
-    /* Check aliasing of r and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b, c, r;
-        mpz_t d, e, f, g, h, s;
-
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-        fmpz_init(r);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-        mpz_init(h);
-        mpz_init(s);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_tdiv_qr(c, b, a, b);
-        mpz_tdiv_qr(f, s, d, e);
-
-        fmpz_get_mpz(g, c);
-        fmpz_get_mpz(h, b);
-
-        result = (mpz_cmp(f, g) == 0 && mpz_cmp(h, s) == 0);
+        result = (mpz_cmp(f, g) == 0 && mpz_cmp(h, s) == 0) && _fmpz_is_canonical(c) && _fmpz_is_canonical(r);
         if (!result)
         {
             flint_printf("FAIL:\n");

--- a/src/fmpz/test/t-tdiv_r_2exp.c
+++ b/src/fmpz/test/t-tdiv_r_2exp.c
@@ -40,12 +40,21 @@ main(void)
         fmpz_get_mpz(d, a);
         x = n_randint(state, 200);
 
-        fmpz_tdiv_r_2exp(b, a, x);
+        if (n_randint(state, 2))
+        {
+            fmpz_tdiv_r_2exp(b, a, x);
+        }
+        else
+        {
+            fmpz_set(b, a);
+            fmpz_tdiv_r_2exp(b, b, x);
+        }
+
         mpz_tdiv_r_2exp(e, d, x);
 
         fmpz_get_mpz(f, b);
 
-        result = (mpz_cmp(e, f) == 0);
+        result = (mpz_cmp(e, f) == 0) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL 1:\n");
@@ -56,45 +65,6 @@ main(void)
 
         fmpz_clear(a);
         fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a;
-        mpz_t d, e, f;
-        ulong x;
-
-        fmpz_init(a);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-        x = n_randint(state, 200);
-
-        fmpz_tdiv_r_2exp(a, a, x);
-        mpz_tdiv_r_2exp(e, d, x);
-
-        fmpz_get_mpz(f, a);
-
-        result = (mpz_cmp(e, f) == 0);
-        if (!result)
-        {
-            flint_printf("FAIL 2:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, exp = %Mu\n", d, e, f, x);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
 
         mpz_clear(d);
         mpz_clear(e);

--- a/src/fmpz/test/t-tdiv_ui.c
+++ b/src/fmpz/test/t-tdiv_ui.c
@@ -23,8 +23,6 @@ main(void)
     flint_printf("tdiv_ui....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a;
@@ -42,7 +40,7 @@ main(void)
         r1 = fmpz_tdiv_ui(a, x);
         r2 = flint_mpz_tdiv_ui(b, x);
 
-        result = (r1 == r2);
+        result = (r1 == r2) && _fmpz_is_canonical(a);
         if (!result)
         {
             flint_printf("FAIL:\n");

--- a/src/fmpz/test/t-tstbit.c
+++ b/src/fmpz/test/t-tstbit.c
@@ -23,8 +23,6 @@ main(void)
     flint_printf("tstbit....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         int k, l;

--- a/src/fmpz/test/t-val2.c
+++ b/src/fmpz/test/t-val2.c
@@ -23,8 +23,6 @@ main(void)
     flint_printf("val2....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t x;

--- a/src/fmpz/test/t-xgcd.c
+++ b/src/fmpz/test/t-xgcd.c
@@ -22,224 +22,11 @@ main(void)
     flint_printf("xgcd....");
     fflush(stdout);
 
-
-
-    /* Test aliasing of d and f, a and g */
-    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t d, a, b, c, f, g, F, G;
-
-        fmpz_init(d);
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-        fmpz_init(f);
-        fmpz_init(g);
-        fmpz_init(F);
-        fmpz_init(G);
-
-        fmpz_randtest_unsigned(G, state, 200);
-        fmpz_add_ui(G, G, 1);
-        fmpz_randm(F, state, G);
-        if (n_randint(state, 2)) fmpz_neg(G, G);
-        if (n_randint(state, 2)) fmpz_neg(F, F);
-        fmpz_set(f, F);
-        fmpz_set(g, G);
-
-        fmpz_xgcd(d, a, b, f, g);
-        fmpz_xgcd(f, g, c, f, g);
-
-        result = (fmpz_equal(d, f)
-               && fmpz_equal(b, c)
-               && fmpz_equal(a, g));
-        if (!result)
-        {
-            flint_printf("FAIL:\n\n");
-            flint_printf("d = "), fmpz_print(d), flint_printf("\n");
-            flint_printf("a = "), fmpz_print(a), flint_printf("\n");
-            flint_printf("b = "), fmpz_print(b), flint_printf("\n");
-            flint_printf("c = "), fmpz_print(c), flint_printf("\n");
-            flint_printf("f = "), fmpz_print(f), flint_printf("\n");
-            flint_printf("g = "), fmpz_print(g), flint_printf("\n");
-            flint_printf("F = "), fmpz_print(F), flint_printf("\n");
-            flint_printf("G = "), fmpz_print(G), flint_printf("\n");
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(d);
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-        fmpz_clear(f);
-        fmpz_clear(g);
-        fmpz_clear(F);
-        fmpz_clear(G);
-    }
-
-    /* Test aliasing of a and f, d and g */
-    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t d, a, b, c, f, g, F, G;
-
-        fmpz_init(d);
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-        fmpz_init(f);
-        fmpz_init(g);
-        fmpz_init(F);
-        fmpz_init(G);
-
-        fmpz_randtest_unsigned(G, state, 200);
-        fmpz_add_ui(G, G, 1);
-        fmpz_randm(F, state, G);
-        if (n_randint(state, 2)) fmpz_neg(G, G);
-        if (n_randint(state, 2)) fmpz_neg(F, F);
-        fmpz_set(f, F);
-        fmpz_set(g, G);
-
-        fmpz_xgcd(d, a, b, f, g);
-        fmpz_xgcd(g, f, c, f, g);
-
-        result = (fmpz_equal(d, g)
-               && fmpz_equal(b, c)
-               && fmpz_equal(a, f));
-        if (!result)
-        {
-            flint_printf("FAIL:\n\n");
-            flint_printf("d = "), fmpz_print(d), flint_printf("\n");
-            flint_printf("a = "), fmpz_print(a), flint_printf("\n");
-            flint_printf("b = "), fmpz_print(b), flint_printf("\n");
-            flint_printf("c = "), fmpz_print(c), flint_printf("\n");
-            flint_printf("f = "), fmpz_print(f), flint_printf("\n");
-            flint_printf("g = "), fmpz_print(g), flint_printf("\n");
-            flint_printf("F = "), fmpz_print(F), flint_printf("\n");
-            flint_printf("G = "), fmpz_print(G), flint_printf("\n");
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(d);
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-        fmpz_clear(f);
-        fmpz_clear(g);
-        fmpz_clear(F);
-        fmpz_clear(G);
-    }
-
-    /* Test aliasing of d and f, b and g */
-    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t d, a, b, c, f, g, F, G;
-
-        fmpz_init(d);
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-        fmpz_init(f);
-        fmpz_init(g);
-        fmpz_init(F);
-        fmpz_init(G);
-
-        fmpz_randtest_unsigned(G, state, 200);
-        fmpz_add_ui(G, G, 1);
-        fmpz_randm(F, state, G);
-        if (n_randint(state, 2)) fmpz_neg(G, G);
-        if (n_randint(state, 2)) fmpz_neg(F, F);
-        fmpz_set(f, F);
-        fmpz_set(g, G);
-
-        fmpz_xgcd(d, a, b, f, g);
-        fmpz_xgcd(f, c, g, f, g);
-
-        result = (fmpz_equal(d, f)
-               && fmpz_equal(a, c)
-               && fmpz_equal(b, g));
-        if (!result)
-        {
-            flint_printf("FAIL:\n\n");
-            flint_printf("d = "), fmpz_print(d), flint_printf("\n");
-            flint_printf("a = "), fmpz_print(a), flint_printf("\n");
-            flint_printf("b = "), fmpz_print(b), flint_printf("\n");
-            flint_printf("c = "), fmpz_print(c), flint_printf("\n");
-            flint_printf("f = "), fmpz_print(f), flint_printf("\n");
-            flint_printf("g = "), fmpz_print(g), flint_printf("\n");
-            flint_printf("F = "), fmpz_print(F), flint_printf("\n");
-            flint_printf("G = "), fmpz_print(G), flint_printf("\n");
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(d);
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-        fmpz_clear(f);
-        fmpz_clear(g);
-        fmpz_clear(F);
-        fmpz_clear(G);
-    }
-
-    /* Test aliasing of b and f, d and g */
-    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t d, a, b, c, f, g, F, G;
-
-        fmpz_init(d);
-        fmpz_init(a);
-        fmpz_init(b);
-        fmpz_init(c);
-        fmpz_init(f);
-        fmpz_init(g);
-        fmpz_init(F);
-        fmpz_init(G);
-
-        fmpz_randtest_unsigned(G, state, 200);
-        fmpz_add_ui(G, G, 1);
-        fmpz_randm(F, state, G);
-        if (n_randint(state, 2)) fmpz_neg(G, G);
-        if (n_randint(state, 2)) fmpz_neg(F, F);
-        fmpz_set(f, F);
-        fmpz_set(g, G);
-
-        fmpz_xgcd(d, a, b, f, g);
-        fmpz_xgcd(g, c, f, f, g);
-
-        result = (fmpz_equal(d, g)
-               && fmpz_equal(a, c)
-               && fmpz_equal(b, f));
-        if (!result)
-        {
-            flint_printf("FAIL:\n\n");
-            flint_printf("d = "), fmpz_print(d), flint_printf("\n");
-            flint_printf("a = "), fmpz_print(a), flint_printf("\n");
-            flint_printf("b = "), fmpz_print(b), flint_printf("\n");
-            flint_printf("c = "), fmpz_print(c), flint_printf("\n");
-            flint_printf("f = "), fmpz_print(f), flint_printf("\n");
-            flint_printf("g = "), fmpz_print(g), flint_printf("\n");
-            flint_printf("F = "), fmpz_print(F), flint_printf("\n");
-            flint_printf("G = "), fmpz_print(G), flint_printf("\n");
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(d);
-        fmpz_clear(a);
-        fmpz_clear(b);
-        fmpz_clear(c);
-        fmpz_clear(f);
-        fmpz_clear(g);
-        fmpz_clear(F);
-        fmpz_clear(G);
-    }
-
     /* Test a f  + b g == d and d >= 0 */
     for (i = 0; i < 1000 * flint_test_multiplier(); i++)
     {
         fmpz_t d, a, b, f, g, t1, t2;
+        int aliasing;
 
         fmpz_init(d);
         fmpz_init(a);
@@ -255,16 +42,51 @@ main(void)
         if (n_randint(state, 2)) fmpz_neg(g, g);
         if (n_randint(state, 2)) fmpz_neg(f, f);
 
-        fmpz_xgcd(d, a, b, f, g);
+        aliasing = n_randint(state, 5);
+
+        if (aliasing == 0)
+        {
+            fmpz_xgcd(d, a, b, f, g);
+        }
+        else if (aliasing == 1)
+        {
+            /* Test aliasing of d and f, a and g */
+            fmpz_set(d, f);
+            fmpz_set(a, g);
+            fmpz_xgcd(d, a, b, d, a);
+        }
+        else if (aliasing == 2)
+        {
+            /* Test aliasing of a and f, d and g */
+            fmpz_set(a, f);
+            fmpz_set(d, g);
+            fmpz_xgcd(d, a, b, a, d);
+        }
+        else if (aliasing == 3)
+        {
+            /* Test aliasing of d and f, b and g */
+            fmpz_set(d, f);
+            fmpz_set(b, g);
+            fmpz_xgcd(d, a, b, d, b);
+        }
+        else
+        {
+            /* Test aliasing of b and f, d and g */
+            fmpz_set(b, f);
+            fmpz_set(d, g);
+            fmpz_xgcd(d, a, b, b, d);
+        }
 
         fmpz_mul(t1, a, f);
         fmpz_mul(t2, b, g);
         fmpz_add(t1, t1, t2);
 
-        result = fmpz_equal(t1, d) && fmpz_sgn(d) >= 0;
+        result = fmpz_equal(t1, d) && fmpz_sgn(d) >= 0 &&
+            _fmpz_is_canonical(d) && _fmpz_is_canonical(a) && _fmpz_is_canonical(b);
         if (!result)
         {
             flint_printf("FAIL:\n\n");
+            flint_printf("aliasing = %d\n", aliasing);
             flint_printf("d = "), fmpz_print(d), flint_printf("\n");
             flint_printf("a = "), fmpz_print(a), flint_printf("\n");
             flint_printf("b = "), fmpz_print(b), flint_printf("\n");

--- a/src/fmpz/test/t-xgcd_partial.c
+++ b/src/fmpz/test/t-xgcd_partial.c
@@ -22,8 +22,6 @@ main(void)
     flint_printf("xgcd_partial....");
     fflush(stdout);
 
-
-
     /* Test co2*r1 - co1*r2 = r2_orig */
     for (i = 0; i < 1000 * flint_test_multiplier(); i++)
     {

--- a/src/fmpz/test/t-xor.c
+++ b/src/fmpz/test/t-xor.c
@@ -22,12 +22,11 @@ main(void)
     flint_printf("xor....");
     fflush(stdout);
 
-
-
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b, c;
         mpz_t d, e, f, g;
+        int aliasing;
 
         fmpz_init(a);
         fmpz_init(b);
@@ -44,12 +43,34 @@ main(void)
         fmpz_get_mpz(d, a);
         fmpz_get_mpz(e, b);
 
-        fmpz_xor(c, a, b);
+        aliasing = n_randint(state, 4);
+
+        if (aliasing == 0)
+        {
+            fmpz_xor(c, a, b);
+        }
+        else if (aliasing == 1)
+        {
+            fmpz_set(c, a);
+            fmpz_xor(c, c, b);
+        }
+        else if (aliasing == 2)
+        {
+            fmpz_set(c, b);
+            fmpz_xor(c, a, c);
+        }
+        else if (aliasing == 3)
+        {
+            fmpz_set(c, a);
+            fmpz_xor(c, a, a);
+            mpz_set(e, d);
+        }
+
         mpz_xor(f, d, e);
 
         fmpz_get_mpz(g, c);
 
-        result = (mpz_cmp(f, g) == 0);
+        result = (mpz_cmp(f, g) == 0) && _fmpz_is_canonical(c);
 
         if (!result)
         {
@@ -62,134 +83,6 @@ main(void)
         fmpz_clear(a);
         fmpz_clear(b);
         fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Check aliasing of a and b */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, c;
-        mpz_t d, f, g;
-
-        fmpz_init(a);
-        fmpz_init(c);
-
-        mpz_init(d);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-
-        fmpz_get_mpz(d, a);
-
-        fmpz_xor(c, a, a);
-        mpz_xor(f, d, d);
-
-        fmpz_get_mpz(g, c);
-
-        result = (mpz_cmp(f, g) == 0);
-
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, f = %Zd, g = %Zd\n", d, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(c);
-
-        mpz_clear(d);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of a and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_xor(a, a, b);
-        mpz_xor(f, d, e);
-
-        fmpz_get_mpz(g, a);
-
-        result = (mpz_cmp(f, g) == 0);
-
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
-
-        mpz_clear(d);
-        mpz_clear(e);
-        mpz_clear(f);
-        mpz_clear(g);
-    }
-
-    /* Test aliasing of b and c */
-    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
-    {
-        fmpz_t a, b;
-        mpz_t d, e, f, g;
-
-        fmpz_init(a);
-        fmpz_init(b);
-
-        mpz_init(d);
-        mpz_init(e);
-        mpz_init(f);
-        mpz_init(g);
-
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest(b, state, 200);
-
-        fmpz_get_mpz(d, a);
-        fmpz_get_mpz(e, b);
-
-        fmpz_xor(b, a, b);
-        mpz_xor(f, d, e);
-
-        fmpz_get_mpz(g, b);
-
-        result = (mpz_cmp(f, g) == 0);
-
-        if (!result)
-        {
-            flint_printf("FAIL:\n");
-            gmp_printf("d = %Zd, e = %Zd, f = %Zd, g = %Zd\n", d, e, f, g);
-            fflush(stdout);
-            flint_abort();
-        }
-
-        fmpz_clear(a);
-        fmpz_clear(b);
 
         mpz_clear(d);
         mpz_clear(e);


### PR DESCRIPTION
As discussed in #1540: do aliasing tests inline with the main tests. Also adds ``_fmpz_is_canonical`` for stronger consistency checks.

``make check MOD=fmpz`` is 25% faster with this patch.