### PR TITLE
Add strict bound to flint_mpn_mulhigh test

### DIFF
--- a/src/mpn_extras/test/t-mulhigh_n.c
+++ b/src/mpn_extras/test/t-mulhigh_n.c
@@ -81,10 +81,12 @@ generic_mulhigh_basecase(mp_ptr rp, mp_srcptr up, mp_srcptr vp, mp_size_t n)
 static ulong lower_bound(ulong n)
 {
     /* These are calculated by hand lower bound for the returned limb */
+    /* mulhi(u, v) truncated at B^n has an error of at most 2 n B^n, which is a
+     * strict inequality */
     if (n < 3)
         return 0;
     else
-        return 4 * n - 8;
+        return 2 * n;
 }
 #endif
 


### PR DESCRIPTION
Not sure why I got it to $4 n$ before... Anyway, one could get even stricter bounds since the error is dominated by a series of high and low single limb multiplications which gives a restriction of the inputs. This should yield a bound of the form $2 n - k$ for some $k$, but I'm unsure how to go about this. This is fine for now.