### PR TITLE
Some fmpz mod improvements

### DIFF
--- a/doc/source/gr_mat.rst
+++ b/doc/source/gr_mat.rst
@@ -288,7 +288,8 @@ Gaussian elimination
     zero but can be certified zero may be overwritten by exact zeros.
 
 .. function:: int gr_mat_lu_classical(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx)
-              int gr_mat_lu_recursive(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx)
+              int gr_mat_lu_recursive(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, slong cutoff, gr_ctx_t ctx)
+              int gr_mat_lu_generic(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx)
               int gr_mat_lu(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx)
 
     Computes a generalized LU decomposition `A = PLU` of a given
@@ -321,6 +322,10 @@ Gaussian elimination
     The *classical* version uses iterative Gaussian elimination.
     The *recursive* version uses a block recursive algorithm
     to take advantage of fast matrix multiplication.
+    The *cutoff* for switching to the classical algorithm is given
+    as an explicit input.
+    The *generic* version calls the recursive algorithm with a
+    default cutoff.
 
 .. function:: int gr_mat_fflu(slong * rank, slong * P, gr_mat_t LU, gr_ptr den, const gr_mat_t A, int rank_check, gr_ctx_t ctx)
 

--- a/src/fmpz_mod_mat/minpoly.c
+++ b/src/fmpz_mod_mat/minpoly.c
@@ -1,6 +1,7 @@
 /*
     Copyright (C) 2015 William Hart
     Copyright (C) 2021 Daniel Schultz
+    Copyright (C) 2024 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -14,180 +15,18 @@
 #include "fmpz_mod.h"
 #include "fmpz_mod_mat.h"
 #include "fmpz_mod_poly.h"
+#include "gr.h"
+#include "gr_mat.h"
 
 void fmpz_mod_mat_minpoly(fmpz_mod_poly_t p, const fmpz_mod_mat_t X,
                                                       const fmpz_mod_ctx_t ctx)
 {
-    slong n = fmpz_mod_mat_nrows(X), i, j, c, c1, c2, r1, r2;
-    slong  * P1, * P2, * L1, * L2;
-    fmpz_mod_mat_t A, B, v;
-    int first_poly = 1, indep = 1;
-    fmpz_mod_poly_t b, g, r;
-    fmpz_t t, h;
-    TMP_INIT;
+    gr_ctx_t gr_ctx;
+    slong n = fmpz_mod_mat_nrows(X);
 
     if (n != fmpz_mod_mat_ncols(X))
-    {
         flint_throw(FLINT_ERROR, "Exception (fmpz_mod_mat_charpoly). Non-square matrix.\n");
-    }
 
-    if (n == 0)
-    {
-        fmpz_mod_poly_one(p, ctx);
-        return;
-    }
-
-    fmpz_init(t);
-
-    if (n == 1)
-    {
-        fmpz_set_ui(t, 1);
-        fmpz_mod_poly_set_coeff_fmpz(p, 1, t, ctx);
-        fmpz_mod_neg(t, fmpz_mod_mat_entry(X, 0, 0), ctx);
-        fmpz_mod_poly_set_coeff_fmpz(p, 0, t, ctx);
-        _fmpz_mod_poly_set_length(p, 2);
-        fmpz_clear(t);
-        return;
-    }
-
-    TMP_START;
-
-    fmpz_init(h);
-    fmpz_mod_poly_init(b, ctx);
-    fmpz_mod_poly_init(g, ctx);
-    fmpz_mod_poly_init(r, ctx);
-    fmpz_mod_poly_one(p, ctx);
-    fmpz_mod_mat_init(A, n + 1, 2*n + 1, fmpz_mod_ctx_modulus(ctx));
-    fmpz_mod_mat_init(B, n, n, fmpz_mod_ctx_modulus(ctx));
-    fmpz_mod_mat_init(v, n, 1, fmpz_mod_ctx_modulus(ctx));
-
-    L1 = (slong *) TMP_ALLOC((n + 1)*sizeof(slong));
-    L2 = (slong *) TMP_ALLOC(n*sizeof(slong));
-    P1 = (slong *) TMP_ALLOC((2*n + 1)*sizeof(slong));
-    P2 = (slong *) TMP_ALLOC(n*sizeof(slong));
-
-    for (i = 1; i <= n + 1; i++)
-        L1[i - 1] = n + i;
-
-    for (i = 1; i <= n; i++)
-        L2[i - 1] = n;
-
-    P2[0] = 0;
-    for (i = 1; i < n; i++)
-        P2[i] = -WORD(1);
-
-    r2 = c2 = 0;
-    first_poly = 1;
-
-    while (r2 < n)
-    {
-        for (i = 0; i < 2*n + 1; i++)
-            P1[i] = -WORD(1);
-
-        for (i = 0; i < n; i++)
-        {
-            fmpz_zero(fmpz_mod_mat_entry(v, i, 0));
-            fmpz_zero(fmpz_mod_mat_entry(B, r2, i));
-            fmpz_zero(fmpz_mod_mat_entry(A, 0, i));
-        }
-
-        P1[c2] = 0;
-        P2[c2] = r2;
-
-        fmpz_one(fmpz_mod_mat_entry(v, c2, 0));
-        fmpz_one(fmpz_mod_mat_entry(B, r2, c2));
-        fmpz_one(fmpz_mod_mat_entry(A, 0, c2));
-        fmpz_one(fmpz_mod_mat_entry(A, 0, n));
-
-        indep = 1;
-
-        r1 = 0;
-        c1 = -WORD(1);
-
-        while (c1 < n && r1 < n)
-        {
-            r1++;
-            r2 = indep ? r2 + 1 : r2;
-
-            fmpz_mod_mat_mul(v, X, v);
-
-            for (i = 0; i < n; i++)
-                fmpz_set(fmpz_mod_mat_entry(A, r1, i), fmpz_mod_mat_entry(v, i, 0));
-
-            for (i = n; i < n + r1; i++)
-                fmpz_zero(fmpz_mod_mat_entry(A, r1, i));
-
-            fmpz_one(fmpz_mod_mat_entry(A, r1, n + r1));
-
-            c1 = _fmpz_mod_mat_reduce_row(A, P1, L1, r1, ctx);
-
-            if (indep && r2 < n && !first_poly)
-            {
-                for (i = 0; i < n; i++)
-                    fmpz_set(fmpz_mod_mat_entry(B, r2, i), fmpz_mod_mat_entry(v, i, 0));
-
-                c = _fmpz_mod_mat_reduce_row(B, P2, L2, r2, ctx);
-
-                indep = c != -WORD(1);
-            }
-        }
-
-        if (first_poly)
-        {
-            for (i = 0; i < n; i++)
-                P2[i] = P1[i];
-
-            r2 = r1;
-        }
-
-        c = -WORD(1);
-
-        for (i = c2 + 1; i < n; i++)
-        {
-            if (P2[i] == -WORD(1))
-            {
-                c = i;
-                break;
-            }
-        }
-
-        c2 = c;
-
-        fmpz_mod_poly_fit_length(b, r1 + 1, ctx);
-        fmpz_mod_inv(h, fmpz_mod_mat_entry(A, r1, n + r1), ctx);
-        for (i = 0; i < r1 + 1; i++)
-        {
-            fmpz_mod_mul(t, fmpz_mod_mat_entry(A, r1, n + i), h, ctx);
-            fmpz_mod_poly_set_coeff_fmpz(b, i, t, ctx);
-        }
-        _fmpz_mod_poly_set_length(b, r1 + 1);
-
-        fmpz_mod_poly_gcd(g, p, b, ctx);
-        fmpz_mod_poly_mul(p, p, b, ctx);
-        fmpz_mod_poly_divrem(p, r, p, g, ctx);
-
-        if (first_poly && r2 < n)
-        {
-            for (i = 0; i < r1; i++)
-            {
-                for (j = 0; j < n; j++)
-                    fmpz_set(fmpz_mod_mat_entry(B, i, j), fmpz_mod_mat_entry(A, i, j));
-            }
-        }
-
-        first_poly = 0;
-    }
-
-    fmpz_mod_mat_clear(A);
-    fmpz_mod_mat_clear(B);
-    fmpz_mod_mat_clear(v);
-
-    fmpz_mod_poly_clear(b, ctx);
-    fmpz_mod_poly_clear(g, ctx);
-    fmpz_mod_poly_clear(r, ctx);
-
-    fmpz_clear(t);
-    fmpz_clear(h);
-
-    TMP_END;
+    _gr_ctx_init_fmpz_mod_from_ref(gr_ctx, ctx);
+    GR_MUST_SUCCEED(gr_mat_minpoly_field((gr_poly_struct *) p, (const gr_mat_struct *) X, gr_ctx));
 }

--- a/src/fmpz_mod_vec/dot.c
+++ b/src/fmpz_mod_vec/dot.c
@@ -12,30 +12,19 @@
 
 #include "fmpz.h"
 #include "fmpz_mod.h"
+#include "fmpz_vec.h"
 #include "fmpz_mod_vec.h"
 
-void _fmpz_mod_vec_dot(
-    fmpz_t d,
-    const fmpz * a,
-    const fmpz * b,
-    slong len,
-    const fmpz_mod_ctx_t ctx)
+void _fmpz_mod_vec_dot(fmpz_t d, const fmpz * a,
+                   const fmpz * b, slong len, const fmpz_mod_ctx_t ctx)
 {
-    fmpz_zero(d);
-    for (len--; len >= 0; len--)
-        fmpz_addmul(d, a + len, b + len);
+    _fmpz_vec_dot(d, a, b, len);
     fmpz_mod_set_fmpz(d, d, ctx);
 }
 
 void _fmpz_mod_vec_dot_rev(fmpz_t r, const fmpz * a,
 		           const fmpz * b, slong len, const fmpz_mod_ctx_t ctx)
 {
-    slong i;
-
-    fmpz_zero(r);
-
-    for (i = 0; i < len; i++)
-        fmpz_addmul(r, a + i, b + len - i - 1);
-
+    _fmpz_vec_dot_general(r, NULL, 0, a, b, 1, len);
     fmpz_mod_set_fmpz(r, r, ctx);
 }

--- a/src/gr.h
+++ b/src/gr.h
@@ -689,6 +689,7 @@ typedef enum
 
     /* Matrix methods (todo: rename -> GR_MAT) */
     GR_METHOD_MAT_MUL,
