### PR TITLE
Use Requires instead direct linking of gmp/mpfr in pkg-config

### DIFF
--- a/flint.pc.in
+++ b/flint.pc.in
@@ -7,5 +7,6 @@ Name: @PACKAGE_NAME@
 Description: Fast Library for Number Theory
 Version: @PACKAGE_VERSION@
 URL: https://flintlib.org/
+Requires: gmp >= 6.2.1 mpfr >= 4.1.0
 Cflags: -I${includedir}
-Libs: -L${libdir} -lflint -lgmp -lmpfr
+Libs: -L${libdir} -lflint


### PR DESCRIPTION
Let pkg-config find gmp/mpfr by itself without direct asking _via_:
```
pkg-config --libs flint gmp mpfr
```

After patch, it is just:
```
pkg-config --libs flint
```