### PR TITLE
Generic basecase for flint_mpn_mul and flint_mpn_mul_n

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -778,6 +778,11 @@ internals."])])
         [AC_MSG_ERROR([`mpn_div_q' was not found in the GMP library. It is needed to enable GMP
 internals.])])
 
+    AC_SEARCH_LIBS([__gmpn_mul_basecase],[gmp],
+        [],
+        [AC_MSG_ERROR([`mpn_mul_basecase' was not found in the GMP library. It is needed to enable GMP
+internals.])])
+
     AC_SEARCH_LIBS([__gmpn_modexact_1_odd],[gmp],
         [AC_DEFINE(FLINT_HAVE_MPN_MODEXACT_1_ODD,1,Define if system has mpn_modexact_1_odd)])
 fi

--- a/src/acb/approx_dot.c
+++ b/src/acb/approx_dot.c
@@ -605,14 +605,14 @@ acb_approx_dot(acb_t res, const acb_t initial, int subtract, acb_srcptr x, slong
                             x1 = ARF_NOPTR_D(xm)[1];
                             y0 = ARF_NOPTR_D(ym)[0];
                             y1 = ARF_NOPTR_D(ym)[1];
-                            flint_mpn_mul_2x2(u3, u2, u1, u0, x1, x0, y1, y0);
+                            FLINT_MPN_MUL_2X2(u3, u2, u1, u0, x1, x0, y1, y0);
                         }
                         else if (xn == 1)
                         {
                             x0 = ARF_NOPTR_D(xm)[0];
                             y0 = ARF_NOPTR_D(ym)[0];
                             y1 = ARF_NOPTR_D(ym)[1];
-                            flint_mpn_mul_2x1(u3, u2, u1, y1, y0, x0);
+                            FLINT_MPN_MUL_2X1(u3, u2, u1, y1, y0, x0);
                             u0 = 0;
                         }
                         else
@@ -620,7 +620,7 @@ acb_approx_dot(acb_t res, const acb_t initial, int subtract, acb_srcptr x, slong
                             x0 = ARF_NOPTR_D(xm)[0];
                             x1 = ARF_NOPTR_D(xm)[1];
                             y0 = ARF_NOPTR_D(ym)[0];
-                            flint_mpn_mul_2x1(u3, u2, u1, x1, x0, y0);
+                            FLINT_MPN_MUL_2X1(u3, u2, u1, x1, x0, y0);
                             u0 = 0;
                         }
 