+    GR_METHOD_MAT_LU,
     GR_METHOD_MAT_DET,
     GR_METHOD_MAT_EXP,
     GR_METHOD_MAT_LOG,

--- a/src/gr/fmpz_mod.c
+++ b/src/gr/fmpz_mod.c
@@ -13,12 +13,14 @@
 #include "fmpz_factor.h"
 #include "fmpz_vec.h"
 #include "fmpz_mod.h"
+#include "fmpz_mod_vec.h"
 #include "fmpz_mod_mat.h"
 #include "fmpz_mod_poly.h"
 #include "fmpz_mod_poly_factor.h"
 #include "gr.h"
 #include "gr_vec.h"
 #include "gr_poly.h"
+#include "gr_mat.h"
 
 typedef struct
 {
@@ -437,6 +439,14 @@ _gr_fmpz_mod_vec_dot_rev(fmpz_t res, const fmpz_t initial, int subtract, const f
 }
 
 int
+_gr_fmpz_mod_vec_addmul_scalar(fmpz * res, const fmpz * vec, slong len, const fmpz_t c, gr_ctx_t ctx)
+{
+    _fmpz_mod_vec_scalar_addmul_fmpz_mod(res, vec, len, c, FMPZ_MOD_CTX(ctx));
+    return GR_SUCCESS;
+}
+
+
+int
 _gr_fmpz_mod_poly_mullow(fmpz * res,
     const fmpz * poly1, slong len1,
     const fmpz * poly2, slong len2, slong n, gr_ctx_t ctx)
@@ -617,6 +627,14 @@ _gr_fmpz_mod_mat_mul(fmpz_mat_t res, const fmpz_mat_t x, const fmpz_mat_t y, gr_
     return GR_SUCCESS;
 }
 
+/* todo: tune cutoff for different bit sizes */
+/* also tune cutoff for triangular solving */
+int
+_gr_fmpz_mod_mat_lu(slong * rank, slong * P, fmpz_mat_t LU, const fmpz_mat_t A, int rank_check, gr_ctx_t ctx)
+{
+    return gr_mat_lu_recursive(rank, P, (gr_mat_struct *) LU, (const gr_mat_struct *) A, rank_check, 8, ctx);
+}
+
 int _fmpz_mod_methods_initialized = 0;
 
 gr_static_method_table _fmpz_mod_methods;
@@ -675,12 +693,14 @@ gr_method_tab_input _fmpz_mod_methods_input[] =
     {GR_METHOD_POW_FMPZ,        (gr_funcptr) _gr_fmpz_mod_pow_fmpz},
     {GR_METHOD_VEC_DOT,         (gr_funcptr) _gr_fmpz_mod_vec_dot},
     {GR_METHOD_VEC_DOT_REV,     (gr_funcptr) _gr_fmpz_mod_vec_dot_rev},
+    {GR_METHOD_VEC_ADDMUL_SCALAR,    (gr_funcptr) _gr_fmpz_mod_vec_addmul_scalar},
     {GR_METHOD_POLY_MULLOW,     (gr_funcptr) _gr_fmpz_mod_poly_mullow},
     {GR_METHOD_POLY_INV_SERIES, (gr_funcptr) _gr_fmpz_mod_poly_inv_series},
     {GR_METHOD_POLY_DIV_SERIES, (gr_funcptr) _gr_fmpz_mod_poly_div_series},
     {GR_METHOD_POLY_DIVREM,     (gr_funcptr) _gr_fmpz_mod_poly_divrem},
     {GR_METHOD_POLY_ROOTS,      (gr_funcptr) _gr_fmpz_mod_roots_gr_poly},
     {GR_METHOD_MAT_MUL,         (gr_funcptr) _gr_fmpz_mod_mat_mul},
+    {GR_METHOD_MAT_LU,          (gr_funcptr) _gr_fmpz_mod_mat_lu},
     {0,                         (gr_funcptr) NULL},
 };
 

