### PR TITLE
x86_64 assembly for `flint_mpn_mul_X`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ configure
 libtool
 flint.pc
 autom4te.cache/
+config.m4
+src/mpn_extras/broadwell/*.s

--- a/Makefile.in
+++ b/Makefile.in
@@ -50,6 +50,7 @@ DLLTOOL:=@DLLTOOL@
 LD:=@LD@
 LDCONFIG:=@LDCONFIG@
 LN_S:=@LN_S@
+M4:=@M4@
 MKDIR_P:=@MKDIR_P@
 STRIP:=@STRIP@
 RM_F:=rm -f
@@ -66,6 +67,8 @@ WANT_NTL:=@WANT_NTL@
 WANT_DEPS:=@WANT_DEPS@
 
 WANT_CXX:=@WANT_CXX@
+
+WANT_ADX_ASSEMBLY:=@WANT_ADX_ASSEMBLY@
 
 GMP_LIB_PATH:=@GMP_LIB_PATH@
 MPFR_LIB_PATH:=@MPFR_LIB_PATH@
@@ -85,6 +88,11 @@ LIBS += -lstdc++ -lntl
 endif
 LIBS2:=-lflint $(LIBS)
 PIC_FLAG:=@PIC_FLAG@
+
+ifeq ($(WANT_ADX_ASSEMBLY),1)
+ASM_OBJ_FLAGS:=$(filter-out -D%,$(CPPFLAGS) $(LIB_CPPFLAGS)) $(filter-out -funroll-loops -pedantic, $(CFLAGS))
+ASM_LOBJ_FLAGS:=$(filter-out -D%,$(PIC_FLAG)) $(ASM_OBJ_FLAGS)
+endif
 
 LDFLAGS:=@LDFLAGS@
 EXTRA_SHARED_FLAGS:=@EXTRA_SHARED_FLAGS@ $(foreach path, $(GMP_LIB_PATH) $(MPFR_LIB_PATH) $(BLAS_LIB_PATH) $(GC_LIB_PATH) $(NTL_LIB_PATH), @WL@-rpath,$(path))
@@ -118,7 +126,7 @@ CFG_FILES :=                                                                \
         $(FLINT_DIR)/config.log         $(SRC_DIR)/flint.h                  \
         $(SRC_DIR)/fft_tuning.h         $(FLINT_DIR)/flint.pc               \
         $(FLINT_DIR)/Makefile           $(SRC_DIR)/fmpz/fmpz.c              \
-        $(SRC_DIR)/gmpcompat.h
+        $(SRC_DIR)/gmpcompat.h          $(SRC_DIR)/config.m4
 
 ################################################################################
 # directories
@@ -199,7 +207,7 @@ TEMPLATE_DIRS :=                                                            \
         fq_embed_templates              fq_templates
 
 BUILD_DIRS :=                                                               \
-		$(BUILD_DIR)                                                        \
+        $(BUILD_DIR)                                                        \
         $(patsubst %, $(BUILD_DIR)/%, $(DIRS))                              \
         $(patsubst %, $(BUILD_DIR)/%/profile, $(DIRS))                      \
         $(patsubst %, $(BUILD_DIR)/%/test, $(DIRS))                         \
@@ -213,6 +221,10 @@ endif
 ifneq ($(COVERAGE), 0)
 BUILD_DIRS +=                                                               \
         $(BUILD_DIR)/coverage
+endif
+ifeq ($(WANT_ADX_ASSEMBLY),1)
+BUILD_DIRS +=                                                               \
+        $(BUILD_DIR)/mpn_extras/broadwell
 endif
 
 INSTALL_DIRS :=                                                             \
@@ -267,6 +279,12 @@ fmpz_lll_SOURCES := $(filter-out $(SRC_DIR)/fmpz_lll/babai.c $(SRC_DIR)/fmpz_lll
 
 SOURCES := $(foreach dir,$(DIRS),$($(dir)_SOURCES))
 
+ifeq ($(WANT_ADX_ASSEMBLY),1)
+mpn_extras_ASM_SOURCES := $(wildcard $(SRC_DIR)/mpn_extras/broadwell/*.asm)
+mpn_extras_S_SOURCES := $(patsubst $(SRC_DIR)/%.asm,$(BUILD_DIR)/%.s,$(mpn_extras_ASM_SOURCES))
+mpn_extras_SOURCES += $(mpn_extras_S_SOURCES)
+endif
+
 define xxx_PROF_SOURCES
 $(1)_PROF_SOURCES := $(wildcard $(SRC_DIR)/$(1)/profile/*.c)
 endef
@@ -303,9 +321,12 @@ EXMP_SOURCES := $(wildcard $(FLINT_DIR)/examples/*.c)
 
 ifneq ($(STATIC), 0)
 define xxx_OBJS
-$(1)_OBJS := $(patsubst $(SRC_DIR)/%.c,$(BUILD_DIR)/%.o,$($(1)_SOURCES))
+$(1)_OBJS := $(patsubst $(SRC_DIR)/%.c,$(BUILD_DIR)/%.o,$(filter-out %.s,$($(1)_SOURCES)))
 endef
 $(foreach dir, $(DIRS), $(eval $(call xxx_OBJS,$(dir))))
+ifeq ($(WANT_ADX_ASSEMBLY),1)
+mpn_extras_OBJS += $(patsubst %.s,%.o,$(mpn_extras_S_SOURCES))
+endif
 OBJS := $(foreach dir, $(DIRS), $($(dir)_OBJS))
 endif
 
@@ -315,9 +336,13 @@ endif
 
 ifneq ($(SHARED), 0)
 define xxx_LOBJS
-$(1)_LOBJS := $(patsubst $(SRC_DIR)/%.c,$(BUILD_DIR)/%.lo,$($(1)_SOURCES))
+$(1)_LOBJS := $(patsubst $(SRC_DIR)/%.c,$(BUILD_DIR)/%.lo,$(filter-out %.s, $($(1)_SOURCES)))
 endef
 $(foreach dir, $(DIRS), $(eval $(call xxx_LOBJS,$(dir))))
+ifeq ($(WANT_ADX_ASSEMBLY),1)
+mpn_extras_LOBJS += $(patsubst %.s,%.lo,$(mpn_extras_S_SOURCES))
+endif
+LOBJS := $(foreach dir, $(DIRS), $($(dir)_LOBJS))
 endif
 
 ################################################################################
@@ -525,6 +550,16 @@ endif
 DEPFLAGS = -MMD -MP -MF $(@:%=%.d)
 
 ################################################################################
+# generated sources
+################################################################################
+
+ifeq ($(WANT_ADX_ASSEMBLY),1)
+$(BUILD_DIR)/%.s: $(SRC_DIR)/%.asm | $(BUILD_DIR)/mpn_extras/broadwell
+	@echo "  M4  $(@:$(BUILD_DIR)/%=%)"
+	@$(M4) $< > $@
+endif
+
+################################################################################
 # objects
 ################################################################################
 
@@ -534,6 +569,12 @@ $(BUILD_DIR)/$(1)/%.o: $(SRC_DIR)/$(1)/%.c | $(BUILD_DIR)/$(1)
 	@echo "  CC  $$(@:$(BUILD_DIR)/%=%)"
 	@$(CC) $(CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) -c $$< -o $$@ $$(DEPFLAGS)
 endef
+
+ifeq ($(WANT_ADX_ASSEMBLY),1)
+%.o: %.s
+	@echo "  CC  $(@:$(BUILD_DIR)/%=%)"
+	@$(CC) $(ASM_OBJ_FLAGS) -c $< -o $@
+endif
 
 $(foreach dir, $(DIRS), $(eval $(call xxx_OBJS_rule,$(dir))))
 endif
@@ -548,6 +589,12 @@ $(BUILD_DIR)/$(1)/%.lo: $(SRC_DIR)/$(1)/%.c | $(BUILD_DIR)/$(1)
 	@echo "  CC  $$(@:$(BUILD_DIR)/%=%)"
 	@$(CC) $(PIC_FLAG) $(CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) -c $$< -o $$@ $$(DEPFLAGS)
 endef
+
+ifeq ($(WANT_ADX_ASSEMBLY),1)
+%.lo: %.s
+	@echo "  CC  $(@:$(BUILD_DIR)/%=%)"
+	@$(CC) $(ASM_LOBJ_FLAGS) -c $< -o $@
+endif
 
 $(foreach dir, $(DIRS), $(eval $(call xxx_LOBJS_rule,$(dir))))
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -236,6 +236,17 @@ yes|no)
 esac],
 enable_gmp_internals="yes")
 
+AC_ARG_ENABLE(assembly,
+[AS_HELP_STRING([--enable-assembly],[Enable assembly routines (if available) [default=yes]])],
+[case $enableval in
+yes|no)
+    ;;
+*)
+    AC_MSG_ERROR([Bad value $enableval for --enable-assembly. Need yes or no.])
+    ;;
+esac],
+enable_assembly="yes")
+
 AC_ARG_ENABLE(avx2,
 [AS_HELP_STRING([--enable-avx2],[Enable AVX2 instructions [default=no]])],
 [case $enableval in
@@ -511,6 +522,8 @@ AC_ARG_VAR([TESTCFLAGS], [Choose different C compiler flags for tests [default=C
 AC_ARG_VAR(ABI, [Desired ABI])
 
 AC_ARG_VAR(LDCONFIG, [ldconfig tool])
+
+AC_ARG_VAR([M4], [m4 macro processor])
 
 ################################################################################
 # check programs and system
@@ -996,6 +1009,106 @@ fi
 CPPFLAGS="-I./src $CPPFLAGS"
 
 ################################################################################
+# Instruction sets
+################################################################################
+
+if test "$enable_assembly" = "yes";
+then
+    AC_MSG_CHECKING([if 64-bit ADX instructions is supported])
+    AC_COMPILE_IFELSE(
+        [AC_LANG_PROGRAM([], [
+#if !defined(__ADX__) || !defined(__GNUC__) || !defined(__x86_64__) || !(defined(__APPLE__) || defined(__unix__)) || defined(__CYGWIN__)
+#error Dead man
+error
+#endif
+         ])],
+        [AC_MSG_RESULT([yes])
+         AC_DEFINE(FLINT_HAVE_ADX,1,[Define if system supports 64-bit ADX instruction set with System V ABI])
+         has_adx="yes"],
+        [AC_MSG_RESULT([no])]
+    )
+fi
+
+################################################################################
+# Assembler
+################################################################################
+
+if test "$has_adx" = "yes" && test "$enable_assembly" = "yes";
+then
+    if test -z "$M4";
+    then
+        # Check for M4
+        AC_PATH_PROG([M4], [m4], [no])
+        if test "$M4" = "no";
+        then
+            AC_MSG_ERROR([Could not find M4 needed to generate assembly source code.])
+        fi
+    fi
+
+    AC_MSG_CHECKING([if assembler supports .size])
+    echo "	.size somestuff, 1" >> conftest.s
+    $CC -c conftest.s > conftest.out 2>&1
+    comstr="d""n""l"
+    if test "$?" = "0";
+    then
+        flint_as_size="yes"
+        AC_MSG_RESULT([yes])
+        case "$host_os" in
+            darwin*)
+                echo ["define(]\`[SIZE]'[,]\`[]'[)$comstr"] >> config.m4
+                ;;
+            *) 
+                echo ["define(]\`[SIZE]'[,]\`[.size	\$][1, \$][2-\$][1]'[)$comstr"] > config.m4
+                ;;
+        esac
+    else
+        flint_as_size="no"
+        AC_MSG_RESULT([no])
+        echo ["define(]\`[SIZE]'[,]\`[]'[)$comstr"] >> config.m4
+    fi
+    rm conftest.*
+
+    AC_MSG_CHECKING([for assembler .type function prefix])
+    flint_as_type=""
+    for func_prefix in "@" "%" "#";
+    do
+        echo "	.type	somestuff,${func_prefix}function" >> conftest.s
+        $CC -c conftest.s > conftest.out 2>&1
+        if test "$?" = "0";
+        then
+            flint_as_type="${func_prefix}"
+            break
+        fi
+    done
+    rm -f conftest.*
+
+    if test "$flint_as_type" = "";
+    then
+        AC_MSG_RESULT([no])
+        echo ["define(]\`[TYPE]'[,]\`[]'[)$comstr"] >> config.m4
+    else
+        AC_MSG_RESULT([${func_prefix}])
+        case "$host_os" in
+            darwin*)
+                echo ["define(]\`[TYPE]'[,]\`[.type	_\$][1, ]${func_prefix}[function]'[)$comstr"] >> config.m4
+                ;;
+            *) 
+                echo ["define(]\`[TYPE]'[,]\`[.type	\$][1, ]${func_prefix}[function]'[)$comstr"] >> config.m4
+                ;;
+        esac
+    fi
+
+    case "$host_os" in
+        darwin*)
+            echo ["define(]\`[FUNC]'[,]\`[_\$][1]'[)$comstr"] >> config.m4
+            ;;
+        *) 
+            echo ["define(]\`[FUNC]'[,]\`[\$][1]'[)$comstr"] >> config.m4
+            ;;
+    esac
+fi
+
+################################################################################
 # fft_small module
 ################################################################################
 
@@ -1186,6 +1299,13 @@ fi
 if test "$enable_gmp_internals" = "yes";
 then
     AC_DEFINE(FLINT_WANT_GMP_INTERNALS,1,[Define to enable use of GMP internals.])
+fi
+
+if test "$has_adx" = "yes" && test "$enable_assembly" = "yes";
+then
+    AC_SUBST(WANT_ADX_ASSEMBLY,1)
+else
+    AC_SUBST(WANT_ADX_ASSEMBLY,0)
 fi
 
 ################################################################################

--- a/dev/gen_mul_basecase.jl
+++ b/dev/gen_mul_basecase.jl
@@ -1,0 +1,1814 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+_regs = ["%rdi", "%rsi", "%rdx", "%rcx", "%r8", "%r9", "%r10", "%r11", "%rax"]
+
+# We have omitted rsp as we cannot use it unless we push it to xmm register
+__regs = ["%rbx", "%rbp", "%r12", "%r13", "%r14", "%r15"]
+
+function reg_8_bit(reg::String)
+    if reg == "%rax"
+        return "%al"
+    elseif reg == "%rbx"
+        return "%bl"
+    elseif reg == "%rcx"
+        return "%cl"
+    elseif reg == "%rdx"
+        return "%dl"
+    elseif reg == "%rsp"
+        return "%spl"
+    elseif reg == "%rbp"
+        return "%bpl"
+    elseif reg == "%rsi"
+        return "%sil"
+    elseif reg == "%rdi"
+        return "%dil"
+    elseif reg == "%r8"
+        return "%r8b"
+    elseif reg == "%r9"
+        return "%r9b"
+    elseif reg == "%r10"
+        return "%r10b"
+    elseif reg == "%r11"
+        return "%r11b"
+    elseif reg == "%r12"
+        return "%r12b"
+    elseif reg == "%r13"
+        return "%r13b"
+    elseif reg == "%r14"
+        return "%r14b"
+    elseif reg == "%r15"
+        return "%r15b"
+    else
+        return "hejhoppgummi"
+    end
+end
+
+function reg_32_bit(reg::String)
+    if reg == "%rax"
+        return "%eax"
+    elseif reg == "%rbx"
+        return "%ebx"
+    elseif reg == "%rcx"
+        return "%ecx"
+    elseif reg == "%rdx"
+        return "%edx"
+    elseif reg == "%rsp"
+        return "%esp"
+    elseif reg == "%rbp"
+        return "%ebp"
+    elseif reg == "%rsi"
+        return "%esi"
+    elseif reg == "%rdi"
+        return "%edi"
+    elseif reg == "%r8"
+        return "%r8d"
+    elseif reg == "%r9"
+        return "%r9d"
+    elseif reg == "%r10"
+        return "%r10d"
+    elseif reg == "%r11"
+        return "%r11d"
+    elseif reg == "%r12"
+        return "%r12d"
+    elseif reg == "%r13"
+        return "%r13d"
+    elseif reg == "%r14"
+        return "%r14d"
+    elseif reg == "%r15"
+        return "%r15d"
+    else
+        return "hejhoppgummi"
+    end
+end
+
+###############################################################################
+# Preamble
+###############################################################################
+
+copyright = "#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#\n"
+
+preamble = "include(`config.m4')dnl\ndnl\n.text\n"
+
+function function_pre_post(funname::String)
+    pre = ".global\tFUNC($funname)
+.p2align\t4, 0x90
+TYPE($funname)
+
+FUNC($funname):
+\t.cfi_startproc\n"
+
+    post = ".$(funname)_end:
+SIZE($(funname), .$(funname)_end)
+.cfi_endproc\n"
+
+    return (pre, post)
+end
+
+###############################################################################
+# m = 1, n = 1
+###############################################################################
+
+function function_body_1(m::Int, n::Int = m)
+    if m != 1 || n != 1
+        error()
+    end
+
+    regs = ["%rcx", "%rax", "%r8", "%r9", "%r10", "%r11"]
+
+    numregs = 2 # Number of registers used
+
+    r0 = regs[1]
+    r1 = regs[2] # Important that r1 is rax
+
+    res_reg = "%rdi"
+    ap_reg = "%rsi"
+    bp_reg = "%rdx"
+
+    body = ""
+
+    body *= "\tmov\t($bp_reg), %rdx\n"
+    body *= "\tmulx\t0*8($ap_reg), $r0, $r1\n"
+    body *= "\tmov\t$r0, 0*8($res_reg)\n"
+    body *= "\tmov\t$r1, 1*8($res_reg)\n"
+
+    return body * "\n\tret\n"
+end
+
+###############################################################################
+# m = 2, n = 1
+###############################################################################
+
+function function_body_2_1(m::Int, n::Int = 1)
+    if m != 2 || n != 1
+        error()
+    end
+
+    regs = ["%rcx", "%r8", "%rax", "%r9", "%r10", "%r11"]
+
+    numregs = 5 # Number of registers used
+
+    r0 = regs[1]
+    r1 = regs[2]
+    r2 = regs[3] # Important that r2 is rax
+    r3 = regs[4]
+    zero_reg = regs[numregs]
+    zero_reg_32 = reg_32_bit(zero_reg)
+
+    res_reg = "%rdi"
+    ap_reg = "%rsi"
+    bp_reg = "%rdx"
+
+    body = ""
+
+    body *= "\tmov\t0*8($bp_reg), %rdx\n"
+    body *= "\txor\t$zero_reg_32, $zero_reg_32\n"
+    body *= "\tmulx\t0*8($ap_reg), $r0, $r1\n"
+    body *= "\tmulx\t1*8($ap_reg), $r3, $r2\n"
+    body *= "\tadcx\t$r3, $r1\n"
+    body *= "\tadcx\t$zero_reg, $r2\n"
+    body *= "\tmov\t$r0, 0*8($res_reg)\n"
+    body *= "\tmov\t$r1, 1*8($res_reg)\n"
+    body *= "\tmov\t$r2, 2*8($res_reg)\n"
+
+    return body * "\n\tret\n"
+end
+
+###############################################################################
+# m = 2, n = 2
+###############################################################################
+
+function function_body_2(m::Int, n::Int = m)
+    if m != 2 || n != 2
+        error()
+    end
+
+    regs = ["%rcx", "%r8", "%r9", "%rax", "%r10", "%r11"]
+
+    numregs = 6 # Number of registers used
+
+    r0 = regs[1]
+    r1 = regs[2]
+    r2 = regs[3]
+    r3 = regs[4] # Important that r3 is rax
+    bp1_reg = regs[numregs - 1]
+    zero_reg = regs[numregs]
+    zero_reg_32 = reg_32_bit(zero_reg)
+
+    res_reg = "%rdi"
+    ap_reg = "%rsi"
+    bp_reg = "%rdx"
+
+    body = ""
+
+    body *= "\tmov\t1*8($bp_reg), $bp1_reg\n"
+    body *= "\tmov\t0*8($bp_reg), %rdx\n"
+    body *= "\txor\t$zero_reg_32, $zero_reg_32\n"
+    body *= "\tmulx\t0*8($ap_reg), $r0, $r1\n"
+    body *= "\tmulx\t1*8($ap_reg), $r3, $r2\n"
+    body *= "\tadcx\t$r3, $r1\n"
+    body *= "\tmov\t$r0, 0*8($res_reg)\n"
+    body *= "\tmov\t$bp1_reg, %rdx\n"
+    body *= "\tmulx\t0*8($ap_reg), $r0, $r3\n"
+    body *= "\tadox\t$r0, $r1\n"
+    body *= "\tadcx\t$r3, $r2\n"
+    body *= "\tmov\t$r1, 1*8($res_reg)\n"
+    body *= "\tmulx\t1*8($ap_reg), $r0, $r3\n"
+    body *= "\tadox\t$r0, $r2\n"
+    body *= "\tadcx\t$zero_reg, $r3\n"
+    body *= "\tadox\t$zero_reg, $r3\n"
+    body *= "\tmov\t$r2, 2*8($res_reg)\n"
+    body *= "\tmov\t$r3, 3*8($res_reg)\n"
+
+    return body * "\n\tret\n"
+end
+
+###############################################################################
+# mul_1 and addmul_1 macros
+###############################################################################
+
+# Assumes bp[0] is already in %rdx.
+# This pushes directly into res, apart from the last limb which is left in r5.
+function mul_1_macro(m::Int)
+    if m < 3
+        error()
+    end
+
+    pre = ".macro\tm$m res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, "
+    pre *= "r0, r1, r2, r3, r4, r5\n"
+    post = ".endm\n"
+
+    r0 = "\\r0"
+    r1 = "\\r1"
+    r2 = "\\r2"
+    r3 = "\\r3"
+    r4 = "\\r4"
+    r5 = "\\r5"
+
+    # Make sure that last limb is pushed into r5
+    if m % 2 == 0
+        r4, r5 = r5, r4
+    elseif m % 4 == 1
+        r1, r5 = r5, r1
+    end
+
+    body = ""
+
+    body *= "\tmulx\t(0+\\ap_offset)*8(\\ap), $r0, $r3\n"
+    body *= "\tmulx\t(1+\\ap_offset)*8(\\ap), $r1, $r4\n"
+    body *= "\tmulx\t(2+\\ap_offset)*8(\\ap), $r2, $r5\n"
+    body *= "\tadd\t$r3, $r1\n"
+    body *= "\tadc\t$r4, $r2\n"
+    body *= "\tmov\t$r0, (0+\\res_offset)*8(\\res)\n"
+    body *= "\tmov\t$r1, (1+\\res_offset)*8(\\res)\n"
+    body *= "\tmov\t$r2, (2+\\res_offset)*8(\\res)\n"
+
+    for ix in 1:(m - 1) ÷ 2 - 1
+        i1 = 2 * ix + 1
+        i2 = 2 * ix + 2
+        body *= "\tmulx\t($i1+\\ap_offset)*8(\\ap), $r3, $r4\n"
+        body *= "\tmulx\t($i2+\\ap_offset)*8(\\ap), $r0, $r1\n"
+        body *= "\tadc\t$r3, $r5\n"
+        body *= "\tadc\t$r4, $r0\n"
+        body *= "\tmov\t$r5, ($i1+\\res_offset)*8(\\res)\n"
+        body *= "\tmov\t$r0, ($i2+\\res_offset)*8(\\res)\n"
+        (r0, r2), (r3, r4), (r1, r5) = (r2, r0), (r3, r4), (r5, r1)
+    end
+
+    if m % 2 == 1
+        body *= "\tadc\t\$0, $r5\n"
+    else
+        body *= "\tmulx\t($(m - 1)+\\ap_offset)*8(\\ap), $r3, $r4\n"
+        body *= "\tadc\t$r3, $r5\n"
+        body *= "\tadc\t\$0, $r4\n"
+        body *= "\tmov\t$r5, ($(m - 1)+\\res_offset)*8(\\res)\n"
+    end
+
+    return pre * body * post
+end
+
+# Assumes b is already in %rdx.
+# Pushes least significant limb into res[res_offset].
+# ip1 can be aliased with rN for N > 0 and scr2
+# ip2 can be aliased with rN for N > 1
+function mulM_macro(n::Int; chain::Bool = false)
+    if n < 2 || n > 8
+        error()
+    end
+
+    pre = ".macro\tm$(n)$(chain ? "_chain" : "") res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, "
+    if chain
+        pre *= "ip1, ip2, "
+    end
+    for jx in 0:n-1
+        pre *= "r$jx, "
+    end
+    pre *= "scr1, scr2, zero\n"
+
+    post = ".endm\n"
+
+    body = ""
+    body *= "\tmulx\t(0+\\ap_offset)*8(\\ap), \\scr1, \\r0\n"
+    if chain
+        body *= "\tadcx\t\\ip1, \\scr1\n"
+        body *= "\tmov\t\\scr1, \\res_offset*8(\\res)\n"
+    end
+    body *= "\tmulx\t(1+\\ap_offset)*8(\\ap), \\scr2, \\r1\n"
+    if !chain
+        body *= "\tmov\t\\scr1, \\res_offset*8(\\res)\n"
+    end
+    body *= "\tadcx\t\\scr2, \\r0\n"
+    if chain
+        body *= "\tadox\t\\ip2, \\r0\n"
+    end
+
+    for jx in 2:n ÷ 2
+        jxm = 2 * (jx - 1)
+        body *= "\tmulx\t($(jxm)+\\ap_offset)*8(\\ap), \\scr1, \\r$jxm\n"
+        body *= "\tmulx\t($(jxm + 1)+\\ap_offset)*8(\\ap), \\scr2, \\r$(jxm + 1)\n"
+        body *= "\tadcx\t\\scr1, \\r$(jxm - 1)\n"
+        body *= "\tadcx\t\\scr2, \\r$jxm\n"
+    end
+
+    if n % 2 == 1
+        body *= "\tmulx\t($(n - 1)+\\ap_offset)*8(\\ap), \\scr1, \\r$(n - 1)\n"
+        body *= "\tadcx\t\\scr1, \\r$(n - 2)\n"
+    end
+
+    body *= "\tadcx\t\\zero, \\r$(n - 1)\n"
+
+    return pre * body * post
+end
+
+# Assumes b is already in %rdx.
+# Pushes least significant limb into res[res_offset].
+function addmulM_macro(n::Int)
+    if n < 2 || n > 8
+        error()
+    end
+
+    pre = ".macro\tam$(n) res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, "
+    for jx in 0:n
+        pre *= "r$jx, "
+    end
+    pre *= "scr, zero\n"
+    post = ".endm\n"
+
+    scr1 = "\\r$n"
+    scr2 = "\\scr"
+    if n % 2 == 1
+        # If n is odd, we need to reorder scr1 and scr2 to make \scr occur at
+        # the right place so that we do not need two scrap registers in the last
+        # multiplication.
+        tmp = scr1
+        scr1 = scr2
+        scr2 = tmp
+    end
+
+    body = ""
+    body *= "\tmulx\t(0+\\ap_offset)*8(\\ap), $scr1, $scr2\n"
+    body *= "\tadcx\t$scr1, \\r0\n"
+    body *= "\tmov\t\\r0, \\res_offset*8(\\res)\n"
+
+    for jx in 1:n - 1
+        body *= "\tmulx\t($(jx)+\\ap_offset)*8(\\ap), \\r0, $(jx % 2 == 1 ? scr1 : scr2)\n"
+        body *= "\tadcx\t$(jx % 2 == 0 ? scr1 : scr2), \\r$jx\n"
+        body *= "\tadox\t\\r0, \\r$jx\n"
+    end
+
+    body *= "\tadcx\t\\zero, \\r$n\n"
+    body *= "\tadox\t\\zero, \\r$n\n"
+
+    return pre * body * post
+end
+
+###############################################################################
+# m ≥ 3, n = 1
+###############################################################################
+
+function function_body_M_1(m::Int)
+    if m < 3
+        error()
+    end
+
+    body = "\tmov\t0*8(%rdx), %rdx\n"
+    # Important that the last entry is rax to set return value
+    body *= "\tm$m\t%rdi, 0, %rsi, 0, %rcx, %r8, %r9, %r10, %r11, %rax\n"
+    body *= "\tmov\t%rax, $m*8(%rdi)\n"
+
+    return body * "\n\tret\n"
+end
+
+###############################################################################
+# m > 8, n = 2
+###############################################################################
+
+function M_2_getN(m::Int)
+    if m <= 8
+        error()
+    elseif m <= 9
+        return 3
+    elseif m <= 12
+        return 4
+    elseif m <= 15
+        return 5
+    elseif m <= 16
+        return 6
+    else
+        error()
+    end
+end
+
+# Needed macros: mN, amN_chain, mN_chain (if m ÷ N == 2),
+# m(m % N)_chain (if m % N > 1) and am(m % N) (if m % N > 1).
+function function_body_M_2(m::Int)
+    if m <= 8
+        error()
+    end
+
+    N = M_2_getN(m)
+
+    # number of available registers is 10
+    regs = ["%rax", "%r9", "%r10", "%r11", "%rbx", "%rbp", "%r12", "%r13", "%r14", "%r15"]
+    preserve_index = 5 # Starting with %rbx, we have to push it to the stack
+
+    used_registers = N + 3
+
+    res = "%rdi"
+    ap = "%rsi"
+    bp = "%rdx"
+    b0 = "%rcx"
+    b1 = "%r8"
+
+    if used_registers > length(regs)
+        error()
+    end
+
+    pre = "\tmov\t0*8($bp), $b0\n"
+    pre *= "\tmov\t1*8($bp), $b1\n"
+    post = ""
+    for jx in preserve_index:used_registers
+        pre = pre * "\tpush\t$(regs[jx])\n"
+        post = "\tpop\t$(regs[jx])\n" * post
+    end
+
+    rg = deepcopy(regs[1:used_registers])
+    if m % N == 0 && (m ÷ N) % 2 == 1
+        rg[1], rg[N + 1] = rg[N + 1], rg[1]
+    elseif m % N == 1
+        rg[1], rg[4] = rg[4], rg[1]
+    elseif m % N > 1 && (m ÷ N) % 2 == 0
+        rg[1], rg[N + 1] = rg[N + 1], rg[1]
+    end
+
+    scr = rg[N + 2]
+    zero = rg[N + 3]
+
+    body = ""
+
+    body *= "\n"
+    body *= "\tmov\t$b0, %rdx\n"
+    body *= "\txor\t$(reg_32_bit(zero)), $(reg_32_bit(zero))\n"
+    body *= "\tm$N\t$res, 0, $ap, 0, "
+    for jx in 2:N
+        body *= "$(rg[jx]), "
+    end
+    body *= "$(rg[1]), $(rg[N + 1]), $scr, $zero\n"
+
+    body *= "\tmov\t$b1, %rdx\n"
+    body *= "\tam$(N)\t$res, 1, $ap, 0, "
+    for jx in 2:N
+        body *= "$(rg[jx]), "
+    end
+    body *= "$(rg[1]), $(rg[N + 1]), $scr, $zero\n"
+    for jx in 3:N
+        body *= "\tmov\t$(rg[jx]), $(jx - 1)*8($res)\n"
+    end
+
+    for ix in 1:m ÷ N - 1
+        body *= "\n"
+        body *= "\tmov\t$b0, %rdx\n"
+        body *= "\tm$(N)_chain\t$res, $(ix * N), $ap, $(ix * N), $(rg[1]), $(rg[N + 1]), "
+        for jx in 2:N
+            body *= "$(rg[jx]), "
+        end
+        body *= "$(rg[N + 1]), $scr, $(rg[1]), $zero\n"
+
+        body *= "\tmov\t$b1, %rdx\n"
+        body *= "\tam$(N)\t$res, $(ix * N + 1), $ap, $(ix * N), "
+        for jx in 2:N
+            body *= "$(rg[jx]), "
+        end
+        body *= "$(rg[N + 1]), $(rg[1]), $scr, $zero\n"
+        for jx in 3:N
+            body *= "\tmov\t$(rg[jx]), $(jx + ix * N - 1)*8($res)\n"
+        end
+        rg[1], rg[N + 1] = rg[N + 1], rg[1]
+    end
+
+    body *= "\n"
+    if m % N == 0
+        body *= "\tmov\t$(rg[1]), $(m)*8($res)\n"
+        body *= "\tmov\t$(rg[N + 1]), $(m + 1)*8($res)\n"
+    elseif m % N == 1
+        body *= "\tmov\t$b0, %rdx\n"
+        body *= "\tmulx\t$((m ÷ N) * N)*8($ap), $(rg[2]), $scr\n"
+        body *= "\tmov\t$b1, %rdx\n"
+        body *= "\tmulx\t$((m ÷ N) * N)*8($ap), $(rg[3]), $(rg[4])\n"
+        body *= "\tadcx\t$(rg[1]), $(rg[2])\n"
+        body *= "\tadcx\t$(rg[N + 1]), $(rg[3])\n"
+        body *= "\tadcx\t$zero, $(rg[4])\n"
+        body *= "\tadox\t$scr, $(rg[3])\n"
+        body *= "\tadox\t$zero, $(rg[4])\n"
+        body *= "\tmov\t$(rg[2]), $((m ÷ N) * N + 0)*8($res)\n"
+        body *= "\tmov\t$(rg[3]), $((m ÷ N) * N + 1)*8($res)\n"
+        body *= "\tmov\t$(rg[4]), $((m ÷ N) * N + 2)*8($res)\n"
+    else
+        body *= "\tmov\t$b0, %rdx\n"
+        body *= "\tm$(m % N)_chain\t$res, $((m ÷ N) * N + 0), $ap, $((m ÷ N) * N), $(rg[1]), $(rg[N + 1]), "
+        for jx in 2:m % N + 1
+            body *= "$(rg[jx]), "
+        end
+        body *= "$scr, $(rg[1]), $zero\n"
+
+        body *= "\tmov\t$b1, %rdx\n"
+        body *= "\tam$(m % N)\t$res, $((m ÷ N) * N + 1), $ap, $((m ÷ N) * N), "
+        for jx in 2:m % N + 1
+            body *= "$(rg[jx]), "
+        end
+        body *= "$(rg[1]), $scr, $zero\n"
+        for jx in 3:m % N + 1
+            body *= "\tmov\t$(rg[jx]), $((m ÷ N) * N + jx - 1)*8($res)\n"
+        end
+        body *= "\tmov\t$(rg[1]), $(m + 1)*8($res)\n"
+    end
+
+    return pre * body * post * "\n\tret\n"
+end
+
+###############################################################################
+# 3 ≤ m ≤ 8, 2 ≤ n ≤ m, or m > 8, 2 ≤ n ≤ 8
+###############################################################################
+
+function function_body_M(m::Int, n::Int = m)
+    if !((3 ≤ m ≤ 8 && 2 ≤ n ≤ m) || (m > 8 && 2 ≤ n ≤ 8))
+        error()
+    end
+
+    if m ≤ 8
+        res_reg = "%rdi"
+        ap_reg = "%rsi"
+        bp_reg_old = "%rdx"
+        bp_reg = "%rcx"
+        mov = "\tmov\t$bp_reg_old, $bp_reg\n"
+    else
+        res_reg = "%rdi"
+        ap_reg_old = "%rdx" # is actually bp
+        ap_reg = "%rcx"
+        bp_reg = "%rsi"
+        mov = "\tmov\t$ap_reg_old, $ap_reg\n"
+        m, n = n, m
+    end
+
+    regs = ["%rax", "%r8", "%r9", "%r10", "%r11", "%rbx", "%rbp", "%r12", "%r13", "%r14", "%r15"]
+    preserve_index = 6 # Starting with %rbx, we have to push it to the stack
+
+    numregs = m + 3 # Number of registers used
+
+    regs_perm = deepcopy(regs[1:m + 1])
+    # We want the most significant limb to fall on rax
+    if n == 2
+        regs_perm[1], regs_perm[m + 1] = regs_perm[m + 1], regs_perm[1]
+    else
+        regs_perm[1], regs_perm[((n - 3) % (m + 1)) + 1] = regs_perm[((n - 3) % (m + 1)) + 1], regs_perm[1]
+    end
+
+    scr_reg = regs[numregs - 1]
+    zero_reg = regs[numregs]
+    zero_reg_32 = reg_32_bit(zero_reg)
+
+    pre = mov
+    pre *= "\tmov\t0*8($bp_reg), %rdx\n"
+    body = ""
+    post = ""
+
+    for jx in preserve_index:numregs
+        pre = pre * "\tpush\t$(regs[jx])\n"
+        post = "\tpop\t$(regs[jx])\n" * post
+    end
+
+    body *= "\n"
+    body *= "\txor\t$zero_reg_32, $zero_reg_32\n"
+    body *= "\n"
+
+    body *= "\tm$m\t$res_reg, 0, $ap_reg, 0, "
+    for jx in 1:m
+        body *= "$(regs_perm[jx]), "
+    end
+    body *= "$(regs_perm[m + 1]), $scr_reg, $zero_reg\n\n"
+
+    for jx in 1:n - 1
+        body *= "\tmov\t$jx*8($bp_reg), %rdx\n"
+        body *= "\tam$m\t$res_reg, $jx, $ap_reg, 0, "
+        for kx in 1:m + 1
+            body *= "$(regs_perm[kx]), "
+        end
+        body *= "$scr_reg, $zero_reg\n"
+
+        # Reorder registers
+        regs_perm[1:m], regs_perm[m + 1] = regs_perm[2:m + 1], regs_perm[1]
+    end
+
+    body *= "\n"
+    for jx in 1:m
+        body *= "\tmov\t$(regs_perm[jx]), $(n + jx - 1)*8($res_reg)\n"
+    end
+    body *= "\n"
+
+    return pre * body * post * "\n\tret\n"
+end
+
+###############################################################################
+# sqr
+###############################################################################
+
+# NOTE: Aliasing must work for squaring.
+
+# NOTE: Although this could be generally programmed, just like the mul case,
+# we can skip some instructions and additional storage when hardcoding each
+# case.
+
+function function_body_sqr_1()
+    regs = ["%rcx", "%rax"]
+
+    r0 = regs[1]
+    r1 = regs[2] # Important that r1 is rax
+
+    res_reg = "%rdi"
+    ap_reg = "%rsi"
+
+    body = ""
+
+    body *= "\tmov\t0*8($ap_reg), %rdx\n"
+    body *= "\tmulx\t%rdx, $r0, $r1\n"
+    body *= "\tmov\t$r0, 0*8($res_reg)\n"
+    body *= "\tmov\t$r1, 1*8($res_reg)\n"
+
+    return body * "\n\tret\n"
+end
+
+function function_body_sqr_2()
+    n = 2
+
+    res = _regs[1]
+    ap = _regs[2]
+
+    this_regs = [_regs[4:end - 1]; __regs]
+
+    w = this_regs[1:3]
+
+    s1 = this_regs[4]
+    s2 = _regs[end]
+
+    pre = "\tmov\t0*8($ap), %rdx\n"
+    post = ""
+
+    body = ""
+
+    # Calculate upper triangle
+    body *= "\txor\t$(reg_32_bit(w[3])), $(reg_32_bit(w[3]))\n"
+    body *= "\tmulx\t1*8($ap), $(w[1]), $(w[2])\n"
+    body *= "\tadd\t$(w[1]), $(w[1])\n"
+    body *= "\tadc\t$(w[2]), $(w[2])\n"
+    body *= "\tadc\t$(w[3]), $(w[3])\n"
+
+    # Calculate diagonal and put into res
+    body *= "\tmulx\t%rdx, $s1, $s2\n"
+    body *= "\tmov\t$s1, 0*8($res)\n"
+    body *= "\tadd\t$s2, $(w[1])\n"
+    body *= "\tmov\t1*8($ap), %rdx\n"
+    body *= "\tmov\t$(w[1]), 1*8($res)\n"
+    body *= "\tmulx\t%rdx, $s1, $s2\n"
+    body *= "\tadc\t$s1, $(w[2])\n"
+    body *= "\tadc\t$(w[3]), $s2\n"
+    body *= "\tmov\t$(w[2]), 2*8($res)\n"
+    body *= "\tmov\t$s2, 3*8($res)\n"
+
+    return pre * body * post * "\n\tret\n"
+end
+
+function function_body_sqr_3()
+    n = 3
+
+    res = _regs[1]
+    ap = _regs[2]
+
+    this_regs = [_regs[4:end - 1]; __regs]
+
+    w = this_regs[1:5]
+
+    scr = _regs[end]
+
+    pre = "\tmov\t0*8($ap), %rdx\n"
+    post = ""
+
+    body = ""
+
+    # Calculate upper triangle
+    body *= "\txor\t$(reg_32_bit(w[5])), $(reg_32_bit(w[5]))\n"
+    body *= "\tmulx\t1*8($ap), $(w[1]), $scr\n" # a0 a1
+    body *= "\tmulx\t2*8($ap), $(w[2]), $(w[3])\n" # a0 a2
+    body *= "\tmov\t1*8($ap), %rdx\n"
+    body *= "\tadd\t$scr, $(w[2])\n"
+    body *= "\tmulx\t2*8($ap), $scr, $(w[4])\n" # a1 a2
+    body *= "\tadc\t$scr, $(w[3])\n"
+    body *= "\tadc\t$(w[5]), $(w[4])\n"
+
+    # Double upper triangle
+    body *= "\tmov\t0*8($ap), %rdx\n"
+    body *= "\tadd\t$(w[1]), $(w[1])\n"
+    body *= "\tadc\t$(w[2]), $(w[2])\n"
+    body *= "\tadc\t$(w[3]), $(w[3])\n"
+    body *= "\tadc\t$(w[4]), $(w[4])\n"
+    body *= "\tadc\t$(w[5]), $(w[5])\n"
+
+    # Calculate diagonal and put into res
+    body *= "\tmulx\t%rdx, %rdx, $scr\n" # a0^2
+    body *= "\tmov\t%rdx, 0*8($res)\n"
+    body *= "\tadd\t$scr, $(w[1])\n"
+    body *= "\tmov\t1*8($ap), %rdx\n"
+    body *= "\tmov\t$(w[1]), 1*8($res)\n"
+    body *= "\tmulx\t%rdx, %rdx, $scr\n" # a1^2
+    body *= "\tadc\t%rdx, $(w[2])\n"
+    body *= "\tadc\t$scr, $(w[3])\n"
+    body *= "\tmov\t2*8($ap), %rdx\n"
+    body *= "\tmov\t$(w[2]), 2*8($res)\n"
+    body *= "\tmov\t$(w[3]), 3*8($res)\n"
+    body *= "\tmulx\t%rdx, %rdx, $scr\n" # a2^2
+    body *= "\tadc\t%rdx, $(w[4])\n"
+    body *= "\tadc\t$(w[5]), $scr\n"
+    body *= "\tmov\t$(w[4]), 4*8($res)\n"
+    body *= "\tmov\t$scr, 5*8($res)\n"
+
+    return pre * body * post * "\n\tret\n"
+end
+
+function function_body_sqr_4()
+    n = 4
+
+    res = _regs[1]
+    ap = _regs[2]
+
+    this_regs = [_regs[4:end - 1]; __regs]
+
+    w = this_regs[1:2 * n - 1]
+
+    s1 = "error s1"
+    s2 = _regs[end] # Important that this is rax
+
+    pre = "\tmov\t0*8($ap), %rdx\n"
+    post = ""
+    for jx in 1:2 * n - 1 - length(_regs[4:end - 1])
+        pre = pre * "\tpush\t$(__regs[jx])\n"
+        post = "\tpop\t$(__regs[jx])\n" * post
+    end
+
+    body = ""
+
+    # Calculate upper triangle
+    body *= "\txor\t$(reg_32_bit(w[7])), $(reg_32_bit(w[7]))\n"
+    body *= "\tmulx\t1*8($ap), $(w[1]), $(w[5])\n" # a0 a1
+    body *= "\tmulx\t2*8($ap), $(w[2]), $(w[6])\n" # a0 a2
+    body *= "\tmulx\t3*8($ap), $(w[3]), $(w[4])\n" # a0 a3
+    body *= "\tmov\t1*8($ap), %rdx\n"
+    body *= "\tadox\t$(w[5]), $(w[2])\n" # ADOX
+    body *= "\tadox\t$(w[6]), $(w[3])\n"
+    body *= "\tmulx\t2*8($ap), $(w[5]), $(w[6])\n" # a1 a2
+    body *= "\tadcx\t$(w[5]), $(w[3])\n" # ADCX
+    body *= "\tadcx\t$(w[6]), $(w[4])\n"
+    body *= "\tmulx\t3*8($ap), $(w[6]), $(w[5])\n" # a1 a3
+    body *= "\tmov\t2*8($ap), %rdx\n"
+    body *= "\tadox\t$(w[6]), $(w[4])\n" # ADOX
+    body *= "\tadox\t$(w[7]), $(w[5])\n" # Add zero
+    body *= "\tmulx\t3*8($ap), %rdx, $(w[6])\n" # a2 a3
+    body *= "\tadcx\t%rdx, $(w[5])\n" # ADCX
+    body *= "\tadc\t$(w[7]), $(w[6])\n" # Add zero
+
+    # Double upper triangle
+    body *= "\tmov\t0*8($ap), %rdx\n"
+    body *= "\tadd\t$(w[1]), $(w[1])\n"
+    body *= "\tadc\t$(w[2]), $(w[2])\n"
+    body *= "\tadc\t$(w[3]), $(w[3])\n"
+    body *= "\tadc\t$(w[4]), $(w[4])\n"
+    body *= "\tadc\t$(w[5]), $(w[5])\n"
+    body *= "\tadc\t$(w[6]), $(w[6])\n"
+    body *= "\tsetc\t$(reg_8_bit(w[7]))\n"
+
+    # Calculate diagonal and put into res
+    body *= "\tmulx\t%rdx, %rdx, $s2\n" # a0^2
+    body *= "\tmov\t%rdx, 0*8($res)\n"
+    body *= "\tadd\t$s2, $(w[1])\n"
+    body *= "\tmov\t1*8($ap), %rdx\n"
+    body *= "\tmov\t$(w[1]), 1*8($res)\n"
+    s1 = w[1]
+    w[1] = "error w[1]"
+    body *= "\tmulx\t%rdx, %rdx, $s2\n" # a1^2
+    body *= "\tadc\t%rdx, $(w[2])\n"
+    body *= "\tadc\t$s2, $(w[3])\n"
+    body *= "\tmov\t2*8($ap), %rdx\n"
+    body *= "\tmov\t$(w[2]), 2*8($res)\n"
+    body *= "\tmov\t$(w[3]), 3*8($res)\n"
+    body *= "\tmulx\t%rdx, $s1, $s2\n" # a2^2
+    body *= "\tadc\t$s1, $(w[4])\n"
+    body *= "\tadc\t$s2, $(w[5])\n"
+    body *= "\tmov\t3*8($ap), %rdx\n"
+    body *= "\tmov\t$(w[4]), 4*8($res)\n"
+    body *= "\tmov\t$(w[5]), 5*8($res)\n"
+    body *= "\tmulx\t%rdx, $s1, $s2\n" # a3^2
+    body *= "\tadc\t$s1, $(w[6])\n"
+    body *= "\tadc\t$(w[7]), $s2\n"
+    body *= "\tmov\t$(w[6]), 6*8($res)\n"
+    body *= "\tmov\t$s2, 7*8($res)\n"
+
+    return pre * body * post * "\n\tret\n"
+end
+
+function function_body_sqr_5()
+    n = 5
+
+    res = _regs[1]
+    ap = _regs[2]
+
+    this_regs = [_regs[4:end - 1]; __regs]
+
+    w = this_regs[1:2 * n - 1]
+
+    s1 = ""
+    s2 = _regs[end] # Important that this is rax
+
+    pre = "\tmov\t0*8($ap), %rdx\n"
+    post = ""
+    for jx in 1:2 * n - 1 - length(_regs[4:end - 1])
+        pre = pre * "\tpush\t$(__regs[jx])\n"
+        post = "\tpop\t$(__regs[jx])\n" * post
+    end
+
+    body = ""
+
+    # Calculate upper triangle
+    body *= "\txor\t$(reg_32_bit(w[9])), $(reg_32_bit(w[9]))\n"
+    body *= "\tmulx\t1*8($ap), $(w[1]), $(w[6])\n" # a0 a1
+    body *= "\tmulx\t2*8($ap), $(w[2]), $(w[7])\n" # a0 a2
+    body *= "\tmulx\t3*8($ap), $(w[3]), $(w[8])\n" # a0 a3
+    body *= "\tmulx\t4*8($ap), $(w[4]), $(w[5])\n" # a0 a4
+    body *= "\tadcx\t$(w[6]), $(w[2])\n"
+    body *= "\tadcx\t$(w[7]), $(w[3])\n"
+    body *= "\tadcx\t$(w[8]), $(w[4])\n"
+    body *= "\tadcx\t$(w[9]), $(w[5])\n" # Add zero
+
+    body *= "\tmov\t1*8($ap), %rdx\n"
+    body *= "\tmulx\t2*8($ap), $(w[8]), $(w[6])\n" # a1 a2
+    body *= "\tadcx\t$(w[8]), $(w[3])\n" # ADCX
+    body *= "\tadcx\t$(w[6]), $(w[4])\n"
+    body *= "\tmulx\t3*8($ap), $(w[8]), $(w[6])\n" # a1 a3
+    body *= "\tadox\t$(w[8]), $(w[4])\n" # ADOX
+    body *= "\tadox\t$(w[6]), $(w[5])\n"
+    body *= "\tmulx\t4*8($ap), $(w[8]), $(w[6])\n" # a1 a4
+    body *= "\tadcx\t$(w[8]), $(w[5])\n" # ADCX
+    body *= "\tadcx\t$(w[9]), $(w[6])\n" # Add zero
+
+    body *= "\tmov\t2*8($ap), %rdx\n"
+    body *= "\tmulx\t3*8($ap), $(w[8]), $(w[7])\n" # a2 a3
+    body *= "\tadcx\t$(w[8]), $(w[5])\n" # ADCX
+    body *= "\tadcx\t$(w[7]), $(w[6])\n"
+    body *= "\tmulx\t4*8($ap), $(w[8]), $(w[7])\n" # a2 a4
+    body *= "\tadox\t$(w[8]), $(w[6])\n" # ADOX
+    body *= "\tadox\t$(w[9]), $(w[7])\n" # Add zero
+
+    body *= "\tmov\t3*8($ap), %rdx\n"
+    body *= "\tmulx\t4*8($ap), %rdx, $(w[8])\n" # a3 a4
+    body *= "\tadcx\t%rdx, $(w[7])\n" # ADCX
+    body *= "\tadc\t$(w[9]), $(w[8])\n" # Add zero
+
+    # Double upper triangle
+    body *= "\tmov\t0*8($ap), %rdx\n"
+    body *= "\tadd\t$(w[1]), $(w[1])\n"
+    body *= "\tadc\t$(w[2]), $(w[2])\n"
+    body *= "\tadc\t$(w[3]), $(w[3])\n"
+    body *= "\tadc\t$(w[4]), $(w[4])\n"
+    body *= "\tadc\t$(w[5]), $(w[5])\n"
+    body *= "\tadc\t$(w[6]), $(w[6])\n"
+    body *= "\tadc\t$(w[7]), $(w[7])\n"
+    body *= "\tadc\t$(w[8]), $(w[8])\n"
+    body *= "\tadc\t$(w[9]), $(w[9])\n"
+
+    # Calculate diagonal and put into res
+    body *= "\tmulx\t%rdx, %rdx, $s2\n" # a0^2
+    body *= "\tmov\t%rdx, 0*8($res)\n"
+    body *= "\tadd\t$s2, $(w[1])\n"
+    body *= "\tmov\t1*8($ap), %rdx\n"
+    body *= "\tmov\t$(w[1]), 1*8($res)\n"
+    s1 = w[1]
+    w[1] = "error w[1]"
+    body *= "\tmulx\t%rdx, %rdx, $s2\n" # a1^2
+    body *= "\tadc\t%rdx, $(w[2])\n"
+    body *= "\tadc\t$s2, $(w[3])\n"
+    body *= "\tmov\t2*8($ap), %rdx\n"
+    body *= "\tmov\t$(w[2]), 2*8($res)\n"
+    body *= "\tmov\t$(w[3]), 3*8($res)\n"
+    body *= "\tmulx\t%rdx, $s1, $s2\n" # a2^2
+    body *= "\tadc\t$s1, $(w[4])\n"
+    body *= "\tadc\t$s2, $(w[5])\n"
+    body *= "\tmov\t3*8($ap), %rdx\n"
+    body *= "\tmov\t$(w[4]), 4*8($res)\n"
+    body *= "\tmov\t$(w[5]), 5*8($res)\n"
+    body *= "\tmulx\t%rdx, $s1, $s2\n" # a3^2
+    body *= "\tadc\t$s1, $(w[6])\n"
+    body *= "\tadc\t$s2, $(w[7])\n"
+    body *= "\tmov\t4*8($ap), %rdx\n"
+    body *= "\tmov\t$(w[6]), 6*8($res)\n"
+    body *= "\tmov\t$(w[7]), 7*8($res)\n"
+    body *= "\tmulx\t%rdx, $s1, $s2\n" # a4^2
+    body *= "\tadc\t$s1, $(w[8])\n"
+    body *= "\tadc\t$(w[9]), $s2\n"
+    body *= "\tmov\t$(w[8]), 8*8($res)\n"
+    body *= "\tmov\t$s2, 9*8($res)\n"
+
+    return pre * body * post * "\n\tret\n"
+end
+
+function function_body_sqr_6()
+    n = 6
+
+    res = _regs[1]
+    ap = _regs[2]
+
+    this_regs = [_regs[4:end - 1]; __regs]
+
+    w = this_regs[1:2 * n - 1]
+
+    s1 = "error s1"
+    s2 = _regs[end] # Important that this is rax
+
+    pre = "\tmov\t0*8($ap), %rdx\n"
+    post = ""
+    for jx in 1:6
+        pre = pre * "\tpush\t$(__regs[jx])\n"
+        post = "\tpop\t$(__regs[jx])\n" * post
+    end
+
+    body = ""
+
+    # Calculate upper triangle
+    body *= "\txor\t$(reg_32_bit(w[11])), $(reg_32_bit(w[11]))\n"
+    body *= "\tmulx\t1*8($ap), $(w[1]), $(w[7])\n" # a0 a1
+    body *= "\tmulx\t2*8($ap), $(w[2]), $(w[8])\n" # a0 a2
+    body *= "\tmulx\t3*8($ap), $(w[3]), $(w[9])\n" # a0 a3
+    body *= "\tmulx\t4*8($ap), $(w[4]), $(w[10])\n" # a0 a4
+    body *= "\tmulx\t5*8($ap), $(w[5]), $(w[6])\n" # a0 a5
+    body *= "\tadcx\t$(w[7]), $(w[2])\n"
+    body *= "\tadcx\t$(w[8]), $(w[3])\n"
+    body *= "\tadcx\t$(w[9]), $(w[4])\n"
+    body *= "\tadcx\t$(w[10]), $(w[5])\n"
+    body *= "\tadcx\t$(w[11]), $(w[6])\n" # Add zero
+
+    body *= "\tmov\t1*8($ap), %rdx\n"
+    body *= "\tmulx\t2*8($ap), $(w[10]), $(w[7])\n" # a1 a2
+    body *= "\tadcx\t$(w[10]), $(w[3])\n" # ADCX
+    body *= "\tadcx\t$(w[7]), $(w[4])\n"
+    body *= "\tmulx\t3*8($ap), $(w[10]), $(w[7])\n" # a1 a3
+    body *= "\tadox\t$(w[10]), $(w[4])\n" # ADOX
+    body *= "\tadox\t$(w[7]), $(w[5])\n"
+    body *= "\tmulx\t4*8($ap), $(w[10]), $(w[7])\n" # a1 a4
+    body *= "\tadcx\t$(w[10]), $(w[5])\n" # ADCX
+    body *= "\tadcx\t$(w[7]), $(w[6])\n"
+    body *= "\tmulx\t5*8($ap), $(w[10]), $(w[7])\n" # a1 a5
+    body *= "\tadox\t$(w[10]), $(w[6])\n" # ADOX
+    body *= "\tadox\t$(w[11]), $(w[7])\n" # Add zero
+    body *= "\tadcx\t$(w[11]), $(w[7])\n" # Add zero
+
+    body *= "\tmov\t2*8($ap), %rdx\n"
+    body *= "\tmulx\t3*8($ap), $(w[10]), $(w[8])\n" # a2 a3
+    body *= "\tadcx\t$(w[10]), $(w[5])\n" # ADCX
+    body *= "\tadcx\t$(w[8]), $(w[6])\n"
+    body *= "\tmulx\t4*8($ap), $(w[10]), $(w[8])\n" # a2 a4
+    body *= "\tadox\t$(w[10]), $(w[6])\n" # ADOX
+    body *= "\tadox\t$(w[8]), $(w[7])\n"
+    body *= "\tmulx\t5*8($ap), $(w[10]), $(w[8])\n" # a2 a5
+    body *= "\tadcx\t$(w[10]), $(w[7])\n" # ADCX
+    body *= "\tadcx\t$(w[11]), $(w[8])\n" # Add zero
+
+    body *= "\tmov\t3*8($ap), %rdx\n"
+    body *= "\tmulx\t4*8($ap), $(w[10]), $(w[9])\n" # a3 a4
+    body *= "\tadcx\t$(w[10]), $(w[7])\n" # ADCX
+    body *= "\tadcx\t$(w[9]), $(w[8])\n"
+    body *= "\tmulx\t5*8($ap), $(w[10]), $(w[9])\n" # a3 a5
+    body *= "\tadox\t$(w[10]), $(w[8])\n" # ADOX
+    body *= "\tadox\t$(w[11]), $(w[9])\n" # Add zero
+
+    body *= "\tmov\t4*8($ap), %rdx\n"
+    body *= "\tmulx\t5*8($ap), %rdx, $(w[10])\n" # a4 a5
+    body *= "\tadcx\t%rdx, $(w[9])\n" # ADCX
+    body *= "\tadc\t$(w[11]), $(w[10])\n" # Add zero
+
+    # Double upper triangle
+    body *= "\tmov\t0*8($ap), %rdx\n"
+    body *= "\tadd\t$(w[1]), $(w[1])\n"
+    body *= "\tadc\t$(w[2]), $(w[2])\n"
+    body *= "\tadc\t$(w[3]), $(w[3])\n"
+    body *= "\tadc\t$(w[4]), $(w[4])\n"
+    body *= "\tadc\t$(w[5]), $(w[5])\n"
+    body *= "\tadc\t$(w[6]), $(w[6])\n"
+    body *= "\tadc\t$(w[7]), $(w[7])\n"
+    body *= "\tadc\t$(w[8]), $(w[8])\n"
+    body *= "\tadc\t$(w[9]), $(w[9])\n"
+    body *= "\tadc\t$(w[10]), $(w[10])\n"
+    body *= "\tsetc\t$(reg_8_bit(w[11]))\n"
+
+    # Calculate diagonal and put into res
+    body *= "\tmulx\t%rdx, %rdx, $s2\n" # a0^2
+    body *= "\tmov\t%rdx, 0*8($res)\n"
+    body *= "\tmov\t1*8($ap), %rdx\n"
+    body *= "\tadd\t$s2, $(w[1])\n"
+    body *= "\tmov\t$(w[1]), 1*8($res)\n"
+    s1 = w[1]
+    w[1] = "error w[1]"
+    body *= "\tmulx\t%rdx, %rdx, $s2\n" # a1^2
+    body *= "\tadc\t%rdx, $(w[2])\n"
+    body *= "\tadc\t$s2, $(w[3])\n"
+    body *= "\tmov\t2*8($ap), %rdx\n"
+    body *= "\tmov\t$(w[2]), 2*8($res)\n"
+    body *= "\tmov\t$(w[3]), 3*8($res)\n"
+    body *= "\tmulx\t%rdx, $s1, $s2\n" # a2^2
+    body *= "\tadc\t$s1, $(w[4])\n"
+    body *= "\tadc\t$s2, $(w[5])\n"
+    body *= "\tmov\t3*8($ap), %rdx\n"
+    body *= "\tmov\t$(w[4]), 4*8($res)\n"
+    body *= "\tmov\t$(w[5]), 5*8($res)\n"
+    body *= "\tmulx\t%rdx, $s1, $s2\n" # a3^2
+    body *= "\tadc\t$s1, $(w[6])\n"
+    body *= "\tadc\t$s2, $(w[7])\n"
+    body *= "\tmov\t4*8($ap), %rdx\n"
+    body *= "\tmov\t$(w[6]), 6*8($res)\n"
+    body *= "\tmov\t$(w[7]), 7*8($res)\n"
+    body *= "\tmulx\t%rdx, $s1, $s2\n" # a4^2
+    body *= "\tadc\t$s1, $(w[8])\n"
+    body *= "\tadc\t$s2, $(w[9])\n"
+    body *= "\tmov\t5*8($ap), %rdx\n"
+    body *= "\tmov\t$(w[8]), 8*8($res)\n"
+    body *= "\tmov\t$(w[9]), 9*8($res)\n"
+    body *= "\tmulx\t%rdx, $s1, $s2\n" # a5^2
+    body *= "\tadc\t$s1, $(w[10])\n"
+    body *= "\tadc\t$(w[11]), $s2\n"
+    body *= "\tmov\t$(w[10]), 10*8($res)\n"
+    body *= "\tmov\t$s2, 11*8($res)\n"
+
+    return pre * body * post * "\n\tret\n"
+end
+
+function function_body_sqr_7()
+    n = 7
+
+    res = _regs[1]
+    ap = _regs[2]
+
+    this_regs = [_regs[4:end - 1]; __regs]
+
+    w = [this_regs[1:3]; _regs[end]; this_regs[5:11]; ["error w[$ix]" for ix in 12:2 * n - 2]]
+
+    s1 = "error s1"
+    s2 = "error s2"
+    zero = this_regs[4]
+
+    pre = "\tmov\t0*8($ap), %rdx\n"
+    post = ""
+    for jx in 1:6
+        pre = pre * "\tpush\t$(__regs[jx])\n"
+        post = "\tpop\t$(__regs[jx])\n" * post
+    end
+
+    body = ""
+
+    # Calculate upper triangle
+    body *= "\txor\t$(reg_32_bit(zero)), $(reg_32_bit(zero))\n"
+    body *= "\tmulx\t1*8($ap), $(w[1]), $(w[5])\n" # a0 a1
+    body *= "\tmulx\t2*8($ap), $(w[2]), $(w[6])\n" # a0 a2
+    body *= "\tmulx\t3*8($ap), $(w[3]), $(w[10])\n" # a0 a3
+    body *= "\tadcx\t$(w[5]), $(w[2])\n"
+    body *= "\tadcx\t$(w[6]), $(w[3])\n"
+    body *= "\tmulx\t4*8($ap), $(w[4]), $(w[8])\n" # a0 a4
+    body *= "\tmulx\t5*8($ap), $(w[5]), $(w[9])\n" # a0 a5
+    body *= "\tmulx\t6*8($ap), $(w[6]), $(w[7])\n" # a0 a6
+    body *= "\tadcx\t$(w[10]), $(w[4])\n"
+    body *= "\tadcx\t$(w[8]), $(w[5])\n"
+    body *= "\tmov\t1*8($ap), %rdx\n"
+    body *= "\tadcx\t$(w[9]), $(w[6])\n"
+    body *= "\tadcx\t$zero, $(w[7])\n"
+
+    body *= "\tmulx\t2*8($ap), $(w[10]), $(w[8])\n" # a1 a2
+    body *= "\tmulx\t3*8($ap), $(w[11]), $(w[9])\n" # a1 a3
+    body *= "\tadcx\t$(w[10]), $(w[3])\n" # ADCX
+    body *= "\tadcx\t$(w[8]), $(w[4])\n"
+    body *= "\tadox\t$(w[11]), $(w[4])\n" # ADOX
+    body *= "\tadox\t$(w[9]), $(w[5])\n"
+    body *= "\tmulx\t4*8($ap), $(w[10]), $(w[8])\n" # a1 a4
+    body *= "\tmulx\t5*8($ap), $(w[11]), $(w[9])\n" # a1 a5
+    body *= "\tadcx\t$(w[10]), $(w[5])\n" # ADCX
+    body *= "\tadcx\t$(w[8]), $(w[6])\n"
+    body *= "\tmulx\t6*8($ap), $(w[10]), $(w[8])\n" # a1 a6
+    body *= "\tadox\t$(w[11]), $(w[6])\n" # ADOX
+    body *= "\tadox\t$(w[9]), $(w[7])\n"
+    body *= "\tmov\t2*8($ap), %rdx\n"
+    body *= "\tadcx\t$(w[10]), $(w[7])\n" # ADCX
+    body *= "\tadox\t$zero, $(w[8])\n"
+    body *= "\tadcx\t$zero, $(w[8])\n"
+
+    body *= "\tmulx\t3*8($ap), $(w[11]), $(w[9])\n" # a2 a3
+    body *= "\tadox\t$(w[11]), $(w[5])\n" # ADOX
+    body *= "\tadox\t$(w[9]), $(w[6])\n"
+    body *= "\tmulx\t4*8($ap), $(w[11]), $(w[9])\n" # a2 a4
+    body *= "\tadcx\t$(w[11]), $(w[6])\n" # ADCX
+    body *= "\tadcx\t$(w[9]), $(w[7])\n"
+    body *= "\tmulx\t5*8($ap), $(w[11]), $(w[9])\n" # a2 a5
+    body *= "\tadox\t$(w[11]), $(w[7])\n" # ADOX
+    body *= "\tadox\t$(w[9]), $(w[8])\n"
+    body *= "\tmulx\t6*8($ap), $(w[11]), $(w[9])\n" # a2 a6
+    body *= "\tadcx\t$(w[11]), $(w[8])\n" # ADCX
+    body *= "\tadox\t$zero, $(w[9])\n"
+    body *= "\tmov\t3*8($ap), %rdx\n"
+    body *= "\tadcx\t$zero, $(w[9])\n"
+
+    body *= "\tmulx\t4*8($ap), $(w[11]), $(w[10])\n" # a3 a4
+    body *= "\tadcx\t$(w[11]), $(w[7])\n" # ADCX
+    body *= "\tadcx\t$(w[10]), $(w[8])\n"
+    body *= "\tmulx\t5*8($ap), $(w[11]), $(w[10])\n" # a3 a5
+    body *= "\tadox\t$(w[11]), $(w[8])\n" # ADOX
+    body *= "\tadox\t$(w[10]), $(w[9])\n"
+    body *= "\tmulx\t6*8($ap), $(w[11]), $(w[10])\n" # a3 a6
+    body *= "\tmov\t4*8($ap), %rdx\n"
+    body *= "\tadcx\t$(w[11]), $(w[9])\n" # ADCX
+    body *= "\tadcx\t$zero, $(w[10])\n"
+
+    w[12] = zero
+    zero = "error zero"
+    body *= "\tmulx\t5*8($ap), $(w[12]), $(w[11])\n" # a4 a5
+    body *= "\tadcx\t$(w[12]), $(w[9])\n" # ADCX
+    body *= "\tadcx\t$(w[11]), $(w[10])\n"
+    body *= "\tmulx\t6*8($ap), $(w[12]), $(w[11])\n" # a4 a6
+    body *= "\tmov\t\$0, %edx\n"
+    body *= "\tadox\t$(w[12]), $(w[10])\n" # ADOX
+    body *= "\tadox\t%rdx, $(w[11])\n"
+    body *= "\tmov\t5*8($ap), %rdx\n"
+
+    body *= "\tmulx\t6*8($ap), %rdx, $(w[12])\n" # a5 a6
+    body *= "\tadcx\t%rdx, $(w[11])\n" # ADCX
+    body *= "\tadc\t\$0, $(w[12])\n"
+    body *= "\ttest\t%al, %al\n"
+
+    # Double upper triangle
+    body *= "\tmov\t0*8($ap), %rdx\n"
+    body *= "\tadcx\t$(w[1]), $(w[1])\n"
+    body *= "\tadcx\t$(w[2]), $(w[2])\n"
+    body *= "\tadcx\t$(w[3]), $(w[3])\n"
+    body *= "\tadcx\t$(w[4]), $(w[4])\n"
+    body *= "\tadcx\t$(w[5]), $(w[5])\n"
+    body *= "\tadcx\t$(w[6]), $(w[6])\n"
+    body *= "\tpush\t$(w[4])\n"
+    body *= "\tadcx\t$(w[7]), $(w[7])\n"
+    body *= "\tadcx\t$(w[8]), $(w[8])\n"
+    body *= "\tadcx\t$(w[9]), $(w[9])\n"
+    body *= "\tadcx\t$(w[10]), $(w[10])\n"
+    body *= "\tadcx\t$(w[11]), $(w[11])\n"
+    body *= "\tadcx\t$(w[12]), $(w[12])\n"
+
+    # Calculate diagonal and put into res
+    s2 = w[4]
+    w[4] = "error w[4]"
+    body *= "\tmulx\t%rdx, %rdx, $s2\n" # a0^2
+    body *= "\tmov\t%rdx, 0*8($res)\n"
+    body *= "\tadox\t$s2, $(w[1])\n"
+    body *= "\tmov\t1*8($ap), %rdx\n"
+    body *= "\tmov\t$(w[1]), 1*8($res)\n"
+    w[4] = w[1]
+    w[1] = "error w[1]"
+    body *= "\tmulx\t%rdx, %rdx, $s2\n" # a1^2
+    body *= "\tadox\t%rdx, $(w[2])\n"
+    body *= "\tadox\t$s2, $(w[3])\n"
+    body *= "\tpop\t$(w[4])\n"
+    body *= "\tmov\t2*8($ap), %rdx\n"
+    body *= "\tmov\t$(w[2]), 2*8($res)\n"
+    body *= "\tmov\t$(w[3]), 3*8($res)\n"
+    s1 = w[2]
+    w[2] = "error w[2]"
+    body *= "\tmulx\t%rdx, %rdx, $s2\n" # a2^2
+    body *= "\tadox\t%rdx, $(w[4])\n"
+    body *= "\tadox\t$s2, $(w[5])\n"
+    body *= "\tmov\t3*8($ap), %rdx\n"
+    body *= "\tmov\t$(w[4]), 4*8($res)\n"
+    body *= "\tmov\t$(w[5]), 5*8($res)\n"
+    zero = w[4]
+    w[4] = "error w[4]"
+    body *= "\tmulx\t%rdx, $s1, $s2\n" # a3^2
+    body *= "\tadox\t$s1, $(w[6])\n"
+    body *= "\tadox\t$s2, $(w[7])\n"
+    body *= "\tmov\t4*8($ap), %rdx\n"
+    body *= "\tmov\t$(w[6]), 6*8($res)\n"
+    body *= "\tmov\t$(w[7]), 7*8($res)\n"
+    body *= "\tmulx\t%rdx, $s1, $s2\n" # a4^2
+    body *= "\tadox\t$s1, $(w[8])\n"
+    body *= "\tadox\t$s2, $(w[9])\n"
+    body *= "\tmov\t5*8($ap), %rdx\n"
+    body *= "\tmov\t$(w[8]), 8*8($res)\n"
+    body *= "\tmov\t$(w[9]), 9*8($res)\n"
+    body *= "\tmulx\t%rdx, $s1, $s2\n" # a5^2
+    body *= "\tadox\t$s1, $(w[10])\n"
+    body *= "\tadox\t$s2, $(w[11])\n"
+    body *= "\tmov\t\$0, $(reg_32_bit(zero))\n"
+    body *= "\tmov\t6*8($ap), %rdx\n"
+    body *= "\tmov\t$(w[10]), 10*8($res)\n"
+    body *= "\tmov\t$(w[11]), 11*8($res)\n"
+    body *= "\tmulx\t%rdx, $s1, $s2\n" # a6^2
+    body *= "\tadox\t$s1, $(w[12])\n"
+    body *= "\tadox\t$zero, $s2\n"
+    body *= "\tadcx\t$zero, $s2\n"
+    body *= "\tmov\t$(w[12]), 12*8($res)\n"
+    body *= "\tmov\t$s2, 13*8($res)\n"
+
+    return pre * body * post * "\n\tret\n"
+end
+
+# NOTE: This function is currently very slow. 
+# FIXME: Would it be smarter to use res as temporary storage?
+function function_body_sqr_8()
+    n = 8
+
+    res = _regs[1]
+    ap = _regs[2]
+
+    this_regs = [_regs[4:end - 1]; __regs]
+
+    w = [this_regs[1:11]; ["error w[$ix]" for ix in 12:2 * n - 2]]
+
+    s1 = "error s1"
+    s2 = "error s2"
+    zero = _regs[end] # rax
+
+    pre = "\tmov\t0*8($ap), %rdx\n"
+    pre *= "\tvmovdqu\t0*8($ap), %ymm0\n"
+    pre *= "\tvmovdqu\t4*8($ap), %ymm1\n"
+    post = ""
+    for jx in 1:6
+        pre = pre * "\tpush\t$(__regs[jx])\n"
+        post = "\tpop\t$(__regs[jx])\n" * post
+    end
+
+    as(m::Int) = "-$(n - m)*8(%rsp)"
+    ws(m::Int) = "-$(5 * n - 26 - m)*8(%rsp)"
+
+    body = ""
+
+    # Move ap to stack, but because of high latency, delay it a bit
+    body *= "\txor\t$(reg_32_bit(zero)), $(reg_32_bit(zero))\n"
+
+    # Calculate upper triangle
+    body *= "\tmulx\t1*8($ap), $(w[1]), $(w[4])\n" # a0 a1
+    body *= "\tmulx\t2*8($ap), $(w[2]), $(w[5])\n" # a0 a2
+    body *= "\tmulx\t3*8($ap), $(w[3]), $(w[6])\n" # a0 a3
+    body *= "\tvmovdqu\t%ymm0, $(as(0))\n"
+    body *= "\tvmovdqu\t%ymm1, $(as(4))\n"
+    body *= "\tadcx\t$(w[4]), $(w[2])\n"
+    body *= "\tadcx\t$(w[5]), $(w[3])\n"
+    body *= "\tmulx\t4*8($ap), $(w[4]), $(w[10])\n" # a0 a4
+    body *= "\tmulx\t5*8($ap), $(w[5]), $(w[11])\n" # a0 a5
+    body *= "\tadcx\t$(w[6]), $(w[4])\n"
+    body *= "\tadcx\t$(w[10]), $(w[5])\n"
+    body *= "\tmulx\t6*8($ap), $(w[6]), $(w[9])\n" # a0 a6
+    body *= "\tmulx\t7*8($ap), $(w[7]), $(w[8])\n" # a0 a7
+    body *= "\tmov\t1*8($ap), %rdx\n"
+    body *= "\tadcx\t$(w[11]), $(w[6])\n"
+    body *= "\tadcx\t$(w[9]), $(w[7])\n"
+    body *= "\tadcx\t$zero, $(w[8])\n"
+
+    w[12] = ap
+    ap = "error ap"
+
+    body *= "\tmulx\t$(as(2)), $(w[12]), $(w[11])\n" # a1 a2
+    body *= "\tmulx\t$(as(3)), $(w[10]), $(w[9])\n" # a1 a3
+    body *= "\tadcx\t$(w[12]), $(w[3])\n" # ADCX
+    body *= "\tadcx\t$(w[11]), $(w[4])\n"
+    body *= "\tadox\t$(w[10]), $(w[4])\n" # ADOX
+    body *= "\tadox\t$(w[9]), $(w[5])\n"
+    body *= "\tmulx\t$(as(4)), $(w[12]), $(w[11])\n" # a1 a4
+    body *= "\tmulx\t$(as(5)), $(w[10]), $(w[9])\n" # a1 a5
+    body *= "\tadcx\t$(w[12]), $(w[5])\n" # ADCX
+    body *= "\tadcx\t$(w[11]), $(w[6])\n"
+    body *= "\tadox\t$(w[10]), $(w[6])\n" # ADOX
+    body *= "\tadox\t$(w[9]), $(w[7])\n"
+    body *= "\tmulx\t$(as(6)), $(w[12]), $(w[11])\n" # a1 a6
+    body *= "\tmulx\t$(as(7)), $(w[10]), $(w[9])\n" # a1 a7
+    body *= "\tadcx\t$(w[12]), $(w[7])\n" # ADCX
+    body *= "\tadcx\t$(w[11]), $(w[8])\n"
+    body *= "\tadox\t$(w[10]), $(w[8])\n" # ADOX
+    body *= "\tmov\t$(as(2)), %rdx\n"
+    body *= "\tadox\t$zero, $(w[9])\n"
+    body *= "\tadcx\t$zero, $(w[9])\n"
+
+    body *= "\tmulx\t$(as(3)), $(w[11]), $(w[10])\n" # a2 a3
+    body *= "\tadox\t$(w[11]), $(w[5])\n" # ADOX
+    body *= "\tadox\t$(w[10]), $(w[6])\n"
+    body *= "\tmulx\t$(as(4)), $(w[11]), $(w[10])\n" # a2 a4
+    body *= "\tadcx\t$(w[11]), $(w[6])\n" # ADCX
+    body *= "\tadcx\t$(w[10]), $(w[7])\n"
+    body *= "\tmulx\t$(as(5)), $(w[11]), $(w[10])\n" # a2 a5
+    body *= "\tadox\t$(w[11]), $(w[7])\n" # ADOX
+    body *= "\tadox\t$(w[10]), $(w[8])\n"
+    body *= "\tmulx\t$(as(6)), $(w[11]), $(w[10])\n" # a2 a6
+    body *= "\tadcx\t$(w[11]), $(w[8])\n" # ADCX
+    body *= "\tadcx\t$(w[10]), $(w[9])\n"
+    body *= "\tmulx\t$(as(7)), $(w[11]), $(w[10])\n" # a2 a7
+    body *= "\tadox\t$(w[11]), $(w[9])\n" # ADOX
+    body *= "\tadox\t$zero, $(w[10])\n"
+    body *= "\tmov\t$(as(3)), %rdx\n"
+    body *= "\tadcx\t$zero, $(w[10])\n"
+
+    body *= "\tmov\t$(w[6]), $(ws(0))\n"
+    w[13] = w[6]
+    w[6] = "error w[6]"
+
+    body *= "\tmulx\t$(as(4)), $(w[12]), $(w[11])\n" # a3 a4
+    body *= "\tadcx\t$(w[12]), $(w[7])\n" # ADCX
+    body *= "\tadcx\t$(w[11]), $(w[8])\n"
+    body *= "\tmulx\t$(as(5)), $(w[12]), $(w[11])\n" # a3 a5
+    body *= "\tadox\t$(w[12]), $(w[8])\n" # ADOX
+    body *= "\tadox\t$(w[11]), $(w[9])\n"
+    body *= "\tmulx\t$(as(6)), $(w[12]), $(w[11])\n" # a3 a6
+    body *= "\tadcx\t$(w[12]), $(w[9])\n" # ADCX
+    body *= "\tadcx\t$(w[11]), $(w[10])\n"
+    body *= "\tmulx\t$(as(7)), $(w[12]), $(w[11])\n" # a3 a7
+    body *= "\tadox\t$(w[12]), $(w[10])\n" # ADOX
+    body *= "\tadox\t$zero, $(w[11])\n"
+    body *= "\tmov\t$(as(4)), %rdx\n"
+    body *= "\tadcx\t$zero, $(w[11])\n"
+
+    body *= "\tmulx\t$(as(5)), $(w[13]), $(w[12])\n" # a4 a5
+    body *= "\tadcx\t$(w[13]), $(w[9])\n" # ADCX
+    body *= "\tadcx\t$(w[12]), $(w[10])\n"
+    body *= "\tmulx\t$(as(6)), $(w[13]), $(w[12])\n" # a4 a6
+    body *= "\tadox\t$(w[13]), $(w[10])\n" # ADOX
+    body *= "\tadox\t$(w[12]), $(w[11])\n"
+    body *= "\tmulx\t$(as(7)), $(w[13]), $(w[12])\n" # a4 a7
+    body *= "\tadcx\t$(w[13]), $(w[11])\n" # ADCX
+    body *= "\tadcx\t$zero, $(w[12])\n"
+    body *= "\tmov\t$(as(5)), %rdx\n"
+
+    w[14] = zero
+    zero = "error zero"
+
+    body *= "\tmulx\t$(as(6)), $(w[14]), $(w[13])\n" # a5 a6
+    body *= "\tadcx\t$(w[14]), $(w[11])\n" # ADCX
+    body *= "\tadcx\t$(w[13]), $(w[12])\n"
+    body *= "\tmulx\t$(as(7)), $(w[14]), $(w[13])\n" # a5 a7
+    body *= "\tmov\t$(w[11]), $(ws(1))\n"
+    body *= "\tmov\t\$0, %edx\n"
+    body *= "\tadox\t$(w[14]), $(w[12])\n" # ADOX
+    body *= "\tadox\t%rdx, $(w[13])\n"
+    body *= "\tmov\t$(as(6)), %rdx\n"
+
+    w[6] = w[11]
+    w[11] = "error w[11]"
+    body *= "\tmov\t$(ws(0)), $(w[6])\n"
+
+    body *= "\tmulx\t$(as(7)), %rdx, $(w[14])\n" # a6 a7
+    body *= "\tadcx\t%rdx, $(w[13])\n" # ADCX
+    body *= "\tadc\t\$0, $(w[14])\n"
+    body *= "\ttest\t%al, %al\n"
+
+    # Double upper triangle
+    body *= "\tmov\t$(as(0)), %rdx\n"
+    body *= "\tadcx\t$(w[1]), $(w[1])\n"
+    body *= "\tadcx\t$(w[2]), $(w[2])\n"
+    body *= "\tadcx\t$(w[3]), $(w[3])\n"
+    body *= "\tadcx\t$(w[4]), $(w[4])\n"
+    body *= "\tadcx\t$(w[5]), $(w[5])\n"
+    body *= "\tadcx\t$(w[6]), $(w[6])\n"
+    body *= "\tmov\t$(w[6]), $(ws(0))\n"
+    w[11] = w[6]
+    w[6] = "error w[6]"
+    body *= "\tadcx\t$(w[7]), $(w[7])\n"
+    body *= "\tadcx\t$(w[8]), $(w[8])\n"
+    body *= "\tmov\t$(ws(1)), $(w[11])\n"
+    body *= "\tadcx\t$(w[9]), $(w[9])\n"
+    body *= "\tadcx\t$(w[10]), $(w[10])\n"
+    body *= "\tadcx\t$(w[11]), $(w[11])\n"
+    body *= "\tadcx\t$(w[12]), $(w[12])\n"
+    body *= "\tmov\t$(w[11]), $(ws(1))\n"
+    s2 = w[11]
+    w[11] = "error w[11]"
+    body *= "\tadcx\t$(w[13]), $(w[13])\n"
+    body *= "\tadcx\t$(w[14]), $(w[14])\n"
+    body *= "\tvzeroupper\n"
+    # w[4] and w[11] are stored on stack
+
+    # Calculate diagonal and put into res
+    body *= "\tmulx\t%rdx, %rdx, $s2\n" # a0^2
+    body *= "\tmov\t%rdx, 0*8($res)\n"
+    body *= "\tadox\t$s2, $(w[1])\n"
+    body *= "\tmov\t$(as(1)), %rdx\n"
+    body *= "\tmov\t$(w[1]), 1*8($res)\n"
+    w[6] = w[1]
+    w[1] = "error w[1]"
+    body *= "\tmulx\t%rdx, %rdx, $s2\n" # a1^2
+    body *= "\tadox\t%rdx, $(w[2])\n"
+    body *= "\tmov\t$(ws(0)), $(w[6])\n"
+    body *= "\tadox\t$s2, $(w[3])\n"
+    body *= "\tmov\t$(as(2)), %rdx\n"
+    body *= "\tmov\t$(w[2]), 2*8($res)\n"
+    body *= "\tmov\t$(w[3]), 3*8($res)\n"
+    w[11], zero = w[2], w[3]
+    w[2:3] = ["error w[$ix]" for ix in 2:3]
+    body *= "\tmulx\t%rdx, %rdx, $s2\n" # a2^2
+    body *= "\tadox\t%rdx, $(w[4])\n"
+    body *= "\tadox\t$s2, $(w[5])\n"
+    body *= "\tmov\t$(as(3)), %rdx\n"
+    body *= "\tmov\t$(w[4]), 4*8($res)\n"
+    body *= "\tmov\t$(w[5]), 5*8($res)\n"
+    body *= "\tmov\t$(ws(1)), $(w[11])\n"
+    body *= "\tmulx\t%rdx, %rdx, $s2\n" # a3^2
+    body *= "\tadox\t%rdx, $(w[6])\n"
+    body *= "\tadox\t$s2, $(w[7])\n"
+    body *= "\tmov\t$(as(4)), %rdx\n"
+    body *= "\tmov\t$(w[6]), 6*8($res)\n"
+    body *= "\tmov\t$(w[7]), 7*8($res)\n"
+    body *= "\tmulx\t%rdx, %rdx, $s2\n" # a4^2
+    body *= "\tadox\t%rdx, $(w[8])\n"
+    body *= "\tadox\t$s2, $(w[9])\n"
+    body *= "\tmov\t$(as(5)), %rdx\n"
+    body *= "\tmov\t$(w[8]), 8*8($res)\n"
+    body *= "\tmov\t$(w[9]), 9*8($res)\n"
+    body *= "\tmulx\t%rdx, %rdx, $s2\n" # a5^2
+    body *= "\tadox\t%rdx, $(w[10])\n"
+    body *= "\tadox\t$s2, $(w[11])\n"
+    body *= "\tmov\t$(as(6)), %rdx\n"
+    body *= "\tmov\t$(w[10]), 10*8($res)\n"
+    body *= "\tmov\t$(w[11]), 11*8($res)\n"
+    body *= "\tmulx\t%rdx, %rdx, $s2\n" # a6^2
+    body *= "\tadox\t%rdx, $(w[12])\n"
+    body *= "\tadox\t$s2, $(w[13])\n"
+    body *= "\tmov\t$(as(7)), %rdx\n"
+    body *= "\tmov\t$(w[12]), 12*8($res)\n"
+    body *= "\tmov\t$(w[13]), 13*8($res)\n"
+    body *= "\tmov\t\$0, $(reg_32_bit(zero))\n"
+    body *= "\tmulx\t%rdx, %rdx, $s2\n" # a7^2
+    body *= "\tadox\t%rdx, $(w[14])\n"
+    body *= "\tadox\t$zero, $s2\n"
+    body *= "\tadcx\t$zero, $s2\n"
+    body *= "\tmov\t$(w[14]), 14*8($res)\n"
+    body *= "\tmov\t$s2, 15*8($res)\n"
+
+    return pre * body * post * "\n\tret\n"
+end
+
+# Do mul + addmul
+# DO NOT USE! Slow and currently wrong
+function function_body_sqr_7b()
+    n = 7
+
+    res = _regs[1]
+    ap = _regs[2]
+
+    this_regs = [_regs[4:end - 1]; __regs]
+
+    w = [this_regs[1:8]; ["error w[$ix]" for ix in 9:13]]
+    t = [this_regs[9:11]; __regs[end]; ["error t[$ix]" for ix in 5:10]]
+
+    pre = ""
+    post = ""
+    for jx in 1:6
+        pre = pre * "\tpush\t$(__regs[jx])\n"
+        post = "\tpop\t$(__regs[jx])\n" * post
+    end
+
+    body = ""
+
+    # NOTE: Use adox for adding result and adcx for upper triangle-ish
+
+    # Calculate res[0] and res[1]
+    # w1, ..., w8, t1, ..., t4 exist
+    body *= "\tmov\t0*8($ap), %rdx\n"
+    body *= "\txor\t$(reg_32_bit(w[8])), $(reg_32_bit(w[8]))\n"
+    body *= "\tmulx\t1*8($ap), $(w[1]), $(t[1])\n" # a0 a1
+    body *= "\tmulx\t2*8($ap), $(w[2]), $(t[2])\n" # a0 a2
+    body *= "\tmulx\t3*8($ap), $(w[3]), $(t[3])\n" # a0 a3
+    body *= "\tadcx\t$(t[1]), $(w[2])\n" # Collecting
+    body *= "\tadcx\t$(t[2]), $(w[3])\n"
+    body *= "\tmulx\t4*8($ap), $(w[4]), $(t[1])\n" # a0 a4
+    body *= "\tmulx\t5*8($ap), $(w[5]), $(t[2])\n" # a0 a5
+    body *= "\tadcx\t$(t[3]), $(w[4])\n"
+    body *= "\tadcx\t$(t[1]), $(w[5])\n"
+    body *= "\tmulx\t6*8($ap), $(w[6]), $(w[7])\n" # a0 a6
+    body *= "\tadcx\t$(t[2]), $(w[6])\n"
+    body *= "\tadcx\t$(w[8]), $(w[7])\n"
+    body *= "\tmulx\t%rdx, $(t[1]), $(t[2])\n" # a0^2
+    body *= "\tadcx\t$(w[1]), $(w[1])\n" # Doubling
+    body *= "\tadcx\t$(w[2]), $(w[2])\n"
+    body *= "\tadcx\t$(w[3]), $(w[3])\n"
+    body *= "\tadcx\t$(w[4]), $(w[4])\n"
+    body *= "\tadcx\t$(w[5]), $(w[5])\n"
+    body *= "\tadcx\t$(w[6]), $(w[6])\n"
+    body *= "\tadcx\t$(w[7]), $(w[7])\n"
+    body *= "\tadcx\t$(w[8]), $(w[8])\n"
+    body *= "\tadox\t$(t[2]), $(w[1])\n" # Result, carry will be stored in t4 in next paragraph
+    body *= "\tmov\t$(t[1]), 0*8($res)\n"
+    body *= "\tmov\t$(w[1]), 1*8($res)\n"
+    # w2, ..., w8 in use
+
+    # Calculate res[2] and res[3]
+    # w2, ..., w9, t1, ..., t4 exist
+    w[9] = w[1]
+    w[1] = "error w[1]"
+    body *= "\tmov\t1*8($ap), %rdx\n"
+    body *= "\tmov\t\$0, $(reg_32_bit(w[9]))\n" # Preserve flags
+    body *= "\tmov\t\$0, $(reg_32_bit(t[4]))\n"
+    body *= "\tmulx\t2*8($ap), $(t[1]), $(t[2])\n" # a1 a2
+    body *= "\tadcx\t$(t[1]), $(t[1])\n" # Double subset
+    body *= "\tadcx\t$(w[9]), $(t[4])\n" # Store carry from doubling
+    body *= "\tadcx\t$(t[1]), $(w[3])\n" # Add subset
+    body *= "\tadcx\t$(w[9]), $(t[4])\n" # Store carry from adding
+    body *= "\tmulx\t%rdx, $(t[1]), $(t[3])\n" # a1^2
+    body *= "\tadox\t$(t[1]), $(w[2])\n" # Result
+    body *= "\tadox\t$(t[3]), $(w[3])\n"
+    body *= "\tmov\t$(w[2]), 2*8($res)\n"
+    body *= "\tmov\t$(w[3]), 3*8($res)\n"
+    # w4, ..., w9 and t2, t4 in use
+    # t4 should be added onto res[4]
+    t[5:6] = w[2:3]
+    w[2:3] = ["error w[$ix]" for ix in 2:3]
+    body *= "\tmulx\t3*8($ap), $(t[1]), $(t[3])\n" # a1 a3
+    body *= "\tmulx\t4*8($ap), $(t[5]), $(t[6])\n" # a1 a4
+    body *= "\tadcx\t$(t[1]), $(t[2])\n" # Collect
+    body *= "\tadcx\t$(t[5]), $(t[3])\n"
+    body *= "\tmulx\t5*8($ap), $(t[1]), $(t[5])\n" # a1 a5
+    body *= "\tadcx\t$(t[1]), $(t[6])\n"
+    body *= "\tmulx\t6*8($ap), %rdx, $(t[1])\n" # a1 a6
+    body *= "\tadcx\t%rdx, $(t[5])\n"
+    body *= "\tadcx\t$(w[9]), $(t[1])\n"
+    body *= "\tmov\t\$0, %edx\n"
+    body *= "\tadcx\t$(t[2]), $(t[2])\n" # Double
+    body *= "\tadcx\t$(t[3]), $(t[3])\n"
+    body *= "\tadcx\t$(t[6]), $(t[6])\n"
+    body *= "\tadcx\t$(t[5]), $(t[5])\n"
+    body *= "\tadcx\t$(t[1]), $(t[1])\n"
+    body *= "\tadcx\t$(w[9]), $(w[9])\n"
+    body *= "\tadcx\t$(t[2]), $(w[4])\n" # Add
+    body *= "\tadcx\t$(t[3]), $(w[5])\n"
+    body *= "\tadcx\t$(t[6]), $(w[6])\n"
+    body *= "\tadcx\t$(t[5]), $(w[7])\n"
+    body *= "\tadcx\t$(t[1]), $(w[8])\n"
+    body *= "\tadcx\t%rdx, $(w[9])\n"
+    # w4, ..., w9 and t4 in use
+
+    # Calculate res[4] and res[5]
+    # w4, ..., w10, t1, ..., t5 exist
+    w[10] = t[6]
+    t[6] = "error t[6]"
+    body *= "\tmov\t2*8($ap), %rdx\n"
+    body *= "\tmov\t\$0, $(reg_32_bit(t[5]))\n"
+    body *= "\tmov\t\$0, $(reg_32_bit(w[10]))\n"
+    body *= "\tmulx\t3*8($ap), $(t[1]), $(t[2])\n" # a2 a3
+    body *= "\tadcx\t$(t[1]), $(t[1])\n" # Double subset
+    body *= "\tadcx\t$(w[10]), $(t[5])\n" # Store carry from doubling
+    body *= "\tadcx\t$(t[1]), $(w[5])\n" # Add subset
+    body *= "\tadcx\t$(w[10]), $(t[5])\n" # Store carry from adding
+    body *= "\tmulx\t%rdx, $(t[1]), $(t[3])\n" # a2^2
+    body *= "\tadcx\t$(t[4]), $(t[1])\n" # Add previous carry
+    body *= "\tadcx\t$(w[10]), $(t[3])\n"
+    body *= "\tadox\t$(t[1]), $(w[4])\n" # Result
+    body *= "\tadox\t$(t[3]), $(w[5])\n"
+    body *= "\tmov\t$(w[4]), 4*8($res)\n"
+    body *= "\tmov\t$(w[5]), 5*8($res)\n"
+    # w6, ..., w10 and t2, t5 in use
+    # t5 should be added onto res[6]
+    t[6:7] = w[4:5]
+    w[4:5] = ["error w[$ix]" for ix in 4:5]
+    body *= "\tmulx\t4*8($ap), $(t[1]), $(t[3])\n" # a2 a4
+    body *= "\tmulx\t5*8($ap), $(t[4]), $(t[6])\n" # a2 a5
+    body *= "\tadcx\t$(t[1]), $(t[2])\n" # Collect
+    body *= "\tadcx\t$(t[4]), $(t[3])\n"
+    body *= "\tmulx\t6*8($ap), $(t[1]), $(t[7])\n" # a2 a6
+    body *= "\tadcx\t$(t[1]), $(t[6])\n"
+    body *= "\tadcx\t$(w[10]), $(t[7])\n"
+    body *= "\tmov\t\$0, %edx\n"
+    body *= "\tadcx\t$(t[2]), $(t[2])\n" # Double
+    body *= "\tadcx\t$(t[3]), $(t[3])\n"
+    body *= "\tadcx\t$(t[6]), $(t[6])\n"
+    body *= "\tadcx\t$(t[7]), $(t[7])\n"
+    body *= "\tadcx\t$(w[10]), $(w[10])\n"
+    body *= "\tadcx\t$(t[2]), $(w[6])\n" # Add
+    body *= "\tadcx\t$(t[3]), $(w[7])\n"
+    body *= "\tadcx\t$(t[6]), $(w[8])\n"
+    body *= "\tadcx\t$(t[7]), $(w[9])\n"
+    body *= "\tadcx\t%rdx, $(w[10])\n"
+    # w6, ..., w10 and t5 in use
+
+    # Calculate res[6] and res[7]
+    # w6, ..., w11, t1, ..., t6 exist
+    w[11] = t[7]
+    t[7] = "error t[7]"
+    body *= "\tmov\t3*8($ap), %rdx\n"
+    body *= "\tmov\t\$0, $(reg_32_bit(w[11]))\n"
+    body *= "\tmulx\t4*8($ap), $(t[1]), $(t[4])\n" # a3 a4
+    body *= "\tmulx\t5*8($ap), $(t[2]), $(t[6])\n" # a3 a5
+    body *= "\tadcx\t$(t[4]), $(t[2])\n" # Collect
+    body *= "\tmulx\t6*8($ap), $(t[3]), $(t[4])\n" # a3 a6
+    body *= "\tadcx\t$(t[6]), $(t[3])\n"
+    body *= "\tadcx\t$(w[11]), $(t[4])\n"
+    body *= "\tadcx\t$(t[1]), $(t[1])\n" # Double
+    body *= "\tadcx\t$(t[2]), $(t[2])\n"
+    body *= "\tadcx\t$(t[3]), $(t[3])\n"
+    body *= "\tadcx\t$(t[4]), $(t[4])\n"
+    body *= "\tmulx\t%rdx, %rdx, $(t[6])\n" # a3^2
+    body *= "\tadox\t$(t[5]), %rdx\n" # Add previous carry
+    body *= "\tadox\t$(w[11]), $(t[6])\n"
+    body *= "\tadcx\t$(w[11]), $(w[11])\n" # Last double
+    body *= "\tadox\t%rdx, $(w[6])\n" # Result
+    body *= "\tadox\t$(t[6]), $(w[7])\n"
+    body *= "\tmov\t$(w[6]), 6*8($res)\n"
+    body *= "\tmov\t$(w[7]), 7*8($res)\n"
+    # w8, ..., w11 in use
+
+    # Calculate res[8] and res[9]
+    # w8, ..., w12, t1, ..., t7 exist
+    w[12], t[7] = w[6], w[7]
+    w[6:7] = ["error w[$ix]" for ix in 6:7]
+    body *= "\tmov\t4*8($ap), %rdx\n"
+    body *= "\tmov\t\$0, $(reg_32_bit(w[12]))\n"
+    body *= "\tmov\t\$0, $(reg_32_bit(t[7]))\n"
+    body *= "\tmulx\t5*8($ap), $(t[1]), $(t[4])\n" # a4 a5
+    body *= "\tmulx\t6*8($ap), $(t[2]), $(t[3])\n" # a4 a6
+    body *= "\tmulx\t%rdx, %rdx, $(t[5])\n" # a4^2
+    body *= "\tadcx\t$(t[4]), $(t[2])\n" # Collect
+    body *= "\tadcx\t$(w[12]), $(t[3])\n"
+    body *= "\tadcx\t$(t[1]), $(t[1])\n" # Double
+    body *= "\tadcx\t$(t[2]), $(t[2])\n"
+    body *= "\tadcx\t$(t[3]), $(t[3])\n"
+    body *= "\tadcx\t$(t[7]), $(t[7])\n"
+    body *= "\tadcx\t$(t[1]), $(w[9])\n" # Add
+    body *= "\tadcx\t$(t[2]), $(w[10])\n"
+    body *= "\tadcx\t$(t[3]), $(w[11])\n"
+    body *= "\tadcx\t$(t[7]), $(w[12])\n"
+    body *= "\tadox\t%rdx, $(w[8])\n" # Result
+    body *= "\tadox\t$(t[5]), $(w[9])\n"
+    body *= "\tmov\t$(w[8]), 8*8($res)\n"
+    body *= "\tmov\t$(w[9]), 9*8($res)\n"
+    # w10, ..., w12 in use
+
+    # Calculate res[10] and res[11]
+    # w10, ..., w13, t1, ..., t8 exist
+    w[13], t[8] = w[8], w[9]
+    w[8:9] = ["error w[$ix]" for ix in 8:9]
+    body *= "\tmov\t5*8($ap), %rdx\n"
+    body *= "\tmov\t\$0, $(reg_32_bit(w[13]))\n"
+    body *= "\tmov\t\$0, $(reg_32_bit(t[3]))\n"
+    body *= "\tmulx\t6*8($ap), $(t[1]), $(t[2])\n" # a5 a6
+    body *= "\tmulx\t%rdx, %rdx, $(t[4])\n" # a5^2
+    body *= "\tadcx\t$(t[1]), $(t[1])\n" # Double
+    body *= "\tadcx\t$(t[2]), $(t[2])\n"
+    body *= "\tadcx\t$(t[3]), $(t[3])\n"
+    body *= "\tadcx\t$(t[1]), $(w[11])\n" # Add
+    body *= "\tadcx\t$(t[2]), $(w[12])\n"
+    body *= "\tadcx\t$(t[3]), $(w[13])\n"
+    body *= "\tadox\t%rdx, $(w[10])\n" # Result
+    body *= "\tadox\t$(t[4]), $(w[11])\n"
+    body *= "\tmov\t$(w[10]), 10*8($res)\n"
+    body *= "\tmov\t$(w[11]), 11*8($res)\n"
+    # w12, w13 in use
+
+    # Calculate res[12] and res[13]
+    # w12, w13, t1, ..., t10 exist
+    t[9:10] = w[10:11]
+    w[10:11] = ["error w[$ix]" for ix in 10:11]
+    body *= "\tmov\t6*8($ap), %rdx\n"
+    body *= "\tmulx\t%rdx, $(t[1]), $(t[2])\n" # a6^2
+    body *= "\tadox\t$(t[1]), $(w[12])\n" # Result
+    body *= "\tadox\t$(t[2]), $(w[13])\n"
+    body *= "\tmov\t$(w[12]), 12*8($res)\n"
+    body *= "\tmov\t$(w[13]), 13*8($res)\n"
+
+    return pre * body * post * "\n\tret\n"
+end
+
+###############################################################################
+# Generate file
+###############################################################################
+
+function gen_mul(m::Int, n::Int = m, nofile::Bool = false)
+    (pre, post) = function_pre_post("flint_mpn_mul_$(m)_$n")
+    macros = ""
+    functionbody = ""
+    if m == 1 && n == 1
+        functionbody = function_body_1(m, n)
+    elseif m == 2 && n == 1
+        functionbody = function_body_2_1(m, n)
+    elseif m == 2 && n == 2
+        functionbody = function_body_2(m, n)
+    elseif n == 1
+        macros = mul_1_macro(m)
+        functionbody = function_body_M_1(m)
+    elseif m ≤ 8
+        macros = mulM_macro(m) * "\n" * addmulM_macro(m) * "\n"
+        functionbody = function_body_M(m, n)
+    elseif m > 8 && n != 2
+        macros = mulM_macro(n) * "\n" * addmulM_macro(n) * "\n"
+        functionbody = function_body_M(m, n)
+    elseif n == 2
+        N = M_2_getN(m)
+        macros = mulM_macro(N) * "\n"
+        macros *= addmulM_macro(N) * "\n"
+        if m ÷ N >= 2
+            macros *= mulM_macro(N, chain = true) * "\n"
+        end
+        if m % N > 1
+            macros *= mulM_macro(m % N, chain = true) * "\n"
+            macros *= addmulM_macro(m % N) * "\n"
+        end
+        functionbody = function_body_M_2(m)
+    else
+        error("This won't work for m = $m and n = $n")
+    end
+
+    str = "$copyright\n$preamble\n$macros$pre$functionbody$post"
+
+    if nofile
+        print(str)
+    else
+        path = String(@__DIR__) * "/../src/mpn_extras/broadwell/mul_$(m)_$n.asm"
+        file = open(path, "w")
+        write(file, str)
+        close(file)
+    end
+end
+
+function gen_sqr(m::Int, nofile::Bool = false)
+    (pre, post) = function_pre_post("flint_mpn_sqr_$m")
+    functionbody = ""
+    if m == 1
+        functionbody = function_body_sqr_1()
+    elseif m == 2
+        functionbody = function_body_sqr_2()
+    elseif m == 3
+        functionbody = function_body_sqr_3()
+    elseif m == 4
+        functionbody = function_body_sqr_4()
+    elseif m == 5
+        functionbody = function_body_sqr_5()
+    elseif m == 6
+        functionbody = function_body_sqr_6()
+    elseif m == 7
+        functionbody = function_body_sqr_7()
+    elseif m == 8
+        println("Warning: Generating flint_mpn_sqr_8 which has about the same speed as GMP.")
+        functionbody = function_body_sqr_8()
+    else
+        error("This won't work for m = $m")
+    end
+
+    str = "$copyright\n$preamble\n$pre$functionbody$post"
+
+    if nofile
+        print(str)
+    else
+        path = String(@__DIR__) * "/../src/mpn_extras/broadwell/sqr_$m.asm"
+        file = open(path, "w")
+        write(file, str)
+        close(file)
+    end
+end
+
+function gen_all()
+    for mx in 1:16
+        for nx in 1:min(mx, 8)
+            gen_mul(mx, nx)
+        end
+    end
+
+    for mx in 1:7
+        gen_sqr(mx)
+    end
+end

--- a/src/flint-config.h.in
+++ b/src/flint-config.h.in
@@ -15,6 +15,9 @@
 /* Define if system is strongly ordered */
 #undef FLINT_KNOW_STRONG_ORDER
 
+/* Define if system has the ADX instruction set */
+#undef FLINT_HAVE_ADX
+
 /* Define if system has AVX2 */
 #undef FLINT_HAVE_AVX2
 

--- a/src/mpn_extras.h
+++ b/src/mpn_extras.h
@@ -24,8 +24,10 @@
 #include "flint.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
+
+#define FLINT_MPN_MUL_THRESHOLD 400
 
 #define MPN_NORM(a, an)                         \
     do {                                        \
@@ -72,7 +74,10 @@ flint_mpn_get_d(mp_srcptr ptr, mp_size_t size, mp_size_t sign, long exp);
         r3 += r2 < t1;                                      \
     } while (0)
 
-#define FLINT_MPN_MUL_THRESHOLD 400
+#if FLINT_HAVE_ADX
+mp_limb_t flint_mpn_mul_basecase(mp_ptr res, mp_srcptr ap, mp_srcptr bp, slong alen, slong blen);
+mp_limb_t flint_mpn_sqr_basecase(mp_ptr res, mp_srcptr ap, slong alen);
+#endif
 
 mp_limb_t flint_mpn_mul_large(mp_ptr r1, mp_srcptr i1, mp_size_t n1, mp_srcptr i2, mp_size_t n2);
 

--- a/src/mpn_extras/broadwell/mul_10_1.asm
+++ b/src/mpn_extras/broadwell/mul_10_1.asm
@@ -1,0 +1,61 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m10 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5
+	mulx	(0+\ap_offset)*8(\ap), \r0, \r3
+	mulx	(1+\ap_offset)*8(\ap), \r1, \r5
+	mulx	(2+\ap_offset)*8(\ap), \r2, \r4
+	add	\r3, \r1
+	adc	\r5, \r2
+	mov	\r0, (0+\res_offset)*8(\res)
+	mov	\r1, (1+\res_offset)*8(\res)
+	mov	\r2, (2+\res_offset)*8(\res)
+	mulx	(3+\ap_offset)*8(\ap), \r3, \r5
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r1
+	adc	\r3, \r4
+	adc	\r5, \r0
+	mov	\r4, (3+\res_offset)*8(\res)
+	mov	\r0, (4+\res_offset)*8(\res)
+	mulx	(5+\ap_offset)*8(\ap), \r3, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r2, \r4
+	adc	\r3, \r1
+	adc	\r5, \r2
+	mov	\r1, (5+\res_offset)*8(\res)
+	mov	\r2, (6+\res_offset)*8(\res)
+	mulx	(7+\ap_offset)*8(\ap), \r3, \r5
+	mulx	(8+\ap_offset)*8(\ap), \r0, \r1
+	adc	\r3, \r4
+	adc	\r5, \r0
+	mov	\r4, (7+\res_offset)*8(\res)
+	mov	\r0, (8+\res_offset)*8(\res)
+	mulx	(9+\ap_offset)*8(\ap), \r3, \r5
+	adc	\r3, \r1
+	adc	$0, \r5
+	mov	\r1, (9+\res_offset)*8(\res)
+.endm
+.global	FUNC(flint_mpn_mul_10_1)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_10_1)
+
+FUNC(flint_mpn_mul_10_1):
+	.cfi_startproc
+	mov	0*8(%rdx), %rdx
+	m10	%rdi, 0, %rsi, 0, %rcx, %r8, %r9, %r10, %r11, %rax
+	mov	%rax, 10*8(%rdi)
+
+	ret
+.flint_mpn_mul_10_1_end:
+SIZE(flint_mpn_mul_10_1, .flint_mpn_mul_10_1_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_10_2.asm
+++ b/src/mpn_extras/broadwell/mul_10_2.asm
@@ -1,0 +1,120 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	adcx	\zero, \r3
+.endm
+
+.macro	am4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r4, \scr
+	adcx	\r4, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r4, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	adcx	\zero, \r4
+	adox	\zero, \r4
+.endm
+
+.macro	m4_chain res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, ip1, ip2, r0, r1, r2, r3, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	adcx	\ip1, \scr1
+	mov	\scr1, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	adcx	\scr2, \r0
+	adox	\ip2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	adcx	\zero, \r3
+.endm
+
+.macro	m2_chain res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, ip1, ip2, r0, r1, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	adcx	\ip1, \scr1
+	mov	\scr1, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	adcx	\scr2, \r0
+	adox	\ip2, \r0
+	adcx	\zero, \r1
+.endm
+
+.macro	am2 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r2, \scr
+	adcx	\r2, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r2
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	adcx	\zero, \r2
+	adox	\zero, \r2
+.endm
+
+.global	FUNC(flint_mpn_mul_10_2)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_10_2)
+
+FUNC(flint_mpn_mul_10_2):
+	.cfi_startproc
+	mov	0*8(%rdx), %rcx
+	mov	1*8(%rdx), %r8
+	push	%rbx
+	push	%rbp
+	push	%r12
+
+	mov	%rcx, %rdx
+	xor	%r12d, %r12d
+	m4	%rdi, 0, %rsi, 0, %r9, %r10, %r11, %rbx, %rax, %rbp, %r12
+	mov	%r8, %rdx
+	am4	%rdi, 1, %rsi, 0, %r9, %r10, %r11, %rbx, %rax, %rbp, %r12
+	mov	%r10, 2*8(%rdi)
+	mov	%r11, 3*8(%rdi)
+
+	mov	%rcx, %rdx
+	m4_chain	%rdi, 4, %rsi, 4, %rbx, %rax, %r9, %r10, %r11, %rax, %rbp, %rbx, %r12
+	mov	%r8, %rdx
+	am4	%rdi, 5, %rsi, 4, %r9, %r10, %r11, %rax, %rbx, %rbp, %r12
+	mov	%r10, 6*8(%rdi)
+	mov	%r11, 7*8(%rdi)
+
+	mov	%rcx, %rdx
+	m2_chain	%rdi, 8, %rsi, 8, %rax, %rbx, %r9, %r10, %rbp, %rax, %r12
+	mov	%r8, %rdx
+	am2	%rdi, 9, %rsi, 8, %r9, %r10, %rax, %rbp, %r12
+	mov	%r10, 10*8(%rdi)
+	mov	%rax, 11*8(%rdi)
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_10_2_end:
+SIZE(flint_mpn_mul_10_2, .flint_mpn_mul_10_2_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_10_3.asm
+++ b/src/mpn_extras/broadwell/mul_10_3.asm
@@ -1,0 +1,82 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m3 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	adcx	\scr1, \r1
+	adcx	\zero, \r2
+.endm
+
+.macro	am3 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r3
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r3, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r3
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	adcx	\zero, \r3
+	adox	\zero, \r3
+.endm
+
+.global	FUNC(flint_mpn_mul_10_3)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_10_3)
+
+FUNC(flint_mpn_mul_10_3):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+
+	xor	%ebx, %ebx
+
+	m3	%rdi, 0, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx
+
+	mov	1*8(%rsi), %rdx
+	am3	%rdi, 1, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx
+	mov	2*8(%rsi), %rdx
+	am3	%rdi, 2, %rcx, 0, %r8, %r9, %rax, %r10, %r11, %rbx
+	mov	3*8(%rsi), %rdx
+	am3	%rdi, 3, %rcx, 0, %r9, %rax, %r10, %r8, %r11, %rbx
+	mov	4*8(%rsi), %rdx
+	am3	%rdi, 4, %rcx, 0, %rax, %r10, %r8, %r9, %r11, %rbx
+	mov	5*8(%rsi), %rdx
+	am3	%rdi, 5, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx
+	mov	6*8(%rsi), %rdx
+	am3	%rdi, 6, %rcx, 0, %r8, %r9, %rax, %r10, %r11, %rbx
+	mov	7*8(%rsi), %rdx
+	am3	%rdi, 7, %rcx, 0, %r9, %rax, %r10, %r8, %r11, %rbx
+	mov	8*8(%rsi), %rdx
+	am3	%rdi, 8, %rcx, 0, %rax, %r10, %r8, %r9, %r11, %rbx
+	mov	9*8(%rsi), %rdx
+	am3	%rdi, 9, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx
+
+	mov	%r8, 10*8(%rdi)
+	mov	%r9, 11*8(%rdi)
+	mov	%rax, 12*8(%rdi)
+
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_10_3_end:
+SIZE(flint_mpn_mul_10_3, .flint_mpn_mul_10_3_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_10_4.asm
+++ b/src/mpn_extras/broadwell/mul_10_4.asm
@@ -1,0 +1,90 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	adcx	\zero, \r3
+.endm
+
+.macro	am4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r4, \scr
+	adcx	\r4, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r4, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	adcx	\zero, \r4
+	adox	\zero, \r4
+.endm
+
+.global	FUNC(flint_mpn_mul_10_4)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_10_4)
+
+FUNC(flint_mpn_mul_10_4):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+
+	xor	%ebp, %ebp
+
+	m4	%rdi, 0, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp
+
+	mov	1*8(%rsi), %rdx
+	am4	%rdi, 1, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp
+	mov	2*8(%rsi), %rdx
+	am4	%rdi, 2, %rcx, 0, %r8, %rax, %r10, %r11, %r9, %rbx, %rbp
+	mov	3*8(%rsi), %rdx
+	am4	%rdi, 3, %rcx, 0, %rax, %r10, %r11, %r9, %r8, %rbx, %rbp
+	mov	4*8(%rsi), %rdx
+	am4	%rdi, 4, %rcx, 0, %r10, %r11, %r9, %r8, %rax, %rbx, %rbp
+	mov	5*8(%rsi), %rdx
+	am4	%rdi, 5, %rcx, 0, %r11, %r9, %r8, %rax, %r10, %rbx, %rbp
+	mov	6*8(%rsi), %rdx
+	am4	%rdi, 6, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp
+	mov	7*8(%rsi), %rdx
+	am4	%rdi, 7, %rcx, 0, %r8, %rax, %r10, %r11, %r9, %rbx, %rbp
+	mov	8*8(%rsi), %rdx
+	am4	%rdi, 8, %rcx, 0, %rax, %r10, %r11, %r9, %r8, %rbx, %rbp
+	mov	9*8(%rsi), %rdx
+	am4	%rdi, 9, %rcx, 0, %r10, %r11, %r9, %r8, %rax, %rbx, %rbp
+
+	mov	%r11, 10*8(%rdi)
+	mov	%r9, 11*8(%rdi)
+	mov	%r8, 12*8(%rdi)
+	mov	%rax, 13*8(%rdi)
+
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_10_4_end:
+SIZE(flint_mpn_mul_10_4, .flint_mpn_mul_10_4_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_10_5.asm
+++ b/src/mpn_extras/broadwell/mul_10_5.asm
@@ -1,0 +1,98 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	adcx	\scr1, \r3
+	adcx	\zero, \r4
+.endm
+
+.macro	am5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r5
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	adcx	\zero, \r5
+	adox	\zero, \r5
+.endm
+
+.global	FUNC(flint_mpn_mul_10_5)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_10_5)
+
+FUNC(flint_mpn_mul_10_5):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+
+	xor	%r12d, %r12d
+
+	m5	%rdi, 0, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12
+
+	mov	1*8(%rsi), %rdx
+	am5	%rdi, 1, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12
+	mov	2*8(%rsi), %rdx
+	am5	%rdi, 2, %rcx, 0, %rax, %r9, %r10, %r11, %rbx, %r8, %rbp, %r12
+	mov	3*8(%rsi), %rdx
+	am5	%rdi, 3, %rcx, 0, %r9, %r10, %r11, %rbx, %r8, %rax, %rbp, %r12
+	mov	4*8(%rsi), %rdx
+	am5	%rdi, 4, %rcx, 0, %r10, %r11, %rbx, %r8, %rax, %r9, %rbp, %r12
+	mov	5*8(%rsi), %rdx
+	am5	%rdi, 5, %rcx, 0, %r11, %rbx, %r8, %rax, %r9, %r10, %rbp, %r12
+	mov	6*8(%rsi), %rdx
+	am5	%rdi, 6, %rcx, 0, %rbx, %r8, %rax, %r9, %r10, %r11, %rbp, %r12
+	mov	7*8(%rsi), %rdx
+	am5	%rdi, 7, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12
+	mov	8*8(%rsi), %rdx
+	am5	%rdi, 8, %rcx, 0, %rax, %r9, %r10, %r11, %rbx, %r8, %rbp, %r12
+	mov	9*8(%rsi), %rdx
+	am5	%rdi, 9, %rcx, 0, %r9, %r10, %r11, %rbx, %r8, %rax, %rbp, %r12
+
+	mov	%r10, 10*8(%rdi)
+	mov	%r11, 11*8(%rdi)
+	mov	%rbx, 12*8(%rdi)
+	mov	%r8, 13*8(%rdi)
+	mov	%rax, 14*8(%rdi)
+
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_10_5_end:
+SIZE(flint_mpn_mul_10_5, .flint_mpn_mul_10_5_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_10_6.asm
+++ b/src/mpn_extras/broadwell/mul_10_6.asm
@@ -1,0 +1,106 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	adcx	\zero, \r5
+.endm
+
+.macro	am6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r6, \scr
+	adcx	\r6, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	adcx	\zero, \r6
+	adox	\zero, \r6
+.endm
+
+.global	FUNC(flint_mpn_mul_10_6)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_10_6)
+
+FUNC(flint_mpn_mul_10_6):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+
+	xor	%r13d, %r13d
+
+	m6	%rdi, 0, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13
+
+	mov	1*8(%rsi), %rdx
+	am6	%rdi, 1, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13
+	mov	2*8(%rsi), %rdx
+	am6	%rdi, 2, %rcx, 0, %r8, %r9, %r10, %r11, %rbx, %rbp, %rax, %r12, %r13
+	mov	3*8(%rsi), %rdx
+	am6	%rdi, 3, %rcx, 0, %r9, %r10, %r11, %rbx, %rbp, %rax, %r8, %r12, %r13
+	mov	4*8(%rsi), %rdx
+	am6	%rdi, 4, %rcx, 0, %r10, %r11, %rbx, %rbp, %rax, %r8, %r9, %r12, %r13
+	mov	5*8(%rsi), %rdx
+	am6	%rdi, 5, %rcx, 0, %r11, %rbx, %rbp, %rax, %r8, %r9, %r10, %r12, %r13
+	mov	6*8(%rsi), %rdx
+	am6	%rdi, 6, %rcx, 0, %rbx, %rbp, %rax, %r8, %r9, %r10, %r11, %r12, %r13
+	mov	7*8(%rsi), %rdx
+	am6	%rdi, 7, %rcx, 0, %rbp, %rax, %r8, %r9, %r10, %r11, %rbx, %r12, %r13
+	mov	8*8(%rsi), %rdx
+	am6	%rdi, 8, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13
+	mov	9*8(%rsi), %rdx
+	am6	%rdi, 9, %rcx, 0, %r8, %r9, %r10, %r11, %rbx, %rbp, %rax, %r12, %r13
+
+	mov	%r9, 10*8(%rdi)
+	mov	%r10, 11*8(%rdi)
+	mov	%r11, 12*8(%rdi)
+	mov	%rbx, 13*8(%rdi)
+	mov	%rbp, 14*8(%rdi)
+	mov	%rax, 15*8(%rdi)
+
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_10_6_end:
+SIZE(flint_mpn_mul_10_6, .flint_mpn_mul_10_6_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_10_7.asm
+++ b/src/mpn_extras/broadwell/mul_10_7.asm
@@ -1,0 +1,114 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	adcx	\scr1, \r5
+	adcx	\zero, \r6
+.endm
+
+.macro	am7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r7
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r6
+	adox	\r0, \r6
+	adcx	\zero, \r7
+	adox	\zero, \r7
+.endm
+
+.global	FUNC(flint_mpn_mul_10_7)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_10_7)
+
+FUNC(flint_mpn_mul_10_7):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+
+	xor	%r14d, %r14d
+
+	m7	%rdi, 0, %rcx, 0, %r12, %r8, %r9, %r10, %r11, %rbx, %rbp, %rax, %r13, %r14
+
+	mov	1*8(%rsi), %rdx
+	am7	%rdi, 1, %rcx, 0, %r12, %r8, %r9, %r10, %r11, %rbx, %rbp, %rax, %r13, %r14
+	mov	2*8(%rsi), %rdx
+	am7	%rdi, 2, %rcx, 0, %r8, %r9, %r10, %r11, %rbx, %rbp, %rax, %r12, %r13, %r14
+	mov	3*8(%rsi), %rdx
+	am7	%rdi, 3, %rcx, 0, %r9, %r10, %r11, %rbx, %rbp, %rax, %r12, %r8, %r13, %r14
+	mov	4*8(%rsi), %rdx
+	am7	%rdi, 4, %rcx, 0, %r10, %r11, %rbx, %rbp, %rax, %r12, %r8, %r9, %r13, %r14
+	mov	5*8(%rsi), %rdx
+	am7	%rdi, 5, %rcx, 0, %r11, %rbx, %rbp, %rax, %r12, %r8, %r9, %r10, %r13, %r14
+	mov	6*8(%rsi), %rdx
+	am7	%rdi, 6, %rcx, 0, %rbx, %rbp, %rax, %r12, %r8, %r9, %r10, %r11, %r13, %r14
+	mov	7*8(%rsi), %rdx
+	am7	%rdi, 7, %rcx, 0, %rbp, %rax, %r12, %r8, %r9, %r10, %r11, %rbx, %r13, %r14
+	mov	8*8(%rsi), %rdx
+	am7	%rdi, 8, %rcx, 0, %rax, %r12, %r8, %r9, %r10, %r11, %rbx, %rbp, %r13, %r14
+	mov	9*8(%rsi), %rdx
+	am7	%rdi, 9, %rcx, 0, %r12, %r8, %r9, %r10, %r11, %rbx, %rbp, %rax, %r13, %r14
+
+	mov	%r8, 10*8(%rdi)
+	mov	%r9, 11*8(%rdi)
+	mov	%r10, 12*8(%rdi)
+	mov	%r11, 13*8(%rdi)
+	mov	%rbx, 14*8(%rdi)
+	mov	%rbp, 15*8(%rdi)
+	mov	%rax, 16*8(%rdi)
+
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_10_7_end:
+SIZE(flint_mpn_mul_10_7, .flint_mpn_mul_10_7_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_10_8.asm
+++ b/src/mpn_extras/broadwell/mul_10_8.asm
@@ -1,0 +1,122 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	mulx	(7+\ap_offset)*8(\ap), \scr2, \r7
+	adcx	\scr1, \r5
+	adcx	\scr2, \r6
+	adcx	\zero, \r7
+.endm
+
+.macro	am8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, r8, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r8, \scr
+	adcx	\r8, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r6
+	adox	\r0, \r6
+	mulx	(7+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r7
+	adox	\r0, \r7
+	adcx	\zero, \r8
+	adox	\zero, \r8
+.endm
+
+.global	FUNC(flint_mpn_mul_10_8)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_10_8)
+
+FUNC(flint_mpn_mul_10_8):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+	push	%r15
+
+	xor	%r15d, %r15d
+
+	m8	%rdi, 0, %rcx, 0, %r12, %r8, %r9, %r10, %r11, %rbx, %rbp, %rax, %r13, %r14, %r15
+
+	mov	1*8(%rsi), %rdx
+	am8	%rdi, 1, %rcx, 0, %r12, %r8, %r9, %r10, %r11, %rbx, %rbp, %rax, %r13, %r14, %r15
+	mov	2*8(%rsi), %rdx
+	am8	%rdi, 2, %rcx, 0, %r8, %r9, %r10, %r11, %rbx, %rbp, %rax, %r13, %r12, %r14, %r15
+	mov	3*8(%rsi), %rdx
+	am8	%rdi, 3, %rcx, 0, %r9, %r10, %r11, %rbx, %rbp, %rax, %r13, %r12, %r8, %r14, %r15
+	mov	4*8(%rsi), %rdx
+	am8	%rdi, 4, %rcx, 0, %r10, %r11, %rbx, %rbp, %rax, %r13, %r12, %r8, %r9, %r14, %r15
+	mov	5*8(%rsi), %rdx
+	am8	%rdi, 5, %rcx, 0, %r11, %rbx, %rbp, %rax, %r13, %r12, %r8, %r9, %r10, %r14, %r15
+	mov	6*8(%rsi), %rdx
+	am8	%rdi, 6, %rcx, 0, %rbx, %rbp, %rax, %r13, %r12, %r8, %r9, %r10, %r11, %r14, %r15
+	mov	7*8(%rsi), %rdx
+	am8	%rdi, 7, %rcx, 0, %rbp, %rax, %r13, %r12, %r8, %r9, %r10, %r11, %rbx, %r14, %r15
+	mov	8*8(%rsi), %rdx
+	am8	%rdi, 8, %rcx, 0, %rax, %r13, %r12, %r8, %r9, %r10, %r11, %rbx, %rbp, %r14, %r15
+	mov	9*8(%rsi), %rdx
+	am8	%rdi, 9, %rcx, 0, %r13, %r12, %r8, %r9, %r10, %r11, %rbx, %rbp, %rax, %r14, %r15
+
+	mov	%r12, 10*8(%rdi)
+	mov	%r8, 11*8(%rdi)
+	mov	%r9, 12*8(%rdi)
+	mov	%r10, 13*8(%rdi)
+	mov	%r11, 14*8(%rdi)
+	mov	%rbx, 15*8(%rdi)
+	mov	%rbp, 16*8(%rdi)
+	mov	%rax, 17*8(%rdi)
+
+	pop	%r15
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_10_8_end:
+SIZE(flint_mpn_mul_10_8, .flint_mpn_mul_10_8_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_11_1.asm
+++ b/src/mpn_extras/broadwell/mul_11_1.asm
@@ -1,0 +1,64 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m11 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5
+	mulx	(0+\ap_offset)*8(\ap), \r0, \r3
+	mulx	(1+\ap_offset)*8(\ap), \r1, \r4
+	mulx	(2+\ap_offset)*8(\ap), \r2, \r5
+	add	\r3, \r1
+	adc	\r4, \r2
+	mov	\r0, (0+\res_offset)*8(\res)
+	mov	\r1, (1+\res_offset)*8(\res)
+	mov	\r2, (2+\res_offset)*8(\res)
+	mulx	(3+\ap_offset)*8(\ap), \r3, \r4
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r1
+	adc	\r3, \r5
+	adc	\r4, \r0
+	mov	\r5, (3+\res_offset)*8(\res)
+	mov	\r0, (4+\res_offset)*8(\res)
+	mulx	(5+\ap_offset)*8(\ap), \r3, \r4
+	mulx	(6+\ap_offset)*8(\ap), \r2, \r5
+	adc	\r3, \r1
+	adc	\r4, \r2
+	mov	\r1, (5+\res_offset)*8(\res)
+	mov	\r2, (6+\res_offset)*8(\res)
+	mulx	(7+\ap_offset)*8(\ap), \r3, \r4
+	mulx	(8+\ap_offset)*8(\ap), \r0, \r1
+	adc	\r3, \r5
+	adc	\r4, \r0
+	mov	\r5, (7+\res_offset)*8(\res)
+	mov	\r0, (8+\res_offset)*8(\res)
+	mulx	(9+\ap_offset)*8(\ap), \r3, \r4
+	mulx	(10+\ap_offset)*8(\ap), \r2, \r5
+	adc	\r3, \r1
+	adc	\r4, \r2
+	mov	\r1, (9+\res_offset)*8(\res)
+	mov	\r2, (10+\res_offset)*8(\res)
+	adc	$0, \r5
+.endm
+.global	FUNC(flint_mpn_mul_11_1)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_11_1)
+
+FUNC(flint_mpn_mul_11_1):
+	.cfi_startproc
+	mov	0*8(%rdx), %rdx
+	m11	%rdi, 0, %rsi, 0, %rcx, %r8, %r9, %r10, %r11, %rax
+	mov	%rax, 11*8(%rdi)
+
+	ret
+.flint_mpn_mul_11_1_end:
+SIZE(flint_mpn_mul_11_1, .flint_mpn_mul_11_1_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_11_2.asm
+++ b/src/mpn_extras/broadwell/mul_11_2.asm
@@ -1,0 +1,126 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	adcx	\zero, \r3
+.endm
+
+.macro	am4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r4, \scr
+	adcx	\r4, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r4, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	adcx	\zero, \r4
+	adox	\zero, \r4
+.endm
+
+.macro	m4_chain res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, ip1, ip2, r0, r1, r2, r3, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	adcx	\ip1, \scr1
+	mov	\scr1, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	adcx	\scr2, \r0
+	adox	\ip2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	adcx	\zero, \r3
+.endm
+
+.macro	m3_chain res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, ip1, ip2, r0, r1, r2, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	adcx	\ip1, \scr1
+	mov	\scr1, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	adcx	\scr2, \r0
+	adox	\ip2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	adcx	\scr1, \r1
+	adcx	\zero, \r2
+.endm
+
+.macro	am3 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r3
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r3, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r3
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	adcx	\zero, \r3
+	adox	\zero, \r3
+.endm
+
+.global	FUNC(flint_mpn_mul_11_2)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_11_2)
+
+FUNC(flint_mpn_mul_11_2):
+	.cfi_startproc
+	mov	0*8(%rdx), %rcx
+	mov	1*8(%rdx), %r8
+	push	%rbx
+	push	%rbp
+	push	%r12
+
+	mov	%rcx, %rdx
+	xor	%r12d, %r12d
+	m4	%rdi, 0, %rsi, 0, %r9, %r10, %r11, %rbx, %rax, %rbp, %r12
+	mov	%r8, %rdx
+	am4	%rdi, 1, %rsi, 0, %r9, %r10, %r11, %rbx, %rax, %rbp, %r12
+	mov	%r10, 2*8(%rdi)
+	mov	%r11, 3*8(%rdi)
+
+	mov	%rcx, %rdx
+	m4_chain	%rdi, 4, %rsi, 4, %rbx, %rax, %r9, %r10, %r11, %rax, %rbp, %rbx, %r12
+	mov	%r8, %rdx
+	am4	%rdi, 5, %rsi, 4, %r9, %r10, %r11, %rax, %rbx, %rbp, %r12
+	mov	%r10, 6*8(%rdi)
+	mov	%r11, 7*8(%rdi)
+
+	mov	%rcx, %rdx
+	m3_chain	%rdi, 8, %rsi, 8, %rax, %rbx, %r9, %r10, %r11, %rbp, %rax, %r12
+	mov	%r8, %rdx
+	am3	%rdi, 9, %rsi, 8, %r9, %r10, %r11, %rax, %rbp, %r12
+	mov	%r10, 10*8(%rdi)
+	mov	%r11, 11*8(%rdi)
+	mov	%rax, 12*8(%rdi)
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_11_2_end:
+SIZE(flint_mpn_mul_11_2, .flint_mpn_mul_11_2_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_11_3.asm
+++ b/src/mpn_extras/broadwell/mul_11_3.asm
@@ -1,0 +1,84 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m3 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	adcx	\scr1, \r1
+	adcx	\zero, \r2
+.endm
+
+.macro	am3 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r3
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r3, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r3
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	adcx	\zero, \r3
+	adox	\zero, \r3
+.endm
+
+.global	FUNC(flint_mpn_mul_11_3)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_11_3)
+
+FUNC(flint_mpn_mul_11_3):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+
+	xor	%ebx, %ebx
+
+	m3	%rdi, 0, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx
+
+	mov	1*8(%rsi), %rdx
+	am3	%rdi, 1, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx
+	mov	2*8(%rsi), %rdx
+	am3	%rdi, 2, %rcx, 0, %r8, %r9, %r10, %rax, %r11, %rbx
+	mov	3*8(%rsi), %rdx
+	am3	%rdi, 3, %rcx, 0, %r9, %r10, %rax, %r8, %r11, %rbx
+	mov	4*8(%rsi), %rdx
+	am3	%rdi, 4, %rcx, 0, %r10, %rax, %r8, %r9, %r11, %rbx
+	mov	5*8(%rsi), %rdx
+	am3	%rdi, 5, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx
+	mov	6*8(%rsi), %rdx
+	am3	%rdi, 6, %rcx, 0, %r8, %r9, %r10, %rax, %r11, %rbx
+	mov	7*8(%rsi), %rdx
+	am3	%rdi, 7, %rcx, 0, %r9, %r10, %rax, %r8, %r11, %rbx
+	mov	8*8(%rsi), %rdx
+	am3	%rdi, 8, %rcx, 0, %r10, %rax, %r8, %r9, %r11, %rbx
+	mov	9*8(%rsi), %rdx
+	am3	%rdi, 9, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx
+	mov	10*8(%rsi), %rdx
+	am3	%rdi, 10, %rcx, 0, %r8, %r9, %r10, %rax, %r11, %rbx
+
+	mov	%r9, 11*8(%rdi)
+	mov	%r10, 12*8(%rdi)
+	mov	%rax, 13*8(%rdi)
+
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_11_3_end:
+SIZE(flint_mpn_mul_11_3, .flint_mpn_mul_11_3_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_11_4.asm
+++ b/src/mpn_extras/broadwell/mul_11_4.asm
@@ -1,0 +1,92 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	adcx	\zero, \r3
+.endm
+
+.macro	am4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r4, \scr
+	adcx	\r4, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r4, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	adcx	\zero, \r4
+	adox	\zero, \r4
+.endm
+
+.global	FUNC(flint_mpn_mul_11_4)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_11_4)
+
+FUNC(flint_mpn_mul_11_4):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+
+	xor	%ebp, %ebp
+
+	m4	%rdi, 0, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp
+
+	mov	1*8(%rsi), %rdx
+	am4	%rdi, 1, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp
+	mov	2*8(%rsi), %rdx
+	am4	%rdi, 2, %rcx, 0, %r8, %r9, %rax, %r11, %r10, %rbx, %rbp
+	mov	3*8(%rsi), %rdx
+	am4	%rdi, 3, %rcx, 0, %r9, %rax, %r11, %r10, %r8, %rbx, %rbp
+	mov	4*8(%rsi), %rdx
+	am4	%rdi, 4, %rcx, 0, %rax, %r11, %r10, %r8, %r9, %rbx, %rbp
+	mov	5*8(%rsi), %rdx
+	am4	%rdi, 5, %rcx, 0, %r11, %r10, %r8, %r9, %rax, %rbx, %rbp
+	mov	6*8(%rsi), %rdx
+	am4	%rdi, 6, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp
+	mov	7*8(%rsi), %rdx
+	am4	%rdi, 7, %rcx, 0, %r8, %r9, %rax, %r11, %r10, %rbx, %rbp
+	mov	8*8(%rsi), %rdx
+	am4	%rdi, 8, %rcx, 0, %r9, %rax, %r11, %r10, %r8, %rbx, %rbp
+	mov	9*8(%rsi), %rdx
+	am4	%rdi, 9, %rcx, 0, %rax, %r11, %r10, %r8, %r9, %rbx, %rbp
+	mov	10*8(%rsi), %rdx
+	am4	%rdi, 10, %rcx, 0, %r11, %r10, %r8, %r9, %rax, %rbx, %rbp
+
+	mov	%r10, 11*8(%rdi)
+	mov	%r8, 12*8(%rdi)
+	mov	%r9, 13*8(%rdi)
+	mov	%rax, 14*8(%rdi)
+
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_11_4_end:
+SIZE(flint_mpn_mul_11_4, .flint_mpn_mul_11_4_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_11_5.asm
+++ b/src/mpn_extras/broadwell/mul_11_5.asm
@@ -1,0 +1,100 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	adcx	\scr1, \r3
+	adcx	\zero, \r4
+.endm
+
+.macro	am5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r5
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	adcx	\zero, \r5
+	adox	\zero, \r5
+.endm
+
+.global	FUNC(flint_mpn_mul_11_5)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_11_5)
+
+FUNC(flint_mpn_mul_11_5):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+
+	xor	%r12d, %r12d
+
+	m5	%rdi, 0, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12
+
+	mov	1*8(%rsi), %rdx
+	am5	%rdi, 1, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12
+	mov	2*8(%rsi), %rdx
+	am5	%rdi, 2, %rcx, 0, %r8, %rax, %r10, %r11, %rbx, %r9, %rbp, %r12
+	mov	3*8(%rsi), %rdx
+	am5	%rdi, 3, %rcx, 0, %rax, %r10, %r11, %rbx, %r9, %r8, %rbp, %r12
+	mov	4*8(%rsi), %rdx
+	am5	%rdi, 4, %rcx, 0, %r10, %r11, %rbx, %r9, %r8, %rax, %rbp, %r12
+	mov	5*8(%rsi), %rdx
+	am5	%rdi, 5, %rcx, 0, %r11, %rbx, %r9, %r8, %rax, %r10, %rbp, %r12
+	mov	6*8(%rsi), %rdx
+	am5	%rdi, 6, %rcx, 0, %rbx, %r9, %r8, %rax, %r10, %r11, %rbp, %r12
+	mov	7*8(%rsi), %rdx
+	am5	%rdi, 7, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12
+	mov	8*8(%rsi), %rdx
+	am5	%rdi, 8, %rcx, 0, %r8, %rax, %r10, %r11, %rbx, %r9, %rbp, %r12
+	mov	9*8(%rsi), %rdx
+	am5	%rdi, 9, %rcx, 0, %rax, %r10, %r11, %rbx, %r9, %r8, %rbp, %r12
+	mov	10*8(%rsi), %rdx
+	am5	%rdi, 10, %rcx, 0, %r10, %r11, %rbx, %r9, %r8, %rax, %rbp, %r12
+
+	mov	%r11, 11*8(%rdi)
+	mov	%rbx, 12*8(%rdi)
+	mov	%r9, 13*8(%rdi)
+	mov	%r8, 14*8(%rdi)
+	mov	%rax, 15*8(%rdi)
+
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_11_5_end:
+SIZE(flint_mpn_mul_11_5, .flint_mpn_mul_11_5_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_11_6.asm
+++ b/src/mpn_extras/broadwell/mul_11_6.asm
@@ -1,0 +1,108 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	adcx	\zero, \r5
+.endm
+
+.macro	am6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r6, \scr
+	adcx	\r6, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	adcx	\zero, \r6
+	adox	\zero, \r6
+.endm
+
+.global	FUNC(flint_mpn_mul_11_6)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_11_6)
+
+FUNC(flint_mpn_mul_11_6):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+
+	xor	%r13d, %r13d
+
+	m6	%rdi, 0, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13
+
+	mov	1*8(%rsi), %rdx
+	am6	%rdi, 1, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13
+	mov	2*8(%rsi), %rdx
+	am6	%rdi, 2, %rcx, 0, %rax, %r9, %r10, %r11, %rbx, %rbp, %r8, %r12, %r13
+	mov	3*8(%rsi), %rdx
+	am6	%rdi, 3, %rcx, 0, %r9, %r10, %r11, %rbx, %rbp, %r8, %rax, %r12, %r13
+	mov	4*8(%rsi), %rdx
+	am6	%rdi, 4, %rcx, 0, %r10, %r11, %rbx, %rbp, %r8, %rax, %r9, %r12, %r13
+	mov	5*8(%rsi), %rdx
+	am6	%rdi, 5, %rcx, 0, %r11, %rbx, %rbp, %r8, %rax, %r9, %r10, %r12, %r13
+	mov	6*8(%rsi), %rdx
+	am6	%rdi, 6, %rcx, 0, %rbx, %rbp, %r8, %rax, %r9, %r10, %r11, %r12, %r13
+	mov	7*8(%rsi), %rdx
+	am6	%rdi, 7, %rcx, 0, %rbp, %r8, %rax, %r9, %r10, %r11, %rbx, %r12, %r13
+	mov	8*8(%rsi), %rdx
+	am6	%rdi, 8, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13
+	mov	9*8(%rsi), %rdx
+	am6	%rdi, 9, %rcx, 0, %rax, %r9, %r10, %r11, %rbx, %rbp, %r8, %r12, %r13
+	mov	10*8(%rsi), %rdx
+	am6	%rdi, 10, %rcx, 0, %r9, %r10, %r11, %rbx, %rbp, %r8, %rax, %r12, %r13
+
+	mov	%r10, 11*8(%rdi)
+	mov	%r11, 12*8(%rdi)
+	mov	%rbx, 13*8(%rdi)
+	mov	%rbp, 14*8(%rdi)
+	mov	%r8, 15*8(%rdi)
+	mov	%rax, 16*8(%rdi)
+
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_11_6_end:
+SIZE(flint_mpn_mul_11_6, .flint_mpn_mul_11_6_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_11_7.asm
+++ b/src/mpn_extras/broadwell/mul_11_7.asm
@@ -1,0 +1,116 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	adcx	\scr1, \r5
+	adcx	\zero, \r6
+.endm
+
+.macro	am7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r7
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r6
+	adox	\r0, \r6
+	adcx	\zero, \r7
+	adox	\zero, \r7
+.endm
+
+.global	FUNC(flint_mpn_mul_11_7)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_11_7)
+
+FUNC(flint_mpn_mul_11_7):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+
+	xor	%r14d, %r14d
+
+	m7	%rdi, 0, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14
+
+	mov	1*8(%rsi), %rdx
+	am7	%rdi, 1, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14
+	mov	2*8(%rsi), %rdx
+	am7	%rdi, 2, %rcx, 0, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %rax, %r13, %r14
+	mov	3*8(%rsi), %rdx
+	am7	%rdi, 3, %rcx, 0, %r9, %r10, %r11, %rbx, %rbp, %r12, %rax, %r8, %r13, %r14
+	mov	4*8(%rsi), %rdx
+	am7	%rdi, 4, %rcx, 0, %r10, %r11, %rbx, %rbp, %r12, %rax, %r8, %r9, %r13, %r14
+	mov	5*8(%rsi), %rdx
+	am7	%rdi, 5, %rcx, 0, %r11, %rbx, %rbp, %r12, %rax, %r8, %r9, %r10, %r13, %r14
+	mov	6*8(%rsi), %rdx
+	am7	%rdi, 6, %rcx, 0, %rbx, %rbp, %r12, %rax, %r8, %r9, %r10, %r11, %r13, %r14
+	mov	7*8(%rsi), %rdx
+	am7	%rdi, 7, %rcx, 0, %rbp, %r12, %rax, %r8, %r9, %r10, %r11, %rbx, %r13, %r14
+	mov	8*8(%rsi), %rdx
+	am7	%rdi, 8, %rcx, 0, %r12, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r13, %r14
+	mov	9*8(%rsi), %rdx
+	am7	%rdi, 9, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14
+	mov	10*8(%rsi), %rdx
+	am7	%rdi, 10, %rcx, 0, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %rax, %r13, %r14
+
+	mov	%r9, 11*8(%rdi)
+	mov	%r10, 12*8(%rdi)
+	mov	%r11, 13*8(%rdi)
+	mov	%rbx, 14*8(%rdi)
+	mov	%rbp, 15*8(%rdi)
+	mov	%r12, 16*8(%rdi)
+	mov	%rax, 17*8(%rdi)
+
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_11_7_end:
+SIZE(flint_mpn_mul_11_7, .flint_mpn_mul_11_7_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_11_8.asm
+++ b/src/mpn_extras/broadwell/mul_11_8.asm
@@ -1,0 +1,124 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	mulx	(7+\ap_offset)*8(\ap), \scr2, \r7
+	adcx	\scr1, \r5
+	adcx	\scr2, \r6
+	adcx	\zero, \r7
+.endm
+
+.macro	am8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, r8, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r8, \scr
+	adcx	\r8, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r6
+	adox	\r0, \r6
+	mulx	(7+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r7
+	adox	\r0, \r7
+	adcx	\zero, \r8
+	adox	\zero, \r8
+.endm
+
+.global	FUNC(flint_mpn_mul_11_8)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_11_8)
+
+FUNC(flint_mpn_mul_11_8):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+	push	%r15
+
+	xor	%r15d, %r15d
+
+	m8	%rdi, 0, %rcx, 0, %r13, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %rax, %r14, %r15
+
+	mov	1*8(%rsi), %rdx
+	am8	%rdi, 1, %rcx, 0, %r13, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %rax, %r14, %r15
+	mov	2*8(%rsi), %rdx
+	am8	%rdi, 2, %rcx, 0, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %rax, %r13, %r14, %r15
+	mov	3*8(%rsi), %rdx
+	am8	%rdi, 3, %rcx, 0, %r9, %r10, %r11, %rbx, %rbp, %r12, %rax, %r13, %r8, %r14, %r15
+	mov	4*8(%rsi), %rdx
+	am8	%rdi, 4, %rcx, 0, %r10, %r11, %rbx, %rbp, %r12, %rax, %r13, %r8, %r9, %r14, %r15
+	mov	5*8(%rsi), %rdx
+	am8	%rdi, 5, %rcx, 0, %r11, %rbx, %rbp, %r12, %rax, %r13, %r8, %r9, %r10, %r14, %r15
+	mov	6*8(%rsi), %rdx
+	am8	%rdi, 6, %rcx, 0, %rbx, %rbp, %r12, %rax, %r13, %r8, %r9, %r10, %r11, %r14, %r15
+	mov	7*8(%rsi), %rdx
+	am8	%rdi, 7, %rcx, 0, %rbp, %r12, %rax, %r13, %r8, %r9, %r10, %r11, %rbx, %r14, %r15
+	mov	8*8(%rsi), %rdx
+	am8	%rdi, 8, %rcx, 0, %r12, %rax, %r13, %r8, %r9, %r10, %r11, %rbx, %rbp, %r14, %r15
+	mov	9*8(%rsi), %rdx
+	am8	%rdi, 9, %rcx, 0, %rax, %r13, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %r14, %r15
+	mov	10*8(%rsi), %rdx
+	am8	%rdi, 10, %rcx, 0, %r13, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %rax, %r14, %r15
+
+	mov	%r8, 11*8(%rdi)
+	mov	%r9, 12*8(%rdi)
+	mov	%r10, 13*8(%rdi)
+	mov	%r11, 14*8(%rdi)
+	mov	%rbx, 15*8(%rdi)
+	mov	%rbp, 16*8(%rdi)
+	mov	%r12, 17*8(%rdi)
+	mov	%rax, 18*8(%rdi)
+
+	pop	%r15
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_11_8_end:
+SIZE(flint_mpn_mul_11_8, .flint_mpn_mul_11_8_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_12_1.asm
+++ b/src/mpn_extras/broadwell/mul_12_1.asm
@@ -1,0 +1,67 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m12 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5
+	mulx	(0+\ap_offset)*8(\ap), \r0, \r3
+	mulx	(1+\ap_offset)*8(\ap), \r1, \r5
+	mulx	(2+\ap_offset)*8(\ap), \r2, \r4
+	add	\r3, \r1
+	adc	\r5, \r2
+	mov	\r0, (0+\res_offset)*8(\res)
+	mov	\r1, (1+\res_offset)*8(\res)
+	mov	\r2, (2+\res_offset)*8(\res)
+	mulx	(3+\ap_offset)*8(\ap), \r3, \r5
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r1
+	adc	\r3, \r4
+	adc	\r5, \r0
+	mov	\r4, (3+\res_offset)*8(\res)
+	mov	\r0, (4+\res_offset)*8(\res)
+	mulx	(5+\ap_offset)*8(\ap), \r3, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r2, \r4
+	adc	\r3, \r1
+	adc	\r5, \r2
+	mov	\r1, (5+\res_offset)*8(\res)
+	mov	\r2, (6+\res_offset)*8(\res)
+	mulx	(7+\ap_offset)*8(\ap), \r3, \r5
+	mulx	(8+\ap_offset)*8(\ap), \r0, \r1
+	adc	\r3, \r4
+	adc	\r5, \r0
+	mov	\r4, (7+\res_offset)*8(\res)
+	mov	\r0, (8+\res_offset)*8(\res)
+	mulx	(9+\ap_offset)*8(\ap), \r3, \r5
+	mulx	(10+\ap_offset)*8(\ap), \r2, \r4
+	adc	\r3, \r1
+	adc	\r5, \r2
+	mov	\r1, (9+\res_offset)*8(\res)
+	mov	\r2, (10+\res_offset)*8(\res)
+	mulx	(11+\ap_offset)*8(\ap), \r3, \r5
+	adc	\r3, \r4
+	adc	$0, \r5
+	mov	\r4, (11+\res_offset)*8(\res)
+.endm
+.global	FUNC(flint_mpn_mul_12_1)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_12_1)
+
+FUNC(flint_mpn_mul_12_1):
+	.cfi_startproc
+	mov	0*8(%rdx), %rdx
+	m12	%rdi, 0, %rsi, 0, %rcx, %r8, %r9, %r10, %r11, %rax
+	mov	%rax, 12*8(%rdi)
+
+	ret
+.flint_mpn_mul_12_1_end:
+SIZE(flint_mpn_mul_12_1, .flint_mpn_mul_12_1_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_12_2.asm
+++ b/src/mpn_extras/broadwell/mul_12_2.asm
@@ -1,0 +1,102 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	adcx	\zero, \r3
+.endm
+
+.macro	am4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r4, \scr
+	adcx	\r4, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r4, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	adcx	\zero, \r4
+	adox	\zero, \r4
+.endm
+
+.macro	m4_chain res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, ip1, ip2, r0, r1, r2, r3, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	adcx	\ip1, \scr1
+	mov	\scr1, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	adcx	\scr2, \r0
+	adox	\ip2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	adcx	\zero, \r3
+.endm
+
+.global	FUNC(flint_mpn_mul_12_2)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_12_2)
+
+FUNC(flint_mpn_mul_12_2):
+	.cfi_startproc
+	mov	0*8(%rdx), %rcx
+	mov	1*8(%rdx), %r8
+	push	%rbx
+	push	%rbp
+	push	%r12
+
+	mov	%rcx, %rdx
+	xor	%r12d, %r12d
+	m4	%rdi, 0, %rsi, 0, %r9, %r10, %r11, %rbx, %rax, %rbp, %r12
+	mov	%r8, %rdx
+	am4	%rdi, 1, %rsi, 0, %r9, %r10, %r11, %rbx, %rax, %rbp, %r12
+	mov	%r10, 2*8(%rdi)
+	mov	%r11, 3*8(%rdi)
+
+	mov	%rcx, %rdx
+	m4_chain	%rdi, 4, %rsi, 4, %rbx, %rax, %r9, %r10, %r11, %rax, %rbp, %rbx, %r12
+	mov	%r8, %rdx
+	am4	%rdi, 5, %rsi, 4, %r9, %r10, %r11, %rax, %rbx, %rbp, %r12
+	mov	%r10, 6*8(%rdi)
+	mov	%r11, 7*8(%rdi)
+
+	mov	%rcx, %rdx
+	m4_chain	%rdi, 8, %rsi, 8, %rax, %rbx, %r9, %r10, %r11, %rbx, %rbp, %rax, %r12
+	mov	%r8, %rdx
+	am4	%rdi, 9, %rsi, 8, %r9, %r10, %r11, %rbx, %rax, %rbp, %r12
+	mov	%r10, 10*8(%rdi)
+	mov	%r11, 11*8(%rdi)
+
+	mov	%rbx, 12*8(%rdi)
+	mov	%rax, 13*8(%rdi)
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_12_2_end:
+SIZE(flint_mpn_mul_12_2, .flint_mpn_mul_12_2_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_12_3.asm
+++ b/src/mpn_extras/broadwell/mul_12_3.asm
@@ -1,0 +1,86 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m3 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	adcx	\scr1, \r1
+	adcx	\zero, \r2
+.endm
+
+.macro	am3 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r3
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r3, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r3
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	adcx	\zero, \r3
+	adox	\zero, \r3
+.endm
+
+.global	FUNC(flint_mpn_mul_12_3)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_12_3)
+
+FUNC(flint_mpn_mul_12_3):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+
+	xor	%ebx, %ebx
+
+	m3	%rdi, 0, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx
+
+	mov	1*8(%rsi), %rdx
+	am3	%rdi, 1, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx
+	mov	2*8(%rsi), %rdx
+	am3	%rdi, 2, %rcx, 0, %rax, %r9, %r10, %r8, %r11, %rbx
+	mov	3*8(%rsi), %rdx
+	am3	%rdi, 3, %rcx, 0, %r9, %r10, %r8, %rax, %r11, %rbx
+	mov	4*8(%rsi), %rdx
+	am3	%rdi, 4, %rcx, 0, %r10, %r8, %rax, %r9, %r11, %rbx
+	mov	5*8(%rsi), %rdx
+	am3	%rdi, 5, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx
+	mov	6*8(%rsi), %rdx
+	am3	%rdi, 6, %rcx, 0, %rax, %r9, %r10, %r8, %r11, %rbx
+	mov	7*8(%rsi), %rdx
+	am3	%rdi, 7, %rcx, 0, %r9, %r10, %r8, %rax, %r11, %rbx
+	mov	8*8(%rsi), %rdx
+	am3	%rdi, 8, %rcx, 0, %r10, %r8, %rax, %r9, %r11, %rbx
+	mov	9*8(%rsi), %rdx
+	am3	%rdi, 9, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx
+	mov	10*8(%rsi), %rdx
+	am3	%rdi, 10, %rcx, 0, %rax, %r9, %r10, %r8, %r11, %rbx
+	mov	11*8(%rsi), %rdx
+	am3	%rdi, 11, %rcx, 0, %r9, %r10, %r8, %rax, %r11, %rbx
+
+	mov	%r10, 12*8(%rdi)
+	mov	%r8, 13*8(%rdi)
+	mov	%rax, 14*8(%rdi)
+
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_12_3_end:
+SIZE(flint_mpn_mul_12_3, .flint_mpn_mul_12_3_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_12_4.asm
+++ b/src/mpn_extras/broadwell/mul_12_4.asm
@@ -1,0 +1,94 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	adcx	\zero, \r3
+.endm
+
+.macro	am4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r4, \scr
+	adcx	\r4, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r4, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	adcx	\zero, \r4
+	adox	\zero, \r4
+.endm
+
+.global	FUNC(flint_mpn_mul_12_4)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_12_4)
+
+FUNC(flint_mpn_mul_12_4):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+
+	xor	%ebp, %ebp
+
+	m4	%rdi, 0, %rcx, 0, %r11, %r8, %r9, %r10, %rax, %rbx, %rbp
+
+	mov	1*8(%rsi), %rdx
+	am4	%rdi, 1, %rcx, 0, %r11, %r8, %r9, %r10, %rax, %rbx, %rbp
+	mov	2*8(%rsi), %rdx
+	am4	%rdi, 2, %rcx, 0, %r8, %r9, %r10, %rax, %r11, %rbx, %rbp
+	mov	3*8(%rsi), %rdx
+	am4	%rdi, 3, %rcx, 0, %r9, %r10, %rax, %r11, %r8, %rbx, %rbp
+	mov	4*8(%rsi), %rdx
+	am4	%rdi, 4, %rcx, 0, %r10, %rax, %r11, %r8, %r9, %rbx, %rbp
+	mov	5*8(%rsi), %rdx
+	am4	%rdi, 5, %rcx, 0, %rax, %r11, %r8, %r9, %r10, %rbx, %rbp
+	mov	6*8(%rsi), %rdx
+	am4	%rdi, 6, %rcx, 0, %r11, %r8, %r9, %r10, %rax, %rbx, %rbp
+	mov	7*8(%rsi), %rdx
+	am4	%rdi, 7, %rcx, 0, %r8, %r9, %r10, %rax, %r11, %rbx, %rbp
+	mov	8*8(%rsi), %rdx
+	am4	%rdi, 8, %rcx, 0, %r9, %r10, %rax, %r11, %r8, %rbx, %rbp
+	mov	9*8(%rsi), %rdx
+	am4	%rdi, 9, %rcx, 0, %r10, %rax, %r11, %r8, %r9, %rbx, %rbp
+	mov	10*8(%rsi), %rdx
+	am4	%rdi, 10, %rcx, 0, %rax, %r11, %r8, %r9, %r10, %rbx, %rbp
+	mov	11*8(%rsi), %rdx
+	am4	%rdi, 11, %rcx, 0, %r11, %r8, %r9, %r10, %rax, %rbx, %rbp
+
+	mov	%r8, 12*8(%rdi)
+	mov	%r9, 13*8(%rdi)
+	mov	%r10, 14*8(%rdi)
+	mov	%rax, 15*8(%rdi)
+
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_12_4_end:
+SIZE(flint_mpn_mul_12_4, .flint_mpn_mul_12_4_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_12_5.asm
+++ b/src/mpn_extras/broadwell/mul_12_5.asm
@@ -1,0 +1,102 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	adcx	\scr1, \r3
+	adcx	\zero, \r4
+.endm
+
+.macro	am5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r5
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	adcx	\zero, \r5
+	adox	\zero, \r5
+.endm
+
+.global	FUNC(flint_mpn_mul_12_5)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_12_5)
+
+FUNC(flint_mpn_mul_12_5):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+
+	xor	%r12d, %r12d
+
+	m5	%rdi, 0, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp, %r12
+
+	mov	1*8(%rsi), %rdx
+	am5	%rdi, 1, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp, %r12
+	mov	2*8(%rsi), %rdx
+	am5	%rdi, 2, %rcx, 0, %r8, %r9, %rax, %r11, %rbx, %r10, %rbp, %r12
+	mov	3*8(%rsi), %rdx
+	am5	%rdi, 3, %rcx, 0, %r9, %rax, %r11, %rbx, %r10, %r8, %rbp, %r12
+	mov	4*8(%rsi), %rdx
+	am5	%rdi, 4, %rcx, 0, %rax, %r11, %rbx, %r10, %r8, %r9, %rbp, %r12
+	mov	5*8(%rsi), %rdx
+	am5	%rdi, 5, %rcx, 0, %r11, %rbx, %r10, %r8, %r9, %rax, %rbp, %r12
+	mov	6*8(%rsi), %rdx
+	am5	%rdi, 6, %rcx, 0, %rbx, %r10, %r8, %r9, %rax, %r11, %rbp, %r12
+	mov	7*8(%rsi), %rdx
+	am5	%rdi, 7, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp, %r12
+	mov	8*8(%rsi), %rdx
+	am5	%rdi, 8, %rcx, 0, %r8, %r9, %rax, %r11, %rbx, %r10, %rbp, %r12
+	mov	9*8(%rsi), %rdx
+	am5	%rdi, 9, %rcx, 0, %r9, %rax, %r11, %rbx, %r10, %r8, %rbp, %r12
+	mov	10*8(%rsi), %rdx
+	am5	%rdi, 10, %rcx, 0, %rax, %r11, %rbx, %r10, %r8, %r9, %rbp, %r12
+	mov	11*8(%rsi), %rdx
+	am5	%rdi, 11, %rcx, 0, %r11, %rbx, %r10, %r8, %r9, %rax, %rbp, %r12
+
+	mov	%rbx, 12*8(%rdi)
+	mov	%r10, 13*8(%rdi)
+	mov	%r8, 14*8(%rdi)
+	mov	%r9, 15*8(%rdi)
+	mov	%rax, 16*8(%rdi)
+
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_12_5_end:
+SIZE(flint_mpn_mul_12_5, .flint_mpn_mul_12_5_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_12_6.asm
+++ b/src/mpn_extras/broadwell/mul_12_6.asm
@@ -1,0 +1,110 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	adcx	\zero, \r5
+.endm
+
+.macro	am6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r6, \scr
+	adcx	\r6, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	adcx	\zero, \r6
+	adox	\zero, \r6
+.endm
+
+.global	FUNC(flint_mpn_mul_12_6)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_12_6)
+
+FUNC(flint_mpn_mul_12_6):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+
+	xor	%r13d, %r13d
+
+	m6	%rdi, 0, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12, %r13
+
+	mov	1*8(%rsi), %rdx
+	am6	%rdi, 1, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12, %r13
+	mov	2*8(%rsi), %rdx
+	am6	%rdi, 2, %rcx, 0, %r8, %rax, %r10, %r11, %rbx, %rbp, %r9, %r12, %r13
+	mov	3*8(%rsi), %rdx
+	am6	%rdi, 3, %rcx, 0, %rax, %r10, %r11, %rbx, %rbp, %r9, %r8, %r12, %r13
+	mov	4*8(%rsi), %rdx
+	am6	%rdi, 4, %rcx, 0, %r10, %r11, %rbx, %rbp, %r9, %r8, %rax, %r12, %r13
+	mov	5*8(%rsi), %rdx
+	am6	%rdi, 5, %rcx, 0, %r11, %rbx, %rbp, %r9, %r8, %rax, %r10, %r12, %r13
+	mov	6*8(%rsi), %rdx
+	am6	%rdi, 6, %rcx, 0, %rbx, %rbp, %r9, %r8, %rax, %r10, %r11, %r12, %r13
+	mov	7*8(%rsi), %rdx
+	am6	%rdi, 7, %rcx, 0, %rbp, %r9, %r8, %rax, %r10, %r11, %rbx, %r12, %r13
+	mov	8*8(%rsi), %rdx
+	am6	%rdi, 8, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12, %r13
+	mov	9*8(%rsi), %rdx
+	am6	%rdi, 9, %rcx, 0, %r8, %rax, %r10, %r11, %rbx, %rbp, %r9, %r12, %r13
+	mov	10*8(%rsi), %rdx
+	am6	%rdi, 10, %rcx, 0, %rax, %r10, %r11, %rbx, %rbp, %r9, %r8, %r12, %r13
+	mov	11*8(%rsi), %rdx
+	am6	%rdi, 11, %rcx, 0, %r10, %r11, %rbx, %rbp, %r9, %r8, %rax, %r12, %r13
+
+	mov	%r11, 12*8(%rdi)
+	mov	%rbx, 13*8(%rdi)
+	mov	%rbp, 14*8(%rdi)
+	mov	%r9, 15*8(%rdi)
+	mov	%r8, 16*8(%rdi)
+	mov	%rax, 17*8(%rdi)
+
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_12_6_end:
+SIZE(flint_mpn_mul_12_6, .flint_mpn_mul_12_6_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_12_7.asm
+++ b/src/mpn_extras/broadwell/mul_12_7.asm
@@ -1,0 +1,118 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	adcx	\scr1, \r5
+	adcx	\zero, \r6
+.endm
+
+.macro	am7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r7
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r6
+	adox	\r0, \r6
+	adcx	\zero, \r7
+	adox	\zero, \r7
+.endm
+
+.global	FUNC(flint_mpn_mul_12_7)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_12_7)
+
+FUNC(flint_mpn_mul_12_7):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+
+	xor	%r14d, %r14d
+
+	m7	%rdi, 0, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14
+
+	mov	1*8(%rsi), %rdx
+	am7	%rdi, 1, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14
+	mov	2*8(%rsi), %rdx
+	am7	%rdi, 2, %rcx, 0, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12, %r8, %r13, %r14
+	mov	3*8(%rsi), %rdx
+	am7	%rdi, 3, %rcx, 0, %r9, %r10, %r11, %rbx, %rbp, %r12, %r8, %rax, %r13, %r14
+	mov	4*8(%rsi), %rdx
+	am7	%rdi, 4, %rcx, 0, %r10, %r11, %rbx, %rbp, %r12, %r8, %rax, %r9, %r13, %r14
+	mov	5*8(%rsi), %rdx
+	am7	%rdi, 5, %rcx, 0, %r11, %rbx, %rbp, %r12, %r8, %rax, %r9, %r10, %r13, %r14
+	mov	6*8(%rsi), %rdx
+	am7	%rdi, 6, %rcx, 0, %rbx, %rbp, %r12, %r8, %rax, %r9, %r10, %r11, %r13, %r14
+	mov	7*8(%rsi), %rdx
+	am7	%rdi, 7, %rcx, 0, %rbp, %r12, %r8, %rax, %r9, %r10, %r11, %rbx, %r13, %r14
+	mov	8*8(%rsi), %rdx
+	am7	%rdi, 8, %rcx, 0, %r12, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r13, %r14
+	mov	9*8(%rsi), %rdx
+	am7	%rdi, 9, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14
+	mov	10*8(%rsi), %rdx
+	am7	%rdi, 10, %rcx, 0, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12, %r8, %r13, %r14
+	mov	11*8(%rsi), %rdx
+	am7	%rdi, 11, %rcx, 0, %r9, %r10, %r11, %rbx, %rbp, %r12, %r8, %rax, %r13, %r14
+
+	mov	%r10, 12*8(%rdi)
+	mov	%r11, 13*8(%rdi)
+	mov	%rbx, 14*8(%rdi)
+	mov	%rbp, 15*8(%rdi)
+	mov	%r12, 16*8(%rdi)
+	mov	%r8, 17*8(%rdi)
+	mov	%rax, 18*8(%rdi)
+
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_12_7_end:
+SIZE(flint_mpn_mul_12_7, .flint_mpn_mul_12_7_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_12_8.asm
+++ b/src/mpn_extras/broadwell/mul_12_8.asm
@@ -1,0 +1,126 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	mulx	(7+\ap_offset)*8(\ap), \scr2, \r7
+	adcx	\scr1, \r5
+	adcx	\scr2, \r6
+	adcx	\zero, \r7
+.endm
+
+.macro	am8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, r8, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r8, \scr
+	adcx	\r8, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r6
+	adox	\r0, \r6
+	mulx	(7+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r7
+	adox	\r0, \r7
+	adcx	\zero, \r8
+	adox	\zero, \r8
+.endm
+
+.global	FUNC(flint_mpn_mul_12_8)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_12_8)
+
+FUNC(flint_mpn_mul_12_8):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+	push	%r15
+
+	xor	%r15d, %r15d
+
+	m8	%rdi, 0, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14, %r15
+
+	mov	1*8(%rsi), %rdx
+	am8	%rdi, 1, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14, %r15
+	mov	2*8(%rsi), %rdx
+	am8	%rdi, 2, %rcx, 0, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %rax, %r14, %r15
+	mov	3*8(%rsi), %rdx
+	am8	%rdi, 3, %rcx, 0, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %rax, %r8, %r14, %r15
+	mov	4*8(%rsi), %rdx
+	am8	%rdi, 4, %rcx, 0, %r10, %r11, %rbx, %rbp, %r12, %r13, %rax, %r8, %r9, %r14, %r15
+	mov	5*8(%rsi), %rdx
+	am8	%rdi, 5, %rcx, 0, %r11, %rbx, %rbp, %r12, %r13, %rax, %r8, %r9, %r10, %r14, %r15
+	mov	6*8(%rsi), %rdx
+	am8	%rdi, 6, %rcx, 0, %rbx, %rbp, %r12, %r13, %rax, %r8, %r9, %r10, %r11, %r14, %r15
+	mov	7*8(%rsi), %rdx
+	am8	%rdi, 7, %rcx, 0, %rbp, %r12, %r13, %rax, %r8, %r9, %r10, %r11, %rbx, %r14, %r15
+	mov	8*8(%rsi), %rdx
+	am8	%rdi, 8, %rcx, 0, %r12, %r13, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r14, %r15
+	mov	9*8(%rsi), %rdx
+	am8	%rdi, 9, %rcx, 0, %r13, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %r14, %r15
+	mov	10*8(%rsi), %rdx
+	am8	%rdi, 10, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14, %r15
+	mov	11*8(%rsi), %rdx
+	am8	%rdi, 11, %rcx, 0, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %rax, %r14, %r15
+
+	mov	%r9, 12*8(%rdi)
+	mov	%r10, 13*8(%rdi)
+	mov	%r11, 14*8(%rdi)
+	mov	%rbx, 15*8(%rdi)
+	mov	%rbp, 16*8(%rdi)
+	mov	%r12, 17*8(%rdi)
+	mov	%r13, 18*8(%rdi)
+	mov	%rax, 19*8(%rdi)
+
+	pop	%r15
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_12_8_end:
+SIZE(flint_mpn_mul_12_8, .flint_mpn_mul_12_8_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_13_1.asm
+++ b/src/mpn_extras/broadwell/mul_13_1.asm
@@ -1,0 +1,70 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m13 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5
+	mulx	(0+\ap_offset)*8(\ap), \r0, \r3
+	mulx	(1+\ap_offset)*8(\ap), \r5, \r4
+	mulx	(2+\ap_offset)*8(\ap), \r2, \r1
+	add	\r3, \r5
+	adc	\r4, \r2
+	mov	\r0, (0+\res_offset)*8(\res)
+	mov	\r5, (1+\res_offset)*8(\res)
+	mov	\r2, (2+\res_offset)*8(\res)
+	mulx	(3+\ap_offset)*8(\ap), \r3, \r4
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r5
+	adc	\r3, \r1
+	adc	\r4, \r0
+	mov	\r1, (3+\res_offset)*8(\res)
+	mov	\r0, (4+\res_offset)*8(\res)
+	mulx	(5+\ap_offset)*8(\ap), \r3, \r4
+	mulx	(6+\ap_offset)*8(\ap), \r2, \r1
+	adc	\r3, \r5
+	adc	\r4, \r2
+	mov	\r5, (5+\res_offset)*8(\res)
+	mov	\r2, (6+\res_offset)*8(\res)
+	mulx	(7+\ap_offset)*8(\ap), \r3, \r4
+	mulx	(8+\ap_offset)*8(\ap), \r0, \r5
+	adc	\r3, \r1
+	adc	\r4, \r0
+	mov	\r1, (7+\res_offset)*8(\res)
+	mov	\r0, (8+\res_offset)*8(\res)
+	mulx	(9+\ap_offset)*8(\ap), \r3, \r4
+	mulx	(10+\ap_offset)*8(\ap), \r2, \r1
+	adc	\r3, \r5
+	adc	\r4, \r2
+	mov	\r5, (9+\res_offset)*8(\res)
+	mov	\r2, (10+\res_offset)*8(\res)
+	mulx	(11+\ap_offset)*8(\ap), \r3, \r4
+	mulx	(12+\ap_offset)*8(\ap), \r0, \r5
+	adc	\r3, \r1
+	adc	\r4, \r0
+	mov	\r1, (11+\res_offset)*8(\res)
+	mov	\r0, (12+\res_offset)*8(\res)
+	adc	$0, \r5
+.endm
+.global	FUNC(flint_mpn_mul_13_1)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_13_1)
+
+FUNC(flint_mpn_mul_13_1):
+	.cfi_startproc
+	mov	0*8(%rdx), %rdx
+	m13	%rdi, 0, %rsi, 0, %rcx, %r8, %r9, %r10, %r11, %rax
+	mov	%rax, 13*8(%rdi)
+
+	ret
+.flint_mpn_mul_13_1_end:
+SIZE(flint_mpn_mul_13_1, .flint_mpn_mul_13_1_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_13_2.asm
+++ b/src/mpn_extras/broadwell/mul_13_2.asm
@@ -1,0 +1,137 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	adcx	\scr1, \r3
+	adcx	\zero, \r4
+.endm
+
+.macro	am5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r5
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	adcx	\zero, \r5
+	adox	\zero, \r5
+.endm
+
+.macro	m5_chain res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, ip1, ip2, r0, r1, r2, r3, r4, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	adcx	\ip1, \scr1
+	mov	\scr1, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	adcx	\scr2, \r0
+	adox	\ip2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	adcx	\scr1, \r3
+	adcx	\zero, \r4
+.endm
+
+.macro	m3_chain res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, ip1, ip2, r0, r1, r2, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	adcx	\ip1, \scr1
+	mov	\scr1, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	adcx	\scr2, \r0
+	adox	\ip2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	adcx	\scr1, \r1
+	adcx	\zero, \r2
+.endm
+
+.macro	am3 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r3
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r3, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r3
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	adcx	\zero, \r3
+	adox	\zero, \r3
+.endm
+
+.global	FUNC(flint_mpn_mul_13_2)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_13_2)
+
+FUNC(flint_mpn_mul_13_2):
+	.cfi_startproc
+	mov	0*8(%rdx), %rcx
+	mov	1*8(%rdx), %r8
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+
+	mov	%rcx, %rdx
+	xor	%r13d, %r13d
+	m5	%rdi, 0, %rsi, 0, %r9, %r10, %r11, %rbx, %rbp, %rax, %r12, %r13
+	mov	%r8, %rdx
+	am5	%rdi, 1, %rsi, 0, %r9, %r10, %r11, %rbx, %rbp, %rax, %r12, %r13
+	mov	%r10, 2*8(%rdi)
+	mov	%r11, 3*8(%rdi)
+	mov	%rbx, 4*8(%rdi)
+
+	mov	%rcx, %rdx
+	m5_chain	%rdi, 5, %rsi, 5, %rbp, %rax, %r9, %r10, %r11, %rbx, %rax, %r12, %rbp, %r13
+	mov	%r8, %rdx
+	am5	%rdi, 6, %rsi, 5, %r9, %r10, %r11, %rbx, %rax, %rbp, %r12, %r13
+	mov	%r10, 7*8(%rdi)
+	mov	%r11, 8*8(%rdi)
+	mov	%rbx, 9*8(%rdi)
+
+	mov	%rcx, %rdx
+	m3_chain	%rdi, 10, %rsi, 10, %rax, %rbp, %r9, %r10, %r11, %r12, %rax, %r13
+	mov	%r8, %rdx
+	am3	%rdi, 11, %rsi, 10, %r9, %r10, %r11, %rax, %r12, %r13
+	mov	%r10, 12*8(%rdi)
+	mov	%r11, 13*8(%rdi)
+	mov	%rax, 14*8(%rdi)
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_13_2_end:
+SIZE(flint_mpn_mul_13_2, .flint_mpn_mul_13_2_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_13_3.asm
+++ b/src/mpn_extras/broadwell/mul_13_3.asm
@@ -1,0 +1,88 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m3 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	adcx	\scr1, \r1
+	adcx	\zero, \r2
+.endm
+
+.macro	am3 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r3
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r3, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r3
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	adcx	\zero, \r3
+	adox	\zero, \r3
+.endm
+
+.global	FUNC(flint_mpn_mul_13_3)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_13_3)
+
+FUNC(flint_mpn_mul_13_3):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+
+	xor	%ebx, %ebx
+
+	m3	%rdi, 0, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx
+
+	mov	1*8(%rsi), %rdx
+	am3	%rdi, 1, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx
+	mov	2*8(%rsi), %rdx
+	am3	%rdi, 2, %rcx, 0, %r8, %rax, %r10, %r9, %r11, %rbx
+	mov	3*8(%rsi), %rdx
+	am3	%rdi, 3, %rcx, 0, %rax, %r10, %r9, %r8, %r11, %rbx
+	mov	4*8(%rsi), %rdx
+	am3	%rdi, 4, %rcx, 0, %r10, %r9, %r8, %rax, %r11, %rbx
+	mov	5*8(%rsi), %rdx
+	am3	%rdi, 5, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx
+	mov	6*8(%rsi), %rdx
+	am3	%rdi, 6, %rcx, 0, %r8, %rax, %r10, %r9, %r11, %rbx
+	mov	7*8(%rsi), %rdx
+	am3	%rdi, 7, %rcx, 0, %rax, %r10, %r9, %r8, %r11, %rbx
+	mov	8*8(%rsi), %rdx
+	am3	%rdi, 8, %rcx, 0, %r10, %r9, %r8, %rax, %r11, %rbx
+	mov	9*8(%rsi), %rdx
+	am3	%rdi, 9, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx
+	mov	10*8(%rsi), %rdx
+	am3	%rdi, 10, %rcx, 0, %r8, %rax, %r10, %r9, %r11, %rbx
+	mov	11*8(%rsi), %rdx
+	am3	%rdi, 11, %rcx, 0, %rax, %r10, %r9, %r8, %r11, %rbx
+	mov	12*8(%rsi), %rdx
+	am3	%rdi, 12, %rcx, 0, %r10, %r9, %r8, %rax, %r11, %rbx
+
+	mov	%r9, 13*8(%rdi)
+	mov	%r8, 14*8(%rdi)
+	mov	%rax, 15*8(%rdi)
+
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_13_3_end:
+SIZE(flint_mpn_mul_13_3, .flint_mpn_mul_13_3_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_13_4.asm
+++ b/src/mpn_extras/broadwell/mul_13_4.asm
@@ -1,0 +1,96 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	adcx	\zero, \r3
+.endm
+
+.macro	am4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r4, \scr
+	adcx	\r4, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r4, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	adcx	\zero, \r4
+	adox	\zero, \r4
+.endm
+
+.global	FUNC(flint_mpn_mul_13_4)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_13_4)
+
+FUNC(flint_mpn_mul_13_4):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+
+	xor	%ebp, %ebp
+
+	m4	%rdi, 0, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp
+
+	mov	1*8(%rsi), %rdx
+	am4	%rdi, 1, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp
+	mov	2*8(%rsi), %rdx
+	am4	%rdi, 2, %rcx, 0, %r8, %r9, %r10, %r11, %rax, %rbx, %rbp
+	mov	3*8(%rsi), %rdx
+	am4	%rdi, 3, %rcx, 0, %r9, %r10, %r11, %rax, %r8, %rbx, %rbp
+	mov	4*8(%rsi), %rdx
+	am4	%rdi, 4, %rcx, 0, %r10, %r11, %rax, %r8, %r9, %rbx, %rbp
+	mov	5*8(%rsi), %rdx
+	am4	%rdi, 5, %rcx, 0, %r11, %rax, %r8, %r9, %r10, %rbx, %rbp
+	mov	6*8(%rsi), %rdx
+	am4	%rdi, 6, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp
+	mov	7*8(%rsi), %rdx
+	am4	%rdi, 7, %rcx, 0, %r8, %r9, %r10, %r11, %rax, %rbx, %rbp
+	mov	8*8(%rsi), %rdx
+	am4	%rdi, 8, %rcx, 0, %r9, %r10, %r11, %rax, %r8, %rbx, %rbp
+	mov	9*8(%rsi), %rdx
+	am4	%rdi, 9, %rcx, 0, %r10, %r11, %rax, %r8, %r9, %rbx, %rbp
+	mov	10*8(%rsi), %rdx
+	am4	%rdi, 10, %rcx, 0, %r11, %rax, %r8, %r9, %r10, %rbx, %rbp
+	mov	11*8(%rsi), %rdx
+	am4	%rdi, 11, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp
+	mov	12*8(%rsi), %rdx
+	am4	%rdi, 12, %rcx, 0, %r8, %r9, %r10, %r11, %rax, %rbx, %rbp
+
+	mov	%r9, 13*8(%rdi)
+	mov	%r10, 14*8(%rdi)
+	mov	%r11, 15*8(%rdi)
+	mov	%rax, 16*8(%rdi)
+
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_13_4_end:
+SIZE(flint_mpn_mul_13_4, .flint_mpn_mul_13_4_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_13_5.asm
+++ b/src/mpn_extras/broadwell/mul_13_5.asm
@@ -1,0 +1,104 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	adcx	\scr1, \r3
+	adcx	\zero, \r4
+.endm
+
+.macro	am5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r5
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	adcx	\zero, \r5
+	adox	\zero, \r5
+.endm
+
+.global	FUNC(flint_mpn_mul_13_5)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_13_5)
+
+FUNC(flint_mpn_mul_13_5):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+
+	xor	%r12d, %r12d
+
+	m5	%rdi, 0, %rcx, 0, %r11, %r8, %r9, %r10, %rax, %rbx, %rbp, %r12
+
+	mov	1*8(%rsi), %rdx
+	am5	%rdi, 1, %rcx, 0, %r11, %r8, %r9, %r10, %rax, %rbx, %rbp, %r12
+	mov	2*8(%rsi), %rdx
+	am5	%rdi, 2, %rcx, 0, %r8, %r9, %r10, %rax, %rbx, %r11, %rbp, %r12
+	mov	3*8(%rsi), %rdx
+	am5	%rdi, 3, %rcx, 0, %r9, %r10, %rax, %rbx, %r11, %r8, %rbp, %r12
+	mov	4*8(%rsi), %rdx
+	am5	%rdi, 4, %rcx, 0, %r10, %rax, %rbx, %r11, %r8, %r9, %rbp, %r12
+	mov	5*8(%rsi), %rdx
+	am5	%rdi, 5, %rcx, 0, %rax, %rbx, %r11, %r8, %r9, %r10, %rbp, %r12
+	mov	6*8(%rsi), %rdx
+	am5	%rdi, 6, %rcx, 0, %rbx, %r11, %r8, %r9, %r10, %rax, %rbp, %r12
+	mov	7*8(%rsi), %rdx
+	am5	%rdi, 7, %rcx, 0, %r11, %r8, %r9, %r10, %rax, %rbx, %rbp, %r12
+	mov	8*8(%rsi), %rdx
+	am5	%rdi, 8, %rcx, 0, %r8, %r9, %r10, %rax, %rbx, %r11, %rbp, %r12
+	mov	9*8(%rsi), %rdx
+	am5	%rdi, 9, %rcx, 0, %r9, %r10, %rax, %rbx, %r11, %r8, %rbp, %r12
+	mov	10*8(%rsi), %rdx
+	am5	%rdi, 10, %rcx, 0, %r10, %rax, %rbx, %r11, %r8, %r9, %rbp, %r12
+	mov	11*8(%rsi), %rdx
+	am5	%rdi, 11, %rcx, 0, %rax, %rbx, %r11, %r8, %r9, %r10, %rbp, %r12
+	mov	12*8(%rsi), %rdx
+	am5	%rdi, 12, %rcx, 0, %rbx, %r11, %r8, %r9, %r10, %rax, %rbp, %r12
+
+	mov	%r11, 13*8(%rdi)
+	mov	%r8, 14*8(%rdi)
+	mov	%r9, 15*8(%rdi)
+	mov	%r10, 16*8(%rdi)
+	mov	%rax, 17*8(%rdi)
+
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_13_5_end:
+SIZE(flint_mpn_mul_13_5, .flint_mpn_mul_13_5_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_13_6.asm
+++ b/src/mpn_extras/broadwell/mul_13_6.asm
@@ -1,0 +1,112 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	adcx	\zero, \r5
+.endm
+
+.macro	am6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r6, \scr
+	adcx	\r6, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	adcx	\zero, \r6
+	adox	\zero, \r6
+.endm
+
+.global	FUNC(flint_mpn_mul_13_6)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_13_6)
+
+FUNC(flint_mpn_mul_13_6):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+
+	xor	%r13d, %r13d
+
+	m6	%rdi, 0, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp, %r12, %r13
+
+	mov	1*8(%rsi), %rdx
+	am6	%rdi, 1, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp, %r12, %r13
+	mov	2*8(%rsi), %rdx
+	am6	%rdi, 2, %rcx, 0, %r8, %r9, %rax, %r11, %rbx, %rbp, %r10, %r12, %r13
+	mov	3*8(%rsi), %rdx
+	am6	%rdi, 3, %rcx, 0, %r9, %rax, %r11, %rbx, %rbp, %r10, %r8, %r12, %r13
+	mov	4*8(%rsi), %rdx
+	am6	%rdi, 4, %rcx, 0, %rax, %r11, %rbx, %rbp, %r10, %r8, %r9, %r12, %r13
+	mov	5*8(%rsi), %rdx
+	am6	%rdi, 5, %rcx, 0, %r11, %rbx, %rbp, %r10, %r8, %r9, %rax, %r12, %r13
+	mov	6*8(%rsi), %rdx
+	am6	%rdi, 6, %rcx, 0, %rbx, %rbp, %r10, %r8, %r9, %rax, %r11, %r12, %r13
+	mov	7*8(%rsi), %rdx
+	am6	%rdi, 7, %rcx, 0, %rbp, %r10, %r8, %r9, %rax, %r11, %rbx, %r12, %r13
+	mov	8*8(%rsi), %rdx
+	am6	%rdi, 8, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp, %r12, %r13
+	mov	9*8(%rsi), %rdx
+	am6	%rdi, 9, %rcx, 0, %r8, %r9, %rax, %r11, %rbx, %rbp, %r10, %r12, %r13
+	mov	10*8(%rsi), %rdx
+	am6	%rdi, 10, %rcx, 0, %r9, %rax, %r11, %rbx, %rbp, %r10, %r8, %r12, %r13
+	mov	11*8(%rsi), %rdx
+	am6	%rdi, 11, %rcx, 0, %rax, %r11, %rbx, %rbp, %r10, %r8, %r9, %r12, %r13
+	mov	12*8(%rsi), %rdx
+	am6	%rdi, 12, %rcx, 0, %r11, %rbx, %rbp, %r10, %r8, %r9, %rax, %r12, %r13
+
+	mov	%rbx, 13*8(%rdi)
+	mov	%rbp, 14*8(%rdi)
+	mov	%r10, 15*8(%rdi)
+	mov	%r8, 16*8(%rdi)
+	mov	%r9, 17*8(%rdi)
+	mov	%rax, 18*8(%rdi)
+
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_13_6_end:
+SIZE(flint_mpn_mul_13_6, .flint_mpn_mul_13_6_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_13_7.asm
+++ b/src/mpn_extras/broadwell/mul_13_7.asm
@@ -1,0 +1,120 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	adcx	\scr1, \r5
+	adcx	\zero, \r6
+.endm
+
+.macro	am7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r7
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r6
+	adox	\r0, \r6
+	adcx	\zero, \r7
+	adox	\zero, \r7
+.endm
+
+.global	FUNC(flint_mpn_mul_13_7)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_13_7)
+
+FUNC(flint_mpn_mul_13_7):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+
+	xor	%r14d, %r14d
+
+	m7	%rdi, 0, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14
+
+	mov	1*8(%rsi), %rdx
+	am7	%rdi, 1, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14
+	mov	2*8(%rsi), %rdx
+	am7	%rdi, 2, %rcx, 0, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12, %r9, %r13, %r14
+	mov	3*8(%rsi), %rdx
+	am7	%rdi, 3, %rcx, 0, %rax, %r10, %r11, %rbx, %rbp, %r12, %r9, %r8, %r13, %r14
+	mov	4*8(%rsi), %rdx
+	am7	%rdi, 4, %rcx, 0, %r10, %r11, %rbx, %rbp, %r12, %r9, %r8, %rax, %r13, %r14
+	mov	5*8(%rsi), %rdx
+	am7	%rdi, 5, %rcx, 0, %r11, %rbx, %rbp, %r12, %r9, %r8, %rax, %r10, %r13, %r14
+	mov	6*8(%rsi), %rdx
+	am7	%rdi, 6, %rcx, 0, %rbx, %rbp, %r12, %r9, %r8, %rax, %r10, %r11, %r13, %r14
+	mov	7*8(%rsi), %rdx
+	am7	%rdi, 7, %rcx, 0, %rbp, %r12, %r9, %r8, %rax, %r10, %r11, %rbx, %r13, %r14
+	mov	8*8(%rsi), %rdx
+	am7	%rdi, 8, %rcx, 0, %r12, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp, %r13, %r14
+	mov	9*8(%rsi), %rdx
+	am7	%rdi, 9, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14
+	mov	10*8(%rsi), %rdx
+	am7	%rdi, 10, %rcx, 0, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12, %r9, %r13, %r14
+	mov	11*8(%rsi), %rdx
+	am7	%rdi, 11, %rcx, 0, %rax, %r10, %r11, %rbx, %rbp, %r12, %r9, %r8, %r13, %r14
+	mov	12*8(%rsi), %rdx
+	am7	%rdi, 12, %rcx, 0, %r10, %r11, %rbx, %rbp, %r12, %r9, %r8, %rax, %r13, %r14
+
+	mov	%r11, 13*8(%rdi)
+	mov	%rbx, 14*8(%rdi)
+	mov	%rbp, 15*8(%rdi)
+	mov	%r12, 16*8(%rdi)
+	mov	%r9, 17*8(%rdi)
+	mov	%r8, 18*8(%rdi)
+	mov	%rax, 19*8(%rdi)
+
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_13_7_end:
+SIZE(flint_mpn_mul_13_7, .flint_mpn_mul_13_7_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_13_8.asm
+++ b/src/mpn_extras/broadwell/mul_13_8.asm
@@ -1,0 +1,128 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	mulx	(7+\ap_offset)*8(\ap), \scr2, \r7
+	adcx	\scr1, \r5
+	adcx	\scr2, \r6
+	adcx	\zero, \r7
+.endm
+
+.macro	am8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, r8, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r8, \scr
+	adcx	\r8, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r6
+	adox	\r0, \r6
+	mulx	(7+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r7
+	adox	\r0, \r7
+	adcx	\zero, \r8
+	adox	\zero, \r8
+.endm
+
+.global	FUNC(flint_mpn_mul_13_8)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_13_8)
+
+FUNC(flint_mpn_mul_13_8):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+	push	%r15
+
+	xor	%r15d, %r15d
+
+	m8	%rdi, 0, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14, %r15
+
+	mov	1*8(%rsi), %rdx
+	am8	%rdi, 1, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14, %r15
+	mov	2*8(%rsi), %rdx
+	am8	%rdi, 2, %rcx, 0, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r8, %r14, %r15
+	mov	3*8(%rsi), %rdx
+	am8	%rdi, 3, %rcx, 0, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r8, %rax, %r14, %r15
+	mov	4*8(%rsi), %rdx
+	am8	%rdi, 4, %rcx, 0, %r10, %r11, %rbx, %rbp, %r12, %r13, %r8, %rax, %r9, %r14, %r15
+	mov	5*8(%rsi), %rdx
+	am8	%rdi, 5, %rcx, 0, %r11, %rbx, %rbp, %r12, %r13, %r8, %rax, %r9, %r10, %r14, %r15
+	mov	6*8(%rsi), %rdx
+	am8	%rdi, 6, %rcx, 0, %rbx, %rbp, %r12, %r13, %r8, %rax, %r9, %r10, %r11, %r14, %r15
+	mov	7*8(%rsi), %rdx
+	am8	%rdi, 7, %rcx, 0, %rbp, %r12, %r13, %r8, %rax, %r9, %r10, %r11, %rbx, %r14, %r15
+	mov	8*8(%rsi), %rdx
+	am8	%rdi, 8, %rcx, 0, %r12, %r13, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r14, %r15
+	mov	9*8(%rsi), %rdx
+	am8	%rdi, 9, %rcx, 0, %r13, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12, %r14, %r15
+	mov	10*8(%rsi), %rdx
+	am8	%rdi, 10, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14, %r15
+	mov	11*8(%rsi), %rdx
+	am8	%rdi, 11, %rcx, 0, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r8, %r14, %r15
+	mov	12*8(%rsi), %rdx
+	am8	%rdi, 12, %rcx, 0, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r8, %rax, %r14, %r15
+
+	mov	%r10, 13*8(%rdi)
+	mov	%r11, 14*8(%rdi)
+	mov	%rbx, 15*8(%rdi)
+	mov	%rbp, 16*8(%rdi)
+	mov	%r12, 17*8(%rdi)
+	mov	%r13, 18*8(%rdi)
+	mov	%r8, 19*8(%rdi)
+	mov	%rax, 20*8(%rdi)
+
+	pop	%r15
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_13_8_end:
+SIZE(flint_mpn_mul_13_8, .flint_mpn_mul_13_8_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_14_1.asm
+++ b/src/mpn_extras/broadwell/mul_14_1.asm
@@ -1,0 +1,73 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m14 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5
+	mulx	(0+\ap_offset)*8(\ap), \r0, \r3
+	mulx	(1+\ap_offset)*8(\ap), \r1, \r5
+	mulx	(2+\ap_offset)*8(\ap), \r2, \r4
+	add	\r3, \r1
+	adc	\r5, \r2
+	mov	\r0, (0+\res_offset)*8(\res)
+	mov	\r1, (1+\res_offset)*8(\res)
+	mov	\r2, (2+\res_offset)*8(\res)
+	mulx	(3+\ap_offset)*8(\ap), \r3, \r5
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r1
+	adc	\r3, \r4
+	adc	\r5, \r0
+	mov	\r4, (3+\res_offset)*8(\res)
+	mov	\r0, (4+\res_offset)*8(\res)
+	mulx	(5+\ap_offset)*8(\ap), \r3, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r2, \r4
+	adc	\r3, \r1
+	adc	\r5, \r2
+	mov	\r1, (5+\res_offset)*8(\res)
+	mov	\r2, (6+\res_offset)*8(\res)
+	mulx	(7+\ap_offset)*8(\ap), \r3, \r5
+	mulx	(8+\ap_offset)*8(\ap), \r0, \r1
+	adc	\r3, \r4
+	adc	\r5, \r0
+	mov	\r4, (7+\res_offset)*8(\res)
+	mov	\r0, (8+\res_offset)*8(\res)
+	mulx	(9+\ap_offset)*8(\ap), \r3, \r5
+	mulx	(10+\ap_offset)*8(\ap), \r2, \r4
+	adc	\r3, \r1
+	adc	\r5, \r2
+	mov	\r1, (9+\res_offset)*8(\res)
+	mov	\r2, (10+\res_offset)*8(\res)
+	mulx	(11+\ap_offset)*8(\ap), \r3, \r5
+	mulx	(12+\ap_offset)*8(\ap), \r0, \r1
+	adc	\r3, \r4
+	adc	\r5, \r0
+	mov	\r4, (11+\res_offset)*8(\res)
+	mov	\r0, (12+\res_offset)*8(\res)
+	mulx	(13+\ap_offset)*8(\ap), \r3, \r5
+	adc	\r3, \r1
+	adc	$0, \r5
+	mov	\r1, (13+\res_offset)*8(\res)
+.endm
+.global	FUNC(flint_mpn_mul_14_1)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_14_1)
+
+FUNC(flint_mpn_mul_14_1):
+	.cfi_startproc
+	mov	0*8(%rdx), %rdx
+	m14	%rdi, 0, %rsi, 0, %rcx, %r8, %r9, %r10, %r11, %rax
+	mov	%rax, 14*8(%rdi)
+
+	ret
+.flint_mpn_mul_14_1_end:
+SIZE(flint_mpn_mul_14_1, .flint_mpn_mul_14_1_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_14_2.asm
+++ b/src/mpn_extras/broadwell/mul_14_2.asm
@@ -1,0 +1,143 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	adcx	\scr1, \r3
+	adcx	\zero, \r4
+.endm
+
+.macro	am5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r5
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	adcx	\zero, \r5
+	adox	\zero, \r5
+.endm
+
+.macro	m5_chain res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, ip1, ip2, r0, r1, r2, r3, r4, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	adcx	\ip1, \scr1
+	mov	\scr1, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	adcx	\scr2, \r0
+	adox	\ip2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	adcx	\scr1, \r3
+	adcx	\zero, \r4
+.endm
+
+.macro	m4_chain res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, ip1, ip2, r0, r1, r2, r3, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	adcx	\ip1, \scr1
+	mov	\scr1, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	adcx	\scr2, \r0
+	adox	\ip2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	adcx	\zero, \r3
+.endm
+
+.macro	am4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r4, \scr
+	adcx	\r4, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r4, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	adcx	\zero, \r4
+	adox	\zero, \r4
+.endm
+
+.global	FUNC(flint_mpn_mul_14_2)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_14_2)
+
+FUNC(flint_mpn_mul_14_2):
+	.cfi_startproc
+	mov	0*8(%rdx), %rcx
+	mov	1*8(%rdx), %r8
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+
+	mov	%rcx, %rdx
+	xor	%r13d, %r13d
+	m5	%rdi, 0, %rsi, 0, %r9, %r10, %r11, %rbx, %rbp, %rax, %r12, %r13
+	mov	%r8, %rdx
+	am5	%rdi, 1, %rsi, 0, %r9, %r10, %r11, %rbx, %rbp, %rax, %r12, %r13
+	mov	%r10, 2*8(%rdi)
+	mov	%r11, 3*8(%rdi)
+	mov	%rbx, 4*8(%rdi)
+
+	mov	%rcx, %rdx
+	m5_chain	%rdi, 5, %rsi, 5, %rbp, %rax, %r9, %r10, %r11, %rbx, %rax, %r12, %rbp, %r13
+	mov	%r8, %rdx
+	am5	%rdi, 6, %rsi, 5, %r9, %r10, %r11, %rbx, %rax, %rbp, %r12, %r13
+	mov	%r10, 7*8(%rdi)
+	mov	%r11, 8*8(%rdi)
+	mov	%rbx, 9*8(%rdi)
+
+	mov	%rcx, %rdx
+	m4_chain	%rdi, 10, %rsi, 10, %rax, %rbp, %r9, %r10, %r11, %rbx, %r12, %rax, %r13
+	mov	%r8, %rdx
+	am4	%rdi, 11, %rsi, 10, %r9, %r10, %r11, %rbx, %rax, %r12, %r13
+	mov	%r10, 12*8(%rdi)
+	mov	%r11, 13*8(%rdi)
+	mov	%rbx, 14*8(%rdi)
+	mov	%rax, 15*8(%rdi)
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_14_2_end:
+SIZE(flint_mpn_mul_14_2, .flint_mpn_mul_14_2_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_14_3.asm
+++ b/src/mpn_extras/broadwell/mul_14_3.asm
@@ -1,0 +1,90 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m3 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	adcx	\scr1, \r1
+	adcx	\zero, \r2
+.endm
+
+.macro	am3 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r3
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r3, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r3
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	adcx	\zero, \r3
+	adox	\zero, \r3
+.endm
+
+.global	FUNC(flint_mpn_mul_14_3)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_14_3)
+
+FUNC(flint_mpn_mul_14_3):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+
+	xor	%ebx, %ebx
+
+	m3	%rdi, 0, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx
+
+	mov	1*8(%rsi), %rdx
+	am3	%rdi, 1, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx
+	mov	2*8(%rsi), %rdx
+	am3	%rdi, 2, %rcx, 0, %r8, %r9, %rax, %r10, %r11, %rbx
+	mov	3*8(%rsi), %rdx
+	am3	%rdi, 3, %rcx, 0, %r9, %rax, %r10, %r8, %r11, %rbx
+	mov	4*8(%rsi), %rdx
+	am3	%rdi, 4, %rcx, 0, %rax, %r10, %r8, %r9, %r11, %rbx
+	mov	5*8(%rsi), %rdx
+	am3	%rdi, 5, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx
+	mov	6*8(%rsi), %rdx
+	am3	%rdi, 6, %rcx, 0, %r8, %r9, %rax, %r10, %r11, %rbx
+	mov	7*8(%rsi), %rdx
+	am3	%rdi, 7, %rcx, 0, %r9, %rax, %r10, %r8, %r11, %rbx
+	mov	8*8(%rsi), %rdx
+	am3	%rdi, 8, %rcx, 0, %rax, %r10, %r8, %r9, %r11, %rbx
+	mov	9*8(%rsi), %rdx
+	am3	%rdi, 9, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx
+	mov	10*8(%rsi), %rdx
+	am3	%rdi, 10, %rcx, 0, %r8, %r9, %rax, %r10, %r11, %rbx
+	mov	11*8(%rsi), %rdx
+	am3	%rdi, 11, %rcx, 0, %r9, %rax, %r10, %r8, %r11, %rbx
+	mov	12*8(%rsi), %rdx
+	am3	%rdi, 12, %rcx, 0, %rax, %r10, %r8, %r9, %r11, %rbx
+	mov	13*8(%rsi), %rdx
+	am3	%rdi, 13, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx
+
+	mov	%r8, 14*8(%rdi)
+	mov	%r9, 15*8(%rdi)
+	mov	%rax, 16*8(%rdi)
+
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_14_3_end:
+SIZE(flint_mpn_mul_14_3, .flint_mpn_mul_14_3_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_14_4.asm
+++ b/src/mpn_extras/broadwell/mul_14_4.asm
@@ -1,0 +1,98 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	adcx	\zero, \r3
+.endm
+
+.macro	am4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r4, \scr
+	adcx	\r4, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r4, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	adcx	\zero, \r4
+	adox	\zero, \r4
+.endm
+
+.global	FUNC(flint_mpn_mul_14_4)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_14_4)
+
+FUNC(flint_mpn_mul_14_4):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+
+	xor	%ebp, %ebp
+
+	m4	%rdi, 0, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp
+
+	mov	1*8(%rsi), %rdx
+	am4	%rdi, 1, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp
+	mov	2*8(%rsi), %rdx
+	am4	%rdi, 2, %rcx, 0, %rax, %r9, %r10, %r11, %r8, %rbx, %rbp
+	mov	3*8(%rsi), %rdx
+	am4	%rdi, 3, %rcx, 0, %r9, %r10, %r11, %r8, %rax, %rbx, %rbp
+	mov	4*8(%rsi), %rdx
+	am4	%rdi, 4, %rcx, 0, %r10, %r11, %r8, %rax, %r9, %rbx, %rbp
+	mov	5*8(%rsi), %rdx
+	am4	%rdi, 5, %rcx, 0, %r11, %r8, %rax, %r9, %r10, %rbx, %rbp
+	mov	6*8(%rsi), %rdx
+	am4	%rdi, 6, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp
+	mov	7*8(%rsi), %rdx
+	am4	%rdi, 7, %rcx, 0, %rax, %r9, %r10, %r11, %r8, %rbx, %rbp
+	mov	8*8(%rsi), %rdx
+	am4	%rdi, 8, %rcx, 0, %r9, %r10, %r11, %r8, %rax, %rbx, %rbp
+	mov	9*8(%rsi), %rdx
+	am4	%rdi, 9, %rcx, 0, %r10, %r11, %r8, %rax, %r9, %rbx, %rbp
+	mov	10*8(%rsi), %rdx
+	am4	%rdi, 10, %rcx, 0, %r11, %r8, %rax, %r9, %r10, %rbx, %rbp
+	mov	11*8(%rsi), %rdx
+	am4	%rdi, 11, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp
+	mov	12*8(%rsi), %rdx
+	am4	%rdi, 12, %rcx, 0, %rax, %r9, %r10, %r11, %r8, %rbx, %rbp
+	mov	13*8(%rsi), %rdx
+	am4	%rdi, 13, %rcx, 0, %r9, %r10, %r11, %r8, %rax, %rbx, %rbp
+
+	mov	%r10, 14*8(%rdi)
+	mov	%r11, 15*8(%rdi)
+	mov	%r8, 16*8(%rdi)
+	mov	%rax, 17*8(%rdi)
+
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_14_4_end:
+SIZE(flint_mpn_mul_14_4, .flint_mpn_mul_14_4_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_14_5.asm
+++ b/src/mpn_extras/broadwell/mul_14_5.asm
@@ -1,0 +1,106 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	adcx	\scr1, \r3
+	adcx	\zero, \r4
+.endm
+
+.macro	am5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r5
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	adcx	\zero, \r5
+	adox	\zero, \r5
+.endm
+
+.global	FUNC(flint_mpn_mul_14_5)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_14_5)
+
+FUNC(flint_mpn_mul_14_5):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+
+	xor	%r12d, %r12d
+
+	m5	%rdi, 0, %rcx, 0, %rbx, %r8, %r9, %r10, %r11, %rax, %rbp, %r12
+
+	mov	1*8(%rsi), %rdx
+	am5	%rdi, 1, %rcx, 0, %rbx, %r8, %r9, %r10, %r11, %rax, %rbp, %r12
+	mov	2*8(%rsi), %rdx
+	am5	%rdi, 2, %rcx, 0, %r8, %r9, %r10, %r11, %rax, %rbx, %rbp, %r12
+	mov	3*8(%rsi), %rdx
+	am5	%rdi, 3, %rcx, 0, %r9, %r10, %r11, %rax, %rbx, %r8, %rbp, %r12
+	mov	4*8(%rsi), %rdx
+	am5	%rdi, 4, %rcx, 0, %r10, %r11, %rax, %rbx, %r8, %r9, %rbp, %r12
+	mov	5*8(%rsi), %rdx
+	am5	%rdi, 5, %rcx, 0, %r11, %rax, %rbx, %r8, %r9, %r10, %rbp, %r12
+	mov	6*8(%rsi), %rdx
+	am5	%rdi, 6, %rcx, 0, %rax, %rbx, %r8, %r9, %r10, %r11, %rbp, %r12
+	mov	7*8(%rsi), %rdx
+	am5	%rdi, 7, %rcx, 0, %rbx, %r8, %r9, %r10, %r11, %rax, %rbp, %r12
+	mov	8*8(%rsi), %rdx
+	am5	%rdi, 8, %rcx, 0, %r8, %r9, %r10, %r11, %rax, %rbx, %rbp, %r12
+	mov	9*8(%rsi), %rdx
+	am5	%rdi, 9, %rcx, 0, %r9, %r10, %r11, %rax, %rbx, %r8, %rbp, %r12
+	mov	10*8(%rsi), %rdx
+	am5	%rdi, 10, %rcx, 0, %r10, %r11, %rax, %rbx, %r8, %r9, %rbp, %r12
+	mov	11*8(%rsi), %rdx
+	am5	%rdi, 11, %rcx, 0, %r11, %rax, %rbx, %r8, %r9, %r10, %rbp, %r12
+	mov	12*8(%rsi), %rdx
+	am5	%rdi, 12, %rcx, 0, %rax, %rbx, %r8, %r9, %r10, %r11, %rbp, %r12
+	mov	13*8(%rsi), %rdx
+	am5	%rdi, 13, %rcx, 0, %rbx, %r8, %r9, %r10, %r11, %rax, %rbp, %r12
+
+	mov	%r8, 14*8(%rdi)
+	mov	%r9, 15*8(%rdi)
+	mov	%r10, 16*8(%rdi)
+	mov	%r11, 17*8(%rdi)
+	mov	%rax, 18*8(%rdi)
+
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_14_5_end:
+SIZE(flint_mpn_mul_14_5, .flint_mpn_mul_14_5_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_14_6.asm
+++ b/src/mpn_extras/broadwell/mul_14_6.asm
@@ -1,0 +1,114 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	adcx	\zero, \r5
+.endm
+
+.macro	am6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r6, \scr
+	adcx	\r6, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	adcx	\zero, \r6
+	adox	\zero, \r6
+.endm
+
+.global	FUNC(flint_mpn_mul_14_6)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_14_6)
+
+FUNC(flint_mpn_mul_14_6):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+
+	xor	%r13d, %r13d
+
+	m6	%rdi, 0, %rcx, 0, %r11, %r8, %r9, %r10, %rax, %rbx, %rbp, %r12, %r13
+
+	mov	1*8(%rsi), %rdx
+	am6	%rdi, 1, %rcx, 0, %r11, %r8, %r9, %r10, %rax, %rbx, %rbp, %r12, %r13
+	mov	2*8(%rsi), %rdx
+	am6	%rdi, 2, %rcx, 0, %r8, %r9, %r10, %rax, %rbx, %rbp, %r11, %r12, %r13
+	mov	3*8(%rsi), %rdx
+	am6	%rdi, 3, %rcx, 0, %r9, %r10, %rax, %rbx, %rbp, %r11, %r8, %r12, %r13
+	mov	4*8(%rsi), %rdx
+	am6	%rdi, 4, %rcx, 0, %r10, %rax, %rbx, %rbp, %r11, %r8, %r9, %r12, %r13
+	mov	5*8(%rsi), %rdx
+	am6	%rdi, 5, %rcx, 0, %rax, %rbx, %rbp, %r11, %r8, %r9, %r10, %r12, %r13
+	mov	6*8(%rsi), %rdx
+	am6	%rdi, 6, %rcx, 0, %rbx, %rbp, %r11, %r8, %r9, %r10, %rax, %r12, %r13
+	mov	7*8(%rsi), %rdx
+	am6	%rdi, 7, %rcx, 0, %rbp, %r11, %r8, %r9, %r10, %rax, %rbx, %r12, %r13
+	mov	8*8(%rsi), %rdx
+	am6	%rdi, 8, %rcx, 0, %r11, %r8, %r9, %r10, %rax, %rbx, %rbp, %r12, %r13
+	mov	9*8(%rsi), %rdx
+	am6	%rdi, 9, %rcx, 0, %r8, %r9, %r10, %rax, %rbx, %rbp, %r11, %r12, %r13
+	mov	10*8(%rsi), %rdx
+	am6	%rdi, 10, %rcx, 0, %r9, %r10, %rax, %rbx, %rbp, %r11, %r8, %r12, %r13
+	mov	11*8(%rsi), %rdx
+	am6	%rdi, 11, %rcx, 0, %r10, %rax, %rbx, %rbp, %r11, %r8, %r9, %r12, %r13
+	mov	12*8(%rsi), %rdx
+	am6	%rdi, 12, %rcx, 0, %rax, %rbx, %rbp, %r11, %r8, %r9, %r10, %r12, %r13
+	mov	13*8(%rsi), %rdx
+	am6	%rdi, 13, %rcx, 0, %rbx, %rbp, %r11, %r8, %r9, %r10, %rax, %r12, %r13
+
+	mov	%rbp, 14*8(%rdi)
+	mov	%r11, 15*8(%rdi)
+	mov	%r8, 16*8(%rdi)
+	mov	%r9, 17*8(%rdi)
+	mov	%r10, 18*8(%rdi)
+	mov	%rax, 19*8(%rdi)
+
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_14_6_end:
+SIZE(flint_mpn_mul_14_6, .flint_mpn_mul_14_6_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_14_7.asm
+++ b/src/mpn_extras/broadwell/mul_14_7.asm
@@ -1,0 +1,122 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	adcx	\scr1, \r5
+	adcx	\zero, \r6
+.endm
+
+.macro	am7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r7
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r6
+	adox	\r0, \r6
+	adcx	\zero, \r7
+	adox	\zero, \r7
+.endm
+
+.global	FUNC(flint_mpn_mul_14_7)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_14_7)
+
+FUNC(flint_mpn_mul_14_7):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+
+	xor	%r14d, %r14d
+
+	m7	%rdi, 0, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp, %r12, %r13, %r14
+
+	mov	1*8(%rsi), %rdx
+	am7	%rdi, 1, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp, %r12, %r13, %r14
+	mov	2*8(%rsi), %rdx
+	am7	%rdi, 2, %rcx, 0, %r8, %r9, %rax, %r11, %rbx, %rbp, %r12, %r10, %r13, %r14
+	mov	3*8(%rsi), %rdx
+	am7	%rdi, 3, %rcx, 0, %r9, %rax, %r11, %rbx, %rbp, %r12, %r10, %r8, %r13, %r14
+	mov	4*8(%rsi), %rdx
+	am7	%rdi, 4, %rcx, 0, %rax, %r11, %rbx, %rbp, %r12, %r10, %r8, %r9, %r13, %r14
+	mov	5*8(%rsi), %rdx
+	am7	%rdi, 5, %rcx, 0, %r11, %rbx, %rbp, %r12, %r10, %r8, %r9, %rax, %r13, %r14
+	mov	6*8(%rsi), %rdx
+	am7	%rdi, 6, %rcx, 0, %rbx, %rbp, %r12, %r10, %r8, %r9, %rax, %r11, %r13, %r14
+	mov	7*8(%rsi), %rdx
+	am7	%rdi, 7, %rcx, 0, %rbp, %r12, %r10, %r8, %r9, %rax, %r11, %rbx, %r13, %r14
+	mov	8*8(%rsi), %rdx
+	am7	%rdi, 8, %rcx, 0, %r12, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp, %r13, %r14
+	mov	9*8(%rsi), %rdx
+	am7	%rdi, 9, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp, %r12, %r13, %r14
+	mov	10*8(%rsi), %rdx
+	am7	%rdi, 10, %rcx, 0, %r8, %r9, %rax, %r11, %rbx, %rbp, %r12, %r10, %r13, %r14
+	mov	11*8(%rsi), %rdx
+	am7	%rdi, 11, %rcx, 0, %r9, %rax, %r11, %rbx, %rbp, %r12, %r10, %r8, %r13, %r14
+	mov	12*8(%rsi), %rdx
+	am7	%rdi, 12, %rcx, 0, %rax, %r11, %rbx, %rbp, %r12, %r10, %r8, %r9, %r13, %r14
+	mov	13*8(%rsi), %rdx
+	am7	%rdi, 13, %rcx, 0, %r11, %rbx, %rbp, %r12, %r10, %r8, %r9, %rax, %r13, %r14
+
+	mov	%rbx, 14*8(%rdi)
+	mov	%rbp, 15*8(%rdi)
+	mov	%r12, 16*8(%rdi)
+	mov	%r10, 17*8(%rdi)
+	mov	%r8, 18*8(%rdi)
+	mov	%r9, 19*8(%rdi)
+	mov	%rax, 20*8(%rdi)
+
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_14_7_end:
+SIZE(flint_mpn_mul_14_7, .flint_mpn_mul_14_7_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_14_8.asm
+++ b/src/mpn_extras/broadwell/mul_14_8.asm
@@ -1,0 +1,130 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	mulx	(7+\ap_offset)*8(\ap), \scr2, \r7
+	adcx	\scr1, \r5
+	adcx	\scr2, \r6
+	adcx	\zero, \r7
+.endm
+
+.macro	am8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, r8, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r8, \scr
+	adcx	\r8, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r6
+	adox	\r0, \r6
+	mulx	(7+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r7
+	adox	\r0, \r7
+	adcx	\zero, \r8
+	adox	\zero, \r8
+.endm
+
+.global	FUNC(flint_mpn_mul_14_8)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_14_8)
+
+FUNC(flint_mpn_mul_14_8):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+	push	%r15
+
+	xor	%r15d, %r15d
+
+	m8	%rdi, 0, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14, %r15
+
+	mov	1*8(%rsi), %rdx
+	am8	%rdi, 1, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14, %r15
+	mov	2*8(%rsi), %rdx
+	am8	%rdi, 2, %rcx, 0, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12, %r13, %r9, %r14, %r15
+	mov	3*8(%rsi), %rdx
+	am8	%rdi, 3, %rcx, 0, %rax, %r10, %r11, %rbx, %rbp, %r12, %r13, %r9, %r8, %r14, %r15
+	mov	4*8(%rsi), %rdx
+	am8	%rdi, 4, %rcx, 0, %r10, %r11, %rbx, %rbp, %r12, %r13, %r9, %r8, %rax, %r14, %r15
+	mov	5*8(%rsi), %rdx
+	am8	%rdi, 5, %rcx, 0, %r11, %rbx, %rbp, %r12, %r13, %r9, %r8, %rax, %r10, %r14, %r15
+	mov	6*8(%rsi), %rdx
+	am8	%rdi, 6, %rcx, 0, %rbx, %rbp, %r12, %r13, %r9, %r8, %rax, %r10, %r11, %r14, %r15
+	mov	7*8(%rsi), %rdx
+	am8	%rdi, 7, %rcx, 0, %rbp, %r12, %r13, %r9, %r8, %rax, %r10, %r11, %rbx, %r14, %r15
+	mov	8*8(%rsi), %rdx
+	am8	%rdi, 8, %rcx, 0, %r12, %r13, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp, %r14, %r15
+	mov	9*8(%rsi), %rdx
+	am8	%rdi, 9, %rcx, 0, %r13, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12, %r14, %r15
+	mov	10*8(%rsi), %rdx
+	am8	%rdi, 10, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14, %r15
+	mov	11*8(%rsi), %rdx
+	am8	%rdi, 11, %rcx, 0, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12, %r13, %r9, %r14, %r15
+	mov	12*8(%rsi), %rdx
+	am8	%rdi, 12, %rcx, 0, %rax, %r10, %r11, %rbx, %rbp, %r12, %r13, %r9, %r8, %r14, %r15
+	mov	13*8(%rsi), %rdx
+	am8	%rdi, 13, %rcx, 0, %r10, %r11, %rbx, %rbp, %r12, %r13, %r9, %r8, %rax, %r14, %r15
+
+	mov	%r11, 14*8(%rdi)
+	mov	%rbx, 15*8(%rdi)
+	mov	%rbp, 16*8(%rdi)
+	mov	%r12, 17*8(%rdi)
+	mov	%r13, 18*8(%rdi)
+	mov	%r9, 19*8(%rdi)
+	mov	%r8, 20*8(%rdi)
+	mov	%rax, 21*8(%rdi)
+
+	pop	%r15
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_14_8_end:
+SIZE(flint_mpn_mul_14_8, .flint_mpn_mul_14_8_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_15_1.asm
+++ b/src/mpn_extras/broadwell/mul_15_1.asm
@@ -1,0 +1,76 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m15 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5
+	mulx	(0+\ap_offset)*8(\ap), \r0, \r3
+	mulx	(1+\ap_offset)*8(\ap), \r1, \r4
+	mulx	(2+\ap_offset)*8(\ap), \r2, \r5
+	add	\r3, \r1
+	adc	\r4, \r2
+	mov	\r0, (0+\res_offset)*8(\res)
+	mov	\r1, (1+\res_offset)*8(\res)
+	mov	\r2, (2+\res_offset)*8(\res)
+	mulx	(3+\ap_offset)*8(\ap), \r3, \r4
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r1
+	adc	\r3, \r5
+	adc	\r4, \r0
+	mov	\r5, (3+\res_offset)*8(\res)
+	mov	\r0, (4+\res_offset)*8(\res)
+	mulx	(5+\ap_offset)*8(\ap), \r3, \r4
+	mulx	(6+\ap_offset)*8(\ap), \r2, \r5
+	adc	\r3, \r1
+	adc	\r4, \r2
+	mov	\r1, (5+\res_offset)*8(\res)
+	mov	\r2, (6+\res_offset)*8(\res)
+	mulx	(7+\ap_offset)*8(\ap), \r3, \r4
+	mulx	(8+\ap_offset)*8(\ap), \r0, \r1
+	adc	\r3, \r5
+	adc	\r4, \r0
+	mov	\r5, (7+\res_offset)*8(\res)
+	mov	\r0, (8+\res_offset)*8(\res)
+	mulx	(9+\ap_offset)*8(\ap), \r3, \r4
+	mulx	(10+\ap_offset)*8(\ap), \r2, \r5
+	adc	\r3, \r1
+	adc	\r4, \r2
+	mov	\r1, (9+\res_offset)*8(\res)
+	mov	\r2, (10+\res_offset)*8(\res)
+	mulx	(11+\ap_offset)*8(\ap), \r3, \r4
+	mulx	(12+\ap_offset)*8(\ap), \r0, \r1
+	adc	\r3, \r5
+	adc	\r4, \r0
+	mov	\r5, (11+\res_offset)*8(\res)
+	mov	\r0, (12+\res_offset)*8(\res)
+	mulx	(13+\ap_offset)*8(\ap), \r3, \r4
+	mulx	(14+\ap_offset)*8(\ap), \r2, \r5
+	adc	\r3, \r1
+	adc	\r4, \r2
+	mov	\r1, (13+\res_offset)*8(\res)
+	mov	\r2, (14+\res_offset)*8(\res)
+	adc	$0, \r5
+.endm
+.global	FUNC(flint_mpn_mul_15_1)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_15_1)
+
+FUNC(flint_mpn_mul_15_1):
+	.cfi_startproc
+	mov	0*8(%rdx), %rdx
+	m15	%rdi, 0, %rsi, 0, %rcx, %r8, %r9, %r10, %r11, %rax
+	mov	%rax, 15*8(%rdi)
+
+	ret
+.flint_mpn_mul_15_1_end:
+SIZE(flint_mpn_mul_15_1, .flint_mpn_mul_15_1_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_15_2.asm
+++ b/src/mpn_extras/broadwell/mul_15_2.asm
@@ -1,0 +1,114 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	adcx	\scr1, \r3
+	adcx	\zero, \r4
+.endm
+
+.macro	am5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r5
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	adcx	\zero, \r5
+	adox	\zero, \r5
+.endm
+
+.macro	m5_chain res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, ip1, ip2, r0, r1, r2, r3, r4, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	adcx	\ip1, \scr1
+	mov	\scr1, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	adcx	\scr2, \r0
+	adox	\ip2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	adcx	\scr1, \r3
+	adcx	\zero, \r4
+.endm
+
+.global	FUNC(flint_mpn_mul_15_2)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_15_2)
+
+FUNC(flint_mpn_mul_15_2):
+	.cfi_startproc
+	mov	0*8(%rdx), %rcx
+	mov	1*8(%rdx), %r8
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+
+	mov	%rcx, %rdx
+	xor	%r13d, %r13d
+	m5	%rdi, 0, %rsi, 0, %r9, %r10, %r11, %rbx, %rbp, %rax, %r12, %r13
+	mov	%r8, %rdx
+	am5	%rdi, 1, %rsi, 0, %r9, %r10, %r11, %rbx, %rbp, %rax, %r12, %r13
+	mov	%r10, 2*8(%rdi)
+	mov	%r11, 3*8(%rdi)
+	mov	%rbx, 4*8(%rdi)
+
+	mov	%rcx, %rdx
+	m5_chain	%rdi, 5, %rsi, 5, %rbp, %rax, %r9, %r10, %r11, %rbx, %rax, %r12, %rbp, %r13
+	mov	%r8, %rdx
+	am5	%rdi, 6, %rsi, 5, %r9, %r10, %r11, %rbx, %rax, %rbp, %r12, %r13
+	mov	%r10, 7*8(%rdi)
+	mov	%r11, 8*8(%rdi)
+	mov	%rbx, 9*8(%rdi)
+
+	mov	%rcx, %rdx
+	m5_chain	%rdi, 10, %rsi, 10, %rax, %rbp, %r9, %r10, %r11, %rbx, %rbp, %r12, %rax, %r13
+	mov	%r8, %rdx
+	am5	%rdi, 11, %rsi, 10, %r9, %r10, %r11, %rbx, %rbp, %rax, %r12, %r13
+	mov	%r10, 12*8(%rdi)
+	mov	%r11, 13*8(%rdi)
+	mov	%rbx, 14*8(%rdi)
+
+	mov	%rbp, 15*8(%rdi)
+	mov	%rax, 16*8(%rdi)
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_15_2_end:
+SIZE(flint_mpn_mul_15_2, .flint_mpn_mul_15_2_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_15_3.asm
+++ b/src/mpn_extras/broadwell/mul_15_3.asm
@@ -1,0 +1,92 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m3 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	adcx	\scr1, \r1
+	adcx	\zero, \r2
+.endm
+
+.macro	am3 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r3
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r3, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r3
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	adcx	\zero, \r3
+	adox	\zero, \r3
+.endm
+
+.global	FUNC(flint_mpn_mul_15_3)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_15_3)
+
+FUNC(flint_mpn_mul_15_3):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+
+	xor	%ebx, %ebx
+
+	m3	%rdi, 0, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx
+
+	mov	1*8(%rsi), %rdx
+	am3	%rdi, 1, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx
+	mov	2*8(%rsi), %rdx
+	am3	%rdi, 2, %rcx, 0, %r8, %r9, %r10, %rax, %r11, %rbx
+	mov	3*8(%rsi), %rdx
+	am3	%rdi, 3, %rcx, 0, %r9, %r10, %rax, %r8, %r11, %rbx
+	mov	4*8(%rsi), %rdx
+	am3	%rdi, 4, %rcx, 0, %r10, %rax, %r8, %r9, %r11, %rbx
+	mov	5*8(%rsi), %rdx
+	am3	%rdi, 5, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx
+	mov	6*8(%rsi), %rdx
+	am3	%rdi, 6, %rcx, 0, %r8, %r9, %r10, %rax, %r11, %rbx
+	mov	7*8(%rsi), %rdx
+	am3	%rdi, 7, %rcx, 0, %r9, %r10, %rax, %r8, %r11, %rbx
+	mov	8*8(%rsi), %rdx
+	am3	%rdi, 8, %rcx, 0, %r10, %rax, %r8, %r9, %r11, %rbx
+	mov	9*8(%rsi), %rdx
+	am3	%rdi, 9, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx
+	mov	10*8(%rsi), %rdx
+	am3	%rdi, 10, %rcx, 0, %r8, %r9, %r10, %rax, %r11, %rbx
+	mov	11*8(%rsi), %rdx
+	am3	%rdi, 11, %rcx, 0, %r9, %r10, %rax, %r8, %r11, %rbx
+	mov	12*8(%rsi), %rdx
+	am3	%rdi, 12, %rcx, 0, %r10, %rax, %r8, %r9, %r11, %rbx
+	mov	13*8(%rsi), %rdx
+	am3	%rdi, 13, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx
+	mov	14*8(%rsi), %rdx
+	am3	%rdi, 14, %rcx, 0, %r8, %r9, %r10, %rax, %r11, %rbx
+
+	mov	%r9, 15*8(%rdi)
+	mov	%r10, 16*8(%rdi)
+	mov	%rax, 17*8(%rdi)
+
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_15_3_end:
+SIZE(flint_mpn_mul_15_3, .flint_mpn_mul_15_3_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_15_4.asm
+++ b/src/mpn_extras/broadwell/mul_15_4.asm
@@ -1,0 +1,100 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	adcx	\zero, \r3
+.endm
+
+.macro	am4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r4, \scr
+	adcx	\r4, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r4, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	adcx	\zero, \r4
+	adox	\zero, \r4
+.endm
+
+.global	FUNC(flint_mpn_mul_15_4)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_15_4)
+
+FUNC(flint_mpn_mul_15_4):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+
+	xor	%ebp, %ebp
+
+	m4	%rdi, 0, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp
+
+	mov	1*8(%rsi), %rdx
+	am4	%rdi, 1, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp
+	mov	2*8(%rsi), %rdx
+	am4	%rdi, 2, %rcx, 0, %r8, %rax, %r10, %r11, %r9, %rbx, %rbp
+	mov	3*8(%rsi), %rdx
+	am4	%rdi, 3, %rcx, 0, %rax, %r10, %r11, %r9, %r8, %rbx, %rbp
+	mov	4*8(%rsi), %rdx
+	am4	%rdi, 4, %rcx, 0, %r10, %r11, %r9, %r8, %rax, %rbx, %rbp
+	mov	5*8(%rsi), %rdx
+	am4	%rdi, 5, %rcx, 0, %r11, %r9, %r8, %rax, %r10, %rbx, %rbp
+	mov	6*8(%rsi), %rdx
+	am4	%rdi, 6, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp
+	mov	7*8(%rsi), %rdx
+	am4	%rdi, 7, %rcx, 0, %r8, %rax, %r10, %r11, %r9, %rbx, %rbp
+	mov	8*8(%rsi), %rdx
+	am4	%rdi, 8, %rcx, 0, %rax, %r10, %r11, %r9, %r8, %rbx, %rbp
+	mov	9*8(%rsi), %rdx
+	am4	%rdi, 9, %rcx, 0, %r10, %r11, %r9, %r8, %rax, %rbx, %rbp
+	mov	10*8(%rsi), %rdx
+	am4	%rdi, 10, %rcx, 0, %r11, %r9, %r8, %rax, %r10, %rbx, %rbp
+	mov	11*8(%rsi), %rdx
+	am4	%rdi, 11, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp
+	mov	12*8(%rsi), %rdx
+	am4	%rdi, 12, %rcx, 0, %r8, %rax, %r10, %r11, %r9, %rbx, %rbp
+	mov	13*8(%rsi), %rdx
+	am4	%rdi, 13, %rcx, 0, %rax, %r10, %r11, %r9, %r8, %rbx, %rbp
+	mov	14*8(%rsi), %rdx
+	am4	%rdi, 14, %rcx, 0, %r10, %r11, %r9, %r8, %rax, %rbx, %rbp
+
+	mov	%r11, 15*8(%rdi)
+	mov	%r9, 16*8(%rdi)
+	mov	%r8, 17*8(%rdi)
+	mov	%rax, 18*8(%rdi)
+
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_15_4_end:
+SIZE(flint_mpn_mul_15_4, .flint_mpn_mul_15_4_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_15_5.asm
+++ b/src/mpn_extras/broadwell/mul_15_5.asm
@@ -1,0 +1,108 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	adcx	\scr1, \r3
+	adcx	\zero, \r4
+.endm
+
+.macro	am5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r5
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	adcx	\zero, \r5
+	adox	\zero, \r5
+.endm
+
+.global	FUNC(flint_mpn_mul_15_5)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_15_5)
+
+FUNC(flint_mpn_mul_15_5):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+
+	xor	%r12d, %r12d
+
+	m5	%rdi, 0, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12
+
+	mov	1*8(%rsi), %rdx
+	am5	%rdi, 1, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12
+	mov	2*8(%rsi), %rdx
+	am5	%rdi, 2, %rcx, 0, %r8, %r9, %r10, %r11, %rbx, %rax, %rbp, %r12
+	mov	3*8(%rsi), %rdx
+	am5	%rdi, 3, %rcx, 0, %r9, %r10, %r11, %rbx, %rax, %r8, %rbp, %r12
+	mov	4*8(%rsi), %rdx
+	am5	%rdi, 4, %rcx, 0, %r10, %r11, %rbx, %rax, %r8, %r9, %rbp, %r12
+	mov	5*8(%rsi), %rdx
+	am5	%rdi, 5, %rcx, 0, %r11, %rbx, %rax, %r8, %r9, %r10, %rbp, %r12
+	mov	6*8(%rsi), %rdx
+	am5	%rdi, 6, %rcx, 0, %rbx, %rax, %r8, %r9, %r10, %r11, %rbp, %r12
+	mov	7*8(%rsi), %rdx
+	am5	%rdi, 7, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12
+	mov	8*8(%rsi), %rdx
+	am5	%rdi, 8, %rcx, 0, %r8, %r9, %r10, %r11, %rbx, %rax, %rbp, %r12
+	mov	9*8(%rsi), %rdx
+	am5	%rdi, 9, %rcx, 0, %r9, %r10, %r11, %rbx, %rax, %r8, %rbp, %r12
+	mov	10*8(%rsi), %rdx
+	am5	%rdi, 10, %rcx, 0, %r10, %r11, %rbx, %rax, %r8, %r9, %rbp, %r12
+	mov	11*8(%rsi), %rdx
+	am5	%rdi, 11, %rcx, 0, %r11, %rbx, %rax, %r8, %r9, %r10, %rbp, %r12
+	mov	12*8(%rsi), %rdx
+	am5	%rdi, 12, %rcx, 0, %rbx, %rax, %r8, %r9, %r10, %r11, %rbp, %r12
+	mov	13*8(%rsi), %rdx
+	am5	%rdi, 13, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12
+	mov	14*8(%rsi), %rdx
+	am5	%rdi, 14, %rcx, 0, %r8, %r9, %r10, %r11, %rbx, %rax, %rbp, %r12
+
+	mov	%r9, 15*8(%rdi)
+	mov	%r10, 16*8(%rdi)
+	mov	%r11, 17*8(%rdi)
+	mov	%rbx, 18*8(%rdi)
+	mov	%rax, 19*8(%rdi)
+
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_15_5_end:
+SIZE(flint_mpn_mul_15_5, .flint_mpn_mul_15_5_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_15_6.asm
+++ b/src/mpn_extras/broadwell/mul_15_6.asm
@@ -1,0 +1,116 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	adcx	\zero, \r5
+.endm
+
+.macro	am6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r6, \scr
+	adcx	\r6, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	adcx	\zero, \r6
+	adox	\zero, \r6
+.endm
+
+.global	FUNC(flint_mpn_mul_15_6)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_15_6)
+
+FUNC(flint_mpn_mul_15_6):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+
+	xor	%r13d, %r13d
+
+	m6	%rdi, 0, %rcx, 0, %rbx, %r8, %r9, %r10, %r11, %rax, %rbp, %r12, %r13
+
+	mov	1*8(%rsi), %rdx
+	am6	%rdi, 1, %rcx, 0, %rbx, %r8, %r9, %r10, %r11, %rax, %rbp, %r12, %r13
+	mov	2*8(%rsi), %rdx
+	am6	%rdi, 2, %rcx, 0, %r8, %r9, %r10, %r11, %rax, %rbp, %rbx, %r12, %r13
+	mov	3*8(%rsi), %rdx
+	am6	%rdi, 3, %rcx, 0, %r9, %r10, %r11, %rax, %rbp, %rbx, %r8, %r12, %r13
+	mov	4*8(%rsi), %rdx
+	am6	%rdi, 4, %rcx, 0, %r10, %r11, %rax, %rbp, %rbx, %r8, %r9, %r12, %r13
+	mov	5*8(%rsi), %rdx
+	am6	%rdi, 5, %rcx, 0, %r11, %rax, %rbp, %rbx, %r8, %r9, %r10, %r12, %r13
+	mov	6*8(%rsi), %rdx
+	am6	%rdi, 6, %rcx, 0, %rax, %rbp, %rbx, %r8, %r9, %r10, %r11, %r12, %r13
+	mov	7*8(%rsi), %rdx
+	am6	%rdi, 7, %rcx, 0, %rbp, %rbx, %r8, %r9, %r10, %r11, %rax, %r12, %r13
+	mov	8*8(%rsi), %rdx
+	am6	%rdi, 8, %rcx, 0, %rbx, %r8, %r9, %r10, %r11, %rax, %rbp, %r12, %r13
+	mov	9*8(%rsi), %rdx
+	am6	%rdi, 9, %rcx, 0, %r8, %r9, %r10, %r11, %rax, %rbp, %rbx, %r12, %r13
+	mov	10*8(%rsi), %rdx
+	am6	%rdi, 10, %rcx, 0, %r9, %r10, %r11, %rax, %rbp, %rbx, %r8, %r12, %r13
+	mov	11*8(%rsi), %rdx
+	am6	%rdi, 11, %rcx, 0, %r10, %r11, %rax, %rbp, %rbx, %r8, %r9, %r12, %r13
+	mov	12*8(%rsi), %rdx
+	am6	%rdi, 12, %rcx, 0, %r11, %rax, %rbp, %rbx, %r8, %r9, %r10, %r12, %r13
+	mov	13*8(%rsi), %rdx
+	am6	%rdi, 13, %rcx, 0, %rax, %rbp, %rbx, %r8, %r9, %r10, %r11, %r12, %r13
+	mov	14*8(%rsi), %rdx
+	am6	%rdi, 14, %rcx, 0, %rbp, %rbx, %r8, %r9, %r10, %r11, %rax, %r12, %r13
+
+	mov	%rbx, 15*8(%rdi)
+	mov	%r8, 16*8(%rdi)
+	mov	%r9, 17*8(%rdi)
+	mov	%r10, 18*8(%rdi)
+	mov	%r11, 19*8(%rdi)
+	mov	%rax, 20*8(%rdi)
+
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_15_6_end:
+SIZE(flint_mpn_mul_15_6, .flint_mpn_mul_15_6_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_15_7.asm
+++ b/src/mpn_extras/broadwell/mul_15_7.asm
@@ -1,0 +1,124 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	adcx	\scr1, \r5
+	adcx	\zero, \r6
+.endm
+
+.macro	am7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r7
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r6
+	adox	\r0, \r6
+	adcx	\zero, \r7
+	adox	\zero, \r7
+.endm
+
+.global	FUNC(flint_mpn_mul_15_7)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_15_7)
+
+FUNC(flint_mpn_mul_15_7):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+
+	xor	%r14d, %r14d
+
+	m7	%rdi, 0, %rcx, 0, %r11, %r8, %r9, %r10, %rax, %rbx, %rbp, %r12, %r13, %r14
+
+	mov	1*8(%rsi), %rdx
+	am7	%rdi, 1, %rcx, 0, %r11, %r8, %r9, %r10, %rax, %rbx, %rbp, %r12, %r13, %r14
+	mov	2*8(%rsi), %rdx
+	am7	%rdi, 2, %rcx, 0, %r8, %r9, %r10, %rax, %rbx, %rbp, %r12, %r11, %r13, %r14
+	mov	3*8(%rsi), %rdx
+	am7	%rdi, 3, %rcx, 0, %r9, %r10, %rax, %rbx, %rbp, %r12, %r11, %r8, %r13, %r14
+	mov	4*8(%rsi), %rdx
+	am7	%rdi, 4, %rcx, 0, %r10, %rax, %rbx, %rbp, %r12, %r11, %r8, %r9, %r13, %r14
+	mov	5*8(%rsi), %rdx
+	am7	%rdi, 5, %rcx, 0, %rax, %rbx, %rbp, %r12, %r11, %r8, %r9, %r10, %r13, %r14
+	mov	6*8(%rsi), %rdx
+	am7	%rdi, 6, %rcx, 0, %rbx, %rbp, %r12, %r11, %r8, %r9, %r10, %rax, %r13, %r14
+	mov	7*8(%rsi), %rdx
+	am7	%rdi, 7, %rcx, 0, %rbp, %r12, %r11, %r8, %r9, %r10, %rax, %rbx, %r13, %r14
+	mov	8*8(%rsi), %rdx
+	am7	%rdi, 8, %rcx, 0, %r12, %r11, %r8, %r9, %r10, %rax, %rbx, %rbp, %r13, %r14
+	mov	9*8(%rsi), %rdx
+	am7	%rdi, 9, %rcx, 0, %r11, %r8, %r9, %r10, %rax, %rbx, %rbp, %r12, %r13, %r14
+	mov	10*8(%rsi), %rdx
+	am7	%rdi, 10, %rcx, 0, %r8, %r9, %r10, %rax, %rbx, %rbp, %r12, %r11, %r13, %r14
+	mov	11*8(%rsi), %rdx
+	am7	%rdi, 11, %rcx, 0, %r9, %r10, %rax, %rbx, %rbp, %r12, %r11, %r8, %r13, %r14
+	mov	12*8(%rsi), %rdx
+	am7	%rdi, 12, %rcx, 0, %r10, %rax, %rbx, %rbp, %r12, %r11, %r8, %r9, %r13, %r14
+	mov	13*8(%rsi), %rdx
+	am7	%rdi, 13, %rcx, 0, %rax, %rbx, %rbp, %r12, %r11, %r8, %r9, %r10, %r13, %r14
+	mov	14*8(%rsi), %rdx
+	am7	%rdi, 14, %rcx, 0, %rbx, %rbp, %r12, %r11, %r8, %r9, %r10, %rax, %r13, %r14
+
+	mov	%rbp, 15*8(%rdi)
+	mov	%r12, 16*8(%rdi)
+	mov	%r11, 17*8(%rdi)
+	mov	%r8, 18*8(%rdi)
+	mov	%r9, 19*8(%rdi)
+	mov	%r10, 20*8(%rdi)
+	mov	%rax, 21*8(%rdi)
+
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_15_7_end:
+SIZE(flint_mpn_mul_15_7, .flint_mpn_mul_15_7_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_15_8.asm
+++ b/src/mpn_extras/broadwell/mul_15_8.asm
@@ -1,0 +1,132 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	mulx	(7+\ap_offset)*8(\ap), \scr2, \r7
+	adcx	\scr1, \r5
+	adcx	\scr2, \r6
+	adcx	\zero, \r7
+.endm
+
+.macro	am8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, r8, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r8, \scr
+	adcx	\r8, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r6
+	adox	\r0, \r6
+	mulx	(7+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r7
+	adox	\r0, \r7
+	adcx	\zero, \r8
+	adox	\zero, \r8
+.endm
+
+.global	FUNC(flint_mpn_mul_15_8)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_15_8)
+
+FUNC(flint_mpn_mul_15_8):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+	push	%r15
+
+	xor	%r15d, %r15d
+
+	m8	%rdi, 0, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp, %r12, %r13, %r14, %r15
+
+	mov	1*8(%rsi), %rdx
+	am8	%rdi, 1, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp, %r12, %r13, %r14, %r15
+	mov	2*8(%rsi), %rdx
+	am8	%rdi, 2, %rcx, 0, %r8, %r9, %rax, %r11, %rbx, %rbp, %r12, %r13, %r10, %r14, %r15
+	mov	3*8(%rsi), %rdx
+	am8	%rdi, 3, %rcx, 0, %r9, %rax, %r11, %rbx, %rbp, %r12, %r13, %r10, %r8, %r14, %r15
+	mov	4*8(%rsi), %rdx
+	am8	%rdi, 4, %rcx, 0, %rax, %r11, %rbx, %rbp, %r12, %r13, %r10, %r8, %r9, %r14, %r15
+	mov	5*8(%rsi), %rdx
+	am8	%rdi, 5, %rcx, 0, %r11, %rbx, %rbp, %r12, %r13, %r10, %r8, %r9, %rax, %r14, %r15
+	mov	6*8(%rsi), %rdx
+	am8	%rdi, 6, %rcx, 0, %rbx, %rbp, %r12, %r13, %r10, %r8, %r9, %rax, %r11, %r14, %r15
+	mov	7*8(%rsi), %rdx
+	am8	%rdi, 7, %rcx, 0, %rbp, %r12, %r13, %r10, %r8, %r9, %rax, %r11, %rbx, %r14, %r15
+	mov	8*8(%rsi), %rdx
+	am8	%rdi, 8, %rcx, 0, %r12, %r13, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp, %r14, %r15
+	mov	9*8(%rsi), %rdx
+	am8	%rdi, 9, %rcx, 0, %r13, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp, %r12, %r14, %r15
+	mov	10*8(%rsi), %rdx
+	am8	%rdi, 10, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp, %r12, %r13, %r14, %r15
+	mov	11*8(%rsi), %rdx
+	am8	%rdi, 11, %rcx, 0, %r8, %r9, %rax, %r11, %rbx, %rbp, %r12, %r13, %r10, %r14, %r15
+	mov	12*8(%rsi), %rdx
+	am8	%rdi, 12, %rcx, 0, %r9, %rax, %r11, %rbx, %rbp, %r12, %r13, %r10, %r8, %r14, %r15
+	mov	13*8(%rsi), %rdx
+	am8	%rdi, 13, %rcx, 0, %rax, %r11, %rbx, %rbp, %r12, %r13, %r10, %r8, %r9, %r14, %r15
+	mov	14*8(%rsi), %rdx
+	am8	%rdi, 14, %rcx, 0, %r11, %rbx, %rbp, %r12, %r13, %r10, %r8, %r9, %rax, %r14, %r15
+
+	mov	%rbx, 15*8(%rdi)
+	mov	%rbp, 16*8(%rdi)
+	mov	%r12, 17*8(%rdi)
+	mov	%r13, 18*8(%rdi)
+	mov	%r10, 19*8(%rdi)
+	mov	%r8, 20*8(%rdi)
+	mov	%r9, 21*8(%rdi)
+	mov	%rax, 22*8(%rdi)
+
+	pop	%r15
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_15_8_end:
+SIZE(flint_mpn_mul_15_8, .flint_mpn_mul_15_8_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_16_1.asm
+++ b/src/mpn_extras/broadwell/mul_16_1.asm
@@ -1,0 +1,79 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m16 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5
+	mulx	(0+\ap_offset)*8(\ap), \r0, \r3
+	mulx	(1+\ap_offset)*8(\ap), \r1, \r5
+	mulx	(2+\ap_offset)*8(\ap), \r2, \r4
+	add	\r3, \r1
+	adc	\r5, \r2
+	mov	\r0, (0+\res_offset)*8(\res)
+	mov	\r1, (1+\res_offset)*8(\res)
+	mov	\r2, (2+\res_offset)*8(\res)
+	mulx	(3+\ap_offset)*8(\ap), \r3, \r5
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r1
+	adc	\r3, \r4
+	adc	\r5, \r0
+	mov	\r4, (3+\res_offset)*8(\res)
+	mov	\r0, (4+\res_offset)*8(\res)
+	mulx	(5+\ap_offset)*8(\ap), \r3, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r2, \r4
+	adc	\r3, \r1
+	adc	\r5, \r2
+	mov	\r1, (5+\res_offset)*8(\res)
+	mov	\r2, (6+\res_offset)*8(\res)
+	mulx	(7+\ap_offset)*8(\ap), \r3, \r5
+	mulx	(8+\ap_offset)*8(\ap), \r0, \r1
+	adc	\r3, \r4
+	adc	\r5, \r0
+	mov	\r4, (7+\res_offset)*8(\res)
+	mov	\r0, (8+\res_offset)*8(\res)
+	mulx	(9+\ap_offset)*8(\ap), \r3, \r5
+	mulx	(10+\ap_offset)*8(\ap), \r2, \r4
+	adc	\r3, \r1
+	adc	\r5, \r2
+	mov	\r1, (9+\res_offset)*8(\res)
+	mov	\r2, (10+\res_offset)*8(\res)
+	mulx	(11+\ap_offset)*8(\ap), \r3, \r5
+	mulx	(12+\ap_offset)*8(\ap), \r0, \r1
+	adc	\r3, \r4
+	adc	\r5, \r0
+	mov	\r4, (11+\res_offset)*8(\res)
+	mov	\r0, (12+\res_offset)*8(\res)
+	mulx	(13+\ap_offset)*8(\ap), \r3, \r5
+	mulx	(14+\ap_offset)*8(\ap), \r2, \r4
+	adc	\r3, \r1
+	adc	\r5, \r2
+	mov	\r1, (13+\res_offset)*8(\res)
+	mov	\r2, (14+\res_offset)*8(\res)
+	mulx	(15+\ap_offset)*8(\ap), \r3, \r5
+	adc	\r3, \r4
+	adc	$0, \r5
+	mov	\r4, (15+\res_offset)*8(\res)
+.endm
+.global	FUNC(flint_mpn_mul_16_1)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_16_1)
+
+FUNC(flint_mpn_mul_16_1):
+	.cfi_startproc
+	mov	0*8(%rdx), %rdx
+	m16	%rdi, 0, %rsi, 0, %rcx, %r8, %r9, %r10, %r11, %rax
+	mov	%rax, 16*8(%rdi)
+
+	ret
+.flint_mpn_mul_16_1_end:
+SIZE(flint_mpn_mul_16_1, .flint_mpn_mul_16_1_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_16_2.asm
+++ b/src/mpn_extras/broadwell/mul_16_2.asm
@@ -1,0 +1,154 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	adcx	\zero, \r5
+.endm
+
+.macro	am6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r6, \scr
+	adcx	\r6, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	adcx	\zero, \r6
+	adox	\zero, \r6
+.endm
+
+.macro	m6_chain res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, ip1, ip2, r0, r1, r2, r3, r4, r5, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	adcx	\ip1, \scr1
+	mov	\scr1, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	adcx	\scr2, \r0
+	adox	\ip2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	adcx	\zero, \r5
+.endm
+
+.macro	m4_chain res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, ip1, ip2, r0, r1, r2, r3, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	adcx	\ip1, \scr1
+	mov	\scr1, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	adcx	\scr2, \r0
+	adox	\ip2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	adcx	\zero, \r3
+.endm
+
+.macro	am4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r4, \scr
+	adcx	\r4, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r4, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	adcx	\zero, \r4
+	adox	\zero, \r4
+.endm
+
+.global	FUNC(flint_mpn_mul_16_2)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_16_2)
+
+FUNC(flint_mpn_mul_16_2):
+	.cfi_startproc
+	mov	0*8(%rdx), %rcx
+	mov	1*8(%rdx), %r8
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+
+	mov	%rcx, %rdx
+	xor	%r14d, %r14d
+	m6	%rdi, 0, %rsi, 0, %r9, %r10, %r11, %rbx, %rbp, %r12, %rax, %r13, %r14
+	mov	%r8, %rdx
+	am6	%rdi, 1, %rsi, 0, %r9, %r10, %r11, %rbx, %rbp, %r12, %rax, %r13, %r14
+	mov	%r10, 2*8(%rdi)
+	mov	%r11, 3*8(%rdi)
+	mov	%rbx, 4*8(%rdi)
+	mov	%rbp, 5*8(%rdi)
+
+	mov	%rcx, %rdx
+	m6_chain	%rdi, 6, %rsi, 6, %r12, %rax, %r9, %r10, %r11, %rbx, %rbp, %rax, %r13, %r12, %r14
+	mov	%r8, %rdx
+	am6	%rdi, 7, %rsi, 6, %r9, %r10, %r11, %rbx, %rbp, %rax, %r12, %r13, %r14
+	mov	%r10, 8*8(%rdi)
+	mov	%r11, 9*8(%rdi)
+	mov	%rbx, 10*8(%rdi)
+	mov	%rbp, 11*8(%rdi)
+
+	mov	%rcx, %rdx
+	m4_chain	%rdi, 12, %rsi, 12, %rax, %r12, %r9, %r10, %r11, %rbx, %r13, %rax, %r14
+	mov	%r8, %rdx
+	am4	%rdi, 13, %rsi, 12, %r9, %r10, %r11, %rbx, %rax, %r13, %r14
+	mov	%r10, 14*8(%rdi)
+	mov	%r11, 15*8(%rdi)
+	mov	%rbx, 16*8(%rdi)
+	mov	%rax, 17*8(%rdi)
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_16_2_end:
+SIZE(flint_mpn_mul_16_2, .flint_mpn_mul_16_2_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_16_3.asm
+++ b/src/mpn_extras/broadwell/mul_16_3.asm
@@ -1,0 +1,94 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m3 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	adcx	\scr1, \r1
+	adcx	\zero, \r2
+.endm
+
+.macro	am3 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r3
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r3, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r3
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	adcx	\zero, \r3
+	adox	\zero, \r3
+.endm
+
+.global	FUNC(flint_mpn_mul_16_3)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_16_3)
+
+FUNC(flint_mpn_mul_16_3):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+
+	xor	%ebx, %ebx
+
+	m3	%rdi, 0, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx
+
+	mov	1*8(%rsi), %rdx
+	am3	%rdi, 1, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx
+	mov	2*8(%rsi), %rdx
+	am3	%rdi, 2, %rcx, 0, %rax, %r9, %r10, %r8, %r11, %rbx
+	mov	3*8(%rsi), %rdx
+	am3	%rdi, 3, %rcx, 0, %r9, %r10, %r8, %rax, %r11, %rbx
+	mov	4*8(%rsi), %rdx
+	am3	%rdi, 4, %rcx, 0, %r10, %r8, %rax, %r9, %r11, %rbx
+	mov	5*8(%rsi), %rdx
+	am3	%rdi, 5, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx
+	mov	6*8(%rsi), %rdx
+	am3	%rdi, 6, %rcx, 0, %rax, %r9, %r10, %r8, %r11, %rbx
+	mov	7*8(%rsi), %rdx
+	am3	%rdi, 7, %rcx, 0, %r9, %r10, %r8, %rax, %r11, %rbx
+	mov	8*8(%rsi), %rdx
+	am3	%rdi, 8, %rcx, 0, %r10, %r8, %rax, %r9, %r11, %rbx
+	mov	9*8(%rsi), %rdx
+	am3	%rdi, 9, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx
+	mov	10*8(%rsi), %rdx
+	am3	%rdi, 10, %rcx, 0, %rax, %r9, %r10, %r8, %r11, %rbx
+	mov	11*8(%rsi), %rdx
+	am3	%rdi, 11, %rcx, 0, %r9, %r10, %r8, %rax, %r11, %rbx
+	mov	12*8(%rsi), %rdx
+	am3	%rdi, 12, %rcx, 0, %r10, %r8, %rax, %r9, %r11, %rbx
+	mov	13*8(%rsi), %rdx
+	am3	%rdi, 13, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx
+	mov	14*8(%rsi), %rdx
+	am3	%rdi, 14, %rcx, 0, %rax, %r9, %r10, %r8, %r11, %rbx
+	mov	15*8(%rsi), %rdx
+	am3	%rdi, 15, %rcx, 0, %r9, %r10, %r8, %rax, %r11, %rbx
+
+	mov	%r10, 16*8(%rdi)
+	mov	%r8, 17*8(%rdi)
+	mov	%rax, 18*8(%rdi)
+
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_16_3_end:
+SIZE(flint_mpn_mul_16_3, .flint_mpn_mul_16_3_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_16_4.asm
+++ b/src/mpn_extras/broadwell/mul_16_4.asm
@@ -1,0 +1,102 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	adcx	\zero, \r3
+.endm
+
+.macro	am4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r4, \scr
+	adcx	\r4, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r4, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	adcx	\zero, \r4
+	adox	\zero, \r4
+.endm
+
+.global	FUNC(flint_mpn_mul_16_4)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_16_4)
+
+FUNC(flint_mpn_mul_16_4):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+
+	xor	%ebp, %ebp
+
+	m4	%rdi, 0, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp
+
+	mov	1*8(%rsi), %rdx
+	am4	%rdi, 1, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp
+	mov	2*8(%rsi), %rdx
+	am4	%rdi, 2, %rcx, 0, %r8, %r9, %rax, %r11, %r10, %rbx, %rbp
+	mov	3*8(%rsi), %rdx
+	am4	%rdi, 3, %rcx, 0, %r9, %rax, %r11, %r10, %r8, %rbx, %rbp
+	mov	4*8(%rsi), %rdx
+	am4	%rdi, 4, %rcx, 0, %rax, %r11, %r10, %r8, %r9, %rbx, %rbp
+	mov	5*8(%rsi), %rdx
+	am4	%rdi, 5, %rcx, 0, %r11, %r10, %r8, %r9, %rax, %rbx, %rbp
+	mov	6*8(%rsi), %rdx
+	am4	%rdi, 6, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp
+	mov	7*8(%rsi), %rdx
+	am4	%rdi, 7, %rcx, 0, %r8, %r9, %rax, %r11, %r10, %rbx, %rbp
+	mov	8*8(%rsi), %rdx
+	am4	%rdi, 8, %rcx, 0, %r9, %rax, %r11, %r10, %r8, %rbx, %rbp
+	mov	9*8(%rsi), %rdx
+	am4	%rdi, 9, %rcx, 0, %rax, %r11, %r10, %r8, %r9, %rbx, %rbp
+	mov	10*8(%rsi), %rdx
+	am4	%rdi, 10, %rcx, 0, %r11, %r10, %r8, %r9, %rax, %rbx, %rbp
+	mov	11*8(%rsi), %rdx
+	am4	%rdi, 11, %rcx, 0, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp
+	mov	12*8(%rsi), %rdx
+	am4	%rdi, 12, %rcx, 0, %r8, %r9, %rax, %r11, %r10, %rbx, %rbp
+	mov	13*8(%rsi), %rdx
+	am4	%rdi, 13, %rcx, 0, %r9, %rax, %r11, %r10, %r8, %rbx, %rbp
+	mov	14*8(%rsi), %rdx
+	am4	%rdi, 14, %rcx, 0, %rax, %r11, %r10, %r8, %r9, %rbx, %rbp
+	mov	15*8(%rsi), %rdx
+	am4	%rdi, 15, %rcx, 0, %r11, %r10, %r8, %r9, %rax, %rbx, %rbp
+
+	mov	%r10, 16*8(%rdi)
+	mov	%r8, 17*8(%rdi)
+	mov	%r9, 18*8(%rdi)
+	mov	%rax, 19*8(%rdi)
+
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_16_4_end:
+SIZE(flint_mpn_mul_16_4, .flint_mpn_mul_16_4_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_16_5.asm
+++ b/src/mpn_extras/broadwell/mul_16_5.asm
@@ -1,0 +1,110 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	adcx	\scr1, \r3
+	adcx	\zero, \r4
+.endm
+
+.macro	am5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r5
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	adcx	\zero, \r5
+	adox	\zero, \r5
+.endm
+
+.global	FUNC(flint_mpn_mul_16_5)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_16_5)
+
+FUNC(flint_mpn_mul_16_5):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+
+	xor	%r12d, %r12d
+
+	m5	%rdi, 0, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12
+
+	mov	1*8(%rsi), %rdx
+	am5	%rdi, 1, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12
+	mov	2*8(%rsi), %rdx
+	am5	%rdi, 2, %rcx, 0, %rax, %r9, %r10, %r11, %rbx, %r8, %rbp, %r12
+	mov	3*8(%rsi), %rdx
+	am5	%rdi, 3, %rcx, 0, %r9, %r10, %r11, %rbx, %r8, %rax, %rbp, %r12
+	mov	4*8(%rsi), %rdx
+	am5	%rdi, 4, %rcx, 0, %r10, %r11, %rbx, %r8, %rax, %r9, %rbp, %r12
+	mov	5*8(%rsi), %rdx
+	am5	%rdi, 5, %rcx, 0, %r11, %rbx, %r8, %rax, %r9, %r10, %rbp, %r12
+	mov	6*8(%rsi), %rdx
+	am5	%rdi, 6, %rcx, 0, %rbx, %r8, %rax, %r9, %r10, %r11, %rbp, %r12
+	mov	7*8(%rsi), %rdx
+	am5	%rdi, 7, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12
+	mov	8*8(%rsi), %rdx
+	am5	%rdi, 8, %rcx, 0, %rax, %r9, %r10, %r11, %rbx, %r8, %rbp, %r12
+	mov	9*8(%rsi), %rdx
+	am5	%rdi, 9, %rcx, 0, %r9, %r10, %r11, %rbx, %r8, %rax, %rbp, %r12
+	mov	10*8(%rsi), %rdx
+	am5	%rdi, 10, %rcx, 0, %r10, %r11, %rbx, %r8, %rax, %r9, %rbp, %r12
+	mov	11*8(%rsi), %rdx
+	am5	%rdi, 11, %rcx, 0, %r11, %rbx, %r8, %rax, %r9, %r10, %rbp, %r12
+	mov	12*8(%rsi), %rdx
+	am5	%rdi, 12, %rcx, 0, %rbx, %r8, %rax, %r9, %r10, %r11, %rbp, %r12
+	mov	13*8(%rsi), %rdx
+	am5	%rdi, 13, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12
+	mov	14*8(%rsi), %rdx
+	am5	%rdi, 14, %rcx, 0, %rax, %r9, %r10, %r11, %rbx, %r8, %rbp, %r12
+	mov	15*8(%rsi), %rdx
+	am5	%rdi, 15, %rcx, 0, %r9, %r10, %r11, %rbx, %r8, %rax, %rbp, %r12
+
+	mov	%r10, 16*8(%rdi)
+	mov	%r11, 17*8(%rdi)
+	mov	%rbx, 18*8(%rdi)
+	mov	%r8, 19*8(%rdi)
+	mov	%rax, 20*8(%rdi)
+
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_16_5_end:
+SIZE(flint_mpn_mul_16_5, .flint_mpn_mul_16_5_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_16_6.asm
+++ b/src/mpn_extras/broadwell/mul_16_6.asm
@@ -1,0 +1,118 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	adcx	\zero, \r5
+.endm
+
+.macro	am6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r6, \scr
+	adcx	\r6, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	adcx	\zero, \r6
+	adox	\zero, \r6
+.endm
+
+.global	FUNC(flint_mpn_mul_16_6)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_16_6)
+
+FUNC(flint_mpn_mul_16_6):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+
+	xor	%r13d, %r13d
+
+	m6	%rdi, 0, %rcx, 0, %rbp, %r8, %r9, %r10, %r11, %rbx, %rax, %r12, %r13
+
+	mov	1*8(%rsi), %rdx
+	am6	%rdi, 1, %rcx, 0, %rbp, %r8, %r9, %r10, %r11, %rbx, %rax, %r12, %r13
+	mov	2*8(%rsi), %rdx
+	am6	%rdi, 2, %rcx, 0, %r8, %r9, %r10, %r11, %rbx, %rax, %rbp, %r12, %r13
+	mov	3*8(%rsi), %rdx
+	am6	%rdi, 3, %rcx, 0, %r9, %r10, %r11, %rbx, %rax, %rbp, %r8, %r12, %r13
+	mov	4*8(%rsi), %rdx
+	am6	%rdi, 4, %rcx, 0, %r10, %r11, %rbx, %rax, %rbp, %r8, %r9, %r12, %r13
+	mov	5*8(%rsi), %rdx
+	am6	%rdi, 5, %rcx, 0, %r11, %rbx, %rax, %rbp, %r8, %r9, %r10, %r12, %r13
+	mov	6*8(%rsi), %rdx
+	am6	%rdi, 6, %rcx, 0, %rbx, %rax, %rbp, %r8, %r9, %r10, %r11, %r12, %r13
+	mov	7*8(%rsi), %rdx
+	am6	%rdi, 7, %rcx, 0, %rax, %rbp, %r8, %r9, %r10, %r11, %rbx, %r12, %r13
+	mov	8*8(%rsi), %rdx
+	am6	%rdi, 8, %rcx, 0, %rbp, %r8, %r9, %r10, %r11, %rbx, %rax, %r12, %r13
+	mov	9*8(%rsi), %rdx
+	am6	%rdi, 9, %rcx, 0, %r8, %r9, %r10, %r11, %rbx, %rax, %rbp, %r12, %r13
+	mov	10*8(%rsi), %rdx
+	am6	%rdi, 10, %rcx, 0, %r9, %r10, %r11, %rbx, %rax, %rbp, %r8, %r12, %r13
+	mov	11*8(%rsi), %rdx
+	am6	%rdi, 11, %rcx, 0, %r10, %r11, %rbx, %rax, %rbp, %r8, %r9, %r12, %r13
+	mov	12*8(%rsi), %rdx
+	am6	%rdi, 12, %rcx, 0, %r11, %rbx, %rax, %rbp, %r8, %r9, %r10, %r12, %r13
+	mov	13*8(%rsi), %rdx
+	am6	%rdi, 13, %rcx, 0, %rbx, %rax, %rbp, %r8, %r9, %r10, %r11, %r12, %r13
+	mov	14*8(%rsi), %rdx
+	am6	%rdi, 14, %rcx, 0, %rax, %rbp, %r8, %r9, %r10, %r11, %rbx, %r12, %r13
+	mov	15*8(%rsi), %rdx
+	am6	%rdi, 15, %rcx, 0, %rbp, %r8, %r9, %r10, %r11, %rbx, %rax, %r12, %r13
+
+	mov	%r8, 16*8(%rdi)
+	mov	%r9, 17*8(%rdi)
+	mov	%r10, 18*8(%rdi)
+	mov	%r11, 19*8(%rdi)
+	mov	%rbx, 20*8(%rdi)
+	mov	%rax, 21*8(%rdi)
+
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_16_6_end:
+SIZE(flint_mpn_mul_16_6, .flint_mpn_mul_16_6_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_16_7.asm
+++ b/src/mpn_extras/broadwell/mul_16_7.asm
@@ -1,0 +1,126 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	adcx	\scr1, \r5
+	adcx	\zero, \r6
+.endm
+
+.macro	am7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r7
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r6
+	adox	\r0, \r6
+	adcx	\zero, \r7
+	adox	\zero, \r7
+.endm
+
+.global	FUNC(flint_mpn_mul_16_7)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_16_7)
+
+FUNC(flint_mpn_mul_16_7):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+
+	xor	%r14d, %r14d
+
+	m7	%rdi, 0, %rcx, 0, %rbx, %r8, %r9, %r10, %r11, %rax, %rbp, %r12, %r13, %r14
+
+	mov	1*8(%rsi), %rdx
+	am7	%rdi, 1, %rcx, 0, %rbx, %r8, %r9, %r10, %r11, %rax, %rbp, %r12, %r13, %r14
+	mov	2*8(%rsi), %rdx
+	am7	%rdi, 2, %rcx, 0, %r8, %r9, %r10, %r11, %rax, %rbp, %r12, %rbx, %r13, %r14
+	mov	3*8(%rsi), %rdx
+	am7	%rdi, 3, %rcx, 0, %r9, %r10, %r11, %rax, %rbp, %r12, %rbx, %r8, %r13, %r14
+	mov	4*8(%rsi), %rdx
+	am7	%rdi, 4, %rcx, 0, %r10, %r11, %rax, %rbp, %r12, %rbx, %r8, %r9, %r13, %r14
+	mov	5*8(%rsi), %rdx
+	am7	%rdi, 5, %rcx, 0, %r11, %rax, %rbp, %r12, %rbx, %r8, %r9, %r10, %r13, %r14
+	mov	6*8(%rsi), %rdx
+	am7	%rdi, 6, %rcx, 0, %rax, %rbp, %r12, %rbx, %r8, %r9, %r10, %r11, %r13, %r14
+	mov	7*8(%rsi), %rdx
+	am7	%rdi, 7, %rcx, 0, %rbp, %r12, %rbx, %r8, %r9, %r10, %r11, %rax, %r13, %r14
+	mov	8*8(%rsi), %rdx
+	am7	%rdi, 8, %rcx, 0, %r12, %rbx, %r8, %r9, %r10, %r11, %rax, %rbp, %r13, %r14
+	mov	9*8(%rsi), %rdx
+	am7	%rdi, 9, %rcx, 0, %rbx, %r8, %r9, %r10, %r11, %rax, %rbp, %r12, %r13, %r14
+	mov	10*8(%rsi), %rdx
+	am7	%rdi, 10, %rcx, 0, %r8, %r9, %r10, %r11, %rax, %rbp, %r12, %rbx, %r13, %r14
+	mov	11*8(%rsi), %rdx
+	am7	%rdi, 11, %rcx, 0, %r9, %r10, %r11, %rax, %rbp, %r12, %rbx, %r8, %r13, %r14
+	mov	12*8(%rsi), %rdx
+	am7	%rdi, 12, %rcx, 0, %r10, %r11, %rax, %rbp, %r12, %rbx, %r8, %r9, %r13, %r14
+	mov	13*8(%rsi), %rdx
+	am7	%rdi, 13, %rcx, 0, %r11, %rax, %rbp, %r12, %rbx, %r8, %r9, %r10, %r13, %r14
+	mov	14*8(%rsi), %rdx
+	am7	%rdi, 14, %rcx, 0, %rax, %rbp, %r12, %rbx, %r8, %r9, %r10, %r11, %r13, %r14
+	mov	15*8(%rsi), %rdx
+	am7	%rdi, 15, %rcx, 0, %rbp, %r12, %rbx, %r8, %r9, %r10, %r11, %rax, %r13, %r14
+
+	mov	%r12, 16*8(%rdi)
+	mov	%rbx, 17*8(%rdi)
+	mov	%r8, 18*8(%rdi)
+	mov	%r9, 19*8(%rdi)
+	mov	%r10, 20*8(%rdi)
+	mov	%r11, 21*8(%rdi)
+	mov	%rax, 22*8(%rdi)
+
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_16_7_end:
+SIZE(flint_mpn_mul_16_7, .flint_mpn_mul_16_7_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_16_8.asm
+++ b/src/mpn_extras/broadwell/mul_16_8.asm
@@ -1,0 +1,134 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	mulx	(7+\ap_offset)*8(\ap), \scr2, \r7
+	adcx	\scr1, \r5
+	adcx	\scr2, \r6
+	adcx	\zero, \r7
+.endm
+
+.macro	am8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, r8, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r8, \scr
+	adcx	\r8, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r6
+	adox	\r0, \r6
+	mulx	(7+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r7
+	adox	\r0, \r7
+	adcx	\zero, \r8
+	adox	\zero, \r8
+.endm
+
+.global	FUNC(flint_mpn_mul_16_8)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_16_8)
+
+FUNC(flint_mpn_mul_16_8):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+	push	%r15
+
+	xor	%r15d, %r15d
+
+	m8	%rdi, 0, %rcx, 0, %r11, %r8, %r9, %r10, %rax, %rbx, %rbp, %r12, %r13, %r14, %r15
+
+	mov	1*8(%rsi), %rdx
+	am8	%rdi, 1, %rcx, 0, %r11, %r8, %r9, %r10, %rax, %rbx, %rbp, %r12, %r13, %r14, %r15
+	mov	2*8(%rsi), %rdx
+	am8	%rdi, 2, %rcx, 0, %r8, %r9, %r10, %rax, %rbx, %rbp, %r12, %r13, %r11, %r14, %r15
+	mov	3*8(%rsi), %rdx
+	am8	%rdi, 3, %rcx, 0, %r9, %r10, %rax, %rbx, %rbp, %r12, %r13, %r11, %r8, %r14, %r15
+	mov	4*8(%rsi), %rdx
+	am8	%rdi, 4, %rcx, 0, %r10, %rax, %rbx, %rbp, %r12, %r13, %r11, %r8, %r9, %r14, %r15
+	mov	5*8(%rsi), %rdx
+	am8	%rdi, 5, %rcx, 0, %rax, %rbx, %rbp, %r12, %r13, %r11, %r8, %r9, %r10, %r14, %r15
+	mov	6*8(%rsi), %rdx
+	am8	%rdi, 6, %rcx, 0, %rbx, %rbp, %r12, %r13, %r11, %r8, %r9, %r10, %rax, %r14, %r15
+	mov	7*8(%rsi), %rdx
+	am8	%rdi, 7, %rcx, 0, %rbp, %r12, %r13, %r11, %r8, %r9, %r10, %rax, %rbx, %r14, %r15
+	mov	8*8(%rsi), %rdx
+	am8	%rdi, 8, %rcx, 0, %r12, %r13, %r11, %r8, %r9, %r10, %rax, %rbx, %rbp, %r14, %r15
+	mov	9*8(%rsi), %rdx
+	am8	%rdi, 9, %rcx, 0, %r13, %r11, %r8, %r9, %r10, %rax, %rbx, %rbp, %r12, %r14, %r15
+	mov	10*8(%rsi), %rdx
+	am8	%rdi, 10, %rcx, 0, %r11, %r8, %r9, %r10, %rax, %rbx, %rbp, %r12, %r13, %r14, %r15
+	mov	11*8(%rsi), %rdx
+	am8	%rdi, 11, %rcx, 0, %r8, %r9, %r10, %rax, %rbx, %rbp, %r12, %r13, %r11, %r14, %r15
+	mov	12*8(%rsi), %rdx
+	am8	%rdi, 12, %rcx, 0, %r9, %r10, %rax, %rbx, %rbp, %r12, %r13, %r11, %r8, %r14, %r15
+	mov	13*8(%rsi), %rdx
+	am8	%rdi, 13, %rcx, 0, %r10, %rax, %rbx, %rbp, %r12, %r13, %r11, %r8, %r9, %r14, %r15
+	mov	14*8(%rsi), %rdx
+	am8	%rdi, 14, %rcx, 0, %rax, %rbx, %rbp, %r12, %r13, %r11, %r8, %r9, %r10, %r14, %r15
+	mov	15*8(%rsi), %rdx
+	am8	%rdi, 15, %rcx, 0, %rbx, %rbp, %r12, %r13, %r11, %r8, %r9, %r10, %rax, %r14, %r15
+
+	mov	%rbp, 16*8(%rdi)
+	mov	%r12, 17*8(%rdi)
+	mov	%r13, 18*8(%rdi)
+	mov	%r11, 19*8(%rdi)
+	mov	%r8, 20*8(%rdi)
+	mov	%r9, 21*8(%rdi)
+	mov	%r10, 22*8(%rdi)
+	mov	%rax, 23*8(%rdi)
+
+	pop	%r15
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_16_8_end:
+SIZE(flint_mpn_mul_16_8, .flint_mpn_mul_16_8_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_1_1.asm
+++ b/src/mpn_extras/broadwell/mul_1_1.asm
@@ -1,0 +1,30 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.global	FUNC(flint_mpn_mul_1_1)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_1_1)
+
+FUNC(flint_mpn_mul_1_1):
+	.cfi_startproc
+	mov	(%rdx), %rdx
+	mulx	0*8(%rsi), %rcx, %rax
+	mov	%rcx, 0*8(%rdi)
+	mov	%rax, 1*8(%rdi)
+
+	ret
+.flint_mpn_mul_1_1_end:
+SIZE(flint_mpn_mul_1_1, .flint_mpn_mul_1_1_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_2_1.asm
+++ b/src/mpn_extras/broadwell/mul_2_1.asm
@@ -1,0 +1,35 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.global	FUNC(flint_mpn_mul_2_1)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_2_1)
+
+FUNC(flint_mpn_mul_2_1):
+	.cfi_startproc
+	mov	0*8(%rdx), %rdx
+	xor	%r10d, %r10d
+	mulx	0*8(%rsi), %rcx, %r8
+	mulx	1*8(%rsi), %r9, %rax
+	adcx	%r9, %r8
+	adcx	%r10, %rax
+	mov	%rcx, 0*8(%rdi)
+	mov	%r8, 1*8(%rdi)
+	mov	%rax, 2*8(%rdi)
+
+	ret
+.flint_mpn_mul_2_1_end:
+SIZE(flint_mpn_mul_2_1, .flint_mpn_mul_2_1_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_2_2.asm
+++ b/src/mpn_extras/broadwell/mul_2_2.asm
@@ -1,0 +1,44 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.global	FUNC(flint_mpn_mul_2_2)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_2_2)
+
+FUNC(flint_mpn_mul_2_2):
+	.cfi_startproc
+	mov	1*8(%rdx), %r10
+	mov	0*8(%rdx), %rdx
+	xor	%r11d, %r11d
+	mulx	0*8(%rsi), %rcx, %r8
+	mulx	1*8(%rsi), %rax, %r9
+	adcx	%rax, %r8
+	mov	%rcx, 0*8(%rdi)
+	mov	%r10, %rdx
+	mulx	0*8(%rsi), %rcx, %rax
+	adox	%rcx, %r8
+	adcx	%rax, %r9
+	mov	%r8, 1*8(%rdi)
+	mulx	1*8(%rsi), %rcx, %rax
+	adox	%rcx, %r9
+	adcx	%r11, %rax
+	adox	%r11, %rax
+	mov	%r9, 2*8(%rdi)
+	mov	%rax, 3*8(%rdi)
+
+	ret
+.flint_mpn_mul_2_2_end:
+SIZE(flint_mpn_mul_2_2, .flint_mpn_mul_2_2_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_3_1.asm
+++ b/src/mpn_extras/broadwell/mul_3_1.asm
@@ -1,0 +1,40 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m3 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5
+	mulx	(0+\ap_offset)*8(\ap), \r0, \r3
+	mulx	(1+\ap_offset)*8(\ap), \r1, \r4
+	mulx	(2+\ap_offset)*8(\ap), \r2, \r5
+	add	\r3, \r1
+	adc	\r4, \r2
+	mov	\r0, (0+\res_offset)*8(\res)
+	mov	\r1, (1+\res_offset)*8(\res)
+	mov	\r2, (2+\res_offset)*8(\res)
+	adc	$0, \r5
+.endm
+.global	FUNC(flint_mpn_mul_3_1)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_3_1)
+
+FUNC(flint_mpn_mul_3_1):
+	.cfi_startproc
+	mov	0*8(%rdx), %rdx
+	m3	%rdi, 0, %rsi, 0, %rcx, %r8, %r9, %r10, %r11, %rax
+	mov	%rax, 3*8(%rdi)
+
+	ret
+.flint_mpn_mul_3_1_end:
+SIZE(flint_mpn_mul_3_1, .flint_mpn_mul_3_1_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_3_2.asm
+++ b/src/mpn_extras/broadwell/mul_3_2.asm
@@ -1,0 +1,66 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m3 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	adcx	\scr1, \r1
+	adcx	\zero, \r2
+.endm
+
+.macro	am3 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r3
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r3, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r3
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	adcx	\zero, \r3
+	adox	\zero, \r3
+.endm
+
+.global	FUNC(flint_mpn_mul_3_2)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_3_2)
+
+FUNC(flint_mpn_mul_3_2):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+
+	xor	%ebx, %ebx
+
+	m3	%rdi, 0, %rsi, 0, %r10, %r8, %r9, %rax, %r11, %rbx
+
+	mov	1*8(%rcx), %rdx
+	am3	%rdi, 1, %rsi, 0, %r10, %r8, %r9, %rax, %r11, %rbx
+
+	mov	%r8, 2*8(%rdi)
+	mov	%r9, 3*8(%rdi)
+	mov	%rax, 4*8(%rdi)
+
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_3_2_end:
+SIZE(flint_mpn_mul_3_2, .flint_mpn_mul_3_2_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_3_3.asm
+++ b/src/mpn_extras/broadwell/mul_3_3.asm
@@ -1,0 +1,68 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m3 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	adcx	\scr1, \r1
+	adcx	\zero, \r2
+.endm
+
+.macro	am3 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r3
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r3, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r3
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	adcx	\zero, \r3
+	adox	\zero, \r3
+.endm
+
+.global	FUNC(flint_mpn_mul_3_3)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_3_3)
+
+FUNC(flint_mpn_mul_3_3):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+
+	xor	%ebx, %ebx
+
+	m3	%rdi, 0, %rsi, 0, %rax, %r8, %r9, %r10, %r11, %rbx
+
+	mov	1*8(%rcx), %rdx
+	am3	%rdi, 1, %rsi, 0, %rax, %r8, %r9, %r10, %r11, %rbx
+	mov	2*8(%rcx), %rdx
+	am3	%rdi, 2, %rsi, 0, %r8, %r9, %r10, %rax, %r11, %rbx
+
+	mov	%r9, 3*8(%rdi)
+	mov	%r10, 4*8(%rdi)
+	mov	%rax, 5*8(%rdi)
+
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_3_3_end:
+SIZE(flint_mpn_mul_3_3, .flint_mpn_mul_3_3_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_4_1.asm
+++ b/src/mpn_extras/broadwell/mul_4_1.asm
@@ -1,0 +1,43 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5
+	mulx	(0+\ap_offset)*8(\ap), \r0, \r3
+	mulx	(1+\ap_offset)*8(\ap), \r1, \r5
+	mulx	(2+\ap_offset)*8(\ap), \r2, \r4
+	add	\r3, \r1
+	adc	\r5, \r2
+	mov	\r0, (0+\res_offset)*8(\res)
+	mov	\r1, (1+\res_offset)*8(\res)
+	mov	\r2, (2+\res_offset)*8(\res)
+	mulx	(3+\ap_offset)*8(\ap), \r3, \r5
+	adc	\r3, \r4
+	adc	$0, \r5
+	mov	\r4, (3+\res_offset)*8(\res)
+.endm
+.global	FUNC(flint_mpn_mul_4_1)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_4_1)
+
+FUNC(flint_mpn_mul_4_1):
+	.cfi_startproc
+	mov	0*8(%rdx), %rdx
+	m4	%rdi, 0, %rsi, 0, %rcx, %r8, %r9, %r10, %r11, %rax
+	mov	%rax, 4*8(%rdi)
+
+	ret
+.flint_mpn_mul_4_1_end:
+SIZE(flint_mpn_mul_4_1, .flint_mpn_mul_4_1_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_4_2.asm
+++ b/src/mpn_extras/broadwell/mul_4_2.asm
@@ -1,0 +1,74 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	adcx	\zero, \r3
+.endm
+
+.macro	am4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r4, \scr
+	adcx	\r4, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r4, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	adcx	\zero, \r4
+	adox	\zero, \r4
+.endm
+
+.global	FUNC(flint_mpn_mul_4_2)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_4_2)
+
+FUNC(flint_mpn_mul_4_2):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+	push	%rbp
+
+	xor	%ebp, %ebp
+
+	m4	%rdi, 0, %rsi, 0, %r11, %r8, %r9, %r10, %rax, %rbx, %rbp
+
+	mov	1*8(%rcx), %rdx
+	am4	%rdi, 1, %rsi, 0, %r11, %r8, %r9, %r10, %rax, %rbx, %rbp
+
+	mov	%r8, 2*8(%rdi)
+	mov	%r9, 3*8(%rdi)
+	mov	%r10, 4*8(%rdi)
+	mov	%rax, 5*8(%rdi)
+
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_4_2_end:
+SIZE(flint_mpn_mul_4_2, .flint_mpn_mul_4_2_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_4_3.asm
+++ b/src/mpn_extras/broadwell/mul_4_3.asm
@@ -1,0 +1,76 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	adcx	\zero, \r3
+.endm
+
+.macro	am4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r4, \scr
+	adcx	\r4, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r4, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	adcx	\zero, \r4
+	adox	\zero, \r4
+.endm
+
+.global	FUNC(flint_mpn_mul_4_3)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_4_3)
+
+FUNC(flint_mpn_mul_4_3):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+	push	%rbp
+
+	xor	%ebp, %ebp
+
+	m4	%rdi, 0, %rsi, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp
+
+	mov	1*8(%rcx), %rdx
+	am4	%rdi, 1, %rsi, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp
+	mov	2*8(%rcx), %rdx
+	am4	%rdi, 2, %rsi, 0, %r8, %r9, %r10, %r11, %rax, %rbx, %rbp
+
+	mov	%r9, 3*8(%rdi)
+	mov	%r10, 4*8(%rdi)
+	mov	%r11, 5*8(%rdi)
+	mov	%rax, 6*8(%rdi)
+
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_4_3_end:
+SIZE(flint_mpn_mul_4_3, .flint_mpn_mul_4_3_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_4_4.asm
+++ b/src/mpn_extras/broadwell/mul_4_4.asm
@@ -1,0 +1,78 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	adcx	\zero, \r3
+.endm
+
+.macro	am4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r4, \scr
+	adcx	\r4, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r4, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	adcx	\zero, \r4
+	adox	\zero, \r4
+.endm
+
+.global	FUNC(flint_mpn_mul_4_4)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_4_4)
+
+FUNC(flint_mpn_mul_4_4):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+	push	%rbp
+
+	xor	%ebp, %ebp
+
+	m4	%rdi, 0, %rsi, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp
+
+	mov	1*8(%rcx), %rdx
+	am4	%rdi, 1, %rsi, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp
+	mov	2*8(%rcx), %rdx
+	am4	%rdi, 2, %rsi, 0, %rax, %r9, %r10, %r11, %r8, %rbx, %rbp
+	mov	3*8(%rcx), %rdx
+	am4	%rdi, 3, %rsi, 0, %r9, %r10, %r11, %r8, %rax, %rbx, %rbp
+
+	mov	%r10, 4*8(%rdi)
+	mov	%r11, 5*8(%rdi)
+	mov	%r8, 6*8(%rdi)
+	mov	%rax, 7*8(%rdi)
+
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_4_4_end:
+SIZE(flint_mpn_mul_4_4, .flint_mpn_mul_4_4_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_5_1.asm
+++ b/src/mpn_extras/broadwell/mul_5_1.asm
@@ -1,0 +1,46 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5
+	mulx	(0+\ap_offset)*8(\ap), \r0, \r3
+	mulx	(1+\ap_offset)*8(\ap), \r5, \r4
+	mulx	(2+\ap_offset)*8(\ap), \r2, \r1
+	add	\r3, \r5
+	adc	\r4, \r2
+	mov	\r0, (0+\res_offset)*8(\res)
+	mov	\r5, (1+\res_offset)*8(\res)
+	mov	\r2, (2+\res_offset)*8(\res)
+	mulx	(3+\ap_offset)*8(\ap), \r3, \r4
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r5
+	adc	\r3, \r1
+	adc	\r4, \r0
+	mov	\r1, (3+\res_offset)*8(\res)
+	mov	\r0, (4+\res_offset)*8(\res)
+	adc	$0, \r5
+.endm
+.global	FUNC(flint_mpn_mul_5_1)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_5_1)
+
+FUNC(flint_mpn_mul_5_1):
+	.cfi_startproc
+	mov	0*8(%rdx), %rdx
+	m5	%rdi, 0, %rsi, 0, %rcx, %r8, %r9, %r10, %r11, %rax
+	mov	%rax, 5*8(%rdi)
+
+	ret
+.flint_mpn_mul_5_1_end:
+SIZE(flint_mpn_mul_5_1, .flint_mpn_mul_5_1_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_5_2.asm
+++ b/src/mpn_extras/broadwell/mul_5_2.asm
@@ -1,0 +1,82 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	adcx	\scr1, \r3
+	adcx	\zero, \r4
+.endm
+
+.macro	am5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r5
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	adcx	\zero, \r5
+	adox	\zero, \r5
+.endm
+
+.global	FUNC(flint_mpn_mul_5_2)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_5_2)
+
+FUNC(flint_mpn_mul_5_2):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+
+	xor	%r12d, %r12d
+
+	m5	%rdi, 0, %rsi, 0, %rbx, %r8, %r9, %r10, %r11, %rax, %rbp, %r12
+
+	mov	1*8(%rcx), %rdx
+	am5	%rdi, 1, %rsi, 0, %rbx, %r8, %r9, %r10, %r11, %rax, %rbp, %r12
+
+	mov	%r8, 2*8(%rdi)
+	mov	%r9, 3*8(%rdi)
+	mov	%r10, 4*8(%rdi)
+	mov	%r11, 5*8(%rdi)
+	mov	%rax, 6*8(%rdi)
+
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_5_2_end:
+SIZE(flint_mpn_mul_5_2, .flint_mpn_mul_5_2_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_5_3.asm
+++ b/src/mpn_extras/broadwell/mul_5_3.asm
@@ -1,0 +1,84 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	adcx	\scr1, \r3
+	adcx	\zero, \r4
+.endm
+
+.macro	am5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r5
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	adcx	\zero, \r5
+	adox	\zero, \r5
+.endm
+
+.global	FUNC(flint_mpn_mul_5_3)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_5_3)
+
+FUNC(flint_mpn_mul_5_3):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+
+	xor	%r12d, %r12d
+
+	m5	%rdi, 0, %rsi, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12
+
+	mov	1*8(%rcx), %rdx
+	am5	%rdi, 1, %rsi, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12
+	mov	2*8(%rcx), %rdx
+	am5	%rdi, 2, %rsi, 0, %r8, %r9, %r10, %r11, %rbx, %rax, %rbp, %r12
+
+	mov	%r9, 3*8(%rdi)
+	mov	%r10, 4*8(%rdi)
+	mov	%r11, 5*8(%rdi)
+	mov	%rbx, 6*8(%rdi)
+	mov	%rax, 7*8(%rdi)
+
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_5_3_end:
+SIZE(flint_mpn_mul_5_3, .flint_mpn_mul_5_3_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_5_4.asm
+++ b/src/mpn_extras/broadwell/mul_5_4.asm
@@ -1,0 +1,86 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	adcx	\scr1, \r3
+	adcx	\zero, \r4
+.endm
+
+.macro	am5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r5
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	adcx	\zero, \r5
+	adox	\zero, \r5
+.endm
+
+.global	FUNC(flint_mpn_mul_5_4)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_5_4)
+
+FUNC(flint_mpn_mul_5_4):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+
+	xor	%r12d, %r12d
+
+	m5	%rdi, 0, %rsi, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12
+
+	mov	1*8(%rcx), %rdx
+	am5	%rdi, 1, %rsi, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12
+	mov	2*8(%rcx), %rdx
+	am5	%rdi, 2, %rsi, 0, %rax, %r9, %r10, %r11, %rbx, %r8, %rbp, %r12
+	mov	3*8(%rcx), %rdx
+	am5	%rdi, 3, %rsi, 0, %r9, %r10, %r11, %rbx, %r8, %rax, %rbp, %r12
+
+	mov	%r10, 4*8(%rdi)
+	mov	%r11, 5*8(%rdi)
+	mov	%rbx, 6*8(%rdi)
+	mov	%r8, 7*8(%rdi)
+	mov	%rax, 8*8(%rdi)
+
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_5_4_end:
+SIZE(flint_mpn_mul_5_4, .flint_mpn_mul_5_4_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_5_5.asm
+++ b/src/mpn_extras/broadwell/mul_5_5.asm
@@ -1,0 +1,88 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	adcx	\scr1, \r3
+	adcx	\zero, \r4
+.endm
+
+.macro	am5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r5
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	adcx	\zero, \r5
+	adox	\zero, \r5
+.endm
+
+.global	FUNC(flint_mpn_mul_5_5)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_5_5)
+
+FUNC(flint_mpn_mul_5_5):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+
+	xor	%r12d, %r12d
+
+	m5	%rdi, 0, %rsi, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12
+
+	mov	1*8(%rcx), %rdx
+	am5	%rdi, 1, %rsi, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12
+	mov	2*8(%rcx), %rdx
+	am5	%rdi, 2, %rsi, 0, %r8, %rax, %r10, %r11, %rbx, %r9, %rbp, %r12
+	mov	3*8(%rcx), %rdx
+	am5	%rdi, 3, %rsi, 0, %rax, %r10, %r11, %rbx, %r9, %r8, %rbp, %r12
+	mov	4*8(%rcx), %rdx
+	am5	%rdi, 4, %rsi, 0, %r10, %r11, %rbx, %r9, %r8, %rax, %rbp, %r12
+
+	mov	%r11, 5*8(%rdi)
+	mov	%rbx, 6*8(%rdi)
+	mov	%r9, 7*8(%rdi)
+	mov	%r8, 8*8(%rdi)
+	mov	%rax, 9*8(%rdi)
+
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_5_5_end:
+SIZE(flint_mpn_mul_5_5, .flint_mpn_mul_5_5_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_6_1.asm
+++ b/src/mpn_extras/broadwell/mul_6_1.asm
@@ -1,0 +1,49 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5
+	mulx	(0+\ap_offset)*8(\ap), \r0, \r3
+	mulx	(1+\ap_offset)*8(\ap), \r1, \r5
+	mulx	(2+\ap_offset)*8(\ap), \r2, \r4
+	add	\r3, \r1
+	adc	\r5, \r2
+	mov	\r0, (0+\res_offset)*8(\res)
+	mov	\r1, (1+\res_offset)*8(\res)
+	mov	\r2, (2+\res_offset)*8(\res)
+	mulx	(3+\ap_offset)*8(\ap), \r3, \r5
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r1
+	adc	\r3, \r4
+	adc	\r5, \r0
+	mov	\r4, (3+\res_offset)*8(\res)
+	mov	\r0, (4+\res_offset)*8(\res)
+	mulx	(5+\ap_offset)*8(\ap), \r3, \r5
+	adc	\r3, \r1
+	adc	$0, \r5
+	mov	\r1, (5+\res_offset)*8(\res)
+.endm
+.global	FUNC(flint_mpn_mul_6_1)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_6_1)
+
+FUNC(flint_mpn_mul_6_1):
+	.cfi_startproc
+	mov	0*8(%rdx), %rdx
+	m6	%rdi, 0, %rsi, 0, %rcx, %r8, %r9, %r10, %r11, %rax
+	mov	%rax, 6*8(%rdi)
+
+	ret
+.flint_mpn_mul_6_1_end:
+SIZE(flint_mpn_mul_6_1, .flint_mpn_mul_6_1_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_6_2.asm
+++ b/src/mpn_extras/broadwell/mul_6_2.asm
@@ -1,0 +1,90 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	adcx	\zero, \r5
+.endm
+
+.macro	am6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r6, \scr
+	adcx	\r6, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	adcx	\zero, \r6
+	adox	\zero, \r6
+.endm
+
+.global	FUNC(flint_mpn_mul_6_2)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_6_2)
+
+FUNC(flint_mpn_mul_6_2):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+
+	xor	%r13d, %r13d
+
+	m6	%rdi, 0, %rsi, 0, %rbp, %r8, %r9, %r10, %r11, %rbx, %rax, %r12, %r13
+
+	mov	1*8(%rcx), %rdx
+	am6	%rdi, 1, %rsi, 0, %rbp, %r8, %r9, %r10, %r11, %rbx, %rax, %r12, %r13
+
+	mov	%r8, 2*8(%rdi)
+	mov	%r9, 3*8(%rdi)
+	mov	%r10, 4*8(%rdi)
+	mov	%r11, 5*8(%rdi)
+	mov	%rbx, 6*8(%rdi)
+	mov	%rax, 7*8(%rdi)
+
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_6_2_end:
+SIZE(flint_mpn_mul_6_2, .flint_mpn_mul_6_2_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_6_3.asm
+++ b/src/mpn_extras/broadwell/mul_6_3.asm
@@ -1,0 +1,92 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	adcx	\zero, \r5
+.endm
+
+.macro	am6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r6, \scr
+	adcx	\r6, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	adcx	\zero, \r6
+	adox	\zero, \r6
+.endm
+
+.global	FUNC(flint_mpn_mul_6_3)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_6_3)
+
+FUNC(flint_mpn_mul_6_3):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+
+	xor	%r13d, %r13d
+
+	m6	%rdi, 0, %rsi, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13
+
+	mov	1*8(%rcx), %rdx
+	am6	%rdi, 1, %rsi, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13
+	mov	2*8(%rcx), %rdx
+	am6	%rdi, 2, %rsi, 0, %r8, %r9, %r10, %r11, %rbx, %rbp, %rax, %r12, %r13
+
+	mov	%r9, 3*8(%rdi)
+	mov	%r10, 4*8(%rdi)
+	mov	%r11, 5*8(%rdi)
+	mov	%rbx, 6*8(%rdi)
+	mov	%rbp, 7*8(%rdi)
+	mov	%rax, 8*8(%rdi)
+
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_6_3_end:
+SIZE(flint_mpn_mul_6_3, .flint_mpn_mul_6_3_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_6_4.asm
+++ b/src/mpn_extras/broadwell/mul_6_4.asm
@@ -1,0 +1,94 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	adcx	\zero, \r5
+.endm
+
+.macro	am6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r6, \scr
+	adcx	\r6, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	adcx	\zero, \r6
+	adox	\zero, \r6
+.endm
+
+.global	FUNC(flint_mpn_mul_6_4)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_6_4)
+
+FUNC(flint_mpn_mul_6_4):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+
+	xor	%r13d, %r13d
+
+	m6	%rdi, 0, %rsi, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13
+
+	mov	1*8(%rcx), %rdx
+	am6	%rdi, 1, %rsi, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13
+	mov	2*8(%rcx), %rdx
+	am6	%rdi, 2, %rsi, 0, %rax, %r9, %r10, %r11, %rbx, %rbp, %r8, %r12, %r13
+	mov	3*8(%rcx), %rdx
+	am6	%rdi, 3, %rsi, 0, %r9, %r10, %r11, %rbx, %rbp, %r8, %rax, %r12, %r13
+
+	mov	%r10, 4*8(%rdi)
+	mov	%r11, 5*8(%rdi)
+	mov	%rbx, 6*8(%rdi)
+	mov	%rbp, 7*8(%rdi)
+	mov	%r8, 8*8(%rdi)
+	mov	%rax, 9*8(%rdi)
+
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_6_4_end:
+SIZE(flint_mpn_mul_6_4, .flint_mpn_mul_6_4_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_6_5.asm
+++ b/src/mpn_extras/broadwell/mul_6_5.asm
@@ -1,0 +1,96 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	adcx	\zero, \r5
+.endm
+
+.macro	am6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r6, \scr
+	adcx	\r6, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	adcx	\zero, \r6
+	adox	\zero, \r6
+.endm
+
+.global	FUNC(flint_mpn_mul_6_5)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_6_5)
+
+FUNC(flint_mpn_mul_6_5):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+
+	xor	%r13d, %r13d
+
+	m6	%rdi, 0, %rsi, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12, %r13
+
+	mov	1*8(%rcx), %rdx
+	am6	%rdi, 1, %rsi, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12, %r13
+	mov	2*8(%rcx), %rdx
+	am6	%rdi, 2, %rsi, 0, %r8, %rax, %r10, %r11, %rbx, %rbp, %r9, %r12, %r13
+	mov	3*8(%rcx), %rdx
+	am6	%rdi, 3, %rsi, 0, %rax, %r10, %r11, %rbx, %rbp, %r9, %r8, %r12, %r13
+	mov	4*8(%rcx), %rdx
+	am6	%rdi, 4, %rsi, 0, %r10, %r11, %rbx, %rbp, %r9, %r8, %rax, %r12, %r13
+
+	mov	%r11, 5*8(%rdi)
+	mov	%rbx, 6*8(%rdi)
+	mov	%rbp, 7*8(%rdi)
+	mov	%r9, 8*8(%rdi)
+	mov	%r8, 9*8(%rdi)
+	mov	%rax, 10*8(%rdi)
+
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_6_5_end:
+SIZE(flint_mpn_mul_6_5, .flint_mpn_mul_6_5_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_6_6.asm
+++ b/src/mpn_extras/broadwell/mul_6_6.asm
@@ -1,0 +1,98 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	adcx	\zero, \r5
+.endm
+
+.macro	am6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r6, \scr
+	adcx	\r6, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	adcx	\zero, \r6
+	adox	\zero, \r6
+.endm
+
+.global	FUNC(flint_mpn_mul_6_6)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_6_6)
+
+FUNC(flint_mpn_mul_6_6):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+
+	xor	%r13d, %r13d
+
+	m6	%rdi, 0, %rsi, 0, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp, %r12, %r13
+
+	mov	1*8(%rcx), %rdx
+	am6	%rdi, 1, %rsi, 0, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp, %r12, %r13
+	mov	2*8(%rcx), %rdx
+	am6	%rdi, 2, %rsi, 0, %r8, %r9, %rax, %r11, %rbx, %rbp, %r10, %r12, %r13
+	mov	3*8(%rcx), %rdx
+	am6	%rdi, 3, %rsi, 0, %r9, %rax, %r11, %rbx, %rbp, %r10, %r8, %r12, %r13
+	mov	4*8(%rcx), %rdx
+	am6	%rdi, 4, %rsi, 0, %rax, %r11, %rbx, %rbp, %r10, %r8, %r9, %r12, %r13
+	mov	5*8(%rcx), %rdx
+	am6	%rdi, 5, %rsi, 0, %r11, %rbx, %rbp, %r10, %r8, %r9, %rax, %r12, %r13
+
+	mov	%rbx, 6*8(%rdi)
+	mov	%rbp, 7*8(%rdi)
+	mov	%r10, 8*8(%rdi)
+	mov	%r8, 9*8(%rdi)
+	mov	%r9, 10*8(%rdi)
+	mov	%rax, 11*8(%rdi)
+
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_6_6_end:
+SIZE(flint_mpn_mul_6_6, .flint_mpn_mul_6_6_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_7_1.asm
+++ b/src/mpn_extras/broadwell/mul_7_1.asm
@@ -1,0 +1,52 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5
+	mulx	(0+\ap_offset)*8(\ap), \r0, \r3
+	mulx	(1+\ap_offset)*8(\ap), \r1, \r4
+	mulx	(2+\ap_offset)*8(\ap), \r2, \r5
+	add	\r3, \r1
+	adc	\r4, \r2
+	mov	\r0, (0+\res_offset)*8(\res)
+	mov	\r1, (1+\res_offset)*8(\res)
+	mov	\r2, (2+\res_offset)*8(\res)
+	mulx	(3+\ap_offset)*8(\ap), \r3, \r4
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r1
+	adc	\r3, \r5
+	adc	\r4, \r0
+	mov	\r5, (3+\res_offset)*8(\res)
+	mov	\r0, (4+\res_offset)*8(\res)
+	mulx	(5+\ap_offset)*8(\ap), \r3, \r4
+	mulx	(6+\ap_offset)*8(\ap), \r2, \r5
+	adc	\r3, \r1
+	adc	\r4, \r2
+	mov	\r1, (5+\res_offset)*8(\res)
+	mov	\r2, (6+\res_offset)*8(\res)
+	adc	$0, \r5
+.endm
+.global	FUNC(flint_mpn_mul_7_1)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_7_1)
+
+FUNC(flint_mpn_mul_7_1):
+	.cfi_startproc
+	mov	0*8(%rdx), %rdx
+	m7	%rdi, 0, %rsi, 0, %rcx, %r8, %r9, %r10, %r11, %rax
+	mov	%rax, 7*8(%rdi)
+
+	ret
+.flint_mpn_mul_7_1_end:
+SIZE(flint_mpn_mul_7_1, .flint_mpn_mul_7_1_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_7_2.asm
+++ b/src/mpn_extras/broadwell/mul_7_2.asm
@@ -1,0 +1,98 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	adcx	\scr1, \r5
+	adcx	\zero, \r6
+.endm
+
+.macro	am7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r7
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r6
+	adox	\r0, \r6
+	adcx	\zero, \r7
+	adox	\zero, \r7
+.endm
+
+.global	FUNC(flint_mpn_mul_7_2)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_7_2)
+
+FUNC(flint_mpn_mul_7_2):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+
+	xor	%r14d, %r14d
+
+	m7	%rdi, 0, %rsi, 0, %r12, %r8, %r9, %r10, %r11, %rbx, %rbp, %rax, %r13, %r14
+
+	mov	1*8(%rcx), %rdx
+	am7	%rdi, 1, %rsi, 0, %r12, %r8, %r9, %r10, %r11, %rbx, %rbp, %rax, %r13, %r14
+
+	mov	%r8, 2*8(%rdi)
+	mov	%r9, 3*8(%rdi)
+	mov	%r10, 4*8(%rdi)
+	mov	%r11, 5*8(%rdi)
+	mov	%rbx, 6*8(%rdi)
+	mov	%rbp, 7*8(%rdi)
+	mov	%rax, 8*8(%rdi)
+
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_7_2_end:
+SIZE(flint_mpn_mul_7_2, .flint_mpn_mul_7_2_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_7_3.asm
+++ b/src/mpn_extras/broadwell/mul_7_3.asm
@@ -1,0 +1,100 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	adcx	\scr1, \r5
+	adcx	\zero, \r6
+.endm
+
+.macro	am7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r7
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r6
+	adox	\r0, \r6
+	adcx	\zero, \r7
+	adox	\zero, \r7
+.endm
+
+.global	FUNC(flint_mpn_mul_7_3)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_7_3)
+
+FUNC(flint_mpn_mul_7_3):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+
+	xor	%r14d, %r14d
+
+	m7	%rdi, 0, %rsi, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14
+
+	mov	1*8(%rcx), %rdx
+	am7	%rdi, 1, %rsi, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14
+	mov	2*8(%rcx), %rdx
+	am7	%rdi, 2, %rsi, 0, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %rax, %r13, %r14
+
+	mov	%r9, 3*8(%rdi)
+	mov	%r10, 4*8(%rdi)
+	mov	%r11, 5*8(%rdi)
+	mov	%rbx, 6*8(%rdi)
+	mov	%rbp, 7*8(%rdi)
+	mov	%r12, 8*8(%rdi)
+	mov	%rax, 9*8(%rdi)
+
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_7_3_end:
+SIZE(flint_mpn_mul_7_3, .flint_mpn_mul_7_3_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_7_4.asm
+++ b/src/mpn_extras/broadwell/mul_7_4.asm
@@ -1,0 +1,102 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	adcx	\scr1, \r5
+	adcx	\zero, \r6
+.endm
+
+.macro	am7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r7
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r6
+	adox	\r0, \r6
+	adcx	\zero, \r7
+	adox	\zero, \r7
+.endm
+
+.global	FUNC(flint_mpn_mul_7_4)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_7_4)
+
+FUNC(flint_mpn_mul_7_4):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+
+	xor	%r14d, %r14d
+
+	m7	%rdi, 0, %rsi, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14
+
+	mov	1*8(%rcx), %rdx
+	am7	%rdi, 1, %rsi, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14
+	mov	2*8(%rcx), %rdx
+	am7	%rdi, 2, %rsi, 0, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12, %r8, %r13, %r14
+	mov	3*8(%rcx), %rdx
+	am7	%rdi, 3, %rsi, 0, %r9, %r10, %r11, %rbx, %rbp, %r12, %r8, %rax, %r13, %r14
+
+	mov	%r10, 4*8(%rdi)
+	mov	%r11, 5*8(%rdi)
+	mov	%rbx, 6*8(%rdi)
+	mov	%rbp, 7*8(%rdi)
+	mov	%r12, 8*8(%rdi)
+	mov	%r8, 9*8(%rdi)
+	mov	%rax, 10*8(%rdi)
+
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_7_4_end:
+SIZE(flint_mpn_mul_7_4, .flint_mpn_mul_7_4_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_7_5.asm
+++ b/src/mpn_extras/broadwell/mul_7_5.asm
@@ -1,0 +1,104 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	adcx	\scr1, \r5
+	adcx	\zero, \r6
+.endm
+
+.macro	am7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r7
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r6
+	adox	\r0, \r6
+	adcx	\zero, \r7
+	adox	\zero, \r7
+.endm
+
+.global	FUNC(flint_mpn_mul_7_5)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_7_5)
+
+FUNC(flint_mpn_mul_7_5):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+
+	xor	%r14d, %r14d
+
+	m7	%rdi, 0, %rsi, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14
+
+	mov	1*8(%rcx), %rdx
+	am7	%rdi, 1, %rsi, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14
+	mov	2*8(%rcx), %rdx
+	am7	%rdi, 2, %rsi, 0, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12, %r9, %r13, %r14
+	mov	3*8(%rcx), %rdx
+	am7	%rdi, 3, %rsi, 0, %rax, %r10, %r11, %rbx, %rbp, %r12, %r9, %r8, %r13, %r14
+	mov	4*8(%rcx), %rdx
+	am7	%rdi, 4, %rsi, 0, %r10, %r11, %rbx, %rbp, %r12, %r9, %r8, %rax, %r13, %r14
+
+	mov	%r11, 5*8(%rdi)
+	mov	%rbx, 6*8(%rdi)
+	mov	%rbp, 7*8(%rdi)
+	mov	%r12, 8*8(%rdi)
+	mov	%r9, 9*8(%rdi)
+	mov	%r8, 10*8(%rdi)
+	mov	%rax, 11*8(%rdi)
+
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_7_5_end:
+SIZE(flint_mpn_mul_7_5, .flint_mpn_mul_7_5_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_7_6.asm
+++ b/src/mpn_extras/broadwell/mul_7_6.asm
@@ -1,0 +1,106 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	adcx	\scr1, \r5
+	adcx	\zero, \r6
+.endm
+
+.macro	am7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r7
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r6
+	adox	\r0, \r6
+	adcx	\zero, \r7
+	adox	\zero, \r7
+.endm
+
+.global	FUNC(flint_mpn_mul_7_6)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_7_6)
+
+FUNC(flint_mpn_mul_7_6):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+
+	xor	%r14d, %r14d
+
+	m7	%rdi, 0, %rsi, 0, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp, %r12, %r13, %r14
+
+	mov	1*8(%rcx), %rdx
+	am7	%rdi, 1, %rsi, 0, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp, %r12, %r13, %r14
+	mov	2*8(%rcx), %rdx
+	am7	%rdi, 2, %rsi, 0, %r8, %r9, %rax, %r11, %rbx, %rbp, %r12, %r10, %r13, %r14
+	mov	3*8(%rcx), %rdx
+	am7	%rdi, 3, %rsi, 0, %r9, %rax, %r11, %rbx, %rbp, %r12, %r10, %r8, %r13, %r14
+	mov	4*8(%rcx), %rdx
+	am7	%rdi, 4, %rsi, 0, %rax, %r11, %rbx, %rbp, %r12, %r10, %r8, %r9, %r13, %r14
+	mov	5*8(%rcx), %rdx
+	am7	%rdi, 5, %rsi, 0, %r11, %rbx, %rbp, %r12, %r10, %r8, %r9, %rax, %r13, %r14
+
+	mov	%rbx, 6*8(%rdi)
+	mov	%rbp, 7*8(%rdi)
+	mov	%r12, 8*8(%rdi)
+	mov	%r10, 9*8(%rdi)
+	mov	%r8, 10*8(%rdi)
+	mov	%r9, 11*8(%rdi)
+	mov	%rax, 12*8(%rdi)
+
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_7_6_end:
+SIZE(flint_mpn_mul_7_6, .flint_mpn_mul_7_6_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_7_7.asm
+++ b/src/mpn_extras/broadwell/mul_7_7.asm
@@ -1,0 +1,108 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	adcx	\scr1, \r5
+	adcx	\zero, \r6
+.endm
+
+.macro	am7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r7
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r6
+	adox	\r0, \r6
+	adcx	\zero, \r7
+	adox	\zero, \r7
+.endm
+
+.global	FUNC(flint_mpn_mul_7_7)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_7_7)
+
+FUNC(flint_mpn_mul_7_7):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+
+	xor	%r14d, %r14d
+
+	m7	%rdi, 0, %rsi, 0, %r11, %r8, %r9, %r10, %rax, %rbx, %rbp, %r12, %r13, %r14
+
+	mov	1*8(%rcx), %rdx
+	am7	%rdi, 1, %rsi, 0, %r11, %r8, %r9, %r10, %rax, %rbx, %rbp, %r12, %r13, %r14
+	mov	2*8(%rcx), %rdx
+	am7	%rdi, 2, %rsi, 0, %r8, %r9, %r10, %rax, %rbx, %rbp, %r12, %r11, %r13, %r14
+	mov	3*8(%rcx), %rdx
+	am7	%rdi, 3, %rsi, 0, %r9, %r10, %rax, %rbx, %rbp, %r12, %r11, %r8, %r13, %r14
+	mov	4*8(%rcx), %rdx
+	am7	%rdi, 4, %rsi, 0, %r10, %rax, %rbx, %rbp, %r12, %r11, %r8, %r9, %r13, %r14
+	mov	5*8(%rcx), %rdx
+	am7	%rdi, 5, %rsi, 0, %rax, %rbx, %rbp, %r12, %r11, %r8, %r9, %r10, %r13, %r14
+	mov	6*8(%rcx), %rdx
+	am7	%rdi, 6, %rsi, 0, %rbx, %rbp, %r12, %r11, %r8, %r9, %r10, %rax, %r13, %r14
+
+	mov	%rbp, 7*8(%rdi)
+	mov	%r12, 8*8(%rdi)
+	mov	%r11, 9*8(%rdi)
+	mov	%r8, 10*8(%rdi)
+	mov	%r9, 11*8(%rdi)
+	mov	%r10, 12*8(%rdi)
+	mov	%rax, 13*8(%rdi)
+
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_7_7_end:
+SIZE(flint_mpn_mul_7_7, .flint_mpn_mul_7_7_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_8_1.asm
+++ b/src/mpn_extras/broadwell/mul_8_1.asm
@@ -1,0 +1,55 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5
+	mulx	(0+\ap_offset)*8(\ap), \r0, \r3
+	mulx	(1+\ap_offset)*8(\ap), \r1, \r5
+	mulx	(2+\ap_offset)*8(\ap), \r2, \r4
+	add	\r3, \r1
+	adc	\r5, \r2
+	mov	\r0, (0+\res_offset)*8(\res)
+	mov	\r1, (1+\res_offset)*8(\res)
+	mov	\r2, (2+\res_offset)*8(\res)
+	mulx	(3+\ap_offset)*8(\ap), \r3, \r5
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r1
+	adc	\r3, \r4
+	adc	\r5, \r0
+	mov	\r4, (3+\res_offset)*8(\res)
+	mov	\r0, (4+\res_offset)*8(\res)
+	mulx	(5+\ap_offset)*8(\ap), \r3, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r2, \r4
+	adc	\r3, \r1
+	adc	\r5, \r2
+	mov	\r1, (5+\res_offset)*8(\res)
+	mov	\r2, (6+\res_offset)*8(\res)
+	mulx	(7+\ap_offset)*8(\ap), \r3, \r5
+	adc	\r3, \r4
+	adc	$0, \r5
+	mov	\r4, (7+\res_offset)*8(\res)
+.endm
+.global	FUNC(flint_mpn_mul_8_1)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_8_1)
+
+FUNC(flint_mpn_mul_8_1):
+	.cfi_startproc
+	mov	0*8(%rdx), %rdx
+	m8	%rdi, 0, %rsi, 0, %rcx, %r8, %r9, %r10, %r11, %rax
+	mov	%rax, 8*8(%rdi)
+
+	ret
+.flint_mpn_mul_8_1_end:
+SIZE(flint_mpn_mul_8_1, .flint_mpn_mul_8_1_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_8_2.asm
+++ b/src/mpn_extras/broadwell/mul_8_2.asm
@@ -1,0 +1,106 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	mulx	(7+\ap_offset)*8(\ap), \scr2, \r7
+	adcx	\scr1, \r5
+	adcx	\scr2, \r6
+	adcx	\zero, \r7
+.endm
+
+.macro	am8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, r8, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r8, \scr
+	adcx	\r8, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r6
+	adox	\r0, \r6
+	mulx	(7+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r7
+	adox	\r0, \r7
+	adcx	\zero, \r8
+	adox	\zero, \r8
+.endm
+
+.global	FUNC(flint_mpn_mul_8_2)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_8_2)
+
+FUNC(flint_mpn_mul_8_2):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+	push	%r15
+
+	xor	%r15d, %r15d
+
+	m8	%rdi, 0, %rsi, 0, %r13, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %rax, %r14, %r15
+
+	mov	1*8(%rcx), %rdx
+	am8	%rdi, 1, %rsi, 0, %r13, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %rax, %r14, %r15
+
+	mov	%r8, 2*8(%rdi)
+	mov	%r9, 3*8(%rdi)
+	mov	%r10, 4*8(%rdi)
+	mov	%r11, 5*8(%rdi)
+	mov	%rbx, 6*8(%rdi)
+	mov	%rbp, 7*8(%rdi)
+	mov	%r12, 8*8(%rdi)
+	mov	%rax, 9*8(%rdi)
+
+	pop	%r15
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_8_2_end:
+SIZE(flint_mpn_mul_8_2, .flint_mpn_mul_8_2_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_8_3.asm
+++ b/src/mpn_extras/broadwell/mul_8_3.asm
@@ -1,0 +1,108 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	mulx	(7+\ap_offset)*8(\ap), \scr2, \r7
+	adcx	\scr1, \r5
+	adcx	\scr2, \r6
+	adcx	\zero, \r7
+.endm
+
+.macro	am8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, r8, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r8, \scr
+	adcx	\r8, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r6
+	adox	\r0, \r6
+	mulx	(7+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r7
+	adox	\r0, \r7
+	adcx	\zero, \r8
+	adox	\zero, \r8
+.endm
+
+.global	FUNC(flint_mpn_mul_8_3)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_8_3)
+
+FUNC(flint_mpn_mul_8_3):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+	push	%r15
+
+	xor	%r15d, %r15d
+
+	m8	%rdi, 0, %rsi, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14, %r15
+
+	mov	1*8(%rcx), %rdx
+	am8	%rdi, 1, %rsi, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14, %r15
+	mov	2*8(%rcx), %rdx
+	am8	%rdi, 2, %rsi, 0, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %rax, %r14, %r15
+
+	mov	%r9, 3*8(%rdi)
+	mov	%r10, 4*8(%rdi)
+	mov	%r11, 5*8(%rdi)
+	mov	%rbx, 6*8(%rdi)
+	mov	%rbp, 7*8(%rdi)
+	mov	%r12, 8*8(%rdi)
+	mov	%r13, 9*8(%rdi)
+	mov	%rax, 10*8(%rdi)
+
+	pop	%r15
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_8_3_end:
+SIZE(flint_mpn_mul_8_3, .flint_mpn_mul_8_3_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_8_4.asm
+++ b/src/mpn_extras/broadwell/mul_8_4.asm
@@ -1,0 +1,110 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	mulx	(7+\ap_offset)*8(\ap), \scr2, \r7
+	adcx	\scr1, \r5
+	adcx	\scr2, \r6
+	adcx	\zero, \r7
+.endm
+
+.macro	am8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, r8, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r8, \scr
+	adcx	\r8, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r6
+	adox	\r0, \r6
+	mulx	(7+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r7
+	adox	\r0, \r7
+	adcx	\zero, \r8
+	adox	\zero, \r8
+.endm
+
+.global	FUNC(flint_mpn_mul_8_4)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_8_4)
+
+FUNC(flint_mpn_mul_8_4):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+	push	%r15
+
+	xor	%r15d, %r15d
+
+	m8	%rdi, 0, %rsi, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14, %r15
+
+	mov	1*8(%rcx), %rdx
+	am8	%rdi, 1, %rsi, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14, %r15
+	mov	2*8(%rcx), %rdx
+	am8	%rdi, 2, %rsi, 0, %rax, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r8, %r14, %r15
+	mov	3*8(%rcx), %rdx
+	am8	%rdi, 3, %rsi, 0, %r9, %r10, %r11, %rbx, %rbp, %r12, %r13, %r8, %rax, %r14, %r15
+
+	mov	%r10, 4*8(%rdi)
+	mov	%r11, 5*8(%rdi)
+	mov	%rbx, 6*8(%rdi)
+	mov	%rbp, 7*8(%rdi)
+	mov	%r12, 8*8(%rdi)
+	mov	%r13, 9*8(%rdi)
+	mov	%r8, 10*8(%rdi)
+	mov	%rax, 11*8(%rdi)
+
+	pop	%r15
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_8_4_end:
+SIZE(flint_mpn_mul_8_4, .flint_mpn_mul_8_4_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_8_5.asm
+++ b/src/mpn_extras/broadwell/mul_8_5.asm
@@ -1,0 +1,112 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	mulx	(7+\ap_offset)*8(\ap), \scr2, \r7
+	adcx	\scr1, \r5
+	adcx	\scr2, \r6
+	adcx	\zero, \r7
+.endm
+
+.macro	am8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, r8, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r8, \scr
+	adcx	\r8, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r6
+	adox	\r0, \r6
+	mulx	(7+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r7
+	adox	\r0, \r7
+	adcx	\zero, \r8
+	adox	\zero, \r8
+.endm
+
+.global	FUNC(flint_mpn_mul_8_5)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_8_5)
+
+FUNC(flint_mpn_mul_8_5):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+	push	%r15
+
+	xor	%r15d, %r15d
+
+	m8	%rdi, 0, %rsi, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14, %r15
+
+	mov	1*8(%rcx), %rdx
+	am8	%rdi, 1, %rsi, 0, %r9, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12, %r13, %r14, %r15
+	mov	2*8(%rcx), %rdx
+	am8	%rdi, 2, %rsi, 0, %r8, %rax, %r10, %r11, %rbx, %rbp, %r12, %r13, %r9, %r14, %r15
+	mov	3*8(%rcx), %rdx
+	am8	%rdi, 3, %rsi, 0, %rax, %r10, %r11, %rbx, %rbp, %r12, %r13, %r9, %r8, %r14, %r15
+	mov	4*8(%rcx), %rdx
+	am8	%rdi, 4, %rsi, 0, %r10, %r11, %rbx, %rbp, %r12, %r13, %r9, %r8, %rax, %r14, %r15
+
+	mov	%r11, 5*8(%rdi)
+	mov	%rbx, 6*8(%rdi)
+	mov	%rbp, 7*8(%rdi)
+	mov	%r12, 8*8(%rdi)
+	mov	%r13, 9*8(%rdi)
+	mov	%r9, 10*8(%rdi)
+	mov	%r8, 11*8(%rdi)
+	mov	%rax, 12*8(%rdi)
+
+	pop	%r15
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_8_5_end:
+SIZE(flint_mpn_mul_8_5, .flint_mpn_mul_8_5_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_8_6.asm
+++ b/src/mpn_extras/broadwell/mul_8_6.asm
@@ -1,0 +1,114 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	mulx	(7+\ap_offset)*8(\ap), \scr2, \r7
+	adcx	\scr1, \r5
+	adcx	\scr2, \r6
+	adcx	\zero, \r7
+.endm
+
+.macro	am8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, r8, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r8, \scr
+	adcx	\r8, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r6
+	adox	\r0, \r6
+	mulx	(7+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r7
+	adox	\r0, \r7
+	adcx	\zero, \r8
+	adox	\zero, \r8
+.endm
+
+.global	FUNC(flint_mpn_mul_8_6)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_8_6)
+
+FUNC(flint_mpn_mul_8_6):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+	push	%r15
+
+	xor	%r15d, %r15d
+
+	m8	%rdi, 0, %rsi, 0, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp, %r12, %r13, %r14, %r15
+
+	mov	1*8(%rcx), %rdx
+	am8	%rdi, 1, %rsi, 0, %r10, %r8, %r9, %rax, %r11, %rbx, %rbp, %r12, %r13, %r14, %r15
+	mov	2*8(%rcx), %rdx
+	am8	%rdi, 2, %rsi, 0, %r8, %r9, %rax, %r11, %rbx, %rbp, %r12, %r13, %r10, %r14, %r15
+	mov	3*8(%rcx), %rdx
+	am8	%rdi, 3, %rsi, 0, %r9, %rax, %r11, %rbx, %rbp, %r12, %r13, %r10, %r8, %r14, %r15
+	mov	4*8(%rcx), %rdx
+	am8	%rdi, 4, %rsi, 0, %rax, %r11, %rbx, %rbp, %r12, %r13, %r10, %r8, %r9, %r14, %r15
+	mov	5*8(%rcx), %rdx
+	am8	%rdi, 5, %rsi, 0, %r11, %rbx, %rbp, %r12, %r13, %r10, %r8, %r9, %rax, %r14, %r15
+
+	mov	%rbx, 6*8(%rdi)
+	mov	%rbp, 7*8(%rdi)
+	mov	%r12, 8*8(%rdi)
+	mov	%r13, 9*8(%rdi)
+	mov	%r10, 10*8(%rdi)
+	mov	%r8, 11*8(%rdi)
+	mov	%r9, 12*8(%rdi)
+	mov	%rax, 13*8(%rdi)
+
+	pop	%r15
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_8_6_end:
+SIZE(flint_mpn_mul_8_6, .flint_mpn_mul_8_6_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_8_7.asm
+++ b/src/mpn_extras/broadwell/mul_8_7.asm
@@ -1,0 +1,116 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	mulx	(7+\ap_offset)*8(\ap), \scr2, \r7
+	adcx	\scr1, \r5
+	adcx	\scr2, \r6
+	adcx	\zero, \r7
+.endm
+
+.macro	am8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, r8, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r8, \scr
+	adcx	\r8, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r6
+	adox	\r0, \r6
+	mulx	(7+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r7
+	adox	\r0, \r7
+	adcx	\zero, \r8
+	adox	\zero, \r8
+.endm
+
+.global	FUNC(flint_mpn_mul_8_7)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_8_7)
+
+FUNC(flint_mpn_mul_8_7):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+	push	%r15
+
+	xor	%r15d, %r15d
+
+	m8	%rdi, 0, %rsi, 0, %r11, %r8, %r9, %r10, %rax, %rbx, %rbp, %r12, %r13, %r14, %r15
+
+	mov	1*8(%rcx), %rdx
+	am8	%rdi, 1, %rsi, 0, %r11, %r8, %r9, %r10, %rax, %rbx, %rbp, %r12, %r13, %r14, %r15
+	mov	2*8(%rcx), %rdx
+	am8	%rdi, 2, %rsi, 0, %r8, %r9, %r10, %rax, %rbx, %rbp, %r12, %r13, %r11, %r14, %r15
+	mov	3*8(%rcx), %rdx
+	am8	%rdi, 3, %rsi, 0, %r9, %r10, %rax, %rbx, %rbp, %r12, %r13, %r11, %r8, %r14, %r15
+	mov	4*8(%rcx), %rdx
+	am8	%rdi, 4, %rsi, 0, %r10, %rax, %rbx, %rbp, %r12, %r13, %r11, %r8, %r9, %r14, %r15
+	mov	5*8(%rcx), %rdx
+	am8	%rdi, 5, %rsi, 0, %rax, %rbx, %rbp, %r12, %r13, %r11, %r8, %r9, %r10, %r14, %r15
+	mov	6*8(%rcx), %rdx
+	am8	%rdi, 6, %rsi, 0, %rbx, %rbp, %r12, %r13, %r11, %r8, %r9, %r10, %rax, %r14, %r15
+
+	mov	%rbp, 7*8(%rdi)
+	mov	%r12, 8*8(%rdi)
+	mov	%r13, 9*8(%rdi)
+	mov	%r11, 10*8(%rdi)
+	mov	%r8, 11*8(%rdi)
+	mov	%r9, 12*8(%rdi)
+	mov	%r10, 13*8(%rdi)
+	mov	%rax, 14*8(%rdi)
+
+	pop	%r15
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_8_7_end:
+SIZE(flint_mpn_mul_8_7, .flint_mpn_mul_8_7_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_8_8.asm
+++ b/src/mpn_extras/broadwell/mul_8_8.asm
@@ -1,0 +1,118 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	mulx	(7+\ap_offset)*8(\ap), \scr2, \r7
+	adcx	\scr1, \r5
+	adcx	\scr2, \r6
+	adcx	\zero, \r7
+.endm
+
+.macro	am8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, r8, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r8, \scr
+	adcx	\r8, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r6
+	adox	\r0, \r6
+	mulx	(7+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r7
+	adox	\r0, \r7
+	adcx	\zero, \r8
+	adox	\zero, \r8
+.endm
+
+.global	FUNC(flint_mpn_mul_8_8)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_8_8)
+
+FUNC(flint_mpn_mul_8_8):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rcx), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+	push	%r15
+
+	xor	%r15d, %r15d
+
+	m8	%rdi, 0, %rsi, 0, %rbx, %r8, %r9, %r10, %r11, %rax, %rbp, %r12, %r13, %r14, %r15
+
+	mov	1*8(%rcx), %rdx
+	am8	%rdi, 1, %rsi, 0, %rbx, %r8, %r9, %r10, %r11, %rax, %rbp, %r12, %r13, %r14, %r15
+	mov	2*8(%rcx), %rdx
+	am8	%rdi, 2, %rsi, 0, %r8, %r9, %r10, %r11, %rax, %rbp, %r12, %r13, %rbx, %r14, %r15
+	mov	3*8(%rcx), %rdx
+	am8	%rdi, 3, %rsi, 0, %r9, %r10, %r11, %rax, %rbp, %r12, %r13, %rbx, %r8, %r14, %r15
+	mov	4*8(%rcx), %rdx
+	am8	%rdi, 4, %rsi, 0, %r10, %r11, %rax, %rbp, %r12, %r13, %rbx, %r8, %r9, %r14, %r15
+	mov	5*8(%rcx), %rdx
+	am8	%rdi, 5, %rsi, 0, %r11, %rax, %rbp, %r12, %r13, %rbx, %r8, %r9, %r10, %r14, %r15
+	mov	6*8(%rcx), %rdx
+	am8	%rdi, 6, %rsi, 0, %rax, %rbp, %r12, %r13, %rbx, %r8, %r9, %r10, %r11, %r14, %r15
+	mov	7*8(%rcx), %rdx
+	am8	%rdi, 7, %rsi, 0, %rbp, %r12, %r13, %rbx, %r8, %r9, %r10, %r11, %rax, %r14, %r15
+
+	mov	%r12, 8*8(%rdi)
+	mov	%r13, 9*8(%rdi)
+	mov	%rbx, 10*8(%rdi)
+	mov	%r8, 11*8(%rdi)
+	mov	%r9, 12*8(%rdi)
+	mov	%r10, 13*8(%rdi)
+	mov	%r11, 14*8(%rdi)
+	mov	%rax, 15*8(%rdi)
+
+	pop	%r15
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_8_8_end:
+SIZE(flint_mpn_mul_8_8, .flint_mpn_mul_8_8_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_9_1.asm
+++ b/src/mpn_extras/broadwell/mul_9_1.asm
@@ -1,0 +1,58 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m9 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5
+	mulx	(0+\ap_offset)*8(\ap), \r0, \r3
+	mulx	(1+\ap_offset)*8(\ap), \r5, \r4
+	mulx	(2+\ap_offset)*8(\ap), \r2, \r1
+	add	\r3, \r5
+	adc	\r4, \r2
+	mov	\r0, (0+\res_offset)*8(\res)
+	mov	\r5, (1+\res_offset)*8(\res)
+	mov	\r2, (2+\res_offset)*8(\res)
+	mulx	(3+\ap_offset)*8(\ap), \r3, \r4
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r5
+	adc	\r3, \r1
+	adc	\r4, \r0
+	mov	\r1, (3+\res_offset)*8(\res)
+	mov	\r0, (4+\res_offset)*8(\res)
+	mulx	(5+\ap_offset)*8(\ap), \r3, \r4
+	mulx	(6+\ap_offset)*8(\ap), \r2, \r1
+	adc	\r3, \r5
+	adc	\r4, \r2
+	mov	\r5, (5+\res_offset)*8(\res)
+	mov	\r2, (6+\res_offset)*8(\res)
+	mulx	(7+\ap_offset)*8(\ap), \r3, \r4
+	mulx	(8+\ap_offset)*8(\ap), \r0, \r5
+	adc	\r3, \r1
+	adc	\r4, \r0
+	mov	\r1, (7+\res_offset)*8(\res)
+	mov	\r0, (8+\res_offset)*8(\res)
+	adc	$0, \r5
+.endm
+.global	FUNC(flint_mpn_mul_9_1)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_9_1)
+
+FUNC(flint_mpn_mul_9_1):
+	.cfi_startproc
+	mov	0*8(%rdx), %rdx
+	m9	%rdi, 0, %rsi, 0, %rcx, %r8, %r9, %r10, %r11, %rax
+	mov	%rax, 9*8(%rdi)
+
+	ret
+.flint_mpn_mul_9_1_end:
+SIZE(flint_mpn_mul_9_1, .flint_mpn_mul_9_1_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_9_2.asm
+++ b/src/mpn_extras/broadwell/mul_9_2.asm
@@ -1,0 +1,90 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m3 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	adcx	\scr1, \r1
+	adcx	\zero, \r2
+.endm
+
+.macro	am3 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r3
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r3, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r3
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	adcx	\zero, \r3
+	adox	\zero, \r3
+.endm
+
+.macro	m3_chain res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, ip1, ip2, r0, r1, r2, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	adcx	\ip1, \scr1
+	mov	\scr1, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	adcx	\scr2, \r0
+	adox	\ip2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	adcx	\scr1, \r1
+	adcx	\zero, \r2
+.endm
+
+.global	FUNC(flint_mpn_mul_9_2)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_9_2)
+
+FUNC(flint_mpn_mul_9_2):
+	.cfi_startproc
+	mov	0*8(%rdx), %rcx
+	mov	1*8(%rdx), %r8
+	push	%rbx
+	push	%rbp
+
+	mov	%rcx, %rdx
+	xor	%ebp, %ebp
+	m3	%rdi, 0, %rsi, 0, %r9, %r10, %r11, %rax, %rbx, %rbp
+	mov	%r8, %rdx
+	am3	%rdi, 1, %rsi, 0, %r9, %r10, %r11, %rax, %rbx, %rbp
+	mov	%r10, 2*8(%rdi)
+
+	mov	%rcx, %rdx
+	m3_chain	%rdi, 3, %rsi, 3, %r11, %rax, %r9, %r10, %rax, %rbx, %r11, %rbp
+	mov	%r8, %rdx
+	am3	%rdi, 4, %rsi, 3, %r9, %r10, %rax, %r11, %rbx, %rbp
+	mov	%r10, 5*8(%rdi)
+
+	mov	%rcx, %rdx
+	m3_chain	%rdi, 6, %rsi, 6, %rax, %r11, %r9, %r10, %r11, %rbx, %rax, %rbp
+	mov	%r8, %rdx
+	am3	%rdi, 7, %rsi, 6, %r9, %r10, %r11, %rax, %rbx, %rbp
+	mov	%r10, 8*8(%rdi)
+
+	mov	%r11, 9*8(%rdi)
+	mov	%rax, 10*8(%rdi)
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_9_2_end:
+SIZE(flint_mpn_mul_9_2, .flint_mpn_mul_9_2_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_9_3.asm
+++ b/src/mpn_extras/broadwell/mul_9_3.asm
@@ -1,0 +1,80 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m3 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	adcx	\scr1, \r1
+	adcx	\zero, \r2
+.endm
+
+.macro	am3 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r3
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r3, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r3
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	adcx	\zero, \r3
+	adox	\zero, \r3
+.endm
+
+.global	FUNC(flint_mpn_mul_9_3)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_9_3)
+
+FUNC(flint_mpn_mul_9_3):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+
+	xor	%ebx, %ebx
+
+	m3	%rdi, 0, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx
+
+	mov	1*8(%rsi), %rdx
+	am3	%rdi, 1, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx
+	mov	2*8(%rsi), %rdx
+	am3	%rdi, 2, %rcx, 0, %r8, %rax, %r10, %r9, %r11, %rbx
+	mov	3*8(%rsi), %rdx
+	am3	%rdi, 3, %rcx, 0, %rax, %r10, %r9, %r8, %r11, %rbx
+	mov	4*8(%rsi), %rdx
+	am3	%rdi, 4, %rcx, 0, %r10, %r9, %r8, %rax, %r11, %rbx
+	mov	5*8(%rsi), %rdx
+	am3	%rdi, 5, %rcx, 0, %r9, %r8, %rax, %r10, %r11, %rbx
+	mov	6*8(%rsi), %rdx
+	am3	%rdi, 6, %rcx, 0, %r8, %rax, %r10, %r9, %r11, %rbx
+	mov	7*8(%rsi), %rdx
+	am3	%rdi, 7, %rcx, 0, %rax, %r10, %r9, %r8, %r11, %rbx
+	mov	8*8(%rsi), %rdx
+	am3	%rdi, 8, %rcx, 0, %r10, %r9, %r8, %rax, %r11, %rbx
+
+	mov	%r9, 9*8(%rdi)
+	mov	%r8, 10*8(%rdi)
+	mov	%rax, 11*8(%rdi)
+
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_9_3_end:
+SIZE(flint_mpn_mul_9_3, .flint_mpn_mul_9_3_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_9_4.asm
+++ b/src/mpn_extras/broadwell/mul_9_4.asm
@@ -1,0 +1,88 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	adcx	\zero, \r3
+.endm
+
+.macro	am4 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r4, \scr
+	adcx	\r4, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r4, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r4
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	adcx	\zero, \r4
+	adox	\zero, \r4
+.endm
+
+.global	FUNC(flint_mpn_mul_9_4)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_9_4)
+
+FUNC(flint_mpn_mul_9_4):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+
+	xor	%ebp, %ebp
+
+	m4	%rdi, 0, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp
+
+	mov	1*8(%rsi), %rdx
+	am4	%rdi, 1, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp
+	mov	2*8(%rsi), %rdx
+	am4	%rdi, 2, %rcx, 0, %rax, %r9, %r10, %r11, %r8, %rbx, %rbp
+	mov	3*8(%rsi), %rdx
+	am4	%rdi, 3, %rcx, 0, %r9, %r10, %r11, %r8, %rax, %rbx, %rbp
+	mov	4*8(%rsi), %rdx
+	am4	%rdi, 4, %rcx, 0, %r10, %r11, %r8, %rax, %r9, %rbx, %rbp
+	mov	5*8(%rsi), %rdx
+	am4	%rdi, 5, %rcx, 0, %r11, %r8, %rax, %r9, %r10, %rbx, %rbp
+	mov	6*8(%rsi), %rdx
+	am4	%rdi, 6, %rcx, 0, %r8, %rax, %r9, %r10, %r11, %rbx, %rbp
+	mov	7*8(%rsi), %rdx
+	am4	%rdi, 7, %rcx, 0, %rax, %r9, %r10, %r11, %r8, %rbx, %rbp
+	mov	8*8(%rsi), %rdx
+	am4	%rdi, 8, %rcx, 0, %r9, %r10, %r11, %r8, %rax, %rbx, %rbp
+
+	mov	%r10, 9*8(%rdi)
+	mov	%r11, 10*8(%rdi)
+	mov	%r8, 11*8(%rdi)
+	mov	%rax, 12*8(%rdi)
+
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_9_4_end:
+SIZE(flint_mpn_mul_9_4, .flint_mpn_mul_9_4_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_9_5.asm
+++ b/src/mpn_extras/broadwell/mul_9_5.asm
@@ -1,0 +1,96 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	adcx	\scr1, \r3
+	adcx	\zero, \r4
+.endm
+
+.macro	am5 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r5
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r5, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r5
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	adcx	\zero, \r5
+	adox	\zero, \r5
+.endm
+
+.global	FUNC(flint_mpn_mul_9_5)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_9_5)
+
+FUNC(flint_mpn_mul_9_5):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+
+	xor	%r12d, %r12d
+
+	m5	%rdi, 0, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12
+
+	mov	1*8(%rsi), %rdx
+	am5	%rdi, 1, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12
+	mov	2*8(%rsi), %rdx
+	am5	%rdi, 2, %rcx, 0, %r8, %r9, %r10, %r11, %rbx, %rax, %rbp, %r12
+	mov	3*8(%rsi), %rdx
+	am5	%rdi, 3, %rcx, 0, %r9, %r10, %r11, %rbx, %rax, %r8, %rbp, %r12
+	mov	4*8(%rsi), %rdx
+	am5	%rdi, 4, %rcx, 0, %r10, %r11, %rbx, %rax, %r8, %r9, %rbp, %r12
+	mov	5*8(%rsi), %rdx
+	am5	%rdi, 5, %rcx, 0, %r11, %rbx, %rax, %r8, %r9, %r10, %rbp, %r12
+	mov	6*8(%rsi), %rdx
+	am5	%rdi, 6, %rcx, 0, %rbx, %rax, %r8, %r9, %r10, %r11, %rbp, %r12
+	mov	7*8(%rsi), %rdx
+	am5	%rdi, 7, %rcx, 0, %rax, %r8, %r9, %r10, %r11, %rbx, %rbp, %r12
+	mov	8*8(%rsi), %rdx
+	am5	%rdi, 8, %rcx, 0, %r8, %r9, %r10, %r11, %rbx, %rax, %rbp, %r12
+
+	mov	%r9, 9*8(%rdi)
+	mov	%r10, 10*8(%rdi)
+	mov	%r11, 11*8(%rdi)
+	mov	%rbx, 12*8(%rdi)
+	mov	%rax, 13*8(%rdi)
+
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_9_5_end:
+SIZE(flint_mpn_mul_9_5, .flint_mpn_mul_9_5_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_9_6.asm
+++ b/src/mpn_extras/broadwell/mul_9_6.asm
@@ -1,0 +1,104 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	adcx	\zero, \r5
+.endm
+
+.macro	am6 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r6, \scr
+	adcx	\r6, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r6, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r6
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	adcx	\zero, \r6
+	adox	\zero, \r6
+.endm
+
+.global	FUNC(flint_mpn_mul_9_6)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_9_6)
+
+FUNC(flint_mpn_mul_9_6):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+
+	xor	%r13d, %r13d
+
+	m6	%rdi, 0, %rcx, 0, %rbp, %r8, %r9, %r10, %r11, %rbx, %rax, %r12, %r13
+
+	mov	1*8(%rsi), %rdx
+	am6	%rdi, 1, %rcx, 0, %rbp, %r8, %r9, %r10, %r11, %rbx, %rax, %r12, %r13
+	mov	2*8(%rsi), %rdx
+	am6	%rdi, 2, %rcx, 0, %r8, %r9, %r10, %r11, %rbx, %rax, %rbp, %r12, %r13
+	mov	3*8(%rsi), %rdx
+	am6	%rdi, 3, %rcx, 0, %r9, %r10, %r11, %rbx, %rax, %rbp, %r8, %r12, %r13
+	mov	4*8(%rsi), %rdx
+	am6	%rdi, 4, %rcx, 0, %r10, %r11, %rbx, %rax, %rbp, %r8, %r9, %r12, %r13
+	mov	5*8(%rsi), %rdx
+	am6	%rdi, 5, %rcx, 0, %r11, %rbx, %rax, %rbp, %r8, %r9, %r10, %r12, %r13
+	mov	6*8(%rsi), %rdx
+	am6	%rdi, 6, %rcx, 0, %rbx, %rax, %rbp, %r8, %r9, %r10, %r11, %r12, %r13
+	mov	7*8(%rsi), %rdx
+	am6	%rdi, 7, %rcx, 0, %rax, %rbp, %r8, %r9, %r10, %r11, %rbx, %r12, %r13
+	mov	8*8(%rsi), %rdx
+	am6	%rdi, 8, %rcx, 0, %rbp, %r8, %r9, %r10, %r11, %rbx, %rax, %r12, %r13
+
+	mov	%r8, 9*8(%rdi)
+	mov	%r9, 10*8(%rdi)
+	mov	%r10, 11*8(%rdi)
+	mov	%r11, 12*8(%rdi)
+	mov	%rbx, 13*8(%rdi)
+	mov	%rax, 14*8(%rdi)
+
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_9_6_end:
+SIZE(flint_mpn_mul_9_6, .flint_mpn_mul_9_6_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_9_7.asm
+++ b/src/mpn_extras/broadwell/mul_9_7.asm
@@ -1,0 +1,112 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	adcx	\scr1, \r5
+	adcx	\zero, \r6
+.endm
+
+.macro	am7 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr, \r7
+	adcx	\scr, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r7, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \r7
+	adcx	\scr, \r6
+	adox	\r0, \r6
+	adcx	\zero, \r7
+	adox	\zero, \r7
+.endm
+
+.global	FUNC(flint_mpn_mul_9_7)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_9_7)
+
+FUNC(flint_mpn_mul_9_7):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+
+	xor	%r14d, %r14d
+
+	m7	%rdi, 0, %rcx, 0, %rbp, %r8, %r9, %r10, %r11, %rbx, %rax, %r12, %r13, %r14
+
+	mov	1*8(%rsi), %rdx
+	am7	%rdi, 1, %rcx, 0, %rbp, %r8, %r9, %r10, %r11, %rbx, %rax, %r12, %r13, %r14
+	mov	2*8(%rsi), %rdx
+	am7	%rdi, 2, %rcx, 0, %r8, %r9, %r10, %r11, %rbx, %rax, %r12, %rbp, %r13, %r14
+	mov	3*8(%rsi), %rdx
+	am7	%rdi, 3, %rcx, 0, %r9, %r10, %r11, %rbx, %rax, %r12, %rbp, %r8, %r13, %r14
+	mov	4*8(%rsi), %rdx
+	am7	%rdi, 4, %rcx, 0, %r10, %r11, %rbx, %rax, %r12, %rbp, %r8, %r9, %r13, %r14
+	mov	5*8(%rsi), %rdx
+	am7	%rdi, 5, %rcx, 0, %r11, %rbx, %rax, %r12, %rbp, %r8, %r9, %r10, %r13, %r14
+	mov	6*8(%rsi), %rdx
+	am7	%rdi, 6, %rcx, 0, %rbx, %rax, %r12, %rbp, %r8, %r9, %r10, %r11, %r13, %r14
+	mov	7*8(%rsi), %rdx
+	am7	%rdi, 7, %rcx, 0, %rax, %r12, %rbp, %r8, %r9, %r10, %r11, %rbx, %r13, %r14
+	mov	8*8(%rsi), %rdx
+	am7	%rdi, 8, %rcx, 0, %r12, %rbp, %r8, %r9, %r10, %r11, %rbx, %rax, %r13, %r14
+
+	mov	%rbp, 9*8(%rdi)
+	mov	%r8, 10*8(%rdi)
+	mov	%r9, 11*8(%rdi)
+	mov	%r10, 12*8(%rdi)
+	mov	%r11, 13*8(%rdi)
+	mov	%rbx, 14*8(%rdi)
+	mov	%rax, 15*8(%rdi)
+
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_9_7_end:
+SIZE(flint_mpn_mul_9_7, .flint_mpn_mul_9_7_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/mul_9_8.asm
+++ b/src/mpn_extras/broadwell/mul_9_8.asm
@@ -1,0 +1,120 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.macro	m8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, scr1, scr2, zero
+	mulx	(0+\ap_offset)*8(\ap), \scr1, \r0
+	mulx	(1+\ap_offset)*8(\ap), \scr2, \r1
+	mov	\scr1, \res_offset*8(\res)
+	adcx	\scr2, \r0
+	mulx	(2+\ap_offset)*8(\ap), \scr1, \r2
+	mulx	(3+\ap_offset)*8(\ap), \scr2, \r3
+	adcx	\scr1, \r1
+	adcx	\scr2, \r2
+	mulx	(4+\ap_offset)*8(\ap), \scr1, \r4
+	mulx	(5+\ap_offset)*8(\ap), \scr2, \r5
+	adcx	\scr1, \r3
+	adcx	\scr2, \r4
+	mulx	(6+\ap_offset)*8(\ap), \scr1, \r6
+	mulx	(7+\ap_offset)*8(\ap), \scr2, \r7
+	adcx	\scr1, \r5
+	adcx	\scr2, \r6
+	adcx	\zero, \r7
+.endm
+
+.macro	am8 res=%rdi, res_offset=0, ap=%rsi, ap_offset=0, r0, r1, r2, r3, r4, r5, r6, r7, r8, scr, zero
+	mulx	(0+\ap_offset)*8(\ap), \r8, \scr
+	adcx	\r8, \r0
+	mov	\r0, \res_offset*8(\res)
+	mulx	(1+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r1
+	adox	\r0, \r1
+	mulx	(2+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r2
+	adox	\r0, \r2
+	mulx	(3+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r3
+	adox	\r0, \r3
+	mulx	(4+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r4
+	adox	\r0, \r4
+	mulx	(5+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r5
+	adox	\r0, \r5
+	mulx	(6+\ap_offset)*8(\ap), \r0, \scr
+	adcx	\r8, \r6
+	adox	\r0, \r6
+	mulx	(7+\ap_offset)*8(\ap), \r0, \r8
+	adcx	\scr, \r7
+	adox	\r0, \r7
+	adcx	\zero, \r8
+	adox	\zero, \r8
+.endm
+
+.global	FUNC(flint_mpn_mul_9_8)
+.p2align	4, 0x90
+TYPE(flint_mpn_mul_9_8)
+
+FUNC(flint_mpn_mul_9_8):
+	.cfi_startproc
+	mov	%rdx, %rcx
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+	push	%r15
+
+	xor	%r15d, %r15d
+
+	m8	%rdi, 0, %rcx, 0, %rbp, %r8, %r9, %r10, %r11, %rbx, %rax, %r12, %r13, %r14, %r15
+
+	mov	1*8(%rsi), %rdx
+	am8	%rdi, 1, %rcx, 0, %rbp, %r8, %r9, %r10, %r11, %rbx, %rax, %r12, %r13, %r14, %r15
+	mov	2*8(%rsi), %rdx
+	am8	%rdi, 2, %rcx, 0, %r8, %r9, %r10, %r11, %rbx, %rax, %r12, %r13, %rbp, %r14, %r15
+	mov	3*8(%rsi), %rdx
+	am8	%rdi, 3, %rcx, 0, %r9, %r10, %r11, %rbx, %rax, %r12, %r13, %rbp, %r8, %r14, %r15
+	mov	4*8(%rsi), %rdx
+	am8	%rdi, 4, %rcx, 0, %r10, %r11, %rbx, %rax, %r12, %r13, %rbp, %r8, %r9, %r14, %r15
+	mov	5*8(%rsi), %rdx
+	am8	%rdi, 5, %rcx, 0, %r11, %rbx, %rax, %r12, %r13, %rbp, %r8, %r9, %r10, %r14, %r15
+	mov	6*8(%rsi), %rdx
+	am8	%rdi, 6, %rcx, 0, %rbx, %rax, %r12, %r13, %rbp, %r8, %r9, %r10, %r11, %r14, %r15
+	mov	7*8(%rsi), %rdx
+	am8	%rdi, 7, %rcx, 0, %rax, %r12, %r13, %rbp, %r8, %r9, %r10, %r11, %rbx, %r14, %r15
+	mov	8*8(%rsi), %rdx
+	am8	%rdi, 8, %rcx, 0, %r12, %r13, %rbp, %r8, %r9, %r10, %r11, %rbx, %rax, %r14, %r15
+
+	mov	%r13, 9*8(%rdi)
+	mov	%rbp, 10*8(%rdi)
+	mov	%r8, 11*8(%rdi)
+	mov	%r9, 12*8(%rdi)
+	mov	%r10, 13*8(%rdi)
+	mov	%r11, 14*8(%rdi)
+	mov	%rbx, 15*8(%rdi)
+	mov	%rax, 16*8(%rdi)
+
+	pop	%r15
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mul_9_8_end:
+SIZE(flint_mpn_mul_9_8, .flint_mpn_mul_9_8_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/sqr_1.asm
+++ b/src/mpn_extras/broadwell/sqr_1.asm
@@ -1,0 +1,30 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.global	FUNC(flint_mpn_sqr_1)
+.p2align	4, 0x90
+TYPE(flint_mpn_sqr_1)
+
+FUNC(flint_mpn_sqr_1):
+	.cfi_startproc
+	mov	0*8(%rsi), %rdx
+	mulx	%rdx, %rcx, %rax
+	mov	%rcx, 0*8(%rdi)
+	mov	%rax, 1*8(%rdi)
+
+	ret
+.flint_mpn_sqr_1_end:
+SIZE(flint_mpn_sqr_1, .flint_mpn_sqr_1_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/sqr_2.asm
+++ b/src/mpn_extras/broadwell/sqr_2.asm
@@ -1,0 +1,42 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.global	FUNC(flint_mpn_sqr_2)
+.p2align	4, 0x90
+TYPE(flint_mpn_sqr_2)
+
+FUNC(flint_mpn_sqr_2):
+	.cfi_startproc
+	mov	0*8(%rsi), %rdx
+	xor	%r9d, %r9d
+	mulx	1*8(%rsi), %rcx, %r8
+	add	%rcx, %rcx
+	adc	%r8, %r8
+	adc	%r9, %r9
+	mulx	%rdx, %r10, %rax
+	mov	%r10, 0*8(%rdi)
+	add	%rax, %rcx
+	mov	1*8(%rsi), %rdx
+	mov	%rcx, 1*8(%rdi)
+	mulx	%rdx, %r10, %rax
+	adc	%r10, %r8
+	adc	%r9, %rax
+	mov	%r8, 2*8(%rdi)
+	mov	%rax, 3*8(%rdi)
+
+	ret
+.flint_mpn_sqr_2_end:
+SIZE(flint_mpn_sqr_2, .flint_mpn_sqr_2_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/sqr_3.asm
+++ b/src/mpn_extras/broadwell/sqr_3.asm
@@ -1,0 +1,57 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.global	FUNC(flint_mpn_sqr_3)
+.p2align	4, 0x90
+TYPE(flint_mpn_sqr_3)
+
+FUNC(flint_mpn_sqr_3):
+	.cfi_startproc
+	mov	0*8(%rsi), %rdx
+	xor	%r11d, %r11d
+	mulx	1*8(%rsi), %rcx, %rax
+	mulx	2*8(%rsi), %r8, %r9
+	mov	1*8(%rsi), %rdx
+	add	%rax, %r8
+	mulx	2*8(%rsi), %rax, %r10
+	adc	%rax, %r9
+	adc	%r11, %r10
+	mov	0*8(%rsi), %rdx
+	add	%rcx, %rcx
+	adc	%r8, %r8
+	adc	%r9, %r9
+	adc	%r10, %r10
+	adc	%r11, %r11
+	mulx	%rdx, %rdx, %rax
+	mov	%rdx, 0*8(%rdi)
+	add	%rax, %rcx
+	mov	1*8(%rsi), %rdx
+	mov	%rcx, 1*8(%rdi)
+	mulx	%rdx, %rdx, %rax
+	adc	%rdx, %r8
+	adc	%rax, %r9
+	mov	2*8(%rsi), %rdx
+	mov	%r8, 2*8(%rdi)
+	mov	%r9, 3*8(%rdi)
+	mulx	%rdx, %rdx, %rax
+	adc	%rdx, %r10
+	adc	%r11, %rax
+	mov	%r10, 4*8(%rdi)
+	mov	%rax, 5*8(%rdi)
+
+	ret
+.flint_mpn_sqr_3_end:
+SIZE(flint_mpn_sqr_3, .flint_mpn_sqr_3_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/sqr_4.asm
+++ b/src/mpn_extras/broadwell/sqr_4.asm
@@ -1,0 +1,78 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.global	FUNC(flint_mpn_sqr_4)
+.p2align	4, 0x90
+TYPE(flint_mpn_sqr_4)
+
+FUNC(flint_mpn_sqr_4):
+	.cfi_startproc
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	xor	%ebp, %ebp
+	mulx	1*8(%rsi), %rcx, %r11
+	mulx	2*8(%rsi), %r8, %rbx
+	mulx	3*8(%rsi), %r9, %r10
+	mov	1*8(%rsi), %rdx
+	adox	%r11, %r8
+	adox	%rbx, %r9
+	mulx	2*8(%rsi), %r11, %rbx
+	adcx	%r11, %r9
+	adcx	%rbx, %r10
+	mulx	3*8(%rsi), %rbx, %r11
+	mov	2*8(%rsi), %rdx
+	adox	%rbx, %r10
+	adox	%rbp, %r11
+	mulx	3*8(%rsi), %rdx, %rbx
+	adcx	%rdx, %r11
+	adc	%rbp, %rbx
+	mov	0*8(%rsi), %rdx
+	add	%rcx, %rcx
+	adc	%r8, %r8
+	adc	%r9, %r9
+	adc	%r10, %r10
+	adc	%r11, %r11
+	adc	%rbx, %rbx
+	setc	%bpl
+	mulx	%rdx, %rdx, %rax
+	mov	%rdx, 0*8(%rdi)
+	add	%rax, %rcx
+	mov	1*8(%rsi), %rdx
+	mov	%rcx, 1*8(%rdi)
+	mulx	%rdx, %rdx, %rax
+	adc	%rdx, %r8
+	adc	%rax, %r9
+	mov	2*8(%rsi), %rdx
+	mov	%r8, 2*8(%rdi)
+	mov	%r9, 3*8(%rdi)
+	mulx	%rdx, %rcx, %rax
+	adc	%rcx, %r10
+	adc	%rax, %r11
+	mov	3*8(%rsi), %rdx
+	mov	%r10, 4*8(%rdi)
+	mov	%r11, 5*8(%rdi)
+	mulx	%rdx, %rcx, %rax
+	adc	%rcx, %rbx
+	adc	%rbp, %rax
+	mov	%rbx, 6*8(%rdi)
+	mov	%rax, 7*8(%rdi)
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_sqr_4_end:
+SIZE(flint_mpn_sqr_4, .flint_mpn_sqr_4_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/sqr_5.asm
+++ b/src/mpn_extras/broadwell/sqr_5.asm
@@ -1,0 +1,103 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.global	FUNC(flint_mpn_sqr_5)
+.p2align	4, 0x90
+TYPE(flint_mpn_sqr_5)
+
+FUNC(flint_mpn_sqr_5):
+	.cfi_startproc
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	xor	%r13d, %r13d
+	mulx	1*8(%rsi), %rcx, %rbx
+	mulx	2*8(%rsi), %r8, %rbp
+	mulx	3*8(%rsi), %r9, %r12
+	mulx	4*8(%rsi), %r10, %r11
+	adcx	%rbx, %r8
+	adcx	%rbp, %r9
+	adcx	%r12, %r10
+	adcx	%r13, %r11
+	mov	1*8(%rsi), %rdx
+	mulx	2*8(%rsi), %r12, %rbx
+	adcx	%r12, %r9
+	adcx	%rbx, %r10
+	mulx	3*8(%rsi), %r12, %rbx
+	adox	%r12, %r10
+	adox	%rbx, %r11
+	mulx	4*8(%rsi), %r12, %rbx
+	adcx	%r12, %r11
+	adcx	%r13, %rbx
+	mov	2*8(%rsi), %rdx
+	mulx	3*8(%rsi), %r12, %rbp
+	adcx	%r12, %r11
+	adcx	%rbp, %rbx
+	mulx	4*8(%rsi), %r12, %rbp
+	adox	%r12, %rbx
+	adox	%r13, %rbp
+	mov	3*8(%rsi), %rdx
+	mulx	4*8(%rsi), %rdx, %r12
+	adcx	%rdx, %rbp
+	adc	%r13, %r12
+	mov	0*8(%rsi), %rdx
+	add	%rcx, %rcx
+	adc	%r8, %r8
+	adc	%r9, %r9
+	adc	%r10, %r10
+	adc	%r11, %r11
+	adc	%rbx, %rbx
+	adc	%rbp, %rbp
+	adc	%r12, %r12
+	adc	%r13, %r13
+	mulx	%rdx, %rdx, %rax
+	mov	%rdx, 0*8(%rdi)
+	add	%rax, %rcx
+	mov	1*8(%rsi), %rdx
+	mov	%rcx, 1*8(%rdi)
+	mulx	%rdx, %rdx, %rax
+	adc	%rdx, %r8
+	adc	%rax, %r9
+	mov	2*8(%rsi), %rdx
+	mov	%r8, 2*8(%rdi)
+	mov	%r9, 3*8(%rdi)
+	mulx	%rdx, %rcx, %rax
+	adc	%rcx, %r10
+	adc	%rax, %r11
+	mov	3*8(%rsi), %rdx
+	mov	%r10, 4*8(%rdi)
+	mov	%r11, 5*8(%rdi)
+	mulx	%rdx, %rcx, %rax
+	adc	%rcx, %rbx
+	adc	%rax, %rbp
+	mov	4*8(%rsi), %rdx
+	mov	%rbx, 6*8(%rdi)
+	mov	%rbp, 7*8(%rdi)
+	mulx	%rdx, %rcx, %rax
+	adc	%rcx, %r12
+	adc	%r13, %rax
+	mov	%r12, 8*8(%rdi)
+	mov	%rax, 9*8(%rdi)
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_sqr_5_end:
+SIZE(flint_mpn_sqr_5, .flint_mpn_sqr_5_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/sqr_6.asm
+++ b/src/mpn_extras/broadwell/sqr_6.asm
@@ -1,0 +1,131 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.global	FUNC(flint_mpn_sqr_6)
+.p2align	4, 0x90
+TYPE(flint_mpn_sqr_6)
+
+FUNC(flint_mpn_sqr_6):
+	.cfi_startproc
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+	push	%r15
+	xor	%r15d, %r15d
+	mulx	1*8(%rsi), %rcx, %rbp
+	mulx	2*8(%rsi), %r8, %r12
+	mulx	3*8(%rsi), %r9, %r13
+	mulx	4*8(%rsi), %r10, %r14
+	mulx	5*8(%rsi), %r11, %rbx
+	adcx	%rbp, %r8
+	adcx	%r12, %r9
+	adcx	%r13, %r10
+	adcx	%r14, %r11
+	adcx	%r15, %rbx
+	mov	1*8(%rsi), %rdx
+	mulx	2*8(%rsi), %r14, %rbp
+	adcx	%r14, %r9
+	adcx	%rbp, %r10
+	mulx	3*8(%rsi), %r14, %rbp
+	adox	%r14, %r10
+	adox	%rbp, %r11
+	mulx	4*8(%rsi), %r14, %rbp
+	adcx	%r14, %r11
+	adcx	%rbp, %rbx
+	mulx	5*8(%rsi), %r14, %rbp
+	adox	%r14, %rbx
+	adox	%r15, %rbp
+	adcx	%r15, %rbp
+	mov	2*8(%rsi), %rdx
+	mulx	3*8(%rsi), %r14, %r12
+	adcx	%r14, %r11
+	adcx	%r12, %rbx
+	mulx	4*8(%rsi), %r14, %r12
+	adox	%r14, %rbx
+	adox	%r12, %rbp
+	mulx	5*8(%rsi), %r14, %r12
+	adcx	%r14, %rbp
+	adcx	%r15, %r12
+	mov	3*8(%rsi), %rdx
+	mulx	4*8(%rsi), %r14, %r13
+	adcx	%r14, %rbp
+	adcx	%r13, %r12
+	mulx	5*8(%rsi), %r14, %r13
+	adox	%r14, %r12
+	adox	%r15, %r13
+	mov	4*8(%rsi), %rdx
+	mulx	5*8(%rsi), %rdx, %r14
+	adcx	%rdx, %r13
+	adc	%r15, %r14
+	mov	0*8(%rsi), %rdx
+	add	%rcx, %rcx
+	adc	%r8, %r8
+	adc	%r9, %r9
+	adc	%r10, %r10
+	adc	%r11, %r11
+	adc	%rbx, %rbx
+	adc	%rbp, %rbp
+	adc	%r12, %r12
+	adc	%r13, %r13
+	adc	%r14, %r14
+	setc	%r15b
+	mulx	%rdx, %rdx, %rax
+	mov	%rdx, 0*8(%rdi)
+	mov	1*8(%rsi), %rdx
+	add	%rax, %rcx
+	mov	%rcx, 1*8(%rdi)
+	mulx	%rdx, %rdx, %rax
+	adc	%rdx, %r8
+	adc	%rax, %r9
+	mov	2*8(%rsi), %rdx
+	mov	%r8, 2*8(%rdi)
+	mov	%r9, 3*8(%rdi)
+	mulx	%rdx, %rcx, %rax
+	adc	%rcx, %r10
+	adc	%rax, %r11
+	mov	3*8(%rsi), %rdx
+	mov	%r10, 4*8(%rdi)
+	mov	%r11, 5*8(%rdi)
+	mulx	%rdx, %rcx, %rax
+	adc	%rcx, %rbx
+	adc	%rax, %rbp
+	mov	4*8(%rsi), %rdx
+	mov	%rbx, 6*8(%rdi)
+	mov	%rbp, 7*8(%rdi)
+	mulx	%rdx, %rcx, %rax
+	adc	%rcx, %r12
+	adc	%rax, %r13
+	mov	5*8(%rsi), %rdx
+	mov	%r12, 8*8(%rdi)
+	mov	%r13, 9*8(%rdi)
+	mulx	%rdx, %rcx, %rax
+	adc	%rcx, %r14
+	adc	%r15, %rax
+	mov	%r14, 10*8(%rdi)
+	mov	%rax, 11*8(%rdi)
+	pop	%r15
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_sqr_6_end:
+SIZE(flint_mpn_sqr_6, .flint_mpn_sqr_6_end)
+.cfi_endproc

--- a/src/mpn_extras/broadwell/sqr_7.asm
+++ b/src/mpn_extras/broadwell/sqr_7.asm
@@ -1,0 +1,163 @@
+#
+#   Copyright (C) 2023 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 2.1 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#
+
+include(`config.m4')dnl
+dnl
+.text
+
+.global	FUNC(flint_mpn_sqr_7)
+.p2align	4, 0x90
+TYPE(flint_mpn_sqr_7)
+
+FUNC(flint_mpn_sqr_7):
+	.cfi_startproc
+	mov	0*8(%rsi), %rdx
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+	push	%r15
+	xor	%r10d, %r10d
+	mulx	1*8(%rsi), %rcx, %r11
+	mulx	2*8(%rsi), %r8, %rbx
+	mulx	3*8(%rsi), %r9, %r14
+	adcx	%r11, %r8
+	adcx	%rbx, %r9
+	mulx	4*8(%rsi), %rax, %r12
+	mulx	5*8(%rsi), %r11, %r13
+	mulx	6*8(%rsi), %rbx, %rbp
+	adcx	%r14, %rax
+	adcx	%r12, %r11
+	mov	1*8(%rsi), %rdx
+	adcx	%r13, %rbx
+	adcx	%r10, %rbp
+	mulx	2*8(%rsi), %r14, %r12
+	mulx	3*8(%rsi), %r15, %r13
+	adcx	%r14, %r9
+	adcx	%r12, %rax
+	adox	%r15, %rax
+	adox	%r13, %r11
+	mulx	4*8(%rsi), %r14, %r12
+	mulx	5*8(%rsi), %r15, %r13
+	adcx	%r14, %r11
+	adcx	%r12, %rbx
+	mulx	6*8(%rsi), %r14, %r12
+	adox	%r15, %rbx
+	adox	%r13, %rbp
+	mov	2*8(%rsi), %rdx
+	adcx	%r14, %rbp
+	adox	%r10, %r12
+	adcx	%r10, %r12
+	mulx	3*8(%rsi), %r15, %r13
+	adox	%r15, %r11
+	adox	%r13, %rbx
+	mulx	4*8(%rsi), %r15, %r13
+	adcx	%r15, %rbx
+	adcx	%r13, %rbp
+	mulx	5*8(%rsi), %r15, %r13
+	adox	%r15, %rbp
+	adox	%r13, %r12
+	mulx	6*8(%rsi), %r15, %r13
+	adcx	%r15, %r12
+	adox	%r10, %r13
+	mov	3*8(%rsi), %rdx
+	adcx	%r10, %r13
+	mulx	4*8(%rsi), %r15, %r14
+	adcx	%r15, %rbp
+	adcx	%r14, %r12
+	mulx	5*8(%rsi), %r15, %r14
+	adox	%r15, %r12
+	adox	%r14, %r13
+	mulx	6*8(%rsi), %r15, %r14
+	mov	4*8(%rsi), %rdx
+	adcx	%r15, %r13
+	adcx	%r10, %r14
+	mulx	5*8(%rsi), %r10, %r15
+	adcx	%r10, %r13
+	adcx	%r15, %r14
+	mulx	6*8(%rsi), %r10, %r15
+	mov	$0, %edx
+	adox	%r10, %r14
+	adox	%rdx, %r15
+	mov	5*8(%rsi), %rdx
+	mulx	6*8(%rsi), %rdx, %r10
+	adcx	%rdx, %r15
+	adc	$0, %r10
+	test	%al, %al
+	mov	0*8(%rsi), %rdx
+	adcx	%rcx, %rcx
+	adcx	%r8, %r8
+	adcx	%r9, %r9
+	adcx	%rax, %rax
+	adcx	%r11, %r11
+	adcx	%rbx, %rbx
+	push	%rax
+	adcx	%rbp, %rbp
+	adcx	%r12, %r12
+	adcx	%r13, %r13
+	adcx	%r14, %r14
+	adcx	%r15, %r15
+	adcx	%r10, %r10
+	mulx	%rdx, %rdx, %rax
+	mov	%rdx, 0*8(%rdi)
+	adox	%rax, %rcx
+	mov	1*8(%rsi), %rdx
+	mov	%rcx, 1*8(%rdi)
+	mulx	%rdx, %rdx, %rax
+	adox	%rdx, %r8
+	adox	%rax, %r9
+	pop	%rcx
+	mov	2*8(%rsi), %rdx
+	mov	%r8, 2*8(%rdi)
+	mov	%r9, 3*8(%rdi)
+	mulx	%rdx, %rdx, %rax
+	adox	%rdx, %rcx
+	adox	%rax, %r11
+	mov	3*8(%rsi), %rdx
+	mov	%rcx, 4*8(%rdi)
+	mov	%r11, 5*8(%rdi)
+	mulx	%rdx, %r8, %rax
+	adox	%r8, %rbx
+	adox	%rax, %rbp
+	mov	4*8(%rsi), %rdx
+	mov	%rbx, 6*8(%rdi)
+	mov	%rbp, 7*8(%rdi)
+	mulx	%rdx, %r8, %rax
+	adox	%r8, %r12
+	adox	%rax, %r13
+	mov	5*8(%rsi), %rdx
+	mov	%r12, 8*8(%rdi)
+	mov	%r13, 9*8(%rdi)
+	mulx	%rdx, %r8, %rax
+	adox	%r8, %r14
+	adox	%rax, %r15
+	mov	$0, %ecx
+	mov	6*8(%rsi), %rdx
+	mov	%r14, 10*8(%rdi)
+	mov	%r15, 11*8(%rdi)
+	mulx	%rdx, %r8, %rax
+	adox	%r8, %r10
+	adox	%rcx, %rax
+	adcx	%rcx, %rax
+	mov	%r10, 12*8(%rdi)
+	mov	%rax, 13*8(%rdi)
+	pop	%r15
+	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_sqr_7_end:
+SIZE(flint_mpn_sqr_7, .flint_mpn_sqr_7_end)
+.cfi_endproc

--- a/src/mpn_extras/mul_basecase.c
+++ b/src/mpn_extras/mul_basecase.c
@@ -1,0 +1,192 @@
+/*
+    Copyright (C) 2023 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "mpn_extras.h"
+
+#if FLINT_HAVE_ADX
+
+mp_limb_t flint_mpn_mul_1_1(mp_ptr, mp_srcptr, mp_srcptr);
+
+mp_limb_t flint_mpn_mul_2_1(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_2_2(mp_ptr, mp_srcptr, mp_srcptr);
+
+mp_limb_t flint_mpn_mul_3_1(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_3_2(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_3_3(mp_ptr, mp_srcptr, mp_srcptr);
+
+mp_limb_t flint_mpn_mul_4_1(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_4_2(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_4_3(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_4_4(mp_ptr, mp_srcptr, mp_srcptr);
+
+mp_limb_t flint_mpn_mul_5_1(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_5_2(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_5_3(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_5_4(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_5_5(mp_ptr, mp_srcptr, mp_srcptr);
+
+mp_limb_t flint_mpn_mul_6_1(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_6_2(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_6_3(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_6_4(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_6_5(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_6_6(mp_ptr, mp_srcptr, mp_srcptr);
+
+mp_limb_t flint_mpn_mul_7_1(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_7_2(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_7_3(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_7_4(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_7_5(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_7_6(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_7_7(mp_ptr, mp_srcptr, mp_srcptr);
+
+mp_limb_t flint_mpn_mul_8_1(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_8_2(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_8_3(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_8_4(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_8_5(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_8_6(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_8_7(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_8_8(mp_ptr, mp_srcptr, mp_srcptr);
+
+mp_limb_t flint_mpn_mul_9_1(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_9_2(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_9_3(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_9_4(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_9_5(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_9_6(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_9_7(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_9_8(mp_ptr, mp_srcptr, mp_srcptr);
+
+mp_limb_t flint_mpn_mul_10_1(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_10_2(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_10_3(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_10_4(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_10_5(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_10_6(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_10_7(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_10_8(mp_ptr, mp_srcptr, mp_srcptr);
+
+mp_limb_t flint_mpn_mul_11_1(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_11_2(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_11_3(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_11_4(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_11_5(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_11_6(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_11_7(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_11_8(mp_ptr, mp_srcptr, mp_srcptr);
+
+mp_limb_t flint_mpn_mul_12_1(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_12_2(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_12_3(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_12_4(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_12_5(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_12_6(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_12_7(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_12_8(mp_ptr, mp_srcptr, mp_srcptr);
+
+mp_limb_t flint_mpn_mul_13_1(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_13_2(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_13_3(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_13_4(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_13_5(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_13_6(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_13_7(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_13_8(mp_ptr, mp_srcptr, mp_srcptr);
+
+mp_limb_t flint_mpn_mul_14_1(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_14_2(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_14_3(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_14_4(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_14_5(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_14_6(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_14_7(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_14_8(mp_ptr, mp_srcptr, mp_srcptr);
+
+mp_limb_t flint_mpn_mul_15_1(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_15_2(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_15_3(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_15_4(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_15_5(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_15_6(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_15_7(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_15_8(mp_ptr, mp_srcptr, mp_srcptr);
+
+mp_limb_t flint_mpn_mul_16_1(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_16_2(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_16_3(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_16_4(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_16_5(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_16_6(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_16_7(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_16_8(mp_ptr, mp_srcptr, mp_srcptr);
+
+#define _MUL(mx, nx) flint_mpn_mul_##mx##_##nx
+#define MUL(mx, nx) _MUL(mx, nx)
+
+static mp_limb_t (* mul_funcs[][8])(mp_ptr, mp_srcptr, mp_srcptr) =
+{
+    {MUL( 1,1),      NULL,      NULL,      NULL,      NULL,      NULL,      NULL,      NULL},
+    {MUL( 2,1), MUL( 2,2),      NULL,      NULL,      NULL,      NULL,      NULL,      NULL},
+    {MUL( 3,1), MUL( 3,2), MUL( 3,3),      NULL,      NULL,      NULL,      NULL,      NULL},
+    {MUL( 4,1), MUL( 4,2), MUL( 4,3), MUL( 4,4),      NULL,      NULL,      NULL,      NULL},
+    {MUL( 5,1), MUL( 5,2), MUL( 5,3), MUL( 5,4), MUL( 5,5),      NULL,      NULL,      NULL},
+    {MUL( 6,1), MUL( 6,2), MUL( 6,3), MUL( 6,4), MUL( 6,5), MUL( 6,6),      NULL,      NULL},
+    {MUL( 7,1), MUL( 7,2), MUL( 7,3), MUL( 7,4), MUL( 7,5), MUL( 7,6), MUL( 7,7),      NULL},
+    {MUL( 8,1), MUL( 8,2), MUL( 8,3), MUL( 8,4), MUL( 8,5), MUL( 8,6), MUL( 8,7), MUL( 8,8)},
+    {MUL( 9,1), MUL( 9,2), MUL( 9,3), MUL( 9,4), MUL( 9,5), MUL( 9,6), MUL( 9,7), MUL( 9,8)},
+    {MUL(10,1), MUL(10,2), MUL(10,3), MUL(10,4), MUL(10,5), MUL(10,6), MUL(10,7), MUL(10,8)},
+    {MUL(11,1), MUL(11,2), MUL(11,3), MUL(11,4), MUL(11,5), MUL(11,6), MUL(11,7), MUL(11,8)},
+    {MUL(12,1), MUL(12,2), MUL(12,3), MUL(12,4), MUL(12,5), MUL(12,6), MUL(12,7), MUL(12,8)},
+    {MUL(13,1), MUL(13,2), MUL(13,3), MUL(13,4), MUL(13,5), MUL(13,6), MUL(13,7), MUL(13,8)},
+    {MUL(14,1), MUL(14,2), MUL(14,3), MUL(14,4), MUL(14,5), MUL(14,6), MUL(14,7), MUL(14,8)},
+    {MUL(15,1), MUL(15,2), MUL(15,3), MUL(15,4), MUL(15,5), MUL(15,6), MUL(15,7), MUL(15,8)},
+    {MUL(16,1), MUL(16,2), MUL(16,3), MUL(16,4), MUL(16,5), MUL(16,6), MUL(16,7), MUL(16,8)},
+};
+
+/* NOTE: Important that the inputs are in this order to avoid additional moves
+ * when calling `mul_funcs'. */
+mp_limb_t
+flint_mpn_mul_basecase(mp_ptr res, mp_srcptr ap, mp_srcptr bp, slong alen, slong blen)
+{
+    FLINT_ASSERT(alen >= blen);
+    FLINT_ASSERT(blen >= 1);
+    FLINT_ASSERT(alen <= 32);
+
+    if (alen <= 16 && blen <= 8)
+    {
+        return mul_funcs[alen - 1][blen - 1](res, ap, bp);
+    }
+    else if (alen <= 16)
+    {
+        /* 1 <= m <= 16, 8 < n <= m */
+        /* Calculate a * [b0, b1] */
+        return 0;
+    }
+    else if (blen <= 8)
+    {
+        /* 16 < m <= 32, 1 <= n <= 8 */
+        /* Calculate [a0, a1] * b */
+        return 0;
+    }
+    else if (alen <= 16)
+    {
+        /* 16 < m <= 32, 8 < n <= m */
+        /* Calculate [a0, a1] * [b0, b1] */
+        return 0;
+    }
+}
+
+#else
+
+typedef int this_file_is_empty;
+
+#endif

--- a/src/mpn_extras/profile/p-mul_basecase.c
+++ b/src/mpn_extras/profile/p-mul_basecase.c
@@ -1,0 +1,67 @@
+/*
+    Copyright (C) 2023 Fredrik Johansson
+    Copyright (C) 2023 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "mpn_extras.h"
+#include "profiler.h"
+
+#if !FLINT_HAVE_ADX
+# error ADX must be activated
+#endif
+
+#define mpn_mul_basecase __gmpn_mul_basecase
+void mpn_mul_basecase(mp_ptr, mp_srcptr, mp_size_t, mp_srcptr, mp_size_t);
+
+int main(void)
+{
+    mp_limb_t res1[24];
+    mp_limb_t res2[24];
+    mp_limb_t ap[16];
+    mp_limb_t bp[8];
+    slong mx, nx;
+
+    flint_printf("       ");
+    for (nx = 1; nx <= 8; nx++)
+        flint_printf("%6wd  ", nx);
+    flint_printf("\n\n");
+
+    for (mx = 1; mx <= 16; mx++)
+    {
+        flint_printf("m = %2wd:", mx);
+
+        for (nx = 1; nx <= FLINT_MIN(mx, WORD(8)); nx++)
+        {
+            double t1, t2, __;
+
+            mpn_random2(ap, mx);
+            mpn_random2(bp, nx);
+
+            TIMEIT_START
+            mpn_mul_basecase(res1, ap, mx, bp, nx);
+            TIMEIT_STOP_VALUES(__, t1)
+
+            TIMEIT_START
+            flint_mpn_mul_basecase(res2, ap, bp, mx, nx);
+            TIMEIT_STOP_VALUES(__, t2)
+
+            flint_printf("%7.2fx", t1 / t2);
+
+            if (mpn_cmp(res1, res2, mx + nx) != 0)
+                flint_abort();
+        }
+
+        flint_printf("\n\n");
+    }
+
+    flint_cleanup_master();
+
+    return 0;
+}

--- a/src/mpn_extras/profile/p-sqr_basecase.c
+++ b/src/mpn_extras/profile/p-sqr_basecase.c
@@ -1,0 +1,62 @@
+/*
+    Copyright (C) 2023 Fredrik Johansson
+    Copyright (C) 2023 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "mpn_extras.h"
+#include "profiler.h"
+
+#if !FLINT_HAVE_ADX
+# error ADX must be activated
+#endif
+
+#define mpn_sqr_basecase __gmpn_sqr_basecase
+void mpn_sqr_basecase(mp_ptr, mp_srcptr, mp_size_t);
+
+int main(void)
+{
+    mp_limb_t res1[14];
+    mp_limb_t res2[14];
+    mp_limb_t ap[7];
+    slong mx;
+
+    for (mx = 1; mx <= 7; mx++)
+    {
+        double t1, t2, t3, __;
+
+        flint_printf("m = %2wd:", mx);
+
+        mpn_random2(ap, mx);
+
+        TIMEIT_START
+        mpn_sqr_basecase(res1, ap, mx);
+        TIMEIT_STOP_VALUES(__, t1)
+
+        TIMEIT_START
+        flint_mpn_sqr_basecase(res2, ap, mx);
+        TIMEIT_STOP_VALUES(__, t2)
+
+        TIMEIT_START
+        flint_mpn_mul_basecase(res2, ap, ap, mx, mx);
+        TIMEIT_STOP_VALUES(__, t3)
+
+        flint_printf("%7.2fx", t1 / t2);
+        flint_printf("    %7.2fx", t1 / t3);
+
+        /* if (mpn_cmp(res1, res2, 2 * mx) != 0) */
+        /*     flint_abort(); */
+
+        flint_printf("\n\n");
+    }
+
+    flint_cleanup_master();
+
+    return 0;
+}

--- a/src/mpn_extras/sqr_basecase.c
+++ b/src/mpn_extras/sqr_basecase.c
@@ -1,0 +1,50 @@
+/*
+    Copyright (C) 2023 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "mpn_extras.h"
+
+#if FLINT_HAVE_ADX
+
+mp_limb_t flint_mpn_sqr_1(mp_ptr, mp_srcptr);
+mp_limb_t flint_mpn_sqr_2(mp_ptr, mp_srcptr);
+mp_limb_t flint_mpn_sqr_3(mp_ptr, mp_srcptr);
+mp_limb_t flint_mpn_sqr_4(mp_ptr, mp_srcptr);
+mp_limb_t flint_mpn_sqr_5(mp_ptr, mp_srcptr);
+mp_limb_t flint_mpn_sqr_6(mp_ptr, mp_srcptr);
+mp_limb_t flint_mpn_sqr_7(mp_ptr, mp_srcptr);
+
+static mp_limb_t (* sqr_funcs[])(mp_ptr, mp_srcptr) =
+{
+    flint_mpn_sqr_1,
+    flint_mpn_sqr_2,
+    flint_mpn_sqr_3,
+    flint_mpn_sqr_4,
+    flint_mpn_sqr_5,
+    flint_mpn_sqr_6,
+    flint_mpn_sqr_7
+};
+
+/* NOTE: Important that the inputs are in this order to avoid additional moves
+ * when calling `mul_funcs'. */
+mp_limb_t
+flint_mpn_sqr_basecase(mp_ptr res, mp_srcptr ap, slong alen)
+{
+    FLINT_ASSERT(alen > 0);
+    FLINT_ASSERT(alen < 8);
+
+    return sqr_funcs[alen - 1](res, ap);
+}
+
+#else
+
+typedef int this_file_is_empty;
+
+#endif

--- a/src/mpn_extras/test/main.c
+++ b/src/mpn_extras/test/main.c
@@ -22,11 +22,13 @@
 #include "t-mod_preinvn.c"
 #include "t-mul.c"
 #include "t-mul_n.c"
+#include "t-mul_basecase.c"
 #include "t-mulmod_2expp1.c"
 #include "t-mulmod_preinv1.c"
 #include "t-mulmod_preinvn.c"
 #include "t-remove_2exp.c"
 #include "t-remove_power.c"
+#include "t-sqr_basecase.c"
 
 /* Array of test functions ***************************************************/
 
@@ -40,11 +42,13 @@ test_struct tests[] =
     TEST_FUNCTION(flint_mpn_mod_preinvn),
     TEST_FUNCTION(flint_mpn_mul),
     TEST_FUNCTION(flint_mpn_mul_n),
+    TEST_FUNCTION(flint_mpn_mul_basecase),
     TEST_FUNCTION(flint_mpn_mulmod_2expp1),
     TEST_FUNCTION(flint_mpn_mulmod_preinv1),
     TEST_FUNCTION(flint_mpn_mulmod_preinvn),
     TEST_FUNCTION(flint_mpn_remove_2exp),
-    TEST_FUNCTION(flint_mpn_remove_power)
+    TEST_FUNCTION(flint_mpn_remove_power),
+    TEST_FUNCTION(flint_mpn_sqr_basecase)
 };
 
 /* main function *************************************************************/

--- a/src/mpn_extras/test/t-mul_basecase.c
+++ b/src/mpn_extras/test/t-mul_basecase.c
@@ -1,0 +1,60 @@
+/*
+    Copyright (C) 2023, 2024 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "mpn_extras.h"
+
+#if FLINT_HAVE_ADX
+
+TEST_FUNCTION_START(flint_mpn_mul_basecase, state)
+{
+    slong ix;
+
+    for (ix = 0; ix < 1000000 * flint_test_multiplier(); ix++)
+    {
+        mp_limb_t res1[24] = {UWORD(0)};
+        mp_limb_t res2[24] = {UWORD(0)};
+        mp_limb_t ret1, ret2;
+        mp_limb_t ap[16];
+        mp_limb_t bp[8];
+        slong alen, blen;
+
+        alen = 1 + n_randint(state, 16);
+        blen = 1 + n_randint(state, FLINT_MIN(alen, WORD(8)));
+
+        mpn_random2(ap, alen);
+        mpn_random2(bp, blen);
+
+        ret1 = flint_mpn_mul_basecase(res1, ap, bp, alen, blen);
+        ret2 = mpn_mul(res2, ap, alen, bp, blen);
+
+        if (mpn_cmp(res1, res2, alen + blen) || ret1 != ret2)
+            flint_throw(FLINT_TEST_FAIL,
+                    "ix = %wd\n"
+                    "alen = %wd\n"
+                    "blen = %wd\n"
+                    "ap = %{ulong*}\n"
+                    "bp = %{ulong*}\n"
+                    "ret1 = %wu\n"
+                    "ret2 = %wu\n"
+                    "Got:      %{ulong*}\n"
+                    "Expected: %{ulong*}\n",
+                    ix, alen, blen, ap, alen, bp, blen, ret1, ret2, res1, alen + blen, res2, alen + blen);
+    }
+
+    TEST_FUNCTION_END(state);
+}
+#else
+TEST_FUNCTION_START(flint_mpn_mul_basecase, state)
+{
+    TEST_FUNCTION_END_SKIPPED(state);
+}
+#endif

--- a/src/mpn_extras/test/t-sqr_basecase.c
+++ b/src/mpn_extras/test/t-sqr_basecase.c
@@ -1,0 +1,54 @@
+/*
+    Copyright (C) 2024 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "mpn_extras.h"
+
+#if FLINT_HAVE_ADX
+
+TEST_FUNCTION_START(flint_mpn_sqr_basecase, state)
+{
+    slong ix;
+
+    for (ix = 0; ix < 1000000 * flint_test_multiplier(); ix++)
+    {
+        mp_limb_t res1[14] = {UWORD(0)};
+        mp_limb_t res2[14] = {UWORD(0)};
+        mp_limb_t ret1;
+        mp_limb_t ap[7];
+        slong alen;
+
+        alen = 1 + n_randint(state, 7);
+
+        mpn_random2(ap, alen);
+
+        ret1 = flint_mpn_sqr_basecase(res1, ap, alen);
+        mpn_sqr(res2, ap, alen);
+
+        if (mpn_cmp(res1, res2, 2 * alen) || ret1 != res1[2 * alen - 1])
+            flint_throw(FLINT_TEST_FAIL,
+                    "ix = %wd\n"
+                    "alen = %wd\n"
+                    "ap = %{ulong*}\n"
+                    "ret1 = %wu\n"
+                    "Got:      %{ulong*}\n"
+                    "Expected: %{ulong*}\n",
+                    ix, alen, ap, alen, ret1, res1, 2 * alen, res2, 2 * alen);
+    }
+
+    TEST_FUNCTION_END(state);
+}
+#else
+TEST_FUNCTION_START(flint_mpn_sqr_basecase, state)
+{
+    TEST_FUNCTION_END_SKIPPED(state);
+}
+#endif


### PR DESCRIPTION
I think this should be sort of optimal. Perhaps one could further optimize it by aligning the instructions in some way. This effectively performs mul with X addmuls. For ARM, I think one should use my strategy seen in the first commit, but with the `adcx` and `adox` instructions, this should be faster.

I haven't tested it yet, but it probably doesn't work as it is my first time writing something proper in assembly.

Requires Intel ADX instruction set for `adcx` and `adox`. I don't know how to set up the configuration such that we can detect whether the CPU supports these instructions.