--- a/src/acb/dot.c
+++ b/src/acb/dot.c
@@ -763,7 +763,7 @@ acb_dot(acb_t res, const acb_t initial, int subtract, acb_srcptr x, slong xstep,
                             y1 = ARF_NOPTR_D(ym)[1];
                             xtop = x1;
                             ytop = y1;
-                            flint_mpn_mul_2x2(u3, u2, u1, u0, x1, x0, y1, y0);
+                            FLINT_MPN_MUL_2X2(u3, u2, u1, u0, x1, x0, y1, y0);
                         }
                         else if (xn == 1)
                         {
@@ -772,7 +772,7 @@ acb_dot(acb_t res, const acb_t initial, int subtract, acb_srcptr x, slong xstep,
                             y1 = ARF_NOPTR_D(ym)[1];
                             xtop = x0;
                             ytop = y1;
-                            flint_mpn_mul_2x1(u3, u2, u1, y1, y0, x0);
+                            FLINT_MPN_MUL_2X1(u3, u2, u1, y1, y0, x0);
                             u0 = 0;
                         }
                         else
@@ -782,7 +782,7 @@ acb_dot(acb_t res, const acb_t initial, int subtract, acb_srcptr x, slong xstep,
                             y0 = ARF_NOPTR_D(ym)[0];
                             xtop = x1;
                             ytop = y0;
-                            flint_mpn_mul_2x1(u3, u2, u1, x1, x0, y0);
+                            FLINT_MPN_MUL_2X1(u3, u2, u1, x1, x0, y0);
                             u0 = 0;
                         }
 

--- a/src/acf/approx_dot.c
+++ b/src/acf/approx_dot.c
@@ -605,14 +605,14 @@ acf_approx_dot(acf_t res, const acf_t initial, int subtract, acf_srcptr x, slong
                             x1 = ARF_NOPTR_D(xm)[1];
                             y0 = ARF_NOPTR_D(ym)[0];
                             y1 = ARF_NOPTR_D(ym)[1];
-                            flint_mpn_mul_2x2(u3, u2, u1, u0, x1, x0, y1, y0);
+                            FLINT_MPN_MUL_2X2(u3, u2, u1, u0, x1, x0, y1, y0);
                         }
                         else if (xn == 1)
                         {
                             x0 = ARF_NOPTR_D(xm)[0];
                             y0 = ARF_NOPTR_D(ym)[0];
                             y1 = ARF_NOPTR_D(ym)[1];
-                            flint_mpn_mul_2x1(u3, u2, u1, y1, y0, x0);
+                            FLINT_MPN_MUL_2X1(u3, u2, u1, y1, y0, x0);
                             u0 = 0;
                         }
                         else
@@ -620,7 +620,7 @@ acf_approx_dot(acf_t res, const acf_t initial, int subtract, acf_srcptr x, slong
                             x0 = ARF_NOPTR_D(xm)[0];
                             x1 = ARF_NOPTR_D(xm)[1];
                             y0 = ARF_NOPTR_D(ym)[0];
-                            flint_mpn_mul_2x1(u3, u2, u1, x1, x0, y0);
+                            FLINT_MPN_MUL_2X1(u3, u2, u1, x1, x0, y0);
                             u0 = 0;
                         }
 

--- a/src/arb/approx_dot.c
+++ b/src/arb/approx_dot.c
@@ -284,7 +284,7 @@ arb_approx_dot(arb_t res, const arb_t initial, int subtract, arb_srcptr x, slong
                 y0 = ARF_NOPTR_D(ym)[0];
                 y1 = ARF_NOPTR_D(ym)[1];
 
-                flint_mpn_mul_2x2(u3, u2, u1, u0, x1, x0, y1, y0);
+                FLINT_MPN_MUL_2X2(u3, u2, u1, u0, x1, x0, y1, y0);
 
                 u1 = (u1 >> shift) | (u2 << (FLINT_BITS - shift));
                 u2 = (u2 >> shift) | (u3 << (FLINT_BITS - shift));
@@ -324,14 +324,14 @@ arb_approx_dot(arb_t res, const arb_t initial, int subtract, arb_srcptr x, slong
                     x1 = ARF_NOPTR_D(xm)[1];
                     y0 = ARF_NOPTR_D(ym)[0];
                     y1 = ARF_NOPTR_D(ym)[1];
-                    flint_mpn_mul_2x2(u3, u2, u1, u0, x1, x0, y1, y0);
+                    FLINT_MPN_MUL_2X2(u3, u2, u1, u0, x1, x0, y1, y0);
                 }
                 else if (xn == 1)
                 {
                     x0 = ARF_NOPTR_D(xm)[0];
                     y0 = ARF_NOPTR_D(ym)[0];
                     y1 = ARF_NOPTR_D(ym)[1];
-                    flint_mpn_mul_2x1(u3, u2, u1, y1, y0, x0);
+                    FLINT_MPN_MUL_2X1(u3, u2, u1, y1, y0, x0);
                     u0 = 0;
                 }
                 else
@@ -339,7 +339,7 @@ arb_approx_dot(arb_t res, const arb_t initial, int subtract, arb_srcptr x, slong
                     x0 = ARF_NOPTR_D(xm)[0];
                     x1 = ARF_NOPTR_D(xm)[1];
                     y0 = ARF_NOPTR_D(ym)[0];
-                    flint_mpn_mul_2x1(u3, u2, u1, x1, x0, y0);
+                    FLINT_MPN_MUL_2X1(u3, u2, u1, x1, x0, y0);
                     u0 = 0;
                 }
 

--- a/src/arb/atan_taylor_naive.c
+++ b/src/arb/atan_taylor_naive.c
@@ -10,6 +10,7 @@
 */
 
 #include "arb.h"
+#include "mpn_extras.h"
 
 void
 _arb_atan_taylor_naive(mp_ptr y, mp_limb_t * error,
@@ -48,7 +49,7 @@ _arb_atan_taylor_naive(mp_ptr y, mp_limb_t * error,
     flint_mpn_copyi(x1 + 1, x, xn);
 
     /* x2 = x * x */
-    mpn_mul_n(u, x1, x1, nn);
+    flint_mpn_mul_n(u, x1, x1, nn);
     flint_mpn_copyi(x2, u + nn, nn);
 
     /* s = t = x */
@@ -58,7 +59,7 @@ _arb_atan_taylor_naive(mp_ptr y, mp_limb_t * error,
     for (k = 1; k < N; k++)
     {
         /* t = t * x2 */
-        mpn_mul_n(u, t, x2, nn);
+        flint_mpn_mul_n(u, t, x2, nn);
         flint_mpn_copyi(t, u + nn, nn);
 
         /* u = t / (2k+1) */

--- a/src/arb/atan_taylor_rs.c
+++ b/src/arb/atan_taylor_rs.c
@@ -10,6 +10,7 @@
 */
 
 #include "arb.h"
+#include "mpn_extras.h"
 
 /* See verify_taylor.py for code to generate tables and
    proof of correctness */
@@ -583,10 +584,10 @@ void _arb_atan_taylor_rs(mp_ptr y, mp_limb_t * error,
 
             /* higher index ---> */
             /* t = |          | x^2 (lo) | x^2 (hi) | */
-            mpn_sqr(t + xn, x, xn);
+            flint_mpn_sqr(t + xn, x, xn);
 
             /* t = | x^3 (lo) | x^3 (hi) | x^2 (hi) | */
-            mpn_mul_n(t, t + 2 * xn, x, xn);
+            flint_mpn_mul_n(t, t + 2 * xn, x, xn);
 
             /* y = x - x^3 / 3 */
             mpn_divrem_1(t, 0, t + xn, xn, 3);
@@ -618,13 +619,13 @@ void _arb_atan_taylor_rs(mp_ptr y, mp_limb_t * error,
 #define XPOW_WRITE(__k) (xpow + (m - (__k)) * xn)
 #define XPOW_READ(__k) (xpow + (m - (__k) + 1) * xn)
 
-        mpn_sqr(XPOW_WRITE(1), x, xn);
-        mpn_sqr(XPOW_WRITE(2), XPOW_READ(1), xn);
+        flint_mpn_sqr(XPOW_WRITE(1), x, xn);
+        flint_mpn_sqr(XPOW_WRITE(2), XPOW_READ(1), xn);
 
         for (k = 4; k <= m; k += 2)
         {
-            mpn_mul_n(XPOW_WRITE(k - 1), XPOW_READ(k / 2), XPOW_READ(k / 2 - 1), xn);
-            mpn_sqr(XPOW_WRITE(k), XPOW_READ(k / 2), xn);
+            flint_mpn_mul_n(XPOW_WRITE(k - 1), XPOW_READ(k / 2), XPOW_READ(k / 2 - 1), xn);
+            flint_mpn_sqr(XPOW_WRITE(k), XPOW_READ(k / 2), xn);
         }
 
         flint_mpn_zero(s, xn + 1);
@@ -672,7 +673,7 @@ void _arb_atan_taylor_rs(mp_ptr y, mp_limb_t * error,
                 /* Outer polynomial evaluation: multiply by (x^2)^m */
                 if (k != 0)
                 {
-                    mpn_mul(t, s, xn + 1, XPOW_READ(m), xn);
+                    flint_mpn_mul(t, s, xn + 1, XPOW_READ(m), xn);
                     flint_mpn_copyi(s, t + xn, xn + 1);
                 }
 
@@ -691,7 +692,7 @@ void _arb_atan_taylor_rs(mp_ptr y, mp_limb_t * error,
 
         /* finally divide by denominator and multiply by x */
         mpn_divrem_1(s, 0, s, xn + 1, odd_reciprocal_tab_denom[0]);
-        mpn_mul(t, s, xn + 1, x, xn);
+        flint_mpn_mul(t, s, xn + 1, x, xn);
         flint_mpn_copyi(y, t + xn, xn);
 
         /* error bound (ulp) */

--- a/src/arb/dot.c
+++ b/src/arb/dot.c
@@ -709,7 +709,7 @@ arb_dot(arb_t res, const arb_t initial, int subtract, arb_srcptr x, slong xstep,
                 xtop = x1;
                 ytop = y1;
 
-                flint_mpn_mul_2x2(u3, u2, u1, u0, x1, x0, y1, y0);
+                FLINT_MPN_MUL_2X2(u3, u2, u1, u0, x1, x0, y1, y0);
 
                 u0 = (u0 != 0) || ((u1 << (FLINT_BITS - shift)) != 0);
                 u1 = (u1 >> shift) | (u2 << (FLINT_BITS - shift));
@@ -754,7 +754,7 @@ arb_dot(arb_t res, const arb_t initial, int subtract, arb_srcptr x, slong xstep,
                     y1 = ARF_NOPTR_D(ym)[1];
                     xtop = x1;
                     ytop = y1;
-                    flint_mpn_mul_2x2(u3, u2, u1, u0, x1, x0, y1, y0);
+                    FLINT_MPN_MUL_2X2(u3, u2, u1, u0, x1, x0, y1, y0);
                 }
                 else if (xn == 1)
                 {
@@ -763,7 +763,7 @@ arb_dot(arb_t res, const arb_t initial, int subtract, arb_srcptr x, slong xstep,
                     y1 = ARF_NOPTR_D(ym)[1];
                     xtop = x0;
                     ytop = y1;
-                    flint_mpn_mul_2x1(u3, u2, u1, y1, y0, x0);
+                    FLINT_MPN_MUL_2X1(u3, u2, u1, y1, y0, x0);
                     u0 = 0;
                 }
                 else
@@ -773,7 +773,7 @@ arb_dot(arb_t res, const arb_t initial, int subtract, arb_srcptr x, slong xstep,
                     y0 = ARF_NOPTR_D(ym)[0];
                     xtop = x1;
                     ytop = y0;
-                    flint_mpn_mul_2x1(u3, u2, u1, x1, x0, y0);
+                    FLINT_MPN_MUL_2X1(u3, u2, u1, x1, x0, y0);
                     u0 = 0;
                 }
 

--- a/src/arb/exp_arf.c
+++ b/src/arb/exp_arf.c
@@ -11,6 +11,7 @@
 
 #include "arb.h"
 #include "thread_support.h"
+#include "mpn_extras.h"
 
 #define TMP_ALLOC_LIMBS(__n) TMP_ALLOC((__n) * sizeof(mp_limb_t))
 
@@ -307,7 +308,7 @@ arb_exp_arf(arb_t z, const arf_t x, slong prec, int minus_one, slong maglim)
             error += UWORD(1) << (wprounded-wp);
 
             /* 1 + sinh^2, with wn + 1 limbs */
-            mpn_sqr(u, t, wn);
+            flint_mpn_sqr(u, t, wn);
             u[2 * wn] = 1;
 
             /* cosh, with wn + 1 limbs */
@@ -339,7 +340,7 @@ arb_exp_arf(arb_t z, const arf_t x, slong prec, int minus_one, slong maglim)
                 mpn_rshift(t, t, wn + 1, 1);
                 error = (error >> 1) + 2;
 
-                mpn_mul_n(u, t, arb_exp_tab1[p1] + ARB_EXP_TAB1_LIMBS - wn, wn);
+                flint_mpn_mul_n(u, t, arb_exp_tab1[p1] + ARB_EXP_TAB1_LIMBS - wn, wn);
 
                 /* (t + err1 * ulp) * (u + err2 * ulp) + 1ulp = t*u +
                    (err1*u + err2*t + t*u*ulp + 1) * ulp
@@ -366,13 +367,13 @@ arb_exp_arf(arb_t z, const arf_t x, slong prec, int minus_one, slong maglim)
                 mpn_rshift(t, t, wn + 1, 1);
                 error = (error >> 1) + 2;
 
-                mpn_mul_n(u, arb_exp_tab21[p1] + ARB_EXP_TAB2_LIMBS - wn,
+                flint_mpn_mul_n(u, arb_exp_tab21[p1] + ARB_EXP_TAB2_LIMBS - wn,
                              arb_exp_tab22[p2] + ARB_EXP_TAB2_LIMBS - wn, wn);
 
                 /* error of w <= 4 ulp */
                 flint_mpn_copyi(w, u + wn, wn);  /* todo: avoid with better alloc */
 
-                mpn_mul_n(u, t, w, wn);
+                flint_mpn_mul_n(u, t, w, wn);
 
                 /* (t + err1 * ulp) * (w + 4 * ulp) + 1ulp = t*u +
                    (err1*w + 4*t + t*w*ulp + 1) * ulp

--- a/src/arb/exp_taylor_naive.c
+++ b/src/arb/exp_taylor_naive.c
@@ -10,6 +10,7 @@
 */
 
 #include "arb.h"
+#include "mpn_extras.h"
 
 void
 _arb_exp_taylor_naive(mp_ptr y, mp_limb_t * error,
@@ -45,7 +46,7 @@ _arb_exp_taylor_naive(mp_ptr y, mp_limb_t * error,
         s[nn] += mpn_add_n(s, s, t, nn);
 
         /* t = t * x / (k + 1) */
-        mpn_mul_n(u, t, v, nn);
+        flint_mpn_mul_n(u, t, v, nn);
         flint_mpn_copyi(t, u + nn, nn);
         mpn_divrem_1(t, 0, t, nn, k + 1);
     }

--- a/src/arb/exp_taylor_rs.c
+++ b/src/arb/exp_taylor_rs.c
@@ -10,6 +10,7 @@
 */
 
 #include "arb.h"
+#include "mpn_extras.h"
 
 /* See verify_taylor.py for code to generate tables and
    proof of correctness */
@@ -1222,7 +1223,7 @@ void _arb_exp_taylor_rs(mp_ptr y, mp_limb_t * error,
             /* 1 + x + x^2 / 2 */
             t = TMP_ALLOC_LIMBS(2 * xn);
 
-            mpn_sqr(t, x, xn);
+            flint_mpn_sqr(t, x, xn);
             mpn_rshift(t + xn, t + xn, xn, 1);
             y[xn] = mpn_add_n(y, x, t + xn, xn) + 1;
 
@@ -1251,12 +1252,12 @@ void _arb_exp_taylor_rs(mp_ptr y, mp_limb_t * error,
 #define XPOW_READ(__k) (xpow + (m - (__k) + 1) * xn)
 
         flint_mpn_copyi(XPOW_READ(1), x, xn);
-        mpn_sqr(XPOW_WRITE(2), XPOW_READ(1), xn);
+        flint_mpn_sqr(XPOW_WRITE(2), XPOW_READ(1), xn);
 
         for (k = 4; k <= m; k += 2)
         {
-            mpn_mul_n(XPOW_WRITE(k - 1), XPOW_READ(k / 2), XPOW_READ(k / 2 - 1), xn);
-            mpn_sqr(XPOW_WRITE(k), XPOW_READ(k / 2), xn);
+            flint_mpn_mul_n(XPOW_WRITE(k - 1), XPOW_READ(k / 2), XPOW_READ(k / 2 - 1), xn);
+            flint_mpn_sqr(XPOW_WRITE(k), XPOW_READ(k / 2), xn);
         }
 
         flint_mpn_zero(s, xn + 1);
@@ -1285,7 +1286,7 @@ void _arb_exp_taylor_rs(mp_ptr y, mp_limb_t * error,
                 /* Outer polynomial evaluation: multiply by x^m */
                 if (k != 0)
                 {
-                    mpn_mul(t, s, xn + 1, XPOW_READ(m), xn);
+                    flint_mpn_mul(t, s, xn + 1, XPOW_READ(m), xn);
                     flint_mpn_copyi(s, t + xn, xn + 1);
                 }
 

--- a/src/arb/sin_cos.c
+++ b/src/arb/sin_cos.c
@@ -261,7 +261,7 @@ _arb_sin_cos(arb_t zsin, arb_t zcos, const arf_t x, const mag_t xrad, slong prec
         }
         else
         {
-            mpn_sqr(ta, sina, wn);
+            flint_mpn_sqr(ta, sina, wn);
             /* 1 - s^2 (negation guaranteed to have borrow) */
             mpn_neg(ta, ta, 2 * wn);
             /* top limb of ta must be nonzero, so no need to normalize
@@ -320,15 +320,15 @@ _arb_sin_cos(arb_t zsin, arb_t zcos, const arf_t x, const mag_t xrad, slong prec
 
         if ((want_sin && !swapsincos) || (want_cos && swapsincos))
         {
-            mpn_mul_n(ta, sina, cosc, wn);
-            mpn_mul_n(tb, cosa, sinc, wn);
+            flint_mpn_mul_n(ta, sina, cosc, wn);
+            flint_mpn_mul_n(tb, cosa, sinc, wn);
             mpn_add_n(w, ta + wn, tb + wn, wn);
         }
 
         if ((want_cos && !swapsincos) || (want_sin && swapsincos))
         {
-            mpn_mul_n(ta, cosa, cosc, wn);
-            mpn_mul_n(tb, sina, sinc, wn);
+            flint_mpn_mul_n(ta, cosa, cosc, wn);
+            flint_mpn_mul_n(tb, sina, sinc, wn);
             mpn_sub_n(ta, ta + wn, tb + wn, wn);
         }
 
@@ -346,27 +346,27 @@ _arb_sin_cos(arb_t zsin, arb_t zcos, const arf_t x, const mag_t xrad, slong prec
         sind = arb_sin_cos_tab22[2 * p2] + ARB_SIN_COS_TAB2_LIMBS - wn;
         cosd = arb_sin_cos_tab22[2 * p2 + 1] + ARB_SIN_COS_TAB2_LIMBS - wn;
 
-        mpn_mul_n(ta, sinc, cosd, wn);
-        mpn_mul_n(tb, cosc, sind, wn);
+        flint_mpn_mul_n(ta, sinc, cosd, wn);
+        flint_mpn_mul_n(tb, cosc, sind, wn);
         mpn_add_n(sinb, ta + wn, tb + wn, wn);
 
-        mpn_mul_n(ta, cosc, cosd, wn);
-        mpn_mul_n(tb, sinc, sind, wn);
+        flint_mpn_mul_n(ta, cosc, cosd, wn);
+        flint_mpn_mul_n(tb, sinc, sind, wn);
         mpn_sub_n(cosb, ta + wn, tb + wn, wn);
 
         error2 = 2 * 1 + 2 * 1 + 3;
 
         if ((want_sin && !swapsincos) || (want_cos && swapsincos))
         {
-            mpn_mul_n(ta, sina, cosb, wn);
-            mpn_mul_n(tb, cosa, sinb, wn);
+            flint_mpn_mul_n(ta, sina, cosb, wn);
+            flint_mpn_mul_n(tb, cosa, sinb, wn);
             mpn_add_n(w, ta + wn, tb + wn, wn);
         }
 
         if ((want_cos && !swapsincos) || (want_sin && swapsincos))
         {
-            mpn_mul_n(ta, cosa, cosb, wn);
-            mpn_mul_n(tb, sina, sinb, wn);
+            flint_mpn_mul_n(ta, cosa, cosb, wn);
+            flint_mpn_mul_n(tb, sina, sinb, wn);
             mpn_sub_n(ta, ta + wn, tb + wn, wn);
         }
 

--- a/src/arb/sin_cos_taylor_naive.c
+++ b/src/arb/sin_cos_taylor_naive.c
@@ -10,6 +10,7 @@
 */
 
 #include "arb.h"
+#include "mpn_extras.h"
 
 void
 _arb_sin_cos_taylor_naive(mp_ptr ysin, mp_ptr ycos, mp_limb_t * error,
@@ -56,7 +57,7 @@ _arb_sin_cos_taylor_naive(mp_ptr ysin, mp_ptr ycos, mp_limb_t * error,
             s2[nn] -= mpn_sub_n(s2, s2, t, nn);
 
         /* t = t * x / (k + 1) */
-        mpn_mul_n(u, t, v, nn);
+        flint_mpn_mul_n(u, t, v, nn);
         flint_mpn_copyi(t, u + nn, nn);
         mpn_divrem_1(t, 0, t, nn, k + 1);
     }

--- a/src/arb/sin_cos_taylor_rs.c
+++ b/src/arb/sin_cos_taylor_rs.c
@@ -10,6 +10,7 @@
 */
 
 #include "arb.h"
+#include "mpn_extras.h"
 
 /* See verify_taylor.py for code to generate tables and
    proof of correctness */
@@ -72,13 +73,13 @@ void _arb_sin_cos_taylor_rs(mp_ptr ysin, mp_ptr ycos,
 #define XPOW_WRITE(__k) (xpow + (m - (__k)) * xn)
 #define XPOW_READ(__k) (xpow + (m - (__k) + 1) * xn)
 
-        mpn_sqr(XPOW_WRITE(1), x, xn);
-        mpn_sqr(XPOW_WRITE(2), XPOW_READ(1), xn);
+        flint_mpn_sqr(XPOW_WRITE(1), x, xn);
+        flint_mpn_sqr(XPOW_WRITE(2), XPOW_READ(1), xn);
 
         for (k = 4; k <= m; k += 2)
         {
-            mpn_mul_n(XPOW_WRITE(k - 1), XPOW_READ(k / 2), XPOW_READ(k / 2 - 1), xn);
-            mpn_sqr(XPOW_WRITE(k), XPOW_READ(k / 2), xn);
+            flint_mpn_mul_n(XPOW_WRITE(k - 1), XPOW_READ(k / 2), XPOW_READ(k / 2 - 1), xn);
+            flint_mpn_sqr(XPOW_WRITE(k), XPOW_READ(k / 2), xn);
         }
 
         for (cosorsin = sinonly; cosorsin < 2; cosorsin++)
@@ -118,7 +119,7 @@ void _arb_sin_cos_taylor_rs(mp_ptr ysin, mp_ptr ycos,
                     /* Outer polynomial evaluation: multiply by x^m */
                     if (k != 0)
                     {
-                        mpn_mul(t, s, xn + 1, XPOW_READ(m), xn);
+                        flint_mpn_mul(t, s, xn + 1, XPOW_READ(m), xn);
                         flint_mpn_copyi(s, t + xn, xn + 1);
                     }
 
@@ -151,7 +152,7 @@ void _arb_sin_cos_taylor_rs(mp_ptr ysin, mp_ptr ycos,
             else
             {
                 mpn_divrem_1(s, 0, s, xn + 1, factorial_tab_denom[0]);
-                mpn_mul(t, s, xn + 1, x, xn);
+                flint_mpn_mul(t, s, xn + 1, x, xn);
                 flint_mpn_copyi(ysin, t + xn, xn);
             }
         }

--- a/src/arb/ui_pow_ui.c
+++ b/src/arb/ui_pow_ui.c
@@ -187,7 +187,7 @@ arb_ui_pow_ui(arb_t res, ulong a, ulong exp, slong prec)
                         mp_limb_t y0, y1;
                         y0 = yman[0];
                         y1 = yman[1];
-                        flint_mpn_mul_2x1(yman[2], yman[1], yman[0], y1, y0, aodd);
+                        FLINT_MPN_MUL_2X1(yman[2], yman[1], yman[0], y1, y0, aodd);
                         yn += (yman[2] != 0);
                     }
                 }
@@ -198,7 +198,7 @@ arb_ui_pow_ui(arb_t res, ulong a, ulong exp, slong prec)
                    wp_limbs, we might want to go to the floating-point
                    code here */
                 yexp_lo *= 2;
-                mpn_sqr(tmp, yman, yn);
+                flint_mpn_sqr(tmp, yman, yn);
                 yn = 2 * yn;
                 yn -= (tmp[yn - 1] == 0);
 

--- a/src/arf/approx_dot.c
+++ b/src/arf/approx_dot.c
@@ -280,7 +280,7 @@ arf_approx_dot(arf_t res, const arf_t initial, int subtract, arf_srcptr x, slong
                 y0 = ARF_NOPTR_D(ym)[0];
                 y1 = ARF_NOPTR_D(ym)[1];
 
-                flint_mpn_mul_2x2(u3, u2, u1, u0, x1, x0, y1, y0);
+                FLINT_MPN_MUL_2X2(u3, u2, u1, u0, x1, x0, y1, y0);
 
                 u1 = (u1 >> shift) | (u2 << (FLINT_BITS - shift));
                 u2 = (u2 >> shift) | (u3 << (FLINT_BITS - shift));
@@ -320,14 +320,14 @@ arf_approx_dot(arf_t res, const arf_t initial, int subtract, arf_srcptr x, slong
                     x1 = ARF_NOPTR_D(xm)[1];
                     y0 = ARF_NOPTR_D(ym)[0];
                     y1 = ARF_NOPTR_D(ym)[1];
-                    flint_mpn_mul_2x2(u3, u2, u1, u0, x1, x0, y1, y0);
+                    FLINT_MPN_MUL_2X2(u3, u2, u1, u0, x1, x0, y1, y0);
                 }
                 else if (xn == 1)
                 {
                     x0 = ARF_NOPTR_D(xm)[0];
                     y0 = ARF_NOPTR_D(ym)[0];
                     y1 = ARF_NOPTR_D(ym)[1];
-                    flint_mpn_mul_2x1(u3, u2, u1, y1, y0, x0);
+                    FLINT_MPN_MUL_2X1(u3, u2, u1, y1, y0, x0);
                     u0 = 0;
                 }
                 else
@@ -335,7 +335,7 @@ arf_approx_dot(arf_t res, const arf_t initial, int subtract, arf_srcptr x, slong
                     x0 = ARF_NOPTR_D(xm)[0];
                     x1 = ARF_NOPTR_D(xm)[1];
                     y0 = ARF_NOPTR_D(ym)[0];
-                    flint_mpn_mul_2x1(u3, u2, u1, x1, x0, y0);
+                    FLINT_MPN_MUL_2X1(u3, u2, u1, x1, x0, y0);
                     u0 = 0;
                 }
 

--- a/src/arf/div.c
+++ b/src/arf/div.c
@@ -109,9 +109,9 @@ arf_div(arf_ptr z, arf_srcptr x, arf_srcptr y, slong prec, arf_rnd_t rnd)
            tptr[sn + xn] is guaranteed to be zero in that case since the
            approximate quotient cannot be larger than the true quotient. */
         if (zn >= yn)
-            mpn_mul(tptr, zptr, zn, yptr, yn);
+            flint_mpn_mul(tptr, zptr, zn, yptr, yn);
         else
-            mpn_mul(tptr, yptr, yn, zptr, zn);
+            flint_mpn_mul(tptr, yptr, yn, zptr, zn);
 
         /* The quotient is not exact. Perturbing the approximate quotient
            and rounding gives the correct the result. */

--- a/src/arf/mul_rnd_any.c
+++ b/src/arf/mul_rnd_any.c
@@ -51,25 +51,7 @@ arf_mul_rnd_any(arf_ptr z, arf_srcptr x, arf_srcptr y,
         alloc = zn = xn + yn;
         ARF_MUL_TMP_ALLOC(tmp, alloc)
 
-        if (yn == 1)
-        {
-            tmp[zn - 1] = mpn_mul_1(tmp, xptr, xn, yptr[0]);
-        }
-        else if (yn >= FLINT_MPN_MUL_THRESHOLD)
-        {
-            flint_mpn_mul_large(tmp, xptr, xn, yptr, yn);
-        }
-        else if (xn == yn)
-        {
-            if (xptr == yptr)
-                mpn_sqr(tmp, xptr, xn);
-            else
-                mpn_mul_n(tmp, xptr, yptr, yn);
-        }
-        else
-        {
-            mpn_mul(tmp, xptr, xn, yptr, yn);
-        }
+        FLINT_MPN_MUL_WITH_SPECIAL_CASES(tmp, xptr, xn, yptr, yn);
 
         inexact = _arf_set_round_mpn(z, &fix, tmp, zn, sgnbit, prec, rnd);
         _fmpz_add2_fast(ARF_EXPREF(z), ARF_EXPREF(x), ARF_EXPREF(y), fix);

--- a/src/arf/mul_rnd_down.c
+++ b/src/arf/mul_rnd_down.c
@@ -118,7 +118,7 @@ arf_mul_rnd_down(arf_ptr z, arf_srcptr x, arf_srcptr y, slong prec)
             y0 = ARF_NOPTR_D(y)[0];
             y1 = ARF_NOPTR_D(y)[1];
 
-            flint_mpn_mul_2x2(zz[3], zz[2], zz[1], zz[0], x1, x0, y1, y0);
+            FLINT_MPN_MUL_2X2(zz[3], zz[2], zz[1], zz[0], x1, x0, y1, y0);
 
             /* Likely case, must be inexact */
             if (prec <= 2 * FLINT_BITS)
@@ -167,7 +167,7 @@ arf_mul_rnd_down(arf_ptr z, arf_srcptr x, arf_srcptr y, slong prec)
         else
         {
             y0 = ARF_NOPTR_D(y)[0];
-            flint_mpn_mul_2x1(zz[2], zz[1], zz[0], x1, x0, y0);
+            FLINT_MPN_MUL_2X1(zz[2], zz[1], zz[0], x1, x0, y0);
         }
 
         zn = xn + yn;
@@ -194,25 +194,7 @@ arf_mul_rnd_down(arf_ptr z, arf_srcptr x, arf_srcptr y, slong prec)
         alloc = zn = xn + yn;
         ARF_MUL_TMP_ALLOC(tmp, alloc)
 
-        if (yn >= FLINT_MPN_MUL_THRESHOLD)
-        {
-            flint_mpn_mul_large(tmp, xptr, xn, yptr, yn);
-        }
-        else if (xn == yn)
-        {
-            if (xptr == yptr)
-                mpn_sqr(tmp, xptr, xn);
-            else
-                mpn_mul_n(tmp, xptr, yptr, yn);
-        }
-        else if (yn == 1)
-        {
-            tmp[zn - 1] = mpn_mul_1(tmp, xptr, xn, yptr[0]);
-        }
-        else
-        {
-            mpn_mul(tmp, xptr, xn, yptr, yn);
-        }
+        FLINT_MPN_MUL_WITH_SPECIAL_CASES(tmp, xptr, xn, yptr, yn);
 
         ret = _arf_set_round_mpn(z, &expfix, tmp, zn, sgnbit, prec, ARF_RND_DOWN);
         _fmpz_add2_fast(ARF_EXPREF(z), ARF_EXPREF(x), ARF_EXPREF(y), expfix);

--- a/src/fmpq/reconstruct_fmpz_2.c
+++ b/src/fmpq/reconstruct_fmpz_2.c
@@ -557,8 +557,8 @@ gauss:
 
     /* (m11, m12) = (m12 + Q*m11, m11), use R for temp */
     mdet *= -1;
-    ex0 = (Qlen > m_len) ? mpn_mul(R, Q, Qlen, m11, m_len)
-                         : mpn_mul(R, m11, m_len, Q, Qlen);
+    ex0 = (Qlen > m_len) ? flint_mpn_mul(R, Q, Qlen, m11, m_len)
+                         : flint_mpn_mul(R, m11, m_len, Q, Qlen);
     m_len = Qlen + m_len - (ex0 == 0);
     ex0 = mpn_add_n(R, R, m12, m_len);
     R[m_len] = ex0;

--- a/src/fmpz/mul.c
+++ b/src/fmpz/mul.c
@@ -61,7 +61,7 @@ flint_mpz_mul(mpz_ptr z, mpz_srcptr x, mpz_srcptr y)
         if (xn == 2)
         {
             mp_limb_t r3, r2, r1, r0;
-            flint_mpn_mul_2x2(r3, r2, r1, r0, xd[1], xd[0], yd[1], yd[0]);
+            FLINT_MPN_MUL_2X2(r3, r2, r1, r0, xd[1], xd[0], yd[1], yd[0]);
             zd[0] = r0;
             zd[1] = r1;
             zd[2] = r2;
@@ -93,7 +93,7 @@ flint_mpz_mul(mpz_ptr z, mpz_srcptr x, mpz_srcptr y)
         if (xn == 2)
         {
             mp_limb_t r2, r1, r0;
-            flint_mpn_mul_2x1(r2, r1, r0, xd[1], xd[0], yd[0]);
+            FLINT_MPN_MUL_2X1(r2, r1, r0, xd[1], xd[0], yd[0]);
             zd[0] = r0;
             zd[1] = r1;
             zd[2] = top = r2;

--- a/src/fmpz_mod_mpoly/mul_johnson.c
+++ b/src/fmpz_mod_mpoly/mul_johnson.c
@@ -119,7 +119,7 @@ void _fmpz_mod_mpoly_mul_johnson1(
                     *store++ = x->i;
                     *store++ = x->j;
                     hind[x->i] |= WORD(1);
-                    mpn_mul_n(t_d, Bcoeffs_packed + n*x->i,
+                    flint_mpn_mul_n(t_d, Bcoeffs_packed + n*x->i,
                                    Ccoeffs_packed + n*x->j, n);
                     acc_d[2*n] += mpn_add_n(acc_d, acc_d, t_d, 2*n);
                 } while ((x = x->next) != NULL);
@@ -329,7 +329,7 @@ void _fmpz_mod_mpoly_mul_johnson(
                     *store++ = x->i;
                     *store++ = x->j;
                     hind[x->i] |= WORD(1);
-                    mpn_mul_n(t_d, Bcoeffs_packed + n*x->i,
+                    flint_mpn_mul_n(t_d, Bcoeffs_packed + n*x->i,
                                    Ccoeffs_packed + n*x->j, n);
                     acc_d[2*n] += mpn_add_n(acc_d, acc_d, t_d, 2*n);
                 } while ((x = x->next) != NULL);

--- a/src/mpn_extras/factor_trial_tree.c
+++ b/src/mpn_extras/factor_trial_tree.c
@@ -91,7 +91,7 @@ _factor_trial_tree_init(void)
             /* multiply entries in pairs */
 	        for (i = 0, j = 0; j < k/2; j++, i+=(2*n))
             {
-                mpn_mul_n(_factor_trial_tree[m + 1] + i,
+                flint_mpn_mul_n(_factor_trial_tree[m + 1] + i,
 		        _factor_trial_tree[m] + i,
 		        _factor_trial_tree[m] + i + n, n);
 	        }

--- a/src/mpn_extras/mul.c
+++ b/src/mpn_extras/mul.c
@@ -1,0 +1,868 @@
+/*
+    Copyright (C) 2023 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "mpn_extras.h"
+
+void __gmpn_mul_basecase(mp_ptr, mp_srcptr, mp_size_t, mp_srcptr, mp_size_t);
+
+/* Some helper macros that eventually should be public. */
+
+/* {s0,s1,s2} = u[0]v[n-1] + u[1]v[n-2] + ... */
+/* Assumes n >= 2 */
+#define NN_DOTREV_S3_1X1(s2, s1, s0, u, v, n) \
+    do { \
+        mp_limb_t __dt0, __dt1, __ds0, __ds1, __ds2; \
+        slong __i; \
+        FLINT_ASSERT((n) >= 2); \
+        umul_ppmm(__ds1, __ds0, (u)[0], (v)[(n) - 1]); \
+        umul_ppmm(__dt1, __dt0, (u)[1], (v)[(n) - 2]); \
+        add_sssaaaaaa(__ds2, __ds1, __ds0, 0, __ds1, __ds0, 0, __dt1, __dt0); \
+        for (__i = 2; __i < (n); __i++) \
+        { \
+            umul_ppmm(__dt1, __dt0, (u)[i], (v)[(n) - 1 - __i]); \
+            add_sssaaaaaa(__ds2, __ds1, __ds0, __ds2, __ds1, __ds0, 0, __dt1, __dt0); \
+        } \
+        (s0) = __ds0; (s1) = __ds1; (s2) = __ds2; \
+    } while (0) \
+
+/* {r0,r1,r2} = {s0,s1,s2} + u[0]v[n-1] + u[1]v[n-2] + ... */
+/* Assumes n >= 1. May have s2 != 0, but the final sum is assumed to fit in 3 limbs. */
+#define NN_DOTREV_S3_A3_1X1(r2, r1, r0, s2, s1, s0, u, v, n) \
+    do { \
+        mp_limb_t __dt0, __dt1, __ds0, __ds1, __ds2; \
+        slong __i; \
+        FLINT_ASSERT((n) >= 1); \
+        __ds0 = (s0); __ds1 = (s1); __ds2 = (s2); \
+        for (__i = 0; __i < (n); __i++) \
+        { \
+            umul_ppmm(__dt1, __dt0, (u)[__i], (v)[(n) - 1 - __i]); \
+            add_sssaaaaaa(__ds2, __ds1, __ds0, __ds2, __ds1, __ds0, 0, __dt1, __dt0); \
+        } \
+        (r0) = __ds0; (r1) = __ds1; (r2) = __ds2; \
+    } while (0) \
+
+#define NN_MUL_1X1 umul_ppmm
+
+/* {r0,r1} = {s0,s1} + x * y, with no carry-out. */
+#define NN_ADDMUL_S2_A2_1X1(r1, r0, s1, s0, x, y) \
+    do { \
+        mp_limb_t __dt0, __dt1; \
+        umul_ppmm(__dt1, __dt0, (x), (y)); \
+        add_ssaaaa(r1, r0, s1, s0, __dt1, __dt0); \
+    } while (0); \
+
+
+/*
+Generic version of mul_n:
+
+void flint_mpn_mul_n_basecase(mp_ptr res, mp_srcptr u, mp_srcptr v, mp_size_t n)
+{
+    mp_limb_t b, a;
+    slong i;
+
+    NN_MUL_1X1(a, res[0], u[0], v[0]);
+    NN_DOTREV_S3_A3_1X1(b, a, res[1], 0, 0, a, u, v, 2);
+
+    for (i = 2; i < n; i++)
+        NN_DOTREV_S3_A3_1X1(b, a, res[i], 0, b, a, u, v, i + 1);
+
+    for (i = n; i < 2 * n - 2; i++)
+        NN_DOTREV_S3_A3_1X1(b, a, res[i], 0, b, a, u + i - n + 1, v + i - n + 1, 2 * n - i - 1);
+
+    NN_ADDMUL_S2_A2_1X1(res[2 * n - 1], res[2 * n - 2], b, a, u[n - 1], v[n - 1]);
+}
+
+The compiler may refuse to unroll the nested loops, so we generate the code.
+
+Schema for a general n x m multiply (here n = 7, m = 4):
+
+    v0   u0 u1 u2 u3 u4 u5 u6 .
+    v1      u0 u1 u2 u3 u4 u5 u6 .
+    v2         u0 u1 u2 u3 u4 u5 u6 .
+    v3            u0 u1 u2 u3 u4 u5 u6 .
+
+def mul1v(n):
+    print("mp_limb_t flint_mpn_mul_%ix1v(mp_ptr res, mp_srcptr u, mp_limb_t v0)" % n)
+    print("{")
+    print("    mp_limb_t a;")
+    print("    NN_MUL_1X1(a, res[0], u[0], v0);")
+    for i in range(1, n-1):
+        print("    NN_ADDMUL_S2_A2_1X1(a, res[%i], 0, a, u[%i], v0);" % (i, i))
+    print("    NN_ADDMUL_S2_A2_1X1(a, res[%i], 0, a, u[%i], v0);" % (n - 1, n - 1))
+    print("    return a;")
+    print("}")
+
+def mulnm(n, m):
+    if m == 1:
+        print("mp_limb_t flint_mpn_mul_%ix1(mp_ptr res, mp_srcptr u, mp_srcptr v)" % n)
+        print("{")
+        print("    mp_limb_t a, v0 = v[0];")
+        print("    NN_MUL_1X1(a, res[0], u[0], v0);")
+        for i in range(1, n-1):
+            print("    NN_ADDMUL_S2_A2_1X1(a, res[%i], 0, a, u[%i], v0);" % (i, i))
+        print("    NN_ADDMUL_S2_A2_1X1(res[%i], res[%i], 0, a, u[%i], v0);" % (n, n - 1, n - 1))
+        print("    return res[%i];" % n)
+        print("}")
+    elif m == 2:
+        print("mp_limb_t flint_mpn_mul_%ix%i(mp_ptr res, mp_srcptr u, mp_srcptr v)" % (n, m))
+        print("{")
+        print("    mp_limb_t b, a;")
+        print("    mp_limb_t w[2];")
+        print("    w[0] = v[0];")
+        print("    w[1] = v[1];")
+        print("    NN_MUL_1X1(a, res[0], u[0], w[0]);")
+        print("    NN_DOTREV_S3_A3_1X1(b, a, res[1], 0, 0, a, u, w, 2);")
+        for i in range(2, m):
+            print("    NN_DOTREV_S3_A3_1X1(b, a, res[%i], 0, b, a, u, w, %i);" % (i, i + 1))
+        for i in range(m, n):
+            print("    NN_DOTREV_S3_A3_1X1(b, a, res[%i], 0, b, a, u + %i, w, %i);" % (i, i - m + 1, m))
+        for i in range(n, n+m-2):
+            print("    NN_DOTREV_S3_A3_1X1(b, a, res[%i], 0, b, a, u + %i, w + %i, %i);" % (i, i - m + 1, i - n + 1, n + m - i - 1))
+        print("    NN_ADDMUL_S2_A2_1X1(res[%i], res[%i], b, a, u[%i], w[%i]);" % (n + m - 1, n + m - 2, n - 1, m - 1))
+        print("    return res[%i];" % (n + m - 1))
+        print("}")
+    else:
+        print("mp_limb_t flint_mpn_mul_%ix%i(mp_ptr res, mp_srcptr u, mp_srcptr v)" % (n, m))
+        print("{")
+        print("    mp_limb_t b, a;")
+        print("    NN_MUL_1X1(a, res[0], u[0], v[0]);")
+        print("    NN_DOTREV_S3_A3_1X1(b, a, res[1], 0, 0, a, u, v, 2);")
+        for i in range(2, m):
+            print("    NN_DOTREV_S3_A3_1X1(b, a, res[%i], 0, b, a, u, v, %i);" % (i, i + 1))
+        for i in range(m, n):
+            print("    NN_DOTREV_S3_A3_1X1(b, a, res[%i], 0, b, a, u + %i, v, %i);" % (i, i - m + 1, m))
+        for i in range(n, n+m-2):
+            print("    NN_DOTREV_S3_A3_1X1(b, a, res[%i], 0, b, a, u + %i, v + %i, %i);" % (i, i - m + 1, i - n + 1, n + m - i - 1))
+        print("    NN_ADDMUL_S2_A2_1X1(res[%i], res[%i], b, a, u[%i], v[%i]);" % (n + m - 1, n + m - 2, n - 1, m - 1))
+        print("    return res[%i];" % (n + m - 1))
+        print("}")
+
+for n in range(2, 8):
+    for m in range(1, n+1):
+        if n >= 8 and m >= 5:
+            print("void flint_mpn_mul_%ix%i(mp_ptr res, mp_srcptr u, mp_srcptr v)" % (n, m))
+            print("{")
+            print("    __gmpn_mul_basecase(res, u, %i, v, %i);" % (n, m))
+            print("}")
+        else:
+            mulnm(n, m)
+        print()
+    print()
+
+for n in range(8, 17):
+    mulnm(n, 1)
+    print()
+    #mulnm(n, 2)
+    #print()
+
+*/
+
+
+mp_limb_t flint_mpn_mul_1x1(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    NN_MUL_1X1(res[1], res[0], u[0], v[0]);
+    return res[1];
+}
+
+mp_limb_t flint_mpn_mul_2x1(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t a, v0 = v[0];
+    NN_MUL_1X1(a, res[0], u[0], v0);
+    NN_ADDMUL_S2_A2_1X1(res[2], res[1], 0, a, u[1], v0);
+    return res[2];
+}
+
+mp_limb_t flint_mpn_mul_2x2(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t b, a;
+    mp_limb_t w[2];
+    w[0] = v[0];
+    w[1] = v[1];
+    NN_MUL_1X1(a, res[0], u[0], w[0]);
+    NN_DOTREV_S3_A3_1X1(b, a, res[1], 0, 0, a, u, w, 2);
+    NN_ADDMUL_S2_A2_1X1(res[3], res[2], b, a, u[1], w[1]);
+    return res[3];
+}
+
+mp_limb_t flint_mpn_mul_3x1(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t a, v0 = v[0];
+    NN_MUL_1X1(a, res[0], u[0], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[1], 0, a, u[1], v0);
+    NN_ADDMUL_S2_A2_1X1(res[3], res[2], 0, a, u[2], v0);
+    return res[3];
+}
+
+mp_limb_t flint_mpn_mul_3x2(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t b, a;
+    mp_limb_t w[2];
+    w[0] = v[0];
+    w[1] = v[1];
+    NN_MUL_1X1(a, res[0], u[0], w[0]);
+    NN_DOTREV_S3_A3_1X1(b, a, res[1], 0, 0, a, u, w, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[2], 0, b, a, u + 1, w, 2);
+    NN_ADDMUL_S2_A2_1X1(res[4], res[3], b, a, u[2], w[1]);
+    return res[4];
+}
+
+mp_limb_t flint_mpn_mul_3x3(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t b, a;
+    NN_MUL_1X1(a, res[0], u[0], v[0]);
+    NN_DOTREV_S3_A3_1X1(b, a, res[1], 0, 0, a, u, v, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[2], 0, b, a, u, v, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[3], 0, b, a, u + 1, v + 1, 2);
+    NN_ADDMUL_S2_A2_1X1(res[5], res[4], b, a, u[2], v[2]);
+    return res[5];
+}
+
+
+mp_limb_t flint_mpn_mul_4x1(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t a, v0 = v[0];
+    NN_MUL_1X1(a, res[0], u[0], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[1], 0, a, u[1], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[2], 0, a, u[2], v0);
+    NN_ADDMUL_S2_A2_1X1(res[4], res[3], 0, a, u[3], v0);
+    return res[4];
+}
+
+mp_limb_t flint_mpn_mul_4x2(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t b, a;
+    mp_limb_t w[2];
+    w[0] = v[0];
+    w[1] = v[1];
+    NN_MUL_1X1(a, res[0], u[0], w[0]);
+    NN_DOTREV_S3_A3_1X1(b, a, res[1], 0, 0, a, u, w, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[2], 0, b, a, u + 1, w, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[3], 0, b, a, u + 2, w, 2);
+    NN_ADDMUL_S2_A2_1X1(res[5], res[4], b, a, u[3], w[1]);
+    return res[5];
+}
+
+mp_limb_t flint_mpn_mul_4x3(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t b, a;
+    NN_MUL_1X1(a, res[0], u[0], v[0]);
+    NN_DOTREV_S3_A3_1X1(b, a, res[1], 0, 0, a, u, v, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[2], 0, b, a, u, v, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[3], 0, b, a, u + 1, v, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[4], 0, b, a, u + 2, v + 1, 2);
+    NN_ADDMUL_S2_A2_1X1(res[6], res[5], b, a, u[3], v[2]);
+    return res[6];
+}
+
+mp_limb_t flint_mpn_mul_4x4(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t b, a;
+    NN_MUL_1X1(a, res[0], u[0], v[0]);
+    NN_DOTREV_S3_A3_1X1(b, a, res[1], 0, 0, a, u, v, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[2], 0, b, a, u, v, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[3], 0, b, a, u, v, 4);
+    NN_DOTREV_S3_A3_1X1(b, a, res[4], 0, b, a, u + 1, v + 1, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[5], 0, b, a, u + 2, v + 2, 2);
+    NN_ADDMUL_S2_A2_1X1(res[7], res[6], b, a, u[3], v[3]);
+    return res[7];
+}
+
+
+mp_limb_t flint_mpn_mul_5x1(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t a, v0 = v[0];
+    NN_MUL_1X1(a, res[0], u[0], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[1], 0, a, u[1], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[2], 0, a, u[2], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[3], 0, a, u[3], v0);
+    NN_ADDMUL_S2_A2_1X1(res[5], res[4], 0, a, u[4], v0);
+    return res[5];
+}
+
+mp_limb_t flint_mpn_mul_5x2(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t b, a;
+    mp_limb_t w[2];
+    w[0] = v[0];
+    w[1] = v[1];
+    NN_MUL_1X1(a, res[0], u[0], w[0]);
+    NN_DOTREV_S3_A3_1X1(b, a, res[1], 0, 0, a, u, w, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[2], 0, b, a, u + 1, w, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[3], 0, b, a, u + 2, w, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[4], 0, b, a, u + 3, w, 2);
+    NN_ADDMUL_S2_A2_1X1(res[6], res[5], b, a, u[4], w[1]);
+    return res[6];
+}
+
+mp_limb_t flint_mpn_mul_5x3(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t b, a;
+    NN_MUL_1X1(a, res[0], u[0], v[0]);
+    NN_DOTREV_S3_A3_1X1(b, a, res[1], 0, 0, a, u, v, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[2], 0, b, a, u, v, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[3], 0, b, a, u + 1, v, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[4], 0, b, a, u + 2, v, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[5], 0, b, a, u + 3, v + 1, 2);
+    NN_ADDMUL_S2_A2_1X1(res[7], res[6], b, a, u[4], v[2]);
+    return res[7];
+}
+
+mp_limb_t flint_mpn_mul_5x4(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t b, a;
+    NN_MUL_1X1(a, res[0], u[0], v[0]);
+    NN_DOTREV_S3_A3_1X1(b, a, res[1], 0, 0, a, u, v, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[2], 0, b, a, u, v, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[3], 0, b, a, u, v, 4);
+    NN_DOTREV_S3_A3_1X1(b, a, res[4], 0, b, a, u + 1, v, 4);
+    NN_DOTREV_S3_A3_1X1(b, a, res[5], 0, b, a, u + 2, v + 1, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[6], 0, b, a, u + 3, v + 2, 2);
+    NN_ADDMUL_S2_A2_1X1(res[8], res[7], b, a, u[4], v[3]);
+    return res[8];
+}
+
+mp_limb_t flint_mpn_mul_5x5(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t b, a;
+    NN_MUL_1X1(a, res[0], u[0], v[0]);
+    NN_DOTREV_S3_A3_1X1(b, a, res[1], 0, 0, a, u, v, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[2], 0, b, a, u, v, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[3], 0, b, a, u, v, 4);
+    NN_DOTREV_S3_A3_1X1(b, a, res[4], 0, b, a, u, v, 5);
+    NN_DOTREV_S3_A3_1X1(b, a, res[5], 0, b, a, u + 1, v + 1, 4);
+    NN_DOTREV_S3_A3_1X1(b, a, res[6], 0, b, a, u + 2, v + 2, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[7], 0, b, a, u + 3, v + 3, 2);
+    NN_ADDMUL_S2_A2_1X1(res[9], res[8], b, a, u[4], v[4]);
+    return res[9];
+}
+
+
+mp_limb_t flint_mpn_mul_6x1(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t a, v0 = v[0];
+    NN_MUL_1X1(a, res[0], u[0], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[1], 0, a, u[1], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[2], 0, a, u[2], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[3], 0, a, u[3], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[4], 0, a, u[4], v0);
+    NN_ADDMUL_S2_A2_1X1(res[6], res[5], 0, a, u[5], v0);
+    return res[6];
+}
+
+mp_limb_t flint_mpn_mul_6x2(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t b, a;
+    mp_limb_t w[2];
+    w[0] = v[0];
+    w[1] = v[1];
+    NN_MUL_1X1(a, res[0], u[0], w[0]);
+    NN_DOTREV_S3_A3_1X1(b, a, res[1], 0, 0, a, u, w, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[2], 0, b, a, u + 1, w, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[3], 0, b, a, u + 2, w, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[4], 0, b, a, u + 3, w, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[5], 0, b, a, u + 4, w, 2);
+    NN_ADDMUL_S2_A2_1X1(res[7], res[6], b, a, u[5], w[1]);
+    return res[7];
+}
+
+mp_limb_t flint_mpn_mul_6x3(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t b, a;
+    NN_MUL_1X1(a, res[0], u[0], v[0]);
+    NN_DOTREV_S3_A3_1X1(b, a, res[1], 0, 0, a, u, v, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[2], 0, b, a, u, v, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[3], 0, b, a, u + 1, v, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[4], 0, b, a, u + 2, v, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[5], 0, b, a, u + 3, v, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[6], 0, b, a, u + 4, v + 1, 2);
+    NN_ADDMUL_S2_A2_1X1(res[8], res[7], b, a, u[5], v[2]);
+    return res[8];
+}
+
+mp_limb_t flint_mpn_mul_6x4(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t b, a;
+    NN_MUL_1X1(a, res[0], u[0], v[0]);
+    NN_DOTREV_S3_A3_1X1(b, a, res[1], 0, 0, a, u, v, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[2], 0, b, a, u, v, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[3], 0, b, a, u, v, 4);
+    NN_DOTREV_S3_A3_1X1(b, a, res[4], 0, b, a, u + 1, v, 4);
+    NN_DOTREV_S3_A3_1X1(b, a, res[5], 0, b, a, u + 2, v, 4);
+    NN_DOTREV_S3_A3_1X1(b, a, res[6], 0, b, a, u + 3, v + 1, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[7], 0, b, a, u + 4, v + 2, 2);
+    NN_ADDMUL_S2_A2_1X1(res[9], res[8], b, a, u[5], v[3]);
+    return res[9];
+}
+
+mp_limb_t flint_mpn_mul_6x5(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t b, a;
+    NN_MUL_1X1(a, res[0], u[0], v[0]);
+    NN_DOTREV_S3_A3_1X1(b, a, res[1], 0, 0, a, u, v, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[2], 0, b, a, u, v, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[3], 0, b, a, u, v, 4);
+    NN_DOTREV_S3_A3_1X1(b, a, res[4], 0, b, a, u, v, 5);
+    NN_DOTREV_S3_A3_1X1(b, a, res[5], 0, b, a, u + 1, v, 5);
+    NN_DOTREV_S3_A3_1X1(b, a, res[6], 0, b, a, u + 2, v + 1, 4);
+    NN_DOTREV_S3_A3_1X1(b, a, res[7], 0, b, a, u + 3, v + 2, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[8], 0, b, a, u + 4, v + 3, 2);
+    NN_ADDMUL_S2_A2_1X1(res[10], res[9], b, a, u[5], v[4]);
+    return res[10];
+}
+
+mp_limb_t flint_mpn_mul_6x6(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t b, a;
+    NN_MUL_1X1(a, res[0], u[0], v[0]);
+    NN_DOTREV_S3_A3_1X1(b, a, res[1], 0, 0, a, u, v, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[2], 0, b, a, u, v, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[3], 0, b, a, u, v, 4);
+    NN_DOTREV_S3_A3_1X1(b, a, res[4], 0, b, a, u, v, 5);
+    NN_DOTREV_S3_A3_1X1(b, a, res[5], 0, b, a, u, v, 6);
+    NN_DOTREV_S3_A3_1X1(b, a, res[6], 0, b, a, u + 1, v + 1, 5);
+    NN_DOTREV_S3_A3_1X1(b, a, res[7], 0, b, a, u + 2, v + 2, 4);
+    NN_DOTREV_S3_A3_1X1(b, a, res[8], 0, b, a, u + 3, v + 3, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[9], 0, b, a, u + 4, v + 4, 2);
+    NN_ADDMUL_S2_A2_1X1(res[11], res[10], b, a, u[5], v[5]);
+    return res[11];
+}
+
+
+mp_limb_t flint_mpn_mul_7x1(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t a, v0 = v[0];
+    NN_MUL_1X1(a, res[0], u[0], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[1], 0, a, u[1], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[2], 0, a, u[2], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[3], 0, a, u[3], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[4], 0, a, u[4], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[5], 0, a, u[5], v0);
+    NN_ADDMUL_S2_A2_1X1(res[7], res[6], 0, a, u[6], v0);
+    return res[7];
+}
+
+mp_limb_t flint_mpn_mul_7x2(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t b, a;
+    mp_limb_t w[2];
+    w[0] = v[0];
+    w[1] = v[1];
+    NN_MUL_1X1(a, res[0], u[0], w[0]);
+    NN_DOTREV_S3_A3_1X1(b, a, res[1], 0, 0, a, u, w, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[2], 0, b, a, u + 1, w, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[3], 0, b, a, u + 2, w, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[4], 0, b, a, u + 3, w, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[5], 0, b, a, u + 4, w, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[6], 0, b, a, u + 5, w, 2);
+    NN_ADDMUL_S2_A2_1X1(res[8], res[7], b, a, u[6], w[1]);
+    return res[8];
+}
+
+mp_limb_t flint_mpn_mul_7x3(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t b, a;
+    NN_MUL_1X1(a, res[0], u[0], v[0]);
+    NN_DOTREV_S3_A3_1X1(b, a, res[1], 0, 0, a, u, v, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[2], 0, b, a, u, v, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[3], 0, b, a, u + 1, v, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[4], 0, b, a, u + 2, v, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[5], 0, b, a, u + 3, v, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[6], 0, b, a, u + 4, v, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[7], 0, b, a, u + 5, v + 1, 2);
+    NN_ADDMUL_S2_A2_1X1(res[9], res[8], b, a, u[6], v[2]);
+    return res[9];
+}
+
+mp_limb_t flint_mpn_mul_7x4(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t b, a;
+    NN_MUL_1X1(a, res[0], u[0], v[0]);
+    NN_DOTREV_S3_A3_1X1(b, a, res[1], 0, 0, a, u, v, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[2], 0, b, a, u, v, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[3], 0, b, a, u, v, 4);
+    NN_DOTREV_S3_A3_1X1(b, a, res[4], 0, b, a, u + 1, v, 4);
+    NN_DOTREV_S3_A3_1X1(b, a, res[5], 0, b, a, u + 2, v, 4);
+    NN_DOTREV_S3_A3_1X1(b, a, res[6], 0, b, a, u + 3, v, 4);
+    NN_DOTREV_S3_A3_1X1(b, a, res[7], 0, b, a, u + 4, v + 1, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[8], 0, b, a, u + 5, v + 2, 2);
+    NN_ADDMUL_S2_A2_1X1(res[10], res[9], b, a, u[6], v[3]);
+    return res[10];
+}
+
+mp_limb_t flint_mpn_mul_7x5(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t b, a;
+    NN_MUL_1X1(a, res[0], u[0], v[0]);
+    NN_DOTREV_S3_A3_1X1(b, a, res[1], 0, 0, a, u, v, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[2], 0, b, a, u, v, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[3], 0, b, a, u, v, 4);
+    NN_DOTREV_S3_A3_1X1(b, a, res[4], 0, b, a, u, v, 5);
+    NN_DOTREV_S3_A3_1X1(b, a, res[5], 0, b, a, u + 1, v, 5);
+    NN_DOTREV_S3_A3_1X1(b, a, res[6], 0, b, a, u + 2, v, 5);
+    NN_DOTREV_S3_A3_1X1(b, a, res[7], 0, b, a, u + 3, v + 1, 4);
+    NN_DOTREV_S3_A3_1X1(b, a, res[8], 0, b, a, u + 4, v + 2, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[9], 0, b, a, u + 5, v + 3, 2);
+    NN_ADDMUL_S2_A2_1X1(res[11], res[10], b, a, u[6], v[4]);
+    return res[11];
+}
+
+mp_limb_t flint_mpn_mul_7x6(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t b, a;
+    NN_MUL_1X1(a, res[0], u[0], v[0]);
+    NN_DOTREV_S3_A3_1X1(b, a, res[1], 0, 0, a, u, v, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[2], 0, b, a, u, v, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[3], 0, b, a, u, v, 4);
+    NN_DOTREV_S3_A3_1X1(b, a, res[4], 0, b, a, u, v, 5);
+    NN_DOTREV_S3_A3_1X1(b, a, res[5], 0, b, a, u, v, 6);
+    NN_DOTREV_S3_A3_1X1(b, a, res[6], 0, b, a, u + 1, v, 6);
+    NN_DOTREV_S3_A3_1X1(b, a, res[7], 0, b, a, u + 2, v + 1, 5);
+    NN_DOTREV_S3_A3_1X1(b, a, res[8], 0, b, a, u + 3, v + 2, 4);
+    NN_DOTREV_S3_A3_1X1(b, a, res[9], 0, b, a, u + 4, v + 3, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[10], 0, b, a, u + 5, v + 4, 2);
+    NN_ADDMUL_S2_A2_1X1(res[12], res[11], b, a, u[6], v[5]);
+    return res[12];
+}
+
+mp_limb_t flint_mpn_mul_7x7(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t b, a;
+    NN_MUL_1X1(a, res[0], u[0], v[0]);
+    NN_DOTREV_S3_A3_1X1(b, a, res[1], 0, 0, a, u, v, 2);
+    NN_DOTREV_S3_A3_1X1(b, a, res[2], 0, b, a, u, v, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[3], 0, b, a, u, v, 4);
+    NN_DOTREV_S3_A3_1X1(b, a, res[4], 0, b, a, u, v, 5);
+    NN_DOTREV_S3_A3_1X1(b, a, res[5], 0, b, a, u, v, 6);
+    NN_DOTREV_S3_A3_1X1(b, a, res[6], 0, b, a, u, v, 7);
+    NN_DOTREV_S3_A3_1X1(b, a, res[7], 0, b, a, u + 1, v + 1, 6);
+    NN_DOTREV_S3_A3_1X1(b, a, res[8], 0, b, a, u + 2, v + 2, 5);
+    NN_DOTREV_S3_A3_1X1(b, a, res[9], 0, b, a, u + 3, v + 3, 4);
+    NN_DOTREV_S3_A3_1X1(b, a, res[10], 0, b, a, u + 4, v + 4, 3);
+    NN_DOTREV_S3_A3_1X1(b, a, res[11], 0, b, a, u + 5, v + 5, 2);
+    NN_ADDMUL_S2_A2_1X1(res[13], res[12], b, a, u[6], v[6]);
+    return res[13];
+}
+
+mp_limb_t flint_mpn_mul_8x1(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t a, v0 = v[0];
+    NN_MUL_1X1(a, res[0], u[0], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[1], 0, a, u[1], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[2], 0, a, u[2], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[3], 0, a, u[3], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[4], 0, a, u[4], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[5], 0, a, u[5], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[6], 0, a, u[6], v0);
+    NN_ADDMUL_S2_A2_1X1(res[8], res[7], 0, a, u[7], v0);
+    return res[8];
+}
+
+mp_limb_t flint_mpn_mul_9x1(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t a, v0 = v[0];
+    NN_MUL_1X1(a, res[0], u[0], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[1], 0, a, u[1], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[2], 0, a, u[2], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[3], 0, a, u[3], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[4], 0, a, u[4], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[5], 0, a, u[5], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[6], 0, a, u[6], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[7], 0, a, u[7], v0);
+    NN_ADDMUL_S2_A2_1X1(res[9], res[8], 0, a, u[8], v0);
+    return res[9];
+}
+
+mp_limb_t flint_mpn_mul_10x1(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t a, v0 = v[0];
+    NN_MUL_1X1(a, res[0], u[0], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[1], 0, a, u[1], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[2], 0, a, u[2], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[3], 0, a, u[3], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[4], 0, a, u[4], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[5], 0, a, u[5], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[6], 0, a, u[6], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[7], 0, a, u[7], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[8], 0, a, u[8], v0);
+    NN_ADDMUL_S2_A2_1X1(res[10], res[9], 0, a, u[9], v0);
+    return res[10];
+}
+
+mp_limb_t flint_mpn_mul_11x1(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t a, v0 = v[0];
+    NN_MUL_1X1(a, res[0], u[0], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[1], 0, a, u[1], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[2], 0, a, u[2], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[3], 0, a, u[3], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[4], 0, a, u[4], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[5], 0, a, u[5], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[6], 0, a, u[6], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[7], 0, a, u[7], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[8], 0, a, u[8], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[9], 0, a, u[9], v0);
+    NN_ADDMUL_S2_A2_1X1(res[11], res[10], 0, a, u[10], v0);
+    return res[11];
+}
+
+mp_limb_t flint_mpn_mul_12x1(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t a, v0 = v[0];
+    NN_MUL_1X1(a, res[0], u[0], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[1], 0, a, u[1], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[2], 0, a, u[2], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[3], 0, a, u[3], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[4], 0, a, u[4], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[5], 0, a, u[5], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[6], 0, a, u[6], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[7], 0, a, u[7], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[8], 0, a, u[8], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[9], 0, a, u[9], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[10], 0, a, u[10], v0);
+    NN_ADDMUL_S2_A2_1X1(res[12], res[11], 0, a, u[11], v0);
+    return res[12];
+}
+
+mp_limb_t flint_mpn_mul_13x1(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t a, v0 = v[0];
+    NN_MUL_1X1(a, res[0], u[0], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[1], 0, a, u[1], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[2], 0, a, u[2], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[3], 0, a, u[3], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[4], 0, a, u[4], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[5], 0, a, u[5], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[6], 0, a, u[6], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[7], 0, a, u[7], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[8], 0, a, u[8], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[9], 0, a, u[9], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[10], 0, a, u[10], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[11], 0, a, u[11], v0);
+    NN_ADDMUL_S2_A2_1X1(res[13], res[12], 0, a, u[12], v0);
+    return res[13];
+}
+
+mp_limb_t flint_mpn_mul_14x1(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t a, v0 = v[0];
+    NN_MUL_1X1(a, res[0], u[0], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[1], 0, a, u[1], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[2], 0, a, u[2], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[3], 0, a, u[3], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[4], 0, a, u[4], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[5], 0, a, u[5], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[6], 0, a, u[6], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[7], 0, a, u[7], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[8], 0, a, u[8], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[9], 0, a, u[9], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[10], 0, a, u[10], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[11], 0, a, u[11], v0);
+    NN_ADDMUL_S2_A2_1X1(a, res[12], 0, a, u[12], v0);
+    NN_ADDMUL_S2_A2_1X1(res[14], res[13], 0, a, u[13], v0);
+    return res[14];
+}
+
+typedef mp_limb_t (*flint_mpn_mul_func_t)(mp_ptr, mp_srcptr, mp_srcptr);
+
+const flint_mpn_mul_func_t flint_mpn_mul_tab[8][8] = {
+    { NULL, },
+    { NULL, flint_mpn_mul_1x1, },
+    { NULL, flint_mpn_mul_2x1, flint_mpn_mul_2x2, },
+    { NULL, flint_mpn_mul_3x1, flint_mpn_mul_3x2, flint_mpn_mul_3x3, },
+    { NULL, flint_mpn_mul_4x1, flint_mpn_mul_4x2, flint_mpn_mul_4x3, flint_mpn_mul_4x4, },
+    { NULL, flint_mpn_mul_5x1, flint_mpn_mul_5x2, flint_mpn_mul_5x3, flint_mpn_mul_5x4, flint_mpn_mul_5x5, },
+    { NULL, flint_mpn_mul_6x1, flint_mpn_mul_6x2, flint_mpn_mul_6x3, flint_mpn_mul_6x4, flint_mpn_mul_6x5, flint_mpn_mul_6x6, },
+    { NULL, flint_mpn_mul_7x1, flint_mpn_mul_7x2, flint_mpn_mul_7x3, flint_mpn_mul_7x4, flint_mpn_mul_7x5, flint_mpn_mul_7x6, flint_mpn_mul_7x7, },
+};
+
+const flint_mpn_mul_func_t flint_mpn_mul_n_tab[8] = {
+    NULL,
+    flint_mpn_mul_1x1,
+    flint_mpn_mul_2x2,
+    flint_mpn_mul_3x3,
+    flint_mpn_mul_4x4,
+    flint_mpn_mul_5x5,
+    flint_mpn_mul_6x6,
+    flint_mpn_mul_7x7,
+};
+
+const flint_mpn_mul_func_t flint_mpn_mul_1_tab[15] = {
+    NULL,
+    flint_mpn_mul_1x1,
+    flint_mpn_mul_2x1,
+    flint_mpn_mul_3x1,
+    flint_mpn_mul_4x1,
+    flint_mpn_mul_5x1,
+    flint_mpn_mul_6x1,
+    flint_mpn_mul_7x1,
+    flint_mpn_mul_8x1,
+    flint_mpn_mul_9x1,
+    flint_mpn_mul_10x1,
+    flint_mpn_mul_11x1,
+    flint_mpn_mul_12x1,
+    flint_mpn_mul_13x1,
+    flint_mpn_mul_14x1,
+};
+
+FLINT_FORCE_INLINE
+mp_limb_t flint_mpn_mul_1x1_inline(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    NN_MUL_1X1(res[1], res[0], u[0], v[0]);
+    return res[1];
+}
+
+FLINT_FORCE_INLINE
+mp_limb_t flint_mpn_mul_2x1_inline(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t a, v0 = v[0];
+    NN_MUL_1X1(a, res[0], u[0], v0);
+    NN_ADDMUL_S2_A2_1X1(res[2], res[1], 0, a, u[1], v0);
+    return res[2];
+}
+
+FLINT_FORCE_INLINE
+mp_limb_t flint_mpn_mul_2x2_inline(mp_ptr res, mp_srcptr u, mp_srcptr v)
+{
+    mp_limb_t b, a;
+    NN_MUL_1X1(a, res[0], u[0], v[0]);
+    NN_DOTREV_S3_A3_1X1(b, a, res[1], 0, 0, a, u, v, 2);
+    NN_ADDMUL_S2_A2_1X1(res[3], res[2], b, a, u[1], v[1]);
+    return res[3];
+}
+
+#define MUL_STATS 0
+
+#if MUL_STATS
+
+slong mulcount[17][17] = { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+                           { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+                           { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+                           { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+                           { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+                           { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+                           { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+                           { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+                           { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+                           { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+                           { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+                           { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+                           { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+                           { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+                           { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+                           { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+                           { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, };
+
+slong mulcounter = 0;
+
+#define T mulncount
+#endif
+
+void
+flint_mpn_mul_n(mp_ptr z, mp_srcptr x, mp_srcptr y, mp_size_t n)
+{
+    FLINT_ASSERT(n >= 1);
+    FLINT_ASSERT(z != x);
+    FLINT_ASSERT(z != y);
+
+#if MUL_STATS
+    mulcounter++;
+    mulcount[FLINT_MIN(n, 16)][FLINT_MIN(n,16)]++;
+    if (mulcounter % 10000 == 0)
+    {
+        flint_printf("count %wd\n", mulcounter);
+        int i, j;
+        for (i = 1; i <= 16; i++)
+        {
+            for (j = 1; j <= i; j++)
+            {
+                flint_printf("%7wd ", mulcount[i][j]);
+            }
+            flint_printf("\n");
+        }
+
+    }
+#endif
+
+    /* Experimentally inline n = 2. Whether this is beneficial depends on the
+       distribution of inputs. We do not waste a branch on checking for n = 1,
+       following the assumption that many callers already handle single-limb
+       input specially. */
+    if (n == 2)
+        flint_mpn_mul_2x2_inline(z, x, y);
+    else if (n <= 7)
+        flint_mpn_mul_n_tab[n](z, x, y);
+    else if (n <= 14)
+        __gmpn_mul_basecase(z, x, n, y, n);
+    else if (n < FLINT_MPN_MUL_THRESHOLD)
+        mpn_mul_n(z, x, y, n);
+    else
+        flint_mpn_mul_large(z, x, n, y, n);
+}
+
+mp_limb_t
+flint_mpn_mul(mp_ptr z, mp_srcptr x, mp_size_t xn, mp_srcptr y, mp_size_t yn)
+{
+    FLINT_ASSERT(xn >= yn);
+    FLINT_ASSERT(yn >= 1);
+    FLINT_ASSERT(z != x);
+    FLINT_ASSERT(z != y);
+
+#if MUL_STATS
+    mulcounter++;
+    mulcount[FLINT_MIN(xn, 16)][FLINT_MIN(yn, 16)]++;
+    if (mulcounter % 10000 == 0)
+    {
+        flint_printf("count %wd\n", mulcounter);
+        int i, j;
+        for (i = 1; i <= 16; i++)
+        {
+            for (j = 1; j <= i; j++)
+            {
+                flint_printf("%7wd ", mulcount[i][j]);
+            }
+            flint_printf("\n");
+        }
+    }
+#endif
+
+    /* Experimentally inline n = 2. Whether this is beneficial depends on the
+       distribution of inputs. We do not waste a branch on checking for n = 1,
+       following the assumption that many callers already handle single-limb
+       input specially. */
+    if (xn == 2)
+    {
+        if (yn == 1)
+            return flint_mpn_mul_2x1_inline(z, x, y);
+        else
+            return flint_mpn_mul_2x2_inline(z, x, y);
+    }
+    else if (xn <= 7)
+    {
+        return flint_mpn_mul_tab[xn][yn](z, x, y);
+    }
+    else if (yn == 1)
+    {
+        if (xn <= 12)
+            return flint_mpn_mul_1_tab[xn](z, x, y);
+        else
+            return (z[xn + yn - 1] = mpn_mul_1(z, x, xn, y[0]));
+    }
+    else if (xn <= 14)
+    {
+        __gmpn_mul_basecase(z, x, xn, y, yn);
+        return z[xn + yn - 1];
+    }
+    else if (yn < FLINT_MPN_MUL_THRESHOLD)
+        return mpn_mul(z, x, xn, y, yn);
+    else
+        return flint_mpn_mul_large(z, x, xn, y, yn);
+}
+

--- a/src/mpn_extras/mulmod_2expp1_basecase.c
+++ b/src/mpn_extras/mulmod_2expp1_basecase.c
@@ -31,9 +31,9 @@ flint_mpn_mulmod_2expp1_internal(mp_ptr xp, mp_srcptr yp, mp_srcptr zp,
     flint_mpn_mul_large(tp, yp, n, zp, n);
 #else
     if (yp == zp)
-        mpn_sqr(tp, yp, n);
+        flint_mpn_sqr(tp, yp, n);
     else
-        mpn_mul_n(tp, yp, zp, n);
+        flint_mpn_mul_n(tp, yp, zp, n);
 #endif
 
     if (k == 0)

--- a/src/mpn_extras/mulmod_preinv1.c
+++ b/src/mpn_extras/mulmod_preinv1.c
@@ -33,9 +33,9 @@ void flint_mpn_mulmod_preinv1(mp_ptr r,
       t = flint_malloc(5*n*sizeof(mp_limb_t));
 
    if (a == b)
-      mpn_sqr(t, a, n);
+      flint_mpn_sqr(t, a, n);
    else
-      mpn_mul_n(t, a, b, n);
+      flint_mpn_mul_n(t, a, b, n);
 
    if (norm)
       mpn_rshift(t, t, 2*n, norm);

--- a/src/mpn_extras/profile/p-mul_n.c
+++ b/src/mpn_extras/profile/p-mul_n.c
@@ -1,0 +1,85 @@
+/*
+    Copyright (C) 2023 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "flint.h"
+#include "mpn_extras.h"
+#include "profiler.h"
+
+#define MAXN 15
+
+int main()
+{
+    flint_rand_t state;
+    flint_randinit(state);
+
+    {
+        mp_limb_t x[MAXN], y[MAXN], r[2 * MAXN], s[2 * MAXN];
+        slong i, n, m;
+
+        for (i = 0; i < MAXN; i++)
+        {
+            x[i] = n_randtest(state);
+            y[i] = n_randtest(state);
+        }
+
+        for (n = 1; n <= MAXN; n++)
+        {
+            flint_printf("n = %wd    ", n);
+
+            for (m = 1; m <= n; m++)
+            {
+                double t1, t2, __;
+
+                TIMEIT_START
+                mpn_mul(r, x, n, y, m);
+                TIMEIT_STOP_VALUES(__, t1)
+                TIMEIT_START
+                flint_mpn_mul(s, x, n, y, m);
+                TIMEIT_STOP_VALUES(__, t2)
+
+                flint_printf("%.3fx  ", t1 / t2);
+
+                if (mpn_cmp(r, s, n + m) != 0)
+                    flint_abort();
+            }
+
+            flint_printf("\n");
+        }
+
+        for (n = 1; n <= MAXN; n++)
+        {
+            double t1, t2, __;
+
+            flint_printf("n = %wd    ", n);
+
+            TIMEIT_START
+#if 0
+            __gmpn_mul_basecase(r, x, n, y, n);
+#else
+            mpn_mul_n(r, x, y, n);
+#endif
+            TIMEIT_STOP_VALUES(__, t1)
+            TIMEIT_START
+            flint_mpn_mul_n(s, x, y, n);
+            TIMEIT_STOP_VALUES(__, t2)
+
+            flint_printf("%g    %g   %.3fx\n", t1, t2, t1 / t2);
+
+            if (mpn_cmp(r, s, 2 * n) != 0)
+                flint_abort();
+        }
+    }
+
+    flint_randclear(state);
+    flint_cleanup_master();
+    return 0;
+}
+

--- a/src/mpn_extras/remove_power.c
+++ b/src/mpn_extras/remove_power.c
@@ -60,7 +60,7 @@ mp_size_t flint_mpn_remove_power_ascending(mp_ptr x, mp_size_t xsize,
             break;
         maxi = i + 1;
         square[i + 1] = flint_malloc(sizeof(mp_limb_t) * sqsize);
-        mpn_sqr(square[i + 1], square[i], square_size[i]);
+        flint_mpn_sqr(square[i + 1], square[i], square_size[i]);
         if (square[i + 1][sqsize - 1] == 0)
             sqsize -= 1;
         square_size[i + 1] = sqsize;

--- a/src/mpn_extras/test/main.c
+++ b/src/mpn_extras/test/main.c
@@ -20,6 +20,8 @@
 #include "t-fmms1.c"
 #include "t-gcd_full.c"
 #include "t-mod_preinvn.c"
+#include "t-mul.c"
+#include "t-mul_n.c"
 #include "t-mulmod_2expp1.c"
 #include "t-mulmod_preinv1.c"
 #include "t-mulmod_preinvn.c"
@@ -36,6 +38,8 @@ test_struct tests[] =
     TEST_FUNCTION(flint_mpn_fmms1),
     TEST_FUNCTION(flint_mpn_gcd_full),
     TEST_FUNCTION(flint_mpn_mod_preinvn),
+    TEST_FUNCTION(flint_mpn_mul),
+    TEST_FUNCTION(flint_mpn_mul_n),
     TEST_FUNCTION(flint_mpn_mulmod_2expp1),
     TEST_FUNCTION(flint_mpn_mulmod_preinv1),
     TEST_FUNCTION(flint_mpn_mulmod_preinvn),

--- a/src/mpn_extras/test/t-mul.c
+++ b/src/mpn_extras/test/t-mul.c
@@ -1,0 +1,67 @@
+/*
+    Copyright (C) 2023 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "mpn_extras.h"
+
+TEST_FUNCTION_START(flint_mpn_mul, state)
+{
+    slong iter;
+
+    if (!state->gmp_init)
+        _flint_rand_init_gmp(state);
+
+    for (iter = 0; iter < 1000000 * flint_test_multiplier(); iter++)
+    {
+        slong i, n, m;
+        mp_ptr X, Y, R1, R2;
+        mp_limb_t ret1, ret2;
+
+        n = 1 + n_randint(state, 15);
+        if (n_randint(state, 10000) == 0)
+            n = 1 + n_randint(state, 1000);
+        m = 1 + n_randint(state, n);
+
+        X = flint_malloc(sizeof(mp_limb_t) * n);
+        Y = flint_malloc(sizeof(mp_limb_t) * m);
+        R1 = flint_malloc(sizeof(mp_limb_t) * (n + m));
+        R2 = flint_malloc(sizeof(mp_limb_t) * (n + m));
+
+        mpz_t z;
+        z->_mp_d = X; z->_mp_alloc = z->_mp_size = n;
+        mpz_rrandomb(z, state->gmp_state, n * FLINT_BITS);
+        z->_mp_d = X; z->_mp_alloc = z->_mp_size = m;
+        mpz_rrandomb(z, state->gmp_state, m * FLINT_BITS);
+
+        for (i = 0; i < n + m; i++)
+            R1[i] = n_randtest(state);
+
+        ret1 = flint_mpn_mul(R1, X, n, Y, m);
+        ret2 = mpn_mul(R2, X, n, Y, m);
+
+        if (mpn_cmp(R1, R2, n + m) != 0 || ret1 != ret2)
+        {
+            flint_printf("FAIL: n = %wd\n", n);
+            flint_printf("X = "); flint_mpn_debug(X, n);
+            flint_printf("Y = "); flint_mpn_debug(Y, m);
+            flint_printf("R1 = "); flint_mpn_debug(R1, n + m);
+            flint_printf("R2 = "); flint_mpn_debug(R2, n + m);
+            flint_abort();
+        }
+
+        flint_free(X);
+        flint_free(Y);
+        flint_free(R1);
+        flint_free(R2);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/mpn_extras/test/t-mul_n.c
+++ b/src/mpn_extras/test/t-mul_n.c
@@ -1,0 +1,65 @@
+/*
+    Copyright (C) 2023 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "mpn_extras.h"
+
+TEST_FUNCTION_START(flint_mpn_mul_n, state)
+{
+    slong iter;
+
+    if (!state->gmp_init)
+        _flint_rand_init_gmp(state);
+
+    for (iter = 0; iter < 1000000 * flint_test_multiplier(); iter++)
+    {
+        slong i, n;
+        mp_ptr X, Y, R1, R2;
+
+        n = 1 + n_randint(state, 15);
+        if (n_randint(state, 10000) == 0)
+            n = 1 + n_randint(state, 1000);
+
+        X = flint_malloc(sizeof(mp_limb_t) * n);
+        Y = flint_malloc(sizeof(mp_limb_t) * n);
+        R1 = flint_malloc(sizeof(mp_limb_t) * 2 * n);
+        R2 = flint_malloc(sizeof(mp_limb_t) * 2 * n);
+
+        mpz_t z;
+        z->_mp_d = X; z->_mp_alloc = z->_mp_size = n;
+        mpz_rrandomb(z, state->gmp_state, n * FLINT_BITS);
+        z->_mp_d = Y;
+        mpz_rrandomb(z, state->gmp_state, n * FLINT_BITS);
+
+        for (i = 0; i < 2 * n; i++)
+            R1[i] = n_randtest(state);
+
+        flint_mpn_mul_n(R1, X, Y, n);
+        mpn_mul_n(R2, X, Y, n);
+
+        if (mpn_cmp(R1, R2, 2 * n) != 0)
+        {
+            flint_printf("FAIL: n = %wd\n", n);
+            flint_printf("X = "); flint_mpn_debug(X, n);
+            flint_printf("Y = "); flint_mpn_debug(Y, n);
+            flint_printf("R1 = "); flint_mpn_debug(R1, 2 * n);
+            flint_printf("R2 = "); flint_mpn_debug(R2, 2 * n);
+            flint_abort();
+        }
+
+        flint_free(X);
+        flint_free(Y);
+        flint_free(R1);
+        flint_free(R2);
+    }
+
+    TEST_FUNCTION_END(state);
+}


### PR DESCRIPTION
Speedup vs gmp-6.3.0 on zen3:

```flint_mpn_mul``` vs ```mpn_mul```:

```
n = 1    1.550x  
n = 2    1.899x  1.996x  
n = 3    2.004x  2.262x  2.201x  
n = 4    2.192x  2.019x  1.723x  1.671x  
n = 5    1.721x  1.654x  1.474x  1.384x  1.364x  
n = 6    1.916x  1.436x  1.333x  1.224x  1.083x  1.144x  
n = 7    2.063x  1.453x  1.276x  1.137x  1.086x  1.083x  1.063x  
n = 8    1.492x  1.019x  1.031x  1.037x  1.030x  1.013x  1.011x  1.003x  
n = 9    1.425x  1.050x  1.029x  1.017x  1.023x  1.000x  0.997x  1.009x  1.011x  
n = 10    1.406x  1.048x  1.169x  1.026x  1.008x  1.014x  1.003x  1.008x  1.005x  1.007x  
n = 11    1.321x  1.073x  1.031x  1.019x  1.012x  1.016x  1.014x  1.012x  1.013x  1.012x  1.009x  
n = 12    1.263x  1.025x  1.011x  1.004x  1.022x  1.006x  1.005x  1.010x  0.994x  1.012x  1.000x  1.003x  
n = 13    1.105x  1.031x  1.022x  1.017x  1.013x  1.014x  1.012x  1.004x  1.012x  1.011x  1.011x  1.007x  1.005x  
n = 14    1.217x  1.029x  1.021x  1.008x  0.997x  1.008x  1.005x  1.006x  1.013x  1.007x  1.006x  1.000x  1.004x  1.000x  
n = 15    1.202x  0.949x  0.964x  0.962x  0.977x  0.978x  0.979x  0.985x  0.983x  0.989x  0.984x  0.991x  0.985x  0.988x  0.998x  
```

```flint_mpn_mul_n``` vs ```mpn_mul_n```:

```
n = 1    4.09e-09    2.67e-09   1.532x
n = 2    5.04e-09    2.5e-09   2.016x
n = 3    9.25e-09    4.09e-09   2.262x
n = 4    1.22e-08    7.28e-09   1.676x
n = 5    1.59e-08    1.19e-08   1.336x
n = 6    1.98e-08    1.71e-08   1.158x
n = 7    2.5e-08    2.34e-08   1.068x
n = 8    3.03e-08    2.95e-08   1.027x
n = 9    3.73e-08    3.63e-08   1.028x
n = 10    4.51e-08    4.42e-08   1.020x
n = 11    5.49e-08    5.42e-08   1.013x
n = 12    6.24e-08    6.15e-08   1.015x
n = 13    7.4e-08    7.32e-08   1.011x
n = 14    8.34e-08    8.26e-08   1.010x
n = 15    9.75e-08    9.85e-08   0.990x