--- a/src/gr_generic/generic.c
+++ b/src/gr_generic/generic.c
@@ -2874,6 +2874,7 @@ const gr_method_tab_input _gr_generic_methods[] =
     {GR_METHOD_POLY_EXP_SERIES,         (gr_funcptr) _gr_poly_exp_series_generic},
 
     {GR_METHOD_MAT_MUL,                 (gr_funcptr) gr_mat_mul_generic},
+    {GR_METHOD_MAT_LU,                  (gr_funcptr) gr_mat_lu_generic},
     {GR_METHOD_MAT_DET,                 (gr_funcptr) gr_mat_det_generic},
     {GR_METHOD_MAT_EXP,                 (gr_funcptr) gr_mat_exp_jordan},
     {GR_METHOD_MAT_LOG,                 (gr_funcptr) gr_mat_log_jordan},

--- a/src/gr_mat.h
+++ b/src/gr_mat.h
@@ -56,12 +56,14 @@ typedef int ((*gr_method_mat_unary_op)(gr_mat_t, const gr_mat_t, gr_ctx_ptr));
 typedef int ((*gr_method_mat_binary_op)(gr_mat_t, const gr_mat_t, const gr_mat_t, gr_ctx_ptr));
 typedef int ((*gr_method_mat_pivot_op)(slong *, gr_mat_t, slong, slong, slong, gr_ctx_ptr));
 typedef int ((*gr_method_mat_diagonalization_op)(gr_vec_t, gr_mat_t, gr_mat_t, const gr_mat_t, int, gr_ctx_ptr));
