### PR TITLE
gr_series division improvements

### DIFF
--- a/src/gr/test/main.c
+++ b/src/gr/test/main.c
@@ -52,6 +52,7 @@
 #include "t-polynomial_nmod8.c"
 #include "t-psl2z.c"
 #include "t-qqbar.c"
+#include "t-series.c"
 #include "t-series_acb.c"
 #include "t-series_arb.c"
 #include "t-series_fmpq.c"
@@ -102,6 +103,7 @@ test_struct tests[] =
     TEST_FUNCTION(gr_polynomial_nmod8),
     TEST_FUNCTION(gr_psl2z),
     TEST_FUNCTION(gr_qqbar),
+    TEST_FUNCTION(gr_series),
     TEST_FUNCTION(gr_series_acb),
     TEST_FUNCTION(gr_series_arb),
     TEST_FUNCTION(gr_series_fmpq),

--- a/src/gr/test/t-series.c
+++ b/src/gr/test/t-series.c
@@ -1,0 +1,37 @@
+/*
+    Copyright (C) 2024 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "gr.h"
+
+TEST_FUNCTION_START(gr_series, state)
+{
+    gr_ctx_t R, Rx;
+    int flags = 0;
+    slong i;
+    slong iter;
+
+    for (iter = 0; iter < 10 * flint_test_multiplier(); iter++)
+    {
+        for (i = 0; i < 4; i++)
+        {
+            gr_ctx_init_random(R, state);
+            gr_ctx_init_gr_series(Rx, R, i);
+            /* hack: avoid collisions with parent ring generators */
+            GR_MUST_SUCCEED(gr_ctx_set_gen_name(Rx, "u"));
+            gr_test_ring(Rx, 10, flags);
+            gr_ctx_clear(Rx);
+            gr_ctx_clear(R);
+        }
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/gr/test_ring.c
+++ b/src/gr/test_ring.c
@@ -124,6 +124,8 @@ gr_test_set_ui(gr_ctx_t R, flint_rand_t state, int test_flags)
     if ((test_flags & GR_TEST_VERBOSE) || status == GR_TEST_FAIL)
     {
         flint_printf("\n");
+        flint_printf("set_ui\n");
+        gr_ctx_println(R);
         flint_printf("a = %wu\n", a);
         flint_printf("b = %wu\n", b);
         flint_printf("c = %wu\n", c);
@@ -180,6 +182,8 @@ gr_test_set_si(gr_ctx_t R, flint_rand_t state, int test_flags)
     if ((test_flags & GR_TEST_VERBOSE) || status == GR_TEST_FAIL)
     {
         flint_printf("\n");
+        flint_printf("set_si\n");
+        gr_ctx_println(R);
         flint_printf("a = %wd\n", a);
         flint_printf("b = %wd\n", b);
         flint_printf("c = %wd\n", c);
@@ -238,6 +242,8 @@ gr_test_set_fmpz(gr_ctx_t R, flint_rand_t state, int test_flags)
     if ((test_flags & GR_TEST_VERBOSE) || status == GR_TEST_FAIL)
     {
         flint_printf("\n");
+        flint_printf("set_fmpz\n");
+        gr_ctx_println(R);
         flint_printf("a = "); fmpz_print(a); flint_printf("\n");
         flint_printf("b = "); fmpz_print(b); flint_printf("\n");
         flint_printf("c = "); fmpz_print(c); flint_printf("\n");
@@ -300,6 +306,7 @@ gr_test_set_fmpq(gr_ctx_t R, flint_rand_t state, int test_flags)
     if ((test_flags & GR_TEST_VERBOSE) || status == GR_TEST_FAIL)
     {
         flint_printf("\n");
+        flint_printf("set_fmpq\n");
         gr_ctx_println(R);
         flint_printf("a = "); fmpq_print(a); flint_printf("\n");
         flint_printf("b = "); fmpq_print(b); flint_printf("\n");

--- a/src/gr_poly/sqrt_series.c
+++ b/src/gr_poly/sqrt_series.c
@@ -20,7 +20,7 @@ _gr_poly_sqrt_series_generic(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_
 
     status = _gr_poly_sqrt_series_newton(res, f, flen, len, 2, ctx);
 
-    if (status != GR_SUCCESS && gr_ctx_is_field(ctx) == T_FALSE)
+    if (status == GR_DOMAIN && gr_ctx_is_field(ctx) != T_TRUE)
         return GR_UNABLE;
 
     return status;

--- a/src/python/flint_ctypes.py
+++ b/src/python/flint_ctypes.py
@@ -496,6 +496,23 @@ class gr_ctx:
         """
         return self._ctx_predicate(libflint.gr_ctx_is_commutative_ring, "is_commutative_ring")
 
+    def is_zero_ring(self):
+        """
+        Return whether this structure is the zero ring.
+
+            >>> ZZ.is_zero_ring()
+            False
+            >>> ZZmod(1).is_zero_ring()
+            True
+            >>> Mat(ZZ, 0).is_zero_ring()
+            True
+            >>> PowerSeriesModRing(ZZ, 0).is_zero_ring()
+            True
+            >>> Vec(ZZ, 0).is_zero_ring()
+            True
+        """
+        return self._ctx_predicate(libflint.gr_ctx_is_zero_ring, "is_zero_ring")
+
     def _set_gen_name(self, s):
         status = libflint.gr_ctx_set_gen_name(self._ref, ctypes.c_char_p(str(s).encode('ascii')))
         self._str = None

--- a/src/python/flint_ctypes.py
+++ b/src/python/flint_ctypes.py
@@ -7814,6 +7814,123 @@ def test_ca_notebook_examples():
     with optimistic_logic:
         RRx(str(RRx("1+2*x")/3)) == RRx([1,2])/3
 
+def test_gr_series():
+
+    x = QQser.gen()
+    # default prec is 6
+    O6 = x**6
+    On = lambda n: QQser(PowerSeriesRing(QQ, n, "x").gen() ** n)
+    O0 = On(0)
+    O1 = On(1)
+    O2 = On(2)
+    O3 = On(3)
+    O4 = On(4)
+    O5 = On(5)
+
+    assert x / x == 1
+    assert (2 * x) / (3 * x) == QQ(2) / 3
+    assert (2 + 2*x) / (1 + x) == 2
+    assert str(x / (x.exp() - 1)) == "1 + (-1/2)*x + (1/12)*x^2 + (-1/720)*x^4 + O(x^5)"
+
+    assert str(x**6 / 1) == "0 + O(x^6)"
+    assert str(x**6 / x) == "0 + O(x^5)"
+    assert str(x**6 / x**5) == "0 + O(x^1)"
+    assert str(x**6 / x**5) == "0 + O(x^1)"
+
+    assert str(1 / (1 + x)) == "1 - x + x^2 - x^3 + x^4 - x^5 + O(x^6)"
+    assert str(1 / (1 + x + O5)) == "1 - x + x^2 - x^3 + x^4 + O(x^5)"
+    assert str((1 + O5) / (1 + x)) == "1 - x + x^2 - x^3 + x^4 + O(x^5)"
+    assert str((1 + O5) / (1 + x + O4)) == "1 - x + x^2 - x^3 + O(x^4)"
+    assert str((1 + O4) / (1 + x + O5)) == "1 - x + x^2 - x^3 + O(x^4)"
+    assert str(x / (x + x**2)) == "1 - x + x^2 - x^3 + x^4 - x^5 + O(x^6)"
+    assert str(x / (x + x**2 + O5)) == "1 - x + x^2 - x^3 + O(x^4)"
+    assert str((x + O5) / (x + x**2)) == "1 - x + x^2 - x^3 + O(x^4)"
+    assert str((x + O5) / (x + x**2 + O4)) == "1 - x + x^2 + O(x^3)"
+    assert str((x + O4) / (x + x**2 + O5)) == "1 - x + x^2 + O(x^3)"
+
+    assert str(O5 / 1) == "0 + O(x^5)"
+    assert str(O5 / x) == "0 + O(x^4)"
+    assert str(O5 / x**4) == "0 + O(x^1)"
+    assert str(O5 / x**5) == "0 + O(x^0)"
+    assert raises(lambda: O5 / x**6, FlintUnableError)
+
+    assert raises(lambda: (0 * x) / 0, FlintDomainError)
+    assert raises(lambda: x / 0, FlintDomainError)
+
+    assert raises(lambda: O0 / 0, FlintDomainError)
+    assert raises(lambda: O1 / 0, FlintDomainError)
+
+    assert raises(lambda: 0 / O0, FlintUnableError)
+    assert raises(lambda: 0 / O0, FlintUnableError)
+    assert raises(lambda: 0 / O1, FlintUnableError)
+    assert raises(lambda: 0 / O2, FlintUnableError)
+
+    assert raises(lambda: O0 / O0, FlintUnableError)
+    assert raises(lambda: O1 / O0, FlintUnableError)
+    assert raises(lambda: O0 / O1, FlintUnableError)
+
+    assert raises(lambda: 1 / O0, FlintUnableError)
+    assert raises(lambda: 1 / O1, FlintDomainError)
+    assert raises(lambda: 1 / O2, FlintDomainError)
+
+    assert raises(lambda: x / O0, FlintUnableError)
+    assert raises(lambda: x / O1, FlintUnableError)
+    assert raises(lambda: x / O2, FlintDomainError)
+
+    assert raises(lambda: x**2 / O0, FlintUnableError)
+    assert raises(lambda: x**2 / O1, FlintUnableError)
+    assert raises(lambda: x**2 / O2, FlintUnableError)
+    assert raises(lambda: (x**0) / 0, FlintDomainError)
+
+    assert raises(lambda: x**3 / O2, FlintUnableError)
+    assert raises(lambda: x**3 / O3, FlintUnableError)
+
+    R = RRser
+    x = R.gen()
+    a = R(RR("0 +/- 1e-10"))
+    On = lambda n: QQser(PowerSeriesRing(QQ, n, "x").gen() ** n)
+    O6 = x**6
+    O0 = On(0)
+    O1 = On(1)
+    O2 = On(2)
+    O3 = On(3)
+    O4 = On(4)
+    O5 = On(5)
+
+    assert raises(lambda: a == 0, Undecidable)
+    assert raises(lambda: a * x == 0, Undecidable)
+    assert not (a + x == 0)
+    assert (a + x != 0)
+
+    assert raises(lambda: 1 / a, FlintUnableError)
+    assert raises(lambda: 1 / (a * x), FlintDomainError)
+    assert raises(lambda: (a * x) / (a * x**2), FlintUnableError)
+    assert raises(lambda: (a * x + x**3) / (a * x**2), FlintUnableError)
+    assert raises(lambda: (x**3) / (a * x**4), FlintDomainError)
+    assert raises(lambda: (a * x + x**3) / (a * x**2), FlintUnableError)
+
+    R = PowerSeriesModRing(QQ, 6)
+    x = R.gen()
+
+    assert x**6 == 0
+    assert x**5 != 0
+    assert x / x == 1
+    assert str(1 / (1 + x)) == "1 - x + x^2 - x^3 + x^4 - x^5 (mod x^6)"
+    assert str(x / (x + x**2)) == "1 - x + x^2 - x^3 + x^4 - x^5 (mod x^6)"
+
+    # note: nonunique quotient, currently permitted
+    assert str(x / (x.exp() - 1)) == "1 + (-1/2)*x + (1/12)*x^2 + (-1/720)*x^4 + (1/720)*x^5 (mod x^6)"
+
+    assert raises(lambda: x / 0, FlintDomainError)
+
+    x = PowerSeriesRing(ZZmod(1)).gen()
+    assert x + x == 0
+    assert x - x == 0
+    assert x * x == 0
+    assert x / x == 0
+
+
+
 if __name__ == "__main__":
     from time import time
     print("Testing flint_ctypes")


### PR DESCRIPTION
When dividing two exact power series and the quotient happens to be an exact polynomial, one now gets an exact result:

```
>>> x = QQser.gen()
>>> (1 - x**2) / (x - 1)              # previously had + O(x^6)
-1 - x
>>> (1 - x**2) / (x - 1 + x**2)
-1 - x - x^2 - 2*x^3 - 3*x^4 - 5*x^5 + O(x^6)
```

Division now allows leading zeros:

```
>>> x / x
1
>>> x**5 + x**6
x^5 + O(x^6)
>>> (x**5 + x**6) / x**2
x^3 + O(x^4)
>>> x / (x.exp() - 1)
1 + (-1/2)*x + (1/12)*x^2 + (-1/720)*x^4 + O(x^5)
```

Also adds more tests for ``gr_series`` and fixes a bug in ``gr_poly_sqrt_series``.