### PR TITLE
[DO NOT MERGE] Show that some primes given in mpn_ctx_init works but fails tests

### DIFF
--- a/src/fft_small/test/t-mul.c
+++ b/src/fft_small/test/t-mul.c
@@ -83,5 +83,15 @@ TEST_FUNCTION_START(mpn_ctx_mpn_mul, state)
         mpn_ctx_clear(R);
     }
 
+    /* Generate more parts of code */
+    /* TODO: p = 16567 fails the test. This has a bn_bound of 0. */
+    /* TODO: p = 8796093022237 also fails the test. This has a bn_bound of 12. */
+    {
+        mpn_ctx_t R;
+        mpn_ctx_init(R, UWORD(16567));
+        test_mul(R, 50, 1000 * flint_test_multiplier(), state);
+        mpn_ctx_clear(R);
+    }
+
     TEST_FUNCTION_END(state);
 }


### PR DESCRIPTION
@fredrik-johansson why does this fail? If something is wrong with these primes, then it should generate an error, not fail the tests...