### PR TITLE
Attempt to fix mpoly performance regressions

### DIFF
--- a/src/fmpz_mpoly/divides_array.c
+++ b/src/fmpz_mpoly/divides_array.c
@@ -91,13 +91,15 @@ void _fmpz_mpoly_submul_array1_slong2(ulong * poly1,
       {
          for (i = ii; i < FLINT_MIN(ii + BLOCK, len2); i++)
          {
-            c2 = poly1 + 2*((slong) exp2[i]);
+            /* hack: see mul_array */
+            c2 = poly1 + (((slong) exp2[i]) << 1);
 
             if (poly2[i] != 0)
             {
                for (j = jj; j < FLINT_MIN(jj + BLOCK, len3); j++)
                {
-                  c = c2 + 2*((slong) exp3[j]);
+                  /* hack: see mul_array */
+                  c = c2 + (((slong) exp3[j]) << 1);
 
                   smul_ppmm(p[1], p[0], poly2[i], poly3[j]);
                   sub_ddmmss(c[1], c[0], c[1], c[0], p[1], p[0]);
@@ -247,13 +249,13 @@ void _fmpz_mpoly_submul_array1_slong2_1(ulong * poly1,
    ulong p[2]; /* for products of coefficients */
    ulong * c2, * c;
 
-   c2 = poly1 + 2*((slong) exp2);
+   c2 = poly1 + (((slong) exp2) << 1);
 
    if (d != 0)
    {
       for (j = 0; j < len3; j++)
       {
-         c = c2 + 2*((slong) exp3[j]);
+         c = c2 + (((slong) exp3[j]) << 1);
 
          smul_ppmm(p[1], p[0], d, poly3[j]);
          sub_ddmmss(c[1], c[0], c[1], c[0], p[1], p[0]);

--- a/src/fmpz_mpoly/mul_array.c
+++ b/src/fmpz_mpoly/mul_array.c
@@ -15,6 +15,12 @@
 #include "mpoly.h"
 #include "fmpz_mpoly.h"
 
+/* Currently we do not -funroll-loops by default in the fmpz_mpoly module,
+   but it is worthwhile for the basic loops here. */
+#pragma GCC push_options
+#pragma GCC optimize("-funroll-loops")
+
+
 /*
     NOTE: this file is dirty - it assumes that a zero fmpz is zero
 */
@@ -123,6 +129,7 @@ void _fmpz_mpoly_addmul_array1_slong(ulong * poly1,
    The input polynomials are broken into blocks to improve
    cache efficiency.
 */
+
 void _fmpz_mpoly_addmul_array1_slong2(ulong * poly1,
                  const slong * poly2, const ulong * exp2, slong len2,
                            const slong * poly3, const ulong * exp3, slong len3)
@@ -137,13 +144,21 @@ void _fmpz_mpoly_addmul_array1_slong2(ulong * poly1,
       {
          for (i = ii; i < FLINT_MIN(ii + BLOCK, len2); i++)
          {
-            c2 = poly1 + 2*((slong) exp2[i]);
+            /* Hack: both the (slong) cast and writing as a shift by 1
+               instead of a multiply by 2 are needed to get GCC to
+               generate good code on Zen3. Check
+
+                   build/fmpz_mpoly/profile/p-mul 1 dense 30 20
+
+               before changing this. */
+            c2 = poly1 + (((slong) exp2[i]) << 1);
 
             if (poly2[i] != 0)
             {
                for (j = jj; j < FLINT_MIN(jj + BLOCK, len3); j++)
                {
-                  c = c2 + 2*((slong) exp3[j]);
+                  /* Hack. */
+                  c = c2 + (((slong) exp3[j]) << 1);
 
                   smul_ppmm(p[1], p[0], poly2[i], poly3[j]);
                   add_ssaaaa(c[1], c[0], c[1], c[0], p[1], p[0]);
@@ -153,6 +168,8 @@ void _fmpz_mpoly_addmul_array1_slong2(ulong * poly1,
       }
    }
 }
+
+#pragma GCC pop_options
 
 /*
    Addmul into a dense array poly1, given polys with coefficients

--- a/src/n_poly/nmod_n_fq_interp.c
+++ b/src/n_poly/nmod_n_fq_interp.c
@@ -13,6 +13,11 @@
 #include "fq_nmod.h"
 #include "n_poly.h"
 
+/* -O3 seems to result in worse code here. Check results for
+   nmod_mpoly_factor/profile/p-factor */
+
+#pragma GCC optimize ("-O2,-funroll-loops")
+
 /*
     conversion between polynomials in coefficient form and point-value form
     and arithmetic in point-value form


### PR DESCRIPTION
Our new default compiler flags have caused some performance regressions for nmod_mpoly and fmpz_mpoly arithmetic, at least with GCC 11 on Zen3 (see #1775). Here's an attempt to regain speed at least for some of the most important functions.

FLINT 3.0 timings:

```
build/fmpz_mpoly/profile/p-mul 1 dense 30 20            639
build/nmod_mpoly/profile/p-mul 1 dense 30 20            642
factoring benchmarks:
nmod_mpoly (8 benchmarks)                11.363
fmpz_mpoly (2 benchmarks)                 1.513
```

Current ``main`` timings:

```
build/fmpz_mpoly/profile/p-mul 1 dense 30 20            870
build/nmod_mpoly/profile/p-mul 1 dense 30 20            892
factoring benchmarks:
nmod_mpoly (8 benchmarks)                12.428
fmpz_mpoly (2 benchmarks)                 1.580
```

This PR:

```
build/fmpz_mpoly/profile/p-mul 1 dense 30 20            533
build/nmod_mpoly/profile/p-mul 1 dense 30 20            476
factoring benchmarks:
nmod_mpoly (8 benchmarks)                11.300
fmpz_mpoly (2 benchmarks)                 1.473
```