### PR TITLE
Add `gr_contains_zero`

### DIFF
--- a/doc/source/gr.rst
+++ b/doc/source/gr.rst
@@ -504,6 +504,20 @@ Basic properties
 
     Returns whether *x* represents a rational number.
 
+.. function:: truth_t gr_contains_zero(gr_srcptr x, gr_ctx_t ctx)
+
+    Returns whether *x* contains the ring element 0. If the domain is exact,
+    this is equivalent to calling :func:`gr_is_zero`. If *x* is an ``arb``
+    (respectively ``acb``) element, this returns whether zero is contained in
+    the ball (respectively rectangle). If *x* is a polynomial, this returns
+    whether all coefficients contain the zero element of the base ring. If *x*
+    is a matrix, this returns whether all entries contain the zero element of
+    the base ring.
+
+    See also :func:`gr_poly_contains_zero_poly`,
+    :func:`gr_mat_contains_zero_mat`, and
+    :func:`_gr_vec_contains_zero_vec`.
+
 Arithmetic
 ........................................................................
 

--- a/doc/source/gr_generic.rst
+++ b/doc/source/gr_generic.rst
@@ -34,6 +34,10 @@
               truth_t gr_generic_is_one(gr_srcptr x, gr_ctx_t ctx)
               truth_t gr_generic_is_neg_one(gr_srcptr x, gr_ctx_t ctx)
 
+.. function:: truth_t gr_generic_contains_zero(gr_srcptr x, gr_ctx_t ctx)
+
+    Returns the same result as :func:`gr_generic_is_zero`, as a fallback.
+
 .. function:: int gr_generic_neg_one(gr_ptr res, gr_ctx_t ctx)
 
 .. function:: int gr_generic_set_other(gr_ptr res, gr_srcptr x, gr_ctx_t xctx, gr_ctx_t ctx)
@@ -219,6 +223,12 @@ To do: move to ``gr_vec``
 .. function:: truth_t gr_generic_vec_equal(gr_srcptr vec1, gr_srcptr vec2, slong len, gr_ctx_t ctx)
 
 .. function:: int gr_generic_vec_is_zero(gr_srcptr vec, slong len, gr_ctx_t ctx)
+
+.. function:: int gr_generic_vec_contains_zero_vec(gr_srcptr vec, slong len, gr_ctx_t ctx)
+
+    Returns whether *vec* contains the zero vector, in the sense that all
+    elements contain the zero element of the base ring, as described
+    in :func:`gr_contains_zero`.
 
 .. function:: int gr_generic_vec_dot(gr_ptr res, gr_srcptr initial, int subtract, gr_srcptr vec1, gr_srcptr vec2, slong len, gr_ctx_t ctx)
 

--- a/doc/source/gr_mat.rst
+++ b/doc/source/gr_mat.rst
@@ -137,6 +137,12 @@ Assignment and special values
     Returns whether *mat* respectively is the zero matrix or
     the scalar matrix with 1 or -1 on the main diagonal.
 
+.. function:: truth_t gr_mat_contains_zero_mat(const gr_mat_t mat, gr_ctx_t ctx)
+
+    Returns whether *mat* contains the zero matrix, in the sense that all its
+    entries contain the zero element of the base ring, as described
+    in :func:`gr_contains_zero`.
+
 .. function:: truth_t gr_mat_is_scalar(const gr_mat_t mat, gr_ctx_t ctx)
 
     Returns whether *mat* is a scalar matrix, being a diagonal matrix

--- a/doc/source/gr_poly.rst
+++ b/doc/source/gr_poly.rst
@@ -126,6 +126,12 @@ Basic manipulation
               truth_t gr_poly_is_gen(const gr_poly_t poly, gr_ctx_t ctx)
               truth_t gr_poly_is_scalar(const gr_poly_t poly, gr_ctx_t ctx)
 
+.. function:: truth_t gr_poly_contains_zero_poly(const gr_poly_t poly, gr_ctx_t ctx)
+
+    Returns whether *poly* contains the zero polynomial, in the sense that all
+    its coefficients contain the zero element of the base ring, as described
+    in :func:`gr_contains_zero`.
+
 .. function:: int gr_poly_set_scalar(gr_poly_t poly, gr_srcptr c, gr_ctx_t ctx)
               int gr_poly_set_si(gr_poly_t poly, slong c, gr_ctx_t ctx)
               int gr_poly_set_ui(gr_poly_t poly, ulong c, gr_ctx_t ctx)

