### PR TITLE
Strongly ordered functions

### DIFF
--- a/CMake/cmake_config.h.in
+++ b/CMake/cmake_config.h.in
@@ -20,6 +20,8 @@
 
 #cmakedefine FLINT_HAVE_FFT_SMALL
 
+#cmakedefine01 FLINT_KNOW_STRONG_ORDER
+
 #ifdef _MSC_VER
 # if defined(FLINT_BUILD_DLL)
 #  define FLINT_DLL __declspec(dllexport)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,16 @@ endif()
 option(BUILD_SHARED_LIBS "Build shared libs" on)
 option(WITH_NTL "Build tests for NTL interface or not" off)
 
+# Check if strongly ordered memory
+set(STRONGLY_ORDERED_CPUS x86_64 x86 i386 i586 AMD64)
+if(CMAKE_SYSTEM_PROCESSOR IN_LIST STRONGLY_ORDERED_CPUS)
+    message(STATUS "Checking if system is strongly ordered - yes")
+    set(FLINT_KNOW_STRONG_ORDER ON)
+else()
+    message(STATUS "Checking if system is strongly ordered - unsure")
+    set(FLINT_KNOW_STRONG_ORDER OFF)
+endif()
+
 # Find dependencies
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(GMP REQUIRED IMPORTED_TARGET gmp>=6.2.1)

--- a/configure.ac
+++ b/configure.ac
@@ -871,53 +871,6 @@ AC_MSG_ERROR([Couldn't find alloca, which is required for FLINT. Please submit a
 report to <https://github.com/flintlib/flint/issues/> and specify your
 operating system.])])
 
-AC_MSG_CHECKING([if $CC has popcount intrinsics])
-AC_COMPILE_IFELSE(
-    [AC_LANG_PROGRAM([],[long int x = __builtin_popcountl(3);])],
-    [AC_COMPILE_IFELSE(
-        [AC_LANG_PROGRAM([],[long long int x = __builtin_popcountll(3);])],
-        [AC_MSG_RESULT([yes])
-         has_popcount="yes"
-         AC_DEFINE(FLINT_HAS_POPCNT,1,[Define if compiler has popcount intrinsics])],
-        [AC_MSG_RESULT([no])]
-    )],
-    [AC_MSG_RESULT([no])]
-)
-
-AC_MSG_CHECKING([if $CC has CLZ intrinsics])
-AC_COMPILE_IFELSE(
-    [AC_LANG_PROGRAM([],[long int x = __builtin_clzl(3);])],
-    [AC_COMPILE_IFELSE(
-        [AC_LANG_PROGRAM([],[long long int x = __builtin_clzll(3);])],
-        [AC_MSG_RESULT([yes])
-         has_clz="yes"
-         AC_DEFINE(FLINT_HAS_CLZ,1,[Define if compiler has CLZ intrinsics])],
-        [AC_MSG_RESULT([no])]
-    )],
-    [AC_MSG_RESULT([no])]
-)
-
-AC_MSG_CHECKING([if $CC has CTZ intrinsics])
-AC_COMPILE_IFELSE(
-    [AC_LANG_PROGRAM([],[long int x = __builtin_ctzl(3);])],
-    [AC_COMPILE_IFELSE(
-        [AC_LANG_PROGRAM([],[long long int x = __builtin_ctzll(3);])],
-        [AC_MSG_RESULT([yes])
-         has_ctz="yes"
-         AC_DEFINE(FLINT_HAS_CTZ,1,[Define if compiler has CTZ intrinsics])],
-        [AC_MSG_RESULT([no])]
-    )],
-    [AC_MSG_RESULT([no])]
-)
-
-AC_MSG_CHECKING([if $CC has __builtin_constant_p])
-AC_COMPILE_IFELSE(
-    [AC_LANG_PROGRAM([], [int a = __builtin_constant_p(0 == 1);])],
-    [AC_MSG_RESULT([yes])
-     AC_DEFINE(FLINT_HAVE_CONSTANT_P,1,[Define if compiler has __builtin_constant_p])],
-    [AC_MSG_RESULT([no])]
-)
-
 ################################################################################
 # CFLAGS
 ################################################################################

--- a/configure.ac
+++ b/configure.ac
@@ -641,6 +641,24 @@ then
 fi
 AC_SUBST(LDCONFIG)
 
