### PR TITLE
Remove space between function and :: in documentation

### DIFF
--- a/doc/source/acb.rst
+++ b/doc/source/acb.rst
@@ -890,13 +890,13 @@ Rising factorials
     These functions are aliases for :func:`acb_hypgeom_rising_ui`
     and :func:`acb_hypgeom_rising`.
 
-.. function :: void acb_rising2_ui(acb_t u, acb_t v, const acb_t x, ulong n, slong prec)
+.. function:: void acb_rising2_ui(acb_t u, acb_t v, const acb_t x, ulong n, slong prec)
 
     Letting `u(x) = x (x+1) (x+2) \cdots (x+n-1)`, simultaneously compute
     `u(x)` and `v(x) = u'(x)`.
     This function is a wrapper of :func:`acb_hypgeom_rising_ui_jet`.
 
-.. function :: void acb_rising_ui_get_mag(mag_t bound, const acb_t x, ulong n)
+.. function:: void acb_rising_ui_get_mag(mag_t bound, const acb_t x, ulong n)
 
     Computes an upper bound for the absolute value of
     the rising factorial `z = x (x+1) (x+2) \cdots (x+n-1)`.

--- a/doc/source/acb_hypgeom.rst
+++ b/doc/source/acb_hypgeom.rst
@@ -1251,7 +1251,7 @@ Dilogarithm
 The dilogarithm function
 is given by `\operatorname{Li}_2(z) = -\int_0^z \frac{\log(1-t)}{t} dt = z {}_3F_2(1,1,1,2,2,z)`.
 
-.. function :: void acb_hypgeom_dilog_bernoulli(acb_t res, const acb_t z, slong prec)
+.. function:: void acb_hypgeom_dilog_bernoulli(acb_t res, const acb_t z, slong prec)
 
     Computes the dilogarithm using a series expansion in `w = \log(z)`,
     with rate of convergence `|w/(2\pi)|^n`. This provides good convergence

--- a/doc/source/arb.rst
+++ b/doc/source/arb.rst
@@ -1356,7 +1356,7 @@ Gamma function and factorials
     compared to *prec*, it is more efficient to convert *x* to an approximation
     and use :func:`arb_rising_ui`.
 
-.. function :: void arb_rising2_ui(arb_t u, arb_t v, const arb_t x, ulong n, slong prec)
+.. function:: void arb_rising2_ui(arb_t u, arb_t v, const arb_t x, ulong n, slong prec)
 
     Letting `u(x) = x (x+1) (x+2) \cdots (x+n-1)`, simultaneously compute
     `u(x)` and `v(x) = u'(x)`.


### PR DESCRIPTION
A few functions in the documentation had a space between `function` and `::`. It seems to not affect the website, but syntax highlighting in Emacs complained about it and, the reason I noticed it, my "parser" skipped those lines. 