### PR TITLE
Add `-fprofile-update=atomic` to CFLAGS for coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ config.status
 configure
 libtool
 flint.pc
+autom4te.cache/

--- a/configure.ac
+++ b/configure.ac
@@ -919,9 +919,16 @@ AX_CHECK_COMPILE_FLAG([-Werror=unknown-warning-option], [CFLAGS="-Werror=unknown
 if test "$enable_coverage" = "yes";
 then
     AX_CHECK_COMPILE_FLAG([--coverage],
-    [save_CFLAGS="--coverage $save_CFLAGS"],
-    [AC_MSG_ERROR([$CC does not to support test coverage flags])])
+        [save_CFLAGS="--coverage $save_CFLAGS"],
+        [AC_MSG_ERROR([$CC does not to support test coverage flags])])
     LDFLAGS="--coverage $LDFLAGS"
+
+    if test "$enable_pthread" = "yes";
+    then
+        AX_CHECK_COMPILE_FLAG([-fprofile-update=atomic],
+            [save_CFLAGS="-fprofile-update=atomic $save_CFLAGS"],
+            [AC_MSG_ERROR([$CC does not to support multi-threaded test coverage flags])])
+    fi
 fi
 
 if test "$enable_debug" = "yes";


### PR DESCRIPTION
Tried to run `make coverage` and got some errors. I think one can get negative counts if one does not use this flag. Let's see if this improves coverage a bit.