+dnl FIXME: Improve this check to include more processors.
+AC_MSG_CHECKING([if memory is strongly-ordered])
+case "$host_cpu" in
+    x86_64|x86|i386|i586)
+        flint_know_strong_order="yes"
+        AC_MSG_CHECKING([yes])
+        ;;
+    *)
+        flint_know_strong_order="no"
+        AC_MSG_CHECKING([unsure])
+        ;;
+esac
+
+if test "$flint_know_strong_order" = "yes";
+then
+    AC_DEFINE(FLINT_KNOW_STRONG_ORDER,1,[Define if system is strongly ordered])]
+fi
+
 ################################################################################
 # check headers
 ################################################################################

--- a/configure.ac
+++ b/configure.ac
@@ -646,17 +646,17 @@ AC_MSG_CHECKING([if memory is strongly-ordered])
 case "$host_cpu" in
     x86_64|x86|i386|i586)
         flint_know_strong_order="yes"
-        AC_MSG_CHECKING([yes])
+        AC_MSG_RESULT([yes])
         ;;
     *)
         flint_know_strong_order="no"
-        AC_MSG_CHECKING([unsure])
+        AC_MSG_RESULT([unsure])
         ;;
 esac
 
 if test "$flint_know_strong_order" = "yes";
 then
-    AC_DEFINE(FLINT_KNOW_STRONG_ORDER,1,[Define if system is strongly ordered])]
+    AC_DEFINE(FLINT_KNOW_STRONG_ORDER,1,[Define if system is strongly ordered])
 fi
 
 ################################################################################

--- a/doc/source/fmpz_mpoly.rst
+++ b/doc/source/fmpz_mpoly.rst
@@ -777,15 +777,28 @@ Internal Functions
 
 .. function:: int fmpz_mpoly_divides_monagan_pearce(fmpz_mpoly_t poly1, const fmpz_mpoly_t poly2, const fmpz_mpoly_t poly3, const fmpz_mpoly_ctx_t ctx)
 
+    Set ``poly1`` to ``poly2`` divided by ``poly3`` and return 1 if the quotient
+    is exact. Otherwise return 0. The function uses the algorithm of Michael
+    Monagan and Roman Pearce. Note that the function
+    ``fmpz_mpoly_div_monagan_pearce`` below may be much faster if the quotient
+    is known to be exact.
+
 .. function:: int fmpz_mpoly_divides_heap_threaded(fmpz_mpoly_t Q, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx)
 
-    Set ``poly1`` to ``poly2`` divided by ``poly3`` and return 1 if
-    the quotient is exact. Otherwise return 0. The function uses the algorithm
-    of Michael Monagan and Roman Pearce. Note that the function
-    ``fmpz_mpoly_div_monagan_pearce`` below may be much faster if the
-    quotient is known to be exact.
+    The same method as used as in :func:``fmpz_mpoly_divides_monagan_pearce``,
+    but is also multi-threaded.
 
-    The threaded version takes an upper limit on the number of threads to use, while the first version always uses one thread.
+.. note::
+
+    This function is only defined if the machine is known to be strongly ordered
+    during the configuration. To check whether this function is defined during
+    compilation-time, use the C preprocessor macro
+    ``#ifdef fmpz_mpoly_divides_heap_threaded``.
+
+    Note that, if the system is known to be strongly ordered, the underlying
+    algorithm for this function is utilized in :func:``fmpz_mpoly_divides``.
+    Hence, you may find it easier to use this function instead if the C
+    preprocessor is not available.
 
 .. function:: slong _fmpz_mpoly_div_monagan_pearce(fmpz ** polyq, ulong ** expq, slong * allocq, const fmpz * poly2, const ulong * exp2, slong len2, const fmpz * poly3, const ulong * exp3, slong len3, slong bits, slong N, const mp_limb_t * cmpmask)
 

--- a/doc/source/nmod_mpoly.rst
+++ b/doc/source/nmod_mpoly.rst
@@ -518,8 +518,21 @@ The division functions assume that the modulus is prime.
 
 .. function:: int nmod_mpoly_divides_heap_threaded(nmod_mpoly_t Q, const nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx)
 
