### PR TITLE
Some fixes in documentation

### DIFF
--- a/doc/source/fft_small.rst
+++ b/doc/source/fft_small.rst
@@ -41,7 +41,7 @@ Polynomial arithmetic
 ---------------------------------------------------------------------------------
 
 .. function:: void _nmod_poly_mul_mid_mpn_ctx(ulong * z, ulong zl, ulong zh, const ulong * a, ulong an, const ulong * b, ulong bn, nmod_t mod, mpn_ctx_t R)
-              void _nmod_poly_mul_mid_default_mpn_ctx(z res, slong zl, slong zh, mp_srcptr a, slong an, mp_srcptr b, slong bn, nmod_t mod);
+              void _nmod_poly_mul_mid_default_mpn_ctx(mp_ptr res, slong zl, slong zh, mp_srcptr a, slong an, mp_srcptr b, slong bn, nmod_t mod)
 
     Writes to ``z`` the middle product containing coefficients in the
     range `[zl, zh)` of the product of the polynomials  ``(a, an)`` and ``(b, bn)``,

--- a/doc/source/fmpq_poly.rst
+++ b/doc/source/fmpq_poly.rst
@@ -599,10 +599,6 @@ Scalar multiplication and division
     Sets ``rop`` to `c` times ``op``.  Assumes that the ``fmpz_t c``
     is not part of ``rop``.
 
-.. function:: void fmpq_poly_scalar_mul_mpq(fmpq_poly_t rop, const fmpq_poly_t op, const fmpq_t c)
-
-    Sets ``rop`` to `c` times ``op``.
-
 .. function:: void _fmpq_poly_scalar_div_fmpz(fmpz * rpoly, fmpz_t rden, const fmpz * poly, const fmpz_t den, slong len, const fmpz_t c)
 
     Sets ``(rpoly, rden, len)`` to ``(poly, den, len)`` divided by `c`,

--- a/doc/source/fmpq_poly.rst
+++ b/doc/source/fmpq_poly.rst
@@ -586,11 +586,9 @@ Scalar multiplication and division
     Supports aliasing of ``(rpoly, den)`` and ``(poly, den)``.
     The ``fmpz_t``'s `r` and `s` may not be part of ``(rpoly, rden)``.
 
-.. function:: void fmpq_poly_scalar_mul_si(fmpq_poly_t rop, const fmpq_poly_t op, slong c)
-
-    Sets ``rop`` to `c` times ``op``.
-
-.. function:: void fmpq_poly_scalar_mul_ui(fmpq_poly_t rop, const fmpq_poly_t op, ulong c)
+.. function:: void fmpq_poly_scalar_mul_fmpq(fmpq_poly_t rop, const fmpq_poly_t op, const fmpq_t c)
+              void fmpq_poly_scalar_mul_si(fmpq_poly_t rop, const fmpq_poly_t op, slong c)
+              void fmpq_poly_scalar_mul_ui(fmpq_poly_t rop, const fmpq_poly_t op, ulong c)
 
     Sets ``rop`` to `c` times ``op``.
 

--- a/doc/source/gr_mat.rst
+++ b/doc/source/gr_mat.rst
@@ -224,7 +224,7 @@ Arithmetic
 .. function:: int gr_mat_sub(gr_mat_t res, const gr_mat_t mat1, const gr_mat_t mat2, gr_ctx_t ctx)
 
 .. function:: int gr_mat_mul_classical(gr_mat_t res, const gr_mat_t mat1, const gr_mat_t mat2, gr_ctx_t ctx)
-              int gr_mat_mul_strassen(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
+              int gr_mat_mul_strassen(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx)
               int gr_mat_mul_generic(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx)
               int gr_mat_mul(gr_mat_t res, const gr_mat_t mat1, const gr_mat_t mat2, gr_ctx_t ctx)
 


### PR DESCRIPTION
Some tiny typos in the documentation that prevented me to autogenerate Cython headers for sage.