### PR TITLE
Disable debug information for runners

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -265,11 +265,6 @@ jobs:
           fi
           echo "All good!"
 
-      - if: failure()
-        name: "Print config.log"
-        run: |
-          cat config.log
-
 
 
   ##############################################################################

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -200,7 +200,7 @@ jobs:
         continue-on-error: true
         with:
           operating_system: freebsd
-          version: '13.1'
+          version: '13.2'
           shell: bash
           run: |
             yes | sudo pkg install pkgconf
@@ -264,6 +264,11 @@ jobs:
             exit 6
           fi
           echo "All good!"
+
+      - if: failure()
+        name: "Print config.log"
+        run: |
+          cat config.log
 
 
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -253,6 +253,7 @@ jobs:
             echo "Building failed!"
             exit 4
           elif test ! -f _is_checked;
+          then
             echo "Check failed!"
             exit 5
           fi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -226,9 +226,11 @@ jobs:
               --disable-static \
               --disable-debug
             touch _is_configured
-            gmake -j$(expr $(nproc) + 1)
-            touch _is_built
-            gmake -j$(expr $(nproc) + 1) check
+            gmake -j$(expr $(sysctl -n hw.ncpu) + 1)
+            touch _is_library_built
+            gmake -j$(expr $(sysctl -n hw.ncpu) + 1) tests
+            touch _is_tests_built
+            gmake -j$(expr $(sysctl -n hw.ncpu) + 1) check
             touch _is_checked
 
         # Sometimes the FreeBSD runner cannot exit properly. We created files
@@ -248,14 +250,18 @@ jobs:
           then
             echo "Configuration failed!"
             exit 3
-          elif test ! -f _is_built;
+          elif test ! -f _is_library_built;
           then
-            echo "Building failed!"
+            echo "Building library failed!"
             exit 4
+          elif test ! -f _is_tests_built;
+          then
+            echo "Building tests failed!"
+            exit 5
           elif test ! -f _is_checked;
           then
             echo "Check failed!"
-            exit 5
+            exit 6
           fi
           echo "All good!"
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,10 +16,10 @@ concurrency:
 
 jobs:
   ##############################################################################
-  # ubuntu with gcc
+  # ubuntu, gcc, avx2, code coverage
   ##############################################################################
-  ubuntu-gcc:
-    name: Ubuntu GCC, default flags with AVX2, Code Coverage (x10)
+  ubuntu-avx2-codecoverage:
+    name: Ubuntu GCC, AVX2, Code Coverage (x10)
 
     runs-on: ubuntu-latest
 
@@ -46,7 +46,11 @@ jobs:
       - name: "Configure"
         run: |
           ./bootstrap.sh
-          ./configure CC=${CC} --enable-avx2 --disable-static --enable-coverage
+          ./configure \
+            CC=${CC} \
+            --enable-avx2 \
+            --disable-static \
+            --enable-coverage
 
       - name: "Compile library"
         run: |
@@ -67,14 +71,10 @@ jobs:
       - name: "Upload coverage data"
         uses: codecov/codecov-action@v3.1.1
 
-      - if: failure()
-        name: "If failure, stop all other jobs"
-        uses: andymckay/cancel-action@0.3
-
 
 
   ##############################################################################
-  # ubuntu with gcc (assert)
+  # ubuntu, gcc, assert
   ##############################################################################
   ubuntu-gcc-assert:
     name: Ubuntu GCC (assert, x2)
@@ -83,7 +83,6 @@ jobs:
 
     env:
       CC: "gcc"
-      CFLAGS: "-Wall -Werror=implicit-function-declaration"
       FLINT_TEST_MULTIPLIER: "2"
 
     steps:
@@ -104,7 +103,13 @@ jobs:
       - name: "Configure"
         run: |
           ./bootstrap.sh
-          ./configure CC=${CC} CFLAGS="${CFLAGS}" --with-gmp=/usr --with-mpfr=/usr --enable-assert --disable-static
+          ./configure \
+            CC=${CC} \
+            --with-gmp=/usr \
+            --with-mpfr=/usr \
+            --enable-assert \
+            --disable-static \
+            --disable-debug
 
       - name: "Compile library"
         run: |
@@ -119,10 +124,6 @@ jobs:
         run: |
           $MAKE check
 
-      - if: failure()
-        name: "If failure, stop all other jobs"
-        uses: andymckay/cancel-action@0.3
-
 
 
   ##############################################################################
@@ -134,8 +135,6 @@ jobs:
     runs-on: macos-latest
 
     env:
-      CFLAGS: "-Wall"
-      EXTRA_OPTIONS: "--disable-static --enable-shared"
       CC: "gcc"
       FLINT_TEST_MULTIPLIER: "3"
 
