### PR TITLE
Enable running specific tests through `make check MOD=... ARGS=...`

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -760,6 +760,9 @@ tests: library $(TESTS)
 %_TEST_RUN: %
 	@$<
 
+%_TEST_RUN_ARGS: %
+	@$< $(ARGS)
+
 # Parallel running of same test file
 ifneq ($(NJOBS),)
 number_generator=$(words $2) $(if $(word $1,$2),,$(call number_generator,$1,w $2))
@@ -786,6 +789,15 @@ check: library
 	@echo 'All Python tests passed.'
 endif
 else ifdef MOD
+ifdef ARGS
+ifneq ($(words $(sort $(MOD))),1)
+$(error Can only check one modules with arguments.)
+else
+check: library $(patsubst %,%_TEST_RUN_ARGS, $($(sort $(MOD))_TESTS))
+	@echo ''
+	@echo 'All tests passed for $(sort $(MOD)).'
+endif
+else
 ifeq ($(NJOBS),)
 check: library $(patsubst %,%_TEST_RUN,$(foreach dir, $(MOD), $($(dir)_TESTS)))
 	@echo ''
@@ -809,6 +821,7 @@ else ifeq ($(words $(sort $(MOD))),2)
 	@echo 'All tests passed for $(firstword $(sort $(MOD))) and $(lastword $(sort $(MOD))).'
 else
 	@echo 'All tests passed for $(foreach dir,$(filter-out $(lastword $(filter-out $(lastword $(sort $(MOD))),$(sort $(MOD)))) $(lastword $(sort $(MOD))),$(sort $(MOD))),$(dir),) $(lastword $(filter-out $(lastword $(sort $(MOD))),$(sort $(MOD)))) and $(lastword $(sort $(MOD))).'
+endif
 endif
 endif
 else
@@ -952,11 +965,11 @@ src/flint.h: src/flint.h.in config.status
 libtool: config.status
 	./config.status $@
 
-src/gmpcompat.h: src/@GMPCOMPAT_H_IN@ config.status
-	./config.status $@
+# The following are only linked during configuration
 
-# The following two are only linked during configuration
-
+# src/gmpcompat.h: src/@GMPCOMPAT_H_IN@ config.status
+# 	./config.status $@
+# 
 # src/fmpz/fmpz.c: @FMPZ_C_IN@ config.status
 # 	./config.status $@
 #

--- a/configure.ac
+++ b/configure.ac
@@ -877,7 +877,7 @@ FLINT_CHECK_GMP_H(6,2,1)
 FLINT_GMP_LONG_LONG_LIMB([gmpcompat_h_in="gmpcompat-longlong.h.in"],
                          [gmpcompat_h_in="gmpcompat.h.in"])
 
-AC_CONFIG_FILES([src/gmpcompat.h:src/$gmpcompat_h_in],[],[gmpcompat_h_in="$gmpcompat_h_in"])
+AC_CONFIG_LINKS([src/gmpcompat.h:src/$gmpcompat_h_in],[],[gmpcompat_h_in="$gmpcompat_h_in"])
 AC_SUBST(GMPCOMPAT_H_IN, $gmpcompat_h_in)
 
 ################################################################################


### PR DESCRIPTION
Also link gmpcompat.h instead of making a hard copy

Solves #1752

Note that it currently does not work in parallel.

Example: `make check MOD=fmpz ARGS="fmpz_mul fmpz_sub"`