-    Do the operation of ``nmod_mpoly_divides`` using a heap and multiple threads.
-    This function should only be called once ``global_thread_pool`` has been initialized.
+    Do the operation of ``nmod_mpoly_divides`` using the heap and multiple
+    threads. This function should only be called once ``global_thread_pool`` has
+    been initialized.
+
+.. note::
+
+    This function is only defined if the machine is known to be strongly ordered
+    during the configuration. To check whether this function is defined during
+    compilation-time, use the C preprocessor macro
+    ``#ifdef nmod_mpoly_divides_heap_threaded``.
+
+    Note that, if the system is known to be strongly ordered, the underlying
+    algorithm for this function is utilized in :func:``nmod_mpoly_divides``.
+    Hence, you may find it easier to use this function instead if the C
+    preprocessor is not available.
 
 
 Greatest Common Divisor

--- a/src/flint-config.h.in
+++ b/src/flint-config.h.in
@@ -12,23 +12,11 @@
 /* Define if system is big endian. */
 #undef FLINT_BIG_ENDIAN
 
-/* Define if compiler has CLZ intrinsics */
-#undef FLINT_HAS_CLZ
-
-/* Define if compiler has CTZ intrinsics */
-#undef FLINT_HAS_CTZ
-
-/* Define if compiler has popcount intrinsics */
-#undef FLINT_HAS_POPCNT
-
 /* Define if system has AVX2 */
 #undef FLINT_HAVE_AVX2
 
 /* Define if system has AVX512 */
 #undef FLINT_HAVE_AVX512
-
-/* Define if compiler has __builtin_constant_p */
-#undef FLINT_HAVE_CONSTANT_P
 
 /* Define to use the fft_small module */
 #undef FLINT_HAVE_FFT_SMALL

--- a/src/flint-config.h.in
+++ b/src/flint-config.h.in
@@ -12,6 +12,9 @@
 /* Define if system is big endian. */
 #undef FLINT_BIG_ENDIAN
 
+/* Define if system is strongly ordered */
+#undef FLINT_KNOW_STRONG_ORDER
+
 /* Define if system has AVX2 */
 #undef FLINT_HAVE_AVX2
 

--- a/src/flint.h.in
+++ b/src/flint.h.in
@@ -68,12 +68,6 @@
 # define FLINT_HAVE_FILE
 #endif
 
-#ifdef FLINT_HAVE_CONSTANT_P
-# define FLINT_CONSTANT_P __builtin_constant_p
-#else
-# define FLINT_CONSTANT_P(x) 0
-#endif
-
 #ifdef FLINT_INLINES_C
 # define FLINT_INLINE
 #else
@@ -123,6 +117,7 @@ typedef struct __FLINT_FILE FLINT_FILE;
 # define FLINT_OPTIMIZE_NESTED_2(part) FLINT_OPTIMIZE_NESTED_3(GCC optimize part)
 # define FLINT_OPTIMIZE_NESTED_1(part) FLINT_OPTIMIZE_NESTED_2(#part)
 # define FLINT_OPTIMIZE(x) FLINT_OPTIMIZE_NESTED_1(x)
+# define FLINT_CONSTANT_P __builtin_constant_p
 # define FLINT_UNREACHABLE __builtin_unreachable()
 #else
 # define __attribute__(x)
@@ -143,6 +138,7 @@ typedef struct __FLINT_FILE FLINT_FILE;
 # define FLINT_PUSH_OPTIONS
 # define FLINT_POP_OPTIONS
 # define FLINT_OPTIMIZE(x)
+# define FLINT_CONSTANT_P(x) 0
 #endif
 
 #if defined(__cplusplus)

--- a/src/fmpq_poly/test/t-resultant.c
+++ b/src/fmpq_poly/test/t-resultant.c
@@ -14,6 +14,7 @@
 #include "fmpq_poly.h"
 
 #ifdef __GNUC__
+# pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Woverlength-strings"
 #endif
 

--- a/src/fmpq_poly/test/t-resultant_div.c
+++ b/src/fmpq_poly/test/t-resultant_div.c
@@ -14,6 +14,7 @@
 #include "fmpq_poly.h"
 
 #ifdef __GNUC__
+# pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Woverlength-strings"
 #endif
 