@@ -160,11 +159,13 @@ jobs:
       - name: "Configure"
         run: |
           ./bootstrap.sh
-          ./configure CC=${CC} CFLAGS="${CFLAGS}" \
-              --with-gmp=$(brew --prefix) \
-              --with-mpfr=$(brew --prefix) \
-              --with-blas=$(brew --prefix)/opt/openblas \
-              ${EXTRA_OPTIONS}
+          ./configure \
+            CC=${CC} \
+            --with-gmp=$(brew --prefix) \
+            --with-mpfr=$(brew --prefix) \
+            --with-blas=$(brew --prefix)/opt/openblas \
+            --disable-static \
+            --disable-debug
 
       - name: "Compile library"
         run: |
@@ -177,10 +178,6 @@ jobs:
       - name: "Check"
         run: |
           $MAKE check
-
-      - if: failure()
-        name: "If failure, stop all other jobs"
-        uses: andymckay/cancel-action@0.3
 
 
 
@@ -217,14 +214,17 @@ jobs:
             clang --version
             autoconf --version
             libtool --version
-            touch _is_installed
+            touch _is_setup
             ./bootstrap.sh
             touch _is_bootstrapped
-            ./configure CC=clang CFLAGS="-Wall" --disable-static --enable-shared  \
-                --with-gmp-include=$(pkgconf --variable=includedir gmp)           \
-                --with-gmp-lib=$(pkgconf --variable=libdir gmp)                   \
-                --with-mpfr-include=$(pkgconf --variable=includedir mpfr)         \
-                --with-mpfr-lib=$(pkgconf --variable=libdir mpfr)
+            ./configure \
+              CC=clang \
+              --with-gmp-include=$(pkgconf --variable=includedir gmp) \
+              --with-gmp-lib=$(pkgconf --variable=libdir gmp) \
+              --with-mpfr-include=$(pkgconf --variable=includedir mpfr) \
+              --with-mpfr-lib=$(pkgconf --variable=libdir mpfr) \
+              --disable-static \
+              --disable-debug
             touch _is_configured
             gmake -j$(expr $(nproc) + 1)
             touch _is_built
@@ -233,43 +233,30 @@ jobs:
 
         # Sometimes the FreeBSD runner cannot exit properly. We created files
         # for each step to show that it was able to run the tests.
-      - name: "Check that everything was okay"
+      - if: always()
+        name: "Check that everything was okay"
         run: |
-          if test -e _is_installed;
+          if test ! -f _is_setup;
           then
-            if test -e _is_bootstrapped;
-            then
-              if test -e _is_configured;
-              then
-                if test -e _is_built;
-                then
-                  if test -e _is_checked;
-                  then
-                    echo "All good!"
-                  else
-                    echo "Check failed!"
-                    exit 5
-                  fi
-                else
-                  echo "Building failed!"
-                  exit 4
-                fi
-              else
-                echo "Configuration failed!"
-                exit 3
-              fi
-            else
-              echo "Bootstrap failed!"
-              exit 2
-            fi
-          else
-            echo "Installation failed!"
+            echo "Setup failed!"
             exit 1
+          elif test ! -f _is_bootstrapped;
+          then
+            echo "Bootstrap failed!"
+            exit 2
+          elif test ! -f _is_configured;
+          then
+            echo "Configuration failed!"
+            exit 3
+          elif test ! -f _is_built;
+          then
+            echo "Building failed!"
+            exit 4
+          elif test ! -f _is_checked;
+            echo "Check failed!"
+            exit 5
           fi
-
-      # - if: failure()
-      #   name: "If failure, stop all other jobs"
-      #   uses: andymckay/cancel-action@0.3
+          echo "All good!"
 
 
 
@@ -287,8 +274,6 @@ jobs:
 
     env:
       REPO: /cygdrive/d/a/flint/flint # FIXME: De-hardcode this
-      CFLAGS: "-Wall"
-      EXTRA_OPTIONS: "--enable-shared --disable-static"
       CC: "gcc"
       FLINT_TEST_MULTIPLIER: "0.5"
 
@@ -314,7 +299,10 @@ jobs:
           dos2unix configure
           dos2unix bootstrap.sh
           ./bootstrap.sh
-          ./configure CC=${CC} CFLAGS="${CFLAGS}" ${EXTRA_OPTIONS}
+          ./configure \
+            CC=${CC} \
+            --disable-static \
+            --disable-debug
 
       - name: "Compile library"
         run: |
@@ -331,10 +319,6 @@ jobs:
           cd ${REPO}
           $MAKE check
 
-      - if: failure()
-        name: "If failure, stop all other jobs"
-        uses: andymckay/cancel-action@0.3
-
 
 
   #############################################################################
