### PR TITLE
Refactor gr power series

### DIFF
--- a/doc/source/gr_domains.rst
+++ b/doc/source/gr_domains.rst
@@ -293,6 +293,25 @@ Polynomial rings
     with monomial ordering *ord*.
     Elements have type :type:`gr_mpoly_struct`.
 
+Power series
+-------------------------------------------------------------------------------
+
+.. function:: void gr_ctx_init_series_mod_gr_poly(gr_ctx_t ctx, gr_ctx_t base_ring, slong n)
+
+    Initializes *ctx* to a ring of truncated power series `R[[x]] / \langle x^n \rangle`
+    over the given *base_ring*.
+    Elements have type :type:`gr_poly_struct`.
+    It is assumed that all inputs are already truncated to length *n*,
+    and this invariant is enforced for all outputs.
+
+.. function:: void gr_ctx_init_gr_series(gr_ctx_t ctx, gr_ctx_t base_ring, slong prec)
+
+    Initializes *ctx* to a ring of power series `R[[x]]` over the given *base_ring*.
+    Elements are generally inexact, having an error term `O(x^n)`.
+    The parameter *prec* defines the default precision.
+    Elements have type ``gr_series_struct`` (this type is currently internal).
+
+
 Fraction fields
 -------------------------------------------------------------------------------
 

--- a/src/gr.h
+++ b/src/gr.h
@@ -728,7 +728,7 @@ typedef enum
     GR_CTX_FMPZ_POLY, GR_CTX_FMPQ_POLY, GR_CTX_GR_POLY,
     GR_CTX_FMPZ_MPOLY, GR_CTX_GR_MPOLY,
     GR_CTX_FMPZ_MPOLY_Q,
-    GR_CTX_GR_SERIES, GR_CTX_GR_SERIES_MOD,
+    GR_CTX_GR_SERIES, GR_CTX_GR_SERIES_MOD, GR_CTX_SERIES_MOD_GR_POLY,
     GR_CTX_GR_MAT,
     GR_CTX_GR_VEC,
     GR_CTX_PSL2Z, GR_CTX_DIRICHLET_GROUP, GR_CTX_PERM,
@@ -1437,9 +1437,44 @@ void gr_ctx_init_fmpz_mpoly_q(gr_ctx_t ctx, slong nvars, const ordering_t ord);
 #endif
 
 /* Generic series */
+/* TODO: move parts of this to its own module */
+
+typedef struct
+{
+    gr_ctx_struct * base_ring;
+    slong n;
+    char * var;
+}
+series_mod_ctx_t;
+
+typedef struct
+{
+    slong mod;      /* exact truncation */
+    slong prec;     /* default approximate truncation */
+}
+gr_series_ctx_struct;
+
+typedef gr_series_ctx_struct gr_series_ctx_t[1];
+
+typedef struct
+{
+    gr_ctx_struct * base_ring;
+    gr_series_ctx_struct sctx;
+    char * var;
+}
+series_ctx_t;
+
+#define SERIES_CTX(ring_ctx) ((series_ctx_t *)((ring_ctx)))
+#define SERIES_ELEM_CTX(ring_ctx) (SERIES_CTX(ring_ctx)->base_ring)
+#define SERIES_SCTX(ring_ctx) (&(((series_ctx_t *)((ring_ctx)))->sctx))
+
+#define SERIES_MOD_CTX(ring_ctx) ((series_mod_ctx_t *)((ring_ctx)))
+#define SERIES_MOD_ELEM_CTX(ring_ctx) (SERIES_MOD_CTX(ring_ctx)->base_ring)
+#define SERIES_MOD_N(ring_ctx) (SERIES_MOD_CTX(ring_ctx)->n)
 
 void gr_ctx_init_gr_series(gr_ctx_t ctx, gr_ctx_t base_ring, slong prec);
 void gr_ctx_init_gr_series_mod(gr_ctx_t ctx, gr_ctx_t base_ring, slong mod);
+void gr_ctx_init_series_mod_gr_poly(gr_ctx_t ctx, gr_ctx_t base_ring, slong n);
 
 /* Generic vectors */
 

--- a/src/gr.h
+++ b/src/gr.h
@@ -728,7 +728,7 @@ typedef enum
     GR_CTX_FMPZ_POLY, GR_CTX_FMPQ_POLY, GR_CTX_GR_POLY,
     GR_CTX_FMPZ_MPOLY, GR_CTX_GR_MPOLY,
     GR_CTX_FMPZ_MPOLY_Q,
-    GR_CTX_GR_SERIES, GR_CTX_GR_SERIES_MOD, GR_CTX_SERIES_MOD_GR_POLY,
+    GR_CTX_GR_SERIES, GR_CTX_SERIES_MOD_GR_POLY,
     GR_CTX_GR_MAT,
     GR_CTX_GR_VEC,
     GR_CTX_PSL2Z, GR_CTX_DIRICHLET_GROUP, GR_CTX_PERM,
@@ -1449,7 +1449,6 @@ series_mod_ctx_t;
 
 typedef struct
 {
-    slong mod;      /* exact truncation */
     slong prec;     /* default approximate truncation */
 }
 gr_series_ctx_struct;
@@ -1473,7 +1472,6 @@ series_ctx_t;
 #define SERIES_MOD_N(ring_ctx) (SERIES_MOD_CTX(ring_ctx)->n)
 
 void gr_ctx_init_gr_series(gr_ctx_t ctx, gr_ctx_t base_ring, slong prec);
-void gr_ctx_init_gr_series_mod(gr_ctx_t ctx, gr_ctx_t base_ring, slong mod);
 void gr_ctx_init_series_mod_gr_poly(gr_ctx_t ctx, gr_ctx_t base_ring, slong n);
 
 /* Generic vectors */

--- a/src/gr/series.c
+++ b/src/gr/series.c
@@ -21,6 +21,20 @@
 # include <string.h>
 #endif
 
+#define SERIES_ERR_EXACT WORD_MAX
+#define SERIES_ERR_MAX WORD_MAX / 4
+
+typedef struct
+{
+    gr_poly_struct poly;
+    slong error;
+}
+gr_series_struct;
+
+typedef gr_series_struct gr_series_t[1];
+
+
+
 /* arb wrappers todo: elementary functions; pfq, coulomb, zeta/dirichlet deflated */
 
 static const char * default_var = "x";
@@ -66,28 +80,6 @@ gr_poly_sub_series(gr_poly_t res, const gr_poly_t poly1,
     _gr_poly_normalise(res, ctx);
     return status;
 }
-
-#define SERIES_ERR_EXACT WORD_MAX
-#define SERIES_ERR_MAX WORD_MAX / 4
-
-typedef struct
-{
-    gr_poly_struct poly;
-    slong error;
-}
-gr_series_struct;
-
-typedef gr_series_struct gr_series_t[1];
-
-typedef struct
-{
-    slong mod;      /* exact truncation */
-    slong prec;     /* default approximate truncation */
-}
-gr_series_ctx_struct;
-
-typedef gr_series_ctx_struct gr_series_ctx_t[1];
-
 
 void
 gr_series_init(gr_series_t res, gr_series_ctx_t sctx, gr_ctx_t cctx)
@@ -1858,19 +1850,6 @@ gr_series_hypgeom_pfq(gr_series_t res, const gr_series_vec_t a, const gr_series_
     return status;
 }
 