--- a/src/fmpz_mpoly.h
+++ b/src/fmpz_mpoly.h
@@ -770,12 +770,16 @@ int fmpz_mpoly_divides(fmpz_mpoly_t Q,
 int fmpz_mpoly_divides_monagan_pearce(fmpz_mpoly_t Q,
        const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
 
+#if FLINT_KNOW_STRONG_ORDER
+#define fmpz_mpoly_divides_heap_threaded fmpz_mpoly_divides_heap_threaded
 int fmpz_mpoly_divides_heap_threaded(fmpz_mpoly_t Q,
        const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
 
+#define _fmpz_mpoly_divides_heap_threaded_pool _fmpz_mpoly_divides_heap_threaded_pool
 int _fmpz_mpoly_divides_heap_threaded_pool(fmpz_mpoly_t Q,
        const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx,
                         const thread_pool_handle * handles, slong num_handles);
+#endif
 
 slong _fmpz_mpoly_divides_array(fmpz ** poly1, ulong ** exp1,
          slong * alloc, const fmpz * poly2, const ulong * exp2, slong len2,

--- a/src/fmpz_mpoly/divides.c
+++ b/src/fmpz_mpoly/divides.c
@@ -9,8 +9,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "thread_support.h"
 #include "fmpz_mpoly.h"
+
+#ifdef _fmpz_mpoly_divides_heap_threaded_pool
+
+#include "thread_support.h"
 
 int fmpz_mpoly_divides(
     fmpz_mpoly_t Q,
@@ -52,4 +55,24 @@ int fmpz_mpoly_divides(
 
     return divides;
 }
+#else
+int fmpz_mpoly_divides(
+    fmpz_mpoly_t Q,
+    const fmpz_mpoly_t A,
+    const fmpz_mpoly_t B,
+    const fmpz_mpoly_ctx_t ctx)
+{
+    if (B->length == 0)
+    {
+        flint_throw(FLINT_DIVZERO, "Divide by zero in fmpz_mpoly_divides");
+    }
 
+    if (A->length == 0)
+    {
+        fmpz_mpoly_zero(Q, ctx);
+        return 1;
+    }
+
+    return fmpz_mpoly_divides_monagan_pearce(Q, A, B, ctx);
+}
+#endif

--- a/src/fmpz_mpoly/divides_heap_threaded.c
+++ b/src/fmpz_mpoly/divides_heap_threaded.c
@@ -9,9 +9,12 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly.h"
+
+#if FLINT_KNOW_STRONG_ORDER
+
 #include "thread_support.h"
 #include "ulong_extras.h"
-#include "fmpz_mpoly.h"
 
 /*
     a thread safe mpoly supports three mutating operations
@@ -34,9 +37,9 @@ typedef struct _fmpz_mpoly_ts_struct
 typedef fmpz_mpoly_ts_struct fmpz_mpoly_ts_t[1];
 
 /* Bcoeff is changed */
-void fmpz_mpoly_ts_init(fmpz_mpoly_ts_t A,
-                              fmpz * Bcoeff, ulong * Bexp, slong Blen,
-                                                    flint_bitcnt_t bits, slong N)
+static void fmpz_mpoly_ts_init(fmpz_mpoly_ts_t A,
+        fmpz * Bcoeff, ulong * Bexp, slong Blen,
+        flint_bitcnt_t bits, slong N)
 {
     slong i;
     flint_bitcnt_t idx = FLINT_BIT_COUNT(Blen);
@@ -61,7 +64,7 @@ void fmpz_mpoly_ts_init(fmpz_mpoly_ts_t A,
     }
 }
 
-void fmpz_mpoly_ts_print(const fmpz_mpoly_ts_t B, const char ** x,
+static void fmpz_mpoly_ts_print(const fmpz_mpoly_ts_t B, const char ** x,
                                                     const fmpz_mpoly_ctx_t ctx)
 {
     fmpz_mpoly_t A;
@@ -75,7 +78,7 @@ void fmpz_mpoly_ts_print(const fmpz_mpoly_ts_t B, const char ** x,
     fmpz_mpoly_assert_canonical(A, ctx);
 }
 
-void fmpz_mpoly_ts_clear(fmpz_mpoly_ts_t A)
+static void fmpz_mpoly_ts_clear(fmpz_mpoly_ts_t A)
 {
     slong i;
 
@@ -95,7 +98,7 @@ void fmpz_mpoly_ts_clear(fmpz_mpoly_ts_t A)
     }
 }
 
-void fmpz_mpoly_ts_clear_poly(fmpz_mpoly_t Q, fmpz_mpoly_ts_t A)
+static void fmpz_mpoly_ts_clear_poly(fmpz_mpoly_t Q, fmpz_mpoly_ts_t A)
 {
     if (Q->alloc != 0)
     {
@@ -126,7 +129,7 @@ void fmpz_mpoly_ts_clear_poly(fmpz_mpoly_t Q, fmpz_mpoly_ts_t A)
 
 
 /* put B on the end of A - Bcoeff is changed*/
-void fmpz_mpoly_ts_append(fmpz_mpoly_ts_t A,
+static void fmpz_mpoly_ts_append(fmpz_mpoly_ts_t A,
                              fmpz * Bcoeff, ulong * Bexps, slong Blen, slong N)
 {
 /* TODO: this needs barriers on non-x86 */
@@ -330,7 +333,7 @@ static void divides_heap_base_add_chunk(divides_heap_base_t H, divides_heap_chun
     saveD: 0 means we can modify coeffs of input D
            1 means we must not modify coeffs of input D
 */
-slong _fmpz_mpoly_mulsub_stripe1(fmpz ** A_coeff, ulong ** A_exp, slong * A_alloc,
+static slong _fmpz_mpoly_mulsub_stripe1(fmpz ** A_coeff, ulong ** A_exp, slong * A_alloc,
                          const fmpz * Dcoeff, const ulong * Dexp, slong Dlen, int saveD,
                          const fmpz * Bcoeff, const ulong * Bexp, slong Blen,
                          const fmpz * Ccoeff, const ulong * Cexp, slong Clen,
@@ -606,7 +609,7 @@ slong _fmpz_mpoly_mulsub_stripe1(fmpz ** A_coeff, ulong ** A_exp, slong * A_allo
 }
 
 
-slong _fmpz_mpoly_mulsub_stripe(fmpz ** A_coeff, ulong ** A_exp, slong * A_alloc,
+static slong _fmpz_mpoly_mulsub_stripe(fmpz ** A_coeff, ulong ** A_exp, slong * A_alloc,
                          const fmpz * Dcoeff, const ulong * Dexp, slong Dlen, int saveD,
                          const fmpz * Bcoeff, const ulong * Bexp, slong Blen,
                          const fmpz * Ccoeff, const ulong * Cexp, slong Clen,
@@ -911,7 +914,7 @@ slong _fmpz_mpoly_mulsub_stripe(fmpz ** A_coeff, ulong ** A_exp, slong * A_alloc
     Q = stripe of A/B (assume A != 0)
     return Qlen = 0 if exact division is impossible
 */
-slong _fmpz_mpoly_divides_stripe1(
+static slong _fmpz_mpoly_divides_stripe1(
                         fmpz ** Q_coeff,     ulong ** Q_exp, slong * Q_alloc,
                     const fmpz * Acoeff, const ulong * Aexp, slong Alen,
                     const fmpz * Bcoeff, const ulong * Bexp, slong Blen,
@@ -1248,7 +1251,7 @@ not_exact_division:
     goto cleanup;
 }
 
-slong _fmpz_mpoly_divides_stripe(
+static slong _fmpz_mpoly_divides_stripe(
                         fmpz ** Q_coeff,     ulong ** Q_exp, slong * Q_alloc,
                     const fmpz * Acoeff, const ulong * Aexp, slong Alen,
                     const fmpz * Bcoeff, const ulong * Bexp, slong Blen,
@@ -1945,21 +1948,21 @@ static void worker_loop(void * varg)
 #if FLINT_USES_PTHREAD
             pthread_mutex_lock(&H->mutex);
 #endif
-	    if (L->lock != -1)
+            if (L->lock != -1)
             {
                 L->lock = -1;
 #if FLINT_USES_PTHREAD
                 pthread_mutex_unlock(&H->mutex);
 #endif
-		trychunk(W, L);
+                trychunk(W, L);
 #if FLINT_USES_PTHREAD
                 pthread_mutex_lock(&H->mutex);
 #endif
-		L->lock = 0;
+                L->lock = 0;
 #if FLINT_USES_PTHREAD
                 pthread_mutex_unlock(&H->mutex);
 #endif
-		break;
+                break;
             }
             else
             {
@@ -2003,10 +2006,6 @@ int _fmpz_mpoly_divides_heap_threaded_pool(
     ulong * texps, * qexps;
     divides_heap_base_t H;
     TMP_INIT;
-
-#if !FLINT_KNOW_STRONG_ORDER
-    return fmpz_mpoly_divides_monagan_pearce(Q, A, B, ctx);
-#endif
 
     if (B->length < 2 || A->length < 2)
     {
@@ -2245,3 +2244,6 @@ int fmpz_mpoly_divides_heap_threaded(
 
     return divides;
 }
+#else
+typedef int this_file_is_empty;
+#endif

--- a/src/fmpz_mpoly/test/t-divides_heap_threaded.c
+++ b/src/fmpz_mpoly/test/t-divides_heap_threaded.c
@@ -12,6 +12,7 @@
 #include "test_helpers.h"
 #include "fmpz_mpoly.h"
 
+#if defined(fmpz_mpoly_divides_heap_threaded)
 TEST_FUNCTION_START(fmpz_mpoly_divides_heap_threaded, state)
 {
     int result, result2;
@@ -417,3 +418,9 @@ TEST_FUNCTION_START(fmpz_mpoly_divides_heap_threaded, state)
 
     TEST_FUNCTION_END(state);
 }
+#else
+TEST_FUNCTION_START(fmpz_mpoly_divides_heap_threaded, state)
+{
+    TEST_FUNCTION_END_SKIPPED(state);
+}
+#endif

--- a/src/gr_generic/test/t-fmpz_mpoly_evaluate.c
+++ b/src/gr_generic/test/t-fmpz_mpoly_evaluate.c
@@ -93,5 +93,5 @@ TEST_FUNCTION_START(gr_generic_fmpz_mpoly_evaluate, state)
         gr_ctx_clear(ctx);
     }
 
-    TEST_FUNCTION_END(state);
+    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
 }

--- a/src/gr_generic/test/t-fmpz_poly_evaluate.c
+++ b/src/gr_generic/test/t-fmpz_poly_evaluate.c
@@ -115,5 +115,5 @@ TEST_FUNCTION_START(gr_generic_fmpz_poly_evaluate, state)
         gr_ctx_clear(ctx);
     }
 
-    TEST_FUNCTION_END(state);
+    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
 }

--- a/src/nmod_mpoly.h
+++ b/src/nmod_mpoly.h
@@ -917,12 +917,16 @@ int _nmod_mpoly_divides_threaded_pool(nmod_mpoly_t Q,
 int nmod_mpoly_divides_monagan_pearce(nmod_mpoly_t Q,
        const nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx);
 
+#if FLINT_KNOW_STRONG_ORDER
+#define nmod_mpoly_divides_heap_threaded nmod_mpoly_divides_heap_threaded
 int nmod_mpoly_divides_heap_threaded(nmod_mpoly_t Q,
        const nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx);
 
+#define _nmod_mpoly_divides_heap_threaded_pool _nmod_mpoly_divides_heap_threaded_pool
 int _nmod_mpoly_divides_heap_threaded_pool(nmod_mpoly_t Q,
        const nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx,
                         const thread_pool_handle * handles, slong num_handles);
+#endif
 
 int nmod_mpoly_divides_dense(nmod_mpoly_t Q,
        const nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx);
@@ -1556,9 +1560,12 @@ void nmod_mpolyun_divexact_last(nmod_mpolyun_t A, n_poly_t b,
 int nmod_mpolyn_divides(nmod_mpolyn_t Q, const nmod_mpolyn_t A,
                             const nmod_mpolyn_t B, const nmod_mpoly_ctx_t ctx);
 
+#if FLINT_KNOW_STRONG_ORDER
+#define nmod_mpolyn_divides_threaded_pool nmod_mpolyn_divides_threaded_pool
 int nmod_mpolyn_divides_threaded_pool(nmod_mpolyn_t Q,
     const nmod_mpolyn_t A, const nmod_mpolyn_t B, const nmod_mpoly_ctx_t ctx,
                         const thread_pool_handle * handles, slong num_handles);
+#endif
 
 int nmod_mpolyun_divides(nmod_mpolyun_t Q, const nmod_mpolyun_t A,
                            const nmod_mpolyun_t B, const nmod_mpoly_ctx_t ctx);

--- a/src/nmod_mpoly/divides.c
+++ b/src/nmod_mpoly/divides.c
@@ -133,6 +133,7 @@ int _nmod_mpoly_divides_threaded_pool(
         goto cleanup;
     }
 
+#ifdef _nmod_mpoly_divides_heap_threaded_pool
     if (num_handles > 0)
     {
         divides = _nmod_mpoly_divides_heap_threaded_pool(Q, A, B, ctx,
@@ -142,6 +143,9 @@ int _nmod_mpoly_divides_threaded_pool(
     {
         divides = nmod_mpoly_divides_monagan_pearce(Q, A, B, ctx);
     }
+#else
+    divides = nmod_mpoly_divides_monagan_pearce(Q, A, B, ctx);
+#endif
 
 cleanup:
 

--- a/src/nmod_mpoly/divides_heap_threaded.c
+++ b/src/nmod_mpoly/divides_heap_threaded.c
@@ -9,8 +9,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "thread_support.h"
 #include "nmod_mpoly.h"
+
+#if FLINT_KNOW_STRONG_ORDER
+
+#include "thread_support.h"
 #include "fmpz_mpoly.h"
 
 #define PROFILE_THIS 0
@@ -1710,10 +1713,6 @@ int _nmod_mpoly_divides_heap_threaded_pool(
 #endif
     TMP_INIT;
 
-#if !FLINT_KNOW_STRONG_ORDER
-    return nmod_mpoly_divides_monagan_pearce(Q, A, B, ctx);
-#endif
-
     if (B->length < 2 || A->length < 2)
     {
         return nmod_mpoly_divides_monagan_pearce(Q, A, B, ctx);
@@ -1967,3 +1966,6 @@ int nmod_mpoly_divides_heap_threaded(
 
     return divides;
 }
+#else
+typedef int this_file_is_empty;
+#endif

--- a/src/nmod_mpoly/gcd_brown.c
+++ b/src/nmod_mpoly/gcd_brown.c
@@ -1163,10 +1163,15 @@ compute_split:
     {
         nmod_mpolyn_content_last(t1, G, ctx);
         nmod_mpolyn_divexact_last(G, t1, ctx);
+#ifdef nmod_mpolyn_divides_threaded_pool
         success =            nmod_mpolyn_divides_threaded_pool(T1, A, G,
                                                     ctx, handles, num_handles);
         success = success && nmod_mpolyn_divides_threaded_pool(T2, B, G,
                                                     ctx, handles, num_handles);
+#else
+        success = nmod_mpolyn_divides(T1, A, G, ctx);
+        success = success && nmod_mpolyn_divides(T2, B, G, ctx);
+#endif
         if (success)
         {
             ulong temp;
@@ -1185,10 +1190,15 @@ successful_fix_lc:
     {
         nmod_mpolyn_content_last(t1, Abar, ctx);
         nmod_mpolyn_divexact_last(Abar, t1, ctx);
+#ifdef nmod_mpolyn_divides_threaded_pool
         success =            nmod_mpolyn_divides_threaded_pool(T1, A, Abar,
                                                     ctx, handles, num_handles);
         success = success && nmod_mpolyn_divides_threaded_pool(T2, B, T1,
                                                     ctx, handles, num_handles);
+#else
+        success = nmod_mpolyn_divides(T1, A, Abar, ctx);
+        success = success && nmod_mpolyn_divides(T2, B, T1, ctx);
+#endif
         if (success)
         {
             nmod_mpolyn_swap(T1, G);
@@ -1200,10 +1210,15 @@ successful_fix_lc:
     {
         nmod_mpolyn_content_last(t1, Bbar, ctx);
         nmod_mpolyn_divexact_last(Bbar, t1, ctx);
+#ifdef nmod_mpolyn_divides_threaded_pool
         success =            nmod_mpolyn_divides_threaded_pool(T1, B, Bbar,
                                                     ctx, handles, num_handles);
         success = success && nmod_mpolyn_divides_threaded_pool(T2, A, T1,
                                                     ctx, handles, num_handles);
+#else
+        success = nmod_mpolyn_divides(T1, B, Bbar, ctx);
+        success = success && nmod_mpolyn_divides(T2, A, T1, ctx);
+#endif
         if (success)
         {
             nmod_mpolyn_swap(T1, G);

--- a/src/nmod_mpoly/mpolyn_divides_threaded.c
+++ b/src/nmod_mpoly/mpolyn_divides_threaded.c
@@ -9,8 +9,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "thread_pool.h"
 #include "nmod_mpoly.h"
+
+#if FLINT_KNOW_STRONG_ORDER
+
+#include "thread_pool.h"
 #include "fmpz_mpoly.h"
 
 typedef struct _nmod_mpolyn_stripe_struct
@@ -1735,10 +1738,6 @@ int nmod_mpolyn_divides_threaded_pool(
     FLINT_ASSERT(B->bits == bits);
     FLINT_ASSERT(Q->bits == bits);
 
-#if !FLINT_KNOW_STRONG_ORDER
-    return nmod_mpolyn_divides(Q, A, B, ctx);
-#endif
-
     if (B->length < 2 || A->length < 2)
     {
         return nmod_mpolyn_divides(Q, A, B, ctx);
@@ -1885,5 +1884,6 @@ cleanup1:
 
     return divides;
 }
-
-
+#else
+typedef int this_file_is_empty;
+#endif

--- a/src/nmod_mpoly/test/main.c
+++ b/src/nmod_mpoly/test/main.c
@@ -48,7 +48,7 @@
 #include "t-get_term.c"
 #include "t-get_term_monomial.c"
 #include "t-inflate_deflate.c"
-#include "t-mpolyn_divides_threaded.c"
+#include "t-mpolyn_divides_threaded_pool.c"
 #include "t-mpolyuu_divides.c"
 #include "t-mul_array.c"
 #include "t-mul_array_threaded.c"
@@ -111,7 +111,7 @@ test_struct tests[] =
     TEST_FUNCTION(nmod_mpoly_get_term),
     TEST_FUNCTION(nmod_mpoly_get_term_monomial),
     TEST_FUNCTION(nmod_mpoly_inflate_deflate),
-    TEST_FUNCTION(nmod_mpoly_mpolyn_divides_threaded),
+    TEST_FUNCTION(nmod_mpolyn_divides_threaded_pool),
     TEST_FUNCTION(nmod_mpoly_mpolyuu_divides),
     TEST_FUNCTION(nmod_mpoly_mul_array),
     TEST_FUNCTION(nmod_mpoly_mul_array_threaded),

--- a/src/nmod_mpoly/test/t-divides_heap_threaded.c
+++ b/src/nmod_mpoly/test/t-divides_heap_threaded.c
@@ -12,6 +12,7 @@
 #include "test_helpers.h"
 #include "nmod_mpoly.h"
 
+#if defined(nmod_mpoly_divides_heap_threaded)
 TEST_FUNCTION_START(nmod_mpoly_divides_heap_threaded, state)
 {
     int i, j, result, result2, max_threads = 5, tmul = 30;
@@ -428,3 +429,9 @@ TEST_FUNCTION_START(nmod_mpoly_divides_heap_threaded, state)
 
     TEST_FUNCTION_END(state);
 }
+#else
+TEST_FUNCTION_START(nmod_mpoly_divides_heap_threaded, state)
+{
+    TEST_FUNCTION_END_SKIPPED(state);
+}
+#endif

--- a/src/nmod_mpoly/test/t-mpolyn_divides_threaded_pool.c
+++ b/src/nmod_mpoly/test/t-mpolyn_divides_threaded_pool.c
@@ -13,6 +13,7 @@
 #include "thread_support.h"
 #include "nmod_mpoly.h"
 
+#if defined(nmod_mpolyn_divides_threaded_pool)
 void _divides_check(
     const nmod_mpoly_t A,
     const nmod_mpoly_t B,
@@ -127,7 +128,7 @@ cleanup:
     flint_free(stride);
 }
 
-TEST_FUNCTION_START(nmod_mpoly_mpolyn_divides_threaded, state)
+TEST_FUNCTION_START(nmod_mpolyn_divides_threaded_pool, state)
 {
     slong i, j, max_threads = 5, tmul = 50;
 #ifdef _WIN32
@@ -223,3 +224,9 @@ TEST_FUNCTION_START(nmod_mpoly_mpolyn_divides_threaded, state)
 
     TEST_FUNCTION_END(state);
 }
+#else
+TEST_FUNCTION_START(nmod_mpolyn_divides_threaded_pool, state)
+{
+    TEST_FUNCTION_END_SKIPPED(state);
+}
+#endif


### PR DESCRIPTION
Only define and declare some multithreaded "divides" function for multivariate polynomials requiring strongly ordered CPUs in order to not fool the user.

If they are declared, the function name is also a preprocessor constant equal to its name, so if one in C wants to check whether this function is available during compile time, one can just use `#ifdef MYFUNC`.

Just as a note, if the system is known to be strongly ordered, these functions are called in `X_mpoly_divides`, so no real loss there (I am thinking of users that cannot use the C preprocessor).

This is also documented.

Solves #1685 