### PR TITLE
Randomize nbits in fft_small's nmod_poly tests

### DIFF
--- a/src/fft_small/test/t-nmod_poly_divrem.c
+++ b/src/fft_small/test/t-nmod_poly_divrem.c
@@ -23,16 +23,17 @@ TEST_FUNCTION_START(_nmod_poly_divrem_mpn_ctx, state)
 
     mpn_ctx_init(R, UWORD(0x0003f00000000001));
 
-    for (nbits = 2; nbits <= FLINT_BITS; nbits++)
     {
         ulong * a, * b, * q1, * q2, * q3, * r1, * r2, * r3;
         ulong an, bn, qn, i, reps;
         nmod_poly_divrem_precomp_struct M[1];
 
-        for (reps = 0; reps < 100 * flint_test_multiplier(); reps++)
+        for (reps = 0; reps < 1000 * flint_test_multiplier(); reps++)
         {
             flint_set_num_threads(1 + n_randint(state, 10));
 
+            /* 2 <= nbits <= FLINT_BITS */
+            nbits = 2 + n_randint(state, FLINT_BITS - 1);
             nmod_init(&mod, n_randbits(state, nbits));
 
             bn = 2 + n_randint(state, 5000);

--- a/src/fft_small/test/t-nmod_poly_mul.c
+++ b/src/fft_small/test/t-nmod_poly_mul.c
@@ -73,15 +73,17 @@ TEST_FUNCTION_START(_nmod_poly_mul_mid_mpn_ctx, state)
     }
 #endif
 
-    for (nbits = 1; nbits <= FLINT_BITS; nbits ++)
+    /* Check squaring */
     {
         ulong * a, *b, * c, * d;
         ulong an, zn, zl, zh, sz, i, reps;
 
-        for (reps = 0; reps < 100 * flint_test_multiplier(); reps++)
+        for (reps = 0; reps < 1000 * flint_test_multiplier(); reps++)
         {
             flint_set_num_threads(1 + n_randint(state, 10));
 
+            /* 1 <= nbits <= FLINT_BITS */
+            nbits = 1 + n_randint(state, FLINT_BITS);
             nmod_init(&mod, n_randbits(state, nbits));
 
             an = 1 + n_randint(state, 7000);
@@ -122,15 +124,17 @@ TEST_FUNCTION_START(_nmod_poly_mul_mid_mpn_ctx, state)
         }
     }
 
-    for (nbits = 1; nbits <= FLINT_BITS; nbits ++)
+    /* Check multiplication */
     {
         ulong * a, * b, * c, * d;
         ulong an, bn, zn, zl, zh, sz, i, reps;
 
-        for (reps = 0; reps < 100 * flint_test_multiplier(); reps++)
+        for (reps = 0; reps < 1000 * flint_test_multiplier(); reps++)
         {
             flint_set_num_threads(1 + n_randint(state, 10));
 
+            /* 1 <= nbits <= FLINT_BITS */
+            nbits = 1 + n_randint(state, FLINT_BITS);
             nmod_init(&mod, n_randbits(state, nbits));
 
             an = 1 + n_randint(state, 7000);


### PR DESCRIPTION
This will also reduce the test time.