### PR TITLE
Publish prereleases only as a draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
       - if: env.TAG_NAME == 'nightly'
         run: |
           (echo 'SUBJECT=FLINT nightly release';
-           echo 'PRERELEASE=--prerelease') >> $GITHUB_ENV
+           echo 'PRERELEASE=--prerelease --draft') >> $GITHUB_ENV
           gh release delete nightly --yes || true
           git push origin :nightly || true
 


### PR DESCRIPTION
Following discussion in #1852.

I'm not very familiar with GitHub Actions, but probably there's a more convoluted way to delete the old assets and upload new assets every night.

Another way would be to have a nightly build that produces the binaries as artifacts (e.g. see the .deb package produced by this [M2 build](https://github.com/Macaulay2/M2/actions/runs/8407411391)).