### PR TITLE
Introduce FLINT_SWAP macro to replace PTR_SWAP, DOUBLE_SWAP, ...

### DIFF
--- a/src/acb_mat.h
+++ b/src/acb_mat.h
@@ -376,19 +376,10 @@ acb_mat_swap_rows(acb_mat_t mat, slong * perm, slong r, slong s)
 {
     if (r != s)
     {
-        acb_ptr u;
-        slong t;
-
         if (perm != NULL)
-        {
-            t = perm[s];
-            perm[s] = perm[r];
-            perm[r] = t;
-        }
+            FLINT_SWAP(slong, perm[r], perm[s]);
 
-        u = mat->rows[s];
-        mat->rows[s] = mat->rows[r];
-        mat->rows[r] = u;
+        FLINT_SWAP(acb_ptr, mat->rows[r], mat->rows[s]);
     }
 }
 

--- a/src/arb.h
+++ b/src/arb.h
@@ -138,9 +138,7 @@ void arb_set(arb_t x, const arb_t y);
 ARB_INLINE void
 arb_swap(arb_t x, arb_t y)
 {
-    arb_struct t = *x;
-    *x = *y;
-    *y = t;
+    FLINT_SWAP(arb_struct, *x, *y);
 }
 
 void arb_set_round(arb_t z, const arb_t x, slong prec);

--- a/src/arb_mat.h
+++ b/src/arb_mat.h
@@ -44,9 +44,7 @@ void arb_mat_clear(arb_mat_t mat);
 ARB_MAT_INLINE void
 arb_mat_swap(arb_mat_t mat1, arb_mat_t mat2)
 {
-    arb_mat_struct t = *mat1;
-    *mat1 = *mat2;
-    *mat2 = t;
+    FLINT_SWAP(arb_mat_struct, *mat1, *mat2);
 }
 
 ARB_MAT_INLINE void
@@ -332,19 +330,10 @@ arb_mat_swap_rows(arb_mat_t mat, slong * perm, slong r, slong s)
 {
     if (r != s)
     {
-        arb_ptr u;
-        slong t;
-
         if (perm != NULL)
-        {
-            t = perm[s];
-            perm[s] = perm[r];
-            perm[r] = t;
-        }
+            FLINT_SWAP(slong, perm[r], perm[s]);
 
-        u = mat->rows[s];
-        mat->rows[s] = mat->rows[r];
-        mat->rows[r] = u;
+        FLINT_SWAP(arb_ptr, mat->rows[r], mat->rows[s]);
     }
 }
 

--- a/src/arf.h
+++ b/src/arf.h
@@ -323,12 +323,7 @@ int arf_cmp_d(const arf_t x, double y);
 ARF_INLINE void
 arf_swap(arf_t y, arf_t x)
 {
-    if (x != y)
-    {
-        arf_struct t = *x;
-        *x = *y;
-        *y = t;
-    }
+    FLINT_SWAP(arf_struct, *x, *y);
 }
 
 void arf_set(arf_t y, const arf_t x);

--- a/src/arf/add.c
+++ b/src/arf/add.c
@@ -63,8 +63,7 @@ arf_add(arf_ptr z, arf_srcptr x, arf_srcptr y, slong prec, arf_rnd_t rnd)
 
     if (shift < 0)
     {
-        arf_srcptr __t;
-        __t = x; x = y; y = __t;
+        FLINT_SWAP(arf_srcptr, x, y);
         shift = -shift;
     }
 

--- a/src/arf/mul_rnd_any.c
+++ b/src/arf/mul_rnd_any.c
@@ -28,9 +28,8 @@ arf_mul_rnd_any(arf_ptr z, arf_srcptr x, arf_srcptr y,
 
     if (yn > xn)
     {
-        arf_srcptr __t; mp_size_t __u;
-        __t = x; x = y; y = __t;
-        __u = xn; xn = yn; yn = __u;
+        FLINT_SWAP(arf_srcptr, x, y);
+        FLINT_SWAP(mp_size_t, xn, yn);
     }
 
     /* Either operand is a special value. */

--- a/src/arf/mul_rnd_down.c
+++ b/src/arf/mul_rnd_down.c
@@ -29,9 +29,8 @@ arf_mul_rnd_down(arf_ptr z, arf_srcptr x, arf_srcptr y, slong prec)
 
     if (yn > xn)
     {
-        arf_srcptr __t; mp_size_t __u;
-        __t = x; x = y; y = __t;
-        __u = xn; xn = yn; yn = __u;
+        FLINT_SWAP(arf_srcptr, x, y);
+        FLINT_SWAP(mp_size_t, xn, yn);
     }
 
     /* Either operand is a special value. */

--- a/src/ca/swap.c
+++ b/src/ca/swap.c
@@ -14,9 +14,6 @@
 void
 ca_swap(ca_t x, ca_t y, ca_ctx_t ctx)
 {
-    ca_t tmp;
-    *tmp = *x;
-    *x = *y;
-    *y = *tmp;
+    FLINT_SWAP(ca_struct, *x, *y);
 }
 

--- a/src/ca_mat.h
+++ b/src/ca_mat.h
@@ -56,9 +56,7 @@ void ca_mat_clear(ca_mat_t mat, ca_ctx_t ctx);
 CA_MAT_INLINE void
 ca_mat_swap(ca_mat_t mat1, ca_mat_t mat2, ca_ctx_t ctx)
 {
-    ca_mat_struct t = *mat1;
-    *mat1 = *mat2;
-    *mat2 = t;
+    FLINT_SWAP(ca_mat_struct, *mat1, *mat2);
 }
 
 /* Window matrices */
@@ -249,19 +247,10 @@ _ca_mat_swap_rows(ca_mat_t mat, slong * perm, slong r, slong s)
 {
     if (r != s)
     {
-        ca_ptr u;
-        slong t;
-
         if (perm != NULL)
-        {
-            t = perm[s];
-            perm[s] = perm[r];
-            perm[r] = t;
-        }
+            FLINT_SWAP(slong, perm[r], perm[s]);
 
-        u = mat->rows[s];
-        mat->rows[s] = mat->rows[r];
-        mat->rows[r] = u;
+        FLINT_SWAP(ca_ptr, mat->rows[r], mat->rows[s]);
     }
 }
 

--- a/src/d_mat.h
+++ b/src/d_mat.h
@@ -78,7 +78,7 @@ d_mat_swap_entrywise(d_mat_t mat1, d_mat_t mat2)
        double * row1 = mat1->rows[i];
        double * row2 = mat2->rows[i];
        for (j = 0; j < d_mat_ncols(mat1); j++)
-          DOUBLE_SWAP(row1[j], row2[j]);
+          FLINT_SWAP(double, row1[j], row2[j]);
     }
 }
 
@@ -135,11 +135,7 @@ void d_mat_swap_rows(d_mat_t mat, slong r, slong s)
 {
     if (r != s)
     {
-        double * u;
-
-        u = mat->rows[s];
-        mat->rows[s] = mat->rows[r];
-        mat->rows[r] = u;
+        FLINT_SWAP(double *, mat->rows[r], mat->rows[s]);
     }
 }
 

--- a/src/d_mat/swap.c
+++ b/src/d_mat/swap.c
@@ -15,12 +15,5 @@
 void
 d_mat_swap(d_mat_t mat1, d_mat_t mat2)
 {
-    if (mat1 != mat2)
-    {
-        d_mat_struct tmp;
-
-        tmp = *mat1;
-        *mat1 = *mat2;
-        *mat2 = tmp;
-    }
+    FLINT_SWAP(d_mat_struct, *mat1, *mat2);
 }

--- a/src/fexpr.h
+++ b/src/fexpr.h
@@ -147,11 +147,8 @@ fexpr_set(fexpr_t res, const fexpr_t expr)
 FEXPR_INLINE void
 fexpr_swap(fexpr_t a, fexpr_t b)
 {
-    fexpr_struct tmp = *a;
-    *a = *b;
-    *b = tmp;
+    FLINT_SWAP(fexpr_struct, *a, *b);
 }
-
 
 FEXPR_INLINE int
 _mpn_equal(mp_srcptr a, mp_srcptr b, slong len)

