### PR TITLE
flint_mpn_sqr basecases up to 14

### DIFF
--- a/src/mpn_extras.h
+++ b/src/mpn_extras.h
@@ -134,7 +134,7 @@ flint_mpn_get_d(mp_srcptr ptr, mp_size_t size, mp_size_t sign, long exp);
 #define FLINT_MPN_MUL_FUNC_TAB_WIDTH 17
 #define FLINT_HAVE_MUL_FUNC(n, m) ((n) <= 16)
 #define FLINT_HAVE_MUL_N_FUNC(n) ((n) <= 16)
-#define FLINT_HAVE_SQR_FUNC(n) ((n) <= 7)
+#define FLINT_HAVE_SQR_FUNC(n) ((n) <= 14)
 #else
 #define FLINT_MPN_MUL_FUNC_TAB_WIDTH 8
 #define FLINT_HAVE_MUL_FUNC(n, m) ((n) <= 7 || ((n) <= 14 && (m) == 1))

--- a/src/mpn_extras/profile/p-sqr_basecase.c
+++ b/src/mpn_extras/profile/p-sqr_basecase.c
@@ -18,12 +18,12 @@ void mpn_sqr_basecase(mp_ptr, mp_srcptr, mp_size_t);
 
 int main(void)
 {
-    mp_limb_t res1[14];
-    mp_limb_t res2[14];
-    mp_limb_t ap[7];
+    mp_limb_t res1[28];
+    mp_limb_t res2[28];
+    mp_limb_t ap[14];
     slong mx;
 
-    for (mx = 1; mx <= 7; mx++)
+    for (mx = 1; mx <= 14; mx++)
     {
         double t1, t2, t3, __attribute__((unused)) __;
 

--- a/src/mpn_extras/sqr_basecase.c
+++ b/src/mpn_extras/sqr_basecase.c
@@ -21,6 +21,98 @@ mp_limb_t flint_mpn_sqr_5(mp_ptr, mp_srcptr);
 mp_limb_t flint_mpn_sqr_6(mp_ptr, mp_srcptr);
 mp_limb_t flint_mpn_sqr_7(mp_ptr, mp_srcptr);
 
+
+mp_limb_t flint_mpn_mul_7_2(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_7_3(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_7_4(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_7_5(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_7_6(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_7_7(mp_ptr, mp_srcptr, mp_srcptr);
+mp_limb_t flint_mpn_mul_8_7(mp_ptr, mp_srcptr, mp_srcptr);
+
+mp_limb_t flint_mpn_sqr_8(mp_ptr res, mp_srcptr x)
+{
+    mp_limb_t t[8];
+    mp_limb_t b = x[7];
+    flint_mpn_sqr_7(res, x);
+    umul_ppmm(res[15], res[14], b, b);
+    t[7] = mpn_lshift(t, x, 7, 1);
+    res[15] += mpn_addmul_1(res + 7, t, 8, b);
+    return res[15];
+}
+
+mp_limb_t flint_mpn_sqr_9(mp_ptr res, mp_srcptr x)
+{
+    mp_limb_t t[10];
+    flint_mpn_sqr_7(res, x);
+    flint_mpn_sqr_2(res + 14, x + 7);
+    flint_mpn_mul_7_2(t, x, x + 7);
+    t[9] = 0;
+    res[17] += mpn_addmul_1(res + 7, t, 10, 2);
+    return res[17];
+}
+
+mp_limb_t flint_mpn_sqr_10(mp_ptr res, mp_srcptr x)
+{
+    mp_limb_t t[12];
+    flint_mpn_sqr_7(res, x);
+    flint_mpn_sqr_3(res + 14, x + 7);
+    flint_mpn_mul_7_3(t, x, x + 7);
+    t[10] = 0;
+    t[11] = 0;
+    res[19] += mpn_addmul_1(res + 7, t, 12, 2);
+    return res[19];
+}
+
+mp_limb_t flint_mpn_sqr_11(mp_ptr res, mp_srcptr x)
+{
+    mp_limb_t t[14];
+    flint_mpn_sqr_7(res, x);
+    flint_mpn_sqr_4(res + 14, x + 7);
+    flint_mpn_mul_7_4(t, x, x + 7);
+    t[11] = 0;
+    t[12] = 0;
+    t[13] = 0;
+    res[21] += mpn_addmul_1(res + 7, t, 14, 2);
+    return res[21];
+}
+
+mp_limb_t flint_mpn_sqr_12(mp_ptr res, mp_srcptr x)
+{
+    mp_limb_t t[12];
+    mp_limb_t cy;
+    flint_mpn_sqr_7(res, x);
+    flint_mpn_sqr_5(res + 14, x + 7);
+    flint_mpn_mul_7_5(t, x, x + 7);
+    cy = mpn_addmul_1(res + 7, t, 12, 2);
+    mpn_add_1(res + 19, res + 19, 5, cy);
+    return res[23];
+}
+
+mp_limb_t flint_mpn_sqr_13(mp_ptr res, mp_srcptr x)
+{
+    mp_limb_t t[13];
+    mp_limb_t cy;
+    flint_mpn_sqr_7(res, x);
+    flint_mpn_sqr_6(res + 14, x + 7);
+    flint_mpn_mul_7_6(t, x, x + 7);
+    cy = mpn_addmul_1(res + 7, t, 13, 2);
+    mpn_add_1(res + 20, res + 20, 6, cy);
+    return res[25];
+}
+
+mp_limb_t flint_mpn_sqr_14(mp_ptr res, mp_srcptr x)
+{
+    mp_limb_t t[14];
+    mp_limb_t cy;
+    flint_mpn_sqr_7(res, x);
+    flint_mpn_sqr_7(res + 14, x + 7);
+    flint_mpn_mul_7_7(t, x, x + 7);
+    cy = mpn_addmul_1(res + 7, t, 14, 2);
+    mpn_add_1(res + 21, res + 21, 7, cy);
+    return res[27];
+}
+
 const flint_mpn_sqr_func_t flint_mpn_sqr_func_tab[] = {
     NULL,
     flint_mpn_sqr_1,
@@ -29,7 +121,14 @@ const flint_mpn_sqr_func_t flint_mpn_sqr_func_tab[] = {
     flint_mpn_sqr_4,
     flint_mpn_sqr_5,
     flint_mpn_sqr_6,
-    flint_mpn_sqr_7
+    flint_mpn_sqr_7,
+    flint_mpn_sqr_8,
+    flint_mpn_sqr_9,
+    flint_mpn_sqr_10,
+    flint_mpn_sqr_11,
+    flint_mpn_sqr_12,
+    flint_mpn_sqr_13,
+    flint_mpn_sqr_14,
 };
 
 #else

--- a/src/mpn_extras/test/t-sqr_basecase.c
+++ b/src/mpn_extras/test/t-sqr_basecase.c
@@ -20,13 +20,13 @@ TEST_FUNCTION_START(flint_mpn_sqr_basecase, state)
 
     for (ix = 0; ix < 100000 * flint_test_multiplier(); ix++)
     {
-        mp_limb_t res1[14] = {UWORD(0)};
-        mp_limb_t res2[14] = {UWORD(0)};
+        mp_limb_t res1[28] = {UWORD(0)};
+        mp_limb_t res2[28] = {UWORD(0)};
         mp_limb_t ret1;
-        mp_limb_t ap[7];
+        mp_limb_t ap[14];
         slong alen;
 
-        alen = 1 + n_randint(state, 7);
+        alen = 1 + n_randint(state, 14);
 
         mpn_random2(ap, alen);
 


### PR DESCRIPTION
~5% speedup over ``mpn_sqr_basecase``. This would be a bit faster with assembly code for ``res += 2*tmp`` instead of doing a ``mpn_addmul_1`` + ``mpn_add_1``.

```
m =  1:   0.90x
m =  2:   1.00x
m =  3:   1.15x
m =  4:   1.56x
m =  5:   1.50x
m =  6:   1.46x
m =  7:   1.35x
m =  8:   1.04x
m =  9:   1.10x
m = 10:   1.05x
m = 11:   1.01x
m = 12:   1.07x
m = 13:   1.05x
m = 14:   1.06x
```