### PR TITLE
Add d_mul_2exp and replace slow ldexp calls

### DIFF
--- a/doc/source/d_vec.rst
+++ b/doc/source/d_vec.rst
@@ -65,7 +65,7 @@ Comparison
     are within ``eps`` of each other, otherwise returns `0`.
 
 
-Addition and subtraction
+Arithmetic
 --------------------------------------------------------------------------------
 
 
@@ -77,6 +77,11 @@ Addition and subtraction
 .. function:: void _d_vec_sub(double * res, const double * vec1, const double * vec2, slong len2)
 
     Sets ``(res, len2)`` to ``(vec1, len2)`` minus ``(vec2, len2)``.
+
+
+.. function:: void _d_vec_mul_2exp(double * res, const double * vec, slong len, int e)
+
+    Sets ``(res, len)`` to ``(vec, len)`` multiplied by `2^e`.
 
 
 Dot product and norm

--- a/doc/source/double_extras.rst
+++ b/doc/source/double_extras.rst
@@ -33,6 +33,17 @@ Arithmetic
     ``len`` coefficients. Requires that ``len`` is nonzero.
 
 
+.. function:: double d_mul_2exp_inrange(double x, int i)
+              double d_mul_2exp_inrange2(double x, int i)
+              double d_mul_2exp(double x, int i)
+
+    Returns `x \cdot 2^i`.
+
+    The *inrange* version requires that `2^i` is in the normal exponent
+    range. The *inrange2* version additionally requires that both
+    `x` and `x \cdot 2^i` are in the normal exponent range,
+    and in particular also assumes that `x \ne 0`.
+
 
 Special functions
 --------------------------------------------------------------------------------

--- a/src/arb_mat/addmul_rad_mag_fast.c
+++ b/src/arb_mat/addmul_rad_mag_fast.c
@@ -18,6 +18,8 @@
 # include <math.h>
 #endif
 
+#include "double_extras.h"
+
 /* Block size for better cache locality. */
 #define BLOCK_SIZE 32
 
@@ -101,7 +103,7 @@ static inline slong _mag_get_exp(const mag_t x)
 static double
 mag_get_d_fixed_si(const mag_t x, slong e)
 {
-    return ldexp(MAG_MAN(x), MAG_EXP(x) - e - MAG_BITS);
+    return d_mul_2exp(MAG_MAN(x), MAG_EXP(x) - e - MAG_BITS);
 }
 
 void

--- a/src/arf/get.c
+++ b/src/arf/get.c
@@ -97,7 +97,7 @@ arf_get_d(const arf_t x, arf_rnd_t rnd)
         else
             v = (double)(tp[1]) + (double)(tp[0]) * ldexp(1,-32);
 
-        v = ldexp(v, ARF_EXP(t) - FLINT_BITS);
+        v = d_mul_2exp(v, ARF_EXP(t) - FLINT_BITS);
 
         if (ARF_SGNBIT(t))
             v = -v;

--- a/src/d_vec.h
+++ b/src/d_vec.h
@@ -12,7 +12,14 @@
 #ifndef D_VEC_H
 #define D_VEC_H
 
+#ifdef D_VEC_INLINES_C
+#define D_VEC_INLINE
+#else
+#define D_VEC_INLINE static inline
+#endif
+
 #include "flint.h"
+#include "double_extras.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -45,11 +52,31 @@ int _d_vec_is_zero(const double * vec, slong len);
 
 int _d_vec_is_approx_zero(const double * vec, slong len, double eps);
 
-/*  Addition  ****************************************************************/
+/*  Arithmetic  ****************************************************************/
 
 void _d_vec_add(double * res, const double * vec1, const double * vec2, slong len2);
 
 void _d_vec_sub(double * res, const double * vec1, const double * vec2, slong len2);
+
+D_VEC_INLINE
+void _d_vec_mul_2exp(double * res, const double * x, slong len, int e)
+{
+    slong i;
+
+    if (e >= D_MIN_NORMAL_EXPONENT && e <= D_MAX_NORMAL_EXPONENT)
+    {
+        double_uint64_u u;
+        u.i = ((int64_t) (e + D_EXPONENT_BIAS)) << D_EXPONENT_SHIFT;
+
+        for (i = 0; i < len; i++)
+            res[i] = x[i] * u.f;
+    }
+    else
+    {
+        for (i = 0; i < len; i++)
+            res[i] = ldexp(x[i], e);
+    }
+}
 
 /*  Dot product and norm  **************************************/
 