--- a/src/fft_small/nmod_poly_mul.c
+++ b/src/fft_small/nmod_poly_mul.c
@@ -1365,8 +1365,8 @@ void _nmod_poly_mul_mid(
 
     if (an < bn)
     {
-        PTR_SWAP(const ulong, a, b);
-        ULONG_SWAP(an, bn);
+        FLINT_SWAP(const ulong *, a, b);
+        FLINT_SWAP(ulong, an, bn);
     }
 
     if (zl > bn - 1)

--- a/src/fft_small/profile/p-nmod_poly_mul.c
+++ b/src/fft_small/profile/p-nmod_poly_mul.c
@@ -135,7 +135,7 @@ int main(void)
             bn = 1 + zn - an;
 
             if (an < bn)
-                ULONG_SWAP(an, bn);
+                FLINT_SWAP(ulong, an, bn);
 
             nreps = 1 + 100000000/(zn*n_nbits(zn));
 

--- a/src/flint.h.in
+++ b/src/flint.h.in
@@ -323,49 +323,7 @@ ulong n_randtest_not_zero(flint_rand_t);
 #define FLINT_ABS(x) ((slong)(x) < 0 ? (-(x)) : (x))
 #define FLINT_SIGN_EXT(x) (-(ulong)((slong)(x) < 0))
 #define FLINT_SGN(x) ((0 < (slong)(x)) - ((slong)(x) < 0))
-
-#define MP_PTR_SWAP(x, y) \
-    do { \
-        mp_limb_t * __txxx; \
-        __txxx = x; \
-        x = y; \
-        y = __txxx; \
-    } while (0)
-
-#define SLONG_SWAP(A, B)    \
-    do {                    \
-        slong __t_m_p_ = A; \
-        A = B;              \
-        B = __t_m_p_;       \
-    } while (0)
-
-#define ULONG_SWAP(A, B)    \
-    do {                    \
-        ulong __t_m_p_ = A; \
-        A = B;              \
-        B = __t_m_p_;       \
-    } while (0)
-
-#define MP_LIMB_SWAP(A, B)      \
-    do {                        \
-        mp_limb_t __t_m_p_ = A; \
-        A = B;                  \
-        B = __t_m_p_;           \
-    } while (0)
-
-#define DOUBLE_SWAP(A, B)    \
-    do {                     \
-        double __t_m_p_ = A; \
-        A = B;               \
-        B = __t_m_p_;        \
-    } while (0)
-
-#define PTR_SWAP(T, A, B)    \
-    do {                    \
-        T* __t_m_p_ = A; \
-        A = B;              \
-        B = __t_m_p_;       \
-    } while (0)
+#define FLINT_SWAP(T, x, y) do { T _swap_t = (x); (x) = (y); (y) = _swap_t; } while(0)
 
 #define r_shift(in, shift) \
     ((shift == FLINT_BITS) ? WORD(0) : ((in) >> (shift)))

--- a/src/fmpq/get_cfrac_helpers.c
+++ b/src/fmpq/get_cfrac_helpers.c
@@ -577,8 +577,8 @@ its_ok:
 
     _fmpq_cfrac_list_append_ui(s, s_temp, written);
 
-    FLINT_MPZ_PTR_SWAP(xn, yn);
-    FLINT_MPZ_PTR_SWAP(xd, yd);
+    FLINT_SWAP(mpz_ptr, xn, yn);
+    FLINT_SWAP(mpz_ptr, xd, yd);
 
     goto again;
 
@@ -765,10 +765,10 @@ again:
     /* already checked that s will fit new terms */
     _fmpq_cfrac_list_append_ui(s, s_temp, written);
 
-    FLINT_MPZ_PTR_SWAP(xln, yln);
-    FLINT_MPZ_PTR_SWAP(xld, yld);
-    FLINT_MPZ_PTR_SWAP(xrn, yrn);
-    FLINT_MPZ_PTR_SWAP(xrd, yrd);
+    FLINT_SWAP(mpz_ptr, xln, yln);
+    FLINT_SWAP(mpz_ptr, xld, yld);
+    FLINT_SWAP(mpz_ptr, xrn, yrn);
+    FLINT_SWAP(mpz_ptr, xrd, yrd);
 
     goto again;
 

--- a/src/fmpq/reconstruct_fmpz_2.c
+++ b/src/fmpq/reconstruct_fmpz_2.c
@@ -769,8 +769,8 @@ again:
     /* a = s; b = t */
     s->_mp_size = s_len;
     t->_mp_size = t_len;
-    FLINT_MPZ_PTR_SWAP(a, s);
-    FLINT_MPZ_PTR_SWAP(b, t);
+    FLINT_SWAP(mpz_ptr, a, s);
+    FLINT_SWAP(mpz_ptr, b, t);
 
     /* so a > n. see if further a > n >= b. */
     if (t_len < n_len || (t_len == n_len && mpn_cmp(t_ptr, n_ptr, n_len) <= 0))

--- a/src/fmpq_mat/invert.c
+++ b/src/fmpq_mat/invert.c
@@ -24,27 +24,16 @@ void fmpq_mat_invert_cols(fmpq_mat_t mat, slong * perm)
 {
     if (!fmpq_mat_is_empty(mat))
     {
-        slong t;
-        slong i;
+        slong t, i;
         slong c = mat->c;
         slong k = mat->c/2;
 
-        if (perm)
-        {
+        if (perm != NULL)
             for (i = 0; i < k; i++)
-            {
-                t = perm[i];
-                perm[i] = perm[c - i - 1];
-                perm[c - i - 1] = t;
-            }
-        }
+                FLINT_SWAP(slong, perm[i], perm[c - i - 1]);
 
         for (t = 0; t < mat->r; t++)
-        {
             for (i = 0; i < k; i++)
-            {
                 fmpq_swap(fmpq_mat_entry(mat, t, i), fmpq_mat_entry(mat, t, c - i - 1));
-            }
-        }
     }
 }

--- a/src/fmpq_mat/swap.c
+++ b/src/fmpq_mat/swap.c
@@ -16,14 +16,7 @@
 void
 fmpq_mat_swap(fmpq_mat_t mat1, fmpq_mat_t mat2)
 {
-    if (mat1 != mat2)
-    {
-        fmpq_mat_struct tmp;
-
-        tmp = *mat1;
-        *mat1 = *mat2;
-        *mat2 = tmp;
-    }
+    FLINT_SWAP(fmpq_mat_struct, *mat1, *mat2);
 }
 
 void
@@ -41,19 +34,13 @@ fmpq_mat_swap_cols(fmpq_mat_t mat, slong * perm, slong r, slong s)
 {
     if (r != s && !fmpq_mat_is_empty(mat))
     {
-        slong t;
+        slong i;
 
         if (perm)
-        {
-            t = perm[s];
-            perm[s] = perm[r];
-            perm[r] = t;
-        }
+            FLINT_SWAP(slong, perm[r], perm[s]);
 
-       for (t = 0; t < mat->r; t++)
-       {
-           fmpq_swap(fmpq_mat_entry(mat, t, r), fmpq_mat_entry(mat, t, s));
-       }
+        for (i = 0; i < mat->r; i++)
+            fmpq_swap(fmpq_mat_entry(mat, i, r), fmpq_mat_entry(mat, i, s));
     }
 }
 
@@ -62,18 +49,9 @@ fmpq_mat_swap_rows(fmpq_mat_t mat, slong * perm, slong r, slong s)
 {
     if (r != s && !fmpq_mat_is_empty(mat))
     {
-        fmpq * u;
-        slong t;
-
         if (perm)
-        {
-            t = perm[s];
-            perm[s] = perm[r];
-            perm[r] = t;
-        }
+            FLINT_SWAP(slong, perm[r], perm[s]);
 
-        u = mat->rows[s];
-        mat->rows[s] = mat->rows[r];
-        mat->rows[r] = u;
+        FLINT_SWAP(fmpq *, mat->rows[r], mat->rows[s]);
     }
 }

--- a/src/fmpq_mpoly.h
+++ b/src/fmpq_mpoly.h
@@ -206,9 +206,7 @@ FMPQ_MPOLY_INLINE
 void fmpq_mpoly_swap(fmpq_mpoly_t A,
                                 fmpq_mpoly_t B, const fmpq_mpoly_ctx_t ctx)
 {
-    fmpq_mpoly_struct t = *A;
-    *A = *B;
-    *B = t;
+    FLINT_SWAP(fmpq_mpoly_struct, *A, *B);
 }
 
 
@@ -827,9 +825,7 @@ FMPQ_MPOLY_INLINE
 void fmpq_mpoly_univar_swap(fmpq_mpoly_univar_t A, fmpq_mpoly_univar_t B,
                                                     const fmpq_mpoly_ctx_t ctx)
 {
-   fmpq_mpoly_univar_struct t = *A;
-   *A = *B;
-   *B = t;
+    FLINT_SWAP(fmpq_mpoly_univar_struct, *A, *B);
 }
 
 FMPQ_MPOLY_INLINE

--- a/src/fmpq_mpoly/test/t-content_vars.c
+++ b/src/fmpq_mpoly/test/t-content_vars.c
@@ -51,7 +51,7 @@ TEST_FUNCTION_START(fmpq_mpoly_content_vars, state)
         {
             slong k1 = n_randint(state, nvars);
             slong k2 = n_randint(state, nvars);
-            SLONG_SWAP(vars[k1], vars[k2]);
+            FLINT_SWAP(slong, vars[k1], vars[k2]);
         }
 
         num_vars = 1 + n_randint(state, nvars);

--- a/src/fmpq_poly/swap.c
+++ b/src/fmpq_poly/swap.c
@@ -15,21 +15,5 @@
 
 void fmpq_poly_swap(fmpq_poly_t poly1, fmpq_poly_t poly2)
 {
-    slong t;
-    fmpz * tptr;
-
-    t             = poly1->length;
-    poly1->length = poly2->length;
-    poly2->length = t;
-
-    t             = poly1->alloc;
-    poly1->alloc  = poly2->alloc;
-    poly2->alloc  = t;
-
-    tptr          = poly1->coeffs;
-    poly1->coeffs = poly2->coeffs;
-    poly2->coeffs = tptr;
-
-    fmpz_swap(poly1->den, poly2->den);
+    FLINT_SWAP(fmpq_poly_struct, *poly1, *poly2);
 }
-

--- a/src/fmpz/multi_CRT_precompute.c
+++ b/src/fmpz/multi_CRT_precompute.c
@@ -70,7 +70,7 @@ static int _fill_pfrac(
         if (cmp > 0)
         {
             fmpz_swap(v + j, v + j + 1);
-            SLONG_SWAP(link[j], link[j + 1]);
+            FLINT_SWAP(slong, link[j], link[j + 1]);
         }
 
         fmpz_gcdinv(g, s, v + j + 0, v + j + 1);
@@ -223,7 +223,7 @@ int fmpz_multi_CRT_precompute(
             }
         }
         fmpz_swap(v + j, v + minp);
-        SLONG_SWAP(link[j], link[minp]);
+        FLINT_SWAP(slong, link[j], link[minp]);
 
         minp = j + 1;
         mind = v + j + 1;
@@ -236,7 +236,7 @@ int fmpz_multi_CRT_precompute(
             }
         }
         fmpz_swap(v + j + 1, v + minp);
-        SLONG_SWAP(link[j + 1], link[minp]);
+        FLINT_SWAP(slong, link[j + 1], link[minp]);
 
         fmpz_mul(v + i, v + j, v + j + 1);
         link[i] = j;

--- a/src/fmpz/multi_mod_precompute.c
+++ b/src/fmpz/multi_mod_precompute.c
@@ -50,7 +50,7 @@ static int _fill_sort(slong * link, fmpz * v, slong j)
         if (cmp > 0)
         {
             fmpz_swap(v + j, v + j + 1);
-            SLONG_SWAP(link[j], link[j + 1]);
+            FLINT_SWAP(slong, link[j], link[j + 1]);
         }
 
         if (!_fill_sort(link, v, link[j + 0]))
@@ -183,7 +183,7 @@ int fmpz_multi_mod_precompute(
             }
         }
         fmpz_swap(v + j, v + minp);
-        SLONG_SWAP(link[j], link[minp]);
+        FLINT_SWAP(slong, link[j], link[minp]);
 
         minp = j + 1;
         mind = v + j + 1;
@@ -196,7 +196,7 @@ int fmpz_multi_mod_precompute(
             }
         }
         fmpz_swap(v + j + 1, v + minp);
-        SLONG_SWAP(link[j + 1], link[minp]);
+        FLINT_SWAP(slong, link[j + 1], link[minp]);
 
         fmpz_mul(v + i, v + j, v + j + 1);
         link[i] = j;

--- a/src/fmpz/test/t-multi_CRT_ui.c
+++ b/src/fmpz/test/t-multi_CRT_ui.c
@@ -45,7 +45,7 @@ try_again:
         bits1 = n_randint(state, FLINT_BITS*3/4) + FLINT_BITS/4;
         bits2 = n_randint(state, FLINT_BITS*3/4) + FLINT_BITS/4;
         if (bits1 > bits2)
-            ULONG_SWAP(bits1, bits2);
+            FLINT_SWAP(ulong, bits1, bits2);
 
         fmpz_one(prod);
         for (j = 0; j < num_primes; j++)

