### PR TITLE
fix missing single header in Makefile

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -254,7 +254,8 @@ SINGLE_HEADERS :=                                                           \
         profiler.h      templates.h                                         \
                                                                             \
         longlong.h                        longlong_asm_clang.h              \
-        longlong_asm_gcc.h                longlong_div_gnu.h                \
+        longlong_asm_gcc.h                longlong_asm_gnu.h                \
+        longlong_div_gnu.h                                                  \
         longlong_msc_arm64.h              longlong_msc_x86.h                \
                                                                             \
         gmpcompat.h                                                         \


### PR DESCRIPTION
The recent file longlong_asm_gnu was not copied upon make install.