### PR TITLE
Fixes for generator-related methods in the gr module

### DIFF
--- a/doc/source/gr.rst
+++ b/doc/source/gr.rst
@@ -471,10 +471,12 @@ Special values
     "generator" depends on the domain.
 
 .. function:: int gr_gens(gr_vec_t res, gr_ctx_t ctx)
+              int gr_gens_recursive(gr_vec_t res, gr_ctx_t ctx)
 
     Sets *res* to a vector containing the generators of this domain
     where this makes sense, for example in a multivariate polynomial
-    ring.
+    ring. The *recursive* version also includes any generators
+    of the base ring, and of any recursive base rings.
 
 Basic properties
 ........................................................................

--- a/src/gr.h
+++ b/src/gr.h
@@ -604,6 +604,7 @@ typedef enum
 
     GR_METHOD_GEN,
     GR_METHOD_GENS,
+    GR_METHOD_GENS_RECURSIVE,
 
     /* Finite field methods */
     GR_METHOD_CTX_FQ_PRIME,
@@ -1152,6 +1153,7 @@ GR_INLINE WARN_UNUSED_RESULT int gr_cmpabs_other(int * res, gr_srcptr x, gr_srcp
 
 GR_INLINE WARN_UNUSED_RESULT int gr_gen(gr_ptr res, gr_ctx_t ctx) { return GR_CONSTANT_OP(ctx, GEN)(res, ctx); }
 GR_INLINE WARN_UNUSED_RESULT int gr_gens(gr_vec_t res, gr_ctx_t ctx) { return GR_VEC_CTX_OP(ctx, GENS)(res, ctx); }
+GR_INLINE WARN_UNUSED_RESULT int gr_gens_recursive(gr_vec_t res, gr_ctx_t ctx) { return GR_VEC_CTX_OP(ctx, GENS_RECURSIVE)(res, ctx); }
 
 GR_INLINE WARN_UNUSED_RESULT int gr_ctx_fq_prime(fmpz_t res, gr_ctx_t ctx) { return GR_CONSTANT_OP_GET_FMPZ(ctx, CTX_FQ_PRIME)(res, ctx); }
 GR_INLINE WARN_UNUSED_RESULT int gr_ctx_fq_degree(slong * res, gr_ctx_t ctx) { return GR_CONSTANT_OP_GET_SI(ctx, CTX_FQ_DEGREE)(res, ctx); }

--- a/src/gr/fmpq_poly.c
+++ b/src/gr/fmpq_poly.c
@@ -15,6 +15,8 @@
 #include "fmpq_poly.h"
 #include "gr.h"
 #include "gr_poly.h"
+#include "gr_vec.h"
+#include "gr_generic.h"
 
 int
 _gr_fmpq_poly_ctx_write(gr_stream_t out, gr_ctx_t ctx)
@@ -684,6 +686,7 @@ gr_method_tab_input _fmpq_poly_methods_input[] =
     {GR_METHOD_ZERO,            (gr_funcptr) _gr_fmpq_poly_zero},
     {GR_METHOD_ONE,             (gr_funcptr) _gr_fmpq_poly_one},
     {GR_METHOD_GEN,             (gr_funcptr) _gr_fmpq_poly_gen},
+    {GR_METHOD_GENS,            (gr_funcptr) gr_generic_gens_single},
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_fmpq_poly_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_fmpq_poly_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) _gr_fmpq_poly_is_neg_one},

--- a/src/gr/fmpz_mpoly.c
+++ b/src/gr/fmpz_mpoly.c
@@ -20,6 +20,7 @@
 typedef struct
 {
     fmpz_mpoly_ctx_t mctx;
+    char ** vars;
 }
 _gr_fmpz_mpoly_ctx_t;
 
@@ -44,8 +45,45 @@ int _gr_fmpz_mpoly_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 void
 _gr_fmpz_mpoly_ctx_clear(gr_ctx_t ctx)
 {
+    if (MPOLYNOMIAL_CTX(ctx)->vars != NULL)
+    {
+        slong i;
+        for (i = 0; i < MPOLYNOMIAL_MCTX(ctx)->minfo->nvars; i++)
+            flint_free(MPOLYNOMIAL_CTX(ctx)->vars[i]);
+        flint_free(MPOLYNOMIAL_CTX(ctx)->vars);
+    }
+
     fmpz_mpoly_ctx_clear(MPOLYNOMIAL_MCTX(ctx));
     flint_free(GR_CTX_DATA_AS_PTR(ctx));
+}
+
+int
+_gr_fmpz_mpoly_ctx_set_gen_names(gr_ctx_t ctx, const char ** s)
+{
+    slong i, nvars, len;
+
+    nvars = MPOLYNOMIAL_MCTX(ctx)->minfo->nvars;
+
+    if (MPOLYNOMIAL_CTX(ctx)->vars == NULL)
+    {
+        MPOLYNOMIAL_CTX(ctx)->vars = flint_malloc(nvars * sizeof(char *));
+        for (i = 0; i < nvars; i++)
+            MPOLYNOMIAL_CTX(ctx)->vars[i] = NULL;
+    }
+    else
+    {
+        for (i = 0; i < nvars; i++)
+            flint_free(MPOLYNOMIAL_CTX(ctx)->vars[i]);
+    }
+
+    for (i = 0; i < nvars; i++)
+    {
+        len = strlen(s[i]);
+        MPOLYNOMIAL_CTX(ctx)->vars[i] = flint_realloc(MPOLYNOMIAL_CTX(ctx)->vars[i], len + 1);
+        memcpy(MPOLYNOMIAL_CTX(ctx)->vars[i], s[i], len + 1);
+    }
+
+    return GR_SUCCESS;
 }
 
 void
