### PR TITLE
CMake: Add Find<package>.cmake modules

### DIFF
--- a/CMake/FindCBLAS.cmake
+++ b/CMake/FindCBLAS.cmake
@@ -2,27 +2,44 @@
 #
 # Once done this will define
 #  CBLAS_FOUND        - system has a BLAS library
-#  CBLAS_INCLUDE_DIRS - the header directory containing cblas.h
-#  CBLAS_LIBRARIES    - the CBLAS library
+#  CBLAS_INCLUDE_DIR  - the header directory containing cblas.h
+#  CBLAS_LIBRARY      - the CBLAS library
 
 # Copyright (c) 2020, Mahrud Sayrafi, <mahrud@umn.edu>
 # Redistribution and use is allowed according to the terms of the BSD license.
 
-find_path(CBLAS_INCLUDE_DIRS NAMES cblas.h
+find_path(CBLAS_INCLUDE_DIR NAMES cblas.h
   HINTS CBLAS_ROOT ENV CBLAS_ROOT
   PATHS ${INCLUDE_INSTALL_DIR} ${CMAKE_INSTALL_PREFIX}/include
   PATH_SUFFIXES openblas cblas blis flexiblas
   )
 
-find_library(CBLAS_LIBRARIES NAMES accelerate openblas cblas blas blis flexiblas
+find_library(CBLAS_LIBRARY NAMES accelerate openblas cblas blas blis flexiblas
   HINTS CBLAS_ROOT ENV CBLAS_ROOT
   PATHS ${LIB_INSTALL_DIR} ${CMAKE_INSTALL_PREFIX}/lib
   PATH_SUFFIXES openblas cblas blis flexiblas
   )
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(CBLAS
-  "Could NOT find a BLAS compatible library or 'cblas.h', install BLAS or set CBLAS_ROOT."
-  CBLAS_INCLUDE_DIRS CBLAS_LIBRARIES)
+find_package_handle_standard_args( CBLAS
+  FOUND_VAR CBLAS_FOUND
+  REQUIRED_VARS
+    CBLAS_LIBRARY
+    CBLAS_INCLUDE_DIR
+  )
 
-mark_as_advanced(CBLAS_LIBRARIES CBLAS_INCLUDE_DIRS)
+if(CBLAS_FOUND)
+  set(CBLAS_INCLUDE_DIRS ${CBLAS_INCLUDE_DIR})
+  set(CBLAS_LIBRARIES ${CBLAS_LIBRARY})
+  if(NOT TARGET CBLAS::CBLAS)
+    add_library(CBLAS::CBLAS UNKNOWN IMPORTED)
+    set_target_properties( CBLAS::CBLAS
+      PROPERTIES
+        IMPORTED_LOCATION "${CBLAS_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${CBLAS_INCLUDE_DIR}" 
+      )
+  endif()
+  mark_as_advanced(CBLAS_ROOT)
+endif()
+
+mark_as_advanced(CBLAS_LIBRARY CBLAS_INCLUDE_DIR)

--- a/CMake/Findgmp.cmake
+++ b/CMake/Findgmp.cmake
@@ -1,0 +1,66 @@
+
+set(GMP_ROOT_DIR "${GMP_ROOT_DIR}"  CACHE PATH "Directory to search for gmp" )
+
+find_package(PkgConfig QUIET)
+if( PkgConfig_FOUND )
+  pkg_search_module(PC_GMP QUIET gmp)
+  if( PC_GMP_FOUND )
+    set( GMP_VERSION ${PC_GMP_VERSION} )
+  endif()
+endif()
+
+find_path( GMP_INCLUDE_DIR
+  NAMES gmp.h
+  PATHS "${GMP_ROOT_DIR}"
+  HINTS ${PC_GMP_INCLUDEDIR} ${PC_GMP_INCLUDE_DIRS}
+  )
+find_library( GMP_LIBRARY
+  NAMES gmp
+  PATHS "${GMP_ROOT_DIR}"
+  HINTS ${PC_GMP_LIBDIR} ${PC_GMP_LIBRARY_DIRS}
+  )
+
+if(NOT PC_GMP_FOUND)
+  set( _VERSION_FILE ${GMP_INCLUDE_DIR}/gmp.h )
+  if( EXISTS ${_VERSION_FILE} )
+    file( STRINGS ${_VERSION_FILE} _VERSION_LINE REGEX "define[ ]+__GNU_MP_VERSION[ ]+" )
+    if( _VERSION_LINE )
+      string( REGEX REPLACE ".*define[ ]+__GNU_MP_VERSION[ ]+(.*)[ ]*" "\\1" GMP_VERSION_MAJOR "${_VERSION_LINE}" )
+    endif()
+    file( STRINGS ${_VERSION_FILE} _VERSION_LINE REGEX "define[ ]+__GNU_MP_VERSION_MINOR[ ]+" )
+    if( _VERSION_LINE )
+      string( REGEX REPLACE ".*define[ ]+__GNU_MP_VERSION_MINOR[ ]+(.*)[ ]*" "\\1" GMP_VERSION_MINOR "${_VERSION_LINE}" )
+    endif()
+    file( STRINGS ${_VERSION_FILE} _VERSION_LINE REGEX "define[ ]+__GNU_MP_VERSION_PATCHLEVEL[ ]+" )
+    if( _VERSION_LINE )
+      string( REGEX REPLACE ".*define[ ]+__GNU_MP_VERSION_PATCHLEVEL[ ]+(.*)[ ]*" "\\1" GMP_VERSION_PATCHLEVEL "${_VERSION_LINE}" )
+    endif()
+    set( GMP_VERSION "${GMP_VERSION_MAJOR}.${GMP_VERSION_MINOR}.${GMP_VERSION_PATCHLEVEL}")
+  endif()
+  unset( _VERSION_FILE )
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args( gmp
+  FOUND_VAR GMP_FOUND
+  REQUIRED_VARS
+    GMP_LIBRARY
+    GMP_INCLUDE_DIR
+  VERSION_VAR GMP_VERSION
+  )
+
+if(GMP_FOUND)
+  set(GMP_INCLUDE_DIRS ${GMP_INCLUDE_DIR})
+  set(GMP_LIBRARIES ${GMP_LIBRARY})
+  if(NOT TARGET gmp::gmp)
+    add_library(gmp::gmp UNKNOWN IMPORTED)
+    set_target_properties( gmp::gmp
+      PROPERTIES
+        IMPORTED_LOCATION "${GMP_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${GMP_INCLUDE_DIR}" 
+      )
+  endif()
+  mark_as_advanced(GMP_ROOT_DIR)
+endif()
+
+mark_as_advanced(GMP_INCLUDE_DIR GMP_LIBRARY)

--- a/CMake/Findmpfr.cmake
+++ b/CMake/Findmpfr.cmake
@@ -1,0 +1,57 @@
+
+set(MPFR_ROOT_DIR "${MPFR_ROOT_DIR}"  CACHE PATH "Directory to search for mpfr" )
+
+find_package(PkgConfig QUIET)
+if( PkgConfig_FOUND )
+  pkg_search_module(PC_MPFR QUIET mpfr)
+  if( PC_MPFR_FOUND )
+    set( MPFR_VERSION ${PC_MPFR_VERSION} )
+  endif()
+endif()
+
+find_path( MPFR_INCLUDE_DIR
+  NAMES mpfr.h
+  PATHS "${MPFR_ROOT_DIR}"
+  HINTS ${PC_MPFR_INCLUDEDIR} ${PC_MPFR_INCLUDE_DIRS}
+  )
+find_library( MPFR_LIBRARY
+  NAMES mpfr
+  PATHS "${MPFR_ROOT_DIR}"
+  HINTS ${PC_MPFR_LIBDIR} ${PC_MPFR_LIBRARY_DIRS}
+  )
+
+if(NOT PC_MPFR_FOUND)
+  set( _VERSION_FILE ${MPFR_INCLUDE_DIR}/mpfr.h )
+  if( EXISTS ${_VERSION_FILE} )
+    file( STRINGS ${_VERSION_FILE} _VERSION_LINE REGEX "define[ ]+MPFR_VERSION_STRING" )
+    if( _VERSION_LINE )
+      string( REGEX REPLACE ".*define[ ]+MPFR_VERSION_STRING[ ]+\"([^\"]*)\".*" "\\1" MPFR_VERSION "${_VERSION_LINE}" )
+    endif()
+  endif()
+  unset( _VERSION_FILE )
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args( mpfr
+  FOUND_VAR MPFR_FOUND
+  REQUIRED_VARS
+    MPFR_LIBRARY
+    MPFR_INCLUDE_DIR
+  VERSION_VAR MPFR_VERSION
+  )
+
+if(MPFR_FOUND)
+  set(MPFR_INCLUDE_DIRS ${MPFR_INCLUDE_DIR})
+  set(MPFR_LIBRARIES ${MPFR_LIBRARY})
+  if(NOT TARGET mpfr::mpfr)
+    add_library(mpfr::mpfr UNKNOWN IMPORTED)
+    set_target_properties( mpfr::mpfr
+      PROPERTIES
+        IMPORTED_LOCATION "${MPFR_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${MPFR_INCLUDE_DIR}" 
+      )
+  endif()
+  mark_as_advanced(MPFR_ROOT_DIR)
+endif()
+
+mark_as_advanced(MPFR_INCLUDE_DIR MPFR_LIBRARY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ endif()
 include(CheckCCompilerFlag)
 include(CheckCSourceRuns)
 include(CheckIPOSupported)
-include(FindPkgConfig)
 include(CMakePackageConfigHelpers)
 
 # Source of truth for project version
@@ -107,11 +106,12 @@ else()
 endif()
 
 # Find dependencies
-find_package(PkgConfig REQUIRED)
 set(GMP_MIN_VERSION 6.2.1)
+find_package(gmp ${GMP_MIN_VERSION} REQUIRED)
+
 set(MPFR_MIN_VERSION 4.1.0)
-pkg_check_modules(GMP REQUIRED IMPORTED_TARGET gmp>=${GMP_MIN_VERSION})
-pkg_check_modules(MPFR REQUIRED IMPORTED_TARGET mpfr>=${MPFR_MIN_VERSION})
+find_package(mpfr ${MPFR_MIN_VERSION} REQUIRED)
+
 if (WITH_NTL)
     find_package(NTL REQUIRED)
 endif()
@@ -146,7 +146,7 @@ endif()
 
 # Check if fft_small module is available
 message(STATUS "Checking whether fft_small module is available")
-set(CMAKE_REQUIRED_INCLUDES ${GMP_INCLUDE_DIRS})
+set(CMAKE_REQUIRED_LIBRARIES gmp::gmp)
 if(HAS_FLAG_ARCH)
     set(CMAKE_REQUIRED_FLAGS "-march=${ENABLE_ARCH}")
 endif()
@@ -315,7 +315,7 @@ else()
 endif()
 
 # gmpcompat.h configuration
-set(CMAKE_REQUIRED_INCLUDES ${GMP_INCLUDE_DIRS})
+set(CMAKE_REQUIRED_LIBRARIES gmp::gmp)
 check_c_source_compiles([[#include <gmp.h>
   #ifndef _LONG_LONG_LIMB
   # error mp_limb_t != unsigned long long limb
@@ -387,10 +387,13 @@ list(APPEND HEADERS ${TEMP})
 
 add_library(flint ${SOURCES})
 target_link_libraries(flint PUBLIC
-    PkgConfig::GMP PkgConfig::MPFR ${PThreads_LIBRARIES})
+    gmp::gmp
+    mpfr::mpfr
+    ${PThreads_LIBRARIES}
+)
 
 if(FLINT_USES_BLAS)
-    target_link_libraries(flint PUBLIC ${CBLAS_LIBRARIES})
+    target_link_libraries(flint PUBLIC CBLAS::CBLAS)
 endif()
 
 # Include directories
@@ -398,14 +401,8 @@ endif()
 target_include_directories(flint PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src;${CMAKE_CURRENT_BINARY_DIR}>"
     "$<INSTALL_INTERFACE:include/flint>"
-    ${GMP_INCLUDE_DIRS}
-    ${MPFR_INCLUDE_DIRS}
     ${PThreads_INCLUDE_DIRS}
 )
-
-if(FLINT_USES_BLAS)
-    target_include_directories(flint PUBLIC ${CBLAS_INCLUDE_DIRS})
-endif()
 
 if(BUILD_SHARED_LIBS AND MSVC)
     # Export all functions automatically (except global data)
@@ -513,6 +510,8 @@ install(FILES
         "${CMAKE_CURRENT_BINARY_DIR}/flintConfig.cmake"
         "${CMAKE_CURRENT_BINARY_DIR}/flintConfigVersion.cmake"
         "CMake/FindCBLAS.cmake"
+        "CMake/Findgmp.cmake"
+        "CMake/Findmpfr.cmake"
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/flint
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,7 +418,7 @@ if (HAS_FLAG_UNROLL_LOOPS)
     target_compile_options(flint PUBLIC "-funroll-loops")
 endif()
 
-if(NOT "${ENABLE_ARCH}" STREQUAL "NO")
+if(NOT MSVC AND NOT "${ENABLE_ARCH}" STREQUAL "NO")
     target_compile_options(flint PUBLIC "-march=${ENABLE_ARCH}")
 endif()
 

--- a/flintConfig.cmake.in
+++ b/flintConfig.cmake.in
@@ -1,15 +1,15 @@
 @PACKAGE_INIT@
 
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(GMP REQUIRED IMPORTED_TARGET gmp>=@GMP_MIN_VERSION@)
-pkg_check_modules(MPFR REQUIRED IMPORTED_TARGET mpfr>=@MPFR_MIN_VERSION@)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 
-if(@CBLAS_FOUND@)
+find_package(gmp @GMP_MIN_VERSION@ REQUIRED)
+find_package(mpfr @MPFR_MIN_VERSION@ REQUIRED)
+
+if(@FLINT_USES_BLAS@)
   find_package(CBLAS REQUIRED)
 endif()
 
 if(NOT MSVC)
-  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
   find_package(Threads REQUIRED)
 endif()
 


### PR DESCRIPTION
This is how typically CMake is used to find and link to libraries.

- Linking to an imported target passes all its properties (link flags, compile flags, compile definitions, include directories), no need to add them separately.

- pkgconfig is no longer required.