### PR TITLE
Use mulhigh in mpn_*_preinvn methods

### DIFF
--- a/src/generic_files/test_helpers.c
+++ b/src/generic_files/test_helpers.c
@@ -28,7 +28,7 @@ double flint_test_multiplier(void)
         {
             _flint_test_multiplier = strtod(s, NULL);
 
-            if (!(_flint_test_multiplier >= 0.0 && _flint_test_multiplier <= 1000.0))
+            if (!(_flint_test_multiplier >= 0.0 && _flint_test_multiplier <= 100000.0))
                 _flint_test_multiplier = 1.0;
         }
     }

--- a/src/mpn_extras.h
+++ b/src/mpn_extras.h
@@ -390,6 +390,22 @@ mp_limb_t flint_mpn_mulhigh_n(mp_ptr rp, mp_srcptr xp, mp_srcptr yp, mp_size_t n
         return _flint_mpn_mulhigh_n(rp, xp, yp, n);
 }
 
+/* We just want the high n limbs, but rp has low limbs available
+   which can be used for scratch space or for doing a full multiply
+   without temporary allocations. */
+MPN_EXTRAS_INLINE
+void flint_mpn_mul_or_mulhigh_n(mp_ptr rp, mp_srcptr xp, mp_srcptr yp, mp_size_t n)
+{
+    FLINT_ASSERT(n >= 1);
+
+    if (FLINT_HAVE_MULHIGH_FUNC(n))
+        rp[n - 1] = flint_mpn_mulhigh_func_tab[n](rp + n, xp, yp);
+    else if (n < FLINT_MPN_MULHIGH_MUL_CUTOFF)
+        rp[n - 1] = _flint_mpn_mulhigh_n(rp + n, xp, yp, n);
+    else
+        flint_mpn_mul_n(rp, xp, yp, n);
+}
+
 #define FLINT_MPN_SQRHIGH_MULDERS_CUTOFF 90
 #define FLINT_MPN_SQRHIGH_SQR_CUTOFF 2000
 #define FLINT_MPN_SQRHIGH_K_TAB_SIZE 2048

