### PR TITLE
Fix flint_mpn random functions

### DIFF
--- a/doc/source/mpn_extras.rst
+++ b/doc/source/mpn_extras.rst
@@ -321,17 +321,16 @@ Random Number Generation
 --------------------------------------------------------------------------------
 
 
-.. function:: void flint_mpn_rrandom(mp_limb_t * rp, gmp_randstate_t state, mp_size_t n)
+.. function:: void flint_mpn_rrandom(mp_ptr rp, flint_rand_t state, mp_size_t n)
 
     Generates a random number with ``n`` limbs and stores 
     it on ``rp``. The number it generates will tend to have
     long strings of zeros and ones in the binary representation.
-    
+
     Useful for testing functions and algorithms, since this kind of random
     numbers have proven to be more likely to trigger corner-case bugs.
-    
 
-.. function:: void flint_mpn_urandomb(mp_limb_t * rp, gmp_randstate_t state, flint_bitcnt_t n)
+.. function:: void flint_mpn_urandomb(mp_ptr rp, flint_rand_t state, flint_bitcnt_t n)
 
     Generates a uniform random number of ``n`` bits and stores 
     it on ``rp``.

--- a/src/arb/test/t-atan_taylor_rs.c
+++ b/src/arb/test/t-atan_taylor_rs.c
@@ -17,8 +17,6 @@ TEST_FUNCTION_START(arb_atan_taylor_rs, state)
 {
     slong iter;
 
-    _flint_rand_init_gmp(state);
-
     for (iter = 0; iter < 100000 * 0.1 * flint_test_multiplier(); iter++)
     {
         mp_ptr x, y1, y2, t;
@@ -36,7 +34,7 @@ TEST_FUNCTION_START(arb_atan_taylor_rs, state)
         y2 = flint_malloc(sizeof(mp_limb_t) * xn);
         t = flint_malloc(sizeof(mp_limb_t) * xn);
 
-        flint_mpn_rrandom(x, state->gmp_state, xn);
+        flint_mpn_rrandom(x, state, xn);
         x[xn - 1] &= (LIMB_ONES >> 4);
 
         _arb_atan_taylor_naive(y1, &err1, x, xn, N, alternating);

--- a/src/arb/test/t-exp_taylor_rs.c
+++ b/src/arb/test/t-exp_taylor_rs.c
@@ -17,8 +17,6 @@ TEST_FUNCTION_START(arb_exp_taylor_rs, state)
 {
     slong iter;
 
-    _flint_rand_init_gmp(state);
-
     for (iter = 0; iter < 100000 * 0.1 * flint_test_multiplier(); iter++)
     {
         mp_ptr x, y1, y2, t;
@@ -35,9 +33,9 @@ TEST_FUNCTION_START(arb_exp_taylor_rs, state)
         y2 = flint_malloc(sizeof(mp_limb_t) * (xn + 1));
         t = flint_malloc(sizeof(mp_limb_t) * (xn + 1));
 
-        flint_mpn_rrandom(x, state->gmp_state, xn);
-        flint_mpn_rrandom(y1, state->gmp_state, xn + 1);
-        flint_mpn_rrandom(y2, state->gmp_state, xn + 1);
+        flint_mpn_rrandom(x, state, xn);
+        flint_mpn_rrandom(y1, state, xn + 1);
+        flint_mpn_rrandom(y2, state, xn + 1);
         x[xn - 1] &= (LIMB_ONES >> 4);
 
         _arb_exp_taylor_naive(y1, &err1, x, xn, N);

--- a/src/arb/test/t-sin_cos_taylor_rs.c
+++ b/src/arb/test/t-sin_cos_taylor_rs.c
@@ -17,8 +17,6 @@ TEST_FUNCTION_START(arb_sin_cos_taylor_rs, state)
 {
     slong iter;
 
-    _flint_rand_init_gmp(state);
-
     for (iter = 0; iter < 100000 * 0.1 * flint_test_multiplier(); iter++)
     {
         mp_ptr x, y1s, y1c, y2s, y2c, t;
@@ -37,11 +35,11 @@ TEST_FUNCTION_START(arb_sin_cos_taylor_rs, state)
         y2c = flint_malloc(sizeof(mp_limb_t) * xn);
         t = flint_malloc(sizeof(mp_limb_t) * xn);
 
-        flint_mpn_rrandom(x, state->gmp_state, xn);
-        flint_mpn_rrandom(y1s, state->gmp_state, xn);
-        flint_mpn_rrandom(y1c, state->gmp_state, xn);
-        flint_mpn_rrandom(y2s, state->gmp_state, xn);
-        flint_mpn_rrandom(y2c, state->gmp_state, xn);
+        flint_mpn_rrandom(x, state, xn);
+        flint_mpn_rrandom(y1s, state, xn);
+        flint_mpn_rrandom(y1c, state, xn);
+        flint_mpn_rrandom(y2s, state, xn);
+        flint_mpn_rrandom(y2c, state, xn);
         x[xn - 1] &= (LIMB_ONES >> 4);
 
         _arb_sin_cos_taylor_naive(y1s, y1c, &err1, x, xn, N);

--- a/src/fft.h
+++ b/src/fft.h
@@ -41,9 +41,9 @@ mp_limb_t flint_mpn_sumdiff_n(mp_ptr s, mp_ptr d, mp_srcptr x, mp_srcptr y, mp_s
          nn[limbs] = 1; \
       } else { \
          if (n_randint(state, 2) == 0) \
-            flint_mpn_rrandom(nn, state->gmp_state, limbs); \
+            flint_mpn_rrandom(nn, state, limbs); \
          else \
-            flint_mpn_urandomb(nn, state->gmp_state, limbs*FLINT_BITS); \
+            flint_mpn_urandomb(nn, state, limbs * FLINT_BITS); \
          nn[limbs] = n_randint(state, 1024); \
       } \
       if (n_randint(state, 2)) \

--- a/src/fft/profile/p-mul_mfa_truncate_sqrt2.c
+++ b/src/fft/profile/p-mul_mfa_truncate_sqrt2.c
@@ -26,9 +26,6 @@ main(void)
     flint_printf("mul_mfa_truncate_sqrt2....");
     fflush(stdout);
 
-
-    _flint_rand_init_gmp(state);
-
     depth = 13;
     w = 2;
     iters = 1;
@@ -49,8 +46,8 @@ main(void)
        r1 = i2 + int_limbs;
        /* r2 = r1 + 2*int_limbs; */
 
-       flint_mpn_urandomb(i1, state->gmp_state, int_limbs*FLINT_BITS);
-       flint_mpn_urandomb(i2, state->gmp_state, int_limbs*FLINT_BITS);
+       flint_mpn_urandomb(i1, state, int_limbs*FLINT_BITS);
+       flint_mpn_urandomb(i2, state, int_limbs*FLINT_BITS);
 
        for (j = 0; j < iters; j++)
           mul_mfa_truncate_sqrt2(r1, i1, int_limbs, i2, int_limbs, depth, w);

--- a/src/fft/profile/p-mul_truncate_sqrt2.c
+++ b/src/fft/profile/p-mul_truncate_sqrt2.c
@@ -26,9 +26,6 @@ main(void)
     flint_printf("mul_truncate_sqrt2....");
     fflush(stdout);
 
-
-    _flint_rand_init_gmp(state);
-
     depth = 13;
     w = 1;
     iters = 1;
@@ -49,8 +46,8 @@ main(void)
        r1 = i2 + int_limbs;
        /* r2 = r1 + 2*int_limbs; */
 
-       flint_mpn_urandomb(i1, state->gmp_state, int_limbs*FLINT_BITS);
-       flint_mpn_urandomb(i2, state->gmp_state, int_limbs*FLINT_BITS);
+       flint_mpn_urandomb(i1, state, int_limbs*FLINT_BITS);
+       flint_mpn_urandomb(i2, state, int_limbs*FLINT_BITS);
 
        /* mpn_mul(r2, i1, int_limbs, i2, int_limbs); */
        for (j = 0; j < iters; j++)

--- a/src/fft/test/t-adjust.c
+++ b/src/fft/test/t-adjust.c
@@ -41,8 +41,6 @@ TEST_FUNCTION_START(fft_adjust, state)
     mpz_t p, m2a, m2b, mn1;
     mp_limb_t * nn1, * r1;
 
-    _flint_rand_init_gmp(state);
-
     mpz_init(p);
     mpz_init(m2a);
     mpz_init(m2b);

--- a/src/fft/test/t-adjust_sqrt2.c
+++ b/src/fft/test/t-adjust_sqrt2.c
@@ -47,8 +47,6 @@ TEST_FUNCTION_START(fft_adjust_sqrt2, state)
     mpz_t p, m2a, m2b, mn1;
     mp_limb_t * nn1, * r1, * temp;
 
-    _flint_rand_init_gmp(state);
-
     mpz_init(p);
     mpz_init(m2a);
     mpz_init(m2b);

--- a/src/fft/test/t-butterfly.c
+++ b/src/fft/test/t-butterfly.c
@@ -55,8 +55,6 @@ TEST_FUNCTION_START(fft_ifft_butterfly, state)
     mpz_t p, ma, mb, m2a, m2b, mn1, mn2;
     mp_limb_t * nn1, * nn2, * r1, * r2;
 
-    _flint_rand_init_gmp(state);
-
     mpz_init(p);
     mpz_init(ma);
     mpz_init(mb);

--- a/src/fft/test/t-butterfly_lshB.c
+++ b/src/fft/test/t-butterfly_lshB.c
@@ -46,8 +46,6 @@ TEST_FUNCTION_START(butterfly_lshB, state)
     mpz_t p, ma, mb, m2a, m2b, mn1, mn2;
     mp_limb_t * nn1, * nn2, * r1, * r2;
 
-    _flint_rand_init_gmp(state);
-
     mpz_init(p);
     mpz_init(ma);
     mpz_init(mb);
@@ -79,7 +77,7 @@ TEST_FUNCTION_START(butterfly_lshB, state)
                     nn2 = flint_malloc((limbs + 1)*sizeof(mp_limb_t));
                     r1 = flint_malloc((limbs + 1)*sizeof(mp_limb_t));
                     r2 = flint_malloc((limbs + 1)*sizeof(mp_limb_t));
-                    flint_mpn_rrandom(nn1, state->gmp_state, limbs);
+                    flint_mpn_rrandom(nn1, state, limbs);
                     random_fermat(nn1, state, limbs);
                     random_fermat(nn2, state, limbs);
 

--- a/src/fft/test/t-butterfly_rshB.c
+++ b/src/fft/test/t-butterfly_rshB.c
@@ -60,8 +60,6 @@ TEST_FUNCTION_START(butterfly_rshB, state)
     mpz_t p, ma, mb, m2a, m2b, mn1, mn2;
     mp_limb_t * nn1, * nn2, * r1, * r2;
 
-    _flint_rand_init_gmp(state);
-
     mpz_init(p);
     mpz_init(ma);
     mpz_init(mb);
@@ -93,7 +91,7 @@ TEST_FUNCTION_START(butterfly_rshB, state)
                     nn2 = flint_malloc((limbs + 1)*sizeof(mp_limb_t));
                     r1 = flint_malloc((limbs + 1)*sizeof(mp_limb_t));
                     r2 = flint_malloc((limbs + 1)*sizeof(mp_limb_t));
-                    flint_mpn_rrandom(nn1, state->gmp_state, limbs);
+                    flint_mpn_rrandom(nn1, state, limbs);
                     random_fermat(nn1, state, limbs);
                     random_fermat(nn2, state, limbs);
 

--- a/src/fft/test/t-butterfly_sqrt2.c
+++ b/src/fft/test/t-butterfly_sqrt2.c
@@ -61,8 +61,6 @@ TEST_FUNCTION_START(fft_ifft_butterfly_sqrt2, state)
     mpz_t p, ma, mb, m2a, m2b, mn1, mn2;
     mp_limb_t * nn1, * nn2, * r1, * r2, * temp;
 
-    _flint_rand_init_gmp(state);
-
     mpz_init(p);
     mpz_init(ma);
     mpz_init(mb);

--- a/src/fft/test/t-butterfly_twiddle.c
+++ b/src/fft/test/t-butterfly_twiddle.c
@@ -58,8 +58,6 @@ TEST_FUNCTION_START(fft_ifft_butterfly_twiddle, state)
     mp_limb_t * nn1, * nn2, * r1, * r2;
     flint_bitcnt_t b1, b2;
 
-    _flint_rand_init_gmp(state);
-
     mpz_init(p);
     mpz_init(ma);
     mpz_init(mb);

--- a/src/fft/test/t-convolution.c
+++ b/src/fft/test/t-convolution.c
@@ -17,8 +17,6 @@ TEST_FUNCTION_START(fft_convolution, state)
 {
     flint_bitcnt_t depth, w, maxdepth;
 
-    _flint_rand_init_gmp(state);
-
     maxdepth = (flint_test_multiplier() > 10) ? 13 :
                (flint_test_multiplier() > 1)  ? 12 : 11;
 

--- a/src/fft/test/t-convolution_precache.c
+++ b/src/fft/test/t-convolution_precache.c
@@ -17,8 +17,6 @@ TEST_FUNCTION_START(fft_convolution_precache, state)
 {
     flint_bitcnt_t depth, w, maxdepth;
 
-    _flint_rand_init_gmp(state);
-
     maxdepth = (flint_test_multiplier() > 10) ? 13 :
                (flint_test_multiplier() > 1)  ? 12 : 11;
 

--- a/src/fft/test/t-div_2expmod_2expp1.c
+++ b/src/fft/test/t-div_2expmod_2expp1.c
@@ -36,8 +36,6 @@ TEST_FUNCTION_START(mpn_div_2expmod_2expp1, state)
     mp_limb_t * nn, * r;
     mpz_t p, m1, m2, mn1, mn2;
 
-    _flint_rand_init_gmp(state);
-
     mpz_init(m1);
     mpz_init(m2);
     mpz_init(mn1);

--- a/src/fft/test/t-fft_ifft_mfa_truncate_sqrt2.c
+++ b/src/fft/test/t-fft_ifft_mfa_truncate_sqrt2.c
@@ -17,8 +17,6 @@ TEST_FUNCTION_START(fft_ifft_mfa_truncate_sqrt2, state)
 {
     flint_bitcnt_t depth, w, maxdepth;
 
-    _flint_rand_init_gmp(state);
-
     maxdepth = (flint_test_multiplier() > 10) ? 13 :
                (flint_test_multiplier() > 1)  ? 12 : 11;
 

--- a/src/fft/test/t-fft_ifft_negacyclic.c
+++ b/src/fft/test/t-fft_ifft_negacyclic.c
@@ -17,8 +17,6 @@ TEST_FUNCTION_START(fft_ifft_negacyclic, state)
 {
     flint_bitcnt_t depth, w, maxdepth;
 
-    _flint_rand_init_gmp(state);
-
     maxdepth = (flint_test_multiplier() > 10) ? 12 :
                (flint_test_multiplier() > 1)  ? 11 : 10;
 

--- a/src/fft/test/t-fft_ifft_radix2.c
+++ b/src/fft/test/t-fft_ifft_radix2.c
@@ -17,8 +17,6 @@ TEST_FUNCTION_START(fft_ifft_radix2, state)
 {
     flint_bitcnt_t depth, w, maxdepth;
 
-    _flint_rand_init_gmp(state);
-
     maxdepth = (flint_test_multiplier() > 10) ? 12 :
                (flint_test_multiplier() > 1)  ? 11 : 10;
 

--- a/src/fft/test/t-fft_ifft_truncate.c
+++ b/src/fft/test/t-fft_ifft_truncate.c
@@ -17,8 +17,6 @@ TEST_FUNCTION_START(fft_ifft_truncate, state)
 {
     flint_bitcnt_t depth, w, maxdepth;
 
-    _flint_rand_init_gmp(state);
-
     maxdepth = (flint_test_multiplier() > 10) ? 12 :
                (flint_test_multiplier() > 1)  ? 11 : 10;
 

--- a/src/fft/test/t-fft_ifft_truncate_sqrt2.c
+++ b/src/fft/test/t-fft_ifft_truncate_sqrt2.c
@@ -17,8 +17,6 @@ TEST_FUNCTION_START(fft_ifft_truncate_sqrt2, state)
 {
     flint_bitcnt_t depth, w, maxdepth;
 
-    _flint_rand_init_gmp(state);
-
     maxdepth = (flint_test_multiplier() > 10) ? 12 :
                (flint_test_multiplier() > 1)  ? 11 : 10;
 

--- a/src/fft/test/t-mul_2expmod_2expp1.c
+++ b/src/fft/test/t-mul_2expmod_2expp1.c
@@ -36,8 +36,6 @@ TEST_FUNCTION_START(mpn_mul_2expmod_2expp1, state)
     mp_limb_t * nn, * r;
     mpz_t p, m1, m2, mn1, mn2;
 
-    _flint_rand_init_gmp(state);
-
     mpz_init(m1);
     mpz_init(m2);
     mpz_init(mn1);

--- a/src/fft/test/t-mul_fft_main.c
+++ b/src/fft/test/t-mul_fft_main.c
@@ -17,8 +17,6 @@ TEST_FUNCTION_START(flint_mpn_mul_fft_main, state)
 {
     flint_bitcnt_t depth, w, maxdepth;
 
-    _flint_rand_init_gmp(state);
-
     maxdepth = (flint_test_multiplier() > 10) ? 12 :
                (flint_test_multiplier() > 1)  ? 11 : 10;
 
@@ -65,8 +63,8 @@ TEST_FUNCTION_START(flint_mpn_mul_fft_main, state)
                r1 = i2 + n2;
                r2 = r1 + n1 + n2;
 
-               flint_mpn_urandomb(i1, state->gmp_state, b1);
-               flint_mpn_urandomb(i2, state->gmp_state, b2);
+               flint_mpn_urandomb(i1, state, b1);
+               flint_mpn_urandomb(i2, state, b2);
 
                mpn_mul(r2, i1, n1, i2, n2);
                flint_mpn_mul_fft_main(r1, i1, n1, i2, n2);

--- a/src/fft/test/t-mul_mfa_truncate_sqrt2.c
+++ b/src/fft/test/t-mul_mfa_truncate_sqrt2.c
@@ -17,8 +17,6 @@ TEST_FUNCTION_START(mul_mfa_truncate_sqrt2, state)
 {
     flint_bitcnt_t depth, w, maxdepth;
 
-    _flint_rand_init_gmp(state);
-
     maxdepth = (flint_test_multiplier() >= 10) ? 13 :
                (flint_test_multiplier() >= 1)  ? 12 : 11;
 

--- a/src/fft/test/t-mul_truncate_sqrt2.c
+++ b/src/fft/test/t-mul_truncate_sqrt2.c
@@ -17,8 +17,6 @@ TEST_FUNCTION_START(mul_truncate_sqrt2, state)
 {
     flint_bitcnt_t depth, w, maxdepth;
 
-    _flint_rand_init_gmp(state);
-
     maxdepth = (flint_test_multiplier() > 10) ? 12 :
                (flint_test_multiplier() > 1)  ? 11 : 10;
 

--- a/src/fft/test/t-mulmod_2expp1.c
+++ b/src/fft/test/t-mulmod_2expp1.c
@@ -18,8 +18,6 @@ TEST_FUNCTION_START(fft_mulmod_2expp1, state)
     flint_bitcnt_t depth, w, maxdepth;
     int iters;
 
-    _flint_rand_init_gmp(state);
-
     maxdepth = (flint_test_multiplier() > 10) ? 18 : 15;
 
     for (iters = 0; iters < 100; iters++)

--- a/src/fft/test/t-negmod_2expp1.c
+++ b/src/fft/test/t-negmod_2expp1.c
@@ -36,8 +36,6 @@ TEST_FUNCTION_START(mpn_negmod_2expp1, state)
     mp_limb_t * a, * z;
     mpz_t p, z1, z2;
 
-    _flint_rand_init_gmp(state);
-
     mpz_init(z1);
     mpz_init(z2);
     mpz_init(p);

--- a/src/fft/test/t-normmod_2expp1.c
+++ b/src/fft/test/t-normmod_2expp1.c
@@ -36,8 +36,6 @@ TEST_FUNCTION_START(mpn_normmod_2expp1, state)
     mp_limb_t * nn;
     mpz_t p, m1, m2;
 
-    _flint_rand_init_gmp(state);
-
     mpz_init(m1);
     mpz_init(m2);
     mpz_init(p);

--- a/src/fft/test/t-split_combine_bits.c
+++ b/src/fft/test/t-split_combine_bits.c
@@ -18,8 +18,6 @@ TEST_FUNCTION_START(fft_split_combine_bits, state)
     int i;
     mp_size_t j;
 
-    _flint_rand_init_gmp(state);
-
     for (i = 0; i < 1000 * flint_test_multiplier(); i++)
     {
         mp_size_t total_limbs = n_randint(state, 1000) + 1;
@@ -35,7 +33,7 @@ TEST_FUNCTION_START(fft_split_combine_bits, state)
         for (j = 0; j < length; j++)
            poly[j] = flint_malloc((limbs + 1)*sizeof(mp_limb_t));
 
-        flint_mpn_urandomb(in, state->gmp_state, total_limbs*FLINT_BITS);
+        flint_mpn_urandomb(in, state, total_limbs*FLINT_BITS);
 
         fft_split_bits(poly, in, total_limbs, bits, limbs);
         fft_combine_bits(out, poly, length, bits, limbs, total_limbs);

--- a/src/fft/tune/tune-fft.c
+++ b/src/fft/tune/tune-fft.c
@@ -33,9 +33,6 @@ main(void)
     flint_printf("#define FFT_TAB \\\n");
     fflush(stdout);
 
-
-    _flint_rand_init_gmp(state);
-
     flint_printf("   { "); fflush(stdout);
     for (depth = 6; depth <= 10; depth++)
     {
@@ -60,8 +57,8 @@ main(void)
             i2 = i1 + n1;
             r1 = i2 + n2;
 
-            flint_mpn_urandomb(i1, state->gmp_state, b1);
-            flint_mpn_urandomb(i2, state->gmp_state, b2);
+            flint_mpn_urandomb(i1, state, b1);
+            flint_mpn_urandomb(i2, state, b2);
 
             best_off = -1;
 
@@ -119,8 +116,8 @@ main(void)
             r1 = i2 + int_limbs + 1;
             tt = r1 + 2*(int_limbs + 1);
 
-            flint_mpn_urandomb(i1, state->gmp_state, int_limbs*FLINT_BITS);
-            flint_mpn_urandomb(i2, state->gmp_state, int_limbs*FLINT_BITS);
+            flint_mpn_urandomb(i1, state, int_limbs*FLINT_BITS);
+            flint_mpn_urandomb(i2, state, int_limbs*FLINT_BITS);
             i1[int_limbs] = 0;
             i2[int_limbs] = 0;
 

--- a/src/fft_small/profile/p-fft_small_vs_gmp.c
+++ b/src/fft_small/profile/p-fft_small_vs_gmp.c
@@ -33,8 +33,8 @@ int main(void)
     r = flint_malloc(2 * sizeof(mp_limb_t) * FLINT_MAX(N_MAX_MUL, N_MAX_SQR));
     s = flint_malloc(2 * sizeof(mp_limb_t) * FLINT_MAX(N_MAX_MUL, N_MAX_SQR));
 
-    mpn_random2(x, FLINT_MAX(N_MAX_MUL, N_MAX_SQR));
-    mpn_random2(y, FLINT_MAX(N_MAX_MUL, N_MAX_SQR));
+    flint_mpn_rrandom(x, state, FLINT_MAX(N_MAX_MUL, N_MAX_SQR));
+    flint_mpn_rrandom(y, state, FLINT_MAX(N_MAX_MUL, N_MAX_SQR));
 
     flint_printf("mpn_mul_n vs fft_small\n\n");
 

--- a/src/fft_small/test/t-mpn_add_inplace_c.c
+++ b/src/fft_small/test/t-mpn_add_inplace_c.c
@@ -38,8 +38,6 @@ TEST_FUNCTION_START(flint_mpn_add_inplace_c, state)
 {
     slong iter;
 
-    _flint_rand_init_gmp(state);
-
     for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
     {
         mp_limb_t a[10], b[10], c[10];
@@ -49,8 +47,8 @@ TEST_FUNCTION_START(flint_mpn_add_inplace_c, state)
         bn = 1 + n_randint(state, 4);
         an = bn + n_randint(state, 4);
 
-        flint_mpn_rrandom(a, state->gmp_state, an);
-        flint_mpn_rrandom(b, state->gmp_state, bn);
+        flint_mpn_rrandom(a, state, an);
+        flint_mpn_rrandom(b, state, bn);
         flint_mpn_copyi(c, a, an);
         cf = n_randint(state, 2);
 
@@ -70,8 +68,8 @@ TEST_FUNCTION_START(flint_mpn_add_inplace_c, state)
     {
         mp_limb_t a[8], b[8], c[8], d[8];
 
-        flint_mpn_rrandom(a, state->gmp_state, 8);
-        flint_mpn_rrandom(b, state->gmp_state, 8);
+        flint_mpn_rrandom(a, state, 8);
+        flint_mpn_rrandom(b, state, 8);
         flint_mpn_copyi(c, a, 8);
         flint_mpn_copyi(d, a, 8);
 

--- a/src/mpn_extras.h
+++ b/src/mpn_extras.h
@@ -662,25 +662,8 @@ double flint_mpn_get_d(mp_srcptr ptr, mp_size_t size, mp_size_t sign, long exp);
 
 /* random ********************************************************************/
 
-MPN_EXTRAS_INLINE
-void flint_mpn_rrandom(mp_limb_t *rp, gmp_randstate_t state, mp_size_t n)
-{
-  __mpz_struct str;
-  str._mp_d = rp;
-  str._mp_alloc = n;
-  str._mp_size =n;
-  mpz_rrandomb(&str,state,FLINT_BITS*n);
-}
-
-MPN_EXTRAS_INLINE
-void flint_mpn_urandomb(mp_limb_t *rp, gmp_randstate_t state, flint_bitcnt_t n)
-{
-  __mpz_struct str;
-  str._mp_d = rp;
-  str._mp_alloc = (n + FLINT_BITS - 1)/FLINT_BITS;
-  str._mp_size = (n + FLINT_BITS - 1)/FLINT_BITS;
-  mpz_rrandomb(&str,state,n);
-}
+void flint_mpn_rrandom(mp_ptr rp, flint_rand_t state, mp_size_t n);
+void flint_mpn_urandomb(mp_ptr rp, flint_rand_t state, flint_bitcnt_t n);
 
 /******************************************************************************
     Divisions where the quotient is expected to be small. All function do:

--- a/src/mpn_extras/random.c
+++ b/src/mpn_extras/random.c
@@ -1,0 +1,42 @@
+/*
+    Copyright (C) 2024 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "flint.h"
+#include "mpn_extras.h"
+
+void flint_mpn_rrandom(mp_ptr rp, flint_rand_t state, mp_size_t n)
+{
+    __mpz_struct str;
+    str._mp_d = rp;
+    str._mp_alloc = n;
+    str._mp_size = n;
+    _flint_rand_init_gmp(state);
+    FLINT_ASSERT(n >= 1);
+    /* Randomly generate numbers where the top limb has the highest bit
+       set or not. TODO: do we want this function to generate
+       numbers where one or more leading limbs can be zero, or should
+       that be a separate function? The documentation does not specify
+       precisely what this function does. */
+    if (n_randint(state, 2))
+        mpz_rrandomb(&str, state->gmp_state, FLINT_BITS * n);
+    else
+        mpz_rrandomb(&str, state->gmp_state, FLINT_BITS * n - n_randint(state, FLINT_BITS));
+}
+
+void flint_mpn_urandomb(mp_ptr rp, flint_rand_t state, flint_bitcnt_t n)
+{
+    __mpz_struct str;
+    str._mp_d = rp;
+    str._mp_alloc = (n + FLINT_BITS - 1)/FLINT_BITS;
+    str._mp_size = (n + FLINT_BITS - 1)/FLINT_BITS;
+    _flint_rand_init_gmp(state);
+    mpz_urandomb(&str, state->gmp_state, n);
+}

--- a/src/mpn_extras/test/t-2add_n_inplace.c
+++ b/src/mpn_extras/test/t-2add_n_inplace.c
@@ -34,9 +34,9 @@ TEST_FUNCTION_START(flint_mpn_2add_n_inplace, state)
 
         n = N_MIN + n_randint(state, N_MAX - N_MIN + 1);
 
-        mpn_random2(rp, N_MAX);
-        mpn_random2(ap, N_MAX);
-        mpn_random2(bp, N_MAX);
+        flint_mpn_rrandom(rp, state, N_MAX);
+        flint_mpn_rrandom(ap, state, N_MAX);
+        flint_mpn_rrandom(bp, state, N_MAX);
         flint_mpn_copyi(rp1, rp, N_MAX);
         flint_mpn_copyi(rp2, rp, N_MAX);
 

--- a/src/mpn_extras/test/t-mul.c
+++ b/src/mpn_extras/test/t-mul.c
@@ -41,10 +41,10 @@ TEST_FUNCTION_START(flint_mpn_mul, state)
         rp1 = flint_malloc(sizeof(mp_limb_t) * (m + n));
         rp2 = flint_malloc(sizeof(mp_limb_t) * (m + n));
 
-        mpn_random2(xp, m);
-        mpn_random2(yp, n);
+        flint_mpn_rrandom(xp, state, m);
+        flint_mpn_rrandom(yp, state, n);
 
-        mpn_random(rp2, m + n);
+        flint_mpn_rrandom(rp2, state, m + n);
 
         ret1 = mpn_mul(rp1, xp, m, yp, n);
         ret2 = flint_mpn_mul(rp2, xp, m, yp, n);

--- a/src/mpn_extras/test/t-mul_n.c
+++ b/src/mpn_extras/test/t-mul_n.c
@@ -30,8 +30,8 @@ TEST_FUNCTION_START(flint_mpn_mul_n, state)
         R1 = flint_malloc(sizeof(mp_limb_t) * 2 * n);
         R2 = flint_malloc(sizeof(mp_limb_t) * 2 * n);
 
-        mpn_random2(X, n);
-        mpn_random2(Y, n);
+        flint_mpn_rrandom(X, state, n);
+        flint_mpn_rrandom(Y, state, n);
 
         for (i = 0; i < 2 * n; i++)
             R1[i] = n_randtest(state);

--- a/src/mpn_extras/test/t-mul_toom22.c
+++ b/src/mpn_extras/test/t-mul_toom22.c
@@ -33,8 +33,8 @@ TEST_FUNCTION_START(flint_mpn_mul_toom22, state)
         R1 = flint_malloc(sizeof(mp_limb_t) * (2 * n));
         R2 = flint_malloc(sizeof(mp_limb_t) * (2 * n));
 
-        mpn_random2(X, n);
-        mpn_random2(Y, m);
+        flint_mpn_rrandom(X, state, n);
+        flint_mpn_rrandom(Y, state, m);
 
         for (i = 0; i < n + m; i++)
             R1[i] = n_randtest(state);

--- a/src/mpn_extras/test/t-mulhigh_n.c
+++ b/src/mpn_extras/test/t-mulhigh_n.c
@@ -116,8 +116,8 @@ TEST_FUNCTION_START(flint_mpn_mulhigh_n, state)
         xp = flint_malloc(sizeof(mp_limb_t) * n);
         yp = flint_malloc(sizeof(mp_limb_t) * n);
 
-        mpn_random2(xp, n);
-        mpn_random2(yp, n);
+        flint_mpn_rrandom(xp, state, n);
+        flint_mpn_rrandom(yp, state, n);
 
         if (n <= FLINT_MAX(FLINT_MPN_MULHIGH_MULDERS_CUTOFF, FLINT_MPN_MULHIGH_FUNC_TAB_WIDTH))
         {

--- a/src/mpn_extras/test/t-mulhigh_normalised.c
+++ b/src/mpn_extras/test/t-mulhigh_normalised.c
@@ -31,8 +31,8 @@ TEST_FUNCTION_START(flint_mpn_mulhigh_normalised, state)
 
         n = 1 + n_randint(state, N_MAX);
 
-        mpn_random2(xp, n);
-        mpn_random2(yp, n);
+        flint_mpn_rrandom(xp, state, n);
+        flint_mpn_rrandom(yp, state, n);
         xp[n - 1] |= (UWORD(1) << (FLINT_BITS - 1));
         yp[n - 1] |= (UWORD(1) << (FLINT_BITS - 1));
 

--- a/src/mpn_extras/test/t-mullow_n.c
+++ b/src/mpn_extras/test/t-mullow_n.c
@@ -34,11 +34,8 @@ TEST_FUNCTION_START(flint_mpn_mullow_n, state)
         xp = flint_malloc(sizeof(mp_limb_t) * n);
         yp = flint_malloc(sizeof(mp_limb_t) * n);
 
-        mpn_random2(xp, n);
-        mpn_random2(yp, n);
-
-        if (ix < 1)
-            continue;
+        flint_mpn_rrandom(xp, state, n);
+        flint_mpn_rrandom(yp, state, n);
 
         ret = flint_mpn_mullow_n(rp, xp, yp, n);
         flint_mpn_mul_n(rpf, xp, yp, n);

--- a/src/mpn_extras/test/t-mulmod_2expp1.c
+++ b/src/mpn_extras/test/t-mulmod_2expp1.c
@@ -16,13 +16,10 @@
 TEST_FUNCTION_START(flint_mpn_mulmod_2expp1, state)
 {
     ulong xn, yn, b, zn, c, dn;
-    gmp_randstate_t rands;
     int k, cc;
     mp_limb_t xp[10000], dp[10000], qp[10000], yp[10000];
     mp_limb_t rp[10000], zp[10000], tp[10000], tb;
     int result = 1;
-
-    gmp_randinit_default(rands);
 
     b = 1;
     tb = 1;
@@ -45,8 +42,8 @@ TEST_FUNCTION_START(flint_mpn_mulmod_2expp1, state)
             dn++; /* dp is 2^b+1 */
 
         for (c = 0; c < 20; c++) {
-            mpn_random2(xp, xn);
-            mpn_random2(yp, xn);
+            flint_mpn_rrandom(xp, state, xn);
+            flint_mpn_rrandom(yp, state, xn);
             xp[xn-1] &= GMP_NUMB_MASK >> k;
             yp[xn-1] &= GMP_NUMB_MASK >> k;
             mpn_mul_n(zp, xp, yp, xn);
@@ -90,7 +87,7 @@ TEST_FUNCTION_START(flint_mpn_mulmod_2expp1, state)
             dn++; /* dp is 2^b+1 */
 
         for (c = 0; c < 20; c++) {
-            mpn_random2(xp, xn);
+            flint_mpn_rrandom(xp, state, xn);
             mpn_zero(yp, xn); /* set yp to 2^b */
             xp[xn-1] &= GMP_NUMB_MASK >> k;
             yp[xn-1] &= GMP_NUMB_MASK >> k;
@@ -143,7 +140,7 @@ TEST_FUNCTION_START(flint_mpn_mulmod_2expp1, state)
             dn++; /* dp is 2^b+1 */
 
         for (c = 0; c < 20; c++) {
-            mpn_random2(xp, xn);
+            flint_mpn_rrandom(xp, state, xn);
             mpn_zero(yp, xn); /* set yp to 2^b */
             xp[xn-1] &= GMP_NUMB_MASK >> k;
             yp[xn-1] &= GMP_NUMB_MASK >> k;
@@ -212,8 +209,6 @@ TEST_FUNCTION_START(flint_mpn_mulmod_2expp1, state)
                 TEST_FUNCTION_FAIL("b = %wd\n", b);
         }
     }
-
-    gmp_randclear(rands);
 
     TEST_FUNCTION_END(state);
 }

--- a/src/mpn_extras/test/t-sqr.c
+++ b/src/mpn_extras/test/t-sqr.c
@@ -38,7 +38,7 @@ TEST_FUNCTION_START(flint_mpn_sqr, state)
         rp1 = flint_malloc(sizeof(mp_limb_t) * 2 * n);
         rp2 = flint_malloc(sizeof(mp_limb_t) * 2 * n);
 
-        mpn_random2(xp, n);
+        flint_mpn_rrandom(xp, state, n);
 
         for (i = 0; i < 2 * n; i++)
             rp1[i] = n_randtest(state);

--- a/src/mpn_extras/test/t-sqrhigh.c
+++ b/src/mpn_extras/test/t-sqrhigh.c
@@ -115,7 +115,7 @@ TEST_FUNCTION_START(flint_mpn_sqrhigh, state)
 
         xp = flint_malloc(sizeof(mp_limb_t) * n);
 
-        mpn_random2(xp, n);
+        flint_mpn_rrandom(xp, state, n);
 
         if (n <= FLINT_MAX(FLINT_MPN_SQRHIGH_MULDERS_CUTOFF, FLINT_MPN_SQRHIGH_FUNC_TAB_WIDTH))
         {


### PR DESCRIPTION
* Have both ``flint_mpn_rrandom`` and ``flint_mpn_urandomb`` take a flint randstate as input instead of a gmp randstate
* ``flint_mpn_urandomb`` was not actually generating uniformly random numbers
* Have ``flint_mpn_rrandom`` generate numbers where the msb of the top limb is not set. (It's not clear whether this function should also generate numbers with zeroed leading limbs; perhaps we want separate functions for this.)
* Don't use ``mpn_random2`` in test code as this creates global state
