### PR TITLE
Fix some fft_small tests

### DIFF
--- a/src/fft_small/test/main.c
+++ b/src/fft_small/test/main.c
@@ -17,6 +17,7 @@
 #include "t-fmpz_poly_mul.c"
 #include "t-mpn_add_inplace_c.c"
 #include "t-mul.c"
+#include "t-nmod_poly_divrem.c"
 #include "t-nmod_poly_mul.c"
 #include "t-sd_fft.c"
 
@@ -27,6 +28,7 @@ test_struct tests[] =
     TEST_FUNCTION(_fmpz_poly_mul_mid_mpn_ctx),
     TEST_FUNCTION(flint_mpn_add_inplace_c),
     TEST_FUNCTION(mpn_ctx_mpn_mul),
+    TEST_FUNCTION(_nmod_poly_divrem_mpn_ctx),
     TEST_FUNCTION(_nmod_poly_mul_mid_mpn_ctx),
     TEST_FUNCTION(sd_fft)
 };

--- a/src/fft_small/test/t-fmpz_poly_mul.c
+++ b/src/fft_small/test/t-fmpz_poly_mul.c
@@ -25,8 +25,6 @@ TEST_FUNCTION_START(_fmpz_poly_mul_mid_mpn_ctx, state)
         fmpz * a, * c, * d;
         ulong an, zn, zl, zh, sz, i, reps, abits;
 