--- a/doc/source/gr_vec.rst
+++ b/doc/source/gr_vec.rst
@@ -87,6 +87,12 @@ Types and basic operations
 
 .. function:: truth_t _gr_vec_is_zero(gr_srcptr vec, slong len, gr_ctx_t ctx)
 
+.. function:: truth_t _gr_vec_contains_zero_vec(gr_srcptr vec, slong len, gr_ctx_t ctx)
+
+    Returns whether *vec* contains the zero vector, in the sense that all
+    elements contain the zero element of the base ring, as described
+    in :func:`gr_contains_zero`.
+
 .. function:: int _gr_vec_normalise(slong * res, gr_srcptr vec, slong len, gr_ctx_t ctx)
 
 .. function:: slong _gr_vec_normalise_weak(gr_srcptr vec, slong len, gr_ctx_t ctx)

--- a/src/gr.h
+++ b/src/gr.h
@@ -182,6 +182,8 @@ typedef enum
     GR_METHOD_IS_ONE,
     GR_METHOD_IS_NEG_ONE,
 
+    GR_METHOD_CONTAINS_ZERO,
+
     GR_METHOD_EQUAL,
 
     GR_METHOD_SET,
@@ -631,6 +633,7 @@ typedef enum
     GR_METHOD_VEC_ZERO,
     GR_METHOD_VEC_EQUAL,
     GR_METHOD_VEC_IS_ZERO,
+    GR_METHOD_VEC_CONTAINS_ZERO_VEC,
     GR_METHOD_VEC_NEG,
 
     GR_METHOD_VEC_NORMALISE,
@@ -1051,6 +1054,8 @@ GR_INLINE WARN_UNUSED_RESULT int gr_set_fexpr(gr_ptr res, fexpr_vec_t inputs, gr
 GR_INLINE truth_t gr_is_zero(gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_PREDICATE(ctx, IS_ZERO)(x, ctx); }
 GR_INLINE truth_t gr_is_one(gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_PREDICATE(ctx, IS_ONE)(x, ctx); }
 GR_INLINE truth_t gr_is_neg_one(gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_PREDICATE(ctx, IS_NEG_ONE)(x, ctx); }
+
+GR_INLINE truth_t gr_contains_zero(gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_PREDICATE(ctx, CONTAINS_ZERO)(x, ctx); }
 
 GR_INLINE truth_t gr_equal(gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_PREDICATE(ctx, EQUAL)(x, y, ctx); }
 GR_INLINE truth_t gr_not_equal(gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return truth_not(GR_BINARY_PREDICATE(ctx, EQUAL)(x, y, ctx)); }

--- a/src/gr/acb.c
+++ b/src/gr/acb.c
@@ -396,6 +396,12 @@ _gr_acb_is_neg_one(const acb_t x, const gr_ctx_t ctx)
 }
 
 truth_t
+_gr_acb_contains_zero(const acb_t x, const gr_ctx_t ctx)
+{
+    return acb_contains_zero(x) ? T_TRUE : T_FALSE;
+}
+
+truth_t
 _gr_acb_equal(const acb_t x, const acb_t y, const gr_ctx_t ctx)
 {
     if (acb_is_exact(x) && acb_equal(x, y))
@@ -2055,6 +2061,7 @@ gr_method_tab_input _acb_methods_input[] =
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_acb_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_acb_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) _gr_acb_is_neg_one},
+    {GR_METHOD_CONTAINS_ZERO,   (gr_funcptr) _gr_acb_contains_zero},
     {GR_METHOD_EQUAL,           (gr_funcptr) _gr_acb_equal},
     {GR_METHOD_SET,             (gr_funcptr) _gr_acb_set},
     {GR_METHOD_SET_SI,          (gr_funcptr) _gr_acb_set_si},

--- a/src/gr/arb.c
+++ b/src/gr/arb.c
@@ -373,6 +373,12 @@ _gr_arb_is_neg_one(const arb_t x, const gr_ctx_t ctx)
 }
 
 truth_t
+_gr_arb_contains_zero(const arb_t x, const gr_ctx_t ctx)
+{
+    return arb_contains_zero(x) ? T_TRUE : T_FALSE;
+}
+
+truth_t
 _gr_arb_equal(const arb_t x, const arb_t y, const gr_ctx_t ctx)
 {
     if (arb_is_exact(x) && arb_equal(x, y))
@@ -1778,6 +1784,7 @@ gr_method_tab_input _arb_methods_input[] =
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_arb_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_arb_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) _gr_arb_is_neg_one},
+    {GR_METHOD_CONTAINS_ZERO,   (gr_funcptr) _gr_arb_contains_zero},
     {GR_METHOD_EQUAL,           (gr_funcptr) _gr_arb_equal},
     {GR_METHOD_SET,             (gr_funcptr) _gr_arb_set},
     {GR_METHOD_SET_SI,          (gr_funcptr) _gr_arb_set_si},