--- a/src/d_vec/dot_heuristic.c
+++ b/src/d_vec/dot_heuristic.c
@@ -36,8 +36,8 @@ _d_vec_dot_heuristic(const double *vec1, const double *vec2, slong len2,
     {
         p = frexp(psum, &pexp);
         n = frexp(nsum, &nexp);
-        p = ldexp(1.0, pexp - D_BITS);
-        n = ldexp(1.0, nexp - D_BITS);
+        p = d_mul_2exp(1.0, pexp - D_BITS);
+        n = d_mul_2exp(1.0, nexp - D_BITS);
         d = FLINT_MAX(p, n);
         *err = 2 * len2 * d;
     }

--- a/src/d_vec/inlines.c
+++ b/src/d_vec/inlines.c
@@ -1,6 +1,5 @@
 /*
-    Copyright (C) 2012 Fredrik Johansson
-    Copyright (C) 2014 Abhinav Baid
+    Copyright (C) 2015 William Hart
 
     This file is part of FLINT.
 
@@ -10,13 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "double_extras.h"
+#define D_VEC_INLINES_C
 
-int
-d_is_nan(double x)
-{
-    if (x != x)
-        return 1;
-    else
-        return 0;
-}
+#include "flint.h"
+#include "d_vec.h"

--- a/src/double_extras.h
+++ b/src/double_extras.h
@@ -18,6 +18,7 @@
 #define DOUBLE_EXTRAS_INLINE static inline
 #endif
 
+#include <stdint.h>
 #include <math.h>
 #include "flint.h"
 
@@ -50,9 +51,55 @@ double d_polyval(const double * poly, int len, double x)
 
 double d_lambertw(double x);
 
-int d_is_nan(double x);
+DOUBLE_EXTRAS_INLINE
+int d_is_nan(double x)
+{
+    return x != x;
+}
 
 double d_log2(double x);
+
+typedef union
+{
+    double f;
+    uint64_t i;
+}
+double_uint64_u;
+
+#define D_MIN_NORMAL_EXPONENT -1022
+#define D_MAX_NORMAL_EXPONENT 1023
+#define D_EXPONENT_BIAS 1023
+#define D_EXPONENT_SHIFT 52
+
+/* Assumes that 2^i is in the normal exponent range. */
+FLINT_FORCE_INLINE double d_mul_2exp_inrange(double x, int i)
+{
+    FLINT_ASSERT(i >= D_MIN_NORMAL_EXPONENT && i <= D_MAX_NORMAL_EXPONENT);
+    double_uint64_u u;
+    u.i = ((int64_t) (i + D_EXPONENT_BIAS)) << D_EXPONENT_SHIFT;
+    return x * u.f;
+}
+
+/* Assumes that 2^i, x and x*2^i are all in the normal exponent range. */
+/* In particular, also assumes x != 0. */
+FLINT_FORCE_INLINE double d_mul_2exp_inrange2(double x, int i)
+{
+    FLINT_ASSERT(i >= D_MIN_NORMAL_EXPONENT && i <= D_MAX_NORMAL_EXPONENT);
+    FLINT_ASSERT(x != 0);
+
+    double_uint64_u u;
+    u.f = x;
+    u.i += ((int64_t) i) << D_EXPONENT_SHIFT;
+    return u.f;
+}
+
+FLINT_FORCE_INLINE double d_mul_2exp(double x, int i)
+{
+    if (i >= D_MIN_NORMAL_EXPONENT && i <= D_MAX_NORMAL_EXPONENT)
+        return d_mul_2exp_inrange(x, i);
+    else
+        return ldexp(x, i);
+}
 
 #ifdef __cplusplus
 }

--- a/src/double_extras/test/main.c
+++ b/src/double_extras/test/main.c
@@ -17,6 +17,7 @@
 #include "t-is_nan.c"
 #include "t-lambertw.c"
 #include "t-log2.c"
+#include "t-mul_2exp.c"
 #include "t-randtest.c"
 #include "t-randtest_signed.c"
 
@@ -27,6 +28,7 @@ test_struct tests[] =
     TEST_FUNCTION(d_is_nan),
     TEST_FUNCTION(d_lambertw),
     TEST_FUNCTION(d_log2),
+    TEST_FUNCTION(d_mul_2exp),
     TEST_FUNCTION(d_randtest),
     TEST_FUNCTION(d_randtest_signed)
 };

--- a/src/double_extras/test/t-mul_2exp.c
+++ b/src/double_extras/test/t-mul_2exp.c
@@ -15,10 +15,25 @@
 #include "double_extras.h"
 #include "d_vec.h"
 
+static int
+_check_results(double res1, double res2)
+{
+    if (d_is_nan(res2))
+        return d_is_nan(res1);
+    else
+#if !defined(_MSC_VER)
+        return res1 == res2;
+#else
+        /* MSVC's ldexp doesn't give the same result as multiplying by 2^e
+           for subnormals, so relax the test */
+        return (res1 == res2) || fabs(res1 - res2) < 1e-300;
+#endif
+}
+
 TEST_FUNCTION_START(d_mul_2exp, state)
 {
     double x, res1, res2;
-    int e, ok;
+    int e;
     slong iter;
 
     for (iter = 0; iter < 10000 * flint_test_multiplier(); iter++)
@@ -29,12 +44,7 @@ TEST_FUNCTION_START(d_mul_2exp, state)
         res1 = d_mul_2exp(x, e);
         res2 = ldexp(x, e);
 
-        if (d_is_nan(res2))
-            ok = d_is_nan(res1);
-        else
-            ok = res1 == res2;
-
-        if (!ok)
+        if (!_check_results(res1, res2))
             TEST_FUNCTION_FAIL("x = %.20g\n res1 = %.20g\n res2 = %.20g\n", x, res1, res2);
     }
 
