### PR TITLE
removing spaces before colons

### DIFF
--- a/doc/source/acb.rst
+++ b/doc/source/acb.rst
@@ -936,13 +936,13 @@ Gamma function
 
     Computes the logarithmic sine function defined by
 
-    .. math ::
+    .. math::
 
         S(z) = \log(\pi) - \log \Gamma(z) + \log \Gamma(1-z)
 
     which is equal to
 
-    .. math ::
+    .. math::
 
         S(z) = \int_{1/2}^z \pi \cot(\pi t) dt
 
@@ -950,7 +950,7 @@ Gamma function
     if `0 < \arg(z) \le \pi` and through the lower half plane
     if `-\pi < \arg(z) \le 0`. Equivalently,
 
-    .. math ::
+    .. math::
 
         S(z) = \log(\sin(\pi(z-n))) \mp n \pi i, \quad n = \lfloor \operatorname{re}(z) \rfloor
 
@@ -983,7 +983,7 @@ Gamma function
     The generalization to other values of *s* is due to
     Espinosa and Moll [EM2004]_:
 
-    .. math ::
+    .. math::
 
         \psi(s,z) = \frac{\zeta'(s+1,z) + (\gamma + \psi(-s)) \zeta(s+1,z)}{\Gamma(-s)}
 
@@ -997,7 +997,7 @@ Gamma function
     in analogy with the logarithmic gamma function. The functional
     equation
 
-    .. math ::
+    .. math::
 
         \log G(z+1) = \log \Gamma(z) + \log G(z).
 
@@ -1007,7 +1007,7 @@ Gamma function
     relation `G(z+1) = \Gamma(z) G(z)` together with the initial value
     `G(1) = 1`. For general *z*, we use the formula
 
-    .. math ::
+    .. math::
 
         \log G(z) = (z-1) \log \Gamma(z) - \zeta'(-1,z) + \zeta'(-1).
 

--- a/doc/source/acb_calc.rst
+++ b/doc/source/acb_calc.rst
@@ -104,7 +104,7 @@ Integration
 
     Computes a rigorous enclosure of the integral
 
-    .. math ::
+    .. math::
 
         I = \int_a^b f(t) dt
 
@@ -282,7 +282,7 @@ Local integration algorithms
     For the interval `[-1,1]`, the error of the *n*-point Gauss-Legendre
     rule is bounded by
 
-    .. math ::
+    .. math::
 
         \left| I - \sum_{k=0}^{n-1} w_k f(x_k) \right| \le \frac{64 M}{15 (\rho-1) \rho^{2n-1}}
 
@@ -312,7 +312,7 @@ Integration (old)
 
     Sets *bound* to a ball containing the value of the integral
 
-    .. math ::
+    .. math::
 
         C(x,r) = \frac{1}{2 \pi r} \oint_{|z-x| = r} |f(z)| dz
                = \int_0^1 |f(x+re^{2\pi i t})| dt
@@ -330,7 +330,7 @@ Integration (old)
 
     Computes the integral
 
-    .. math ::
+    .. math::
 
         I = \int_a^b f(t) dt
 
@@ -342,7 +342,7 @@ Integration (old)
     formula. More precisely, if the Taylor series of *f* centered at the point
     *m* is `f(m+x) = \sum_{n=0}^{\infty} a_n x^n`, then
 
-    .. math ::
+    .. math::
 
         \int f(m+x) = \left( \sum_{n=0}^{N-1} a_n \frac{x^{n+1}}{n+1} \right)
                   + \left( \sum_{n=N}^{\infty} a_n \frac{x^{n+1}}{n+1} \right).
@@ -350,7 +350,7 @@ Integration (old)
     For sufficiently small *x*, the second series converges and its
     absolute value is bounded by
 
-    .. math ::
+    .. math::
 
         \sum_{n=N}^{\infty} \frac{C(m,R)}{R^n} \frac{|x|^{n+1}}{N+1}
             = \frac{C(m,R) R x}{(R-x)(N+1)} \left( \frac{x}{R} \right)^N.

--- a/doc/source/acb_dirichlet.rst
+++ b/doc/source/acb_dirichlet.rst
@@ -7,7 +7,7 @@ This module allows working with values of Dirichlet characters,
 Dirichlet L-functions, and related functions.
 A Dirichlet L-function is the analytic continuation of an L-series
 
-.. math ::
+.. math::
 
     L(s,\chi) = \sum_{k=1}^\infty \frac{\chi(k)}{k^s}
 
@@ -139,17 +139,17 @@ The Riemann-Siegel (RS) formula is implemented closely following
 J. Arias de Reyna [Ari2011]_.
 For `s = \sigma + it` with `t > 0`, the expansion takes the form
 
-.. math ::
+.. math::
 
     \zeta(s) = \mathcal{R}(s) + X(s) \overline{\mathcal{R}}(1-s), \quad X(s) = \pi^{s-1/2} \frac{\Gamma((1-s)/2)}{\Gamma(s/2)}
 
 where
 
-.. math ::
+.. math::
 
     \mathcal{R}(s) = \sum_{k=1}^N \frac{1}{k^s} + (-1)^{N-1} U a^{-\sigma} \left[ \sum_{k=0}^K \frac{C_k(p)}{a^k} + RS_K \right]
 
-.. math ::
+.. math::
 
     U = \exp\left(-i\left[ \frac{t}{2} \log\left(\frac{t}{2\pi}\right)-\frac{t}{2}-\frac{\pi}{8} \right]\right), \quad
     a = \sqrt{\frac{t}{2\pi}}, \quad N = \lfloor a \rfloor, \quad p = 1-2(a-N).
@@ -276,7 +276,7 @@ Lerch transcendent
 
     Computes the Lerch transcendent
 
-    .. math ::
+    .. math::
 
         \Phi(z,s,a) = \sum_{k=0}^{\infty} \frac{z^k}{(k+a)^s}
 
@@ -285,7 +285,7 @@ Lerch transcendent
     The *direct* version evaluates a truncation of the defining series.
     The *integral* version uses the Hankel contour integral
 
-    .. math ::
+    .. math::
 
         \Phi(z,s,a) = -\frac{\Gamma(1-s)}{2 \pi i} \int_C \frac{(-t)^{s-1} e^{-a t}}{1 - z e^{-t}} dt
 
@@ -304,7 +304,7 @@ Stieltjes constants
     `\gamma_n(a)` which is the coefficient in the Laurent series of the
     Hurwitz zeta function at the pole
 
-    .. math ::
+    .. math::
 
         \zeta(s,a) = \frac{1}{s-1} + \sum_{n=0}^\infty \frac{(-1)^n}{n!} \gamma_n(a) (s-1)^n.
 
@@ -547,14 +547,14 @@ Dirichlet L-functions
     An error bound is computed via :func:`mag_hurwitz_zeta_uiui`.
     If *s* is complex, replace it with its real part. Since
 
-    .. math ::
+    .. math::
 
         \frac{1}{L(s,\chi)} = \prod_{p} \left(1 - \frac{\chi(p)}{p^s}\right)
                 = \sum_{k=1}^{\infty} \frac{\mu(k)\chi(k)}{k^s}
 
     and the truncated product gives all smooth-index terms in the series, we have
 
-    .. math ::
+    .. math::
 
         \left|\prod_{p < N} \left(1 - \frac{\chi(p)}{p^s}\right) - \frac{1}{L(s,\chi)}\right|
         \le \sum_{k=N}^{\infty} \frac{1}{k^s} = \zeta(s,N).
@@ -593,7 +593,7 @@ Dirichlet L-functions
     i.e. `L(s), L'(s), \ldots, L^{(len-1)}(s) / (len-1)!`.
     If *deflate* is set, computes the expansion of
 
-    .. math ::
+    .. math::
 
         L(s,\chi) - \frac{\sum_{k=1}^q \chi(k)}{(s-1)q}
 
@@ -623,7 +623,7 @@ Currently, these methods require *chi* to be a primitive character.
     Computes the phase function used to construct the Z-function.
     We have
 
-    .. math ::
+    .. math::
 
         \theta(t) = -\frac{t}{2} \log(\pi/q) - \frac{i \log(\epsilon)}{2}
             + \frac{\log \Gamma((s+\delta)/2) - \log \Gamma((1-s+\delta)/2)}{2i}
@@ -777,7 +777,7 @@ and formulas described by David J. Platt in [Pla2017]_.
 
     Compute `\Lambda(t) e^{\pi t/4}` where
 
-    .. math ::
+    .. math::
 
         \Lambda(t) = \pi^{-\frac{it}{2}}
                          \Gamma\left(\frac{\frac{1}{2}+it}{2}\right)

--- a/doc/source/acb_elliptic.rst
+++ b/doc/source/acb_elliptic.rst
@@ -26,7 +26,7 @@ Complete elliptic integrals
 
     Computes the complete elliptic integral of the first kind
 
-    .. math ::
+    .. math::
 
         K(m) = \int_0^{\pi/2} \frac{dt}{\sqrt{1-m \sin^2 t}}
                   = \int_0^1
@@ -51,7 +51,7 @@ Complete elliptic integrals
 
     Computes the complete elliptic integral of the second kind
 
-     .. math ::
+     .. math::
 
         E(m) = \int_0^{\pi/2} \sqrt{1-m \sin^2 t} \, dt =
                     \int_0^1
@@ -64,7 +64,7 @@ Complete elliptic integrals
 
     Evaluates the complete elliptic integral of the third kind
 
-     .. math ::
+     .. math::
 
         \Pi(n, m) = \int_0^{\pi/2}
             \frac{dt}{(1-n \sin^2 t) \sqrt{1-m \sin^2 t}} =
@@ -83,7 +83,7 @@ Legendre incomplete elliptic integrals
     Evaluates the Legendre incomplete elliptic integral of the first kind,
     given by
 
-     .. math ::
+     .. math::
 
         F(\phi,m) = \int_0^{\phi} \frac{dt}{\sqrt{1-m \sin^2 t}}
                   = \int_0^{\sin \phi}
@@ -92,7 +92,7 @@ Legendre incomplete elliptic integrals
     on the standard strip `-\pi/2 \le \operatorname{Re}(\phi) \le \pi/2`.
     Outside this strip, the function extends quasiperiodically as
 
-    .. math ::
+    .. math::
 
         F(\phi + n \pi, m) = 2 n K(m) + F(\phi,m), n \in \mathbb{Z}.
 
@@ -111,7 +111,7 @@ Legendre incomplete elliptic integrals
     Evaluates the Legendre incomplete elliptic integral of the second kind,
     given by
 
-     .. math ::
+     .. math::
 
         E(\phi,m) = \int_0^{\phi} \sqrt{1-m \sin^2 t} \, dt =
                     \int_0^{\sin \phi}
@@ -120,7 +120,7 @@ Legendre incomplete elliptic integrals
     on the standard strip `-\pi/2 \le \operatorname{Re}(\phi) \le \pi/2`.
     Outside this strip, the function extends quasiperiodically as
 
-    .. math ::
+    .. math::
 
         E(\phi + n \pi, m) = 2 n E(m) + E(\phi,m), n \in \mathbb{Z}.
 
@@ -139,7 +139,7 @@ Legendre incomplete elliptic integrals
     Evaluates the Legendre incomplete elliptic integral of the third kind,
     given by
 
-     .. math ::
+     .. math::
 
         \Pi(n, \phi, m) = \int_0^{\phi}
             \frac{dt}{(1-n \sin^2 t) \sqrt{1-m \sin^2 t}} =
@@ -149,7 +149,7 @@ Legendre incomplete elliptic integrals
     on the standard strip `-\pi/2 \le \operatorname{Re}(\phi) \le \pi/2`.
     Outside this strip, the function extends quasiperiodically as
 
-    .. math ::
+    .. math::
 
         \Pi(n, \phi + k \pi, m) = 2 k \Pi(n,m) + \Pi(n,\phi,m), k \in \mathbb{Z}.
 
@@ -178,7 +178,7 @@ in [Car1995]_ and chapter 19 in [NIST2012]_.
 
     Evaluates the Carlson symmetric elliptic integral of the first kind
 
-    .. math ::
+    .. math::
 
         R_F(x,y,z) = \frac{1}{2}
             \int_0^{\infty} \frac{dt}{\sqrt{(t+x)(t+y)(t+z)}}
@@ -205,7 +205,7 @@ in [Car1995]_ and chapter 19 in [NIST2012]_.
 
     Evaluates the Carlson symmetric elliptic integral of the second kind
 
-    .. math ::
+    .. math::
 
         R_G(x,y,z) = \frac{1}{4} \int_0^{\infty}
             \frac{t}{\sqrt{(t+x)(t+y)(t+z)}}
@@ -224,7 +224,7 @@ in [Car1995]_ and chapter 19 in [NIST2012]_.
 
     Evaluates the Carlson symmetric elliptic integral of the third kind
 
-    .. math ::
+    .. math::
 
         R_J(x,y,z,p) = \frac{3}{2}
             \int_0^{\infty} \frac{dt}{(t+p)\sqrt{(t+x)(t+y)(t+z)}}
@@ -285,7 +285,7 @@ The main reference is chapter 23 in [NIST2012]_.
 
     Computes Weierstrass's elliptic function
 
-    .. math ::
+    .. math::
 
         \wp(z, \tau) = \frac{1}{z^2} + \sum_{n^2+m^2 \ne 0}
             \left[ \frac{1}{(z+m+n\tau)^2} - \frac{1}{(m+n\tau)^2} \right]
@@ -293,7 +293,7 @@ The main reference is chapter 23 in [NIST2012]_.
     which satisfies `\wp(z, \tau) = \wp(z + 1, \tau) = \wp(z + \tau, \tau)`.
     To evaluate the function efficiently, we use the formula
 
-    .. math ::
+    .. math::
 
         \wp(z, \tau) = \pi^2 \theta_2^2(0,\tau) \theta_3^2(0,\tau)
             \frac{\theta_4^2(z,\tau)}{\theta_1^2(z,\tau)} -
@@ -337,7 +337,7 @@ The main reference is chapter 23 in [NIST2012]_.
     satisfies `\wp(\wp^{-1}(z, \tau), \tau) = z`. This function is given
     by the elliptic integral
 
-    .. math ::
+    .. math::
 
         \wp^{-1}(z, \tau) = \frac{1}{2} \int_z^{\infty} \frac{dt}{\sqrt{(t-e_1)(t-e_2)(t-e_3)}}
             = R_F(z-e_1,z-e_2,z-e_3).
@@ -346,7 +346,7 @@ The main reference is chapter 23 in [NIST2012]_.
 
     Computes the Weierstrass zeta function
 
-    .. math ::
+    .. math::
 
         \zeta(z, \tau) = \frac{1}{z} + \sum_{n^2+m^2 \ne 0}
             \left[ \frac{1}{z-m-n\tau} + \frac{1}{m+n\tau} + \frac{z}{(m+n\tau)^2} \right]
@@ -358,7 +358,7 @@ The main reference is chapter 23 in [NIST2012]_.
 
     Computes the Weierstrass sigma function
 
-    .. math ::
+    .. math::
 
         \sigma(z, \tau) = z \prod_{n^2+m^2 \ne 0}
             \left[ \left(1-\frac{z}{m+n\tau}\right)

--- a/doc/source/acb_hypgeom.rst
+++ b/doc/source/acb_hypgeom.rst
@@ -5,7 +5,7 @@
 
 The generalized hypergeometric function is formally defined by
 
-.. math ::
+.. math::
 
     {}_pF_q(a_1,\ldots,a_p;b_1,\ldots,b_q;z) =
     \sum_{k=0}^\infty \frac{(a_1)_k\dots(a_p)_k}{(b_1)_k\dots(b_q)_k} \frac {z^k} {k!}.
@@ -120,13 +120,13 @@ Convergent series
 
 In this section, we define
 
-.. math ::
+.. math::
 
     T(k) = \frac{\prod_{i=0}^{p-1} (a_i)_k}{\prod_{i=0}^{q-1} (b_i)_k} z^k
 
 and
 
-.. math ::
+.. math::
 
     {}_pf_{q}(a_0,\ldots,a_{p-1}; b_0 \ldots b_{q-1}; z) = {}_{p+1}F_{q}(a_0,\ldots,a_{p-1},1; b_0 \ldots b_{q-1}; z) = \sum_{k=0}^{\infty} T(k)
 
@@ -197,7 +197,7 @@ or remove a 1 from the `a_i` parameters if there is one.
 
     Computes
 
-    .. math ::
+    .. math::
 
         {}_pf_{q}(z)
             = \sum_{k=0}^{\infty} T(k)
@@ -337,7 +337,7 @@ Confluent hypergeometric functions
     The *asymp* version uses the asymptotic expansions of Bessel
     functions, together with the connection formulas
 
-    .. math ::
+    .. math::
 
         \frac{{}_0F_1(a,z)}{\Gamma(a)} = (-z)^{(1-a)/2} J_{a-1}(2 \sqrt{-z}) =
                                          z^{(1-a)/2} I_{a-1}(2 \sqrt{z}).
@@ -364,7 +364,7 @@ Error functions and Fresnel integrals
 
     Computes the error function respectively using
 
-    .. math ::
+    .. math::
 
         \operatorname{erf}(z) &= \frac{2z}{\sqrt{\pi}}
             {}_1F_1(\tfrac{1}{2}, \tfrac{3}{2}, -z^2)
@@ -451,18 +451,18 @@ Bessel functions
     via :func:`acb_hypgeom_u_asymp`.
     For all complex `\nu, z`, we have
 
-    .. math ::
+    .. math::
 
         J_{\nu}(z) = \frac{z^{\nu}}{2^{\nu} e^{iz} \Gamma(\nu+1)}
             {}_1F_1(\nu+\tfrac{1}{2}, 2\nu+1, 2iz) = A_{+} B_{+} + A_{-} B_{-}
 
     where
 
-    .. math ::
+    .. math::
 
         A_{\pm} = z^{\nu} (z^2)^{-\tfrac{1}{2}-\nu} (\mp i z)^{\tfrac{1}{2}+\nu} (2 \pi)^{-1/2} = (\pm iz)^{-1/2-\nu} z^{\nu} (2 \pi)^{-1/2}
 
-    .. math ::
+    .. math::
 
         B_{\pm} = e^{\pm i z} U^{*}(\nu+\tfrac{1}{2}, 2\nu+1, \mp 2iz).
 
@@ -475,7 +475,7 @@ Bessel functions
 
     Computes the Bessel function of the first kind from
 
-    .. math ::
+    .. math::
 
         J_{\nu}(z) = \frac{1}{\Gamma(\nu+1)} \left(\frac{z}{2}\right)^{\nu}
                      {}_0F_1\left(\nu+1, -\frac{z^2}{4}\right).
@@ -490,13 +490,13 @@ Bessel functions
     Computes the Bessel function of the second kind `Y_{\nu}(z)` from the
     formula
 
-    .. math ::
+    .. math::
 
         Y_{\nu}(z) = \frac{\cos(\nu \pi) J_{\nu}(z) - J_{-\nu}(z)}{\sin(\nu \pi)}
 
     unless `\nu = n` is an integer in which case the limit value
 
-    .. math ::
+    .. math::
 
         Y_n(z) = -\frac{2}{\pi} \left( i^n K_n(iz) +
             \left[\log(iz)-\log(z)\right] J_n(z) \right)
@@ -528,7 +528,7 @@ Modified Bessel functions
     asymptotic series (see :func:`acb_hypgeom_bessel_j_asymp`),
     the convergent series
 
-    .. math ::
+    .. math::
 
         I_{\nu}(z) = \frac{1}{\Gamma(\nu+1)} \left(\frac{z}{2}\right)^{\nu}
                      {}_0F_1\left(\nu+1, \frac{z^2}{4}\right),
@@ -543,7 +543,7 @@ Modified Bessel functions
     Computes the modified Bessel function of the second kind via
     via :func:`acb_hypgeom_u_asymp`. For all `\nu` and all `z \ne 0`, we have
 
-    .. math ::
+    .. math::
 
         K_{\nu}(z) = \left(\frac{2z}{\pi}\right)^{-1/2} e^{-z}
             U^{*}(\nu+\tfrac{1}{2}, 2\nu+1, 2z).
@@ -556,7 +556,7 @@ Modified Bessel functions
     as a power series truncated to length *len*,
     given `\nu, z \in \mathbb{C}[[x]]`. Uses the formula
 
-    .. math ::
+    .. math::
 
         K_{\nu}(z) = \frac{1}{2} \frac{\pi}{\sin(\pi \nu)} \left[
                     \left(\frac{z}{2}\right)^{-\nu}
@@ -577,7 +577,7 @@ Modified Bessel functions
 
     Computes the modified Bessel function of the second kind from
 
-    .. math ::
+    .. math::
 
         K_{\nu}(z) = \frac{1}{2} \left[
                     \left(\frac{z}{2}\right)^{-\nu}
@@ -686,7 +686,7 @@ Coulomb wave functions
 
 Coulomb wave functions are solutions of the Coulomb wave equation
 
-.. math ::
+.. math::
 
     y'' + \left(1 - \frac{2 \eta}{z} - \frac{\ell(\ell+1)}{z^2}\right) y = 0
 
@@ -759,19 +759,19 @@ Incomplete gamma and beta functions
 
     The different methods respectively implement the formulas
 
-    .. math ::
+    .. math::
 
         \Gamma(s,z) = e^{-z} U(1-s,1-s,z)
 
-    .. math ::
+    .. math::
 
         \Gamma(s,z) = \Gamma(s) - \frac{z^s}{s} {}_1F_1(s, s+1, -z)
 
-    .. math ::
+    .. math::
 
         \Gamma(s,z) = \Gamma(s) - \frac{z^s e^{-z}}{s} {}_1F_1(1, s+1, z)
 
-    .. math ::
+    .. math::
 
         \Gamma(s,z) = \frac{(-1)^n}{n!} (\psi(n+1) - \log(z))
                     + \frac{(-1)^n}{(n+1)!} z \, {}_2F_2(1,1,2,2+n,-z)
@@ -822,11 +822,11 @@ Incomplete gamma and beta functions
     In general, the integral must be interpreted using analytic continuation.
     The precise definitions for all parameter values are
 
-    .. math ::
+    .. math::
 
         B(a,b;z) = \frac{z^a}{a} {}_2F_1(a, 1-b, a+1, z)
 
-    .. math ::
+    .. math::
 
         I(a,b;z) = \frac{\Gamma(a+b)}{\Gamma(b)} z^a {}_2{\widetilde F}_1(a, 1-b, a+1, z).
 
@@ -863,12 +863,12 @@ The branch cut conventions of the following functions match Mathematica.
     Computes the exponential integral `\operatorname{Ei}(z)`, respectively
     using
 
-    .. math ::
+    .. math::
 
         \operatorname{Ei}(z) = -e^z U(1,1,-z) - \log(-z)
             + \frac{1}{2} \left(\log(z) - \log\left(\frac{1}{z}\right) \right)
 
-    .. math ::
+    .. math::
 
         \operatorname{Ei}(z) = z {}_2F_2(1, 1; 2, 2; z) + \gamma
             + \frac{1}{2} \left(\log(z) - \log\left(\frac{1}{z}\right) \right)
@@ -891,13 +891,13 @@ The branch cut conventions of the following functions match Mathematica.
     Computes the sine integral `\operatorname{Si}(z)`, respectively
     using
 
-    .. math ::
+    .. math::
 
         \operatorname{Si}(z) = \frac{i}{2} \left[
             e^{iz} U(1,1,-iz) - e^{-iz} U(1,1,iz) + 
             \log(-iz) - \log(iz) \right]
 
-    .. math ::
+    .. math::
 
         \operatorname{Si}(z) = z {}_1F_2(\tfrac{1}{2}; \tfrac{3}{2}, \tfrac{3}{2}; -\tfrac{z^2}{4})
 
@@ -919,13 +919,13 @@ The branch cut conventions of the following functions match Mathematica.
     Computes the cosine integral `\operatorname{Ci}(z)`, respectively
     using
 
-    .. math ::
+    .. math::
 
         \operatorname{Ci}(z) = \log(z) - \frac{1}{2} \left[
             e^{iz} U(1,1,-iz) + e^{-iz} U(1,1,iz) + 
             \log(-iz) + \log(iz) \right]
 
-    .. math ::
+    .. math::
 
         \operatorname{Ci}(z) = -\tfrac{z^2}{4}
             {}_2F_3(1, 1; 2, 2, \tfrac{3}{2}; -\tfrac{z^2}{4})
@@ -962,13 +962,13 @@ The branch cut conventions of the following functions match Mathematica.
     Computes the hyperbolic cosine integral `\operatorname{Chi}(z)`, respectively
     using
 
-    .. math ::
+    .. math::
 
         \operatorname{Chi}(z) = -\frac{1}{2} \left[
             e^{z} U(1,1,-z) + e^{-z} U(1,1,z) + 
             \log(-z) - \log(z) \right]
 
-    .. math ::
+    .. math::
 
         \operatorname{Chi}(z) = \tfrac{z^2}{4}
             {}_2F_3(1, 1; 2, 2, \tfrac{3}{2}; \tfrac{z^2}{4})
@@ -1003,7 +1003,7 @@ Gauss hypergeometric function
 
 The following methods compute the Gauss hypergeometric function
 
-.. math ::
+.. math::
 
     F(z) = {}_2F_1(a,b,c,z) = \sum_{k=0}^{\infty} \frac{(a)_k (b)_k}{(c)_k} \frac{z^k}{k!}
 
@@ -1096,11 +1096,11 @@ Orthogonal polynomials and functions
 
     Computes the Chebyshev polynomial (or Chebyshev function) of first or second kind
 
-    .. math ::
+    .. math::
 
         T_n(z) = {}_2F_1\left(-n,n,\frac{1}{2},\frac{1-z}{2}\right)
 
-    .. math ::
+    .. math::
 
         U_n(z) = (n+1) {}_2F_1\left(-n,n+2,\frac{3}{2},\frac{1-z}{2}\right).
 
@@ -1113,7 +1113,7 @@ Orthogonal polynomials and functions
 
     Computes the Jacobi polynomial (or Jacobi function)
 
-    .. math ::
+    .. math::
 
         P_n^{(a,b)}(z)=\frac{(a+1)_n}{\Gamma(n+1)} {}_2F_1\left(-n,n+a+b+1,a+1,\frac{1-z}{2}\right).
 
@@ -1126,7 +1126,7 @@ Orthogonal polynomials and functions
 
     Computes the Gegenbauer polynomial (or Gegenbauer function)
 
-    .. math ::
+    .. math::
 
         C_n^{m}(z)=\frac{(2m)_n}{\Gamma(n+1)} {}_2F_1\left(-n,2m+n,m+\frac{1}{2},\frac{1-z}{2}\right).
 
@@ -1139,7 +1139,7 @@ Orthogonal polynomials and functions
 
     Computes the Laguerre polynomial (or Laguerre function)
 
-    .. math ::
+    .. math::
 
         L_n^{m}(z)=\frac{(m+1)_n}{\Gamma(n+1)} {}_1F_1\left(-n,m+1,z\right).
 
@@ -1158,7 +1158,7 @@ Orthogonal polynomials and functions
 
     Computes the Hermite polynomial (or Hermite function)
 
-    .. math ::
+    .. math::
 
         H_n(z) = 2^n \sqrt{\pi} \left(
             \frac{1}{\Gamma((1-n)/2)} {}_1F_1\left(-\frac{n}{2},\frac{1}{2},z^2\right)
@@ -1174,14 +1174,14 @@ Orthogonal polynomials and functions
     Many different branch cut conventions appear in the literature.
     If *type* is 0, the version
 
-    .. math ::
+    .. math::
 
         P_n^m(z) = \frac{(1+z)^{m/2}}{(1-z)^{m/2}}
             \mathbf{F}\left(-n, n+1, 1-m, \frac{1-z}{2}\right)
 
     is computed, and if *type* is 1, the alternative version
 
-    .. math ::
+    .. math::
 
         {\mathcal P}_n^m(z) = \frac{(z+1)^{m/2}}{(z-1)^{m/2}}
             \mathbf{F}\left(-n, n+1, 1-m, \frac{1-z}{2}\right).
@@ -1198,7 +1198,7 @@ Orthogonal polynomials and functions
     Many different branch cut conventions appear in the literature.
     If *type* is 0, the version
 
-    .. math ::
+    .. math::
 
         Q_n^m(z) = \frac{\pi}{2 \sin(\pi m)}
             \left( \cos(\pi m) P_n^m(z) -
@@ -1206,7 +1206,7 @@ Orthogonal polynomials and functions
 
     is computed, and if *type* is 1, the alternative version
 
-    .. math ::
+    .. math::
 
         \mathcal{Q}_n^m(z) = \frac{\pi}{2 \sin(\pi m)} e^{\pi i m}
             \left( \mathcal{P}_n^m(z) -
@@ -1237,7 +1237,7 @@ Orthogonal polynomials and functions
     latitude angle *theta*, and longitude angle *phi*, normalized
     such that
 
-    .. math ::
+    .. math::
 
         Y_n^m(\theta, \phi) = \sqrt{\frac{2n+1}{4\pi} \frac{(n-m)!}{(n+m)!}} e^{im\phi} P_n^m(\cos(\theta)).
 

--- a/doc/source/acb_mat.rst
+++ b/doc/source/acb_mat.rst
@@ -238,7 +238,7 @@ Special matrices
     the matrix is extended periodically along the larger dimension).
     Here, we use the normalized DFT matrix
 
-    .. math ::
+    .. math::
 
         A_{j,k} = \frac{\omega^{jk}}{\sqrt{n}}, \quad \omega = e^{-2\pi i/n}.
 
@@ -577,7 +577,7 @@ Special functions
 
     Sets *B* to the exponential of the matrix *A*, defined by the Taylor series
 
-    .. math ::
+    .. math::
 
         \exp(A) = \sum_{k=0}^{\infty} \frac{A^k}{k!}.
 

--- a/doc/source/acb_modular.rst
+++ b/doc/source/acb_modular.rst
@@ -33,7 +33,7 @@ The modular group
     Represents an element of the modular group `\text{PSL}(2, \mathbb{Z})`,
     namely an integer matrix
 
-    .. math ::
+    .. math::
 
         \begin{pmatrix} a & b \\ c & d \end{pmatrix}
 
@@ -106,7 +106,7 @@ Modular transformations
     Applies the modular transformation *g* to the complex number *z*,
     evaluating
 
-    .. math ::
+    .. math::
 
         w = g z = \frac{az+b}{cz+d}.
 
@@ -181,22 +181,22 @@ Unfortunately, there are many inconsistent notational variations for
 Jacobi theta functions in the literature. Unless otherwise noted,
 we use the functions
 
-.. math ::
+.. math::
 
     \theta_1(z,\tau) = -i \sum_{n=-\infty}^{\infty} (-1)^n \exp(\pi i [(n + 1/2)^2 \tau + (2n + 1) z])
                      = 2 q_{1/4} \sum_{n=0}^{\infty} (-1)^n q^{n(n+1)} \sin((2n+1) \pi z)
 
-.. math ::
+.. math::
 
     \theta_2(z,\tau) = \sum_{n=-\infty}^{\infty} \exp(\pi i [(n + 1/2)^2 \tau + (2n + 1) z])
                      = 2 q_{1/4} \sum_{n=0}^{\infty} q^{n(n+1)} \cos((2n+1) \pi z)
 
-.. math ::
+.. math::
 
     \theta_3(z,\tau) = \sum_{n=-\infty}^{\infty} \exp(\pi i [n^2 \tau + 2n z])
                      = 1 + 2 \sum_{n=1}^{\infty} q^{n^2} \cos(2n \pi z)
 
-.. math ::
+.. math::
 
     \theta_4(z,\tau) = \sum_{n=-\infty}^{\infty} (-1)^n \exp(\pi i [n^2 \tau + 2n z])
                      = 1 + 2 \sum_{n=1}^{\infty} (-1)^n q^{n^2} \cos(2n \pi z)
@@ -217,13 +217,13 @@ To avoid confusion, we only write `q^k` when `k` is an integer.
     (*R* and *S* should be arrays of length 4)
     and `C \in \{0, 1\}` such that
 
-    .. math ::
+    .. math::
 
         \theta_{1+i}(z,\tau) = \exp(\pi i R_i / 4) \cdot A \cdot B \cdot \theta_{1+S_i}(z',\tau')
 
     where `z' = z, A = B = 1` if `C = 0`, and
 
-    .. math ::
+    .. math::
 
         z' = \frac{-z}{c \tau + d}, \quad
         A = \sqrt{\frac{i}{c \tau + d}}, \quad
@@ -244,27 +244,27 @@ To avoid confusion, we only write `q^k` when `k` is an integer.
     We need the function `\theta_{m,n}(z,\tau)` defined for `m, n \in \mathbb{Z}` by
     (beware of the typos in [Rad1973]_)
 
-    .. math ::
+    .. math::
 
         \theta_{0,0}(z,\tau) = \theta_3(z,\tau), \quad
         \theta_{0,1}(z,\tau) = \theta_4(z,\tau)
 
-    .. math ::
+    .. math::
 
         \theta_{1,0}(z,\tau) = \theta_2(z,\tau), \quad
         \theta_{1,1}(z,\tau) = i \theta_1(z,\tau)
 
-    .. math ::
+    .. math::
 
         \theta_{m+2,n}(z,\tau) = (-1)^n \theta_{m,n}(z,\tau)
 
-    .. math ::
+    .. math::
 
         \theta_{m,n+2}(z,\tau) = \theta_{m,n}(z,\tau).
 
     Then we may write
 
-    .. math ::
+    .. math::
 
         \theta_1(z,\tau) &= \varepsilon_1 A B \theta_1(z', \tau')
 
@@ -280,7 +280,7 @@ To avoid confusion, we only write `q^k` when `k` is an integer.
     function by `\varepsilon(a,b,c,d) = \exp(\pi i R(a,b,c,d) / 12)`
     (see :func:`acb_modular_epsilon_arg`), then:
 
-    .. math ::
+    .. math::
 
         \varepsilon_1(a,b,c,d) &= \exp(\pi i [R(-d,b,c,-a) + 1] / 4)
 
@@ -305,7 +305,7 @@ To avoid confusion, we only write `q^k` when `k` is an integer.
     Simultaneously computes the first *len* coefficients of each of the
     formal power series
 
-    .. math ::
+    .. math::
 
         \theta_1(z+x,\tau) / q_{1/4} \in \mathbb{C}[[x]]
 
@@ -341,7 +341,7 @@ To avoid confusion, we only write `q^k` when `k` is an integer.
     `\pm (k+2) = \pm 2, \pm 3, \pm 4, \ldots` etc. The scheme
     is illustrated by the following table:
 
-    .. math ::
+    .. math::
 
         \begin{array}{llll}
                & \theta_1, \theta_2 & q^0 & (w^1 \pm w^{-1}) \\
@@ -359,7 +359,7 @@ To avoid confusion, we only write `q^k` when `k` is an integer.
     `F = \lfloor (N+1)/2 \rfloor + 1`. The error of the
     zeroth derivative can be bounded as
 
-    .. math ::
+    .. math::
 
         2 Q^E W^{N+2} \left[ 1 + Q^F W + Q^{2F} W^2 + \ldots \right]
         = \frac{2 Q^E W^{N+2}}{1 - Q^F W}
@@ -372,14 +372,14 @@ To avoid confusion, we only write `q^k` when `k` is an integer.
     `\pi^r`, but we omit this until we rescale the coefficients
     at the end of the computation). Thus we have the error bound
 
-    .. math ::
+    .. math::
 
         2 Q^E W^{N+2} (N+2)^r \left[ 1 + Q^F W \frac{(N+3)^r}{(N+2)^r} + Q^{2F} W^2 \frac{(N+4)^r}{(N+2)^r} + \ldots \right]
 
     which by the inequality `(1 + m/(N+2))^r \le \exp(mr/(N+2))`
     can be bounded as
 
-    .. math ::
+    .. math::
 
         \frac{2 Q^E W^{N+2} (N+2)^r}{1 - Q^F W \exp(r/(N+2))},
 
@@ -461,7 +461,7 @@ Dedekind eta function
     Evaluates the Dedekind eta function
     without the leading 24th root, i.e.
 
-    .. math :: \exp(-\pi i \tau/12) \eta(\tau) = \sum_{n=-\infty}^{\infty} (-1)^n q^{(3n^2-n)/2}
+    .. math:: \exp(-\pi i \tau/12) \eta(\tau) = \sum_{n=-\infty}^{\infty} (-1)^n q^{(3n^2-n)/2}
 
     given `q = \exp(2 \pi i \tau)`, by summing the defining series.
 
@@ -480,7 +480,7 @@ Dedekind eta function
     `\varepsilon(a,b,c,d) = \exp(\pi i R / 12)` is the 24th root of unity in
     the transformation formula for the Dedekind eta function,
 
-    .. math ::
+    .. math::
 
         \eta\left(\frac{a\tau+b}{c\tau+d}\right) = \varepsilon (a,b,c,d)
             \sqrt{c\tau+d} \eta(\tau).
@@ -516,7 +516,7 @@ Modular forms
     Computes the modular discriminant `\Delta(\tau) = \eta(\tau)^{24}`,
     which transforms as
 
-    .. math ::
+    .. math::
 
         \Delta\left(\frac{a\tau+b}{c\tau+d}\right) = (c\tau+d)^{12} \Delta(\tau).
 
@@ -529,13 +529,13 @@ Modular forms
     of Eisenstein series `G_4(\tau), G_6(\tau), G_8(\tau), \ldots`,
     defined by
 
-    .. math ::
+    .. math::
 
         G_{2k}(\tau) = \sum_{m^2 + n^2 \ne 0} \frac{1}{(m+n\tau )^{2k}}
 
     and satisfying
 
-    .. math ::
+    .. math::
 
         G_{2k} \left(\frac{a\tau+b}{c\tau+d}\right) = (c\tau+d)^{2k} G_{2k}(\tau).
 
@@ -567,7 +567,7 @@ Class polynomials
     Sets *res* to the Hilbert class polynomial of discriminant *D*,
     defined as
 
-    .. math ::
+    .. math::
 
         H_D(x) = \prod_{(a,b,c)} \left(x - j\left(\frac{-b+\sqrt{D}}{2a}\right)\right)
 

--- a/doc/source/acb_poly.rst
+++ b/doc/source/acb_poly.rst
@@ -725,7 +725,7 @@ Elementary functions
 
     Uses the formula
 
-    .. math ::
+    .. math::
 
         \tan^{-1}(f(x)) = \int f'(x) / (1+f(x)^2) dx,
 
@@ -905,7 +905,7 @@ Power sums
 
     Computes
 
-    .. math ::
+    .. math::
 
         z = S(s,a,n) = \sum_{k=0}^{n-1} \frac{q^k}{(k+a)^{s+t}}
 
@@ -918,7 +918,7 @@ Power sums
 
     Computes
 
-    .. math ::
+    .. math::
 
         z = S(s,1,n) \sum_{k=1}^n \frac{1}{k^{s+t}}
 
@@ -986,7 +986,7 @@ Zeta function
     In particular, expanding `\zeta(s,a) + 1/(1-s)` with `s = 1+x`
     gives the Stieltjes constants
 
-    .. math ::
+    .. math::
 
         \sum_{k=0}^{n-1} \frac{(-1)^k}{k!} \gamma_k(a) x^k`.
 
@@ -1060,7 +1060,7 @@ Root-finding
     Sets *bound* to an upper bound for the magnitude of all the complex
     roots of *poly*. Uses Fujiwara's bound
 
-    .. math ::
+    .. math::
 
         2 \max \left\{\left|\frac{a_{n-1}}{a_n}\right|,
                       \left|\frac{a_{n-2}}{a_n}\right|^{1/2},
@@ -1080,7 +1080,7 @@ Root-finding
     where `n` is the degree of `f`. Proof: assume that the distance
     to the nearest root exceeds `r = |f(m)/f'(m)| n`. Then
 
-    .. math ::
+    .. math::
 
         \left|\frac{f'(m)}{f(m)}\right| =
             \left|\sum_i \frac{1}{m-\zeta_i}\right|

--- a/doc/source/acb_theta.rst
+++ b/doc/source/acb_theta.rst
@@ -15,7 +15,7 @@ Siegel upper half-space `\mathbb{H}_g`, which consists of all symmetric
 Riemann theta function of characteristic `(a,b)` is the following analytic
 function in `\tau\in \mathbb{H}_g` and `z\in \mathbb{C}^g`:
 
-    .. math ::
+    .. math::
 
         \theta_{a,b}(z,\tau) = \sum_{n\in \mathbb{Z}^{g} + \tfrac a2} \exp(\pi i n^T\tau n + 2\pi i n^T (z + \tfrac b2)),
 
@@ -133,7 +133,7 @@ In the following functions (with the exception of :func:`sp2gz_is_correct`) we
 always assume that the input matrix *mat* is square of even size `2g`, and
 write it as
 
-    .. math ::
+    .. math::
 
         m = \begin{pmatrix} \alpha&\beta\\ \gamma&\delta \end{pmatrix}
 
@@ -169,7 +169,7 @@ where `\alpha,\beta,\gamma,\delta` are `g\times g` blocks.
     Assuming that *mat* is a symplectic matrix of size `2r\times 2r` and *res*
     is square of size `2g\times 2g` for some `g\geq r`, sets *res* to the symplectic matrix
 
-        .. math ::
+        .. math::
 
             \begin{pmatrix} \alpha && \beta & \\ & I_{g-r} && 0_{g-r} \\ \gamma &&\delta &\\ & 0_{g-r} && I_{g-r} \end{pmatrix}
 
@@ -511,7 +511,7 @@ Naive algorithms: error bounds
 By [EK2023]_, for any `v\in \mathbb{R}^g` and any upper-triangular Cholesky
 matrix `C`, and any `R` such that `R^2 \geq\max(4,\mathit{ord})`, we have
 
-    .. math ::
+    .. math::
 
         \sum_{n\in C\mathbb{Z}^g + v,\ \lVert n\rVert^2 \geq R^2} \lVert n\rVert^{\mathit{ord}} e^{-\lVert n\rVert^2}
         \leq 2^{2g+2} R^{g-1+p} e^{-R^2} \prod_{j=0}^{g-1} (1 + \gamma_j^{-1})
@@ -541,7 +541,7 @@ common compact domain and use only one ellipsoid, following [DHBHS2004]_.
     bounded. (We set `a=0` instead if the entries of this vector have an
     unreasonably large magnitude.) Then
 
-        .. math ::
+        .. math::
 
             \begin{aligned}
             \theta_{0,b}(z,\tau) &= e^{\pi y^T Y^{-1} y} \sum_{n\in \mathbb{Z}^g}
@@ -558,7 +558,7 @@ common compact domain and use only one ellipsoid, following [DHBHS2004]_.
     for the error bound, and is stored as the `k^{\mathrm{th}}` entry of
     *us*. The quantity
 
-        .. math ::
+        .. math::
 
             c = u \exp(\pi i (a^T X a - 2a^T x + i r^T Y r))
 
@@ -589,13 +589,13 @@ compute:
 - the vector `v_2` with entries `x^j` for `n_{\mathrm{min}}\leq j\leq
   n_{\mathrm{max}}`, where
 
-    .. math ::
+    .. math::
 
         x = \exp(2 \pi i z_0) \prod_{k = 1}^{g-1} \exp(2 \pi i n_k \tau_{0,k}),
 
 - the cofactor `c\in \mathbb{C}` given by
 
-    .. math ::
+    .. math::
 
         c = \prod_{k = 1}^{g-1} \exp(2 \pi i n_k z_k) \cdot
         \prod_{1\leq j\leq k < g} \exp(\pi i (2 - \delta_{j,k}) n_j n_k \tau_{j,k}).
@@ -664,7 +664,7 @@ directly.
     We reduce to calling :func:`acb_theta_naive_0b`
     by writing
 
-        .. math ::
+        .. math::
 
             \theta_{a,b}(z,\tau) = \exp(\pi i \tfrac{a^T}{2} \tau \tfrac a2)
             \exp(\pi i a^T(z + \tfrac b 2)) \theta_{0,b}(z + \tau \tfrac{a}{2}, \tau).
@@ -680,7 +680,7 @@ This section contains methods to evaluate the successive partial derivatives of
 `\theta_{a,b}(z,\tau)` with respect to the `g` coordinates of `z`. Derivatives
 with respect to `\tau` are accounted for by the heat equation
 
-    .. math ::
+    .. math::
 
         \frac{\partial\theta_{a,b}}{\partial \tau_{j,k}} = \frac{1}{2\pi i(1 +\delta_{j,k})}
         \frac{\partial^2\theta_{a,b}}{\partial z_j \partial z_k}.
@@ -691,7 +691,7 @@ as vectors of type :type:`slong` and length `g`. In agreement with
 as in the Taylor expansion, so that the tuple `(k_0,\ldots,k_{g-1})`
 corresponds to the differential operator
 
-    .. math ::
+    .. math::
 
         \frac{1}{k_0!}\cdots\frac{1}{k_{g-1}!} \cdot \frac{\partial^{|k|}}{\partial z_0^{k_0}\cdots \partial z_{g-1}^{k_{g-1}}},
 
@@ -703,7 +703,7 @@ orders is `(0,0)`, `(1,0)`, `(0,1)`, `(2,0)`, `(1,1)`, etc.
 The naive algorithms for derivatives will evaluate a partial sum of the
 differentiated series:
 
-    .. math ::
+    .. math::
 
         \frac{\partial^{|k|}\theta_{a,b}}{\partial z_0^{k_0}\cdots \partial z_{g-1}^{k_{g-1}}}(z,\tau) = (2\pi i)^{|k|} \sum_{n\in \mathbb{Z}^g + \tfrac a2} n_0^{k_0} \cdots n_{g-1}^{k_{g-1}}
         e^{\pi i n^T \tau n + 2\pi i n^T (z + \tfrac b2)}.
@@ -755,13 +755,13 @@ differentiated series:
 
     We can rewrite the above sum as
 
-        .. math ::
+        .. math::
 
             (2\pi i)^{|k|} e^{\pi y^T Y^{-1} y} \sum_{n\in \mathbb{Z}^g + \tfrac a2} n_0^{k_0} \cdots n_{g-1}^{k_{g-1}} e^{\pi i(\cdots)} e^{-\pi (n + Y^{-1}y)^T Y (n + Y^{-1}y)}.
 
     We ignore the leading multiplicative factor. Writing `m = C n + v`, we have
 
-        .. math ::
+        .. math::
 
             n_0^{k_0}\cdots n_{g-1}^{k_{g-1}}\leq
             (\lVert C^{-1}\rVert_\infty \lVert n\rVert_2 + \lVert Y^{-1}y\rVert_\infty)^{|k|}.
@@ -769,7 +769,7 @@ differentiated series:
     Using the upper bound from :func:`acb_theta_naive_radius`, we see that the
     absolute value of the tail of the series is bounded above by
 
-        .. math ::
+        .. math::
 
             (\lVert C^{-1} \rVert_\infty R + \lVert Y^{-1}y \rVert_\infty)^{|k|}
              2^{2g+2} R^{g-1} e^{-R^2} \prod_{j=0}^{g-1} (1 + \gamma_j^{-1}).
@@ -816,14 +816,14 @@ We refer to [EK2023]_ for a detailed description of the quasi-linear algorithm
 implemented here. In a nutshell, the algorithm relies on the following
 duplication formula: for all `z,z'\in \mathbb{C}^g` and `\tau\in \mathbb{H}_g`,
 
-    .. math ::
+    .. math::
 
         \theta_{a,0}(z,\tau) \theta_{a,0}(z',\tau) = \sum_{a'\in(\mathbb{Z}/2\mathbb{Z})^g}
         \theta_{a',0}(z+z',2\tau) \theta_{a+a',0}(z-z',2\tau).
 
 In particular,
 
-    .. math ::
+    .. math::
 
         \begin{aligned}
         \theta_{a,0}(z,\tau)^2 &= \sum_{a'\in (\mathbb{Z}/2\mathbb{Z})^g}
@@ -838,7 +838,7 @@ Applying one of these duplication formulas amounts to taking a step in a
 (generalized) AGM sequence. These formulas also have analogues for all theta
 values, not just `\theta_{a,0}`: for instance, we have
 
-    .. math ::
+    .. math::
 
         \theta_{a,b}(0,\tau)^2 = \sum_{a'\in (\mathbb{Z}/2\mathbb{Z})^g} (-1)^{a'^Tb}
         \theta_{a',0}(0,2\tau)\theta_{a+a',0}(0,2\tau).
@@ -981,7 +981,7 @@ Quasi-linear algorithms: AGM steps
     the following reason: keeping notation from :func:`acb_theta_dist_a0`, for
     each `b\in \{0,1\}^g`, the sum
 
-        .. math ::
+        .. math::
 
             \mathrm{Dist}_\tau(-Y^{-1}y, \mathbb{Z}^g + \tfrac b2)^2
             + \mathrm{Dist}_\tau(-Y^{-1} y, \mathbb{Z}^g + \tfrac{b + k}{2})^2
@@ -1041,7 +1041,7 @@ domain, however `\mathrm{Im}(\tau)` may have large eigenvalues.
     list all of them. Then, for a given choice of `n_1`, the sum of the
     corresponding terms in the theta series is
 
-        .. math ::
+        .. math::
 
             e^{\pi i \bigl((n_1 + \tfrac{a_1}{2})\tau_1 (n_1 + \tfrac{a_1}{2}) + 2 (n_1
             + \tfrac{a_1}{2}) z_1\bigr)}
@@ -1103,13 +1103,13 @@ probabilistic algorithm where we gradually increase *guard* and first choose `t
     characteristic `(a,b)`, we have (borrowing notation from
     :func:`acb_theta_ql_a0_split`): either
 
-        .. math ::
+        .. math::
 
             |\theta_{a,b}(z,\tau) - c i^{\,n_1^Tb_1} \theta_{a_0,b_0}(z', \tau_0)| \leq u
 
     when the last `g-s` coordinates of `a` equal `n_1` modulo 2, or
 
-        .. math ::
+        .. math::
 
             |\theta_{a,b}(z,\tau)|\leq u
 
@@ -1130,7 +1130,7 @@ probabilistic algorithm where we gradually increase *guard* and first choose `t
     \{0,1\}^{g-s}` be the corresponding characteristic. We can then write the
     sum defining `\theta_{a,b}` over `E` as
 
-        .. math ::
+        .. math::
 
             e^{\pi i (\tfrac{n_1^T}{2} \tau_1 \tfrac{n_1}{2} + n_1^T(z_1 + \tfrac{b_1}{2}))}
             \sum_{n_0\in E_0 \cap (\mathbb{Z}^s + \tfrac{a_0}{2})}
@@ -1157,7 +1157,7 @@ Quasi-linear algorithms: derivatives
 We implement an algorithm for derivatives of theta functions on the reduced
 domain based on finite differences. Consider the Taylor expansion:
 
-    .. math ::
+    .. math::
 
         \theta_{a,b}(z + h, \tau)
         = \sum_{k\in \mathbb{Z}^g,\ k\geq 0} a_k\, h_0^{k_0}\cdots h_{g-1}^{k_{g-1}}.
@@ -1171,7 +1171,7 @@ derivation tuple that is bounded by `m-1` elementwise. A constant proportion,
 for fixed `g`, of this set consists of all tuples of total order at most
 `m-1`. More precisely, fix `p\in \mathbb{Z}^g`. Then
 
-    .. math ::
+    .. math::
 
         \sum_{n\in \{0,\ldots,m-1\}^g} \zeta^{-p^T n} \theta_{a,b}(z + h_n, \tau)
         = m^g \sum_{\substack{k\in \mathbb{Z}^g,\ k\geq 0,\\ k = p\ (\text{mod } m)}}
@@ -1182,7 +1182,7 @@ formula: if `|\theta_{a,b}(z,\tau)|\leq c` uniformly on a ball of radius `\rho`
 centered in `z` for `\lVert\cdot\rVert_\infty`, then the sum is `m^g
 (a_p\,\varepsilon^{|p|} + T)` with
 
-    .. math ::
+    .. math::
 
         |T|\leq 2c g\,\frac{\varepsilon^{|p|+m}}{\rho^m}.
 
@@ -1202,15 +1202,15 @@ transform.
     any choice of `\rho`, one can take `c = c_0\exp((c_1 + c_2\rho)^2)`
     above. We can take
 
-        .. math ::
+        .. math::
 
             c_0 = 2^g \prod_{j=0}^{g-1} (1 + 2\gamma_j^{-1}),
 
-        .. math ::
+        .. math::
 
             c_1 = \sqrt{\pi y^T Y^{-1} y},
 
-        .. math ::
+        .. math::
 
             c_2 = \sup_{\lVert x \rVert_\infty\leq 1}
               \sqrt{\pi x^T \mathrm{Im}(\tau)^{-1} x}.
@@ -1267,7 +1267,7 @@ The functions in this section implement the theta transformation formula of
 `(z,\tau)\in \mathbb{C}^g\times \mathbb{H}_g`, and any characteristic `(a,b)`,
 we have
 
-    .. math ::
+    .. math::
 
         \theta_{a,b}(m\cdot(z,\tau)) = \kappa(m) \zeta_8^{e(m, a, b)} \det(\gamma\tau + \delta)^{1/2} e^{\pi i z^T (\gamma\tau + \delta)^{-1} \gamma z} \theta_{a',b'}(z,\tau)
 
@@ -1350,7 +1350,7 @@ We use the following notation. Fix `k,j\geq 0`. A Siegel modular form of weight
 at most `j`) such that for any `\tau\in \mathbb{H}_g` and
 `m\in \mathrm{Sp}_4(\mathbb{Z})`, we have
 
-    .. math ::
+    .. math::
 
         f((\alpha\tau + \beta)(\gamma\tau + \delta)^{-1}) = \det(\gamma\tau +
         \delta)^k\cdot \mathrm{Sym}^j(\gamma\tau + \delta)(f(\tau)).
@@ -1359,7 +1359,7 @@ Here `\alpha,\beta,\gamma,\delta` are the `g\times g` blocks of `m`, and the
 notation `\mathrm{Sym}^j(r)` where `r = \bigl(\begin{smallmatrix} a & b\\ c &
 d\end{smallmatrix}\bigr)\in \mathrm{GL}_2(\mathbb{C})` stands for the map
 
-    .. math ::
+    .. math::
 
         P(X) \mapsto (b X + d)^j P\bigl(\tfrac{a X + c}{b X + d}\bigr).
 
@@ -1404,7 +1404,7 @@ modular forms and covariants.
     `h` of degrees `m` and `n`: considering `g` and `h` as homogeneous
     polynomials of degree `m` (resp. `n`) in `x_1,x_2`, this sets *res* to
 
-        .. math ::
+        .. math::
 
             (g,h)_k := \frac{(m-k)!(n-k)!}{m!n!}  \sum_{j=0}^{k} (-1)^{k-j} \binom{k}{j}
             \frac{\partial^k g}{\partial x_1^{k-j}\partial x_2^j}
@@ -1438,7 +1438,7 @@ modular forms and covariants.
 
     We use the formulas from §7.1 in [Str2014]_, with the following normalizations:
 
-        .. math ::
+        .. math::
 
             \psi_4 = h_4/4, \quad \psi_6 = h_6/4,\quad \chi_{10} = -2^{-12} h_{10},
             \quad \chi_{12} = 2^{-15}h_{12}.
@@ -1449,7 +1449,7 @@ modular forms and covariants.
     \tau_3\end{smallmatrix}\bigr)` and `q_j = \exp(2\pi i \tau_j)`, the Fourier
     expansions of these modular forms begin as follows:
 
-        .. math ::
+        .. math::
 
             \begin{aligned} \psi_4(\tau) &= 1 + 240(q_1 + q_3) + \cdots\\
             \psi_6(\tau) &= 1 - 504(q_1 + q_3) + \cdots\\
@@ -1471,7 +1471,7 @@ modular forms and covariants.
     modular form of weight `\det^{35}\otimes \mathrm{Sym}^0` up to scalars, and is
     normalized as follows:
 
-        .. math ::
+        .. math::
 
             \chi_{35}(\tau) = q_1^2 q_3^2 (q_1 - q_3 )(q_2 - q_2^{-1}) + \cdots
 
@@ -1486,7 +1486,7 @@ modular forms and covariants.
     given values of *dth*, computed as in e.g.
     :func:`acb_theta_g2_jet_naive_1`. We have by [CFG2017]_:
 
-        .. math ::
+        .. math::
 
             \chi_{3,6}(\tau) = \frac{1}{64\pi^6} \prod_{(a,b) \text{ odd}}
             \left(\frac{\partial \theta_{a,b}}{\partial z_1}(0,\tau) x_1 +

--- a/doc/source/agm.rst
+++ b/doc/source/agm.rst
@@ -42,14 +42,14 @@ Rather than running the AGM iteration until `a_n` and `b_n` agree to
 they agree to about `p/10` bits and finish with a series expansion.
 With `z = (a-b)/(a+b)`, we have
 
-.. math ::
+.. math::
 
     \operatorname{agm}(a,b) = \frac{(a+b) \pi}{4 K(z^2)},
 
 valid at least when `|z| < 1` and `a, b` have nonnegative real part,
 and
 
-.. math ::
+.. math::
 
     \frac{\pi}{4 K(z^2)} = \tfrac{1}{2} - \tfrac{1}{8} z^2 - \tfrac{5}{128} z^4 - \tfrac{11}{512} z^6 - \tfrac{469}{32768} z^8 + \ldots
 
@@ -68,7 +68,7 @@ By Cauchy's integral formula, `|M^{(k)}(z) / k!| \le C D^k` where
 `C = \max(1, |z| + r)` and `D = 1/r`, for any `0 < r < |z|` (we
 choose *r* to be of the order `|z| / 4`). Taylor expansion now gives
 
-.. math ::
+.. math::
 
     \left|\frac{M(z+h) - M(z)}{h} - M'(z)\right| \le \frac{C D^2 h}{1 - D h}
 
@@ -86,7 +86,7 @@ When *z* is not exact, we evaluate at the midpoint as above
 and bound the propagated error using derivatives.
 Again by Cauchy's integral formula, we have
 
-.. math ::
+.. math::
 
     |M'(z+\varepsilon)| \le \frac{\max(1, |z|+|\varepsilon|+r)}{r}
 
@@ -102,17 +102,17 @@ Higher derivatives
 The function `W(z) = 1 / M(z)` is D-finite. The coefficients of
 `W(z+x) = \sum_{k=0}^{\infty} c_k x^k` satisfy
 
-.. math ::
+.. math::
 
     -2 z (z^2-1) c_2 = (3z^2-1) c_1 + z c_0,
 
-.. math ::
+.. math::
 
     -(k+2)(k+3) z (z^2-1) c_{k+3} = (k+2)^2 (3z^2-1) c_{k+2} + (3k(k+3)+7)z c_{k+1} + (k+1)^2 c_{k}
 
 in general, and
 
-.. math ::
+.. math::
 
     -(k+2)^2 c_{k+2} = (3k(k+3)+7) c_{k+1} + (k+1)^2 c_{k}
 

--- a/doc/source/arb.rst
+++ b/doc/source/arb.rst
@@ -874,7 +874,7 @@ Arithmetic
     Sets `z = x / y`, rounded to *prec* bits. If *y* contains zero, *z* is
     set to `0 \pm \infty`. Otherwise, error propagation uses the rule
 
-    .. math ::
+    .. math::
         \left| \frac{x}{y} - \frac{x+\xi_1 a}{y+\xi_2 b} \right| =
         \left|\frac{x \xi_2 b - y \xi_1 a}{y (y+\xi_2 b)}\right| \le
         \frac{|xb|+|ya|}{|y| (|y|-b)}
@@ -989,7 +989,7 @@ Powers and roots
     if input interval is `[m-r, m+r]` with `r \le m`, the error is largest at
     `m-r` where it satisfies
 
-    .. math ::
+    .. math::
 
         m^{1/k} - (m-r)^{1/k} = m^{1/k} [1 - (1-r/m)^{1/k}]
 
@@ -1530,14 +1530,14 @@ Bernoulli numbers and polynomials
 
     For *n* from 0 to *len* - 1, sets entry *n* in the output vector *res* to
 
-    .. math ::
+    .. math::
 
         S_n(a,b) = \frac{1}{n+1}\left(B_{n+1}(b) - B_{n+1}(a)\right)
 
     where `B_n(x)` is a Bernoulli polynomial. If *a* and *b* are integers
     and `b \ge a`, this is equivalent to
 
-    .. math ::
+    .. math::
 
         S_n(a,b) = \sum_{k=a}^{b-1} k^n.
 
@@ -1765,7 +1765,7 @@ Internals for computing elementary functions
     Computes the arctangent of *x*.
     Initially, the argument-halving formula
 
-    .. math ::
+    .. math::
 
         \operatorname{atan}(x) = 2 \operatorname{atan}\left(\frac{x}{1+\sqrt{1+x^2}}\right)
 
@@ -1773,7 +1773,7 @@ Internals for computing elementary functions
     Then a version of the bit-burst algorithm is used.
     The functional equation
 
-    .. math ::
+    .. math::
 
         \operatorname{atan}(x) = \operatorname{atan}(p/q) +
             \operatorname{atan}(w),

--- a/doc/source/arb_hypgeom.rst
+++ b/doc/source/arb_hypgeom.rst
@@ -160,7 +160,7 @@ Confluent hypergeometric functions
     Computes the confluent hypergeometric function using numerical integration
     of the representation
 
-    .. math ::
+    .. math::
 
         {}_1F_1(a,b,z) = \frac{\Gamma(b)}{\Gamma(a) \Gamma(b-a)} \int_0^1 e^{zt} t^{a-1} (1-t)^{b-a-1} dt.
 
@@ -176,7 +176,7 @@ Confluent hypergeometric functions
     Computes the confluent hypergeometric function `U(a,b,z)` using numerical integration
     of the representation
 
-    .. math ::
+    .. math::
 
         U(a,b,z) = \frac{1}{\Gamma(a)} \int_0^{\infty} e^{-zt} t^{a-1} (1+t)^{b-a-1} dt.
 
@@ -201,7 +201,7 @@ Gauss hypergeometric function
     Computes the Gauss hypergeometric function using numerical integration
     of the representation
 
-    .. math ::
+    .. math::
 
         {}_2F_1(a,b,c,z) = \frac{\Gamma(a)}{\Gamma(b) \Gamma(c-b)} \int_0^1 t^{b-1} (1-t)^{c-b-1} (1-zt)^{-a} dt.
 
@@ -629,7 +629,7 @@ Orthogonal polynomials and functions
     Sets *res* to the *k*-th root of the Legendre polynomial `P_n(x)`.
     We index the roots in decreasing order
 
-    .. math ::
+    .. math::
 
         1 > x_0 > x_1 > \ldots > x_{n-1} > -1
 

--- a/doc/source/arb_mat.rst
+++ b/doc/source/arb_mat.rst
@@ -250,7 +250,7 @@ Special matrices
     There are many different conventions for defining DCT matrices; here,
     we use the normalized "DCT-II" transform matrix
 
-    .. math ::
+    .. math::
 
         A_{j,k} = \sqrt{\frac{2}{n}} \cos\left(\frac{\pi j}{n} \left(k+\frac{1}{2}\right)\right)
 
@@ -708,7 +708,7 @@ Special functions
 
     Sets *B* to the exponential of the matrix *A*, defined by the Taylor series
 
-    .. math ::
+    .. math::
 
         \exp(A) = \sum_{k=0}^{\infty} \frac{A^k}{k!}.
 
@@ -718,7 +718,7 @@ Special functions
     The elementwise error when truncating the Taylor series after *N*
     terms is bounded by the error in the infinity norm, for which we have
 
-    .. math ::
+    .. math::
         \left\|\exp(2^{-r}A) - \sum_{k=0}^{N-1}
             \frac{\left(2^{-r} A\right)^k}{k!} \right\|_{\infty} =
         \left\|\sum_{k=N}^{\infty} \frac{\left(2^{-r} A\right)^k}{k!}\right\|_{\infty} \le

--- a/doc/source/arb_poly.rst
+++ b/doc/source/arb_poly.rst
@@ -298,7 +298,7 @@ Arithmetic
     `c` as the weighted arithmetic mean of the slopes,
     rounded to the nearest integer:
 
-    .. math ::
+    .. math::
 
         c = \left\lfloor
             \frac{(e_2 - e_1) + (f_2 + f_1)}{(a_2 - a_1) + (b_2 - b_1)}
@@ -512,7 +512,7 @@ Product trees
 
     Generates the polynomial
 
-    .. math ::
+    .. math::
 
         \left(\prod_{i=0}^{rn-1} (x-r_i)\right) \left(\prod_{i=0}^{cn-1} (x-c_i)(x-\bar{c_i})\right)
 
@@ -805,7 +805,7 @@ Powers and elementary functions
 
     Uses the formulas
 
-    .. math ::
+    .. math::
 
         \tan^{-1}(f(x)) = \int f'(x) / (1+f(x)^2) dx,
 
@@ -996,7 +996,7 @@ Zeta function
     In particular, expanding `\zeta(s,a) + 1/(1-s)` with `s = 1+x`
     gives the Stieltjes constants
 
-    .. math ::
+    .. math::
 
         \sum_{k=0}^{n-1} \frac{(-1)^k}{k!} \gamma_k(a) x^k.
 
@@ -1010,7 +1010,7 @@ Zeta function
     Sets *res* to the series expansion of the Riemann-Siegel theta
     function
 
-    .. math ::
+    .. math::
 
         \theta(h) = \arg \left(\Gamma\left(\frac{2ih+1}{4}\right)\right) - \frac{\log \pi}{2} h
 
@@ -1027,7 +1027,7 @@ Zeta function
 
     Sets *res* to the series expansion of the Riemann-Siegel Z-function
 
-    .. math ::
+    .. math::
 
         Z(h) = e^{i\theta(h)} \zeta(1/2+ih).
 
@@ -1049,7 +1049,7 @@ Root-finding
     Sets *bound* to an upper bound for the magnitude of all the complex
     roots of *poly*. Uses Fujiwara's bound
 
-    .. math ::
+    .. math::
 
         2 \max \left\{\left|\frac{a_{n-1}}{a_n}\right|,
                       \left|\frac{a_{n-2}}{a_n}\right|^{1/2},

--- a/doc/source/arith.rst
+++ b/doc/source/arith.rst
@@ -42,7 +42,7 @@ Stirling numbers
     kind `S_2(n, k)`.  The Stirling numbers are defined using the
     generating functions
 
-    .. math ::
+    .. math::
 
         x_{(n)} = \sum_{k=0}^n S_1(n,k) x^k
 
@@ -156,7 +156,7 @@ Bell numbers
 
     After handling special cases, we use the formula
 
-    .. math ::
+    .. math::
 
         B_n = \sum_{k=0}^n \frac{(n-k)^n}{(n-k)!}
             \sum_{j=0}^k \frac{(-1)^j}{j!}.
@@ -279,7 +279,7 @@ Bernoulli numbers and polynomials
     numerators and denominators of `B_0, B_1, B_2, \ldots, B_{n-1}`
     inclusive. Uses the generating function
 
-    .. math ::
+    .. math::
 
         \frac{x^2}{\cosh(x)-1} = \sum_{k=0}^{\infty}
             \frac{(2-4k) B_{2k}}{(2k)!} x^{2k}
@@ -330,7 +330,7 @@ The corresponding Euler polynomials are defined by
 
     Sets ``poly`` to the Euler polynomial `E_n(x)`. Uses the formula
 
-    .. math ::
+    .. math::
 
         E_n(x) = \frac{2}{n+1}\left(B_{n+1}(x) -
             2^{n+1}B_{n+1}\left(\frac{x}{2}\right)\right),
@@ -383,7 +383,7 @@ Multiplicative functions
     We use the theta function identity
 
 
-    .. math ::
+    .. math::
 
 
         f(q) = q  \Biggl( \sum_{k \geq 0} (-1)^k (2k+1) q^{k(k+1)/2} \Biggr)^8
@@ -443,7 +443,7 @@ Number of partitions
 
     Symbolically evaluates the exponential sum
 
-    .. math ::
+    .. math::
 
         A_k(n) = \sum_{h=0}^{k-1}
             \exp\left(\pi i \left[ s(h,k) - \frac{2hn}{k}\right]\right)
@@ -475,13 +475,13 @@ Number of partitions
     The Hardy-Ramanujan-Rademacher formula is given with error bounds
     in [Rademacher1937]_. We evaluate it in the form
 
-    .. math ::
+    .. math::
 
         p(n) = \sum_{k=1}^N B_k(n) U(C/k) + R(n,N)
 
     where
 
-    .. math ::
+    .. math::
 
         U(x) = \cosh(x) + \frac{\sinh(x)}{x},
             \quad C = \frac{\pi}{6} \sqrt{24n-1}
@@ -490,7 +490,7 @@ Number of partitions
 
     and where `A_k(n)` is a certain exponential sum. The remainder satisfies
 
-    .. math ::
+    .. math::
 
         |R(n,N)| < \frac{44 \pi^2}{225 \sqrt{3}} N^{-1/2} +
             \frac{\pi \sqrt{2}}{75} \left(\frac{N}{n-1}\right)^{1/2}
@@ -559,6 +559,6 @@ Sums of squares
     This effectively computes the `q`-expansion of `\vartheta_3(q)`
     raised to the `k`-th power, i.e.
 
-    .. math ::
+    .. math::
 
         \vartheta_3^k(q) = \left( \sum_{i=-\infty}^{\infty} q^{i^2} \right)^k.

--- a/doc/source/bernoulli.rst
+++ b/doc/source/bernoulli.rst
@@ -7,7 +7,7 @@ This module provides helper functions for exact or approximate calculation
 of the Bernoulli numbers, which are defined by the exponential
 generating function
 
-.. math ::
+.. math::
 
     \frac{x}{e^x-1} = \sum_{n=0}^{\infty} B_n \frac{x^n}{n!}.
 

--- a/doc/source/ca.rst
+++ b/doc/source/ca.rst
@@ -931,7 +931,7 @@ Complex parts
 
     Sets *res* to the sign of *x*, defined by
 
-    .. math ::
+    .. math::
 
         \operatorname{sgn}(x) = \begin{cases} 0 & x = 0 \\ \frac{x}{|x|} & x \ne 0 \end{cases}
 
@@ -1498,19 +1498,19 @@ Superficial options (printing) can be changed at any time.
     Default representation of trigonometric functions.
     The following values are possible:
 
-    .. macro :: CA_TRIG_DIRECT
+    .. macro:: CA_TRIG_DIRECT
 
         Use the direct functions (with some exceptions).
 
-    .. macro :: CA_TRIG_EXPONENTIAL
+    .. macro:: CA_TRIG_EXPONENTIAL
 
         Use complex exponentials.
 
-    .. macro :: CA_TRIG_SINE_COSINE
+    .. macro:: CA_TRIG_SINE_COSINE
 
         Use sines and cosines.
 
-    .. macro :: CA_TRIG_TANGENT
+    .. macro:: CA_TRIG_TANGENT
 
         Use tangents.
 

--- a/doc/source/constants.rst
+++ b/doc/source/constants.rst
@@ -11,7 +11,7 @@ Pi
 
 `\pi` is computed using the Chudnovsky series
 
-    .. math ::
+    .. math::
 
         \frac{1}{\pi} = 12 \sum^\infty_{k=0}
         \frac{(-1)^k (6k)! (13591409 + 545140134k)}{(3k)!(k!)^3 640320^{3k + 3/2}}
@@ -27,11 +27,11 @@ Logarithms of integers
 
 We use the formulas
 
-.. math ::
+.. math::
 
     \log(2) = \frac{3}{4} \sum_{k=0}^{\infty} \frac{(-1)^k (k!)^2}{2^k (2k+1)!}
 
-.. math ::
+.. math::
 
     \log(10) = 46 \operatorname{atanh}(1/31) + 34 \operatorname{atanh}(1/49) + 20 \operatorname{atanh}(1/161)
 
@@ -42,18 +42,18 @@ Euler's constant
 Euler's constant `\gamma` is computed using
 the Brent-McMillan formula ([BM1980]_,  [MPFR2012]_)
 
-.. math ::
+.. math::
 
     \gamma = \frac{S_0(2n) - K_0(2n)}{I_0(2n)} - \log(n)
 
 in which `n` is a free parameter and
 
-.. math ::
+.. math::
 
     S_0(x) = \sum_{k=0}^{\infty} \frac{H_k}{(k!)^2} \left(\frac{x}{2}\right)^{2k}, \quad
     I_0(x) = \sum_{k=0}^{\infty} \frac{1}{(k!)^2} \left(\frac{x}{2}\right)^{2k}
 
-.. math ::
+.. math::
 
     2x I_0(x) K_0(x) \sim \sum_{k=0}^{\infty} \frac{[(2k)!]^3}{(k!)^4 8^{2k} x^{2k}}.
 
@@ -70,14 +70,14 @@ Catalan's constant
 
 Catalan's constant is computed using the hypergeometric series
 
-.. math ::
+.. math::
 
     C = \frac{1}{768} \sum_{k=1}^{\infty} \frac{(-4096)^k P(k)}
         {k^3 (2k-1)(3k-1)(3k-2)(6k-1)(6k-5) {5k \choose k} {10k \choose 5k} {12k \choose 6k}}
 
 where
 
-.. math ::
+.. math::
 
     \begin{matrix}
         P(k) & = -43203456k^6 + 92809152k^5 - 76613904k^4 \\
@@ -92,13 +92,13 @@ Apery's constant
 
 Apery's constant `\zeta(3)` is computed using the hypergeometric series
 
-.. math ::
+.. math::
 
     \zeta(3) = \frac{1}{48} \sum_{k=1}^{\infty} \frac{(-1)^{k-1} P(k)}{k^5 (2k-1)^3(3k-1)(3k-2)(4k-1)(4k-3)(6k-1)(6k-5){5k \choose k}{5k \choose 2k}{9k \choose 4k}{10k \choose 5k}{12k \choose 6k}}
 
 where
 
-.. math ::
+.. math::
 
     \begin{matrix}
         P(k) & = 1565994397644288k^{11} - 6719460725627136k^{10} + 12632254526031264k^9 \\
@@ -114,7 +114,7 @@ Khinchin's constant
 
 Khinchin's constant `K_0` is computed using the formula
 
-.. math ::
+.. math::
 
     \log K_0 = \frac{1}{\log 2} \left[
     \sum_{k=2}^{N-1} \log \left(\frac{k-1}{k} \right) \log \left(\frac{k+1}{k} \right)
@@ -126,7 +126,7 @@ where `N \ge 2` is a free parameter that can be used for tuning [BBC1997]_.
 If the infinite series is truncated after `n = M`, the remainder
 is smaller in absolute value than
 
-.. math ::
+.. math::
 
     \sum_{n=M+1}^{\infty} \zeta(2n, N) = 
     \sum_{n=M+1}^{\infty} \sum_{k=0}^{\infty} (k+N)^{-2n} \le
@@ -152,7 +152,7 @@ Reciprocal Fibonacci constant
 
 We use Gosper's series ([Gos1974]_, corrected in [Arn2012]_)
 
-.. math ::
+.. math::
 
     \sum_{n=1}^{\infty} \frac{1}{F_n} = \sum_{n=0}^{\infty}
         \frac{(-1)^{n(n-1)/2} (F_{4n+3} + (-1)^n F_{2n+2})}{F_{2n+1} F_{2n+2} L_1 L_3 \cdots L_{2n+1}}

--- a/doc/source/examples_calcium.rst
+++ b/doc/source/examples_calcium.rst
@@ -130,7 +130,7 @@ machin.c
 
 This program checks several variations of Machin's formula
 
-.. math ::
+.. math::
 
     \frac{\pi}{4} = 4 \operatorname{atan}\left(\frac{1}{5}\right) - \operatorname{atan}\left(\frac{1}{239}\right)
 
@@ -170,7 +170,7 @@ swinnerton_dyer_poly.c
 
 This program computes the coefficients of the Swinnerton-Dyer polynomial
 
-.. math ::
+.. math::
 
     S_n = \prod (x \pm \sqrt{2} \pm \sqrt{3} \pm \sqrt{5} \pm \ldots \pm \sqrt{p_n})
 
@@ -276,7 +276,7 @@ eigenvalues `\lambda_1, \ldots, \lambda_n`,
 as exact algebraic numbers, and verifies
 the exact trace and determinant formulas
 
-.. math ::
+.. math::
 
     \lambda_1 + \lambda_2 + \ldots + \lambda_n = \operatorname{tr}(H_n), \quad
     \lambda_1 \lambda_2 \cdots \lambda_n = \operatorname{det}(H_n).
@@ -315,13 +315,13 @@ discrete Fourier transform (DFT) in exact arithmetic.
 For the input vector `\textbf{x} = (x_n)_{n=0}^{N-1}`, it verifies
 the identity
 
-.. math ::
+.. math::
 
     \textbf{x} - \operatorname{DFT}^{-1}(\operatorname{DFT}(\textbf{x})) = 0
 
 where
 
-.. math ::
+.. math::
 
     \operatorname{DFT}(\textbf{x})_n = \sum_{k=0}^{N-1} \omega^{-kn} x_k, \quad
     \operatorname{DFT}^{-1}(\textbf{x})_n = \frac{1}{N} \sum_{k=0}^{N-1} \omega^{kn} x_k,

--- a/doc/source/fexpr_builtin.rst
+++ b/doc/source/fexpr_builtin.rst
@@ -210,13 +210,13 @@ Booleans and logic
 
     ``Cases(Case(f(x), P(x)), Case(g(x), Otherwise))`` denotes:
 
-    .. math ::
+    .. math::
 
         \begin{cases} f(x), & P(x)\\g(x), & \text{otherwise}\\ \end{cases}
 
     ``Cases(Case(f(x), P(x)), Case(g(x), Q(x)), Case(h(x), Otherwise))`` denotes:
 
-    .. math ::
+    .. math::
 
         \begin{cases} f(x), & P(x)\\g(x), & Q(x)\\h(x), & \text{otherwise}\\ \end{cases}
 

--- a/doc/source/fmpq.rst
+++ b/doc/source/fmpq.rst
@@ -645,7 +645,7 @@ Continued fractions
     the ``rem`` variable. The return value is the number `k` of generated
     terms. The output satisfies
 
-    .. math ::
+    .. math::
 
         x = c_0 + \cfrac{1}{c_1 + \cfrac{1}{c_2 +
             \cfrac{1}{ \ddots + \cfrac{1}{c_{k-1} + r }}}}
@@ -678,7 +678,7 @@ Continued fractions
 
     Sets `x` to the value of the continued fraction
 
-    .. math ::
+    .. math::
 
         x = c_0 + \cfrac{1}{c_1 + \cfrac{1}{c_2 +
             \cfrac{1}{ \ddots + \cfrac{1}{c_{n-1}}}}}
@@ -718,14 +718,14 @@ Most of the definitions and relations used in the following section
 are given by Apostol [Apostol1997]_. The Dedekind sum `s(h,k)` is
 defined for all integers `h` and `k` as
 
-.. math ::
+.. math::
 
      s(h,k) = \sum_{i=1}^{k-1} \left(\left(\frac{i}{k}\right)\right)
      \left(\left(\frac{hi}{k}\right)\right)
 
 where
 
-.. math ::
+.. math::
 
     ((x))=\begin{cases}
     x-\lfloor x\rfloor-1/2 &\mbox{if }
@@ -735,7 +735,7 @@ where
 
 If `0 < h < k` and `(h,k) = 1`, this reduces to
 
-.. math ::
+.. math::
 
     s(h,k) = \sum_{i=1}^{k-1} \frac{i}{k}
         \left(\frac{hi}{k}-\left\lfloor\frac{hi}{k}\right\rfloor
@@ -746,7 +746,7 @@ Letting `r_0 = k`, `r_1 = h`, `r_2, r_3, \ldots, r_n, r_{n+1} = 1`
 be the remainder sequence in the Euclidean algorithm for
 computing GCD of `h` and `k`,
 
-.. math ::
+.. math::
     s(h,k) = \frac{1-(-1)^n}{8} - \frac{1}{12} \sum_{i=1}^{n+1}
     (-1)^i \left(\frac{1+r_i^2+r_{i-1}^2}{r_i r_{i-1}}\right).
 

--- a/doc/source/fmpq_poly.rst
+++ b/doc/source/fmpq_poly.rst
@@ -988,7 +988,7 @@ Greatest common divisor
     letting `x` and `y` denote the leading coefficients, the resultant
     is defined as
 
-    .. math ::
+    .. math::
 
 
          x^{\deg(f)} y^{\deg(g)} \prod_{1 \leq i, j \leq n} (r_i - s_j).

--- a/doc/source/fmpz.rst
+++ b/doc/source/fmpz.rst
@@ -1065,7 +1065,7 @@ Greatest common divisor
     canonical solution to satisfy one of the following if one of the given
     conditions apply:
 
-    .. math ::
+    .. math::
 
         \operatorname{xgcd}(\pm g, g) &= \bigl(|g|, 0, \operatorname{sgn}(g)\bigr)
 
@@ -1087,7 +1087,7 @@ Greatest common divisor
     If the pair `(f, g)` does not satisfy any of these conditions, the solution
     `(d, a, b)` will satisfy the following:
 
-    .. math ::
+    .. math::
 
         |a| < \Bigl| \frac{g}{2 d} \Bigr|,
         \qquad |b| < \Bigl| \frac{f}{2 d} \Bigr|.

--- a/doc/source/fmpz_factor.rst
+++ b/doc/source/fmpz_factor.rst
@@ -226,11 +226,11 @@ Factoring of ``fmpz`` integers using ECM
     Sets the point `(x : z)` to two times `(x_0 : z_0)` modulo `n` according
     to the formula
 
-    .. math ::
+    .. math::
 
         x = (x_0 + z_0)^2 \cdot (x_0 - z_0)^2 \mod n,
 
-    .. math ::
+    .. math::
 
         z = 4 x_0 z_0 \left((x_0 - z_0)^2 + 4a_{24}x_0z_0\right) \mod n.
 
@@ -243,7 +243,7 @@ Factoring of ``fmpz`` integers using ECM
     Sets the point `(x : z)` to the sum of `(x_1 : z_1)` and `(x_2 : z_2)`
     modulo `n`, given the difference `(x_0 : z_0)` according to the formula
 
-    .. math ::
+    .. math::
 
         x = 4z_0(x_1x_2 - z_1z_2)^2 \mod n, \\ z = 4x_0(x_2z_1 - x_1z_2)^2 \mod n.
 

--- a/doc/source/fmpz_mod_poly.rst
+++ b/doc/source/fmpz_mod_poly.rst
@@ -1084,7 +1084,7 @@ Greatest common divisor
     Computes the HGCD of `a` and `b`, that is, a matrix~`M`, a sign~`\sigma`
     and two polynomials `A` and `B` such that
 
-    .. math ::
+    .. math::
 
         (A,B)^t = \sigma M^{-1} (a,b)^t.
 
@@ -1333,7 +1333,7 @@ Resultant
     `g(x) = b_n x^n + \dotsb + b_0` of degrees `m` and `n`, the resultant
     is defined to be
 
-    .. math ::
+    .. math::
 
 
             a_m^n b_n^m \prod_{(x, y) : f(x) = g(y) = 0} (x - y).
@@ -1389,7 +1389,7 @@ Resultant
     `g(x) = b_n x^n + \dotsb + b_0` of degrees `m` and `n`, the resultant
     is defined to be
 
-    .. math ::
+    .. math::
 
 
             a_m^n b_n^m \prod_{(x, y) : f(x) = g(y) = 0} (x - y).
@@ -1415,7 +1415,7 @@ Resultant
     `g(x) = b_n x^n + \dotsb + b_0` of degrees `m` and `n`, the resultant
     is defined to be
 
-    .. math ::
+    .. math::
 
 
             a_m^n b_n^m \prod_{(x, y) : f(x) = g(y) = 0} (x - y).
@@ -1794,7 +1794,7 @@ The following functions provide the functionality to solve the
 radix conversion problems for polynomials, which is to express
 a polynomial `f(X)` with respect to a given radix `r(X)` as
 
-    .. math ::
+    .. math::
 
         f(X) = \sum_{i = 0}^{N} b_i(X) r(X)^i
 
@@ -1865,7 +1865,7 @@ depends on~`r` and an upper bound on the degree of~`f`.
     computes polynomials `B_0, \dotsc, B_N` of degree less than `\deg(R)`
     such that
 
-    .. math ::
+    .. math::
 
         F = B_0 + B_1 R + \dotsb + B_N R^N,
 
@@ -1953,7 +1953,7 @@ Berlekamp-Massey Algorithm
     At any point in time, after, say, `n` points have been added, a call to :func:`fmpz_mod_berlekamp_massey_reduce` will
     calculate the polynomials `U`, `V` and `R` in the extended euclidean remainder sequence with
 
-    .. math ::
+    .. math::
 
         U*x^n + V*(a_1*x^{n-1} + \cdots + a_{n-1}*x + a_n) = R, \quad \deg(U) < \deg(V) \le n/2, \quad \deg(R) < n/2.
 
@@ -1961,14 +1961,14 @@ Berlekamp-Massey Algorithm
     This class differs from :func:`fmpz_mod_poly_minpoly` in the following respect. Let `v_i` denote the coefficient of `x^i` in `V`.
     :func:`fmpz_mod_poly_minpoly` will return a polynomial `V` of lowest degree that annihilates the whole sequence `a_1, \dots, a_n` as
 
-    .. math ::
+    .. math::
 
         \sum_{i} v_i a_{j + i} = 0, \quad 1 \le j \le n - \deg(V).
 
     The cost is that a polynomial of degree `n-1` might be returned and the return is not generally uniquely determined by the input sequence.
     For the fmpz_mod_berlekamp_massey_t we have
 
-    .. math ::
+    .. math::
 
         \sum_{i,j} v_i a_{j+i} x^{-j} = -U + \frac{R}{x^n}\text{,}
 

--- a/doc/source/fmpz_poly.rst
+++ b/doc/source/fmpz_poly.rst
@@ -1009,13 +1009,13 @@ Powering
     polynomial as `P(x) = p_0 + p_1 x + \dotsb + p_m x^m` with `p_0 \neq 0`
     and let
 
-    .. math ::
+    .. math::
 
         P(x)^n = a(n, 0) + a(n, 1) x + \dotsb + a(n, mn) x^{mn}.
 
     Then `a(n, 0) = p_0^n` and, for all `1 \leq k \leq mn`,
 
-    .. math ::
+    .. math::
 
         a(n, k) =
             (k p_0)^{-1} \sum_{i = 1}^m p_i \bigl( (n + 1) i - k \bigr) a(n, k-i).
@@ -1347,7 +1347,7 @@ Greatest common divisor
 
     This ensures that the equality
 
-    .. math ::
+    .. math::
 
         f g = \gcd(f, g) \operatorname{lcm}(f, g)
 
@@ -1366,7 +1366,7 @@ Greatest common divisor
     `g(x) = b_n x^n + \dotsb + b_0` of degrees `m` and `n`, the resultant
     is defined to be
 
-    .. math ::
+    .. math::
 
         a_m^n b_n^m \prod_{(x, y) : f(x) = g(y) = 0} (x - y).
 
@@ -1398,7 +1398,7 @@ Greatest common divisor
     `g(x) = b_n x^n + \dotsb + b_0` of degrees `m` and `n`, the resultant
     is defined to be
 
-    .. math ::
+    .. math::
 
         a_m^n b_n^m \prod_{(x, y) : f(x) = g(y) = 0} (x - y).
 
@@ -1421,7 +1421,7 @@ Greatest common divisor
     `g(x) = b_n x^n + \dotsb + b_0` of degrees `m` and `n`, the resultant
     is defined to be
 
-    .. math ::
+    .. math::
 
         a_m^n b_n^m \prod_{(x, y) : f(x) = g(y) = 0} (x - y).
 
@@ -2808,7 +2808,7 @@ Hensel lifting
 
     The lifting formulae are
 
-    .. math ::
+    .. math::
 
         G = \biggl( \bigl( \frac{f-gh}{p} \bigr) b \bmod g \biggr) p + g
 
@@ -3155,7 +3155,7 @@ Roots
     Computes a nonnegative integer ``bound`` that bounds the absolute
     value of all complex roots of ``poly``. Uses Fujiwara's bound
 
-    .. math ::
+    .. math::
 
         2 \max \left(
             \left|\frac{a_{n-1}}{a_n}\right|,
@@ -3219,7 +3219,7 @@ Minimal polynomials
     We use the sparse power series algorithm described as Algorithm 4
     [ArnoldMonagan2011]_. The algorithm is based on the identity
 
-    .. math ::
+    .. math::
 
         \Phi_n(x) = \prod_{d|n} (x^d - 1)^{\mu(n/d)}.
 
@@ -3373,21 +3373,21 @@ Eulerian numbers and polynomials
 
 Eulerian numbers are the coefficients to the Eulerian polynomials
 
-.. math ::
+.. math::
 
     A_n(x) = \sum_{m = 0}^{n} A(n, m) x^m,
 
 where the Eulerian polynomials are defined by the exponential generating
 function
 
-.. math ::
+.. math::
 
     \frac{x - 1}{x - e^{(x - 1) t}}
     = \sum_{n = 0}^{\infty} A_n(x) \frac{t^n}{n!}.
 
 The Eulerian numbers can be expressed explicitly via the formula
 
-.. math ::
+.. math::
 
     A(n, m) = \sum_{k = 0}^{m + 1} (-1)^k \binom{n + 1}{k} (m + 1 - k)^n.
 

--- a/doc/source/fmpz_poly_factor.rst
+++ b/doc/source/fmpz_poly_factor.rst
@@ -85,7 +85,7 @@ Factoring algorithms
     have no repeated factors.  None of the returned factors will have
     the same exponent. That is we return `g_i` and unique `e_i` such that
 
-    .. math ::
+    .. math::
 
 
         F = c \prod_{i} g_i^{e_i}

--- a/doc/source/formulas.rst
+++ b/doc/source/formulas.rst
@@ -18,13 +18,13 @@ fixed), so for brevity we simply express the bounds in terms of `|a|`.
 
 **Theorem (generic first-order bound)**:
 
-.. math ::
+.. math::
 
     |f(x+a) - f(x)| \le \min(2 C_0, C_1 |a|)
 
 where
 
-.. math ::
+.. math::
 
     C_0 = \sup_{|t| \le |a|} |f(x+t)|, \quad C_1 = \sup_{|t| \le |a|} |f'(x+t)|.
 
@@ -32,21 +32,21 @@ The statement is valid with either `a, t \in \mathbb{R}` or `a, t \in \mathbb{C}
 
 **Theorem (product)**: For `x, y \in \mathbb{C}` and `a, b \in \mathbb{C}`,
 
-.. math ::
+.. math::
 
     \left| (x+a)(y+b) - x y \right| \le |xb| + |ya| + |ab|.
 
 **Theorem (quotient)**: For `x, y \in \mathbb{C}` and `a, b \in \mathbb{C}`
 with `|b| < |y|`,
 
-.. math ::
+.. math::
 
         \left| \frac{x}{y} - \frac{x+a}{y+b} \right|
         \le \frac{|xb|+|ya|}{|y| (|y|-|b|)}.
 
 **Theorem (square root)**: For `x, a \in \mathbb{R}` with `0 \le |a| \le x`,
 
-.. math ::
+.. math::
 
     \left| \sqrt{x+a} - \sqrt{x} \right|
         \le \sqrt{x} \left(1 - \sqrt{1-\frac{|a|}{x}}\right)
@@ -57,21 +57,21 @@ where the first inequality is an equality if `a \le 0`.
 
 **Theorem (reciprocal square root)**: For `x, a \in \mathbb{R}` with `0 \le |a| < x`,
 
-.. math ::
+.. math::
 
     \left| \frac{1}{\sqrt{x+a}} - \frac{1}{\sqrt{x}} \right|
         \le \frac{|a|}{2 (x-|a|)^{3/2}}.
 
 **Theorem (k-th root)**: For `k > 1` and `x, a \in \mathbb{R}` with `0 \le |a| \le x`,
 
-.. math ::
+.. math::
 
     \left| (x+a)^{1/k} - x^{1/k} \right|
         \le x^{1/k} \min\left(1, \frac{1}{k} \, \log\left(1+\frac{|a|}{x-|a|}\right)\right).
 
 *Proof*: The error is largest when `a = -r` is negative, and
 
-.. math ::
+.. math::
 
     x^{1/k} - (x-r)^{1/k} &= x^{1/k} [1 - (1-r/x)^{1/k}]
 
@@ -83,7 +83,7 @@ where the first inequality is an equality if `a \le 0`.
 
 **Theorem (logarithm)**: For `x, a \in \mathbb{R}` with `0 \le |a| < x`,
 
-.. math ::
+.. math::
 
     |\log(x+a) - \log(x)| \le \log\left(1 + \frac{|a|}{x-|a|}\right),
 
@@ -94,13 +94,13 @@ with equality if `a \le 0`.
 
 **Theorem (inverse tangent)**: For `x, a \in \mathbb{R}`,
 
-.. math ::
+.. math::
 
     |\operatorname{atan}(x+a) - \operatorname{atan}(x)| \le \min(\pi, C_1 |a|).
 
 where
 
-.. math ::
+.. math::
 
     C_1 = \sup_{|t| \le |a|} \frac{1}{1 + (x+t)^2}.
 
@@ -108,7 +108,7 @@ If `|a| < |x|`, then `C_1 = (1 + (|x| - |a|)^2)^{-1}` gives a monotone bound.
 
 An exact bound: if `|a| < |x|` or `|x(x+a)| < 1`, then
 
-.. math ::
+.. math::
 
     |\operatorname{atan}(x+a) - \operatorname{atan}(x)| =
         \operatorname{atan}\left(\frac{|a|}{1 + x(x+a)}\right).
@@ -121,14 +121,14 @@ Sums and series
 
 **Theorem (geometric bound)**: If `|c_k| \le C` and `|z| \le D < 1`, then
 
-.. math ::
+.. math::
 
     \left| \sum_{k=N}^{\infty} c_k z^k \right| \le \frac{C D^N}{1 - D}.
 
 **Theorem (integral bound)**: If `f(x)` is nonnegative and
 monotone decreasing, then
 
-.. math ::
+.. math::
 
     \int_N^{\infty} f(x) \le \sum_{k=N}^{\infty} f(k) \le f(N) + \int_N^{\infty} f(x) dx.
 
@@ -140,20 +140,20 @@ If `f(z) = \sum_{k=0}^{\infty} c_k z^k` is analytic (on an open
 subset of `\mathbb{C}` containing the disk `D = \{ z : |z| \le R \}`
 in its interior, where `R > 0`), then
 
-.. math ::
+.. math::
 
     c_k = \frac{1}{2\pi i} \int_{|z|=R} \frac{f(z)}{z^{k+1}}\, dz.
 
 **Corollary (derivative bound)**:
 
-.. math ::
+.. math::
 
     |c_k| \le \frac{C}{R^k}, \quad C = \max_{|z|=R} |f(z)|.
 
 **Corollary (Taylor series tail)**:
 If `0 \le r < R` and `|z| \le r`, then
 
-.. math ::
+.. math::
 
     \left|\sum_{k=N}^{\infty} c_k z^k\right| \le
         \frac{C D^N}{1-D}, \quad D = \left|\frac{r}{R}\right|.
@@ -164,21 +164,21 @@ Euler-Maclaurin formula
 **Theorem (Euler-Maclaurin)**:
 If `f(t)` is `2M`-times differentiable, then
 
-.. math ::
+.. math::
 
     \sum_{k=L}^U f(k) = S + I + T + R
 
-.. math ::
+.. math::
 
     S = \sum_{k=L}^{N-1} f(k), \quad I = \int_N^U f(t) dt,
 
-.. math ::
+.. math::
 
     T = \frac{1}{2} \left( f(N) + f(U) \right) + 
         \sum_{k=1}^M \frac{B_{2k}}{(2k)!}
         \left(f^{(2k-1)}(U) - f^{(2k-1)}(N)\right),
 
-.. math ::
+.. math::
 
     R = -\int_N^U \frac{B_{2M}(t - \lfloor t \rfloor)}{(2M)!} f^{(2M)}(t) dt.
 
@@ -186,7 +186,7 @@ If `f(t)` is `2M`-times differentiable, then
 
 **Theorem (remainder bound)**:
 
-.. math ::
+.. math::
 
     |R| \le \frac{4}{(2\pi)^{2M}} \int_N^U \left| f^{(2M)}(t) \right| dt.
 
@@ -195,7 +195,7 @@ If `f(t) = f(t,x) = \sum_{k=0}^{\infty} a_k(t) x^k` and
 `R = R(x) = \sum_{k=0}^{\infty} c_k x^k`
 are analytic functions of `x`, then
 
-.. math ::
+.. math::
 
     |c_k| \le \frac{4}{(2\pi)^{2M}} \int_N^U |a_k^{(2M)}(t)| dt.
 

--- a/doc/source/fq_mat.rst
+++ b/doc/source/fq_mat.rst
@@ -431,7 +431,7 @@ Triangular solving
 
     Uses the block inversion formula
 
-    .. math ::
+    .. math::
         \begin{pmatrix} A & 0 \\ C & D \end{pmatrix}^{-1}
         \begin{pmatrix} X \\ Y \end{pmatrix} =
         \begin{pmatrix} A^{-1} X \\ D^{-1} ( Y - C A^{-1} X ) \end{pmatrix}
@@ -467,7 +467,7 @@ Triangular solving
 
     Uses the block inversion formula
 
-    .. math ::
+    .. math::
         \begin{pmatrix} A & B \\ 0 & D \end{pmatrix}^{-1}
         \begin{pmatrix} X \\ Y \end{pmatrix} =
         \begin{pmatrix} A^{-1} (X - B D^{-1} Y) \\ D^{-1} Y \end{pmatrix}

--- a/doc/source/fq_nmod_mat.rst
+++ b/doc/source/fq_nmod_mat.rst
@@ -430,7 +430,7 @@ Triangular solving
 
     Uses the block inversion formula
 
-    .. math ::
+    .. math::
         \begin{pmatrix} A & 0 \\ C & D \end{pmatrix}^{-1}
         \begin{pmatrix} X \\ Y \end{pmatrix} =
         \begin{pmatrix} A^{-1} X \\ D^{-1} ( Y - C A^{-1} X ) \end{pmatrix}
@@ -466,7 +466,7 @@ Triangular solving
 
     Uses the block inversion formula
 
-    .. math ::
+    .. math::
         \begin{pmatrix} A & B \\ 0 & D \end{pmatrix}^{-1}
         \begin{pmatrix} X \\ Y \end{pmatrix} =
         \begin{pmatrix} A^{-1} (X - B D^{-1} Y) \\ D^{-1} Y \end{pmatrix}

--- a/doc/source/fq_nmod_poly.rst
+++ b/doc/source/fq_nmod_poly.rst
@@ -400,7 +400,7 @@ Multiplication
     change the representation to
 
 
-    .. math ::
+    .. math::
 
 
         \begin{split}

--- a/doc/source/fq_poly.rst
+++ b/doc/source/fq_poly.rst
@@ -397,7 +397,7 @@ Multiplication
     but polynomials in `\mathbf{F}_q[Y]` of large degree `n`, we
     change the representation to
 
-    .. math ::
+    .. math::
 
 
         \begin{split}

--- a/doc/source/fq_zech_mat.rst
+++ b/doc/source/fq_zech_mat.rst
@@ -397,7 +397,7 @@ Triangular solving
 
     Uses the block inversion formula
 
-    .. math ::
+    .. math::
       \begin{pmatrix} A & 0 \\ C & D \end{pmatrix}^{-1}
       \begin{pmatrix} X \\ Y \end{pmatrix} =
       \begin{pmatrix} A^{-1} X \\ D^{-1} ( Y - C A^{-1} X ) \end{pmatrix}
@@ -433,7 +433,7 @@ Triangular solving
 
     Uses the block inversion formula
 
-    .. math ::
+    .. math::
         \begin{pmatrix} A & B \\ 0 & D \end{pmatrix}^{-1}
         \begin{pmatrix} X \\ Y \end{pmatrix} =
         \begin{pmatrix} A^{-1} (X - B D^{-1} Y) \\ D^{-1} Y \end{pmatrix}

--- a/doc/source/fq_zech_poly.rst
+++ b/doc/source/fq_zech_poly.rst
@@ -400,7 +400,7 @@ Multiplication
     change the representation to
 
 
-    .. math ::
+    .. math::
 
 
         \begin{split}

--- a/doc/source/gamma.rst
+++ b/doc/source/gamma.rst
@@ -8,7 +8,7 @@ The Stirling series
 
 In general, the gamma function is computed via the Stirling series
 
-.. math ::
+.. math::
 
     \log \Gamma(z) = \left(z-\frac{1}{2}\right)\log z - z +
           \frac{\ln {2 \pi}}{2}
@@ -17,7 +17,7 @@ In general, the gamma function is computed via the Stirling series
 
 where ([Olv1997]_ pp. 293-295) the remainder term is exactly
 
-.. math ::
+.. math::
 
     R_n(z) = \int_0^{\infty} \frac{B_{2n} - {\tilde B}_{2n}(x)}{2n(x+z)^{2n}} dx.
 
@@ -29,7 +29,7 @@ that the numerator of the integrand is bounded in
 absolute value by `2 |B_{2n}|`, the remainder can be shown
 to satisfy the bound
 
-.. math ::
+.. math::
 
     |[t^k] R_n(z+t)| \le 2 |B_{2n}|
         \frac{\Gamma(2n+k-1)}{\Gamma(k+1) \Gamma(2n+1)}
@@ -39,7 +39,7 @@ where `b = 1/\cos(\operatorname{arg}(z)/2)`.
 Note that by trigonometric identities, assuming that `z = x+yi`, we
 have `b = \sqrt{1 + u^2}` where
 
-.. math ::
+.. math::
 
     u = \frac{y}{\sqrt{x^2 + y^2} + x} = \frac{\sqrt{x^2 + y^2} - x}{y}.
 
@@ -69,19 +69,19 @@ The cases `\Gamma(1) = 1` and `\Gamma(1/2) = \sqrt \pi` are trivial.
 We reduce all remaining cases to `\Gamma(1/3)` or `\Gamma(1/4)`
 using the following relations:
 
-.. math ::
+.. math::
 
     \Gamma(2/3) = \frac{2 \pi}{3^{1/2} \Gamma(1/3)}, \quad \quad
     \Gamma(3/4) = \frac{2^{1/2} \pi}{\Gamma(1/4)},
 
-.. math ::
+.. math::
 
     \Gamma(1/6) = \frac{\Gamma(1/3)^2}{(\pi/3)^{1/2} 2^{1/3}}, \quad \quad
     \Gamma(5/6) = \frac{2 \pi (\pi/3)^{1/2} 2^{1/3}}{\Gamma(1/3)^2}.
 
 We compute `\Gamma(1/3)` and `\Gamma(1/4)` rapidly to high precision using
 
-.. math ::
+.. math::
 
     \Gamma(1/3) = \left( \frac{12 \pi^4}{\sqrt{10}}
         \sum_{k=0}^{\infty}
@@ -90,7 +90,7 @@ We compute `\Gamma(1/3)` and `\Gamma(1/4)` rapidly to high precision using
 
 An alternative formula which could be used for `\Gamma(1/3)` is
 
-.. math ::
+.. math::
 
     \Gamma(1/3) = \frac{2^{4/9} \pi^{2/3}}{3^{1/12} \left( \operatorname{agm}\left(1,\frac{1}{2} \sqrt{2+\sqrt{3}}\right)\right)^{1/3}},
 

--- a/doc/source/gr_poly.rst
+++ b/doc/source/gr_poly.rst
@@ -509,7 +509,7 @@ GCD
     Computes the HGCD of `a` and `b`, that is, a matrix `M`, a sign `\sigma`
     and two polynomials `A` and `B` such that
 
-    .. math ::
+    .. math::
 
         (A,B)^t = \sigma M^{-1} (a,b)^t.
 

--- a/doc/source/hurwitz.rst
+++ b/doc/source/hurwitz.rst
@@ -16,14 +16,14 @@ Parameter Taylor series
 To evaluate `\zeta(s,a)` for several nearby parameter values, the following
 Taylor expansion is useful:
 
-.. math ::
+.. math::
 
     \zeta(s,a+x) = \sum_{k=0}^{\infty} (-x)^k \frac{(s)_k}{k!} \zeta(s+k,a)
 
 We assume that `a \ge 1` is real and that `\sigma = \operatorname{re}(s)`
 with `K + \sigma > 1`. The tail is bounded by
 
-.. math ::
+.. math::
 
     \sum_{k=K}^{\infty} |x|^k \frac{|(s)_k|}{k!} \zeta(\sigma+k,a) \le
     \sum_{k=K}^{\infty}
@@ -32,7 +32,7 @@ with `K + \sigma > 1`. The tail is bounded by
 
 Denote the term on the right by `T(k)`. Then
 
-.. math ::
+.. math::
 
     \left|\frac{T(k+1)}{T(k)}\right| =
             \frac{|x|}{a}
@@ -46,7 +46,7 @@ Denote the term on the right by `T(k)`. Then
 
 and if `C < 1`,
 
-.. math ::
+.. math::
 
     \sum_{k=K}^{\infty} T(k) \le \frac{T(K)}{1-C}.
 

--- a/doc/source/hypergeometric.rst
+++ b/doc/source/hypergeometric.rst
@@ -13,13 +13,13 @@ Convergent series
 
 Let
 
-.. math ::
+.. math::
 
     T(k) = \frac{\prod_{i=0}^{p-1} (a_i)_k}{\prod_{i=0}^{q-1} (b_i)_k} z^k.
 
 We compute a factor *C* such that
 
-.. math ::
+.. math::
 
     \left|\sum_{k=n}^{\infty} T(k)\right| \le C |T(n)|.
 
@@ -28,13 +28,13 @@ parameters *b*. If this does not hold, *C* is set to infinity.
 Otherwise, we cancel out pairs of parameters
 `a` and `b` against each other. We have
 
-.. math ::
+.. math::
 
     \left|\frac{a+k}{b+k}\right| = \left|1 + \frac{a-b}{b+k}\right| \le 1 + \frac{|a-b|}{|b+n|}
 
 and
 
-.. math ::
+.. math::
 
     \left|\frac{1}{b+k}\right| \le \frac{1}{|b+n|}
 
@@ -60,14 +60,14 @@ First, we fix some notation, assuming that `A` and `B` are power series:
 
 Using the formulas
 
-.. math ::
+.. math::
 
     (A B)_{[k]} = \sum_{j=0}^k A_{[j]} B_{[k-j]}, \quad (1 / B)_{[k]} = \frac{1}{B_{[0]}} \sum_{j=1}^k -B_{[j]} (1/B)_{[k-j]},
 
 it is easy prove the following bounds for the coefficients
 of sums, products and quotients of formal power series:
 
-.. math ::
+.. math::
 
     |A + B| \le |A| + |B|,
     \quad |A B|  \le |A| |B|,
@@ -75,7 +75,7 @@ of sums, products and quotients of formal power series:
 
 If `p \le q` and `\operatorname{Re}({b_i}_{[0]}+N) > 0` for all `b_i`, then we may take
 
-.. math ::
+.. math::
 
     D = |z| \, \prod_{i=1}^p \left(1 + \frac{|a_i-b_i|}{\mathcal{R}(b_i+N)}\right) \prod_{i=p+1}^{q} \frac{1}{\mathcal{R}(b_i + N)}.
 
@@ -98,7 +98,7 @@ let `U^{*} = z^a U(a,b,z)`.
 For all `z \ne 0` and `b \notin \mathbb{Z}` (but valid for all `b` as a limit),
 we have (DLMF 13.2.42)
 
-.. math ::
+.. math::
 
     U(a,b,z)
         = \frac{\Gamma(1-b)}{\Gamma(a-b+1)} M(a,b,z)
@@ -106,7 +106,7 @@ we have (DLMF 13.2.42)
 
 Moreover, for all `z \ne 0` we have
 
-.. math ::
+.. math::
 
     \frac{{}_1F_1(a,b,z)}{\Gamma(b)}
         = \frac{(-z)^{-a}}{\Gamma(b-a)} U^{*}(a,b,z)
@@ -116,13 +116,13 @@ which is equivalent to DLMF 13.2.41 (but simpler in form).
 
 We have the asymptotic expansion
 
-.. math ::
+.. math::
 
     U^{*}(a,b,z) \sim {}_2F_0(a, a-b+1, -1/z)
 
 where `{}_2F_0(a,b,z)` denotes a formal hypergeometric series, i.e.
 
-.. math ::
+.. math::
 
     U^{*}(a,b,z) = \sum_{k=0}^{n-1} \frac{(a)_k (a-b+1)_k}{k! (-z)^k} + \varepsilon_n(z).
 
@@ -140,17 +140,17 @@ Otherwise, if `|z| \ge 2r`, set `R = 3`.
 Otherwise, the bound is infinite.
 If the bound is finite, we have
 
-.. math ::
+.. math::
 
     |\varepsilon_n(z)| \le 2 \alpha C_n \left|\frac{(a)_n (a-b+1)_n}{n! z^n} \right| \exp(2 \alpha \rho C_1 / |z|)
 
 in terms of the following auxiliary quantities
 
-.. math ::
+.. math::
 
     \sigma = |(b-2a)/z|
 
-.. math ::
+.. math::
 
     C_n = \begin{cases}
     1                              & \text{if } R = 1 \\
@@ -158,26 +158,26 @@ in terms of the following auxiliary quantities
     (\chi(n) + \sigma \nu^2 n) \nu^n & \text{if } R = 3
     \end{cases}
 
-.. math ::
+.. math::
 
     \nu = \left(\tfrac{1}{2} + \tfrac{1}{2}\sqrt{1-4\sigma^2}\right)^{-1/2} \le 1 + 2 \sigma^2
 
-.. math ::
+.. math::
 
     \chi(n) = \sqrt{\pi} \Gamma(\tfrac{1}{2}n+1) / \Gamma(\tfrac{1}{2} n + \tfrac{1}{2})
 
-.. math ::
+.. math::
 
     \sigma' = \begin{cases}
     \sigma & \text{if } R \ne 3 \\
     \nu \sigma & \text{if } R = 3
     \end{cases}
 
-.. math ::
+.. math::
 
     \alpha = (1 - \sigma')^{-1}
 
-.. math ::
+.. math::
 
     \rho = \tfrac{1}{2} |2a^2-2ab+b| + \sigma' (1+ \tfrac{1}{4} \sigma') (1-\sigma')^{-2}
 
@@ -189,30 +189,30 @@ Asymptotic series for Airy functions
 Error bounds are based on Olver (DLMF section 9.7).
 For `\arg(z) < \pi` and `\zeta = (2/3) z^{3/2}`, we have
 
-.. math ::
+.. math::
 
     \operatorname{Ai}(z) = \frac{e^{-\zeta}}{2 \sqrt{\pi} z^{1/4}} \left[S_n(\zeta) + R_n(z)\right], \quad
     \operatorname{Ai}'(z) = -\frac{z^{1/4} e^{-\zeta}}{2 \sqrt{\pi}} \left[(S'_n(\zeta) + R'_n(z)\right]
 
-.. math ::
+.. math::
 
     S_n(\zeta) = \sum_{k=0}^{n-1} (-1)^k \frac{u(k)}{\zeta^k}, \quad
     S'_n(\zeta) = \sum_{k=0}^{n-1} (-1)^k \frac{v(k)}{\zeta^k}
 
-.. math ::
+.. math::
 
     u(k) = \frac{(1/6)_k (5/6)_k}{2^k k!}, \quad
     v(k) = \frac{6k+1}{1-6k} u(k).
 
 Assuming that *n* is positive, the error terms are bounded by
 
-.. math ::
+.. math::
 
     |R_n(z)|  \le C |u(n)| |\zeta|^{-n}, \quad |R'_n(z)| \le C |v(n)| |\zeta|^{-n}
 
 where
 
-.. math ::
+.. math::
 
     C = \begin{cases}
         2 \exp(7 / (36 |\zeta|)) & |\arg(z)| \le \pi/3 \\
@@ -223,7 +223,7 @@ where
 For computing Bi when *z* is roughly in the positive half-plane, we use the
 connection formulas
 
-.. math ::
+.. math::
 
     \operatorname{Bi}(z) = -i (2 w^{+1} \operatorname{Ai}(z w^{-2}) - \operatorname{Ai}(z))
 
@@ -231,15 +231,15 @@ connection formulas
 
 where `w = \exp(\pi i/3)`. Combining roots of unity gives
 
-.. math ::
+.. math::
 
     \operatorname{Bi}(z) = \frac{1}{2 \sqrt{\pi} z^{1/4}} [2X + iY]
 
-.. math ::
+.. math::
 
     \operatorname{Bi}(z) = \frac{1}{2 \sqrt{\pi} z^{1/4}} [2X - iY]
 
-.. math ::
+.. math::
 
     X = \exp(+\zeta) [S_n(-\zeta) + R_n(z w^{\mp 2})], \quad Y = \exp(-\zeta) [S_n(\zeta) + R_n(z)]
 
@@ -249,11 +249,11 @@ We proceed analogously for the derivative of Bi.
 
 In the negative half-plane, we use the connection formulas
 
-.. math ::
+.. math::
 
     \operatorname{Ai}(z) = e^{+\pi i/3} \operatorname{Ai}(z_1)  +  e^{-\pi i/3} \operatorname{Ai}(z_2)
 
-.. math ::
+.. math::
 
     \operatorname{Bi}(z) = e^{-\pi i/6} \operatorname{Ai}(z_1)  +  e^{+\pi i/6} \operatorname{Ai}(z_2)
 
@@ -262,19 +262,19 @@ Provided that `|\arg(-z)| < 2 \pi / 3`, we have
 `|\arg(z_1)|, |\arg(z_2)| < \pi`, and thus the asymptotic expansion
 for Ai can be used. As before, we collect roots of unity to obtain
 
-.. math ::
+.. math::
 
     \operatorname{Ai}(z) = A_1 [S_n(i \zeta)  + R_n(z_1)]
                          + A_2 [S_n(-i \zeta) + R_n(z_2)]
 
-.. math ::
+.. math::
 
     \operatorname{Bi}(z) = A_3 [S_n(i \zeta)  + R_n(z_1)]
                          + A_4 [S_n(-i \zeta) + R_n(z_2)]
 
 where `\zeta = (2/3) (-z)^{3/2}` and
 
-.. math ::
+.. math::
 
     A_1 = \frac{\exp(-i (\zeta - \pi/4))}{2 \sqrt{\pi} (-z)^{1/4}}, \quad
     A_2 = \frac{\exp(+i (\zeta - \pi/4))}{2 \sqrt{\pi} (-z)^{1/4}}, \quad
@@ -292,7 +292,7 @@ In this case, we use Taylor series to analytically continue the solution
 of the hypergeometric differential equation from the origin.
 The function `f(z) = {}_2F_1(a,b,c,z_0+z)` satisfies
 
-.. math ::
+.. math::
 
     f''(z) = -\frac{((z_0+z)(a+b+1)-c)}{(z_0+z)(z_0-1+z)} f'(z) - \frac{a b}{(z_0+z)(z_0-1+z)} f(z).
 
@@ -302,7 +302,7 @@ compute `f(z), f'(z)` to high accuracy
 for sufficiently small `z`.
 Some experimentation showed that two continuation steps
 
-.. math ::
+.. math::
 
     0 \quad \to \quad 0.375 \pm 0.625i \quad \to \quad 0.5 \pm 0.8125i \quad \to \quad z
 
@@ -312,7 +312,7 @@ using the Cauchy-Kovalevskaya majorant method,
 following the outline in [Hoe2001]_.
 The differential equation is majorized by
 
-.. math ::
+.. math::
 
     g''(z) = \frac{N+1}{2} \left( \frac{\nu}{1-\nu z} \right) g'(z)
     + \frac{(N+1)N}{2} \left( \frac{\nu}{1-\nu z} \right)^2 g(z)
@@ -322,7 +322,7 @@ are chosen sufficiently large. It follows that we can compute explicit
 numbers `A, N, \nu` such that the simple solution `g(z) = A (1-\nu z)^{-N}`
 of the differential equation provides the bound
 
-.. math ::
+.. math::
 
     |f_{[k]}| \le g_{[k]} = A {{N+k} \choose k} \nu^k.
 

--- a/doc/source/hypgeom.rst
+++ b/doc/source/hypgeom.rst
@@ -6,7 +6,7 @@
 This module provides functions for high-precision evaluation of series
 of the form
 
-.. math ::
+.. math::
 
     \sum_{k=0}^{n-1} \frac{A(k)}{B(k)} \prod_{j=1}^k \frac{P(k)}{Q(k)} z^k
 
@@ -28,13 +28,13 @@ Strategy for error bounding
 We wish to evaluate `S(z) = \sum_{k=0}^{\infty} T(k) z^k` where `T(k)`
 satisfies `T(0) = 1` and
 
-.. math ::
+.. math::
 
     T(k) = R(k) T(k-1) = \left( \frac{P(k)}{Q(k)} \right) T(k-1)
 
 for given polynomials
 
-.. math ::
+.. math::
 
     P(k) = a_p k^p + a_{p-1} k^{p-1} + \ldots a_0
 
@@ -46,20 +46,20 @@ integers (if there are positive integer roots, the sum is either finite
 or undefined). With these conditions satisfied, our goal is to find a
 parameter `n \ge 0` such that
 
-.. math ::
+.. math::
 
     \left\lvert \sum_{k=n}^{\infty} T(k) z^k \right\rvert \le 2^{-d}.
 
 We can rewrite the hypergeometric term ratio as
 
-.. math ::
+.. math::
 
     z R(k) = z \frac{P(k)}{Q(k)} =
         z \left( \frac{a_p}{b_q} \right) \frac{1}{k^{q-p}} F(k)
 
 where
 
-.. math ::
+.. math::
 
     F(k) = \frac{
     1 + \tilde a_{1} / k + \tilde a_{2} / k^2 + \ldots + \tilde a_q / k^p
@@ -70,7 +70,7 @@ where
 and where `\tilde a_i = a_{p-i} / a_p`, `\tilde b_i = b_{q-i} / b_q`.
 Next, we define
 
-.. math ::
+.. math::
 
     C = \max_{1 \le i \le p} |\tilde a_i|^{(1/i)},
     \quad D = \max_{1 \le i \le q} |\tilde b_i|^{(1/i)}.
@@ -78,21 +78,21 @@ Next, we define
 Now, if `k > C`, the magnitude of the numerator of `F(k)` is
 bounded from above by
 
-.. math ::
+.. math::
 
     1 + \sum_{i=1}^p \left(\frac{C}{k}\right)^i \le 1 + \frac{C}{k-C}
 
 and if `k > 2D`, the magnitude of the denominator of `F(k)` is bounded
 from below by
 
-.. math ::
+.. math::
 
     1 - \sum_{i=1}^q \left(\frac{D}{k}\right)^i \ge 1 + \frac{D}{D-k}.
 
 Putting the inequalities together gives the following bound,
 valid for `k > K = \max(C, 2D)`:
 
-.. math ::
+.. math::
 
     |F(k)| \le \frac{k (k-D)}{(k-C)(k-2D)} = \left(1 + \frac{C}{k-C} \right)
     \left(1 + \frac{D}{k-2D} \right).
@@ -100,7 +100,7 @@ valid for `k > K = \max(C, 2D)`:
 Let `r = q-p` and `\tilde z = |z a_p / b_q|`. Assuming
 `k > \max(C, 2D, {\tilde z}^{1/r})`, we have
 
-.. math ::
+.. math::
 
     |z R(k)| \le G(k) = \frac{\tilde z F(k)}{k^r}
 
@@ -162,7 +162,7 @@ Error bounding
     and `\tilde z = z (a_p / b_q)`, such that for `k > K`, the hypergeometric
     term ratio is bounded by
 
-    .. math ::
+    .. math::
 
         \frac{\tilde z}{k^r} \frac{k(k-D)}{(k-C)(k-2D)}.
 

--- a/doc/source/introduction_calcium.rst
+++ b/doc/source/introduction_calcium.rst
@@ -9,7 +9,7 @@ Exact numbers in Calcium
 The core idea behind Calcium is to represent real and complex
 numbers as elements of extension fields
 
-.. math ::
+.. math::
 
     \mathbb{Q}(a_1, \ldots, a_n)
 
@@ -20,7 +20,7 @@ The system constructs such fields automatically as needed
 to represent the results of computations.
 Any extension field is isomorphic to a formal field
 
-.. math ::
+.. math::
 
     \mathbb{Q}(a_1,\ldots,a_n) \;\; \cong \;\; K_{\text{formal}} := \operatorname{Frac}(\mathbb{Q}[X_1,\ldots,X_n] / I)
 
@@ -42,7 +42,7 @@ As an important special case, Calcium can be used for
 arithmetic in algebraic number fields (embedded explicitly in
 `\mathbb{C}`)
 
-.. math ::
+.. math::
 
     \mathbb{Q}(a) \cong \mathbb{Q}[X] / \langle f(X) \rangle
 

--- a/doc/source/issues.rst
+++ b/doc/source/issues.rst
@@ -87,13 +87,13 @@ This assumption is made to improve performance.
 For example, the call ``arb_mul(z, x, x, prec)``
 sets *z* to a ball enclosing the set
 
-.. math ::
+.. math::
 
     \{ t^2 \,:\, t \in x \}
 
 and not the (generally larger) set
 
-.. math ::
+.. math::
 
     \{ t u \,:\, t \in x, u \in x \}.
 

--- a/doc/source/mag.rst
+++ b/doc/source/mag.rst
@@ -510,7 +510,7 @@ Special functions
 
     Sets *res* to an upper bound for
 
-    .. math ::
+    .. math::
 
         \sum_{k=N}^{\infty} \frac{z^k \log^d(k)}{k^s}.
 
@@ -524,7 +524,7 @@ Special functions
     Sets *res* to an upper bound for `\zeta(s,a) = \sum_{k=0}^{\infty} (k+a)^{-s}`.
     We use the formula
 
-    .. math ::
+    .. math::
 
         \zeta(s,a) \le \frac{1}{a^s} + \frac{1}{(s-1) a^{s-1}}
 

--- a/doc/source/nmod_mat.rst
+++ b/doc/source/nmod_mat.rst
@@ -483,7 +483,7 @@ Triangular solving
 
     Uses the block inversion formula
 
-    .. math ::
+    .. math::
         \begin{pmatrix} A & 0 \\ C & D \end{pmatrix}^{-1}
         \begin{pmatrix} X \\ Y \end{pmatrix} =
         \begin{pmatrix} A^{-1} X \\ D^{-1} ( Y - C A^{-1} X ) \end{pmatrix}
@@ -519,7 +519,7 @@ Triangular solving
 
     Uses the block inversion formula
 
-    .. math ::
+    .. math::
         \begin{pmatrix} A & B \\ 0 & D \end{pmatrix}^{-1}
         \begin{pmatrix} X \\ Y \end{pmatrix} =
         \begin{pmatrix} A^{-1} (X - B D^{-1} Y) \\ D^{-1} Y \end{pmatrix}

--- a/doc/source/nmod_poly.rst
+++ b/doc/source/nmod_poly.rst
@@ -1680,7 +1680,7 @@ Greatest common divisor
     Computes the HGCD of `a` and `b`, that is, a matrix `M`, a sign `\sigma`
     and two polynomials `A` and `B` such that
 
-    .. math ::
+    .. math::
 
 
         (A,B)^t = M^{-1} (a,b)^t, \sigma = \det(M),
@@ -1829,7 +1829,7 @@ Greatest common divisor
     `g(x) = b_n x^n + \dotsb + b_0` of degrees `m` and `n`, the resultant
     is defined to be
 
-    .. math ::
+    .. math::
             a_m^n b_n^m \prod_{(x, y) : f(x) = g(y) = 0} (x - y).
 
 
@@ -1882,7 +1882,7 @@ Greatest common divisor
     `g(x) = b_n x^n + \dotsb + b_0` of degrees `m` and `n`, the resultant
     is defined to be
 
-    .. math ::
+    .. math::
 
 
             a_m^n b_n^m \prod_{(x, y) : f(x) = g(y) = 0} (x - y).
@@ -1908,7 +1908,7 @@ Greatest common divisor
     `g(x) = b_n x^n + \dotsb + b_0` of degrees `m` and `n`, the resultant
     is defined to be
 
-    .. math ::
+    .. math::
 
 
             a_m^n b_n^m \prod_{(x, y) : f(x) = g(y) = 0} (x - y).
@@ -2425,7 +2425,7 @@ Berlekamp-Massey Algorithm
     At any point in time, after, say, `n` points have been added, a call to :func:`nmod_berlekamp_massey_reduce` will
     calculate the polynomials `U`, `V` and `R` in the extended euclidean remainder sequence with
 
-    .. math ::
+    .. math::
 
         U x^n + V (a_1 x^{n-1} + a_{n-1} x + \cdots + a_n) = R, \quad \deg(U) < \deg(V) \le n/2, \quad \deg(R) < n/2.
 
@@ -2433,14 +2433,14 @@ Berlekamp-Massey Algorithm
     This class differs from :func:`fmpz_mod_poly_minpoly` in the following respect. Let `v_i` denote the coefficient of `x^i` in `V`.
     :func:`fmpz_mod_poly_minpoly` will return a polynomial `V` of lowest degree that annihilates the whole sequence `a_1, \dots, a_n` as
 
-    .. math ::
+    .. math::
 
         \sum_{i} v_i a_{j + i} = 0, \quad 1 \le j \le n - \deg(V).
 
     The cost is that a polynomial of degree `n-1` might be returned and the return is not generally uniquely determined by the input sequence.
     For the nmod_berlekamp_massey_t we have
 
-    .. math ::
+    .. math::
 
         \sum_{i,j} v_i a_{j+i} x^{-j} = -U + \frac{R}{x^n}\text{,}
 

--- a/doc/source/padic.rst
+++ b/doc/source/padic.rst
@@ -414,7 +414,7 @@ Exponential
 
     The `p`-adic exponential function is defined by the usual series 
 
-    .. math ::
+    .. math::
 
 
         \exp_p(x) = \sum_{i = 0}^{\infty} \frac{x^i}{i!}
@@ -450,7 +450,7 @@ Logarithm
 
     Returns `b` such that for all `i \geq b` we have 
 
-    .. math ::
+    .. math::
 
 
         i v - \operatorname{ord}_p(i) \geq N
@@ -469,7 +469,7 @@ Logarithm
 
     Computes 
 
-    .. math ::
+    .. math::
 
         z = - \sum_{i = 1}^{\infty} \frac{y^i}{i} \pmod{p^N},
 
@@ -478,7 +478,7 @@ Logarithm
     Note that this can be used to compute the `p`-adic logarithm 
     via the equation 
 
-    .. math ::
+    .. math::
 
         \log(x) & = \sum_{i=1}^{\infty} (-1)^{i-1} \frac{(x-1)^i}{i} \\
                 & = - \sum_{i=1}^{\infty} \frac{(1-x)^i}{i}.
@@ -499,7 +499,7 @@ Logarithm
 
     The `p`-adic logarithm function is defined by the usual series 
 
-    .. math ::
+    .. math::
 
         \log_p(x) = \sum_{i=1}^{\infty} (-1)^{i-1} \frac{(x-1)^i}{i}
 
@@ -524,7 +524,7 @@ Logarithm
     Uses an algorithm based on a result of Satoh, Skjernaa and Taguchi 
     that `\operatorname{ord}_p\bigl(a^{p^k} - 1\bigr) > k`, which implies that 
 
-    .. math ::
+    .. math::
 
         \log(a) \equiv p^{-k} \Bigl( \log\bigl(a^{p^k}\bigr) \pmod{p^{N+k}} 
                                                           \Bigr) \pmod{p^N}.

--- a/doc/source/partitions.rst
+++ b/doc/source/partitions.rst
@@ -23,7 +23,7 @@ terms. This gives a significant speedup for small (e.g. `n < 10^6`).
 
     Sets `b` to an upper bound for
 
-    .. math ::
+    .. math::
 
         M(n,N) = \frac{44 \pi^2}{225 \sqrt 3} N^{-1/2}
                   + \frac{\pi \sqrt{2}}{75} \left( \frac{N}{n-1} \right)^{1/2}

--- a/doc/source/polylogarithms.rst
+++ b/doc/source/polylogarithms.rst
@@ -5,7 +5,7 @@ Algorithms for polylogarithms
 
 The polylogarithm is defined for `s, z \in \mathbb{C}` with `|z| < 1` by
 
-.. math ::
+.. math::
 
     \operatorname{Li}_s(z) = \sum_{k=1}^{\infty} \frac{z^k}{k^s}
 
@@ -19,14 +19,14 @@ The power sum converges rapidly when `|z| \ll 1`.
 To compute the series expansion with respect to `s`, we substitute
 `s \to s + x \in \mathbb{C}[[x]]` and obtain
 
-.. math ::
+.. math::
 
     \operatorname{Li}_{s+x}(z) = \sum_{d=0}^{\infty} x^d
         \frac{(-1)^d}{d!} \sum_{k=1}^{\infty} T(k)
 
 where
 
-.. math ::
+.. math::
 
         T(k) = \frac{z^k \log^d(k)}{k^s}.
 
@@ -35,27 +35,27 @@ via the following strategy, implemented in :func:`mag_polylog_tail`.
 
 Denote the terms by `T(k)`. We pick a nonincreasing function `U(k)` such that
 
-.. math ::
+.. math::
 
     \frac{T(k+1)}{T(k)} = z \left(\frac{k}{k+1}\right)^s
         \left( \frac{\log(k+1)}{\log(k)} \right)^d \le U(k).
 
 Then, as soon as `U(N) < 1`,
 
-.. math ::
+.. math::
 
     \sum_{k=N}^{\infty} T(k)
         \le T(N) \sum_{k=0}^{\infty} U(N)^k = \frac{T(N)}{1 - U(N)}.
 
 In particular, we take
 
-.. math ::
+.. math::
 
     U(k) = z \; B(k, \max(0, -s)) \; B(k \log(k), d)
 
 where `B(m,n) = (1 + 1/m)^n`. This follows from the bounds
 
-.. math ::
+.. math::
 
     \left(\frac{k}{k+1}\right)^{s}
     \le \begin{cases}
@@ -65,7 +65,7 @@ where `B(m,n) = (1 + 1/m)^n`. This follows from the bounds
 
 and
 
-.. math ::
+.. math::
 
     \left( \frac{\log(k+1)}{\log(k)} \right)^d \le
         \left(1 + \frac{1}{k \log(k)}\right)^d.
@@ -76,7 +76,7 @@ Expansion for general z
 For general complex `s, z`, we write the polylogarithm as a sum of
 two Hurwitz zeta functions
 
-.. math ::
+.. math::
 
     \operatorname{Li}_s(z) = \frac{\Gamma(v)}{(2\pi)^v}
         \left[
@@ -97,7 +97,7 @@ To compute the series expansion with respect to `v`, we substitute
 obtain the power series for `\operatorname{Li}_{s+x}(z)`).
 The right hand side becomes
 
-.. math ::
+.. math::
 
     \Gamma(v+x) [E_1 Z_1 + E_2 Z_2]
 
@@ -109,7 +109,7 @@ a leading `1/x` term. In this case,
 we compute the deflated series `\tilde Z_1, \tilde Z_2 = \zeta(x,\ldots) - 1/x`.
 Then
 
-.. math ::
+.. math::
 
     E_1 Z_1 + E_2 Z_2 = (E_1 + E_2)/x + E_1 \tilde Z_1 + E_2 \tilde Z_2.
 

--- a/doc/source/qadic.rst
+++ b/doc/source/qadic.rst
@@ -366,7 +366,7 @@ Special functions
 
     Computes 
 
-    .. math ::
+    .. math::
 
         z = - \sum_{i = 1}^{\infty} \frac{y^i}{i} \pmod{p^N}.
 
@@ -375,7 +375,7 @@ Special functions
     Note that this can be used to compute the `p`-adic logarithm 
     via the equation 
 
-    .. math ::
+    .. math::
 
         \log(x) & = \sum_{i=1}^{\infty} (-1)^{i-1} \frac{(x-1)^i}{i} \\
                 & = - \sum_{i=1}^{\infty} \frac{(1-x)^i}{i}.
@@ -399,7 +399,7 @@ Special functions
 
     Computes `(z, d)` as 
 
-    .. math ::
+    .. math::
 
 
         z = - \sum_{i = 1}^{\infty} \frac{y^i}{i} \pmod{p^N}.
@@ -420,7 +420,7 @@ Special functions
 
     Computes `(z, d)` as 
 
-    .. math ::
+    .. math::
 
         z = - \sum_{i = 1}^{\infty} \frac{y^i}{i} \pmod{p^N}.
 
@@ -428,7 +428,7 @@ Special functions
     Note that this can be used to compute the `p`-adic logarithm 
     via the equation 
 
-    .. math ::
+    .. math::
 
         \log(x) & = \sum_{i=1}^{\infty} (-1)^{i-1} \frac{(x-1)^i}{i} \\
                 & = - \sum_{i=1}^{\infty} \frac{(1-x)^i}{i}.
@@ -450,7 +450,7 @@ Special functions
 
     The `p`-adic logarithm function is defined by the usual series 
 
-    .. math ::
+    .. math::
 
 
         \log_p(x) = \sum_{i=1}^{\infty} (-1)^{i-1} \frac{(x-1)^i}{i}
@@ -548,7 +548,7 @@ Special functions
     Whenever ``op`` has valuation greater than `(p-1)^{-1}`, this 
     routine computes its norm ``rop`` via 
 
-    .. math ::
+    .. math::
 
 
         \operatorname{Norm} (x) = \exp \Bigl( \bigl( \operatorname{Trace} \log (x) \bigr) \Bigr).
@@ -567,7 +567,7 @@ Special functions
 
     Sets ``rop`` to the norm of ``op``, using the formula 
 
-    .. math ::
+    .. math::
 
 
         \operatorname{Norm}(x) = \ell(f)^{-\deg(a)} \operatorname{Res}(f(X), a(X)),

--- a/doc/source/qqbar.rst
+++ b/doc/source/qqbar.rst
@@ -222,7 +222,7 @@ Input and output
 For example, *print*, *printn* and *printnd* with `n = 6` give
 the following output for the numbers 0, 1, `i`, `\varphi`, `\sqrt{2}-\sqrt{3} i`:
 
-.. code ::
+.. code::
 
     deg 1 [0, 1] 0
     deg 1 [-1, 1] 1.00000
@@ -758,7 +758,7 @@ Symbolic expressions and conversion to radicals
     Assuming that *x* has degree 1 or 2, computes integers *a*, *b*, *c*
     and *q* such that
 
-        .. math ::
+        .. math::
 
             x = \frac{a + b \sqrt{c}}{q}
 

--- a/doc/source/ulong_extras.rst
+++ b/doc/source/ulong_extras.rst
@@ -734,7 +734,7 @@ Prime number generation and counting
 
     We use the following estimates, valid for `n > 5` :
 
-    .. math ::
+    .. math::
 
         p_n  & >  n (\ln n + \ln \ln n - 1) \\
         p_n  & <  n (\ln n + \ln \ln n) \\

--- a/doc/source/using.rst
+++ b/doc/source/using.rst
@@ -436,7 +436,7 @@ Generically, when evaluating a fixed expression (that is, when the
 sequence of operations does not depend on the precision), the
 absolute or relative error will be bounded by
 
-.. math ::
+.. math::
 
     2^{O(1) - prec}
 
@@ -545,7 +545,7 @@ This is not just a failsafe, but occasionally a useful optimization.
 It is not entirely uncommon to have formulas where one term
 is modest and another term decreases exponentially, such as:
 
-.. math ::
+.. math::
 
     \log(x) + \sin(x) \exp(-x).
 


### PR DESCRIPTION
Following #1688
Done via
```
git grep -El '\.\.[ ]+([a-zA-Z0-9_]*)[ ]+::' | xargs -n1 sed -i '' -E -e 's/\.\.[ ]+([a-zA-Z0-9_]*)[ ]+::/.. \1::/g'
```

Here is a more "readable" diff:
```
git diff trunk | grep -E '^(-|\+).*::' | sort -u                                                                                                         ✔
+        .. math::
+     .. math::
+    .. macro:: CA_TRIG_DIRECT
+    .. macro:: CA_TRIG_EXPONENTIAL
+    .. macro:: CA_TRIG_SINE_COSINE
+    .. macro:: CA_TRIG_TANGENT
+    .. math::
+    .. math:: \exp(-\pi i \tau/12) \eta(\tau) = \sum_{n=-\infty}^{\infty} (-1)^n q^{(3n^2-n)/2}
+.. code::
+.. math::
-        .. math ::
-     .. math ::
-    .. macro :: CA_TRIG_DIRECT
-    .. macro :: CA_TRIG_EXPONENTIAL
-    .. macro :: CA_TRIG_SINE_COSINE
-    .. macro :: CA_TRIG_TANGENT
-    .. math ::
-    .. math :: \exp(-\pi i \tau/12) \eta(\tau) = \sum_{n=-\infty}^{\infty} (-1)^n q^{(3n^2-n)/2}
-.. code ::
-.. math ::