--- a/src/fmpz_mat.h
+++ b/src/fmpz_mat.h
@@ -260,19 +260,10 @@ void fmpz_mat_swap_rows(fmpz_mat_t mat, slong * perm, slong r, slong s)
 {
     if (r != s && !fmpz_mat_is_empty(mat))
     {
-        fmpz * u;
-        slong t;
+        if (perm != NULL)
+            FLINT_SWAP(slong, perm[r], perm[s]);
 
-        if (perm)
-        {
-            t = perm[s];
-            perm[s] = perm[r];
-            perm[r] = t;
-        }
-
-        u = mat->rows[s];
-        mat->rows[s] = mat->rows[r];
-        mat->rows[r] = u;
+        FLINT_SWAP(fmpz *, mat->rows[r], mat->rows[s]);
     }
 }
 

--- a/src/fmpz_mat/invert.c
+++ b/src/fmpz_mat/invert.c
@@ -24,27 +24,16 @@ void fmpz_mat_invert_cols(fmpz_mat_t mat, slong * perm)
 {
     if (!fmpz_mat_is_empty(mat))
     {
-        slong t;
-        slong i;
+        slong t, i;
         slong c = mat->c;
         slong k = mat->c/2;
 
-        if (perm)
-        {
+        if (perm != NULL)
             for (i = 0; i < k; i++)
-            {
-                t = perm[i];
-                perm[i] = perm[c - i - 1];
-                perm[c - i - 1] = t;
-            }
-        }
+                FLINT_SWAP(slong, perm[i], perm[c - i - 1]);
 
         for (t = 0; t < mat->r; t++)
-        {
             for (i = 0; i < k; i++)
-            {
                 fmpz_swap(fmpz_mat_entry(mat, t, i), fmpz_mat_entry(mat, t, c - i - 1));
-            }
-        }
     }
 }

--- a/src/fmpz_mat/swap.c
+++ b/src/fmpz_mat/swap.c
@@ -15,14 +15,7 @@
 void
 fmpz_mat_swap(fmpz_mat_t mat1, fmpz_mat_t mat2)
 {
-    if (mat1 != mat2)
-    {
-        fmpz_mat_struct tmp;
-
-        tmp = *mat1;
-        *mat1 = *mat2;
-        *mat2 = tmp;
-    }
+    FLINT_SWAP(fmpz_mat_struct, *mat1, *mat2);
 }
 
 void
@@ -40,18 +33,12 @@ fmpz_mat_swap_cols(fmpz_mat_t mat, slong * perm, slong r, slong s)
 {
     if (r != s && !fmpz_mat_is_empty(mat))
     {
-        slong t;
+        slong i;
 
         if (perm)
-        {
-            t = perm[s];
-            perm[s] = perm[r];
-            perm[r] = t;
-        }
+            FLINT_SWAP(slong, perm[r], perm[s]);
 
-       for (t = 0; t < mat->r; t++)
-       {
-           fmpz_swap(fmpz_mat_entry(mat, t, r), fmpz_mat_entry(mat, t, s));
-       }
+       for (i = 0; i < mat->r; i++)
+           fmpz_swap(fmpz_mat_entry(mat, i, r), fmpz_mat_entry(mat, i, s));
     }
 }

--- a/src/fmpz_mat/swap.c
+++ b/src/fmpz_mat/swap.c
@@ -35,7 +35,7 @@ fmpz_mat_swap_cols(fmpz_mat_t mat, slong * perm, slong r, slong s)
     {
         slong i;
 
-        if (perm)
+        if (perm != NULL)
             FLINT_SWAP(slong, perm[r], perm[s]);
 
        for (i = 0; i < mat->r; i++)

--- a/src/fmpz_mod_mat/swap.c
+++ b/src/fmpz_mod_mat/swap.c
@@ -15,14 +15,7 @@
 void
 fmpz_mod_mat_swap(fmpz_mod_mat_t mat1, fmpz_mod_mat_t mat2)
 {
-    if (mat1 != mat2)
-    {
-        fmpz_mod_mat_struct tmp;
-
-        tmp = *mat1;
-        *mat1 = *mat2;
-        *mat2 = tmp;
-    }
+    FLINT_SWAP(fmpz_mod_mat_struct, *mat1, *mat2);
 }
 
 void

--- a/src/fmpz_mod_mpoly.h
+++ b/src/fmpz_mod_mpoly.h
@@ -202,9 +202,7 @@ FMPZ_MOD_MPOLY_INLINE
 void fmpz_mod_mpoly_swap(fmpz_mod_mpoly_t A, fmpz_mod_mpoly_t B,
                                                 const fmpz_mod_mpoly_ctx_t ctx)
 {
-    fmpz_mod_mpoly_struct t = *A;
-    *A = *B;
-    *B = t;
+    FLINT_SWAP(fmpz_mod_mpoly_struct, *A, *B);
 }
 
 /* Constants *****************************************************************/
@@ -856,9 +854,7 @@ FMPZ_MOD_MPOLY_INLINE
 void fmpz_mod_mpoly_univar_swap(fmpz_mod_mpoly_univar_t A,
                      fmpz_mod_mpoly_univar_t B, const fmpz_mod_mpoly_ctx_t ctx)
 {
-    fmpz_mod_mpoly_univar_struct t = *A;
-    *A = *B;
-    *B = t;
+    FLINT_SWAP(fmpz_mod_mpoly_univar_struct, *A, *B);
 }
 
 FMPZ_MOD_MPOLY_INLINE

--- a/src/fmpz_mod_mpoly/sort_terms.c
+++ b/src/fmpz_mod_mpoly/sort_terms.c
@@ -49,7 +49,7 @@ void _fmpz_mod_mpoly_radix_sort1(
                                                    Aexps[j - 1], cmpmask); j--)
                 {
                     fmpz_swap(Acoeffs + j, Acoeffs + j - 1);
-                    ULONG_SWAP(Aexps[j], Aexps[j - 1]);
+                    FLINT_SWAP(ulong, Aexps[j], Aexps[j - 1]);
                 }
             }
 
@@ -73,7 +73,7 @@ void _fmpz_mod_mpoly_radix_sort1(
             if ((Aexps[cur] & mask) != cmp)
             {
                 fmpz_swap(Acoeffs + cur, Acoeffs + mid);
-                ULONG_SWAP(Aexps[cur], Aexps[mid]);
+                FLINT_SWAP(ulong, Aexps[cur], Aexps[mid]);
                 mid++;
             }
         }

--- a/src/fmpz_mod_mpoly/test/t-evaluate.c
+++ b/src/fmpz_mod_mpoly/test/t-evaluate.c
@@ -52,7 +52,7 @@ TEST_FUNCTION_START(fmpz_mod_mpoly_evaluate, state)
         {
             slong a = n_randint(state, nvars);
             slong b = n_randint(state, nvars);
-            SLONG_SWAP(perm[a], perm[b]);
+            FLINT_SWAP(slong, perm[a], perm[b]);
         }
 
         for (j = 0; j < 4; j++)

--- a/src/fmpz_mod_mpoly/univar.c
+++ b/src/fmpz_mod_mpoly/univar.c
@@ -602,7 +602,7 @@ static void mpoly_univar_swap_fmpz_mod_mpoly_univar(
         fmpz_mod_mpoly_swap(COEFF(A, i), B->coeffs + i, ctx);
     }
 
-    SLONG_SWAP(A->length, B->length);
+    FLINT_SWAP(slong, A->length, B->length);
 }
 
 int fmpz_mod_mpoly_univar_pseudo_gcd(

--- a/src/fmpz_mod_mpoly_factor/bpoly_factor_smprime.c
+++ b/src/fmpz_mod_mpoly_factor/bpoly_factor_smprime.c
@@ -391,7 +391,7 @@ static void _fmpz_mod_bpoly_lift_build_tree(
             }
         }
         fmpz_mod_bpoly_swap(v + j, v + minp, ctx);
-        SLONG_SWAP(link[j], link[minp]);
+        FLINT_SWAP(slong, link[j], link[minp]);
 
         minp = j + 1;
         mind = fmpz_mod_bpoly_degree0(v + j + 1, ctx);
@@ -404,7 +404,7 @@ static void _fmpz_mod_bpoly_lift_build_tree(
             }
         }
         fmpz_mod_bpoly_swap(v + j + 1, v + minp, ctx);
-        SLONG_SWAP(link[j + 1], link[minp]);
+        FLINT_SWAP(slong, link[j + 1], link[minp]);
 
         fmpz_mod_bpoly_mul_series(v + i, v + j, v + j + 1, L->fac_lift_order, ctx);
         link[i] = j;

--- a/src/fmpz_mod_mpoly_factor/factor_content.c
+++ b/src/fmpz_mod_mpoly_factor/factor_content.c
@@ -53,7 +53,7 @@ FLINT_ASSERT(fmpz_mod_mpoly_is_canonical(a, ctx));
     /* sort vars by decreasing length */
     for (i = 1; i < mvars; i++)
         for (j = i; j > 0 && u[vars[j]].length > u[vars[j - 1]].length; j--)
