### PR TITLE
Refactor fq_default to use gr generics

### DIFF
--- a/doc/source/fq_default.rst
+++ b/doc/source/fq_default.rst
@@ -78,6 +78,11 @@ Context Management
     Returns `1` if the context contains an ``fq_zech`` context, `2` if it
     contains an ``fq_mod`` context and `3` if it contains an ``fq`` context.
 
+.. function:: void * fq_default_ctx_inner(const fq_default_ctx_t ctx)
+
+    Returns a pointer to the internal context object of type
+    ``fq_ctx_t``, ``fq_zech_ctx_t``, ``fmpz_mod_ctx_t``, etc.
+
 .. function:: slong fq_default_ctx_degree(const fq_default_ctx_t ctx)
 
     Returns the degree of the field extension

--- a/doc/source/gr_domains.rst
+++ b/doc/source/gr_domains.rst
@@ -121,9 +121,11 @@ Base rings and fields
     of integers modulo *n* where
     elements have type :type:`fmpz`. The modulus must be positive.
 
-.. function:: void gr_ctx_fmpz_mod_set_primality(gr_ctx_t ctx, truth_t is_prime)
+.. function:: void gr_ctx_nmod_set_primality(gr_ctx_t ctx, truth_t is_prime)
+              void gr_ctx_fmpz_mod_set_primality(gr_ctx_t ctx, truth_t is_prime)
 
-    For a ring initialized with :func:`gr_ctx_init_fmpz_mod`,
+    For a ring initialized with :func:`gr_ctx_init_nmod`
+    or :func:`gr_ctx_init_fmpz_mod` respectively,
     indicate whether the modulus is prime. This can speed up
     some computations.
 

--- a/src/fq_default.h
+++ b/src/fq_default.h
@@ -27,6 +27,7 @@
 #include "fq.h"
 #include "fq_nmod.h"
 #include "fq_zech.h"
+#include "gr.h"
 
 #define FQ_DEFAULT_FQ_ZECH  1
 #define FQ_DEFAULT_FQ_NMOD  2
@@ -53,6 +54,8 @@ typedef fq_default_struct fq_default_t[1];
 
 typedef struct
 {
+    gr_ctx_t gr_ctx;
+    int _gr_inited;
     int type;
     union ctx
     {
@@ -72,46 +75,54 @@ typedef struct
 
 typedef fq_default_ctx_struct fq_default_ctx_t[1];
 
-FQ_DEFAULT_INLINE void fq_default_ctx_init_type(fq_default_ctx_t ctx,
-                            const fmpz_t p, slong d, const char *var, int type)
-{
-    int bits = fmpz_bits(p);
+#define FQ_DEFAULT_TYPE(ctx) ((ctx)->type)
+#define FQ_DEFAULT_GR_CTX(ctx) ((gr_ctx_struct *) ((ctx)->gr_ctx))
 
-    if (type == FQ_DEFAULT_FQ_ZECH || (type == 0 && d > 1 && bits*d <= 16))
-    {
-        ctx->type = FQ_DEFAULT_FQ_ZECH;
-        fq_zech_ctx_init_ui(ctx->ctx.fq_zech, *p, d, var);
-    }
-    else if (type == FQ_DEFAULT_FQ_NMOD || (type == 0 && d > 1 && fmpz_abs_fits_ui(p)))
-    {
-        ctx->type = FQ_DEFAULT_FQ_NMOD;
-        fq_nmod_ctx_init_ui(ctx->ctx.fq_nmod, *p, d, var);
-    }
-    else if (type == FQ_DEFAULT_NMOD || (type == 0 && d == 1 && fmpz_abs_fits_ui(p)))
-    {
-        ctx->type = FQ_DEFAULT_NMOD;
-        nmod_init(&ctx->ctx.nmod.mod, fmpz_get_ui(p));
-        ctx->ctx.nmod.a = 0;
-    }
-    else if (type == FQ_DEFAULT_FMPZ_MOD || (type == 0 && d == 1))
-    {
-        ctx->type = FQ_DEFAULT_FMPZ_MOD;
-        fmpz_mod_ctx_init(ctx->ctx.fmpz_mod.mod, p);
-        fmpz_init_set_ui(ctx->ctx.fmpz_mod.a, 0);
-    }
-    else
-    {
-        ctx->type = FQ_DEFAULT_FQ;
-        fq_ctx_init(ctx->ctx.fq, p, d, var);
-    }
+#define FQ_DEFAULT_CTX_FQ_OLD(ctx) ((ctx)->ctx.fq)
+#define FQ_DEFAULT_CTX_FQ(ctx) ((fq_ctx_struct *) GR_CTX_DATA_AS_PTR(FQ_DEFAULT_GR_CTX(ctx)))
+
+#define FQ_DEFAULT_CTX_FQ_ZECH_OLD(ctx) ((ctx)->ctx.fq_zech)
+#define FQ_DEFAULT_CTX_FQ_ZECH(ctx) ((fq_zech_ctx_struct *) GR_CTX_DATA_AS_PTR(FQ_DEFAULT_GR_CTX(ctx)))
+
+#define FQ_DEFAULT_CTX_FQ_NMOD_OLD(ctx) ((ctx)->ctx.fq_nmod)
+#define FQ_DEFAULT_CTX_FQ_NMOD(ctx) ((fq_nmod_ctx_struct *) GR_CTX_DATA_AS_PTR(FQ_DEFAULT_GR_CTX(ctx)))
+
+#define FQ_DEFAULT_CTX_NMOD_OLD(ctx) ((ctx)->ctx.nmod)
+#define FQ_DEFAULT_CTX_NMOD(ctx) ((nmod_t *) FQ_DEFAULT_GR_CTX(ctx))[0]
+
+#define FQ_DEFAULT_CTX_FMPZ_MOD_OLD(ctx) ((ctx)->ctx.fmpz_mod)
+#define FQ_DEFAULT_CTX_FMPZ_MOD(ctx) ((fmpz_mod_ctx_struct *) GR_CTX_DATA_AS_PTR(FQ_DEFAULT_GR_CTX(ctx)))
+
+typedef struct
+{
+    fmpz_mod_ctx_struct * ctx;
+    truth_t is_prime;
+    fmpz a;    /* when used as finite field with defining polynomial x - a */
 }
+_gr_fmpz_mod_ctx_struct;
+
+typedef struct
+{
+    nmod_t nmod;
+    ulong a;   /* when used as finite field with defining polynomial x - a */
+}
+_gr_nmod_ctx_struct;
+
+#define NMOD_CTX_A(ring_ctx) (&((((_gr_nmod_ctx_struct *)(ring_ctx))->a)))
+#define FMPZ_MOD_CTX_A(ring_ctx) (&((((_gr_fmpz_mod_ctx_struct *)(ring_ctx))->a)))
+
+#define FQ_DEFAULT_CTX_NMOD_A(ctx) NMOD_CTX_A(ctx)
+#define FQ_DEFAULT_CTX_FMPZ_MOD_A(ctx) FMPZ_MOD_CTX_A(ctx)
+
+
+void fq_default_ctx_init_type(fq_default_ctx_t ctx,
+                            const fmpz_t p, slong d, const char *var, int type);
 
 FQ_DEFAULT_INLINE void fq_default_ctx_init(fq_default_ctx_t ctx,
                                       const fmpz_t p, slong d, const char *var)
 {
     fq_default_ctx_init_type(ctx, p, d, var, 0);
 }
-
 
 void fq_default_ctx_init_modulus_type(fq_default_ctx_t ctx,
                 const fmpz_mod_poly_t modulus, fmpz_mod_ctx_t mod_ctx,
@@ -130,79 +141,86 @@ void fq_default_ctx_init_modulus_nmod(fq_default_ctx_t ctx,
 
 FQ_DEFAULT_INLINE void fq_default_ctx_clear(fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+        if (!ctx->_gr_inited)
+            flint_abort();
+
+
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_ctx_clear(ctx->ctx.fq_zech);
+        fq_zech_ctx_clear(FQ_DEFAULT_CTX_FQ_ZECH_OLD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_ctx_clear(ctx->ctx.fq_nmod);
+        fq_nmod_ctx_clear(FQ_DEFAULT_CTX_FQ_NMOD_OLD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_ctx_clear(ctx->ctx.fmpz_mod.mod);
-        fmpz_clear(ctx->ctx.fmpz_mod.a);
+        fmpz_mod_ctx_clear(FQ_DEFAULT_CTX_FMPZ_MOD_OLD(ctx).mod);
+        fmpz_clear(FQ_DEFAULT_CTX_FMPZ_MOD_OLD(ctx).a);
     }
     else
     {
-        fq_ctx_clear(ctx->ctx.fq);
+        fq_ctx_clear(FQ_DEFAULT_CTX_FQ_OLD(ctx));
     }
+
+    if (ctx->_gr_inited)
+        gr_ctx_clear(FQ_DEFAULT_GR_CTX(ctx));
 }
 
 FQ_DEFAULT_INLINE int fq_default_ctx_type(const fq_default_ctx_t ctx)
 {
-    return ctx->type;
+    return FQ_DEFAULT_TYPE(ctx);
 }
 
 FQ_DEFAULT_INLINE slong fq_default_ctx_degree(const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_ctx_degree(ctx->ctx.fq_zech);
+        return fq_zech_ctx_degree(FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_ctx_degree(ctx->ctx.fq_nmod);
+        return fq_nmod_ctx_degree(FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
         return 1;
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
     {
         return 1;
     }
     else
     {
-        return fq_ctx_degree(ctx->ctx.fq);
+        return fq_ctx_degree(FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
 FQ_DEFAULT_INLINE void fq_default_ctx_prime(fmpz_t prime,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
-        fmpz_set_ui(prime, fq_zech_ctx_prime(ctx->ctx.fq_zech));
+        fmpz_set_ui(prime, fq_zech_ctx_prime(FQ_DEFAULT_CTX_FQ_ZECH(ctx)));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
-        fmpz_set_ui(prime, fq_nmod_ctx_prime(ctx->ctx.fq_nmod));
+        fmpz_set_ui(prime, fq_nmod_ctx_prime(FQ_DEFAULT_CTX_FQ_NMOD(ctx)));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
-        fmpz_set_ui(prime, ctx->ctx.nmod.mod.n);
+        fmpz_set_ui(prime, FQ_DEFAULT_CTX_NMOD(ctx).n);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_set(prime, fmpz_mod_ctx_modulus(ctx->ctx.fmpz_mod.mod));
+        fmpz_set(prime, fmpz_mod_ctx_modulus(FQ_DEFAULT_CTX_FMPZ_MOD(ctx)));
     }
     else
     {
-        fmpz_set(prime, fq_ctx_prime(ctx->ctx.fq));
+        fmpz_set(prime, fq_ctx_prime(FQ_DEFAULT_CTX_FQ(ctx)));
     }
 }
 
@@ -212,25 +230,25 @@ void fq_default_ctx_modulus(fmpz_mod_poly_t p,
 FQ_DEFAULT_INLINE void fq_default_ctx_order(fmpz_t f,
 		                                    const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
-        fmpz_set_ui(f, fq_zech_ctx_order_ui(ctx->ctx.fq_zech));
+        fmpz_set_ui(f, fq_zech_ctx_order_ui(FQ_DEFAULT_CTX_FQ_ZECH(ctx)));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_ctx_order(f, ctx->ctx.fq_nmod);
+        fq_nmod_ctx_order(f, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
-        fmpz_set_ui(f, ctx->ctx.nmod.mod.n);
+        fmpz_set_ui(f, FQ_DEFAULT_CTX_NMOD(ctx).n);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_set(f, fmpz_mod_ctx_modulus(ctx->ctx.fmpz_mod.mod));
+        fmpz_set(f, fmpz_mod_ctx_modulus(FQ_DEFAULT_CTX_FMPZ_MOD(ctx)));
     }
     else
     {
-        fq_ctx_order(f, ctx->ctx.fq);
+        fq_ctx_order(f, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -245,75 +263,38 @@ void fq_default_ctx_print(const fq_default_ctx_t ctx);
 FQ_DEFAULT_INLINE void fq_default_init(fq_default_t rop,
 		                                    const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
-    {
-        fq_zech_init(rop->fq_zech, ctx->ctx.fq_zech);
-    }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
-    {
-        fq_nmod_init(rop->fq_nmod, ctx->ctx.fq_nmod);
-    }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
-    {
-        rop->nmod = 0;
-    }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
-    {
-        fmpz_init(rop->fmpz_mod);
-    }
-    else
-    {
-        fq_init(rop->fq, ctx->ctx.fq);
-    }
+    gr_init(rop, FQ_DEFAULT_GR_CTX(ctx));
 }
 
 FQ_DEFAULT_INLINE void fq_default_init2(fq_default_t rop,
 		                                    const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_init2(rop->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_init2(rop->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_init2(rop->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_init2(rop->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
         rop->nmod = 0;
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_init(rop->fmpz_mod);
     }
     else
     {
-        fq_init2(rop->fq, ctx->ctx.fq);
+        fq_init2(rop->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
 FQ_DEFAULT_INLINE void fq_default_clear(fq_default_t rop,
 		                                    const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
-    {
-        fq_zech_clear(rop->fq_zech, ctx->ctx.fq_zech);
-    }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
-    {
-        fq_nmod_clear(rop->fq_nmod, ctx->ctx.fq_nmod);
-    }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
-    {
-    }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
-    {
-        fmpz_clear(rop->fmpz_mod);
-    }
-    else
-    {
-        fq_clear(rop->fq, ctx->ctx.fq);
-    }
+    gr_clear(rop, FQ_DEFAULT_GR_CTX(ctx));
 }
 
 /* Predicates ****************************************************************/
@@ -321,375 +302,110 @@ FQ_DEFAULT_INLINE void fq_default_clear(fq_default_t rop,
 FQ_DEFAULT_INLINE int fq_default_is_invertible(const fq_default_t op,
 		                                    const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_is_invertible(op->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_is_invertible(op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_is_invertible(op->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_is_invertible(op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
         return op->nmod != 0;
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
     {
         return !fmpz_is_zero(op->fmpz_mod);
     }
     else
     {
-        return fq_is_invertible(op->fq, ctx->ctx.fq);
+        return fq_is_invertible(op->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
 /* Basic arithmetic **********************************************************/
 
+/* GR_IGNORE(...) because we assume that basic arithmetic is well-implemented */
+
 FQ_DEFAULT_INLINE void fq_default_add(fq_default_t rop, const fq_default_t op1,
 		            const fq_default_t op2, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
-    {
-        fq_zech_add(rop->fq_zech, op1->fq_zech, op2->fq_zech, ctx->ctx.fq_zech);
-    }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
-    {
-        fq_nmod_add(rop->fq_nmod, op1->fq_nmod, op2->fq_nmod, ctx->ctx.fq_nmod);
-    }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
-    {
-        rop->nmod = nmod_add(op1->nmod, op2->nmod, ctx->ctx.nmod.mod);
-    }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
-    {
-        fmpz_mod_add(rop->fmpz_mod, op1->fmpz_mod, op2->fmpz_mod,
-                                                        ctx->ctx.fmpz_mod.mod);
-    }
-    else
-    {
-        fq_add(rop->fq, op1->fq, op2->fq, ctx->ctx.fq);
-    }
+    GR_IGNORE(gr_add(rop, op1, op2, FQ_DEFAULT_GR_CTX(ctx)));
 }
 
 FQ_DEFAULT_INLINE void fq_default_sub(fq_default_t rop, const fq_default_t op1,
 		            const fq_default_t op2, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
-    {
-        fq_zech_sub(rop->fq_zech, op1->fq_zech, op2->fq_zech, ctx->ctx.fq_zech);
-    }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
-    {
-        fq_nmod_sub(rop->fq_nmod, op1->fq_nmod, op2->fq_nmod, ctx->ctx.fq_nmod);
-    }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
-    {
-        rop->nmod = nmod_sub(op1->nmod, op2->nmod, ctx->ctx.nmod.mod);
-    }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
-    {
-        fmpz_mod_sub(rop->fmpz_mod, op1->fmpz_mod, op2->fmpz_mod,
-                                                        ctx->ctx.fmpz_mod.mod);
-    }
-    else
-    {
-        fq_sub(rop->fq, op1->fq, op2->fq, ctx->ctx.fq);
-    }
+    GR_IGNORE(gr_sub(rop, op1, op2, FQ_DEFAULT_GR_CTX(ctx)));
 }
 
 FQ_DEFAULT_INLINE void fq_default_sub_one(fq_default_t rop,
 		            const fq_default_t op1, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
-    {
-        fq_zech_sub_one(rop->fq_zech, op1->fq_zech, ctx->ctx.fq_zech);
-    }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
-    {
-        fq_nmod_sub_one(rop->fq_nmod, op1->fq_nmod, ctx->ctx.fq_nmod);
-    }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
-    {
-        rop->nmod = nmod_sub(op1->nmod, 1, ctx->ctx.nmod.mod);
-    }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
-    {
-        fmpz_sub_ui(rop->fmpz_mod, op1->fmpz_mod, 1);
-        fmpz_mod(rop->fmpz_mod, rop->fmpz_mod,
-                                  fmpz_mod_ctx_modulus(ctx->ctx.fmpz_mod.mod));
-    }
-    else
-    {
-        fq_sub_one(rop->fq, op1->fq, ctx->ctx.fq);
-    }
+    GR_IGNORE(gr_sub_ui(rop, op1, 1, FQ_DEFAULT_GR_CTX(ctx)));
 }
 
 FQ_DEFAULT_INLINE void fq_default_neg(fq_default_t rop,
 		            const fq_default_t op1, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
-    {
-        fq_zech_neg(rop->fq_zech, op1->fq_zech, ctx->ctx.fq_zech);
-    }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
-    {
-        fq_nmod_neg(rop->fq_nmod, op1->fq_nmod, ctx->ctx.fq_nmod);
-    }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
-    {
-        rop->nmod = nmod_neg(op1->nmod, ctx->ctx.nmod.mod);
-    }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
-    {
-        fmpz_mod_neg(rop->fmpz_mod, op1->fmpz_mod, ctx->ctx.fmpz_mod.mod);
-    }
-    else
-    {
-        fq_neg(rop->fq, op1->fq, ctx->ctx.fq);
-    }
+    GR_IGNORE(gr_neg(rop, op1, FQ_DEFAULT_GR_CTX(ctx)));
 }
 
 FQ_DEFAULT_INLINE void fq_default_mul(fq_default_t rop, const fq_default_t op1,
                             const fq_default_t op2, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
-    {
-        fq_zech_mul(rop->fq_zech, op1->fq_zech, op2->fq_zech, ctx->ctx.fq_zech);
-    }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
-    {
-        fq_nmod_mul(rop->fq_nmod, op1->fq_nmod, op2->fq_nmod, ctx->ctx.fq_nmod);
-    }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
-    {
-        rop->nmod = nmod_mul(op1->nmod, op2->nmod, ctx->ctx.nmod.mod);
-    }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
-    {
-        fmpz_mod_mul(rop->fmpz_mod, op1->fmpz_mod, op2->fmpz_mod,
-                                                        ctx->ctx.fmpz_mod.mod);
-    }
-    else
-    {
-        fq_mul(rop->fq, op1->fq, op2->fq, ctx->ctx.fq);
-    }
+    GR_IGNORE(gr_mul(rop, op1, op2, FQ_DEFAULT_GR_CTX(ctx)));
 }
 
 FQ_DEFAULT_INLINE void fq_default_mul_fmpz(fq_default_t rop,
              const fq_default_t op, const fmpz_t x, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
-    {
-        fq_zech_mul_fmpz(rop->fq_zech, op->fq_zech, x, ctx->ctx.fq_zech);
-    }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
-    {
-        fq_nmod_mul_fmpz(rop->fq_nmod, op->fq_nmod, x, ctx->ctx.fq_nmod);
-    }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
-    {
-        rop->nmod = nmod_mul(op->nmod, fmpz_get_nmod(x, ctx->ctx.nmod.mod),
-                                                            ctx->ctx.nmod.mod);
-    }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
-    {
-        fmpz_mul(rop->fmpz_mod, op->fmpz_mod, x);
-        fmpz_mod(rop->fmpz_mod, rop->fmpz_mod,
-                                  fmpz_mod_ctx_modulus(ctx->ctx.fmpz_mod.mod));
-    }
-    else
-    {
-        fq_mul_fmpz(rop->fq, op->fq, x, ctx->ctx.fq);
-    }
+    GR_IGNORE(gr_mul_fmpz(rop, op, x, FQ_DEFAULT_GR_CTX(ctx)));
 }
 
 FQ_DEFAULT_INLINE void fq_default_mul_si(fq_default_t rop,
 		    const fq_default_t op, slong x, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
-    {
-        fq_zech_mul_si(rop->fq_zech, op->fq_zech, x, ctx->ctx.fq_zech);
-    }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
-    {
-        fq_nmod_mul_si(rop->fq_nmod, op->fq_nmod, x, ctx->ctx.fq_nmod);
-    }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
-    {
-        ulong xu = FLINT_ABS(x);
-        NMOD_RED(xu, xu, ctx->ctx.nmod.mod);
-        if (x < 0)
-            xu = nmod_neg(xu, ctx->ctx.nmod.mod);
-        rop->nmod = nmod_mul(op->nmod, xu, ctx->ctx.nmod.mod);
-    }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
-    {
-        fmpz_mul_si(rop->fmpz_mod, op->fmpz_mod, x);
-        fmpz_mod(rop->fmpz_mod, rop->fmpz_mod,
-                                  fmpz_mod_ctx_modulus(ctx->ctx.fmpz_mod.mod));
-    }
-    else
-    {
-        fq_mul_si(rop->fq, op->fq, x, ctx->ctx.fq);
-    }
+    GR_IGNORE(gr_mul_si(rop, op, x, FQ_DEFAULT_GR_CTX(ctx)));
 }
 
 FQ_DEFAULT_INLINE void fq_default_mul_ui(fq_default_t rop,
 		    const fq_default_t op, ulong x, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
-    {
-        fq_zech_mul_ui(rop->fq_zech, op->fq_zech, x, ctx->ctx.fq_zech);
-    }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
-    {
-        fq_nmod_mul_ui(rop->fq_nmod, op->fq_nmod, x, ctx->ctx.fq_nmod);
-    }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
-    {
-        NMOD_RED(x, x, ctx->ctx.nmod.mod);
-        rop->nmod = nmod_mul(op->nmod, x, ctx->ctx.nmod.mod);
-    }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
-    {
-        fmpz_mul_ui(rop->fmpz_mod, op->fmpz_mod, x);
-        fmpz_mod(rop->fmpz_mod, rop->fmpz_mod,
-                                  fmpz_mod_ctx_modulus(ctx->ctx.fmpz_mod.mod));
-    }
-    else
-    {
-        fq_mul_ui(rop->fq, op->fq, x, ctx->ctx.fq);
-    }
+    GR_IGNORE(gr_mul_ui(rop, op, x, FQ_DEFAULT_GR_CTX(ctx)));
 }
+
+/* todo: verify all implementations define mul_fmpz, mul_si, mul_ui, sqr, pow_fmpz, pow_ui */
 
 FQ_DEFAULT_INLINE void fq_default_sqr(fq_default_t rop,
                              const fq_default_t op, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
-    {
-        fq_zech_sqr(rop->fq_zech, op->fq_zech, ctx->ctx.fq_zech);
-    }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
-    {
-        fq_nmod_sqr(rop->fq_nmod, op->fq_nmod, ctx->ctx.fq_nmod);
-    }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
-    {
-        rop->nmod = nmod_mul(op->nmod, op->nmod, ctx->ctx.nmod.mod);
-    }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
-    {
-        fmpz_mod_mul(rop->fmpz_mod, op->fmpz_mod, op->fmpz_mod,
-                                                        ctx->ctx.fmpz_mod.mod);
-    }
-    else
-    {
-        fq_sqr(rop->fq, op->fq, ctx->ctx.fq);
-    }
+    GR_IGNORE(gr_sqr(rop, op, FQ_DEFAULT_GR_CTX(ctx)));
 }
 
 FQ_DEFAULT_INLINE void fq_default_inv(fq_default_t rop,
 		            const fq_default_t op1, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
-    {
-        fq_zech_inv(rop->fq_zech, op1->fq_zech, ctx->ctx.fq_zech);
-    }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
-    {
-        fq_nmod_inv(rop->fq_nmod, op1->fq_nmod, ctx->ctx.fq_nmod);
-    }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
-    {
-        rop->nmod = nmod_inv(op1->nmod, ctx->ctx.nmod.mod);
-    }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
-    {
-        fmpz_mod_inv(rop->fmpz_mod, op1->fmpz_mod, ctx->ctx.fmpz_mod.mod);
-    }
-    else
-    {
-        fq_inv(rop->fq, op1->fq, ctx->ctx.fq);
-    }
+    GR_MUST_SUCCEED(gr_inv(rop, op1, FQ_DEFAULT_GR_CTX(ctx)));
 }
 
 FQ_DEFAULT_INLINE void fq_default_div(fq_default_t rop, fq_default_t op1,
                                   fq_default_t op2, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
-    {
-        fq_zech_div(rop->fq_zech, op1->fq_zech, op2->fq_zech, ctx->ctx.fq_zech);
-    }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
-    {
-        fq_nmod_div(rop->fq_nmod, op1->fq_nmod, op2->fq_nmod, ctx->ctx.fq_nmod);
-    }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
-    {
-        rop->nmod = nmod_div(op1->nmod, op2->nmod, ctx->ctx.nmod.mod);
-    }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
-    {
-        fmpz_t t;
-        fmpz_init(t);
-        fmpz_mod_inv(t, op2->fmpz_mod, ctx->ctx.fmpz_mod.mod);
-        fmpz_mod_mul(rop->fmpz_mod, op1->fmpz_mod, t, ctx->ctx.fmpz_mod.mod);
-        fmpz_clear(t);
-    }
-    else
-    {
-        fq_div(rop->fq, op1->fq, op2->fq, ctx->ctx.fq);
-    }
+    GR_MUST_SUCCEED(gr_div(rop, op1, op2, FQ_DEFAULT_GR_CTX(ctx)));
 }
 
 FQ_DEFAULT_INLINE void fq_default_pow(fq_default_t rop,
 	    const fq_default_t op1, const fmpz_t e, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
-    {
-        fq_zech_pow(rop->fq_zech, op1->fq_zech, e, ctx->ctx.fq_zech);
-    }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
-    {
-        fq_nmod_pow(rop->fq_nmod, op1->fq_nmod, e, ctx->ctx.fq_nmod);
-    }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
-    {
-        rop->nmod = nmod_pow_fmpz(op1->nmod, e, ctx->ctx.nmod.mod);
-    }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
-    {
-        fmpz_mod_pow_fmpz(rop->fmpz_mod, op1->fmpz_mod, e, ctx->ctx.fmpz_mod.mod);
-    }
-    else
-    {
-        fq_pow(rop->fq, op1->fq, e, ctx->ctx.fq);
-    }
+    GR_MUST_SUCCEED(gr_pow_fmpz(rop, op1, e, FQ_DEFAULT_GR_CTX(ctx)));
 }
 
 FQ_DEFAULT_INLINE void fq_default_pow_ui(fq_default_t rop,
               const fq_default_t op, const ulong e, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
-    {
-        fq_zech_pow_ui(rop->fq_zech, op->fq_zech, e, ctx->ctx.fq_zech);
-    }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
-    {
-        fq_nmod_pow_ui(rop->fq_nmod, op->fq_nmod, e, ctx->ctx.fq_nmod);
-    }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
-    {
-        rop->nmod = nmod_pow_ui(op->nmod, e, ctx->ctx.nmod.mod);
-    }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
-    {
-        fmpz_mod_pow_ui(rop->fmpz_mod, op->fmpz_mod, e, ctx->ctx.fmpz_mod.mod);
-    }
-    else
-    {
-        fq_pow_ui(rop->fq, op->fq, e, ctx->ctx.fq);
-    }
+    GR_MUST_SUCCEED(gr_pow_ui(rop, op, e, FQ_DEFAULT_GR_CTX(ctx)));
 }
 
 /* Roots *********************************************************************/
@@ -697,15 +413,15 @@ FQ_DEFAULT_INLINE void fq_default_pow_ui(fq_default_t rop,
 FQ_DEFAULT_INLINE int fq_default_sqrt(fq_default_t rop,
 		             const fq_default_t op, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_sqrt(rop->fq_zech, op->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_sqrt(rop->fq_zech, op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_sqrt(rop->fq_nmod, op->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_sqrt(rop->fq_nmod, op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
         if (op->nmod == 0)
         {
@@ -714,74 +430,73 @@ FQ_DEFAULT_INLINE int fq_default_sqrt(fq_default_t rop,
         }
         else
         {
-            rop->nmod = n_sqrtmod(op->nmod, ctx->ctx.nmod.mod.n);
+            rop->nmod = n_sqrtmod(op->nmod, FQ_DEFAULT_CTX_NMOD(ctx).n);
             return rop->nmod != 0;
         }
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_sqrtmod(rop->fmpz_mod, op->fmpz_mod,
-                                  fmpz_mod_ctx_modulus(ctx->ctx.fmpz_mod.mod));
+                                  fmpz_mod_ctx_modulus(FQ_DEFAULT_CTX_FMPZ_MOD(ctx)));
     }
     else
     {
-        return fq_sqrt(rop->fq, op->fq, ctx->ctx.fq);
+        return fq_sqrt(rop->fq, op->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
 FQ_DEFAULT_INLINE void fq_default_pth_root(fq_default_t rop,
 		            const fq_default_t op1, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_pth_root(rop->fq_zech, op1->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_pth_root(rop->fq_zech, op1->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_pth_root(rop->fq_nmod, op1->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_pth_root(rop->fq_nmod, op1->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
         rop->nmod = op1->nmod;
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_set(rop->fmpz_mod, op1->fmpz_mod);
     }
     else
     {
-        fq_pth_root(rop->fq, op1->fq, ctx->ctx.fq);
+        fq_pth_root(rop->fq, op1->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
 FQ_DEFAULT_INLINE int fq_default_is_square(const fq_default_t op,
 		                                    const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_is_square(op->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_is_square(op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_is_square(op->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_is_square(op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
-        return op->nmod == 0 || n_sqrtmod(op->nmod, ctx->ctx.nmod.mod.n) != 0;
+        return op->nmod == 0 || n_sqrtmod(op->nmod, FQ_DEFAULT_CTX_NMOD(ctx).n) != 0;
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
     {
         int res;
         fmpz_t t;
         fmpz_init(t);
-        res = fmpz_sqrtmod(t, op->fmpz_mod,
-                                  fmpz_mod_ctx_modulus(ctx->ctx.fmpz_mod.mod));
+        res = fmpz_sqrtmod(t, op->fmpz_mod, fmpz_mod_ctx_modulus(FQ_DEFAULT_CTX_FMPZ_MOD(ctx)));
         fmpz_clear(t);
         return res;
     }
     else
     {
-        return fq_is_square(op->fq, ctx->ctx.fq);
+        return fq_is_square(op->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -790,100 +505,100 @@ FQ_DEFAULT_INLINE int fq_default_is_square(const fq_default_t op,
 FQ_DEFAULT_INLINE void fq_default_randtest(fq_default_t rop,
 		                flint_rand_t state, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_randtest(rop->fq_zech, state, ctx->ctx.fq_zech);
+        fq_zech_randtest(rop->fq_zech, state, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_randtest(rop->fq_nmod, state, ctx->ctx.fq_nmod);
+        fq_nmod_randtest(rop->fq_nmod, state, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
-        rop->nmod = n_randint(state, ctx->ctx.nmod.mod.n);
+        rop->nmod = n_randint(state, FQ_DEFAULT_CTX_NMOD(ctx).n);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_rand(rop->fmpz_mod, state, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_rand(rop->fmpz_mod, state, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
-        fq_randtest(rop->fq, state, ctx->ctx.fq);
+        fq_randtest(rop->fq, state, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
 FQ_DEFAULT_INLINE void fq_default_randtest_not_zero(fq_default_t rop,
 		                flint_rand_t state, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_randtest_not_zero(rop->fq_zech, state, ctx->ctx.fq_zech);
+        fq_zech_randtest_not_zero(rop->fq_zech, state, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_randtest_not_zero(rop->fq_nmod, state, ctx->ctx.fq_nmod);
+        fq_nmod_randtest_not_zero(rop->fq_nmod, state, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
-        rop->nmod = n_randint(state, ctx->ctx.nmod.mod.n - 1) + 1;
+        rop->nmod = n_randint(state, FQ_DEFAULT_CTX_NMOD(ctx).n - 1) + 1;
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_rand_not_zero(rop->fmpz_mod, state, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_rand_not_zero(rop->fmpz_mod, state, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
-        fq_randtest_not_zero(rop->fq, state, ctx->ctx.fq);
+        fq_randtest_not_zero(rop->fq, state, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
 FQ_DEFAULT_INLINE void fq_default_rand(fq_default_t rop,
 		                flint_rand_t state, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_rand(rop->fq_zech, state, ctx->ctx.fq_zech);
+        fq_zech_rand(rop->fq_zech, state, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_rand(rop->fq_nmod, state, ctx->ctx.fq_nmod);
+        fq_nmod_rand(rop->fq_nmod, state, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
-        rop->nmod = n_randint(state, ctx->ctx.nmod.mod.n);
+        rop->nmod = n_randint(state, FQ_DEFAULT_CTX_NMOD(ctx).n);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_rand(rop->fmpz_mod, state, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_rand(rop->fmpz_mod, state, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
-        fq_rand(rop->fq, state, ctx->ctx.fq);
+        fq_rand(rop->fq, state, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
 FQ_DEFAULT_INLINE void fq_default_rand_not_zero(fq_default_t rop,
 		                flint_rand_t state, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_rand_not_zero(rop->fq_zech, state, ctx->ctx.fq_zech);
+        fq_zech_rand_not_zero(rop->fq_zech, state, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_rand_not_zero(rop->fq_nmod, state, ctx->ctx.fq_nmod);
+        fq_nmod_rand_not_zero(rop->fq_nmod, state, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
-        rop->nmod = n_randint(state, ctx->ctx.nmod.mod.n - 1) + 1;
+        rop->nmod = n_randint(state, FQ_DEFAULT_CTX_NMOD(ctx).n - 1) + 1;
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_rand_not_zero(rop->fmpz_mod, state, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_rand_not_zero(rop->fmpz_mod, state, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
-        fq_rand_not_zero(rop->fq, state, ctx->ctx.fq);
+        fq_rand_not_zero(rop->fq, state, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -892,75 +607,75 @@ FQ_DEFAULT_INLINE void fq_default_rand_not_zero(fq_default_t rop,
 FQ_DEFAULT_INLINE int fq_default_equal(const fq_default_t op1,
 		            const fq_default_t op2, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_equal(op1->fq_zech, op2->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_equal(op1->fq_zech, op2->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_equal(op1->fq_nmod, op2->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_equal(op1->fq_nmod, op2->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
         return op1->nmod == op2->nmod;
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_equal(op1->fmpz_mod, op2->fmpz_mod);
     }
     else
     {
-        return fq_equal(op1->fq, op2->fq, ctx->ctx.fq);
+        return fq_equal(op1->fq, op2->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
 FQ_DEFAULT_INLINE int fq_default_is_zero(const fq_default_t op,
 		                                    const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_is_zero(op->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_is_zero(op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_is_zero(op->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_is_zero(op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
         return op->nmod == 0;
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_is_zero(op->fmpz_mod);
     }
     else
     {
-        return fq_is_zero(op->fq, ctx->ctx.fq);
+        return fq_is_zero(op->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
 FQ_DEFAULT_INLINE int fq_default_is_one(const fq_default_t op,
 		                                    const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_is_one(op->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_is_one(op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_is_one(op->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_is_one(op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
         return op->nmod == 1;
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_is_one(op->fmpz_mod);
     }
     else
     {
-        return fq_is_one(op->fq, ctx->ctx.fq);
+        return fq_is_one(op->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -969,225 +684,83 @@ FQ_DEFAULT_INLINE int fq_default_is_one(const fq_default_t op,
 FQ_DEFAULT_INLINE void fq_default_set(fq_default_t rop,
 		             const fq_default_t op, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
-    {
-        fq_zech_set(rop->fq_zech, op->fq_zech, ctx->ctx.fq_zech);
-    }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
-    {
-        fq_nmod_set(rop->fq_nmod, op->fq_nmod, ctx->ctx.fq_nmod);
-    }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
-    {
-        rop->nmod = op->nmod;
-    }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
-    {
-        fmpz_set(rop->fmpz_mod, op->fmpz_mod);
-    }
-    else
-    {
-        fq_set(rop->fq, op->fq, ctx->ctx.fq);
-    }
+    GR_IGNORE(gr_set(rop, op, FQ_DEFAULT_GR_CTX(ctx)));
 }
 
 FQ_DEFAULT_INLINE void fq_default_set_fmpz(fq_default_t rop,
 		                    const fmpz_t x, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
-    {
-        fq_zech_set_fmpz(rop->fq_zech, x, ctx->ctx.fq_zech);
-    }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
-    {
-        fq_nmod_set_fmpz(rop->fq_nmod, x, ctx->ctx.fq_nmod);
-    }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
-    {
-        rop->nmod = fmpz_get_nmod(x, ctx->ctx.nmod.mod);
-    }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
-    {
-        fmpz_mod(rop->fmpz_mod, x, fmpz_mod_ctx_modulus(ctx->ctx.fmpz_mod.mod));
-    }
-    else
-    {
-        fq_set_fmpz(rop->fq, x, ctx->ctx.fq);
-    }
+    GR_IGNORE(gr_set_fmpz(rop, x, FQ_DEFAULT_GR_CTX(ctx)));
 }
 
 FQ_DEFAULT_INLINE void fq_default_set_ui(fq_default_t rop,
 		                     const ulong x, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
-    {
-        fq_zech_set_ui(rop->fq_zech, x, ctx->ctx.fq_zech);
-    }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
-    {
-        fq_nmod_set_ui(rop->fq_nmod, x, ctx->ctx.fq_nmod);
-    }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
-    {
-        NMOD_RED(rop->nmod, x, ctx->ctx.nmod.mod);
-    }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
-    {
-        fmpz_set_ui(rop->fmpz_mod, x);
-        fmpz_mod(rop->fmpz_mod, rop->fmpz_mod,
-                                  fmpz_mod_ctx_modulus(ctx->ctx.fmpz_mod.mod));
-    }
-    else
-    {
-        fq_set_ui(rop->fq, x, ctx->ctx.fq);
-    }
+    GR_IGNORE(gr_set_ui(rop, x, FQ_DEFAULT_GR_CTX(ctx)));
 }
 
 FQ_DEFAULT_INLINE void fq_default_set_si(fq_default_t rop,
 		                     const slong x, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
-    {
-        fq_zech_set_si(rop->fq_zech, x, ctx->ctx.fq_zech);
-    }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
-    {
-        fq_nmod_set_si(rop->fq_nmod, x, ctx->ctx.fq_nmod);
-    }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
-    {
-        ulong xu = FLINT_ABS(x);
-        NMOD_RED(xu, xu, ctx->ctx.nmod.mod);
-        if (x < 0)
-            xu = nmod_neg(xu, ctx->ctx.nmod.mod);
-        rop->nmod = xu;
-    }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
-    {
-        fmpz_set_si(rop->fmpz_mod, x);
-        fmpz_mod(rop->fmpz_mod, rop->fmpz_mod,
-                                  fmpz_mod_ctx_modulus(ctx->ctx.fmpz_mod.mod));
-    }
-    else
-    {
-        fq_set_si(rop->fq, x, ctx->ctx.fq);
-    }
+    GR_IGNORE(gr_set_si(rop, x, FQ_DEFAULT_GR_CTX(ctx)));
 }
 
 FQ_DEFAULT_INLINE void fq_default_zero(fq_default_t rop,
 		                                    const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
-    {
-        fq_zech_zero(rop->fq_zech, ctx->ctx.fq_zech);
-    }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
-    {
-        fq_nmod_zero(rop->fq_nmod, ctx->ctx.fq_nmod);
-    }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
-    {
-        rop->nmod = 0;
-    }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
-    {
-        fmpz_zero(rop->fmpz_mod);
-    }
-    else
-    {
-        fq_zero(rop->fq, ctx->ctx.fq);
-    }
+    GR_IGNORE(gr_zero(rop, FQ_DEFAULT_GR_CTX(ctx)));
 }
 
 FQ_DEFAULT_INLINE void fq_default_one(fq_default_t rop,
 		                                    const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
-    {
-        fq_zech_one(rop->fq_zech, ctx->ctx.fq_zech);
-    }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
-    {
-        fq_nmod_one(rop->fq_nmod, ctx->ctx.fq_nmod);
-    }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
-    {
-        rop->nmod = 1;
-    }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
-    {
-        fmpz_one(rop->fmpz_mod);
-    }
-    else
-    {
-        fq_one(rop->fq, ctx->ctx.fq);
-    }
+    GR_IGNORE(gr_one(rop, FQ_DEFAULT_GR_CTX(ctx)));
 }
 
+/* todo: should this swap the fq_default_structs? */
 FQ_DEFAULT_INLINE void fq_default_swap(fq_default_t op1,
 		                  fq_default_t op2, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
-    {
-        fq_zech_swap(op1->fq_zech, op2->fq_zech, ctx->ctx.fq_zech);
-    }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
-    {
-        fq_nmod_swap(op1->fq_nmod, op2->fq_nmod, ctx->ctx.fq_nmod);
-    }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
-    {
-        ulong t = op1->nmod;
-        op1->nmod = op2->nmod;
-        op2->nmod = t;
-    }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
-    {
-        fmpz_swap(op1->fmpz_mod, op2->fmpz_mod);
-    }
-    else
-    {
-        fq_swap(op1->fq, op2->fq, ctx->ctx.fq);
-    }
+    gr_swap(op1, op2, FQ_DEFAULT_GR_CTX(ctx));
 }
 
 FQ_DEFAULT_INLINE void fq_default_gen(fq_default_t rop,
 		                                    const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_gen(rop->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_gen(rop->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_gen(rop->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_gen(rop->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
-        rop->nmod = ctx->ctx.nmod.a;
+        rop->nmod = *FQ_DEFAULT_CTX_NMOD_A(ctx);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_set(rop->fmpz_mod, ctx->ctx.fmpz_mod.a);
+        fmpz_set(rop->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD_A(ctx));
     }
     else
     {
-        fq_gen(rop->fq, ctx->ctx.fq);
+        fq_gen(rop->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
 FQ_DEFAULT_INLINE void fq_default_get_nmod_poly(nmod_poly_t poly,
                              const fq_default_t op, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_get_nmod_poly(poly, op->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_get_nmod_poly(poly, op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_get_nmod_poly(poly, op->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_get_nmod_poly(poly, op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
         nmod_poly_fit_length(poly, 1);
         poly->length = (op->nmod != 0);
@@ -1202,17 +775,17 @@ FQ_DEFAULT_INLINE void fq_default_get_nmod_poly(nmod_poly_t poly,
 FQ_DEFAULT_INLINE void fq_default_set_nmod_poly(fq_default_t op,
                             const nmod_poly_t poly, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_set_nmod_poly(op->fq_zech, poly, ctx->ctx.fq_zech);
+        fq_zech_set_nmod_poly(op->fq_zech, poly, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_set_nmod_poly(op->fq_nmod, poly, ctx->ctx.fq_nmod);
+        fq_nmod_set_nmod_poly(op->fq_nmod, poly, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
-        op->nmod = nmod_poly_evaluate_nmod(poly, ctx->ctx.nmod.a);
+        op->nmod = nmod_poly_evaluate_nmod(poly, *FQ_DEFAULT_CTX_NMOD_A(ctx));
     }
     else
     {
@@ -1223,27 +796,27 @@ FQ_DEFAULT_INLINE void fq_default_set_nmod_poly(fq_default_t op,
 FQ_DEFAULT_INLINE int fq_default_get_fmpz(fmpz_t z, const fq_default_t op,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_get_fmpz(z, op->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_get_fmpz(z, op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_get_fmpz(z, op->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_get_fmpz(z, op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
         fmpz_set_ui(z, op->nmod);
         return 1;
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_set(z, op->fmpz_mod);
         return 1;
     }
     else
     {
-        return fq_get_fmpz(z, op->fq, ctx->ctx.fq);
+        return fq_get_fmpz(z, op->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1262,29 +835,29 @@ void fq_default_set_fmpz_poly(fq_default_t op,
 FQ_DEFAULT_INLINE void fq_default_get_coeff_fmpz(fmpz_t c,
                           fq_default_t op, slong n, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
         nmod_poly_t p;
         ulong c0;
-        nmod_poly_init(p, fq_zech_ctx_prime(ctx->ctx.fq_zech));
-        fq_zech_get_nmod_poly(p, op->fq_zech, ctx->ctx.fq_zech);
+        nmod_poly_init(p, fq_zech_ctx_prime(FQ_DEFAULT_CTX_FQ_ZECH(ctx)));
+        fq_zech_get_nmod_poly(p, op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
         c0 = nmod_poly_get_coeff_ui(p, n);
         fmpz_set_ui(c, c0);
         nmod_poly_clear(p);
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
         ulong c0 = nmod_poly_get_coeff_ui((nmod_poly_struct *) op->fq_nmod, n);
         fmpz_set_ui(c, c0);
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
         if (n != 0)
             fmpz_zero(c);
         else
             fmpz_set_ui(c, op->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
     {
         if (n != 0)
             fmpz_zero(c);
@@ -1294,7 +867,7 @@ FQ_DEFAULT_INLINE void fq_default_get_coeff_fmpz(fmpz_t c,
     else
     {
         fmpz_mod_ctx_t mod_ctx;
-        fmpz_mod_ctx_init(mod_ctx, fq_ctx_prime(ctx->ctx.fq));
+        fmpz_mod_ctx_init(mod_ctx, fq_ctx_prime(FQ_DEFAULT_CTX_FQ(ctx)));
         fmpz_mod_poly_get_coeff_fmpz(c,
 		                  (fmpz_mod_poly_struct *) op->fq, n, mod_ctx);
         fmpz_mod_ctx_clear(mod_ctx);
@@ -1314,15 +887,15 @@ void fq_default_print_pretty(const fq_default_t op, const fq_default_ctx_t ctx);
 FQ_DEFAULT_INLINE char * fq_default_get_str(const fq_default_t op,
 		                                    const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_get_str(op->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_get_str(op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_get_str(op->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_get_str(op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
         fmpz_t f;
         char* s;
@@ -1331,28 +904,28 @@ FQ_DEFAULT_INLINE char * fq_default_get_str(const fq_default_t op,
         fmpz_clear(f);
         return s;
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_get_str(NULL, 10, op->fmpz_mod);
     }
     else
     {
-        return fq_get_str(op->fq, ctx->ctx.fq);
+        return fq_get_str(op->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
 FQ_DEFAULT_INLINE char * fq_default_get_str_pretty(const fq_default_t op,
 		                                    const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_get_str_pretty(op->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_get_str_pretty(op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_get_str_pretty(op->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_get_str_pretty(op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
         fmpz_t f;
         char* s;
@@ -1361,13 +934,13 @@ FQ_DEFAULT_INLINE char * fq_default_get_str_pretty(const fq_default_t op,
         fmpz_clear(f);
         return s;
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_get_str(NULL, 10, op->fmpz_mod);
     }
     else
     {
-        return fq_get_str_pretty(op->fq, ctx->ctx.fq);
+        return fq_get_str_pretty(op->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1376,75 +949,75 @@ FQ_DEFAULT_INLINE char * fq_default_get_str_pretty(const fq_default_t op,
 FQ_DEFAULT_INLINE void fq_default_trace(fmpz_t rop,
 		             const fq_default_t op, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_trace(rop, op->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_trace(rop, op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_trace(rop, op->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_trace(rop, op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
         fmpz_set_ui(rop, op->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_set(rop, op->fmpz_mod);
     }
     else
     {
-        fq_trace(rop, op->fq, ctx->ctx.fq);
+        fq_trace(rop, op->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
 FQ_DEFAULT_INLINE void fq_default_frobenius(fq_default_t rop,
 		    const fq_default_t op, slong e, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_frobenius(rop->fq_zech, op->fq_zech, e, ctx->ctx.fq_zech);
+        fq_zech_frobenius(rop->fq_zech, op->fq_zech, e, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_frobenius(rop->fq_nmod, op->fq_nmod, e, ctx->ctx.fq_nmod);
+        fq_nmod_frobenius(rop->fq_nmod, op->fq_nmod, e, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
         rop->nmod = op->nmod;
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_set(rop->fmpz_mod, op->fmpz_mod);
     }
     else
     {
-        fq_frobenius(rop->fq, op->fq, e, ctx->ctx.fq);
+        fq_frobenius(rop->fq, op->fq, e, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
 FQ_DEFAULT_INLINE void fq_default_norm(fmpz_t rop,
 		             const fq_default_t op, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_norm(rop, op->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_norm(rop, op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_norm(rop, op->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_norm(rop, op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
     {
         fmpz_set_ui(rop, op->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_set(rop, op->fmpz_mod);
     }
     else
     {
-        fq_norm(rop, op->fq, ctx->ctx.fq);
+        fq_norm(rop, op->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 

--- a/src/fq_default.h
+++ b/src/fq_default.h
@@ -107,6 +107,14 @@ FQ_DEFAULT_INLINE void fq_default_ctx_init(fq_default_ctx_t ctx,
     fq_default_ctx_init_type(ctx, p, d, var, 0);
 }
 
+FQ_DEFAULT_INLINE void * fq_default_ctx_inner(const fq_default_ctx_t ctx)
+{
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
+        return (void *) &FQ_DEFAULT_CTX_NMOD(ctx);
+    else
+        return (void *) GR_CTX_DATA_AS_PTR(ctx);
+}
+
 void fq_default_ctx_init_modulus_type(fq_default_ctx_t ctx,
                 const fmpz_mod_poly_t modulus, fmpz_mod_ctx_t mod_ctx,
                                                    const char * var, int type);

--- a/src/fq_default.h
+++ b/src/fq_default.h
@@ -59,9 +59,9 @@ typedef struct
     int type;
     union ctx
     {
-        fq_ctx_t fq;
-        fq_nmod_ctx_t fq_nmod;
-        fq_zech_ctx_t fq_zech;
+        fq_ctx_t fq_UNUSED;
+        fq_nmod_ctx_t fq_nmod_UNUSED;
+        fq_zech_ctx_t fq_zech_UNUSED;
         struct {
             nmod_t mod;
             mp_limb_t a;    /* minpoly is x - a */
@@ -78,13 +78,8 @@ typedef fq_default_ctx_struct fq_default_ctx_t[1];
 #define FQ_DEFAULT_TYPE(ctx) ((ctx)->type)
 #define FQ_DEFAULT_GR_CTX(ctx) ((gr_ctx_struct *) ((ctx)->gr_ctx))
 
-#define FQ_DEFAULT_CTX_FQ_OLD(ctx) ((ctx)->ctx.fq)
 #define FQ_DEFAULT_CTX_FQ(ctx) ((fq_ctx_struct *) GR_CTX_DATA_AS_PTR(FQ_DEFAULT_GR_CTX(ctx)))
-
-#define FQ_DEFAULT_CTX_FQ_ZECH_OLD(ctx) ((ctx)->ctx.fq_zech)
 #define FQ_DEFAULT_CTX_FQ_ZECH(ctx) ((fq_zech_ctx_struct *) GR_CTX_DATA_AS_PTR(FQ_DEFAULT_GR_CTX(ctx)))
-
-#define FQ_DEFAULT_CTX_FQ_NMOD_OLD(ctx) ((ctx)->ctx.fq_nmod)
 #define FQ_DEFAULT_CTX_FQ_NMOD(ctx) ((fq_nmod_ctx_struct *) GR_CTX_DATA_AS_PTR(FQ_DEFAULT_GR_CTX(ctx)))
 
 #define FQ_DEFAULT_CTX_NMOD_OLD(ctx) ((ctx)->ctx.nmod)
@@ -141,29 +136,13 @@ void fq_default_ctx_init_modulus_nmod(fq_default_ctx_t ctx,
 
 FQ_DEFAULT_INLINE void fq_default_ctx_clear(fq_default_ctx_t ctx)
 {
-        if (!ctx->_gr_inited)
-            flint_abort();
+    if (!ctx->_gr_inited)
+        flint_abort();
 
-
-    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
-    {
-        fq_zech_ctx_clear(FQ_DEFAULT_CTX_FQ_ZECH_OLD(ctx));
-    }
-    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
-    {
-        fq_nmod_ctx_clear(FQ_DEFAULT_CTX_FQ_NMOD_OLD(ctx));
-    }
-    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
-    {
-    }
-    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
+    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_ctx_clear(FQ_DEFAULT_CTX_FMPZ_MOD_OLD(ctx).mod);
         fmpz_clear(FQ_DEFAULT_CTX_FMPZ_MOD_OLD(ctx).a);
-    }
-    else
-    {
-        fq_ctx_clear(FQ_DEFAULT_CTX_FQ_OLD(ctx));
     }
 
     if (ctx->_gr_inited)

--- a/src/fq_default.h
+++ b/src/fq_default.h
@@ -65,7 +65,7 @@ typedef struct
         struct {
             nmod_t mod;
             mp_limb_t a;    /* minpoly is x - a */
-        } nmod;
+        } nmod_UNUSED;
         struct {
             fmpz_mod_ctx_t mod;
             fmpz_t a;       /* minpoly is x - a */
@@ -276,33 +276,6 @@ FQ_DEFAULT_INLINE void fq_default_clear(fq_default_t rop,
     gr_clear(rop, FQ_DEFAULT_GR_CTX(ctx));
 }
 
-/* Predicates ****************************************************************/
-
-FQ_DEFAULT_INLINE int fq_default_is_invertible(const fq_default_t op,
-		                                    const fq_default_ctx_t ctx)
-{
-    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_ZECH)
-    {
-        return fq_zech_is_invertible(op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
-    }
-    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FQ_NMOD)
-    {
-        return fq_nmod_is_invertible(op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
-    }
-    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_NMOD)
-    {
-        return op->nmod != 0;
-    }
-    else if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
-    {
-        return !fmpz_is_zero(op->fmpz_mod);
-    }
-    else
-    {
-        return fq_is_invertible(op->fq, FQ_DEFAULT_CTX_FQ(ctx));
-    }
-}
-
 /* Basic arithmetic **********************************************************/
 
 /* GR_IGNORE(...) because we assume that basic arithmetic is well-implemented */
@@ -359,6 +332,16 @@ FQ_DEFAULT_INLINE void fq_default_sqr(fq_default_t rop,
                              const fq_default_t op, const fq_default_ctx_t ctx)
 {
     GR_IGNORE(gr_sqr(rop, op, FQ_DEFAULT_GR_CTX(ctx)));
+}
+
+FQ_DEFAULT_INLINE int fq_default_is_invertible(const fq_default_t op,
+		                                    const fq_default_ctx_t ctx)
+{
+    truth_t is_inv = gr_is_invertible(op, FQ_DEFAULT_GR_CTX(ctx));
+    if (is_inv == T_UNKNOWN)
+        flint_throw(FLINT_ERROR, "is_invertible failed");
+    return (is_inv == T_TRUE);
+
 }
 
 FQ_DEFAULT_INLINE void fq_default_inv(fq_default_t rop,
@@ -590,7 +573,7 @@ FQ_DEFAULT_INLINE void fq_default_one(fq_default_t rop,
     GR_IGNORE(gr_one(rop, FQ_DEFAULT_GR_CTX(ctx)));
 }
 
-/* todo: should this swap the fq_default_structs? */
+/* todo: should this swap the fq_default_struct? */
 FQ_DEFAULT_INLINE void fq_default_swap(fq_default_t op1,
 		                  fq_default_t op2, const fq_default_ctx_t ctx)
 {

--- a/src/fq_default.h
+++ b/src/fq_default.h
@@ -55,22 +55,7 @@ typedef fq_default_struct fq_default_t[1];
 typedef struct
 {
     gr_ctx_t gr_ctx;
-    int _gr_inited;
     int type;
-    union ctx
-    {
-        fq_ctx_t fq_UNUSED;
-        fq_nmod_ctx_t fq_nmod_UNUSED;
-        fq_zech_ctx_t fq_zech_UNUSED;
-        struct {
-            nmod_t mod;
-            mp_limb_t a;    /* minpoly is x - a */
-        } nmod_UNUSED;
-        struct {
-            fmpz_mod_ctx_t mod;
-            fmpz_t a;       /* minpoly is x - a */
-        } fmpz_mod;
-    } ctx;
 } fq_default_ctx_struct;
 
 typedef fq_default_ctx_struct fq_default_ctx_t[1];
@@ -81,11 +66,7 @@ typedef fq_default_ctx_struct fq_default_ctx_t[1];
 #define FQ_DEFAULT_CTX_FQ(ctx) ((fq_ctx_struct *) GR_CTX_DATA_AS_PTR(FQ_DEFAULT_GR_CTX(ctx)))
 #define FQ_DEFAULT_CTX_FQ_ZECH(ctx) ((fq_zech_ctx_struct *) GR_CTX_DATA_AS_PTR(FQ_DEFAULT_GR_CTX(ctx)))
 #define FQ_DEFAULT_CTX_FQ_NMOD(ctx) ((fq_nmod_ctx_struct *) GR_CTX_DATA_AS_PTR(FQ_DEFAULT_GR_CTX(ctx)))
-
-#define FQ_DEFAULT_CTX_NMOD_OLD(ctx) ((ctx)->ctx.nmod)
 #define FQ_DEFAULT_CTX_NMOD(ctx) ((nmod_t *) FQ_DEFAULT_GR_CTX(ctx))[0]
-
-#define FQ_DEFAULT_CTX_FMPZ_MOD_OLD(ctx) ((ctx)->ctx.fmpz_mod)
 #define FQ_DEFAULT_CTX_FMPZ_MOD(ctx) ((fmpz_mod_ctx_struct *) GR_CTX_DATA_AS_PTR(FQ_DEFAULT_GR_CTX(ctx)))
 
 typedef struct
@@ -136,17 +117,7 @@ void fq_default_ctx_init_modulus_nmod(fq_default_ctx_t ctx,
 
 FQ_DEFAULT_INLINE void fq_default_ctx_clear(fq_default_ctx_t ctx)
 {
-    if (!ctx->_gr_inited)
-        flint_abort();
-
-    if (FQ_DEFAULT_TYPE(ctx) == FQ_DEFAULT_FMPZ_MOD)
-    {
-        fmpz_mod_ctx_clear(FQ_DEFAULT_CTX_FMPZ_MOD_OLD(ctx).mod);
-        fmpz_clear(FQ_DEFAULT_CTX_FMPZ_MOD_OLD(ctx).a);
-    }
-
-    if (ctx->_gr_inited)
-        gr_ctx_clear(FQ_DEFAULT_GR_CTX(ctx));
+    gr_ctx_clear(FQ_DEFAULT_GR_CTX(ctx));
 }
 
 FQ_DEFAULT_INLINE int fq_default_ctx_type(const fq_default_ctx_t ctx)

--- a/src/fq_default/ctx.c
+++ b/src/fq_default/ctx.c
@@ -35,9 +35,6 @@ void fq_default_ctx_init_type(fq_default_ctx_t ctx,
     else if (type == FQ_DEFAULT_NMOD || (type == 0 && d == 1 && fmpz_abs_fits_ui(p)))
     {
         FQ_DEFAULT_TYPE(ctx) = FQ_DEFAULT_NMOD;
-        nmod_init(&FQ_DEFAULT_CTX_NMOD_OLD(ctx).mod, fmpz_get_ui(p));
-        FQ_DEFAULT_CTX_NMOD_OLD(ctx).a = 0;
-
         ctx->_gr_inited = 1;
         gr_ctx_init_nmod(FQ_DEFAULT_GR_CTX(ctx), fmpz_get_ui(p));
         NMOD_CTX_A(FQ_DEFAULT_GR_CTX(ctx))[0] = 0;
@@ -101,17 +98,20 @@ void fq_default_ctx_init_modulus_type(fq_default_ctx_t ctx,
     }
     else if (type == FQ_DEFAULT_NMOD || (type == 0 && d == 1 && fmpz_abs_fits_ui(p)))
     {
-        mp_limb_t c0, c1;
+        mp_limb_t c0, c1, a;
+        nmod_t mod;
+
         ctx->type = FQ_DEFAULT_NMOD;
-        nmod_init(&ctx->ctx.nmod.mod, fmpz_get_ui(p));
+
+        nmod_init(&mod, fmpz_get_ui(p));
         c0 = fmpz_get_ui(modulus->coeffs + 0);
         c1 = fmpz_get_ui(modulus->coeffs + 1);
-        c0 = nmod_neg(c0, ctx->ctx.nmod.mod);
-        ctx->ctx.nmod.a = nmod_div(c0, c1, ctx->ctx.nmod.mod);
+        c0 = nmod_neg(c0, mod);
+        a = nmod_div(c0, c1, mod);
 
         ctx->_gr_inited = 1;
-        gr_ctx_init_nmod(FQ_DEFAULT_GR_CTX(ctx), fmpz_get_ui(p));
-        NMOD_CTX_A(FQ_DEFAULT_GR_CTX(ctx))[0] = ctx->ctx.nmod.a;
+        _gr_ctx_init_nmod(FQ_DEFAULT_GR_CTX(ctx), &mod);
+        NMOD_CTX_A(FQ_DEFAULT_GR_CTX(ctx))[0] = a;
         gr_ctx_nmod_set_primality(FQ_DEFAULT_GR_CTX(ctx), T_TRUE);
     }
     else if (type == FQ_DEFAULT_FMPZ_MOD || (type == 0 && d == 1))
@@ -172,17 +172,19 @@ void fq_default_ctx_init_modulus_nmod_type(fq_default_ctx_t ctx,
     }
     else if (type == FQ_DEFAULT_NMOD || (type == 0 && d == 1))
     {
-        mp_limb_t c0, c1;
+        mp_limb_t c0, c1, a;
+        nmod_t mod;
+
         ctx->type = FQ_DEFAULT_NMOD;
-        nmod_init(&ctx->ctx.nmod.mod, p);
+        nmod_init(&mod, p);
         c0 = modulus->coeffs[0];
         c1 = modulus->coeffs[1];
-        c0 = nmod_neg(c0, ctx->ctx.nmod.mod);
-        ctx->ctx.nmod.a = nmod_div(c0, c1, ctx->ctx.nmod.mod);
+        c0 = nmod_neg(c0, mod);
+        a = nmod_div(c0, c1, mod);
 
         ctx->_gr_inited = 1;
-        gr_ctx_init_nmod(FQ_DEFAULT_GR_CTX(ctx), p);
-        NMOD_CTX_A(FQ_DEFAULT_GR_CTX(ctx))[0] = ctx->ctx.nmod.a;
+        _gr_ctx_init_nmod(FQ_DEFAULT_GR_CTX(ctx), &mod);
+        NMOD_CTX_A(FQ_DEFAULT_GR_CTX(ctx))[0] = a;
         gr_ctx_nmod_set_primality(FQ_DEFAULT_GR_CTX(ctx), T_TRUE);
     }
     else if (type == FQ_DEFAULT_FMPZ_MOD || (type == 0 && d == 1))

--- a/src/fq_default/ctx.c
+++ b/src/fq_default/ctx.c
@@ -41,6 +41,7 @@ void fq_default_ctx_init_type(fq_default_ctx_t ctx,
         ctx->_gr_inited = 1;
         gr_ctx_init_nmod(FQ_DEFAULT_GR_CTX(ctx), fmpz_get_ui(p));
         NMOD_CTX_A(FQ_DEFAULT_GR_CTX(ctx))[0] = 0;
+        gr_ctx_nmod_set_primality(FQ_DEFAULT_GR_CTX(ctx), T_TRUE);
     }
     else if (type == FQ_DEFAULT_FMPZ_MOD || (type == 0 && d == 1))
     {
@@ -111,6 +112,7 @@ void fq_default_ctx_init_modulus_type(fq_default_ctx_t ctx,
         ctx->_gr_inited = 1;
         gr_ctx_init_nmod(FQ_DEFAULT_GR_CTX(ctx), fmpz_get_ui(p));
         NMOD_CTX_A(FQ_DEFAULT_GR_CTX(ctx))[0] = ctx->ctx.nmod.a;
+        gr_ctx_nmod_set_primality(FQ_DEFAULT_GR_CTX(ctx), T_TRUE);
     }
     else if (type == FQ_DEFAULT_FMPZ_MOD || (type == 0 && d == 1))
     {
@@ -181,6 +183,7 @@ void fq_default_ctx_init_modulus_nmod_type(fq_default_ctx_t ctx,
         ctx->_gr_inited = 1;
         gr_ctx_init_nmod(FQ_DEFAULT_GR_CTX(ctx), p);
         NMOD_CTX_A(FQ_DEFAULT_GR_CTX(ctx))[0] = ctx->ctx.nmod.a;
+        gr_ctx_nmod_set_primality(FQ_DEFAULT_GR_CTX(ctx), T_TRUE);
     }
     else if (type == FQ_DEFAULT_FMPZ_MOD || (type == 0 && d == 1))
     {

--- a/src/fq_default/ctx.c
+++ b/src/fq_default/ctx.c
@@ -23,17 +23,12 @@ void fq_default_ctx_init_type(fq_default_ctx_t ctx,
     if (type == FQ_DEFAULT_FQ_ZECH || (type == 0 && d > 1 && bits*d <= 16))
     {
         FQ_DEFAULT_TYPE(ctx) = FQ_DEFAULT_FQ_ZECH;
-
-        fq_zech_ctx_init_ui(FQ_DEFAULT_CTX_FQ_ZECH_OLD(ctx), *p, d, var);
-
         ctx->_gr_inited = 1;
         gr_ctx_init_fq_zech(FQ_DEFAULT_GR_CTX(ctx), *p, d, var);
     }
     else if (type == FQ_DEFAULT_FQ_NMOD || (type == 0 && d > 1 && fmpz_abs_fits_ui(p)))
     {
         FQ_DEFAULT_TYPE(ctx) = FQ_DEFAULT_FQ_NMOD;
-        fq_nmod_ctx_init_ui(FQ_DEFAULT_CTX_FQ_NMOD_OLD(ctx), *p, d, var);
-
         ctx->_gr_inited = 1;
         gr_ctx_init_fq_nmod(FQ_DEFAULT_GR_CTX(ctx), *p, d, var);
     }
@@ -60,8 +55,6 @@ void fq_default_ctx_init_type(fq_default_ctx_t ctx,
     else
     {
         FQ_DEFAULT_TYPE(ctx) = FQ_DEFAULT_FQ;
-        fq_ctx_init(FQ_DEFAULT_CTX_FQ_OLD(ctx), p, d, var);
-
         ctx->_gr_inited = 1;
         gr_ctx_init_fq(FQ_DEFAULT_GR_CTX(ctx), p, d, var);
     }
@@ -91,19 +84,7 @@ void fq_default_ctx_init_modulus_type(fq_default_ctx_t ctx,
     {
         if (gr_ctx_init_fq_zech_modulus_fmpz_mod_poly(FQ_DEFAULT_GR_CTX(ctx), modulus, mod_ctx, var) == GR_SUCCESS)
         {
-
-            nmod_poly_t nmodulus;
-            fq_nmod_ctx_struct * fq_nmod_ctx;
             ctx->type = FQ_DEFAULT_FQ_ZECH;
-            nmod_poly_init(nmodulus, fmpz_get_ui(p));
-            fmpz_mod_poly_get_nmod_poly(nmodulus, modulus);
-            fq_nmod_ctx = flint_malloc(sizeof(fq_nmod_ctx_struct));
-            fq_nmod_ctx_init_modulus(fq_nmod_ctx, nmodulus, var);
-            if (!fq_zech_ctx_init_fq_nmod_ctx_check(ctx->ctx.fq_zech, fq_nmod_ctx))
-                flint_abort();
-            ctx->ctx.fq_zech->owns_fq_nmod_ctx = 1;
-            nmod_poly_clear(nmodulus);
-
             ctx->_gr_inited = 1;
         }
         else
@@ -113,13 +94,7 @@ void fq_default_ctx_init_modulus_type(fq_default_ctx_t ctx,
     }
     else if (type == FQ_DEFAULT_FQ_NMOD || (type == 0 && d > 1 && fmpz_abs_fits_ui(p)))
     {
-        nmod_poly_t nmodulus;
         ctx->type = FQ_DEFAULT_FQ_NMOD;
-        nmod_poly_init(nmodulus, fmpz_get_ui(p));
-        fmpz_mod_poly_get_nmod_poly(nmodulus, modulus);
-        fq_nmod_ctx_init_modulus(ctx->ctx.fq_nmod, nmodulus, var);
-        nmod_poly_clear(nmodulus);
-
         GR_MUST_SUCCEED(gr_ctx_init_fq_nmod_modulus_fmpz_mod_poly(FQ_DEFAULT_GR_CTX(ctx), modulus, mod_ctx, var));
         ctx->_gr_inited = 1;
     }
@@ -155,8 +130,6 @@ void fq_default_ctx_init_modulus_type(fq_default_ctx_t ctx,
     else
     {
         ctx->type = FQ_DEFAULT_FQ;
-        fq_ctx_init_modulus(ctx->ctx.fq, modulus, mod_ctx, var);
-
         GR_MUST_SUCCEED(gr_ctx_init_fq_modulus_fmpz_mod_poly(FQ_DEFAULT_GR_CTX(ctx), modulus, mod_ctx, var));
         ctx->_gr_inited = 1;
     }
@@ -181,13 +154,7 @@ void fq_default_ctx_init_modulus_nmod_type(fq_default_ctx_t ctx,
     {
         if (gr_ctx_init_fq_zech_modulus_nmod_poly(FQ_DEFAULT_GR_CTX(ctx), modulus, var) == GR_SUCCESS)
         {
-            fq_nmod_ctx_struct * fq_nmod_ctx = flint_malloc(sizeof(fq_nmod_ctx_struct));
             ctx->type = FQ_DEFAULT_FQ_ZECH;
-            fq_nmod_ctx_init_modulus(fq_nmod_ctx, modulus, var);
-            if (!fq_zech_ctx_init_fq_nmod_ctx_check(ctx->ctx.fq_zech, fq_nmod_ctx))
-                flint_abort();
-            ctx->ctx.fq_zech->owns_fq_nmod_ctx = 1;
-
             ctx->_gr_inited = 1;
         }
         else
@@ -198,8 +165,6 @@ void fq_default_ctx_init_modulus_nmod_type(fq_default_ctx_t ctx,
     else if (type == FQ_DEFAULT_FQ_NMOD || (type == 0 && d > 1))
     {
         ctx->type = FQ_DEFAULT_FQ_NMOD;
-        fq_nmod_ctx_init_modulus(ctx->ctx.fq_nmod, modulus, var);
-
         GR_MUST_SUCCEED(gr_ctx_init_fq_nmod_modulus_nmod_poly(FQ_DEFAULT_GR_CTX(ctx), modulus, var));
         ctx->_gr_inited = 1;
     }
@@ -238,19 +203,7 @@ void fq_default_ctx_init_modulus_nmod_type(fq_default_ctx_t ctx,
     }
     else
     {
-        fmpz_mod_ctx_t fmod_ctx;
-        fmpz_mod_poly_t fmod;
-        fmpz_t p;
         ctx->type = FQ_DEFAULT_FQ;
-        fmpz_init_set_ui(p, modulus->mod.n);
-        fmpz_mod_ctx_init(fmod_ctx, p);
-        fmpz_mod_poly_init(fmod, fmod_ctx);
-        fmpz_mod_poly_set_nmod_poly(fmod, modulus);
-        fq_ctx_init_modulus(ctx->ctx.fq, fmod, fmod_ctx, var);
-        fmpz_mod_poly_clear(fmod, fmod_ctx);
-        fmpz_mod_ctx_clear(fmod_ctx);
-        fmpz_clear(p);
-
         GR_MUST_SUCCEED(gr_ctx_init_fq_modulus_nmod_poly(FQ_DEFAULT_GR_CTX(ctx), modulus, var));
         ctx->_gr_inited = 1;
     }
@@ -271,26 +224,26 @@ void fq_default_ctx_modulus(fmpz_mod_poly_t p, const fq_default_ctx_t ctx)
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        nmod_poly_struct const * mod = fq_nmod_ctx_modulus(ctx->ctx.fq_nmod);
+        nmod_poly_struct const * mod = fq_nmod_ctx_modulus(FQ_DEFAULT_CTX_FQ_NMOD(ctx));
         fmpz_mod_poly_set_nmod_poly(p, mod);
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
         _fmpz_mod_poly_fit_length(p, 2);
         _fmpz_mod_poly_set_length(p, 2);
-        fmpz_set_ui(p->coeffs + 0, nmod_neg(ctx->ctx.nmod.a, ctx->ctx.nmod.mod));
+        fmpz_set_ui(p->coeffs + 0, nmod_neg(FQ_DEFAULT_CTX_NMOD_A(ctx)[0], FQ_DEFAULT_CTX_NMOD(ctx)));
         fmpz_one(p->coeffs + 1);
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         _fmpz_mod_poly_fit_length(p, 2);
         _fmpz_mod_poly_set_length(p, 2);
-        fmpz_mod_neg(p->coeffs + 0, ctx->ctx.fmpz_mod.a, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_neg(p->coeffs + 0, FQ_DEFAULT_CTX_FMPZ_MOD_A(ctx), FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
         fmpz_one(p->coeffs + 1);
     }
     else
     {
-        fmpz_mod_ctx_struct const * mod = ctx->ctx.fq->ctxp;
-        fmpz_mod_poly_set(p, ctx->ctx.fq->modulus, mod);
+        fmpz_mod_ctx_struct const * mod = FQ_DEFAULT_CTX_FQ(ctx)->ctxp;
+        fmpz_mod_poly_set(p, FQ_DEFAULT_CTX_FQ(ctx)->modulus, mod);
     }
 }

--- a/src/fq_default/ctx.c
+++ b/src/fq_default/ctx.c
@@ -12,7 +12,6 @@
 
 #include "fq_default.h"
 
-
 void fq_default_ctx_init_type(fq_default_ctx_t ctx,
                             const fmpz_t p, slong d, const char *var, int type)
 {
@@ -20,30 +19,25 @@ void fq_default_ctx_init_type(fq_default_ctx_t ctx,
 
     if (type == FQ_DEFAULT_FQ_ZECH || (type == 0 && d > 1 && bits*d <= 16))
     {
-        FQ_DEFAULT_TYPE(ctx) = FQ_DEFAULT_FQ_ZECH;
         gr_ctx_init_fq_zech(FQ_DEFAULT_GR_CTX(ctx), *p, d, var);
     }
     else if (type == FQ_DEFAULT_FQ_NMOD || (type == 0 && d > 1 && fmpz_abs_fits_ui(p)))
     {
-        FQ_DEFAULT_TYPE(ctx) = FQ_DEFAULT_FQ_NMOD;
         gr_ctx_init_fq_nmod(FQ_DEFAULT_GR_CTX(ctx), *p, d, var);
     }
     else if (type == FQ_DEFAULT_NMOD || (type == 0 && d == 1 && fmpz_abs_fits_ui(p)))
     {
-        FQ_DEFAULT_TYPE(ctx) = FQ_DEFAULT_NMOD;
         gr_ctx_init_nmod(FQ_DEFAULT_GR_CTX(ctx), fmpz_get_ui(p));
         NMOD_CTX_A(FQ_DEFAULT_GR_CTX(ctx))[0] = 0;
         gr_ctx_nmod_set_primality(FQ_DEFAULT_GR_CTX(ctx), T_TRUE);
     }
     else if (type == FQ_DEFAULT_FMPZ_MOD || (type == 0 && d == 1))
     {
-        FQ_DEFAULT_TYPE(ctx) = FQ_DEFAULT_FMPZ_MOD;
         gr_ctx_init_fmpz_mod(FQ_DEFAULT_GR_CTX(ctx), p);
         gr_ctx_fmpz_mod_set_primality(FQ_DEFAULT_GR_CTX(ctx), T_TRUE);
     }
     else
     {
-        FQ_DEFAULT_TYPE(ctx) = FQ_DEFAULT_FQ;
         gr_ctx_init_fq(FQ_DEFAULT_GR_CTX(ctx), p, d, var);
     }
 }
@@ -68,22 +62,17 @@ void fq_default_ctx_init_modulus_type(fq_default_ctx_t ctx,
 
     if (type == FQ_DEFAULT_FQ_ZECH || (type == 0 && d > 1 && bits*d <= 16))
     {
-        if (gr_ctx_init_fq_zech_modulus_fmpz_mod_poly(FQ_DEFAULT_GR_CTX(ctx), modulus, mod_ctx, var) == GR_SUCCESS)
-            ctx->type = FQ_DEFAULT_FQ_ZECH;
-        else
-            fq_default_ctx_init_modulus_type(ctx, modulus, mod_ctx, var, FQ_DEFAULT_FQ_NMOD);
+        if (gr_ctx_init_fq_zech_modulus_fmpz_mod_poly(FQ_DEFAULT_GR_CTX(ctx), modulus, mod_ctx, var) != GR_SUCCESS)
+            fq_default_ctx_init_modulus_type(ctx, modulus, mod_ctx, var, _FQ_DEFAULT_FQ_NMOD);
     }
     else if (type == FQ_DEFAULT_FQ_NMOD || (type == 0 && d > 1 && fmpz_abs_fits_ui(p)))
     {
-        ctx->type = FQ_DEFAULT_FQ_NMOD;
         GR_MUST_SUCCEED(gr_ctx_init_fq_nmod_modulus_fmpz_mod_poly(FQ_DEFAULT_GR_CTX(ctx), modulus, mod_ctx, var));
     }
     else if (type == FQ_DEFAULT_NMOD || (type == 0 && d == 1 && fmpz_abs_fits_ui(p)))
     {
         mp_limb_t c0, c1, a;
         nmod_t mod;
-
-        ctx->type = FQ_DEFAULT_NMOD;
 
         nmod_init(&mod, fmpz_get_ui(p));
         c0 = fmpz_get_ui(modulus->coeffs + 0);
@@ -97,8 +86,6 @@ void fq_default_ctx_init_modulus_type(fq_default_ctx_t ctx,
     }
     else if (type == FQ_DEFAULT_FMPZ_MOD || (type == 0 && d == 1))
     {
-        ctx->type = FQ_DEFAULT_FMPZ_MOD;
-
         gr_ctx_init_fmpz_mod(FQ_DEFAULT_GR_CTX(ctx), p);
         gr_ctx_fmpz_mod_set_primality(FQ_DEFAULT_GR_CTX(ctx), T_TRUE);
 
@@ -111,7 +98,6 @@ void fq_default_ctx_init_modulus_type(fq_default_ctx_t ctx,
     }
     else
     {
-        ctx->type = FQ_DEFAULT_FQ;
         GR_MUST_SUCCEED(gr_ctx_init_fq_modulus_fmpz_mod_poly(FQ_DEFAULT_GR_CTX(ctx), modulus, mod_ctx, var));
     }
 }
@@ -131,14 +117,11 @@ void fq_default_ctx_init_modulus_nmod_type(fq_default_ctx_t ctx,
 
     if (type == FQ_DEFAULT_FQ_ZECH || (type == 0 && d > 1 && bits*d <= 16))
     {
-        if (gr_ctx_init_fq_zech_modulus_nmod_poly(FQ_DEFAULT_GR_CTX(ctx), modulus, var) == GR_SUCCESS)
-            ctx->type = FQ_DEFAULT_FQ_ZECH;
-        else
-            fq_default_ctx_init_modulus_nmod_type(ctx, modulus, var, FQ_DEFAULT_FQ_NMOD);
+        if (gr_ctx_init_fq_zech_modulus_nmod_poly(FQ_DEFAULT_GR_CTX(ctx), modulus, var) != GR_SUCCESS)
+            fq_default_ctx_init_modulus_nmod_type(ctx, modulus, var, _FQ_DEFAULT_FQ_NMOD);
     }
     else if (type == FQ_DEFAULT_FQ_NMOD || (type == 0 && d > 1))
     {
-        ctx->type = FQ_DEFAULT_FQ_NMOD;
         GR_MUST_SUCCEED(gr_ctx_init_fq_nmod_modulus_nmod_poly(FQ_DEFAULT_GR_CTX(ctx), modulus, var));
     }
     else if (type == FQ_DEFAULT_NMOD || (type == 0 && d == 1))
@@ -146,7 +129,6 @@ void fq_default_ctx_init_modulus_nmod_type(fq_default_ctx_t ctx,
         mp_limb_t c0, c1, a;
         nmod_t mod;
 
-        ctx->type = FQ_DEFAULT_NMOD;
         nmod_init(&mod, p);
         c0 = modulus->coeffs[0];
         c1 = modulus->coeffs[1];
@@ -161,7 +143,6 @@ void fq_default_ctx_init_modulus_nmod_type(fq_default_ctx_t ctx,
     {
         fmpz_t pp;
         mp_limb_t c0, c1, a;
-        ctx->type = FQ_DEFAULT_FMPZ_MOD;
 
         c0 = modulus->coeffs[0];
         c1 = modulus->coeffs[1];
@@ -176,7 +157,6 @@ void fq_default_ctx_init_modulus_nmod_type(fq_default_ctx_t ctx,
     }
     else
     {
-        ctx->type = FQ_DEFAULT_FQ;
         GR_MUST_SUCCEED(gr_ctx_init_fq_modulus_nmod_poly(FQ_DEFAULT_GR_CTX(ctx), modulus, var));
     }
 }
@@ -189,24 +169,24 @@ void fq_default_ctx_init_modulus_nmod(fq_default_ctx_t ctx,
 
 void fq_default_ctx_modulus(fmpz_mod_poly_t p, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         nmod_poly_struct const * mod = fq_zech_ctx_modulus(FQ_DEFAULT_CTX_FQ_ZECH(ctx));
         fmpz_mod_poly_set_nmod_poly(p, mod);
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         nmod_poly_struct const * mod = fq_nmod_ctx_modulus(FQ_DEFAULT_CTX_FQ_NMOD(ctx));
         fmpz_mod_poly_set_nmod_poly(p, mod);
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         _fmpz_mod_poly_fit_length(p, 2);
         _fmpz_mod_poly_set_length(p, 2);
         fmpz_set_ui(p->coeffs + 0, nmod_neg(FQ_DEFAULT_CTX_NMOD_A(ctx)[0], FQ_DEFAULT_CTX_NMOD(ctx)));
         fmpz_one(p->coeffs + 1);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         _fmpz_mod_poly_fit_length(p, 2);
         _fmpz_mod_poly_set_length(p, 2);

--- a/src/fq_default/get_set.c
+++ b/src/fq_default/get_set.c
@@ -114,9 +114,9 @@ void fq_default_set_fmpz_mod_poly(fq_default_t op,
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
         nmod_poly_t p;
-        nmod_poly_init_mod(p, ctx->ctx.nmod.mod);
+        nmod_poly_init_mod(p, FQ_DEFAULT_CTX_NMOD(ctx));
         fmpz_mod_poly_get_nmod_poly(p, poly);
-        op->nmod = nmod_poly_evaluate_nmod(p, ctx->ctx.nmod.a);
+        op->nmod = nmod_poly_evaluate_nmod(p, *FQ_DEFAULT_CTX_NMOD_A(ctx));
         nmod_poly_clear(p);
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
@@ -154,9 +154,9 @@ void fq_default_set_fmpz_poly(fq_default_t op,
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
         nmod_poly_t p;
-        nmod_poly_init_mod(p, ctx->ctx.nmod.mod);
+        nmod_poly_init_mod(p, FQ_DEFAULT_CTX_NMOD(ctx));
         fmpz_poly_get_nmod_poly(p, poly);
-        op->nmod = nmod_poly_evaluate_nmod(p, ctx->ctx.nmod.a);
+        op->nmod = nmod_poly_evaluate_nmod(p, *FQ_DEFAULT_CTX_NMOD_A(ctx));
         nmod_poly_clear(p);
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)

--- a/src/fq_default/get_set.c
+++ b/src/fq_default/get_set.c
@@ -15,7 +15,7 @@
 void fq_default_get_fmpz_mod_poly(fmpz_mod_poly_t poly,
                              const fq_default_t op, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         nmod_poly_t p;
         ulong mod = fq_zech_ctx_prime(FQ_DEFAULT_CTX_FQ_ZECH(ctx));
@@ -24,7 +24,7 @@ void fq_default_get_fmpz_mod_poly(fmpz_mod_poly_t poly,
         fmpz_mod_poly_set_nmod_poly(poly, p);
         nmod_poly_clear(p);
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         nmod_poly_t p;
         ulong mod = fq_nmod_ctx_prime(FQ_DEFAULT_CTX_FQ_NMOD(ctx));
@@ -33,13 +33,13 @@ void fq_default_get_fmpz_mod_poly(fmpz_mod_poly_t poly,
         fmpz_mod_poly_set_nmod_poly(poly, p);
         nmod_poly_clear(p);
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         _fmpz_mod_poly_fit_length(poly, 1);
         fmpz_set_ui(poly->coeffs + 0, op->nmod);
         _fmpz_mod_poly_set_length(poly, op->nmod != 0);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         _fmpz_mod_poly_fit_length(poly, 1);
         fmpz_set(poly->coeffs + 0, op->fmpz_mod);
@@ -54,7 +54,7 @@ void fq_default_get_fmpz_mod_poly(fmpz_mod_poly_t poly,
 void fq_default_get_fmpz_poly(fmpz_poly_t poly,
                              const fq_default_t op, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         nmod_poly_t p;
         ulong mod = fq_zech_ctx_prime(FQ_DEFAULT_CTX_FQ_ZECH(ctx));
@@ -63,7 +63,7 @@ void fq_default_get_fmpz_poly(fmpz_poly_t poly,
         fmpz_poly_set_nmod_poly(poly, p);
         nmod_poly_clear(p);
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         nmod_poly_t p;
         ulong mod = fq_nmod_ctx_prime(FQ_DEFAULT_CTX_FQ_NMOD(ctx));
@@ -72,13 +72,13 @@ void fq_default_get_fmpz_poly(fmpz_poly_t poly,
         fmpz_poly_set_nmod_poly(poly, p);
         nmod_poly_clear(p);
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         fmpz_poly_fit_length(poly, 1);
         fmpz_set_ui(poly->coeffs + 0, op->nmod);
         _fmpz_poly_set_length(poly, op->nmod != 0);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_poly_fit_length(poly, 1);
         fmpz_set(poly->coeffs + 0, op->fmpz_mod);
@@ -93,7 +93,7 @@ void fq_default_get_fmpz_poly(fmpz_poly_t poly,
 void fq_default_set_fmpz_mod_poly(fq_default_t op,
                         const fmpz_mod_poly_t poly, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         nmod_poly_t p;
         ulong mod = fq_zech_ctx_prime(FQ_DEFAULT_CTX_FQ_ZECH(ctx));
@@ -102,7 +102,7 @@ void fq_default_set_fmpz_mod_poly(fq_default_t op,
         fq_zech_set_nmod_poly(op->fq_zech, p, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
         nmod_poly_clear(p);
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         nmod_poly_t p;
         ulong mod = fq_nmod_ctx_prime(FQ_DEFAULT_CTX_FQ_NMOD(ctx));
@@ -111,7 +111,7 @@ void fq_default_set_fmpz_mod_poly(fq_default_t op,
         fq_nmod_set_nmod_poly(op->fq_nmod, p, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
         nmod_poly_clear(p);
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_t p;
         nmod_poly_init_mod(p, FQ_DEFAULT_CTX_NMOD(ctx));
@@ -119,7 +119,7 @@ void fq_default_set_fmpz_mod_poly(fq_default_t op,
         op->nmod = nmod_poly_evaluate_nmod(p, *FQ_DEFAULT_CTX_NMOD_A(ctx));
         nmod_poly_clear(p);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_evaluate_fmpz(op->fmpz_mod, poly, FQ_DEFAULT_CTX_FMPZ_MOD_A(ctx),
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -133,7 +133,7 @@ void fq_default_set_fmpz_mod_poly(fq_default_t op,
 void fq_default_set_fmpz_poly(fq_default_t op,
                             const fmpz_poly_t poly, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         nmod_poly_t p;
         ulong mod = fq_zech_ctx_prime(FQ_DEFAULT_CTX_FQ_ZECH(ctx));
@@ -142,7 +142,7 @@ void fq_default_set_fmpz_poly(fq_default_t op,
         fq_zech_set_nmod_poly(op->fq_zech, p, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
         nmod_poly_clear(p);
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         nmod_poly_t p;
         ulong mod = fq_nmod_ctx_prime(FQ_DEFAULT_CTX_FQ_NMOD(ctx));
@@ -151,7 +151,7 @@ void fq_default_set_fmpz_poly(fq_default_t op,
         fq_nmod_set_nmod_poly(op->fq_nmod, p, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
         nmod_poly_clear(p);
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_t p;
         nmod_poly_init_mod(p, FQ_DEFAULT_CTX_NMOD(ctx));
@@ -159,7 +159,7 @@ void fq_default_set_fmpz_poly(fq_default_t op,
         op->nmod = nmod_poly_evaluate_nmod(p, *FQ_DEFAULT_CTX_NMOD_A(ctx));
         nmod_poly_clear(p);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_t p;
         fmpz_mod_poly_init(p, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));

--- a/src/fq_default/get_set.c
+++ b/src/fq_default/get_set.c
@@ -18,9 +18,9 @@ void fq_default_get_fmpz_mod_poly(fmpz_mod_poly_t poly,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         nmod_poly_t p;
-        ulong mod = fq_zech_ctx_prime(ctx->ctx.fq_zech);
+        ulong mod = fq_zech_ctx_prime(FQ_DEFAULT_CTX_FQ_ZECH(ctx));
         nmod_poly_init(p, mod);
-        fq_zech_get_nmod_poly(p, op->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_get_nmod_poly(p, op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
         fmpz_mod_poly_set_nmod_poly(poly, p);
         nmod_poly_clear(p);
     }
@@ -57,9 +57,9 @@ void fq_default_get_fmpz_poly(fmpz_poly_t poly,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         nmod_poly_t p;
-        ulong mod = fq_zech_ctx_prime(ctx->ctx.fq_zech);
+        ulong mod = fq_zech_ctx_prime(FQ_DEFAULT_CTX_FQ_ZECH(ctx));
         nmod_poly_init(p, mod);
-        fq_zech_get_nmod_poly(p, op->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_get_nmod_poly(p, op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
         fmpz_poly_set_nmod_poly(poly, p);
         nmod_poly_clear(p);
     }
@@ -96,10 +96,10 @@ void fq_default_set_fmpz_mod_poly(fq_default_t op,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         nmod_poly_t p;
-        ulong mod = fq_zech_ctx_prime(ctx->ctx.fq_zech);
+        ulong mod = fq_zech_ctx_prime(FQ_DEFAULT_CTX_FQ_ZECH(ctx));
         nmod_poly_init(p, mod);
         fmpz_mod_poly_get_nmod_poly(p, poly);
-        fq_zech_set_nmod_poly(op->fq_zech, p, ctx->ctx.fq_zech);
+        fq_zech_set_nmod_poly(op->fq_zech, p, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
         nmod_poly_clear(p);
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
@@ -136,10 +136,10 @@ void fq_default_set_fmpz_poly(fq_default_t op,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         nmod_poly_t p;
-        ulong mod = fq_zech_ctx_prime(ctx->ctx.fq_zech);
+        ulong mod = fq_zech_ctx_prime(FQ_DEFAULT_CTX_FQ_ZECH(ctx));
         nmod_poly_init(p, mod);
         fmpz_poly_get_nmod_poly(p, poly);
-        fq_zech_set_nmod_poly(op->fq_zech, p, ctx->ctx.fq_zech);
+        fq_zech_set_nmod_poly(op->fq_zech, p, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
         nmod_poly_clear(p);
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)

--- a/src/fq_default/get_set.c
+++ b/src/fq_default/get_set.c
@@ -27,9 +27,9 @@ void fq_default_get_fmpz_mod_poly(fmpz_mod_poly_t poly,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         nmod_poly_t p;
-        ulong mod = fq_nmod_ctx_prime(ctx->ctx.fq_nmod);
+        ulong mod = fq_nmod_ctx_prime(FQ_DEFAULT_CTX_FQ_NMOD(ctx));
         nmod_poly_init(p, mod);
-        fq_nmod_get_nmod_poly(p, op->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_get_nmod_poly(p, op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
         fmpz_mod_poly_set_nmod_poly(poly, p);
         nmod_poly_clear(p);
     }
@@ -47,7 +47,7 @@ void fq_default_get_fmpz_mod_poly(fmpz_mod_poly_t poly,
     }
     else
     {
-        fq_get_fmpz_mod_poly(poly, op->fq, ctx->ctx.fq);
+        fq_get_fmpz_mod_poly(poly, op->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -66,9 +66,9 @@ void fq_default_get_fmpz_poly(fmpz_poly_t poly,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         nmod_poly_t p;
-        ulong mod = fq_nmod_ctx_prime(ctx->ctx.fq_nmod);
+        ulong mod = fq_nmod_ctx_prime(FQ_DEFAULT_CTX_FQ_NMOD(ctx));
         nmod_poly_init(p, mod);
-        fq_nmod_get_nmod_poly(p, op->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_get_nmod_poly(p, op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
         fmpz_poly_set_nmod_poly(poly, p);
         nmod_poly_clear(p);
     }
@@ -86,7 +86,7 @@ void fq_default_get_fmpz_poly(fmpz_poly_t poly,
     }
     else
     {
-        fq_get_fmpz_poly(poly, op->fq, ctx->ctx.fq);
+        fq_get_fmpz_poly(poly, op->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -105,10 +105,10 @@ void fq_default_set_fmpz_mod_poly(fq_default_t op,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         nmod_poly_t p;
-        ulong mod = fq_nmod_ctx_prime(ctx->ctx.fq_nmod);
+        ulong mod = fq_nmod_ctx_prime(FQ_DEFAULT_CTX_FQ_NMOD(ctx));
         nmod_poly_init(p, mod);
         fmpz_mod_poly_get_nmod_poly(p, poly);
-        fq_nmod_set_nmod_poly(op->fq_nmod, p, ctx->ctx.fq_nmod);
+        fq_nmod_set_nmod_poly(op->fq_nmod, p, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
         nmod_poly_clear(p);
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
@@ -126,7 +126,7 @@ void fq_default_set_fmpz_mod_poly(fq_default_t op,
     }
     else
     {
-        fq_set_fmpz_mod_poly(op->fq, poly, ctx->ctx.fq);
+        fq_set_fmpz_mod_poly(op->fq, poly, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -145,10 +145,10 @@ void fq_default_set_fmpz_poly(fq_default_t op,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         nmod_poly_t p;
-        ulong mod = fq_nmod_ctx_prime(ctx->ctx.fq_nmod);
+        ulong mod = fq_nmod_ctx_prime(FQ_DEFAULT_CTX_FQ_NMOD(ctx));
         nmod_poly_init(p, mod);
         fmpz_poly_get_nmod_poly(p, poly);
-        fq_nmod_set_nmod_poly(op->fq_nmod, p, ctx->ctx.fq_nmod);
+        fq_nmod_set_nmod_poly(op->fq_nmod, p, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
         nmod_poly_clear(p);
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
@@ -170,6 +170,6 @@ void fq_default_set_fmpz_poly(fq_default_t op,
     }
     else
     {
-        fq_set_fmpz_poly(op->fq, poly, ctx->ctx.fq);
+        fq_set_fmpz_poly(op->fq, poly, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }

--- a/src/fq_default/get_set.c
+++ b/src/fq_default/get_set.c
@@ -121,8 +121,8 @@ void fq_default_set_fmpz_mod_poly(fq_default_t op,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_evaluate_fmpz(op->fmpz_mod, poly, ctx->ctx.fmpz_mod.a,
-                                                        ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_evaluate_fmpz(op->fmpz_mod, poly, FQ_DEFAULT_CTX_FMPZ_MOD_A(ctx),
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -162,11 +162,11 @@ void fq_default_set_fmpz_poly(fq_default_t op,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_t p;
-        fmpz_mod_poly_init(p, ctx->ctx.fmpz_mod.mod);
-        fmpz_mod_poly_set_fmpz_poly(p, poly, ctx->ctx.fmpz_mod.mod);
-        fmpz_mod_poly_evaluate_fmpz(op->fmpz_mod, p, ctx->ctx.fmpz_mod.a,
-                                                        ctx->ctx.fmpz_mod.mod);
-        fmpz_mod_poly_clear(p, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_init(p, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
+        fmpz_mod_poly_set_fmpz_poly(p, poly, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
+        fmpz_mod_poly_evaluate_fmpz(op->fmpz_mod, p, FQ_DEFAULT_CTX_FMPZ_MOD_A(ctx),
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
+        fmpz_mod_poly_clear(p, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {

--- a/src/fq_default/io.c
+++ b/src/fq_default/io.c
@@ -22,7 +22,7 @@ int fq_default_ctx_fprint(FILE * file, const fq_default_ctx_t ctx)
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_ctx_fprint(file, ctx->ctx.fq_nmod);
+        return fq_nmod_ctx_fprint(file, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -40,7 +40,7 @@ int fq_default_ctx_fprint(FILE * file, const fq_default_ctx_t ctx)
     }
     else
     {
-        return fq_ctx_fprint(file, ctx->ctx.fq);
+        return fq_ctx_fprint(file, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -52,7 +52,7 @@ int fq_default_fprint(FILE * file, const fq_default_t op, const fq_default_ctx_t
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_fprint(file, op->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_fprint(file, op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -64,7 +64,7 @@ int fq_default_fprint(FILE * file, const fq_default_t op, const fq_default_ctx_t
     }
     else
     {
-        return fq_fprint(file, op->fq, ctx->ctx.fq);
+        return fq_fprint(file, op->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -76,7 +76,7 @@ int fq_default_fprint_pretty(FILE * file, const fq_default_t op, const fq_defaul
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_fprint_pretty(file, op->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_fprint_pretty(file, op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -88,7 +88,7 @@ int fq_default_fprint_pretty(FILE * file, const fq_default_t op, const fq_defaul
     }
     else
     {
-        return fq_fprint_pretty(file, op->fq, ctx->ctx.fq);
+        return fq_fprint_pretty(file, op->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 

--- a/src/fq_default/io.c
+++ b/src/fq_default/io.c
@@ -18,7 +18,7 @@ int fq_default_ctx_fprint(FILE * file, const fq_default_ctx_t ctx)
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_ctx_fprint(file, ctx->ctx.fq_zech);
+        return fq_zech_ctx_fprint(file, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -48,7 +48,7 @@ int fq_default_fprint(FILE * file, const fq_default_t op, const fq_default_ctx_t
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_fprint(file, op->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_fprint(file, op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -72,7 +72,7 @@ int fq_default_fprint_pretty(FILE * file, const fq_default_t op, const fq_defaul
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_fprint_pretty(file, op->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_fprint_pretty(file, op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {

--- a/src/fq_default/io.c
+++ b/src/fq_default/io.c
@@ -33,7 +33,7 @@ int fq_default_ctx_fprint(FILE * file, const fq_default_ctx_t ctx)
         int z = flint_fprintf(file, "p = ");
         if (z <= 0)
             return z;
-        z = fmpz_fprint(file, fmpz_mod_ctx_modulus(ctx->ctx.fmpz_mod.mod));
+        z = fmpz_fprint(file, fmpz_mod_ctx_modulus(FQ_DEFAULT_CTX_FMPZ_MOD(ctx)));
         if (z <= 0)
             return z;
         return flint_fprintf(file, "\n");

--- a/src/fq_default/io.c
+++ b/src/fq_default/io.c
@@ -16,19 +16,19 @@
 
 int fq_default_ctx_fprint(FILE * file, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_ctx_fprint(file, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_ctx_fprint(file, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return flint_fprintf(file, "p = %wu\n", FQ_DEFAULT_CTX_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         int z = flint_fprintf(file, "p = ");
         if (z <= 0)
@@ -46,19 +46,19 @@ int fq_default_ctx_fprint(FILE * file, const fq_default_ctx_t ctx)
 
 int fq_default_fprint(FILE * file, const fq_default_t op, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_fprint(file, op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_fprint(file, op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return flint_fprintf(file, "%wu", op->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_fprint(file, op->fmpz_mod);
     }
@@ -70,19 +70,19 @@ int fq_default_fprint(FILE * file, const fq_default_t op, const fq_default_ctx_t
 
 int fq_default_fprint_pretty(FILE * file, const fq_default_t op, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_fprint_pretty(file, op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_fprint_pretty(file, op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return flint_fprintf(file, "%wu", op->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_fprint(file, op->fmpz_mod);
     }

--- a/src/fq_default/io.c
+++ b/src/fq_default/io.c
@@ -26,7 +26,7 @@ int fq_default_ctx_fprint(FILE * file, const fq_default_ctx_t ctx)
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
-        return flint_fprintf(file, "p = %wu\n", ctx->ctx.nmod.mod.n);
+        return flint_fprintf(file, "p = %wu\n", FQ_DEFAULT_CTX_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {

--- a/src/fq_default/io.c
+++ b/src/fq_default/io.c
@@ -12,6 +12,8 @@
 #include <stdio.h>
 #include "fq_default.h"
 
+#include "gr.h"
+
 /* printing *******************************************************************/
 
 int fq_default_ctx_fprint(FILE * file, const fq_default_ctx_t ctx)
@@ -26,7 +28,7 @@ int fq_default_ctx_fprint(FILE * file, const fq_default_ctx_t ctx)
     }
     else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
-        return flint_fprintf(file, "p = %wu\n", FQ_DEFAULT_CTX_NMOD(ctx));
+        return flint_fprintf(file, "p = %wu\n", FQ_DEFAULT_CTX_NMOD(ctx).n);
     }
     else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {

--- a/src/fq_default/test/t-ctx_init_modulus.c
+++ b/src/fq_default/test/t-ctx_init_modulus.c
@@ -38,9 +38,7 @@ TEST_FUNCTION_START(fq_default_ctx_init_modulus, state)
         fq_default_ctx_init_modulus(ctx, mod, mod_ctx, "x");
 
         fq_default_init(fq, ctx);
-
         fq_default_randtest(fq, state, ctx);
-
         fq_default_clear(fq, ctx);
 
         fq_default_ctx_clear(ctx);
@@ -74,9 +72,7 @@ TEST_FUNCTION_START(fq_default_ctx_init_modulus, state)
         fq_default_ctx_init_modulus(ctx, mod, mod_ctx, "x");
 
         fq_default_init(fq, ctx);
-
         fq_default_randtest(fq, state, ctx);
-
         fq_default_clear(fq, ctx);
 
         fq_default_ctx_clear(ctx);
@@ -109,9 +105,7 @@ TEST_FUNCTION_START(fq_default_ctx_init_modulus, state)
         fq_default_ctx_init_modulus(ctx, mod, mod_ctx, "x");
 
         fq_default_init(fq, ctx);
-
         fq_default_randtest(fq, state, ctx);
-
         fq_default_clear(fq, ctx);
 
         fq_default_ctx_clear(ctx);

--- a/src/fq_default/test/t-ctx_init_modulus_nmod.c
+++ b/src/fq_default/test/t-ctx_init_modulus_nmod.c
@@ -60,9 +60,7 @@ TEST_FUNCTION_START(fq_default_ctx_init_modulus_nmod, state)
         fq_default_ctx_init_modulus_nmod_type(ctx, mod, "x", 3);
 
         fq_default_init(fq, ctx);
-
         fq_default_randtest(fq, state, ctx);
-
         fq_default_clear(fq, ctx);
 
         fq_default_ctx_clear(ctx);
@@ -108,7 +106,10 @@ TEST_FUNCTION_START(fq_default_ctx_init_modulus_nmod, state)
             flint_abort();
         }
 
+        fq_default_init(fq, ctx);
+        fq_default_randtest(fq, state, ctx);
         fq_default_clear(fq, ctx);
+
         fq_default_ctx_clear(ctx);
         fmpz_mod_poly_clear(mod2, mod_ctx);
         fmpz_mod_poly_clear(mod3, mod_ctx);
@@ -136,7 +137,8 @@ TEST_FUNCTION_START(fq_default_ctx_init_modulus_nmod, state)
         nmod_poly_set_coeff_ui(mod, 0, 2);
         nmod_poly_set_coeff_ui(mod, 1, 1);
 
-        fq_default_ctx_init_modulus_nmod_type(ctx, mod, "x", _FQ_DEFAULT_FMPZ_MOD);
+        fq_default_ctx_init_modulus_nmod_type(ctx, mod, "x", FQ_DEFAULT_FMPZ_MOD);
+        FLINT_TEST(fq_default_ctx_type(ctx) == FQ_DEFAULT_FMPZ_MOD);
 
         fmpz_init(pp);
         fmpz_set_ui(pp, 3);
@@ -157,7 +159,10 @@ TEST_FUNCTION_START(fq_default_ctx_init_modulus_nmod, state)
             flint_abort();
         }
 
+        fq_default_init(fq, ctx);
+        fq_default_randtest(fq, state, ctx);
         fq_default_clear(fq, ctx);
+
         fq_default_ctx_clear(ctx);
         fmpz_mod_poly_clear(mod2, mod_ctx);
         fmpz_mod_poly_clear(mod3, mod_ctx);

--- a/src/fq_default/test/t-ctx_init_modulus_nmod.c
+++ b/src/fq_default/test/t-ctx_init_modulus_nmod.c
@@ -136,7 +136,7 @@ TEST_FUNCTION_START(fq_default_ctx_init_modulus_nmod, state)
         nmod_poly_set_coeff_ui(mod, 0, 2);
         nmod_poly_set_coeff_ui(mod, 1, 1);
 
-        fq_default_ctx_init_modulus_nmod_type(ctx, mod, "x", FQ_DEFAULT_FMPZ_MOD);
+        fq_default_ctx_init_modulus_nmod_type(ctx, mod, "x", _FQ_DEFAULT_FMPZ_MOD);
 
         fmpz_init(pp);
         fmpz_set_ui(pp, 3);

--- a/src/fq_default/test/t-init.c
+++ b/src/fq_default/test/t-init.c
@@ -23,41 +23,61 @@ TEST_FUNCTION_START(fq_default_init, state)
         fmpz_t p;
 
         fmpz_init(p);
-
         fmpz_set_ui(p, 3);
 
         fq_default_ctx_init(ctx, p, 3, "x");
-
         fq_default_init(fq, ctx);
-
         fq_default_clear(fq, ctx);
-
         fq_default_randtest(fq, state, ctx);
-
         fq_default_ctx_clear(ctx);
 
         fq_default_ctx_init(ctx, p, 16, "x");
-
         fq_default_init(fq, ctx);
-
         fq_default_randtest(fq, state, ctx);
-
         fq_default_clear(fq, ctx);
-
         fq_default_ctx_clear(ctx);
 
         fmpz_set_str(p, "73786976294838206473", 10);
-
         fq_default_ctx_init(ctx, p, 1, "x");
-
         fq_default_init(fq, ctx);
-
         fq_default_randtest(fq, state, ctx);
-
         fq_default_clear(fq, ctx);
-
         fq_default_ctx_clear(ctx);
 
+        fmpz_clear(p);
+    }
+
+    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    {
+        fmpz_t p;
+        fq_default_ctx_t ctx;
+        fq_default_t x, y;
+        int type = 1 + n_randint(state, 5);
+
+        fmpz_init(p);
+        fmpz_set_ui(p, 7);
+        fq_default_ctx_init_type(ctx, p, 1, "x", type);
+        FLINT_TEST(fq_default_ctx_type(ctx) == type);
+        fq_default_init(x, ctx);
+        fq_default_init(y, ctx);
+        fq_default_randtest(x, state, ctx);
+        fq_default_sqr(y, x, ctx);
+
+        if (type == FQ_DEFAULT_FQ)
+            fq_sqr((fq_struct *) x, (const fq_struct *) x, (const fq_ctx_struct *) fq_default_ctx_inner(ctx));
+        else if (type == FQ_DEFAULT_FQ_NMOD)
+            fq_nmod_sqr((fq_nmod_struct *) x, (const fq_nmod_struct *) x, (const fq_nmod_ctx_struct *) fq_default_ctx_inner(ctx));
+        else if (type == FQ_DEFAULT_FQ_ZECH)
+            fq_zech_sqr((fq_zech_struct *) x, (const fq_zech_struct *) x, (const fq_zech_ctx_struct *) fq_default_ctx_inner(ctx));
+        else if (type == FQ_DEFAULT_FMPZ_MOD)
+            fmpz_mod_mul((fmpz *) x, (const fmpz *) x, (const fmpz *) x, (const fmpz_mod_ctx_struct *) fq_default_ctx_inner(ctx));
+        else
+            ((ulong *) x)[0] = nmod_mul(((ulong *) x)[0], ((ulong *) x)[0], *((const nmod_t *) fq_default_ctx_inner(ctx)));
+
+        FLINT_TEST(fq_default_equal(x, y, ctx));
+        fq_default_clear(x, ctx);
+        fq_default_clear(y, ctx);
+        fq_default_ctx_clear(ctx);
         fmpz_clear(p);
     }
 

--- a/src/fq_default_mat.h
+++ b/src/fq_default_mat.h
@@ -47,19 +47,19 @@ typedef fq_default_mat_struct fq_default_mat_t[1];
 FQ_DEFAULT_MAT_INLINE void fq_default_mat_init(fq_default_mat_t mat,
                             slong rows, slong cols, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_init(mat->fq_zech, rows, cols, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_init(mat->fq_nmod, rows, cols, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_init(mat->nmod, rows, cols, FQ_DEFAULT_CTX_NMOD(ctx).n);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_init(mat->fmpz_mod, rows, cols, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -72,19 +72,19 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_init(fq_default_mat_t mat,
 FQ_DEFAULT_MAT_INLINE void fq_default_mat_init_set(fq_default_mat_t mat,
                         const fq_default_mat_t src, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_init_set(mat->fq_zech, src->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_init_set(mat->fq_nmod, src->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_init_set(mat->nmod, src->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_init_set(mat->fmpz_mod, src->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -97,19 +97,19 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_init_set(fq_default_mat_t mat,
 FQ_DEFAULT_MAT_INLINE void fq_default_mat_swap(fq_default_mat_t mat1,
                                fq_default_mat_t mat2, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_swap(mat1->fq_zech, mat2->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_swap(mat1->fq_nmod, mat2->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_swap(mat1->nmod, mat2->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_swap(mat1->fmpz_mod, mat2->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -122,19 +122,19 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_swap(fq_default_mat_t mat1,
 FQ_DEFAULT_MAT_INLINE void fq_default_mat_set(fq_default_mat_t mat1,
                        const fq_default_mat_t mat2, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_set(mat1->fq_zech, mat2->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_set(mat1->fq_nmod, mat2->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_set(mat1->nmod, mat2->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_set(mat1->fmpz_mod, mat2->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -147,19 +147,19 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_set(fq_default_mat_t mat1,
 FQ_DEFAULT_MAT_INLINE void fq_default_mat_clear(fq_default_mat_t mat,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_clear(mat->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_clear(mat->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_clear(mat->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_clear(mat->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -172,19 +172,19 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_clear(fq_default_mat_t mat,
 FQ_DEFAULT_MAT_INLINE int fq_default_mat_equal(const fq_default_mat_t mat1,
                        const fq_default_mat_t mat2, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_mat_equal(mat1->fq_zech, mat2->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_mat_equal(mat1->fq_nmod, mat2->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_mat_equal(mat1->nmod, mat2->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_mat_equal(mat1->fmpz_mod, mat2->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -197,19 +197,19 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_equal(const fq_default_mat_t mat1,
 FQ_DEFAULT_MAT_INLINE int fq_default_mat_is_zero(const fq_default_mat_t mat,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_mat_is_zero(mat->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_mat_is_zero(mat->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_mat_is_zero(mat->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_mat_is_zero(mat->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -222,19 +222,19 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_is_zero(const fq_default_mat_t mat,
 FQ_DEFAULT_MAT_INLINE int fq_default_mat_is_one(const fq_default_mat_t mat,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_mat_is_one(mat->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_mat_is_one(mat->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_mat_is_one(mat->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_mat_is_one(mat->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -247,19 +247,19 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_is_one(const fq_default_mat_t mat,
 FQ_DEFAULT_MAT_INLINE int
 fq_default_mat_is_empty(const fq_default_mat_t mat, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_mat_is_empty(mat->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_mat_is_empty(mat->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_mat_is_empty(mat->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_mat_is_empty(mat->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -273,19 +273,19 @@ FQ_DEFAULT_MAT_INLINE int
 fq_default_mat_is_square(const fq_default_mat_t mat,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_mat_is_square(mat->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_mat_is_square(mat->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_mat_is_square(mat->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_mat_is_square(mat->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -299,21 +299,21 @@ FQ_DEFAULT_MAT_INLINE void
 fq_default_mat_entry(fq_default_t val, const fq_default_mat_t mat,
 		                  slong i, slong j, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_set(val->fq_zech,
                         fq_zech_mat_entry(mat->fq_zech, i, j), FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_set(val->fq_nmod,
                         fq_nmod_mat_entry(mat->fq_nmod, i, j), FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         val->nmod = nmod_mat_entry(mat->nmod, i, j);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_set(val->fmpz_mod, fmpz_mod_mat_entry(mat->fmpz_mod, i, j));
     }
@@ -327,19 +327,19 @@ FQ_DEFAULT_MAT_INLINE void
 fq_default_mat_entry_set(fq_default_mat_t mat, slong i, slong j,
                               const fq_default_t x, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_entry_set(mat->fq_zech, i, j, x->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_entry_set(mat->fq_nmod, i, j, x->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_entry(mat->nmod, i, j) = x->nmod;
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_set(fmpz_mod_mat_entry(mat->fmpz_mod, i, j), x->fmpz_mod);
     }
@@ -363,19 +363,19 @@ fq_default_mat_entry_set_fmpz(fq_default_mat_t mat, slong i, slong j,
 FQ_DEFAULT_MAT_INLINE slong
 fq_default_mat_nrows(const fq_default_mat_t mat, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_mat_nrows(mat->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_mat_nrows(mat->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_mat_nrows(mat->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_mat_nrows(mat->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -388,19 +388,19 @@ fq_default_mat_nrows(const fq_default_mat_t mat, const fq_default_ctx_t ctx)
 FQ_DEFAULT_MAT_INLINE slong
 fq_default_mat_ncols(const fq_default_mat_t mat, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_mat_ncols(mat->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_mat_ncols(mat->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_mat_ncols(mat->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_mat_ncols(mat->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -414,19 +414,19 @@ FQ_DEFAULT_MAT_INLINE void
 fq_default_mat_swap_rows(fq_default_mat_t mat,
                     slong * perm, slong r, slong s, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_swap_rows(mat->fq_zech, perm, r, s, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_swap_rows(mat->fq_nmod, perm, r, s, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_swap_rows(mat->nmod, perm, r, s);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_swap_rows(mat->fmpz_mod, perm, r, s, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -440,19 +440,19 @@ FQ_DEFAULT_MAT_INLINE void
 fq_default_mat_invert_rows(fq_default_mat_t mat,
                                       slong * perm, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_invert_rows(mat->fq_zech, perm, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_invert_rows(mat->fq_nmod, perm, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_invert_rows(mat->nmod, perm);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_invert_rows(mat->fmpz_mod, perm, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -466,19 +466,19 @@ FQ_DEFAULT_MAT_INLINE void
 fq_default_mat_swap_cols(fq_default_mat_t mat,
                     slong * perm, slong r, slong s, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_swap_cols(mat->fq_zech, perm, r, s, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_swap_cols(mat->fq_nmod, perm, r, s, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_swap_cols(mat->nmod, perm, r, s);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_swap_cols(mat->fmpz_mod, perm, r, s, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -492,19 +492,19 @@ FQ_DEFAULT_MAT_INLINE void
 fq_default_mat_invert_cols(fq_default_mat_t mat,
                                       slong * perm, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_invert_cols(mat->fq_zech, perm, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_invert_cols(mat->fq_nmod, perm, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_invert_cols(mat->nmod, perm);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_invert_cols(mat->fmpz_mod, perm, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -519,19 +519,19 @@ fq_default_mat_invert_cols(fq_default_mat_t mat,
 FQ_DEFAULT_MAT_INLINE void fq_default_mat_zero(fq_default_mat_t A,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_zero(A->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_zero(A->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_zero(A->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_zero(A->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -544,19 +544,19 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_zero(fq_default_mat_t A,
 FQ_DEFAULT_MAT_INLINE void fq_default_mat_one(fq_default_mat_t A,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_one(A->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_one(A->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_one(A->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_one(A->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -572,19 +572,19 @@ FQ_DEFAULT_MAT_INLINE
 void fq_default_mat_set_nmod_mat(fq_default_mat_t mat1,
 		             const nmod_mat_t mat2, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_set_nmod_mat(mat1->fq_zech, mat2, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_set_nmod_mat(mat1->fq_nmod, mat2, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_set(mat1->nmod, mat2);
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         fmpz_mod_mat_set_nmod_mat(mat1->fmpz_mod, mat2, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -598,19 +598,19 @@ FQ_DEFAULT_MAT_INLINE
 void fq_default_mat_set_fmpz_mod_mat(fq_default_mat_t mat1,
                          const fmpz_mod_mat_t mat2, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_set_fmpz_mod_mat(mat1->fq_zech, mat2, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_set_fmpz_mod_mat(mat1->fq_nmod, mat2, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         fmpz_mat_get_nmod_mat(mat1->nmod, mat2);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_set(mat1->fmpz_mod, mat2, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -626,7 +626,7 @@ void fq_default_mat_set_fmpz_mat(fq_default_mat_t mat1,
 {
     fmpz_mod_mat_t mod_mat;
 
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fmpz_mod_ctx_t ctx2;
         fmpz_t prime;
@@ -639,7 +639,7 @@ void fq_default_mat_set_fmpz_mat(fq_default_mat_t mat1,
         fmpz_mod_ctx_clear(ctx2);
         fmpz_clear(prime);
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
 
         fmpz_mod_ctx_t ctx2;
@@ -653,12 +653,12 @@ void fq_default_mat_set_fmpz_mat(fq_default_mat_t mat1,
         fmpz_mod_ctx_clear(ctx2);
         fmpz_clear(prime);
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         fmpz_mat_get_nmod_mat(mat1->nmod, mat2);
         return;
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_set_fmpz_mat(mat1->fmpz_mod, mat2, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
         return;
@@ -682,22 +682,22 @@ void fq_default_mat_window_init(fq_default_mat_t window,
     const fq_default_mat_t mat, slong r1, slong c1, slong r2, slong c2,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_window_init(window->fq_zech,
                                mat->fq_zech, r1, c1, r2, c2, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_window_init(window->fq_nmod,
                                mat->fq_nmod, r1, c1, r2, c2, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_window_init(window->nmod,
                                mat->nmod, r1, c1, r2, c2);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_window_init(window->fmpz_mod,
                                mat->fmpz_mod, r1, c1, r2, c2, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -713,19 +713,19 @@ FQ_DEFAULT_MAT_INLINE
 void fq_default_mat_window_clear(fq_default_mat_t window,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_window_clear(window->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_window_clear(window->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_window_clear(window->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_window_clear(window->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -741,21 +741,21 @@ void fq_default_mat_concat_horizontal(fq_default_mat_t res,
           const fq_default_mat_t mat1,  const fq_default_mat_t mat2,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_concat_horizontal(res->fq_zech,
                                mat1->fq_zech, mat2->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_concat_horizontal(res->fq_nmod,
                                mat1->fq_nmod, mat2->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_concat_horizontal(res->nmod, mat1->nmod, mat2->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_concat_horizontal(res->fmpz_mod,
                                        mat1->fmpz_mod, mat2->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -771,21 +771,21 @@ void fq_default_mat_concat_vertical(fq_default_mat_t res,
           const fq_default_mat_t mat1,  const fq_default_mat_t mat2,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_concat_vertical(res->fq_zech,
                                mat1->fq_zech, mat2->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_concat_vertical(res->fq_nmod,
                                mat1->fq_nmod, mat2->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_concat_vertical(res->nmod, mat1->nmod, mat2->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_concat_vertical(res->fmpz_mod,
                                      mat1->fmpz_mod, mat2->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -813,19 +813,19 @@ int fq_default_mat_print_pretty(const fq_default_mat_t mat, const fq_default_ctx
 FQ_DEFAULT_MAT_INLINE void fq_default_mat_randtest(fq_default_mat_t mat,
                                 flint_rand_t state, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_randtest(mat->fq_zech, state, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_randtest(mat->fq_nmod, state, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_randtest(mat->nmod, state);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_randtest(mat->fmpz_mod, state, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -838,19 +838,19 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_randtest(fq_default_mat_t mat,
 FQ_DEFAULT_MAT_INLINE void fq_default_mat_randrank(fq_default_mat_t mat,
                     flint_rand_t state, slong rank, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_randrank(mat->fq_zech, state, rank, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_randrank(mat->fq_nmod, state, rank, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_randrank(mat->nmod, state, rank);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_randrank(mat->fmpz_mod, state, rank, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -865,19 +865,19 @@ FQ_DEFAULT_MAT_INLINE
 void fq_default_mat_randops(fq_default_mat_t mat,
                    flint_rand_t state, slong count, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_randops(mat->fq_zech, state, count, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_randops(mat->fq_nmod, state, count, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_randops(mat->nmod, state, count);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_randops(mat->fmpz_mod, state, count, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -891,19 +891,19 @@ FQ_DEFAULT_MAT_INLINE
 void fq_default_mat_randtril(fq_default_mat_t mat,
                       flint_rand_t state, int unit, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_randtril(mat->fq_zech, state, unit, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_randtril(mat->fq_nmod, state, unit, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_randtril(mat->nmod, state, unit);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_randtril(mat->fmpz_mod, state, unit, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -917,19 +917,19 @@ FQ_DEFAULT_MAT_INLINE
 void fq_default_mat_randtriu(fq_default_mat_t mat,
                       flint_rand_t state, int unit, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_randtriu(mat->fq_zech, state, unit, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_randtriu(mat->fq_nmod, state, unit, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_randtriu(mat->nmod, state, unit);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_randtriu(mat->fmpz_mod, state, unit, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -949,19 +949,19 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_add(fq_default_mat_t C,
                       const fq_default_mat_t A, const fq_default_mat_t B,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_add(C->fq_zech, A->fq_zech, B->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_add(C->fq_nmod, A->fq_nmod, B->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_add(C->nmod, A->nmod, B->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_add(C->fmpz_mod, A->fmpz_mod, B->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -975,19 +975,19 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_sub(fq_default_mat_t C,
                       const fq_default_mat_t A, const fq_default_mat_t B,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_sub(C->fq_zech, A->fq_zech, B->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_sub(C->fq_nmod, A->fq_nmod, B->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_sub(C->nmod, A->nmod, B->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_sub(C->fmpz_mod, A->fmpz_mod, B->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -1000,19 +1000,19 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_sub(fq_default_mat_t C,
 FQ_DEFAULT_MAT_INLINE void fq_default_mat_neg(fq_default_mat_t B,
                           const fq_default_mat_t A, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_neg(B->fq_zech, A->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_neg(B->fq_nmod, A->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_neg(B->nmod, A->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_neg(B->fmpz_mod, A->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -1026,21 +1026,21 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_submul(fq_default_mat_t D,
                         const fq_default_mat_t C, const fq_default_mat_t A,
                           const fq_default_mat_t B, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_submul(D->fq_zech,
                          C->fq_zech, A->fq_zech, B->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_submul(D->fq_nmod,
                          C->fq_nmod, A->fq_nmod, B->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_submul(D->nmod, C->nmod, A->nmod, B->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_submul(D->fmpz_mod, C->fmpz_mod, A->fmpz_mod, B->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -1058,19 +1058,19 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_mul(fq_default_mat_t C,
                       const fq_default_mat_t A, const fq_default_mat_t B,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_mul(C->fq_zech, A->fq_zech, B->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_mul(C->fq_nmod, A->fq_nmod, B->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_mul(C->nmod, A->nmod, B->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_mul(C->fmpz_mod, A->fmpz_mod, B->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -1083,19 +1083,19 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_mul(fq_default_mat_t C,
 FQ_DEFAULT_MAT_INLINE slong fq_default_mat_lu(slong * P,
                   fq_default_mat_t A, int rank_check, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_mat_lu(P, A->fq_zech, rank_check, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_mat_lu(P, A->fq_nmod, rank_check, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_mat_lu(P, A->nmod, rank_check);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_mat_lu(P, A->fmpz_mod, rank_check, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -1110,19 +1110,19 @@ FQ_DEFAULT_MAT_INLINE slong fq_default_mat_lu(slong * P,
 FQ_DEFAULT_MAT_INLINE int fq_default_mat_inv(fq_default_mat_t B,
                                   fq_default_mat_t A, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_mat_inv(B->fq_zech, A->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_mat_inv(B->fq_nmod, A->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_mat_inv(B->nmod, A->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_mat_inv(B->fmpz_mod, A->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -1137,20 +1137,20 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_inv(fq_default_mat_t B,
 FQ_DEFAULT_MAT_INLINE slong fq_default_mat_rref(fq_default_mat_t B, const fq_default_mat_t A,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_mat_rref(B->fq_zech, A->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_mat_rref(B->fq_nmod, A->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_set(B->nmod, A->nmod);
         return nmod_mat_rref(B->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_mat_rref(B->fmpz_mod, A->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -1163,19 +1163,19 @@ FQ_DEFAULT_MAT_INLINE slong fq_default_mat_rref(fq_default_mat_t B, const fq_def
 FQ_DEFAULT_MAT_INLINE slong fq_default_mat_nullspace(fq_default_mat_t X,
                           const fq_default_mat_t A, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_mat_nullspace(X->fq_zech, A->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_mat_nullspace(X->fq_nmod, A->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_mat_nullspace(X->nmod, A->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_mat_nullspace(X->fmpz_mod, A->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -1188,19 +1188,19 @@ FQ_DEFAULT_MAT_INLINE slong fq_default_mat_nullspace(fq_default_mat_t X,
 FQ_DEFAULT_MAT_INLINE slong fq_default_mat_rank(const fq_default_mat_t A,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_mat_rank(A->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_mat_rank(A->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_mat_rank(A->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_mat_rank(A->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -1214,19 +1214,19 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_solve_tril(fq_default_mat_t X,
                          const fq_default_mat_t L, const fq_default_mat_t B,
                                           int unit, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_solve_tril(X->fq_zech, L->fq_zech, B->fq_zech, unit, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_solve_tril(X->fq_nmod, L->fq_nmod, B->fq_nmod, unit, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_solve_tril(X->nmod, L->nmod, B->nmod, unit);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_solve_tril(X->fmpz_mod, L->fmpz_mod, B->fmpz_mod, unit, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -1240,19 +1240,19 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_solve_triu(fq_default_mat_t X,
                         const fq_default_mat_t U, const fq_default_mat_t B,
                                           int unit, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_solve_triu(X->fq_zech, U->fq_zech, B->fq_zech, unit, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_solve_triu(X->fq_nmod, U->fq_nmod, B->fq_nmod, unit, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_solve_triu(X->nmod, U->nmod, B->nmod, unit);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_solve_triu(X->fmpz_mod, U->fmpz_mod, B->fmpz_mod, unit, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -1268,21 +1268,21 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_solve(fq_default_mat_t X,
                       const fq_default_mat_t A, const fq_default_mat_t C,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_mat_solve(X->fq_zech,
                                      A->fq_zech, C->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_mat_solve(X->fq_nmod,
                                      A->fq_nmod, C->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_mat_solve(X->nmod, A->nmod, C->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_mat_solve(X->fmpz_mod, A->fmpz_mod, C->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -1298,21 +1298,21 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_can_solve(fq_default_mat_t X,
                       const fq_default_mat_t A, const fq_default_mat_t B,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_mat_can_solve(X->fq_zech,
                                      A->fq_zech, B->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_mat_can_solve(X->fq_nmod,
                                      A->fq_nmod, B->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_mat_can_solve(X->nmod, A->nmod, B->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_mat_can_solve(X->fmpz_mod, A->fmpz_mod, B->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -1328,19 +1328,19 @@ FQ_DEFAULT_MAT_INLINE
 void fq_default_mat_similarity(fq_default_mat_t A, slong r,
                                       fq_default_t d, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_similarity(A->fq_zech, r, d->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_similarity(A->fq_nmod, r, d->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_similarity(A->nmod, r, d->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_similarity(A->fmpz_mod, r, d->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }

--- a/src/fq_default_mat.h
+++ b/src/fq_default_mat.h
@@ -49,7 +49,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_init(fq_default_mat_t mat,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_init(mat->fq_zech, rows, cols, ctx->ctx.fq_zech);
+        fq_zech_mat_init(mat->fq_zech, rows, cols, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -74,7 +74,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_init_set(fq_default_mat_t mat,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_init_set(mat->fq_zech, src->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_mat_init_set(mat->fq_zech, src->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -99,7 +99,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_swap(fq_default_mat_t mat1,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_swap(mat1->fq_zech, mat2->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_mat_swap(mat1->fq_zech, mat2->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -124,7 +124,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_set(fq_default_mat_t mat1,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_set(mat1->fq_zech, mat2->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_mat_set(mat1->fq_zech, mat2->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -149,7 +149,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_clear(fq_default_mat_t mat,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_clear(mat->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_mat_clear(mat->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -174,7 +174,7 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_equal(const fq_default_mat_t mat1,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_mat_equal(mat1->fq_zech, mat2->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_mat_equal(mat1->fq_zech, mat2->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -199,7 +199,7 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_is_zero(const fq_default_mat_t mat,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_mat_is_zero(mat->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_mat_is_zero(mat->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -224,7 +224,7 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_is_one(const fq_default_mat_t mat,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_mat_is_one(mat->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_mat_is_one(mat->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -249,7 +249,7 @@ fq_default_mat_is_empty(const fq_default_mat_t mat, const fq_default_ctx_t ctx)
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_mat_is_empty(mat->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_mat_is_empty(mat->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -275,7 +275,7 @@ fq_default_mat_is_square(const fq_default_mat_t mat,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_mat_is_square(mat->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_mat_is_square(mat->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -302,7 +302,7 @@ fq_default_mat_entry(fq_default_t val, const fq_default_mat_t mat,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_set(val->fq_zech,
-                        fq_zech_mat_entry(mat->fq_zech, i, j), ctx->ctx.fq_zech);
+                        fq_zech_mat_entry(mat->fq_zech, i, j), FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -329,7 +329,7 @@ fq_default_mat_entry_set(fq_default_mat_t mat, slong i, slong j,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_entry_set(mat->fq_zech, i, j, x->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_mat_entry_set(mat->fq_zech, i, j, x->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -365,7 +365,7 @@ fq_default_mat_nrows(const fq_default_mat_t mat, const fq_default_ctx_t ctx)
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_mat_nrows(mat->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_mat_nrows(mat->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -390,7 +390,7 @@ fq_default_mat_ncols(const fq_default_mat_t mat, const fq_default_ctx_t ctx)
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_mat_ncols(mat->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_mat_ncols(mat->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -416,7 +416,7 @@ fq_default_mat_swap_rows(fq_default_mat_t mat,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_swap_rows(mat->fq_zech, perm, r, s, ctx->ctx.fq_zech);
+        fq_zech_mat_swap_rows(mat->fq_zech, perm, r, s, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -442,7 +442,7 @@ fq_default_mat_invert_rows(fq_default_mat_t mat,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_invert_rows(mat->fq_zech, perm, ctx->ctx.fq_zech);
+        fq_zech_mat_invert_rows(mat->fq_zech, perm, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -468,7 +468,7 @@ fq_default_mat_swap_cols(fq_default_mat_t mat,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_swap_cols(mat->fq_zech, perm, r, s, ctx->ctx.fq_zech);
+        fq_zech_mat_swap_cols(mat->fq_zech, perm, r, s, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -494,7 +494,7 @@ fq_default_mat_invert_cols(fq_default_mat_t mat,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_invert_cols(mat->fq_zech, perm, ctx->ctx.fq_zech);
+        fq_zech_mat_invert_cols(mat->fq_zech, perm, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -521,7 +521,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_zero(fq_default_mat_t A,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_zero(A->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_mat_zero(A->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -546,7 +546,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_one(fq_default_mat_t A,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_one(A->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_mat_one(A->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -574,7 +574,7 @@ void fq_default_mat_set_nmod_mat(fq_default_mat_t mat1,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_set_nmod_mat(mat1->fq_zech, mat2, ctx->ctx.fq_zech);
+        fq_zech_mat_set_nmod_mat(mat1->fq_zech, mat2, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -600,7 +600,7 @@ void fq_default_mat_set_fmpz_mod_mat(fq_default_mat_t mat1,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_set_fmpz_mod_mat(mat1->fq_zech, mat2, ctx->ctx.fq_zech);
+        fq_zech_mat_set_fmpz_mod_mat(mat1->fq_zech, mat2, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -630,11 +630,11 @@ void fq_default_mat_set_fmpz_mat(fq_default_mat_t mat1,
     {
         fmpz_mod_ctx_t ctx2;
         fmpz_t prime;
-        fmpz_init_set_ui(prime, fq_zech_ctx_prime(ctx->ctx.fq_zech));
+        fmpz_init_set_ui(prime, fq_zech_ctx_prime(FQ_DEFAULT_CTX_FQ_ZECH(ctx)));
         fmpz_mod_ctx_init(ctx2, prime);
         fmpz_mod_mat_init(mod_mat, mat2->r, mat2->c, ctx2);
         fmpz_mod_mat_set_fmpz_mat(mod_mat, mat2, ctx2);
-        fq_zech_mat_set_fmpz_mod_mat(mat1->fq_zech, mod_mat, ctx->ctx.fq_zech);
+        fq_zech_mat_set_fmpz_mod_mat(mat1->fq_zech, mod_mat, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
         fmpz_mod_mat_clear(mod_mat, ctx2);
         fmpz_mod_ctx_clear(ctx2);
         fmpz_clear(prime);
@@ -685,7 +685,7 @@ void fq_default_mat_window_init(fq_default_mat_t window,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_window_init(window->fq_zech,
-                               mat->fq_zech, r1, c1, r2, c2, ctx->ctx.fq_zech);
+                               mat->fq_zech, r1, c1, r2, c2, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -715,7 +715,7 @@ void fq_default_mat_window_clear(fq_default_mat_t window,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_window_clear(window->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_mat_window_clear(window->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -744,7 +744,7 @@ void fq_default_mat_concat_horizontal(fq_default_mat_t res,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_concat_horizontal(res->fq_zech,
-                               mat1->fq_zech, mat2->fq_zech, ctx->ctx.fq_zech);
+                               mat1->fq_zech, mat2->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -774,7 +774,7 @@ void fq_default_mat_concat_vertical(fq_default_mat_t res,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_concat_vertical(res->fq_zech,
-                               mat1->fq_zech, mat2->fq_zech, ctx->ctx.fq_zech);
+                               mat1->fq_zech, mat2->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -815,7 +815,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_randtest(fq_default_mat_t mat,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_randtest(mat->fq_zech, state, ctx->ctx.fq_zech);
+        fq_zech_mat_randtest(mat->fq_zech, state, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -840,7 +840,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_randrank(fq_default_mat_t mat,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_randrank(mat->fq_zech, state, rank, ctx->ctx.fq_zech);
+        fq_zech_mat_randrank(mat->fq_zech, state, rank, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -867,7 +867,7 @@ void fq_default_mat_randops(fq_default_mat_t mat,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_randops(mat->fq_zech, state, count, ctx->ctx.fq_zech);
+        fq_zech_mat_randops(mat->fq_zech, state, count, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -893,7 +893,7 @@ void fq_default_mat_randtril(fq_default_mat_t mat,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_randtril(mat->fq_zech, state, unit, ctx->ctx.fq_zech);
+        fq_zech_mat_randtril(mat->fq_zech, state, unit, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -919,7 +919,7 @@ void fq_default_mat_randtriu(fq_default_mat_t mat,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_randtriu(mat->fq_zech, state, unit, ctx->ctx.fq_zech);
+        fq_zech_mat_randtriu(mat->fq_zech, state, unit, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -951,7 +951,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_add(fq_default_mat_t C,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_add(C->fq_zech, A->fq_zech, B->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_mat_add(C->fq_zech, A->fq_zech, B->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -977,7 +977,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_sub(fq_default_mat_t C,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_sub(C->fq_zech, A->fq_zech, B->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_mat_sub(C->fq_zech, A->fq_zech, B->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1002,7 +1002,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_neg(fq_default_mat_t B,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_neg(B->fq_zech, A->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_mat_neg(B->fq_zech, A->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1029,7 +1029,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_submul(fq_default_mat_t D,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_submul(D->fq_zech,
-                         C->fq_zech, A->fq_zech, B->fq_zech, ctx->ctx.fq_zech);
+                         C->fq_zech, A->fq_zech, B->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1060,7 +1060,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_mul(fq_default_mat_t C,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_mul(C->fq_zech, A->fq_zech, B->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_mat_mul(C->fq_zech, A->fq_zech, B->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1085,7 +1085,7 @@ FQ_DEFAULT_MAT_INLINE slong fq_default_mat_lu(slong * P,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_mat_lu(P, A->fq_zech, rank_check, ctx->ctx.fq_zech);
+        return fq_zech_mat_lu(P, A->fq_zech, rank_check, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1112,7 +1112,7 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_inv(fq_default_mat_t B,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_mat_inv(B->fq_zech, A->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_mat_inv(B->fq_zech, A->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1139,7 +1139,7 @@ FQ_DEFAULT_MAT_INLINE slong fq_default_mat_rref(fq_default_mat_t B, const fq_def
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_mat_rref(B->fq_zech, A->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_mat_rref(B->fq_zech, A->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1165,7 +1165,7 @@ FQ_DEFAULT_MAT_INLINE slong fq_default_mat_nullspace(fq_default_mat_t X,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_mat_nullspace(X->fq_zech, A->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_mat_nullspace(X->fq_zech, A->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1190,7 +1190,7 @@ FQ_DEFAULT_MAT_INLINE slong fq_default_mat_rank(const fq_default_mat_t A,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_mat_rank(A->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_mat_rank(A->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1216,7 +1216,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_solve_tril(fq_default_mat_t X,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_solve_tril(X->fq_zech, L->fq_zech, B->fq_zech, unit, ctx->ctx.fq_zech);
+        fq_zech_mat_solve_tril(X->fq_zech, L->fq_zech, B->fq_zech, unit, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1242,7 +1242,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_solve_triu(fq_default_mat_t X,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_solve_triu(X->fq_zech, U->fq_zech, B->fq_zech, unit, ctx->ctx.fq_zech);
+        fq_zech_mat_solve_triu(X->fq_zech, U->fq_zech, B->fq_zech, unit, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1271,7 +1271,7 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_solve(fq_default_mat_t X,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_mat_solve(X->fq_zech,
-                                     A->fq_zech, C->fq_zech, ctx->ctx.fq_zech);
+                                     A->fq_zech, C->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1301,7 +1301,7 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_can_solve(fq_default_mat_t X,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_mat_can_solve(X->fq_zech,
-                                     A->fq_zech, B->fq_zech, ctx->ctx.fq_zech);
+                                     A->fq_zech, B->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1330,7 +1330,7 @@ void fq_default_mat_similarity(fq_default_mat_t A, slong r,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_similarity(A->fq_zech, r, d->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_mat_similarity(A->fq_zech, r, d->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {

--- a/src/fq_default_mat.h
+++ b/src/fq_default_mat.h
@@ -57,7 +57,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_init(fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
-        nmod_mat_init(mat->nmod, rows, cols, ctx->ctx.nmod.mod.n);
+        nmod_mat_init(mat->nmod, rows, cols, FQ_DEFAULT_CTX_NMOD(ctx).n);
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {

--- a/src/fq_default_mat.h
+++ b/src/fq_default_mat.h
@@ -61,7 +61,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_init(fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_init(mat->fmpz_mod, rows, cols, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_init(mat->fmpz_mod, rows, cols, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -86,7 +86,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_init_set(fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_init_set(mat->fmpz_mod, src->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_init_set(mat->fmpz_mod, src->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -111,7 +111,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_swap(fq_default_mat_t mat1,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_swap(mat1->fmpz_mod, mat2->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_swap(mat1->fmpz_mod, mat2->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -136,7 +136,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_set(fq_default_mat_t mat1,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_set(mat1->fmpz_mod, mat2->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_set(mat1->fmpz_mod, mat2->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -161,7 +161,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_clear(fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_clear(mat->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_clear(mat->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -186,7 +186,7 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_equal(const fq_default_mat_t mat1,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_mat_equal(mat1->fmpz_mod, mat2->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_mat_equal(mat1->fmpz_mod, mat2->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -211,7 +211,7 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_is_zero(const fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_mat_is_zero(mat->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_mat_is_zero(mat->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -236,7 +236,7 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_is_one(const fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_mat_is_one(mat->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_mat_is_one(mat->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -261,7 +261,7 @@ fq_default_mat_is_empty(const fq_default_mat_t mat, const fq_default_ctx_t ctx)
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_mat_is_empty(mat->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_mat_is_empty(mat->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -287,7 +287,7 @@ fq_default_mat_is_square(const fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_mat_is_square(mat->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_mat_is_square(mat->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -377,7 +377,7 @@ fq_default_mat_nrows(const fq_default_mat_t mat, const fq_default_ctx_t ctx)
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_mat_nrows(mat->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_mat_nrows(mat->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -402,7 +402,7 @@ fq_default_mat_ncols(const fq_default_mat_t mat, const fq_default_ctx_t ctx)
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_mat_ncols(mat->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_mat_ncols(mat->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -428,7 +428,7 @@ fq_default_mat_swap_rows(fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_swap_rows(mat->fmpz_mod, perm, r, s, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_swap_rows(mat->fmpz_mod, perm, r, s, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -454,7 +454,7 @@ fq_default_mat_invert_rows(fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_invert_rows(mat->fmpz_mod, perm, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_invert_rows(mat->fmpz_mod, perm, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -480,7 +480,7 @@ fq_default_mat_swap_cols(fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_swap_cols(mat->fmpz_mod, perm, r, s, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_swap_cols(mat->fmpz_mod, perm, r, s, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -506,7 +506,7 @@ fq_default_mat_invert_cols(fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_invert_cols(mat->fmpz_mod, perm, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_invert_cols(mat->fmpz_mod, perm, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -533,7 +533,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_zero(fq_default_mat_t A,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_zero(A->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_zero(A->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -558,7 +558,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_one(fq_default_mat_t A,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_one(A->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_one(A->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -586,7 +586,7 @@ void fq_default_mat_set_nmod_mat(fq_default_mat_t mat1,
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
-        fmpz_mod_mat_set_nmod_mat(mat1->fmpz_mod, mat2, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_set_nmod_mat(mat1->fmpz_mod, mat2, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -612,7 +612,7 @@ void fq_default_mat_set_fmpz_mod_mat(fq_default_mat_t mat1,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_set(mat1->fmpz_mod, mat2, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_set(mat1->fmpz_mod, mat2, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -660,7 +660,7 @@ void fq_default_mat_set_fmpz_mat(fq_default_mat_t mat1,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_set_fmpz_mat(mat1->fmpz_mod, mat2, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_set_fmpz_mat(mat1->fmpz_mod, mat2, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
         return;
     }
     else
@@ -700,7 +700,7 @@ void fq_default_mat_window_init(fq_default_mat_t window,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_window_init(window->fmpz_mod,
-                               mat->fmpz_mod, r1, c1, r2, c2, ctx->ctx.fmpz_mod.mod);
+                               mat->fmpz_mod, r1, c1, r2, c2, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -727,7 +727,7 @@ void fq_default_mat_window_clear(fq_default_mat_t window,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_window_clear(window->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_window_clear(window->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -758,7 +758,7 @@ void fq_default_mat_concat_horizontal(fq_default_mat_t res,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_concat_horizontal(res->fmpz_mod,
-                                       mat1->fmpz_mod, mat2->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+                                       mat1->fmpz_mod, mat2->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -788,7 +788,7 @@ void fq_default_mat_concat_vertical(fq_default_mat_t res,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_concat_vertical(res->fmpz_mod,
-                                     mat1->fmpz_mod, mat2->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+                                     mat1->fmpz_mod, mat2->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -827,7 +827,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_randtest(fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_randtest(mat->fmpz_mod, state, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_randtest(mat->fmpz_mod, state, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -852,7 +852,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_randrank(fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_randrank(mat->fmpz_mod, state, rank, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_randrank(mat->fmpz_mod, state, rank, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -879,7 +879,7 @@ void fq_default_mat_randops(fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_randops(mat->fmpz_mod, state, count, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_randops(mat->fmpz_mod, state, count, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -905,7 +905,7 @@ void fq_default_mat_randtril(fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_randtril(mat->fmpz_mod, state, unit, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_randtril(mat->fmpz_mod, state, unit, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -931,7 +931,7 @@ void fq_default_mat_randtriu(fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_randtriu(mat->fmpz_mod, state, unit, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_randtriu(mat->fmpz_mod, state, unit, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -963,7 +963,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_add(fq_default_mat_t C,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_add(C->fmpz_mod, A->fmpz_mod, B->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_add(C->fmpz_mod, A->fmpz_mod, B->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -989,7 +989,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_sub(fq_default_mat_t C,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_sub(C->fmpz_mod, A->fmpz_mod, B->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_sub(C->fmpz_mod, A->fmpz_mod, B->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1014,7 +1014,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_neg(fq_default_mat_t B,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_neg(B->fmpz_mod, A->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_neg(B->fmpz_mod, A->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1042,7 +1042,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_submul(fq_default_mat_t D,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_submul(D->fmpz_mod, C->fmpz_mod, A->fmpz_mod, B->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_submul(D->fmpz_mod, C->fmpz_mod, A->fmpz_mod, B->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1072,7 +1072,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_mul(fq_default_mat_t C,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_mul(C->fmpz_mod, A->fmpz_mod, B->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_mul(C->fmpz_mod, A->fmpz_mod, B->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1097,7 +1097,7 @@ FQ_DEFAULT_MAT_INLINE slong fq_default_mat_lu(slong * P,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_mat_lu(P, A->fmpz_mod, rank_check, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_mat_lu(P, A->fmpz_mod, rank_check, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1124,7 +1124,7 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_inv(fq_default_mat_t B,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_mat_inv(B->fmpz_mod, A->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_mat_inv(B->fmpz_mod, A->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1152,7 +1152,7 @@ FQ_DEFAULT_MAT_INLINE slong fq_default_mat_rref(fq_default_mat_t B, const fq_def
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_mat_rref(B->fmpz_mod, A->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_mat_rref(B->fmpz_mod, A->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1177,7 +1177,7 @@ FQ_DEFAULT_MAT_INLINE slong fq_default_mat_nullspace(fq_default_mat_t X,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_mat_nullspace(X->fmpz_mod, A->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_mat_nullspace(X->fmpz_mod, A->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1202,7 +1202,7 @@ FQ_DEFAULT_MAT_INLINE slong fq_default_mat_rank(const fq_default_mat_t A,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_mat_rank(A->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_mat_rank(A->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1228,7 +1228,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_solve_tril(fq_default_mat_t X,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_solve_tril(X->fmpz_mod, L->fmpz_mod, B->fmpz_mod, unit, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_solve_tril(X->fmpz_mod, L->fmpz_mod, B->fmpz_mod, unit, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1254,7 +1254,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_solve_triu(fq_default_mat_t X,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_solve_triu(X->fmpz_mod, U->fmpz_mod, B->fmpz_mod, unit, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_solve_triu(X->fmpz_mod, U->fmpz_mod, B->fmpz_mod, unit, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1284,7 +1284,7 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_solve(fq_default_mat_t X,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_mat_solve(X->fmpz_mod, A->fmpz_mod, C->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_mat_solve(X->fmpz_mod, A->fmpz_mod, C->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1314,7 +1314,7 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_can_solve(fq_default_mat_t X,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_mat_can_solve(X->fmpz_mod, A->fmpz_mod, B->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_mat_can_solve(X->fmpz_mod, A->fmpz_mod, B->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1342,7 +1342,7 @@ void fq_default_mat_similarity(fq_default_mat_t A, slong r,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_similarity(A->fmpz_mod, r, d->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_similarity(A->fmpz_mod, r, d->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {

--- a/src/fq_default_mat.h
+++ b/src/fq_default_mat.h
@@ -53,7 +53,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_init(fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_init(mat->fq_nmod, rows, cols, ctx->ctx.fq_nmod);
+        fq_nmod_mat_init(mat->fq_nmod, rows, cols, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -65,7 +65,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_init(fq_default_mat_t mat,
     }
     else
     {
-        fq_mat_init(mat->fq, rows, cols, ctx->ctx.fq);
+        fq_mat_init(mat->fq, rows, cols, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -78,7 +78,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_init_set(fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_init_set(mat->fq_nmod, src->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_mat_init_set(mat->fq_nmod, src->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -90,7 +90,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_init_set(fq_default_mat_t mat,
     }
     else
     {
-        fq_mat_init_set(mat->fq, src->fq, ctx->ctx.fq);
+        fq_mat_init_set(mat->fq, src->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -103,7 +103,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_swap(fq_default_mat_t mat1,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_swap(mat1->fq_nmod, mat2->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_mat_swap(mat1->fq_nmod, mat2->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -115,7 +115,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_swap(fq_default_mat_t mat1,
     }
     else
     {
-        fq_mat_swap(mat1->fq, mat2->fq, ctx->ctx.fq);
+        fq_mat_swap(mat1->fq, mat2->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -128,7 +128,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_set(fq_default_mat_t mat1,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_set(mat1->fq_nmod, mat2->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_mat_set(mat1->fq_nmod, mat2->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -140,7 +140,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_set(fq_default_mat_t mat1,
     }
     else
     {
-        fq_mat_set(mat1->fq, mat2->fq, ctx->ctx.fq);
+        fq_mat_set(mat1->fq, mat2->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -153,7 +153,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_clear(fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_clear(mat->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_mat_clear(mat->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -165,7 +165,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_clear(fq_default_mat_t mat,
     }
     else
     {
-        fq_mat_clear(mat->fq, ctx->ctx.fq);
+        fq_mat_clear(mat->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -178,7 +178,7 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_equal(const fq_default_mat_t mat1,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_mat_equal(mat1->fq_nmod, mat2->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_mat_equal(mat1->fq_nmod, mat2->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -190,7 +190,7 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_equal(const fq_default_mat_t mat1,
     }
     else
     {
-        return fq_mat_equal(mat1->fq, mat2->fq, ctx->ctx.fq);
+        return fq_mat_equal(mat1->fq, mat2->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -203,7 +203,7 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_is_zero(const fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_mat_is_zero(mat->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_mat_is_zero(mat->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -215,7 +215,7 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_is_zero(const fq_default_mat_t mat,
     }
     else
     {
-        return fq_mat_is_zero(mat->fq, ctx->ctx.fq);
+        return fq_mat_is_zero(mat->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -228,7 +228,7 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_is_one(const fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_mat_is_one(mat->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_mat_is_one(mat->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -240,7 +240,7 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_is_one(const fq_default_mat_t mat,
     }
     else
     {
-        return fq_mat_is_one(mat->fq, ctx->ctx.fq);
+        return fq_mat_is_one(mat->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -253,7 +253,7 @@ fq_default_mat_is_empty(const fq_default_mat_t mat, const fq_default_ctx_t ctx)
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_mat_is_empty(mat->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_mat_is_empty(mat->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -265,7 +265,7 @@ fq_default_mat_is_empty(const fq_default_mat_t mat, const fq_default_ctx_t ctx)
     }
     else
     {
-        return fq_mat_is_empty(mat->fq, ctx->ctx.fq);
+        return fq_mat_is_empty(mat->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -279,7 +279,7 @@ fq_default_mat_is_square(const fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_mat_is_square(mat->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_mat_is_square(mat->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -291,7 +291,7 @@ fq_default_mat_is_square(const fq_default_mat_t mat,
     }
     else
     {
-        return fq_mat_is_square(mat->fq, ctx->ctx.fq);
+        return fq_mat_is_square(mat->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -307,7 +307,7 @@ fq_default_mat_entry(fq_default_t val, const fq_default_mat_t mat,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_set(val->fq_nmod,
-                        fq_nmod_mat_entry(mat->fq_nmod, i, j), ctx->ctx.fq_nmod);
+                        fq_nmod_mat_entry(mat->fq_nmod, i, j), FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -319,7 +319,7 @@ fq_default_mat_entry(fq_default_t val, const fq_default_mat_t mat,
     }
     else
     {
-        fq_set(val->fq, fq_mat_entry(mat->fq, i, j), ctx->ctx.fq);
+        fq_set(val->fq, fq_mat_entry(mat->fq, i, j), FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -333,7 +333,7 @@ fq_default_mat_entry_set(fq_default_mat_t mat, slong i, slong j,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_entry_set(mat->fq_nmod, i, j, x->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_mat_entry_set(mat->fq_nmod, i, j, x->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -345,7 +345,7 @@ fq_default_mat_entry_set(fq_default_mat_t mat, slong i, slong j,
     }
     else
     {
-        fq_mat_entry_set(mat->fq, i, j, x->fq, ctx->ctx.fq);
+        fq_mat_entry_set(mat->fq, i, j, x->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -369,7 +369,7 @@ fq_default_mat_nrows(const fq_default_mat_t mat, const fq_default_ctx_t ctx)
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_mat_nrows(mat->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_mat_nrows(mat->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -381,7 +381,7 @@ fq_default_mat_nrows(const fq_default_mat_t mat, const fq_default_ctx_t ctx)
     }
     else
     {
-        return fq_mat_nrows(mat->fq, ctx->ctx.fq);
+        return fq_mat_nrows(mat->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -394,7 +394,7 @@ fq_default_mat_ncols(const fq_default_mat_t mat, const fq_default_ctx_t ctx)
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_mat_ncols(mat->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_mat_ncols(mat->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -406,7 +406,7 @@ fq_default_mat_ncols(const fq_default_mat_t mat, const fq_default_ctx_t ctx)
     }
     else
     {
-        return fq_mat_ncols(mat->fq, ctx->ctx.fq);
+        return fq_mat_ncols(mat->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -420,7 +420,7 @@ fq_default_mat_swap_rows(fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_swap_rows(mat->fq_nmod, perm, r, s, ctx->ctx.fq_nmod);
+        fq_nmod_mat_swap_rows(mat->fq_nmod, perm, r, s, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -432,7 +432,7 @@ fq_default_mat_swap_rows(fq_default_mat_t mat,
     }
     else
     {
-        fq_mat_swap_rows(mat->fq, perm, r, s, ctx->ctx.fq);
+        fq_mat_swap_rows(mat->fq, perm, r, s, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -446,7 +446,7 @@ fq_default_mat_invert_rows(fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_invert_rows(mat->fq_nmod, perm, ctx->ctx.fq_nmod);
+        fq_nmod_mat_invert_rows(mat->fq_nmod, perm, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -458,7 +458,7 @@ fq_default_mat_invert_rows(fq_default_mat_t mat,
     }
     else
     {
-        fq_mat_invert_rows(mat->fq, perm, ctx->ctx.fq);
+        fq_mat_invert_rows(mat->fq, perm, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -472,7 +472,7 @@ fq_default_mat_swap_cols(fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_swap_cols(mat->fq_nmod, perm, r, s, ctx->ctx.fq_nmod);
+        fq_nmod_mat_swap_cols(mat->fq_nmod, perm, r, s, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -484,7 +484,7 @@ fq_default_mat_swap_cols(fq_default_mat_t mat,
     }
     else
     {
-        fq_mat_swap_cols(mat->fq, perm, r, s, ctx->ctx.fq);
+        fq_mat_swap_cols(mat->fq, perm, r, s, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -498,7 +498,7 @@ fq_default_mat_invert_cols(fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_invert_cols(mat->fq_nmod, perm, ctx->ctx.fq_nmod);
+        fq_nmod_mat_invert_cols(mat->fq_nmod, perm, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -510,7 +510,7 @@ fq_default_mat_invert_cols(fq_default_mat_t mat,
     }
     else
     {
-        fq_mat_invert_cols(mat->fq, perm, ctx->ctx.fq);
+        fq_mat_invert_cols(mat->fq, perm, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -525,7 +525,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_zero(fq_default_mat_t A,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_zero(A->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_mat_zero(A->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -537,7 +537,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_zero(fq_default_mat_t A,
     }
     else
     {
-        fq_mat_zero(A->fq, ctx->ctx.fq);
+        fq_mat_zero(A->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -550,7 +550,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_one(fq_default_mat_t A,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_one(A->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_mat_one(A->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -562,7 +562,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_one(fq_default_mat_t A,
     }
     else
     {
-        fq_mat_one(A->fq, ctx->ctx.fq);
+        fq_mat_one(A->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -578,7 +578,7 @@ void fq_default_mat_set_nmod_mat(fq_default_mat_t mat1,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_set_nmod_mat(mat1->fq_nmod, mat2, ctx->ctx.fq_nmod);
+        fq_nmod_mat_set_nmod_mat(mat1->fq_nmod, mat2, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -590,7 +590,7 @@ void fq_default_mat_set_nmod_mat(fq_default_mat_t mat1,
     }
     else
     {
-        fq_mat_set_nmod_mat(mat1->fq, mat2, ctx->ctx.fq);
+        fq_mat_set_nmod_mat(mat1->fq, mat2, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -604,7 +604,7 @@ void fq_default_mat_set_fmpz_mod_mat(fq_default_mat_t mat1,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_set_fmpz_mod_mat(mat1->fq_nmod, mat2, ctx->ctx.fq_nmod);
+        fq_nmod_mat_set_fmpz_mod_mat(mat1->fq_nmod, mat2, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -616,7 +616,7 @@ void fq_default_mat_set_fmpz_mod_mat(fq_default_mat_t mat1,
     }
     else
     {
-        fq_mat_set_fmpz_mod_mat(mat1->fq, mat2, ctx->ctx.fq);
+        fq_mat_set_fmpz_mod_mat(mat1->fq, mat2, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -644,11 +644,11 @@ void fq_default_mat_set_fmpz_mat(fq_default_mat_t mat1,
 
         fmpz_mod_ctx_t ctx2;
         fmpz_t prime;
-        fmpz_init_set_ui(prime, fq_nmod_ctx_prime(ctx->ctx.fq_nmod));
+        fmpz_init_set_ui(prime, fq_nmod_ctx_prime(FQ_DEFAULT_CTX_FQ_NMOD(ctx)));
         fmpz_mod_ctx_init(ctx2, prime);
         fmpz_mod_mat_init(mod_mat, mat2->r, mat2->c, ctx2);
         fmpz_mod_mat_set_fmpz_mat(mod_mat, mat2, ctx2);
-        fq_nmod_mat_set_fmpz_mod_mat(mat1->fq_nmod, mod_mat, ctx->ctx.fq_nmod);
+        fq_nmod_mat_set_fmpz_mod_mat(mat1->fq_nmod, mod_mat, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
         fmpz_mod_mat_clear(mod_mat, ctx2);
         fmpz_mod_ctx_clear(ctx2);
         fmpz_clear(prime);
@@ -666,10 +666,10 @@ void fq_default_mat_set_fmpz_mat(fq_default_mat_t mat1,
     else
     {
         fmpz_mod_ctx_t ctx2;
-        fmpz_mod_ctx_init(ctx2, fq_ctx_prime(ctx->ctx.fq));
+        fmpz_mod_ctx_init(ctx2, fq_ctx_prime(FQ_DEFAULT_CTX_FQ(ctx)));
         fmpz_mod_mat_init(mod_mat, mat2->r, mat2->c, ctx2);
         fmpz_mod_mat_set_fmpz_mat(mod_mat, mat2, ctx2);
-        fq_mat_set_fmpz_mod_mat(mat1->fq, mod_mat, ctx->ctx.fq);
+        fq_mat_set_fmpz_mod_mat(mat1->fq, mod_mat, FQ_DEFAULT_CTX_FQ(ctx));
         fmpz_mod_mat_clear(mod_mat, ctx2);
         fmpz_mod_ctx_clear(ctx2);
     }
@@ -690,7 +690,7 @@ void fq_default_mat_window_init(fq_default_mat_t window,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_window_init(window->fq_nmod,
-                               mat->fq_nmod, r1, c1, r2, c2, ctx->ctx.fq_nmod);
+                               mat->fq_nmod, r1, c1, r2, c2, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -705,7 +705,7 @@ void fq_default_mat_window_init(fq_default_mat_t window,
     else
     {
         fq_mat_window_init(window->fq,
-                                         mat->fq, r1, c1, r2, c2, ctx->ctx.fq);
+                                         mat->fq, r1, c1, r2, c2, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -719,7 +719,7 @@ void fq_default_mat_window_clear(fq_default_mat_t window,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_window_clear(window->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_mat_window_clear(window->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -731,7 +731,7 @@ void fq_default_mat_window_clear(fq_default_mat_t window,
     }
     else
     {
-        fq_mat_window_clear(window->fq, ctx->ctx.fq);
+        fq_mat_window_clear(window->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 
 }
@@ -749,7 +749,7 @@ void fq_default_mat_concat_horizontal(fq_default_mat_t res,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_concat_horizontal(res->fq_nmod,
-                               mat1->fq_nmod, mat2->fq_nmod, ctx->ctx.fq_nmod);
+                               mat1->fq_nmod, mat2->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -762,7 +762,7 @@ void fq_default_mat_concat_horizontal(fq_default_mat_t res,
     }
     else
     {
-        fq_mat_concat_horizontal(res->fq, mat1->fq, mat2->fq, ctx->ctx.fq);
+        fq_mat_concat_horizontal(res->fq, mat1->fq, mat2->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -779,7 +779,7 @@ void fq_default_mat_concat_vertical(fq_default_mat_t res,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_concat_vertical(res->fq_nmod,
-                               mat1->fq_nmod, mat2->fq_nmod, ctx->ctx.fq_nmod);
+                               mat1->fq_nmod, mat2->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -792,7 +792,7 @@ void fq_default_mat_concat_vertical(fq_default_mat_t res,
     }
     else
     {
-        fq_mat_concat_vertical(res->fq, mat1->fq, mat2->fq, ctx->ctx.fq);
+        fq_mat_concat_vertical(res->fq, mat1->fq, mat2->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -819,7 +819,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_randtest(fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_randtest(mat->fq_nmod, state, ctx->ctx.fq_nmod);
+        fq_nmod_mat_randtest(mat->fq_nmod, state, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -831,7 +831,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_randtest(fq_default_mat_t mat,
     }
     else
     {
-        fq_mat_randtest(mat->fq, state, ctx->ctx.fq);
+        fq_mat_randtest(mat->fq, state, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -844,7 +844,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_randrank(fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_randrank(mat->fq_nmod, state, rank, ctx->ctx.fq_nmod);
+        fq_nmod_mat_randrank(mat->fq_nmod, state, rank, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -856,7 +856,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_randrank(fq_default_mat_t mat,
     }
     else
     {
-        fq_mat_randrank(mat->fq, state, rank, ctx->ctx.fq);
+        fq_mat_randrank(mat->fq, state, rank, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -871,7 +871,7 @@ void fq_default_mat_randops(fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_randops(mat->fq_nmod, state, count, ctx->ctx.fq_nmod);
+        fq_nmod_mat_randops(mat->fq_nmod, state, count, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -883,7 +883,7 @@ void fq_default_mat_randops(fq_default_mat_t mat,
     }
     else
     {
-        fq_mat_randops(mat->fq, state, count, ctx->ctx.fq);
+        fq_mat_randops(mat->fq, state, count, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -897,7 +897,7 @@ void fq_default_mat_randtril(fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_randtril(mat->fq_nmod, state, unit, ctx->ctx.fq_nmod);
+        fq_nmod_mat_randtril(mat->fq_nmod, state, unit, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -909,7 +909,7 @@ void fq_default_mat_randtril(fq_default_mat_t mat,
     }
     else
     {
-        fq_mat_randtril(mat->fq, state, unit, ctx->ctx.fq);
+        fq_mat_randtril(mat->fq, state, unit, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -923,7 +923,7 @@ void fq_default_mat_randtriu(fq_default_mat_t mat,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_randtriu(mat->fq_nmod, state, unit, ctx->ctx.fq_nmod);
+        fq_nmod_mat_randtriu(mat->fq_nmod, state, unit, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -935,7 +935,7 @@ void fq_default_mat_randtriu(fq_default_mat_t mat,
     }
     else
     {
-        fq_mat_randtriu(mat->fq, state, unit, ctx->ctx.fq);
+        fq_mat_randtriu(mat->fq, state, unit, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -955,7 +955,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_add(fq_default_mat_t C,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_add(C->fq_nmod, A->fq_nmod, B->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_mat_add(C->fq_nmod, A->fq_nmod, B->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -967,7 +967,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_add(fq_default_mat_t C,
     }
     else
     {
-        fq_mat_add(C->fq, A->fq, B->fq, ctx->ctx.fq);
+        fq_mat_add(C->fq, A->fq, B->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -981,7 +981,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_sub(fq_default_mat_t C,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_sub(C->fq_nmod, A->fq_nmod, B->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_mat_sub(C->fq_nmod, A->fq_nmod, B->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -993,7 +993,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_sub(fq_default_mat_t C,
     }
     else
     {
-        fq_mat_sub(C->fq, A->fq, B->fq, ctx->ctx.fq);
+        fq_mat_sub(C->fq, A->fq, B->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1006,7 +1006,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_neg(fq_default_mat_t B,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_neg(B->fq_nmod, A->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_mat_neg(B->fq_nmod, A->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1018,7 +1018,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_neg(fq_default_mat_t B,
     }
     else
     {
-        fq_mat_neg(B->fq, A->fq, ctx->ctx.fq);
+        fq_mat_neg(B->fq, A->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1034,7 +1034,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_submul(fq_default_mat_t D,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_submul(D->fq_nmod,
-                         C->fq_nmod, A->fq_nmod, B->fq_nmod, ctx->ctx.fq_nmod);
+                         C->fq_nmod, A->fq_nmod, B->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1046,7 +1046,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_submul(fq_default_mat_t D,
     }
     else
     {
-        fq_mat_submul(D->fq, C->fq, A->fq, B->fq, ctx->ctx.fq);
+        fq_mat_submul(D->fq, C->fq, A->fq, B->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1064,7 +1064,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_mul(fq_default_mat_t C,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_mul(C->fq_nmod, A->fq_nmod, B->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_mat_mul(C->fq_nmod, A->fq_nmod, B->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1076,7 +1076,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_mul(fq_default_mat_t C,
     }
     else
     {
-        fq_mat_mul(C->fq, A->fq, B->fq, ctx->ctx.fq);
+        fq_mat_mul(C->fq, A->fq, B->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1089,7 +1089,7 @@ FQ_DEFAULT_MAT_INLINE slong fq_default_mat_lu(slong * P,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_mat_lu(P, A->fq_nmod, rank_check, ctx->ctx.fq_nmod);
+        return fq_nmod_mat_lu(P, A->fq_nmod, rank_check, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1101,7 +1101,7 @@ FQ_DEFAULT_MAT_INLINE slong fq_default_mat_lu(slong * P,
     }
     else
     {
-        return fq_mat_lu(P, A->fq, rank_check, ctx->ctx.fq);
+        return fq_mat_lu(P, A->fq, rank_check, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1116,7 +1116,7 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_inv(fq_default_mat_t B,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_mat_inv(B->fq_nmod, A->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_mat_inv(B->fq_nmod, A->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1128,7 +1128,7 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_inv(fq_default_mat_t B,
     }
     else
     {
-        return fq_mat_inv(B->fq, A->fq, ctx->ctx.fq);
+        return fq_mat_inv(B->fq, A->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1143,7 +1143,7 @@ FQ_DEFAULT_MAT_INLINE slong fq_default_mat_rref(fq_default_mat_t B, const fq_def
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_mat_rref(B->fq_nmod, A->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_mat_rref(B->fq_nmod, A->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1156,7 +1156,7 @@ FQ_DEFAULT_MAT_INLINE slong fq_default_mat_rref(fq_default_mat_t B, const fq_def
     }
     else
     {
-        return fq_mat_rref(B->fq, A->fq, ctx->ctx.fq);
+        return fq_mat_rref(B->fq, A->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1169,7 +1169,7 @@ FQ_DEFAULT_MAT_INLINE slong fq_default_mat_nullspace(fq_default_mat_t X,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_mat_nullspace(X->fq_nmod, A->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_mat_nullspace(X->fq_nmod, A->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1181,7 +1181,7 @@ FQ_DEFAULT_MAT_INLINE slong fq_default_mat_nullspace(fq_default_mat_t X,
     }
     else
     {
-        return fq_mat_nullspace(X->fq, A->fq, ctx->ctx.fq);
+        return fq_mat_nullspace(X->fq, A->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1194,7 +1194,7 @@ FQ_DEFAULT_MAT_INLINE slong fq_default_mat_rank(const fq_default_mat_t A,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_mat_rank(A->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_mat_rank(A->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1206,7 +1206,7 @@ FQ_DEFAULT_MAT_INLINE slong fq_default_mat_rank(const fq_default_mat_t A,
     }
     else
     {
-        return fq_mat_rank(A->fq, ctx->ctx.fq);
+        return fq_mat_rank(A->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1220,7 +1220,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_solve_tril(fq_default_mat_t X,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_solve_tril(X->fq_nmod, L->fq_nmod, B->fq_nmod, unit, ctx->ctx.fq_nmod);
+        fq_nmod_mat_solve_tril(X->fq_nmod, L->fq_nmod, B->fq_nmod, unit, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1232,7 +1232,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_solve_tril(fq_default_mat_t X,
     }
     else
     {
-        fq_mat_solve_tril(X->fq, L->fq, B->fq, unit, ctx->ctx.fq);
+        fq_mat_solve_tril(X->fq, L->fq, B->fq, unit, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1246,7 +1246,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_solve_triu(fq_default_mat_t X,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_solve_triu(X->fq_nmod, U->fq_nmod, B->fq_nmod, unit, ctx->ctx.fq_nmod);
+        fq_nmod_mat_solve_triu(X->fq_nmod, U->fq_nmod, B->fq_nmod, unit, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1258,7 +1258,7 @@ FQ_DEFAULT_MAT_INLINE void fq_default_mat_solve_triu(fq_default_mat_t X,
     }
     else
     {
-        fq_mat_solve_triu(X->fq, U->fq, B->fq, unit, ctx->ctx.fq);
+        fq_mat_solve_triu(X->fq, U->fq, B->fq, unit, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1276,7 +1276,7 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_solve(fq_default_mat_t X,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_mat_solve(X->fq_nmod,
-                                     A->fq_nmod, C->fq_nmod, ctx->ctx.fq_nmod);
+                                     A->fq_nmod, C->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1288,7 +1288,7 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_solve(fq_default_mat_t X,
     }
     else
     {
-        return fq_mat_solve(X->fq, A->fq, C->fq, ctx->ctx.fq);
+        return fq_mat_solve(X->fq, A->fq, C->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1306,7 +1306,7 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_can_solve(fq_default_mat_t X,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_mat_can_solve(X->fq_nmod,
-                                     A->fq_nmod, B->fq_nmod, ctx->ctx.fq_nmod);
+                                     A->fq_nmod, B->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1318,7 +1318,7 @@ FQ_DEFAULT_MAT_INLINE int fq_default_mat_can_solve(fq_default_mat_t X,
     }
     else
     {
-        return fq_mat_can_solve(X->fq, A->fq, B->fq, ctx->ctx.fq);
+        return fq_mat_can_solve(X->fq, A->fq, B->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1334,7 +1334,7 @@ void fq_default_mat_similarity(fq_default_mat_t A, slong r,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_similarity(A->fq_nmod, r, d->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_mat_similarity(A->fq_nmod, r, d->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1346,7 +1346,7 @@ void fq_default_mat_similarity(fq_default_mat_t A, slong r,
     }
     else
     {
-        fq_mat_similarity(A->fq, r, d->fq, ctx->ctx.fq);
+        fq_mat_similarity(A->fq, r, d->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 

--- a/src/fq_default_mat/io.c
+++ b/src/fq_default_mat/io.c
@@ -28,7 +28,7 @@ int fq_default_mat_fprint(FILE * file, const fq_default_mat_t mat, const fq_defa
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
-        return fmpz_mod_mat_fprint(file, mat->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_mat_fprint(file, mat->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -52,7 +52,7 @@ int fq_default_mat_fprint_pretty(FILE * file, const fq_default_mat_t mat, const 
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_mat_fprint_pretty(file, mat->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_mat_fprint_pretty(file, mat->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {

--- a/src/fq_default_mat/io.c
+++ b/src/fq_default_mat/io.c
@@ -16,7 +16,7 @@ int fq_default_mat_fprint(FILE * file, const fq_default_mat_t mat, const fq_defa
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_mat_fprint(file, mat->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_mat_fprint(file, mat->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -40,7 +40,7 @@ int fq_default_mat_fprint_pretty(FILE * file, const fq_default_mat_t mat, const 
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_mat_fprint_pretty(file, mat->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_mat_fprint_pretty(file, mat->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {

--- a/src/fq_default_mat/io.c
+++ b/src/fq_default_mat/io.c
@@ -14,19 +14,19 @@
 
 int fq_default_mat_fprint(FILE * file, const fq_default_mat_t mat, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_mat_fprint(file, mat->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_mat_fprint(file, mat->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_mat_fprint(file, mat->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return fmpz_mod_mat_fprint(file, mat->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -38,19 +38,19 @@ int fq_default_mat_fprint(FILE * file, const fq_default_mat_t mat, const fq_defa
 
 int fq_default_mat_fprint_pretty(FILE * file, const fq_default_mat_t mat, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_mat_fprint_pretty(file, mat->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_mat_fprint_pretty(file, mat->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_mat_fprint_pretty(file, mat->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_mat_fprint_pretty(file, mat->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }

--- a/src/fq_default_mat/io.c
+++ b/src/fq_default_mat/io.c
@@ -20,7 +20,7 @@ int fq_default_mat_fprint(FILE * file, const fq_default_mat_t mat, const fq_defa
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_mat_fprint(file, mat->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_mat_fprint(file, mat->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -32,7 +32,7 @@ int fq_default_mat_fprint(FILE * file, const fq_default_mat_t mat, const fq_defa
     }
     else
     {
-        return fq_mat_fprint(file, mat->fq, ctx->ctx.fq);
+        return fq_mat_fprint(file, mat->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -44,7 +44,7 @@ int fq_default_mat_fprint_pretty(FILE * file, const fq_default_mat_t mat, const 
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_mat_fprint_pretty(file, mat->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_mat_fprint_pretty(file, mat->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -56,7 +56,7 @@ int fq_default_mat_fprint_pretty(FILE * file, const fq_default_mat_t mat, const 
     }
     else
     {
-        return fq_mat_fprint_pretty(file, mat->fq, ctx->ctx.fq);
+        return fq_mat_fprint_pretty(file, mat->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 

--- a/src/fq_default_poly.h
+++ b/src/fq_default_poly.h
@@ -54,7 +54,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_init(fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_init(poly->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_poly_init(poly->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -66,7 +66,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_init(fq_default_poly_t poly,
     }
     else
     {
-        fq_poly_init(poly->fq, ctx->ctx.fq);
+        fq_poly_init(poly->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -79,7 +79,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_init2(fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_init2(poly->fq_nmod, alloc, ctx->ctx.fq_nmod);
+        fq_nmod_poly_init2(poly->fq_nmod, alloc, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -91,7 +91,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_init2(fq_default_poly_t poly,
     }
     else
     {
-        fq_poly_init2(poly->fq, alloc, ctx->ctx.fq);
+        fq_poly_init2(poly->fq, alloc, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -104,7 +104,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_realloc(fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_realloc(poly->fq_nmod, alloc, ctx->ctx.fq_nmod);
+        fq_nmod_poly_realloc(poly->fq_nmod, alloc, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -116,7 +116,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_realloc(fq_default_poly_t poly,
     }
     else
     {
-        fq_poly_realloc(poly->fq, alloc, ctx->ctx.fq);
+        fq_poly_realloc(poly->fq, alloc, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -129,7 +129,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_truncate(fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_truncate(poly->fq_nmod, len, ctx->ctx.fq_nmod);
+        fq_nmod_poly_truncate(poly->fq_nmod, len, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -141,7 +141,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_truncate(fq_default_poly_t poly,
     }
     else
     {
-        fq_poly_truncate(poly->fq, len, ctx->ctx.fq);
+        fq_poly_truncate(poly->fq, len, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -156,7 +156,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_set_trunc(fq_default_poly_t poly1,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_set_trunc(poly1->fq_nmod,
-		                        poly2->fq_nmod, len, ctx->ctx.fq_nmod);
+		                        poly2->fq_nmod, len, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -169,7 +169,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_set_trunc(fq_default_poly_t poly1,
     }
     else
     {
-        fq_poly_set_trunc(poly1->fq, poly2->fq, len, ctx->ctx.fq);
+        fq_poly_set_trunc(poly1->fq, poly2->fq, len, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -182,7 +182,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_fit_length(fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_fit_length(poly->fq_nmod, len, ctx->ctx.fq_nmod);
+        fq_nmod_poly_fit_length(poly->fq_nmod, len, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -194,7 +194,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_fit_length(fq_default_poly_t poly,
     }
     else
     {
-        fq_poly_fit_length(poly->fq, len, ctx->ctx.fq);
+        fq_poly_fit_length(poly->fq, len, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -208,7 +208,7 @@ void _fq_default_poly_set_length(fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        _fq_nmod_poly_set_length(poly->fq_nmod, len, ctx->ctx.fq_nmod);
+        _fq_nmod_poly_set_length(poly->fq_nmod, len, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -220,7 +220,7 @@ void _fq_default_poly_set_length(fq_default_poly_t poly,
     }
     else
     {
-        _fq_poly_set_length(poly->fq, len, ctx->ctx.fq);
+        _fq_poly_set_length(poly->fq, len, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -233,7 +233,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_clear(fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_clear(poly->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_poly_clear(poly->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -245,7 +245,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_clear(fq_default_poly_t poly,
     }
     else
     {
-        fq_poly_clear(poly->fq, ctx->ctx.fq);
+        fq_poly_clear(poly->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -261,7 +261,7 @@ fq_default_poly_length(const fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_poly_length(poly->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_poly_length(poly->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -273,7 +273,7 @@ fq_default_poly_length(const fq_default_poly_t poly,
     }
     else
     {
-        return fq_poly_length(poly->fq, ctx->ctx.fq);
+        return fq_poly_length(poly->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -287,7 +287,7 @@ fq_default_poly_degree(const fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_poly_degree(poly->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_poly_degree(poly->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -299,7 +299,7 @@ fq_default_poly_degree(const fq_default_poly_t poly,
     }
     else
     {
-        return fq_poly_degree(poly->fq, ctx->ctx.fq);
+        return fq_poly_degree(poly->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -314,7 +314,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_randtest(fq_default_poly_t f,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_randtest(f->fq_nmod, state, len, ctx->ctx.fq_nmod);
+        fq_nmod_poly_randtest(f->fq_nmod, state, len, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -326,7 +326,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_randtest(fq_default_poly_t f,
     }
     else
     {
-        fq_poly_randtest(f->fq, state, len, ctx->ctx.fq);
+        fq_poly_randtest(f->fq, state, len, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -340,7 +340,7 @@ void fq_default_poly_randtest_not_zero(fq_default_poly_t f,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_randtest_not_zero(f->fq_nmod, state, len, ctx->ctx.fq_nmod);
+        fq_nmod_poly_randtest_not_zero(f->fq_nmod, state, len, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -353,7 +353,7 @@ void fq_default_poly_randtest_not_zero(fq_default_poly_t f,
     }
     else
     {
-        fq_poly_randtest_not_zero(f->fq, state, len, ctx->ctx.fq);
+        fq_poly_randtest_not_zero(f->fq, state, len, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -367,7 +367,7 @@ void fq_default_poly_randtest_monic(fq_default_poly_t f,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_randtest_monic(f->fq_nmod, state, len, ctx->ctx.fq_nmod);
+        fq_nmod_poly_randtest_monic(f->fq_nmod, state, len, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -380,7 +380,7 @@ void fq_default_poly_randtest_monic(fq_default_poly_t f,
     }
     else
     {
-        fq_poly_randtest_monic(f->fq, state, len, ctx->ctx.fq);
+        fq_poly_randtest_monic(f->fq, state, len, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -396,7 +396,7 @@ void fq_default_poly_randtest_irreducible(fq_default_poly_t f,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_randtest_irreducible(f->fq_nmod,
-                                                 state, len, ctx->ctx.fq_nmod);
+                                                 state, len, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -409,7 +409,7 @@ void fq_default_poly_randtest_irreducible(fq_default_poly_t f,
     }
     else
     {
-        fq_poly_randtest_irreducible(f->fq, state, len, ctx->ctx.fq);
+        fq_poly_randtest_irreducible(f->fq, state, len, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -424,7 +424,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_set(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_set(rop->fq_nmod, op->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_poly_set(rop->fq_nmod, op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -436,7 +436,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_set(fq_default_poly_t rop,
     }
     else
     {
-        fq_poly_set(rop->fq, op->fq, ctx->ctx.fq);
+        fq_poly_set(rop->fq, op->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -450,7 +450,7 @@ void fq_default_poly_set_fq_default(fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_set_fq_nmod(poly->fq_nmod, c->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_poly_set_fq_nmod(poly->fq_nmod, c->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -464,7 +464,7 @@ void fq_default_poly_set_fq_default(fq_default_poly_t poly,
     }
     else
     {
-        fq_poly_set_fq(poly->fq, c->fq, ctx->ctx.fq);
+        fq_poly_set_fq(poly->fq, c->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -477,7 +477,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_swap(fq_default_poly_t op1,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_swap(op1->fq_nmod, op2->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_poly_swap(op1->fq_nmod, op2->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -489,7 +489,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_swap(fq_default_poly_t op1,
     }
     else
     {
-        fq_poly_swap(op1->fq, op2->fq, ctx->ctx.fq);
+        fq_poly_swap(op1->fq, op2->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -502,7 +502,7 @@ fq_default_poly_zero(fq_default_poly_t poly, const fq_default_ctx_t ctx)
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_zero(poly->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_poly_zero(poly->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -514,7 +514,7 @@ fq_default_poly_zero(fq_default_poly_t poly, const fq_default_ctx_t ctx)
     }
     else
     {
-        fq_poly_zero(poly->fq, ctx->ctx.fq);
+        fq_poly_zero(poly->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -527,7 +527,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_one(fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_one(poly->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_poly_one(poly->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -539,7 +539,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_one(fq_default_poly_t poly,
     }
     else
     {
-        fq_poly_one(poly->fq, ctx->ctx.fq);
+        fq_poly_one(poly->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -552,7 +552,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_gen(fq_default_poly_t f,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_gen(f->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_poly_gen(f->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -565,7 +565,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_gen(fq_default_poly_t f,
     }
     else
     {
-        fq_poly_gen(f->fq, ctx->ctx.fq);
+        fq_poly_gen(f->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -578,7 +578,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_make_monic(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_make_monic(rop->fq_nmod, op->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_poly_make_monic(rop->fq_nmod, op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -591,7 +591,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_make_monic(fq_default_poly_t rop,
     }
     else
     {
-        fq_poly_make_monic(rop->fq, op->fq, ctx->ctx.fq);
+        fq_poly_make_monic(rop->fq, op->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -604,7 +604,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_reverse(fq_default_poly_t res,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_reverse(res->fq_nmod, poly->fq_nmod, n, ctx->ctx.fq_nmod);
+        fq_nmod_poly_reverse(res->fq_nmod, poly->fq_nmod, n, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -617,7 +617,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_reverse(fq_default_poly_t res,
     }
     else
     {
-        fq_poly_reverse(res->fq, poly->fq, n, ctx->ctx.fq);
+        fq_poly_reverse(res->fq, poly->fq, n, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -631,7 +631,7 @@ ulong fq_default_poly_deflation(const fq_default_poly_t input,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_poly_deflation(input->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_poly_deflation(input->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -643,7 +643,7 @@ ulong fq_default_poly_deflation(const fq_default_poly_t input,
     }
     else
     {
-        return fq_poly_deflation(input->fq, ctx->ctx.fq);
+        return fq_poly_deflation(input->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -658,7 +658,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_deflate(fq_default_poly_t result,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_deflate(result->fq_nmod,
-                                  input->fq_nmod, deflation, ctx->ctx.fq_nmod);
+                                  input->fq_nmod, deflation, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -671,7 +671,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_deflate(fq_default_poly_t result,
     }
     else
     {
-        fq_poly_deflate(result->fq, input->fq, deflation, ctx->ctx.fq);
+        fq_poly_deflate(result->fq, input->fq, deflation, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -686,7 +686,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_inflate(fq_default_poly_t result,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_inflate(result->fq_nmod,
-                                  input->fq_nmod, inflation, ctx->ctx.fq_nmod);
+                                  input->fq_nmod, inflation, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -699,7 +699,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_inflate(fq_default_poly_t result,
     }
     else
     {
-        fq_poly_inflate(result->fq, input->fq, inflation, ctx->ctx.fq);
+        fq_poly_inflate(result->fq, input->fq, inflation, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -714,7 +714,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_get_coeff(fq_default_t x,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_get_coeff(x->fq_nmod, poly->fq_nmod, n, ctx->ctx.fq_nmod);
+        fq_nmod_poly_get_coeff(x->fq_nmod, poly->fq_nmod, n, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -727,7 +727,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_get_coeff(fq_default_t x,
     }
     else
     {
-        fq_poly_get_coeff(x->fq, poly->fq, n, ctx->ctx.fq);
+        fq_poly_get_coeff(x->fq, poly->fq, n, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -740,7 +740,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_set_coeff(fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_set_coeff(poly->fq_nmod, n, x->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_poly_set_coeff(poly->fq_nmod, n, x->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -753,7 +753,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_set_coeff(fq_default_poly_t poly,
     }
     else
     {
-        fq_poly_set_coeff(poly->fq, n, x->fq, ctx->ctx.fq);
+        fq_poly_set_coeff(poly->fq, n, x->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -767,7 +767,7 @@ fq_default_poly_set_coeff_fmpz(fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_set_coeff_fmpz(poly->fq_nmod, n, x, ctx->ctx.fq_nmod);
+        fq_nmod_poly_set_coeff_fmpz(poly->fq_nmod, n, x, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -780,7 +780,7 @@ fq_default_poly_set_coeff_fmpz(fq_default_poly_t poly,
     }
     else
     {
-        fq_poly_set_coeff_fmpz(poly->fq, n, x, ctx->ctx.fq);
+        fq_poly_set_coeff_fmpz(poly->fq, n, x, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -794,7 +794,7 @@ void fq_default_poly_set_nmod_poly(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_set_nmod_poly(rop->fq_nmod, op, ctx->ctx.fq_nmod);
+        fq_nmod_poly_set_nmod_poly(rop->fq_nmod, op, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -806,7 +806,7 @@ void fq_default_poly_set_nmod_poly(fq_default_poly_t rop,
     }
     else
     {
-        fq_poly_set_nmod_poly(rop->fq, op, ctx->ctx.fq);
+        fq_poly_set_nmod_poly(rop->fq, op, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -820,7 +820,7 @@ void fq_default_poly_set_fmpz_mod_poly(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_set_fmpz_mod_poly(rop->fq_nmod, op, ctx->ctx.fq_nmod);
+        fq_nmod_poly_set_fmpz_mod_poly(rop->fq_nmod, op, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -832,7 +832,7 @@ void fq_default_poly_set_fmpz_mod_poly(fq_default_poly_t rop,
     }
     else
     {
-        fq_poly_set_fmpz_mod_poly(rop->fq, op, ctx->ctx.fq);
+        fq_poly_set_fmpz_mod_poly(rop->fq, op, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -852,7 +852,7 @@ int fq_default_poly_equal(const fq_default_poly_t poly1,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_poly_equal(poly1->fq_nmod, poly2->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_poly_equal(poly1->fq_nmod, poly2->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -865,7 +865,7 @@ int fq_default_poly_equal(const fq_default_poly_t poly1,
     }
     else
     {
-        return fq_poly_equal(poly1->fq, poly2->fq, ctx->ctx.fq);
+        return fq_poly_equal(poly1->fq, poly2->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -881,7 +881,7 @@ int fq_default_poly_equal_trunc(const fq_default_poly_t poly1,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_poly_equal_trunc(poly1->fq_nmod,
-                                          poly2->fq_nmod, n, ctx->ctx.fq_nmod);
+                                          poly2->fq_nmod, n, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -894,7 +894,7 @@ int fq_default_poly_equal_trunc(const fq_default_poly_t poly1,
     }
     else
     {
-        return fq_poly_equal_trunc(poly1->fq, poly2->fq, n, ctx->ctx.fq);
+        return fq_poly_equal_trunc(poly1->fq, poly2->fq, n, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -908,7 +908,7 @@ fq_default_poly_is_zero(const fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_poly_is_zero(poly->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_poly_is_zero(poly->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -920,7 +920,7 @@ fq_default_poly_is_zero(const fq_default_poly_t poly,
     }
     else
     {
-        return fq_poly_is_zero(poly->fq, ctx->ctx.fq);
+        return fq_poly_is_zero(poly->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -933,7 +933,7 @@ fq_default_poly_is_one(const fq_default_poly_t op, const fq_default_ctx_t ctx)
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_poly_is_one(op->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_poly_is_one(op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -945,7 +945,7 @@ fq_default_poly_is_one(const fq_default_poly_t op, const fq_default_ctx_t ctx)
     }
     else
     {
-       return fq_poly_is_one(op->fq, ctx->ctx.fq);
+       return fq_poly_is_one(op->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -958,7 +958,7 @@ fq_default_poly_is_unit(const fq_default_poly_t op, const fq_default_ctx_t ctx)
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_poly_is_unit(op->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_poly_is_unit(op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -970,7 +970,7 @@ fq_default_poly_is_unit(const fq_default_poly_t op, const fq_default_ctx_t ctx)
     }
     else
     {
-        return fq_poly_is_unit(op->fq, ctx->ctx.fq);
+        return fq_poly_is_unit(op->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -984,7 +984,7 @@ fq_default_poly_is_gen(const fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_poly_is_gen(poly->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_poly_is_gen(poly->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -996,7 +996,7 @@ fq_default_poly_is_gen(const fq_default_poly_t poly,
     }
     else
     {
-        return fq_poly_is_gen(poly->fq, ctx->ctx.fq);
+        return fq_poly_is_gen(poly->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1012,7 +1012,7 @@ fq_default_poly_equal_fq_default(const fq_default_poly_t poly,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_poly_equal_fq_nmod(poly->fq_nmod,
-		                                 c->fq_nmod, ctx->ctx.fq_nmod);
+		                                 c->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1031,7 +1031,7 @@ fq_default_poly_equal_fq_default(const fq_default_poly_t poly,
     }
     else
     {
-        return fq_poly_equal_fq(poly->fq, c->fq, ctx->ctx.fq);
+        return fq_poly_equal_fq(poly->fq, c->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1049,7 +1049,7 @@ void fq_default_poly_add(fq_default_poly_t rop, const fq_default_poly_t op1,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_add(rop->fq_nmod,
-                                 op1->fq_nmod, op2->fq_nmod, ctx->ctx.fq_nmod);
+                                 op1->fq_nmod, op2->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1062,7 +1062,7 @@ void fq_default_poly_add(fq_default_poly_t rop, const fq_default_poly_t op1,
     }
     else
     {
-        fq_poly_add(rop->fq, op1->fq, op2->fq, ctx->ctx.fq);
+        fq_poly_add(rop->fq, op1->fq, op2->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1075,7 +1075,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_add_si(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_add_si(rop->fq_nmod, op1->fq_nmod, c, ctx->ctx.fq_nmod);
+        fq_nmod_poly_add_si(rop->fq_nmod, op1->fq_nmod, c, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1093,7 +1093,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_add_si(fq_default_poly_t rop,
     }
     else
     {
-        fq_poly_add_si(rop->fq, op1->fq, c, ctx->ctx.fq);
+        fq_poly_add_si(rop->fq, op1->fq, c, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1110,7 +1110,7 @@ void fq_default_poly_add_series(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_add_series(rop->fq_nmod,
-                              op1->fq_nmod, op2->fq_nmod, n, ctx->ctx.fq_nmod);
+                              op1->fq_nmod, op2->fq_nmod, n, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1123,7 +1123,7 @@ void fq_default_poly_add_series(fq_default_poly_t rop,
     }
     else
     {
-        fq_poly_add_series(rop->fq, op1->fq, op2->fq, n, ctx->ctx.fq);
+        fq_poly_add_series(rop->fq, op1->fq, op2->fq, n, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1139,7 +1139,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_sub(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_sub(rop->fq_nmod,
-                                 op1->fq_nmod, op2->fq_nmod, ctx->ctx.fq_nmod);
+                                 op1->fq_nmod, op2->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1152,7 +1152,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_sub(fq_default_poly_t rop,
     }
     else
     {
-        fq_poly_sub(rop->fq, op1->fq, op2->fq, ctx->ctx.fq);
+        fq_poly_sub(rop->fq, op1->fq, op2->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1168,7 +1168,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_sub_series(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_sub_series(rop->fq_nmod,
-                              op1->fq_nmod, op2->fq_nmod, n, ctx->ctx.fq_nmod);
+                              op1->fq_nmod, op2->fq_nmod, n, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1181,7 +1181,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_sub_series(fq_default_poly_t rop,
     }
     else
     {
-        fq_poly_sub_series(rop->fq, op1->fq, op2->fq, n, ctx->ctx.fq);
+        fq_poly_sub_series(rop->fq, op1->fq, op2->fq, n, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1194,7 +1194,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_neg(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_neg(rop->fq_nmod, op->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_poly_neg(rop->fq_nmod, op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1206,7 +1206,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_neg(fq_default_poly_t rop,
     }
     else
     {
-        fq_poly_neg(rop->fq, op->fq, ctx->ctx.fq);
+        fq_poly_neg(rop->fq, op->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1225,7 +1225,7 @@ void fq_default_poly_scalar_mul_fq_default(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_scalar_mul_fq_nmod(rop->fq_nmod,
-                                    op->fq_nmod, x->fq_nmod, ctx->ctx.fq_nmod);
+                                    op->fq_nmod, x->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1238,7 +1238,7 @@ void fq_default_poly_scalar_mul_fq_default(fq_default_poly_t rop,
     }
     else
     {
-        fq_poly_scalar_mul_fq(rop->fq, op->fq, x->fq, ctx->ctx.fq);
+        fq_poly_scalar_mul_fq(rop->fq, op->fq, x->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1255,7 +1255,7 @@ void fq_default_poly_scalar_div_fq_default(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_scalar_div_fq_nmod(rop->fq_nmod,
-                                    op->fq_nmod, x->fq_nmod, ctx->ctx.fq_nmod);
+                                    op->fq_nmod, x->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1273,7 +1273,7 @@ void fq_default_poly_scalar_div_fq_default(fq_default_poly_t rop,
     }
     else
     {
-        fq_poly_scalar_div_fq(rop->fq, op->fq, x->fq, ctx->ctx.fq);
+        fq_poly_scalar_div_fq(rop->fq, op->fq, x->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1290,7 +1290,7 @@ void fq_default_poly_scalar_addmul_fq_default(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_scalar_addmul_fq_nmod(rop->fq_nmod,
-                                    op->fq_nmod, x->fq_nmod, ctx->ctx.fq_nmod);
+                                    op->fq_nmod, x->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1303,7 +1303,7 @@ void fq_default_poly_scalar_addmul_fq_default(fq_default_poly_t rop,
     }
     else
     {
-        fq_poly_scalar_addmul_fq(rop->fq, op->fq, x->fq, ctx->ctx.fq);
+        fq_poly_scalar_addmul_fq(rop->fq, op->fq, x->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1320,7 +1320,7 @@ void fq_default_poly_scalar_submul_fq_default(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_scalar_submul_fq_nmod(rop->fq_nmod,
-                                    op->fq_nmod, x->fq_nmod, ctx->ctx.fq_nmod);
+                                    op->fq_nmod, x->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1338,7 +1338,7 @@ void fq_default_poly_scalar_submul_fq_default(fq_default_poly_t rop,
     }
     else
     {
-        fq_poly_scalar_submul_fq(rop->fq, op->fq, x->fq, ctx->ctx.fq);
+        fq_poly_scalar_submul_fq(rop->fq, op->fq, x->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1356,7 +1356,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_mul(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_mul(rop->fq_nmod,
-                                 op1->fq_nmod, op2->fq_nmod, ctx->ctx.fq_nmod);
+                                 op1->fq_nmod, op2->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1369,7 +1369,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_mul(fq_default_poly_t rop,
     }
     else
     {
-        fq_poly_mul(rop->fq, op1->fq, op2->fq, ctx->ctx.fq);
+        fq_poly_mul(rop->fq, op1->fq, op2->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1385,7 +1385,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_mullow(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_mullow(rop->fq_nmod,
-                              op1->fq_nmod, op2->fq_nmod, n, ctx->ctx.fq_nmod);
+                              op1->fq_nmod, op2->fq_nmod, n, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1398,7 +1398,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_mullow(fq_default_poly_t rop,
     }
     else
     {
-        fq_poly_mullow(rop->fq, op1->fq, op2->fq, n, ctx->ctx.fq);
+        fq_poly_mullow(rop->fq, op1->fq, op2->fq, n, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1414,7 +1414,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_mulhigh(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_mulhigh(rop->fq_nmod,
-                          op1->fq_nmod, op2->fq_nmod, start, ctx->ctx.fq_nmod);
+                          op1->fq_nmod, op2->fq_nmod, start, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1427,7 +1427,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_mulhigh(fq_default_poly_t rop,
     }
     else
     {
-        fq_poly_mulhigh(rop->fq, op1->fq, op2->fq, start, ctx->ctx.fq);
+        fq_poly_mulhigh(rop->fq, op1->fq, op2->fq, start, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1443,7 +1443,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_mulmod(fq_default_poly_t res,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_mulmod(res->fq_nmod, poly1->fq_nmod, poly2->fq_nmod,
-                                                 f->fq_nmod, ctx->ctx.fq_nmod);
+                                                 f->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1456,7 +1456,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_mulmod(fq_default_poly_t res,
     }
     else
     {
-        fq_poly_mulmod(res->fq, poly1->fq, poly2->fq, f->fq, ctx->ctx.fq);
+        fq_poly_mulmod(res->fq, poly1->fq, poly2->fq, f->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1471,7 +1471,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_sqr(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_sqr(rop->fq_nmod, op->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_poly_sqr(rop->fq_nmod, op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1483,7 +1483,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_sqr(fq_default_poly_t rop,
     }
     else
     {
-        fq_poly_sqr(rop->fq, op->fq, ctx->ctx.fq);
+        fq_poly_sqr(rop->fq, op->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1499,7 +1499,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_pow(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_pow(rop->fq_nmod, op->fq_nmod, e, ctx->ctx.fq_nmod);
+        fq_nmod_poly_pow(rop->fq_nmod, op->fq_nmod, e, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1511,7 +1511,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_pow(fq_default_poly_t rop,
     }
     else
     {
-        fq_poly_pow(rop->fq, op->fq, e, ctx->ctx.fq);
+        fq_poly_pow(rop->fq, op->fq, e, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1528,7 +1528,7 @@ void fq_default_poly_pow_trunc(fq_default_poly_t res,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_pow_trunc(res->fq_nmod,
-                                    poly->fq_nmod, e, trunc, ctx->ctx.fq_nmod);
+                                    poly->fq_nmod, e, trunc, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1541,7 +1541,7 @@ void fq_default_poly_pow_trunc(fq_default_poly_t res,
     }
     else
     {
-        fq_poly_pow_trunc(res->fq, poly->fq, e, trunc, ctx->ctx.fq);
+        fq_poly_pow_trunc(res->fq, poly->fq, e, trunc, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1558,7 +1558,7 @@ void fq_default_poly_powmod_fmpz_binexp(fq_default_poly_t res,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_powmod_fmpz_binexp(res->fq_nmod,
-                               poly->fq_nmod, e, f->fq_nmod, ctx->ctx.fq_nmod);
+                               poly->fq_nmod, e, f->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1571,7 +1571,7 @@ void fq_default_poly_powmod_fmpz_binexp(fq_default_poly_t res,
     }
     else
     {
-        fq_poly_powmod_fmpz_binexp(res->fq, poly->fq, e, f->fq, ctx->ctx.fq);
+        fq_poly_powmod_fmpz_binexp(res->fq, poly->fq, e, f->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1588,7 +1588,7 @@ void fq_default_poly_powmod_ui_binexp(fq_default_poly_t res,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_powmod_ui_binexp(res->fq_nmod,
-                               poly->fq_nmod, e, f->fq_nmod, ctx->ctx.fq_nmod);
+                               poly->fq_nmod, e, f->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1601,7 +1601,7 @@ void fq_default_poly_powmod_ui_binexp(fq_default_poly_t res,
     }
     else
     {
-        fq_poly_powmod_ui_binexp(res->fq, poly->fq, e, f->fq, ctx->ctx.fq);
+        fq_poly_powmod_ui_binexp(res->fq, poly->fq, e, f->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1617,7 +1617,7 @@ void fq_default_poly_shift_left(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_shift_left(rop->fq_nmod, op->fq_nmod, n, ctx->ctx.fq_nmod);
+        fq_nmod_poly_shift_left(rop->fq_nmod, op->fq_nmod, n, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1630,7 +1630,7 @@ void fq_default_poly_shift_left(fq_default_poly_t rop,
     }
     else
     {
-        fq_poly_shift_left(rop->fq, op->fq, n, ctx->ctx.fq);
+        fq_poly_shift_left(rop->fq, op->fq, n, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1644,7 +1644,7 @@ void fq_default_poly_shift_right(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_shift_right(rop->fq_nmod, op->fq_nmod, n, ctx->ctx.fq_nmod);
+        fq_nmod_poly_shift_right(rop->fq_nmod, op->fq_nmod, n, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1657,7 +1657,7 @@ void fq_default_poly_shift_right(fq_default_poly_t rop,
     }
     else
     {
-        fq_poly_shift_right(rop->fq, op->fq, n, ctx->ctx.fq);
+        fq_poly_shift_right(rop->fq, op->fq, n, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1673,7 +1673,7 @@ slong fq_default_poly_hamming_weight(const fq_default_poly_t op,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_poly_hamming_weight(op->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_poly_hamming_weight(op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1685,7 +1685,7 @@ slong fq_default_poly_hamming_weight(const fq_default_poly_t op,
     }
     else
     {
-        return fq_poly_hamming_weight(op->fq, ctx->ctx.fq);
+        return fq_poly_hamming_weight(op->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1703,7 +1703,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_gcd(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_gcd(rop->fq_nmod,
-		                 op1->fq_nmod, op2->fq_nmod, ctx->ctx.fq_nmod);
+		                 op1->fq_nmod, op2->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1716,7 +1716,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_gcd(fq_default_poly_t rop,
     }
     else
     {
-        fq_poly_gcd(rop->fq, op1->fq, op2->fq, ctx->ctx.fq);
+        fq_poly_gcd(rop->fq, op1->fq, op2->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1734,7 +1734,7 @@ fq_default_poly_xgcd(fq_default_poly_t G,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_xgcd(G->fq_nmod,
-             S->fq_nmod, T->fq_nmod, A->fq_nmod, B->fq_nmod, ctx->ctx.fq_nmod);
+             S->fq_nmod, T->fq_nmod, A->fq_nmod, B->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1747,7 +1747,7 @@ fq_default_poly_xgcd(fq_default_poly_t G,
     }
     else
     {
-        fq_poly_xgcd(G->fq, S->fq, T->fq, A->fq, B->fq, ctx->ctx.fq);
+        fq_poly_xgcd(G->fq, S->fq, T->fq, A->fq, B->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1762,7 +1762,7 @@ FQ_DEFAULT_POLY_INLINE ulong fq_default_poly_remove(fq_default_poly_t f,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_poly_remove(f->fq_nmod, g->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_poly_remove(f->fq_nmod, g->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1775,7 +1775,7 @@ FQ_DEFAULT_POLY_INLINE ulong fq_default_poly_remove(fq_default_poly_t f,
     }
     else
     {
-        return fq_poly_remove(f->fq, g->fq, ctx->ctx.fq);
+        return fq_poly_remove(f->fq, g->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1792,7 +1792,7 @@ fq_default_poly_divrem(fq_default_poly_t Q, fq_default_poly_t R,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_divrem(Q->fq_nmod,
-                         R->fq_nmod, A->fq_nmod, B->fq_nmod, ctx->ctx.fq_nmod);
+                         R->fq_nmod, A->fq_nmod, B->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1805,7 +1805,7 @@ fq_default_poly_divrem(fq_default_poly_t Q, fq_default_poly_t R,
     }
     else
     {
-        fq_poly_divrem(Q->fq, R->fq, A->fq, B->fq, ctx->ctx.fq);
+        fq_poly_divrem(Q->fq, R->fq, A->fq, B->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1820,7 +1820,7 @@ fq_default_poly_rem(fq_default_poly_t R,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_rem(R->fq_nmod, A->fq_nmod, B->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_poly_rem(R->fq_nmod, A->fq_nmod, B->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1833,7 +1833,7 @@ fq_default_poly_rem(fq_default_poly_t R,
     }
     else
     {
-        fq_poly_rem(R->fq, A->fq, B->fq, ctx->ctx.fq);
+        fq_poly_rem(R->fq, A->fq, B->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1848,7 +1848,7 @@ fq_default_poly_inv_series(fq_default_poly_t Qinv,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_inv_series(Qinv->fq_nmod, Q->fq_nmod, n, ctx->ctx.fq_nmod);
+        fq_nmod_poly_inv_series(Qinv->fq_nmod, Q->fq_nmod, n, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1861,7 +1861,7 @@ fq_default_poly_inv_series(fq_default_poly_t Qinv,
     }
     else
     {
-        fq_poly_inv_series(Qinv->fq, Q->fq, n, ctx->ctx.fq);
+        fq_poly_inv_series(Qinv->fq, Q->fq, n, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1877,7 +1877,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_div_series(fq_default_poly_t Q,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_div_series(Q->fq_nmod,
-                                  A->fq_nmod, B->fq_nmod, n, ctx->ctx.fq_nmod);
+                                  A->fq_nmod, B->fq_nmod, n, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1890,7 +1890,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_div_series(fq_default_poly_t Q,
     }
     else
     {
-        fq_poly_div_series(Q->fq, A->fq, B->fq, n, ctx->ctx.fq);
+        fq_poly_div_series(Q->fq, A->fq, B->fq, n, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1908,7 +1908,7 @@ FQ_DEFAULT_POLY_INLINE int fq_default_poly_divides(fq_default_poly_t Q,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_poly_divides(Q->fq_nmod,
-                                     A->fq_nmod, B->fq_nmod, ctx->ctx.fq_nmod);
+                                     A->fq_nmod, B->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1921,7 +1921,7 @@ FQ_DEFAULT_POLY_INLINE int fq_default_poly_divides(fq_default_poly_t Q,
     }
     else
     {
-        return fq_poly_divides(Q->fq, A->fq, B->fq, ctx->ctx.fq);
+        return fq_poly_divides(Q->fq, A->fq, B->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1937,7 +1937,7 @@ void fq_default_poly_derivative(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_derivative(rop->fq_nmod, op->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_poly_derivative(rop->fq_nmod, op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1950,7 +1950,7 @@ void fq_default_poly_derivative(fq_default_poly_t rop,
     }
     else
     {
-        fq_poly_derivative(rop->fq, op->fq, ctx->ctx.fq);
+        fq_poly_derivative(rop->fq, op->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1966,7 +1966,7 @@ void fq_default_poly_invsqrt_series(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_invsqrt_series(rop->fq_nmod, op->fq_nmod, n, ctx->ctx.fq_nmod);
+        fq_nmod_poly_invsqrt_series(rop->fq_nmod, op->fq_nmod, n, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -1978,7 +1978,7 @@ void fq_default_poly_invsqrt_series(fq_default_poly_t rop,
     }
     else
     {
-        fq_poly_invsqrt_series(rop->fq, op->fq, n, ctx->ctx.fq);
+        fq_poly_invsqrt_series(rop->fq, op->fq, n, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -1992,7 +1992,7 @@ void fq_default_poly_sqrt_series(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_sqrt_series(rop->fq_nmod, op->fq_nmod, n, ctx->ctx.fq_nmod);
+        fq_nmod_poly_sqrt_series(rop->fq_nmod, op->fq_nmod, n, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -2004,7 +2004,7 @@ void fq_default_poly_sqrt_series(fq_default_poly_t rop,
     }
     else
     {
-        fq_poly_sqrt_series(rop->fq, op->fq, n, ctx->ctx.fq);
+        fq_poly_sqrt_series(rop->fq, op->fq, n, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -2018,7 +2018,7 @@ int fq_default_poly_sqrt(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_poly_sqrt(rop->fq_nmod, op->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_poly_sqrt(rop->fq_nmod, op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -2030,7 +2030,7 @@ int fq_default_poly_sqrt(fq_default_poly_t rop,
     }
     else
     {
-        return fq_poly_sqrt(rop->fq, op->fq, ctx->ctx.fq);
+        return fq_poly_sqrt(rop->fq, op->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -2049,7 +2049,7 @@ void fq_default_poly_evaluate_fq_default(fq_default_t res,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_evaluate_fq_nmod(res->fq_nmod,
-		                     f->fq_nmod, a->fq_nmod, ctx->ctx.fq_nmod);
+		                     f->fq_nmod, a->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -2062,7 +2062,7 @@ void fq_default_poly_evaluate_fq_default(fq_default_t res,
     }
     else
     {
-        fq_poly_evaluate_fq(res->fq, f->fq, a->fq, ctx->ctx.fq);
+        fq_poly_evaluate_fq(res->fq, f->fq, a->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -2081,7 +2081,7 @@ void fq_default_poly_compose(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_compose(rop->fq_nmod,
-                                 op1->fq_nmod, op2->fq_nmod, ctx->ctx.fq_nmod);
+                                 op1->fq_nmod, op2->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -2094,7 +2094,7 @@ void fq_default_poly_compose(fq_default_poly_t rop,
     }
     else
     {
-        fq_poly_compose(rop->fq, op1->fq, op2->fq, ctx->ctx.fq);
+        fq_poly_compose(rop->fq, op1->fq, op2->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -2111,7 +2111,7 @@ void fq_default_poly_compose_mod(fq_default_poly_t res,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_compose_mod(res->fq_nmod,
-             poly1->fq_nmod, poly2->fq_nmod, poly3->fq_nmod, ctx->ctx.fq_nmod);
+             poly1->fq_nmod, poly2->fq_nmod, poly3->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -2125,7 +2125,7 @@ void fq_default_poly_compose_mod(fq_default_poly_t res,
     else
     {
         fq_poly_compose_mod(res->fq,
-                                 poly1->fq, poly2->fq, poly3->fq, ctx->ctx.fq);
+                                 poly1->fq, poly2->fq, poly3->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -2149,7 +2149,7 @@ char * fq_default_poly_get_str_pretty(const fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_poly_get_str_pretty(poly->fq_nmod, x, ctx->ctx.fq_nmod);
+        return fq_nmod_poly_get_str_pretty(poly->fq_nmod, x, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -2162,7 +2162,7 @@ char * fq_default_poly_get_str_pretty(const fq_default_poly_t poly,
     }
     else
     {
-        return fq_poly_get_str_pretty(poly->fq, x, ctx->ctx.fq);
+        return fq_poly_get_str_pretty(poly->fq, x, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -2176,7 +2176,7 @@ char * fq_default_poly_get_str(const fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_poly_get_str(poly->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_poly_get_str(poly->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -2188,7 +2188,7 @@ char * fq_default_poly_get_str(const fq_default_poly_t poly,
     }
     else
     {
-        return fq_poly_get_str(poly->fq, ctx->ctx.fq);
+        return fq_poly_get_str(poly->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -2206,7 +2206,7 @@ void fq_default_mat_charpoly(fq_default_poly_t p,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_charpoly(p->fq_nmod, M->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_mat_charpoly(p->fq_nmod, M->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -2218,7 +2218,7 @@ void fq_default_mat_charpoly(fq_default_poly_t p,
     }
     else
     {
-        fq_mat_charpoly(p->fq, M->fq, ctx->ctx.fq);
+        fq_mat_charpoly(p->fq, M->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -2234,7 +2234,7 @@ void fq_default_mat_minpoly(fq_default_poly_t p,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_mat_minpoly(p->fq_nmod, X->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_mat_minpoly(p->fq_nmod, X->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -2246,7 +2246,7 @@ void fq_default_mat_minpoly(fq_default_poly_t p,
     }
     else
     {
-        fq_mat_minpoly(p->fq, X->fq, ctx->ctx.fq);
+        fq_mat_minpoly(p->fq, X->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 

--- a/src/fq_default_poly.h
+++ b/src/fq_default_poly.h
@@ -62,7 +62,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_init(fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_init(poly->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_init(poly->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -87,7 +87,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_init2(fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_init2(poly->fmpz_mod, alloc, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_init2(poly->fmpz_mod, alloc, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -112,7 +112,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_realloc(fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_realloc(poly->fmpz_mod, alloc, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_realloc(poly->fmpz_mod, alloc, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -137,7 +137,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_truncate(fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_truncate(poly->fmpz_mod, len, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_truncate(poly->fmpz_mod, len, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -165,7 +165,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_set_trunc(fq_default_poly_t poly1,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_set_trunc(poly1->fmpz_mod,
-                                  poly2->fmpz_mod, len, ctx->ctx.fmpz_mod.mod);
+                                  poly2->fmpz_mod, len, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -190,7 +190,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_fit_length(fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_fit_length(poly->fmpz_mod, len, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_fit_length(poly->fmpz_mod, len, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -241,7 +241,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_clear(fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_clear(poly->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_clear(poly->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -269,7 +269,7 @@ fq_default_poly_length(const fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_poly_length(poly->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_poly_length(poly->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -295,7 +295,7 @@ fq_default_poly_degree(const fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_poly_degree(poly->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_poly_degree(poly->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -322,7 +322,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_randtest(fq_default_poly_t f,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_randtest(f->fmpz_mod, state, len, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_randtest(f->fmpz_mod, state, len, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -349,7 +349,7 @@ void fq_default_poly_randtest_not_zero(fq_default_poly_t f,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_randtest_not_zero(f->fmpz_mod, state, len,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -376,7 +376,7 @@ void fq_default_poly_randtest_monic(fq_default_poly_t f,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_randtest_monic(f->fmpz_mod, state, len,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -405,7 +405,7 @@ void fq_default_poly_randtest_irreducible(fq_default_poly_t f,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_randtest_irreducible(f->fmpz_mod, state, len,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -432,7 +432,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_set(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_set(rop->fmpz_mod, op->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_set(rop->fmpz_mod, op->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -460,7 +460,7 @@ void fq_default_poly_set_fq_default(fq_default_poly_t poly,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_set_fmpz(poly->fmpz_mod, c->fmpz_mod,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -485,7 +485,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_swap(fq_default_poly_t op1,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_swap(op1->fmpz_mod, op2->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_swap(op1->fmpz_mod, op2->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -510,7 +510,7 @@ fq_default_poly_zero(fq_default_poly_t poly, const fq_default_ctx_t ctx)
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_zero(poly->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_zero(poly->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -535,7 +535,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_one(fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_one(poly->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_one(poly->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -561,7 +561,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_gen(fq_default_poly_t f,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_gen(f->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_gen(f->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -587,7 +587,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_make_monic(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_make_monic(rop->fmpz_mod, op->fmpz_mod,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -613,7 +613,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_reverse(fq_default_poly_t res,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_reverse(res->fmpz_mod, poly->fmpz_mod, n,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -639,7 +639,7 @@ ulong fq_default_poly_deflation(const fq_default_poly_t input,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_poly_deflation(input->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_poly_deflation(input->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -667,7 +667,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_deflate(fq_default_poly_t result,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_deflate(result->fmpz_mod, input->fmpz_mod, deflation,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -695,7 +695,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_inflate(fq_default_poly_t result,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_inflate(result->fmpz_mod, input->fmpz_mod, inflation,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -723,7 +723,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_get_coeff(fq_default_t x,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_get_coeff_fmpz(x->fmpz_mod, poly->fmpz_mod, n,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -749,7 +749,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_set_coeff(fq_default_poly_t poly,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_set_coeff_fmpz(poly->fmpz_mod, n, x->fmpz_mod,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -776,7 +776,7 @@ fq_default_poly_set_coeff_fmpz(fq_default_poly_t poly,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_set_coeff_fmpz(poly->fmpz_mod, n, x,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -828,7 +828,7 @@ void fq_default_poly_set_fmpz_mod_poly(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_set(rop->fmpz_mod, op, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_set(rop->fmpz_mod, op, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -861,7 +861,7 @@ int fq_default_poly_equal(const fq_default_poly_t poly1,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_poly_equal(poly1->fmpz_mod, poly2->fmpz_mod,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -890,7 +890,7 @@ int fq_default_poly_equal_trunc(const fq_default_poly_t poly1,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_poly_equal_trunc(poly1->fmpz_mod, poly2->fmpz_mod, n,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -916,7 +916,7 @@ fq_default_poly_is_zero(const fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_poly_is_zero(poly->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_poly_is_zero(poly->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -941,7 +941,7 @@ fq_default_poly_is_one(const fq_default_poly_t op, const fq_default_ctx_t ctx)
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_poly_is_one(op->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_poly_is_one(op->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -966,7 +966,7 @@ fq_default_poly_is_unit(const fq_default_poly_t op, const fq_default_ctx_t ctx)
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_poly_is_unit(op->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_poly_is_unit(op->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -992,7 +992,7 @@ fq_default_poly_is_gen(const fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_poly_is_gen(poly->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_poly_is_gen(poly->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1058,7 +1058,7 @@ void fq_default_poly_add(fq_default_poly_t rop, const fq_default_poly_t op1,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_add(rop->fmpz_mod, op1->fmpz_mod, op2->fmpz_mod,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1084,7 +1084,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_add_si(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_add_si(rop->fmpz_mod, op1->fmpz_mod, c,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1114,7 +1114,7 @@ void fq_default_poly_add_series(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_add_series(rop->fmpz_mod, op1->fmpz_mod, op2->fmpz_mod, n,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1143,7 +1143,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_sub(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_sub(rop->fmpz_mod, op1->fmpz_mod, op2->fmpz_mod,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1172,7 +1172,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_sub_series(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_sub_series(rop->fmpz_mod, op1->fmpz_mod, op2->fmpz_mod, n,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1197,7 +1197,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_neg(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_neg(rop->fmpz_mod, op->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_neg(rop->fmpz_mod, op->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1229,7 +1229,7 @@ void fq_default_poly_scalar_mul_fq_default(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_scalar_mul_fmpz(rop->fmpz_mod, op->fmpz_mod, x->fmpz_mod,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1261,9 +1261,9 @@ void fq_default_poly_scalar_div_fq_default(fq_default_poly_t rop,
     {
         fmpz_t t;
         fmpz_init(t);
-        fmpz_mod_inv(t, x->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_inv(t, x->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
         fmpz_mod_poly_scalar_mul_fmpz(rop->fmpz_mod, op->fmpz_mod, t,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
         fmpz_clear(t);
     }
     else
@@ -1294,7 +1294,7 @@ void fq_default_poly_scalar_addmul_fq_default(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_scalar_addmul_fmpz(rop->fmpz_mod, op->fmpz_mod,
-                                           x->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+                                           x->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1326,9 +1326,9 @@ void fq_default_poly_scalar_submul_fq_default(fq_default_poly_t rop,
     {
         fmpz_t t;
         fmpz_init(t);
-        fmpz_mod_neg(t, x->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_neg(t, x->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
         fmpz_mod_poly_scalar_addmul_fmpz(rop->fmpz_mod, op->fmpz_mod, t,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
         fmpz_clear(t);
     }
     else
@@ -1360,7 +1360,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_mul(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_mul(rop->fmpz_mod, op1->fmpz_mod,
-                                         op2->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+                                         op2->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1389,7 +1389,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_mullow(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_mullow(rop->fmpz_mod, op1->fmpz_mod, op2->fmpz_mod, n,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1418,7 +1418,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_mulhigh(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_mulhigh(rop->fmpz_mod, op1->fmpz_mod, op2->fmpz_mod,
-                                                 start, ctx->ctx.fmpz_mod.mod);
+                                                 start, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1447,7 +1447,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_mulmod(fq_default_poly_t res,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_mulmod(res->fmpz_mod, poly1->fmpz_mod, poly2->fmpz_mod,
-                                           f->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+                                           f->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1474,7 +1474,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_sqr(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_sqr(rop->fmpz_mod, op->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_sqr(rop->fmpz_mod, op->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1502,7 +1502,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_pow(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_pow(rop->fmpz_mod, op->fmpz_mod, e, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_pow(rop->fmpz_mod, op->fmpz_mod, e, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1532,7 +1532,7 @@ void fq_default_poly_pow_trunc(fq_default_poly_t res,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_pow_trunc(res->fmpz_mod, poly->fmpz_mod, e, trunc,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1562,7 +1562,7 @@ void fq_default_poly_powmod_fmpz_binexp(fq_default_poly_t res,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_powmod_fmpz_binexp(res->fmpz_mod, poly->fmpz_mod, e,
-                                           f->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+                                           f->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1592,7 +1592,7 @@ void fq_default_poly_powmod_ui_binexp(fq_default_poly_t res,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_powmod_ui_binexp(res->fmpz_mod, poly->fmpz_mod, e,
-                                           f->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+                                           f->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1621,7 +1621,7 @@ void fq_default_poly_shift_left(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_shift_left(rop->fmpz_mod, op->fmpz_mod, n,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1648,7 +1648,7 @@ void fq_default_poly_shift_right(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_shift_right(rop->fmpz_mod, op->fmpz_mod, n,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1676,7 +1676,7 @@ slong fq_default_poly_hamming_weight(const fq_default_poly_t op,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_poly_hamming_weight(op->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_poly_hamming_weight(op->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1707,7 +1707,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_gcd(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_gcd(rop->fmpz_mod, op1->fmpz_mod, op2->fmpz_mod,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1738,7 +1738,7 @@ fq_default_poly_xgcd(fq_default_poly_t G,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_xgcd(G->fmpz_mod, S->fmpz_mod, T->fmpz_mod, A->fmpz_mod,
-                                           B->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+                                           B->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1766,7 +1766,7 @@ FQ_DEFAULT_POLY_INLINE ulong fq_default_poly_remove(fq_default_poly_t f,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_poly_remove(f->fmpz_mod, g->fmpz_mod,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1796,7 +1796,7 @@ fq_default_poly_divrem(fq_default_poly_t Q, fq_default_poly_t R,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_divrem(Q->fmpz_mod, R->fmpz_mod, A->fmpz_mod,
-                                           B->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+                                           B->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1824,7 +1824,7 @@ fq_default_poly_rem(fq_default_poly_t R,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_rem(R->fmpz_mod, A->fmpz_mod, B->fmpz_mod,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1852,7 +1852,7 @@ fq_default_poly_inv_series(fq_default_poly_t Qinv,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_inv_series(Qinv->fmpz_mod, Q->fmpz_mod, n,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1881,7 +1881,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_div_series(fq_default_poly_t Q,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_div_series(Q->fmpz_mod, A->fmpz_mod, B->fmpz_mod, n,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1912,7 +1912,7 @@ FQ_DEFAULT_POLY_INLINE int fq_default_poly_divides(fq_default_poly_t Q,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_poly_divides(Q->fmpz_mod, A->fmpz_mod, B->fmpz_mod,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1941,7 +1941,7 @@ void fq_default_poly_derivative(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_derivative(rop->fmpz_mod, op->fmpz_mod,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1969,7 +1969,7 @@ void fq_default_poly_invsqrt_series(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_invsqrt_series(rop->fmpz_mod, op->fmpz_mod, n, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_invsqrt_series(rop->fmpz_mod, op->fmpz_mod, n, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -1995,7 +1995,7 @@ void fq_default_poly_sqrt_series(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_sqrt_series(rop->fmpz_mod, op->fmpz_mod, n, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_sqrt_series(rop->fmpz_mod, op->fmpz_mod, n, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -2021,7 +2021,7 @@ int fq_default_poly_sqrt(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_poly_sqrt(rop->fmpz_mod, op->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_poly_sqrt(rop->fmpz_mod, op->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -2053,7 +2053,7 @@ void fq_default_poly_evaluate_fq_default(fq_default_t res,
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
         fmpz_mod_poly_evaluate_fmpz(res->fmpz_mod, f->fmpz_mod, a->fmpz_mod,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -2085,7 +2085,7 @@ void fq_default_poly_compose(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_compose(rop->fmpz_mod, op1->fmpz_mod, op2->fmpz_mod,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -2115,7 +2115,7 @@ void fq_default_poly_compose_mod(fq_default_poly_t res,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_compose_mod(res->fmpz_mod, poly1->fmpz_mod,
-                      poly2->fmpz_mod, poly3->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+                      poly2->fmpz_mod, poly3->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -2153,7 +2153,7 @@ char * fq_default_poly_get_str_pretty(const fq_default_poly_t poly,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_poly_get_str_pretty(poly->fmpz_mod, x,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -2179,7 +2179,7 @@ char * fq_default_poly_get_str(const fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_poly_get_str(poly->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_poly_get_str(poly->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -2209,7 +2209,7 @@ void fq_default_mat_charpoly(fq_default_poly_t p,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_charpoly(p->fmpz_mod, M->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_charpoly(p->fmpz_mod, M->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -2237,7 +2237,7 @@ void fq_default_mat_minpoly(fq_default_poly_t p,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_mat_minpoly(p->fmpz_mod, X->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_mat_minpoly(p->fmpz_mod, X->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {

--- a/src/fq_default_poly.h
+++ b/src/fq_default_poly.h
@@ -58,7 +58,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_init(fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
-        nmod_poly_init(poly->nmod, ctx->ctx.nmod.mod.n);
+        nmod_poly_init(poly->nmod, FQ_DEFAULT_CTX_NMOD(ctx).n);
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
@@ -83,7 +83,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_init2(fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
-        nmod_poly_init2(poly->nmod, ctx->ctx.nmod.mod.n, alloc);
+        nmod_poly_init2(poly->nmod, FQ_DEFAULT_CTX_NMOD(ctx).n, alloc);
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
@@ -771,7 +771,7 @@ fq_default_poly_set_coeff_fmpz(fq_default_poly_t poly,
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
-        nmod_poly_set_coeff_ui(poly->nmod, n, fmpz_get_nmod(x, ctx->ctx.nmod.mod));
+        nmod_poly_set_coeff_ui(poly->nmod, n, fmpz_get_nmod(x, FQ_DEFAULT_CTX_NMOD(ctx)));
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
@@ -1079,12 +1079,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_add_si(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
-        ulong xu = FLINT_ABS(c);
-        NMOD_RED(xu, xu, ctx->ctx.nmod.mod);
-        if (c < 0)
-            xu = nmod_neg(xu, ctx->ctx.nmod.mod);
-
-        nmod_poly_add_ui(rop->nmod, op1->nmod, xu);
+        nmod_poly_add_ui(rop->nmod, op1->nmod, nmod_set_si(c, FQ_DEFAULT_CTX_NMOD(ctx)));
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
@@ -1260,7 +1255,7 @@ void fq_default_poly_scalar_div_fq_default(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
         nmod_poly_scalar_mul_nmod(rop->nmod, op->nmod,
-                                         nmod_inv(x->nmod, ctx->ctx.nmod.mod));
+                                         nmod_inv(x->nmod, FQ_DEFAULT_CTX_NMOD(ctx)));
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
@@ -1325,7 +1320,7 @@ void fq_default_poly_scalar_submul_fq_default(fq_default_poly_t rop,
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
         nmod_poly_scalar_addmul_nmod(rop->nmod, op->nmod,
-                                         nmod_neg(x->nmod, ctx->ctx.nmod.mod));
+                                         nmod_neg(x->nmod, FQ_DEFAULT_CTX_NMOD(ctx)));
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {

--- a/src/fq_default_poly.h
+++ b/src/fq_default_poly.h
@@ -48,19 +48,19 @@ typedef fq_default_poly_struct fq_default_poly_t[1];
 FQ_DEFAULT_POLY_INLINE void fq_default_poly_init(fq_default_poly_t poly,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_init(poly->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_init(poly->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_init(poly->nmod, FQ_DEFAULT_CTX_NMOD(ctx).n);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_init(poly->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -73,19 +73,19 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_init(fq_default_poly_t poly,
 FQ_DEFAULT_POLY_INLINE void fq_default_poly_init2(fq_default_poly_t poly,
                                        slong alloc, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_init2(poly->fq_zech, alloc, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_init2(poly->fq_nmod, alloc, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_init2(poly->nmod, FQ_DEFAULT_CTX_NMOD(ctx).n, alloc);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_init2(poly->fmpz_mod, alloc, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -98,19 +98,19 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_init2(fq_default_poly_t poly,
 FQ_DEFAULT_POLY_INLINE void fq_default_poly_realloc(fq_default_poly_t poly,
                                        slong alloc, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_realloc(poly->fq_zech, alloc, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_realloc(poly->fq_nmod, alloc, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_realloc(poly->nmod, alloc);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_realloc(poly->fmpz_mod, alloc, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -123,19 +123,19 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_realloc(fq_default_poly_t poly,
 FQ_DEFAULT_POLY_INLINE void fq_default_poly_truncate(fq_default_poly_t poly,
                                          slong len, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_truncate(poly->fq_zech, len, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_truncate(poly->fq_nmod, len, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_truncate(poly->nmod, len);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_truncate(poly->fmpz_mod, len, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -148,21 +148,21 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_truncate(fq_default_poly_t poly,
 FQ_DEFAULT_POLY_INLINE void fq_default_poly_set_trunc(fq_default_poly_t poly1,
                   fq_default_poly_t poly2, slong len, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_set_trunc(poly1->fq_zech,
 		                        poly2->fq_zech, len, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_set_trunc(poly1->fq_nmod,
 		                        poly2->fq_nmod, len, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_set_trunc(poly1->nmod, poly2->nmod, len);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_set_trunc(poly1->fmpz_mod,
                                   poly2->fmpz_mod, len, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -176,19 +176,19 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_set_trunc(fq_default_poly_t poly1,
 FQ_DEFAULT_POLY_INLINE void fq_default_poly_fit_length(fq_default_poly_t poly,
                                          slong len, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_fit_length(poly->fq_zech, len, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_fit_length(poly->fq_nmod, len, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_fit_length(poly->nmod, len);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_fit_length(poly->fmpz_mod, len, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -202,19 +202,19 @@ FQ_DEFAULT_POLY_INLINE
 void _fq_default_poly_set_length(fq_default_poly_t poly,
                                          slong len, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         _fq_zech_poly_set_length(poly->fq_zech, len, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         _fq_nmod_poly_set_length(poly->fq_nmod, len, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         _nmod_poly_set_length(poly->nmod, len);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         _fmpz_mod_poly_set_length(poly->fmpz_mod, len);
     }
@@ -227,19 +227,19 @@ void _fq_default_poly_set_length(fq_default_poly_t poly,
 FQ_DEFAULT_POLY_INLINE void fq_default_poly_clear(fq_default_poly_t poly,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_clear(poly->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_clear(poly->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_clear(poly->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_clear(poly->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -255,19 +255,19 @@ FQ_DEFAULT_POLY_INLINE slong
 fq_default_poly_length(const fq_default_poly_t poly,
 		                                    const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_poly_length(poly->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_poly_length(poly->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_poly_length(poly->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_poly_length(poly->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -281,19 +281,19 @@ FQ_DEFAULT_POLY_INLINE slong
 fq_default_poly_degree(const fq_default_poly_t poly,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_poly_degree(poly->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_poly_degree(poly->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_poly_degree(poly->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_poly_degree(poly->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -308,19 +308,19 @@ fq_default_poly_degree(const fq_default_poly_t poly,
 FQ_DEFAULT_POLY_INLINE void fq_default_poly_randtest(fq_default_poly_t f,
                      flint_rand_t state, slong len, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_randtest(f->fq_zech, state, len, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_randtest(f->fq_nmod, state, len, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_randtest(f->nmod, state, len);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_randtest(f->fmpz_mod, state, len, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -334,19 +334,19 @@ FQ_DEFAULT_POLY_INLINE
 void fq_default_poly_randtest_not_zero(fq_default_poly_t f,
                      flint_rand_t state, slong len, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_randtest_not_zero(f->fq_zech, state, len, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_randtest_not_zero(f->fq_nmod, state, len, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_randtest_not_zero(f->nmod, state, len);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_randtest_not_zero(f->fmpz_mod, state, len,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -361,19 +361,19 @@ FQ_DEFAULT_POLY_INLINE
 void fq_default_poly_randtest_monic(fq_default_poly_t f,
                      flint_rand_t state, slong len, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_randtest_monic(f->fq_zech, state, len, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_randtest_monic(f->fq_nmod, state, len, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_randtest_monic(f->nmod, state, len);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_randtest_monic(f->fmpz_mod, state, len,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -388,21 +388,21 @@ FQ_DEFAULT_POLY_INLINE
 void fq_default_poly_randtest_irreducible(fq_default_poly_t f,
                      flint_rand_t state, slong len, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_randtest_irreducible(f->fq_zech,
                                                  state, len, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_randtest_irreducible(f->fq_nmod,
                                                  state, len, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_randtest_irreducible(f->nmod, state, len);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_randtest_irreducible(f->fmpz_mod, state, len,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -418,19 +418,19 @@ void fq_default_poly_randtest_irreducible(fq_default_poly_t f,
 FQ_DEFAULT_POLY_INLINE void fq_default_poly_set(fq_default_poly_t rop,
                         const fq_default_poly_t op, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_set(rop->fq_zech, op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_set(rop->fq_nmod, op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_set(rop->nmod, op->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_set(rop->fmpz_mod, op->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -444,20 +444,20 @@ FQ_DEFAULT_POLY_INLINE
 void fq_default_poly_set_fq_default(fq_default_poly_t poly,
                               const fq_default_t c, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_set_fq_zech(poly->fq_zech, c->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_set_fq_nmod(poly->fq_nmod, c->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_zero(poly->nmod);
         nmod_poly_set_coeff_ui(poly->nmod, 0, c->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_set_fmpz(poly->fmpz_mod, c->fmpz_mod,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -471,19 +471,19 @@ void fq_default_poly_set_fq_default(fq_default_poly_t poly,
 FQ_DEFAULT_POLY_INLINE void fq_default_poly_swap(fq_default_poly_t op1,
                                fq_default_poly_t op2, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_swap(op1->fq_zech, op2->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_swap(op1->fq_nmod, op2->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_swap(op1->nmod, op2->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_swap(op1->fmpz_mod, op2->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -496,19 +496,19 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_swap(fq_default_poly_t op1,
 FQ_DEFAULT_POLY_INLINE void
 fq_default_poly_zero(fq_default_poly_t poly, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_zero(poly->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_zero(poly->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_zero(poly->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_zero(poly->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -521,19 +521,19 @@ fq_default_poly_zero(fq_default_poly_t poly, const fq_default_ctx_t ctx)
 FQ_DEFAULT_POLY_INLINE void fq_default_poly_one(fq_default_poly_t poly,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_one(poly->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_one(poly->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_one(poly->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_one(poly->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -546,20 +546,20 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_one(fq_default_poly_t poly,
 FQ_DEFAULT_POLY_INLINE void fq_default_poly_gen(fq_default_poly_t f,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_gen(f->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_gen(f->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_one(f->nmod);
         nmod_poly_shift_left(f->nmod, f->nmod, 1);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_gen(f->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -572,19 +572,19 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_gen(fq_default_poly_t f,
 FQ_DEFAULT_POLY_INLINE void fq_default_poly_make_monic(fq_default_poly_t rop,
                         const fq_default_poly_t op, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_make_monic(rop->fq_zech, op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_make_monic(rop->fq_nmod, op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_make_monic(rop->nmod, op->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_make_monic(rop->fmpz_mod, op->fmpz_mod,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -598,19 +598,19 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_make_monic(fq_default_poly_t rop,
 FQ_DEFAULT_POLY_INLINE void fq_default_poly_reverse(fq_default_poly_t res,
              const fq_default_poly_t poly, slong n, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_reverse(res->fq_zech, poly->fq_zech, n, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_reverse(res->fq_nmod, poly->fq_nmod, n, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_reverse(res->nmod, poly->nmod, n);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_reverse(res->fmpz_mod, poly->fmpz_mod, n,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -625,19 +625,19 @@ FQ_DEFAULT_POLY_INLINE
 ulong fq_default_poly_deflation(const fq_default_poly_t input,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_poly_deflation(input->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_poly_deflation(input->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_poly_deflation(input->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_poly_deflation(input->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -650,21 +650,21 @@ ulong fq_default_poly_deflation(const fq_default_poly_t input,
 FQ_DEFAULT_POLY_INLINE void fq_default_poly_deflate(fq_default_poly_t result,
     const fq_default_poly_t input, ulong deflation, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_deflate(result->fq_zech,
                                   input->fq_zech, deflation, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_deflate(result->fq_nmod,
                                   input->fq_nmod, deflation, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_deflate(result->nmod, input->nmod, deflation);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_deflate(result->fmpz_mod, input->fmpz_mod, deflation,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -678,21 +678,21 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_deflate(fq_default_poly_t result,
 FQ_DEFAULT_POLY_INLINE void fq_default_poly_inflate(fq_default_poly_t result,
     const fq_default_poly_t input, ulong inflation, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_inflate(result->fq_zech,
                                   input->fq_zech, inflation, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_inflate(result->fq_nmod,
                                   input->fq_nmod, inflation, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_inflate(result->nmod, input->nmod, inflation);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_inflate(result->fmpz_mod, input->fmpz_mod, inflation,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -708,19 +708,19 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_inflate(fq_default_poly_t result,
 FQ_DEFAULT_POLY_INLINE void fq_default_poly_get_coeff(fq_default_t x,
              const fq_default_poly_t poly, slong n, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_get_coeff(x->fq_zech, poly->fq_zech, n, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_get_coeff(x->fq_nmod, poly->fq_nmod, n, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         x->nmod = nmod_poly_get_coeff_ui(poly->nmod, n);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_get_coeff_fmpz(x->fmpz_mod, poly->fmpz_mod, n,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -734,19 +734,19 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_get_coeff(fq_default_t x,
 FQ_DEFAULT_POLY_INLINE void fq_default_poly_set_coeff(fq_default_poly_t poly,
                      slong n, const fq_default_t x, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_set_coeff(poly->fq_zech, n, x->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_set_coeff(poly->fq_nmod, n, x->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_set_coeff_ui(poly->nmod, n, x->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_set_coeff_fmpz(poly->fmpz_mod, n, x->fmpz_mod,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -761,19 +761,19 @@ FQ_DEFAULT_POLY_INLINE void
 fq_default_poly_set_coeff_fmpz(fq_default_poly_t poly,
                            slong n, const fmpz_t x, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_set_coeff_fmpz(poly->fq_zech, n, x, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_set_coeff_fmpz(poly->fq_nmod, n, x, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_set_coeff_ui(poly->nmod, n, fmpz_get_nmod(x, FQ_DEFAULT_CTX_NMOD(ctx)));
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_set_coeff_fmpz(poly->fmpz_mod, n, x,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -788,19 +788,19 @@ FQ_DEFAULT_POLY_INLINE
 void fq_default_poly_set_nmod_poly(fq_default_poly_t rop,
                           const     nmod_poly_t op, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_set_nmod_poly(rop->fq_zech, op, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_set_nmod_poly(rop->fq_nmod, op, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_set(rop->nmod, op);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_set_nmod_poly(rop->fmpz_mod, op);
     }
@@ -814,19 +814,19 @@ FQ_DEFAULT_POLY_INLINE
 void fq_default_poly_set_fmpz_mod_poly(fq_default_poly_t rop,
                           const fmpz_mod_poly_t op, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_set_fmpz_mod_poly(rop->fq_zech, op, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_set_fmpz_mod_poly(rop->fq_nmod, op, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         fmpz_mod_poly_get_nmod_poly(rop->nmod, op);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_set(rop->fmpz_mod, op, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -846,19 +846,19 @@ FQ_DEFAULT_POLY_INLINE
 int fq_default_poly_equal(const fq_default_poly_t poly1,
                      const fq_default_poly_t poly2, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_poly_equal(poly1->fq_zech, poly2->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_poly_equal(poly1->fq_nmod, poly2->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_poly_equal(poly1->nmod, poly2->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_poly_equal(poly1->fmpz_mod, poly2->fmpz_mod,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -873,21 +873,21 @@ FQ_DEFAULT_POLY_INLINE
 int fq_default_poly_equal_trunc(const fq_default_poly_t poly1,
             const fq_default_poly_t poly2, slong n, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_poly_equal_trunc(poly1->fq_zech,
                                           poly2->fq_zech, n, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_poly_equal_trunc(poly1->fq_nmod,
                                           poly2->fq_nmod, n, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_poly_equal_trunc(poly1->nmod, poly2->nmod, n);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_poly_equal_trunc(poly1->fmpz_mod, poly2->fmpz_mod, n,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -902,19 +902,19 @@ FQ_DEFAULT_POLY_INLINE int
 fq_default_poly_is_zero(const fq_default_poly_t poly,
 		                                    const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_poly_is_zero(poly->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_poly_is_zero(poly->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_poly_is_zero(poly->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_poly_is_zero(poly->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -927,19 +927,19 @@ fq_default_poly_is_zero(const fq_default_poly_t poly,
 FQ_DEFAULT_POLY_INLINE int
 fq_default_poly_is_one(const fq_default_poly_t op, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_poly_is_one(op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_poly_is_one(op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_poly_is_one(op->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_poly_is_one(op->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -952,19 +952,19 @@ fq_default_poly_is_one(const fq_default_poly_t op, const fq_default_ctx_t ctx)
 FQ_DEFAULT_POLY_INLINE int
 fq_default_poly_is_unit(const fq_default_poly_t op, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_poly_is_unit(op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_poly_is_unit(op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_poly_is_unit(op->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_poly_is_unit(op->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -978,19 +978,19 @@ FQ_DEFAULT_POLY_INLINE int
 fq_default_poly_is_gen(const fq_default_poly_t poly,
 		                                    const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_poly_is_gen(poly->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_poly_is_gen(poly->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_poly_is_gen(poly->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_poly_is_gen(poly->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -1004,24 +1004,24 @@ FQ_DEFAULT_POLY_INLINE int
 fq_default_poly_equal_fq_default(const fq_default_poly_t poly,
                               const fq_default_t c, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_poly_equal_fq_zech(poly->fq_zech,
 		                                 c->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_poly_equal_fq_nmod(poly->fq_nmod,
 		                                 c->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         if (c->nmod == 0)
             return poly->nmod->length == 0;
         else
             return poly->nmod->length == 1 && poly->nmod->coeffs[0] == c->nmod;
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         if (fmpz_is_zero(c->fmpz_mod))
             return poly->fmpz_mod->length == 0;
@@ -1041,21 +1041,21 @@ FQ_DEFAULT_POLY_INLINE
 void fq_default_poly_add(fq_default_poly_t rop, const fq_default_poly_t op1,
                        const fq_default_poly_t op2, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_add(rop->fq_zech,
                                  op1->fq_zech, op2->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_add(rop->fq_nmod,
                                  op1->fq_nmod, op2->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_add(rop->nmod, op1->nmod, op2->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_add(rop->fmpz_mod, op1->fmpz_mod, op2->fmpz_mod,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -1069,19 +1069,19 @@ void fq_default_poly_add(fq_default_poly_t rop, const fq_default_poly_t op1,
 FQ_DEFAULT_POLY_INLINE void fq_default_poly_add_si(fq_default_poly_t rop,
               const fq_default_poly_t op1, slong c, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_add_si(rop->fq_zech, op1->fq_zech, c, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_add_si(rop->fq_nmod, op1->fq_nmod, c, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_add_ui(rop->nmod, op1->nmod, nmod_set_si(c, FQ_DEFAULT_CTX_NMOD(ctx)));
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_add_si(rop->fmpz_mod, op1->fmpz_mod, c,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -1097,21 +1097,21 @@ void fq_default_poly_add_series(fq_default_poly_t rop,
 		const fq_default_poly_t op1, const fq_default_poly_t op2,
                                            slong n, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_add_series(rop->fq_zech,
                               op1->fq_zech, op2->fq_zech, n, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_add_series(rop->fq_nmod,
                               op1->fq_nmod, op2->fq_nmod, n, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_add_series(rop->nmod, op1->nmod, op2->nmod, n);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_add_series(rop->fmpz_mod, op1->fmpz_mod, op2->fmpz_mod, n,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -1126,21 +1126,21 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_sub(fq_default_poly_t rop,
                 const fq_default_poly_t op1, const fq_default_poly_t op2,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_sub(rop->fq_zech,
                                  op1->fq_zech, op2->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_sub(rop->fq_nmod,
                                  op1->fq_nmod, op2->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_sub(rop->nmod, op1->nmod, op2->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_sub(rop->fmpz_mod, op1->fmpz_mod, op2->fmpz_mod,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -1155,21 +1155,21 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_sub_series(fq_default_poly_t rop,
 		const fq_default_poly_t op1, const fq_default_poly_t op2,
                                            slong n, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_sub_series(rop->fq_zech,
                               op1->fq_zech, op2->fq_zech, n, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_sub_series(rop->fq_nmod,
                               op1->fq_nmod, op2->fq_nmod, n, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_sub_series(rop->nmod, op1->nmod, op2->nmod, n);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_sub_series(rop->fmpz_mod, op1->fmpz_mod, op2->fmpz_mod, n,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -1183,19 +1183,19 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_sub_series(fq_default_poly_t rop,
 FQ_DEFAULT_POLY_INLINE void fq_default_poly_neg(fq_default_poly_t rop,
                         const fq_default_poly_t op, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_neg(rop->fq_zech, op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_neg(rop->fq_nmod, op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_neg(rop->nmod, op->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_neg(rop->fmpz_mod, op->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -1212,21 +1212,21 @@ void fq_default_poly_scalar_mul_fq_default(fq_default_poly_t rop,
                  const fq_default_poly_t op, const fq_default_t x,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_scalar_mul_fq_zech(rop->fq_zech,
                                     op->fq_zech, x->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_scalar_mul_fq_nmod(rop->fq_nmod,
                                     op->fq_nmod, x->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_scalar_mul_nmod(rop->nmod, op->nmod, x->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_scalar_mul_fmpz(rop->fmpz_mod, op->fmpz_mod, x->fmpz_mod,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -1242,22 +1242,22 @@ void fq_default_poly_scalar_div_fq_default(fq_default_poly_t rop,
                  const fq_default_poly_t op, const fq_default_t x,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_scalar_div_fq_zech(rop->fq_zech,
                                     op->fq_zech, x->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_scalar_div_fq_nmod(rop->fq_nmod,
                                     op->fq_nmod, x->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_scalar_mul_nmod(rop->nmod, op->nmod,
                                          nmod_inv(x->nmod, FQ_DEFAULT_CTX_NMOD(ctx)));
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_t t;
         fmpz_init(t);
@@ -1277,21 +1277,21 @@ void fq_default_poly_scalar_addmul_fq_default(fq_default_poly_t rop,
                  const fq_default_poly_t op, const fq_default_t x,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_scalar_addmul_fq_zech(rop->fq_zech,
                                     op->fq_zech, x->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_scalar_addmul_fq_nmod(rop->fq_nmod,
                                     op->fq_nmod, x->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_scalar_addmul_nmod(rop->nmod, op->nmod, x->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_scalar_addmul_fmpz(rop->fmpz_mod, op->fmpz_mod,
                                            x->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -1307,22 +1307,22 @@ void fq_default_poly_scalar_submul_fq_default(fq_default_poly_t rop,
                  const fq_default_poly_t op, const fq_default_t x,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_scalar_submul_fq_zech(rop->fq_zech,
                                     op->fq_zech, x->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_scalar_submul_fq_nmod(rop->fq_nmod,
                                     op->fq_nmod, x->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_scalar_addmul_nmod(rop->nmod, op->nmod,
                                          nmod_neg(x->nmod, FQ_DEFAULT_CTX_NMOD(ctx)));
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_t t;
         fmpz_init(t);
@@ -1343,21 +1343,21 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_mul(fq_default_poly_t rop,
                  const fq_default_poly_t op1, const fq_default_poly_t op2,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_mul(rop->fq_zech,
                                  op1->fq_zech, op2->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_mul(rop->fq_nmod,
                                  op1->fq_nmod, op2->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_mul(rop->nmod, op1->nmod, op2->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_mul(rop->fmpz_mod, op1->fmpz_mod,
                                          op2->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -1372,21 +1372,21 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_mullow(fq_default_poly_t rop,
                  const fq_default_poly_t op1, const fq_default_poly_t op2,
                                            slong n, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_mullow(rop->fq_zech,
                               op1->fq_zech, op2->fq_zech, n, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_mullow(rop->fq_nmod,
                               op1->fq_nmod, op2->fq_nmod, n, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_mullow(rop->nmod, op1->nmod, op2->nmod, n);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_mullow(rop->fmpz_mod, op1->fmpz_mod, op2->fmpz_mod, n,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -1401,21 +1401,21 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_mulhigh(fq_default_poly_t rop,
                  const fq_default_poly_t op1, const fq_default_poly_t op2,
                                        slong start, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_mulhigh(rop->fq_zech,
                           op1->fq_zech, op2->fq_zech, start, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_mulhigh(rop->fq_nmod,
                           op1->fq_nmod, op2->fq_nmod, start, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_mulhigh(rop->nmod, op1->nmod, op2->nmod, start);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_mulhigh(rop->fmpz_mod, op1->fmpz_mod, op2->fmpz_mod,
                                                  start, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -1430,21 +1430,21 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_mulmod(fq_default_poly_t res,
                  const fq_default_poly_t poly1, const fq_default_poly_t poly2,
                          const fq_default_poly_t f, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_mulmod(res->fq_zech, poly1->fq_zech, poly2->fq_zech,
                                                  f->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_mulmod(res->fq_nmod, poly1->fq_nmod, poly2->fq_nmod,
                                                  f->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_mulmod(res->nmod, poly1->nmod, poly2->nmod, f->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_mulmod(res->fmpz_mod, poly1->fmpz_mod, poly2->fmpz_mod,
                                            f->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -1460,19 +1460,19 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_mulmod(fq_default_poly_t res,
 FQ_DEFAULT_POLY_INLINE void fq_default_poly_sqr(fq_default_poly_t rop,
                         const fq_default_poly_t op, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_sqr(rop->fq_zech, op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_sqr(rop->fq_nmod, op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_mul(rop->nmod, op->nmod, op->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_sqr(rop->fmpz_mod, op->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -1488,19 +1488,19 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_pow(fq_default_poly_t rop,
                                       const fq_default_poly_t op, ulong e,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_pow(rop->fq_zech, op->fq_zech, e, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_pow(rop->fq_nmod, op->fq_nmod, e, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_pow(rop->nmod, op->nmod, e);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_pow(rop->fmpz_mod, op->fmpz_mod, e, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -1515,21 +1515,21 @@ void fq_default_poly_pow_trunc(fq_default_poly_t res,
                                     const fq_default_poly_t poly, ulong e,
 				       slong trunc, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_pow_trunc(res->fq_zech,
                                     poly->fq_zech, e, trunc, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_pow_trunc(res->fq_nmod,
                                     poly->fq_nmod, e, trunc, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_pow_trunc(res->nmod, poly->nmod, e, trunc);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_pow_trunc(res->fmpz_mod, poly->fmpz_mod, e, trunc,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -1545,21 +1545,21 @@ void fq_default_poly_powmod_fmpz_binexp(fq_default_poly_t res,
                              const fq_default_poly_t poly, const fmpz_t e,
                          const fq_default_poly_t f, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_powmod_fmpz_binexp(res->fq_zech,
                                poly->fq_zech, e, f->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_powmod_fmpz_binexp(res->fq_nmod,
                                poly->fq_nmod, e, f->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_powmod_fmpz_binexp(res->nmod, poly->nmod, (fmpz*) e, f->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_powmod_fmpz_binexp(res->fmpz_mod, poly->fmpz_mod, e,
                                            f->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -1575,21 +1575,21 @@ void fq_default_poly_powmod_ui_binexp(fq_default_poly_t res,
                          const fq_default_poly_t poly, ulong e,
                          const fq_default_poly_t f, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_powmod_ui_binexp(res->fq_zech,
                                poly->fq_zech, e, f->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_powmod_ui_binexp(res->fq_nmod,
                                poly->fq_nmod, e, f->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_powmod_ui_binexp(res->nmod, poly->nmod, e, f->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_powmod_ui_binexp(res->fmpz_mod, poly->fmpz_mod, e,
                                            f->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -1606,19 +1606,19 @@ FQ_DEFAULT_POLY_INLINE
 void fq_default_poly_shift_left(fq_default_poly_t rop,
                const fq_default_poly_t op, slong n, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_shift_left(rop->fq_zech, op->fq_zech, n, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_shift_left(rop->fq_nmod, op->fq_nmod, n, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_shift_left(rop->nmod, op->nmod, n);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_shift_left(rop->fmpz_mod, op->fmpz_mod, n,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -1633,19 +1633,19 @@ FQ_DEFAULT_POLY_INLINE
 void fq_default_poly_shift_right(fq_default_poly_t rop,
                const fq_default_poly_t op, slong n, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_shift_right(rop->fq_zech, op->fq_zech, n, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_shift_right(rop->fq_nmod, op->fq_nmod, n, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_shift_right(rop->nmod, op->nmod, n);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_shift_right(rop->fmpz_mod, op->fmpz_mod, n,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -1662,19 +1662,19 @@ FQ_DEFAULT_POLY_INLINE
 slong fq_default_poly_hamming_weight(const fq_default_poly_t op,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_poly_hamming_weight(op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_poly_hamming_weight(op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_poly_hamming_weight(op->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_poly_hamming_weight(op->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -1690,21 +1690,21 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_gcd(fq_default_poly_t rop,
                   const fq_default_poly_t op1, const fq_default_poly_t op2,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_gcd(rop->fq_zech,
 		                 op1->fq_zech, op2->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_gcd(rop->fq_nmod,
 		                 op1->fq_nmod, op2->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_gcd(rop->nmod, op1->nmod, op2->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_gcd(rop->fmpz_mod, op1->fmpz_mod, op2->fmpz_mod,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -1721,21 +1721,21 @@ fq_default_poly_xgcd(fq_default_poly_t G,
                   const fq_default_poly_t A, const fq_default_poly_t B,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_xgcd(G->fq_zech,
              S->fq_zech, T->fq_zech, A->fq_zech, B->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_xgcd(G->fq_nmod,
              S->fq_nmod, T->fq_nmod, A->fq_nmod, B->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_xgcd(G->nmod, S->nmod, T->nmod, A->nmod, B->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_xgcd(G->fmpz_mod, S->fmpz_mod, T->fmpz_mod, A->fmpz_mod,
                                            B->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -1751,19 +1751,19 @@ fq_default_poly_xgcd(fq_default_poly_t G,
 FQ_DEFAULT_POLY_INLINE ulong fq_default_poly_remove(fq_default_poly_t f,
                          const fq_default_poly_t g, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_poly_remove(f->fq_zech, g->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_poly_remove(f->fq_nmod, g->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_poly_remove(f->nmod, g->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_poly_remove(f->fmpz_mod, g->fmpz_mod,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -1779,21 +1779,21 @@ fq_default_poly_divrem(fq_default_poly_t Q, fq_default_poly_t R,
                    const fq_default_poly_t A, const fq_default_poly_t B,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_divrem(Q->fq_zech,
                          R->fq_zech, A->fq_zech, B->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_divrem(Q->fq_nmod,
                          R->fq_nmod, A->fq_nmod, B->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_divrem(Q->nmod, R->nmod, A->nmod, B->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_divrem(Q->fmpz_mod, R->fmpz_mod, A->fmpz_mod,
                                            B->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -1809,19 +1809,19 @@ fq_default_poly_rem(fq_default_poly_t R,
              const fq_default_poly_t A, const fq_default_poly_t B,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_rem(R->fq_zech, A->fq_zech, B->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_rem(R->fq_nmod, A->fq_nmod, B->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_rem(R->nmod, A->nmod, B->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_rem(R->fmpz_mod, A->fmpz_mod, B->fmpz_mod,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -1837,19 +1837,19 @@ fq_default_poly_inv_series(fq_default_poly_t Qinv,
                                const fq_default_poly_t Q, slong n,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_inv_series(Qinv->fq_zech, Q->fq_zech, n, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_inv_series(Qinv->fq_nmod, Q->fq_nmod, n, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_inv_series(Qinv->nmod, Q->nmod, n);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_inv_series(Qinv->fmpz_mod, Q->fmpz_mod, n,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -1864,21 +1864,21 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_div_series(fq_default_poly_t Q,
                const fq_default_poly_t A, const fq_default_poly_t B,
                                            slong n, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_div_series(Q->fq_zech,
                                   A->fq_zech, B->fq_zech, n, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_div_series(Q->fq_nmod,
                                   A->fq_nmod, B->fq_nmod, n, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_div_series(Q->nmod, A->nmod, B->nmod, n);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_div_series(Q->fmpz_mod, A->fmpz_mod, B->fmpz_mod, n,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -1895,21 +1895,21 @@ FQ_DEFAULT_POLY_INLINE int fq_default_poly_divides(fq_default_poly_t Q,
                       const fq_default_poly_t A, const fq_default_poly_t B,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_poly_divides(Q->fq_zech,
                                      A->fq_zech, B->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_poly_divides(Q->fq_nmod,
                                      A->fq_nmod, B->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_poly_divides(Q->nmod, A->nmod, B->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_poly_divides(Q->fmpz_mod, A->fmpz_mod, B->fmpz_mod,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -1926,19 +1926,19 @@ FQ_DEFAULT_POLY_INLINE
 void fq_default_poly_derivative(fq_default_poly_t rop,
                         const fq_default_poly_t op, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_derivative(rop->fq_zech, op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_derivative(rop->fq_nmod, op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_derivative(rop->nmod, op->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_derivative(rop->fmpz_mod, op->fmpz_mod,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -1955,19 +1955,19 @@ FQ_DEFAULT_POLY_INLINE
 void fq_default_poly_invsqrt_series(fq_default_poly_t rop,
                     const fq_default_poly_t op, slong n, fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_invsqrt_series(rop->fq_zech, op->fq_zech, n, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_invsqrt_series(rop->fq_nmod, op->fq_nmod, n, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_invsqrt_series(rop->nmod, op->nmod, n);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_invsqrt_series(rop->fmpz_mod, op->fmpz_mod, n, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -1981,19 +1981,19 @@ FQ_DEFAULT_POLY_INLINE
 void fq_default_poly_sqrt_series(fq_default_poly_t rop,
                     const fq_default_poly_t op, slong n, fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_sqrt_series(rop->fq_zech, op->fq_zech, n, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_sqrt_series(rop->fq_nmod, op->fq_nmod, n, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_sqrt_series(rop->nmod, op->nmod, n);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_sqrt_series(rop->fmpz_mod, op->fmpz_mod, n, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -2007,19 +2007,19 @@ FQ_DEFAULT_POLY_INLINE
 int fq_default_poly_sqrt(fq_default_poly_t rop,
                               const fq_default_poly_t op, fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_poly_sqrt(rop->fq_zech, op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_poly_sqrt(rop->fq_nmod, op->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_poly_sqrt(rop->nmod, op->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_poly_sqrt(rop->fmpz_mod, op->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -2036,21 +2036,21 @@ void fq_default_poly_evaluate_fq_default(fq_default_t res,
                            const fq_default_poly_t f, const fq_default_t a,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_evaluate_fq_zech(res->fq_zech,
 		                     f->fq_zech, a->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_evaluate_fq_nmod(res->fq_nmod,
 		                     f->fq_nmod, a->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         res->nmod = nmod_poly_evaluate_nmod(f->nmod, a->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         fmpz_mod_poly_evaluate_fmpz(res->fmpz_mod, f->fmpz_mod, a->fmpz_mod,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -2068,21 +2068,21 @@ void fq_default_poly_compose(fq_default_poly_t rop,
             const fq_default_poly_t op1, const fq_default_poly_t op2,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_compose(rop->fq_zech,
                                  op1->fq_zech, op2->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_compose(rop->fq_nmod,
                                  op1->fq_nmod, op2->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_compose(rop->nmod, op1->nmod, op2->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_compose(rop->fmpz_mod, op1->fmpz_mod, op2->fmpz_mod,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -2098,21 +2098,21 @@ void fq_default_poly_compose_mod(fq_default_poly_t res,
             const fq_default_poly_t poly1, const fq_default_poly_t poly2,
                      const fq_default_poly_t poly3, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_compose_mod(res->fq_zech,
              poly1->fq_zech, poly2->fq_zech, poly3->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_compose_mod(res->fq_nmod,
              poly1->fq_nmod, poly2->fq_nmod, poly3->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_compose_mod(res->nmod, poly1->nmod, poly2->nmod, poly3->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_compose_mod(res->fmpz_mod, poly1->fmpz_mod,
                       poly2->fmpz_mod, poly3->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -2138,19 +2138,19 @@ FQ_DEFAULT_POLY_INLINE
 char * fq_default_poly_get_str_pretty(const fq_default_poly_t poly,
                                      const char *x, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_poly_get_str_pretty(poly->fq_zech, x, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_poly_get_str_pretty(poly->fq_nmod, x, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_poly_get_str_pretty(poly->nmod, x);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_poly_get_str_pretty(poly->fmpz_mod, x,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -2165,19 +2165,19 @@ FQ_DEFAULT_POLY_INLINE
 char * fq_default_poly_get_str(const fq_default_poly_t poly,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_poly_get_str(poly->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_poly_get_str(poly->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_poly_get_str(poly->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_poly_get_str(poly->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -2195,19 +2195,19 @@ FQ_DEFAULT_POLY_INLINE
 void fq_default_mat_charpoly(fq_default_poly_t p,
                           const fq_default_mat_t M, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_charpoly(p->fq_zech, M->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_charpoly(p->fq_nmod, M->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_charpoly(p->nmod, M->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_charpoly(p->fmpz_mod, M->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -2223,19 +2223,19 @@ FQ_DEFAULT_POLY_INLINE
 void fq_default_mat_minpoly(fq_default_poly_t p,
                           const fq_default_mat_t X, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_mat_minpoly(p->fq_zech, X->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_mat_minpoly(p->fq_nmod, X->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_mat_minpoly(p->nmod, X->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_mat_minpoly(p->fmpz_mod, X->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }

--- a/src/fq_default_poly.h
+++ b/src/fq_default_poly.h
@@ -50,7 +50,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_init(fq_default_poly_t poly,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_init(poly->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_poly_init(poly->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -75,7 +75,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_init2(fq_default_poly_t poly,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_init2(poly->fq_zech, alloc, ctx->ctx.fq_zech);
+        fq_zech_poly_init2(poly->fq_zech, alloc, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -100,7 +100,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_realloc(fq_default_poly_t poly,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_realloc(poly->fq_zech, alloc, ctx->ctx.fq_zech);
+        fq_zech_poly_realloc(poly->fq_zech, alloc, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -125,7 +125,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_truncate(fq_default_poly_t poly,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_truncate(poly->fq_zech, len, ctx->ctx.fq_zech);
+        fq_zech_poly_truncate(poly->fq_zech, len, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -151,7 +151,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_set_trunc(fq_default_poly_t poly1,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_set_trunc(poly1->fq_zech,
-		                        poly2->fq_zech, len, ctx->ctx.fq_zech);
+		                        poly2->fq_zech, len, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -178,7 +178,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_fit_length(fq_default_poly_t poly,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_fit_length(poly->fq_zech, len, ctx->ctx.fq_zech);
+        fq_zech_poly_fit_length(poly->fq_zech, len, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -204,7 +204,7 @@ void _fq_default_poly_set_length(fq_default_poly_t poly,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        _fq_zech_poly_set_length(poly->fq_zech, len, ctx->ctx.fq_zech);
+        _fq_zech_poly_set_length(poly->fq_zech, len, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -229,7 +229,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_clear(fq_default_poly_t poly,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_clear(poly->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_poly_clear(poly->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -257,7 +257,7 @@ fq_default_poly_length(const fq_default_poly_t poly,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_poly_length(poly->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_poly_length(poly->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -283,7 +283,7 @@ fq_default_poly_degree(const fq_default_poly_t poly,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_poly_degree(poly->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_poly_degree(poly->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -310,7 +310,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_randtest(fq_default_poly_t f,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_randtest(f->fq_zech, state, len, ctx->ctx.fq_zech);
+        fq_zech_poly_randtest(f->fq_zech, state, len, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -336,7 +336,7 @@ void fq_default_poly_randtest_not_zero(fq_default_poly_t f,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_randtest_not_zero(f->fq_zech, state, len, ctx->ctx.fq_zech);
+        fq_zech_poly_randtest_not_zero(f->fq_zech, state, len, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -363,7 +363,7 @@ void fq_default_poly_randtest_monic(fq_default_poly_t f,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_randtest_monic(f->fq_zech, state, len, ctx->ctx.fq_zech);
+        fq_zech_poly_randtest_monic(f->fq_zech, state, len, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -391,7 +391,7 @@ void fq_default_poly_randtest_irreducible(fq_default_poly_t f,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_randtest_irreducible(f->fq_zech,
-                                                 state, len, ctx->ctx.fq_zech);
+                                                 state, len, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -420,7 +420,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_set(fq_default_poly_t rop,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_set(rop->fq_zech, op->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_poly_set(rop->fq_zech, op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -446,7 +446,7 @@ void fq_default_poly_set_fq_default(fq_default_poly_t poly,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_set_fq_zech(poly->fq_zech, c->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_poly_set_fq_zech(poly->fq_zech, c->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -473,7 +473,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_swap(fq_default_poly_t op1,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_swap(op1->fq_zech, op2->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_poly_swap(op1->fq_zech, op2->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -498,7 +498,7 @@ fq_default_poly_zero(fq_default_poly_t poly, const fq_default_ctx_t ctx)
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_zero(poly->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_poly_zero(poly->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -523,7 +523,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_one(fq_default_poly_t poly,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_one(poly->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_poly_one(poly->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -548,7 +548,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_gen(fq_default_poly_t f,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_gen(f->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_poly_gen(f->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -574,7 +574,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_make_monic(fq_default_poly_t rop,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_make_monic(rop->fq_zech, op->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_poly_make_monic(rop->fq_zech, op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -600,7 +600,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_reverse(fq_default_poly_t res,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_reverse(res->fq_zech, poly->fq_zech, n, ctx->ctx.fq_zech);
+        fq_zech_poly_reverse(res->fq_zech, poly->fq_zech, n, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -627,7 +627,7 @@ ulong fq_default_poly_deflation(const fq_default_poly_t input,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_poly_deflation(input->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_poly_deflation(input->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -653,7 +653,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_deflate(fq_default_poly_t result,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_deflate(result->fq_zech,
-                                  input->fq_zech, deflation, ctx->ctx.fq_zech);
+                                  input->fq_zech, deflation, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -681,7 +681,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_inflate(fq_default_poly_t result,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_inflate(result->fq_zech,
-                                  input->fq_zech, inflation, ctx->ctx.fq_zech);
+                                  input->fq_zech, inflation, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -710,7 +710,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_get_coeff(fq_default_t x,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_get_coeff(x->fq_zech, poly->fq_zech, n, ctx->ctx.fq_zech);
+        fq_zech_poly_get_coeff(x->fq_zech, poly->fq_zech, n, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -736,7 +736,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_set_coeff(fq_default_poly_t poly,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_set_coeff(poly->fq_zech, n, x->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_poly_set_coeff(poly->fq_zech, n, x->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -763,7 +763,7 @@ fq_default_poly_set_coeff_fmpz(fq_default_poly_t poly,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_set_coeff_fmpz(poly->fq_zech, n, x, ctx->ctx.fq_zech);
+        fq_zech_poly_set_coeff_fmpz(poly->fq_zech, n, x, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -790,7 +790,7 @@ void fq_default_poly_set_nmod_poly(fq_default_poly_t rop,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_set_nmod_poly(rop->fq_zech, op, ctx->ctx.fq_zech);
+        fq_zech_poly_set_nmod_poly(rop->fq_zech, op, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -816,7 +816,7 @@ void fq_default_poly_set_fmpz_mod_poly(fq_default_poly_t rop,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_set_fmpz_mod_poly(rop->fq_zech, op, ctx->ctx.fq_zech);
+        fq_zech_poly_set_fmpz_mod_poly(rop->fq_zech, op, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -848,7 +848,7 @@ int fq_default_poly_equal(const fq_default_poly_t poly1,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_poly_equal(poly1->fq_zech, poly2->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_poly_equal(poly1->fq_zech, poly2->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -876,7 +876,7 @@ int fq_default_poly_equal_trunc(const fq_default_poly_t poly1,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_poly_equal_trunc(poly1->fq_zech,
-                                          poly2->fq_zech, n, ctx->ctx.fq_zech);
+                                          poly2->fq_zech, n, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -904,7 +904,7 @@ fq_default_poly_is_zero(const fq_default_poly_t poly,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_poly_is_zero(poly->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_poly_is_zero(poly->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -929,7 +929,7 @@ fq_default_poly_is_one(const fq_default_poly_t op, const fq_default_ctx_t ctx)
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_poly_is_one(op->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_poly_is_one(op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -954,7 +954,7 @@ fq_default_poly_is_unit(const fq_default_poly_t op, const fq_default_ctx_t ctx)
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_poly_is_unit(op->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_poly_is_unit(op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -980,7 +980,7 @@ fq_default_poly_is_gen(const fq_default_poly_t poly,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_poly_is_gen(poly->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_poly_is_gen(poly->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1007,7 +1007,7 @@ fq_default_poly_equal_fq_default(const fq_default_poly_t poly,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_poly_equal_fq_zech(poly->fq_zech,
-		                                 c->fq_zech, ctx->ctx.fq_zech);
+		                                 c->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1044,7 +1044,7 @@ void fq_default_poly_add(fq_default_poly_t rop, const fq_default_poly_t op1,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_add(rop->fq_zech,
-                                 op1->fq_zech, op2->fq_zech, ctx->ctx.fq_zech);
+                                 op1->fq_zech, op2->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1071,7 +1071,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_add_si(fq_default_poly_t rop,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_add_si(rop->fq_zech, op1->fq_zech, c, ctx->ctx.fq_zech);
+        fq_zech_poly_add_si(rop->fq_zech, op1->fq_zech, c, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1105,7 +1105,7 @@ void fq_default_poly_add_series(fq_default_poly_t rop,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_add_series(rop->fq_zech,
-                              op1->fq_zech, op2->fq_zech, n, ctx->ctx.fq_zech);
+                              op1->fq_zech, op2->fq_zech, n, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1134,7 +1134,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_sub(fq_default_poly_t rop,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_sub(rop->fq_zech,
-                                 op1->fq_zech, op2->fq_zech, ctx->ctx.fq_zech);
+                                 op1->fq_zech, op2->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1163,7 +1163,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_sub_series(fq_default_poly_t rop,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_sub_series(rop->fq_zech,
-                              op1->fq_zech, op2->fq_zech, n, ctx->ctx.fq_zech);
+                              op1->fq_zech, op2->fq_zech, n, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1190,7 +1190,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_neg(fq_default_poly_t rop,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_neg(rop->fq_zech, op->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_poly_neg(rop->fq_zech, op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1220,7 +1220,7 @@ void fq_default_poly_scalar_mul_fq_default(fq_default_poly_t rop,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_scalar_mul_fq_zech(rop->fq_zech,
-                                    op->fq_zech, x->fq_zech, ctx->ctx.fq_zech);
+                                    op->fq_zech, x->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1250,7 +1250,7 @@ void fq_default_poly_scalar_div_fq_default(fq_default_poly_t rop,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_scalar_div_fq_zech(rop->fq_zech,
-                                    op->fq_zech, x->fq_zech, ctx->ctx.fq_zech);
+                                    op->fq_zech, x->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1285,7 +1285,7 @@ void fq_default_poly_scalar_addmul_fq_default(fq_default_poly_t rop,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_scalar_addmul_fq_zech(rop->fq_zech,
-                                    op->fq_zech, x->fq_zech, ctx->ctx.fq_zech);
+                                    op->fq_zech, x->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1315,7 +1315,7 @@ void fq_default_poly_scalar_submul_fq_default(fq_default_poly_t rop,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_scalar_submul_fq_zech(rop->fq_zech,
-                                    op->fq_zech, x->fq_zech, ctx->ctx.fq_zech);
+                                    op->fq_zech, x->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1351,7 +1351,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_mul(fq_default_poly_t rop,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_mul(rop->fq_zech,
-                                 op1->fq_zech, op2->fq_zech, ctx->ctx.fq_zech);
+                                 op1->fq_zech, op2->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1380,7 +1380,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_mullow(fq_default_poly_t rop,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_mullow(rop->fq_zech,
-                              op1->fq_zech, op2->fq_zech, n, ctx->ctx.fq_zech);
+                              op1->fq_zech, op2->fq_zech, n, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1409,7 +1409,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_mulhigh(fq_default_poly_t rop,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_mulhigh(rop->fq_zech,
-                          op1->fq_zech, op2->fq_zech, start, ctx->ctx.fq_zech);
+                          op1->fq_zech, op2->fq_zech, start, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1438,7 +1438,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_mulmod(fq_default_poly_t res,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_mulmod(res->fq_zech, poly1->fq_zech, poly2->fq_zech,
-                                                 f->fq_zech, ctx->ctx.fq_zech);
+                                                 f->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1467,7 +1467,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_sqr(fq_default_poly_t rop,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_sqr(rop->fq_zech, op->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_poly_sqr(rop->fq_zech, op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1495,7 +1495,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_pow(fq_default_poly_t rop,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_pow(rop->fq_zech, op->fq_zech, e, ctx->ctx.fq_zech);
+        fq_zech_poly_pow(rop->fq_zech, op->fq_zech, e, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1523,7 +1523,7 @@ void fq_default_poly_pow_trunc(fq_default_poly_t res,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_pow_trunc(res->fq_zech,
-                                    poly->fq_zech, e, trunc, ctx->ctx.fq_zech);
+                                    poly->fq_zech, e, trunc, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1553,7 +1553,7 @@ void fq_default_poly_powmod_fmpz_binexp(fq_default_poly_t res,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_powmod_fmpz_binexp(res->fq_zech,
-                               poly->fq_zech, e, f->fq_zech, ctx->ctx.fq_zech);
+                               poly->fq_zech, e, f->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1583,7 +1583,7 @@ void fq_default_poly_powmod_ui_binexp(fq_default_poly_t res,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_powmod_ui_binexp(res->fq_zech,
-                               poly->fq_zech, e, f->fq_zech, ctx->ctx.fq_zech);
+                               poly->fq_zech, e, f->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1613,7 +1613,7 @@ void fq_default_poly_shift_left(fq_default_poly_t rop,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_shift_left(rop->fq_zech, op->fq_zech, n, ctx->ctx.fq_zech);
+        fq_zech_poly_shift_left(rop->fq_zech, op->fq_zech, n, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1640,7 +1640,7 @@ void fq_default_poly_shift_right(fq_default_poly_t rop,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_shift_right(rop->fq_zech, op->fq_zech, n, ctx->ctx.fq_zech);
+        fq_zech_poly_shift_right(rop->fq_zech, op->fq_zech, n, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1669,7 +1669,7 @@ slong fq_default_poly_hamming_weight(const fq_default_poly_t op,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_poly_hamming_weight(op->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_poly_hamming_weight(op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1698,7 +1698,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_gcd(fq_default_poly_t rop,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_gcd(rop->fq_zech,
-		                 op1->fq_zech, op2->fq_zech, ctx->ctx.fq_zech);
+		                 op1->fq_zech, op2->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1729,7 +1729,7 @@ fq_default_poly_xgcd(fq_default_poly_t G,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_xgcd(G->fq_zech,
-             S->fq_zech, T->fq_zech, A->fq_zech, B->fq_zech, ctx->ctx.fq_zech);
+             S->fq_zech, T->fq_zech, A->fq_zech, B->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1758,7 +1758,7 @@ FQ_DEFAULT_POLY_INLINE ulong fq_default_poly_remove(fq_default_poly_t f,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_poly_remove(f->fq_zech, g->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_poly_remove(f->fq_zech, g->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1787,7 +1787,7 @@ fq_default_poly_divrem(fq_default_poly_t Q, fq_default_poly_t R,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_divrem(Q->fq_zech,
-                         R->fq_zech, A->fq_zech, B->fq_zech, ctx->ctx.fq_zech);
+                         R->fq_zech, A->fq_zech, B->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1816,7 +1816,7 @@ fq_default_poly_rem(fq_default_poly_t R,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_rem(R->fq_zech, A->fq_zech, B->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_poly_rem(R->fq_zech, A->fq_zech, B->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1844,7 +1844,7 @@ fq_default_poly_inv_series(fq_default_poly_t Qinv,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_inv_series(Qinv->fq_zech, Q->fq_zech, n, ctx->ctx.fq_zech);
+        fq_zech_poly_inv_series(Qinv->fq_zech, Q->fq_zech, n, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1872,7 +1872,7 @@ FQ_DEFAULT_POLY_INLINE void fq_default_poly_div_series(fq_default_poly_t Q,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_div_series(Q->fq_zech,
-                                  A->fq_zech, B->fq_zech, n, ctx->ctx.fq_zech);
+                                  A->fq_zech, B->fq_zech, n, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1903,7 +1903,7 @@ FQ_DEFAULT_POLY_INLINE int fq_default_poly_divides(fq_default_poly_t Q,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_poly_divides(Q->fq_zech,
-                                     A->fq_zech, B->fq_zech, ctx->ctx.fq_zech);
+                                     A->fq_zech, B->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1933,7 +1933,7 @@ void fq_default_poly_derivative(fq_default_poly_t rop,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_derivative(rop->fq_zech, op->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_poly_derivative(rop->fq_zech, op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1962,7 +1962,7 @@ void fq_default_poly_invsqrt_series(fq_default_poly_t rop,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_invsqrt_series(rop->fq_zech, op->fq_zech, n, ctx->ctx.fq_zech);
+        fq_zech_poly_invsqrt_series(rop->fq_zech, op->fq_zech, n, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -1988,7 +1988,7 @@ void fq_default_poly_sqrt_series(fq_default_poly_t rop,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_sqrt_series(rop->fq_zech, op->fq_zech, n, ctx->ctx.fq_zech);
+        fq_zech_poly_sqrt_series(rop->fq_zech, op->fq_zech, n, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -2014,7 +2014,7 @@ int fq_default_poly_sqrt(fq_default_poly_t rop,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_poly_sqrt(rop->fq_zech, op->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_poly_sqrt(rop->fq_zech, op->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -2044,7 +2044,7 @@ void fq_default_poly_evaluate_fq_default(fq_default_t res,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_evaluate_fq_zech(res->fq_zech,
-		                     f->fq_zech, a->fq_zech, ctx->ctx.fq_zech);
+		                     f->fq_zech, a->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -2076,7 +2076,7 @@ void fq_default_poly_compose(fq_default_poly_t rop,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_compose(rop->fq_zech,
-                                 op1->fq_zech, op2->fq_zech, ctx->ctx.fq_zech);
+                                 op1->fq_zech, op2->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -2106,7 +2106,7 @@ void fq_default_poly_compose_mod(fq_default_poly_t res,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_compose_mod(res->fq_zech,
-             poly1->fq_zech, poly2->fq_zech, poly3->fq_zech, ctx->ctx.fq_zech);
+             poly1->fq_zech, poly2->fq_zech, poly3->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -2145,7 +2145,7 @@ char * fq_default_poly_get_str_pretty(const fq_default_poly_t poly,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_poly_get_str_pretty(poly->fq_zech, x, ctx->ctx.fq_zech);
+        return fq_zech_poly_get_str_pretty(poly->fq_zech, x, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -2172,7 +2172,7 @@ char * fq_default_poly_get_str(const fq_default_poly_t poly,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_poly_get_str(poly->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_poly_get_str(poly->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -2202,7 +2202,7 @@ void fq_default_mat_charpoly(fq_default_poly_t p,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_charpoly(p->fq_zech, M->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_mat_charpoly(p->fq_zech, M->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -2230,7 +2230,7 @@ void fq_default_mat_minpoly(fq_default_poly_t p,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_mat_minpoly(p->fq_zech, X->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_mat_minpoly(p->fq_zech, X->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {

--- a/src/fq_default_poly/io.c
+++ b/src/fq_default_poly/io.c
@@ -18,7 +18,7 @@ int fq_default_poly_fprint(FILE * file, const fq_default_poly_t poly, const fq_d
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_poly_fprint(file, poly->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_poly_fprint(file, poly->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -43,7 +43,7 @@ int fq_default_poly_fprint_pretty(FILE * file, const fq_default_poly_t poly, con
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_poly_fprint_pretty(file,
-                                           poly->fq_zech, x, ctx->ctx.fq_zech);
+                                           poly->fq_zech, x, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {

--- a/src/fq_default_poly/io.c
+++ b/src/fq_default_poly/io.c
@@ -16,19 +16,19 @@
 
 int fq_default_poly_fprint(FILE * file, const fq_default_poly_t poly, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_poly_fprint(file, poly->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_poly_fprint(file, poly->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_poly_fprint(file, poly->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_poly_fprint(file, poly->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -40,21 +40,21 @@ int fq_default_poly_fprint(FILE * file, const fq_default_poly_t poly, const fq_d
 
 int fq_default_poly_fprint_pretty(FILE * file, const fq_default_poly_t poly, const char *x, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_poly_fprint_pretty(file,
                                            poly->fq_zech, x, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_poly_fprint_pretty(file,
                                            poly->fq_nmod, x, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_poly_fprint_pretty(file, poly->nmod, x);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_poly_fprint_pretty(file, poly->fmpz_mod, x,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));

--- a/src/fq_default_poly/io.c
+++ b/src/fq_default_poly/io.c
@@ -22,7 +22,7 @@ int fq_default_poly_fprint(FILE * file, const fq_default_poly_t poly, const fq_d
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_poly_fprint(file, poly->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_poly_fprint(file, poly->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -34,7 +34,7 @@ int fq_default_poly_fprint(FILE * file, const fq_default_poly_t poly, const fq_d
     }
     else
     {
-        return fq_poly_fprint(file, poly->fq, ctx->ctx.fq);
+        return fq_poly_fprint(file, poly->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -48,7 +48,7 @@ int fq_default_poly_fprint_pretty(FILE * file, const fq_default_poly_t poly, con
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_poly_fprint_pretty(file,
-                                           poly->fq_nmod, x, ctx->ctx.fq_nmod);
+                                           poly->fq_nmod, x, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -61,7 +61,7 @@ int fq_default_poly_fprint_pretty(FILE * file, const fq_default_poly_t poly, con
     }
     else
     {
-        return fq_poly_fprint_pretty(file, poly->fq, x, ctx->ctx.fq);
+        return fq_poly_fprint_pretty(file, poly->fq, x, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 

--- a/src/fq_default_poly/io.c
+++ b/src/fq_default_poly/io.c
@@ -30,7 +30,7 @@ int fq_default_poly_fprint(FILE * file, const fq_default_poly_t poly, const fq_d
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_poly_fprint(file, poly->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_poly_fprint(file, poly->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -57,7 +57,7 @@ int fq_default_poly_fprint_pretty(FILE * file, const fq_default_poly_t poly, con
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_poly_fprint_pretty(file, poly->fmpz_mod, x,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {

--- a/src/fq_default_poly/set_fmpz_poly.c
+++ b/src/fq_default_poly/set_fmpz_poly.c
@@ -19,7 +19,7 @@ void fq_default_poly_set_fmpz_poly(fq_default_poly_t rop,
     fmpz_mod_poly_t mod_poly;
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fmpz_mod_ctx_init_ui(mod, fq_zech_ctx_prime(ctx->ctx.fq_zech));
+        fmpz_mod_ctx_init_ui(mod, fq_zech_ctx_prime(FQ_DEFAULT_CTX_FQ_ZECH(ctx)));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {

--- a/src/fq_default_poly/set_fmpz_poly.c
+++ b/src/fq_default_poly/set_fmpz_poly.c
@@ -17,19 +17,19 @@ void fq_default_poly_set_fmpz_poly(fq_default_poly_t rop,
 {
     fmpz_mod_ctx_t mod;
     fmpz_mod_poly_t mod_poly;
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fmpz_mod_ctx_init_ui(mod, fq_zech_ctx_prime(FQ_DEFAULT_CTX_FQ_ZECH(ctx)));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fmpz_mod_ctx_init_ui(mod, fq_nmod_ctx_prime(FQ_DEFAULT_CTX_FQ_NMOD(ctx)));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         fmpz_mod_ctx_init_ui(mod, FQ_DEFAULT_CTX_NMOD(ctx).n);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_init(mod_poly, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
         fmpz_mod_poly_set_fmpz_poly(mod_poly, op, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));

--- a/src/fq_default_poly/set_fmpz_poly.c
+++ b/src/fq_default_poly/set_fmpz_poly.c
@@ -27,7 +27,7 @@ void fq_default_poly_set_fmpz_poly(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
-        fmpz_mod_ctx_init_ui(mod, ctx->ctx.nmod.mod.n);
+        fmpz_mod_ctx_init_ui(mod, FQ_DEFAULT_CTX_NMOD(ctx).n);
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {

--- a/src/fq_default_poly/set_fmpz_poly.c
+++ b/src/fq_default_poly/set_fmpz_poly.c
@@ -23,7 +23,7 @@ void fq_default_poly_set_fmpz_poly(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fmpz_mod_ctx_init_ui(mod, fq_nmod_ctx_prime(ctx->ctx.fq_nmod));
+        fmpz_mod_ctx_init_ui(mod, fq_nmod_ctx_prime(FQ_DEFAULT_CTX_FQ_NMOD(ctx)));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -39,7 +39,7 @@ void fq_default_poly_set_fmpz_poly(fq_default_poly_t rop,
     }
     else
     {
-        fmpz_mod_ctx_init(mod, fq_ctx_prime(ctx->ctx.fq));
+        fmpz_mod_ctx_init(mod, fq_ctx_prime(FQ_DEFAULT_CTX_FQ(ctx)));
     }
     fmpz_mod_poly_init(mod_poly, mod);
     fmpz_mod_poly_set_fmpz_poly(mod_poly, op, mod);

--- a/src/fq_default_poly/set_fmpz_poly.c
+++ b/src/fq_default_poly/set_fmpz_poly.c
@@ -31,10 +31,10 @@ void fq_default_poly_set_fmpz_poly(fq_default_poly_t rop,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_init(mod_poly, ctx->ctx.fmpz_mod.mod);
-        fmpz_mod_poly_set_fmpz_poly(mod_poly, op, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_init(mod_poly, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
+        fmpz_mod_poly_set_fmpz_poly(mod_poly, op, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
         fq_default_poly_set_fmpz_mod_poly(rop, mod_poly, ctx);
-        fmpz_mod_poly_clear(mod_poly, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_clear(mod_poly, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
         return;
     }
     else

--- a/src/fq_default_poly_factor.h
+++ b/src/fq_default_poly_factor.h
@@ -54,7 +54,7 @@ void fq_default_poly_factor_init(fq_default_poly_factor_t fac,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_factor_init(fac->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_poly_factor_init(fac->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -66,7 +66,7 @@ void fq_default_poly_factor_init(fq_default_poly_factor_t fac,
     }
     else
     {
-        fq_poly_factor_init(fac->fq, ctx->ctx.fq);
+        fq_poly_factor_init(fac->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -80,7 +80,7 @@ void fq_default_poly_factor_clear(fq_default_poly_factor_t fac,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_factor_clear(fac->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_poly_factor_clear(fac->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -92,7 +92,7 @@ void fq_default_poly_factor_clear(fq_default_poly_factor_t fac,
     }
     else
     {
-        fq_poly_factor_clear(fac->fq, ctx->ctx.fq);
+        fq_poly_factor_clear(fac->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -106,7 +106,7 @@ void fq_default_poly_factor_realloc(fq_default_poly_factor_t fac,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_factor_realloc(fac->fq_nmod, alloc, ctx->ctx.fq_nmod);
+        fq_nmod_poly_factor_realloc(fac->fq_nmod, alloc, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -118,7 +118,7 @@ void fq_default_poly_factor_realloc(fq_default_poly_factor_t fac,
     }
     else
     {
-        fq_poly_factor_realloc(fac->fq, alloc, ctx->ctx.fq);
+        fq_poly_factor_realloc(fac->fq, alloc, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -132,7 +132,7 @@ void fq_default_poly_factor_fit_length(fq_default_poly_factor_t fac,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_factor_fit_length(fac->fq_nmod, len, ctx->ctx.fq_nmod);
+        fq_nmod_poly_factor_fit_length(fac->fq_nmod, len, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -144,7 +144,7 @@ void fq_default_poly_factor_fit_length(fq_default_poly_factor_t fac,
     }
     else
     {
-        fq_poly_factor_fit_length(fac->fq, len, ctx->ctx.fq);
+        fq_poly_factor_fit_length(fac->fq, len, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -210,7 +210,7 @@ void fq_default_poly_factor_set(fq_default_poly_factor_t res,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_factor_set(res->fq_nmod, fac->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_poly_factor_set(res->fq_nmod, fac->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -222,7 +222,7 @@ void fq_default_poly_factor_set(fq_default_poly_factor_t res,
     }
     else
     {
-        fq_poly_factor_set(res->fq, fac->fq, ctx->ctx.fq);
+        fq_poly_factor_set(res->fq, fac->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -238,7 +238,7 @@ void fq_default_poly_factor_insert(fq_default_poly_factor_t fac,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_factor_insert(fac->fq_nmod,
-                                         poly->fq_nmod, exp, ctx->ctx.fq_nmod);
+                                         poly->fq_nmod, exp, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -251,7 +251,7 @@ void fq_default_poly_factor_insert(fq_default_poly_factor_t fac,
     }
     else
     {
-        fq_poly_factor_insert(fac->fq, poly->fq, exp, ctx->ctx.fq);
+        fq_poly_factor_insert(fac->fq, poly->fq, exp, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -267,7 +267,7 @@ void fq_default_poly_factor_get_poly(fq_default_poly_t poly,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_factor_get_poly(poly->fq_nmod,
-                                            fac->fq_nmod, i, ctx->ctx.fq_nmod);
+                                            fac->fq_nmod, i, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -280,7 +280,7 @@ void fq_default_poly_factor_get_poly(fq_default_poly_t poly,
     }
     else
     {
-        fq_poly_factor_get_poly(poly->fq, fac->fq, i, ctx->ctx.fq);
+        fq_poly_factor_get_poly(poly->fq, fac->fq, i, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -294,7 +294,7 @@ void fq_default_poly_factor_print(const fq_default_poly_factor_t fac,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_factor_print(fac->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_poly_factor_print(fac->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -306,7 +306,7 @@ void fq_default_poly_factor_print(const fq_default_poly_factor_t fac,
     }
     else
     {
-        fq_poly_factor_print(fac->fq, ctx->ctx.fq);
+        fq_poly_factor_print(fac->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -320,7 +320,7 @@ void fq_default_poly_factor_print_pretty(const fq_default_poly_factor_t fac,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_factor_print_pretty(fac->fq_nmod, var, ctx->ctx.fq_nmod);
+        fq_nmod_poly_factor_print_pretty(fac->fq_nmod, var, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -333,7 +333,7 @@ void fq_default_poly_factor_print_pretty(const fq_default_poly_factor_t fac,
     }
     else
     {
-        fq_poly_factor_print_pretty(fac->fq, var, ctx->ctx.fq);
+        fq_poly_factor_print_pretty(fac->fq, var, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -347,7 +347,7 @@ void fq_default_poly_factor_concat(fq_default_poly_factor_t res,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_factor_concat(res->fq_nmod, fac->fq_nmod, ctx->ctx.fq_nmod);
+        fq_nmod_poly_factor_concat(res->fq_nmod, fac->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -360,7 +360,7 @@ void fq_default_poly_factor_concat(fq_default_poly_factor_t res,
     }
     else
     {
-        fq_poly_factor_concat(res->fq, fac->fq, ctx->ctx.fq);
+        fq_poly_factor_concat(res->fq, fac->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -374,7 +374,7 @@ void fq_default_poly_factor_pow(fq_default_poly_factor_t fac,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        fq_nmod_poly_factor_pow(fac->fq_nmod, exp, ctx->ctx.fq_nmod);
+        fq_nmod_poly_factor_pow(fac->fq_nmod, exp, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -386,7 +386,7 @@ void fq_default_poly_factor_pow(fq_default_poly_factor_t fac,
     }
     else
     {
-        fq_poly_factor_pow(fac->fq, exp, ctx->ctx.fq);
+        fq_poly_factor_pow(fac->fq, exp, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -400,7 +400,7 @@ int fq_default_poly_is_squarefree(const fq_default_poly_t f,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_poly_is_squarefree(f->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_poly_is_squarefree(f->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -412,7 +412,7 @@ int fq_default_poly_is_squarefree(const fq_default_poly_t f,
     }
     else
     {
-        return fq_poly_is_squarefree(f->fq, ctx->ctx.fq);
+        return fq_poly_is_squarefree(f->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -428,7 +428,7 @@ void fq_default_poly_factor_squarefree(fq_default_poly_factor_t res,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_factor_squarefree(res->fq_nmod,
-		                                 f->fq_nmod, ctx->ctx.fq_nmod);
+		                                 f->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -441,7 +441,7 @@ void fq_default_poly_factor_squarefree(fq_default_poly_factor_t res,
     }
     else
     {
-        fq_poly_factor_squarefree(res->fq, f->fq, ctx->ctx.fq);
+        fq_poly_factor_squarefree(res->fq, f->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -455,7 +455,7 @@ int fq_default_poly_is_irreducible(const fq_default_poly_t f,
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
-        return fq_nmod_poly_is_irreducible(f->fq_nmod, ctx->ctx.fq_nmod);
+        return fq_nmod_poly_is_irreducible(f->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -467,7 +467,7 @@ int fq_default_poly_is_irreducible(const fq_default_poly_t f,
     }
     else
     {
-        return fq_poly_is_irreducible(f->fq, ctx->ctx.fq);
+        return fq_poly_is_irreducible(f->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -484,7 +484,7 @@ void fq_default_poly_factor_distinct_deg(fq_default_poly_factor_t res,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_factor_distinct_deg(res->fq_nmod,
-                                        poly->fq_nmod, degs, ctx->ctx.fq_nmod);
+                                        poly->fq_nmod, degs, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -497,7 +497,7 @@ void fq_default_poly_factor_distinct_deg(fq_default_poly_factor_t res,
     }
     else
     {
-        fq_poly_factor_distinct_deg(res->fq, poly->fq, degs, ctx->ctx.fq);
+        fq_poly_factor_distinct_deg(res->fq, poly->fq, degs, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -513,7 +513,7 @@ void fq_default_poly_factor_equal_deg(fq_default_poly_factor_t factors,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_factor_equal_deg(factors->fq_nmod,
-                                            pol->fq_nmod, d, ctx->ctx.fq_nmod);
+                                            pol->fq_nmod, d, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -526,7 +526,7 @@ void fq_default_poly_factor_equal_deg(fq_default_poly_factor_t factors,
     }
     else
     {
-        fq_poly_factor_equal_deg(factors->fq, pol->fq, d, ctx->ctx.fq);
+        fq_poly_factor_equal_deg(factors->fq, pol->fq, d, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -543,7 +543,7 @@ void fq_default_poly_factor(fq_default_poly_factor_t result,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_factor(result->fq_nmod,
-                     leading_coeff->fq_nmod, input->fq_nmod, ctx->ctx.fq_nmod);
+                     leading_coeff->fq_nmod, input->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -561,7 +561,7 @@ void fq_default_poly_factor(fq_default_poly_factor_t result,
     }
     else
     {
-        fq_poly_factor(result->fq, leading_coeff->fq, input->fq, ctx->ctx.fq);
+        fq_poly_factor(result->fq, leading_coeff->fq, input->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -577,7 +577,7 @@ void fq_default_poly_factor_split_single(fq_default_poly_t linfactor,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_factor_split_single(linfactor->fq_nmod,
-                                             input->fq_nmod, ctx->ctx.fq_nmod);
+                                             input->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -589,7 +589,7 @@ void fq_default_poly_factor_split_single(fq_default_poly_t linfactor,
     }
     else
     {
-        fq_poly_factor_split_single(linfactor->fq, input->fq, ctx->ctx.fq);
+        fq_poly_factor_split_single(linfactor->fq, input->fq, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 
@@ -606,7 +606,7 @@ void fq_default_poly_roots(fq_default_poly_factor_t r,
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_roots(r->fq_nmod,
-                              f->fq_nmod, with_multiplicity, ctx->ctx.fq_nmod);
+                              f->fq_nmod, with_multiplicity, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
@@ -619,7 +619,7 @@ void fq_default_poly_roots(fq_default_poly_factor_t r,
     }
     else
     {
-        fq_poly_roots(r->fq, f->fq, with_multiplicity, ctx->ctx.fq);
+        fq_poly_roots(r->fq, f->fq, with_multiplicity, FQ_DEFAULT_CTX_FQ(ctx));
     }
 }
 

--- a/src/fq_default_poly_factor.h
+++ b/src/fq_default_poly_factor.h
@@ -62,7 +62,7 @@ void fq_default_poly_factor_init(fq_default_poly_factor_t fac,
     }
     else if (ctx->type == FQ_DEFAULT_NMOD)
     {
-        fmpz_mod_poly_factor_init(fac->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_factor_init(fac->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -88,7 +88,7 @@ void fq_default_poly_factor_clear(fq_default_poly_factor_t fac,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_factor_clear(fac->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_factor_clear(fac->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -114,7 +114,7 @@ void fq_default_poly_factor_realloc(fq_default_poly_factor_t fac,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_factor_realloc(fac->fmpz_mod, alloc, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_factor_realloc(fac->fmpz_mod, alloc, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -140,7 +140,7 @@ void fq_default_poly_factor_fit_length(fq_default_poly_factor_t fac,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_factor_fit_length(fac->fmpz_mod, len, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_factor_fit_length(fac->fmpz_mod, len, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -218,7 +218,7 @@ void fq_default_poly_factor_set(fq_default_poly_factor_t res,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_factor_set(res->fmpz_mod, fac->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_factor_set(res->fmpz_mod, fac->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -247,7 +247,7 @@ void fq_default_poly_factor_insert(fq_default_poly_factor_t fac,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_factor_insert(fac->fmpz_mod,
-                                   poly->fmpz_mod, exp, ctx->ctx.fmpz_mod.mod);
+                                   poly->fmpz_mod, exp, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -276,7 +276,7 @@ void fq_default_poly_factor_get_poly(fq_default_poly_t poly,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_factor_get_poly(poly->fmpz_mod,
-                                      fac->fmpz_mod, i, ctx->ctx.fmpz_mod.mod);
+                                      fac->fmpz_mod, i, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -302,7 +302,7 @@ void fq_default_poly_factor_print(const fq_default_poly_factor_t fac,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_factor_print(fac->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_factor_print(fac->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -329,7 +329,7 @@ void fq_default_poly_factor_print_pretty(const fq_default_poly_factor_t fac,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_factor_print_pretty(fac->fmpz_mod, var,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -356,7 +356,7 @@ void fq_default_poly_factor_concat(fq_default_poly_factor_t res,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_factor_concat(res->fmpz_mod, fac->fmpz_mod,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -382,7 +382,7 @@ void fq_default_poly_factor_pow(fq_default_poly_factor_t fac,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        fmpz_mod_poly_factor_pow(fac->fmpz_mod, exp, ctx->ctx.fmpz_mod.mod);
+        fmpz_mod_poly_factor_pow(fac->fmpz_mod, exp, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -408,7 +408,7 @@ int fq_default_poly_is_squarefree(const fq_default_poly_t f,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_poly_is_squarefree(f->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_poly_is_squarefree(f->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -437,7 +437,7 @@ void fq_default_poly_factor_squarefree(fq_default_poly_factor_t res,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_factor_squarefree(res->fmpz_mod, f->fmpz_mod,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -463,7 +463,7 @@ int fq_default_poly_is_irreducible(const fq_default_poly_t f,
     }
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
-        return fmpz_mod_poly_is_irreducible(f->fmpz_mod, ctx->ctx.fmpz_mod.mod);
+        return fmpz_mod_poly_is_irreducible(f->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -493,7 +493,7 @@ void fq_default_poly_factor_distinct_deg(fq_default_poly_factor_t res,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_factor_distinct_deg(res->fmpz_mod, poly->fmpz_mod, degs,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -522,7 +522,7 @@ void fq_default_poly_factor_equal_deg(fq_default_poly_factor_t factors,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_factor_equal_deg(factors->fmpz_mod, pol->fmpz_mod, d,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {
@@ -552,7 +552,7 @@ void fq_default_poly_factor(fq_default_poly_factor_t result,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_factor(result->fmpz_mod, input->fmpz_mod,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
         if (input->fmpz_mod->length < 1)
             fmpz_zero(leading_coeff->fmpz_mod);
         else
@@ -615,7 +615,7 @@ void fq_default_poly_roots(fq_default_poly_factor_t r,
     else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_roots(r->fmpz_mod, f->fmpz_mod, with_multiplicity,
-                                                        ctx->ctx.fmpz_mod.mod);
+                                                        FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
     else
     {

--- a/src/fq_default_poly_factor.h
+++ b/src/fq_default_poly_factor.h
@@ -50,7 +50,7 @@ void fq_default_poly_factor_init(fq_default_poly_factor_t fac,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_factor_init(fac->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_poly_factor_init(fac->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -76,7 +76,7 @@ void fq_default_poly_factor_clear(fq_default_poly_factor_t fac,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_factor_clear(fac->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_poly_factor_clear(fac->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -102,7 +102,7 @@ void fq_default_poly_factor_realloc(fq_default_poly_factor_t fac,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_factor_realloc(fac->fq_zech, alloc, ctx->ctx.fq_zech);
+        fq_zech_poly_factor_realloc(fac->fq_zech, alloc, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -128,7 +128,7 @@ void fq_default_poly_factor_fit_length(fq_default_poly_factor_t fac,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_factor_fit_length(fac->fq_zech, len, ctx->ctx.fq_zech);
+        fq_zech_poly_factor_fit_length(fac->fq_zech, len, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -206,7 +206,7 @@ void fq_default_poly_factor_set(fq_default_poly_factor_t res,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_factor_set(res->fq_zech, fac->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_poly_factor_set(res->fq_zech, fac->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -233,7 +233,7 @@ void fq_default_poly_factor_insert(fq_default_poly_factor_t fac,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_factor_insert(fac->fq_zech,
-                                         poly->fq_zech, exp, ctx->ctx.fq_zech);
+                                         poly->fq_zech, exp, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -262,7 +262,7 @@ void fq_default_poly_factor_get_poly(fq_default_poly_t poly,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_factor_get_poly(poly->fq_zech,
-                                            fac->fq_zech, i, ctx->ctx.fq_zech);
+                                            fac->fq_zech, i, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -290,7 +290,7 @@ void fq_default_poly_factor_print(const fq_default_poly_factor_t fac,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_factor_print(fac->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_poly_factor_print(fac->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -316,7 +316,7 @@ void fq_default_poly_factor_print_pretty(const fq_default_poly_factor_t fac,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_factor_print_pretty(fac->fq_zech, var, ctx->ctx.fq_zech);
+        fq_zech_poly_factor_print_pretty(fac->fq_zech, var, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -343,7 +343,7 @@ void fq_default_poly_factor_concat(fq_default_poly_factor_t res,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_factor_concat(res->fq_zech, fac->fq_zech, ctx->ctx.fq_zech);
+        fq_zech_poly_factor_concat(res->fq_zech, fac->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -370,7 +370,7 @@ void fq_default_poly_factor_pow(fq_default_poly_factor_t fac,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        fq_zech_poly_factor_pow(fac->fq_zech, exp, ctx->ctx.fq_zech);
+        fq_zech_poly_factor_pow(fac->fq_zech, exp, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -396,7 +396,7 @@ int fq_default_poly_is_squarefree(const fq_default_poly_t f,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_poly_is_squarefree(f->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_poly_is_squarefree(f->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -423,7 +423,7 @@ void fq_default_poly_factor_squarefree(fq_default_poly_factor_t res,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_factor_squarefree(res->fq_zech,
-		                                 f->fq_zech, ctx->ctx.fq_zech);
+		                                 f->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -451,7 +451,7 @@ int fq_default_poly_is_irreducible(const fq_default_poly_t f,
 {
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
-        return fq_zech_poly_is_irreducible(f->fq_zech, ctx->ctx.fq_zech);
+        return fq_zech_poly_is_irreducible(f->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -479,7 +479,7 @@ void fq_default_poly_factor_distinct_deg(fq_default_poly_factor_t res,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_factor_distinct_deg(res->fq_zech,
-                                        poly->fq_zech, degs, ctx->ctx.fq_zech);
+                                        poly->fq_zech, degs, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -508,7 +508,7 @@ void fq_default_poly_factor_equal_deg(fq_default_poly_factor_t factors,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_factor_equal_deg(factors->fq_zech,
-                                            pol->fq_zech, d, ctx->ctx.fq_zech);
+                                            pol->fq_zech, d, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -538,7 +538,7 @@ void fq_default_poly_factor(fq_default_poly_factor_t result,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_factor(result->fq_zech,
-                     leading_coeff->fq_zech, input->fq_zech, ctx->ctx.fq_zech);
+                     leading_coeff->fq_zech, input->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -572,7 +572,7 @@ void fq_default_poly_factor_split_single(fq_default_poly_t linfactor,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_factor_split_single(linfactor->fq_zech,
-                                             input->fq_zech, ctx->ctx.fq_zech);
+                                             input->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {
@@ -601,7 +601,7 @@ void fq_default_poly_roots(fq_default_poly_factor_t r,
     if (ctx->type == FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_roots(r->fq_zech,
-                              f->fq_zech, with_multiplicity, ctx->ctx.fq_zech);
+                              f->fq_zech, with_multiplicity, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
     else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
     {

--- a/src/fq_default_poly_factor.h
+++ b/src/fq_default_poly_factor.h
@@ -48,19 +48,19 @@ FQ_DEFAULT_POLY_FACTOR_INLINE
 void fq_default_poly_factor_init(fq_default_poly_factor_t fac,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_factor_init(fac->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_factor_init(fac->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_factor_init(fac->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         fmpz_mod_poly_factor_init(fac->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -74,19 +74,19 @@ FQ_DEFAULT_POLY_FACTOR_INLINE
 void fq_default_poly_factor_clear(fq_default_poly_factor_t fac,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_factor_clear(fac->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_factor_clear(fac->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_factor_clear(fac->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_factor_clear(fac->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -100,19 +100,19 @@ FQ_DEFAULT_POLY_FACTOR_INLINE
 void fq_default_poly_factor_realloc(fq_default_poly_factor_t fac,
                                        slong alloc, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_factor_realloc(fac->fq_zech, alloc, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_factor_realloc(fac->fq_nmod, alloc, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_factor_realloc(fac->nmod, alloc);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_factor_realloc(fac->fmpz_mod, alloc, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -126,19 +126,19 @@ FQ_DEFAULT_POLY_FACTOR_INLINE
 void fq_default_poly_factor_fit_length(fq_default_poly_factor_t fac,
                                          slong len, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_factor_fit_length(fac->fq_zech, len, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_factor_fit_length(fac->fq_nmod, len, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_factor_fit_length(fac->nmod, len);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_factor_fit_length(fac->fmpz_mod, len, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -152,19 +152,19 @@ FQ_DEFAULT_POLY_FACTOR_INLINE
 slong fq_default_poly_factor_length(fq_default_poly_factor_t fac,
                                                    const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fac->fq_zech->num;
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fac->fq_nmod->num;
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return fac->nmod->num;
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fac->fmpz_mod->num;
     }
@@ -178,19 +178,19 @@ FQ_DEFAULT_POLY_FACTOR_INLINE
 slong fq_default_poly_factor_exp(fq_default_poly_factor_t fac, slong i,
                                                    const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fac->fq_zech->exp[i];
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fac->fq_nmod->exp[i];
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return fac->nmod->exp[i];
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fac->fmpz_mod->exp[i];
     }
@@ -204,19 +204,19 @@ FQ_DEFAULT_POLY_FACTOR_INLINE
 void fq_default_poly_factor_set(fq_default_poly_factor_t res,
                 const fq_default_poly_factor_t fac, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_factor_set(res->fq_zech, fac->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_factor_set(res->fq_nmod, fac->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_factor_set(res->nmod, fac->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_factor_set(res->fmpz_mod, fac->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -230,21 +230,21 @@ FQ_DEFAULT_POLY_FACTOR_INLINE
 void fq_default_poly_factor_insert(fq_default_poly_factor_t fac,
            const fq_default_poly_t poly, slong exp, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_factor_insert(fac->fq_zech,
                                          poly->fq_zech, exp, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_factor_insert(fac->fq_nmod,
                                          poly->fq_nmod, exp, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_factor_insert(fac->nmod, poly->nmod, exp);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_factor_insert(fac->fmpz_mod,
                                    poly->fmpz_mod, exp, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -259,21 +259,21 @@ FQ_DEFAULT_POLY_FACTOR_INLINE
 void fq_default_poly_factor_get_poly(fq_default_poly_t poly,
        const fq_default_poly_factor_t fac, slong i, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_factor_get_poly(poly->fq_zech,
                                             fac->fq_zech, i, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_factor_get_poly(poly->fq_nmod,
                                             fac->fq_nmod, i, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_factor_get_poly(poly->nmod, fac->nmod, i);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_factor_get_poly(poly->fmpz_mod,
                                       fac->fmpz_mod, i, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -288,19 +288,19 @@ FQ_DEFAULT_POLY_FACTOR_INLINE
 void fq_default_poly_factor_print(const fq_default_poly_factor_t fac,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_factor_print(fac->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_factor_print(fac->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_factor_print(fac->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_factor_print(fac->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -314,19 +314,19 @@ FQ_DEFAULT_POLY_FACTOR_INLINE
 void fq_default_poly_factor_print_pretty(const fq_default_poly_factor_t fac,
                                   const char * var, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_factor_print_pretty(fac->fq_zech, var, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_factor_print_pretty(fac->fq_nmod, var, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_factor_print_pretty(fac->nmod, var);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_factor_print_pretty(fac->fmpz_mod, var,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -341,19 +341,19 @@ FQ_DEFAULT_POLY_FACTOR_INLINE
 void fq_default_poly_factor_concat(fq_default_poly_factor_t res,
                 const fq_default_poly_factor_t fac, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_factor_concat(res->fq_zech, fac->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_factor_concat(res->fq_nmod, fac->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_factor_concat(res->nmod, fac->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_factor_concat(res->fmpz_mod, fac->fmpz_mod,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -368,19 +368,19 @@ FQ_DEFAULT_POLY_FACTOR_INLINE
 void fq_default_poly_factor_pow(fq_default_poly_factor_t fac,
                                          slong exp, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_factor_pow(fac->fq_zech, exp, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_factor_pow(fac->fq_nmod, exp, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_factor_pow(fac->nmod, exp);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_factor_pow(fac->fmpz_mod, exp, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -394,19 +394,19 @@ FQ_DEFAULT_POLY_FACTOR_INLINE
 int fq_default_poly_is_squarefree(const fq_default_poly_t f,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_poly_is_squarefree(f->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_poly_is_squarefree(f->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_poly_is_squarefree(f->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_poly_is_squarefree(f->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -420,21 +420,21 @@ FQ_DEFAULT_POLY_FACTOR_INLINE
 void fq_default_poly_factor_squarefree(fq_default_poly_factor_t res,
                          const fq_default_poly_t f, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_factor_squarefree(res->fq_zech,
 		                                 f->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_factor_squarefree(res->fq_nmod,
 		                                 f->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_factor_squarefree(res->nmod, f->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_factor_squarefree(res->fmpz_mod, f->fmpz_mod,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -449,19 +449,19 @@ FQ_DEFAULT_POLY_FACTOR_INLINE
 int fq_default_poly_is_irreducible(const fq_default_poly_t f,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         return fq_zech_poly_is_irreducible(f->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         return fq_nmod_poly_is_irreducible(f->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         return nmod_poly_is_irreducible(f->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         return fmpz_mod_poly_is_irreducible(f->fmpz_mod, FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
     }
@@ -476,21 +476,21 @@ void fq_default_poly_factor_distinct_deg(fq_default_poly_factor_t res,
                         const fq_default_poly_t poly, slong * const * degs,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_factor_distinct_deg(res->fq_zech,
                                         poly->fq_zech, degs, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_factor_distinct_deg(res->fq_nmod,
                                         poly->fq_nmod, degs, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_factor_distinct_deg(res->nmod, poly->nmod, degs);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_factor_distinct_deg(res->fmpz_mod, poly->fmpz_mod, degs,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -505,21 +505,21 @@ FQ_DEFAULT_POLY_FACTOR_INLINE
 void fq_default_poly_factor_equal_deg(fq_default_poly_factor_t factors,
               const fq_default_poly_t pol, slong d, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_factor_equal_deg(factors->fq_zech,
                                             pol->fq_zech, d, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_factor_equal_deg(factors->fq_nmod,
                                             pol->fq_nmod, d, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_factor_equal_deg(factors->nmod, pol->nmod, d);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_factor_equal_deg(factors->fmpz_mod, pol->fmpz_mod, d,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -535,21 +535,21 @@ void fq_default_poly_factor(fq_default_poly_factor_t result,
             fq_default_t leading_coeff, const fq_default_poly_t input,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_factor(result->fq_zech,
                      leading_coeff->fq_zech, input->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_factor(result->fq_nmod,
                      leading_coeff->fq_nmod, input->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         leading_coeff->nmod = nmod_poly_factor(result->nmod, input->nmod);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_factor(result->fmpz_mod, input->fmpz_mod,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));
@@ -569,21 +569,21 @@ FQ_DEFAULT_POLY_FACTOR_INLINE
 void fq_default_poly_factor_split_single(fq_default_poly_t linfactor,
                      const fq_default_poly_t input, const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_factor_split_single(linfactor->fq_zech,
                                              input->fq_zech, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_factor_split_single(linfactor->fq_nmod,
                                              input->fq_nmod, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         flint_throw(FLINT_ERROR, "operation not implemented");
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         flint_throw(FLINT_ERROR, "operation not implemented");
     }
@@ -598,21 +598,21 @@ void fq_default_poly_roots(fq_default_poly_factor_t r,
                     const fq_default_poly_t f, int with_multiplicity,
                                                     const fq_default_ctx_t ctx)
 {
-    if (ctx->type == FQ_DEFAULT_FQ_ZECH)
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_ZECH)
     {
         fq_zech_poly_roots(r->fq_zech,
                               f->fq_zech, with_multiplicity, FQ_DEFAULT_CTX_FQ_ZECH(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_FQ_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FQ_NMOD)
     {
         fq_nmod_poly_roots(r->fq_nmod,
                               f->fq_nmod, with_multiplicity, FQ_DEFAULT_CTX_FQ_NMOD(ctx));
     }
-    else if (ctx->type == FQ_DEFAULT_NMOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
     {
         nmod_poly_roots(r->nmod, f->nmod, with_multiplicity);
     }
-    else if (ctx->type == FQ_DEFAULT_FMPZ_MOD)
+    else if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_FMPZ_MOD)
     {
         fmpz_mod_poly_roots(r->fmpz_mod, f->fmpz_mod, with_multiplicity,
                                                         FQ_DEFAULT_CTX_FMPZ_MOD(ctx));

--- a/src/gr.h
+++ b/src/gr.h
@@ -1362,6 +1362,7 @@ void gr_ctx_fmpz_mod_set_primality(gr_ctx_t ctx, truth_t is_prime);
 
 void gr_ctx_init_nmod(gr_ctx_t ctx, ulong n);
 void _gr_ctx_init_nmod(gr_ctx_t ctx, void * nmod_t_ref);
+void gr_ctx_nmod_set_primality(gr_ctx_t ctx, truth_t is_prime);
 
 void gr_ctx_init_nmod8(gr_ctx_t ctx, unsigned char n);
 void gr_ctx_init_nmod32(gr_ctx_t ctx, unsigned int n);

--- a/src/gr/fmpz_mod.c
+++ b/src/gr/fmpz_mod.c
@@ -405,6 +405,48 @@ _gr_fmpz_mod_pow_fmpz(fmpz_t res, const fmpz_t x, const fmpz_t exp, const gr_ctx
     return fmpz_mod_pow_fmpz(res, x, exp, FMPZ_MOD_CTX(ctx)) ? GR_SUCCESS : GR_DOMAIN;
 }
 
+int
+_gr_fmpz_mod_sqrt(fmpz_t res, const fmpz_t x, const gr_ctx_t ctx)
+{
+    if (fmpz_is_zero(x) || fmpz_is_one(x))
+    {
+        fmpz_set(res, x);
+        return GR_SUCCESS;
+    }
+    else if (FMPZ_MOD_IS_PRIME(ctx) == T_TRUE)
+    {
+        return fmpz_sqrtmod(res, x, FMPZ_MOD_CTX(ctx)->n) ? GR_SUCCESS : GR_DOMAIN;
+    }
+    else
+    {
+        /* todo: implement the general case */
+        return GR_UNABLE;
+    }
+}
+
+truth_t
+_gr_fmpz_mod_is_square(const fmpz_t x, const gr_ctx_t ctx)
+{
+    if (fmpz_is_zero(x) || fmpz_is_one(x))
+    {
+        return T_TRUE;
+    }
+    else if (FMPZ_MOD_IS_PRIME(ctx) == T_TRUE)
+    {
+        fmpz_t t;
+        truth_t ans;
+        fmpz_init(t);
+        ans = fmpz_sqrtmod(t, x, FMPZ_MOD_CTX(ctx)->n) ? T_TRUE : T_FALSE;
+        fmpz_clear(t);
+        return ans;
+    }
+    else
+    {
+        /* todo: implement the general case */
+        return T_UNKNOWN;
+    }
+}
+
 /* todo: len 1 */
 int
 _gr_fmpz_mod_vec_dot(fmpz_t res, const fmpz_t initial, int subtract, const fmpz * vec1, const fmpz * vec2, slong len, gr_ctx_t ctx)
@@ -694,6 +736,8 @@ gr_method_tab_input _fmpz_mod_methods_input[] =
     {GR_METHOD_INV,             (gr_funcptr) _gr_fmpz_mod_inv},
     {GR_METHOD_POW_UI,          (gr_funcptr) _gr_fmpz_mod_pow_ui},
     {GR_METHOD_POW_FMPZ,        (gr_funcptr) _gr_fmpz_mod_pow_fmpz},
+    {GR_METHOD_SQRT,            (gr_funcptr) _gr_fmpz_mod_sqrt},
+    {GR_METHOD_IS_SQUARE,       (gr_funcptr) _gr_fmpz_mod_is_square},
     {GR_METHOD_VEC_DOT,         (gr_funcptr) _gr_fmpz_mod_vec_dot},
     {GR_METHOD_VEC_DOT_REV,     (gr_funcptr) _gr_fmpz_mod_vec_dot_rev},
     {GR_METHOD_VEC_ADDMUL_SCALAR,    (gr_funcptr) _gr_fmpz_mod_vec_addmul_scalar},

--- a/src/gr/fmpz_mod.c
+++ b/src/gr/fmpz_mod.c
@@ -26,11 +26,13 @@ typedef struct
 {
     fmpz_mod_ctx_struct * ctx;
     truth_t is_prime;
+    fmpz a;    /* when used as finite field with defining polynomial x - a */
 }
-fmpz_mod_ctx_extended_struct;
+_gr_fmpz_mod_ctx_struct;
 
-#define FMPZ_MOD_CTX(ring_ctx) ((((fmpz_mod_ctx_extended_struct *)(ring_ctx))->ctx))
-#define FMPZ_MOD_IS_PRIME(ring_ctx) (((fmpz_mod_ctx_extended_struct *)(ring_ctx))->is_prime)
+#define FMPZ_MOD_CTX(ring_ctx) ((((_gr_fmpz_mod_ctx_struct *)(ring_ctx))->ctx))
+#define FMPZ_MOD_IS_PRIME(ring_ctx) (((_gr_fmpz_mod_ctx_struct *)(ring_ctx))->is_prime)
+#define FMPZ_MOD_CTX_A(ring_ctx) (&((((_gr_fmpz_mod_ctx_struct *)(ring_ctx))->a)))
 
 int
 _gr_fmpz_mod_ctx_write(gr_stream_t out, gr_ctx_t ctx)
@@ -46,6 +48,7 @@ _gr_fmpz_mod_ctx_clear(gr_ctx_t ctx)
 {
     fmpz_mod_ctx_clear(FMPZ_MOD_CTX(ctx));
     flint_free(FMPZ_MOD_CTX(ctx));
+    fmpz_clear(FMPZ_MOD_CTX_A(ctx));
 }
 
 truth_t
@@ -714,6 +717,7 @@ gr_ctx_init_fmpz_mod(gr_ctx_t ctx, const fmpz_t n)
     FMPZ_MOD_CTX(ctx) = flint_malloc(sizeof(fmpz_mod_ctx_struct));
     fmpz_mod_ctx_init(FMPZ_MOD_CTX(ctx), n);
     FMPZ_MOD_IS_PRIME(ctx) = T_UNKNOWN;
+    fmpz_init(FMPZ_MOD_CTX_A(ctx));
 
     ctx->size_limit = WORD_MAX;
 
@@ -734,6 +738,7 @@ _gr_ctx_init_fmpz_mod_from_ref(gr_ctx_t ctx, const void * fctx)
 
     FMPZ_MOD_CTX(ctx) = (fmpz_mod_ctx_struct *) fctx;
     FMPZ_MOD_IS_PRIME(ctx) = T_UNKNOWN;
+    fmpz_init(FMPZ_MOD_CTX_A(ctx));
 
     ctx->size_limit = WORD_MAX;
 

--- a/src/gr/fq.c
+++ b/src/gr/fq.c
@@ -254,6 +254,33 @@ _gr_fq_div(fq_t res, const fq_t x, const fq_t y, const gr_ctx_t ctx)
     }
 }
 
+int
+_gr_fq_sqr(fq_t res, const fq_t x, const gr_ctx_t ctx)
+{
+    fq_sqr(res, x, FQ_CTX(ctx));
+    return GR_SUCCESS;
+}
+
+int
+_gr_fq_pow_ui(fq_t res, const fq_t x, ulong y, const gr_ctx_t ctx)
+{
+    fq_pow_ui(res, x, y, FQ_CTX(ctx));
+    return GR_SUCCESS;
+}
+
+int
+_gr_fq_pow_fmpz(fq_t res, const fq_t x, const fmpz_t y, gr_ctx_t ctx)
+{
+    if (fmpz_sgn(y) < 0)
+    {
+        return gr_generic_pow_fmpz(res, x, y, ctx);
+    }
+    else
+    {
+        fq_pow(res, x, y, FQ_CTX(ctx));
+        return GR_SUCCESS;
+    }
+}
 
 truth_t
 _gr_fq_is_invertible(const fq_t x, const gr_ctx_t ctx)
@@ -674,17 +701,23 @@ gr_method_tab_input _fq_methods_input[] =
     {GR_METHOD_MUL_SI,          (gr_funcptr) _gr_fq_mul_si},
     {GR_METHOD_MUL_FMPZ,        (gr_funcptr) _gr_fq_mul_fmpz},
 /*
-    todo ...
     {GR_METHOD_SI_MUL,          (gr_funcptr) _gr_fq_si_mul},
     {GR_METHOD_UI_MUL,          (gr_funcptr) _gr_fq_ui_mul},
     {GR_METHOD_FMPZ_MUL,        (gr_funcptr) _gr_fq_fmpz_mul},
+*/
+
+/*
     {GR_METHOD_MUL_OTHER,        (gr_funcptr) _gr_fq_mul_other},
     {GR_METHOD_OTHER_MUL,        (gr_funcptr) _gr_fq_other_mul},
 */
+    {GR_METHOD_SQR,             (gr_funcptr) _gr_fq_sqr},
+    {GR_METHOD_POW_UI,           (gr_funcptr) _gr_fq_pow_ui},
+    {GR_METHOD_POW_FMPZ,         (gr_funcptr) _gr_fq_pow_fmpz},
 
     {GR_METHOD_IS_INVERTIBLE,   (gr_funcptr) _gr_fq_is_invertible},
     {GR_METHOD_INV,             (gr_funcptr) _gr_fq_inv},
     {GR_METHOD_DIV,             (gr_funcptr) _gr_fq_div},
+
     {GR_METHOD_IS_SQUARE,       (gr_funcptr) _gr_fq_is_square},
     {GR_METHOD_SQRT,            (gr_funcptr) _gr_fq_sqrt},
 

--- a/src/gr/fq.c
+++ b/src/gr/fq.c
@@ -12,6 +12,8 @@
 #include "fmpz.h"
 #include "fmpz_vec.h"
 #include "fmpz_poly.h"
+#include "fmpz_mod.h"
+#include "fmpz_mod_poly.h"
 #include "gr.h"
 #include "fq.h"
 #include "fq_poly.h"
@@ -727,4 +729,30 @@ gr_ctx_init_fq(gr_ctx_t ctx, const fmpz_t p, slong d, const char * var)
     fq_ctx = flint_malloc(sizeof(fq_ctx_struct));
     fq_ctx_init(fq_ctx, p, d, var == NULL ? "a" : var);
     _gr_ctx_init_fq_from_ref(ctx, fq_ctx);
+}
+
+int gr_ctx_init_fq_modulus_fmpz_mod_poly(gr_ctx_t ctx, const fmpz_mod_poly_t modulus, fmpz_mod_ctx_t mod_ctx, const char * var)
+{
+    fq_ctx_struct * fq_ctx;
+    fq_ctx = flint_malloc(sizeof(fq_ctx_struct));
+    fq_ctx_init_modulus(fq_ctx, modulus, mod_ctx, var == NULL ? "a" : var);
+    _gr_ctx_init_fq_from_ref(ctx, fq_ctx);
+    return GR_SUCCESS;
+}
+
+int gr_ctx_init_fq_modulus_nmod_poly(gr_ctx_t ctx, const nmod_poly_t modulus, const char * var)
+{
+    fmpz_mod_ctx_t fmod_ctx;
+    fmpz_mod_poly_t fmod;
+    fmpz_t p;
+    int status;
+    fmpz_init_set_ui(p, modulus->mod.n);
+    fmpz_mod_ctx_init(fmod_ctx, p);
+    fmpz_mod_poly_init(fmod, fmod_ctx);
+    fmpz_mod_poly_set_nmod_poly(fmod, modulus);
+    status = gr_ctx_init_fq_modulus_fmpz_mod_poly(ctx, fmod, fmod_ctx, var);
+    fmpz_mod_poly_clear(fmod, fmod_ctx);
+    fmpz_mod_ctx_clear(fmod_ctx);
+    fmpz_clear(p);
+    return status;
 }

--- a/src/gr/fq_nmod.c
+++ b/src/gr/fq_nmod.c
@@ -17,6 +17,7 @@
 #include "fq_nmod_mat.h"
 #include "fq_nmod_poly.h"
 #include "fq_nmod_poly_factor.h"
+#include "fmpz_mod_poly.h"
 #include "gr.h"
 #include "gr_vec.h"
 #include "gr_poly.h"
@@ -684,4 +685,29 @@ gr_ctx_init_fq_nmod(gr_ctx_t ctx, ulong p, slong d, const char * var)
     fq_nmod_ctx = flint_malloc(sizeof(fq_nmod_ctx_struct));
     fq_nmod_ctx_init_ui(fq_nmod_ctx, p, d, var == NULL ? "a" : var);
     _gr_ctx_init_fq_nmod_from_ref(ctx, fq_nmod_ctx);
+}
+
+int gr_ctx_init_fq_nmod_modulus_nmod_poly(gr_ctx_t ctx, const nmod_poly_t modulus, const char * var)
+{
+    fq_nmod_ctx_struct * fq_nmod_ctx;
+    fq_nmod_ctx = flint_malloc(sizeof(fq_nmod_ctx_struct));
+    fq_nmod_ctx_init_modulus(fq_nmod_ctx, modulus, var == NULL ? "a" : var);
+    _gr_ctx_init_fq_nmod_from_ref(ctx, fq_nmod_ctx);
+    return GR_SUCCESS;
+}
+
+int
+gr_ctx_init_fq_nmod_modulus_fmpz_mod_poly(gr_ctx_t ctx, const fmpz_mod_poly_t modulus, fmpz_mod_ctx_t mod_ctx, const char * var)
+{
+    nmod_poly_t nmodulus;
+    int status;
+
+    if (!fmpz_abs_fits_ui(mod_ctx->n))
+        return GR_UNABLE;
+
+    nmod_poly_init(nmodulus, fmpz_get_ui(mod_ctx->n));
+    fmpz_mod_poly_get_nmod_poly(nmodulus, modulus);
+    status = gr_ctx_init_fq_nmod_modulus_nmod_poly(ctx, nmodulus, var);
+    nmod_poly_clear(nmodulus);
+    return status;
 }

--- a/src/gr/fq_nmod.c
+++ b/src/gr/fq_nmod.c
@@ -221,6 +221,33 @@ _gr_fq_nmod_div(fq_nmod_t res, const fq_nmod_t x, const fq_nmod_t y, const gr_ct
     }
 }
 
+int
+_gr_fq_nmod_sqr(fq_nmod_t res, const fq_nmod_t x, const gr_ctx_t ctx)
+{
+    fq_nmod_sqr(res, x, FQ_CTX(ctx));
+    return GR_SUCCESS;
+}
+
+int
+_gr_fq_nmod_pow_ui(fq_nmod_t res, const fq_nmod_t x, ulong y, const gr_ctx_t ctx)
+{
+    fq_nmod_pow_ui(res, x, y, FQ_CTX(ctx));
+    return GR_SUCCESS;
+}
+
+int
+_gr_fq_nmod_pow_fmpz(fq_nmod_t res, const fq_nmod_t x, const fmpz_t y, gr_ctx_t ctx)
+{
+    if (fmpz_sgn(y) < 0)
+    {
+        return gr_generic_pow_fmpz(res, x, y, ctx);
+    }
+    else
+    {
+        fq_nmod_pow(res, x, y, FQ_CTX(ctx));
+        return GR_SUCCESS;
+    }
+}
 
 truth_t
 _gr_fq_nmod_is_invertible(const fq_nmod_t x, const gr_ctx_t ctx)
@@ -638,6 +665,10 @@ gr_method_tab_input _fq_nmod_methods_input[] =
     {GR_METHOD_IS_INVERTIBLE,   (gr_funcptr) _gr_fq_nmod_is_invertible},
     {GR_METHOD_INV,             (gr_funcptr) _gr_fq_nmod_inv},
     {GR_METHOD_DIV,             (gr_funcptr) _gr_fq_nmod_div},
+    {GR_METHOD_SQR,             (gr_funcptr) _gr_fq_nmod_sqr},
+    {GR_METHOD_POW_UI,           (gr_funcptr) _gr_fq_nmod_pow_ui},
+    {GR_METHOD_POW_FMPZ,         (gr_funcptr) _gr_fq_nmod_pow_fmpz},
+
     {GR_METHOD_IS_SQUARE,       (gr_funcptr) _gr_fq_nmod_is_square},
     {GR_METHOD_SQRT,            (gr_funcptr) _gr_fq_nmod_sqrt},
 

--- a/src/gr/fq_zech.c
+++ b/src/gr/fq_zech.c
@@ -222,6 +222,33 @@ _gr_fq_zech_div(fq_zech_t res, const fq_zech_t x, const fq_zech_t y, const gr_ct
     }
 }
 
+int
+_gr_fq_zech_sqr(fq_zech_t res, const fq_zech_t x, const gr_ctx_t ctx)
+{
+    fq_zech_sqr(res, x, FQ_CTX(ctx));
+    return GR_SUCCESS;
+}
+
+int
+_gr_fq_zech_pow_ui(fq_zech_t res, const fq_zech_t x, ulong y, const gr_ctx_t ctx)
+{
+    fq_zech_pow_ui(res, x, y, FQ_CTX(ctx));
+    return GR_SUCCESS;
+}
+
+int
+_gr_fq_zech_pow_fmpz(fq_zech_t res, const fq_zech_t x, const fmpz_t y, gr_ctx_t ctx)
+{
+    if (fmpz_sgn(y) < 0)
+    {
+        return gr_generic_pow_fmpz(res, x, y, ctx);
+    }
+    else
+    {
+        fq_zech_pow(res, x, y, FQ_CTX(ctx));
+        return GR_SUCCESS;
+    }
+}
 
 truth_t
 _gr_fq_zech_is_invertible(const fq_zech_t x, const gr_ctx_t ctx)
@@ -526,6 +553,9 @@ gr_method_tab_input _fq_zech_methods_input[] =
     {GR_METHOD_IS_INVERTIBLE,   (gr_funcptr) _gr_fq_zech_is_invertible},
     {GR_METHOD_INV,             (gr_funcptr) _gr_fq_zech_inv},
     {GR_METHOD_DIV,             (gr_funcptr) _gr_fq_zech_div},
+    {GR_METHOD_IS_SQUARE,       (gr_funcptr) _gr_fq_zech_is_square},
+    {GR_METHOD_SQRT,            (gr_funcptr) _gr_fq_zech_sqrt},
+
     {GR_METHOD_IS_SQUARE,       (gr_funcptr) _gr_fq_zech_is_square},
     {GR_METHOD_SQRT,            (gr_funcptr) _gr_fq_zech_sqrt},
 

--- a/src/gr/fq_zech.c
+++ b/src/gr/fq_zech.c
@@ -16,6 +16,8 @@
 #include "fq_zech_poly.h"
 #include "fq_zech_poly_factor.h"
 #include "fq_zech_mat.h"
+#include "nmod_poly.h"
+#include "fmpz_mod_poly.h"
 #include "gr.h"
 #include "gr_vec.h"
 #include "gr_generic.h"
@@ -577,5 +579,47 @@ gr_ctx_init_fq_zech(gr_ctx_t ctx, ulong p, slong d, const char * var)
 
     fq_zech_ctx = flint_malloc(sizeof(fq_zech_ctx_struct));
     fq_zech_ctx_init_ui(fq_zech_ctx, p, d, var == NULL ? "a" : var);
+
     _gr_ctx_init_fq_zech_from_ref(ctx, fq_zech_ctx);
+}
+
+int
+gr_ctx_init_fq_zech_modulus_nmod_poly(gr_ctx_t ctx, const nmod_poly_t modulus, const char * var)
+{
+    fq_zech_ctx_struct * fq_zech_ctx;
+    fq_nmod_ctx_struct * fq_nmod_ctx;
+
+    fq_nmod_ctx = flint_malloc(sizeof(fq_nmod_ctx_struct));
+    fq_zech_ctx = flint_malloc(sizeof(fq_zech_ctx_struct));
+
+    fq_nmod_ctx_init_modulus(fq_nmod_ctx, modulus, var == NULL ? "a" : var);
+
+    if (fq_zech_ctx_init_fq_nmod_ctx_check(fq_zech_ctx, fq_nmod_ctx))
+    {
+        fq_zech_ctx->owns_fq_nmod_ctx = 1;
+        _gr_ctx_init_fq_zech_from_ref(ctx, fq_zech_ctx);
+        return GR_SUCCESS;
+    }
+    else
+    {
+        fq_nmod_ctx_clear(fq_nmod_ctx);
+        flint_free(fq_nmod_ctx);
+        return GR_DOMAIN;
+    }
+}
+
+int
+gr_ctx_init_fq_zech_modulus_fmpz_mod_poly(gr_ctx_t ctx, const fmpz_mod_poly_t modulus, fmpz_mod_ctx_t mod_ctx, const char * var)
+{
+    nmod_poly_t nmodulus;
+    int status;
+
+    if (!fmpz_abs_fits_ui(mod_ctx->n))
+        return GR_UNABLE;
+
+    nmod_poly_init(nmodulus, fmpz_get_ui(mod_ctx->n));
+    fmpz_mod_poly_get_nmod_poly(nmodulus, modulus);
+    status = gr_ctx_init_fq_zech_modulus_nmod_poly(ctx, nmodulus, var);
+    nmod_poly_clear(nmodulus);
+    return status;
 }

--- a/src/gr/nmod.c
+++ b/src/gr/nmod.c
@@ -534,7 +534,7 @@ _gr_nmod_is_square(const ulong * x, gr_ctx_t ctx)
     if (y == 0)
         return T_FALSE;
     else
-        return T_UNKNOWN;
+        return T_TRUE;
 }
 
 int

--- a/src/gr/nmod.c
+++ b/src/gr/nmod.c
@@ -19,8 +19,19 @@
 #include "gr_mat.h"
 #include "gr_poly.h"
 
-#define NMOD_CTX_REF(ring_ctx) (((nmod_t *)((ring_ctx))))
+typedef struct
+{
+    nmod_t nmod;
+    ulong a;   /* when used as finite field with defining polynomial x - a */
+}
+_gr_nmod_ctx_struct;
+
+#define NMOD_CTX_REF(ring_ctx) (&((((_gr_nmod_ctx_struct *)(ring_ctx))->nmod)))
 #define NMOD_CTX(ring_ctx) (*NMOD_CTX_REF(ring_ctx))
+
+/* when used as finite field when defining polynomial x - a, allow storing the coefficient a */
+#define NMOD_CTX_A(ring_ctx) (&((((_gr_nmod_ctx_struct *)(ring_ctx))->a)))
+
 
 void
 _gr_nmod_ctx_write(gr_stream_t out, gr_ctx_t ctx)

--- a/src/gr/nmod.c
+++ b/src/gr/nmod.c
@@ -18,16 +18,19 @@
 #include "gr_vec.h"
 #include "gr_mat.h"
 #include "gr_poly.h"
+#include "gr_generic.h"
 
 typedef struct
 {
     nmod_t nmod;
     ulong a;   /* when used as finite field with defining polynomial x - a */
+    truth_t is_prime;
 }
 _gr_nmod_ctx_struct;
 
 #define NMOD_CTX_REF(ring_ctx) (&((((_gr_nmod_ctx_struct *)(ring_ctx))->nmod)))
 #define NMOD_CTX(ring_ctx) (*NMOD_CTX_REF(ring_ctx))
+#define NMOD_IS_PRIME(ring_ctx) (((_gr_nmod_ctx_struct *)(ring_ctx))->is_prime)
 
 /* when used as finite field when defining polynomial x - a, allow storing the coefficient a */
 #define NMOD_CTX_A(ring_ctx) (&((((_gr_nmod_ctx_struct *)(ring_ctx))->a)))
@@ -41,11 +44,12 @@ _gr_nmod_ctx_write(gr_stream_t out, gr_ctx_t ctx)
     gr_stream_write(out, " (_gr_nmod)");
 }
 
-/* todo: n_is_prime is fast, but this should still be cached
-   or use a fixed table lookup */
 truth_t
 _gr_nmod_ctx_is_field(const gr_ctx_t ctx)
 {
+    if (NMOD_IS_PRIME(ctx) != T_UNKNOWN)
+        return NMOD_IS_PRIME(ctx);
+
     return n_is_prime(NMOD_CTX(ctx).n) ? T_TRUE : T_FALSE;
 }
 
@@ -501,9 +505,8 @@ _gr_nmod_sqrt(ulong * res, const ulong * x, gr_ctx_t ctx)
         return GR_SUCCESS;
     }
 
-    /* todo: caching prime status */
-    /* todo: handle non-primes */
-    if (!n_is_prime(NMOD_CTX(ctx).n))
+    /* todo: implement the general case */
+    if (gr_ctx_is_field(ctx) != T_TRUE)
         return GR_UNABLE;
 
     res[0] = n_sqrtmod(x[0], NMOD_CTX(ctx).n);
@@ -514,7 +517,47 @@ _gr_nmod_sqrt(ulong * res, const ulong * x, gr_ctx_t ctx)
         return GR_SUCCESS;
 }
 
-/* todo: pow_ui, ... */
+truth_t
+_gr_nmod_is_square(const ulong * x, gr_ctx_t ctx)
+{
+    ulong y;
+
+    if (x[0] <= 1)
+        return T_TRUE;
+
+    /* todo: implement the general case */
+    if (gr_ctx_is_field(ctx) != T_TRUE)
+        return T_UNKNOWN;
+
+    y = n_sqrtmod(x[0], NMOD_CTX(ctx).n);
+
+    if (y == 0)
+        return T_FALSE;
+    else
+        return T_UNKNOWN;
+}
+
+int
+_gr_nmod_pow_ui(ulong * res, const ulong * x, ulong y, const gr_ctx_t ctx)
+{
+    res[0] = nmod_pow_ui(x[0], y, NMOD_CTX(ctx));
+    return GR_SUCCESS;
+}
+
+int
+_gr_nmod_pow_fmpz(ulong * res, const ulong * x, const fmpz_t y, gr_ctx_t ctx)
+{
+    if (fmpz_sgn(y) < 0)
+    {
+        return gr_generic_pow_fmpz(res, x, y, ctx);
+    }
+    else
+    {
+        res[0] = nmod_pow_fmpz(x[0], y, NMOD_CTX(ctx));
+        return GR_SUCCESS;
+    }
+}
+
 
 void
 _gr_nmod_vec_init(ulong * res, slong len, gr_ctx_t ctx)
@@ -1432,6 +1475,9 @@ gr_method_tab_input __gr_nmod_methods_input[] =
     {GR_METHOD_DIVIDES,         (gr_funcptr) _gr_nmod_divides},
     {GR_METHOD_IS_INVERTIBLE,   (gr_funcptr) _gr_nmod_is_invertible},
     {GR_METHOD_INV,             (gr_funcptr) _gr_nmod_inv},
+    {GR_METHOD_POW_UI,          (gr_funcptr) _gr_nmod_pow_ui},
+    {GR_METHOD_POW_FMPZ,        (gr_funcptr) _gr_nmod_pow_fmpz},
+    {GR_METHOD_IS_SQUARE,       (gr_funcptr) _gr_nmod_is_square},
     {GR_METHOD_SQRT,            (gr_funcptr) _gr_nmod_sqrt},
     {GR_METHOD_VEC_INIT,        (gr_funcptr) _gr_nmod_vec_init},
     {GR_METHOD_VEC_CLEAR,       (gr_funcptr) _gr_nmod_vec_clear},
@@ -1478,6 +1524,7 @@ gr_ctx_init_nmod(gr_ctx_t ctx, ulong n)
     ctx->which_ring = GR_CTX_NMOD;
     ctx->sizeof_elem = sizeof(ulong);
     ctx->size_limit = WORD_MAX;
+    NMOD_IS_PRIME(ctx) = T_UNKNOWN;
 
     nmod_init(NMOD_CTX_REF(ctx), n);
 
@@ -1496,6 +1543,7 @@ _gr_ctx_init_nmod(gr_ctx_t ctx, void * nmod_t_ref)
     ctx->which_ring = GR_CTX_NMOD;
     ctx->sizeof_elem = sizeof(ulong);
     ctx->size_limit = WORD_MAX;
+    NMOD_IS_PRIME(ctx) = T_UNKNOWN;
 
     *NMOD_CTX_REF(ctx) = ((nmod_t *) nmod_t_ref)[0];
     ctx->methods = __gr_nmod_methods;
@@ -1505,4 +1553,10 @@ _gr_ctx_init_nmod(gr_ctx_t ctx, void * nmod_t_ref)
         gr_method_tab_init(__gr_nmod_methods, __gr_nmod_methods_input);
         __gr_nmod_methods_initialized = 1;
     }
+}
+
+void
+gr_ctx_nmod_set_primality(gr_ctx_t ctx, truth_t is_prime)
+{
+    NMOD_IS_PRIME(ctx) = is_prime;
 }

--- a/src/gr/test/t-fmpz_mod.c
+++ b/src/gr/test/t-fmpz_mod.c
@@ -22,11 +22,24 @@ TEST_FUNCTION_START(gr_fmpz_mod, state)
 
     fmpz_init(n);
 
+    for (iter = 0; iter < 1000; iter++)
+    {
+        fmpz_randtest_not_zero(n, state, 200);
+        fmpz_abs(n, n);
+        gr_ctx_init_fmpz_mod(ZZn, n);
+        if (n_randint(state, 2))
+            gr_ctx_fmpz_mod_set_primality(ZZn, fmpz_is_probabprime(n) ? T_TRUE : T_FALSE);
+        gr_test_ring(ZZn, 10, flags);
+        gr_ctx_clear(ZZn);
+    }
+
     for (iter = 0; iter < 100; iter++)
     {
         fmpz_randtest_not_zero(n, state, 200);
         fmpz_abs(n, n);
         gr_ctx_init_fmpz_mod(ZZn, n);
+        if (n_randint(state, 2))
+            gr_ctx_fmpz_mod_set_primality(ZZn, fmpz_is_probabprime(n) ? T_TRUE : T_FALSE);
         gr_test_ring(ZZn, 100, flags);
         gr_ctx_clear(ZZn);
     }

--- a/src/gr/test/t-nmod.c
+++ b/src/gr/test/t-nmod.c
@@ -17,11 +17,15 @@ TEST_FUNCTION_START(gr_nmod, state)
 {
     gr_ctx_t ZZn;
     int flags = GR_TEST_ALWAYS_ABLE;
+    slong iter;
     ulong n;
 
-    for (n = 1; n < 100; n++)
+    for (iter = 0; iter < 100; iter++)
     {
-        gr_ctx_init_nmod(ZZn, n_randtest_not_zero(state));
+        n = n_randtest_not_zero(state);
+        gr_ctx_init_nmod(ZZn, n);
+        if (n_randint(state, 2))
+            gr_ctx_nmod_set_primality(ZZn, n_is_prime(n) ? T_TRUE : T_FALSE);
         gr_test_ring(ZZn, 100, flags);
         gr_ctx_clear(ZZn);
     }


### PR DESCRIPTION
A start of reimplementing ``fq_default`` so that it's just syntactic sugar over ``gr`` generics. In particular, ``fq_default_ctx`` is now just an alias for ``gr_ctx``. This PR also adds some missing functionality for ``nmod``, ``fmpz_mod`` etc. ``gr`` contexts to make this work.

A lot of ``fq_default`` methods remain as if-statements; everything should be changed to ``gr`` method calls eventually, but this will require more work.

I've tried to make the documented interface completely backwards compatible, but there is possibly going to be some unanticipated breakage in Nemo, e.g. (there will certainly be breakage if some external code attempts to directly access the internals of the ``fq_default`` context object).