@@ -96,14 +134,7 @@ _gr_fmpz_mpoly_randtest_small(fmpz_mpoly_t res, flint_rand_t state, gr_ctx_t ctx
 int
 _gr_fmpz_mpoly_write(gr_stream_t out, fmpz_mpoly_t poly, gr_ctx_t ctx)
 {
-/*
-    if (out->fp != NULL)
-        fmpz_mpoly_fprint_pretty(out->fp, poly, NULL, MPOLYNOMIAL_MCTX(ctx));
-    else
-*/
-    gr_stream_write_free(out, fmpz_mpoly_get_str_pretty(poly, NULL, MPOLYNOMIAL_MCTX(ctx)));
-
-    /* todo: error handling */
+    gr_stream_write_free(out, fmpz_mpoly_get_str_pretty(poly, (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
     return GR_SUCCESS;
 }
 
@@ -507,6 +538,7 @@ gr_method_tab_input _gr_fmpz_mpoly_methods_input[] =
     {GR_METHOD_CTX_IS_FINITE,                   (gr_funcptr) gr_generic_ctx_predicate_false},
     {GR_METHOD_CTX_IS_FINITE_CHARACTERISTIC,    (gr_funcptr) gr_generic_ctx_predicate_false},
     {GR_METHOD_CTX_IS_THREADSAFE,               (gr_funcptr) gr_generic_ctx_predicate_true},
+    {GR_METHOD_CTX_SET_GEN_NAMES,               (gr_funcptr) _gr_fmpz_mpoly_ctx_set_gen_names},
     {GR_METHOD_INIT,        (gr_funcptr) _gr_fmpz_mpoly_init},
     {GR_METHOD_CLEAR,       (gr_funcptr) _gr_fmpz_mpoly_clear},
     {GR_METHOD_SWAP,        (gr_funcptr) _gr_fmpz_mpoly_swap},
@@ -564,6 +596,7 @@ gr_ctx_init_fmpz_mpoly(gr_ctx_t ctx, slong nvars, const ordering_t ord)
     ctx->size_limit = WORD_MAX;
 
     fmpz_mpoly_ctx_init(MPOLYNOMIAL_MCTX(ctx), nvars, ord);
+    MPOLYNOMIAL_CTX(ctx)->vars = NULL;
 
     ctx->methods = _gr_fmpz_mpoly_methods;
 

--- a/src/gr/fmpz_mpoly.c
+++ b/src/gr/fmpz_mpoly.c
@@ -139,7 +139,7 @@ _gr_fmpz_mpoly_one(fmpz_mpoly_t res, gr_ctx_t ctx)
     return GR_SUCCESS;
 }
 
-truth_t
+int
 _gr_fmpz_mpoly_gens(gr_vec_t res, gr_ctx_t ctx)
 {
     slong i, n;

--- a/src/gr/fmpz_mpoly_q.c
+++ b/src/gr/fmpz_mpoly_q.c
@@ -151,7 +151,7 @@ _gr_fmpz_mpoly_q_one(fmpz_mpoly_q_t res, gr_ctx_t ctx)
     return GR_SUCCESS;
 }
 
-truth_t
+int
 _gr_fmpz_mpoly_q_gens(gr_vec_t res, gr_ctx_t ctx)
 {
     slong i, n;

--- a/src/gr/fmpz_mpoly_q.c
+++ b/src/gr/fmpz_mpoly_q.c
@@ -20,6 +20,7 @@
 typedef struct
 {
     fmpz_mpoly_ctx_t mctx;
+    char ** vars;
 }
 _gr_fmpz_mpoly_ctx_t;
 
@@ -41,12 +42,12 @@ int _gr_fmpz_mpoly_q_ctx_write(gr_stream_t out, gr_ctx_t ctx)
     return GR_SUCCESS;
 }
 
-void
-_gr_fmpz_mpoly_q_ctx_clear(gr_ctx_t ctx)
-{
-    fmpz_mpoly_ctx_clear(MPOLYNOMIAL_MCTX(ctx));
-    flint_free(GR_CTX_DATA_AS_PTR(ctx));
-}
+/* Some methods are identical to their fmpz_mpoly counterparts */
+void _gr_fmpz_mpoly_ctx_clear(gr_ctx_t ctx);
+int _gr_fmpz_mpoly_ctx_set_gen_names(gr_ctx_t ctx, const char ** s);
+
+#define _gr_fmpz_mpoly_q_ctx_clear _gr_fmpz_mpoly_ctx_clear
+#define _gr_fmpz_mpoly_q_ctx_set_gen_names _gr_fmpz_mpoly_ctx_set_gen_names
 
 void
 _gr_fmpz_mpoly_q_init(fmpz_mpoly_q_t res, gr_ctx_t ctx)
@@ -98,21 +99,21 @@ _gr_fmpz_mpoly_q_write(gr_stream_t out, fmpz_mpoly_q_t f, gr_ctx_t ctx)
 {
     if (fmpz_mpoly_is_one(fmpz_mpoly_q_denref(f), MPOLYNOMIAL_MCTX(ctx)))
     {
-        gr_stream_write_free(out, fmpz_mpoly_get_str_pretty(fmpz_mpoly_q_numref(f), NULL, MPOLYNOMIAL_MCTX(ctx)));
+        gr_stream_write_free(out, fmpz_mpoly_get_str_pretty(fmpz_mpoly_q_numref(f), (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
     }
     else if (fmpz_mpoly_is_fmpz(fmpz_mpoly_q_denref(f), MPOLYNOMIAL_MCTX(ctx)))
     {
         gr_stream_write(out, "(");
-        gr_stream_write_free(out, fmpz_mpoly_get_str_pretty(fmpz_mpoly_q_numref(f), NULL, MPOLYNOMIAL_MCTX(ctx)));
+        gr_stream_write_free(out, fmpz_mpoly_get_str_pretty(fmpz_mpoly_q_numref(f), (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
         gr_stream_write(out, ")/");
-        gr_stream_write_free(out, fmpz_mpoly_get_str_pretty(fmpz_mpoly_q_denref(f), NULL, MPOLYNOMIAL_MCTX(ctx)));
+        gr_stream_write_free(out, fmpz_mpoly_get_str_pretty(fmpz_mpoly_q_denref(f), (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
     }
     else
     {
         gr_stream_write(out, "(");
-        gr_stream_write_free(out, fmpz_mpoly_get_str_pretty(fmpz_mpoly_q_numref(f), NULL, MPOLYNOMIAL_MCTX(ctx)));
+        gr_stream_write_free(out, fmpz_mpoly_get_str_pretty(fmpz_mpoly_q_numref(f), (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
         gr_stream_write(out, ")/(");
-        gr_stream_write_free(out, fmpz_mpoly_get_str_pretty(fmpz_mpoly_q_denref(f), NULL, MPOLYNOMIAL_MCTX(ctx)));
+        gr_stream_write_free(out, fmpz_mpoly_get_str_pretty(fmpz_mpoly_q_denref(f), (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
         gr_stream_write(out, ")");
     }
 
@@ -525,6 +526,7 @@ gr_method_tab_input _gr_fmpz_mpoly_q_methods_input[] =
     {GR_METHOD_CTX_IS_FINITE,                   (gr_funcptr) gr_generic_ctx_predicate_false},
     {GR_METHOD_CTX_IS_FINITE_CHARACTERISTIC,    (gr_funcptr) gr_generic_ctx_predicate_false},
     {GR_METHOD_CTX_IS_THREADSAFE,               (gr_funcptr) gr_generic_ctx_predicate_true},
+    {GR_METHOD_CTX_SET_GEN_NAMES,               (gr_funcptr) _gr_fmpz_mpoly_q_ctx_set_gen_names},
     {GR_METHOD_INIT,        (gr_funcptr) _gr_fmpz_mpoly_q_init},
     {GR_METHOD_CLEAR,       (gr_funcptr) _gr_fmpz_mpoly_q_clear},
     {GR_METHOD_SWAP,        (gr_funcptr) _gr_fmpz_mpoly_q_swap},
@@ -594,6 +596,7 @@ gr_ctx_init_fmpz_mpoly_q(gr_ctx_t ctx, slong nvars, const ordering_t ord)
     ctx->size_limit = WORD_MAX;
 
     fmpz_mpoly_ctx_init(MPOLYNOMIAL_MCTX(ctx), nvars, ord);
+    MPOLYNOMIAL_CTX(ctx)->vars = NULL;
 
     ctx->methods = _gr_fmpz_mpoly_q_methods;
 

--- a/src/gr/fmpz_poly.c
+++ b/src/gr/fmpz_poly.c
@@ -19,6 +19,7 @@
 #include "gr.h"
 #include "gr_vec.h"
 #include "gr_poly.h"
+#include "gr_generic.h"
 #include "fmpz_poly_factor.h"
 
 #define FMPZ_POLY_CTX(ctx) POLYNOMIAL_CTX(ctx)
@@ -788,6 +789,7 @@ gr_method_tab_input _fmpz_poly_methods_input[] =
     {GR_METHOD_ZERO,            (gr_funcptr) _gr_fmpz_poly_zero},
     {GR_METHOD_ONE,             (gr_funcptr) _gr_fmpz_poly_one},
     {GR_METHOD_GEN,             (gr_funcptr) _gr_fmpz_poly_gen},
+    {GR_METHOD_GENS,            (gr_funcptr) gr_generic_gens_single},
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_fmpz_poly_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_fmpz_poly_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) _gr_fmpz_poly_is_neg_one},

--- a/src/gr/fmpzi.c
+++ b/src/gr/fmpzi.c
@@ -15,6 +15,7 @@
 #include "qqbar.h"
 #include "fmpzi.h"
 #include "gr.h"
+#include "gr_generic.h"
 
 int
 _gr_fmpzi_ctx_write(gr_stream_t out, gr_ctx_t ctx)
@@ -998,6 +999,7 @@ gr_method_tab_input _fmpzi_methods_input[] =
 */
 
     {GR_METHOD_GEN,             (gr_funcptr) _gr_fmpzi_i},
+    {GR_METHOD_GENS,            (gr_funcptr) gr_generic_gens_single},
 
     {GR_METHOD_I,               (gr_funcptr) _gr_fmpzi_i},
     {GR_METHOD_PI,              (gr_funcptr) gr_not_in_domain},

--- a/src/gr/fq.c
+++ b/src/gr/fq.c
@@ -18,6 +18,7 @@
 #include "fq_mat.h"
 #include "fq_poly_factor.h"
 #include "gr_vec.h"
+#include "gr_generic.h"
 
 #define FQ_CTX(ring_ctx) ((fq_ctx_struct *)(GR_CTX_DATA_AS_PTR(ring_ctx)))
 
@@ -653,7 +654,8 @@ gr_method_tab_input _fq_methods_input[] =
     {GR_METHOD_WRITE,           (gr_funcptr) _gr_fq_write},
     {GR_METHOD_ZERO,            (gr_funcptr) _gr_fq_zero},
     {GR_METHOD_ONE,             (gr_funcptr) _gr_fq_one},
-    {GR_METHOD_GEN,                     (gr_funcptr) _gr_fq_gen},
+    {GR_METHOD_GEN,             (gr_funcptr) _gr_fq_gen},
+    {GR_METHOD_GENS,            (gr_funcptr) gr_generic_gens_single},
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_fq_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_fq_is_one},
     {GR_METHOD_EQUAL,           (gr_funcptr) _gr_fq_equal},

--- a/src/gr/fq_nmod.c
+++ b/src/gr/fq_nmod.c
@@ -20,6 +20,7 @@
 #include "gr.h"
 #include "gr_vec.h"
 #include "gr_poly.h"
+#include "gr_generic.h"
 
 #define FQ_CTX(ring_ctx) ((fq_nmod_ctx_struct *)(GR_CTX_DATA_AS_PTR(ring_ctx)))
 
@@ -618,6 +619,7 @@ gr_method_tab_input _fq_nmod_methods_input[] =
     {GR_METHOD_ZERO,            (gr_funcptr) _gr_fq_nmod_zero},
     {GR_METHOD_ONE,             (gr_funcptr) _gr_fq_nmod_one},
     {GR_METHOD_GEN,             (gr_funcptr) _gr_fq_nmod_gen},
+    {GR_METHOD_GENS,            (gr_funcptr) gr_generic_gens_single},
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_fq_nmod_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_fq_nmod_is_one},
     {GR_METHOD_EQUAL,           (gr_funcptr) _gr_fq_nmod_equal},

--- a/src/gr/fq_zech.c
+++ b/src/gr/fq_zech.c
@@ -18,6 +18,7 @@
 #include "fq_zech_mat.h"
 #include "gr.h"
 #include "gr_vec.h"
+#include "gr_generic.h"
 
 #define FQ_CTX(ring_ctx) ((fq_zech_ctx_struct *)(GR_CTX_DATA_AS_PTR(ring_ctx)))
 
@@ -505,6 +506,7 @@ gr_method_tab_input _fq_zech_methods_input[] =
     {GR_METHOD_ZERO,            (gr_funcptr) _gr_fq_zech_zero},
     {GR_METHOD_ONE,             (gr_funcptr) _gr_fq_zech_one},
     {GR_METHOD_GEN,             (gr_funcptr) _gr_fq_zech_gen},
+    {GR_METHOD_GENS,            (gr_funcptr) gr_generic_gens_single},
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_fq_zech_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_fq_zech_is_one},
     {GR_METHOD_EQUAL,           (gr_funcptr) _gr_fq_zech_equal},

--- a/src/gr/mpoly.c
+++ b/src/gr/mpoly.c
@@ -130,6 +130,56 @@ _gr_gr_mpoly_is_one(const gr_mpoly_t poly, gr_ctx_t ctx)
 }
 
 int
+_gr_gr_mpoly_gens(gr_vec_t res, gr_ctx_t ctx)
+{
+    slong i, n;
+    int status = GR_SUCCESS;
+
+    n = MPOLYNOMIAL_MCTX(ctx)->nvars;
+
+    gr_vec_set_length(res, n, ctx);
+    for (i = 0; i < n; i++)
+        status |= gr_mpoly_gen(((gr_mpoly_struct *) res->entries) + i, i, MPOLYNOMIAL_MCTX(ctx), MPOLYNOMIAL_ELEM_CTX(ctx));
+
+    return status;
+}
+
+int
+_gr_gr_mpoly_gens_recursive(gr_vec_t vec, gr_ctx_t ctx)
+{
+    int status;
+    gr_vec_t vec1;
+    slong i, n, m;
+
+    /* Get generators of the element ring */
+    gr_vec_init(vec1, 0, MPOLYNOMIAL_ELEM_CTX(ctx));
+    status = gr_gens_recursive(vec1, MPOLYNOMIAL_ELEM_CTX(ctx));
+    n = vec1->length;
+
+    m = MPOLYNOMIAL_MCTX(ctx)->nvars;
+
+    gr_vec_set_length(vec, n + m, ctx);
+
+    /* Promote to polynomials */
+    for (i = 0; i < n; i++)
+    {
+        status |= gr_mpoly_set_scalar(gr_vec_entry_ptr(vec, i, ctx),
+                gr_vec_entry_srcptr(vec1, i, MPOLYNOMIAL_ELEM_CTX(ctx)),
+                    MPOLYNOMIAL_MCTX(ctx), MPOLYNOMIAL_ELEM_CTX(ctx));
+    }
+
+    for (i = 0; i < m; i++)
+    {
+        status |= gr_mpoly_gen(((gr_mpoly_struct *) vec->entries) + n + i,
+            i, MPOLYNOMIAL_MCTX(ctx), MPOLYNOMIAL_ELEM_CTX(ctx));
+    }
+
+    gr_vec_clear(vec1, MPOLYNOMIAL_ELEM_CTX(ctx));
+
+    return status;
+}
+
+int
 _gr_gr_mpoly_zero(gr_mpoly_t res, gr_ctx_t ctx)
 {
     return gr_mpoly_zero(res, MPOLYNOMIAL_MCTX(ctx), MPOLYNOMIAL_ELEM_CTX(ctx));
@@ -224,6 +274,8 @@ gr_method_tab_input _gr__gr_gr_mpoly_methods_input[] =
     {GR_METHOD_SET_SHALLOW, (gr_funcptr) _gr_gr_mpoly_set_shallow},
     {GR_METHOD_RANDTEST,    (gr_funcptr) _gr_gr_mpoly_randtest},
     {GR_METHOD_WRITE,       (gr_funcptr) _gr_gr_mpoly_write},
+    {GR_METHOD_GENS,        (gr_funcptr) _gr_gr_mpoly_gens},
+    {GR_METHOD_GENS_RECURSIVE,       (gr_funcptr) _gr_gr_mpoly_gens_recursive},
     {GR_METHOD_ZERO,        (gr_funcptr) _gr_gr_mpoly_zero},
     {GR_METHOD_ONE,         (gr_funcptr) _gr_gr_mpoly_one},
     {GR_METHOD_IS_ZERO,     (gr_funcptr) _gr_gr_mpoly_is_zero},

--- a/src/gr/mpoly.c
+++ b/src/gr/mpoly.c
@@ -18,6 +18,7 @@ typedef struct
 {
     gr_ctx_struct * base_ring;
     mpoly_ctx_t mctx;
+    char ** vars;
 }
 _gr_gr_mpoly_ctx_t;
 
@@ -44,8 +45,45 @@ int _gr_gr_mpoly_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 void
 _gr_gr_mpoly_ctx_clear(gr_ctx_t ctx)
 {
+    if (MPOLYNOMIAL_CTX(ctx)->vars != NULL)
+    {
+        slong i;
+        for (i = 0; i < MPOLYNOMIAL_MCTX(ctx)->nvars; i++)
+            flint_free(MPOLYNOMIAL_CTX(ctx)->vars[i]);
+        flint_free(MPOLYNOMIAL_CTX(ctx)->vars);
+    }
+
     mpoly_ctx_clear(MPOLYNOMIAL_MCTX(ctx));
     flint_free(GR_CTX_DATA_AS_PTR(ctx));
+}
+
+int
+_gr_gr_mpoly_ctx_set_gen_names(gr_ctx_t ctx, const char ** s)
+{
+    slong i, nvars, len;
+
+    nvars = MPOLYNOMIAL_MCTX(ctx)->nvars;
+
+    if (MPOLYNOMIAL_CTX(ctx)->vars == NULL)
+    {
+        MPOLYNOMIAL_CTX(ctx)->vars = flint_malloc(nvars * sizeof(char *));
+        for (i = 0; i < nvars; i++)
+            MPOLYNOMIAL_CTX(ctx)->vars[i] = NULL;
+    }
+    else
+    {
+        for (i = 0; i < nvars; i++)
+            flint_free(MPOLYNOMIAL_CTX(ctx)->vars[i]);
+    }
+
+    for (i = 0; i < nvars; i++)
+    {
+        len = strlen(s[i]);
+        MPOLYNOMIAL_CTX(ctx)->vars[i] = flint_realloc(MPOLYNOMIAL_CTX(ctx)->vars[i], len + 1);
+        memcpy(MPOLYNOMIAL_CTX(ctx)->vars[i], s[i], len + 1);
+    }
+
+    return GR_SUCCESS;
 }
 
 truth_t
@@ -108,7 +146,7 @@ _gr_gr_mpoly_randtest(gr_mpoly_t res, flint_rand_t state, gr_ctx_t ctx)
 int
 _gr_gr_mpoly_write(gr_stream_t out, gr_mpoly_t poly, gr_ctx_t ctx)
 {
-    return gr_mpoly_write_pretty(out, poly, NULL, MPOLYNOMIAL_MCTX(ctx), MPOLYNOMIAL_ELEM_CTX(ctx));
+    return gr_mpoly_write_pretty(out, poly, (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx), MPOLYNOMIAL_ELEM_CTX(ctx));
 }
 
 truth_t
@@ -268,6 +306,7 @@ gr_method_tab_input _gr__gr_gr_mpoly_methods_input[] =
     {GR_METHOD_CTX_IS_INTEGRAL_DOMAIN,  (gr_funcptr) _gr_gr_mpoly_ctx_is_integral_domain},
     {GR_METHOD_CTX_IS_FIELD,            (gr_funcptr) _gr_gr_mpoly_ctx_is_field},
     {GR_METHOD_CTX_IS_THREADSAFE,       (gr_funcptr) _gr_gr_mpoly_ctx_is_threadsafe},
+    {GR_METHOD_CTX_SET_GEN_NAMES,       (gr_funcptr) _gr_gr_mpoly_ctx_set_gen_names},
     {GR_METHOD_INIT,        (gr_funcptr) _gr_gr_mpoly_init},
     {GR_METHOD_CLEAR,       (gr_funcptr) _gr_gr_mpoly_clear},
     {GR_METHOD_SWAP,        (gr_funcptr) _gr_gr_mpoly_swap},
@@ -303,6 +342,7 @@ gr_ctx_init_gr_mpoly(gr_ctx_t ctx, gr_ctx_t base_ring, slong nvars, const orderi
 
     MPOLYNOMIAL_ELEM_CTX(ctx) = base_ring;
     mpoly_ctx_init(MPOLYNOMIAL_MCTX(ctx), nvars, ord);
+    MPOLYNOMIAL_CTX(ctx)->vars = NULL;
 
     ctx->methods = _gr__gr_gr_mpoly_methods;
 

--- a/src/gr/nf.c
+++ b/src/gr/nf.c
@@ -19,6 +19,7 @@
 #include "gr_generic.h"
 #include "gr_vec.h"
 #include "gr_poly.h"
+#include "gr_generic.h"
 
 typedef struct
 {
@@ -543,6 +544,7 @@ gr_method_tab_input _nf_methods_input[] =
     {GR_METHOD_ZERO,            (gr_funcptr) _gr_nf_zero},
     {GR_METHOD_ONE,             (gr_funcptr) _gr_nf_one},
     {GR_METHOD_GEN,             (gr_funcptr) _gr_nf_gen},
+    {GR_METHOD_GENS,            (gr_funcptr) gr_generic_gens_single},
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_nf_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_nf_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) _gr_nf_is_neg_one},

--- a/src/gr_generic.h
+++ b/src/gr_generic.h
@@ -93,6 +93,10 @@ WARN_UNUSED_RESULT int gr_generic_randtest_not_zero(gr_ptr x, flint_rand_t state
 
 WARN_UNUSED_RESULT int gr_generic_randtest_small(gr_ptr x, flint_rand_t state, gr_ctx_t ctx);
 
+WARN_UNUSED_RESULT int gr_generic_gens(gr_vec_t vec, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_generic_gens_single(gr_vec_t vec, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_generic_gens_recursive(gr_vec_t vec, gr_ctx_t ctx);
+
 WARN_UNUSED_RESULT truth_t gr_generic_is_zero(gr_srcptr x, gr_ctx_t ctx);
 WARN_UNUSED_RESULT truth_t gr_generic_is_one(gr_srcptr x, gr_ctx_t ctx);
 WARN_UNUSED_RESULT truth_t gr_generic_is_neg_one(gr_srcptr x, gr_ctx_t ctx);

--- a/src/gr_generic/generic.c
+++ b/src/gr_generic/generic.c
@@ -141,6 +141,23 @@ int gr_generic_randtest_small(gr_ptr x, flint_rand_t state, gr_ctx_t ctx)
     return status;
 }
 
+int gr_generic_gens(gr_vec_t vec, gr_ctx_t ctx)
+{
+    gr_vec_set_length(vec, 0, ctx);
+    return GR_SUCCESS;
+}
+
+int gr_generic_gens_single(gr_vec_t vec, gr_ctx_t ctx)
+{
+    gr_vec_set_length(vec, 1, ctx);
+    return gr_gen(vec->entries, ctx);
+}
+
+int gr_generic_gens_recursive(gr_vec_t vec, gr_ctx_t ctx)
+{
+    return gr_gens(vec, ctx);
+}
+
 /* Generic arithmetic functions */
 
 truth_t gr_generic_is_zero(gr_srcptr x, gr_ctx_t ctx)
@@ -2482,6 +2499,9 @@ const gr_method_tab_input _gr_generic_methods[] =
     {GR_METHOD_RANDTEST,                (gr_funcptr) gr_generic_randtest},
     {GR_METHOD_RANDTEST_NOT_ZERO,       (gr_funcptr) gr_generic_randtest_not_zero},
     {GR_METHOD_RANDTEST_SMALL,          (gr_funcptr) gr_generic_randtest_small},
+
+    {GR_METHOD_GENS,                    (gr_funcptr) gr_generic_gens},
+    {GR_METHOD_GENS_RECURSIVE,          (gr_funcptr) gr_generic_gens_recursive},
 
     {GR_METHOD_ZERO,                    (gr_funcptr) gr_generic_zero},
     {GR_METHOD_ONE,                     (gr_funcptr) gr_generic_one},

--- a/src/gr_mpoly/write.c
+++ b/src/gr_mpoly/write.c
@@ -11,11 +11,34 @@
 */
 
 #include <stdio.h>
+#include <ctype.h>
+#include <stdio.h>
 #include "gr_mpoly.h"
+#include "fmpz_vec.h"
 
 static char * _gr_mpoly_default_vars[8] = {
     "x", "y", "z", "s", "t", "u", "v", "w"
 };
+
+static int
+want_parens(const char * s)
+{
+    if (s[0] == '(' || s[0] == '[' || s[0] == '{')
+        return 0;
+
+    if (s[0] == '-')
+        s++;
+
+    while (s[0] != '\0')
+    {
+        if (!isalnum(s[0]) && s[0] != '.')
+            return 1;
+
+        s++;
+    }
+
+    return 0;
+}
 
 /* todo: error handling */
 int gr_mpoly_write_pretty(gr_stream_t out, const gr_mpoly_t A,
@@ -26,6 +49,7 @@ int gr_mpoly_write_pretty(gr_stream_t out, const gr_mpoly_t A,
     slong bits = A->bits;
     slong i, j, N;
     fmpz * exponents;
+    char * s;
     char ** x = (char **) x_in;
     TMP_INIT;
 
@@ -67,32 +91,88 @@ int gr_mpoly_write_pretty(gr_stream_t out, const gr_mpoly_t A,
 
     for (i = 0; i < len; i++)
     {
-        if (i > 0)
-        {
-            gr_stream_write(out, " + ");
-        }
+        int removed_coeff = 0;
 
-        gr_stream_write(out, "(");
-        gr_write(out, GR_ENTRY(A->coeffs, i, cctx->sizeof_elem), cctx);
-        gr_stream_write(out, ")");
+        gr_get_str(&s, GR_ENTRY(A->coeffs, i, cctx->sizeof_elem), cctx);
+
+        if (!strcmp(s, "1"))
+        {
+            flint_free(s);
+            if (i > 0)
+                gr_stream_write(out, " + ");
+            removed_coeff = 1;
+        }
+        else if (!strcmp(s, "-1"))
+        {
+            flint_free(s);
+
+            if (i > 0)
+                gr_stream_write(out, " - ");
+            else
+                gr_stream_write(out, "-");
+
+            removed_coeff = -1;
+        }
+        else
+        {
+            if (want_parens(s))
+            {
+                if (i > 0)
+                    gr_stream_write(out, " + ");
+
+                gr_stream_write(out, "(");
+                gr_stream_write_free(out, s);
+                gr_stream_write(out, ")");
+            }
+            else
+            {
+                if (i > 0 && s[0] == '-')
+                {
+                    gr_stream_write(out, " - ");
+                    gr_stream_write(out, s + 1);
+                    flint_free(s);
+                }
+                else
+                {
+                    if (i > 0)
+                        gr_stream_write(out, " + ");
+
+                    gr_stream_write_free(out, s);
+                }
+            }
+        }
 
         mpoly_get_monomial_ffmpz(exponents, exp + N*i, bits, mctx);
 
-        for (j = 0; j < mctx->nvars; j++)
+        if (_fmpz_vec_is_zero(exponents, mctx->nvars))
         {
-            int cmp = fmpz_cmp_ui(exponents + j, 1);
+            if (removed_coeff != 0)
+                gr_stream_write(out, "1");
+        }
+        else
+        {
+            int have_printed_var = 0;
 
-            if (cmp > 0)
+            for (j = 0; j < mctx->nvars; j++)
             {
-                gr_stream_write(out, "*");
-                gr_stream_write(out, x[j]);
-                gr_stream_write(out, "^");
-                gr_stream_write_fmpz(out, exponents + j);
-            }
-            else if (cmp == 0)
-            {
-                gr_stream_write(out, "*");
-                gr_stream_write(out, x[j]);
+                int cmp = fmpz_cmp_ui(exponents + j, 1);
+
+                if (cmp > 0)
+                {
+                    if (have_printed_var || !removed_coeff)
+                        gr_stream_write(out, "*");
+                    gr_stream_write(out, x[j]);
+                    gr_stream_write(out, "^");
+                    gr_stream_write_fmpz(out, exponents + j);
+                    have_printed_var = 1;
+                }
+                else if (cmp == 0)
+                {
+                    if (have_printed_var || !removed_coeff)
+                        gr_stream_write(out, "*");
+                    gr_stream_write(out, x[j]);
+                    have_printed_var = 1;
+                }
             }
         }
     }

--- a/src/gr_mpoly/write.c
+++ b/src/gr_mpoly/write.c
@@ -1,6 +1,6 @@
 /*
     Copyright (C) 2020 Daniel Schultz
-    Copyright (C) 2022 Fredrik Johansson
+    Copyright (C) 2022, 2024 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -17,7 +17,7 @@
 #include "fmpz_vec.h"
 
 static char * _gr_mpoly_default_vars[8] = {
-    "x", "y", "z", "s", "t", "u", "v", "w"
+    "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8"
 };
 
 static int

--- a/src/gr_poly/write.c
+++ b/src/gr_poly/write.c
@@ -67,6 +67,8 @@ gr_poly_write(gr_stream_t out, const gr_poly_t poly, const char * x, gr_ctx_t ct
 
         if (i >= 1 && !strcmp(s, "1"))
         {
+            flint_free(s);
+
             if (printed_previously)
                 gr_stream_write(out, " + ");
 
@@ -80,6 +82,8 @@ gr_poly_write(gr_stream_t out, const gr_poly_t poly, const char * x, gr_ctx_t ct
         }
         else if (i >= 1 && !strcmp(s, "-1"))
         {
+            flint_free(s);
+
             if (printed_previously)
                 gr_stream_write(out, " - ");
             else

--- a/src/python/flint_ctypes.py
+++ b/src/python/flint_ctypes.py
@@ -7514,6 +7514,14 @@ def test_mpoly():
     assert str((1+I)*x - I*y) == "(1+I)*x - I*y"
     assert str(x+1+I) == "x + (1+I)"
 
+    x, y = PolynomialRing_gr_mpoly(ZZx, 1, ["y"]).gens(recursive=True)
+    assert str(x+1) == "(x+1)"
+    assert str((x+1)*y) == "(x+1)*y"
+    assert str((x+1)*y + (x+2)) == "(x+1)*y + (x+2)"
+    assert str((x+1)*y**2 + (x+2)*y)
+    assert str((x+1)*y**2 - (x+2)*y) == "(x+1)*y^2 + (-x-2)*y"
+
+
 def test_mpoly_q():
     assert str(FractionField_fmpz_mpoly_q(2).gens()) == '[x1, x2]'
     assert str(FractionField_fmpz_mpoly_q(2, ["a", "b"]).gens()) == '[a, b]'


### PR DESCRIPTION
* Add ``gr_gens_recursive``
* Allow changing variable name for ``gr_series``
* Prettier printing for ``gr_mpoly``
* Support ``gr_gens`` for ``gr_mpoly``
* Fix memory leak in ``gr_poly_write``
* More tests
* Wrap ``gr_mpoly`` in ``flint_ctypes``
* Allow setting generator names for ``gr_mpoly``, ``fmpz_mpoly`` and ``fmpz_mpoly_q`` generic rings