@@ -48,9 +58,7 @@ TEST_FUNCTION_START(d_mul_2exp, state)
         res1 = d_mul_2exp_inrange2(x, e);
         res2 = ldexp(x, e);
 
-        ok = res1 == res2;
-
-        if (!ok)
+        if (!(res1 == res2))
             TEST_FUNCTION_FAIL("x = %.20g\n res1 = %.20g\n res2 = %.20g\n", x, res1, res2);
     }
 
@@ -62,12 +70,7 @@ TEST_FUNCTION_START(d_mul_2exp, state)
         res1 = d_mul_2exp_inrange(x, e);
         res2 = ldexp(x, e);
 
-        if (d_is_nan(res2))
-            ok = d_is_nan(res1);
-        else
-            ok = res1 == res2;
-
-        if (!ok)
+        if (!_check_results(res1, res2))
             TEST_FUNCTION_FAIL("x = %.20g\n res1 = %.20g\n res2 = %.20g\n", x, res1, res2);
     }
 
@@ -89,12 +92,7 @@ TEST_FUNCTION_START(d_mul_2exp, state)
             res1 = r[i];
             res2 = ldexp(v[i], e);
 
-            if (d_is_nan(res2))
-                ok = d_is_nan(res1);
-            else
-                ok = res1 == res2;
-
-            if (!ok)
+            if (!_check_results(res1, res2))
                 TEST_FUNCTION_FAIL("x = %.20g\n res1 = %.20g\n res2 = %.20g\n", x, res1, res2);
         }
     }

--- a/src/double_extras/test/t-mul_2exp.c
+++ b/src/double_extras/test/t-mul_2exp.c
@@ -1,0 +1,103 @@
+/*
+    Copyright (C) 2024 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include <float.h>
+#include "ulong_extras.h"
+#include "double_extras.h"
+#include "d_vec.h"
+
+TEST_FUNCTION_START(d_mul_2exp, state)
+{
+    double x, res1, res2;
+    int e, ok;
+    slong iter;
+
+    for (iter = 0; iter < 10000 * flint_test_multiplier(); iter++)
+    {
+        x = d_randtest_special(state, -1024, 1024);
+        e = n_randint(state, 3000) - 1500;
+
+        res1 = d_mul_2exp(x, e);
+        res2 = ldexp(x, e);
+
+        if (d_is_nan(res2))
+            ok = d_is_nan(res1);
+        else
+            ok = res1 == res2;
+
+        if (!ok)
+            TEST_FUNCTION_FAIL("x = %.20g\n res1 = %.20g\n res2 = %.20g\n", x, res1, res2);
+    }
+
+    for (iter = 0; iter < 10000 * flint_test_multiplier(); iter++)
+    {
+        do {
+            x = d_randtest_signed(state, -256, 256);
+        } while (x == 0.0);
+        e = n_randint(state, 512) - 256;
+
+        res1 = d_mul_2exp_inrange2(x, e);
+        res2 = ldexp(x, e);
+
+        ok = res1 == res2;
+
+        if (!ok)
+            TEST_FUNCTION_FAIL("x = %.20g\n res1 = %.20g\n res2 = %.20g\n", x, res1, res2);
+    }
+
+    for (iter = 0; iter < 10000 * flint_test_multiplier(); iter++)
+    {
+        x = d_randtest_special(state, -1024, 1024);
+        e = n_randint(state, D_MAX_NORMAL_EXPONENT - D_MIN_NORMAL_EXPONENT + 1) + D_MIN_NORMAL_EXPONENT;
+
+        res1 = d_mul_2exp_inrange(x, e);
+        res2 = ldexp(x, e);
+
+        if (d_is_nan(res2))
+            ok = d_is_nan(res1);
+        else
+            ok = res1 == res2;
+
+        if (!ok)
+            TEST_FUNCTION_FAIL("x = %.20g\n res1 = %.20g\n res2 = %.20g\n", x, res1, res2);
+    }
+
+    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
+    {
+        double v[5] = { 0, 0, 0, 0, 0 };
+        double r[10] = { 0, 0, 0, 0, 0 };
+        slong i, n = n_randint(state, 5);
+
+        for (i = 0; i < n; i++)
+            x = d_randtest_special(state, -1024, 1024);
+
+        e = n_randint(state, 3000) - 1500;
+
+        _d_vec_mul_2exp(r, v, n, e);
+
+        for (i = 0; i < n; i++)
+        {
+            res1 = r[i];
+            res2 = ldexp(v[i], e);
+
+            if (d_is_nan(res2))
+                ok = d_is_nan(res1);
+            else
+                ok = res1 == res2;
+
+            if (!ok)
+                TEST_FUNCTION_FAIL("x = %.20g\n res1 = %.20g\n res2 = %.20g\n", x, res1, res2);
+        }
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/fmpz/set.c
+++ b/src/fmpz/set.c
@@ -13,6 +13,7 @@
 */
 
 #include <math.h>
+#include "double_extras.h"
 #include "gmpcompat.h"
 #include "fmpz.h"
 
@@ -32,23 +33,6 @@ fmpz_set(fmpz_t f, const fmpz_t g)
         __mpz_struct * mf = _fmpz_promote(f);
         mpz_set(mf, COEFF_TO_PTR(*g));
     }
