### PR TITLE
Set parallel level on MSVC runner

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -406,13 +406,14 @@ jobs:
       - name: "Build"
         run: |
           cd build
-          cmake --build . --parallel
+          # NOTE: Number of threads for Github's CI runners are 4.
+          cmake --build . -j5
 
       - name: "Check"
         run: |
           cd build
           set "FLINT_TEST_MULTIPLIER=1"
-          ctest --parallel --output-on-failure --timeout 450
+          ctest -j5 --output-on-failure --timeout 450
 
 
 


### PR DESCRIPTION
Specify parallel level as it is faster, and now increase from the previous number of 3 to 5 as [Github's CI runners provide 4 threads](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)