### PR TITLE
Add threshold for fft_small which is set during configuration

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -389,8 +389,6 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1.13.0
         with:
           arch: x86_64
-          toolset: 14.37.32822
-          vsversion: 17.6.0
 
       - name: "Configure"
         run: |

--- a/CMake/cmake_config.h.in
+++ b/CMake/cmake_config.h.in
@@ -20,6 +20,9 @@
 
 #cmakedefine01 FLINT_KNOW_STRONG_ORDER
 
+/* Just set to some reasonable threshold */
+#define FLINT_FFT_SMALL_THRESHOLD 600
+
 #ifdef _MSC_VER
 # if defined(FLINT_BUILD_DLL)
 #  define FLINT_DLL __declspec(dllexport)

--- a/configure.ac
+++ b/configure.ac
@@ -983,12 +983,31 @@ fi
 CPPFLAGS="-I./src $CPPFLAGS"
 
 ################################################################################
+# Architecture
+################################################################################
+
+FLINT_ARCH
+
+################################################################################
 # fft_small module
 ################################################################################
 
 FLINT_CHECK_FFT_SMALL(
     [AC_SUBST(FFT_SMALL, [fft_small\ \ \ ])
-     AC_DEFINE(FLINT_HAVE_FFT_SMALL, 1, [Define to use the fft_small module])],
+     AC_DEFINE(FLINT_HAVE_FFT_SMALL, 1, [Define to use the fft_small module])
+
+     case $flint_cv_arch in
+         FAST_VROUNDPD_PATTERN)
+             fft_small_threshold="400"
+             ;;
+         SLOW_VROUNDPD_PATTERN)
+             fft_small_threshold="1540"
+             ;;
+         *)
+             fft_small_threshold="500"
+             ;;
+     esac
+     AC_DEFINE_UNQUOTED(FLINT_FFT_SMALL_THRESHOLD,[$fft_small_threshold],[Define to set threshold for when to use fft_small module])],
     [AC_SUBST(FFT_SMALL, [\ \ \ \ \ \ \ \ \ \ \ \ ])])
 
 ################################################################################

--- a/src/fft_small/profile/p-fft_small_vs_gmp.c
+++ b/src/fft_small/profile/p-fft_small_vs_gmp.c
@@ -1,0 +1,88 @@
+/*
+    Copyright (C) 2023 Fredrik Johansson
+    Copyright (C) 2024 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "mpn_extras.h"
+
+#if FLINT_HAVE_FFT_SMALL
+
+#include "fft_small.h"
+#include "profiler.h"
+
+#define N_MIN_MUL 1500
+#define N_MAX_MUL 1600
+
+#define N_MIN_SQR 2900
+#define N_MAX_SQR 3200
+
+int main(void)
+{
+    mp_ptr x, y, r, s;
+    slong n;
+
+    x = flint_malloc(sizeof(mp_limb_t) * FLINT_MAX(N_MAX_MUL, N_MAX_SQR));
+    y = flint_malloc(sizeof(mp_limb_t) * FLINT_MAX(N_MAX_MUL, N_MAX_SQR));
+    r = flint_malloc(2 * sizeof(mp_limb_t) * FLINT_MAX(N_MAX_MUL, N_MAX_SQR));
+    s = flint_malloc(2 * sizeof(mp_limb_t) * FLINT_MAX(N_MAX_MUL, N_MAX_SQR));
+
+    mpn_random2(x, FLINT_MAX(N_MAX_MUL, N_MAX_SQR));
+    mpn_random2(y, FLINT_MAX(N_MAX_MUL, N_MAX_SQR));
+
+    flint_printf("mpn_mul_n vs fft_small\n\n");
+
+    for (n = N_MIN_MUL; n <= N_MAX_MUL; n += 5)
+    {
+        double t1, t2, FLINT_SET_BUT_UNUSED(__);
+
+        flint_printf("n = %4wd: ", n);
+
+        TIMEIT_START
+        mpn_mul_n(r, x, y, n);
+        TIMEIT_STOP_VALUES(__, t1)
+
+        TIMEIT_START
+        mpn_mul_default_mpn_ctx(s, x, n, y, n);
+        TIMEIT_STOP_VALUES(__, t2)
+
+        flint_printf("%.2f\n", t1 / t2);
+    }
+
+    flint_printf("mpn_sqr vs fft_small\n\n");
+
+    for (n = N_MIN_SQR; n <= N_MAX_SQR; n += 10)
+    {
+        double t1, t2, FLINT_SET_BUT_UNUSED(__);
+
+        flint_printf("n = %4wd: ", n);
+
+        TIMEIT_START
+        mpn_sqr(r, x, n);
+        TIMEIT_STOP_VALUES(__, t1)
+
+        TIMEIT_START
+        mpn_mul_default_mpn_ctx(s, x, n, x, n);
+        TIMEIT_STOP_VALUES(__, t2)
+
+        flint_printf("%.2f\n", t1 / t2);
+    }
+
+    flint_free(x);
+    flint_free(y);
+    flint_free(r);
+    flint_free(s);
+
+    flint_cleanup_master();
+
+    return 0;
+}
+#else
+int main(void) { return 0; }
+#endif

--- a/src/flint-config.h.in
+++ b/src/flint-config.h.in
@@ -15,6 +15,9 @@
 /* Define if system is strongly ordered */
 #undef FLINT_KNOW_STRONG_ORDER
 
