### PR TITLE
Reset nmod_poly_factor_t before writing to it

### DIFF
--- a/src/nmod_poly_factor/factor.c
+++ b/src/nmod_poly_factor/factor.c
@@ -154,6 +154,7 @@ mp_limb_t
 nmod_poly_factor_with_berlekamp(nmod_poly_factor_t result,
     const nmod_poly_t input)
 {
+    result->num = 0;
     return __nmod_poly_factor_deflation(result, input, BERLEKAMP);
 }
 
@@ -161,6 +162,7 @@ mp_limb_t
 nmod_poly_factor_with_cantor_zassenhaus(nmod_poly_factor_t result,
     const nmod_poly_t input)
 {
+    result->num = 0;
     return __nmod_poly_factor_deflation(result, input, ZASSENHAUS);
 }
 
@@ -168,6 +170,7 @@ mp_limb_t
 nmod_poly_factor_with_kaltofen_shoup(nmod_poly_factor_t result,
     const nmod_poly_t input)
 {
+    result->num = 0;
     return __nmod_poly_factor_deflation(result, input, KALTOFEN);
 }
 

--- a/src/nmod_poly_factor/factor_cantor_zassenhaus.c
+++ b/src/nmod_poly_factor/factor_cantor_zassenhaus.c
@@ -31,6 +31,8 @@ nmod_poly_factor_cantor_zassenhaus(nmod_poly_factor_t res, const nmod_poly_t f)
 
     nmod_poly_make_monic(v, f);
 
+    res->num = 0;
+
     i = 0;
     do
     {

--- a/src/nmod_poly_factor/factor_distinct_deg.c
+++ b/src/nmod_poly_factor/factor_distinct_deg.c
@@ -38,6 +38,8 @@ void nmod_poly_factor_distinct_deg(nmod_poly_factor_t res,
 
     nmod_poly_make_monic(v, poly);
 
+    res->num = 0;
+
     if (n == 1)
     {
         nmod_poly_factor_insert(res, v, 1);

--- a/src/nmod_poly_factor/factor_distinct_deg_threaded.c
+++ b/src/nmod_poly_factor/factor_distinct_deg_threaded.c
@@ -176,6 +176,8 @@ void nmod_poly_factor_distinct_deg_threaded(nmod_poly_factor_t res,
 
     nmod_poly_make_monic(v, poly);
 
+    res->num = 0;
+
     if (n == 1)
     {
         nmod_poly_factor_insert(res, v, 1);

--- a/src/nmod_poly_factor/factor_kaltofen_shoup.c
+++ b/src/nmod_poly_factor/factor_kaltofen_shoup.c
@@ -18,12 +18,14 @@ void nmod_poly_factor_kaltofen_shoup(nmod_poly_factor_t res,
 {
     nmod_poly_t v;
     nmod_poly_factor_t sq_free, dist_deg;
-    slong i, j, k, l, res_num, dist_deg_num;
+    slong i, j, k, l, res_num;
     slong * degs;
 
     nmod_poly_init_mod(v, poly->mod);
 
     nmod_poly_make_monic(v, poly);
+
+    res->num = 0;
 
     if (poly->length <= 2)
     {
@@ -48,8 +50,6 @@ void nmod_poly_factor_kaltofen_shoup(nmod_poly_factor_t res,
     nmod_poly_factor_init(dist_deg);
     for (i = 0; i < sq_free->num; i++)
     {
-        dist_deg_num = dist_deg->num;
-
         if ((flint_get_num_threads() > 1) &&
             ((sq_free->p + i)->length > (1024*flint_get_num_threads())/4))
             nmod_poly_factor_distinct_deg_threaded(dist_deg, sq_free->p + i,
@@ -58,7 +58,7 @@ void nmod_poly_factor_kaltofen_shoup(nmod_poly_factor_t res,
             nmod_poly_factor_distinct_deg(dist_deg, sq_free->p + i, &degs);
 
         /* compute equal-degree factorisation */
-        for (j = dist_deg_num, l = 0; j < dist_deg->num; j++, l++)
+        for (j = 0, l = 0; j < dist_deg->num; j++, l++)
         {
             res_num = res->num;
 

--- a/src/nmod_poly_factor/factor_squarefree.c
+++ b/src/nmod_poly_factor/factor_squarefree.c
@@ -22,9 +22,10 @@ nmod_poly_factor_squarefree(nmod_poly_factor_t res, const nmod_poly_t f)
     mp_limb_t p;
     slong deg, i;
 
+    res->num = 0;
+
     if (f->length <= 1)
     {
-        res->num = 0;
         return;
     }
 


### PR DESCRIPTION
Some of the functions in `nmod_poly_factor` (sometimes) appended factors to the given factorization instead of replacing it. For example:
```cpp
#include <cassert>
#include <flint/nmod_poly.h>
#include <flint/nmod_poly_factor.h>

int main() {
	nmod_poly_t f;
	nmod_poly_init(f, 5);
	nmod_poly_set_coeff_ui(f, 1, 1);
	nmod_poly_factor_t fac;
	nmod_poly_factor_init(fac);
	nmod_poly_factor_squarefree(fac, f);
	assert(fac->exp[0] == 1); // succeeds
	nmod_poly_factor_squarefree(fac, f);
	assert(fac->exp[0] == 1); // fails
	return 0;
}
```
The implementation of `nmod_poly_factor_kaltofen_shoup` assumed that `nmod_poly_factor_distinct_deg` appends the factors. I think either the documentation or the implementation of `nmod_poly_factor_distinct_deg` should be changed.

For `nmod_poly_factor_equal_deg`, I think a reasonable interpretation of the documentation is that the factors are appended, so I didn't change the behavior.