-}
-
-void fmpz_set_d_2exp(fmpz_t f, double m, slong exp)
-{
-   int exp2;
-
-   m = frexp(m, &exp2);
-   exp += exp2;
-
-   if (exp >= 53)
-   {
-      fmpz_set_d(f, ldexp(m, 53));
-      fmpz_mul_2exp(f, f, exp - 53);
-   } else if (exp < 0)
-      fmpz_set_ui(f, 0);
-   else
-      fmpz_set_d(f, ldexp(m, exp));
 }
 
 #if FLINT64   /* 2^53 */
@@ -74,6 +58,23 @@ fmpz_set_d(fmpz_t f, double c)
         mpz_set_d(z, c);
         _fmpz_demote_val(f);
     }
+}
+
+void fmpz_set_d_2exp(fmpz_t f, double m, slong exp)
+{
+   int exp2;
+
+   m = frexp(m, &exp2);
+   exp += exp2;
+
+   if (exp >= 53)
+   {
+      fmpz_set_d(f, m * ldexp(1.0, 53));
+      fmpz_mul_2exp(f, f, exp - 53);
+   } else if (exp < 0)
+      fmpz_set_ui(f, 0);
+   else
+      fmpz_set_d(f, d_mul_2exp_inrange(m, exp));
 }
 
 void