+/* Define to set threshold for when to use fft_small module */
+#undef FLINT_FFT_SMALL_THRESHOLD
+
 /* Define if system has the ADX instruction set */
 #undef FLINT_HAVE_ADX
 

--- a/src/mpn_extras.h
+++ b/src/mpn_extras.h
@@ -121,26 +121,26 @@ flint_mpn_get_d(mp_srcptr ptr, mp_size_t size, mp_size_t sign, long exp);
 /* General multiplication ****************************************************/
 
 #ifdef FLINT_HAVE_FFT_SMALL
-#define FLINT_FFT_MUL_THRESHOLD 400
-#define FLINT_FFT_SQR_THRESHOLD 800
+# define FLINT_FFT_MUL_THRESHOLD FLINT_FFT_SMALL_THRESHOLD
+# define FLINT_FFT_SQR_THRESHOLD (2 * FLINT_FFT_SMALL_THRESHOLD)
 #else
 /* FLINT's FFT can beat GMP below this threshold but apparently
    not consistently. Something needs retuning? */
-#define FLINT_FFT_MUL_THRESHOLD 32000
-#define FLINT_FFT_SQR_THRESHOLD 32000
+# define FLINT_FFT_MUL_THRESHOLD 32000
+# define FLINT_FFT_SQR_THRESHOLD 32000
 #endif
 
 #if FLINT_HAVE_ADX
-#define FLINT_MPN_MUL_FUNC_TAB_WIDTH 17
-#define FLINT_MPN_SQR_FUNC_TAB_WIDTH 14
-#define FLINT_HAVE_MUL_FUNC(n, m) ((n) <= 16)
-#define FLINT_HAVE_MUL_N_FUNC(n) ((n) <= 16)
-#define FLINT_HAVE_SQR_FUNC(n) ((n) <= FLINT_MPN_SQR_FUNC_TAB_WIDTH)
+# define FLINT_MPN_MUL_FUNC_TAB_WIDTH 17
+# define FLINT_MPN_SQR_FUNC_TAB_WIDTH 14
+# define FLINT_HAVE_MUL_FUNC(n, m) ((n) <= 16)
+# define FLINT_HAVE_MUL_N_FUNC(n) ((n) <= 16)
+# define FLINT_HAVE_SQR_FUNC(n) ((n) <= FLINT_MPN_SQR_FUNC_TAB_WIDTH)
 #else
-#define FLINT_MPN_MUL_FUNC_TAB_WIDTH 8
-#define FLINT_HAVE_MUL_FUNC(n, m) ((n) <= 7 || ((n) <= 14 && (m) == 1))
-#define FLINT_HAVE_MUL_N_FUNC(n) ((n) <= 7)
-#define FLINT_HAVE_SQR_FUNC(n) (0)
+# define FLINT_MPN_MUL_FUNC_TAB_WIDTH 8
+# define FLINT_HAVE_MUL_FUNC(n, m) ((n) <= 7 || ((n) <= 14 && (m) == 1))
+# define FLINT_HAVE_MUL_N_FUNC(n) ((n) <= 7)
+# define FLINT_HAVE_SQR_FUNC(n) (0)
 #endif
 
 #define FLINT_MUL_USE_FUNC_TAB 1


### PR DESCRIPTION
Also use preprocessor instead of compiler in the configuration process to speed things up.

Solves #1790 and #1789.

On Skylake, I get the following timings on Skylake with `fft_small/profile/p-fft_small_vs_gmp.c`:
```
mpn_mul_n vs flint_mpn_mul_n
n =  900: 1.06
n =  936: 0.90
n =  973: 0.92
n = 1011: 0.87
n = 1051: 0.90
n = 1093: 0.93
n = 1136: 0.95
n = 1181: 1.04
n = 1228: 1.05
n = 1277: 1.07
n = 1328: 1.09
n = 1381: 0.81
n = 1436: 0.84
n = 1493: 0.86
n = 1552: 1.18
n = 1614: 1.22
n = 1678: 1.01
n = 1745: 1.28
n = 1814: 1.33
n = 1886: 1.01
n = 1961: 1.06
n = 2039: 1.04
n = 2120: 1.07
n = 2204: 1.14
n = 2292: 1.16
n = 2383: 1.38
n = 2478: 1.39
n = 2577: 1.41
n = 2680: 1.44
n = 2787: 1.03
n = 2898: 1.08
n = 3013: 1.08
n = 3133: 1.57
n = 3258: 1.60
n = 3388: 1.63
n = 3523: 1.64
n = 3663: 1.71
n = 3809: 1.26
n = 3961: 1.58
```
And zooming in on the range 1500-1600, we see something wierd:
```
mpn_mul_n vs flint_mpn_mul_n

n = 1500: 0.86
n = 1505: 0.90
n = 1510: 0.89
n = 1515: 0.89
n = 1520: 0.89
n = 1525: 0.89
n = 1530: 0.89
n = 1535: 0.89
n = 1540: 1.17
n = 1545: 1.19
n = 1550: 1.19
n = 1555: 1.20
n = 1560: 1.20
n = 1565: 1.20
n = 1570: 1.22
n = 1575: 1.22
n = 1580: 1.21
n = 1585: 1.22
n = 1590: 1.22
n = 1595: 1.22
n = 1600: 1.22
```
Hence, I set the threshold for CPUs with fast `vroundpd` to 400, and for slow to 1540.