### PR TITLE
Enable make tune for non-ADX cpus

### DIFF
--- a/src/mpn_extras/tune/tune-mulhigh.c
+++ b/src/mpn_extras/tune/tune-mulhigh.c
@@ -12,6 +12,9 @@
 #include "profiler.h"
 #include "mpn_extras.h"
 
+/* FIXME: Remove this preprocessor conditional */
+#if FLINT_HAVE_ASSEMBLY_x86_64_adx
+
 #undef TIMEIT_END_REPEAT
 #define TIMEIT_END_REPEAT(__timer, __reps) \
             } \
@@ -160,3 +163,6 @@ main()
     flint_free(Y);
     flint_free(Z);
 }
+#else
+int main(void) { return 0; }
+#endif

--- a/src/mpn_extras/tune/tune-sqrhigh.c
+++ b/src/mpn_extras/tune/tune-sqrhigh.c
@@ -12,6 +12,9 @@
 #include "profiler.h"
 #include "mpn_extras.h"
 
+/* FIXME: Remove this preprocessor conditional */
+#if FLINT_HAVE_ASSEMBLY_x86_64_adx
+
 #undef TIMEIT_END_REPEAT
 #define TIMEIT_END_REPEAT(__timer, __reps) \
             } \
@@ -163,3 +166,6 @@ main()
     flint_free(X);
     flint_free(Z);
 }
+#else
+int main(void) { return 0; }
+#endif


### PR DESCRIPTION
Just a temporary fix until we have a mulhigh for all CPUs.

As pointed out in #1829 