--- a/src/fmpz_lll/babai.c
+++ b/src/fmpz_lll/babai.c
@@ -110,7 +110,7 @@ FUNC_HEAD
             {
                 /* test of the relaxed size-reduction condition */
                 tmp = fabs(d_mat_entry(mu, kappa, j));
-                tmp = ldexp(tmp, expo[kappa] - expo[j]);
+                tmp = d_mul_2exp(tmp, expo[kappa] - expo[j]);
 
                 if (tmp > halfplus)
                 {
@@ -124,7 +124,7 @@ FUNC_HEAD
                         {
                             for (k = zeros + 1; k < j; k++)
                             {
-                                tmp = ldexp(d_mat_entry(mu, j, k), exponent);
+                                tmp = d_mul_2exp(d_mat_entry(mu, j, k), exponent);
                                 d_mat_entry(mu, kappa, k) =
                                     d_mat_entry(mu, kappa, k) - tmp;
                             }
@@ -141,7 +141,7 @@ FUNC_HEAD
                         {
                             for (k = zeros + 1; k < j; k++)
                             {
-                                tmp = ldexp(d_mat_entry(mu, j, k), exponent);
+                                tmp = d_mul_2exp(d_mat_entry(mu, j, k), exponent);
                                 d_mat_entry(mu, kappa, k) =
                                     d_mat_entry(mu, kappa, k) + tmp;
                             }
@@ -157,7 +157,7 @@ FUNC_HEAD
                     }
                     else        /* we must have |X| >= 2 */
                     {
-                        tmp = ldexp(d_mat_entry(mu, kappa, j), -exponent);
+                        tmp = d_mul_2exp(d_mat_entry(mu, kappa, j), -exponent);
                         if ((tmp < (double) FMPZ_LLL_MAX_LONG)
                             && (tmp > (double) -FMPZ_LLL_MAX_LONG))
                         {
@@ -169,7 +169,7 @@ FUNC_HEAD
                             for (k = zeros + 1; k < j; k++)
                             {
                                 rtmp = tmp * d_mat_entry(mu, j, k);
-                                rtmp = ldexp(rtmp, exponent);
+                                rtmp = d_mul_2exp(rtmp, exponent);
                                 d_mat_entry(mu, kappa, k) =
                                     d_mat_entry(mu, kappa, k) - rtmp;
                             }
@@ -214,7 +214,7 @@ FUNC_HEAD
                                 {
                                     rtmp =
                                         ((double) xx) * d_mat_entry(mu, j, k);
-                                    rtmp = ldexp(rtmp, expo[j] - expo[kappa]);
+                                    rtmp = d_mul_2exp(rtmp, expo[j] - expo[kappa]);
                                     d_mat_entry(mu, kappa, k) =
                                         d_mat_entry(mu, kappa, k) - rtmp;
                                 }
@@ -242,7 +242,7 @@ FUNC_HEAD
                                     rtmp =
                                         ((double) xx) * d_mat_entry(mu, j, k);
                                     rtmp =
-                                        ldexp(rtmp,
+                                        d_mul_2exp(rtmp,
                                               exponent + expo[j] -
                                               expo[kappa]);
                                     d_mat_entry(mu, kappa, k) =
@@ -325,25 +325,25 @@ FUNC_HEAD
                 if (j > zeros + 2)
                 {
                     tmp =
-                        ldexp(d_mat_entry(mu, j, zeros + 1) * d_mat_entry(r,
+                        d_mul_2exp(d_mat_entry(mu, j, zeros + 1) * d_mat_entry(r,
                                                                           kappa,
                                                                           zeros
                                                                           + 1),
                               (expo[j] - expo[zeros + 1]));
                     rtmp = fmpz_get_d_2exp(&exp, fmpz_mat_entry(GM, kappa, j));
-                    rtmp = ldexp(rtmp, (exp - expo[kappa])) - tmp;
+                    rtmp = d_mul_2exp(rtmp, (exp - expo[kappa])) - tmp;
 
                     for (k = zeros + 2; k < j - 1; k++)
                     {
                         tmp =
-                            ldexp(d_mat_entry(mu, j, k) *
+                            d_mul_2exp(d_mat_entry(mu, j, k) *
                                   d_mat_entry(r, kappa, k),
                                   (expo[j] - expo[k]));
                         rtmp = rtmp - tmp;
                     }
 
                     tmp =
-                        ldexp(d_mat_entry(mu, j, j - 1) * d_mat_entry(r, kappa,
+                        d_mul_2exp(d_mat_entry(mu, j, j - 1) * d_mat_entry(r, kappa,
                                                                       j - 1),
                               (expo[j] - expo[j - 1]));
                     d_mat_entry(r, kappa, j) = rtmp - tmp;
@@ -351,7 +351,7 @@ FUNC_HEAD
                 else if (j == zeros + 2)
                 {
                     tmp =
-                        ldexp(d_mat_entry(mu, j, zeros + 1) * d_mat_entry(r,
+                        d_mul_2exp(d_mat_entry(mu, j, zeros + 1) * d_mat_entry(r,
                                                                           kappa,
                                                                           zeros
                                                                           + 1),
@@ -359,7 +359,7 @@ FUNC_HEAD
                     d_mat_entry(r, kappa, j) =
                         fmpz_get_d_2exp(&exp, fmpz_mat_entry(GM, kappa, j));
                     d_mat_entry(r, kappa, j) =
-                        ldexp(d_mat_entry(r, kappa, j),
+                        d_mul_2exp(d_mat_entry(r, kappa, j),
                               (exp - expo[kappa])) - tmp;
                 }
                 else
@@ -367,7 +367,7 @@ FUNC_HEAD
                     d_mat_entry(r, kappa, j) =
                         fmpz_get_d_2exp(&exp, fmpz_mat_entry(GM, kappa, j));
                     d_mat_entry(r, kappa, j) =
-                        ldexp(d_mat_entry(r, kappa, j), (exp - expo[kappa]));
+                        d_mul_2exp(d_mat_entry(r, kappa, j), (exp - expo[kappa]));
                 }
 
                 d_mat_entry(mu, kappa, j) =
@@ -401,7 +401,7 @@ FUNC_HEAD
             {
                 /* test of the relaxed size-reduction condition */
                 tmp = fabs(d_mat_entry(mu, kappa, j));
-                tmp = ldexp(tmp, expo[kappa] - expo[j]);
+                tmp = d_mul_2exp(tmp, expo[kappa] - expo[j]);
 
                 if (tmp > halfplus)
                 {
@@ -416,7 +416,7 @@ FUNC_HEAD
                             fmpz_set_ui(x + j - zeros - 1, 1);
                             for (k = zeros + 1; k < j; k++)
                             {
-                                tmp = ldexp(d_mat_entry(mu, j, k), exponent);
+                                tmp = d_mul_2exp(d_mat_entry(mu, j, k), exponent);
                                 d_mat_entry(mu, kappa, k) =
                                     d_mat_entry(mu, kappa, k) - tmp;
                             }
@@ -437,7 +437,7 @@ FUNC_HEAD
                             fmpz_set_si(x + j - zeros - 1, -WORD(1));
                             for (k = zeros + 1; k < j; k++)
                             {
-                                tmp = ldexp(d_mat_entry(mu, j, k), exponent);
+                                tmp = d_mul_2exp(d_mat_entry(mu, j, k), exponent);
                                 d_mat_entry(mu, kappa, k) =
                                     d_mat_entry(mu, kappa, k) + tmp;
                             }
@@ -456,7 +456,7 @@ FUNC_HEAD
                     }
                     else        /* we must have |X| >= 2 */
                     {
-                        tmp = ldexp(d_mat_entry(mu, kappa, j), -exponent);
+                        tmp = d_mul_2exp(d_mat_entry(mu, kappa, j), -exponent);
                         if ((tmp < (double) FMPZ_LLL_MAX_LONG)
                             && (tmp > (double) -FMPZ_LLL_MAX_LONG))
                         {
@@ -468,7 +468,7 @@ FUNC_HEAD
                             for (k = zeros + 1; k < j; k++)
                             {
                                 rtmp = tmp * d_mat_entry(mu, j, k);
-                                rtmp = ldexp(rtmp, exponent);
+                                rtmp = d_mul_2exp(rtmp, exponent);
                                 d_mat_entry(mu, kappa, k) =
                                     d_mat_entry(mu, kappa, k) - rtmp;
                             }
@@ -523,7 +523,7 @@ FUNC_HEAD
                                 {
                                     rtmp =
                                         ((double) xx) * d_mat_entry(mu, j, k);
-                                    rtmp = ldexp(rtmp, expo[j] - expo[kappa]);
+                                    rtmp = d_mul_2exp(rtmp, expo[j] - expo[kappa]);
                                     d_mat_entry(mu, kappa, k) =
                                         d_mat_entry(mu, kappa, k) - rtmp;
                                 }
@@ -557,7 +557,7 @@ FUNC_HEAD
                                     rtmp =
                                         ((double) xx) * d_mat_entry(mu, j, k);
                                     rtmp =
-                                        ldexp(rtmp,
+                                        d_mul_2exp(rtmp,
                                               exponent + expo[j] -
                                               expo[kappa]);
                                     d_mat_entry(mu, kappa, k) =
@@ -620,12 +620,12 @@ FUNC_HEAD
         } while (test);
 
         s[zeros + 1] = fmpz_get_d_2exp(&exp, fmpz_mat_entry(GM, kappa, kappa));
-        s[zeros + 1] = ldexp(s[zeros + 1], exp - expo[kappa]);
+        s[zeros + 1] = d_mul_2exp(s[zeros + 1], exp - expo[kappa]);
 
         for (k = zeros + 1; k < kappa - 1; k++)
         {
             tmp =
-                ldexp(d_mat_entry(mu, kappa, k) * d_mat_entry(r, kappa, k),
+                d_mul_2exp(d_mat_entry(mu, kappa, k) * d_mat_entry(r, kappa, k),
                       (expo[kappa] - expo[k]));
             s[k + 1] = s[k] - tmp;
         }

--- a/src/fmpz_lll/d_lll.c
+++ b/src/fmpz_lll/d_lll.c
@@ -201,7 +201,7 @@ FUNC_HEAD
             /* ************************************ */
 
             tmp = d_mat_entry(r, kappa - 1, kappa - 1) * ctt;
-            tmp = ldexp(tmp, 2 * (expo[kappa - 1] - expo[kappa]));
+            tmp = d_mul_2exp(tmp, 2 * (expo[kappa - 1] - expo[kappa]));
 
             if (tmp <= s[kappa - 1])
             {
@@ -248,7 +248,7 @@ FUNC_HEAD
                     if (kappa > zeros + 1)
                     {
                         tmp = d_mat_entry(r, kappa - 1, kappa - 1) * ctt;
-                        tmp = ldexp(tmp, 2 * (expo[kappa - 1] - expo[kappa2]));
+                        tmp = d_mul_2exp(tmp, 2 * (expo[kappa - 1] - expo[kappa2]));
                     }
                 } while ((kappa >= zeros + 2) && (s[kappa - 1] <= tmp));
 
@@ -469,7 +469,7 @@ FUNC_HEAD
         {
             d_mat_entry(r, i, i) =
                 fmpz_get_d_2exp(&exp, fmpz_mat_entry(GM, i, i));
-            d_mat_entry(r, i, i) = ldexp(d_mat_entry(r, i, i), exp - expo[i]);
+            d_mat_entry(r, i, i) = d_mul_2exp(d_mat_entry(r, i, i), exp - expo[i]);
         }
 
         for (i = zeros + 1; i < d; i++)
@@ -536,13 +536,13 @@ FUNC_HEAD
             /* ************************************ */
 
             tmp = d_mat_entry(r, kappa - 1, kappa - 1) * ctt;
-            tmp = ldexp(tmp, (expo[kappa - 1] - expo[kappa]));
+            tmp = d_mul_2exp(tmp, (expo[kappa - 1] - expo[kappa]));
 
             if (tmp <= s[kappa - 1])
             {
                 alpha[kappa] = kappa;
                 tmp =
-                    ldexp(d_mat_entry(mu, kappa, kappa - 1) * d_mat_entry(r,
+                    d_mul_2exp(d_mat_entry(mu, kappa, kappa - 1) * d_mat_entry(r,
                                                                           kappa,
                                                                           kappa
                                                                           - 1),
@@ -564,13 +564,13 @@ FUNC_HEAD
                 {
                     fmpz_init(rii);
                     tmp =
-                        ldexp(2 * d_mat_entry(mu, kappa,
+                        d_mul_2exp(2 * d_mat_entry(mu, kappa,
                                               kappa - 1) * d_mat_entry(r,
                                                                        kappa,
                                                                        kappa -
                                                                        1),
                               (expo[kappa] - expo[kappa - 1]));
-                    fmpz_set_d(rii, ldexp(s[kappa - 1] - tmp, expo[kappa]));    /* using a heuristic lower bound on the final GS norm */
+                    fmpz_set_d(rii, d_mul_2exp(s[kappa - 1] - tmp, expo[kappa]));    /* using a heuristic lower bound on the final GS norm */
                     if (fmpz_cmp(rii, gs_B) > 0)
                     {
                         d--;
@@ -588,7 +588,7 @@ FUNC_HEAD
                     if (kappa > zeros + 1)
                     {
                         tmp = d_mat_entry(r, kappa - 1, kappa - 1) * ctt;
-                        tmp = ldexp(tmp, (expo[kappa - 1] - expo[kappa2]));
+                        tmp = d_mul_2exp(tmp, (expo[kappa - 1] - expo[kappa2]));
                     }
                 } while ((kappa >= zeros + 2) && (s[kappa - 1] <= tmp));
 
@@ -679,7 +679,7 @@ FUNC_HEAD
                         fmpz_get_d_2exp(&exp, fmpz_mat_entry
                                         (GM, kappa, kappa));
                     d_mat_entry(r, kappa, kappa) =
-                        ldexp(d_mat_entry(r, kappa, kappa), exp - expo[kappa]);
+                        d_mul_2exp(d_mat_entry(r, kappa, kappa), exp - expo[kappa]);
                 }
 
                 kappa++;
@@ -709,7 +709,7 @@ FUNC_HEAD
             for (i = d - 1; (i >= 0) && (ok > 0); i--)
             {
                 /* rii is the G-S length of ith vector divided by 2 */
-                fmpz_set_d(rii, ldexp(d_mat_entry(r, i, i), expo[i] - 1));
+                fmpz_set_d(rii, d_mul_2exp(d_mat_entry(r, i, i), expo[i] - 1));
                 if ((ok = fmpz_cmp(rii, gs_B)) > 0)
                 {
                     newd--;

--- a/src/fmpz_lll/heuristic_dot.c
+++ b/src/fmpz_lll/heuristic_dot.c
@@ -30,7 +30,7 @@ fmpz_lll_heuristic_dot(const double *vec1, const double *vec2, slong len2,
    double tmp = _d_vec_norm(vec1, len2);
    double tmp2 = _d_vec_norm(vec2, len2);
 
-   tmp = ldexp(tmp*tmp2, -70);
+   tmp = tmp*tmp2 * ldexp(1.0, -70);
    tmp2 = sum*sum;
 
    if (tmp2 <= tmp)

--- a/src/fmpz_poly/evaluate_horner_d_2exp.c
+++ b/src/fmpz_poly/evaluate_horner_d_2exp.c
@@ -1,6 +1,6 @@
 /*
     Copyright (C) 2016 William Hart
-    Copyright (C) 2021 Fredrik Johansson
+    Copyright (C) 2021, 2024 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -11,6 +11,7 @@
 */
 
 #include <math.h>
+#include <double_extras.h>
 #include "fmpz.h"
 #include "fmpz_poly.h"
 
@@ -73,7 +74,7 @@ dpe_add(dpe_t x, dpe_t y)
         if (d > 53 + ADJUSTMENT_DELAY)
             return x;
 
-        res.m = x.m + ldexp(y.m, -d);
+        res.m = x.m + d_mul_2exp_inrange(y.m, -d);
         res.e = x.e;
     }
     else
@@ -83,7 +84,7 @@ dpe_add(dpe_t x, dpe_t y)
         if (d > 53 + ADJUSTMENT_DELAY)
             return y;
 
-        res.m = y.m + ldexp(x.m, -d);
+        res.m = y.m + d_mul_2exp_inrange(x.m, -d);
         res.e = y.e;
     }
 

--- a/src/fmpz_vec/get_d_vec_2exp.c
+++ b/src/fmpz_vec/get_d_vec_2exp.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Fredrik Johansson
+    Copyright (C) 2011, 2024 Fredrik Johansson
     Copyright (C) 2014 Abhinav Baid
 
     This file is part of FLINT.
@@ -12,18 +12,16 @@
 
 #include "fmpz.h"
 #include "fmpz_vec.h"
-
-#ifdef __GNUC__
-# define ldexp __builtin_ldexp
-#else
-# include <math.h>
-#endif
+#include "double_extras.h"
 
 slong
 _fmpz_vec_get_d_vec_2exp(double *appv, const fmpz * vec, slong len)
 {
     slong *exp, i, maxexp = 0L;
-    exp = (slong *) flint_malloc(len * sizeof(slong));
+    TMP_INIT;
+
+    TMP_START;
+    exp = TMP_ALLOC(len * sizeof(slong));
 
     for (i = 0; i < len; i++)
     {
@@ -33,8 +31,8 @@ _fmpz_vec_get_d_vec_2exp(double *appv, const fmpz * vec, slong len)
     }
 
     for (i = 0; i < len; i++)
-        appv[i] = ldexp(appv[i], exp[i] - maxexp);
+        appv[i] = d_mul_2exp(appv[i], exp[i] - maxexp);
 
-    flint_free(exp);
+    TMP_END;
     return maxexp;
 }

--- a/src/fmpzi/divexact.c
+++ b/src/fmpzi/divexact.c
@@ -10,6 +10,7 @@
 */
 
 #include <math.h>
+#include "double_extras.h"
 #include "fmpzi.h"
 
 static void
@@ -107,10 +108,10 @@ fmpzi_divexact(fmpzi_t q, const fmpzi_t x, const fmpzi_t y)
             c = fmpz_get_d_2exp(&cexp, fmpzi_realref(y));
             d = fmpz_get_d_2exp(&dexp, fmpzi_imagref(y));
 
-            a = ldexp(a, FLINT_MAX(aexp - xbits, -1024));
-            b = ldexp(b, FLINT_MAX(bexp - xbits, -1024));
-            c = ldexp(c, FLINT_MAX(cexp - xbits, -1024));
-            d = ldexp(d, FLINT_MAX(dexp - xbits, -1024));
+            a = d_mul_2exp(a, FLINT_MAX(aexp - xbits, -1024));
+            b = d_mul_2exp(b, FLINT_MAX(bexp - xbits, -1024));
+            c = d_mul_2exp(c, FLINT_MAX(cexp - xbits, -1024));
+            d = d_mul_2exp(d, FLINT_MAX(dexp - xbits, -1024));
         }
 
         t = a * c + b * d;

--- a/src/fmpzi/divrem_approx.c
+++ b/src/fmpzi/divrem_approx.c
@@ -10,6 +10,7 @@
 */
 
 #include <math.h>
+#include "double_extras.h"
 #include "fmpzi.h"
 
 void
@@ -60,10 +61,10 @@ fmpzi_divrem_approx(fmpzi_t q, fmpzi_t r, const fmpzi_t x, const fmpzi_t y)
             c = fmpz_get_d_2exp(&cexp, fmpzi_realref(y));
             d = fmpz_get_d_2exp(&dexp, fmpzi_imagref(y));
 
-            a = ldexp(a, FLINT_MAX(aexp - xbits, -1024));
-            b = ldexp(b, FLINT_MAX(bexp - xbits, -1024));
-            c = ldexp(c, FLINT_MAX(cexp - xbits, -1024));
-            d = ldexp(d, FLINT_MAX(dexp - xbits, -1024));
+            a = d_mul_2exp(a, FLINT_MAX(aexp - xbits, -1024));
+            b = d_mul_2exp(b, FLINT_MAX(bexp - xbits, -1024));
+            c = d_mul_2exp(c, FLINT_MAX(cexp - xbits, -1024));
+            d = d_mul_2exp(d, FLINT_MAX(dexp - xbits, -1024));
         }
 
         t = a * c + b * d;

--- a/src/fmpzi/gcd_binary.c
+++ b/src/fmpzi/gcd_binary.c
@@ -10,6 +10,7 @@
 */
 
 #include <math.h>
+#include "double_extras.h"
 #include "fmpzi.h"
 
 double
@@ -27,14 +28,14 @@ fmpzi_norm_approx_d_2exp(slong * exp, const fmpzi_t x)
         if (aexp >= bexp + 64)
             b = 0.0;
         else
-            b = ldexp(b, aexp - bexp);
+            b = d_mul_2exp(b, aexp - bexp);
     }
     else
     {
         if (bexp >= aexp + 64)
             a = 0.0;
         else
-            a = ldexp(a, bexp - aexp);
+            a = d_mul_2exp(a, bexp - aexp);
     }
 
     a = a * a + b * b;

--- a/src/mag/get_d.c
+++ b/src/mag/get_d.c
@@ -32,6 +32,6 @@ mag_get_d(const mag_t z)
     }
     else
     {
-        return ldexp(MAG_MAN(z), MAG_EXP(z) - MAG_BITS);
+        return d_mul_2exp(MAG_MAN(z), MAG_EXP(z) - MAG_BITS);
     }
 }


### PR DESCRIPTION
``ldexp(x, e)`` generates a slow standard library call if ``x`` and ``e`` aren't constants, so it should be avoided in performance-critical places. When the exponents are in range, it is a lot faster to generate ``2^e`` with some bit fiddling and just do an inline multiply.

This removes some more bottlenecks in the polynomial factorisation code. Old timings:

```
$ build/examples/huge_expr -ca
...
Total: cpu/wall(s): 2.312 2.313
virt/peak/res/peak(MB): 58.82 58.82 52.32 52.32

$ build/fmpz_poly_factor/profile/p-factor_hard

P1 has 36 factors: 15 ms
P2 has 12 factors: 29 ms
P3 has 16 factors: 22 ms
P4 has 2 factors: 190 ms
P5 has 1 factors: 8 ms
P6 has 6 factors: 11 ms
P7 has 1 factors: 426 ms
P8 has 1 factors: 127 ms
M12_5 has 1 factors: 423 ms
M12_6 has 2 factors: 5342 ms
T1 has 2 factors: 105 ms
T2 has 2 factors: 114 ms
T3 has 4 factors: 2268 ms
H1 has 28 factors: 2072 ms
S7 has 1 factors: 147 ms
S8 has 1 factors: 1684 ms
C1 has 32 factors: 586 ms
```

New timings:

```
$ build/examples/huge_expr -ca
...
Total: cpu/wall(s): 2.17 2.17
virt/peak/res/peak(MB): 58.82 58.82 52.08 52.08

$ build/fmpz_poly_factor/profile/p-factor_hard 

P1 has 36 factors: 14 ms
P2 has 12 factors: 30 ms
P3 has 16 factors: 23 ms
P4 has 2 factors: 159 ms
P5 has 1 factors: 7 ms
P6 has 6 factors: 10 ms
P7 has 1 factors: 384 ms
P8 has 1 factors: 120 ms
M12_5 has 1 factors: 379 ms
M12_6 has 2 factors: 4990 ms
T1 has 2 factors: 103 ms
T2 has 2 factors: 110 ms
T3 has 4 factors: 1934 ms
H1 has 28 factors: 1943 ms
S7 has 1 factors: 135 ms
S8 has 1 factors: 1473 ms
C1 has 32 factors: 559 ms
```