### PR TITLE
Optimize nmod_poly_gcd with 64-bit moduli

### DIFF
--- a/src/nmod_poly/divrem_basecase.c
+++ b/src/nmod_poly/divrem_basecase.c
@@ -63,7 +63,7 @@ void _nmod_poly_divrem_q1_preinv1(mp_ptr Q, mp_ptr R,
     }
     else
     {
-        mp_limb_t q0, q1, t, t0, t1, s0, s1;
+        mp_limb_t q0, q1, t, t0, t1, t2, s0, s1;
         slong i;
 
         q1 = nmod_mul(A[lenA-1], invL, mod);
@@ -101,10 +101,15 @@ void _nmod_poly_divrem_q1_preinv1(mp_ptr Q, mp_ptr R,
         {
             for (i = 1; i < lenB - 1; i++)
             {
-                t = A[i];
-                NMOD_ADDMUL(t, q1, B[i - 1], mod);
-                NMOD_ADDMUL(t, q0, B[i], mod);
-                R[i] = t;
+                umul_ppmm(t1, t0, q1, B[i - 1]);
+                umul_ppmm(s1, s0, q0, B[i]);
+                add_sssaaaaaa(t2, t1, t0, 0,  t1, t0, 0, 0, A[i]);
+                add_sssaaaaaa(t2, t1, t0, t2, t1, t0, 0, s1, s0);
+                if (t2 != 0)
+                    sub_ddmmss(t2, t1, t2, t1, 0, mod.n);
+                t1 = FLINT_MIN(t1, t1 - mod.n);
+                FLINT_ASSERT(t1 < mod.n);
+                NMOD_RED2(R[i], t1, t0, mod);
             }
         }
     }

--- a/src/nmod_poly/rem.c
+++ b/src/nmod_poly/rem.c
@@ -18,7 +18,7 @@ void _nmod_poly_rem_q1(mp_ptr R,
                        nmod_t mod)
 {
     slong i;
-    mp_limb_t invL, t, q0, q1, t1, t0, s1, s0;
+    mp_limb_t invL, t, q0, q1, t2, t1, t0, s1, s0;
 
     FLINT_ASSERT(lenA == lenB + 1);
     invL = (B[lenB-1] == 1) ? 1 : n_invmod(B[lenB-1], mod.n);
@@ -61,10 +61,15 @@ void _nmod_poly_rem_q1(mp_ptr R,
     {
         for (i = 1; i < lenB - 1; i++)
         {
-            t = A[i];
-            NMOD_ADDMUL(t, q1, B[i - 1], mod);
-            NMOD_ADDMUL(t, q0, B[i], mod);
-            R[i] = t;
+            umul_ppmm(t1, t0, q1, B[i - 1]);
+            umul_ppmm(s1, s0, q0, B[i]);
+            add_sssaaaaaa(t2, t1, t0, 0,  t1, t0, 0, 0, A[i]);
+            add_sssaaaaaa(t2, t1, t0, t2, t1, t0, 0, s1, s0);
+            if (t2 != 0)
+                sub_ddmmss(t2, t1, t2, t1, 0, mod.n);
+            t1 = FLINT_MIN(t1, t1 - mod.n);
+            FLINT_ASSERT(t1 < mod.n);
+            NMOD_RED2(R[i], t1, t0, mod);
         }
     }
 }


### PR DESCRIPTION
Basecase remainders had a fast path for <= 63-bit moduli where an fmma doesn't overflow two limbs, and a slow path for 64-bit moduli. Here we extend the fast path to 64-bit moduli. For gcd of two degree-200 polynomials, this gives a 2x speedup.