-            SLONG_SWAP(vars[j], vars[j - 1]);
+            FLINT_SWAP(slong, vars[j], vars[j - 1]);
 
     for (i = 0; i < mvars; i++)
     {

--- a/src/fmpz_mod_mpoly_factor/gcd_zippel.c
+++ b/src/fmpz_mod_mpoly_factor/gcd_zippel.c
@@ -736,7 +736,7 @@ outer_loop:
 
     for (i = 1; i < Gmarks->length; i++)
         for (j = i; j > 0 && length(perm[j-1]) > length(perm[j]); j--)
-            SLONG_SWAP(perm[j-1], perm[j]);
+            FLINT_SWAP(slong, perm[j-1], perm[j]);
 
     req_zip_images = Gmarks->length - 2;
     j = 0;

--- a/src/fmpz_mod_mpoly_factor/mpoly_hlift_zippel.c
+++ b/src/fmpz_mod_mpoly_factor/mpoly_hlift_zippel.c
@@ -710,7 +710,7 @@ static void fmpz_mod_polyu3_add_zip_limit1(
             for (j = Z->length; j > Zi; j--)
             {
                 fmpz_mod_poly_swap(Zcoeffs + j, Zcoeffs + j - 1, ctx);
-                ULONG_SWAP(Zexps[j], Zexps[j - 1]);
+                FLINT_SWAP(ulong, Zexps[j], Zexps[j - 1]);
             }
 
             Z->length++;

--- a/src/fmpz_mod_mpoly_factor/polyu3_mod_hlift.c
+++ b/src/fmpz_mod_mpoly_factor/polyu3_mod_hlift.c
@@ -42,7 +42,7 @@ static void fmpz_mod_polyu_sort_terms(fmpz_mod_polyu_t A)
     for (j = i; j > 0 && A->exps[j - 1] < A->exps[j]; j--)
     {
         fmpz_swap(A->coeffs + j - 1, A->coeffs + j);
-        ULONG_SWAP(A->exps[j - 1], A->exps[j]);
+        FLINT_SWAP(ulong, A->exps[j - 1], A->exps[j]);
     }
     return;
 }

--- a/src/fmpz_mod_poly.h
+++ b/src/fmpz_mod_poly.h
@@ -189,9 +189,7 @@ FMPZ_MOD_POLY_INLINE
 void fmpz_mod_poly_swap(fmpz_mod_poly_t poly1,
                                fmpz_mod_poly_t poly2, const fmpz_mod_ctx_t ctx)
 {
-    fmpz_mod_poly_struct t = *poly2;
-    *poly2 = *poly1;
-    *poly1 = t;
+    FLINT_SWAP(fmpz_mod_poly_struct, *poly1, *poly2);
 }
 
 void _fmpz_mod_poly_reverse(fmpz * res, const fmpz * poly, slong len, slong n);

--- a/src/fmpz_mpoly.h
+++ b/src/fmpz_mpoly.h
@@ -198,9 +198,7 @@ FMPZ_MPOLY_INLINE
 void fmpz_mpoly_swap(fmpz_mpoly_t A,
                                 fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx)
 {
-   fmpz_mpoly_struct t = *A;
-   *A = *B;
-   *B = t;
+    FLINT_SWAP(fmpz_mpoly_struct, *A, *B);
 }
 
 FMPZ_MPOLY_INLINE
@@ -994,9 +992,7 @@ FMPZ_MPOLY_INLINE
 void fmpz_mpoly_univar_swap(fmpz_mpoly_univar_t A, fmpz_mpoly_univar_t B,
                                                     const fmpz_mpoly_ctx_t ctx)
 {
-   fmpz_mpoly_univar_struct t = *A;
-   *A = *B;
-   *B = t;
+    FLINT_SWAP(fmpz_mpoly_univar_struct, *A, *B);
 }
 
 FMPZ_MPOLY_INLINE

--- a/src/fmpz_mpoly/test/t-content_vars.c
+++ b/src/fmpz_mpoly/test/t-content_vars.c
@@ -51,7 +51,7 @@ TEST_FUNCTION_START(fmpz_mpoly_content_vars, state)
         {
             slong k1 = n_randint(state, nvars);
             slong k2 = n_randint(state, nvars);
-            SLONG_SWAP(vars[k1], vars[k2]);
+            FLINT_SWAP(slong, vars[k1], vars[k2]);
         }
 
         num_vars = 1 + n_randint(state, nvars);

--- a/src/fmpz_mpoly/univar.c
+++ b/src/fmpz_mpoly/univar.c
@@ -580,7 +580,7 @@ static void mpoly_univar_swap_fmpz_mpoly_univar(
         fmpz_mpoly_swap(COEFF(A, i), B->coeffs + i, ctx);
     }
 
-    SLONG_SWAP(A->length, B->length);
+    FLINT_SWAP(slong, A->length, B->length);
 }
 
 int fmpz_mpoly_univar_pseudo_gcd(

--- a/src/fmpz_mpoly_factor/factor_content.c
+++ b/src/fmpz_mpoly_factor/factor_content.c
@@ -48,7 +48,7 @@ static int _split(
     /* sort vars by decreasing length */
     for (i = 1; i < mvars; i++)
         for (j = i; j > 0 && u[vars[j]].length > u[vars[j - 1]].length; j--)
-            SLONG_SWAP(vars[j], vars[j - 1]);
+            FLINT_SWAP(slong, vars[j], vars[j - 1]);
 
     for (i = 0; i < mvars; i++)
     {

--- a/src/fmpz_mpoly_factor/gcd_zippel.c
+++ b/src/fmpz_mpoly_factor/gcd_zippel.c
@@ -168,7 +168,7 @@ outer_loop:
 
     for (i = 1; i < Gmarks->length; i++)
         for (j = i; j > 0 && length(perm[j-1]) > length(perm[j]); j--)
-            SLONG_SWAP(perm[j-1], perm[j]);
+            FLINT_SWAP(slong, perm[j-1], perm[j]);
 
     req_zip_images = Gmarks->length - 2;
     j = 0;

--- a/src/fmpz_mpoly_factor/lcc_kaltofen.c
+++ b/src/fmpz_mpoly_factor/lcc_kaltofen.c
@@ -168,7 +168,7 @@ static void _make_bases_coprime(
             continue;
         A->num--;
         fmpz_poly_swap(A->p + i, A->p + A->num);
-        SLONG_SWAP(A->exp[i], A->exp[A->num]);
+        FLINT_SWAP(slong, A->exp[i], A->exp[A->num]);
         i--;
     }
 
@@ -178,7 +178,7 @@ static void _make_bases_coprime(
             continue;
         B->num--;
         fmpz_poly_swap(B->p + i, B->p + B->num);
-        SLONG_SWAP(B->exp[i], B->exp[B->num]);
+        FLINT_SWAP(slong, B->exp[i], B->exp[B->num]);
         i--;
     }
 

--- a/src/fmpz_poly/gcd_subresultant.c
+++ b/src/fmpz_poly/gcd_subresultant.c
@@ -64,11 +64,9 @@ _fmpz_poly_gcd_subresultant(fmpz * res, const fmpz * poly1, slong len1,
             if (lenA <= 1)
                 break;
 
-            {                       /* Swap A and B */
-                fmpz *T;
-                slong len;
-                T = A, A = B, B = T, len = lenA, lenA = lenB, lenB = len;
-            }
+            /* Swap A and B */
+            FLINT_SWAP(fmpz *, A, B);
+            FLINT_SWAP(slong, lenA, lenB);
 
             if (delta == 1)
             {

--- a/src/fmpz_poly/hensel_build_tree.c
+++ b/src/fmpz_poly/hensel_build_tree.c
@@ -76,11 +76,7 @@ void fmpz_poly_hensel_build_tree(slong *link, fmpz_poly_t *v, fmpz_poly_t *w,
         }
 
         nmod_poly_swap(V[j + 1], V[minp]);
-
-        /* Swap link[j+1] and V[minp] */
-        tmp = link[j + 1];
-        link[j+1] = link[minp];
-        link[minp] = tmp;
+        FLINT_SWAP(slong, link[j + 1], link[minp]);
 
         nmod_poly_mul(V[i], V[j], V[j+1]);
         link[i] = j;

--- a/src/fmpz_poly/swap.c
+++ b/src/fmpz_poly/swap.c
@@ -14,21 +14,5 @@
 void
 fmpz_poly_swap(fmpz_poly_t poly1, fmpz_poly_t poly2)
 {
-    if (poly1 != poly2)
-    {
-        slong temp;
-        fmpz *temp_c;
-
-        temp = poly1->length;
-        poly1->length = poly2->length;
-        poly2->length = temp;
-
-        temp = poly1->alloc;
-        poly1->alloc = poly2->alloc;
-        poly2->alloc = temp;
-
-        temp_c = poly1->coeffs;
-        poly1->coeffs = poly2->coeffs;
-        poly2->coeffs = temp_c;
-    }
+    FLINT_SWAP(fmpz_poly_struct, *poly1, *poly2);
 }

--- a/src/fmpz_poly_mat/swap.c
+++ b/src/fmpz_poly_mat/swap.c
@@ -16,12 +16,5 @@
 void
 fmpz_poly_mat_swap(fmpz_poly_mat_t A, fmpz_poly_mat_t B)
 {
-    if (A != B)
-    {
-        fmpz_poly_mat_struct tmp;
-
-        tmp = *A;
-        *A = *B;
-        *B = tmp;
-    }
+    FLINT_SWAP(fmpz_poly_mat_struct, *A, *B);
 }

--- a/src/fmpzi.h
+++ b/src/fmpzi.h
@@ -79,10 +79,7 @@ fmpzi_conj(fmpzi_t res, const fmpzi_t x)
 FMPZI_INLINE void
 fmpzi_swap(fmpzi_t x, fmpzi_t y)
 {
-    fmpzi_struct t;
-    t = *x;
-    *x = *y;
-    *y = t;
+    FLINT_SWAP(fmpzi_struct, *x, *y);
 }
 
 FMPZI_INLINE void

--- a/src/fmpzi/gcd_shortest.c
+++ b/src/fmpzi/gcd_shortest.c
@@ -312,8 +312,8 @@ void _fmpzi_gcd_shortest(
         slong by_size = fmpz_size(by);
         if (FLINT_MAX(ax_size, ay_size) > FLINT_MAX(bx_size, by_size))
         {
-            PTR_SWAP(const fmpz, ax, bx);
-            PTR_SWAP(const fmpz, ay, by);
+            FLINT_SWAP(const fmpz *, ax, bx);
+            FLINT_SWAP(const fmpz *, ay, by);
         }
     }
 

--- a/src/fq_mat_templates.h
+++ b/src/fq_mat_templates.h
@@ -92,19 +92,10 @@ TEMPLATE(T, mat_swap_rows)(TEMPLATE(T, mat_t) mat, slong * perm, slong r, slong 
 {
     if (r != s && !TEMPLATE(T, mat_is_empty)(mat, ctx))
     {
-        TEMPLATE(T, struct) * u;
-        slong t;
+        if (perm != NULL)
+            FLINT_SWAP(slong, perm[r], perm[s]);
 
-        if (perm)
-        {
-            t = perm[s];
-            perm[s] = perm[r];
-            perm[r] = t;
-        }
-
-        u = mat->rows[s];
-        mat->rows[s] = mat->rows[r];
-        mat->rows[r] = u;
+        FLINT_SWAP(TEMPLATE(T, struct) *, mat->rows[r], mat->rows[s]);
     }
 }
 

--- a/src/fq_mat_templates/mat_invert_cols.c
+++ b/src/fq_mat_templates/mat_invert_cols.c
@@ -19,28 +19,17 @@ TEMPLATE(T, mat_invert_cols)(TEMPLATE(T, mat_t) mat, slong * perm, const TEMPLAT
 {
     if (!TEMPLATE(T, mat_is_empty)(mat, ctx))
     {
-        slong t;
-        slong i;
+        slong t, i;
         slong c = mat->c;
         slong k = mat->c/2;
 
-        if (perm)
-        {
+        if (perm != NULL)
             for (i = 0; i < k; i++)
-            {
-                t = perm[i];
-                perm[i] = perm[c - i - 1];
-                perm[c - i - 1] = t;
-            }
-        }
+                FLINT_SWAP(slong, perm[i], perm[c - i - 1]);
 
         for (t = 0; t < mat->r; t++)
-        {
             for (i = 0; i < k; i++)
-            {
                 TEMPLATE(T, swap)(TEMPLATE(T, mat_entry)(mat, t, i), TEMPLATE(T, mat_entry)(mat, t, c - i - 1), ctx);
-            }
-        }
     }
 }
 

--- a/src/fq_mat_templates/mat_swap_cols.c
+++ b/src/fq_mat_templates/mat_swap_cols.c
@@ -21,17 +21,11 @@ TEMPLATE(T, mat_swap_cols)(TEMPLATE(T, mat_t) mat, slong * perm, slong r, slong 
     {
         slong t;
 
-        if (perm)
-        {
-            t = perm[s];
-            perm[s] = perm[r];
-            perm[r] = t;
-        }
+        if (perm != NULL)
+            FLINT_SWAP(slong, perm[r], perm[s]);
 
-       for (t = 0; t < mat->r; t++)
-       {
-           TEMPLATE(T, swap)(TEMPLATE(T, mat_entry)(mat, t, r), TEMPLATE(T, mat_entry)(mat, t, s), ctx);
-       }
+        for (t = 0; t < mat->r; t++)
+            TEMPLATE(T, swap)(TEMPLATE(T, mat_entry)(mat, t, r), TEMPLATE(T, mat_entry)(mat, t, s), ctx);
     }
 }
 

--- a/src/fq_mat_templates/swap.c
+++ b/src/fq_mat_templates/swap.c
@@ -18,14 +18,7 @@ void
 TEMPLATE(T, mat_swap) (TEMPLATE(T, mat_t) mat1, TEMPLATE(T, mat_t) mat2,
                        const TEMPLATE(T, ctx_t) ctx)
 {
-    if (mat1 != mat2)
-    {
-        TEMPLATE(T, mat_struct) tmp;
-
-        tmp = *mat1;
-        *mat1 = *mat2;
-        *mat2 = tmp;
-    }
+    FLINT_SWAP(TEMPLATE(T, mat_struct), *mat1, *mat2);
 }
 
 

--- a/src/fq_nmod_mpoly.h
+++ b/src/fq_nmod_mpoly.h
@@ -338,9 +338,7 @@ FQ_NMOD_MPOLY_INLINE
 void fq_nmod_mpoly_swap(fq_nmod_mpoly_t A, fq_nmod_mpoly_t B,
                                                  const fq_nmod_mpoly_ctx_t ctx)
 {
-   fq_nmod_mpoly_struct t = *A;
-   *A = *B;
-   *B = t;
+    FLINT_SWAP(fq_nmod_mpoly_struct, *A, *B);
 }
 
 
@@ -1025,9 +1023,7 @@ FQ_NMOD_MPOLY_INLINE
 void fq_nmod_mpoly_univar_swap(fq_nmod_mpoly_univar_t A,
                        fq_nmod_mpoly_univar_t B, const fq_nmod_mpoly_ctx_t ctx)
 {
-   fq_nmod_mpoly_univar_struct t = *A;
-   *A = *B;
-   *B = t;
+    FLINT_SWAP(fq_nmod_mpoly_univar_struct, *A, *B);
 }
 
 FQ_NMOD_MPOLY_INLINE

--- a/src/fq_nmod_mpoly/mpolyu.c
+++ b/src/fq_nmod_mpoly/mpolyu.c
@@ -165,7 +165,7 @@ void fq_nmod_mpolyu_degrees_si(
     mpoly_unpack_vec_ui((ulong *) degs, pmax, bits, ctx->minfo->nvars, 1);
 
     for (i = 0; i < ctx->minfo->nvars/2; i++)
-        SLONG_SWAP(degs[i], degs[ctx->minfo->nvars - i - 1]);
+        FLINT_SWAP(slong, degs[i], degs[ctx->minfo->nvars - i - 1]);
 
     TMP_END;
 }

--- a/src/fq_nmod_mpoly/univar.c
+++ b/src/fq_nmod_mpoly/univar.c
@@ -579,7 +579,7 @@ static void mpoly_univar_swap_fq_nmod_mpoly_univar(
         fq_nmod_mpoly_swap(COEFF(A, i), B->coeffs + i, ctx);
     }
 
-    SLONG_SWAP(A->length, B->length);
+    FLINT_SWAP(slong, A->length, B->length);
 }
 
 int fq_nmod_mpoly_univar_pseudo_gcd(

--- a/src/fq_nmod_mpoly_factor/factor.c
+++ b/src/fq_nmod_mpoly_factor/factor.c
@@ -318,7 +318,7 @@ static int _factor_irred_compressed(
     {
         if (strides[i] == 1)
         {
-            SLONG_SWAP(perm[0], perm[i]);
+            FLINT_SWAP(slong, perm[0], perm[i]);
             break;
         }
     }

--- a/src/fq_nmod_mpoly_factor/factor_content.c
+++ b/src/fq_nmod_mpoly_factor/factor_content.c
@@ -48,7 +48,7 @@ static int _split(
     /* sort vars by decreasing length */
     for (i = 1; i < mvars; i++)
         for (j = i; j > 0 && u[vars[j]].length > u[vars[j - 1]].length; j--)
-            SLONG_SWAP(vars[j], vars[j - 1]);
+            FLINT_SWAP(slong, vars[j], vars[j - 1]);
 
     for (i = 0; i < mvars; i++)
     {

--- a/src/fq_nmod_mpoly_factor/irred_smprime_zippel.c
+++ b/src/fq_nmod_mpoly_factor/irred_smprime_zippel.c
@@ -708,7 +708,7 @@ static void fq_nmod_polyu3_add_zip_limit1(
             for (j = Z->length; j > Zi; j--)
             {
                 n_poly_swap(Zcoeffs + j, Zcoeffs + j - 1);
-                ULONG_SWAP(Zexps[j], Zexps[j - 1]);
+                FLINT_SWAP(ulong, Zexps[j], Zexps[j - 1]);
             }
 
             Z->length++;

--- a/src/fq_nmod_mpoly_factor/n_bpoly_fq_factor_lgprime.c
+++ b/src/fq_nmod_mpoly_factor/n_bpoly_fq_factor_lgprime.c
@@ -435,7 +435,7 @@ static void _hensel_build_tree(
             }
         }
         n_poly_swap(V + j, V + minp);
-        SLONG_SWAP(link[j], link[minp]);
+        FLINT_SWAP(slong, link[j], link[minp]);
 
         minp = j + 1;
         mind = n_poly_degree(V + j + 1);
@@ -448,7 +448,7 @@ static void _hensel_build_tree(
             }
         }
         n_poly_swap(V + j + 1, V + minp);
-        SLONG_SWAP(link[j + 1], link[minp]);
+        FLINT_SWAP(slong, link[j + 1], link[minp]);
 
         n_fq_poly_mul(V + i, V + j, V + j + 1, emb->lgctx);
         link[i] = j;

--- a/src/fq_nmod_mpoly_factor/n_bpoly_fq_factor_smprime.c
+++ b/src/fq_nmod_mpoly_factor/n_bpoly_fq_factor_smprime.c
@@ -136,7 +136,7 @@ static void _hensel_build_tree(
             }
         }
         n_poly_swap(V + j, V + minp);
-        SLONG_SWAP(link[j], link[minp]);
+        FLINT_SWAP(slong, link[j], link[minp]);
 
         minp = j + 1;
         mind = n_poly_degree(V + j + 1);
@@ -149,7 +149,7 @@ static void _hensel_build_tree(
             }
         }
         n_poly_swap(V + j + 1, V + minp);
-        SLONG_SWAP(link[j + 1], link[minp]);
+        FLINT_SWAP(slong, link[j + 1], link[minp]);
 
         n_fq_poly_mul(V + i, V + j, V + j + 1, ctx);
         link[i] = j;

--- a/src/fq_nmod_mpoly_factor/polyu3_hlift.c
+++ b/src/fq_nmod_mpoly_factor/polyu3_hlift.c
@@ -44,7 +44,7 @@ static void n_fq_polyu_sort_terms(
     for (i = 1; i < A->length; i++)
     for (j = i; j > 0 && A->exps[j - 1] < A->exps[j]; j--)
     {
-        ULONG_SWAP(A->exps[j - 1], A->exps[j]);
+        FLINT_SWAP(ulong, A->exps[j - 1], A->exps[j]);
         _n_fq_swap(A->coeffs + d*(j - 1), A->coeffs + d*(j), d);
     }
     return;

--- a/src/fq_poly_templates/swap.c
+++ b/src/fq_poly_templates/swap.c
@@ -19,23 +19,7 @@ void
 TEMPLATE(T, poly_swap) (TEMPLATE(T, poly_t) op1, TEMPLATE(T, poly_t) op2,
                         const TEMPLATE(T, ctx_t) ctx)
 {
-    if (op1 != op2)
-    {
-        slong temp;
-        TEMPLATE(T, struct) * temp_c;
-
-        temp = op1->length;
-        op1->length = op2->length;
-        op2->length = temp;
-
-        temp = op1->alloc;
-        op1->alloc = op2->alloc;
-        op2->alloc = temp;
-
-        temp_c = op1->coeffs;
-        op1->coeffs = op2->coeffs;
-        op2->coeffs = temp_c;
-    }
+     FLINT_SWAP(TEMPLATE(T, poly_struct), *op1, *op2);
 }
 
 

--- a/src/fq_zech_mpoly.h
+++ b/src/fq_zech_mpoly.h
@@ -256,9 +256,7 @@ FQ_ZECH_MPOLY_INLINE
 void fq_zech_mpoly_swap(fq_zech_mpoly_t A, fq_zech_mpoly_t B,
                                                  const fq_zech_mpoly_ctx_t ctx)
 {
-   fq_zech_mpoly_struct t = *A;
-   *A = *B;
-   *B = t;
+    FLINT_SWAP(fq_zech_mpoly_struct, *A, *B);
 }
 
 
@@ -734,9 +732,7 @@ FQ_ZECH_MPOLY_INLINE
 void fq_zech_mpoly_univar_swap(fq_zech_mpoly_univar_t A,
                        fq_zech_mpoly_univar_t B, const fq_zech_mpoly_ctx_t ctx)
 {
-   fq_zech_mpoly_univar_struct t = *A;
-   *A = *B;
-   *B = t;
+    FLINT_SWAP(fq_zech_mpoly_univar_struct, *A, *B);
 }
 
 FQ_ZECH_MPOLY_INLINE

--- a/src/fq_zech_mpoly/sort_terms.c
+++ b/src/fq_zech_mpoly/sort_terms.c
@@ -45,7 +45,7 @@ void _fq_zech_mpoly_radix_sort1(fq_zech_mpoly_t A, slong left, slong right,
                                                  A->exps[j - 1], cmpmask); j--)
                 {
                     fq_zech_swap(A->coeffs + j, A->coeffs + j - 1, NULL);
-                    ULONG_SWAP(A->exps[j], A->exps[j - 1]);
+                    FLINT_SWAP(ulong, A->exps[j], A->exps[j - 1]);
                 }
             }
 
@@ -69,7 +69,7 @@ void _fq_zech_mpoly_radix_sort1(fq_zech_mpoly_t A, slong left, slong right,
             if ((A->exps[cur] & mask) != cmp)
             {
                 fq_zech_swap(A->coeffs + cur, A->coeffs + mid, NULL);
-                ULONG_SWAP(A->exps[cur], A->exps[mid]);
+                FLINT_SWAP(ulong, A->exps[cur], A->exps[mid]);
                 mid++;
             }
         }

--- a/src/fq_zech_mpoly_factor/bpoly_factor_smprime.c
+++ b/src/fq_zech_mpoly_factor/bpoly_factor_smprime.c
@@ -111,7 +111,7 @@ static void _hensel_build_tree(
             }
         }
         fq_zech_poly_swap(V + j, V + minp, ctx);
-        SLONG_SWAP(link[j], link[minp]);
+        FLINT_SWAP(slong, link[j], link[minp]);
 
         minp = j + 1;
         mind = fq_zech_poly_degree(V + j + 1, ctx);
@@ -124,7 +124,7 @@ static void _hensel_build_tree(
             }
         }
         fq_zech_poly_swap(V + j + 1, V + minp, ctx);
-        SLONG_SWAP(link[j + 1], link[minp]);
+        FLINT_SWAP(slong, link[j + 1], link[minp]);
 
         fq_zech_poly_mul(V + i, V + j, V + j + 1, ctx);
         link[i] = j;

--- a/src/fq_zech_mpoly_factor/irred_smprime_zippel.c
+++ b/src/fq_zech_mpoly_factor/irred_smprime_zippel.c
@@ -668,7 +668,7 @@ void fq_zech_polyu3_add_zip_limit1(
             for (j = Z->length; j > Zi; j--)
             {
                 fq_zech_poly_swap(Zcoeffs + j, Zcoeffs + j - 1, ctx);
-                ULONG_SWAP(Zexps[j], Zexps[j - 1]);
+                FLINT_SWAP(ulong, Zexps[j], Zexps[j - 1]);
             }
 
             Z->length++;

--- a/src/fq_zech_mpoly_factor/polyu3_hlift.c
+++ b/src/fq_zech_mpoly_factor/polyu3_hlift.c
@@ -42,7 +42,7 @@ static void fq_zech_polyu_sort_terms(
     for (i = 1; i < A->length; i++)
     for (j = i; j > 0 && A->exps[j - 1] < A->exps[j]; j--)
     {
-        ULONG_SWAP(A->exps[j - 1], A->exps[j]);
+        FLINT_SWAP(ulong, A->exps[j - 1], A->exps[j]);
         fq_zech_swap(A->coeffs + j - 1, A->coeffs + j, ctx);
     }
     return;

--- a/src/gmpcompat.h
+++ b/src/gmpcompat.h
@@ -19,13 +19,6 @@
         ? (mp_ptr) _mpz_realloc(z, len) \
         : ((z)->_mp_d))
 
-#define FLINT_MPZ_PTR_SWAP(a, b)    \
-  do {                              \
-    mpz_ptr __tmp = (a);            \
-    (a) = (b);                      \
-    (b) = __tmp;                    \
-  } while (0)
-
 static __inline__
 void flint_mpz_add_uiui(mpz_ptr a, mpz_srcptr b, ulong c1, ulong c0)
 {

--- a/src/gr_mat.h
+++ b/src/gr_mat.h
@@ -70,13 +70,7 @@ void gr_mat_clear(gr_mat_t mat, gr_ctx_t ctx);
 GR_MAT_INLINE void
 gr_mat_swap(gr_mat_t mat1, gr_mat_t mat2, gr_ctx_t ctx)
 {
-    if (mat1 != mat2)
-    {
-        gr_mat_t tmp;
-        *tmp = *mat1;
-        *mat1 = *mat2;
-        *mat2 = *tmp;
-    }
+    FLINT_SWAP(gr_mat_struct, *mat1, *mat2);
 }
 
 WARN_UNUSED_RESULT int gr_mat_swap_rows(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx);

--- a/src/gr_mat/invert_cols.c
+++ b/src/gr_mat/invert_cols.c
@@ -17,29 +17,17 @@ gr_mat_invert_cols(gr_mat_t mat, slong * perm, gr_ctx_t ctx)
     if (gr_mat_is_empty(mat, ctx) == T_FALSE)
     {
         slong sz = ctx->sizeof_elem;
-
-        slong t;
-        slong i;
+        slong t, i;
         slong c = mat->c;
         slong k = mat->c / 2;
 
         if (perm != NULL)
-        {
             for (i = 0; i < k; i++)
-            {
-                t = perm[i];
-                perm[i] = perm[c - i - 1];
-                perm[c - i - 1] = t;
-            }
-        }
+                FLINT_SWAP(slong, perm[i], perm[c - i - 1]);
 
         for (t = 0; t < mat->r; t++)
-        {
             for (i = 0; i < k; i++)
-            {
                 gr_swap(GR_MAT_ENTRY(mat, t, i, sz), GR_MAT_ENTRY(mat, t, c - i - 1, sz), ctx);
-            }
-        }
     }
 
     return GR_SUCCESS;

--- a/src/gr_mat/swap_cols.c
+++ b/src/gr_mat/swap_cols.c
@@ -22,16 +22,10 @@ gr_mat_swap_cols(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx)
         slong sz = ctx->sizeof_elem;
 
         if (perm != NULL)
-        {
-            t = perm[s];
-            perm[s] = perm[r];
-            perm[r] = t;
-        }
+            FLINT_SWAP(slong, perm[r], perm[s]);
 
         for (t = 0; t < mat->r; t++)
-        {
             gr_swap(GR_MAT_ENTRY(mat, t, r, sz), GR_MAT_ENTRY(mat, t, s, sz), ctx);
-        }
     }
 
     return GR_SUCCESS;

--- a/src/gr_mat/swap_rows.c
+++ b/src/gr_mat/swap_rows.c
@@ -17,19 +17,8 @@ int gr_mat_swap_rows(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx)
 
     if (r != s && gr_mat_is_empty(mat, ctx) == T_FALSE)
     {
-        gr_ptr * u;
-        slong t;
-
-        if (perm != NULL)
-        {
-            t = perm[s];
-            perm[s] = perm[r];
-            perm[r] = t;
-        }
-
-        u = mat->rows[s];
-        mat->rows[s] = mat->rows[r];
-        mat->rows[r] = u;
+        FLINT_SWAP(slong, perm[r], perm[s]);
+        FLINT_SWAP(gr_ptr, mat->rows[r], mat->rows[s]);
     }
 
     return GR_SUCCESS;

--- a/src/gr_mat/swap_rows.c
+++ b/src/gr_mat/swap_rows.c
@@ -17,7 +17,9 @@ int gr_mat_swap_rows(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx)
 
     if (r != s && gr_mat_is_empty(mat, ctx) == T_FALSE)
     {
-        FLINT_SWAP(slong, perm[r], perm[s]);
+        if (perm != NULL)
+            FLINT_SWAP(slong, perm[r], perm[s]);
+
         FLINT_SWAP(gr_ptr, mat->rows[r], mat->rows[s]);
     }
 

--- a/src/gr_mpoly.h
+++ b/src/gr_mpoly.h
@@ -113,9 +113,7 @@ void _gr_mpoly_set_length(gr_mpoly_t A, slong newlen,
 GR_MPOLY_INLINE
 void gr_mpoly_swap(gr_mpoly_t A, gr_mpoly_t B, const mpoly_ctx_t mctx, gr_ctx_t cctx)
 {
-    gr_mpoly_struct t = *A;
-    *A = *B;
-    *B = t;
+    FLINT_SWAP(gr_mpoly_struct, *A, *B);
 }
 
 WARN_UNUSED_RESULT int gr_mpoly_set(gr_mpoly_t A, const gr_mpoly_t B, const mpoly_ctx_t mctx, gr_ctx_t cctx);

--- a/src/gr_mpoly/sort_terms.c
+++ b/src/gr_mpoly/sort_terms.c
@@ -52,7 +52,7 @@ void _gr_mpoly_radix_sort1(
                                                    Aexps[j - 1], cmpmask); j--)
                 {
                     swap(GR_ENTRY(Acoeffs, j, sz), GR_ENTRY(Acoeffs, j - 1, sz), cctx);
-                    ULONG_SWAP(Aexps[j], Aexps[j - 1]);
+                    FLINT_SWAP(ulong, Aexps[j], Aexps[j - 1]);
                 }
             }
 
@@ -76,7 +76,7 @@ void _gr_mpoly_radix_sort1(
             if ((Aexps[cur] & mask) != cmp)
             {
                 swap(GR_ENTRY(Acoeffs, cur, sz), GR_ENTRY(Acoeffs, mid, sz), cctx);
-                ULONG_SWAP(Aexps[cur], Aexps[mid]);
+                FLINT_SWAP(ulong, Aexps[cur], Aexps[mid]);
                 mid++;
             }
         }

--- a/src/gr_poly.h
+++ b/src/gr_poly.h
@@ -55,9 +55,7 @@ GR_POLY_INLINE slong gr_poly_length(const gr_poly_t poly, gr_ctx_t ctx)
 GR_POLY_INLINE void
 gr_poly_swap(gr_poly_t poly1, gr_poly_t poly2, gr_ctx_t ctx)
 {
-    gr_poly_struct t = *poly1;
-    *poly1 = *poly2;
-    *poly2 = t;
+    FLINT_SWAP(gr_poly_struct, *poly1, *poly2);
 }
 
 void gr_poly_fit_length(gr_poly_t poly, slong len, gr_ctx_t ctx);

--- a/src/mpf_mat/swap.c
+++ b/src/mpf_mat/swap.c
@@ -15,12 +15,5 @@
 void
 mpf_mat_swap(mpf_mat_t mat1, mpf_mat_t mat2)
 {
-    if (mat1 != mat2)
-    {
-        mpf_mat_struct tmp;
-
-        tmp = *mat1;
-        *mat1 = *mat2;
-        *mat2 = tmp;
-    }
+    FLINT_SWAP(mpf_mat_struct, *mat1, *mat2);
 }

--- a/src/mpfr_mat/swap.c
+++ b/src/mpfr_mat/swap.c
@@ -16,12 +16,5 @@
 void
 mpfr_mat_swap(mpfr_mat_t mat1, mpfr_mat_t mat2)
 {
-    if (mat1 != mat2)
-    {
-        mpfr_mat_struct tmp;
-
-        tmp = *mat1;
-        *mat1 = *mat2;
-        *mat2 = tmp;
-    }
+    FLINT_SWAP(mpfr_mat_struct, *mat1, *mat2);
 }

--- a/src/mpoly/compression.c
+++ b/src/mpoly/compression.c
@@ -212,7 +212,7 @@ done:
         tmp[i] = i;
     for (i = 1; i < n; i++)
         for (j = i; j > 0 && deg[tmp[j]] < deg[tmp[j - 1]]; j--)
-            SLONG_SWAP(tmp[j], tmp[j - 1]);
+            FLINT_SWAP(slong, tmp[j], tmp[j - 1]);
     m = 1;
     while (m < n && deg[tmp[n - (m + 1)]] > 1)
         m++;

--- a/src/mpoly/gcd_info.c
+++ b/src/mpoly/gcd_info.c
@@ -655,7 +655,7 @@ void mpoly_gcd_info_measure_zippel2(
 
     for (i = 1; i < m; i++)
         for (j = i; j > 0 && NEEDS_SWAP; j--)
-            SLONG_SWAP(perm[j], perm[j - 1]);
+            FLINT_SWAP(slong, perm[j], perm[j - 1]);
 
 
 #define NEEDS_SWAP2                                                           \
@@ -664,7 +664,7 @@ void mpoly_gcd_info_measure_zippel2(
 
     for (i = 3; i < m; i++)
         for (j = i; j > 2 && NEEDS_SWAP; j--)
-            SLONG_SWAP(perm[j], perm[j - 1]);
+            FLINT_SWAP(slong, perm[j], perm[j - 1]);
 
 
     max_main_degree = 0;

--- a/src/mpoly/parse_pretty.c
+++ b/src/mpoly/parse_pretty.c
@@ -141,8 +141,8 @@ void mpoly_parse_add_terminal(mpoly_parse_t E, const char * s, const void * val)
 
     while (n > 0 && E->terminal_strings[n-1].str_len < E->terminal_strings[n].str_len)
     {
-        PTR_SWAP(char, E->terminal_strings[n-1].str, E->terminal_strings[n].str);
-        SLONG_SWAP(E->terminal_strings[n-1].str_len, E->terminal_strings[n].str_len);
+        FLINT_SWAP(char *, E->terminal_strings[n-1].str, E->terminal_strings[n].str);
+        FLINT_SWAP(slong, E->terminal_strings[n-1].str_len, E->terminal_strings[n].str_len);
         E->R->swap(E->terminal_values + E->R->elem_size*(n-1), E->terminal_values + E->R->elem_size*n, E->R->ctx);
         n--;
     }
@@ -267,7 +267,7 @@ again:
 
             if (l1 > l3)
             {
-                SLONG_SWAP(l3, l1);
+                FLINT_SWAP(slong, l3, l1);
                 E->R->swap(E->estore + E->R->elem_size*n3, E->estore + E->R->elem_size*n1, E->R->ctx);
             }
 

--- a/src/mpoly/rbtree.c
+++ b/src/mpoly/rbtree.c
@@ -209,7 +209,7 @@ Case4B:
     nodes[r11].up = r8;
 
 Case4Done:
-    SLONG_SWAP(rdx, r8);
+    FLINT_SWAP(slong, rdx, r8);
 
 Case5:
 
@@ -451,7 +451,7 @@ Case4B:
     nodes[r11].up = r8;
 
 Case4Done:
-    SLONG_SWAP(rdx, r8);
+    FLINT_SWAP(slong, rdx, r8);
 
 Case5:
 

--- a/src/mpoly/test_irreducible.c
+++ b/src/mpoly/test_irreducible.c
@@ -436,7 +436,7 @@ again:
 
     if (Alen < Blen)
     {
-        SLONG_SWAP(Alen, Blen);
+        FLINT_SWAP(slong, Alen, Blen);
         {
             point2d * T = Apoints;
             Apoints = Bpoints;

--- a/src/n_poly.h
+++ b/src/n_poly.h
@@ -222,9 +222,7 @@ void n_poly_set(n_poly_t A, const n_poly_t B)
 N_POLY_INLINE
 void n_poly_swap(n_poly_t A, n_poly_t B)
 {
-    n_poly_struct t = *B;
-    *B = *A;
-    *A = t;
+    FLINT_SWAP(n_poly_struct, *A, *B);
 }
 
 N_POLY_INLINE
@@ -700,7 +698,7 @@ void _n_fq_swap(
 {
     slong i = 0;
     do {
-        MP_LIMB_SWAP(a[i], b[i]);
+        FLINT_SWAP(mp_limb_t, a[i], b[i]);
         i++;
     } while (i < d);
 }

--- a/src/nmod_mat.h
+++ b/src/nmod_mat.h
@@ -75,7 +75,7 @@ nmod_mat_swap_entrywise(nmod_mat_t mat1, nmod_mat_t mat2)
        mp_limb_t * row1 = mat1->rows[i];
        mp_limb_t * row2 = mat2->rows[i];
        for (j = 0; j < nmod_mat_ncols(mat1); j++)
-          MP_LIMB_SWAP(row1[j], row2[j]);
+          FLINT_SWAP(mp_limb_t, row1[j], row2[j]);
     }
 }
 
@@ -216,19 +216,10 @@ void nmod_mat_swap_rows(nmod_mat_t mat, slong * perm, slong r, slong s)
 {
     if (r != s && !nmod_mat_is_empty(mat))
     {
-        mp_limb_t * u;
-        slong t;
-
         if (perm)
-        {
-            t = perm[s];
-            perm[s] = perm[r];
-            perm[r] = t;
-        }
+            FLINT_SWAP(slong, perm[r], perm[s]);
 
-        u = mat->rows[s];
-        mat->rows[s] = mat->rows[r];
-        mat->rows[r] = u;
+        FLINT_SWAP(mp_ptr, mat->rows[r], mat->rows[s]);
     }
 }
 
@@ -246,54 +237,32 @@ void nmod_mat_swap_cols(nmod_mat_t mat, slong * perm, slong r, slong s)
 {
     if (r != s && !nmod_mat_is_empty(mat))
     {
-        slong t;
+        slong i;
 
         if (perm)
-        {
-            t = perm[s];
-            perm[s] = perm[r];
-            perm[r] = t;
-        }
+            FLINT_SWAP(slong, perm[r], perm[s]);
 
-        for (t = 0; t < mat->r; t++)
-        {
-            mp_limb_t c = mat->rows[t][r];
-            mat->rows[t][r] = mat->rows[t][s];
-            mat->rows[t][s] = c;
-        }
+        for (i = 0; i < mat->r; i++)
+            FLINT_SWAP(mp_limb_t, mat->rows[i][r], mat->rows[i][s]);
     }
 }
 
 NMOD_MAT_INLINE
 void nmod_mat_invert_cols(nmod_mat_t mat, slong * perm)
 {
-    if (!(nmod_mat_is_empty(mat)))
+    if (!nmod_mat_is_empty(mat))
     {
-        slong t;
-        slong i;
+        slong t, i;
         slong c = mat->c;
         slong k = mat->c/2;
-        mp_limb_t e;
 
         if (perm)
-        {
             for (i = 0; i < k; i++)
-            {
-                t = perm[i];
-                perm[i] = perm[c - i - 1];
-                perm[c - i - 1] = t;
-            }
-        }
+                FLINT_SWAP(slong, perm[i], perm[c - i - 1]);
 
         for (t = 0; t < mat->r; t++)
-        {
             for (i = 0; i < k; i++)
-            {
-                e = mat->rows[t][i];
-                mat->rows[t][i] = mat->rows[t][c - i - 1];
-                mat->rows[t][c - i - 1] = e;
-            }
-        }
+                FLINT_SWAP(mp_limb_t, mat->rows[t][i], mat->rows[t][c - i - 1]);
     }
 }
 

--- a/src/nmod_mat.h
+++ b/src/nmod_mat.h
@@ -239,7 +239,7 @@ void nmod_mat_swap_cols(nmod_mat_t mat, slong * perm, slong r, slong s)
     {
         slong i;
 
-        if (perm)
+        if (perm != NULL)
             FLINT_SWAP(slong, perm[r], perm[s]);
 
         for (i = 0; i < mat->r; i++)
@@ -256,7 +256,7 @@ void nmod_mat_invert_cols(nmod_mat_t mat, slong * perm)
         slong c = mat->c;
         slong k = mat->c/2;
 
-        if (perm)
+        if (perm != NULL)
             for (i = 0; i < k; i++)
                 FLINT_SWAP(slong, perm[i], perm[c - i - 1]);
 

--- a/src/nmod_mat/swap.c
+++ b/src/nmod_mat/swap.c
@@ -14,8 +14,5 @@
 void
 nmod_mat_swap(nmod_mat_t mat1, nmod_mat_t mat2)
 {
-    nmod_mat_t temp;
-    *temp = *mat1;
-    *mat1 = *mat2;
-    *mat2 = *temp;
+    FLINT_SWAP(nmod_mat_struct, *mat1, *mat2);
 }

--- a/src/nmod_mpoly.h
+++ b/src/nmod_mpoly.h
@@ -420,9 +420,7 @@ int nmod_mpoly_equal(const nmod_mpoly_t A, const nmod_mpoly_t B,
 NMOD_MPOLY_INLINE
 void nmod_mpoly_swap(nmod_mpoly_t A, nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx)
 {
-   nmod_mpoly_struct t = *A;
-   *A = *B;
-   *B = t;
+    FLINT_SWAP(nmod_mpoly_struct, *A, *B);
 }
 
 /* Constants *****************************************************************/

--- a/src/nmod_mpoly/mpolyu.c
+++ b/src/nmod_mpoly/mpolyu.c
@@ -137,7 +137,7 @@ void nmod_mpolyu_degrees_si(
     mpoly_unpack_vec_ui((ulong *) degs, pmax, bits, ctx->minfo->nvars, 1);
 
     for (i = 0; i < ctx->minfo->nvars/2; i++)
-        SLONG_SWAP(degs[i], degs[ctx->minfo->nvars - i - 1]);
+        FLINT_SWAP(slong, degs[i], degs[ctx->minfo->nvars - i - 1]);
 
     TMP_END;
 }

--- a/src/nmod_mpoly/reverse.c
+++ b/src/nmod_mpoly/reverse.c
@@ -28,7 +28,7 @@ void nmod_mpoly_reverse(nmod_mpoly_t A,
     else
     {
         for (i = 0; i < Blen/2; i++)
-            MP_LIMB_SWAP(A->coeffs[i], A->coeffs[Blen - i - 1]);
+            FLINT_SWAP(mp_limb_t, A->coeffs[i], A->coeffs[Blen - i - 1]);
     }
 
     mpoly_reverse(A->exps, B->exps, Blen, N);

--- a/src/nmod_mpoly/test/t-content_vars.c
+++ b/src/nmod_mpoly/test/t-content_vars.c
@@ -82,7 +82,7 @@ TEST_FUNCTION_START(nmod_mpoly_content_vars, state)
         {
             slong k1 = n_randint(state, nvars);
             slong k2 = n_randint(state, nvars);
-            SLONG_SWAP(vars[k1], vars[k2]);
+            FLINT_SWAP(slong, vars[k1], vars[k2]);
         }
 
         num_vars = 1 + n_randint(state, nvars);

--- a/src/nmod_mpoly/univar.c
+++ b/src/nmod_mpoly/univar.c
@@ -577,7 +577,7 @@ static void mpoly_univar_swap_nmod_mpoly_univar(
         nmod_mpoly_swap(COEFF(A, i), B->coeffs + i, ctx);
     }
 
-    SLONG_SWAP(A->length, B->length);
+    FLINT_SWAP(slong, A->length, B->length);
 }
 
 int nmod_mpoly_univar_pseudo_gcd(

--- a/src/nmod_mpoly_factor/factor.c
+++ b/src/nmod_mpoly_factor/factor.c
@@ -316,7 +316,7 @@ static int _factor_irred_compressed(
     {
         if (strides[i] == 1)
         {
-            SLONG_SWAP(perm[0], perm[i]);
+            FLINT_SWAP(slong, perm[0], perm[i]);
             break;
         }
     }

--- a/src/nmod_mpoly_factor/factor_content.c
+++ b/src/nmod_mpoly_factor/factor_content.c
@@ -48,7 +48,7 @@ static int _split(
     /* sort vars by decreasing length */
     for (i = 1; i < mvars; i++)
         for (j = i; j > 0 && u[vars[j]].length > u[vars[j - 1]].length; j--)
-            SLONG_SWAP(vars[j], vars[j - 1]);
+            FLINT_SWAP(slong, vars[j], vars[j - 1]);
 
     for (i = 0; i < mvars; i++)
     {

--- a/src/nmod_mpoly_factor/gcd_zippel.c
+++ b/src/nmod_mpoly_factor/gcd_zippel.c
@@ -774,7 +774,7 @@ outer_loop:
 
     for (i = 1; i < Gmarks->length; i++)
         for (j = i; j > 0 && length(perm[j-1]) > length(perm[j]); j--)
-            SLONG_SWAP(perm[j-1], perm[j]);
+            FLINT_SWAP(slong, perm[j-1], perm[j]);
 
     req_zip_images = Gmarks->length - 2;
     j = 0;

--- a/src/nmod_mpoly_factor/mpoly_hlift_zippel.c
+++ b/src/nmod_mpoly_factor/mpoly_hlift_zippel.c
@@ -489,7 +489,7 @@ static void n_polyu3_add_zip_limit1(
             for (j = Z->length; j > Zi; j--)
             {
                 n_poly_swap(Zcoeffs + j, Zcoeffs + j - 1);
-                ULONG_SWAP(Zexps[j], Zexps[j - 1]);
+                FLINT_SWAP(ulong, Zexps[j], Zexps[j - 1]);
             }
 
             Z->length++;

--- a/src/nmod_mpoly_factor/n_bpoly_mod_factor_lgprime.c
+++ b/src/nmod_mpoly_factor/n_bpoly_mod_factor_lgprime.c
@@ -371,7 +371,7 @@ static void _hensel_build_tree(
             }
         }
         fq_nmod_poly_swap(V + j, V + minp, ctx);
-        SLONG_SWAP(link[j], link[minp]);
+        FLINT_SWAP(slong, link[j], link[minp]);
 
         minp = j + 1;
         mind = fq_nmod_poly_degree(V + j + 1, ctx);
@@ -384,7 +384,7 @@ static void _hensel_build_tree(
             }
         }
         fq_nmod_poly_swap(V + j + 1, V + minp, ctx);
-        SLONG_SWAP(link[j + 1], link[minp]);
+        FLINT_SWAP(slong, link[j + 1], link[minp]);
 
         fq_nmod_poly_mul(V + i, V + j, V + j + 1, ctx);
         link[i] = j;

--- a/src/nmod_mpoly_factor/n_bpoly_mod_factor_smprime.c
+++ b/src/nmod_mpoly_factor/n_bpoly_mod_factor_smprime.c
@@ -361,7 +361,7 @@ static void _n_bpoly_mod_lift_build_tree(
             }
         }
         n_bpoly_swap(v + j, v + minp);
-        SLONG_SWAP(link[j], link[minp]);
+        FLINT_SWAP(slong, link[j], link[minp]);
 
         minp = j + 1;
         mind = n_bpoly_degree0(v + j + 1);
@@ -374,7 +374,7 @@ static void _n_bpoly_mod_lift_build_tree(
             }
         }
         n_bpoly_swap(v + j + 1, v + minp);
-        SLONG_SWAP(link[j + 1], link[minp]);
+        FLINT_SWAP(slong, link[j + 1], link[minp]);
 
         n_bpoly_mod_mul_series(v + i, v + j, v + j + 1, L->fac_lift_order, ctx);
         link[i] = j;

--- a/src/nmod_mpoly_factor/polyu3_mod_hlift.c
+++ b/src/nmod_mpoly_factor/polyu3_mod_hlift.c
@@ -40,8 +40,8 @@ static void n_polyu_sort_terms(n_polyu_t A)
     for (i = 1; i < A->length; i++)
     for (j = i; j > 0 && A->exps[j - 1] < A->exps[j]; j--)
     {
-        MP_LIMB_SWAP(A->coeffs[j - 1], A->coeffs[j]);
-        ULONG_SWAP(A->exps[j - 1], A->exps[j]);
+        FLINT_SWAP(mp_limb_t, A->coeffs[j - 1], A->coeffs[j]);
+        FLINT_SWAP(ulong, A->exps[j - 1], A->exps[j]);
     }
     return;
 }

--- a/src/nmod_poly.h
+++ b/src/nmod_poly.h
@@ -177,20 +177,7 @@ void nmod_poly_set(nmod_poly_t a, const nmod_poly_t b)
 NMOD_POLY_INLINE
 void nmod_poly_swap(nmod_poly_t poly1, nmod_poly_t poly2)
 {
-    slong t;
-    mp_ptr tp;
-
-    t = poly1->alloc;
-    poly1->alloc = poly2->alloc;
-    poly2->alloc = t;
-
-    t = poly1->length;
-    poly1->length = poly2->length;
-    poly2->length = t;
-
-    tp = poly1->coeffs;
-    poly1->coeffs = poly2->coeffs;
-    poly2->coeffs = tp;
+    FLINT_SWAP(nmod_poly_struct, *poly1, *poly2);
 }
 
 NMOD_POLY_INLINE

--- a/src/nmod_poly/compose_horner.c
+++ b/src/nmod_poly/compose_horner.c
@@ -35,7 +35,7 @@ _nmod_poly_compose_horner(mp_ptr res, mp_srcptr poly1, slong len1,
     {
         const slong alloc = (len1 - 1) * (len2 - 1) + 1;
         slong i = len1 - 1, lenr = len2;
-        mp_limb_t *t, *t1, *t2;
+        mp_ptr t, t1, t2;
         TMP_INIT;
 
         TMP_START;
@@ -63,7 +63,7 @@ _nmod_poly_compose_horner(mp_ptr res, mp_srcptr poly1, slong len1,
         {
             _nmod_poly_mul(t2, t1, lenr, poly2, len2, mod);
             lenr += len2 - 1;
-            MP_PTR_SWAP(t1, t2);
+            FLINT_SWAP(mp_ptr, t1, t2);
             t1[0] = n_addmod(t1[0], poly1[i], mod.n);
         }
 

--- a/src/nmod_poly_mat/swap.c
+++ b/src/nmod_poly_mat/swap.c
@@ -16,12 +16,5 @@
 void
 nmod_poly_mat_swap(nmod_poly_mat_t A, nmod_poly_mat_t B)
 {
-    if (A != B)
-    {
-        nmod_poly_mat_struct tmp;
-
-        tmp = *A;
-        *A = *B;
-        *B = tmp;
-    }
+    FLINT_SWAP(nmod_poly_mat_struct, *A, *B);
 }

--- a/src/padic_mat/swap.c
+++ b/src/padic_mat/swap.c
@@ -14,12 +14,5 @@
 
 void padic_mat_swap(padic_mat_t A, padic_mat_t B)
 {
-    slong t;
-
-    fmpz_mat_swap(padic_mat(A), padic_mat(B));
-
-    t         = A->val;
-    A->val = B->val;
-    B->val = t;
+    FLINT_SWAP(padic_mat_struct, *A, *B);
 }
-

--- a/src/padic_poly/swap.c
+++ b/src/padic_poly/swap.c
@@ -13,30 +13,5 @@
 
 void padic_poly_swap(padic_poly_t poly1, padic_poly_t poly2)
 {
-    if (poly1 != poly2)
-    {
-        slong t;
-        fmpz *c;
-
-        t             = poly1->length;
-        poly1->length = poly2->length;
-        poly2->length = t;
-
-        t            = poly1->alloc;
-        poly1->alloc = poly2->alloc;
-        poly2->alloc = t;
-
-        t          = poly1->val;
-        poly1->val = poly2->val;
-        poly2->val = t;
-
-        t        = poly1->N;
-        poly1->N = poly2->N;
-        poly2->N = t;
-
-        c             = poly1->coeffs;
-        poly1->coeffs = poly2->coeffs;
-        poly2->coeffs = c;
-    }
+    FLINT_SWAP(padic_poly_struct, *poly1, *poly2);
 }
-

--- a/src/qqbar/swap.c
+++ b/src/qqbar/swap.c
@@ -15,7 +15,5 @@
 void
 qqbar_swap(qqbar_t x, qqbar_t y)
 {
-    fmpz_poly_swap(QQBAR_POLY(x), QQBAR_POLY(y));
-    acb_swap(QQBAR_ENCLOSURE(x), QQBAR_ENCLOSURE(y));
+    FLINT_SWAP(qqbar_struct, *x, *y);
 }
-


### PR DESCRIPTION
It was a bit silly to have a macro for each C type.

This PR also replaces a bunch of code blocks of the form ``{ type t = x; x = y; y = t; }`` with this macro, but there are surely lots of instances left in the code which I'm not going to bother trying to track down.