-typedef struct
-{
-    gr_ctx_struct * base_ring;
-    gr_series_ctx_struct sctx;
-    char * var;
-}
-series_ctx_t;
-
-#define SERIES_CTX(ring_ctx) ((series_ctx_t *)((ring_ctx)))
-#define SERIES_ELEM_CTX(ring_ctx) (SERIES_CTX(ring_ctx)->base_ring)
-#define SERIES_SCTX(ring_ctx) (&(((series_ctx_t *)((ring_ctx)))->sctx))
-
-
 static void _gr_gr_series_ctx_clear(gr_ctx_t ctx)
 {
     if (SERIES_CTX(ctx)->var != default_var)
@@ -2118,7 +2097,6 @@ gr_method_tab_input _gr_series_methods_input[] =
     {GR_METHOD_CTX_SET_GEN_NAME, (gr_funcptr) _gr_gr_series_ctx_set_gen_name},
     {GR_METHOD_CTX_IS_RING, (gr_funcptr) _gr_gr_series_ctx_is_ring},
     {GR_METHOD_CTX_IS_COMMUTATIVE_RING, (gr_funcptr) _gr_gr_series_ctx_is_commutative_ring},
-
     {GR_METHOD_INIT,        (gr_funcptr) _gr_gr_series_init},
     {GR_METHOD_CLEAR,       (gr_funcptr) _gr_gr_series_clear},
     {GR_METHOD_SWAP,        (gr_funcptr) _gr_gr_series_swap},

--- a/src/gr/series.c
+++ b/src/gr/series.c
@@ -140,27 +140,13 @@ gr_series_write(gr_stream_t out, const gr_series_t x, const char * var, gr_serie
         gr_stream_write(out, ")");
     }
 
-    if (sctx->mod != SERIES_ERR_EXACT)
-    {
-        gr_stream_write(out, " (mod ");
-        gr_stream_write(out, var);
-        gr_stream_write(out, "^");
-        gr_stream_write_si(out, sctx->mod);
-        gr_stream_write(out, ")");
-    }
-
     return GR_SUCCESS;
 }
 
 int
 gr_series_one(gr_series_t res, gr_series_ctx_t sctx, gr_ctx_t cctx)
 {
-    if (sctx->mod == 0)
-    {
-        res->error = SERIES_ERR_EXACT;
-        return gr_poly_zero(&res->poly, cctx);
-    }
-    else if (sctx->prec == 0)
+    if (sctx->prec == 0)
     {
         res->error = 0;
         return gr_poly_zero(&res->poly, cctx);
@@ -182,14 +168,11 @@ gr_series_set(gr_series_t res, const gr_series_t x, gr_series_ctx_t sctx, gr_ctx
     res->error = x->error;
     status |= gr_poly_set(&res->poly, &x->poly, cctx);
 
-    trunc = FLINT_MIN(sctx->prec, sctx->mod);
-    trunc = FLINT_MIN(trunc, res->error);
+    trunc = FLINT_MIN(sctx->prec, res->error);
     len = res->poly.length;
 
     if (len > trunc)
     {
-        if (len <= sctx->mod)
-            res->error = SERIES_ERR_EXACT;
         if (len > sctx->prec)
             res->error = FLINT_MIN(res->error, sctx->prec);
 
@@ -223,14 +206,11 @@ gr_series_neg(gr_series_t res, const gr_series_t x, gr_series_ctx_t sctx, gr_ctx
     res->error = x->error;
     status |= gr_poly_neg(&res->poly, &x->poly, cctx);
 
-    trunc = FLINT_MIN(sctx->prec, sctx->mod);
-    trunc = FLINT_MIN(trunc, res->error);
+    trunc = FLINT_MIN(sctx->prec, res->error);
     len = res->poly.length;
 
     if (len > trunc)
     {
-        if (len <= sctx->mod)
-            res->error = SERIES_ERR_EXACT;
         if (len > sctx->prec)
             res->error = FLINT_MIN(res->error, sctx->prec);
 
@@ -397,9 +377,6 @@ gr_series_is_one(const gr_series_t x, gr_series_ctx_t sctx, gr_ctx_t cctx)
     if (x->error <= 0)
         return T_UNKNOWN;
 
-    if (sctx->mod == 0)
-        return T_TRUE;
-
     if (xlen == 0)
         return gr_ctx_is_zero_ring(cctx);
 
@@ -439,7 +416,6 @@ gr_series_equal(const gr_series_t x, const gr_series_t y, gr_series_ctx_t sctx, 
     err = FLINT_MIN(xerr, yerr);
 
     len = FLINT_MAX(xlen, ylen);
-    len = FLINT_MIN(len, sctx->mod);
     len = FLINT_MIN(len, err);
 
     /* compare exactly or within the error bound */
@@ -450,10 +426,6 @@ gr_series_equal(const gr_series_t x, const gr_series_t y, gr_series_ctx_t sctx, 
 
     if (equal == T_FALSE)
         return T_FALSE;
-
-    /* terms >= x^mod are zero by definition */
-    if (err >= sctx->mod && equal == T_TRUE)
-        return T_TRUE;
 
     return T_UNKNOWN;
 }
@@ -477,13 +449,8 @@ gr_series_add(gr_series_t res, const gr_series_t x, const gr_series_t y, gr_seri
     if (len > sctx->prec)
         err = FLINT_MIN(err, sctx->prec);
 
-    len = FLINT_MIN(len, sctx->mod);
     len = FLINT_MIN(len, sctx->prec);
     len = FLINT_MIN(len, err);
-
-    /* terms >= x^mod are zero by definition */
-    if (err >= sctx->mod)
-        err = SERIES_ERR_EXACT;
 
     res->error = err;
     status |= gr_poly_add_series(&res->poly, &x->poly, &y->poly, len, cctx);
@@ -509,13 +476,8 @@ gr_series_sub(gr_series_t res, const gr_series_t x, const gr_series_t y, gr_seri
     if (len > sctx->prec)
         err = FLINT_MIN(err, sctx->prec);
 
-    len = FLINT_MIN(len, sctx->mod);
     len = FLINT_MIN(len, sctx->prec);
     len = FLINT_MIN(len, err);
-
-    /* terms >= x^mod are zero by definition */
-    if (err >= sctx->mod)
-        err = SERIES_ERR_EXACT;
 
     res->error = err;
     status |= gr_poly_sub_series(&res->poly, &x->poly, &y->poly, len, cctx);
@@ -550,13 +512,8 @@ gr_series_mul(gr_series_t res, const gr_series_t x, const gr_series_t y, gr_seri
     if (len > sctx->prec)
         err = FLINT_MIN(err, sctx->prec);
 
-    len = FLINT_MIN(len, sctx->mod);
     len = FLINT_MIN(len, sctx->prec);
     len = FLINT_MIN(len, err);
-
-    /* terms >= x^mod are zero by definition */
-    if (err >= sctx->mod)
-        err = SERIES_ERR_EXACT;
 
     res->error = err;
     status |= gr_poly_mullow(&res->poly, &x->poly, &y->poly, len, cctx);
@@ -573,9 +530,6 @@ gr_series_inv(gr_series_t res, const gr_series_t x, gr_series_ctx_t sctx, gr_ctx
     xerr = x->error;
     err = xerr;
 
-    if (xlen == 0 && sctx->mod == 0)
-        return gr_series_zero(res, sctx, cctx);
-
     if (xlen == 0 && xerr == SERIES_ERR_EXACT)
     {
         truth_t zero = gr_ctx_is_zero_ring(cctx);
@@ -591,13 +545,8 @@ gr_series_inv(gr_series_t res, const gr_series_t x, gr_series_ctx_t sctx, gr_ctx
     if (xlen == 0 || xerr == 0)
         return GR_UNABLE;
 
-    len = FLINT_MIN(sctx->mod, sctx->prec);
-    len = FLINT_MIN(len, err);
+    len = FLINT_MIN(sctx->prec, err);
     err = len;
-
-    /* terms >= x^mod are zero by definition */
-    if (err >= sctx->mod)
-        err = SERIES_ERR_EXACT;
 
     res->error = err;
     status |= gr_poly_inv_series(&res->poly, &x->poly, len, cctx);
@@ -679,9 +628,6 @@ gr_series_div(gr_series_t res, const gr_series_t x, const gr_series_t y, gr_seri
 
     err = FLINT_MIN(xerr, yerr);
     err = FLINT_MIN(err, sctx->prec);
-    /* terms >= t^mod are zero by definition. */
-    if (err >= sctx->mod)
-        err = SERIES_ERR_EXACT;
 
     if (err <= 0)
     {
@@ -690,8 +636,7 @@ gr_series_div(gr_series_t res, const gr_series_t x, const gr_series_t y, gr_seri
         return status;
     }
 
-    len = FLINT_MIN(sctx->mod, sctx->prec);
-    len = FLINT_MIN(len, err);
+    len = FLINT_MIN(sctx->prec, err);
 
     /* If we have an exact polynomial division, see if we have an exact result. */
     /* TODO: Special case for length 1 divisor. */
@@ -804,13 +749,8 @@ gr_series_sqrt(gr_series_t res, const gr_series_t x, gr_series_ctx_t sctx, gr_ct
     if (xlen > 1 && gr_is_zero(x->poly.coeffs, cctx) != T_FALSE)
         return GR_UNABLE;
 
-    len = FLINT_MIN(sctx->mod, sctx->prec);
-    len = FLINT_MIN(len, err);
+    len = FLINT_MIN(sctx->prec, err);
     err = len;
-
-    /* terms >= x^mod are zero by definition */
-    if (err >= sctx->mod)
-        err = SERIES_ERR_EXACT;
 
     res->error = err;
     status |= gr_poly_sqrt_series(&res->poly, &x->poly, len, cctx);
@@ -829,8 +769,7 @@ gr_series_ ## func(gr_series_t res, const gr_series_t x, gr_series_ctx_t sctx, g
     xerr = x->error; \
     err = xerr; \
  \
-    len = FLINT_MIN(sctx->mod, sctx->prec); \
-    len = FLINT_MIN(len, err); \
+    len = FLINT_MIN(sctx->prec, err); \
     err = len; \
  \
     if (xlen <= 1 && xerr == SERIES_ERR_EXACT) \
@@ -838,9 +777,6 @@ gr_series_ ## func(gr_series_t res, const gr_series_t x, gr_series_ctx_t sctx, g
         len = FLINT_MIN(len, 1); \
         err = SERIES_ERR_EXACT; \
     } \
- \
-    if (err >= sctx->mod) \
-        err = SERIES_ERR_EXACT; \
  \
     res->error = err; \
     status |= gr_poly_ ## func ## _series(&res->poly, &x->poly, len, cctx); \
@@ -883,13 +819,9 @@ gr_series_ ## func(gr_series_t res, const gr_series_t x, gr_series_ctx_t sctx, g
     xerr = x->error; \
     err = xerr; \
  \
-    len = FLINT_MIN(sctx->mod, sctx->prec); \
-    len = FLINT_MIN(len, err); \
+    len = FLINT_MIN(sctx->prec, err); \
     err = len; \
  \
-    if (err >= sctx->mod) \
-        err = SERIES_ERR_EXACT; \
-  \
     if (xlen <= 1 && xerr == SERIES_ERR_EXACT) \
     { \
         len = FLINT_MIN(len, 1); \
@@ -943,12 +875,8 @@ gr_series_fresnel(gr_series_t res1, gr_series_t res2, const gr_series_t x, int n
     xerr = x->error;
     err = xerr;
 
-    len = FLINT_MIN(sctx->mod, sctx->prec);
-    len = FLINT_MIN(len, err);
+    len = FLINT_MIN(sctx->prec, err);
     err = len;
-
-    if (err >= sctx->mod)
-        err = SERIES_ERR_EXACT;
 
     if (xlen <= 1 && xerr == SERIES_ERR_EXACT)
     {
@@ -1011,12 +939,8 @@ gr_series_airy(gr_series_t res1, gr_series_t res2, gr_series_t res3, gr_series_t
     xerr = x->error;
     err = xerr;
 
-    len = FLINT_MIN(sctx->mod, sctx->prec);
-    len = FLINT_MIN(len, err);
+    len = FLINT_MIN(sctx->prec, err);
     err = len;
-
-    if (err >= sctx->mod)
-        err = SERIES_ERR_EXACT;
 
     if (xlen <= 1 && xerr == SERIES_ERR_EXACT)
     {
@@ -1106,12 +1030,8 @@ gr_series_log_integral(gr_series_t res, const gr_series_t x, int offset, gr_seri
     xerr = x->error;
     err = xerr;
 
-    len = FLINT_MIN(sctx->mod, sctx->prec);
-    len = FLINT_MIN(len, err);
+    len = FLINT_MIN(sctx->prec, err);
     err = len;
-
-    if (err >= sctx->mod)
-        err = SERIES_ERR_EXACT;
 
     if (xlen <= 1 && xerr == SERIES_ERR_EXACT)
     {
@@ -1153,12 +1073,8 @@ gr_series_gamma_upper(gr_series_t res, const gr_series_t s, const gr_series_t x,
     xerr = x->error;
     err = xerr;
 
-    len = FLINT_MIN(sctx->mod, sctx->prec);
-    len = FLINT_MIN(len, err);
+    len = FLINT_MIN(sctx->prec, err);
     err = len;
-
-    if (err >= sctx->mod)
-        err = SERIES_ERR_EXACT;
 
     if (xlen <= 1 && xerr == SERIES_ERR_EXACT)
     {
@@ -1212,12 +1128,8 @@ gr_series_gamma_lower(gr_series_t res, const gr_series_t s, const gr_series_t x,
     xerr = x->error;
     err = xerr;
 
-    len = FLINT_MIN(sctx->mod, sctx->prec);
-    len = FLINT_MIN(len, err);
+    len = FLINT_MIN(sctx->prec, err);
     err = len;
-
-    if (err >= sctx->mod)
-        err = SERIES_ERR_EXACT;
 
     if (xlen <= 1 && xerr == SERIES_ERR_EXACT)
     {
@@ -1271,12 +1183,8 @@ gr_series_beta_lower(gr_series_t res, const gr_series_t a, const gr_series_t b, 
     xerr = x->error;
     err = xerr;
 
-    len = FLINT_MIN(sctx->mod, sctx->prec);
-    len = FLINT_MIN(len, err);
+    len = FLINT_MIN(sctx->prec, err);
     err = len;
-
-    if (err >= sctx->mod)
-        err = SERIES_ERR_EXACT;
 
     if (xlen <= 1 && xerr == SERIES_ERR_EXACT)
     {
@@ -1338,12 +1246,8 @@ gr_series_polylog(gr_series_t res, const gr_series_t s, const gr_series_t z, gr_
     xerr = s->error;
     err = xerr;
 
-    len = FLINT_MIN(sctx->mod, sctx->prec);
-    len = FLINT_MIN(len, err);
+    len = FLINT_MIN(sctx->prec, err);
     err = len;
-
-    if (err >= sctx->mod)
-        err = SERIES_ERR_EXACT;
 
     if (xlen <= 1 && xerr == SERIES_ERR_EXACT)
     {
@@ -1386,12 +1290,8 @@ gr_series_hurwitz_zeta(gr_series_t res, const gr_series_t s, const gr_series_t z
     xerr = s->error;
     err = xerr;
 
-    len = FLINT_MIN(sctx->mod, sctx->prec);
-    len = FLINT_MIN(len, err);
+    len = FLINT_MIN(sctx->prec, err);
     err = len;
-
-    if (err >= sctx->mod)
-        err = SERIES_ERR_EXACT;
 
     if (xlen <= 1 && xerr == SERIES_ERR_EXACT)
     {
@@ -1434,12 +1334,8 @@ gr_series_dirichlet_l(gr_series_t res, const dirichlet_group_t G, const dirichle
     xerr = x->error;
     err = xerr;
 
-    len = FLINT_MIN(sctx->mod, sctx->prec);
-    len = FLINT_MIN(len, err);
+    len = FLINT_MIN(sctx->prec, err);
     err = len;
-
-    if (err >= sctx->mod)
-        err = SERIES_ERR_EXACT;
 
     if (xlen <= 1 && xerr == SERIES_ERR_EXACT)
     {
@@ -1474,12 +1370,8 @@ gr_series_dirichlet_hardy_theta(gr_series_t res, const dirichlet_group_t G, cons
     xerr = x->error;
     err = xerr;
 
-    len = FLINT_MIN(sctx->mod, sctx->prec);
-    len = FLINT_MIN(len, err);
+    len = FLINT_MIN(sctx->prec, err);
     err = len;
-
-    if (err >= sctx->mod)
-        err = SERIES_ERR_EXACT;
 
     if (xlen <= 1 && xerr == SERIES_ERR_EXACT)
     {
@@ -1514,12 +1406,8 @@ gr_series_dirichlet_hardy_z(gr_series_t res, const dirichlet_group_t G, const di
     xerr = x->error;
     err = xerr;
 
-    len = FLINT_MIN(sctx->mod, sctx->prec);
-    len = FLINT_MIN(len, err);
+    len = FLINT_MIN(sctx->prec, err);
     err = len;
-
-    if (err >= sctx->mod)
-        err = SERIES_ERR_EXACT;
 
     if (xlen <= 1 && xerr == SERIES_ERR_EXACT)
     {
@@ -1554,12 +1442,8 @@ gr_series_jacobi_theta(gr_series_t res1, gr_series_t res2, gr_series_t res3, gr_
     xerr = x->error;
     err = xerr;
 
-    len = FLINT_MIN(sctx->mod, sctx->prec);
-    len = FLINT_MIN(len, err);
+    len = FLINT_MIN(sctx->prec, err);
     err = len;
-
-    if (err >= sctx->mod)
-        err = SERIES_ERR_EXACT;
 
     if (xlen <= 1 && xerr == SERIES_ERR_EXACT)
     {
@@ -1640,12 +1524,8 @@ gr_series_agm1(gr_series_t res, const gr_series_t x, gr_series_ctx_t sctx, gr_ct
     xerr = x->error;
     err = xerr;
 
-    len = FLINT_MIN(sctx->mod, sctx->prec);
-    len = FLINT_MIN(len, err);
+    len = FLINT_MIN(sctx->prec, err);
     err = len;
-
-    if (err >= sctx->mod)
-        err = SERIES_ERR_EXACT;
 
     if (xlen <= 1 && xerr == SERIES_ERR_EXACT)
     {
@@ -1680,12 +1560,8 @@ gr_series_elliptic_k(gr_series_t res, const gr_series_t x, gr_series_ctx_t sctx,
     xerr = x->error;
     err = xerr;
 
-    len = FLINT_MIN(sctx->mod, sctx->prec);
-    len = FLINT_MIN(len, err);
+    len = FLINT_MIN(sctx->prec, err);
     err = len;
-
-    if (err >= sctx->mod)
-        err = SERIES_ERR_EXACT;
 
     if (xlen <= 1 && xerr == SERIES_ERR_EXACT)
     {
@@ -1720,12 +1596,8 @@ gr_series_weierstrass_p(gr_series_t res, const gr_series_t x, const gr_series_t 
     xerr = x->error;
     err = xerr;
 
-    len = FLINT_MIN(sctx->mod, sctx->prec);
-    len = FLINT_MIN(len, err);
+    len = FLINT_MIN(sctx->prec, err);
     err = len;
-
-    if (err >= sctx->mod)
-        err = SERIES_ERR_EXACT;
 
     if (xlen <= 1 && xerr == SERIES_ERR_EXACT)
     {
@@ -1786,12 +1658,8 @@ gr_series_hypgeom_pfq(gr_series_t res, const gr_series_vec_t a, const gr_series_
     for (i = 0; i < q; i++)
         err = FLINT_MIN(err, b->entries[i].error);
 
-    len = FLINT_MIN(sctx->mod, sctx->prec);
-    len = FLINT_MIN(len, err);
+    len = FLINT_MIN(sctx->prec, err);
     err = len;
-
-    if (err >= sctx->mod)
-        err = SERIES_ERR_EXACT;
 
     aa = GR_TMP_ALLOC(sizeof(acb_poly_struct) * (p + q + 1));
 
@@ -1863,39 +1731,24 @@ static int _gr_gr_series_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
     gr_stream_write(out, "Power series over ");
     gr_ctx_write(out, SERIES_ELEM_CTX(ctx));
-    if (ctx->which_ring == GR_CTX_GR_SERIES_MOD)
-    {
-        gr_stream_write(out, " mod ");
-        gr_stream_write(out, SERIES_CTX(ctx)->var);
-        gr_stream_write(out, "^");
-        gr_stream_write_si(out, SERIES_SCTX(ctx)->mod);
-    }
-
     gr_stream_write(out, " with precision ");
     gr_stream_write(out, "O(");
     gr_stream_write(out, SERIES_CTX(ctx)->var);
     gr_stream_write(out, "^");
     gr_stream_write_si(out, SERIES_SCTX(ctx)->prec);
     gr_stream_write(out, ")");
-
     return GR_SUCCESS;
 }
 
 truth_t
 _gr_gr_series_ctx_is_ring(gr_ctx_t ctx)
 {
-    if (ctx->which_ring == GR_CTX_GR_SERIES_MOD && SERIES_SCTX(ctx)->mod == 0)
-        return T_TRUE;
-
     return gr_ctx_is_ring(SERIES_ELEM_CTX(ctx));
 }
 
 truth_t
 _gr_gr_series_ctx_is_commutative_ring(gr_ctx_t ctx)
 {
-    if (ctx->which_ring == GR_CTX_GR_SERIES_MOD && SERIES_SCTX(ctx)->mod == 0)
-        return T_TRUE;
-
     return gr_ctx_is_commutative_ring(SERIES_ELEM_CTX(ctx));
 }
 
@@ -2035,8 +1888,7 @@ _gr_gr_series_set_other(gr_series_t res, gr_srcptr x, gr_ctx_t x_ctx, gr_ctx_t c
     {
         return gr_series_set_scalar(res, x, SERIES_SCTX(ctx), SERIES_ELEM_CTX(ctx));
     }
-    else if ((x_ctx->which_ring == GR_CTX_GR_SERIES || x_ctx->which_ring == GR_CTX_GR_SERIES_MOD)
-        && !strcmp(SERIES_CTX(x_ctx)->var, SERIES_CTX(ctx)->var))
+    else if (x_ctx->which_ring == GR_CTX_GR_SERIES && !strcmp(SERIES_CTX(x_ctx)->var, SERIES_CTX(ctx)->var))
     {
         int status = GR_SUCCESS;
 
@@ -2179,7 +2031,7 @@ gr_method_tab_input _gr_series_methods_input[] =
 };
 
 static inline void
-_gr_ctx_init_gr_series(gr_ctx_t ctx, gr_ctx_t base_ring, int kind, slong mod, slong prec)
+_gr_ctx_init_gr_series(gr_ctx_t ctx, gr_ctx_t base_ring, int kind, slong prec)
 {
     ctx->which_ring = kind;
     ctx->sizeof_elem = sizeof(gr_series_struct);
@@ -2187,7 +2039,6 @@ _gr_ctx_init_gr_series(gr_ctx_t ctx, gr_ctx_t base_ring, int kind, slong mod, sl
 
     SERIES_CTX(ctx)->base_ring = (gr_ctx_struct *) base_ring;
     SERIES_CTX(ctx)->var = (char *) default_var;
-    SERIES_CTX(ctx)->sctx.mod = mod;
     SERIES_CTX(ctx)->sctx.prec = prec;
 
     ctx->methods = _gr_series_methods;
@@ -2202,14 +2053,5 @@ _gr_ctx_init_gr_series(gr_ctx_t ctx, gr_ctx_t base_ring, int kind, slong mod, sl
 void
 gr_ctx_init_gr_series(gr_ctx_t ctx, gr_ctx_t base_ring, slong prec)
 {
-    _gr_ctx_init_gr_series(ctx, base_ring, GR_CTX_GR_SERIES, SERIES_ERR_EXACT, FLINT_MIN(FLINT_MAX(0, prec), SERIES_ERR_MAX));
-}
-
-void
-gr_ctx_init_gr_series_mod(gr_ctx_t ctx, gr_ctx_t base_ring, slong mod)
-{
-    if (mod >= SERIES_ERR_EXACT)
-        flint_throw(FLINT_ERROR, "(%s)\n", __func__);
-
-    _gr_ctx_init_gr_series(ctx, base_ring, GR_CTX_GR_SERIES_MOD, FLINT_MAX(0, mod), mod);
+    _gr_ctx_init_gr_series(ctx, base_ring, GR_CTX_GR_SERIES, prec);
 }

--- a/src/gr/series.c
+++ b/src/gr/series.c
@@ -424,6 +424,9 @@ gr_series_equal(const gr_series_t x, const gr_series_t y, gr_series_ctx_t sctx, 
     else
         equal = _gr_poly_equal2(y->poly.coeffs, FLINT_MIN(ylen, len), x->poly.coeffs, FLINT_MIN(xlen, len), cctx);
 
+    if (err == SERIES_ERR_EXACT && equal == T_TRUE)
+        return T_TRUE;
+
     if (equal == T_FALSE)
         return T_FALSE;
 

--- a/src/gr/series_mod.c
+++ b/src/gr/series_mod.c
@@ -1,0 +1,477 @@
+/*
+    Copyright (C) 2023, 2024 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <string.h>
+#include "fmpq.h"
+#include "gr_vec.h"
+#include "gr_poly.h"
+#include "gr_generic.h"
+
+#ifdef __GNUC__
+# define strcmp __builtin_strcmp
+#else
+# include <string.h>
+#endif
+
+static const char * default_var = "x";
+
+static void _gr_gr_series_mod_ctx_clear(gr_ctx_t ctx)
+{
+    if (SERIES_MOD_CTX(ctx)->var != default_var)
+        flint_free(SERIES_MOD_CTX(ctx)->var);
+}
+
+static int _gr_gr_series_mod_ctx_write(gr_stream_t out, gr_ctx_t ctx)
+{
+    gr_stream_write(out, "Power series over ");
+    gr_ctx_write(out, SERIES_MOD_ELEM_CTX(ctx));
+    gr_stream_write(out, " mod ");
+    gr_stream_write(out, SERIES_MOD_CTX(ctx)->var);
+    gr_stream_write(out, "^");
+    gr_stream_write_si(out, SERIES_MOD_N(ctx));
+    return GR_SUCCESS;
+}
+
+truth_t
+_gr_gr_series_mod_ctx_is_ring(gr_ctx_t ctx)
+{
+    if (SERIES_MOD_N(ctx) == 0)
+        return T_TRUE;
+
+    return gr_ctx_is_ring(SERIES_MOD_ELEM_CTX(ctx));
+}
+
+truth_t
+_gr_gr_series_mod_ctx_is_commutative_ring(gr_ctx_t ctx)
+{
+    if (SERIES_MOD_N(ctx) == 0)
+        return T_TRUE;
+
+    return gr_ctx_is_commutative_ring(SERIES_MOD_ELEM_CTX(ctx));
+}
+
+truth_t
+_gr_gr_series_mod_ctx_is_integral_domain(gr_ctx_t ctx)
+{
+    if (SERIES_MOD_N(ctx) != 1)
+        return T_FALSE;
+
+    return gr_ctx_is_integral_domain(SERIES_MOD_ELEM_CTX(ctx));
+}
+
+truth_t
+_gr_gr_series_mod_ctx_is_field(gr_ctx_t ctx)
+{
+    if (SERIES_MOD_N(ctx) != 1)
+        return T_FALSE;
+
+    return gr_ctx_is_field(SERIES_MOD_ELEM_CTX(ctx));
+}
+
+int _gr_gr_series_mod_ctx_set_gen_name(gr_ctx_t ctx, const char * s)
+{
+    slong len;
+    len = strlen(s);
+
+    if (SERIES_MOD_CTX(ctx)->var == default_var)
+        SERIES_MOD_CTX(ctx)->var = NULL;
+
+    SERIES_MOD_CTX(ctx)->var = flint_realloc(SERIES_MOD_CTX(ctx)->var, len + 1);
+    memcpy(SERIES_MOD_CTX(ctx)->var, s, len + 1);
+    return GR_SUCCESS;
+}
+
+static int
+_gr_gr_series_mod_gens_recursive(gr_vec_t vec, gr_ctx_t ctx)
+{
+    int status;
+    gr_vec_t vec1;
+    slong i, n;
+
+    /* Get generators of the element ring */
+    gr_vec_init(vec1, 0, SERIES_MOD_ELEM_CTX(ctx));
+    status = gr_gens_recursive(vec1, SERIES_MOD_ELEM_CTX(ctx));
+    n = vec1->length;
+
+    gr_vec_set_length(vec, n + 1, ctx);
+
+    /* Promote to polynomials */
+    for (i = 0; i < n; i++)
+        status |= gr_poly_set_scalar(gr_vec_entry_ptr(vec, i, ctx),
+                gr_vec_entry_srcptr(vec1, i, SERIES_MOD_ELEM_CTX(ctx)),
+                SERIES_MOD_ELEM_CTX(ctx));
+
+    status |= gr_poly_gen(gr_vec_entry_ptr(vec, n, ctx), SERIES_MOD_ELEM_CTX(ctx));
+
+    gr_vec_clear(vec1, SERIES_MOD_ELEM_CTX(ctx));
+
+    return status;
+}
+
+static void _gr_gr_series_mod_init(gr_poly_t res, gr_ctx_t ctx)
+{
+    gr_poly_init(res, SERIES_MOD_ELEM_CTX(ctx));
+}
+
+static void _gr_gr_series_mod_clear(gr_poly_t res, gr_ctx_t ctx)
+{
+    gr_poly_init(res, SERIES_MOD_ELEM_CTX(ctx));
+}
+
+static void _gr_gr_series_mod_swap(gr_poly_t x, gr_poly_t y, gr_ctx_t ctx)
+{
+    gr_poly_swap(x, y, SERIES_MOD_ELEM_CTX(ctx));
+}
+
+static int _gr_gr_series_mod_randtest(gr_poly_t res, flint_rand_t state, gr_ctx_t ctx)
+{
+    return gr_poly_randtest(res, state, SERIES_MOD_N(ctx), SERIES_MOD_ELEM_CTX(ctx));
+}
+
+static int _gr_gr_series_mod_write(gr_stream_t out, const gr_poly_t x, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    status |= gr_poly_write(out, x, SERIES_MOD_CTX(ctx)->var, SERIES_MOD_ELEM_CTX(ctx));
+    gr_stream_write(out, " (mod ");
+    gr_stream_write(out, SERIES_MOD_CTX(ctx)->var);
+    gr_stream_write(out, "^");
+    gr_stream_write_si(out, SERIES_MOD_N(ctx));
+    gr_stream_write(out, ")");
+    return status;
+}
+
+static int _gr_gr_series_mod_zero(gr_poly_t res, gr_ctx_t ctx)
+{
+    return gr_poly_zero(res, SERIES_MOD_ELEM_CTX(ctx));
+}
+
+static int _gr_gr_series_mod_one(gr_poly_t res, gr_ctx_t ctx)
+{
+    return (SERIES_MOD_N(ctx) == 0) ? GR_SUCCESS : gr_poly_one(res, SERIES_MOD_ELEM_CTX(ctx));
+}
+
+static int _gr_gr_series_mod_gen(gr_poly_t res, gr_ctx_t ctx)
+{
+    return (SERIES_MOD_N(ctx) <= 1) ? gr_poly_zero(res, ctx) : gr_poly_gen(res, SERIES_MOD_ELEM_CTX(ctx));
+}
+
+static int _gr_gr_series_mod_set(gr_poly_t res, const gr_poly_t x, gr_ctx_t ctx)
+{
+    return gr_poly_set(res, x, SERIES_MOD_ELEM_CTX(ctx));
+}
+
+static void _gr_gr_series_mod_set_shallow(gr_poly_t res, const gr_poly_t x, gr_ctx_t ctx)
+{
+    *res = *x;
+}
+
+static int _gr_gr_series_mod_set_si(gr_poly_t res, slong c, gr_ctx_t ctx)
+{
+    return (SERIES_MOD_N(ctx) == 0) ? GR_SUCCESS : gr_poly_set_si(res, c, SERIES_MOD_ELEM_CTX(ctx));
+}
+
+static int _gr_gr_series_mod_set_ui(gr_poly_t res, ulong c, gr_ctx_t ctx)
+{
+    return (SERIES_MOD_N(ctx) == 0) ? GR_SUCCESS : gr_poly_set_ui(res, c, SERIES_MOD_ELEM_CTX(ctx));
+}
+
+static int _gr_gr_series_mod_set_fmpz(gr_poly_t res, const fmpz_t c, gr_ctx_t ctx)
+{
+    return (SERIES_MOD_N(ctx) == 0) ? GR_SUCCESS : gr_poly_set_fmpz(res, c, SERIES_MOD_ELEM_CTX(ctx));
+}
+
+static int _gr_gr_series_mod_set_fmpq(gr_poly_t res, const fmpq_t c, gr_ctx_t ctx)
+{
+    return (SERIES_MOD_N(ctx) == 0) ? GR_SUCCESS : gr_poly_set_fmpq(res, c, SERIES_MOD_ELEM_CTX(ctx));
+}
+
+static truth_t _gr_gr_series_mod_is_zero(const gr_poly_t x, gr_ctx_t ctx)
+{
+    return (SERIES_MOD_N(ctx) == 0) ? T_TRUE : gr_poly_is_zero(x, SERIES_MOD_ELEM_CTX(ctx));
+}
+
+static truth_t _gr_gr_series_mod_is_one(const gr_poly_t x, gr_ctx_t ctx)
+{
+    return (SERIES_MOD_N(ctx) == 0) ? T_TRUE : gr_poly_is_one(x, SERIES_MOD_ELEM_CTX(ctx));
+}
+
+static truth_t _gr_gr_series_mod_equal(const gr_poly_t x, const gr_poly_t y, gr_ctx_t ctx)
+{
+    return gr_poly_equal(x, y, SERIES_MOD_ELEM_CTX(ctx));
+}
+
+static int _gr_gr_series_mod_neg(gr_poly_t res, const gr_poly_t x, gr_ctx_t ctx)
+{
+    return gr_poly_neg(res, x, SERIES_MOD_ELEM_CTX(ctx));
+}
+
+static int _gr_gr_series_mod_add(gr_poly_t res, const gr_poly_t x, const gr_poly_t y, gr_ctx_t ctx)
+{
+    return gr_poly_add(res, x, y, SERIES_MOD_ELEM_CTX(ctx));
+}
+
+static int _gr_gr_series_mod_sub(gr_poly_t res, const gr_poly_t x, const gr_poly_t y, gr_ctx_t ctx)
+{
+    return gr_poly_sub(res, x, y, SERIES_MOD_ELEM_CTX(ctx));
+}
+
+static int _gr_gr_series_mod_mul(gr_poly_t res, const gr_poly_t x, const gr_poly_t y, gr_ctx_t ctx)
+{
+    return gr_poly_mullow(res, x, y, SERIES_MOD_N(ctx), SERIES_MOD_ELEM_CTX(ctx));
+}
+
+static int _gr_gr_series_mod_inv(gr_poly_t res, const gr_poly_t x, gr_ctx_t ctx)
+{
+    return gr_poly_inv_series(res, x, SERIES_MOD_N(ctx), SERIES_MOD_ELEM_CTX(ctx));
+}
+
+static int _gr_gr_series_mod_div(gr_poly_t res, const gr_poly_t x, const gr_poly_t y, gr_ctx_t ctx)
+{
+    return gr_poly_div_series(res, x, y, SERIES_MOD_N(ctx), SERIES_MOD_ELEM_CTX(ctx));
+}
+
+#define UNARY_POLY_WRAPPER(func) \
+int \
+_gr_gr_series_mod_ ## func(gr_poly_t res, const gr_poly_t x, gr_ctx_t ctx) \
+{ \
+    return gr_poly_ ## func ## _series(res, x, SERIES_MOD_N(ctx), SERIES_MOD_ELEM_CTX(ctx)); \
+} \
+
+UNARY_POLY_WRAPPER(exp)
+UNARY_POLY_WRAPPER(log)
+UNARY_POLY_WRAPPER(rsqrt)
+UNARY_POLY_WRAPPER(tan)
+UNARY_POLY_WRAPPER(asin)
+UNARY_POLY_WRAPPER(acos)
+UNARY_POLY_WRAPPER(atan)
+UNARY_POLY_WRAPPER(asinh)
+UNARY_POLY_WRAPPER(acosh)
+UNARY_POLY_WRAPPER(atanh)
+
+
+/* fixme: gr_poly_sqrt_series does not deal with leading zeros */
+static int _gr_gr_series_mod_sqrt(gr_poly_t res, const gr_poly_t x, gr_ctx_t ctx)
+{
+    slong n = SERIES_MOD_N(ctx);
+
+    if (n == 0)
+        return GR_SUCCESS;
+
+    if (x->length == 0)
+        return gr_poly_zero(res, SERIES_MOD_ELEM_CTX(ctx));
+
+    if (gr_is_zero(x->coeffs, SERIES_MOD_ELEM_CTX(ctx)) != T_FALSE)
+        return GR_UNABLE;
+
+    return gr_poly_sqrt_series(res, x, n, SERIES_MOD_ELEM_CTX(ctx));
+}
+
+
+typedef struct
+{
+    gr_poly_struct poly;
+    slong error;
+}
+gr_series_struct;
+
+static int
+_set_truncate_poly(gr_poly_t res, const gr_poly_t x, gr_ctx_t x_elem_ctx, slong n, gr_ctx_t elem_ctx)
+{
+    if (x_elem_ctx == elem_ctx)
+    {
+        return gr_poly_truncate(res, x, n, elem_ctx);
+    }
+    else
+    {
+        if (gr_poly_length(x, x_elem_ctx) <= n)
+        {
+            return gr_poly_set_gr_poly_other(res, x, x_elem_ctx, elem_ctx);
+        }
+        else
+        {
+            int status = GR_SUCCESS;
+            gr_poly_t t;
+            gr_poly_init(t, x_elem_ctx);
+            status |= gr_poly_truncate(t, x, n, x_elem_ctx);
+            status |= gr_poly_set_gr_poly_other(res, x, x_elem_ctx, elem_ctx);
+            gr_poly_clear(t, x_elem_ctx);
+            return status;
+        }
+    }
+}
+
+static int
+_gr_gr_series_mod_set_other(gr_poly_t res, gr_srcptr x, gr_ctx_t x_ctx, gr_ctx_t ctx)
+{
+    if (x_ctx == ctx)
+    {
+        return gr_poly_set(res, x, ctx);
+    }
+    else if (x_ctx == SERIES_MOD_ELEM_CTX(ctx))
+    {
+        return (SERIES_MOD_N(ctx) == 0) ? GR_SUCCESS : gr_poly_set_scalar(res, x, SERIES_MOD_ELEM_CTX(ctx));
+    }
+    else if (x_ctx->which_ring == GR_CTX_SERIES_MOD_GR_POLY && !strcmp(SERIES_MOD_CTX(x_ctx)->var, SERIES_MOD_CTX(ctx)->var))
+    {
+        if (SERIES_MOD_N(ctx) <= SERIES_MOD_N(x_ctx))   /* set() does modular reduction */
+            return _set_truncate_poly(res, x, SERIES_MOD_ELEM_CTX(x_ctx), SERIES_MOD_N(ctx), SERIES_MOD_ELEM_CTX(ctx));
+        else
+            return GR_DOMAIN;   /* set() doesn't do lift */
+    }
+    else if (x_ctx->which_ring == GR_CTX_GR_POLY && !strcmp(POLYNOMIAL_CTX(x_ctx)->var, SERIES_MOD_CTX(ctx)->var))
+    {
+        return _set_truncate_poly(res, x, POLYNOMIAL_ELEM_CTX(x_ctx), SERIES_MOD_N(ctx), SERIES_MOD_ELEM_CTX(ctx));
+    }
+    else if (x_ctx->which_ring == GR_CTX_GR_SERIES && !strcmp(SERIES_CTX(x_ctx)->var, SERIES_MOD_CTX(ctx)->var))
+    {
+        /* all coefficients below x^n must be known */
+        if (((const gr_series_struct *) x)->error < SERIES_MOD_N(ctx))
+            return GR_UNABLE;
+        else
+            return _set_truncate_poly(res, &((const gr_series_struct *) x)->poly, SERIES_ELEM_CTX(x_ctx), SERIES_MOD_N(ctx), SERIES_MOD_ELEM_CTX(ctx));
+    }
+    else
+    {
+        int status = GR_SUCCESS;
+
+        gr_poly_fit_length(res, 1, SERIES_MOD_ELEM_CTX(ctx));
+        status = gr_set_other(res->coeffs, x, x_ctx, SERIES_MOD_ELEM_CTX(ctx));
+
+        if (status == GR_SUCCESS)
+        {
+            _gr_poly_set_length(res, 1, SERIES_MOD_ELEM_CTX(ctx));
+            _gr_poly_normalise(res, SERIES_MOD_ELEM_CTX(ctx));
+        }
+        else
+            _gr_poly_set_length(res, 0, SERIES_MOD_ELEM_CTX(ctx));
+
+        status |= gr_poly_truncate(res, res, SERIES_MOD_N(ctx), SERIES_MOD_ELEM_CTX(ctx));
+        return status;
+    }
+
+    return GR_UNABLE;
+}
+
+
+
+int _gr_series_mod_methods_initialized = 0;
+
+gr_static_method_table _gr_series_mod_methods;
+
+gr_method_tab_input _gr_series_mod_methods_input[] =
+{
+    {GR_METHOD_CTX_CLEAR,   (gr_funcptr) _gr_gr_series_mod_ctx_clear},
+    {GR_METHOD_CTX_WRITE,   (gr_funcptr) _gr_gr_series_mod_ctx_write},
+    {GR_METHOD_CTX_SET_GEN_NAME, (gr_funcptr) _gr_gr_series_mod_ctx_set_gen_name},
+    {GR_METHOD_CTX_IS_RING, (gr_funcptr) _gr_gr_series_mod_ctx_is_ring},
+    {GR_METHOD_CTX_IS_COMMUTATIVE_RING, (gr_funcptr) _gr_gr_series_mod_ctx_is_commutative_ring},
+    {GR_METHOD_CTX_IS_INTEGRAL_DOMAIN, (gr_funcptr) _gr_gr_series_mod_ctx_is_integral_domain},
+    {GR_METHOD_CTX_IS_FIELD, (gr_funcptr) _gr_gr_series_mod_ctx_is_field},
+    {GR_METHOD_INIT,        (gr_funcptr) _gr_gr_series_mod_init},
+    {GR_METHOD_CLEAR,       (gr_funcptr) _gr_gr_series_mod_clear},
+    {GR_METHOD_SWAP,        (gr_funcptr) _gr_gr_series_mod_swap},
+    {GR_METHOD_SET_SHALLOW, (gr_funcptr) _gr_gr_series_mod_set_shallow},
+    {GR_METHOD_RANDTEST,    (gr_funcptr) _gr_gr_series_mod_randtest},
+    {GR_METHOD_WRITE,       (gr_funcptr) _gr_gr_series_mod_write},
+    {GR_METHOD_ZERO,        (gr_funcptr) _gr_gr_series_mod_zero},
+    {GR_METHOD_ONE,         (gr_funcptr) _gr_gr_series_mod_one},
+    {GR_METHOD_IS_ZERO,     (gr_funcptr) _gr_gr_series_mod_is_zero},
+    {GR_METHOD_IS_ONE,      (gr_funcptr) _gr_gr_series_mod_is_one},
+    {GR_METHOD_EQUAL,       (gr_funcptr) _gr_gr_series_mod_equal},
+    {GR_METHOD_GEN,         (gr_funcptr) _gr_gr_series_mod_gen},
+    {GR_METHOD_GENS,        (gr_funcptr) gr_generic_gens_single},
+    {GR_METHOD_GENS_RECURSIVE,  (gr_funcptr) _gr_gr_series_mod_gens_recursive},
+    {GR_METHOD_SET,         (gr_funcptr) _gr_gr_series_mod_set},
+    {GR_METHOD_SET_UI,      (gr_funcptr) _gr_gr_series_mod_set_ui},
+    {GR_METHOD_SET_SI,      (gr_funcptr) _gr_gr_series_mod_set_si},
+    {GR_METHOD_SET_FMPZ,    (gr_funcptr) _gr_gr_series_mod_set_fmpz},
+    {GR_METHOD_SET_FMPQ,    (gr_funcptr) _gr_gr_series_mod_set_fmpq},
+    {GR_METHOD_SET_OTHER,   (gr_funcptr) _gr_gr_series_mod_set_other},
+    {GR_METHOD_SET_STR,     (gr_funcptr) gr_generic_set_str_balance_additions},
+    {GR_METHOD_NEG,         (gr_funcptr) _gr_gr_series_mod_neg},
+    {GR_METHOD_ADD,         (gr_funcptr) _gr_gr_series_mod_add},
+    {GR_METHOD_SUB,         (gr_funcptr) _gr_gr_series_mod_sub},
+    {GR_METHOD_MUL,         (gr_funcptr) _gr_gr_series_mod_mul},
+    {GR_METHOD_INV,         (gr_funcptr) _gr_gr_series_mod_inv},
+    {GR_METHOD_DIV,         (gr_funcptr) _gr_gr_series_mod_div},
+    {GR_METHOD_SQRT,        (gr_funcptr) _gr_gr_series_mod_sqrt},
+    {GR_METHOD_RSQRT,       (gr_funcptr) _gr_gr_series_mod_rsqrt},
+    {GR_METHOD_EXP,         (gr_funcptr) _gr_gr_series_mod_exp},
+    {GR_METHOD_LOG,         (gr_funcptr) _gr_gr_series_mod_log},
+    {GR_METHOD_TAN,         (gr_funcptr) _gr_gr_series_mod_tan},
+    {GR_METHOD_ASIN,        (gr_funcptr) _gr_gr_series_mod_asin},
+    {GR_METHOD_ACOS,        (gr_funcptr) _gr_gr_series_mod_acos},
+    {GR_METHOD_ATAN,        (gr_funcptr) _gr_gr_series_mod_atan},
+    {GR_METHOD_ASINH,       (gr_funcptr) _gr_gr_series_mod_asinh},
+    {GR_METHOD_ACOSH,       (gr_funcptr) _gr_gr_series_mod_acosh},
+    {GR_METHOD_ATANH,       (gr_funcptr) _gr_gr_series_mod_atanh},
+/*
+    {GR_METHOD_GAMMA,       (gr_funcptr) _gr_gr_series_mod_gamma},
+    {GR_METHOD_RGAMMA,      (gr_funcptr) _gr_gr_series_mod_rgamma},
+    {GR_METHOD_LGAMMA,      (gr_funcptr) _gr_gr_series_mod_lgamma},
+    {GR_METHOD_DIGAMMA,     (gr_funcptr) _gr_gr_series_mod_digamma},
+    {GR_METHOD_ERF,         (gr_funcptr) _gr_gr_series_mod_erf},
+    {GR_METHOD_ERFC,        (gr_funcptr) _gr_gr_series_mod_erfc},
+    {GR_METHOD_ERFI,        (gr_funcptr) _gr_gr_series_mod_erfi},
+    {GR_METHOD_FRESNEL,     (gr_funcptr) _gr_gr_series_mod_fresnel},
+    {GR_METHOD_FRESNEL_S,   (gr_funcptr) _gr_gr_series_mod_fresnel_s},
+    {GR_METHOD_FRESNEL_C,   (gr_funcptr) _gr_gr_series_mod_fresnel_c},
+    {GR_METHOD_AIRY,        (gr_funcptr) _gr_gr_series_mod_airy},
+    {GR_METHOD_AIRY_AI,        (gr_funcptr) _gr_gr_series_mod_airy_ai},
+    {GR_METHOD_AIRY_AI_PRIME,  (gr_funcptr) _gr_gr_series_mod_airy_ai_prime},
+    {GR_METHOD_AIRY_BI,        (gr_funcptr) _gr_gr_series_mod_airy_bi},
+    {GR_METHOD_AIRY_BI_PRIME,  (gr_funcptr) _gr_gr_series_mod_airy_bi_prime},
+    {GR_METHOD_EXP_INTEGRAL_EI,       (gr_funcptr) _gr_gr_series_mod_exp_integral_ei},
+    {GR_METHOD_COS_INTEGRAL,          (gr_funcptr) _gr_gr_series_mod_cos_integral},
+    {GR_METHOD_COSH_INTEGRAL,         (gr_funcptr) _gr_gr_series_mod_cosh_integral},
+    {GR_METHOD_SIN_INTEGRAL,          (gr_funcptr) _gr_gr_series_mod_sin_integral},
+    {GR_METHOD_SINH_INTEGRAL,         (gr_funcptr) _gr_gr_series_mod_sinh_integral},
+    {GR_METHOD_LOG_INTEGRAL,          (gr_funcptr) _gr_gr_series_mod_log_integral},
+    {GR_METHOD_GAMMA_UPPER,           (gr_funcptr) _gr_gr_series_mod_gamma_upper},
+    {GR_METHOD_GAMMA_LOWER,           (gr_funcptr) _gr_gr_series_mod_gamma_lower},
+    {GR_METHOD_BETA_LOWER,            (gr_funcptr) _gr_gr_series_mod_beta_lower},
+    {GR_METHOD_HYPGEOM_PFQ,           (gr_funcptr) _gr_gr_series_mod_hypgeom_pfq},
+    {GR_METHOD_HURWITZ_ZETA,          (gr_funcptr) _gr_gr_series_mod_hurwitz_zeta},
+    {GR_METHOD_POLYLOG,               (gr_funcptr) _gr_gr_series_mod_polylog},
+    {GR_METHOD_DIRICHLET_L,           (gr_funcptr) _gr_gr_series_mod_dirichlet_l},
+    {GR_METHOD_DIRICHLET_HARDY_Z,     (gr_funcptr) _gr_gr_series_mod_dirichlet_hardy_z},
+    {GR_METHOD_DIRICHLET_HARDY_THETA, (gr_funcptr) _gr_gr_series_mod_dirichlet_hardy_theta},
+    {GR_METHOD_JACOBI_THETA,          (gr_funcptr) _gr_gr_series_mod_jacobi_theta},
+    {GR_METHOD_JACOBI_THETA_1,          (gr_funcptr) _gr_gr_series_mod_jacobi_theta_1},
+    {GR_METHOD_JACOBI_THETA_2,          (gr_funcptr) _gr_gr_series_mod_jacobi_theta_2},
+    {GR_METHOD_JACOBI_THETA_3,          (gr_funcptr) _gr_gr_series_mod_jacobi_theta_3},
+    {GR_METHOD_JACOBI_THETA_4,          (gr_funcptr) _gr_gr_series_mod_jacobi_theta_4},
+    {GR_METHOD_AGM1,                   (gr_funcptr) _gr_gr_series_mod_agm1},
+    {GR_METHOD_ELLIPTIC_K,             (gr_funcptr) _gr_gr_series_mod_elliptic_k},
+    {GR_METHOD_WEIERSTRASS_P,          (gr_funcptr) _gr_gr_series_mod_weierstrass_p},
+*/
+    {0,                     (gr_funcptr) NULL},
+};
+
+void
+gr_ctx_init_series_mod_gr_poly(gr_ctx_t ctx, gr_ctx_t base_ring, slong n)
+{
+    ctx->which_ring = GR_CTX_SERIES_MOD_GR_POLY;
+    ctx->sizeof_elem = sizeof(gr_poly_struct);
+    ctx->size_limit = WORD_MAX;
+
+    SERIES_MOD_CTX(ctx)->base_ring = (gr_ctx_struct *) base_ring;
+    SERIES_MOD_CTX(ctx)->var = (char *) default_var;
+    SERIES_MOD_CTX(ctx)->n = FLINT_MAX(0, n);
+
+    ctx->methods = _gr_series_mod_methods;
+
+    if (!_gr_series_mod_methods_initialized)
+    {
+        gr_method_tab_init(_gr_series_mod_methods, _gr_series_mod_methods_input);
+        _gr_series_mod_methods_initialized = 1;
+    }
+}

--- a/src/gr/test/main.c
+++ b/src/gr/test/main.c
@@ -57,6 +57,7 @@
 #include "t-series_arb.c"
 #include "t-series_fmpq.c"
 #include "t-series_fmpz.c"
+#include "t-series_mod_gr_poly.c"
 #include "t-series_nmod8.c"
 #include "t-vector_acb.c"
 #include "t-vector_arb.c"
@@ -108,6 +109,7 @@ test_struct tests[] =
     TEST_FUNCTION(gr_series_arb),
     TEST_FUNCTION(gr_series_fmpq),
     TEST_FUNCTION(gr_series_fmpz),
+    TEST_FUNCTION(gr_series_mod_gr_poly),
     TEST_FUNCTION(gr_series_nmod8),
     TEST_FUNCTION(gr_vector_acb),
     TEST_FUNCTION(gr_vector_arb),

--- a/src/gr/test/t-series_acb.c
+++ b/src/gr/test/t-series_acb.c
@@ -30,7 +30,7 @@ TEST_FUNCTION_START(gr_series_acb, state)
     for (i = 0; i < 5; i++)
     {
         gr_ctx_init_complex_acb(CCn, 2 + n_randint(state, 200));
-        gr_ctx_init_gr_series_mod(CCnx, CCn, i);
+        gr_ctx_init_series_mod_gr_poly(CCnx, CCn, i);
         gr_test_ring(CCnx, 100, flags);
         gr_ctx_clear(CCnx);
         gr_ctx_clear(CCn);

--- a/src/gr/test/t-series_arb.c
+++ b/src/gr/test/t-series_arb.c
@@ -30,7 +30,7 @@ TEST_FUNCTION_START(gr_series_arb, state)
     for (i = 0; i < 5; i++)
     {
         gr_ctx_init_real_arb(RRn, 2 + n_randint(state, 200));
-        gr_ctx_init_gr_series_mod(RRnx, RRn, i);
+        gr_ctx_init_series_mod_gr_poly(RRnx, RRn, i);
         gr_test_ring(RRnx, 100, flags);
         gr_ctx_clear(RRnx);
         gr_ctx_clear(RRn);

--- a/src/gr/test/t-series_fmpq.c
+++ b/src/gr/test/t-series_fmpq.c
@@ -29,7 +29,7 @@ TEST_FUNCTION_START(gr_series_fmpq, state)
 
     for (i = 0; i < 5; i++)
     {
-        gr_ctx_init_gr_series_mod(QQx, QQ, i);
+        gr_ctx_init_series_mod_gr_poly(QQx, QQ, i);
         gr_test_ring(QQx, 100, flags);
         gr_ctx_clear(QQx);
     }

--- a/src/gr/test/t-series_fmpz.c
+++ b/src/gr/test/t-series_fmpz.c
@@ -29,7 +29,7 @@ TEST_FUNCTION_START(gr_series_fmpz, state)
 
     for (i = 0; i < 5; i++)
     {
-        gr_ctx_init_gr_series_mod(ZZx, ZZ, i);
+        gr_ctx_init_series_mod_gr_poly(ZZx, ZZ, i);
         gr_test_ring(ZZx, 100, flags);
         gr_ctx_clear(ZZx);
     }

--- a/src/gr/test/t-series_mod_gr_poly.c
+++ b/src/gr/test/t-series_mod_gr_poly.c
@@ -1,0 +1,37 @@
+/*
+    Copyright (C) 2024 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "gr.h"
+
+TEST_FUNCTION_START(gr_series_mod_gr_poly, state)
+{
+    gr_ctx_t R, Rx;
+    int flags = 0;
+    slong i;
+    slong iter;
+
+    for (iter = 0; iter < 10 * flint_test_multiplier(); iter++)
+    {
+        for (i = 0; i < 4; i++)
+        {
+            gr_ctx_init_random(R, state);
+            gr_ctx_init_series_mod_gr_poly(Rx, R, i);
+            /* hack: avoid collisions with parent ring generators */
+            GR_MUST_SUCCEED(gr_ctx_set_gen_name(Rx, "u"));
+            gr_test_ring(Rx, 10, flags);
+            gr_ctx_clear(Rx);
+            gr_ctx_clear(R);
+        }
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/gr/test/t-series_nmod8.c
+++ b/src/gr/test/t-series_nmod8.c
@@ -31,7 +31,7 @@ TEST_FUNCTION_START(gr_series_nmod8, state)
     for (i = 0; i < 5; i++)
     {
         gr_ctx_init_nmod8(ZZn, 1 + n_randtest(state) % 255);
-        gr_ctx_init_gr_series_mod(ZZnx, ZZn, i);
+        gr_ctx_init_series_mod_gr_poly(ZZnx, ZZn, i);
         gr_test_ring(ZZnx, 100, flags);
         gr_ctx_clear(ZZnx);
         gr_ctx_clear(ZZn);

--- a/src/gr/test_ring.c
+++ b/src/gr/test_ring.c
@@ -1757,6 +1757,8 @@ gr_test_is_invertible(gr_ctx_t R, flint_rand_t state, int test_flags)
     if ((test_flags & GR_TEST_VERBOSE) || status == GR_TEST_FAIL)
     {
         flint_printf("\n");
+        gr_ctx_println(R);
+        flint_printf("is_invertible\n");
         flint_printf("x = \n"); gr_println(x, R);
         flint_printf("x ^ -1 = \n"); gr_println(x_inv, R);
         flint_printf("status = %d, invertible = %d\n", status, invertible);
@@ -2675,6 +2677,7 @@ gr_test_sqrt(gr_ctx_t R, flint_rand_t state, int test_flags)
     int status = GR_SUCCESS;
     gr_ptr x, y, y2;
     int perfect;
+    char * fail_str = "";
 
     GR_TMP_INIT3(x, y, y2, R);
 
@@ -2700,16 +2703,19 @@ gr_test_sqrt(gr_ctx_t R, flint_rand_t state, int test_flags)
 
     if (status == GR_SUCCESS && gr_equal(y2, x, R) == T_FALSE)
     {
+        fail_str = "y2 == x is FALSE\n";
         status = GR_TEST_FAIL;
     }
 
     if (status == GR_DOMAIN && perfect)
     {
+        fail_str = "status is GR_DOMAIN but input is a perfect square\n";
         status = GR_TEST_FAIL;
     }
 
     if (status == GR_SUCCESS && perfect && gr_is_square(x, R) == T_FALSE)
     {
+        fail_str = "is_square(x) returns T_FALSE but input is a perfect square\n";
         status = GR_TEST_FAIL;
     }
 
@@ -2719,6 +2725,7 @@ gr_test_sqrt(gr_ctx_t R, flint_rand_t state, int test_flags)
     if ((test_flags & GR_TEST_VERBOSE) || status == GR_TEST_FAIL)
     {
         flint_printf("FAIL: sqrt\n");
+        flint_printf("%s\n", fail_str);
         flint_printf("R = "); gr_ctx_println(R);
         flint_printf("x = \n"); gr_println(x, R);
         flint_printf("y = \n"); gr_println(y, R);

--- a/src/gr_poly/inv_series.c
+++ b/src/gr_poly/inv_series.c
@@ -38,7 +38,16 @@ gr_poly_inv_series(gr_poly_t Qinv, const gr_poly_t Q, slong len, gr_ctx_t ctx)
     Qlen = Q->length;
 
     if (Qlen == 0)
-        return GR_DOMAIN;
+    {
+        truth_t is_zero = gr_ctx_is_zero_ring(ctx);
+
+        if (is_zero == T_TRUE)
+            return gr_poly_zero(Qinv, ctx);
+        else if (is_zero == T_FALSE)
+            return GR_DOMAIN;
+        else
+            return GR_UNABLE;
+    }
 
     if (Qlen == 1)
         len = 1;

--- a/src/gr_poly/sqrt_series.c
+++ b/src/gr_poly/sqrt_series.c
@@ -13,6 +13,18 @@
 
 /* todo: characteristic 2, ... */
 
+static truth_t
+_char_two(gr_ctx_t ctx)
+{
+    gr_ptr t;
+    truth_t res;
+    GR_TMP_INIT(t, ctx);
+    GR_MUST_SUCCEED(gr_set_ui(t, 2, ctx));
+    res = gr_is_zero(t, ctx);
+    GR_TMP_CLEAR(t, ctx);
+    return res;
+}
+
 int
 _gr_poly_sqrt_series_generic(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx)
 {
@@ -20,7 +32,7 @@ _gr_poly_sqrt_series_generic(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_
 
     status = _gr_poly_sqrt_series_newton(res, f, flen, len, 2, ctx);
 
-    if (status == GR_DOMAIN && gr_ctx_is_field(ctx) != T_TRUE)
+    if (status == GR_DOMAIN && (gr_ctx_is_field(ctx) != T_TRUE || _char_two(ctx) != T_FALSE))
         return GR_UNABLE;
 
     return status;

--- a/src/python/flint_ctypes.py
+++ b/src/python/flint_ctypes.py
@@ -4028,6 +4028,9 @@ class gr_elem:
             32
             >>> RF(0.5).exp10()
             3.162277660168380
+            >>> x = PowerSeriesModRing(QQ, 5).gen(); x.exp()
+            1 + x + (1/2)*x^2 + (1/6)*x^3 + (1/24)*x^4 (mod x^5)
+
         """
         return self._unary_op(self, libgr.gr_exp10, "exp10($x)")
 
@@ -4047,6 +4050,8 @@ class gr_elem:
             x + (-1/2)*x^2 + (1/3)*x^3 + (-1/4)*x^4 + (1/5)*x^5 + O(x^6)
             >>> QQser(1).log()
             0
+            >>> x = PowerSeriesModRing(QQ, 5).gen(); (1+x).log()
+            x + (-1/2)*x^2 + (1/3)*x^3 + (-1/4)*x^4 (mod x^5)
 
         """
         return self._unary_op(self, libgr.gr_log, "log($x)")
@@ -4071,6 +4076,10 @@ class gr_elem:
         return self._unary_op(self, libgr.gr_cos, "cos($x)")
 
     def tan(self):
+        """
+            >>> x = PowerSeriesModRing(QQ, 5).gen(); x.tan()
+            x + (1/3)*x^3 (mod x^5)
+        """
         return self._unary_op(self, libgr.gr_tan, "tan($x)")
 
     def sinh(self):
@@ -4082,8 +4091,52 @@ class gr_elem:
     def tanh(self):
         return self._unary_op(self, libgr.gr_tanh, "tanh($x)")
 
+    def asin(self):
+        """
+            >>> x = PowerSeriesModRing(QQ, 5).gen(); x.asin()
+            x + (1/6)*x^3 (mod x^5)
+        """
+        return self._unary_op(self, libgr.gr_asin, "asin($x)")
+
+    def acos(self):
+        """
+            >>> x = PowerSeriesModRing(QQ, 5).gen(); x.acos()
+            Traceback (most recent call last):
+              ...
+            FlintUnableError: failed to compute acos(x) in {Power series over Rational field (fmpq) mod x^5} for {x = x (mod x^5)}
+            >>> x = PowerSeriesModRing(RR_ca, 5).gen(); x.acos()
+            (1.57080 {(a)/2 where a = 3.14159 [Pi]}) - x + (-0.166667 {-1/6})*x^3 (mod x^5)
+        """
+        return self._unary_op(self, libgr.gr_acos, "acos($x)")
+
     def atan(self):
+        """
+            >>> x = PowerSeriesModRing(QQ, 5).gen(); x.atan()
+            x + (-1/3)*x^3 (mod x^5)
+        """
         return self._unary_op(self, libgr.gr_atan, "atan($x)")
+
+    def asinh(self):
+        """
+            >>> x = PowerSeriesModRing(QQ, 5).gen(); x.asinh()
+            x + (-1/6)*x^3 (mod x^5)
+        """
+        return self._unary_op(self, libgr.gr_asinh, "asinh($x)")
+
+    def acosh(self):
+        """
+            >>> x = PowerSeriesModRing(CC, 3).gen(); x.acosh()
+            [1.570796326794897 +/- 5.54e-16]*I + (-1.000000000000000*I)*x (mod x^3)
+        """
+        return self._unary_op(self, libgr.gr_acosh, "acosh($x)")
+
+    def atanh(self):
+        """
+            >>> x = PowerSeriesModRing(QQ, 5).gen(); x.atanh()
+            x + (1/3)*x^3 (mod x^5)
+        """
+        return self._unary_op(self, libgr.gr_atanh, "atanh($x)")
+
 
     def exp_pi_i(self):
         r"""
@@ -7885,11 +7938,16 @@ def test_gr_series():
     assert raises(lambda: x**3 / O2, FlintUnableError)
     assert raises(lambda: x**3 / O3, FlintUnableError)
 
-    R2 = PowerSeriesModRing(QQ, 3)
-    assert R2(3 + O4) == R2(3)
-    assert R2(3 + O3) == R2(3)
-    assert raises(lambda: R2(3 + O2), FlintUnableError)
+    R3 = PowerSeriesModRing(QQ, 3)
+    assert R3(3 + O4) == R3(3)
+    assert R3(3 + O3) == R3(3)
+    assert raises(lambda: R3(3 + O2), FlintUnableError)
 
+    R2 = PowerSeriesModRing(QQ, 2)
+    R2b = PowerSeriesModRing(QQ, 2)
+    assert R2(R3(5)) == 5
+    assert R2(2) + R2b(3) == 5
+    assert raises(lambda: R3(R2(5)), FlintDomainError)
 
     R = RRser
     x = R.gen()


### PR DESCRIPTION
Truncated power series ring elements are now represented as plain ``gr_poly_t`` instead of ``gr_series_t``.

This is a lot more efficient and simplifies the logic for both series rings and truncated series rings.

Some functions that previously worked for both kinds of series don't work for truncated series anymore and will have to be reimplemented in the future.

As mentioned in #1517.