### PR TITLE
Use test_multiplier in fft tests

### DIFF
--- a/src/fft/test/t-adjust.c
+++ b/src/fft/test/t-adjust.c
@@ -61,6 +61,9 @@ TEST_FUNCTION_START(fft_adjust, state)
 
                 for (c = 0; c < n; c++)
                 {
+                    if (n_randint(state, 100) > 2.0 + flint_test_multiplier() * 10)
+                        continue;
+
                     set_p(p, n, w);
 
                     nn1 = flint_malloc((limbs+1)*sizeof(mp_limb_t));

--- a/src/fft/test/t-adjust_sqrt2.c
+++ b/src/fft/test/t-adjust_sqrt2.c
@@ -67,6 +67,9 @@ TEST_FUNCTION_START(fft_adjust_sqrt2, state)
 
                 for (c = 1; c < 2*n; c+=2)
                 {
+                    if (n_randint(state, 100) > 2.0 + flint_test_multiplier() * 10)
+                        continue;
+
                     set_p(p, n, w);
 
                     nn1 = flint_malloc((limbs+1)*sizeof(mp_limb_t));

--- a/src/fft/test/t-butterfly.c
+++ b/src/fft/test/t-butterfly.c
@@ -78,6 +78,9 @@ TEST_FUNCTION_START(fft_ifft_butterfly, state)
 
                 for (c = 0; c < n; c++)
                 {
+                    if (n_randint(state, 100) > 2.0 + flint_test_multiplier() * 10)
+                        continue;
+
                     nn1 = flint_malloc((limbs + 1)*sizeof(mp_limb_t));
                     nn2 = flint_malloc((limbs + 1)*sizeof(mp_limb_t));
                     r1 = flint_malloc((limbs + 1)*sizeof(mp_limb_t));
@@ -142,6 +145,9 @@ TEST_FUNCTION_START(fft_ifft_butterfly, state)
 
                 for (c = 0; c < n; c++)
                 {
+                    if (n_randint(state, 100) > 2.0 + flint_test_multiplier() * 10)
+                        continue;
+
                     nn1 = flint_malloc((limbs + 1)*sizeof(mp_limb_t));
                     nn2 = flint_malloc((limbs + 1)*sizeof(mp_limb_t));
                     r1 = flint_malloc((limbs + 1)*sizeof(mp_limb_t));

--- a/src/fft/test/t-butterfly_lshB.c
+++ b/src/fft/test/t-butterfly_lshB.c
@@ -69,6 +69,9 @@ TEST_FUNCTION_START(butterfly_lshB, state)
 
                 for (c = 0; c < limbs; c++)
                 {
+                    if (n_randint(state, 100) > 2.0 + flint_test_multiplier() * 10)
+                        continue;
+
                     x = n_randint(state, limbs);
                     y = n_randint(state, limbs);
 

--- a/src/fft/test/t-butterfly_rshB.c
+++ b/src/fft/test/t-butterfly_rshB.c
@@ -83,6 +83,9 @@ TEST_FUNCTION_START(butterfly_rshB, state)
 
                 for (c = 0; c < limbs; c++)
                 {
+                    if (n_randint(state, 100) > 2.0 + flint_test_multiplier() * 10)
+                        continue;
+
                     x = n_randint(state, limbs);
                     y = n_randint(state, limbs);
 

--- a/src/fft/test/t-butterfly_sqrt2.c
+++ b/src/fft/test/t-butterfly_sqrt2.c
@@ -86,6 +86,9 @@ TEST_FUNCTION_START(fft_ifft_butterfly_sqrt2, state)
 
                 for (c = 1; c < 2*n; c+=2)
                 {
+                    if (n_randint(state, 100) > 2.0 + flint_test_multiplier() * 10)
+                        continue;
+
                     nn1 = flint_malloc((limbs + 1)*sizeof(mp_limb_t));
                     nn2 = flint_malloc((limbs + 1)*sizeof(mp_limb_t));
                     temp = flint_malloc((limbs + 1)*sizeof(mp_limb_t));
@@ -153,6 +156,9 @@ TEST_FUNCTION_START(fft_ifft_butterfly_sqrt2, state)
 
                 for (c = 1; c < 2*n; c+=2)
                 {
+                    if (n_randint(state, 100) > 2.0 + flint_test_multiplier() * 10)
+                        continue;
+
                     nn1 = flint_malloc((limbs + 1)*sizeof(mp_limb_t));
                     nn2 = flint_malloc((limbs + 1)*sizeof(mp_limb_t));
                     temp = flint_malloc((limbs + 1)*sizeof(mp_limb_t));

--- a/src/fft/test/t-butterfly_twiddle.c
+++ b/src/fft/test/t-butterfly_twiddle.c
@@ -81,6 +81,9 @@ TEST_FUNCTION_START(fft_ifft_butterfly_twiddle, state)
 
                 for (c = 0; c < n; c++)
                 {
+                    if (n_randint(state, 100) > 2.0 + flint_test_multiplier() * 10)
+                        continue;
+
                     b1 = n_randint(state, n*w);
                     b2 = n_randint(state, n*w);
                     nn1 = flint_malloc((limbs + 1)*sizeof(mp_limb_t));
@@ -147,6 +150,9 @@ TEST_FUNCTION_START(fft_ifft_butterfly_twiddle, state)
 
                 for (c = 0; c < n; c++)
                 {
+                    if (n_randint(state, 100) > 2.0 + flint_test_multiplier() * 10)
+                        continue;
+
                     b1 = n_randint(state, n*w);
                     b2 = n_randint(state, n*w);
                     nn1 = flint_malloc((limbs + 1)*sizeof(mp_limb_t));

--- a/src/fft/test/t-convolution.c
+++ b/src/fft/test/t-convolution.c
@@ -15,11 +15,14 @@
 
 TEST_FUNCTION_START(fft_convolution, state)
 {
-    flint_bitcnt_t depth, w;
+    flint_bitcnt_t depth, w, maxdepth;
 
     _flint_rand_init_gmp(state);
 
-    for (depth = 6; depth <= 13; depth++)
+    maxdepth = (flint_test_multiplier() > 10) ? 13 :
+               (flint_test_multiplier() > 1)  ? 12 : 11;
+
+    for (depth = 6; depth <= maxdepth; depth++)
     {
         for (w = 1; w <= 5; w++)
         {
@@ -34,15 +37,15 @@ TEST_FUNCTION_START(fft_convolution, state)
 
             trunc = 2*n1*((trunc + 2*n1 - 1)/(2*n1));
             len1 = n_randint(state, trunc);
-	    len2 = trunc - len1 + 1;
+            len2 = trunc - len1 + 1;
 
             ii = flint_malloc((4*(n + n*size) + 5*size)*sizeof(mp_limb_t));
             for (i = 0, ptr = (mp_limb_t *) ii + 4*n; i < 4*n; i++, ptr += size)
             {
                 ii[i] = ptr;
-		if (i < len1)
-		   random_fermat(ii[i], state, limbs);
-		else
+                if (i < len1)
+                    random_fermat(ii[i], state, limbs);
+                else
                     flint_mpn_zero(ii[i], size);
             }
             t1 = ptr;
@@ -56,7 +59,7 @@ TEST_FUNCTION_START(fft_convolution, state)
                 jj[i] = ptr;
 
                 if (i < len2)
-		    random_fermat(jj[i], state, limbs);
+                    random_fermat(jj[i], state, limbs);
                 else
                     flint_mpn_zero(jj[i], size);
             }

--- a/src/fft/test/t-convolution_precache.c
+++ b/src/fft/test/t-convolution_precache.c
@@ -15,11 +15,14 @@
 
 TEST_FUNCTION_START(fft_convolution_precache, state)
 {
-    flint_bitcnt_t depth, w;
+    flint_bitcnt_t depth, w, maxdepth;
 
     _flint_rand_init_gmp(state);
 
-    for (depth = 6; depth <= 13; depth++)
+    maxdepth = (flint_test_multiplier() > 10) ? 13 :
+               (flint_test_multiplier() > 1)  ? 12 : 11;
+
+    for (depth = 6; depth <= maxdepth; depth++)
     {
         for (w = 1; w <= 5; w++)
         {
@@ -34,15 +37,15 @@ TEST_FUNCTION_START(fft_convolution_precache, state)
 
             trunc = 2*n1*((trunc + 2*n1 - 1)/(2*n1));
             len1 = n_randint(state, trunc);
-	    len2 = trunc - len1 + 1;
+            len2 = trunc - len1 + 1;
 
             ii = flint_malloc((4*(n + n*size) + 5*size)*sizeof(mp_limb_t));
             for (i = 0, ptr = (mp_limb_t *) ii + 4*n; i < 4*n; i++, ptr += size)
             {
                 ii[i] = ptr;
-		if (i < len1)
-		   random_fermat(ii[i], state, limbs);
-		else
+                if (i < len1)
+                    random_fermat(ii[i], state, limbs);
+                else
                     flint_mpn_zero(ii[i], size);
             }
             t1 = ptr;
@@ -56,7 +59,7 @@ TEST_FUNCTION_START(fft_convolution_precache, state)
                 jj[i] = ptr;
 
                 if (i < len2)
-		    random_fermat(jj[i], state, limbs);
+                    random_fermat(jj[i], state, limbs);
                 else
                     flint_mpn_zero(jj[i], size);
             }
@@ -81,7 +84,7 @@ TEST_FUNCTION_START(fft_convolution_precache, state)
                 flint_mpn_copyi(jj2[i], jj[i], size);
             }
 
-	    fft_precache(jj, depth, limbs, trunc, &t1, &t2, &s1);
+            fft_precache(jj, depth, limbs, trunc, &t1, &t2, &s1);
             fft_convolution_precache(ii, jj, depth, limbs, trunc, &t1, &t2, &s1, &tt);
             fft_convolution_basic(ii2, jj2, depth, limbs, trunc, &t1, &t2, &s1, &tt);
 

--- a/src/fft/test/t-fft_ifft_mfa_truncate_sqrt2.c
+++ b/src/fft/test/t-fft_ifft_mfa_truncate_sqrt2.c
@@ -15,11 +15,14 @@
 
 TEST_FUNCTION_START(fft_ifft_mfa_truncate_sqrt2, state)
 {
-    flint_bitcnt_t depth, w;
+    flint_bitcnt_t depth, w, maxdepth;
 
     _flint_rand_init_gmp(state);
 
-    for (depth = 6; depth <= 13; depth++)
+    maxdepth = (flint_test_multiplier() > 10) ? 13 :
+               (flint_test_multiplier() > 1)  ? 12 : 11;
+
+    for (depth = 6; depth <= maxdepth; depth++)
     {
         for (w = 1; w <= 5; w++)
         {

--- a/src/fft/test/t-fft_ifft_negacyclic.c
+++ b/src/fft/test/t-fft_ifft_negacyclic.c
@@ -15,12 +15,14 @@
 
 TEST_FUNCTION_START(fft_ifft_negacyclic, state)
 {
-    flint_bitcnt_t depth, w;
+    flint_bitcnt_t depth, w, maxdepth;
 
     _flint_rand_init_gmp(state);
 
-    for (depth = 6; depth <= 12; depth++)
-    {
+    maxdepth = (flint_test_multiplier() > 10) ? 12 :
+               (flint_test_multiplier() > 1)  ? 11 : 10;
+
+    for (depth = 6; depth <= maxdepth; depth++)    {
         for (w = 1; w <= 5; w++)
         {
             mp_size_t n = (UWORD(1)<<depth);

--- a/src/fft/test/t-fft_ifft_radix2.c
+++ b/src/fft/test/t-fft_ifft_radix2.c
@@ -15,11 +15,14 @@
 
 TEST_FUNCTION_START(fft_ifft_radix2, state)
 {
-    flint_bitcnt_t depth, w;
+    flint_bitcnt_t depth, w, maxdepth;
 
     _flint_rand_init_gmp(state);
 
-    for (depth = 6; depth <= 12; depth++)
+    maxdepth = (flint_test_multiplier() > 10) ? 12 :
+               (flint_test_multiplier() > 1)  ? 11 : 10;
+
+    for (depth = 6; depth <= maxdepth; depth++)
     {
         for (w = 1; w <= 5; w++)
         {

--- a/src/fft/test/t-fft_ifft_truncate.c
+++ b/src/fft/test/t-fft_ifft_truncate.c
@@ -15,11 +15,14 @@
 
 TEST_FUNCTION_START(fft_ifft_truncate, state)
 {
-    flint_bitcnt_t depth, w;
+    flint_bitcnt_t depth, w, maxdepth;
 
     _flint_rand_init_gmp(state);
 
-    for (depth = 6; depth <= 12; depth++)
+    maxdepth = (flint_test_multiplier() > 10) ? 12 :
+               (flint_test_multiplier() > 1)  ? 11 : 10;
+
+    for (depth = 6; depth <= maxdepth; depth++)
     {
         for (w = 1; w <= 5; w++)
         {

--- a/src/fft/test/t-fft_ifft_truncate_sqrt2.c
+++ b/src/fft/test/t-fft_ifft_truncate_sqrt2.c
@@ -15,11 +15,14 @@
 
 TEST_FUNCTION_START(fft_ifft_truncate_sqrt2, state)
 {
-    flint_bitcnt_t depth, w;
+    flint_bitcnt_t depth, w, maxdepth;
 
     _flint_rand_init_gmp(state);
 
-    for (depth = 6; depth <= 12; depth++)
+    maxdepth = (flint_test_multiplier() > 10) ? 12 :
+               (flint_test_multiplier() > 1)  ? 11 : 10;
+
+    for (depth = 6; depth <= maxdepth; depth++)
     {
         for (w = 1; w <= 5; w++)
         {

--- a/src/fft/test/t-mul_fft_main.c
+++ b/src/fft/test/t-mul_fft_main.c
@@ -15,11 +15,14 @@
 
 TEST_FUNCTION_START(flint_mpn_mul_fft_main, state)
 {
-    flint_bitcnt_t depth, w;
+    flint_bitcnt_t depth, w, maxdepth;
 
     _flint_rand_init_gmp(state);
 
-    for (depth = 6; depth <= 12; depth++)
+    maxdepth = (flint_test_multiplier() > 10) ? 12 :
+               (flint_test_multiplier() > 1)  ? 11 : 10;
+
+    for (depth = 6; depth <= maxdepth; depth++)
     {
         for (w = 1; w <= 3 - (depth >= 12); w++)
         {
@@ -39,6 +42,8 @@ TEST_FUNCTION_START(flint_mpn_mul_fft_main, state)
 
                if (len2 <= 0)
                   len2 = 2*n + n_randint(state, 2*n) + 1;
+
+               flint_set_num_threads(1 + n_randint(state, 4));
 
                b2 = len2*bits1;
 
@@ -80,6 +85,8 @@ TEST_FUNCTION_START(flint_mpn_mul_fft_main, state)
             }
         }
     }
+
+    flint_set_num_threads(1);
 
     TEST_FUNCTION_END(state);
 }

--- a/src/fft/test/t-mul_mfa_truncate_sqrt2.c
+++ b/src/fft/test/t-mul_mfa_truncate_sqrt2.c
@@ -15,11 +15,14 @@
 
 TEST_FUNCTION_START(mul_mfa_truncate_sqrt2, state)
 {
-    flint_bitcnt_t depth, w;
+    flint_bitcnt_t depth, w, maxdepth;
 
     _flint_rand_init_gmp(state);
 
-    for (depth = 6; depth <= 13; depth++)
+    maxdepth = (flint_test_multiplier() >= 10) ? 13 :
+               (flint_test_multiplier() >= 1)  ? 12 : 11;
+
+    for (depth = 6; depth <= maxdepth; depth++)
     {
         for (w = 1; w <= 3 - (depth >= 12); w++)
         {
@@ -57,7 +60,7 @@ TEST_FUNCTION_START(mul_mfa_truncate_sqrt2, state)
     }
 
     /* test squaring */
-    for (depth = 6; depth <= 13; depth++)
+    for (depth = 6; depth <= maxdepth; depth++)
     {
         for (w = 1; w <= 3 - (depth >= 12); w++)
         {

--- a/src/fft/test/t-mul_truncate_sqrt2.c
+++ b/src/fft/test/t-mul_truncate_sqrt2.c
@@ -15,11 +15,14 @@
 
 TEST_FUNCTION_START(mul_truncate_sqrt2, state)
 {
-    flint_bitcnt_t depth, w;
+    flint_bitcnt_t depth, w, maxdepth;
 
     _flint_rand_init_gmp(state);
 
-    for (depth = 6; depth <= 12; depth++)
+    maxdepth = (flint_test_multiplier() > 10) ? 12 :
+               (flint_test_multiplier() > 1)  ? 11 : 10;
+
+    for (depth = 6; depth <= maxdepth; depth++)
     {
         for (w = 1; w <= 5; w++)
         {
@@ -57,7 +60,7 @@ TEST_FUNCTION_START(mul_truncate_sqrt2, state)
     }
 
     /* test squaring */
-    for (depth = 6; depth <= 12; depth++)
+    for (depth = 6; depth <= maxdepth; depth++)
     {
         for (w = 1; w <= 5; w++)
         {

--- a/src/fft/test/t-mulmod_2expp1.c
+++ b/src/fft/test/t-mulmod_2expp1.c
@@ -15,14 +15,16 @@
 
 TEST_FUNCTION_START(fft_mulmod_2expp1, state)
 {
-    flint_bitcnt_t depth, w;
+    flint_bitcnt_t depth, w, maxdepth;
     int iters;
 
     _flint_rand_init_gmp(state);
 
+    maxdepth = (flint_test_multiplier() > 10) ? 18 : 15;
+
     for (iters = 0; iters < 100; iters++)
     {
-        for (depth = 6; depth <= 18; depth++)
+        for (depth = 6; depth <= maxdepth; depth++)
         {
             for (w = 1; w <= 2; w++)
             {
@@ -72,7 +74,7 @@ TEST_FUNCTION_START(fft_mulmod_2expp1, state)
     /* test squaring */
     for (iters = 0; iters < 100; iters++)
     {
-        for (depth = 6; depth <= 18; depth++)
+        for (depth = 6; depth <= maxdepth; depth++)
         {
             for (w = 1; w <= 2; w++)
             {

--- a/src/fft/test/t-split_combine_bits.c
+++ b/src/fft/test/t-split_combine_bits.c
@@ -20,7 +20,7 @@ TEST_FUNCTION_START(fft_split_combine_bits, state)
 
     _flint_rand_init_gmp(state);
 
-    for (i = 0; i < 10000; i++)
+    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
     {
         mp_size_t total_limbs = n_randint(state, 1000) + 1;
         mp_limb_t * in = flint_malloc(total_limbs*sizeof(mp_limb_t));


### PR DESCRIPTION
The ``fft`` module test code is designed to iterate over all combinations of certain parameters. It could be refactored to choose parameters randomly like other tests, but I decided instead to just skip some iterations depending on``flint_test_multiplier()``. This should still check every case as before if the iterations multiplier is > 10, which is perhaps desirable.

Also adding num_threads randomisation to the main mul test.