### PR TITLE
Mulhigh n basecase

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -569,6 +569,9 @@ DEPFLAGS = -MMD -MP -MF $(@:%=%.d)
 ifeq ($(WANT_ADX_ASSEMBLY),1)
 $(BUILD_DIR)/%.s: $(SRC_DIR)/%.asm | $(BUILD_DIR)/mpn_extras/broadwell
 	@$(M4) $< > $@
+
+$(BUILD_DIR)/%_pic.s: $(SRC_DIR)/%.asm | $(BUILD_DIR)/mpn_extras/broadwell
+	@$(M4) -DPIC $< > $@
 endif
 
 ################################################################################
@@ -603,7 +606,7 @@ $(BUILD_DIR)/$(1)/%.lo: $(SRC_DIR)/$(1)/%.c | $(BUILD_DIR)/$(1)
 endef
 
 ifeq ($(WANT_ADX_ASSEMBLY),1)
-%.lo: %.s
+%.lo: %_pic.s
 	@echo "  CC  $(<:$(BUILD_DIR)/%.s=%.asm)"
 	@$(CC) $(ASM_LOBJ_FLAGS) -c $< -o $@
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -799,6 +799,9 @@ internals.])])
 
     AC_SEARCH_LIBS([__gmpn_modexact_1_odd],[gmp],
         [AC_DEFINE(FLINT_HAVE_MPN_MODEXACT_1_ODD,1,Define if system has mpn_modexact_1_odd)])
+
+    AC_SEARCH_LIBS([__gmpn_addmul_2],[gmp],
+        [AC_DEFINE(FLINT_HAVE_MPN_ADDMUL_2,1,Define if GMP has mpn_addmul_2)])
 fi
 
 if test "$enable_mpfr_check" = "yes";

--- a/dev/gen_mulhigh_basecase.jl
+++ b/dev/gen_mulhigh_basecase.jl
@@ -1,3 +1,32 @@
+#  AMD64 mpn_addmul_1 optimised for Intel Broadwell.
+#
+#  Copyright 2015, 2017 Free Software Foundation, Inc.
+#
+#  This file is part of the GNU MP Library.
+#
+#  The GNU MP Library is free software; you can redistribute it and/or modify
+#  it under the terms of either:
+#
+#    * the GNU Lesser General Public License as published by the Free
+#      Software Foundation; either version 3 of the License, or (at your
+#      option) any later version.
+#
+#  or
+#
+#    * the GNU General Public License as published by the Free Software
+#      Foundation; either version 2 of the License, or (at your option) any
+#      later version.
+#
+#  or both in parallel, as here.
+#
+#  The GNU MP Library is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+#  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#  for more details.
+#
+#  You should have received copies of the GNU General Public License and the
+#  GNU Lesser General Public License along with the GNU MP Library.  If not,
+#  see https://www.gnu.org/licenses/.
 #
 #   Copyright (C) 2024 Albin Ahlbäck
 #
@@ -8,6 +37,8 @@
 #   by the Free Software Foundation; either version 3 of the License, or
 #   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 #
+
+# NOTE: GMP's addmul_1 code is used in mulhigh_basecase.
 
 _regs = ["%rdi", "%rsi", "%rdx", "%rcx", "%r8", "%r9", "%r10", "%r11", "%rax"]
 __regs = ["%rbx", "%rbp", "%r12", "%r13", "%r14", "%r15"]
@@ -92,6 +123,46 @@ end
 # Preamble
 ###############################################################################
 
+GMPaddmul1_copyright = "#  AMD64 mpn_addmul_1 optimised for Intel Broadwell.
+#
+#  Copyright 2015, 2017 Free Software Foundation, Inc.
+#
+#  This file is part of the GNU MP Library.
+#
+#  The GNU MP Library is free software; you can redistribute it and/or modify
+#  it under the terms of either:
+#
+#    * the GNU Lesser General Public License as published by the Free
+#      Software Foundation; either version 3 of the License, or (at your
+#      option) any later version.
+#
+#  or
+#
+#    * the GNU General Public License as published by the Free Software
+#      Foundation; either version 2 of the License, or (at your option) any
+#      later version.
+#
+#  or both in parallel, as here.
+#
+#  The GNU MP Library is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+#  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#  for more details.
+#
+#  You should have received copies of the GNU General Public License and the
+#  GNU Lesser General Public License along with the GNU MP Library.  If not,
+#  see https://www.gnu.org/licenses/.
+#
+#   Copyright (C) 2024 Albin Ahlbäck
+#
+#   This file is part of FLINT.
+#
+#   FLINT is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU Lesser General Public License (LGPL) as published
+#   by the Free Software Foundation; either version 3 of the License, or
+#   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+#\n"
+
 copyright = "#
 #   Copyright (C) 2024 Albin Ahlbäck
 #
@@ -107,7 +178,7 @@ preamble = "include(`config.m4')dnl\ndnl\n.text\n"
 
 function function_pre_post(funname::String)
     pre = ".global\tFUNC($funname)
-.p2align\t4, 0x90
+.p2align\t5, 0x90
 TYPE($funname)
 
 FUNC($funname):
@@ -121,7 +192,7 @@ SIZE($(funname), .$(funname)_end)
 end
 
 ###############################################################################
-# mulhigh
+# mulhigh, hardcoded
 ###############################################################################
 
 function mulhigh_1()
@@ -374,6 +445,378 @@ function mulhigh(n::Int; debug::Bool = false)
     else
         return body * "\tret\n"
     end