--- a/src/gr/matrix.c
+++ b/src/gr/matrix.c
@@ -308,6 +308,12 @@ matrix_is_neg_one(const gr_mat_t mat, gr_ctx_t ctx)
     return gr_mat_is_neg_one(mat, MATRIX_CTX(ctx)->base_ring);
 }
 
+truth_t
+matrix_contains_zero_matrix(const gr_mat_t mat, gr_ctx_t ctx)
+{
+    return gr_mat_contains_zero_mat(mat, MATRIX_CTX(ctx)->base_ring);
+}
+
 int
 matrix_neg(gr_mat_t res, const gr_mat_t mat, gr_ctx_t ctx)
 {
@@ -524,6 +530,7 @@ gr_method_tab_input _gr_mat_methods_input[] =
     {GR_METHOD_IS_ZERO,     (gr_funcptr) matrix_is_zero},
     {GR_METHOD_IS_ONE,      (gr_funcptr) matrix_is_one},
     {GR_METHOD_IS_NEG_ONE,  (gr_funcptr) matrix_is_neg_one},
+    {GR_METHOD_CONTAINS_ZERO, (gr_funcptr) matrix_contains_zero_matrix},
     {GR_METHOD_EQUAL,       (gr_funcptr) matrix_equal},
     {GR_METHOD_SET,         (gr_funcptr) matrix_set},
     {GR_METHOD_SET_UI,      (gr_funcptr) matrix_set_ui},

--- a/src/gr/polynomial.c
+++ b/src/gr/polynomial.c
@@ -361,6 +361,12 @@ polynomial_is_neg_one(const gr_poly_t poly, gr_ctx_t ctx)
 }
 */
 
