### PR TITLE
Specify modules to specifically unroll loops

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -94,6 +94,16 @@ ASM_OBJ_FLAGS:=$(filter-out -D%,$(CPPFLAGS) $(LIB_CPPFLAGS)) $(filter-out -funro
 ASM_LOBJ_FLAGS:=$(filter-out -D%,$(PIC_FLAG)) $(ASM_OBJ_FLAGS)
 endif
 
+UNROLL_LOOPS:=@UNROLL_LOOPS@
+ifeq ($(UNROLL_LOOPS), 1)
+ulong_extras_CFLAGS:=-funroll-loops
+nmod_CFLAGS:=-funroll-loops
+nmod_vec_CFLAGS:=-funroll-loops
+nmod_mat_CFLAGS:=-funroll-loops
+nmod_poly_CFLAGS:=-funroll-loops
+arith_CFLAGS:=-funroll-loops
+endif
+
 LDFLAGS:=@LDFLAGS@
 EXTRA_SHARED_FLAGS:=@EXTRA_SHARED_FLAGS@ $(foreach path, $(GMP_LIB_PATH) $(MPFR_LIB_PATH) $(BLAS_LIB_PATH) $(GC_LIB_PATH) $(NTL_LIB_PATH), @WL@-rpath,$(path))
 EXE_LDFLAGS:=$(LDFLAGS) $(foreach path, $(ABS_FLINT_DIR) $(GMP_LIB_PATH) $(MPFR_LIB_PATH) $(BLAS_LIB_PATH) $(GC_LIB_PATH) $(NTL_LIB_PATH), @WL@-rpath,$(path))
@@ -567,7 +577,7 @@ ifneq ($(STATIC), 0)
 define xxx_OBJS_rule
 $(BUILD_DIR)/$(1)/%.o: $(SRC_DIR)/$(1)/%.c | $(BUILD_DIR)/$(1)
 	@echo "  CC  $$(<:$(SRC_DIR)/%=%)"
-	@$(CC) $(CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) -c $$< -o $$@ $$(DEPFLAGS)
+	@$(CC) $(CFLAGS) $($(1)_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) -c $$< -o $$@ $$(DEPFLAGS)
 endef
 
 ifeq ($(WANT_ADX_ASSEMBLY),1)
@@ -587,7 +597,7 @@ ifneq ($(SHARED), 0)
 define xxx_LOBJS_rule
 $(BUILD_DIR)/$(1)/%.lo: $(SRC_DIR)/$(1)/%.c | $(BUILD_DIR)/$(1)
 	@echo "  CC  $$(<:$(SRC_DIR)/%=%)"
-	@$(CC) $(PIC_FLAG) $(CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) -c $$< -o $$@ $$(DEPFLAGS)
+	@$(CC) $(PIC_FLAG) $(CFLAGS) $($(1)_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) -c $$< -o $$@ $$(DEPFLAGS)
 endef
 
 ifeq ($(WANT_ADX_ASSEMBLY),1)

--- a/configure.ac
+++ b/configure.ac
@@ -998,16 +998,15 @@ fi
 AX_CHECK_COMPILE_FLAG([-std=c11],[DEFAULT_CFLAGS="-std=c11 $DEFAULT_CFLAGS"])
 AX_CHECK_COMPILE_FLAG([-pedantic],[DEFAULT_CFLAGS="-pedantic $DEFAULT_CFLAGS"])
 
-dnl NOTE: The following flags shouldn't be default. They are leftovers from
-dnl previous configure script
-AX_CHECK_COMPILE_FLAG([-funroll-loops],[DEFAULT_CFLAGS="-funroll-loops $DEFAULT_CFLAGS"])
-
 if test "$cflags_set" = "no";
 then
     CFLAGS="$save_CFLAGS $DEFAULT_CFLAGS"
+    AC_SUBST(UNROLL_LOOPS,1)
+    AC_DEFINE(FLINT_UNROLL_LOOPS, 1, [Define to locally unroll some loops])
 else
     CFLAGS="$save_CFLAGS"
     AX_CHECK_COMPILE_FLAG([$CFLAGS],[],AC_MSG_ERROR(["Couldn't compile with given CFLAGS!"]))
+    AC_SUBST(UNROLL_LOOPS,0)
 fi
 
 if test "$testcflags_set" = "no";


### PR DESCRIPTION
Remove `-funroll-loops` as default flag

Treats #1284 