@@ -348,9 +332,7 @@ jobs:
     env:
       LOCAL: ${{ github.workspace }}/local
       LDFLAGS: "-Wl,-rpath,$LOCAL/lib"
-      CFLAGS: "-Wall"
       CC: "clang"
-      EXTRA_OPTIONS: "--disable-static --enable-shared"
       FLINT_TEST_MULTIPLIER: "5"
 
     steps:
@@ -371,7 +353,10 @@ jobs:
       - name: "Configure"
         run: |
           ./bootstrap.sh
-          ./configure CC=${CC} CFLAGS="${CFLAGS}" ${EXTRA_OPTIONS}
+          ./configure \
+            CC=${CC} \
+            --disable-static \
+            --disable-debug
 
       - name: "Compile library"
         run: |
@@ -386,24 +371,19 @@ jobs:
         run: |
           $MAKE check
 
-      - if: failure()
-        name: "If failure, stop all other jobs"
-        uses: andymckay/cancel-action@0.3
-
 
 
   #############################################################################
   # ubuntu with gcc and cmake (no checks)
   #############################################################################
   ubuntu-cmake-gcc:
-    name: Ubuntu GCC via CMake (no check)
+    name: Ubuntu GCC, CMake (no checks)
 
     runs-on: ubuntu-latest
 
     env:
       LOCAL: ${{ github.workspace }}/local
       LDFLAGS: "-Wl,-rpath,$LOCAL/lib"
-      CFLAGS: "-Wall"
 
     steps:
       - uses: actions/checkout@v4
@@ -431,10 +411,6 @@ jobs:
           $MAKE
           ldd lib/libflint.so
 
-      - if: failure()
-        name: "If failure, stop all other jobs"
-        uses: andymckay/cancel-action@0.3
-
 
 
   #############################################################################
@@ -450,8 +426,6 @@ jobs:
         shell: msys2 {0}
 
     env:
-      CFLAGS: "-Wall"
-      EXTRA_OPTIONS: "--enable-shared --disable-static"
       CC: "gcc"
       FLINT_TEST_MULTIPLIER: "0.5"
 
@@ -476,7 +450,10 @@ jobs:
       - name: "Configure"
         run: |
           ./bootstrap.sh
-          ./configure CC=${CC} CFLAGS="${CFLAGS}" ${EXTRA_OPTIONS}
+          ./configure \
+            CC=${CC} \
+            --disable-static \
+            --disable-debug
 
       - name: "Compile library"
         run: |
@@ -489,10 +466,6 @@ jobs:
       - name: "Check"
         run: |
           ${MAKE} check
-
-      - if: failure()
-        name: "If failure, stop all other jobs"
-        uses: andymckay/cancel-action@0.3
 
 
 
@@ -549,17 +522,13 @@ jobs:
           set "FLINT_TEST_MULTIPLIER=1"
           ctest -j3 --output-on-failure --timeout 450
 
-      - if: failure()
-        name: "If failure, stop all other jobs"
-        uses: andymckay/cancel-action@0.3
-
 
 
   ##############################################################################
-  # alpine linux 32-bit
+  # alpine linux, musl, 32-bit (assert)
   ##############################################################################
   alpine-32bit:
-    name: Alpine Linux, musl, 32-bit (x1.5)
+    name: Alpine Linux, musl, 32-bit (assert, x1.5)
 
     runs-on: ubuntu-latest
 
@@ -597,7 +566,11 @@ jobs:
       - name: "Configure"
         run: |
           ./bootstrap.sh
-          ./configure CC=${CC} --disable-static --enable-assert
+          ./configure \
+            CC=${CC} \
+            --enable-assert \
+            --disable-static \
+            --disable-debug
         shell: alpine.sh {0}
 
       - name: "Compile library"
@@ -615,10 +588,6 @@ jobs:
           $MAKE check
         shell: alpine.sh {0}
 
-      - if: failure()
-        name: "If failure, stop all other jobs"
-        uses: andymckay/cancel-action@0.3
-
 
 
   ##############################################################################
@@ -631,8 +600,6 @@ jobs:
 
     env:
       LOCAL: ${{ github.workspace }}/local
-      CFLAGS: ""
-      EXTRA_OPTIONS: "--disable-static --enable-shared"
       CC: "gcc"
 
     steps:
@@ -676,7 +643,14 @@ jobs:
           # configure-script. Hence, we also omit the check for finding MPFR.
           # FIXME: Probably want to fix this.
           ./bootstrap.sh