+typedef int ((*gr_method_mat_lu_op)(slong *, slong *, gr_mat_t, const gr_mat_t, int, gr_ctx_ptr));
 
 #define GR_MAT_UNARY_OP_GET_SCALAR(ctx, NAME) (((gr_method_mat_unary_op_get_scalar *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_MAT_UNARY_OP(ctx, NAME) (((gr_method_mat_unary_op *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_MAT_BINARY_OP(ctx, NAME) (((gr_method_mat_binary_op *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_MAT_PIVOT_OP(ctx, NAME) (((gr_method_mat_pivot_op *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_MAT_DIAGONALIZATION_OP(ctx, NAME) (((gr_method_mat_diagonalization_op *) ctx->methods)[GR_METHOD_ ## NAME])
+#define GR_MAT_LU_OP(ctx, NAME) (((gr_method_mat_lu_op *) ctx->methods)[GR_METHOD_ ## NAME])
 
 void gr_mat_init(gr_mat_t mat, slong rows, slong cols, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mat_init_set(gr_mat_t res, const gr_mat_t mat, gr_ctx_t ctx);
@@ -158,8 +160,9 @@ WARN_UNUSED_RESULT int gr_mat_find_nonzero_pivot_large_abs(slong * pivot_row, gr
 WARN_UNUSED_RESULT int gr_mat_find_nonzero_pivot_generic(slong * pivot_row, gr_mat_t mat, slong start_row, slong end_row, slong column, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mat_find_nonzero_pivot(slong * pivot_row, gr_mat_t mat, slong start_row, slong end_row, slong column, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_lu_recursive(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_mat_lu_recursive(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, slong cutoff, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mat_lu_classical(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_mat_lu_generic(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mat_lu(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx);
 
 WARN_UNUSED_RESULT int gr_mat_fflu(slong * res_rank, slong * P, gr_mat_t LU, gr_ptr den, const gr_mat_t A, int rank_check, gr_ctx_t ctx);

--- a/src/gr_mat/lu.c
+++ b/src/gr_mat/lu.c
@@ -12,7 +12,13 @@
 #include "gr_mat.h"
 
 int
+gr_mat_lu_generic(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx)
+{
+    return gr_mat_lu_recursive(rank, P, LU, A, rank_check, 4, ctx);
+}
+
+int
 gr_mat_lu(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx)
 {
-    return gr_mat_lu_recursive(rank, P, LU, A, rank_check, ctx);
+    return GR_MAT_LU_OP(ctx, MAT_LU)(rank, P, LU, A, rank_check, ctx);
 }

--- a/src/gr_mat/lu_recursive.c
+++ b/src/gr_mat/lu_recursive.c
@@ -40,7 +40,7 @@ _apply_permutation(slong * AP, gr_mat_t A, slong * P, slong n, slong offset)
 }
 
 int
-gr_mat_lu_recursive(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx)
+gr_mat_lu_recursive(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, slong cutoff, gr_ctx_t ctx)
 {
     slong i, j, m, n, r1, r2, n1;
     gr_mat_t A0, A1, A00, A01, A10, A11;
@@ -50,7 +50,7 @@ gr_mat_lu_recursive(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int 
     m = A->r;
     n = A->c;
 
-    if (m < 4 || n < 4)
+    if (m < cutoff || n < cutoff)
         return gr_mat_lu_classical(rank, P, LU, A, rank_check, ctx);
 
     if (LU != A)
@@ -67,7 +67,7 @@ gr_mat_lu_recursive(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int 
     gr_mat_window_init(A0, LU, 0, 0, m, n1, ctx);
     gr_mat_window_init(A1, LU, 0, n1, m, n, ctx);
 
-    status |= gr_mat_lu_recursive(&r1, P1, A0, A0, rank_check, ctx);
+    status |= gr_mat_lu_recursive(&r1, P1, A0, A0, rank_check, cutoff, ctx);
 
     if (status != GR_SUCCESS)
         goto cleanup1;
@@ -99,7 +99,7 @@ gr_mat_lu_recursive(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int 
         gr_mat_clear(T, ctx);
     }
 
-    status |= gr_mat_lu_recursive(&r2, P1, A11, A11, rank_check, ctx);
+    status |= gr_mat_lu_recursive(&r2, P1, A11, A11, rank_check, cutoff, ctx);
 
     if (status != GR_SUCCESS)
         goto cleanup2;

--- a/src/gr_mat/nonsingular_solve_tril.c
+++ b/src/gr_mat/nonsingular_solve_tril.c
@@ -19,14 +19,7 @@ gr_mat_nonsingular_solve_tril_classical(gr_mat_t X,
 {
     slong i, j, n, m;
     gr_ptr tmp;
-#if defined(__GNUC__) && !defined(__clang__)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-    gr_ptr inv;
-#if defined(__GNUC__) && !defined(__clang__)
-# pragma GCC diagnostic pop
-#endif
+    gr_ptr inv = NULL;  /* silence compiler warning */
     gr_ptr s;
     int use_division = 0;
     int status = GR_SUCCESS;
@@ -88,14 +81,7 @@ gr_mat_nonsingular_solve_tril_classical(gr_mat_t X,
 cleanup:
     if (!unit)
     {
-#if defined(__GNUC__) && !defined(__clang__)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
         GR_TMP_CLEAR_VEC(inv, n, ctx);
-#if defined(__GNUC__) && !defined(__clang__)
-# pragma GCC diagnostic pop
-#endif
     }
 
     flint_free(tmp);

--- a/src/gr_mat/nonsingular_solve_triu.c
+++ b/src/gr_mat/nonsingular_solve_triu.c
@@ -18,7 +18,8 @@ gr_mat_nonsingular_solve_triu_classical(gr_mat_t X,
         const gr_mat_t U, const gr_mat_t B, int unit, gr_ctx_t ctx)
 {
     slong i, j, n, m;
-    gr_ptr tmp, inv;
+    gr_ptr tmp;
+    gr_ptr inv = NULL;  /* silence compiler warning */
     gr_ptr s;
     int use_division = 0;
     int status = GR_SUCCESS;
@@ -27,12 +28,6 @@ gr_mat_nonsingular_solve_triu_classical(gr_mat_t X,
 
     n = U->r;
     m = B->c;
-
-    /* silence compiler warning. for whatever reason gcc
-       complains that inv may be uninitialized in this function
-       though exactly the same code in solve_tril generates
-       no warning. */
-    inv = NULL;
 
     if (!unit)
     {

--- a/src/gr_mat/test/t-lu_recursive.c
+++ b/src/gr_mat/test/t-lu_recursive.c
@@ -120,6 +120,7 @@ TEST_FUNCTION_START(gr_mat_lu_recursive, state)
         slong m, n, r, d, rank;
         slong * P;
         int status;
+        slong cutoff;
 
         if (n_randint(state, 2))
             gr_ctx_init_fmpz(ctx);
@@ -131,6 +132,8 @@ TEST_FUNCTION_START(gr_mat_lu_recursive, state)
 
         for (r = 0; r <= FLINT_MIN(m, n); r++)
         {
+            cutoff = 2 + n_randint(state, 5);
+
             gr_mat_init(A, m, n, ctx);
             gr_mat_init(LU, m, n, ctx);
 
@@ -144,7 +147,7 @@ TEST_FUNCTION_START(gr_mat_lu_recursive, state)
 
             P = flint_malloc(sizeof(slong) * m);
 
-            status = gr_mat_lu_recursive(&rank, P, LU, A, 0, ctx);
+            status = gr_mat_lu_recursive(&rank, P, LU, A, 0, cutoff, ctx);
 
             if (status == GR_SUCCESS)
             {
@@ -177,6 +180,7 @@ TEST_FUNCTION_START(gr_mat_lu_recursive, state)
         slong m, n, r, d, rank;
         slong * P;
         int status;
+        slong cutoff;
 
         gr_ctx_init_random(ctx, state);
 
@@ -185,6 +189,8 @@ TEST_FUNCTION_START(gr_mat_lu_recursive, state)
 
         for (r = 0; r <= FLINT_MIN(m, n); r++)
         {
+            cutoff = 2 + n_randint(state, 5);
+
             gr_mat_init(A, m, n, ctx);
             gr_mat_init(LU, m, n, ctx);
 
@@ -198,7 +204,7 @@ TEST_FUNCTION_START(gr_mat_lu_recursive, state)
 
             P = flint_malloc(sizeof(slong) * m);
 
-            status = gr_mat_lu_recursive(&rank, P, LU, A, 0, ctx);
+            status = gr_mat_lu_recursive(&rank, P, LU, A, 0, cutoff, ctx);
 
             if (status == GR_SUCCESS)
             {
@@ -232,6 +238,7 @@ TEST_FUNCTION_START(gr_mat_lu_recursive, state)
         slong n, r, d, rank;
         slong * P;
         int status;
+        slong cutoff;
 
         if (n_randint(state, 2))
             gr_ctx_init_fmpz(ctx);
@@ -242,6 +249,8 @@ TEST_FUNCTION_START(gr_mat_lu_recursive, state)
 
         for (r = 0; r <= n; r++)
         {
+            cutoff = 2 + n_randint(state, 5);
+
             gr_mat_init(A, n, n, ctx);
             gr_mat_init(LU, n, n, ctx);
 
@@ -255,7 +264,7 @@ TEST_FUNCTION_START(gr_mat_lu_recursive, state)
 
             P = flint_malloc(sizeof(slong) * n);
 
-            status = gr_mat_lu_recursive(&rank, P, LU, A, 1, ctx);
+            status = gr_mat_lu_recursive(&rank, P, LU, A, 1, cutoff, ctx);
 
             if (status == GR_SUCCESS)
             {


### PR DESCRIPTION
* Speed up ``_fmpz_mod_vec_dot`` by wrapping ``_fmpz_vec_dot``
* Saving code: ``fmpz_mod_mat_charpoly_berkowitz`` and ``fmpz_mod_mat_minpoly`` based on generics, with no essential slowdown
* Allow overriding cutoff in ``gr_mat_lu_recursive``

Note: ``fmpz_mod_mat_lu``, ``fmpz_mod_mat_solve`` etc. can now all be switched over to generics wrappers, but I'll save that for #779 so that there is a context object to pass in.