+truth_t
+polynomial_contains_zero_polynomial(const gr_poly_t poly, gr_ctx_t ctx)
+{
+    return gr_poly_contains_zero_poly(poly, POLYNOMIAL_ELEM_CTX(ctx));
+}
+
 int
 polynomial_neg(gr_poly_t res, const gr_poly_t mat, gr_ctx_t ctx)
 {
@@ -535,6 +541,9 @@ gr_method_tab_input _gr_poly_methods_input[] =
     {GR_METHOD_IS_ONE,      (gr_funcptr) polynomial_is_one},
     {GR_METHOD_IS_NEG_ONE,  (gr_funcptr) polynomial_is_neg_one},
 */
+
+    {GR_METHOD_CONTAINS_ZERO, (gr_funcptr) polynomial_contains_zero_polynomial},
+
     {GR_METHOD_EQUAL,       (gr_funcptr) polynomial_equal},
     {GR_METHOD_SET,         (gr_funcptr) polynomial_set},
     {GR_METHOD_SET_UI,      (gr_funcptr) polynomial_set_ui},

--- a/src/gr_generic.h
+++ b/src/gr_generic.h
@@ -103,6 +103,8 @@ WARN_UNUSED_RESULT truth_t gr_generic_is_zero(gr_srcptr x, gr_ctx_t ctx);
 WARN_UNUSED_RESULT truth_t gr_generic_is_one(gr_srcptr x, gr_ctx_t ctx);
 WARN_UNUSED_RESULT truth_t gr_generic_is_neg_one(gr_srcptr x, gr_ctx_t ctx);
 
+WARN_UNUSED_RESULT truth_t gr_generic_contains_zero(gr_srcptr x, gr_ctx_t ctx);
+
 WARN_UNUSED_RESULT int gr_generic_neg_one(gr_ptr res, gr_ctx_t ctx);
 
 WARN_UNUSED_RESULT int gr_generic_set_other(gr_ptr res, gr_srcptr x, gr_ctx_t xctx, gr_ctx_t ctx);
@@ -230,6 +232,7 @@ WARN_UNUSED_RESULT int gr_generic_vec_scalar_addmul_si(gr_ptr vec1, gr_srcptr ve
 WARN_UNUSED_RESULT int gr_generic_vec_scalar_submul_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx);
 WARN_UNUSED_RESULT truth_t gr_generic_vec_equal(gr_srcptr vec1, gr_srcptr vec2, slong len, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_generic_vec_is_zero(gr_srcptr vec, slong len, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_generic_vec_contains_zero_vec(gr_srcptr vec, slong len, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_generic_vec_dot(gr_ptr res, gr_srcptr initial, int subtract, gr_srcptr vec1, gr_srcptr vec2, slong len, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_generic_vec_dot_rev(gr_ptr res, gr_srcptr initial, int subtract, gr_srcptr vec1, gr_srcptr vec2, slong len, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_generic_vec_dot_ui(gr_ptr res, gr_srcptr initial, int subtract, gr_srcptr vec1, const ulong * vec2, slong len, gr_ctx_t ctx);

--- a/src/gr_generic/generic.c
+++ b/src/gr_generic/generic.c
@@ -212,6 +212,11 @@ truth_t gr_generic_is_neg_one(gr_srcptr x, gr_ctx_t ctx)
     return eq;
 }
 
+truth_t gr_generic_contains_zero(gr_srcptr x, gr_ctx_t ctx)
+{
+    return gr_generic_is_zero(x, ctx);
+}
+
 int gr_generic_neg_one(gr_ptr res, gr_ctx_t ctx)
 {
     int status;
@@ -2222,6 +2227,28 @@ gr_generic_vec_is_zero(gr_srcptr vec, slong len, gr_ctx_t ctx)
 }
 
 int
+gr_generic_vec_contains_zero_vec(gr_srcptr vec, slong len, gr_ctx_t ctx)
+{
+    gr_method_unary_predicate contains_zero = GR_UNARY_PREDICATE(ctx, CONTAINS_ZERO);
+    truth_t eq, this_eq;
+    slong i, sz;
+
+    sz = ctx->sizeof_elem;
+
+    eq = T_TRUE;
+
+    for (i = 0; i < len; i++)
+    {
+        this_eq = contains_zero(GR_ENTRY(vec, i, sz), ctx);
+
+        if (this_eq == T_FALSE)
+            return T_FALSE;
+    }
+
+    return eq;
+}
+
+int
 gr_generic_vec_dot(gr_ptr res, gr_srcptr initial, int subtract, gr_srcptr vec1, gr_srcptr vec2, slong len, gr_ctx_t ctx)
 {
     gr_method_binary_op mul = GR_BINARY_OP(ctx, MUL);
@@ -2561,6 +2588,8 @@ const gr_method_tab_input _gr_generic_methods[] =
     {GR_METHOD_IS_ONE,                  (gr_funcptr) gr_generic_is_one},
     {GR_METHOD_IS_NEG_ONE,              (gr_funcptr) gr_generic_is_neg_one},
 
+    {GR_METHOD_CONTAINS_ZERO,           (gr_funcptr) gr_generic_contains_zero},
+
     {GR_METHOD_EQUAL,                   (gr_funcptr) gr_generic_equal},
 
     {GR_METHOD_SET,                     (gr_funcptr) gr_generic_set},
@@ -2847,6 +2876,8 @@ const gr_method_tab_input _gr_generic_methods[] =
 
     {GR_METHOD_VEC_EQUAL,               (gr_funcptr) gr_generic_vec_equal},
     {GR_METHOD_VEC_IS_ZERO,             (gr_funcptr) gr_generic_vec_is_zero},
+
+    {GR_METHOD_VEC_CONTAINS_ZERO_VEC,   (gr_funcptr) gr_generic_vec_contains_zero_vec},
 
     {GR_METHOD_VEC_SUM,                 (gr_funcptr) _gr_vec_sum_generic},
     {GR_METHOD_VEC_PRODUCT,             (gr_funcptr) _gr_vec_product_generic},

--- a/src/gr_mat.h
+++ b/src/gr_mat.h
@@ -118,6 +118,8 @@ truth_t gr_mat_is_zero(const gr_mat_t mat, gr_ctx_t ctx);
 truth_t gr_mat_is_one(const gr_mat_t mat, gr_ctx_t ctx);
 truth_t gr_mat_is_neg_one(const gr_mat_t mat, gr_ctx_t ctx);
 
+truth_t gr_mat_contains_zero_mat(const gr_mat_t mat, gr_ctx_t ctx);
+
 WARN_UNUSED_RESULT int gr_mat_zero(gr_mat_t res, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mat_one(gr_mat_t res, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mat_set(gr_mat_t res, const gr_mat_t mat, gr_ctx_t ctx);

--- a/src/gr_mat/contains_zero_mat.c
+++ b/src/gr_mat/contains_zero_mat.c
@@ -1,0 +1,38 @@
+/*
+    Copyright (C) 2024 Ricardo Buring
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "gr_vec.h"
+#include "gr_mat.h"
+
+truth_t
+gr_mat_contains_zero_mat(const gr_mat_t mat, gr_ctx_t ctx)
+{
+    truth_t eq, this_eq;
+    slong i, r, c;
+
+    r = gr_mat_nrows(mat, ctx);
+    c = gr_mat_ncols(mat, ctx);
+
+    if (r == 0 || c == 0)
+        return T_TRUE;
+
+    eq = T_TRUE;
+
+    for (i = 0; i < r; i++)
+    {
+        this_eq = _gr_vec_contains_zero_vec(mat->rows[i], c, ctx);
+
+        if (this_eq == T_FALSE)
+            return T_FALSE;
+    }
+
+    return eq;
+}

--- a/src/gr_poly.h
+++ b/src/gr_poly.h
@@ -99,6 +99,8 @@ truth_t gr_poly_is_one(const gr_poly_t poly, gr_ctx_t ctx);
 truth_t gr_poly_is_gen(const gr_poly_t poly, gr_ctx_t ctx);
 truth_t gr_poly_is_scalar(const gr_poly_t poly, gr_ctx_t ctx);
 
+truth_t gr_poly_contains_zero_poly(const gr_poly_t poly, gr_ctx_t ctx);
+
 WARN_UNUSED_RESULT int gr_poly_set_scalar(gr_poly_t poly, gr_srcptr x, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_set_si(gr_poly_t poly, slong x, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_set_ui(gr_poly_t poly, ulong x, gr_ctx_t ctx);

--- a/src/gr_poly/contains_zero_poly.c
+++ b/src/gr_poly/contains_zero_poly.c
@@ -1,0 +1,23 @@
+/*
+    Copyright (C) 2024 Ricardo Buring
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "gr_vec.h"
+#include "gr_poly.h"
+
+/* todo: faster code when possible */
+truth_t
+gr_poly_contains_zero_poly(const gr_poly_t poly, gr_ctx_t ctx)
+{
+    if (poly->length == 0)
+        return T_TRUE;
+
+    return _gr_vec_contains_zero_vec(poly->coeffs, poly->length, ctx);
+}

--- a/src/gr_vec.h
+++ b/src/gr_vec.h
@@ -156,6 +156,8 @@ GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_submul_scalar_si(gr_ptr vec1, gr_sr
 GR_VEC_INLINE truth_t _gr_vec_equal(gr_srcptr vec1, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_VEC_VEC_PREDICATE(ctx, VEC_EQUAL)(vec1, vec2, len, ctx); }
 GR_VEC_INLINE truth_t _gr_vec_is_zero(gr_srcptr vec, slong len, gr_ctx_t ctx) { return GR_VEC_PREDICATE(ctx, VEC_IS_ZERO)(vec, len, ctx); }
 
+GR_VEC_INLINE truth_t _gr_vec_contains_zero_vec(gr_srcptr vec, slong len, gr_ctx_t ctx) { return GR_VEC_PREDICATE(ctx, VEC_CONTAINS_ZERO_VEC)(vec, len, ctx); }
+
 typedef int ((*gr_method_vec_reduce_op)(gr_ptr, gr_srcptr, slong, gr_ctx_ptr));
 
 typedef int ((*gr_method_vec_dot_op)(gr_ptr, gr_srcptr, int, gr_srcptr, gr_srcptr, slong, gr_ctx_ptr));


### PR DESCRIPTION
Also add `gr_poly_contains_zero_poly`, `gr_mat_contains_zero_mat`, `_gr_vec_contains_zero_vec`, `gr_generic_contains_zero`, and `gr_generic_vec_contains_zero_vec`.

I don't know if this feature is desired generally (feel free to discuss), but personally I find it very convenient.

For example, it is useful when you want to check that a matrix of univariate polynomials satisfies a homogeneous ODE. With this functionality, the check can be implemented with a generic method that works whether the polynomials have `acb` or `arb` or exact coefficients. (See e.g. [`test_divide_and_conquer_flint.c`](https://gitlab.inria.fr/ricardo-thomas.buring/d-finite-fun/-/blob/b9a2b6155ada9169181867700b0b759271d015ca/tests/test_divide_and_conquer_flint.c) for context, currently using a workaround from my ad-hoc [`test_utils_flint.c`](https://gitlab.inria.fr/ricardo-thomas.buring/d-finite-fun/-/blob/b9a2b6155ada9169181867700b0b759271d015ca/test_utils_flint.c) that is specific to `acb`.)

Note that the generic fallback implementation just calls the `is_zero` method, so there is no cost for ring implementers.