-          ./configure CC=${CC} CFLAGS="${CFLAGS}" --prefix=${LOCAL} ${EXTRA_OPTIONS} --with-gmp=${gmp_path} --with-mpfr=${mpfr_path} --disable-mpfr-check
+          ./configure \
+            CC=${CC} \
+            --prefix=${LOCAL} \
+            --with-gmp=${gmp_path} \
+            --with-mpfr=${mpfr_path} \
+            --disable-mpfr-check \
+            --disable-static \
+            --disable-debug
 
       - name: "Compile and install"
         run: |
@@ -699,7 +673,3 @@ jobs:
       - name: "Check Nemo.jl"
         run: |
           julia -e "import Pkg; Pkg.test(\"Nemo\")"
-
-      # - if: failure()
-      #   name: "If failure, stop all other jobs"
-      #   uses: andymckay/cancel-action@0.3

--- a/configure.ac
+++ b/configure.ac
@@ -176,17 +176,6 @@ yes|no)
 esac],
 enable_assert="no")
 
-AC_ARG_ENABLE(debug,
-[AS_HELP_STRING([--enable-debug],[Compile FLINT with debug information [default=yes]])],
-[case $enableval in
-yes|no)
-    ;;
-*)
-    AC_MSG_ERROR([Bad value $enableval for --enable-debug. Need yes or no.])
-    ;;
-esac],
-enable_debug="yes")
-
 AC_ARG_ENABLE(coverage,
 [AS_HELP_STRING([--enable-coverage],[Enable test coverage [default=no]])],
 [case $enableval in
@@ -198,6 +187,20 @@ yes|no)
 esac],
 enable_coverage="no")
 
+AC_ARG_ENABLE(debug,
+[AS_HELP_STRING([--enable-debug],[Compile FLINT with debug information [default=yes]])],
+[case $enableval in
+yes|no)
+    if test "$enableval" = "no" && test "$enable_coverage" = "yes";
+    then
+        AC_MSG_ERROR([Debug information is required by coverage.])
+    fi
+    ;;
+*)
+    AC_MSG_ERROR([Bad value $enableval for --enable-debug. Need yes or no.])
+    ;;
+esac],
+enable_debug="yes")
 
 AC_ARG_ENABLE(dependency-tracking,
 [AS_HELP_STRING([--enable-dependency-tracking],[Enable GCC automated dependency tracking [default=yes]])],
@@ -863,7 +866,7 @@ then
     LDFLAGS="--coverage $LDFLAGS"
 fi
 
-if test "$enable_debug" = "yes" || test "$enable_coverage" = "yes";
+if test "$enable_debug" = "yes";
 then
     if test "$ac_cv_prog_cc_g" = "yes";
     then

--- a/configure.ac
+++ b/configure.ac
@@ -617,7 +617,7 @@ AC_CHECK_HEADERS([stdarg.h math.h float.h errno.h gmp.h mpfr.h],,
 # Optional headers
 # The following headers are checked previously:
 #   unistd.h
-AC_CHECK_HEADERS([fenv.h alloca.h malloc.h sys/param.h windows.h arm_neon.h x86intrin.h immintrin.h])
+AC_CHECK_HEADERS([fenv.h alloca.h malloc.h sys/param.h windows.h arm_neon.h x86intrin.h immintrin.h pthread_np.h])
 
 if test "$enable_pthread" = "yes";
 then

--- a/src/thread_pool/init.c
+++ b/src/thread_pool/init.c
@@ -14,6 +14,10 @@
 
 #include "thread_pool.h"
 
+#if FLINT_USES_PTHREAD && defined(HAVE_PTHREAD_NP_H)
+# include <pthread_np.h>
+#endif
+
 thread_pool_t global_thread_pool;
 int global_thread_pool_initialized = 0;
 

--- a/src/thread_pool/restore_affinity.c
+++ b/src/thread_pool/restore_affinity.c
@@ -14,6 +14,10 @@
 
 #include "thread_pool.h"
 
+#if FLINT_USES_PTHREAD && defined(HAVE_PTHREAD_NP_H)
+# include <pthread_np.h>
+#endif
+
 int thread_pool_restore_affinity(thread_pool_t T)
 {
 #if FLINT_USES_CPUSET && FLINT_USES_PTHREAD

--- a/src/thread_pool/set_affinity.c
+++ b/src/thread_pool/set_affinity.c
@@ -14,6 +14,10 @@
 
 #include "thread_pool.h"
 
+#if FLINT_USES_PTHREAD && defined(HAVE_PTHREAD_NP_H)
+# include <pthread_np.h>
+#endif
+
 /*
     cpus[0] is cpu number for main thread
     cpus[1], ..., cpus[length - 1] are cpu numbers for elements of pool


### PR DESCRIPTION
Unless `--enable-coverage`. Opinions, @fredrik-johansson? We do know that `--enable-debug` enlarges the binaries by quite a bit.