+end
+
+###############################################################################
+# Initial triangle
+###############################################################################
+# ap + ap_os ~= ap + n - 1
+# bp + bp_os ~= bp
+# Triangle with side of size k.
+# Assumes that bp[0] is already in rdx.
+# r0 should be rax.
+function macro_triangle(k::Int)
+    pre = ".macro\ttr_$(k) ap=$(_regs[2]), ap_os=0, bp=$(_regs[5]), bp_os=0, "
+    for ix in 0:k
+        pre *= "r$ix, "
+    end
+    pre *= "sc, zr, zr32\n"
+    post = ".endm\n"
+
+    body = ""
+    body *= "\tmov\t(\\bp_os + 0)*8(\\bp), %rdx\n"
+    body *= "\tmulx\t(\\ap_os - 1)*8(\\ap), \\r0, \\r0\n"
+    body *= "\tmulx\t(\\ap_os - 0)*8(\\ap), \\sc, \\r1\n"
+    body *= "\tadd\t\\sc, \\r0\n"
+    body *= "\tadc\t\$0, \\r1\n"
+    body *= "\txor\t\\zr32, \\zr32\n"
+    body *= "\n"
+
+    for ix in 1:k - 1
+        body *= "\tmov\t(\\bp_os + $ix)*8(\\bp), %rdx\n"
+        body *= "\tmulx\t(\\ap_os - $(ix + 1))*8(\\ap), \\sc, \\sc\n"
+        body *= "\tadcx\t\\sc, \\r0\n"
+        for jx in 1:ix
+            body *= "\tmulx\t(\\ap_os - $(ix - jx + 1))*8(\\ap), \\sc, \\r$(ix + 1)\n"
+            body *= "\tadox\t\\sc, \\r$(jx - 1)\n"
+            body *= "\tadcx\t\\r$(ix + 1), \\r$(jx - 0)\n"
+        end
+        body *= "\tmulx\t(\\ap_os - 0)*8(\\ap), \\sc, \\r$(ix + 1)\n"
+        body *= "\tadox\t\\sc, \\r$(ix + 0)\n"
+        body *= "\tadcx\t\\zr, \\r$(ix + 1)\n"
+        body *= "\tadox\t\\zr, \\r$(ix + 1)\n"
+        if ix != k - 1
+            body *= "\n"
+        end
+    end
+
+    return pre * body * post
+end
+
+# Scheme for n = 11:
+#
+# a/b 0  1  2  3  4  5  6  7  8  9 10
+#   +--------------------------------
+#  0|                            h  x
+#  1|                         h  x  x
+#  2|                      h  x  x  x
+#  3|                   h  x  x  x  x
+#  4|                h  x  x  x  x  x
+#  5|          ^  h  x  x  x  x  x  x
+#  6|          h  x  x  x  x  x  x  x
+#  7|       h  x  ø  x  x  x  x  x  x <- (ap, bp) will initially point to ø
+#  8|    h  x  x  x  x  x  x  x  x  x
+#  9| h  x  x  x  x  x  x  x  x  x  x
+# 10| x  x  x  x  x  x  x  x  x  x  x
+#
+# Scheme for n = 6:
+#
+# a/b 0  1  2  3  4  5
+#   +-----------------
+#  0|             h  x
+#  1|          h  x  x
+#  2|       h  x  ø  x <- (ap, bp) will initially point to ø
+#  3|    h  x  x  x  x
+#  4| h  x  x  x  x  x
+#  5| x  x  x  x  x  x
+#
+# Scheme for n = 5:
+#
+# a/b 0  1  2  3  4
+#   +--------------
+#  0|          h  x
+#  1|       h  x  ø <- (ap, bp) will initially point to ø
+#  2|    h  x  x  x
+#  3| h  x  x  x  x
+#  4| x  x  x  x  x
+#
+# NOTE: The addmul chains in this file uses code from GMP's addmul_1 for
+# Broadwell.
+#
+# NOTE: Assumes that n > k + 1.
+function mulhigh_basecase(k::Int)
+    # Needed registers with an initial triangle of size k:
+    # - rp
+    # - ap
+    # - bp
+    # - n
+    # - rdx for mulx
+    # - rax for ret
+    #
+    # - For initial triangle:
+    #   * k registers
+    #   * sc
+    #   * zr
+    #
+    # - For memory addmul-chains:
+    #   * 4 registers
+    #   * m
+    #   * m_save
+    #
+    # Hence, we need at least 6 + max(k + 2, 6) registers. We set k = 4, so we
+    # need 12 registers.
+    if k != 4
+        error()
+    end
+    rp = _regs[1]
+    ap = _regs[2]
+    bp_old = _regs[3] # rdx
+    n_old = _regs[4] # rcx
+    bp = _regs[5] # rdx is used by mulx
+    ret = _regs[9] # rax for storing the lowest limb
+
+    body = "\tmov\t$bp_old, $bp\n"
+    body *= "\tlea\t-$(k)*8($ap,$n_old,8), $ap\n" # ap += n - k
+    body *= "\tlea\t$(k)*8($bp), $bp\n" # bp += k
+
+    ###########################################################################
+    # Push
+    ###########################################################################
+    for reg in __regs[1:3]
+        body *= "\tpush\t$reg\n"
+    end
+    body *= "\n"
+
+    ###########################################################################
+    # Do initial triangle
+    ###########################################################################
+    r = [_regs[8]; __regs[1:3]]
+    sc = _regs[6] # scrap register
+    zr = _regs[7] # zero
+
+    # Do triangle
+    ap_os = k - 1
+    bp_os = -k
+    body *= "\ttr_$(k)\t$ap, $ap_os, $bp, $bp_os, $ret, "
+    for ix in 1:k
+        body *= "$(r[ix]), "
+    end
+    body *= "$sc, $zr, $(R32(zr))\n"
+
+    # Push into rp
+    for ix in 1:k
+        body *= "\tmov\t$(r[ix]), $(ix - 1)*8($rp)\n"
+    end
+    body *= "\n"
+
+    # Declare r, sc and zr dead
+    r, sc, zr = "dead r", "dead sc", "dead zr"
+
+    ###########################################################################
+    # Addmul chains
+    ###########################################################################
+    # Set n
+    n = _regs[6]
+    body *= "\tlea\t-1($n_old), $n\n"
+
+    # Set m and m_save
+    m, m_save = _regs[4], _regs[7]
+    body *= "\tmov\t\$$(k), $(R32(m_save))\n"
+    body *= "\tmov\t\$$(k), $(R32(m))\n"
+
+    # Declare four scrap registers
+    s0, s1, s2, s3 = __regs[1], __regs[2], __regs[3], _regs[8]
+
+    # Loop
+    body *= "\t.align\t32, 0x90\n"
+    body *= ".Lloop:"
+    body *= "\tmov\t0*8($bp), %rdx\n"
+
+    # Start computing stuff contributing to ret
+    body *= "\tmulx\t-2*8($ap), $s1, $s1\n"
+
+    # Set s0 to m % 8 and set m to m / 8
+    body *= ".Lfin:"
+    body *= "\tmov\t$(R32(m)), $(R32(s0))\n"
+    body *= "\tshr\t\$3, $m\n"
+    body *= "\tand\t\$7, $(R32(s0))\n" # Also resets flags from shr
+
+    # Continue computing stuff contributing to ret
+    body *= "\tmulx\t-1*8($ap), $s2, $s3\n"
+    body *= "\tadcx\t$s1, $ret\n"
+    body *= "\tadox\t$s2, $ret\n"
+    body *= "\tmov\t$s3, $s1\n" # Either s1 or s3 is used before entering loop
+
+    # Set s2 to pointer of .Ljmptab
+    body *= "\tlea\t.Ljmptab(%rip), $s2\n"
+
+    # Jump to label accordingly
+    body *= "ifdef(`PIC',
+`\tmovslq\t($s2,$s0,4), $s0
+\tlea\t($s0,$s2), $s2
+\tjmp\t*$s2
+',`
+\tjmp\t*($s2,$s0,8)
+')\n"
+
+    body *= "\t.section\t.data.rel.ro.local,\"a\",@progbits
+\t.align\t8, 0x90
+ifdef(`PIC',
+`.Ljmptab:
+\t.long\t.Lp0-.Ljmptab
+\t.long\t.Lp1-.Ljmptab
+\t.long\t.Lp2-.Ljmptab
+\t.long\t.Lp3-.Ljmptab
+\t.long\t.Lp4-.Ljmptab
+\t.long\t.Lp5-.Ljmptab
+\t.long\t.Lp6-.Ljmptab
+\t.long\t.Lp7-.Ljmptab',
+`.Ljmptab:
+\t.quad\t.Lp0
+\t.quad\t.Lp1
+\t.quad\t.Lp2
+\t.quad\t.Lp3
+\t.quad\t.Lp4
+\t.quad\t.Lp5
+\t.quad\t.Lp6
+\t.quad\t.Lp7')
+\t.text\n"
+    body *= "\n"
+
+    # Precompute first elements to enter addmul loop
+    body *= ".Lp0:"
+    body *= "\tmulx\t0*8($ap), $s0, $s1\n"
+    body *= "\tadcx\t$s3, $s0\n"
+    body *= "\tlea\t-1*8($ap), $ap\n"
+    body *= "\tlea\t-1*8($ap), $rp\n"
+    body *= "\tlea\t-1($m), $m\n"
+    body *= "\tjmp\t.Lam0\n"
+    body *= ".Lp1:"
+    body *= "\tmulx\t0*8($ap), $s2, $s3\n"
+    body *= "\tadcx\t$s1, $s2\n"
+    body *= "\tjmp\t.Lam1\n"
+    body *= ".Lp2:"
+    body *= "\tmulx\t0*8($ap), $s0, $s1\n"
+    body *= "\tadcx\t$s3, $s0\n"
+    body *= "\tlea\t1*8($ap), $ap\n"
+    body *= "\tlea\t1*8($rp), $rp\n"
+    body *= "\tjmp\t.Lam2\n"
+    body *= ".Lp3:"
+    body *= "\tmulx\t0*8($ap), $s2, $s3\n"
+    body *= "\tadcx\t$s1, $s2\n"
+    body *= "\tlea\t2*8($ap), $ap\n"
+    body *= "\tlea\t-6*8($rp), $rp\n"
+    body *= "\tjmp\t.Lam3\n"
+    body *= ".Lp4:"
+    body *= "\tmulx\t0*8($ap), $s0, $s1\n"
+    body *= "\tadcx\t$s3, $s0\n"
+    body *= "\tlea\t3*8($ap), $ap\n"
+    body *= "\tlea\t-5*8($rp), $rp\n"
+    body *= "\tjmp\t.Lam4\n"
+    # For .Lp5, see below
+    body *= ".Lp6:"
+    body *= "\tmulx\t0*8($ap), $s0, $s1\n"
+    body *= "\tadcx\t$s3, $s0\n"
+    body *= "\tlea\t5*8($ap), $ap\n"
+    body *= "\tlea\t-3*8($rp), $rp\n"
+    body *= "\tjmp\t.Lam6\n"
+    body *= ".Lp7:"
+    body *= "\tmulx\t0*8($ap), $s2, $s3\n"
+    body *= "\tadcx\t$s1, $s2\n"
+    body *= "\tlea\t-2*8($ap), $ap\n"
+    body *= "\tlea\t-2*8($rp), $rp\n"
+    body *= "\tjmp\t.Lam7\n"
+    body *= "\n"
+    body *= ".Lp5:"
+    body *= "\tmulx\t0*8($ap), $s2, $s3\n"
+    body *= "\tadcx\t$s1, $s2\n"
+    body *= "\tlea\t4*8($ap), $ap\n"
+    body *= "\tlea\t-4*8($rp), $rp\n"
+    # body *= "\tjmp\t.Lam5\n"
+
+    body *= "\t.align\t32, 0x90\n"
+    body *= ".Lam5:"
+    body *= "\tmulx\t-3*8($ap), $s0, $s1\n"
+    body *= "\tadcx\t$s3, $s0\n"
+    body *= "\tadox\t4*8($rp), $s2\n"
+    body *= "\tmov\t$s2, 4*8($rp)\n"
+    body *= ".Lam4:"
+    body *= "\tmulx\t-2*8($ap), $s2, $s3\n"
+    body *= "\tadox\t5*8($rp), $s0\n"
+    body *= "\tadcx\t$s1, $s2\n"
+    body *= "\tmov\t$s0, 5*8($rp)\n"
+    body *= ".Lam3:"
+    body *= "\tadox\t6*8($rp), $s2\n"
+    body *= "\tmulx\t-1*8($ap), $s0, $s1\n"
+    body *= "\tmov\t$s2, 6*8($rp)\n"
+    body *= "\tlea\t8*8($rp), $rp\n"
+    body *= "\tadcx\t$s3, $s0\n"
+    body *= ".Lam2:"
+    body *= "\tmulx\t0*8($ap), $s2, $s3\n"
+    body *= "\tadox\t-1*8($rp), $s0\n"
+    body *= "\tadcx\t$s1, $s2\n"
+    body *= "\tmov\t$s0, -1*8($rp)\n"
+    if m != "%rcx"
+        error()
+    end
+    body *= "\tjrcxz\t.Lend\n"
+    body *= ".Lam1:"
+    body *= "\tmulx\t1*8($ap), $s0, $s1\n"
+    body *= "\tadox\t0*8($rp), $s2\n"
+    body *= "\tlea\t-1($m), $m\n"
+    body *= "\tmov\t$s2, 0*8($rp)\n"
+    body *= "\tadcx\t$s3, $s0\n"
+    body *= ".Lam0:"
+    body *= "\tmulx\t2*8($ap), $s2, $s3\n"
+    body *= "\tadcx\t$s1, $s2\n"
+    body *= "\tadox\t1*8($rp), $s0\n"
+    body *= "\tmov\t$s0, 1*8($rp)\n"
+    body *= ".Lam7:"
+    body *= "\tmulx\t3*8($ap), $s0, $s1\n"
+    body *= "\tlea\t8*8($ap), $ap\n"
+    body *= "\tadcx\t$s3, $s0\n"
+    body *= "\tadox\t2*8($rp), $s2\n"
+    body *= "\tmov\t$s2, 2*8($rp)\n"
+    body *= ".Lam6:"
+    body *= "\tmulx\t-4*8($ap), $s2, $s3\n"
+    body *= "\tadox\t3*8($rp), $s0\n"
+    body *= "\tadcx\t$s1, $s2\n"
+    body *= "\tmov\t$s0, 3*8($rp)\n"
+    body *= "\tjmp\t.Lam5\n"
+    body *= "\n"
+
+    # Post addmul-loop
+    body *= ".Lend:"
+    body *= "\tadox\t0*8($rp), $s2\n"
+    body *= "\tadcx\t$m, $s3\n" # Assumes m = 0
+    body *= "\tadox\t$m, $s3\n"
+    body *= "\tlea\t1($m_save), $m\n" # Increase m
+    body *= "\tneg\t$m_save\n"
+    body *= "\tlea\t1*8($bp), $bp\n" # Increase bp
+    body *= "\tmov\t$s2, 0*8($rp)\n"
+    body *= "\tmov\t$s3, 1*8($rp)\n"
+    body *= "\tlea\t1*8($rp,$m_save,8), $rp\n" # Reset rp
+    body *= "\tlea\t($ap,$m_save,8), $ap\n" # Reset ap
+    body *= "\tneg\t$m_save\n"
+    body *= "\tcmp\t$n, $m\n"
+    body *= "\tlea\t1($m_save), $m_save\n" # Increase m_save
+
+    # If m < n, continue looping
+    body *= "\tjb\t.Lloop\n"
+
+    # If m > n, exit
+    body *= "\tja\t.Lexit\n"
+
+    # Else, m == n and so we perform the last addmul chain
+    body *= "\tmov\t0*8($bp), %rdx\n"
+    body *= "\txor\t$(R32(s1)), $(R32(s1))\n" # Set s1 to zero
+    body *= "\tjmp\t.Lfin\n"
+    body *= "\n"
+
+    ###########################################################################
+    # Pop
+    ###########################################################################
+    body *= ".Lexit:"
+    for reg in reverse(__regs[1:3])
+        body *= "\tpop\t$reg\n"
+    end
+    body *= "\n"
+
+    ###########################################################################
+    # Return
+    ###########################################################################
+    body *= "\tret\n"
+    return body
 end
 
 ###############################################################################
@@ -669,6 +1112,23 @@ end
 # Generate file
 ###############################################################################
 
+function gen_mulhigh_basecase(k::Int = 4, nofile::Bool = false)
+    (pre, post) = function_pre_post("flint_mpn_mulhigh_n_basecase")
+    macros = macro_triangle(k) * "\n"
+    functionbody = mulhigh_basecase(k)
+
+    str = "$GMPaddmul1_copyright\n$preamble\n$macros$pre$functionbody$post"
+
+    if nofile
+        print(str)
+    else
+        path = String(@__DIR__) * "/../src/mpn_extras/broadwell/mulhigh_n_basecase.asm"
+        file = open(path, "w")
+        write(file, str)
+        close(file)
+    end
+end
+
 function gen_mulhigh(m::Int, nofile::Bool = false)
     (pre, post) = function_pre_post("flint_mpn_mulhigh_$m")
     functionbody = mulhigh(m)
@@ -702,6 +1162,7 @@ function gen_mulhigh_normalised(m::Int, nofile::Bool = false)
 end
 
 function gen_all()
+    gen_mulhigh_basecase()
     for m in 1:12
         gen_mulhigh(m)
     end

--- a/src/mpn_extras.h
+++ b/src/mpn_extras.h
@@ -231,6 +231,8 @@ flint_mpn_sqr(mp_ptr r, mp_srcptr x, mp_size_t n)
 
 #if FLINT_HAVE_ADX
 # define FLINT_MPN_MULHIGH_N_FUNC_TAB_WIDTH 12
+# define FLINT_HAVE_MPN_MULHIGH_BASECASE 1
+mp_limb_t flint_mpn_mulhigh_basecase(mp_ptr, mp_srcptr, mp_srcptr, mp_size_t);
 #else
 # define FLINT_MPN_MULHIGH_N_FUNC_TAB_WIDTH 0
 #endif

--- a/src/mpn_extras/broadwell/asm-defs.m4
+++ b/src/mpn_extras/broadwell/asm-defs.m4
@@ -1,0 +1,101 @@
+dnl  m4 macros for gmp assembly code, shared by all CPUs.
+
+dnl  Copyright 1999-2006, 2011 Free Software Foundation, Inc.
+
+dnl  This file is part of the GNU MP Library.
+dnl
+dnl  The GNU MP Library is free software; you can redistribute it and/or modify
+dnl  it under the terms of either:
+dnl
+dnl    * the GNU Lesser General Public License as published by the Free
+dnl      Software Foundation; either version 3 of the License, or (at your
+dnl      option) any later version.
+dnl
+dnl  or
+dnl
+dnl    * the GNU General Public License as published by the Free Software
+dnl      Foundation; either version 2 of the License, or (at your option) any
+dnl      later version.
+dnl
+dnl  or both in parallel, as here.
+dnl
+dnl  The GNU MP Library is distributed in the hope that it will be useful, but
+dnl  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+dnl  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+dnl  for more details.
+dnl
+dnl  You should have received copies of the GNU General Public License and the
+dnl  GNU Lesser General Public License along with the GNU MP Library.  If not,
+dnl  see https://www.gnu.org/licenses/.
+
+dnl  m4 macros for amd64 assembler.
+
+dnl  Copyright 1999-2005, 2008, 2009, 2011-2013, 2017 Free Software Foundation,
+dnl  Inc.
+
+dnl  This file is part of the GNU MP Library.
+dnl
+dnl  The GNU MP Library is free software; you can redistribute it and/or modify
+dnl  it under the terms of either:
+dnl
+dnl    * the GNU Lesser General Public License as published by the Free
+dnl      Software Foundation; either version 3 of the License, or (at your
+dnl      option) any later version.
+dnl
+dnl  or
+dnl
+dnl    * the GNU General Public License as published by the Free Software
+dnl      Foundation; either version 2 of the License, or (at your option) any
+dnl      later version.
+dnl
+dnl  or both in parallel, as here.
+dnl
+dnl  The GNU MP Library is distributed in the hope that it will be useful, but
+dnl  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+dnl  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+dnl  for more details.
+dnl
+dnl  You should have received copies of the GNU General Public License and the
+dnl  GNU Lesser General Public License along with the GNU MP Library.  If not,
+dnl  see https://www.gnu.org/licenses/.
+
+define(`R32',
+	`ifelse($1,`%rax',`%eax',
+		$1,`%rbx',`%ebx',
+		$1,`%rcx',`%ecx',
+		$1,`%rdx',`%edx',
+		$1,`%rsi',`%esi',
+		$1,`%rdi',`%edi',
+		$1,`%rbp',`%ebp',
+		$1,`%r8',`%r8d',
+		$1,`%r9',`%r9d',
+		$1,`%r10',`%r10d',
+		$1,`%r11',`%r11d',
+		$1,`%r12',`%r12d',
+		$1,`%r13',`%r13d',
+		$1,`%r14',`%r14d',
+		$1,`%r15',`%r15d')')
+
+define(`R8',
+	`ifelse($1,`%rax',`%al',
+		$1,`%rbx',`%bl',
+		$1,`%rcx',`%cl',
+		$1,`%rdx',`%dl',
+		$1,`%rsi',`%sil',
+		$1,`%rdi',`%dil',
+		$1,`%rbp',`%bpl',
+		$1,`%r8',`%r8b',
+		$1,`%r9',`%r9b',
+		$1,`%r10',`%r10b',
+		$1,`%r11',`%r11b',
+		$1,`%r12',`%r12b',
+		$1,`%r13',`%r13b',
+		$1,`%r14',`%r14b',
+		$1,`%r15',`%r15b')')
+
+define(`L', `.L$1')
+
+define(`ALIGN',
+	`ifelse($1,`8',`.p2align	3, 0x90',
+		$1,`16',`.p2align	4, 0x90',
+		$1,`32',`.p2align	5, 0x90')')

--- a/src/mpn_extras/broadwell/mulhigh_basecase.asm
+++ b/src/mpn_extras/broadwell/mulhigh_basecase.asm
@@ -1,0 +1,310 @@
+dnl  X64-64 mpn_mullo_basecase optimised for Intel Broadwell.
+
+dnl  Contributed to the GNU project by Torbjorn Granlund.
+
+dnl  Copyright 2017 Free Software Foundation, Inc.
+
+dnl  This file is part of the GNU MP Library.
+dnl
+dnl  The GNU MP Library is free software; you can redistribute it and/or modify
+dnl  it under the terms of either:
+dnl
+dnl    * the GNU Lesser General Public License as published by the Free
+dnl      Software Foundation; either version 3 of the License, or (at your
+dnl      option) any later version.
+dnl
+dnl  or
+dnl
+dnl    * the GNU General Public License as published by the Free Software
+dnl      Foundation; either version 2 of the License, or (at your option) any
+dnl      later version.
+dnl
+dnl  or both in parallel, as here.
+dnl
+dnl  The GNU MP Library is distributed in the hope that it will be useful, but
+dnl  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+dnl  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+dnl  for more details.
+dnl
+dnl  You should have received copies of the GNU General Public License and the
+dnl  GNU Lesser General Public License along with the GNU MP Library.  If not,
+dnl  see https://www.gnu.org/licenses/.
+dnl
+dnl   Copyright (C) 2024 Albin Ahlbäck
+dnl
+dnl   This file is part of FLINT.
+dnl
+dnl   FLINT is free software: you can redistribute it and/or modify it under
+dnl   the terms of the GNU Lesser General Public License (LGPL) as published
+dnl   by the Free Software Foundation; either version 3 of the License, or
+dnl   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+dnl
+
+include(`config.m4')
+include(`src/mpn_extras/broadwell/asm-defs.m4')
+
+define(`rp',	   `%rdi')
+define(`ap',	   `%rsi')
+define(`bp_param', `%rdx')
+define(`n',	   `%rcx')
+
+define(`bp',	   `%r8')
+define(`jmpreg',   `%r9')
+define(`nn',	   `%r10')
+define(`m',	   `%r13')
+define(`mm',	   `%r14')
+
+define(`rx',	   `%rax')
+
+define(`r0',	   `%r11')
+define(`r1',	   `%rbx')
+define(`r2',	   `%rbp')
+define(`r3',	   `%r12')
+
+# Idea: Do similar to mpn_mullo_basecase for Skylake.
+
+.text
+
+.global	FUNC(flint_mpn_mulhigh_basecase)
+ALIGN(32)
+TYPE(flint_mpn_mulhigh_basecase)
+
+FUNC(flint_mpn_mulhigh_basecase):
+	.cfi_startproc
+	mov	bp_param, bp
+	lea	-1*8(ap,n,8), ap	# ap += n - 1
+
+	push	%rbx
+	push	%rbp
+	push	%r12
+	push	%r13
+	push	%r14
+
+	# Initial triangle
+	#       h
+	#     h x
+	#   h x x
+	# h x x x
+	# x x x x
+define(`s0', `jmpreg')
+define(`s1', `m')
+define(`s2', `mm')
+define(`s3', `nn')
+	mov	0*8(bp), %rdx
+	xor	R32(s3), R32(s3)
+	mulx	-1*8(ap), rx, rx
+	mulx	0*8(ap), s0, r0
+	add	s0, rx
+	adc	s3, r0
+
+	mov	1*8(bp), %rdx
+	mulx	-2*8(ap), s1, s1
+	mulx	-1*8(ap), r3, r2
+	mulx	0*8(ap), s0, r1
+	add	r3, rx
+	adc	s0, r0
+	adc	s3, r1
+	add	s1, rx
+	adc	r2, r0
+	adc	s3, r1
+
+	mov	2*8(bp), %rdx
+	mulx	-3*8(ap), s0, s0
+	mulx	-2*8(ap), r3, s1
+	add	s0, rx
+	adc	s1, r0
+	mulx	-1*8(ap), s0, s1
+	mulx	0*8(ap), %rdx, r2
+	adc	s1, r1
+	adc	s3, r2
+	add	r3, rx
+	adc	s0, r0
+	adc	%rdx, r1
+	adc	s3, r2
+
+	mov	3*8(bp), %rdx
+	mulx	-4*8(ap), s1, s1
+	mulx	-3*8(ap), s0, s2
+	add	s1, rx
+	adc	s2, r0
+	mulx	-2*8(ap), s1, r3
+	mulx	-1*8(ap), s2, s3
+	adc	r3, r1
+	adc	s3, r2
+	mulx	0*8(ap), %rdx, r3
+	adc	$0, r3
+	add	s0, rx
+	adc	s1, r0
+	adc	s2, r1
+	mov	r0, 0*8(rp)
+	mov	r1, 1*8(rp)
+	adc	%rdx, r2
+	adc	$0, r3
+	mov	r2, 2*8(rp)
+	mov	r3, 3*8(rp)
+undefine(`s0')
+undefine(`s1')
+undefine(`s2')
+undefine(`s3')
+
+	# Addmul chains
+	# - m = -8 * n_cur	(n_cur is the 4 at the start)
+	# - mm = -8 * (n - 1)	(where n is the original n)
+	# - n keeps track of how many loops to do in the addmul-loop.
+	# - nn keeps track of initial n between loops.
+	lea	-1*8(,n,8), R32(mm)
+	lea	4*8(bp), bp
+	lea	-3*8(ap), ap
+	mov	$-4*8, m		# m <- -8 * 4
+	neg	mm			# mm <- -8 * (n - 1)
+	mov	0*8(bp), %rdx
+	xor	R32(nn), R32(nn)	# nn <- 0
+	xor	R32(n), R32(n)		# n <- 0
+	mulx	-2*8(ap), r1, r1
+	adcx	r1, rx
+
+L(f4):	mulx	-1*8(ap), r2, r3
+	mulx	0*8(ap), r0, r1
+	adox	r2, rx
+	adcx	r3, r0
+	lea	3*8(ap), ap
+	lea	-5*8(rp), rp
+	lea	L(f5)(%rip), jmpreg
+	jmp	L(b4)
+
+L(f0):	mulx	-1*8(ap), r2, r3
+	mulx	0*8(ap), r0, r1
+	adox	r2, rx
+	adcx	r3, r0
+	lea	-1*8(ap), ap
+	lea	-1*8(rp), rp
+	lea	L(f1)(%rip), jmpreg
+	jmp	L(b0)
+
+L(f1):	mulx	-1*8(ap), r0, r1
+	mulx	0*8(ap), r2, r3
+	adox	r0, rx
+	adcx	r1, r2
+	lea	1(nn), R32(nn)
+	lea	1(n), R32(n)
+	lea	L(f2)(%rip), jmpreg
+	jmp	L(b1)
+
+L(f7):	mulx	-1*8(ap), r0, r1
+	mulx	0*8(ap), r2, r3
+	adox	r0, rx
+	adcx	r1, r2
+	lea	-2*8(ap), ap
+	lea	-2*8(rp), rp
+	lea	L(f0)(%rip), jmpreg
+	jmp	L(b7)
+
+L(f2):	mulx	-1*8(ap), r2, r3
+	mulx	0*8(ap), r0, r1
+	adox	r2, rx
+	adcx	r3, r0
+	lea	1*8(ap), ap
+	lea	1*8(rp), rp
+	mulx	0*8(ap), r2, r3
+	lea	L(f3)(%rip), jmpreg
+	jmp	L(b2)
+
+L(end):	adox	0*8(rp), r2
+	mov	r2, 0*8(rp)
+	adox	n, r3		# n = 0
+	adc	n, r3		# n = 0
+	add	m, ap		# Reset ap
+	mov	r3, 1*8(rp)
+	lea	-1*8(m), m
+	lea	1*8(bp), bp	# Increase bp
+	lea	2*8(rp,m), rp	# Reset rp
+	mov	0*8(bp), %rdx	# Load bp
+	cmp	R32(m), R32(mm)
+	jge	L(jmp)
+	# If |m| < |mm|: goto jmpreg, but first do high part
+	or	R32(nn), R32(n)	# Reset n, CF and OF
+	mulx	-2*8(ap), r1, r1
+	adcx	r1, rx
+	jmp	*jmpreg
+	# If |m| > |mm|: goto fin
+L(jmp):	jg	L(fin)
+	# If |m| = |mm|: goto jmpreg
+	or	R32(nn), R32(n)	# Reset n, clear CF and OF
+	jmp	*jmpreg
+
+	ALIGN(32)
+L(b2):	adox	-1*8(rp), r0
+	adcx	r1, r2
+	mov	r0, -1*8(rp)
+	jrcxz	L(end)	# Jump if n = 0
+L(b1):	mulx	1*8(ap), r0, r1
+	adox	0*8(rp), r2
+	lea	-1(n), R32(n)
+	mov	r2, 0*8(rp)
+	adcx	r3, r0
+L(b0):	mulx	2*8(ap), r2, r3
+	adcx	r1, r2
+	adox	1*8(rp), r0
+	mov	r0, 1*8(rp)
+L(b7):	mulx	3*8(ap), r0, r1
+	lea	8*8(ap), ap
+	adcx	r3, r0
+	adox	2*8(rp), r2
+	mov	r2, 2*8(rp)
+L(b6):	mulx	-4*8(ap), r2, r3
+	adox	3*8(rp), r0
+	adcx	r1, r2
+	mov	r0, 3*8(rp)
+L(b5):	mulx	-3*8(ap), r0, r1
+	adcx	r3, r0
+	adox	4*8(rp), r2
+	mov	r2, 4*8(rp)
+L(b4):	mulx	-2*8(ap), r2, r3
+	adox	5*8(rp), r0
+	adcx	r1, r2
+	mov	r0, 5*8(rp)
+L(b3):	adox	6*8(rp), r2
+	mulx	-1*8(ap), r0, r1
+	mov	r2, 6*8(rp)
+	lea	8*8(rp), rp
+	adcx	r3, r0
+	mulx	0*8(ap), r2, r3
+	jmp	L(b2)
+
+L(f6):	mulx	-1*8(ap), r2, r3
+	mulx	0*8(ap), r0, r1
+	adox	r2, rx
+	adcx	r3, r0
+	lea	5*8(ap), ap
+	lea	-3*8(rp), rp
+	lea	L(f7)(%rip), jmpreg
+	jmp	L(b6)
+
+L(f5):	mulx	-1*8(ap), r0, r1
+	mulx	0*8(ap), r2, r3
+	adox	r0, rx
+	adcx	r1, r2
+	lea	4*8(ap), ap
+	lea	-4*8(rp), rp
+	lea	L(f6)(%rip), jmpreg
+	jmp	L(b5)
+
+L(f3):	mulx	-1*8(ap), r0, r1
+	mulx	0*8(ap), r2, r3
+	adox	r0, rx
+	adcx	r1, r2
+	lea	2*8(ap), ap
+	lea	-6*8(rp), rp
+	lea	L(f4)(%rip), jmpreg
+	jmp	L(b3)
+
+L(fin):	pop	%r14
+	pop	%r13
+	pop	%r12
+	pop	%rbp
+	pop	%rbx
+
+	ret
+.flint_mpn_mulhigh_basecase_end:
+SIZE(flint_mpn_mulhigh_basecase, .flint_mpn_mulhigh_basecase_end)
+.cfi_endproc

--- a/src/mpn_extras/profile/p-mulhigh_basecase.c
+++ b/src/mpn_extras/profile/p-mulhigh_basecase.c
@@ -12,14 +12,19 @@
 #include "mpn_extras.h"
 #include "profiler.h"
 
+#if !FLINT_HAVE_ADX
+# error
+#endif
+
 #define mpn_mul_basecase __gmpn_mul_basecase
 void mpn_mul_basecase(mp_ptr, mp_srcptr, mp_size_t, mp_srcptr, mp_size_t);
 void mpfr_mulhigh_n(mp_ptr, mp_srcptr, mp_srcptr, mp_size_t);
 
-#define N_MAX FLINT_MPN_MULHIGH_N_FUNC_TAB_WIDTH
-
 int main(void)
 {
+#define N_MIN 6
+#define N_MAX 64
+
     mp_limb_t rf[N_MAX];
     mp_limb_t rg[2 * N_MAX];
     mp_limb_t rm[2 * N_MAX];
@@ -27,6 +32,60 @@ int main(void)
     mp_limb_t yp[N_MAX];
     mp_size_t n;
 
+    flint_printf("Best of mpn_mul_n, mpn_mul_basecase and mpfr_mulhigh_n\nagainst flint_mpn_mulhigh_n_basecase:\n");
+    for (n = N_MIN; n <= N_MAX; n++)
+    {
+        double t1, t2, t3, t4, tmin, __attribute__((unused)) __;
+        int type;
+        flint_printf("n = %2wd:", n);
+
+        mpn_random2(xp, n);
+        mpn_random2(yp, n);
+
+        TIMEIT_START
+        flint_mpn_mulhigh_basecase(rf, xp, yp, n);
+        TIMEIT_STOP_VALUES(__, t1)
+
+        TIMEIT_START
+        mpn_mul_basecase(rg, xp, n, yp, n);
+        TIMEIT_STOP_VALUES(__, t2)
+
+        TIMEIT_START
+        mpn_mul_n(rg, xp, yp, n);
+        TIMEIT_STOP_VALUES(__, t3)
+
+        TIMEIT_START
+        mpfr_mulhigh_n(rm, xp, yp, n);
+        TIMEIT_STOP_VALUES(__, t4)
+
+        if (t2 < t3)
+        {
+            tmin = t2;
+            type = 2;
+        }
+        else
+        {
+            tmin = t3;
+            type = 3;
+        }
+
+        if (tmin < t4)
+            ;
+        else
+        {
+            tmin = t4;
+            type = 4;
+        }
+
+        flint_printf("%7.2fx  (%s)\n",
+                tmin / t1,
+                (type == 2) ? "mpn_mul_basecase" : (type == 3) ? "mpn_mul_n" : "mpfr_mulhigh_n");
+    }
+
+#undef N_MAX
+#define N_MAX FLINT_MPN_MULHIGH_N_FUNC_TAB_WIDTH
+
+#if 0
     flint_printf("           GMP       MPFR\n");
     for (n = 1; n <= N_MAX; n++)
     {
@@ -50,6 +109,7 @@ int main(void)
 
         flint_printf("%7.2fx  %7.2fx\n", t2 / t1, t3 / t1);
     }
+#endif
 
     flint_cleanup_master();
 

--- a/src/mpn_extras/test/main.c
+++ b/src/mpn_extras/test/main.c
@@ -23,6 +23,7 @@
 #include "t-mul.c"
 #include "t-mul_n.c"
 #include "t-mul_basecase.c"
+#include "t-mulhigh_basecase.c"
 #include "t-mulhigh_n.c"
 #include "t-mulhigh_normalised_n.c"
 #include "t-mulmod_2expp1.c"
@@ -45,6 +46,7 @@ test_struct tests[] =
     TEST_FUNCTION(flint_mpn_mul),
     TEST_FUNCTION(flint_mpn_mul_n),
     TEST_FUNCTION(flint_mpn_mul_basecase),
+    TEST_FUNCTION(flint_mpn_mulhigh_basecase),
     TEST_FUNCTION(flint_mpn_mulhigh_n),
     TEST_FUNCTION(flint_mpn_mulhigh_normalised_n),
     TEST_FUNCTION(flint_mpn_mulmod_2expp1),

--- a/src/mpn_extras/test/t-mulhigh_basecase.c
+++ b/src/mpn_extras/test/t-mulhigh_basecase.c
@@ -9,42 +9,36 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include <string.h>
 #include "test_helpers.h"
 #include "mpn_extras.h"
 
-#if FLINT_MPN_MULHIGH_N_FUNC_TAB_WIDTH != 0
+#if FLINT_HAVE_MPN_MULHIGH_BASECASE
 
-# define TEST_MPFR 0
-# define N_MAX FLINT_MPN_MULHIGH_N_FUNC_TAB_WIDTH
+#define N_MIN 6
+#define N_MAX 64
 
-void mpfr_mulhigh_n(mp_ptr rp, mp_srcptr xp, mp_srcptr yp, mp_size_t n);
-
-TEST_FUNCTION_START(flint_mpn_mulhigh_n, state)
+TEST_FUNCTION_START(flint_mpn_mulhigh_basecase, state)
 {
     slong ix;
     int result;
 
     for (ix = 0; ix < 100000 * flint_test_multiplier(); ix++)
     {
-        mp_limb_t rp[N_MAX + 1] = {UWORD(0)};
-        mp_limb_t rp_upperbound[2 * N_MAX] = {UWORD(0)};
-        mp_limb_t rp_lowerbound[2 * N_MAX] = {UWORD(0)};
-#if TEST_MPFR
-        mp_limb_t rp_mpfr[2 * N_MAX] = {UWORD(0)};
-#endif
+        mp_limb_t rp[N_MAX + 1];
+        mp_limb_t rp_upperbound[2 * N_MAX];
+        mp_limb_t rp_lowerbound[2 * N_MAX];
         mp_limb_t borrow;
         mp_limb_t xp[N_MAX];
         mp_limb_t yp[N_MAX];
         mp_size_t n;
         mp_limb_t lb;
 
-        n = 1 + n_randint(state, N_MAX);
+        n = N_MIN + n_randint(state, N_MAX - N_MIN + 1);
 
-        mpn_random2(xp, n);
-        mpn_random2(yp, n);
+        mpn_random2(xp, N_MAX);
+        mpn_random2(yp, N_MAX);
 
-        rp[0] = flint_mpn_mulhigh_n(rp + 1, xp, yp, n);
+        rp[0] = flint_mpn_mulhigh_basecase(rp + 1, xp, yp, n);
 
         /* Check upper bound */
         flint_mpn_mul_n(rp_upperbound, xp, yp, n);
@@ -62,18 +56,8 @@ TEST_FUNCTION_START(flint_mpn_mulhigh_n, state)
                     ix, n, xp, n, yp, n, rp, n + 1, rp_upperbound + n - 1, n + 1);
 
         /* Check lower bound */
+        lb = n + 2;
         memcpy(rp_lowerbound, rp_upperbound, 2 * n * sizeof(mp_limb_t));
-
-        if (n <= 2)
-            lb = 0; /* Multiplication should be "exact" */
-        else if (n == 3)
-            lb = 2;
-        else if (n == 4)
-            lb = 4;
-        else if (n < 6)
-            lb = n + 1;
-        else
-            lb = n + 2;
 
         borrow = mpn_sub_1(rp_lowerbound + n - 1, rp_lowerbound + n - 1, n + 1, lb);
         if (borrow)
@@ -90,31 +74,59 @@ TEST_FUNCTION_START(flint_mpn_mulhigh_n, state)
                     "rp            = %{ulong*}\n"
                     "rp_lowerbound = %{ulong*}\n",
                     ix, n, xp, n, yp, n, rp, n + 1, rp_lowerbound + n - 1, n + 1);
+    }
 
-#if TEST_MPFR
-        /* Check against MPFR */
-        mpfr_mulhigh_n(rp_mpfr, xp, yp, n);
+#undef N_MAX
+#define N_MAX 12
 
-        result = (mpn_cmp(rp + n - 1, rp_mpfr + n - 1, n + 1) == 0);
+    /* Check against hardcoded versions */
+    for (ix = 0; ix < 10000 * flint_test_multiplier(); ix++)
+    {
+        mp_limb_t rp1[N_MAX + 1];
+        mp_limb_t rp2[N_MAX + 1];
+        mp_limb_t xp[N_MAX + 10];
+        mp_limb_t yp[N_MAX + 10];
+        mp_size_t n;
+
+        n = N_MIN + n_randint(state, N_MAX - N_MIN + 1);
+
+        mpn_random2(xp, N_MAX + 10);
+        mpn_random2(yp, N_MAX + 10);
+
+        rp1[0] = flint_mpn_mulhigh_n(rp1 + 1, xp, yp, n);
+        rp2[0] = flint_mpn_mulhigh_basecase(rp2 + 1, xp, yp, n);
+
+        result = (rp1[0] == rp2[0]);
         if (!result)
             TEST_FUNCTION_FAIL(
-                    "flint_mpn_mulhigh_n does not agree with mpfr_mulhigh_n\n"
+                    "Return values are not the same\n"
                     "ix = %wd\n"
                     "n = %wd\n"
                     "xp = %{ulong*}\n"
                     "yp = %{ulong*}\n"
-                    "rp      = %{ulong*}\n"
-                    "rp_mpfr = %{ulong*}\n",
-                    ix, n, xp, n, yp, n, rp + n - 1, n + 1, rp_mpfr + n - 1, n + 1);
-#endif
+                    "Expected: %{ulong*}\n"
+                    "Got:      %{ulong*}\n",
+                    ix, n, xp, n, yp, n, rp1, n + 1, rp2, n + 1);
+
+        result = (mpn_cmp(rp1, rp2, n + 1) == 0);
+        if (!result)
+            TEST_FUNCTION_FAIL(
+                    "Result not the same\n"
+                    "ix = %wd\n"
+                    "n = %wd\n"
+                    "xp = %{ulong*}\n"
+                    "yp = %{ulong*}\n"
+                    "Expected: %{ulong*}\n"
+                    "Got:      %{ulong*}\n",
+                    ix, n, xp, n, yp, n, rp1, n + 1, rp2, n + 1);
     }
 
     TEST_FUNCTION_END(state);
 }
-# undef TEST_MPFR
+# undef N_MIN
 # undef N_MAX
 #else
-TEST_FUNCTION_START(flint_mpn_mulhigh_n, state)
+TEST_FUNCTION_START(flint_mpn_mulhigh_basecase, state)
 {
     TEST_FUNCTION_END_SKIPPED(state);
 }


### PR DESCRIPTION
For big `n`, this seems to be at around 5% faster than MPFR's `mpfr_mulhigh_n` and 70-80% faster than GMP's `mpn_mul_basecase`. For `n = 10`, it outperforms both of these by at least around 25%, and at `n = 20` by at least around 10%.

Note that this gives better precision than MPFR's `mpfr_mulhigh_n`, where we compute the `n + 1` most significant limbs, and, of those computed, the least significant limb is returned and never set in `rp`, hence one may avoid reallocations.

I was honestly expecting a bit better performance compared to MPFR's mulhigh. Perhaps I'll try to optimize it more someday.

I should also emphasize that this code relies on us using LGPL v3 since I copied GMP's `mpn_mullo_basecase` function.

EDIT: Renamed it to `flint_mpn_mulhigh_basecase`.