### PR TITLE
Add human-readable text to documentation of `ordering_t`

### DIFF
--- a/doc/source/mpoly.rst
+++ b/doc/source/mpoly.rst
@@ -20,8 +20,19 @@ Orderings
 --------------------------------------------------------------------------------
 .. type:: ordering_t
 
-     An enumeration of supported term orderings.  Currently one of ``ORD_LEX``, 
-     ``ORD_DEGLEX`` or ``ORD_DEGREVLEX``.
+    Represents one of the following supported term orderings:
+
+    .. macro:: ORD_LEX
+
+        The lexicographic ordering.
+
+    .. macro:: ORD_DEGLEX
+
+        The degree lexicographic ordering.
+
+    .. macro:: ORD_DEGREVLEX
+
+        The degree reverse lexicographic ordering.
 
 .. type:: mpoly_ctx_struct
           mpoly_ctx_t
@@ -39,8 +50,7 @@ Orderings
 
 .. function:: ordering_t mpoly_ordering_randtest(flint_rand_t state)
 
-    Return a random ordering. The possibilities are ``ORD_LEX``,
-    ``ORD_DEGLEX`` and ``ORD_DEGREVLEX``.
+    Return a random term ordering.
 
 .. function:: void mpoly_ctx_init_rand(mpoly_ctx_t mctx, flint_rand_t state, slong max_nvars)
 


### PR DESCRIPTION
Still very minimal, but contains human words.

- Does not completely address https://github.com/flintlib/flint/issues/1551, as there is nothing about what the setting implies for performance.