--- a/src/mpn_extras/divrem_preinvn.c
+++ b/src/mpn_extras/divrem_preinvn.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2013 William Hart
+    Copyright (C) 2024 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -13,7 +14,10 @@
 #include "mpn_extras.h"
 
 /*
-   TODO: speedup mpir's mullow and mulhigh and use instead of mul/mul_n
+TODO:
+ * fixed-length code for small n
+ * use unbalanced mulhigh in the second loop
+ * use mullow
 */
 
 mp_limb_t flint_mpn_divrem_preinvn(mp_ptr qp, mp_ptr rp, mp_srcptr ap, mp_size_t m,
@@ -43,7 +47,7 @@ mp_limb_t flint_mpn_divrem_preinvn(mp_ptr qp, mp_ptr rp, mp_srcptr ap, mp_size_t
    /* 2n by n division */
    while (m >= 2*n)
    {
-      flint_mpn_mul_n(t, dinv, r + n, n);
+      flint_mpn_mul_or_mulhigh_n(t, dinv, r + n, n);
       cy = mpn_add_n(q, t + n, r + n, n);
 
       flint_mpn_mul_n(t, d, q, n);

--- a/src/mpn_extras/mod_preinvn.c
+++ b/src/mpn_extras/mod_preinvn.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2013 William Hart
+    Copyright (C) 2024 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -13,7 +14,10 @@
 #include "mpn_extras.h"
 
 /*
-   TODO: speedup mpir's mullow and mulhigh and use instead of mul/mul_n
+TODO:
+ * fixed-length code for small n
+ * use unbalanced mulhigh in the second loop
+ * use mullow
 */
 
 void flint_mpn_mod_preinvn(mp_ptr rp, mp_srcptr ap, mp_size_t m,
@@ -39,7 +43,7 @@ void flint_mpn_mod_preinvn(mp_ptr rp, mp_srcptr ap, mp_size_t m,
    /* 2n by n division */
    while (m >= 2*n)
    {
-      flint_mpn_mul_n(t, dinv, r + n, n);
+      flint_mpn_mul_or_mulhigh_n(t, dinv, r + n, n);
       cy = mpn_add_n(t + 2*n, t + n, r + n, n);
 
       flint_mpn_mul_n(t, d, t + 2*n, n);

--- a/src/mpn_extras/test/t-mod_preinvn.c
+++ b/src/mpn_extras/test/t-mod_preinvn.c
@@ -29,14 +29,16 @@ TEST_FUNCTION_START(flint_mpn_mod_preinvn, state)
     gmp_randinit_default(st);
 
     /* test flint_mpn_mod_preinvn */
-    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
+    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
-        size = n_randint(state, 200) + 1;
-        size2 = n_randint(state, 200) + size;
+        int alias = n_randint(state, 2);
 
-        mpz_rrandomb(a, st, size2*FLINT_BITS);
+        size = n_randint(state, 20) + 1;
+        size2 = n_randint(state, 20) + size;
+
+        mpz_rrandomb(a, st, size2 * FLINT_BITS);
         do {
-            mpz_rrandomb(d, st, size*FLINT_BITS);
+            mpz_rrandomb(d, st, size * FLINT_BITS);
         } while (mpz_sgn(d) == 0);
 
         /* normalise */
@@ -55,13 +57,24 @@ TEST_FUNCTION_START(flint_mpn_mod_preinvn, state)
         dinv = flint_malloc(size*sizeof(mp_limb_t));
         flint_mpn_preinvn(dinv, d->_mp_d, size);
 
-        flint_mpn_mod_preinvn(r2->_mp_d, a->_mp_d, size2, d->_mp_d, size, dinv);
+        if (alias)
+        {
+            flint_mpn_mod_preinvn(a->_mp_d, a->_mp_d, size2, d->_mp_d, size, dinv);
 
-        /* normalise */
-        while (size && r2->_mp_d[size - 1] == 0) size--;
-        r2->_mp_size = size;
+            /* normalise */
+            while (size && a->_mp_d[size - 1] == 0) size--;
+            a->_mp_size = size;
+        }
+        else
+        {
+            flint_mpn_mod_preinvn(r2->_mp_d, a->_mp_d, size2, d->_mp_d, size, dinv);
 
-        result = (mpz_cmp(r1, r2) == 0);
+            /* normalise */
+            while (size && r2->_mp_d[size - 1] == 0) size--;
+            r2->_mp_size = size;
+        }
+
+        result = (mpz_cmp(r1, alias ? a : r2) == 0);
         if (!result)
             TEST_FUNCTION_FAIL(
                     "%{mpz}\n"
@@ -73,48 +86,6 @@ TEST_FUNCTION_START(flint_mpn_mod_preinvn, state)
 
         flint_free(dinv);
         flint_free(r2->_mp_d);
-    }
-
-    /* test flint_mpn_mod_preinvn alias r and a */
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
-    {
-        size = n_randint(state, 200) + 1;
-        size2 = n_randint(state, 200) + size;
-
-        mpz_rrandomb(a, st, size2*FLINT_BITS);
-        do {
-            mpz_rrandomb(d, st, size*FLINT_BITS);
-        } while (mpz_sgn(d) == 0);
-
-        /* normalise */
-        norm = flint_clz(d->_mp_d[d->_mp_size - 1]);
-        mpz_mul_2exp(d, d, norm);
-        mpz_mul_2exp(a, a, norm);
-        size2 = a->_mp_size;
-
-        /* reduce a mod d */
-        mpz_fdiv_r(r1, a, d);
-
-        dinv = flint_malloc(size*sizeof(mp_limb_t));
-        flint_mpn_preinvn(dinv, d->_mp_d, size);
-
-        flint_mpn_mod_preinvn(a->_mp_d, a->_mp_d, size2, d->_mp_d, size, dinv);
-
-        /* normalise */
-        while (size && a->_mp_d[size - 1] == 0) size--;
-        a->_mp_size = size;
-
-        result = (mpz_cmp(r1, a) == 0);
-        if (!result)
-            TEST_FUNCTION_FAIL(
-                    "%{mpz}\n"
-                    "%{mpz}\n"
-                    "%{mpz}\n"
-                    "size = %wd\n"
-                    "size2 = %wd\n",
-                    a, d, r1, size, size2);
-
-        flint_free(dinv);
     }
 
     mpz_clear(a);

--- a/src/mpn_extras/test/t-mulmod_preinvn.c
+++ b/src/mpn_extras/test/t-mulmod_preinvn.c
@@ -29,14 +29,14 @@ TEST_FUNCTION_START(flint_mpn_mulmod_preinvn, state)
 
     gmp_randinit_default(st);
 
-    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
+    for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
-        size = n_randint(state, 200) + 1;
+        size = n_randint(state, 20) + 1;
 
-        mpz_rrandomb(a, st, size);
-        mpz_rrandomb(b, st, size);
+        mpz_rrandomb(a, st, size * FLINT_BITS);
+        mpz_rrandomb(b, st, size * FLINT_BITS);
         do {
-            mpz_rrandomb(d, st, size);
+            mpz_rrandomb(d, st, size * FLINT_BITS);
         } while (mpz_sgn(d) == 0);
 
         size_d = d->_mp_size;


### PR DESCRIPTION
Speeds up ``flint_mpn_mulmod_preinvn``, ``flint_mpn_mod_preinvn``, ``flint_mpn_divrem_preinvn``. More speedups are possible by using mullow as well and inlining more small-n cases.

Speedup for ``flint_mpn_mulmod_preinvn``:

```
(A) vs flint_mpn_mul_n + mpn_tdiv_qr
(B) vs old code

    vs

1    0.715   1.172
2    2.956   1.432
3    1.541   1.000
4    1.463   1.037
8    1.540   1.092
16    1.225   1.075
32    1.121   1.115
64    1.122   1.075
128    1.106   1.070
256    1.100   1.089
512    1.188   1.016
1024    1.587   1.000
```

Speedup for ``flint_mpn_mod_preinvn``:

```
(A) vs mpn_tdiv_qr
(B) vs old code

      (A)     (B)
1    0.503   0.867
2    0.945   0.885
4    1.947   1.013
8    1.879   1.123
16    1.303   1.114
32    1.199   1.163
64    1.184   1.123
128    1.200   1.116
256    1.120   1.098
512    1.248   1.016
1024    1.873   1.012
2048    2.405   1.000
```