-        fflush(stdout);
-
         for (reps = 0; reps < 1000 * flint_test_multiplier(); reps++)
         {
             flint_set_num_threads(1 + n_randint(state, 10));
@@ -76,8 +74,6 @@ TEST_FUNCTION_START(_fmpz_poly_mul_mid_mpn_ctx, state)
     {
         fmpz * a, * b, * c, * d;
         ulong an, bn, zn, zl, zh, sz, i, reps, abits, bbits;
-
-        fflush(stdout);
 
         for (reps = 0; reps < 1000 * flint_test_multiplier(); reps++)
         {

--- a/src/fft_small/test/t-mpn_add_inplace_c.c
+++ b/src/fft_small/test/t-mpn_add_inplace_c.c
@@ -40,7 +40,7 @@ TEST_FUNCTION_START(flint_mpn_add_inplace_c, state)
 
     _flint_rand_init_gmp(state);
 
-    for (iter = 0; iter < 1000; iter++)
+    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
     {
         mp_limb_t a[10], b[10], c[10];
         mp_size_t an, bn;
@@ -66,7 +66,7 @@ TEST_FUNCTION_START(flint_mpn_add_inplace_c, state)
         }
     }
 
-    for (iter = 0; iter < 1000; iter++)
+    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
     {
         mp_limb_t a[8], b[8], c[8], d[8];
 

--- a/src/fft_small/test/t-mul.c
+++ b/src/fft_small/test/t-mul.c
@@ -78,7 +78,7 @@ TEST_FUNCTION_START(mpn_ctx_mpn_mul, state)
     {
         mpn_ctx_t R;
         mpn_ctx_init(R, UWORD(0x0003f00000000001));
-        test_mul(R, 10, 50000, 5000, state);
+        test_mul(R, 10, 50000, 1000 * flint_test_multiplier(), state);
         mpn_ctx_clear(R);
     }
 

--- a/src/fft_small/test/t-mul.c
+++ b/src/fft_small/test/t-mul.c
@@ -14,15 +14,16 @@
 #include "fft_small.h"
 #include "machine_vectors.h"
 
-void test_mul(mpn_ctx_t R, ulong minsize, ulong maxsize, ulong nreps, flint_rand_t state)
+void test_mul(mpn_ctx_t R, ulong maxsize, ulong nreps, flint_rand_t state)
 {
-    ulong* a = FLINT_ARRAY_ALLOC(maxsize, ulong);
-    ulong* b = FLINT_ARRAY_ALLOC(maxsize, ulong);
-    ulong* c = FLINT_ARRAY_ALLOC(maxsize, ulong);
-    ulong* d = FLINT_ARRAY_ALLOC(maxsize, ulong);
+    ulong * a, * b, * c, *d;
 
-    minsize = n_max(10, minsize);
-    maxsize = n_max(minsize, maxsize);
+    maxsize = n_max(10, maxsize);
+    a = FLINT_ARRAY_ALLOC(maxsize, ulong);
+    b = FLINT_ARRAY_ALLOC(maxsize, ulong);
+    c = FLINT_ARRAY_ALLOC(maxsize, ulong);
+    d = FLINT_ARRAY_ALLOC(maxsize, ulong);
+
     for (ulong rep = 0; rep < nreps; rep++)
     {
         ulong an = 2 + n_randint(state, maxsize - 4);
@@ -78,7 +79,7 @@ TEST_FUNCTION_START(mpn_ctx_mpn_mul, state)
     {
         mpn_ctx_t R;
         mpn_ctx_init(R, UWORD(0x0003f00000000001));
-        test_mul(R, 10, 50000, 1000 * flint_test_multiplier(), state);
+        test_mul(R, 50000, 1000 * flint_test_multiplier(), state);
         mpn_ctx_clear(R);
     }
 

--- a/src/fft_small/test/t-mul.c
+++ b/src/fft_small/test/t-mul.c
@@ -18,7 +18,6 @@ void test_mul(mpn_ctx_t R, ulong maxsize, ulong nreps, flint_rand_t state)
 {
     ulong * a, * b, * c, *d;
 
-    maxsize = n_max(10, maxsize);
     a = FLINT_ARRAY_ALLOC(maxsize, ulong);
     b = FLINT_ARRAY_ALLOC(maxsize, ulong);
     c = FLINT_ARRAY_ALLOC(maxsize, ulong);
@@ -79,7 +78,8 @@ TEST_FUNCTION_START(mpn_ctx_mpn_mul, state)
     {
         mpn_ctx_t R;
         mpn_ctx_init(R, UWORD(0x0003f00000000001));
-        test_mul(R, 50000, 1000 * flint_test_multiplier(), state);
+        test_mul(R, 10000, 1000 * flint_test_multiplier(), state);
+        test_mul(R, 50000, 100 * flint_test_multiplier(), state);
         mpn_ctx_clear(R);
     }
 

--- a/src/fft_small/test/t-nmod_poly_divrem.c
+++ b/src/fft_small/test/t-nmod_poly_divrem.c
@@ -1,0 +1,104 @@
+/*
+    Copyright (C) 2022 Daniel Schultz
+    Copyright (C) 2023 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "nmod.h"
+#include "nmod_poly.h"
+#include "fft_small.h"
+
+TEST_FUNCTION_START(_nmod_poly_divrem_mpn_ctx, state)
+{
+    flint_bitcnt_t nbits;
+    mpn_ctx_t R;
+    nmod_t mod;
+
+    mpn_ctx_init(R, UWORD(0x0003f00000000001));
+
+    for (nbits = 2; nbits <= FLINT_BITS; nbits++)
+    {
+        ulong * a, * b, * q1, * q2, * q3, * r1, * r2, * r3;
+        ulong an, bn, qn, i, reps;
+        nmod_poly_divrem_precomp_struct M[1];
+
+        for (reps = 0; reps < 100 * flint_test_multiplier(); reps++)
+        {
+            flint_set_num_threads(1 + n_randint(state, 10));
+
+            nmod_init(&mod, n_randbits(state, nbits));
+
+            bn = 2 + n_randint(state, 5000);
+            qn = 1 + n_randint(state, 5000);
+            an = bn + qn - 1;
+
+            a = FLINT_ARRAY_ALLOC(an, ulong);
+            b = FLINT_ARRAY_ALLOC(bn, ulong);
+            q1 = FLINT_ARRAY_ALLOC(qn, ulong);
+            q2 = FLINT_ARRAY_ALLOC(qn, ulong);
+            q3 = FLINT_ARRAY_ALLOC(qn, ulong);
+            r1 = FLINT_ARRAY_ALLOC(bn, ulong);
+            r2 = FLINT_ARRAY_ALLOC(bn, ulong);
+            r3 = FLINT_ARRAY_ALLOC(bn, ulong);
+
+            for (i = 0; i < an; i++)
+                a[i] = n_randint(state, mod.n);
+
+            for (i = 0; i < bn; i++)
+                b[i] = n_randint(state, mod.n);
+
+            while (n_gcd(b[bn-1], mod.n) != 1)
+                b[bn-1] = n_randint(state, mod.n);
+
+            _nmod_poly_divrem(q1, r1, a, an, b, bn, mod);
+
+            _nmod_poly_divrem_mpn_ctx(q2, r2, a, an, b, bn, mod, R);
+
+            ulong prec = qn + n_randint(state, 200);
+            _nmod_poly_divrem_precomp_init(M, b, bn, prec, mod, R);
+            _nmod_poly_divrem_precomp(q3, r3, a, an, M, mod, R);
+            _nmod_poly_divrem_precomp_clear(M);
+
+            for (i = qn; i > 0; i--)
+            {
+                if (q1[i-1] != q2[i-1] || q1[i-1] != q3[i-1])
+                {
+                    flint_printf("quotient error at index %wu\n", i-1);
+                    flint_printf("qn=%wu, an=%wu, bn=%wu\n", qn, an, bn);
+                    flint_printf("mod: %wu\n", mod.n);
+                    flint_abort();
+                }
+            }
+
+            for (i = bn-1; i > 0; i--)
+            {
+                if (r1[i-1] != r2[i-1] || r1[i-1] != r3[i-1])
+                {
+                    flint_printf("remainder error at index %wu\n", i-1);
+                    flint_printf("r1[i]=%wu, r2[i]=%wu, bn=%wu\n", r1[i-1], r2[i-1]);
+                    flint_printf("qn=%wu, an=%wu, bn=%wu\n", qn, an, bn);
+                    flint_printf("mod: %wu\n", mod.n);
+                    flint_abort();
+                }
+            }
+
+            flint_free(a);
+            flint_free(b);
+            flint_free(q1);
+            flint_free(q2);
+            flint_free(r1);
+            flint_free(r2);
+        }
+    }
+
+    mpn_ctx_clear(R);
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/fft_small/test/t-nmod_poly_mul.c
+++ b/src/fft_small/test/t-nmod_poly_mul.c
@@ -11,11 +11,9 @@
 */
 
 #include "test_helpers.h"
-#include "ulong_extras.h"
 #include "nmod.h"
 #include "nmod_poly.h"
 #include "fft_small.h"
-#include "profiler.h"
 
 TEST_FUNCTION_START(_nmod_poly_mul_mid_mpn_ctx, state)
 {
@@ -80,7 +78,7 @@ TEST_FUNCTION_START(_nmod_poly_mul_mid_mpn_ctx, state)
         ulong * a, *b, * c, * d;
         ulong an, zn, zl, zh, sz, i, reps;
 
-        for (reps = 0; reps < 100; reps++)
+        for (reps = 0; reps < 100 * flint_test_multiplier(); reps++)
         {
             flint_set_num_threads(1 + n_randint(state, 10));
 
@@ -129,7 +127,7 @@ TEST_FUNCTION_START(_nmod_poly_mul_mid_mpn_ctx, state)
         ulong * a, * b, * c, * d;
         ulong an, bn, zn, zl, zh, sz, i, reps;
 
-        for (reps = 0; reps < 100; reps++)
+        for (reps = 0; reps < 100 * flint_test_multiplier(); reps++)
         {
             flint_set_num_threads(1 + n_randint(state, 10));
 
@@ -174,81 +172,6 @@ TEST_FUNCTION_START(_nmod_poly_mul_mid_mpn_ctx, state)
             flint_free(b);
             flint_free(c);
             flint_free(d);
-        }
-    }
-
-    for (nbits = 2; nbits <= FLINT_BITS; nbits++)
-    {
-        ulong * a, * b, * q1, * q2, * q3, * r1, * r2, * r3;
-        ulong an, bn, qn, i, reps;
-        nmod_poly_divrem_precomp_struct M[1];
-
-        for (reps = 0; reps < 100; reps++)
-        {
-            flint_set_num_threads(1 + n_randint(state, 10));
-
-            nmod_init(&mod, n_randbits(state, nbits));
-
-            bn = 2 + n_randint(state, 5000);
-            qn = 1 + n_randint(state, 5000);
-            an = bn + qn - 1;
-
-            a = FLINT_ARRAY_ALLOC(an, ulong);
-            b = FLINT_ARRAY_ALLOC(bn, ulong);
-            q1 = FLINT_ARRAY_ALLOC(qn, ulong);
-            q2 = FLINT_ARRAY_ALLOC(qn, ulong);
-            q3 = FLINT_ARRAY_ALLOC(qn, ulong);
-            r1 = FLINT_ARRAY_ALLOC(bn, ulong);
-            r2 = FLINT_ARRAY_ALLOC(bn, ulong);
-            r3 = FLINT_ARRAY_ALLOC(bn, ulong);
-
-            for (i = 0; i < an; i++)
-                a[i] = n_randint(state, mod.n);
-
-            for (i = 0; i < bn; i++)
-                b[i] = n_randint(state, mod.n);
-
-            while (n_gcd(b[bn-1], mod.n) != 1)
-                b[bn-1] = n_randint(state, mod.n);
-
-            _nmod_poly_divrem(q1, r1, a, an, b, bn, mod);
-
-            _nmod_poly_divrem_mpn_ctx(q2, r2, a, an, b, bn, mod, R);
-
-            ulong prec = qn + n_randint(state, 200);
-            _nmod_poly_divrem_precomp_init(M, b, bn, prec, mod, R);
-            _nmod_poly_divrem_precomp(q3, r3, a, an, M, mod, R);
-            _nmod_poly_divrem_precomp_clear(M);
-
-            for (i = qn; i > 0; i--)
-            {
-                if (q1[i-1] != q2[i-1] || q1[i-1] != q3[i-1])
-                {
-                    flint_printf("quotient error at index %wu\n", i-1);
-                    flint_printf("qn=%wu, an=%wu, bn=%wu\n", qn, an, bn);
-                    flint_printf("mod: %wu\n", mod.n);
-                    flint_abort();
-                }
-            }
-
-            for (i = bn-1; i > 0; i--)
-            {
-                if (r1[i-1] != r2[i-1] || r1[i-1] != r3[i-1])
-                {
-                    flint_printf("remainder error at index %wu\n", i-1);
-                    flint_printf("r1[i]=%wu, r2[i]=%wu, bn=%wu\n", r1[i-1], r2[i-1]);
-                    flint_printf("qn=%wu, an=%wu, bn=%wu\n", qn, an, bn);
-                    flint_printf("mod: %wu\n", mod.n);
-                    flint_abort();
-                }
-            }
-
-            flint_free(a);
-            flint_free(b);
-            flint_free(q1);
-            flint_free(q2);
-            flint_free(r1);
-            flint_free(r2);
         }
     }
 


### PR DESCRIPTION
@fredrik-johansson do we really need to check with such huge sizes? For instance, the test for `mpn_ctx_mpn_mul` multiplies 25 000 limbs with 25 000 limbs in each test iteration.