### PR TITLE
Use a C++ compiler to compile interfaces/test/t-NTL-interface

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -45,7 +45,7 @@ EXEEXT:=@EXEEXT@
 
 AR:=@AR@
 CC:=@CC@
-CXX:=@CC@
+CXX:=@CXX@
 DLLTOOL:=@DLLTOOL@
 LD:=@LD@
 LN_S:=@LN_S@


### PR DESCRIPTION
When building the NTL test, I ran into an issue with STD:
```
  CXX interfaces/test/t-NTL-interface
thread_pool....In file included from src/interfaces/test/t-NTL-interface.cpp:13:
In file included from /nix/store/d94i3r3yzsld5z32k24jpfy5cmnjsgps-ntl-11.5.1/include/NTL/ZZ.h:19:
In file included from /nix/store/d94i3r3yzsld5z32k24jpfy5cmnjsgps-ntl-11.5.1/include/NTL/tools.h:11:
/nix/store/d94i3r3yzsld5z32k24jpfy5cmnjsgps-ntl-11.5.1/include/NTL/new.h:5:10: fatal error: 'new' file not found
#include <new>
         ^~~~~
```
This is fixed by simply using a C++ compiler to compile C++ code. There doesn't appear to be a compelling historical reason for setting `CXX` to `CC`, but maybe I'm missing something.

I was only able to test this on `v3.0.1`, as something about the configuration step is completely borked on my machine, endlessly printing `= yes` (that's a separate issue, though). The issue with `CXX` should also affect master, though.