### PR TITLE
Introduce `ca_types.h`, `gr_types.h` and `nf_types.h`

### DIFF
--- a/doc/source/gr.rst
+++ b/doc/source/gr.rst
@@ -168,7 +168,7 @@ When the status code is any other value than ``GR_SUCCESS``, any
 output variables may be set to meaningless values.
 
 C functions that return a status code are marked with the
-``WARN_UNUSED_RESULT`` attribute. This allows compilers to
+``FLINT_WARN_UNUSED`` attribute. This allows compilers to
 emit warnings when the status code is ignored.
 
 Flags can be OR'ed and checked only at the top level of a computation

--- a/examples/dft.c
+++ b/examples/dft.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <flint/profiler.h>
+#include <flint/calcium.h>
 #include <flint/ca.h>
 #include <flint/ca_vec.h>
 

--- a/examples/elementary.c
+++ b/examples/elementary.c
@@ -1,6 +1,7 @@
 /* This file is public domain. Author: Fredrik Johansson. */
 
 #include <flint/profiler.h>
+#include <flint/calcium.h>
 #include <flint/ca.h>
 #include <flint/ca_ext.h>
 #include <flint/ca_field.h>

--- a/examples/hilbert_matrix_ca.c
+++ b/examples/hilbert_matrix_ca.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <flint/profiler.h>
 #include <flint/fmpq_mat.h>
+#include <flint/calcium.h>
 #include <flint/ca.h>
 #include <flint/ca_vec.h>
 #include <flint/ca_mat.h>

--- a/examples/huge_expr.c
+++ b/examples/huge_expr.c
@@ -2,6 +2,7 @@
 
 #include <string.h>
 #include <flint/profiler.h>
+#include <flint/calcium.h>
 #include <flint/ca.h>
 #include <flint/gr.h>
 

--- a/examples/integrals_double_exp.c
+++ b/examples/integrals_double_exp.c
@@ -75,7 +75,7 @@ quad(arb_t result,
 {
 
     arb_t x, y, h, x0, pi, w, t;
-    slong order = 0, max_iter = 16, n_eval = 0, flag, j, k;
+    slong order = 0, max_iter = 16, n_eval = 0, FLINT_SET_BUT_UNUSED(flag), j, k;
 
     arb_ptr r = _arb_vec_init(max_iter);
     arb_ptr d = _arb_vec_init(max_iter);
@@ -419,7 +419,7 @@ main(int argc, char *argv[])
     slong num_threads = 1;
     slong prec = 1024;
 
-    int index, c, verbose = 0;
+    int c, verbose = 0;
 
     opterr = 0;
 

--- a/examples/poly_roots.c
+++ b/examples/poly_roots.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <stdlib.h>
+#include <flint/fmpz_poly.h>
 #include <flint/fmpz_poly_factor.h>
 #include <flint/fmpq_poly.h>
 #include <flint/acb.h>

--- a/src/acb.h
+++ b/src/acb.h
@@ -25,9 +25,6 @@
 extern "C" {
 #endif
 
-#define acb_realref(x) (&(x)->real)
-#define acb_imagref(x) (&(x)->imag)
-
 ACB_INLINE void
 acb_init(acb_t x)
 {

--- a/src/acb_types.h
+++ b/src/acb_types.h
@@ -29,6 +29,9 @@ typedef acb_struct acb_t[1];
 typedef acb_struct * acb_ptr;
 typedef const acb_struct * acb_srcptr;
 
+#define acb_realref(x) (&(x)->real)
+#define acb_imagref(x) (&(x)->imag)
+
 typedef struct
 {
     acb_ptr entries;

--- a/src/arb.h
+++ b/src/arb.h
@@ -25,9 +25,6 @@
 extern "C" {
 #endif
 
-#define arb_midref(x) (&(x)->mid)
-#define arb_radref(x) (&(x)->rad)
-
 #define ARB_IS_LAGOM(x) (ARF_IS_LAGOM(arb_midref(x)) && MAG_IS_LAGOM(arb_radref(x)))
 
 #define ARB_RND ARF_RND_DOWN

--- a/src/arb/sin_cos_pi_fmpq_algebraic.c
+++ b/src/arb/sin_cos_pi_fmpq_algebraic.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_poly.h"
 #include "arb.h"
 #include "arb_poly.h"
 #include "arb_fmpz_poly.h"  /* for minpoly */

--- a/src/arb_fmpz_poly.h
+++ b/src/arb_fmpz_poly.h
@@ -12,7 +12,7 @@
 #ifndef ARB_FMPZ_POLY_H
 #define ARB_FMPZ_POLY_H
 
-#include "fmpz_poly.h"
+#include "fmpz_types.h"
 #include "acb_types.h"
 
 #ifdef __cplusplus

--- a/src/arb_fmpz_poly/complex_roots.c
+++ b/src/arb_fmpz_poly/complex_roots.c
@@ -9,9 +9,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "profiler.h"
+#include "fmpz_poly.h"
 #include "acb_poly.h"
 #include "arb_fmpz_poly.h"
-#include "profiler.h"
 
 static int check_accuracy(acb_ptr vec, slong len, slong prec)
 {

--- a/src/arb_fmpz_poly/deflate.c
+++ b/src/arb_fmpz_poly/deflate.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpz.h"
+#include "fmpz_poly.h"
 #include "arb_fmpz_poly.h"
 
 void

--- a/src/arb_fmpz_poly/gauss_period_minpoly.c
+++ b/src/arb_fmpz_poly/gauss_period_minpoly.c
@@ -9,15 +9,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include <math.h>
+#include "fmpz_poly.h"
 #include "arb_poly.h"
 #include "arb_fmpz_poly.h"
 #include "acb_dirichlet.h"
-
-#ifdef __GNUC__
-# define log __builtin_log
-#else
-# include <math.h>
-#endif
 
 void
 arb_fmpz_poly_gauss_period_minpoly(fmpz_poly_t res, ulong q, ulong n)

--- a/src/arb_fmpz_poly/test/t-complex_roots.c
+++ b/src/arb_fmpz_poly/test/t-complex_roots.c
@@ -10,11 +10,12 @@
 */
 
 #include "test_helpers.h"
+#include "fmpz_poly.h"
 #include "fmpz_poly_factor.h"
 #include "fmpq_poly.h"
+#include "arith.h"
 #include "acb.h"
 #include "arb_poly.h"
-#include "arith.h"
 #include "arb_fmpz_poly.h"
 
 void

--- a/src/arb_types.h
+++ b/src/arb_types.h
@@ -40,6 +40,9 @@ typedef arb_struct arb_t[1];
 typedef arb_struct * arb_ptr;
 typedef const arb_struct * arb_srcptr;
 
+#define arb_midref(x) (&(x)->mid)
+#define arb_radref(x) (&(x)->rad)
+
 typedef struct
 {
     arb_ptr entries;

--- a/src/ca.h
+++ b/src/ca.h
@@ -18,12 +18,11 @@
 #define CA_INLINE static inline
 #endif
 
-#include "flint.h"
-#include "fmpz_mpoly_q.h"
 #include "nf_elem.h"
 #include "qqbar.h"
 #include "fmpz_mpoly.h"
 #include "fexpr.h"
+#include "ca_types.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -278,21 +277,8 @@ _ca_make_fmpq(ca_t x, ca_ctx_t ctx)
         _ca_make_field_element(x, ctx->field_qq, ctx);
 }
 
-CA_INLINE void
-_ca_function_fx(ca_t res, calcium_func_code func, const ca_t x, ca_ctx_t ctx)
-{
-    ca_field_srcptr field = _ca_ctx_get_field_fx(ctx, func, x);
-    _ca_make_field_element(res, field, ctx);
-    fmpz_mpoly_q_gen(CA_MPOLY_Q(res), 0, CA_FIELD_MCTX(field, ctx));
-}
-
-CA_INLINE void
-_ca_function_fxy(ca_t res, calcium_func_code func, const ca_t x, const ca_t y, ca_ctx_t ctx)
-{
-    ca_field_srcptr field = _ca_ctx_get_field_fxy(ctx, func, x, y);
-    _ca_make_field_element(res, field, ctx);
-    fmpz_mpoly_q_gen(CA_MPOLY_Q(res), 0, CA_FIELD_MCTX(field, ctx));
-}
+void _ca_function_fx(ca_t res, calcium_func_code func, const ca_t x, ca_ctx_t ctx);
+void _ca_function_fxy(ca_t res, calcium_func_code func, const ca_t x, const ca_t y, ca_ctx_t ctx);
 
 void ca_set(ca_t res, const ca_t x, ca_ctx_t ctx);
 void ca_transfer(ca_t res, ca_ctx_t res_ctx, const ca_t src, ca_ctx_t src_ctx);

--- a/src/ca.h
+++ b/src/ca.h
@@ -21,7 +21,7 @@
 #include "nf_elem.h"
 #include "qqbar.h"
 #include "fmpz_mpoly.h"
-#include "fexpr.h"
+/* #include "fexpr.h" */
 #include "ca_types.h"
 
 #ifdef __cplusplus

--- a/src/ca.h
+++ b/src/ca.h
@@ -18,7 +18,7 @@
 #define CA_INLINE static inline
 #endif
 
-#include "nf_elem.h"
+#include "fmpq.h"
 #include "mpoly_types.h"
 #include "ca_types.h"
 
@@ -29,78 +29,6 @@ extern "C" {
 #define CA_INFO(ctx, args) do { if (ctx->options[CA_OPT_VERBOSE]) \
     do { flint_printf("%s:%d:  ", __FILE__, __LINE__); flint_printf args; } \
     while (0); } while (0);
-
-/* Number object *************************************************************/
-
-#define CA_FMPQ(x)         (&((x)->elem.q))
-#define CA_MPOLY_Q(x)      (&(((x)->elem.mpoly_q)[0]))
-#define CA_NF_ELEM(x)      (&((x)->elem.nf))
-#define CA_FMPQ_NUMREF(x)  (fmpq_numref(CA_FMPQ(x)))
-#define CA_FMPQ_DENREF(x)  (fmpq_denref(CA_FMPQ(x)))
-
-#define CA_FIELD(x, ctx)     ((ca_field_ptr) ((x)->field))
-#define CA_FIELD_ULONG(x)    ((x)->field)
-
-/* We always allocate QQ and QQ(i) */
-#define CA_IS_QQ(x, ctx) (CA_FIELD(x, ctx) == (ctx)->field_qq)
-#define CA_IS_QQ_I(x, ctx) (CA_FIELD(x, ctx) == (ctx)->field_qq_i)
-
-/* Use the low two bits of the field pointer to encode special values. */
-/* The field pointer with the mask removed is NULL for
-   Unknown/Undefined/Uinf, and a normal field pointer for signed
-   infinity (encoding the sign). */
-#define CA_UNKNOWN        UWORD(1)
-#define CA_UNDEFINED      UWORD(2)
-#define CA_INF            UWORD(3)
-#define CA_SPECIAL        (CA_UNKNOWN | CA_UNDEFINED | CA_INF)
-
-#define CA_IS_SPECIAL(x)       (CA_FIELD_ULONG(x) & CA_SPECIAL)
-#define CA_IS_UNKNOWN(x)       (CA_FIELD_ULONG(x) == CA_UNKNOWN)
-#define CA_IS_UNDEFINED(x)     (CA_FIELD_ULONG(x) == CA_UNDEFINED)
-#define CA_IS_INF(x)           ((CA_FIELD_ULONG(x) & CA_SPECIAL) == CA_INF)
-#define CA_IS_UNSIGNED_INF(x)  (CA_FIELD_ULONG(x) == CA_INF)
-#define CA_IS_SIGNED_INF(x)    (CA_IS_INF(x) && !CA_IS_UNSIGNED_INF(x))
-
-#define CA_FIELD_UNSPECIAL(x, ctx) ((ca_field_ptr) (CA_FIELD_ULONG(x) & ~CA_SPECIAL))
-
-/* Extension object **********************************************************/
-
-#define CA_EXT_HEAD(x) ((x)->head)
-#define CA_EXT_HASH(x) ((x)->hash)
-#define CA_EXT_DEPTH(x) ((x)->depth)
-
-#define CA_EXT_IS_QQBAR(x) ((x)->head == CA_QQBar)
-
-#define CA_EXT_QQBAR(_x) (&((_x)->data.qqbar.x))
-#define CA_EXT_QQBAR_NF(_x) ((_x)->data.qqbar.nf)
-
-#define CA_EXT_FUNC_ARGS(x) ((x)->data.func_data.args)
-#define CA_EXT_FUNC_NARGS(x) ((x)->data.func_data.nargs)
-#define CA_EXT_FUNC_ENCLOSURE(x) (&((x)->data.func_data.enclosure))
-#define CA_EXT_FUNC_PREC(x) ((x)->data.func_data.prec)
-
-/* Field object **************************************************************/
-
-#define CA_FIELD_LENGTH(K) ((K)->length)
-#define CA_FIELD_EXT(K) ((K)->ext)
-#define CA_FIELD_EXT_ELEM(K, i) ((K)->ext[i])
-#define CA_FIELD_HASH(K) ((K)->hash)
-
-#define CA_FIELD_IS_QQ(K) ((K)->length == 0)
-#define CA_FIELD_IS_NF(K) ((K)->ideal.length == -1)
-#define CA_FIELD_IS_GENERIC(K) (!CA_FIELD_IS_QQ(K) && !CA_FIELD_IS_NF(K))
-
-#define CA_FIELD_NF(K) (((K)->ext[0]->data.qqbar.nf))
-#define CA_FIELD_NF_QQBAR(K) (&((K)->ext[0]->data.qqbar.x))
-
-#define CA_FIELD_IDEAL(K) (&((K)->ideal))
-#define CA_FIELD_IDEAL_ELEM(K, i) fmpz_mpoly_vec_entry(CA_FIELD_IDEAL(K), i)
-#define CA_FIELD_IDEAL_LENGTH(K) ((K)->ideal.length)
-#define CA_FIELD_IDEAL_ALLOC(K) ((K)->ideal.alloc)
-#define CA_FIELD_IDEAL_P(K) ((K)->ideal.p)
-
-#define CA_MCTX_1(ctx) ((ctx)->mctx[0])
-#define CA_FIELD_MCTX(K, ctx) ((ctx)->mctx[CA_FIELD_LENGTH(K) - 1])
 
 /* Context object ************************************************************/
 

--- a/src/ca.h
+++ b/src/ca.h
@@ -19,9 +19,7 @@
 #endif
 
 #include "nf_elem.h"
-#include "qqbar.h"
-#include "fmpz_mpoly.h"
-/* #include "fexpr.h" */
+#include "mpoly_types.h"
 #include "ca_types.h"
 
 #ifdef __cplusplus
@@ -33,26 +31,6 @@ extern "C" {
     while (0); } while (0);
 
 /* Number object *************************************************************/
-
-typedef union
-{
-    fmpq q;                           /* rational number */
-    nf_elem_struct nf;                /* algebraic number field element */
-    fmpz_mpoly_q_struct * mpoly_q;    /* generic field element */
-}
-ca_elem_struct;
-
-typedef struct
-{
-    ulong field;
-    ca_elem_struct elem;
-}
-ca_struct;
-
-
-typedef ca_struct ca_t[1];
-typedef ca_struct * ca_ptr;
-typedef const ca_struct * ca_srcptr;
 
 #define CA_FMPQ(x)         (&((x)->elem.q))
 #define CA_MPOLY_Q(x)      (&(((x)->elem.mpoly_q)[0]))
@@ -85,41 +63,7 @@ typedef const ca_struct * ca_srcptr;
 
 #define CA_FIELD_UNSPECIAL(x, ctx) ((ca_field_ptr) (CA_FIELD_ULONG(x) & ~CA_SPECIAL))
 
-
-
 /* Extension object **********************************************************/
-
-typedef struct
-{
-    qqbar_struct x;        /* qqbar_t element */
-    nf_struct * nf;        /* antic number field for fast arithmetic */
-}
-ca_ext_qqbar;
-
-typedef struct
-{
-    ca_struct * args;       /* Function arguments x1, ..., xn. */
-    slong nargs;            /* Number of function arguments n. */
-    acb_struct enclosure;   /* Cached numerical enclosure of f(x1,...,xn) */
-    slong prec;             /* Working precision of cached enclosure */
-    qqbar_struct * qqbar;   /* Cached qqbar */
-}
-ca_ext_func_data;
-
-typedef struct
-{
-    calcium_func_code head;   /* f = F_Pi, F_Exp, ... */
-    ulong hash;
-    slong depth;
-    union {
-        ca_ext_qqbar qqbar;
-        ca_ext_func_data func_data;
-    } data;
-} ca_ext_struct;
-
-typedef ca_ext_struct ca_ext_t[1];
-typedef ca_ext_struct * ca_ext_ptr;
-typedef const ca_ext_struct * ca_ext_srcptr;
 
 #define CA_EXT_HEAD(x) ((x)->head)
 #define CA_EXT_HASH(x) ((x)->hash)
@@ -135,33 +79,7 @@ typedef const ca_ext_struct * ca_ext_srcptr;
 #define CA_EXT_FUNC_ENCLOSURE(x) (&((x)->data.func_data.enclosure))
 #define CA_EXT_FUNC_PREC(x) ((x)->data.func_data.prec)
 
-typedef struct
-{
-    ca_ext_struct ** items;
-    slong length;
-    slong alloc;
-
-    slong hash_size;
-    slong * hash_table;
-}
-ca_ext_cache_struct;
-
-typedef ca_ext_cache_struct ca_ext_cache_t[1];
-
 /* Field object **************************************************************/
-
-typedef struct
-{
-    slong length;                /* Number of generators              */
-    ca_ext_struct ** ext;        /* Generators                        */
-    fmpz_mpoly_vec_struct ideal; /* Algebraic relations for reduction */
-    ulong hash;
-}
-ca_field_struct;
-
-typedef ca_field_struct ca_field_t[1];
-typedef ca_field_struct * ca_field_ptr;
-typedef const ca_field_struct * ca_field_srcptr;
 
 #define CA_FIELD_LENGTH(K) ((K)->length)
 #define CA_FIELD_EXT(K) ((K)->ext)
@@ -183,19 +101,6 @@ typedef const ca_field_struct * ca_field_srcptr;
 
 #define CA_MCTX_1(ctx) ((ctx)->mctx[0])
 #define CA_FIELD_MCTX(K, ctx) ((ctx)->mctx[CA_FIELD_LENGTH(K) - 1])
-
-typedef struct
-{
-    ca_field_struct ** items;
-    slong length;
-    slong alloc;
-
-    slong hash_size;
-    slong * hash_table;
-}
-ca_field_cache_struct;
-
-typedef ca_field_cache_struct ca_field_cache_t[1];
 
 /* Context object ************************************************************/
 
@@ -223,20 +128,6 @@ enum
 #define CA_TRIG_EXPONENTIAL  1
 #define CA_TRIG_SINE_COSINE  2
 #define CA_TRIG_TANGENT      3
-
-typedef struct
-{
-    ca_ext_cache_struct ext_cache;              /* Cached extension objects */
-    ca_field_cache_struct field_cache;          /* Cached extension fields  */
-    ca_field_struct * field_qq;                 /* Quick access to QQ      */
-    ca_field_struct * field_qq_i;               /* Quick access to QQ(i)   */
-    fmpz_mpoly_ctx_struct ** mctx;              /* Cached contexts for multivariate polys */
-    slong mctx_len;
-    slong * options;
-}
-ca_ctx_struct;
-
-typedef ca_ctx_struct ca_ctx_t[1];
 
 #define CA_CTX_EXT_CACHE(ctx) (&((ctx)->ext_cache))
 #define CA_CTX_FIELD_CACHE(ctx) (&((ctx)->field_cache))

--- a/src/ca/abs.c
+++ b/src/ca/abs.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "qqbar.h"
 #include "ca.h"
 
 void

--- a/src/ca/add.c
+++ b/src/ca/add.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
+#include "nf_elem.h"
 #include "ca.h"
 
 void

--- a/src/ca/arg.c
+++ b/src/ca/arg.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "qqbar.h"
 #include "ca.h"
 
 void

--- a/src/ca/asin.c
+++ b/src/ca/asin.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "qqbar.h"
 #include "ca.h"
 
 void

--- a/src/ca/atan.c
+++ b/src/ca/atan.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "qqbar.h"
+#include "acb.h"
 #include "ca.h"
 
 void

--- a/src/ca/can_evaluate_qqbar.c
+++ b/src/ca/can_evaluate_qqbar.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
 #include "ca.h"
 
 int

--- a/src/ca/ceil.c
+++ b/src/ca/ceil.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
+#include "fmpz_mpoly_q.h"
 #include "ca.h"
 
 void

--- a/src/ca/check_equal.c
+++ b/src/ca/check_equal.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
+#include "nf_elem.h"
 #include "ca.h"
 
 truth_t

--- a/src/ca/check_ge.c
+++ b/src/ca/check_ge.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
+#include "qqbar.h"
 #include "ca.h"
 
 #define CMP_UNDEFINED -2

--- a/src/ca/check_is_i.c
+++ b/src/ca/check_is_i.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "nf_elem.h"
 #include "ca.h"
 
 truth_t

--- a/src/ca/check_is_imaginary.c
+++ b/src/ca/check_is_imaginary.c
@@ -9,6 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
+#include "nf_elem.h"
+#include "qqbar.h"
 #include "ca.h"
 
 truth_t

--- a/src/ca/check_is_integer.c
+++ b/src/ca/check_is_integer.c
@@ -9,6 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
+#include "nf_elem.h"
+#include "qqbar.h"
 #include "ca.h"
 
 /* todo: fast check in number field */

--- a/src/ca/check_is_neg_i.c
+++ b/src/ca/check_is_neg_i.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "nf_elem.h"
 #include "ca.h"
 
 truth_t

--- a/src/ca/check_is_neg_one.c
+++ b/src/ca/check_is_neg_one.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "nf_elem.h"
 #include "ca.h"
 
 truth_t

--- a/src/ca/check_is_negative_real.c
+++ b/src/ca/check_is_negative_real.c
@@ -9,6 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
+#include "nf_elem.h"
+#include "qqbar.h"
 #include "ca.h"
 
 truth_t

--- a/src/ca/check_is_one.c
+++ b/src/ca/check_is_one.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "nf_elem.h"
 #include "ca.h"
 
 truth_t

--- a/src/ca/check_is_pos_i_inf.c
+++ b/src/ca/check_is_pos_i_inf.c
@@ -10,7 +10,6 @@
 */
 
 #include "ca.h"
-#include "ca_field.h"
 
 truth_t
 ca_check_is_pos_i_inf(const ca_t x, ca_ctx_t ctx)

--- a/src/ca/check_is_rational.c
+++ b/src/ca/check_is_rational.c
@@ -9,6 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
+#include "nf_elem.h"
+#include "qqbar.h"
 #include "ca.h"
 
 /* todo: fast check in number field */

--- a/src/ca/check_is_real.c
+++ b/src/ca/check_is_real.c
@@ -9,6 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
+#include "nf_elem.h"
+#include "qqbar.h"
 #include "ca.h"
 
 truth_t

--- a/src/ca/check_is_zero.c
+++ b/src/ca/check_is_zero.c
@@ -9,6 +9,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
+#include "fmpz_mpoly_q.h"
+#include "nf_elem.h"
+#include "qqbar.h"
+#include "calcium.h"
 #include "ca.h"
 
 truth_t

--- a/src/ca/clear.c
+++ b/src/ca/clear.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
+#include "nf_elem.h"
 #include "ca.h"
 
 #define CHECK_DATA 0

--- a/src/ca/condense_field.c
+++ b/src/ca/condense_field.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
+#include "nf_elem.h"
 #include "ca.h"
 
 ca_field_ptr ca_field_cache_lookup_qqbar(ca_field_cache_t cache, const qqbar_t x, ca_ctx_t ctx);

--- a/src/ca/conj.c
+++ b/src/ca/conj.c
@@ -9,8 +9,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
+#include "nf_elem.h"
+#include "qqbar.h"
 #include "ca.h"
-#include "ca_ext.h"
 #include "ca_field.h"
 #include "ca_vec.h"
 

--- a/src/ca/ctx_init.c
+++ b/src/ca/ctx_init.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "qqbar.h"
 #include "ca.h"
 #include "ca_ext.h"
 #include "ca_field.h"

--- a/src/ca/div.c
+++ b/src/ca/div.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
+#include "nf_elem.h"
 #include "ca.h"
 
 void

--- a/src/ca/equal_repr.c
+++ b/src/ca/equal_repr.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
+#include "nf_elem.h"
 #include "ca.h"
 
 int

--- a/src/ca/erf.c
+++ b/src/ca/erf.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
 #include "ca.h"
 
 void

--- a/src/ca/erfc.c
+++ b/src/ca/erfc.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
 #include "ca.h"
 
 void

--- a/src/ca/erfi.c
+++ b/src/ca/erfi.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
 #include "ca.h"
 
 void

--- a/src/ca/euler.c
+++ b/src/ca/euler.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
 #include "ca.h"
 
 void

--- a/src/ca/exp.c
+++ b/src/ca/exp.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
+#include "qqbar.h"
 #include "ca.h"
 
 int ca_as_fmpq_pi_i(fmpq_t res, const ca_t x, ca_ctx_t ctx)

--- a/src/ca/factor.c
+++ b/src/ca/factor.c
@@ -11,6 +11,7 @@
 
 #include "fmpz_factor.h"
 #include "fmpz_mpoly_factor.h"
+#include "fmpz_mpoly_q.h"
 #include "ca.h"
 
 #define HAVE_MPOLY_FAC 1

--- a/src/ca/floor.c
+++ b/src/ca/floor.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
+#include "fmpz_mpoly_q.h"
 #include "ca.h"
 
 void

--- a/src/ca/fmpq_poly_evaluate.c
+++ b/src/ca/fmpq_poly_evaluate.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpq_poly.h"
 #include "ca.h"
 
 static void

--- a/src/ca/fmpz_mpoly_evaluate.c
+++ b/src/ca/fmpz_mpoly_evaluate.c
@@ -10,6 +10,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
 #include "mpoly.h"
 #include "fmpz_mpoly.h"
 #include "ca.h"

--- a/src/ca/fmpz_mpoly_q_evaluate.c
+++ b/src/ca/fmpz_mpoly_q_evaluate.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
 #include "ca.h"
 
 void

--- a/src/ca/fmpz_poly_evaluate.c
+++ b/src/ca/fmpz_poly_evaluate.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_poly.h"
 #include "ca.h"
 
 void

--- a/src/ca/function.c
+++ b/src/ca/function.c
@@ -9,8 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "ca.h"
 #include "fmpz_mpoly_q.h"
+#include "ca.h"
 
 void _ca_function_fx(ca_t res, calcium_func_code func, const ca_t x, ca_ctx_t ctx)
 {

--- a/src/ca/function.c
+++ b/src/ca/function.c
@@ -1,0 +1,27 @@
+/*
+    Copyright (C) 2020 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "ca.h"
+#include "fmpz_mpoly_q.h"
+
+void _ca_function_fx(ca_t res, calcium_func_code func, const ca_t x, ca_ctx_t ctx)
+{
+    ca_field_srcptr field = _ca_ctx_get_field_fx(ctx, func, x);
+    _ca_make_field_element(res, field, ctx);
+    fmpz_mpoly_q_gen(CA_MPOLY_Q(res), 0, CA_FIELD_MCTX(field, ctx));
+}
+
+void _ca_function_fxy(ca_t res, calcium_func_code func, const ca_t x, const ca_t y, ca_ctx_t ctx)
+{
+    ca_field_srcptr field = _ca_ctx_get_field_fxy(ctx, func, x, y);
+    _ca_make_field_element(res, field, ctx);
+    fmpz_mpoly_q_gen(CA_MPOLY_Q(res), 0, CA_FIELD_MCTX(field, ctx));
+}

--- a/src/ca/get_acb.c
+++ b/src/ca/get_acb.c
@@ -9,7 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "arb_fmpz_poly.h"
+#include "acb.h"
+#include "calcium.h"
 #include "ca.h"
 
 void

--- a/src/ca/get_acb_raw.c
+++ b/src/ca/get_acb_raw.c
@@ -9,7 +9,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
+#include "acb.h"
 #include "arb_fmpz_poly.h"
+#include "nf_elem.h"
 #include "ca.h"
 #include "ca_ext.h"
 

--- a/src/ca/get_fexpr.c
+++ b/src/ca/get_fexpr.c
@@ -9,12 +9,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "nf_elem.h"
+#include "qqbar.h"
 #include "fexpr.h"
 #include "fexpr_builtin.h"
 #include "ca.h"
-#include "ca_ext.h"
-#include "fexpr.h"
-#include "fexpr_builtin.h"
 
 void
 _fexpr_set_fmpz_poly_decreasing(fexpr_t res, const fmpz * coeffs, slong len, const fexpr_t var)

--- a/src/ca/get_qqbar.c
+++ b/src/ca/get_qqbar.c
@@ -9,8 +9,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
+#include "nf_elem.h"
+#include "qqbar.h"
 #include "ca.h"
-#include "ca_ext.h"
 
 int
 ca_get_qqbar(qqbar_t res, const ca_t x, ca_ctx_t ctx)

--- a/src/ca/hash_repr.c
+++ b/src/ca/hash_repr.c
@@ -9,6 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
+#include "nf_elem.h"
+#include "calcium.h"
 #include "ca.h"
 
 ulong ca_hash_repr(const ca_t x, ca_ctx_t ctx)

--- a/src/ca/i.c
+++ b/src/ca/i.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "nf_elem.h"
 #include "ca.h"
 
 void

--- a/src/ca/im.c
+++ b/src/ca/im.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
+#include "nf_elem.h"
 #include "ca.h"
 
 void

--- a/src/ca/inlines.c
+++ b/src/ca/inlines.c
@@ -10,4 +10,5 @@
 */
 
 #define CA_INLINES_C
+
 #include "ca.h"

--- a/src/ca/inv.c
+++ b/src/ca/inv.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
+#include "nf_elem.h"
 #include "ca.h"
 
 void

--- a/src/ca/io.c
+++ b/src/ca/io.c
@@ -10,6 +10,12 @@
 */
 
 #include <stdio.h>
+#include "fmpz_poly.h"
+#include "fmpz_mpoly_q.h"
+#include "acb.h"
+#include "nf_elem.h"
+#include "qqbar.h"
+#include "calcium.h"
 #include "ca.h"
 #include "ca_ext.h"
 #include "ca_field.h"

--- a/src/ca/is_cyclotomic_nf_elem.c
+++ b/src/ca/is_cyclotomic_nf_elem.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "qqbar.h"
 #include "ca.h"
 
 int

--- a/src/ca/is_gen_as_ext.c
+++ b/src/ca/is_gen_as_ext.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
+#include "nf_elem.h"
 #include "ca.h"
 
 ca_ext_ptr

--- a/src/ca/log.c
+++ b/src/ca/log.c
@@ -9,6 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
+#include "nf_elem.h"
+#include "qqbar.h"
 #include "ca.h"
 
 ca_ext_ptr

--- a/src/ca/make_field_element.c
+++ b/src/ca/make_field_element.c
@@ -9,8 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
+#include "nf_elem.h"
 #include "ca.h"
-#include "ca_field.h"
 
 void ca_clear_unchecked(ca_t x, ca_ctx_t ctx);
 

--- a/src/ca/merge_fields.c
+++ b/src/ca/merge_fields.c
@@ -9,10 +9,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "nf_elem.h"
+#include "fmpz_mpoly_q.h"
 #include "ca.h"
 #include "ca_ext.h"
 #include "ca_field.h"
-#include "fmpz_mpoly.h"
 
 void
 _nf_elem_get_fmpz_poly_den_shallow(fmpz_poly_t pol, fmpz_t den, const nf_elem_t a, const nf_t nf)

--- a/src/ca/mul.c
+++ b/src/ca/mul.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
+#include "nf_elem.h"
 #include "ca.h"
 
 void

--- a/src/ca/neg.c
+++ b/src/ca/neg.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
+#include "nf_elem.h"
 #include "ca.h"
 
 void

--- a/src/ca/pi.c
+++ b/src/ca/pi.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
 #include "ca.h"
 
 void

--- a/src/ca/pow.c
+++ b/src/ca/pow.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
+#include "nf_elem.h"
 #include "ca.h"
 
 slong

--- a/src/ca/randtest.c
+++ b/src/ca/randtest.c
@@ -9,6 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpq_poly.h"
+#include "nf_elem.h"
+#include "qqbar.h"
 #include "ca.h"
 
 void

--- a/src/ca/re.c
+++ b/src/ca/re.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
+#include "nf_elem.h"
 #include "ca.h"
 
 void

--- a/src/ca/rewrite_complex_normal_form.c
+++ b/src/ca/rewrite_complex_normal_form.c
@@ -9,6 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
+#include "nf_elem.h"
+#include "qqbar.h"
 #include "ca.h"
 #include "ca_vec.h"
 

--- a/src/ca/set.c
+++ b/src/ca/set.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
+#include "nf_elem.h"
 #include "ca.h"
 
 void

--- a/src/ca/set_d.c
+++ b/src/ca/set_d.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "arf.h"
 #include "ca.h"
 
 void

--- a/src/ca/set_fexpr.c
+++ b/src/ca/set_fexpr.c
@@ -9,10 +9,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "qqbar.h"
 #include "fexpr.h"
 #include "fexpr_builtin.h"
 #include "ca.h"
-#include "ca_ext.h"
 #include "ca_vec.h"
 
 #define BINARY_OP(ca_func) \

--- a/src/ca/set_qqbar.c
+++ b/src/ca/set_qqbar.c
@@ -10,6 +10,10 @@
 */
 
 #include "fmpz_factor.h"
+#include "fmpz_poly.h"
+#include "acb.h"
+#include "qqbar.h"
+#include "nf_elem.h"
 #include "ca.h"
 #include "ca_ext.h"
 #include "ca_field.h"

--- a/src/ca/sgn.c
+++ b/src/ca/sgn.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "qqbar.h"
 #include "ca.h"
 
 void

--- a/src/ca/sin_cos.c
+++ b/src/ca/sin_cos.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "qqbar.h"
 #include "ca.h"
 #include "ca_ext.h"
 #include "ca_vec.h"

--- a/src/ca/sqrt.c
+++ b/src/ca/sqrt.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "qqbar.h"
 #include "ca.h"
 
 void

--- a/src/ca/sqrt_factor.c
+++ b/src/ca/sqrt_factor.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
+#include "qqbar.h"
 #include "ca.h"
 
 void

--- a/src/ca/test/t-erf.c
+++ b/src/ca/test/t-erf.c
@@ -10,6 +10,7 @@
 */
 
 #include "test_helpers.h"
+#include "acb.h"
 #include "ca.h"
 
 void

--- a/src/ca/test/t-field_init_clear.c
+++ b/src/ca/test/t-field_init_clear.c
@@ -10,8 +10,8 @@
 */
 
 #include "test_helpers.h"
+#include "qqbar.h"
 #include "ca.h"
-#include "ca_ext.h"
 #include "ca_field.h"
 
 TEST_FUNCTION_START(ca_field_init_clear, state)

--- a/src/ca/test/t-fmpz_mpoly_evaluate.c
+++ b/src/ca/test/t-fmpz_mpoly_evaluate.c
@@ -10,6 +10,7 @@
 */
 
 #include "test_helpers.h"
+#include "fmpz_mpoly.h"
 #include "ca.h"
 #include "ca_vec.h"
 

--- a/src/ca/test/t-get_fexpr.c
+++ b/src/ca/test/t-get_fexpr.c
@@ -10,6 +10,7 @@
 */
 
 #include "test_helpers.h"
+#include "fexpr.h"
 #include "ca.h"
 
 TEST_FUNCTION_START(ca_get_fexpr, state)

--- a/src/ca/test/t-properties.c
+++ b/src/ca/test/t-properties.c
@@ -10,6 +10,7 @@
 */
 
 #include "test_helpers.h"
+#include "calcium.h"
 #include "ca.h"
 
 TEST_FUNCTION_START(ca_properties, state)

--- a/src/ca/transfer.c
+++ b/src/ca/transfer.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fexpr.h"
 #include "ca.h"
 
 void

--- a/src/ca_ext.h
+++ b/src/ca_ext.h
@@ -18,7 +18,7 @@
 #define CA_EXT_INLINE static inline
 #endif
 
-#include "ca.h"
+#include "ca_types.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -58,17 +58,7 @@ CA_EXT_INLINE slong ca_ext_nargs(const ca_ext_t x, ca_ctx_t ctx)
         return CA_EXT_FUNC_NARGS(x);
 }
 
-CA_EXT_INLINE void ca_ext_get_arg(ca_t res, const ca_ext_t x, slong i, ca_ctx_t ctx)
-{
-    if (CA_EXT_HEAD(x) == CA_QQBar || i < 0 || i >= CA_EXT_FUNC_NARGS(x))
-    {
-        flint_throw(FLINT_ERROR, "ca_ext_get_arg: index out of range\n");
-    }
-    else
-    {
-        ca_set(res, CA_EXT_FUNC_ARGS(x) + i, ctx);
-    }
-}
+void ca_ext_get_arg(ca_t res, const ca_ext_t x, slong i, ca_ctx_t ctx);
 
 CA_EXT_INLINE ulong ca_ext_hash(const ca_ext_t x, ca_ctx_t ctx)
 {

--- a/src/ca_ext/clear.c
+++ b/src/ca_ext/clear.c
@@ -9,6 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
+#include "nf.h"
+#include "qqbar.h"
 #include "ca_ext.h"
 #include "ca_vec.h"
 

--- a/src/ca_ext/cmp_repr.c
+++ b/src/ca_ext/cmp_repr.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "qqbar.h"
+#include "ca.h"
 #include "ca_ext.h"
 
 static int

--- a/src/ca_ext/equal_repr.c
+++ b/src/ca_ext/equal_repr.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "qqbar.h"
+#include "ca.h"
 #include "ca_ext.h"
 
 int

--- a/src/ca_ext/get_acb_raw.c
+++ b/src/ca_ext/get_acb_raw.c
@@ -9,7 +9,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
 #include "acb_hypgeom.h"
+#include "qqbar.h"
+#include "ca.h"
 #include "ca_ext.h"
 
 #define ARB_CONST(f) \

--- a/src/ca_ext/get_arg.c
+++ b/src/ca_ext/get_arg.c
@@ -1,0 +1,25 @@
+/*
+    Copyright (C) 2020 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "ca.h"
+#include "ca_ext.h"
+
+void ca_ext_get_arg(ca_t res, const ca_ext_t x, slong i, ca_ctx_t ctx)
+{
+    if (CA_EXT_HEAD(x) == CA_QQBar || i < 0 || i >= CA_EXT_FUNC_NARGS(x))
+    {
+        flint_throw(FLINT_ERROR, "ca_ext_get_arg: index out of range\n");
+    }
+    else
+    {
+        ca_set(res, CA_EXT_FUNC_ARGS(x) + i, ctx);
+    }
+}

--- a/src/ca_ext/init.c
+++ b/src/ca_ext/init.c
@@ -9,6 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
+#include "nf.h"
+#include "qqbar.h"
 #include "ca_ext.h"
 #include "ca_vec.h"
 

--- a/src/ca_ext/print.c
+++ b/src/ca_ext/print.c
@@ -9,6 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "qqbar.h"
+#include "calcium.h"
+#include "ca.h"
 #include "ca_ext.h"
 
 void

--- a/src/ca_ext/test/t-cache_insert.c
+++ b/src/ca_ext/test/t-cache_insert.c
@@ -10,6 +10,7 @@
 */
 
 #include "test_helpers.h"
+#include "qqbar.h"
 #include "ca.h"
 #include "ca_ext.h"
 

--- a/src/ca_field.h
+++ b/src/ca_field.h
@@ -12,7 +12,7 @@
 #ifndef CA_FIELD_H
 #define CA_FIELD_H
 
-#include "ca.h"
+#include "ca_types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/ca_field/build_ideal.c
+++ b/src/ca_field/build_ideal.c
@@ -10,15 +10,16 @@
 */
 
 #include <stdio.h>
-#include "ca.h"
-#include "ca_ext.h"
-#include "ca_field.h"
-
+#include "fmpz_vec.h"
+#include "fmpz_poly.h"
+#include "fmpz_mpoly_q.h"
+#include "acb.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
 #include "qqbar.h"
-#include "fmpz_mpoly.h"
-
+#include "ca.h"
+#include "ca_ext.h"
+#include "ca_field.h"
 #include "gr.h"
 
 slong

--- a/src/ca_field/build_ideal_erf.c
+++ b/src/ca_field/build_ideal_erf.c
@@ -9,8 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly.h"
 #include "ca.h"
-#include "ca_ext.h"
 #include "ca_field.h"
 
 void _ca_field_ideal_insert_clear_mpoly(ca_field_t K, fmpz_mpoly_t poly, fmpz_mpoly_ctx_t mctx, ca_ctx_t ctx);

--- a/src/ca_field/build_ideal_gamma.c
+++ b/src/ca_field/build_ideal_gamma.c
@@ -9,10 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly_q.h"
 #include "ca.h"
-#include "ca_ext.h"
 #include "ca_field.h"
-#include "fmpz_mpoly.h"
 
 void _ca_field_ideal_insert_clear_mpoly(ca_field_t K, fmpz_mpoly_t poly, fmpz_mpoly_ctx_t mctx, ca_ctx_t ctx);
 void _nf_elem_get_fmpz_poly_den_shallow(fmpz_poly_t pol, fmpz_t den, const nf_elem_t a, const nf_t nf);

--- a/src/ca_field/cache_insert.c
+++ b/src/ca_field/cache_insert.c
@@ -9,7 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "ca_ext.h"
+#include "qqbar.h"
 #include "ca_field.h"
 
 ca_field_ptr ca_field_cache_lookup_qqbar(ca_field_cache_t cache, const qqbar_t x, ca_ctx_t ctx)

--- a/src/ca_field/clear.c
+++ b/src/ca_field/clear.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly.h"
 #include "ca_field.h"
 
 void

--- a/src/ca_field/cmp.c
+++ b/src/ca_field/cmp.c
@@ -9,7 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "ca.h"
+#include "fmpz_mpoly_q.h"
+#include "nf_elem.h"
 #include "ca_ext.h"
 #include "ca_field.h"
 

--- a/src/ca_field/init.c
+++ b/src/ca_field/init.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_mpoly.h"
 #include "ca.h"
 #include "ca_ext.h"
 #include "ca_field.h"

--- a/src/ca_field/print.c
+++ b/src/ca_field/print.c
@@ -9,7 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "ca.h"
+#include "fmpz_mpoly.h"
 #include "ca_ext.h"
 #include "ca_field.h"
 

--- a/src/ca_field/set_ext.c
+++ b/src/ca_field/set_ext.c
@@ -9,8 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "ca.h"
-#include "ca_ext.h"
 #include "ca_field.h"
 
 void

--- a/src/ca_field/test/t-cache_insert.c
+++ b/src/ca_field/test/t-cache_insert.c
@@ -10,6 +10,7 @@
 */
 
 #include "test_helpers.h"
+#include "qqbar.h"
 #include "ca.h"
 #include "ca_ext.h"
 #include "ca_field.h"

--- a/src/ca_mat.h
+++ b/src/ca_mat.h
@@ -18,24 +18,13 @@
 #define CA_MAT_INLINE static inline
 #endif
 
-#include "ca_poly.h"
+#include "ca.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /* Matrix object */
-
-typedef struct
-{
-    ca_ptr entries;
-    slong r;
-    slong c;
-    ca_ptr * rows;
-}
-ca_mat_struct;
-
-typedef ca_mat_struct ca_mat_t[1];
 
 #define ca_mat_entry(mat,i,j) ((mat)->rows[i] + (j))
 #define ca_mat_nrows(mat) ((mat)->r)

--- a/src/ca_mat/adjugate_charpoly.c
+++ b/src/ca_mat/adjugate_charpoly.c
@@ -10,6 +10,7 @@
 */
 
 #include "ca_mat.h"
+#include "ca_poly.h"
 
 void
 ca_mat_adjugate_charpoly(ca_mat_t adj, ca_t det, const ca_mat_t A, ca_ctx_t ctx)

--- a/src/ca_mat/charpoly.c
+++ b/src/ca_mat/charpoly.c
@@ -10,6 +10,7 @@
 */
 
 #include "ca_mat.h"
+#include "ca_poly.h"
 
 void
 _ca_mat_charpoly(ca_ptr cp, const ca_mat_t mat, ca_ctx_t ctx)

--- a/src/ca_mat/charpoly_berkowitz.c
+++ b/src/ca_mat/charpoly_berkowitz.c
@@ -10,6 +10,8 @@
 */
 
 #include "ca_mat.h"
+#include "ca_poly.h"
+#include "gr.h"
 #include "gr_mat.h"
 
 void

--- a/src/ca_mat/charpoly_danilevsky.c
+++ b/src/ca_mat/charpoly_danilevsky.c
@@ -11,6 +11,8 @@
 */
 
 #include "ca_mat.h"
+#include "ca_poly.h"
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/ca_mat/clear.c
+++ b/src/ca_mat/clear.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "ca_vec.h"
 #include "ca_mat.h"
 
 void

--- a/src/ca_mat/det_berkowitz.c
+++ b/src/ca_mat/det_berkowitz.c
@@ -10,6 +10,7 @@
 */
 
 #include "ca_mat.h"
+#include "ca_vec.h"
 
 void
 ca_mat_det_berkowitz(ca_t res, const ca_mat_t A, ca_ctx_t ctx)

--- a/src/ca_mat/det_cofactor.c
+++ b/src/ca_mat/det_cofactor.c
@@ -10,6 +10,7 @@
 */
 
 #include "ca_mat.h"
+#include "gr.h"
 #include "gr_mat.h"
 
 void

--- a/src/ca_mat/dft.c
+++ b/src/ca_mat/dft.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "ca_vec.h"
 #include "ca_mat.h"
 
 void

--- a/src/ca_mat/diagonalization.c
+++ b/src/ca_mat/diagonalization.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "ca_vec.h"
 #include "ca_mat.h"
 
 truth_t

--- a/src/ca_mat/eigenvalues.c
+++ b/src/ca_mat/eigenvalues.c
@@ -10,6 +10,7 @@
 */
 
 #include "ca_mat.h"
+#include "ca_poly.h"
 
 int
 ca_mat_eigenvalues(ca_vec_t lambda, ulong * exp, const ca_mat_t mat, ca_ctx_t ctx)

--- a/src/ca_mat/exp.c
+++ b/src/ca_mat/exp.c
@@ -10,6 +10,7 @@
 */
 
 #include "ca_mat.h"
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/ca_mat/hilbert.c
+++ b/src/ca_mat/hilbert.c
@@ -10,6 +10,7 @@
 */
 
 #include "ca_mat.h"
+#include "gr.h"
 #include "gr_mat.h"
 
 void

--- a/src/ca_mat/init.c
+++ b/src/ca_mat/init.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "ca_vec.h"
 #include "ca_mat.h"
 
 void

--- a/src/ca_mat/jordan_blocks.c
+++ b/src/ca_mat/jordan_blocks.c
@@ -10,6 +10,7 @@
 */
 
 #include "ca_mat.h"
+#include "gr.h"
 #include "gr_mat.h"
 
 void

--- a/src/ca_mat/jordan_form.c
+++ b/src/ca_mat/jordan_form.c
@@ -10,6 +10,7 @@
 */
 
 #include "ca_mat.h"
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/ca_mat/jordan_transformation.c
+++ b/src/ca_mat/jordan_transformation.c
@@ -10,6 +10,7 @@
 */
 
 #include "ca_mat.h"
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/ca_mat/log.c
+++ b/src/ca_mat/log.c
@@ -10,6 +10,7 @@
 */
 
 #include "ca_mat.h"
+#include "gr.h"
 #include "gr_mat.h"
 
 truth_t

--- a/src/ca_mat/lu_classical.c
+++ b/src/ca_mat/lu_classical.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "ca_vec.h"
 #include "ca_mat.h"
 
 int

--- a/src/ca_mat/mul_same_nf.c
+++ b/src/ca_mat/mul_same_nf.c
@@ -9,7 +9,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
+#include "fmpz_poly.h"
 #include "fmpz_poly_mat.h"
+#include "nf_elem.h"
 #include "ca_mat.h"
 
 static const fmpz * _nf_denref(const nf_elem_t a, const nf_t nf)

--- a/src/ca_mat/pascal.c
+++ b/src/ca_mat/pascal.c
@@ -10,6 +10,7 @@
 */
 
 #include "ca_mat.h"
+#include "gr.h"
 #include "gr_mat.h"
 
 void

--- a/src/ca_mat/solve_tril.c
+++ b/src/ca_mat/solve_tril.c
@@ -10,6 +10,7 @@
 */
 
 #include "ca_mat.h"
+#include "gr.h"
 #include "gr_mat.h"
 
 void

--- a/src/ca_mat/solve_triu.c
+++ b/src/ca_mat/solve_triu.c
@@ -10,6 +10,7 @@
 */
 
 #include "ca_mat.h"
+#include "gr.h"
 #include "gr_mat.h"
 
 void

--- a/src/ca_mat/stirling.c
+++ b/src/ca_mat/stirling.c
@@ -10,6 +10,7 @@
 */
 
 #include "ca_mat.h"
+#include "gr.h"
 #include "gr_mat.h"
 
 void

--- a/src/ca_mat/test/t-ca_poly_evaluate.c
+++ b/src/ca_mat/test/t-ca_poly_evaluate.c
@@ -11,6 +11,7 @@
 
 #include "test_helpers.h"
 #include "ca_mat.h"
+#include "ca_poly.h"
 
 TEST_FUNCTION_START(ca_mat_ca_poly_evaluate, state)
 {

--- a/src/ca_mat/test/t-jordan_blocks.c
+++ b/src/ca_mat/test/t-jordan_blocks.c
@@ -10,6 +10,7 @@
 */
 
 #include "test_helpers.h"
+#include "ca_vec.h"
 #include "ca_mat.h"
 
 int

--- a/src/ca_mat/test/t-mul_same_nf.c
+++ b/src/ca_mat/test/t-mul_same_nf.c
@@ -10,6 +10,7 @@
 */
 
 #include "test_helpers.h"
+#include "qqbar.h"
 #include "ca_mat.h"
 
 void

--- a/src/ca_poly.h
+++ b/src/ca_poly.h
@@ -24,36 +24,12 @@
 extern "C" {
 #endif
 
-/* Polynomial object */
-
-typedef struct
-{
-    ca_struct * coeffs;
-    slong alloc;
-    slong length;
-}
-ca_poly_struct;
-
-typedef ca_poly_struct ca_poly_t[1];
-
 /* todo: return NULL when out of bounds? */
 CA_POLY_INLINE ca_ptr
 ca_poly_coeff_ptr(ca_poly_t poly, slong i)
 {
     return poly->coeffs + i;
 }
-
-/* Vectors of polynomials */
-
-typedef struct
-{
-    ca_poly_struct * entries;
-    slong length;
-    slong alloc;
-}
-ca_poly_vec_struct;
-
-typedef ca_poly_vec_struct ca_poly_vec_t[1];
 
 /* Memory management */
 

--- a/src/ca_poly/div_series.c
+++ b/src/ca_poly/div_series.c
@@ -9,6 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
+#include "fmpq_poly.h"
+#include "qqbar.h"
 #include "ca_poly.h"
 
 ca_field_ptr

--- a/src/ca_poly/exp_series.c
+++ b/src/ca_poly/exp_series.c
@@ -9,7 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "ca_vec.h"
+#include "fmpz_vec.h"
+#include "fmpq_poly.h"
+#include "qqbar.h"
 #include "ca_poly.h"
 
 ca_field_ptr

--- a/src/ca_poly/gcd.c
+++ b/src/ca_poly/gcd.c
@@ -12,6 +12,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
+#include "fmpz_poly.h"
 #include "acb_mat.h"
 #include "ca_poly.h"
 

--- a/src/ca_poly/inlines.c
+++ b/src/ca_poly/inlines.c
@@ -10,4 +10,5 @@
 */
 
 #define CA_POLY_INLINES_C
+
 #include "ca_poly.h"

--- a/src/ca_poly/inv_series.c
+++ b/src/ca_poly/inv_series.c
@@ -9,7 +9,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
+#include "fmpq_poly.h"
 #include "arb_poly.h"
+#include "qqbar.h"
 #include "ca_poly.h"
 
 ca_field_ptr

--- a/src/ca_poly/log_series.c
+++ b/src/ca_poly/log_series.c
@@ -11,7 +11,6 @@
 
 #include "ca_poly.h"
 
-
 void
 _ca_poly_log_series(ca_ptr res, ca_srcptr f, slong flen, slong len, ca_ctx_t ctx)
 {

--- a/src/ca_poly/mullow.c
+++ b/src/ca_poly/mullow.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
+#include "fmpz_poly.h"
 #include "ca_poly.h"
 
 ca_field_ptr

--- a/src/ca_poly/mullow_same_nf.c
+++ b/src/ca_poly/mullow_same_nf.c
@@ -9,6 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
+#include "fmpz_poly.h"
+#include "nf_elem.h"
 #include "ca_poly.h"
 
 static const fmpz * _nf_denref(const nf_elem_t a, const nf_t nf)

--- a/src/ca_poly/roots.c
+++ b/src/ca_poly/roots.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
+#include "qqbar.h"
 #include "ca_poly.h"
 
 void

--- a/src/ca_poly/set_fmpq_poly.c
+++ b/src/ca_poly/set_fmpq_poly.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpq_poly.h"
 #include "ca_poly.h"
 
 void

--- a/src/ca_poly/test/t-div_series.c
+++ b/src/ca_poly/test/t-div_series.c
@@ -10,6 +10,7 @@
 */
 
 #include "test_helpers.h"
+#include "qqbar.h"
 #include "ca_poly.h"
 
 /* Defined in t-div_series.c, t-exp_series.c, t-inv_series.c, t-mul.c */

--- a/src/ca_poly/test/t-roots.c
+++ b/src/ca_poly/test/t-roots.c
@@ -10,6 +10,7 @@
 */
 
 #include "test_helpers.h"
+#include "calcium.h"
 #include "ca_poly.h"
 
 TEST_FUNCTION_START(ca_poly_roots, state)

--- a/src/ca_types.h
+++ b/src/ca_types.h
@@ -24,6 +24,68 @@ extern "C" {
 #define calcium_stream_struct gr_stream_struct
 #define calcium_stream_t gr_stream_t
 
+/* builtin functions and constants *******************************************/
+
+typedef enum
+{
+    /* Special case for representing qqbar instances */
+    CA_QQBar,
+    /* Arithmetic */
+    CA_Neg,
+    CA_Add,
+    CA_Sub,
+    CA_Mul,
+    CA_Div,
+    /* Roots */
+    CA_Sqrt,
+    CA_Cbrt,
+    CA_Root,
+    /* Complex parts */
+    CA_Floor,
+    CA_Ceil,
+    CA_Abs,
+    CA_Sign,
+    CA_Re,
+    CA_Im,
+    CA_Arg,
+    CA_Conjugate,
+    /* Elementary constants */
+    CA_Pi,
+    /* Elementary functions */
+    CA_Sin,
+    CA_Cos,
+    CA_Exp,
+    CA_Log,
+    CA_Pow,
+    CA_Tan,
+    CA_Cot,
+    CA_Cosh,
+    CA_Sinh,
+    CA_Tanh,
+    CA_Coth,
+    CA_Atan,
+    CA_Acos,
+    CA_Asin,
+    CA_Acot,
+    CA_Atanh,
+    CA_Acosh,
+    CA_Asinh,
+    CA_Acoth,
+    /* Euler's constant */
+    CA_Euler,
+    /* Gamma and related functions */
+    CA_Gamma,
+    CA_LogGamma,
+    CA_Psi,
+    CA_Erf,
+    CA_Erfc,
+    CA_Erfi,
+    CA_RiemannZeta,
+    CA_HurwitzZeta,
+    CA_FUNC_CODE_LENGTH
+}
+calcium_func_code;
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/ca_types.h
+++ b/src/ca_types.h
@@ -1,4 +1,5 @@
 /*
+    Copyright (C) 2020 Fredrik Johansson
     Copyright (C) 2024 Albin Ahlbäck
 
     This file is part of FLINT.
@@ -12,6 +13,9 @@
 #ifndef CA_TYPES_H
 #define CA_TYPES_H
 
+#include "fmpz_types.h"
+#include "mpoly_types.h"
+#include "acb_types.h"
 #include "gr_types.h"
 
 #ifdef __cplusplus
@@ -85,6 +89,156 @@ typedef enum
     CA_FUNC_CODE_LENGTH
 }
 calcium_func_code;
+
+/* symbolic expressions ******************************************************/
+
+typedef struct
+{
+    ulong * data;
+    slong alloc;
+}
+fexpr_struct;
+
+typedef fexpr_struct fexpr_t[1];
+typedef fexpr_struct * fexpr_ptr;
+typedef const fexpr_struct * fexpr_srcptr;
+
+typedef struct
+{
+    fexpr_struct * entries;
+    slong alloc;
+    slong length;
+}
+fexpr_vec_struct;
+
+typedef fexpr_vec_struct fexpr_vec_t[1];
+
+#define fexpr_vec_entry(vec, i) ((vec)->entries + (i))
+
+/* numbers *******************************************************************/
+
+typedef union
+{
+    fmpq q;                           /* rational number */
+    nf_elem_struct nf;                /* algebraic number field element */
+    fmpz_mpoly_q_struct * mpoly_q;    /* generic field element */
+}
+ca_elem_struct;
+
+typedef struct
+{
+    ulong field;
+    ca_elem_struct elem;
+}
+ca_struct;
+
+typedef ca_struct ca_t[1];
+typedef ca_struct * ca_ptr;
+typedef const ca_struct * ca_srcptr;
+
+/* algebraic numbers via minimal polynomials *********************************/
+
+typedef struct
+{
+    fmpz_poly_struct poly;
+    acb_struct enclosure;
+}
+qqbar_struct;
+
+typedef qqbar_struct qqbar_t[1];
+typedef qqbar_struct * qqbar_ptr;
+typedef const qqbar_struct * qqbar_srcptr;
+
+/* extension objects *********************************************************/
+
+typedef struct
+{
+    qqbar_struct x;        /* qqbar_t element */
+    nf_struct * nf;        /* antic number field for fast arithmetic */
+}
+ca_ext_qqbar;
+
+typedef struct
+{
+    ca_struct * args;       /* Function arguments x1, ..., xn. */
+    slong nargs;            /* Number of function arguments n. */
+    acb_struct enclosure;   /* Cached numerical enclosure of f(x1,...,xn) */
+    slong prec;             /* Working precision of cached enclosure */
+    qqbar_struct * qqbar;   /* Cached qqbar */
+}
+ca_ext_func_data;
+
+typedef struct
+{
+    calcium_func_code head;   /* f = F_Pi, F_Exp, ... */
+    ulong hash;
+    slong depth;
+    union {
+        ca_ext_qqbar qqbar;
+        ca_ext_func_data func_data;
+    } data;
+} ca_ext_struct;
+
+typedef ca_ext_struct ca_ext_t[1];
+typedef ca_ext_struct * ca_ext_ptr;
+typedef const ca_ext_struct * ca_ext_srcptr;
+
+typedef struct
+{
+    ca_ext_struct ** items;
+    slong length;
+    slong alloc;
+
+    slong hash_size;
+    slong * hash_table;
+}
+ca_ext_cache_struct;
+
+typedef ca_ext_cache_struct ca_ext_cache_t[1];
+
+/* field objects *************************************************************/
+
+typedef struct
+{
+    slong length;                /* Number of generators              */
+    ca_ext_struct ** ext;        /* Generators                        */
+    fmpz_mpoly_vec_struct ideal; /* Algebraic relations for reduction */
+    ulong hash;
+}
+ca_field_struct;
+
+typedef ca_field_struct ca_field_t[1];
+typedef ca_field_struct * ca_field_ptr;
+typedef const ca_field_struct * ca_field_srcptr;
+
+typedef struct
+{
+    ca_field_struct ** items;
+    slong length;
+    slong alloc;
+
+    slong hash_size;
+    slong * hash_table;
+}
+ca_field_cache_struct;
+
+typedef ca_field_cache_struct ca_field_cache_t[1];
+
+/* context objects ***********************************************************/
+
+typedef struct
+{
+    ca_ext_cache_struct ext_cache;              /* Cached extension objects */
+    ca_field_cache_struct field_cache;          /* Cached extension fields  */
+    ca_field_struct * field_qq;                 /* Quick access to QQ      */
+    ca_field_struct * field_qq_i;               /* Quick access to QQ(i)   */
+    fmpz_mpoly_ctx_struct ** mctx;              /* Cached contexts for multivariate polys */
+    slong mctx_len;
+    slong * options;
+}
+ca_ctx_struct;
+
+typedef ca_ctx_struct ca_ctx_t[1];
 
 #ifdef __cplusplus
 }

--- a/src/ca_types.h
+++ b/src/ca_types.h
@@ -1,0 +1,31 @@
+/*
+    Copyright (C) 2024 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef CA_TYPES_H
+#define CA_TYPES_H
+
+#include "gr_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* streams *******************************************************************/
+
+/* TODO: Deprecate these and simply replace with gr_stream_struct */
+#define calcium_stream_struct gr_stream_struct
+#define calcium_stream_t gr_stream_t
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CA_TYPES_H */

--- a/src/ca_types.h
+++ b/src/ca_types.h
@@ -309,6 +309,53 @@ ca_ctx_struct;
 
 typedef ca_ctx_struct ca_ctx_t[1];
 
+/* vectors *******************************************************************/
+
+typedef struct
+{
+    ca_ptr entries;
+    slong alloc;
+    slong length;
+}
+ca_vec_struct;
+
+typedef ca_vec_struct ca_vec_t[1];
+
+/* matrices ******************************************************************/
+
+typedef struct
+{
+    ca_ptr entries;
+    slong r;
+    slong c;
+    ca_ptr * rows;
+}
+ca_mat_struct;
+
+typedef ca_mat_struct ca_mat_t[1];
+
+/* polynomials ***************************************************************/
+
+typedef struct
+{
+    ca_struct * coeffs;
+    slong alloc;
+    slong length;
+}
+ca_poly_struct;
+
+typedef ca_poly_struct ca_poly_t[1];
+
+typedef struct
+{
+    ca_poly_struct * entries;
+    slong length;
+    slong alloc;
+}
+ca_poly_vec_struct;
+
+typedef ca_poly_vec_struct ca_poly_vec_t[1];
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/ca_vec.h
+++ b/src/ca_vec.h
@@ -26,16 +26,6 @@ extern "C" {
 
 /* Vector object */
 
-typedef struct
-{
-    ca_ptr entries;
-    slong alloc;
-    slong length;
-}
-ca_vec_struct;
-
-typedef ca_vec_struct ca_vec_t[1];
-
 #define ca_vec_entry(vec, i) ((vec)->entries + (i))
 
 CA_VEC_INLINE ca_ptr

--- a/src/calcium.h
+++ b/src/calcium.h
@@ -18,25 +18,14 @@
 #define CALCIUM_INLINE static inline
 #endif
 
-#include "fmpz.h"
 #include "acb_types.h"
+#include "ca_types.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /* Input and output */
-
-typedef struct
-{
-    FLINT_FILE * fp;
-    char * s;
-    slong len;
-    slong alloc;
-}
-calcium_stream_struct;
-
-typedef calcium_stream_struct calcium_stream_t[1];
 
 #ifdef FLINT_HAVE_FILE
 void calcium_stream_init_file(calcium_stream_t out, FILE * fp);
@@ -65,13 +54,6 @@ void calcium_write_free(calcium_stream_t out, char * s)
 }
 
 /* Triple-valued logic */
-
-typedef enum
-{
-    T_TRUE,
-    T_FALSE,
-    T_UNKNOWN
-} truth_t;
 
 CALCIUM_INLINE void truth_print(truth_t t)
 {

--- a/src/calcium.h
+++ b/src/calcium.h
@@ -62,66 +62,6 @@ CALCIUM_INLINE void truth_print(truth_t t)
     if (t == T_UNKNOWN) flint_printf("T_UNKNOWN");
 }
 
-/* IDs for builtin mathematical functions and constants */
-typedef enum
-{
-    /* Special case for representing qqbar instances */
-    CA_QQBar,
-    /* Arithmetic */
-    CA_Neg,
-    CA_Add,
-    CA_Sub,
-    CA_Mul,
-    CA_Div,
-    /* Roots */
-    CA_Sqrt,
-    CA_Cbrt,
-    CA_Root,
-    /* Complex parts */
-    CA_Floor,
-    CA_Ceil,
-    CA_Abs,
-    CA_Sign,
-    CA_Re,
-    CA_Im,
-    CA_Arg,
-    CA_Conjugate,
-    /* Elementary constants */
-    CA_Pi,
-    /* Elementary functions */
-    CA_Sin,
-    CA_Cos,
-    CA_Exp,
-    CA_Log,
-    CA_Pow,
-    CA_Tan,
-    CA_Cot,
-    CA_Cosh,
-    CA_Sinh,
-    CA_Tanh,
-    CA_Coth,
-    CA_Atan,
-    CA_Acos,
-    CA_Asin,
-    CA_Acot,
-    CA_Atanh,
-    CA_Acosh,
-    CA_Asinh,
-    CA_Acoth,
-    /* Euler's constant */
-    CA_Euler,
-    /* Gamma and related functions */
-    CA_Gamma,
-    CA_LogGamma,
-    CA_Psi,
-    CA_Erf,
-    CA_Erfc,
-    CA_Erfi,
-    CA_RiemannZeta,
-    CA_HurwitzZeta,
-    CA_FUNC_CODE_LENGTH
-} calcium_func_code;
-
 const char * calcium_func_name(calcium_func_code func);
 
 /* Flint extras */

--- a/src/fexpr.h
+++ b/src/fexpr.h
@@ -55,29 +55,6 @@ extern "C" {
 
 #define FEXPR_BUILTIN_ID(head) ((head) >> 16)
 
-typedef struct
-{
-    ulong * data;
-    slong alloc;
-}
-fexpr_struct;
-
-typedef fexpr_struct fexpr_t[1];
-typedef fexpr_struct * fexpr_ptr;
-typedef const fexpr_struct * fexpr_srcptr;
-
-typedef struct
-{
-    fexpr_struct * entries;
-    slong alloc;
-    slong length;
-}
-fexpr_vec_struct;
-
-typedef fexpr_vec_struct fexpr_vec_t[1];
-
-#define fexpr_vec_entry(vec, i) ((vec)->entries + (i))
-
 FEXPR_INLINE void
 fexpr_init(fexpr_t expr)
 {

--- a/src/fexpr.h
+++ b/src/fexpr.h
@@ -22,8 +22,10 @@
 extern "C" {
 #endif
 
+#include "fmpz_types.h"
 #include "mpoly_types.h"
-#include "calcium.h"
+#include "arf_types.h"
+#include "ca_types.h"
 
 #define FEXPR_TYPE_SMALL_INT     UWORD(0)
 #define FEXPR_TYPE_SMALL_SYMBOL  UWORD(1)

--- a/src/fexpr/numerical_enclosure.c
+++ b/src/fexpr/numerical_enclosure.c
@@ -12,6 +12,7 @@
 #include "acb_hypgeom.h"
 #include "acb_modular.h"
 #include "acb_dirichlet.h"
+#include "calcium.h"
 #include "fexpr.h"
 #include "fexpr_builtin.h"
 

--- a/src/fexpr/print.c
+++ b/src/fexpr/print.c
@@ -10,6 +10,8 @@
 */
 
 #include <stdio.h>
+#include "fmpz.h"
+#include "calcium.h"
 #include "fexpr.h"
 #include "fexpr_builtin.h"
 

--- a/src/fexpr/set_fmpz_mpoly.c
+++ b/src/fexpr/set_fmpz_mpoly.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mpoly.h"
 #include "fexpr.h"
 

--- a/src/fexpr/test/t-call_vec.c
+++ b/src/fexpr/test/t-call_vec.c
@@ -10,6 +10,7 @@
 */
 
 #include "test_helpers.h"
+#include "fmpz.h"
 #include "calcium.h"
 #include "fexpr.h"
 

--- a/src/fexpr/write_latex.c
+++ b/src/fexpr/write_latex.c
@@ -10,16 +10,11 @@
 */
 
 #include <stdio.h>
+#include <string.h>
+#include "fmpz.h"
+#include "calcium.h"
 #include "fexpr.h"
 #include "fexpr_builtin.h"
-
-#ifdef __GNUC__
-# define memcpy __builtin_memcpy
-# define strcmp __builtin_strcmp
-# define strlen __builtin_strlen
-#else
-# include <string.h>
-#endif
 
 void fexpr_write_latex_symbol(int * subscript, calcium_stream_t out, const fexpr_t expr, ulong flags);
 int _fexpr_is_symbol_with_trailing_underscore(const fexpr_t expr);

--- a/src/fexpr_builtin.h
+++ b/src/fexpr_builtin.h
@@ -22,7 +22,7 @@
 extern "C" {
 #endif
 
-#include "fexpr.h"
+#include "ca_types.h"
 
 /* Builtin symbols */
 

--- a/src/fft_small/profile/p-fft_small_vs_gmp.c
+++ b/src/fft_small/profile/p-fft_small_vs_gmp.c
@@ -27,6 +27,9 @@ int main(void)
 {
     mp_ptr x, y, r, s;
     slong n;
+    flint_rand_t state;
+
+    flint_randinit(state);
 
     x = flint_malloc(sizeof(mp_limb_t) * FLINT_MAX(N_MAX_MUL, N_MAX_SQR));
     y = flint_malloc(sizeof(mp_limb_t) * FLINT_MAX(N_MAX_MUL, N_MAX_SQR));
@@ -78,6 +81,8 @@ int main(void)
     flint_free(y);
     flint_free(r);
     flint_free(s);
+
+    flint_randclear(state);
 
     flint_cleanup_master();
 

--- a/src/fmpq_poly.h
+++ b/src/fmpq_poly.h
@@ -29,14 +29,6 @@ extern "C" {
 
 /*  Type definitions  ********************************************************/
 
-typedef struct
-{
-   fmpq_poly_struct * powers;
-   slong len;
-} fmpq_poly_powers_precomp_struct;
-
-typedef fmpq_poly_powers_precomp_struct fmpq_poly_powers_precomp_t[1];
-
 #define WEAK_CANONICALISE_CUTOFF 25600
 
 /*  Memory management  *******************************************************/

--- a/src/fmpq_types.h
+++ b/src/fmpq_types.h
@@ -40,6 +40,14 @@ fmpq_poly_struct;
 
 typedef fmpq_poly_struct fmpq_poly_t[1];
 
+typedef struct
+{
+   fmpq_poly_struct * powers;
+   slong len;
+} fmpq_poly_powers_precomp_struct;
+
+typedef fmpq_poly_powers_precomp_struct fmpq_poly_powers_precomp_t[1];
+
 /*
     A polynomial f is represented as
         content * zpoly,

--- a/src/fmpz_mpoly.h
+++ b/src/fmpz_mpoly.h
@@ -942,16 +942,6 @@ void fmpz_mpoly_symmetric(fmpz_mpoly_t res, ulong k, const fmpz_mpoly_ctx_t ctx)
 
 /* Vectors of multivariate polynomials */
 
-typedef struct
-{
-    fmpz_mpoly_struct * p;
-    slong alloc;
-    slong length;
-}
-fmpz_mpoly_vec_struct;
-
-typedef fmpz_mpoly_vec_struct fmpz_mpoly_vec_t[1];
-
 #define fmpz_mpoly_vec_entry(vec, i) ((vec)->p + (i))
 
 void fmpz_mpoly_vec_init(fmpz_mpoly_vec_t vec, slong len, const fmpz_mpoly_ctx_t ctx);

--- a/src/fmpz_poly.h
+++ b/src/fmpz_poly.h
@@ -36,14 +36,6 @@ extern "C" {
 
 typedef struct
 {
-   fmpz ** powers;
-   slong len;
-} fmpz_poly_powers_precomp_struct;
-
-typedef fmpz_poly_powers_precomp_struct fmpz_poly_powers_precomp_t[1];
-
-typedef struct
-{
    mp_limb_t ** jj; /* used by fft_convolution_precache */
    slong n;
    slong len2;

--- a/src/fmpz_types.h
+++ b/src/fmpz_types.h
@@ -51,6 +51,14 @@ typedef fmpz_poly_struct fmpz_poly_t[1];
 
 typedef struct
 {
+   fmpz ** powers;
+   slong len;
+} fmpz_poly_powers_precomp_struct;
+
+typedef fmpz_poly_powers_precomp_struct fmpz_poly_powers_precomp_t[1];
+
+typedef struct
+{
     fmpz c;
     fmpz_poly_struct *p;
     slong *exp;

--- a/src/fmpz_types.h
+++ b/src/fmpz_types.h
@@ -97,6 +97,16 @@ typedef fmpz_mpoly_struct fmpz_mpoly_t[1];
 
 typedef struct
 {
+    fmpz_mpoly_struct * p;
+    slong alloc;
+    slong length;
+}
+fmpz_mpoly_vec_struct;
+
+typedef fmpz_mpoly_vec_struct fmpz_mpoly_vec_t[1];
+
+typedef struct
+{
     fmpz_t constant;
     fmpz_t constant_den;        /* should be one after normal operations */
     fmpz_mpoly_struct * poly;

--- a/src/gr.h
+++ b/src/gr.h
@@ -69,11 +69,6 @@ void gr_stream_write_ui(gr_stream_t out, ulong x);
 void gr_stream_write_free(gr_stream_t out, char * s);
 void gr_stream_write_fmpz(gr_stream_t out, const fmpz_t x);
 
-#define GR_SUCCESS 0
-#define GR_DOMAIN 1
-#define GR_UNABLE 2
-#define GR_TEST_FAIL 4
-
 #define GR_MUST_SUCCEED(expr) do { if ((expr) != GR_SUCCESS) { flint_throw(FLINT_ERROR, "GR_MUST_SUCCEED failure: %s", __FILE__); } } while (0)
 #define GR_IGNORE(expr) do { int ___unused = (expr); (void) ___unused; } while (0)
 

--- a/src/gr.h
+++ b/src/gr.h
@@ -74,7 +74,7 @@ void gr_stream_write_fmpz(gr_stream_t out, const fmpz_t x);
 #define GR_UNABLE 2
 #define GR_TEST_FAIL 4
 
-#define WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#define FLINT_WARN_UNUSED __attribute__((warn_unused_result))
 
 #define GR_MUST_SUCCEED(expr) do { if ((expr) != GR_SUCCESS) { flint_throw(FLINT_ERROR, "GR_MUST_SUCCEED failure: %s", __FILE__); } } while (0)
 #define GR_IGNORE(expr) do { int ___unused = (expr); (void) ___unused; } while (0)
@@ -912,12 +912,12 @@ GR_INLINE truth_t gr_ctx_is_canonical(gr_ctx_t ctx) { return GR_CTX_PREDICATE(ct
 GR_INLINE truth_t gr_ctx_is_threadsafe(gr_ctx_t ctx) { return GR_CTX_PREDICATE(ctx, CTX_IS_THREADSAFE)(ctx); }
 
 GR_INLINE truth_t gr_ctx_has_real_prec(gr_ctx_t ctx) { return GR_CTX_PREDICATE(ctx, CTX_HAS_REAL_PREC)(ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_ctx_set_real_prec(gr_ctx_t ctx, slong prec) { return GR_CTX_SET_SI(ctx, CTX_SET_REAL_PREC)(ctx, prec); }
-GR_INLINE WARN_UNUSED_RESULT int gr_ctx_get_real_prec(slong * prec, gr_ctx_t ctx) { return GR_CTX_GET_SI(ctx, CTX_GET_REAL_PREC)(prec, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_ctx_set_real_prec(gr_ctx_t ctx, slong prec) { return GR_CTX_SET_SI(ctx, CTX_SET_REAL_PREC)(ctx, prec); }
+GR_INLINE FLINT_WARN_UNUSED int gr_ctx_get_real_prec(slong * prec, gr_ctx_t ctx) { return GR_CTX_GET_SI(ctx, CTX_GET_REAL_PREC)(prec, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_ctx_set_is_field(gr_ctx_t ctx, truth_t is_field) { return GR_CTX_SET_TRUTH(ctx, CTX_SET_IS_FIELD)(ctx, is_field); }
-GR_INLINE WARN_UNUSED_RESULT int gr_ctx_set_gen_name(gr_ctx_t ctx, const char * s) { return GR_CTX_SET_STR(ctx, CTX_SET_GEN_NAME)(ctx, s); }
-GR_INLINE WARN_UNUSED_RESULT int gr_ctx_set_gen_names(gr_ctx_t ctx, const char ** s) { return GR_CTX_SET_STRS(ctx, CTX_SET_GEN_NAMES)(ctx, s); }
+GR_INLINE FLINT_WARN_UNUSED int gr_ctx_set_is_field(gr_ctx_t ctx, truth_t is_field) { return GR_CTX_SET_TRUTH(ctx, CTX_SET_IS_FIELD)(ctx, is_field); }
+GR_INLINE FLINT_WARN_UNUSED int gr_ctx_set_gen_name(gr_ctx_t ctx, const char * s) { return GR_CTX_SET_STR(ctx, CTX_SET_GEN_NAME)(ctx, s); }
+GR_INLINE FLINT_WARN_UNUSED int gr_ctx_set_gen_names(gr_ctx_t ctx, const char ** s) { return GR_CTX_SET_STRS(ctx, CTX_SET_GEN_NAMES)(ctx, s); }
 
 GR_INLINE slong _gr_ctx_get_real_prec(gr_ctx_t ctx)
 {
@@ -933,37 +933,37 @@ GR_INLINE void gr_set_shallow(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { GR_VOID_U
 
 GR_INLINE void _gr_length(gr_srcptr x, gr_ctx_t ctx) { _GR_GET_SI_OP(ctx, LENGTH)(x, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_randtest(gr_ptr x, flint_rand_t state, gr_ctx_t ctx) { return GR_RANDTEST(ctx, RANDTEST)(x, state, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_randtest_not_zero(gr_ptr x, flint_rand_t state, gr_ctx_t ctx) { return GR_RANDTEST(ctx, RANDTEST_NOT_ZERO)(x, state, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_randtest_small(gr_ptr x, flint_rand_t state, gr_ctx_t ctx) { return GR_RANDTEST(ctx, RANDTEST_SMALL)(x, state, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_randtest(gr_ptr x, flint_rand_t state, gr_ctx_t ctx) { return GR_RANDTEST(ctx, RANDTEST)(x, state, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_randtest_not_zero(gr_ptr x, flint_rand_t state, gr_ctx_t ctx) { return GR_RANDTEST(ctx, RANDTEST_NOT_ZERO)(x, state, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_randtest_small(gr_ptr x, flint_rand_t state, gr_ctx_t ctx) { return GR_RANDTEST(ctx, RANDTEST_SMALL)(x, state, ctx); }
 GR_INLINE /* todo: warn? */ int gr_write(gr_stream_t out, gr_srcptr x, gr_ctx_t ctx) { return GR_STREAM_IN(ctx, WRITE)(out, x, ctx); }
 GR_INLINE /* todo: warn? */ int gr_write_n(gr_stream_t out, gr_srcptr x, slong n, gr_ctx_t ctx) { return GR_STREAM_IN_SI(ctx, WRITE_N)(out, x, n, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_zero(gr_ptr res, gr_ctx_t ctx) { return GR_CONSTANT_OP(ctx, ZERO)(res, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_one(gr_ptr res, gr_ctx_t ctx) { return GR_CONSTANT_OP(ctx, ONE)(res, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_neg_one(gr_ptr res, gr_ctx_t ctx) { return GR_CONSTANT_OP(ctx, NEG_ONE)(res, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_zero(gr_ptr res, gr_ctx_t ctx) { return GR_CONSTANT_OP(ctx, ZERO)(res, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_one(gr_ptr res, gr_ctx_t ctx) { return GR_CONSTANT_OP(ctx, ONE)(res, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_neg_one(gr_ptr res, gr_ctx_t ctx) { return GR_CONSTANT_OP(ctx, NEG_ONE)(res, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_set(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, SET)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_set_si(gr_ptr res, slong x, gr_ctx_t ctx) { return GR_UNARY_OP_SI(ctx, SET_SI)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_set_ui(gr_ptr res, ulong x, gr_ctx_t ctx) { return GR_UNARY_OP_SI(ctx, SET_UI)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_set_fmpz(gr_ptr res, const fmpz_t x, gr_ctx_t ctx) { return GR_UNARY_OP_FMPZ(ctx, SET_FMPZ)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_set_fmpq(gr_ptr res, const fmpq_t x, gr_ctx_t ctx) { return GR_UNARY_OP_FMPQ(ctx, SET_FMPQ)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_set_d(gr_ptr res, double x, gr_ctx_t ctx) { return GR_UNARY_OP_D(ctx, SET_D)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_set_other(gr_ptr res, gr_srcptr x, gr_ctx_t x_ctx, gr_ctx_t ctx) { return GR_UNARY_OP_OTHER(ctx, SET_OTHER)(res, x, x_ctx, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_set_str(gr_ptr res, const char * x, gr_ctx_t ctx) { return GR_UNARY_OP_STR(ctx, SET_STR)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_set(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, SET)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_set_si(gr_ptr res, slong x, gr_ctx_t ctx) { return GR_UNARY_OP_SI(ctx, SET_SI)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_set_ui(gr_ptr res, ulong x, gr_ctx_t ctx) { return GR_UNARY_OP_SI(ctx, SET_UI)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_set_fmpz(gr_ptr res, const fmpz_t x, gr_ctx_t ctx) { return GR_UNARY_OP_FMPZ(ctx, SET_FMPZ)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_set_fmpq(gr_ptr res, const fmpq_t x, gr_ctx_t ctx) { return GR_UNARY_OP_FMPQ(ctx, SET_FMPQ)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_set_d(gr_ptr res, double x, gr_ctx_t ctx) { return GR_UNARY_OP_D(ctx, SET_D)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_set_other(gr_ptr res, gr_srcptr x, gr_ctx_t x_ctx, gr_ctx_t ctx) { return GR_UNARY_OP_OTHER(ctx, SET_OTHER)(res, x, x_ctx, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_set_str(gr_ptr res, const char * x, gr_ctx_t ctx) { return GR_UNARY_OP_STR(ctx, SET_STR)(res, x, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_get_si(slong * res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP_GET_SI(ctx, GET_SI)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_get_ui(ulong * res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP_GET_UI(ctx, GET_UI)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_get_fmpz(fmpz_t res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP_GET_FMPZ(ctx, GET_FMPZ)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_get_fmpq(fmpq_t res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP_GET_FMPQ(ctx, GET_FMPQ)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_get_d(double * res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP_GET_D(ctx, GET_D)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_get_si(slong * res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP_GET_SI(ctx, GET_SI)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_get_ui(ulong * res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP_GET_UI(ctx, GET_UI)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_get_fmpz(fmpz_t res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP_GET_FMPZ(ctx, GET_FMPZ)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_get_fmpq(fmpq_t res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP_GET_FMPQ(ctx, GET_FMPQ)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_get_d(double * res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP_GET_D(ctx, GET_D)(res, x, ctx); }
 
 #define GR_FEXPR_SERIALIZE (UWORD(1) << 31)
 #define GR_FEXPR_COMPACT (UWORD(1) << 30)
 
 #ifdef FEXPR_H
-GR_INLINE WARN_UNUSED_RESULT int gr_get_fexpr(fexpr_t res, gr_srcptr x, gr_ctx_t ctx) { return GR_GET_FEXPR_OP(ctx, GET_FEXPR)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_get_fexpr_serialize(fexpr_t res, gr_srcptr x, gr_ctx_t ctx) { return GR_GET_FEXPR_OP(ctx, GET_FEXPR_SERIALIZE)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_set_fexpr(gr_ptr res, fexpr_vec_t inputs, gr_vec_t outputs, const fexpr_t x, gr_ctx_t ctx) { return GR_SET_FEXPR_OP(ctx, SET_FEXPR)(res, inputs, outputs, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_get_fexpr(fexpr_t res, gr_srcptr x, gr_ctx_t ctx) { return GR_GET_FEXPR_OP(ctx, GET_FEXPR)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_get_fexpr_serialize(fexpr_t res, gr_srcptr x, gr_ctx_t ctx) { return GR_GET_FEXPR_OP(ctx, GET_FEXPR_SERIALIZE)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_set_fexpr(gr_ptr res, fexpr_vec_t inputs, gr_vec_t outputs, const fexpr_t x, gr_ctx_t ctx) { return GR_SET_FEXPR_OP(ctx, SET_FEXPR)(res, inputs, outputs, x, ctx); }
 #endif
 
 GR_INLINE truth_t gr_is_zero(gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_PREDICATE(ctx, IS_ZERO)(x, ctx); }
@@ -973,141 +973,141 @@ GR_INLINE truth_t gr_is_neg_one(gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_PRE
 GR_INLINE truth_t gr_equal(gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_PREDICATE(ctx, EQUAL)(x, y, ctx); }
 GR_INLINE truth_t gr_not_equal(gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return truth_not(GR_BINARY_PREDICATE(ctx, EQUAL)(x, y, ctx)); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_neg(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, NEG)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_neg(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, NEG)(res, x, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_add(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, ADD)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_add_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx) { return GR_BINARY_OP_UI(ctx, ADD_UI)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_add_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx) { return GR_BINARY_OP_SI(ctx, ADD_SI)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_add_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPZ(ctx, ADD_FMPZ)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_add_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPQ(ctx, ADD_FMPQ)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_add_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx) { return GR_BINARY_OP_OTHER(ctx, ADD_OTHER)(res, x, y, y_ctx, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_other_add(gr_ptr res, gr_srcptr x, gr_ctx_t x_ctx, gr_srcptr y, gr_ctx_t ctx) { return GR_OTHER_BINARY_OP(ctx, OTHER_ADD)(res, x, x_ctx, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_add(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, ADD)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_add_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx) { return GR_BINARY_OP_UI(ctx, ADD_UI)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_add_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx) { return GR_BINARY_OP_SI(ctx, ADD_SI)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_add_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPZ(ctx, ADD_FMPZ)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_add_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPQ(ctx, ADD_FMPQ)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_add_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx) { return GR_BINARY_OP_OTHER(ctx, ADD_OTHER)(res, x, y, y_ctx, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_other_add(gr_ptr res, gr_srcptr x, gr_ctx_t x_ctx, gr_srcptr y, gr_ctx_t ctx) { return GR_OTHER_BINARY_OP(ctx, OTHER_ADD)(res, x, x_ctx, y, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_sub(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, SUB)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_sub_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx) { return GR_BINARY_OP_UI(ctx, SUB_UI)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_sub_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx) { return GR_BINARY_OP_SI(ctx, SUB_SI)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_sub_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPZ(ctx, SUB_FMPZ)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_sub_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPQ(ctx, SUB_FMPQ)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_sub_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx) { return GR_BINARY_OP_OTHER(ctx, SUB_OTHER)(res, x, y, y_ctx, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_other_sub(gr_ptr res, gr_srcptr x, gr_ctx_t x_ctx, gr_srcptr y, gr_ctx_t ctx) { return GR_OTHER_BINARY_OP(ctx, OTHER_SUB)(res, x, x_ctx, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_sub(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, SUB)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_sub_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx) { return GR_BINARY_OP_UI(ctx, SUB_UI)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_sub_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx) { return GR_BINARY_OP_SI(ctx, SUB_SI)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_sub_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPZ(ctx, SUB_FMPZ)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_sub_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPQ(ctx, SUB_FMPQ)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_sub_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx) { return GR_BINARY_OP_OTHER(ctx, SUB_OTHER)(res, x, y, y_ctx, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_other_sub(gr_ptr res, gr_srcptr x, gr_ctx_t x_ctx, gr_srcptr y, gr_ctx_t ctx) { return GR_OTHER_BINARY_OP(ctx, OTHER_SUB)(res, x, x_ctx, y, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_mul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, MUL)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_mul_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx) { return GR_BINARY_OP_UI(ctx, MUL_UI)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_mul_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx) { return GR_BINARY_OP_SI(ctx, MUL_SI)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_mul_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPZ(ctx, MUL_FMPZ)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_mul_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPQ(ctx, MUL_FMPQ)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_mul_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx) { return GR_BINARY_OP_OTHER(ctx, MUL_OTHER)(res, x, y, y_ctx, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_other_mul(gr_ptr res, gr_srcptr x, gr_ctx_t x_ctx, gr_srcptr y, gr_ctx_t ctx) { return GR_OTHER_BINARY_OP(ctx, OTHER_MUL)(res, x, x_ctx, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_mul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, MUL)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_mul_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx) { return GR_BINARY_OP_UI(ctx, MUL_UI)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_mul_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx) { return GR_BINARY_OP_SI(ctx, MUL_SI)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_mul_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPZ(ctx, MUL_FMPZ)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_mul_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPQ(ctx, MUL_FMPQ)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_mul_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx) { return GR_BINARY_OP_OTHER(ctx, MUL_OTHER)(res, x, y, y_ctx, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_other_mul(gr_ptr res, gr_srcptr x, gr_ctx_t x_ctx, gr_srcptr y, gr_ctx_t ctx) { return GR_OTHER_BINARY_OP(ctx, OTHER_MUL)(res, x, x_ctx, y, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_addmul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, ADDMUL)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_addmul_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx) { return GR_BINARY_OP_UI(ctx, ADDMUL_UI)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_addmul_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx) { return GR_BINARY_OP_SI(ctx, ADDMUL_SI)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_addmul_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPZ(ctx, ADDMUL_FMPZ)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_addmul_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPQ(ctx, ADDMUL_FMPQ)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_addmul_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx) { return GR_BINARY_OP_OTHER(ctx, ADDMUL_OTHER)(res, x, y, y_ctx, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_addmul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, ADDMUL)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_addmul_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx) { return GR_BINARY_OP_UI(ctx, ADDMUL_UI)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_addmul_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx) { return GR_BINARY_OP_SI(ctx, ADDMUL_SI)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_addmul_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPZ(ctx, ADDMUL_FMPZ)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_addmul_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPQ(ctx, ADDMUL_FMPQ)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_addmul_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx) { return GR_BINARY_OP_OTHER(ctx, ADDMUL_OTHER)(res, x, y, y_ctx, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_submul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, SUBMUL)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_submul_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx) { return GR_BINARY_OP_UI(ctx, SUBMUL_UI)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_submul_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx) { return GR_BINARY_OP_SI(ctx, SUBMUL_SI)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_submul_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPZ(ctx, SUBMUL_FMPZ)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_submul_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPQ(ctx, SUBMUL_FMPQ)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_submul_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx) { return GR_BINARY_OP_OTHER(ctx, SUBMUL_OTHER)(res, x, y, y_ctx, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_submul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, SUBMUL)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_submul_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx) { return GR_BINARY_OP_UI(ctx, SUBMUL_UI)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_submul_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx) { return GR_BINARY_OP_SI(ctx, SUBMUL_SI)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_submul_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPZ(ctx, SUBMUL_FMPZ)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_submul_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPQ(ctx, SUBMUL_FMPQ)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_submul_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx) { return GR_BINARY_OP_OTHER(ctx, SUBMUL_OTHER)(res, x, y, y_ctx, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_mul_two(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, MUL_TWO)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_sqr(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, SQR)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_mul_two(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, MUL_TWO)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_sqr(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, SQR)(res, x, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_mul_2exp_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx) { return GR_BINARY_OP_SI(ctx, MUL_2EXP_SI)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_mul_2exp_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPZ(ctx, MUL_2EXP_FMPZ)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_set_fmpz_2exp_fmpz(gr_ptr res, const fmpz_t x, const fmpz_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPZ_FMPZ(ctx, SET_FMPZ_2EXP_FMPZ)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_get_fmpz_2exp_fmpz(fmpz_t res1, fmpz_t res2, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP_GET_FMPZ_FMPZ(ctx, GET_FMPZ_2EXP_FMPZ)(res1, res2, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_set_fmpz_10exp_fmpz(gr_ptr res, const fmpz_t x, const fmpz_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPZ_FMPZ(ctx, SET_FMPZ_10EXP_FMPZ)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_mul_2exp_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx) { return GR_BINARY_OP_SI(ctx, MUL_2EXP_SI)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_mul_2exp_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPZ(ctx, MUL_2EXP_FMPZ)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_set_fmpz_2exp_fmpz(gr_ptr res, const fmpz_t x, const fmpz_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPZ_FMPZ(ctx, SET_FMPZ_2EXP_FMPZ)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_get_fmpz_2exp_fmpz(fmpz_t res1, fmpz_t res2, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP_GET_FMPZ_FMPZ(ctx, GET_FMPZ_2EXP_FMPZ)(res1, res2, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_set_fmpz_10exp_fmpz(gr_ptr res, const fmpz_t x, const fmpz_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPZ_FMPZ(ctx, SET_FMPZ_10EXP_FMPZ)(res, x, y, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_inv(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, INV)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_inv(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, INV)(res, x, ctx); }
 GR_INLINE truth_t gr_is_invertible(gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_PREDICATE(ctx, IS_INVERTIBLE)(x, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_div(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, DIV)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_div_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx) { return GR_BINARY_OP_UI(ctx, DIV_UI)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_div_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx) { return GR_BINARY_OP_SI(ctx, DIV_SI)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_div_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPZ(ctx, DIV_FMPZ)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_div_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPQ(ctx, DIV_FMPQ)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_div_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx) { return GR_BINARY_OP_OTHER(ctx, DIV_OTHER)(res, x, y, y_ctx, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_other_div(gr_ptr res, gr_srcptr x, gr_ctx_t x_ctx, gr_srcptr y, gr_ctx_t ctx) { return GR_OTHER_BINARY_OP(ctx, OTHER_DIV)(res, x, x_ctx, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_div(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, DIV)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_div_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx) { return GR_BINARY_OP_UI(ctx, DIV_UI)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_div_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx) { return GR_BINARY_OP_SI(ctx, DIV_SI)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_div_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPZ(ctx, DIV_FMPZ)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_div_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPQ(ctx, DIV_FMPQ)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_div_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx) { return GR_BINARY_OP_OTHER(ctx, DIV_OTHER)(res, x, y, y_ctx, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_other_div(gr_ptr res, gr_srcptr x, gr_ctx_t x_ctx, gr_srcptr y, gr_ctx_t ctx) { return GR_OTHER_BINARY_OP(ctx, OTHER_DIV)(res, x, x_ctx, y, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_div_nonunique(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, DIV_NONUNIQUE)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_div_nonunique(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, DIV_NONUNIQUE)(res, x, y, ctx); }
 GR_INLINE truth_t gr_divides(gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_PREDICATE(ctx, DIVIDES)(x, y, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_divexact(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, DIVEXACT)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_divexact_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx) { return GR_BINARY_OP_UI(ctx, DIVEXACT_UI)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_divexact_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx) { return GR_BINARY_OP_SI(ctx, DIVEXACT_SI)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_divexact_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPZ(ctx, DIVEXACT_FMPZ)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_divexact_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPQ(ctx, DIVEXACT_FMPQ)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_divexact_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx) { return GR_BINARY_OP_OTHER(ctx, DIVEXACT_OTHER)(res, x, y, y_ctx, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_other_divexact(gr_ptr res, gr_srcptr x, gr_ctx_t x_ctx, gr_srcptr y, gr_ctx_t ctx) { return GR_OTHER_BINARY_OP(ctx, OTHER_DIVEXACT)(res, x, x_ctx, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_divexact(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, DIVEXACT)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_divexact_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx) { return GR_BINARY_OP_UI(ctx, DIVEXACT_UI)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_divexact_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx) { return GR_BINARY_OP_SI(ctx, DIVEXACT_SI)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_divexact_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPZ(ctx, DIVEXACT_FMPZ)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_divexact_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPQ(ctx, DIVEXACT_FMPQ)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_divexact_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx) { return GR_BINARY_OP_OTHER(ctx, DIVEXACT_OTHER)(res, x, y, y_ctx, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_other_divexact(gr_ptr res, gr_srcptr x, gr_ctx_t x_ctx, gr_srcptr y, gr_ctx_t ctx) { return GR_OTHER_BINARY_OP(ctx, OTHER_DIVEXACT)(res, x, x_ctx, y, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_euclidean_div(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, EUCLIDEAN_DIV)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_euclidean_rem(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, EUCLIDEAN_REM)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_euclidean_divrem(gr_ptr res1, gr_ptr res2, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_BINARY_OP(ctx, EUCLIDEAN_DIVREM)(res1, res2, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_gcd(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, GCD)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_lcm(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, LCM)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_euclidean_div(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, EUCLIDEAN_DIV)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_euclidean_rem(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, EUCLIDEAN_REM)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_euclidean_divrem(gr_ptr res1, gr_ptr res2, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_BINARY_OP(ctx, EUCLIDEAN_DIVREM)(res1, res2, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_gcd(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, GCD)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_lcm(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, LCM)(res, x, y, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_numerator(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, NUMERATOR)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_denominator(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, DENOMINATOR)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_numerator(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, NUMERATOR)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_denominator(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, DENOMINATOR)(res, x, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_factor(gr_ptr c, gr_vec_t factors, gr_vec_t exponents, gr_srcptr x, int flags, gr_ctx_t ctx) { return GR_FACTOR_OP(ctx, FACTOR)(c, factors, exponents, x, flags, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_factor(gr_ptr c, gr_vec_t factors, gr_vec_t exponents, gr_srcptr x, int flags, gr_ctx_t ctx) { return GR_FACTOR_OP(ctx, FACTOR)(c, factors, exponents, x, flags, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_pow(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, POW)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_pow_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx) { return GR_BINARY_OP_UI(ctx, POW_UI)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_pow_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx) { return GR_BINARY_OP_SI(ctx, POW_SI)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_pow_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPZ(ctx, POW_FMPZ)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_pow_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPQ(ctx, POW_FMPQ)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_pow_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx) { return GR_BINARY_OP_OTHER(ctx, POW_OTHER)(res, x, y, y_ctx, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_other_pow(gr_ptr res, gr_srcptr x, gr_ctx_t x_ctx, gr_srcptr y, gr_ctx_t ctx) { return GR_OTHER_BINARY_OP(ctx, OTHER_POW)(res, x, x_ctx, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_pow(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, POW)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_pow_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx) { return GR_BINARY_OP_UI(ctx, POW_UI)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_pow_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx) { return GR_BINARY_OP_SI(ctx, POW_SI)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_pow_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPZ(ctx, POW_FMPZ)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_pow_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPQ(ctx, POW_FMPQ)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_pow_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx) { return GR_BINARY_OP_OTHER(ctx, POW_OTHER)(res, x, y, y_ctx, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_other_pow(gr_ptr res, gr_srcptr x, gr_ctx_t x_ctx, gr_srcptr y, gr_ctx_t ctx) { return GR_OTHER_BINARY_OP(ctx, OTHER_POW)(res, x, x_ctx, y, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_sqrt(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, SQRT)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_rsqrt(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, RSQRT)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_sqrt(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, SQRT)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_rsqrt(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, RSQRT)(res, x, ctx); }
 GR_INLINE truth_t gr_is_square(gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_PREDICATE(ctx, IS_SQUARE)(x, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_floor(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, FLOOR)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_ceil(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, CEIL)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_trunc(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, TRUNC)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_nint(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, NINT)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_floor(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, FLOOR)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_ceil(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, CEIL)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_trunc(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, TRUNC)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_nint(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, NINT)(res, x, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_abs(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, ABS)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_i(gr_ptr res, gr_ctx_t ctx) { return GR_CONSTANT_OP(ctx, I)(res, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_conj(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, CONJ)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_re(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, RE)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_im(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, IM)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_sgn(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, SGN)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_csgn(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, CSGN)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_arg(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, ARG)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_abs(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, ABS)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_i(gr_ptr res, gr_ctx_t ctx) { return GR_CONSTANT_OP(ctx, I)(res, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_conj(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, CONJ)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_re(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, RE)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_im(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, IM)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_sgn(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, SGN)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_csgn(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, CSGN)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_arg(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, ARG)(res, x, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_pos_inf(gr_ptr res, gr_ctx_t ctx) { return GR_CONSTANT_OP(ctx, POS_INF)(res, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_neg_inf(gr_ptr res, gr_ctx_t ctx) { return GR_CONSTANT_OP(ctx, NEG_INF)(res, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_uinf(gr_ptr res, gr_ctx_t ctx) { return GR_CONSTANT_OP(ctx, UINF)(res, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_undefined(gr_ptr res, gr_ctx_t ctx) { return GR_CONSTANT_OP(ctx, UNDEFINED)(res, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_unknown(gr_ptr res, gr_ctx_t ctx) { return GR_CONSTANT_OP(ctx, UNKNOWN)(res, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_pos_inf(gr_ptr res, gr_ctx_t ctx) { return GR_CONSTANT_OP(ctx, POS_INF)(res, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_neg_inf(gr_ptr res, gr_ctx_t ctx) { return GR_CONSTANT_OP(ctx, NEG_INF)(res, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_uinf(gr_ptr res, gr_ctx_t ctx) { return GR_CONSTANT_OP(ctx, UINF)(res, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_undefined(gr_ptr res, gr_ctx_t ctx) { return GR_CONSTANT_OP(ctx, UNDEFINED)(res, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_unknown(gr_ptr res, gr_ctx_t ctx) { return GR_CONSTANT_OP(ctx, UNKNOWN)(res, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_cmp(int * res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP_GET_INT(ctx, CMP)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_cmpabs(int * res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP_GET_INT(ctx, CMPABS)(res, x, y, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_cmp_other(int * res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx) { return GR_BINARY_OP_OTHER_GET_INT(ctx, CMP_OTHER)(res, x, y, y_ctx, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_cmpabs_other(int * res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx) { return GR_BINARY_OP_OTHER_GET_INT(ctx, CMPABS_OTHER)(res, x, y, y_ctx, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_cmp(int * res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP_GET_INT(ctx, CMP)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_cmpabs(int * res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP_GET_INT(ctx, CMPABS)(res, x, y, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_cmp_other(int * res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx) { return GR_BINARY_OP_OTHER_GET_INT(ctx, CMP_OTHER)(res, x, y, y_ctx, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_cmpabs_other(int * res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx) { return GR_BINARY_OP_OTHER_GET_INT(ctx, CMPABS_OTHER)(res, x, y, y_ctx, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_gen(gr_ptr res, gr_ctx_t ctx) { return GR_CONSTANT_OP(ctx, GEN)(res, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_gens(gr_vec_t res, gr_ctx_t ctx) { return GR_VEC_CTX_OP(ctx, GENS)(res, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_gens_recursive(gr_vec_t res, gr_ctx_t ctx) { return GR_VEC_CTX_OP(ctx, GENS_RECURSIVE)(res, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_gen(gr_ptr res, gr_ctx_t ctx) { return GR_CONSTANT_OP(ctx, GEN)(res, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_gens(gr_vec_t res, gr_ctx_t ctx) { return GR_VEC_CTX_OP(ctx, GENS)(res, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_gens_recursive(gr_vec_t res, gr_ctx_t ctx) { return GR_VEC_CTX_OP(ctx, GENS_RECURSIVE)(res, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_ctx_fq_prime(fmpz_t res, gr_ctx_t ctx) { return GR_CONSTANT_OP_GET_FMPZ(ctx, CTX_FQ_PRIME)(res, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_ctx_fq_degree(slong * res, gr_ctx_t ctx) { return GR_CONSTANT_OP_GET_SI(ctx, CTX_FQ_DEGREE)(res, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_ctx_fq_order(fmpz_t res, gr_ctx_t ctx) { return GR_CONSTANT_OP_GET_FMPZ(ctx, CTX_FQ_ORDER)(res, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_ctx_fq_prime(fmpz_t res, gr_ctx_t ctx) { return GR_CONSTANT_OP_GET_FMPZ(ctx, CTX_FQ_PRIME)(res, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_ctx_fq_degree(slong * res, gr_ctx_t ctx) { return GR_CONSTANT_OP_GET_SI(ctx, CTX_FQ_DEGREE)(res, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_ctx_fq_order(fmpz_t res, gr_ctx_t ctx) { return GR_CONSTANT_OP_GET_FMPZ(ctx, CTX_FQ_ORDER)(res, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_fq_frobenius(gr_ptr res, gr_srcptr x, slong e, gr_ctx_t ctx) { return GR_BINARY_OP_SI(ctx, FQ_FROBENIUS)(res, x, e, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_fq_multiplicative_order(fmpz_t res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP_GET_FMPZ(ctx, FQ_MULTIPLICATIVE_ORDER)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_fq_norm(fmpz_t res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP_GET_FMPZ(ctx, FQ_NORM)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_fq_trace(fmpz_t res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP_GET_FMPZ(ctx, FQ_TRACE)(res, x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT truth_t gr_fq_is_primitive(gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_PREDICATE(ctx, FQ_IS_PRIMITIVE)(x, ctx); }
-GR_INLINE WARN_UNUSED_RESULT int gr_fq_pth_root(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, FQ_PTH_ROOT)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_fq_frobenius(gr_ptr res, gr_srcptr x, slong e, gr_ctx_t ctx) { return GR_BINARY_OP_SI(ctx, FQ_FROBENIUS)(res, x, e, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_fq_multiplicative_order(fmpz_t res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP_GET_FMPZ(ctx, FQ_MULTIPLICATIVE_ORDER)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_fq_norm(fmpz_t res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP_GET_FMPZ(ctx, FQ_NORM)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_fq_trace(fmpz_t res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP_GET_FMPZ(ctx, FQ_TRACE)(res, x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED truth_t gr_fq_is_primitive(gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_PREDICATE(ctx, FQ_IS_PRIMITIVE)(x, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_fq_pth_root(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, FQ_PTH_ROOT)(res, x, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_set_interval_mid_rad(gr_ptr res, gr_srcptr m, gr_srcptr r, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, SET_INTERVAL_MID_RAD)(res, m, r, ctx); }
+GR_INLINE FLINT_WARN_UNUSED int gr_set_interval_mid_rad(gr_ptr res, gr_srcptr m, gr_srcptr r, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, SET_INTERVAL_MID_RAD)(res, m, r, ctx); }
 
 GR_INLINE void _gr_vec_init(gr_ptr vec, slong len, gr_ctx_t ctx) { GR_VEC_INIT_CLEAR_OP(ctx, VEC_INIT)(vec, len, ctx); }
 GR_INLINE void _gr_vec_clear(gr_ptr vec, slong len, gr_ctx_t ctx) { GR_VEC_INIT_CLEAR_OP(ctx, VEC_CLEAR)(vec, len, ctx); }

--- a/src/gr.h
+++ b/src/gr.h
@@ -667,8 +667,6 @@ gr_method_tab_input;
 
 void gr_method_tab_init(gr_funcptr * methods, gr_method_tab_input * tab);
 
-#define GR_CTX_DATA_AS_PTR(ctx) (*(void **) (&(ctx)->data))
-
 GR_INLINE void * gr_ctx_data_ptr(gr_ctx_t ctx) { return (void *) ctx->data; }
 GR_INLINE void * gr_ctx_data_as_ptr(gr_ctx_t ctx) { return (void *) GR_CTX_DATA_AS_PTR(ctx); }
 

--- a/src/gr.h
+++ b/src/gr.h
@@ -77,8 +77,6 @@ void gr_stream_write_fmpz(gr_stream_t out, const fmpz_t x);
 #define GR_MUST_SUCCEED(expr) do { if ((expr) != GR_SUCCESS) { flint_throw(FLINT_ERROR, "GR_MUST_SUCCEED failure: %s", __FILE__); } } while (0)
 #define GR_IGNORE(expr) do { int ___unused = (expr); (void) ___unused; } while (0)
 
-#define GR_ENTRY(vec, i, size) ((void *) (((char *) (vec)) + ((i) * (size))))
-
 GR_INLINE int gr_not_implemented(void) { return GR_UNABLE; }
 GR_INLINE int gr_not_in_domain(void) { return GR_DOMAIN; }
 

--- a/src/gr.h
+++ b/src/gr.h
@@ -74,8 +74,6 @@ void gr_stream_write_fmpz(gr_stream_t out, const fmpz_t x);
 #define GR_UNABLE 2
 #define GR_TEST_FAIL 4
 
-#define FLINT_WARN_UNUSED __attribute__((warn_unused_result))
-
 #define GR_MUST_SUCCEED(expr) do { if ((expr) != GR_SUCCESS) { flint_throw(FLINT_ERROR, "GR_MUST_SUCCEED failure: %s", __FILE__); } } while (0)
 #define GR_IGNORE(expr) do { int ___unused = (expr); (void) ___unused; } while (0)
 

--- a/src/gr.h
+++ b/src/gr.h
@@ -771,7 +771,7 @@ typedef int ((*gr_method_poly_xgcd_op)(slong *, gr_ptr, gr_ptr, gr_ptr, gr_srcpt
 typedef int ((*gr_method_vec_ctx_op)(gr_vec_t, gr_ctx_ptr));
 typedef slong ((*_gr_method_get_si_op)(gr_srcptr, gr_ctx_ptr));
 
-#ifdef FEXPR_H
+#if defined(CA_TYPES_H)
 typedef int ((*gr_method_get_fexpr_op)(fexpr_t, gr_srcptr, gr_ctx_ptr));
 typedef int ((*gr_method_set_fexpr_op)(gr_ptr, fexpr_vec_t, gr_vec_t, const fexpr_t, gr_ctx_ptr));
 #endif
@@ -868,7 +868,7 @@ typedef int ((*gr_method_set_fexpr_op)(gr_ptr, fexpr_vec_t, gr_vec_t, const fexp
 #define GR_POLY_XGCD_OP(ctx, NAME) (((gr_method_poly_xgcd_op *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_VEC_CTX_OP(ctx, NAME) (((gr_method_vec_ctx_op *) ctx->methods)[GR_METHOD_ ## NAME])
 #define _GR_GET_SI_OP(ctx, NAME) (((_gr_method_get_si_op *) ctx->methods)[_GR_METHOD_ ## NAME])
-#ifdef FEXPR_H
+#if defined(CA_TYPES_H)
 #define GR_GET_FEXPR_OP(ctx, NAME) (((gr_method_get_fexpr_op *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_SET_FEXPR_OP(ctx, NAME) (((gr_method_set_fexpr_op *) ctx->methods)[GR_METHOD_ ## NAME])
 #endif
@@ -946,7 +946,7 @@ GR_INLINE FLINT_WARN_UNUSED int gr_get_d(double * res, gr_srcptr x, gr_ctx_t ctx
 #define GR_FEXPR_SERIALIZE (UWORD(1) << 31)
 #define GR_FEXPR_COMPACT (UWORD(1) << 30)
 
-#ifdef FEXPR_H
+#if defined(CA_TYPES_H)
 GR_INLINE FLINT_WARN_UNUSED int gr_get_fexpr(fexpr_t res, gr_srcptr x, gr_ctx_t ctx) { return GR_GET_FEXPR_OP(ctx, GET_FEXPR)(res, x, ctx); }
 GR_INLINE FLINT_WARN_UNUSED int gr_get_fexpr_serialize(fexpr_t res, gr_srcptr x, gr_ctx_t ctx) { return GR_GET_FEXPR_OP(ctx, GET_FEXPR_SERIALIZE)(res, x, ctx); }
 GR_INLINE FLINT_WARN_UNUSED int gr_set_fexpr(gr_ptr res, fexpr_vec_t inputs, gr_vec_t outputs, const fexpr_t x, gr_ctx_t ctx) { return GR_SET_FEXPR_OP(ctx, SET_FEXPR)(res, inputs, outputs, x, ctx); }
@@ -1314,11 +1314,15 @@ void _gr_ctx_init_fq_zech_from_ref(gr_ctx_t ctx, const void * fq_zech_ctx);
 void gr_ctx_init_fmpz_poly(gr_ctx_t ctx);
 void gr_ctx_init_fmpq_poly(gr_ctx_t ctx);
 
-#ifdef FMPQ_POLY_H
+#if defined(FMPQ_TYPES_H)
 void gr_ctx_init_nf(gr_ctx_t ctx, const fmpq_poly_t poly);
-void gr_ctx_init_nf_fmpz_poly(gr_ctx_t ctx, const fmpz_poly_t poly);
-void _gr_ctx_init_nf_from_ref(gr_ctx_t ctx, const void * nfctx);
 #endif
+
+#if defined(FMPZ_TYPES_H)
+void gr_ctx_init_nf_fmpz_poly(gr_ctx_t ctx, const fmpz_poly_t poly);
+#endif
+
+void _gr_ctx_init_nf_from_ref(gr_ctx_t ctx, const void * nfctx);
 
 /* Groups */
 
@@ -1335,12 +1339,9 @@ void gr_ctx_init_gr_poly(gr_ctx_t ctx, gr_ctx_t base_ring);
 
 /* Multivariate */
 
-#ifdef MPOLY_H
+#if defined(MPOLY_TYPES_H)
 void gr_ctx_init_fmpz_mpoly(gr_ctx_t ctx, slong nvars, const ordering_t ord);
 void gr_ctx_init_gr_mpoly(gr_ctx_t ctx, gr_ctx_t base_ring, slong nvars, const ordering_t ord);
-#endif
-
-#ifdef FMPZ_MPOLY_Q_H
 void gr_ctx_init_fmpz_mpoly_q(gr_ctx_t ctx, slong nvars, const ordering_t ord);
 #endif
 

--- a/src/gr.h
+++ b/src/gr.h
@@ -69,9 +69,6 @@ void gr_stream_write_ui(gr_stream_t out, ulong x);
 void gr_stream_write_free(gr_stream_t out, char * s);
 void gr_stream_write_fmpz(gr_stream_t out, const fmpz_t x);
 
-#define GR_MUST_SUCCEED(expr) do { if ((expr) != GR_SUCCESS) { flint_throw(FLINT_ERROR, "GR_MUST_SUCCEED failure: %s", __FILE__); } } while (0)
-#define GR_IGNORE(expr) do { int ___unused = (expr); (void) ___unused; } while (0)
-
 GR_INLINE int gr_not_implemented(void) { return GR_UNABLE; }
 GR_INLINE int gr_not_in_domain(void) { return GR_DOMAIN; }
 

--- a/src/gr/acb.c
+++ b/src/gr/acb.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_poly.h"
 #include "fmpz_poly_factor.h"
 #include "acb.h"
 #include "acb_poly.h"

--- a/src/gr/acf.c
+++ b/src/gr/acf.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_poly.h"
 #include "fmpz_poly_factor.h"
 #include "acf.h"
 #include "acb.h"
@@ -16,7 +17,6 @@
 #include "gr.h"
 #include "gr_generic.h"
 #include "gr_vec.h"
-#include "gr_poly.h"
 
 typedef struct
 {

--- a/src/gr/arb.c
+++ b/src/gr/arb.c
@@ -9,9 +9,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_poly.h"
 #include "fmpz_poly_factor.h"
 #include "fmpq.h"
 #include "arb_poly.h"
+#include "acb.h"
 #include "acb_poly.h"
 #include "arb_mat.h"
 #include "arb_fmpz_poly.h"
@@ -21,7 +23,6 @@
 #include "gr.h"
 #include "gr_generic.h"
 #include "gr_vec.h"
-#include "gr_poly.h"
 
 typedef struct
 {

--- a/src/gr/arf.c
+++ b/src/gr/arf.c
@@ -9,13 +9,13 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_poly.h"
 #include "fmpz_poly_factor.h"
 #include "arb_poly.h"
 #include "acb.h"
 #include "arb_fmpz_poly.h"
 #include "gr.h"
 #include "gr_vec.h"
-#include "gr_poly.h"
 #include "gr_generic.h"
 
 typedef struct

--- a/src/gr/ca.c
+++ b/src/gr/ca.c
@@ -9,15 +9,15 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
 #include "fmpzi.h"
 #include "ca.h"
 #include "ca_mat.h"
 #include "ca_poly.h"
-#include "fexpr.h"
+#include "qqbar.h"
 #include "gr.h"
 #include "gr_generic.h"
 #include "gr_vec.h"
-#include "gr_poly.h"
 #include "gr_special.h"
 
 #define GR_CA_CTX(ring_ctx) ((ca_ctx_struct *)(GR_CTX_DATA_AS_PTR(ring_ctx)))

--- a/src/gr/fmpq_poly.c
+++ b/src/gr/fmpq_poly.c
@@ -9,15 +9,12 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include <stdlib.h>
 #include <string.h>
-#include "fmpz.h"
 #include "fmpq.h"
 #include "fmpq_vec.h"
 #include "fmpq_poly.h"
 #include "gr.h"
 #include "gr_poly.h"
-#include "gr_vec.h"
 #include "gr_generic.h"
 
 #define FMPQ_POLY_CTX(ctx) POLYNOMIAL_CTX(ctx)

--- a/src/gr/fmpz.c
+++ b/src/gr/fmpz.c
@@ -10,19 +10,20 @@
 */
 
 #include <math.h>
-#include "fexpr.h"
-#include "qqbar.h"
+#include "gmpcompat.h"
+#include "fmpz.h"
 #include "fmpz_factor.h"
-#include "fmpz_poly.h"
-#include "fmpz_poly_factor.h"
 #include "fmpz_vec.h"
 #include "fmpz_mat.h"
+#include "fmpz_poly.h"
+#include "fmpz_poly_factor.h"
 #include "fmpq.h"
+#include "fexpr.h"
+#include "qqbar.h"
 #include "gr.h"
 #include "gr_generic.h"
 #include "gr_vec.h"
 #include "gr_special.h"
-#include "gmpcompat.h"
 
 int
 _gr_fmpz_ctx_write(gr_stream_t out, gr_ctx_t ctx)

--- a/src/gr/fmpz_mpoly.c
+++ b/src/gr/fmpz_mpoly.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include "fmpz.h"
 #include "fmpz_mpoly_factor.h"
+#include "fmpz_mpoly.h"
 #include "gr.h"
 #include "gr_vec.h"
 #include "gr_generic.h"

--- a/src/gr/fmpz_poly.c
+++ b/src/gr/fmpz_poly.c
@@ -9,19 +9,17 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include <stdlib.h>
 #include <string.h>
 #include "fmpz.h"
 #include "fmpz_poly.h"
-#include "fmpz_mat.h"
+#include "fmpz_poly_factor.h"
 #include "fmpq.h"
 #include "fmpq_poly.h"
+#include "fmpz_mpoly.h"
 #include "gr.h"
 #include "gr_vec.h"
 #include "gr_poly.h"
 #include "gr_generic.h"
-#include "fmpz_poly_factor.h"
-#include "fmpz_mpoly.h"
 
 #define FMPZ_POLY_CTX(ctx) POLYNOMIAL_CTX(ctx)
 #define FMPZ_POLY_CTX_VAR(ctx) (FMPZ_POLY_CTX(ctx)->var)

--- a/src/gr/fmpzi.c
+++ b/src/gr/fmpzi.c
@@ -11,7 +11,6 @@
 
 #include <math.h>
 #include "fmpq.h"
-#include "fexpr.h"
 #include "qqbar.h"
 #include "fmpzi.h"
 #include "gr.h"

--- a/src/gr/fq.c
+++ b/src/gr/fq.c
@@ -9,18 +9,17 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include <stdlib.h>
 #include <string.h>
 #include "fmpz.h"
 #include "fmpz_vec.h"
 #include "fmpz_poly.h"
 #include "fmpz_mod.h"
 #include "fmpz_mod_poly.h"
-#include "gr.h"
 #include "fq.h"
-#include "fq_poly.h"
 #include "fq_mat.h"
+#include "fq_poly.h"
 #include "fq_poly_factor.h"
+#include "gr.h"
 #include "gr_vec.h"
 #include "gr_generic.h"
 

--- a/src/gr/fq_nmod.c
+++ b/src/gr/fq_nmod.c
@@ -9,20 +9,17 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include <stdlib.h>
 #include <string.h>
 #include "nmod_vec.h"
 #include "nmod_poly.h"
 #include "fmpz.h"
-#include "fq.h"
+#include "fmpz_mod_poly.h"
 #include "fq_nmod.h"
 #include "fq_nmod_mat.h"
 #include "fq_nmod_poly.h"
 #include "fq_nmod_poly_factor.h"
-#include "fmpz_mod_poly.h"
 #include "gr.h"
 #include "gr_vec.h"
-#include "gr_poly.h"
 #include "gr_generic.h"
 
 #define FQ_CTX(ring_ctx) ((fq_nmod_ctx_struct *)(GR_CTX_DATA_AS_PTR(ring_ctx)))

--- a/src/gr/fq_zech.c
+++ b/src/gr/fq_zech.c
@@ -9,17 +9,16 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include <stdlib.h>
 #include <string.h>
+#include "nmod_poly.h"
 #include "fmpz.h"
+#include "fmpz_mod_poly.h"
 #include "fq_nmod.h"
 #include "fq_zech.h"
 #include "fq_zech_vec.h"
 #include "fq_zech_poly.h"
 #include "fq_zech_poly_factor.h"
 #include "fq_zech_mat.h"
-#include "nmod_poly.h"
-#include "fmpz_mod_poly.h"
 #include "gr.h"
 #include "gr_vec.h"
 #include "gr_generic.h"

--- a/src/gr/init_random.c
+++ b/src/gr/init_random.c
@@ -9,11 +9,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "ulong_extras.h"
 #include "fmpz.h"
 #include "fmpz_poly.h"
 #include "fmpq_poly.h"
-#include "ulong_extras.h"
-#include "long_extras.h"
 #include "mpoly.h"
 #include "gr.h"
 

--- a/src/gr/inlines.c
+++ b/src/gr/inlines.c
@@ -10,6 +10,8 @@
 */
 
 #define GR_INLINES_C
-#include "fexpr.h"
+
+#include "ca_types.h"
 #include "gr.h"
+
 #undef GR_INLINES_C

--- a/src/gr/io.c
+++ b/src/gr/io.c
@@ -10,15 +10,9 @@
 */
 
 #include <stdio.h>
+#include <string.h>
 #include "fmpz.h"
 #include "gr.h"
-
-#ifdef __GNUC__
-# define memcpy __builtin_memcpy
-# define strlen __builtin_strlen
-#else
-# include <math.h>
-#endif
 
 /* todo: error handling */
 

--- a/src/gr/matrix.c
+++ b/src/gr/matrix.c
@@ -11,8 +11,6 @@
 
 /* Matrices over generic rings */
 
-#include "fmpz.h"
-#include "fmpq.h"
 #include "gr.h"
 #include "gr_mat.h"
 

--- a/src/gr/mpoly.c
+++ b/src/gr/mpoly.c
@@ -11,6 +11,7 @@
 
 /* Multivariate polynomials over generic rings */
 
+#include "mpoly.h"
 #include "gr.h"
 #include "gr_mpoly.h"
 #include "gr_generic.h"

--- a/src/gr/nf.c
+++ b/src/gr/nf.c
@@ -9,17 +9,14 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include <stdlib.h>
 #include <string.h>
-#include "fexpr.h"
-#include "fmpz.h"
+#include "fmpq_poly.h"
 #include "nf.h"
 #include "nf_elem.h"
+#include "fexpr.h"
 #include "gr.h"
 #include "gr_generic.h"
 #include "gr_vec.h"
-#include "gr_poly.h"
-#include "gr_generic.h"
 
 typedef struct
 {

--- a/src/gr/nmod.c
+++ b/src/gr/nmod.c
@@ -9,14 +9,13 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "fmpz.h"
 #include "nmod.h"
 #include "nmod_vec.h"
 #include "nmod_poly.h"
 #include "nmod_mat.h"
+#include "fmpz.h"
 #include "gr.h"
 #include "gr_vec.h"
-#include "gr_mat.h"
 #include "gr_poly.h"
 #include "gr_generic.h"
 

--- a/src/gr/nmod32.c
+++ b/src/gr/nmod32.c
@@ -10,7 +10,6 @@
 */
 
 #include "fmpz.h"
-#include "fmpq.h"
 #include "nmod.h"
 #include "nmod_vec.h"
 #include "gr.h"

--- a/src/gr/nmod8.c
+++ b/src/gr/nmod8.c
@@ -10,7 +10,6 @@
 */
 
 #include "fmpz.h"
-#include "fmpq.h"
 #include "nmod.h"
 #include "nmod_vec.h"
 #include "gr.h"

--- a/src/gr/polynomial.c
+++ b/src/gr/polynomial.c
@@ -11,20 +11,12 @@
 
 /* Polynomials over generic rings */
 
-#include <stdlib.h>
 #include <string.h>
 #include "fmpz.h"
-#include "ulong_extras.h"
 #include "gr.h"
 #include "gr_vec.h"
 #include "gr_poly.h"
 #include "gr_generic.h"
-
-#ifdef __GNUC__
-# define strcmp __builtin_strcmp
-#else
-# include <string.h>
-#endif
 
 static const char * default_var = "x";
 

--- a/src/gr/qqbar.c
+++ b/src/gr/qqbar.c
@@ -14,13 +14,13 @@
 #include "fmpq.h"
 #include "fmpq_vec.h"
 #include "fmpzi.h"
-#include "fexpr.h"
+#include "arb.h"
 #include "qqbar.h"
+#include "ca.h"
 #include "gr.h"
 #include "gr_generic.h"
 #include "gr_vec.h"
 #include "gr_poly.h"
-#include "ca.h"
 
 typedef struct
 {

--- a/src/gr/series.c
+++ b/src/gr/series.c
@@ -15,12 +15,6 @@
 #include "gr_poly.h"
 #include "gr_generic.h"
 
-#ifdef __GNUC__
-# define strcmp __builtin_strcmp
-#else
-# include <string.h>
-#endif
-
 #define SERIES_ERR_EXACT WORD_MAX
 #define SERIES_ERR_MAX WORD_MAX / 4
 

--- a/src/gr/series_mod.c
+++ b/src/gr/series_mod.c
@@ -10,16 +10,9 @@
 */
 
 #include <string.h>
-#include "fmpq.h"
 #include "gr_vec.h"
 #include "gr_poly.h"
 #include "gr_generic.h"
-
-#ifdef __GNUC__
-# define strcmp __builtin_strcmp
-#else
-# include <string.h>
-#endif
 
 static const char * default_var = "x";
 

--- a/src/gr/vector.c
+++ b/src/gr/vector.c
@@ -11,12 +11,10 @@
 
 /* Vectors over generic rings */
 
-#include "ulong_extras.h"
 #include "fmpz.h"
 #include "gr.h"
 #include "gr_vec.h"
 #include "gr_poly.h"
-#include "gr_special.h"
 
 #define ENTRY_CTX(ctx) (VECTOR_CTX(ctx)->base_ring)
 

--- a/src/gr_generic.h
+++ b/src/gr_generic.h
@@ -22,7 +22,7 @@
 #include "gr.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 #define GR_GENERIC_DEBUG_RINGS 0

--- a/src/gr_generic.h
+++ b/src/gr_generic.h
@@ -18,8 +18,7 @@
 #define GR_GENERIC_INLINE static inline
 #endif
 
-#include "flint.h"
-#include "gr.h"
+#include "gr_types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/gr_generic.h
+++ b/src/gr_generic.h
@@ -67,258 +67,258 @@ void gr_generic_mul(void) { flint_throw(FLINT_ERROR, "ctx must implement mul()\n
 
 /* some useful generic functions, currently not overloadable */
 #ifdef FMPZ_POLY_H
-WARN_UNUSED_RESULT int _gr_fmpz_poly_evaluate_horner(gr_ptr res, const fmpz * f, slong len, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_fmpz_poly_evaluate_horner(gr_ptr res, const fmpz_poly_t f, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_fmpz_poly_evaluate_rectangular(gr_ptr res, const fmpz * f, slong len, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_fmpz_poly_evaluate_rectangular(gr_ptr res, const fmpz_poly_t f, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_fmpz_poly_evaluate(gr_ptr res, const fmpz * f, slong len, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_fmpz_poly_evaluate(gr_ptr res, const fmpz_poly_t f, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_fmpz_poly_evaluate_horner(gr_ptr res, const fmpz * f, slong len, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_fmpz_poly_evaluate_horner(gr_ptr res, const fmpz_poly_t f, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_fmpz_poly_evaluate_rectangular(gr_ptr res, const fmpz * f, slong len, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_fmpz_poly_evaluate_rectangular(gr_ptr res, const fmpz_poly_t f, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_fmpz_poly_evaluate(gr_ptr res, const fmpz * f, slong len, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_fmpz_poly_evaluate(gr_ptr res, const fmpz_poly_t f, gr_srcptr x, gr_ctx_t ctx);
 #endif
 
 #ifdef FMPZ_MPOLY_H
-WARN_UNUSED_RESULT int gr_fmpz_mpoly_evaluate_iter(gr_ptr res, const fmpz_mpoly_t pol, gr_srcptr x, const fmpz_mpoly_ctx_t mctx, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_fmpz_mpoly_evaluate_horner(gr_ptr res, const fmpz_mpoly_t pol, gr_srcptr x, const fmpz_mpoly_ctx_t mctx, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_fmpz_mpoly_evaluate(gr_ptr res, const fmpz_mpoly_t f, gr_srcptr x, const fmpz_mpoly_ctx_t mctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_fmpz_mpoly_evaluate_iter(gr_ptr res, const fmpz_mpoly_t pol, gr_srcptr x, const fmpz_mpoly_ctx_t mctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_fmpz_mpoly_evaluate_horner(gr_ptr res, const fmpz_mpoly_t pol, gr_srcptr x, const fmpz_mpoly_ctx_t mctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_fmpz_mpoly_evaluate(gr_ptr res, const fmpz_mpoly_t f, gr_srcptr x, const fmpz_mpoly_ctx_t mctx, gr_ctx_t ctx);
 #endif
 
 truth_t gr_generic_ctx_predicate(gr_ctx_t ctx);
 truth_t gr_generic_ctx_predicate_true(gr_ctx_t ctx);
 truth_t gr_generic_ctx_predicate_false(gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_ctx_clear(gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_ctx_clear(gr_ctx_t ctx);
 
 void gr_generic_set_shallow(gr_ptr res, gr_srcptr x, const gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_write_n(gr_stream_t out, gr_srcptr x, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_write_n(gr_stream_t out, gr_srcptr x, slong n, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_randtest_not_zero(gr_ptr x, flint_rand_t state, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_randtest_not_zero(gr_ptr x, flint_rand_t state, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_randtest_small(gr_ptr x, flint_rand_t state, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_randtest_small(gr_ptr x, flint_rand_t state, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_gens(gr_vec_t vec, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_gens_single(gr_vec_t vec, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_gens_recursive(gr_vec_t vec, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_gens(gr_vec_t vec, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_gens_single(gr_vec_t vec, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_gens_recursive(gr_vec_t vec, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT truth_t gr_generic_is_zero(gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT truth_t gr_generic_is_one(gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT truth_t gr_generic_is_neg_one(gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED truth_t gr_generic_is_zero(gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED truth_t gr_generic_is_one(gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED truth_t gr_generic_is_neg_one(gr_srcptr x, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_neg_one(gr_ptr res, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_neg_one(gr_ptr res, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_set_other(gr_ptr res, gr_srcptr x, gr_ctx_t xctx, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_set_fmpq(gr_ptr res, const fmpq_t y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_set_other(gr_ptr res, gr_srcptr x, gr_ctx_t xctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_set_fmpq(gr_ptr res, const fmpq_t y, gr_ctx_t ctx);
 
 #define GR_PARSE_BALANCE_ADDITIONS 1
 #define GR_PARSE_RING_EXPONENTS 2
 
-WARN_UNUSED_RESULT int gr_generic_set_str_expr(gr_ptr res, const char * s, int flags, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_set_str(gr_ptr res, const char * s, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_set_str_balance_additions(gr_ptr res, const char * s, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_set_str_ring_exponents(gr_ptr res, const char * s, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_set_str_expr(gr_ptr res, const char * s, int flags, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_set_str(gr_ptr res, const char * s, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_set_str_balance_additions(gr_ptr res, const char * s, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_set_str_ring_exponents(gr_ptr res, const char * s, gr_ctx_t ctx);
 
 #ifdef FEXPR_H
-WARN_UNUSED_RESULT int gr_generic_set_fexpr(gr_ptr res, fexpr_vec_t inputs, gr_vec_t outputs, const fexpr_t expr, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_set_fexpr(gr_ptr res, fexpr_vec_t inputs, gr_vec_t outputs, const fexpr_t expr, gr_ctx_t ctx);
 #endif
 
-WARN_UNUSED_RESULT int gr_generic_add_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_add_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_add_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_add_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_add_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_other_add(gr_ptr res, gr_srcptr x, gr_ctx_t x_ctx, gr_srcptr y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_add_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_add_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_add_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_add_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_add_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_other_add(gr_ptr res, gr_srcptr x, gr_ctx_t x_ctx, gr_srcptr y, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_sub_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_sub_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_sub_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_sub_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_sub_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_other_sub(gr_ptr res, gr_srcptr x, gr_ctx_t x_ctx, gr_srcptr y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_sub_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_sub_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_sub_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_sub_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_sub_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_other_sub(gr_ptr res, gr_srcptr x, gr_ctx_t x_ctx, gr_srcptr y, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_mul_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_mul_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_mul_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_mul_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_mul_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_other_mul(gr_ptr res, gr_srcptr x, gr_ctx_t x_ctx, gr_srcptr y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_mul_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_mul_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_mul_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_mul_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_mul_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_other_mul(gr_ptr res, gr_srcptr x, gr_ctx_t x_ctx, gr_srcptr y, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_addmul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_addmul_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_addmul_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_addmul_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_addmul_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_addmul_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_addmul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_addmul_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_addmul_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_addmul_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_addmul_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_addmul_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_submul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_submul_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_submul_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_submul_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_submul_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_submul_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_submul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_submul_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_submul_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_submul_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_submul_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_submul_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_mul_two(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_mul_two(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_sqr(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_sqr(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_mul_2exp_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_mul_2exp_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_set_fmpz_2exp_fmpz(gr_ptr res, const fmpz_t x, const fmpz_t y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_get_fmpz_2exp_fmpz(fmpz_t res1, fmpz_t res2, gr_ptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_set_fmpz_10exp_fmpz(gr_ptr res, const fmpz_t x, const fmpz_t y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_mul_2exp_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_mul_2exp_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_set_fmpz_2exp_fmpz(gr_ptr res, const fmpz_t x, const fmpz_t y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_get_fmpz_2exp_fmpz(fmpz_t res1, fmpz_t res2, gr_ptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_set_fmpz_10exp_fmpz(gr_ptr res, const fmpz_t x, const fmpz_t y, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_inv(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT truth_t gr_generic_is_invertible(gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_inv(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED truth_t gr_generic_is_invertible(gr_srcptr x, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_div_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_div_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_div_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_div_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_div_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_other_div(gr_ptr res, gr_srcptr x, gr_ctx_t x_ctx, gr_srcptr y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_div_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_div_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_div_si(gr_ptr res, gr_srcptr x, slong y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_div_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_div_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_other_div(gr_ptr res, gr_srcptr x, gr_ctx_t x_ctx, gr_srcptr y, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_divexact(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_divexact(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_pow_fmpz_sliding(gr_ptr f, gr_srcptr g, const fmpz_t pow, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_pow_ui_sliding(gr_ptr f, gr_srcptr g, ulong pow, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_pow_fmpz_binexp(gr_ptr res, gr_srcptr x, const fmpz_t exp, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_pow_ui_binexp(gr_ptr res, gr_srcptr x, ulong e, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_pow_fmpz_sliding(gr_ptr f, gr_srcptr g, const fmpz_t pow, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_pow_ui_sliding(gr_ptr f, gr_srcptr g, ulong pow, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_pow_fmpz_binexp(gr_ptr res, gr_srcptr x, const fmpz_t exp, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_pow_ui_binexp(gr_ptr res, gr_srcptr x, ulong e, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_pow_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t e, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_pow_si(gr_ptr res, gr_srcptr x, slong e, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_pow_ui(gr_ptr res, gr_srcptr x, ulong e, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_pow_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_pow_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_other_pow(gr_ptr res, gr_srcptr x, gr_ctx_t x_ctx, gr_srcptr y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_pow_fmpz(gr_ptr res, gr_srcptr x, const fmpz_t e, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_pow_si(gr_ptr res, gr_srcptr x, slong e, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_pow_ui(gr_ptr res, gr_srcptr x, ulong e, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_pow_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_pow_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_other_pow(gr_ptr res, gr_srcptr x, gr_ctx_t x_ctx, gr_srcptr y, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_numerator(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_denominator(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_numerator(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_denominator(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT truth_t gr_generic_is_square(gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_sqrt(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_rsqrt(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED truth_t gr_generic_is_square(gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_sqrt(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_rsqrt(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_cmp(int * res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_cmpabs(int * res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_cmp_other(int * res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_cmpabs_other(int * res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_cmp(int * res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_cmpabs(int * res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_cmp_other(int * res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_cmpabs_other(int * res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_bernoulli_ui(gr_ptr res, ulong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_bernoulli_fmpz(gr_ptr res, const fmpz_t n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_bernoulli_vec(gr_ptr res, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_eulernum_ui(gr_ptr res, ulong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_eulernum_fmpz(gr_ptr res, const fmpz_t n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_eulernum_vec(gr_ptr res, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_stirling_s1u_uiui(gr_ptr res, ulong x, ulong y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_stirling_s1_uiui(gr_ptr res, ulong x, ulong y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_stirling_s2_uiui(gr_ptr res, ulong x, ulong y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_stirling_s1u_ui_vec(gr_ptr res, ulong x, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_stirling_s1_ui_vec(gr_ptr res, ulong x, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_stirling_s2_ui_vec(gr_ptr res, ulong x, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_bernoulli_ui(gr_ptr res, ulong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_bernoulli_fmpz(gr_ptr res, const fmpz_t n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_bernoulli_vec(gr_ptr res, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_eulernum_ui(gr_ptr res, ulong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_eulernum_fmpz(gr_ptr res, const fmpz_t n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_eulernum_vec(gr_ptr res, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_stirling_s1u_uiui(gr_ptr res, ulong x, ulong y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_stirling_s1_uiui(gr_ptr res, ulong x, ulong y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_stirling_s2_uiui(gr_ptr res, ulong x, ulong y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_stirling_s1u_ui_vec(gr_ptr res, ulong x, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_stirling_s1_ui_vec(gr_ptr res, ulong x, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_stirling_s2_ui_vec(gr_ptr res, ulong x, slong len, gr_ctx_t ctx);
 
 void gr_generic_vec_init(gr_ptr vec, slong len, gr_ctx_t ctx);
 void gr_generic_vec_clear(gr_ptr vec, slong len, gr_ctx_t ctx);
 void gr_generic_vec_swap(gr_ptr vec1, gr_ptr vec2, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_vec_zero(gr_ptr vec, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_set(gr_ptr res, gr_srcptr src, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_neg(gr_ptr res, gr_srcptr src, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_normalise(slong * res, gr_srcptr vec, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT slong gr_generic_vec_normalise_weak(gr_srcptr vec, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_mul_scalar_2exp_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_scalar_addmul(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_scalar_submul(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_scalar_addmul_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_scalar_submul_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT truth_t gr_generic_vec_equal(gr_srcptr vec1, gr_srcptr vec2, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_is_zero(gr_srcptr vec, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_dot(gr_ptr res, gr_srcptr initial, int subtract, gr_srcptr vec1, gr_srcptr vec2, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_dot_rev(gr_ptr res, gr_srcptr initial, int subtract, gr_srcptr vec1, gr_srcptr vec2, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_dot_ui(gr_ptr res, gr_srcptr initial, int subtract, gr_srcptr vec1, const ulong * vec2, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_dot_si(gr_ptr res, gr_srcptr initial, int subtract, gr_srcptr vec1, const slong * vec2, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_dot_fmpz(gr_ptr res, gr_srcptr initial, int subtract, gr_srcptr vec1, const fmpz * vec2, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_set_powers(gr_ptr res, gr_srcptr x, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_reciprocals(gr_ptr res, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_zero(gr_ptr vec, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_set(gr_ptr res, gr_srcptr src, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_neg(gr_ptr res, gr_srcptr src, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_normalise(slong * res, gr_srcptr vec, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED slong gr_generic_vec_normalise_weak(gr_srcptr vec, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_mul_scalar_2exp_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_scalar_addmul(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_scalar_submul(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_scalar_addmul_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_scalar_submul_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED truth_t gr_generic_vec_equal(gr_srcptr vec1, gr_srcptr vec2, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_is_zero(gr_srcptr vec, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_dot(gr_ptr res, gr_srcptr initial, int subtract, gr_srcptr vec1, gr_srcptr vec2, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_dot_rev(gr_ptr res, gr_srcptr initial, int subtract, gr_srcptr vec1, gr_srcptr vec2, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_dot_ui(gr_ptr res, gr_srcptr initial, int subtract, gr_srcptr vec1, const ulong * vec2, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_dot_si(gr_ptr res, gr_srcptr initial, int subtract, gr_srcptr vec1, const slong * vec2, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_dot_fmpz(gr_ptr res, gr_srcptr initial, int subtract, gr_srcptr vec1, const fmpz * vec2, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_set_powers(gr_ptr res, gr_srcptr x, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_reciprocals(gr_ptr res, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_pow_fmpz_sliding(gr_ptr f, gr_srcptr g, const fmpz_t pow, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_pow_ui_sliding(gr_ptr f, gr_srcptr g, ulong pow, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_pow_fmpz_binexp(gr_ptr res, gr_srcptr x, const fmpz_t exp, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_pow_ui_binexp(gr_ptr res, gr_srcptr x, ulong e, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_pow_fmpz_sliding(gr_ptr f, gr_srcptr g, const fmpz_t pow, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_pow_ui_sliding(gr_ptr f, gr_srcptr g, ulong pow, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_pow_fmpz_binexp(gr_ptr res, gr_srcptr x, const fmpz_t exp, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_pow_ui_binexp(gr_ptr res, gr_srcptr x, ulong e, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_vec_add(gr_ptr res, gr_srcptr src1, gr_srcptr src2, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_sub(gr_ptr res, gr_srcptr src1, gr_srcptr src2, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_mul(gr_ptr res, gr_srcptr src1, gr_srcptr src2, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_div(gr_ptr res, gr_srcptr src1, gr_srcptr src2, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_divexact(gr_ptr res, gr_srcptr src1, gr_srcptr src2, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_pow(gr_ptr res, gr_srcptr src1, gr_srcptr src2, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_add(gr_ptr res, gr_srcptr src1, gr_srcptr src2, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_sub(gr_ptr res, gr_srcptr src1, gr_srcptr src2, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_mul(gr_ptr res, gr_srcptr src1, gr_srcptr src2, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_div(gr_ptr res, gr_srcptr src1, gr_srcptr src2, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_divexact(gr_ptr res, gr_srcptr src1, gr_srcptr src2, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_pow(gr_ptr res, gr_srcptr src1, gr_srcptr src2, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_vec_add_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_sub_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_mul_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_div_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_divexact_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_pow_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_add_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_sub_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_mul_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_div_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_divexact_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_pow_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_vec_add_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_sub_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_mul_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_div_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_divexact_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_pow_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_add_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_sub_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_mul_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_div_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_divexact_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_pow_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_vec_add_scalar_ui(gr_ptr vec1, gr_srcptr vec2, slong len, ulong c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_sub_scalar_ui(gr_ptr vec1, gr_srcptr vec2, slong len, ulong c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_mul_scalar_ui(gr_ptr vec1, gr_srcptr vec2, slong len, ulong c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_div_scalar_ui(gr_ptr vec1, gr_srcptr vec2, slong len, ulong c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_divexact_scalar_ui(gr_ptr vec1, gr_srcptr vec2, slong len, ulong c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_pow_scalar_ui(gr_ptr vec1, gr_srcptr vec2, slong len, ulong c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_add_scalar_ui(gr_ptr vec1, gr_srcptr vec2, slong len, ulong c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_sub_scalar_ui(gr_ptr vec1, gr_srcptr vec2, slong len, ulong c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_mul_scalar_ui(gr_ptr vec1, gr_srcptr vec2, slong len, ulong c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_div_scalar_ui(gr_ptr vec1, gr_srcptr vec2, slong len, ulong c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_divexact_scalar_ui(gr_ptr vec1, gr_srcptr vec2, slong len, ulong c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_pow_scalar_ui(gr_ptr vec1, gr_srcptr vec2, slong len, ulong c, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_vec_add_scalar_fmpz(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpz_t c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_sub_scalar_fmpz(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpz_t c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_mul_scalar_fmpz(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpz_t c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_div_scalar_fmpz(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpz_t c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_divexact_scalar_fmpz(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpz_t c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_pow_scalar_fmpz(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpz_t c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_add_scalar_fmpz(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpz_t c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_sub_scalar_fmpz(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpz_t c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_mul_scalar_fmpz(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpz_t c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_div_scalar_fmpz(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpz_t c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_divexact_scalar_fmpz(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpz_t c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_pow_scalar_fmpz(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpz_t c, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_vec_add_scalar_fmpq(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpq_t c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_sub_scalar_fmpq(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpq_t c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_mul_scalar_fmpq(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpq_t c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_div_scalar_fmpq(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpq_t c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_divexact_scalar_fmpq(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpq_t c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_pow_scalar_fmpq(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpq_t c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_add_scalar_fmpq(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpq_t c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_sub_scalar_fmpq(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpq_t c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_mul_scalar_fmpq(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpq_t c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_div_scalar_fmpq(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpq_t c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_divexact_scalar_fmpq(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpq_t c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_pow_scalar_fmpq(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpq_t c, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_scalar_add_vec(gr_ptr vec1, gr_srcptr c, gr_srcptr vec2, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_scalar_sub_vec(gr_ptr vec1, gr_srcptr c, gr_srcptr vec2, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_scalar_mul_vec(gr_ptr vec1, gr_srcptr c, gr_srcptr vec2, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_scalar_div_vec(gr_ptr vec1, gr_srcptr c, gr_srcptr vec2, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_scalar_divexact_vec(gr_ptr vec1, gr_srcptr c, gr_srcptr vec2, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_scalar_pow_vec(gr_ptr vec1, gr_srcptr c, gr_srcptr vec2, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_scalar_add_vec(gr_ptr vec1, gr_srcptr c, gr_srcptr vec2, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_scalar_sub_vec(gr_ptr vec1, gr_srcptr c, gr_srcptr vec2, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_scalar_mul_vec(gr_ptr vec1, gr_srcptr c, gr_srcptr vec2, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_scalar_div_vec(gr_ptr vec1, gr_srcptr c, gr_srcptr vec2, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_scalar_divexact_vec(gr_ptr vec1, gr_srcptr c, gr_srcptr vec2, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_scalar_pow_vec(gr_ptr vec1, gr_srcptr c, gr_srcptr vec2, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_vec_add_other(gr_ptr vec1, gr_srcptr vec2, gr_srcptr vec3, gr_ctx_t ctx3, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_sub_other(gr_ptr vec1, gr_srcptr vec2, gr_srcptr vec3, gr_ctx_t ctx3, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_mul_other(gr_ptr vec1, gr_srcptr vec2, gr_srcptr vec3, gr_ctx_t ctx3, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_div_other(gr_ptr vec1, gr_srcptr vec2, gr_srcptr vec3, gr_ctx_t ctx3, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_divexact_other(gr_ptr vec1, gr_srcptr vec2, gr_srcptr vec3, gr_ctx_t ctx3, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_pow_other(gr_ptr vec1, gr_srcptr vec2, gr_srcptr vec3, gr_ctx_t ctx3, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_add_other(gr_ptr vec1, gr_srcptr vec2, gr_srcptr vec3, gr_ctx_t ctx3, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_sub_other(gr_ptr vec1, gr_srcptr vec2, gr_srcptr vec3, gr_ctx_t ctx3, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_mul_other(gr_ptr vec1, gr_srcptr vec2, gr_srcptr vec3, gr_ctx_t ctx3, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_div_other(gr_ptr vec1, gr_srcptr vec2, gr_srcptr vec3, gr_ctx_t ctx3, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_divexact_other(gr_ptr vec1, gr_srcptr vec2, gr_srcptr vec3, gr_ctx_t ctx3, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_pow_other(gr_ptr vec1, gr_srcptr vec2, gr_srcptr vec3, gr_ctx_t ctx3, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_other_add_vec(gr_ptr vec1, gr_srcptr vec2, gr_ctx_t ctx2, gr_srcptr vec3, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_other_sub_vec(gr_ptr vec1, gr_srcptr vec2, gr_ctx_t ctx2, gr_srcptr vec3, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_other_mul_vec(gr_ptr vec1, gr_srcptr vec2, gr_ctx_t ctx2, gr_srcptr vec3, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_other_div_vec(gr_ptr vec1, gr_srcptr vec2, gr_ctx_t ctx2, gr_srcptr vec3, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_other_divexact_vec(gr_ptr vec1, gr_srcptr vec2, gr_ctx_t ctx2, gr_srcptr vec3, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_other_pow_vec(gr_ptr vec1, gr_srcptr vec2, gr_ctx_t ctx2, gr_srcptr vec3, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_other_add_vec(gr_ptr vec1, gr_srcptr vec2, gr_ctx_t ctx2, gr_srcptr vec3, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_other_sub_vec(gr_ptr vec1, gr_srcptr vec2, gr_ctx_t ctx2, gr_srcptr vec3, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_other_mul_vec(gr_ptr vec1, gr_srcptr vec2, gr_ctx_t ctx2, gr_srcptr vec3, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_other_div_vec(gr_ptr vec1, gr_srcptr vec2, gr_ctx_t ctx2, gr_srcptr vec3, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_other_divexact_vec(gr_ptr vec1, gr_srcptr vec2, gr_ctx_t ctx2, gr_srcptr vec3, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_other_pow_vec(gr_ptr vec1, gr_srcptr vec2, gr_ctx_t ctx2, gr_srcptr vec3, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_vec_add_scalar_other(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t cctx, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_sub_scalar_other(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t cctx, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_mul_scalar_other(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t cctx, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_div_scalar_other(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t cctx, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_divexact_scalar_other(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t cctx, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_vec_pow_scalar_other(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t cctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_add_scalar_other(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t cctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_sub_scalar_other(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t cctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_mul_scalar_other(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t cctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_div_scalar_other(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t cctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_divexact_scalar_other(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t cctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_vec_pow_scalar_other(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t cctx, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_scalar_other_add_vec(gr_ptr vec1, gr_srcptr c, gr_ctx_t cctx, gr_srcptr vec2, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_scalar_other_sub_vec(gr_ptr vec1, gr_srcptr c, gr_ctx_t cctx, gr_srcptr vec2, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_scalar_other_mul_vec(gr_ptr vec1, gr_srcptr c, gr_ctx_t cctx, gr_srcptr vec2, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_scalar_other_div_vec(gr_ptr vec1, gr_srcptr c, gr_ctx_t cctx, gr_srcptr vec2, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_scalar_other_divexact_vec(gr_ptr vec1, gr_srcptr c, gr_ctx_t cctx, gr_srcptr vec2, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_scalar_other_pow_vec(gr_ptr vec1, gr_srcptr c, gr_ctx_t cctx, gr_srcptr vec2, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_scalar_other_add_vec(gr_ptr vec1, gr_srcptr c, gr_ctx_t cctx, gr_srcptr vec2, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_scalar_other_sub_vec(gr_ptr vec1, gr_srcptr c, gr_ctx_t cctx, gr_srcptr vec2, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_scalar_other_mul_vec(gr_ptr vec1, gr_srcptr c, gr_ctx_t cctx, gr_srcptr vec2, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_scalar_other_div_vec(gr_ptr vec1, gr_srcptr c, gr_ctx_t cctx, gr_srcptr vec2, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_scalar_other_divexact_vec(gr_ptr vec1, gr_srcptr c, gr_ctx_t cctx, gr_srcptr vec2, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_scalar_other_pow_vec(gr_ptr vec1, gr_srcptr c, gr_ctx_t cctx, gr_srcptr vec2, slong len, gr_ctx_t ctx);
 
 
 #ifdef __cplusplus

--- a/src/gr_generic.h
+++ b/src/gr_generic.h
@@ -65,7 +65,7 @@ void gr_generic_mul(void) { flint_throw(FLINT_ERROR, "ctx must implement mul()\n
 
 
 /* some useful generic functions, currently not overloadable */
-#ifdef FMPZ_POLY_H
+#if defined(FMPZ_TYPES_H)
 FLINT_WARN_UNUSED int _gr_fmpz_poly_evaluate_horner(gr_ptr res, const fmpz * f, slong len, gr_srcptr x, gr_ctx_t ctx);
 FLINT_WARN_UNUSED int gr_fmpz_poly_evaluate_horner(gr_ptr res, const fmpz_poly_t f, gr_srcptr x, gr_ctx_t ctx);
 FLINT_WARN_UNUSED int _gr_fmpz_poly_evaluate_rectangular(gr_ptr res, const fmpz * f, slong len, gr_srcptr x, gr_ctx_t ctx);
@@ -74,7 +74,7 @@ FLINT_WARN_UNUSED int _gr_fmpz_poly_evaluate(gr_ptr res, const fmpz * f, slong l
 FLINT_WARN_UNUSED int gr_fmpz_poly_evaluate(gr_ptr res, const fmpz_poly_t f, gr_srcptr x, gr_ctx_t ctx);
 #endif
 
-#ifdef FMPZ_MPOLY_H
+#if defined(FMPZ_TYPES_H) && defined(MPOLY_TYPES_H)
 FLINT_WARN_UNUSED int gr_fmpz_mpoly_evaluate_iter(gr_ptr res, const fmpz_mpoly_t pol, gr_srcptr x, const fmpz_mpoly_ctx_t mctx, gr_ctx_t ctx);
 FLINT_WARN_UNUSED int gr_fmpz_mpoly_evaluate_horner(gr_ptr res, const fmpz_mpoly_t pol, gr_srcptr x, const fmpz_mpoly_ctx_t mctx, gr_ctx_t ctx);
 FLINT_WARN_UNUSED int gr_fmpz_mpoly_evaluate(gr_ptr res, const fmpz_mpoly_t f, gr_srcptr x, const fmpz_mpoly_ctx_t mctx, gr_ctx_t ctx);
@@ -115,7 +115,7 @@ FLINT_WARN_UNUSED int gr_generic_set_str(gr_ptr res, const char * s, gr_ctx_t ct
 FLINT_WARN_UNUSED int gr_generic_set_str_balance_additions(gr_ptr res, const char * s, gr_ctx_t ctx);
 FLINT_WARN_UNUSED int gr_generic_set_str_ring_exponents(gr_ptr res, const char * s, gr_ctx_t ctx);
 
-#ifdef FEXPR_H
+#if defined(CA_TYPES_H)
 FLINT_WARN_UNUSED int gr_generic_set_fexpr(gr_ptr res, fexpr_vec_t inputs, gr_vec_t outputs, const fexpr_t expr, gr_ctx_t ctx);
 #endif
 

--- a/src/gr_mat.h
+++ b/src/gr_mat.h
@@ -18,8 +18,9 @@
 #define GR_MAT_INLINE static inline
 #endif
 
-#include "gr.h"
-#include "gr_poly.h"
+#include "fmpz_types.h"
+#include "fmpq_types.h"
+#include "gr_types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/gr_mat.h
+++ b/src/gr_mat.h
@@ -57,7 +57,7 @@ typedef int ((*gr_method_mat_lu_op)(slong *, slong *, gr_mat_t, const gr_mat_t, 
 #define GR_MAT_LU_OP(ctx, NAME) (((gr_method_mat_lu_op *) ctx->methods)[GR_METHOD_ ## NAME])
 
 void gr_mat_init(gr_mat_t mat, slong rows, slong cols, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_init_set(gr_mat_t res, const gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_init_set(gr_mat_t res, const gr_mat_t mat, gr_ctx_t ctx);
 void gr_mat_clear(gr_mat_t mat, gr_ctx_t ctx);
 
 GR_MAT_INLINE void
@@ -66,10 +66,10 @@ gr_mat_swap(gr_mat_t mat1, gr_mat_t mat2, gr_ctx_t FLINT_UNUSED(ctx))
     FLINT_SWAP(gr_mat_struct, *mat1, *mat2);
 }
 
-WARN_UNUSED_RESULT int gr_mat_swap_rows(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_invert_rows(gr_mat_t mat, slong * perm, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_swap_cols(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_invert_cols(gr_mat_t mat, slong * perm, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_swap_rows(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_invert_rows(gr_mat_t mat, slong * perm, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_swap_cols(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_invert_cols(gr_mat_t mat, slong * perm, gr_ctx_t ctx);
 
 void gr_mat_window_init(gr_mat_t window, const gr_mat_t mat, slong r1, slong c1, slong r2, slong c2, gr_ctx_t ctx);
 
@@ -79,16 +79,16 @@ gr_mat_window_clear(gr_mat_t window, gr_ctx_t FLINT_UNUSED(ctx))
     flint_free(window->rows);
 }
 
-WARN_UNUSED_RESULT int gr_mat_concat_horizontal(gr_mat_t res, const gr_mat_t mat1, const gr_mat_t mat2, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_concat_vertical(gr_mat_t res, const gr_mat_t mat1, const gr_mat_t mat2, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_concat_horizontal(gr_mat_t res, const gr_mat_t mat1, const gr_mat_t mat2, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_concat_vertical(gr_mat_t res, const gr_mat_t mat1, const gr_mat_t mat2, gr_ctx_t ctx);
 
 int gr_mat_write(gr_stream_t out, const gr_mat_t mat, gr_ctx_t ctx);
 int gr_mat_print(const gr_mat_t mat, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_randtest(gr_mat_t mat, flint_rand_t state, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_randops(gr_mat_t mat, flint_rand_t state, slong count, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_randpermdiag(int * parity, gr_mat_t mat, flint_rand_t state, gr_ptr diag, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_randrank(gr_mat_t mat, flint_rand_t state, slong rank, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_randtest(gr_mat_t mat, flint_rand_t state, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_randops(gr_mat_t mat, flint_rand_t state, slong count, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_randpermdiag(int * parity, gr_mat_t mat, flint_rand_t state, gr_ptr diag, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_randrank(gr_mat_t mat, flint_rand_t state, slong rank, gr_ctx_t ctx);
 
 GR_MAT_INLINE truth_t
 gr_mat_is_empty(const gr_mat_t mat, gr_ctx_t FLINT_UNUSED(ctx))
@@ -107,177 +107,177 @@ truth_t gr_mat_is_zero(const gr_mat_t mat, gr_ctx_t ctx);
 truth_t gr_mat_is_one(const gr_mat_t mat, gr_ctx_t ctx);
 truth_t gr_mat_is_neg_one(const gr_mat_t mat, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_zero(gr_mat_t res, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_one(gr_mat_t res, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_set(gr_mat_t res, const gr_mat_t mat, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_set_scalar(gr_mat_t res, gr_srcptr c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_set_ui(gr_mat_t res, ulong v, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_set_si(gr_mat_t res, slong v, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_set_fmpz(gr_mat_t res, const fmpz_t v, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_set_fmpq(gr_mat_t res, const fmpq_t v, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_zero(gr_mat_t res, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_one(gr_mat_t res, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_set(gr_mat_t res, const gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_set_scalar(gr_mat_t res, gr_srcptr c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_set_ui(gr_mat_t res, ulong v, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_set_si(gr_mat_t res, slong v, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_set_fmpz(gr_mat_t res, const fmpz_t v, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_set_fmpq(gr_mat_t res, const fmpq_t v, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_set_fmpz_mat(gr_mat_t res, const fmpz_mat_t mat, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_set_fmpq_mat(gr_mat_t res, const fmpq_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_set_fmpz_mat(gr_mat_t res, const fmpz_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_set_fmpq_mat(gr_mat_t res, const fmpq_mat_t mat, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_neg(gr_mat_t res, const gr_mat_t mat, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_swap_entrywise(gr_mat_t mat1, const gr_mat_t mat2, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_add(gr_mat_t res, const gr_mat_t mat1, const gr_mat_t mat2, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_sub(gr_mat_t res, const gr_mat_t mat1, const gr_mat_t mat2, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_neg(gr_mat_t res, const gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_swap_entrywise(gr_mat_t mat1, const gr_mat_t mat2, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_add(gr_mat_t res, const gr_mat_t mat1, const gr_mat_t mat2, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_sub(gr_mat_t res, const gr_mat_t mat1, const gr_mat_t mat2, gr_ctx_t ctx);
 
 /* todo: test, wrap; div; more conversions */
-WARN_UNUSED_RESULT int gr_mat_add_scalar(gr_mat_t res, const gr_mat_t mat, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_sub_scalar(gr_mat_t res, const gr_mat_t mat, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_mul_scalar(gr_mat_t res, const gr_mat_t mat, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_addmul_scalar(gr_mat_t res, const gr_mat_t mat, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_submul_scalar(gr_mat_t res, const gr_mat_t mat, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_div_scalar(gr_mat_t res, const gr_mat_t mat, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_add_scalar(gr_mat_t res, const gr_mat_t mat, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_sub_scalar(gr_mat_t res, const gr_mat_t mat, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_mul_scalar(gr_mat_t res, const gr_mat_t mat, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_addmul_scalar(gr_mat_t res, const gr_mat_t mat, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_submul_scalar(gr_mat_t res, const gr_mat_t mat, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_div_scalar(gr_mat_t res, const gr_mat_t mat, gr_srcptr x, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_mul_classical(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_mul_strassen(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_mul_generic(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_mul(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_mul_classical(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_mul_strassen(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_mul_generic(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_mul(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
 
 /* todo */
-GR_MAT_INLINE WARN_UNUSED_RESULT int
+GR_MAT_INLINE FLINT_WARN_UNUSED int
 gr_mat_sqr(gr_mat_t res, const gr_mat_t mat, gr_ctx_t ctx)
 {
     return gr_mat_mul(res, mat, mat, ctx);
 }
 
-WARN_UNUSED_RESULT int _gr_mat_gr_poly_evaluate(gr_mat_t y, gr_srcptr poly, slong len, const gr_mat_t x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_gr_poly_evaluate(gr_mat_t res, const gr_poly_t f, const gr_mat_t a, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_mat_gr_poly_evaluate(gr_mat_t y, gr_srcptr poly, slong len, const gr_mat_t x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_gr_poly_evaluate(gr_mat_t res, const gr_poly_t f, const gr_mat_t a, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_find_nonzero_pivot_large_abs(slong * pivot_row, gr_mat_t mat, slong start_row, slong end_row, slong column, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_find_nonzero_pivot_generic(slong * pivot_row, gr_mat_t mat, slong start_row, slong end_row, slong column, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_find_nonzero_pivot(slong * pivot_row, gr_mat_t mat, slong start_row, slong end_row, slong column, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_find_nonzero_pivot_large_abs(slong * pivot_row, gr_mat_t mat, slong start_row, slong end_row, slong column, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_find_nonzero_pivot_generic(slong * pivot_row, gr_mat_t mat, slong start_row, slong end_row, slong column, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_find_nonzero_pivot(slong * pivot_row, gr_mat_t mat, slong start_row, slong end_row, slong column, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_lu_recursive(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_lu_classical(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_lu_generic(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_lu(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_lu_recursive(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_lu_classical(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_lu_generic(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_lu(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_fflu(slong * res_rank, slong * P, gr_mat_t LU, gr_ptr den, const gr_mat_t A, int rank_check, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_fflu(slong * res_rank, slong * P, gr_mat_t LU, gr_ptr den, const gr_mat_t A, int rank_check, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_nonsingular_solve_fflu(gr_mat_t X, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_nonsingular_solve_lu(gr_mat_t X, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_nonsingular_solve(gr_mat_t X, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_nonsingular_solve_fflu(gr_mat_t X, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_nonsingular_solve_lu(gr_mat_t X, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_nonsingular_solve(gr_mat_t X, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_nonsingular_solve_fflu_precomp(gr_mat_t X, const slong * perm, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_nonsingular_solve_lu_precomp(gr_mat_t X, const slong * perm, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_nonsingular_solve_fflu_precomp(gr_mat_t X, const slong * perm, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_nonsingular_solve_lu_precomp(gr_mat_t X, const slong * perm, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_nonsingular_solve_den_fflu(gr_mat_t X, gr_ptr den, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_nonsingular_solve_den(gr_mat_t X, gr_ptr den, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_nonsingular_solve_den_fflu(gr_mat_t X, gr_ptr den, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_nonsingular_solve_den(gr_mat_t X, gr_ptr den, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_solve_field(gr_mat_t X, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_solve_field(gr_mat_t X, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_det_berkowitz(gr_ptr res, const gr_mat_t A, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_det_fflu(gr_ptr res, const gr_mat_t A, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_det_lu(gr_ptr res, const gr_mat_t A, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_det_cofactor(gr_ptr res, const gr_mat_t A, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_det_generic_field(gr_ptr res, const gr_mat_t A, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_det_generic_integral_domain(gr_ptr res, const gr_mat_t A, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_det_generic(gr_ptr res, const gr_mat_t A, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_det(gr_ptr res, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_det_berkowitz(gr_ptr res, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_det_fflu(gr_ptr res, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_det_lu(gr_ptr res, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_det_cofactor(gr_ptr res, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_det_generic_field(gr_ptr res, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_det_generic_integral_domain(gr_ptr res, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_det_generic(gr_ptr res, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_det(gr_ptr res, const gr_mat_t A, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_inv(gr_mat_t res, const gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_inv(gr_mat_t res, const gr_mat_t mat, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_adjugate_charpoly(gr_mat_t adj, gr_ptr det, const gr_mat_t A, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_adjugate_cofactor(gr_mat_t adj, gr_ptr det, const gr_mat_t A, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_adjugate(gr_mat_t adj, gr_ptr det, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_adjugate_charpoly(gr_mat_t adj, gr_ptr det, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_adjugate_cofactor(gr_mat_t adj, gr_ptr det, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_adjugate(gr_mat_t adj, gr_ptr det, const gr_mat_t A, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_rank_lu(slong * rank, const gr_mat_t A, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_rank_fflu(slong * rank, const gr_mat_t A, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_rank(slong * rank, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_rank_lu(slong * rank, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_rank_fflu(slong * rank, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_rank(slong * rank, const gr_mat_t A, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_rref_lu(slong * res_rank, gr_mat_t R, const gr_mat_t A, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_rref_fflu(slong * res_rank, gr_mat_t R, const gr_mat_t A, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_rref(slong * res_rank, gr_mat_t R, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_rref_lu(slong * res_rank, gr_mat_t R, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_rref_fflu(slong * res_rank, gr_mat_t R, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_rref(slong * res_rank, gr_mat_t R, const gr_mat_t A, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_rref_den_fflu(slong * res_rank, gr_mat_t R, gr_ptr den, const gr_mat_t A, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_rref_den(slong * res_rank, gr_mat_t R, gr_ptr den, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_rref_den_fflu(slong * res_rank, gr_mat_t R, gr_ptr den, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_rref_den(slong * res_rank, gr_mat_t R, gr_ptr den, const gr_mat_t A, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_nullspace(gr_mat_t X, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_nullspace(gr_mat_t X, const gr_mat_t A, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_ones(gr_mat_t mat, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_pascal(gr_mat_t mat, int triangular, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_stirling(gr_mat_t mat, int kind, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_hilbert(gr_mat_t mat, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_hadamard(gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_ones(gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_pascal(gr_mat_t mat, int triangular, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_stirling(gr_mat_t mat, int kind, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_hilbert(gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_hadamard(gr_mat_t mat, gr_ctx_t ctx);
 /* todo: dft, dct */
 
-WARN_UNUSED_RESULT int gr_mat_transpose(gr_mat_t B, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_transpose(gr_mat_t B, const gr_mat_t A, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_nonsingular_solve_tril_classical(gr_mat_t X, const gr_mat_t L, const gr_mat_t B, int unit, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_nonsingular_solve_tril_recursive(gr_mat_t X, const gr_mat_t L, const gr_mat_t B, int unit, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_nonsingular_solve_tril_generic(gr_mat_t X, const gr_mat_t L, const gr_mat_t B, int unit, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_nonsingular_solve_tril(gr_mat_t X, const gr_mat_t L, const gr_mat_t B, int unit, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_nonsingular_solve_tril_classical(gr_mat_t X, const gr_mat_t L, const gr_mat_t B, int unit, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_nonsingular_solve_tril_recursive(gr_mat_t X, const gr_mat_t L, const gr_mat_t B, int unit, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_nonsingular_solve_tril_generic(gr_mat_t X, const gr_mat_t L, const gr_mat_t B, int unit, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_nonsingular_solve_tril(gr_mat_t X, const gr_mat_t L, const gr_mat_t B, int unit, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_nonsingular_solve_triu_classical(gr_mat_t X, const gr_mat_t U, const gr_mat_t B, int unit, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_nonsingular_solve_triu_recursive(gr_mat_t X, const gr_mat_t U, const gr_mat_t B, int unit, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_nonsingular_solve_triu_generic(gr_mat_t X, const gr_mat_t L, const gr_mat_t B, int unit, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_nonsingular_solve_triu(gr_mat_t X, const gr_mat_t U, const gr_mat_t B, int unit, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_nonsingular_solve_triu_classical(gr_mat_t X, const gr_mat_t U, const gr_mat_t B, int unit, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_nonsingular_solve_triu_recursive(gr_mat_t X, const gr_mat_t U, const gr_mat_t B, int unit, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_nonsingular_solve_triu_generic(gr_mat_t X, const gr_mat_t L, const gr_mat_t B, int unit, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_nonsingular_solve_triu(gr_mat_t X, const gr_mat_t U, const gr_mat_t B, int unit, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_trace(gr_ptr res, const gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_trace(gr_ptr res, const gr_mat_t mat, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_mat_charpoly_berkowitz(gr_ptr res, const gr_mat_t mat, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_charpoly_berkowitz(gr_poly_t res, const gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_mat_charpoly_berkowitz(gr_ptr res, const gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_charpoly_berkowitz(gr_poly_t res, const gr_mat_t mat, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_mat_charpoly_danilevsky_inplace(gr_ptr res, gr_mat_t mat, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_mat_charpoly_danilevsky(gr_ptr res, const gr_mat_t mat, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_charpoly_danilevsky(gr_poly_t res, const gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_mat_charpoly_danilevsky_inplace(gr_ptr res, gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_mat_charpoly_danilevsky(gr_ptr res, const gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_charpoly_danilevsky(gr_poly_t res, const gr_mat_t mat, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_mat_charpoly_faddeev(gr_ptr res, gr_mat_t adj, const gr_mat_t mat, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_charpoly_faddeev(gr_poly_t res, gr_mat_t adj, const gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_mat_charpoly_faddeev(gr_ptr res, gr_mat_t adj, const gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_charpoly_faddeev(gr_poly_t res, gr_mat_t adj, const gr_mat_t mat, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_mat_charpoly_faddeev_bsgs(gr_ptr res, gr_mat_t adj, const gr_mat_t mat, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_charpoly_faddeev_bsgs(gr_poly_t res, gr_mat_t adj, const gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_mat_charpoly_faddeev_bsgs(gr_ptr res, gr_mat_t adj, const gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_charpoly_faddeev_bsgs(gr_poly_t res, gr_mat_t adj, const gr_mat_t mat, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_mat_charpoly_from_hessenberg(gr_ptr res, const gr_mat_t mat, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_charpoly_from_hessenberg(gr_poly_t cp, const gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_mat_charpoly_from_hessenberg(gr_ptr res, const gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_charpoly_from_hessenberg(gr_poly_t cp, const gr_mat_t mat, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_mat_charpoly_gauss(gr_ptr res, const gr_mat_t mat, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_charpoly_gauss(gr_poly_t cp, const gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_mat_charpoly_gauss(gr_ptr res, const gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_charpoly_gauss(gr_poly_t cp, const gr_mat_t mat, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_mat_charpoly_householder(gr_ptr res, const gr_mat_t mat, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_charpoly_householder(gr_poly_t cp, const gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_mat_charpoly_householder(gr_ptr res, const gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_charpoly_householder(gr_poly_t cp, const gr_mat_t mat, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_mat_charpoly(gr_ptr res, const gr_mat_t mat, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_charpoly(gr_poly_t res, const gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_mat_charpoly(gr_ptr res, const gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_charpoly(gr_poly_t res, const gr_mat_t mat, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_hessenberg(gr_mat_t res, const gr_mat_t mat, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_hessenberg_gauss(gr_mat_t res, const gr_mat_t mat, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_hessenberg_householder(gr_mat_t res, const gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_hessenberg(gr_mat_t res, const gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_hessenberg_gauss(gr_mat_t res, const gr_mat_t mat, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_hessenberg_householder(gr_mat_t res, const gr_mat_t mat, gr_ctx_t ctx);
 truth_t gr_mat_is_hessenberg(const gr_mat_t mat, gr_ctx_t ctx);
 
 int gr_mat_reduce_row(slong * column, gr_mat_t A, slong * P, slong * L, slong m, gr_ctx_t ctx);
 int gr_mat_apply_row_similarity(gr_mat_t A, slong r, gr_ptr d, gr_ctx_t ctx);
 int gr_mat_minpoly_field(gr_poly_t p, const gr_mat_t X, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_eigenvalues(gr_vec_t lambda, gr_vec_t mult, const gr_mat_t mat, int flags, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_eigenvalues_other(gr_vec_t lambda, gr_vec_t mult, const gr_mat_t mat, gr_ctx_t mat_ctx, int flags, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_eigenvalues(gr_vec_t lambda, gr_vec_t mult, const gr_mat_t mat, int flags, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_eigenvalues_other(gr_vec_t lambda, gr_vec_t mult, const gr_mat_t mat, gr_ctx_t mat_ctx, int flags, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_diagonalization_precomp(gr_vec_t D, gr_mat_t L, gr_mat_t R, const gr_mat_t A, const gr_vec_t eigenvalues, const gr_vec_t mult, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_diagonalization_generic(gr_vec_t D, gr_mat_t L, gr_mat_t R, const gr_mat_t A, int flags, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_diagonalization(gr_vec_t D, gr_mat_t L, gr_mat_t R, const gr_mat_t A, int flags, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_diagonalization_precomp(gr_vec_t D, gr_mat_t L, gr_mat_t R, const gr_mat_t A, const gr_vec_t eigenvalues, const gr_vec_t mult, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_diagonalization_generic(gr_vec_t D, gr_mat_t L, gr_mat_t R, const gr_mat_t A, int flags, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_diagonalization(gr_vec_t D, gr_mat_t L, gr_mat_t R, const gr_mat_t A, int flags, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_set_jordan_blocks(gr_mat_t mat, const gr_vec_t lambda, slong num_blocks, slong * block_lambda, slong * block_size, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_jordan_blocks(gr_vec_t lambda, slong * num_blocks, slong * block_lambda, slong * block_size, const gr_mat_t A, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_jordan_transformation(gr_mat_t mat, const gr_vec_t lambda, slong num_blocks, slong * block_lambda, slong * block_size, const gr_mat_t A, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_jordan_form(gr_mat_t J, gr_mat_t P, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_set_jordan_blocks(gr_mat_t mat, const gr_vec_t lambda, slong num_blocks, slong * block_lambda, slong * block_size, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_jordan_blocks(gr_vec_t lambda, slong * num_blocks, slong * block_lambda, slong * block_size, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_jordan_transformation(gr_mat_t mat, const gr_vec_t lambda, slong num_blocks, slong * block_lambda, slong * block_size, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_jordan_form(gr_mat_t J, gr_mat_t P, const gr_mat_t A, gr_ctx_t ctx);
 
 truth_t gr_mat_is_scalar(const gr_mat_t mat, gr_ctx_t ctx);
 truth_t gr_mat_is_diagonal(const gr_mat_t mat, gr_ctx_t ctx);
 truth_t gr_mat_is_lower_triangular(const gr_mat_t mat, gr_ctx_t ctx);
 truth_t gr_mat_is_upper_triangular(const gr_mat_t mat, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_mul_diag(gr_mat_t C, const gr_mat_t A, const gr_vec_t D, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_diag_mul(gr_mat_t C, const gr_vec_t D, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_mul_diag(gr_mat_t C, const gr_mat_t A, const gr_vec_t D, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_diag_mul(gr_mat_t C, const gr_vec_t D, const gr_mat_t A, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_exp_jordan(gr_mat_t res, const gr_mat_t A, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_exp(gr_mat_t res, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_exp_jordan(gr_mat_t res, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_exp(gr_mat_t res, const gr_mat_t A, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_log_jordan(gr_mat_t res, const gr_mat_t A, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_log(gr_mat_t res, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_log_jordan(gr_mat_t res, const gr_mat_t A, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_mat_log(gr_mat_t res, const gr_mat_t A, gr_ctx_t ctx);
 
 /* Test functions */
 

--- a/src/gr_mat.h
+++ b/src/gr_mat.h
@@ -22,19 +22,8 @@
 #include "gr_poly.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
-
-typedef struct
-{
-    gr_ptr entries;
-    slong r;
-    slong c;
-    gr_ptr * rows;
-}
-gr_mat_struct;
-
-typedef gr_mat_struct gr_mat_t[1];
 
 #define GR_MAT_ENTRY(mat,i,j,sz) GR_ENTRY((mat)->rows[i], j, sz)
 #define gr_mat_nrows(mat, ctx) ((mat)->r)

--- a/src/gr_mat/add_scalar.c
+++ b/src/gr_mat/add_scalar.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/adjugate_charpoly.c
+++ b/src/gr_mat/adjugate_charpoly.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/adjugate_cofactor.c
+++ b/src/gr_mat/adjugate_cofactor.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/apply_row_similarity.c
+++ b/src/gr_mat/apply_row_similarity.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int gr_mat_apply_row_similarity(gr_mat_t A, slong r, gr_ptr d, gr_ctx_t ctx)

--- a/src/gr_mat/charpoly.c
+++ b/src/gr_mat/charpoly.c
@@ -10,6 +10,7 @@
 */
 
 #include "gr_mat.h"
+#include "gr_poly.h"
 
 /* todo: algorithm selection */
 int

--- a/src/gr_mat/charpoly_berkowitz.c
+++ b/src/gr_mat/charpoly_berkowitz.c
@@ -11,6 +11,7 @@
 
 #include "gr_vec.h"
 #include "gr_mat.h"
+#include "gr_poly.h"
 
 int
 _gr_mat_charpoly_berkowitz(gr_ptr cp, const gr_mat_t mat, gr_ctx_t ctx)

--- a/src/gr_mat/charpoly_faddeev.c
+++ b/src/gr_mat/charpoly_faddeev.c
@@ -10,6 +10,7 @@
 */
 
 #include "gr_mat.h"
+#include "gr_poly.h"
 
 /* todo: when adj != A, could save memory by using as temporary */
 int

--- a/src/gr_mat/charpoly_faddeev_bsgs.c
+++ b/src/gr_mat/charpoly_faddeev_bsgs.c
@@ -12,6 +12,7 @@
 #include "ulong_extras.h"
 #include "gr_vec.h"
 #include "gr_mat.h"
+#include "gr_poly.h"
 
 static int
 gr_mat_trace_prod(gr_ptr res, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx)

--- a/src/gr_mat/clear.c
+++ b/src/gr_mat/clear.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr_vec.h"
 #include "gr_mat.h"
 
 void

--- a/src/gr_mat/det.c
+++ b/src/gr_mat/det.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/det_berkowitz.c
+++ b/src/gr_mat/det_berkowitz.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr_vec.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/det_cofactor.c
+++ b/src/gr_mat/det_cofactor.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 #define E(i,j) GR_MAT_ENTRY(A, i, j, sz)

--- a/src/gr_mat/det_fflu.c
+++ b/src/gr_mat/det_fflu.c
@@ -10,6 +10,7 @@
 */
 
 #include "perm.h"
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/det_lu.c
+++ b/src/gr_mat/det_lu.c
@@ -10,6 +10,7 @@
 */
 
 #include "perm.h"
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/div_scalar.c
+++ b/src/gr_mat/div_scalar.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 /* todo: use a vector function; preinvert when appropriate */

--- a/src/gr_mat/eigenvalues.c
+++ b/src/gr_mat/eigenvalues.c
@@ -10,6 +10,7 @@
 */
 
 #include "gr_mat.h"
+#include "gr_poly.h"
 
 int
 gr_mat_eigenvalues(gr_vec_t lambda, gr_vec_t mult, const gr_mat_t mat, int flags, gr_ctx_t ctx)

--- a/src/gr_mat/find_nonzero_pivot.c
+++ b/src/gr_mat/find_nonzero_pivot.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/hessenberg_gauss.c
+++ b/src/gr_mat/hessenberg_gauss.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int gr_generic_addmul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx);

--- a/src/gr_mat/hessenberg_householder.c
+++ b/src/gr_mat/hessenberg_householder.c
@@ -10,6 +10,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 /* todo: optimize; use dot/norm functions */

--- a/src/gr_mat/hilbert.c
+++ b/src/gr_mat/hilbert.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/init.c
+++ b/src/gr_mat/init.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 void

--- a/src/gr_mat/inlines.c
+++ b/src/gr_mat/inlines.c
@@ -10,5 +10,7 @@
 */
 
 #define GR_MAT_INLINES_C
+
 #include "gr_mat.h"
+
 #undef GR_MAT_INLINES_C

--- a/src/gr_mat/inv.c
+++ b/src/gr_mat/inv.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/invert_cols.c
+++ b/src/gr_mat/invert_cols.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/io.c
+++ b/src/gr_mat/io.c
@@ -10,6 +10,7 @@
 */
 
 #include <stdio.h>
+#include "gr.h"
 #include "gr_mat.h"
 
 /* printing *******************************************************************/

--- a/src/gr_mat/is_diagonal.c
+++ b/src/gr_mat/is_diagonal.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 truth_t gr_mat_is_diagonal(const gr_mat_t mat, gr_ctx_t ctx)

--- a/src/gr_mat/is_hessenberg.c
+++ b/src/gr_mat/is_hessenberg.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 truth_t

--- a/src/gr_mat/is_lower_triangular.c
+++ b/src/gr_mat/is_lower_triangular.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 truth_t gr_mat_is_lower_triangular(const gr_mat_t mat, gr_ctx_t ctx)

--- a/src/gr_mat/is_neg_one.c
+++ b/src/gr_mat/is_neg_one.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 truth_t

--- a/src/gr_mat/is_one.c
+++ b/src/gr_mat/is_one.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 truth_t

--- a/src/gr_mat/is_scalar.c
+++ b/src/gr_mat/is_scalar.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 truth_t

--- a/src/gr_mat/is_upper_triangular.c
+++ b/src/gr_mat/is_upper_triangular.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 truth_t gr_mat_is_upper_triangular(const gr_mat_t mat, gr_ctx_t ctx)

--- a/src/gr_mat/lu.c
+++ b/src/gr_mat/lu.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/lu_recursive.c
+++ b/src/gr_mat/lu_recursive.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 static void

--- a/src/gr_mat/minpoly_field.c
+++ b/src/gr_mat/minpoly_field.c
@@ -10,8 +10,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "gr_poly.h"
+#include "gr.h"
 #include "gr_mat.h"
+#include "gr_poly.h"
 
 int gr_mat_reduce_row(slong * column, gr_mat_t A, slong * P, slong * L, slong m, gr_ctx_t ctx);
 

--- a/src/gr_mat/mul.c
+++ b/src/gr_mat/mul.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/mul_classical.c
+++ b/src/gr_mat/mul_classical.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include <stdint.h>
 #include "gr_vec.h"
 #include "gr_mat.h"
 

--- a/src/gr_mat/mul_strassen.c
+++ b/src/gr_mat/mul_strassen.c
@@ -13,8 +13,6 @@
 
 #include "gr_mat.h"
 
-#include "fmpz_mat.h"
-
 /* todo: optimize for small matrices */
 /* todo: bodrato squaring */
 /* todo: use fused add-mul operations when supported by

--- a/src/gr_mat/nonsingular_solve.c
+++ b/src/gr_mat/nonsingular_solve.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 /* todo: solve_adjugate for n <= 4 */

--- a/src/gr_mat/nonsingular_solve_fflu.c
+++ b/src/gr_mat/nonsingular_solve_fflu.c
@@ -10,6 +10,7 @@
 */
 
 #include "perm.h"
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/nonsingular_solve_fflu_precomp.c
+++ b/src/gr_mat/nonsingular_solve_fflu_precomp.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 /* todo: check that dimensions are compatible */

--- a/src/gr_mat/nonsingular_solve_lu_precomp.c
+++ b/src/gr_mat/nonsingular_solve_lu_precomp.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 /* todo: check that dimensions are compatible */

--- a/src/gr_mat/nullspace.c
+++ b/src/gr_mat/nullspace.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/one.c
+++ b/src/gr_mat/one.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/ones.c
+++ b/src/gr_mat/ones.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/pascal.c
+++ b/src/gr_mat/pascal.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 /* todo: optimize for fmpz */

--- a/src/gr_mat/randops.c
+++ b/src/gr_mat/randops.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/randpermdiag.c
+++ b/src/gr_mat/randpermdiag.c
@@ -10,6 +10,7 @@
 */
 
 #include "perm.h"
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/randrank.c
+++ b/src/gr_mat/randrank.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/rank.c
+++ b/src/gr_mat/rank.c
@@ -10,6 +10,7 @@
 */
 
 #include "perm.h"
+#include "gr.h"
 #include "gr_mat.h"
 
 /* todo: different algorithms */

--- a/src/gr_mat/rank_fflu.c
+++ b/src/gr_mat/rank_fflu.c
@@ -10,6 +10,7 @@
 */
 
 #include "perm.h"
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/reduce_row.c
+++ b/src/gr_mat/reduce_row.c
@@ -10,6 +10,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int gr_mat_reduce_row(slong * column, gr_mat_t A, slong * P, slong * L, slong m, gr_ctx_t ctx)

--- a/src/gr_mat/rref_fflu.c
+++ b/src/gr_mat/rref_fflu.c
@@ -10,6 +10,7 @@
 */
 
 #include "perm.h"
+#include "gr.h"
 #include "gr_mat.h"
 
 static int

--- a/src/gr_mat/rref_lu.c
+++ b/src/gr_mat/rref_lu.c
@@ -10,6 +10,7 @@
 */
 
 #include "perm.h"
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/set_fmpq.c
+++ b/src/gr_mat/set_fmpq.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/set_fmpq_mat.c
+++ b/src/gr_mat/set_fmpq_mat.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpq_mat.h"
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/set_fmpz.c
+++ b/src/gr_mat/set_fmpz.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/set_fmpz_mat.c
+++ b/src/gr_mat/set_fmpz_mat.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpz_mat.h"
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/set_scalar.c
+++ b/src/gr_mat/set_scalar.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/set_si.c
+++ b/src/gr_mat/set_si.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/set_ui.c
+++ b/src/gr_mat/set_ui.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/solve_field.c
+++ b/src/gr_mat/solve_field.c
@@ -11,6 +11,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/stirling.c
+++ b/src/gr_mat/stirling.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 /* todo: optimize for fmpz */

--- a/src/gr_mat/sub_scalar.c
+++ b/src/gr_mat/sub_scalar.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/swap_cols.c
+++ b/src/gr_mat/swap_cols.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/test_det.c
+++ b/src/gr_mat/test_det.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 void gr_mat_test_det(gr_method_mat_unary_op_get_scalar det_impl, flint_rand_t state, slong iters, slong maxn, gr_ctx_t ctx)

--- a/src/gr_mat/test_lu.c
+++ b/src/gr_mat/test_lu.c
@@ -9,8 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "gr_mat.h"
 #include "fmpz_mat.h"
+#include "gr.h"
+#include "gr_mat.h"
 
 static void perm(gr_mat_t A, slong * P)
 {

--- a/src/gr_mat/test_mul.c
+++ b/src/gr_mat/test_mul.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 void gr_mat_test_mul(gr_method_mat_binary_op mul_impl, flint_rand_t state, slong iters, slong maxn, gr_ctx_t ctx)

--- a/src/gr_mat/test_nonsingular_solve_tri.c
+++ b/src/gr_mat/test_nonsingular_solve_tri.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 static void _gr_mat_test_nonsingular_solve_tri(gr_method_mat_binary_op_with_flag solve_impl, int upper, flint_rand_t state, slong iters, slong maxn, gr_ctx_t ctx)

--- a/src/gr_mat/trace.c
+++ b/src/gr_mat/trace.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/transpose.c
+++ b/src/gr_mat/transpose.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mat/write.c
+++ b/src/gr_mat/write.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
 #include "gr_mat.h"
 
 int

--- a/src/gr_mpoly.h
+++ b/src/gr_mpoly.h
@@ -102,9 +102,9 @@ void gr_mpoly_swap(gr_mpoly_t A, gr_mpoly_t B, const mpoly_ctx_t mctx, gr_ctx_t 
     FLINT_SWAP(gr_mpoly_struct, *A, *B);
 }
 
-WARN_UNUSED_RESULT int gr_mpoly_set(gr_mpoly_t A, const gr_mpoly_t B, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_set(gr_mpoly_t A, const gr_mpoly_t B, const mpoly_ctx_t mctx, gr_ctx_t cctx);
 
-GR_MPOLY_INLINE WARN_UNUSED_RESULT
+GR_MPOLY_INLINE FLINT_WARN_UNUSED
 int gr_mpoly_zero(gr_mpoly_t A, const mpoly_ctx_t mctx, gr_ctx_t cctx)
 {
     _gr_mpoly_set_length(A, 0, mctx, cctx);
@@ -121,7 +121,7 @@ truth_t gr_mpoly_is_zero(const gr_mpoly_t A, const mpoly_ctx_t mctx, gr_ctx_t cc
     return _gr_vec_is_zero(A->coeffs, A->length, cctx);
 }
 
-WARN_UNUSED_RESULT int gr_mpoly_gen(gr_mpoly_t A, slong var, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_gen(gr_mpoly_t A, slong var, const mpoly_ctx_t mctx, gr_ctx_t cctx);
 truth_t gr_mpoly_is_gen(const gr_mpoly_t A, slong var, const mpoly_ctx_t mctx, gr_ctx_t cctx);
 
 truth_t gr_mpoly_equal(const gr_mpoly_t A, const gr_mpoly_t B, const mpoly_ctx_t mctx, gr_ctx_t cctx);
@@ -129,11 +129,11 @@ truth_t gr_mpoly_equal(const gr_mpoly_t A, const gr_mpoly_t B, const mpoly_ctx_t
 /* Container operations */
 
 void _gr_mpoly_push_exp_ui(gr_mpoly_t A, const ulong * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
-WARN_UNUSED_RESULT int gr_mpoly_push_term_scalar_ui(gr_mpoly_t A, gr_srcptr c, const ulong * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_push_term_scalar_ui(gr_mpoly_t A, gr_srcptr c, const ulong * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
 void _gr_mpoly_push_exp_fmpz(gr_mpoly_t A, const fmpz * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
-WARN_UNUSED_RESULT int gr_mpoly_push_term_scalar_fmpz(gr_mpoly_t A, gr_srcptr c, const fmpz * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_push_term_scalar_fmpz(gr_mpoly_t A, gr_srcptr c, const fmpz * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
 void gr_mpoly_sort_terms(gr_mpoly_t A, const mpoly_ctx_t mctx, gr_ctx_t cctx);
-WARN_UNUSED_RESULT int gr_mpoly_combine_like_terms(gr_mpoly_t A, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_combine_like_terms(gr_mpoly_t A, const mpoly_ctx_t mctx, gr_ctx_t cctx);
 truth_t gr_mpoly_is_canonical(const gr_mpoly_t A, const mpoly_ctx_t mctx, gr_ctx_t cctx);
 void gr_mpoly_assert_canonical(const gr_mpoly_t A, const mpoly_ctx_t mctx, gr_ctx_t cctx);
 
@@ -148,13 +148,13 @@ int gr_mpoly_print_pretty(const gr_mpoly_t A, const char ** x_in, const mpoly_ct
 
 /* Constants */
 
-WARN_UNUSED_RESULT int gr_mpoly_set_scalar(gr_mpoly_t A, gr_srcptr c, const mpoly_ctx_t mctx, gr_ctx_t cctx);
-WARN_UNUSED_RESULT int gr_mpoly_set_ui(gr_mpoly_t A, ulong c, const mpoly_ctx_t mctx, gr_ctx_t cctx);
-WARN_UNUSED_RESULT int gr_mpoly_set_si(gr_mpoly_t A, slong c, const mpoly_ctx_t mctx, gr_ctx_t cctx);
-WARN_UNUSED_RESULT int gr_mpoly_set_fmpz(gr_mpoly_t A, const fmpz_t c, const mpoly_ctx_t mctx, gr_ctx_t cctx);
-WARN_UNUSED_RESULT int gr_mpoly_set_fmpq(gr_mpoly_t A, const fmpq_t c, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_set_scalar(gr_mpoly_t A, gr_srcptr c, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_set_ui(gr_mpoly_t A, ulong c, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_set_si(gr_mpoly_t A, slong c, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_set_fmpz(gr_mpoly_t A, const fmpz_t c, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_set_fmpq(gr_mpoly_t A, const fmpq_t c, const mpoly_ctx_t mctx, gr_ctx_t cctx);
 
-GR_MPOLY_INLINE WARN_UNUSED_RESULT
+GR_MPOLY_INLINE FLINT_WARN_UNUSED
 int gr_mpoly_one(gr_mpoly_t A, const mpoly_ctx_t mctx, gr_ctx_t cctx)
 {
     return gr_mpoly_set_ui(A, 1, mctx, cctx);
@@ -175,36 +175,36 @@ truth_t gr_mpoly_is_one(const gr_mpoly_t A, const mpoly_ctx_t mctx, gr_ctx_t cct
 
 /* Coefficient/exponent access */
 
-WARN_UNUSED_RESULT int gr_mpoly_get_coeff_scalar_fmpz(gr_ptr c, const gr_mpoly_t A, const fmpz * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
-WARN_UNUSED_RESULT int gr_mpoly_get_coeff_scalar_ui(gr_ptr c, const gr_mpoly_t A, const ulong * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_get_coeff_scalar_fmpz(gr_ptr c, const gr_mpoly_t A, const fmpz * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_get_coeff_scalar_ui(gr_ptr c, const gr_mpoly_t A, const ulong * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
 
-WARN_UNUSED_RESULT int gr_mpoly_set_coeff_scalar_fmpz(gr_mpoly_t A, gr_srcptr c, const fmpz * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
-WARN_UNUSED_RESULT int gr_mpoly_set_coeff_ui_fmpz(gr_mpoly_t A, ulong c, const fmpz * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
-WARN_UNUSED_RESULT int gr_mpoly_set_coeff_si_fmpz(gr_mpoly_t A, slong c, const fmpz * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
-WARN_UNUSED_RESULT int gr_mpoly_set_coeff_fmpz_fmpz(gr_mpoly_t A, const fmpz_t c, const fmpz * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
-WARN_UNUSED_RESULT int gr_mpoly_set_coeff_fmpq_fmpz(gr_mpoly_t A, const fmpq_t c, const fmpz * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_set_coeff_scalar_fmpz(gr_mpoly_t A, gr_srcptr c, const fmpz * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_set_coeff_ui_fmpz(gr_mpoly_t A, ulong c, const fmpz * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_set_coeff_si_fmpz(gr_mpoly_t A, slong c, const fmpz * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_set_coeff_fmpz_fmpz(gr_mpoly_t A, const fmpz_t c, const fmpz * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_set_coeff_fmpq_fmpz(gr_mpoly_t A, const fmpq_t c, const fmpz * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
 
-WARN_UNUSED_RESULT int gr_mpoly_set_coeff_scalar_ui(gr_mpoly_t poly, gr_srcptr c, const ulong * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
-WARN_UNUSED_RESULT int gr_mpoly_set_coeff_ui_ui(gr_mpoly_t A, ulong c, const ulong * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
-WARN_UNUSED_RESULT int gr_mpoly_set_coeff_si_ui(gr_mpoly_t A, slong c, const ulong * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
-WARN_UNUSED_RESULT int gr_mpoly_set_coeff_fmpz_ui(gr_mpoly_t A, const fmpz_t c, const ulong * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
-WARN_UNUSED_RESULT int gr_mpoly_set_coeff_fmpq_ui(gr_mpoly_t A, const fmpq_t c, const ulong * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_set_coeff_scalar_ui(gr_mpoly_t poly, gr_srcptr c, const ulong * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_set_coeff_ui_ui(gr_mpoly_t A, ulong c, const ulong * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_set_coeff_si_ui(gr_mpoly_t A, slong c, const ulong * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_set_coeff_fmpz_ui(gr_mpoly_t A, const fmpz_t c, const ulong * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_set_coeff_fmpq_ui(gr_mpoly_t A, const fmpq_t c, const ulong * exp, const mpoly_ctx_t mctx, gr_ctx_t cctx);
 
 /* Arithmetic */
 
-WARN_UNUSED_RESULT int gr_mpoly_neg(gr_mpoly_t A, const gr_mpoly_t B, const mpoly_ctx_t mctx, gr_ctx_t cctx);
-WARN_UNUSED_RESULT int gr_mpoly_add(gr_mpoly_t A, const gr_mpoly_t B, const gr_mpoly_t C, const mpoly_ctx_t mctx, gr_ctx_t cctx);
-WARN_UNUSED_RESULT int gr_mpoly_sub(gr_mpoly_t A, const gr_mpoly_t B, const gr_mpoly_t C, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_neg(gr_mpoly_t A, const gr_mpoly_t B, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_add(gr_mpoly_t A, const gr_mpoly_t B, const gr_mpoly_t C, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_sub(gr_mpoly_t A, const gr_mpoly_t B, const gr_mpoly_t C, const mpoly_ctx_t mctx, gr_ctx_t cctx);
 
-WARN_UNUSED_RESULT int gr_mpoly_mul(gr_mpoly_t poly1, const gr_mpoly_t poly2, const gr_mpoly_t poly3, const mpoly_ctx_t mctx, gr_ctx_t cctx);
-WARN_UNUSED_RESULT int gr_mpoly_mul_johnson(gr_mpoly_t poly1, const gr_mpoly_t poly2, const gr_mpoly_t poly3, const mpoly_ctx_t mctx, gr_ctx_t cctx);
-WARN_UNUSED_RESULT int gr_mpoly_mul_monomial(gr_mpoly_t A, const gr_mpoly_t B, const gr_mpoly_t C, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_mul(gr_mpoly_t poly1, const gr_mpoly_t poly2, const gr_mpoly_t poly3, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_mul_johnson(gr_mpoly_t poly1, const gr_mpoly_t poly2, const gr_mpoly_t poly3, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_mul_monomial(gr_mpoly_t A, const gr_mpoly_t B, const gr_mpoly_t C, const mpoly_ctx_t mctx, gr_ctx_t cctx);
 
-WARN_UNUSED_RESULT int gr_mpoly_mul_scalar(gr_mpoly_t A, const gr_mpoly_t B, gr_srcptr c, const mpoly_ctx_t mctx, gr_ctx_t cctx);
-WARN_UNUSED_RESULT int gr_mpoly_mul_si(gr_mpoly_t A, const gr_mpoly_t B, slong c, const mpoly_ctx_t mctx, gr_ctx_t cctx);
-WARN_UNUSED_RESULT int gr_mpoly_mul_ui(gr_mpoly_t A, const gr_mpoly_t B, ulong c, const mpoly_ctx_t mctx, gr_ctx_t cctx);
-WARN_UNUSED_RESULT int gr_mpoly_mul_fmpz(gr_mpoly_t A, const gr_mpoly_t B, const fmpz_t c, const mpoly_ctx_t mctx, gr_ctx_t cctx);
-WARN_UNUSED_RESULT int gr_mpoly_mul_fmpq(gr_mpoly_t A, const gr_mpoly_t B, const fmpq_t c, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_mul_scalar(gr_mpoly_t A, const gr_mpoly_t B, gr_srcptr c, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_mul_si(gr_mpoly_t A, const gr_mpoly_t B, slong c, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_mul_ui(gr_mpoly_t A, const gr_mpoly_t B, ulong c, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_mul_fmpz(gr_mpoly_t A, const gr_mpoly_t B, const fmpz_t c, const mpoly_ctx_t mctx, gr_ctx_t cctx);
+FLINT_WARN_UNUSED int gr_mpoly_mul_fmpq(gr_mpoly_t A, const gr_mpoly_t B, const fmpq_t c, const mpoly_ctx_t mctx, gr_ctx_t cctx);
 
 #ifdef __cplusplus
 }

--- a/src/gr_mpoly.h
+++ b/src/gr_mpoly.h
@@ -20,8 +20,13 @@
 #define GR_MPOLY_INLINE static inline
 #endif
 
-#include "mpoly.h"
 #include "gr_vec.h"
+
+#if FLINT_WANT_ASSERT
+# include "mpoly.h" /* For mpoly_words_per_exp */
+#else
+# include "mpoly_types.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/gr_mpoly.h
+++ b/src/gr_mpoly.h
@@ -24,22 +24,8 @@
 #include "gr_vec.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
-
-typedef struct
-{
-    gr_ptr coeffs;
-    ulong * exps;
-    slong length;
-    flint_bitcnt_t bits;    /* number of bits per exponent */
-    slong coeffs_alloc;     /* abs size in mp_limb_t units */
-    slong exps_alloc;       /* abs size in ulong units */
-}
-gr_mpoly_struct;
-
-typedef gr_mpoly_struct gr_mpoly_t[1];
-
 
 /* Memory management */
 

--- a/src/gr_mpoly/add.c
+++ b/src/gr_mpoly/add.c
@@ -9,9 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "mpoly.h"
 #include "gr_mpoly.h"
-
-
 
 slong _gr_mpoly_add(
     slong * Alen,

--- a/src/gr_mpoly/combine_like_terms.c
+++ b/src/gr_mpoly/combine_like_terms.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "mpoly.h"
 #include "gr_mpoly.h"
 
 /*

--- a/src/gr_mpoly/fit_bits.c
+++ b/src/gr_mpoly/fit_bits.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "mpoly.h"
 #include "gr_mpoly.h"
 
 void

--- a/src/gr_mpoly/fit_length.c
+++ b/src/gr_mpoly/fit_length.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "mpoly.h"
 #include "gr_mpoly.h"
 
 void _gr_mpoly_fit_length(

--- a/src/gr_mpoly/fit_length_fit_bits.c
+++ b/src/gr_mpoly/fit_length_fit_bits.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "mpoly.h"
 #include "gr_mpoly.h"
 
 void gr_mpoly_fit_length_fit_bits(

--- a/src/gr_mpoly/fit_length_reset_bits.c
+++ b/src/gr_mpoly/fit_length_reset_bits.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "mpoly.h"
 #include "gr_mpoly.h"
 
 void gr_mpoly_fit_length_reset_bits(

--- a/src/gr_mpoly/gen.c
+++ b/src/gr_mpoly/gen.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "mpoly.h"
 #include "gr_mpoly.h"
 
 int gr_mpoly_gen(

--- a/src/gr_mpoly/get_coeff_scalar_fmpz.c
+++ b/src/gr_mpoly/get_coeff_scalar_fmpz.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpz.h"
+#include "mpoly.h"
 #include "gr_mpoly.h"
 
 /* todo: should have an

--- a/src/gr_mpoly/get_coeff_scalar_ui.c
+++ b/src/gr_mpoly/get_coeff_scalar_ui.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "mpoly.h"
 #include "gr_mpoly.h"
 
 /* todo: should have an

--- a/src/gr_mpoly/init.c
+++ b/src/gr_mpoly/init.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "mpoly.h"
 #include "gr_mpoly.h"
 
 void gr_mpoly_init3(

--- a/src/gr_mpoly/inlines.c
+++ b/src/gr_mpoly/inlines.c
@@ -10,5 +10,7 @@
 */
 
 #define GR_MPOLY_INLINES_C
+
 #include "gr_mpoly.h"
+
 #undef GR_MPOLY_INLINES_C

--- a/src/gr_mpoly/is_canonical.c
+++ b/src/gr_mpoly/is_canonical.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "mpoly.h"
 #include "gr_mpoly.h"
 
 truth_t gr_mpoly_is_canonical(const gr_mpoly_t A, const mpoly_ctx_t mctx, gr_ctx_t cctx)

--- a/src/gr_mpoly/mul_johnson.c
+++ b/src/gr_mpoly/mul_johnson.c
@@ -12,6 +12,7 @@
 
 #include "fmpz.h"
 #include "fmpz_vec.h"
+#include "mpoly.h"
 #include "gr_mpoly.h"
 
 int _gr_mpoly_mul_johnson(

--- a/src/gr_mpoly/mul_monomial.c
+++ b/src/gr_mpoly/mul_monomial.c
@@ -10,6 +10,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "mpoly.h"
 #include "gr_mpoly.h"
 
 int gr_mpoly_mul_monomial(

--- a/src/gr_mpoly/mul_scalar.c
+++ b/src/gr_mpoly/mul_scalar.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpq.h"
+#include "mpoly.h"
 #include "gr_mpoly.h"
 
 /* c is assumed to be reduced mod n */

--- a/src/gr_mpoly/neg.c
+++ b/src/gr_mpoly/neg.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "mpoly.h"
 #include "gr_mpoly.h"
 
 int gr_mpoly_neg(

--- a/src/gr_mpoly/push_term.c
+++ b/src/gr_mpoly/push_term.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "mpoly.h"
 #include "gr_mpoly.h"
 
 void _gr_mpoly_push_exp_ui(

--- a/src/gr_mpoly/randtest_bits.c
+++ b/src/gr_mpoly/randtest_bits.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpz.h"
+#include "mpoly.h"
 #include "gr_mpoly.h"
 
 int gr_mpoly_randtest_bits(gr_mpoly_t A, flint_rand_t state,

--- a/src/gr_mpoly/set.c
+++ b/src/gr_mpoly/set.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "mpoly.h"
 #include "gr_mpoly.h"
 
 int gr_mpoly_set(

--- a/src/gr_mpoly/set_coeff_scalar_fmpz.c
+++ b/src/gr_mpoly/set_coeff_scalar_fmpz.c
@@ -11,6 +11,7 @@
 */
 
 #include "fmpz.h"
+#include "mpoly.h"
 #include "gr_mpoly.h"
 
 int gr_mpoly_set_coeff_scalar_fmpz(

--- a/src/gr_mpoly/set_coeff_scalar_ui.c
+++ b/src/gr_mpoly/set_coeff_scalar_ui.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpz.h"
+#include "mpoly.h"
 #include "gr_mpoly.h"
 
 int gr_mpoly_set_coeff_scalar_ui(gr_mpoly_t poly,

--- a/src/gr_mpoly/set_scalar.c
+++ b/src/gr_mpoly/set_scalar.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpq.h"
+#include "mpoly.h"
 #include "gr_mpoly.h"
 
 int gr_mpoly_set_scalar(gr_mpoly_t A,

--- a/src/gr_mpoly/sort_terms.c
+++ b/src/gr_mpoly/sort_terms.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "mpoly.h"
 #include "gr_mpoly.h"
 
 /*

--- a/src/gr_mpoly/sub.c
+++ b/src/gr_mpoly/sub.c
@@ -9,9 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "mpoly.h"
 #include "gr_mpoly.h"
-
-
 
 slong _gr_mpoly_sub(
     slong * Alen,

--- a/src/gr_mpoly/test/t-add_sub.c
+++ b/src/gr_mpoly/test/t-add_sub.c
@@ -10,6 +10,7 @@
 */
 
 #include "test_helpers.h"
+#include "mpoly.h"
 #include "gr_mpoly.h"
 
 TEST_FUNCTION_START(gr_mpoly_add_sub, state)

--- a/src/gr_mpoly/write.c
+++ b/src/gr_mpoly/write.c
@@ -12,9 +12,9 @@
 
 #include <stdio.h>
 #include <ctype.h>
-#include <stdio.h>
 #include "fmpz.h"
 #include "fmpz_vec.h"
+#include "mpoly.h"
 #include "gr_mpoly.h"
 
 static char * _gr_mpoly_default_vars[8] = {

--- a/src/gr_poly.h
+++ b/src/gr_poly.h
@@ -23,19 +23,8 @@
 #include "gr.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
-
-/* fixme: compatible with flint polys but not with arb, ... */
-typedef struct
-{
-    gr_ptr coeffs;
-    slong alloc;
-    slong length;
-}
-gr_poly_struct;
-
-typedef gr_poly_struct gr_poly_t[1];
 
 void gr_poly_init(gr_poly_t poly, gr_ctx_t ctx);
 void gr_poly_init2(gr_poly_t poly, slong len, gr_ctx_t ctx);

--- a/src/gr_poly.h
+++ b/src/gr_poly.h
@@ -57,23 +57,23 @@ void gr_poly_fit_length(gr_poly_t poly, slong len, gr_ctx_t ctx);
 void _gr_poly_set_length(gr_poly_t poly, slong len, gr_ctx_t ctx);
 void _gr_poly_normalise(gr_poly_t poly, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_poly_set(gr_poly_t res, const gr_poly_t src, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_set(gr_poly_t res, const gr_poly_t src, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_reverse(gr_ptr res, gr_srcptr poly, slong len, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_reverse(gr_poly_t res, const gr_poly_t poly, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_reverse(gr_ptr res, gr_srcptr poly, slong len, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_reverse(gr_poly_t res, const gr_poly_t poly, slong n, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_poly_truncate(gr_poly_t poly, const gr_poly_t src, slong newlen, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_truncate(gr_poly_t poly, const gr_poly_t src, slong newlen, gr_ctx_t ctx);
 
-GR_POLY_INLINE WARN_UNUSED_RESULT int
+GR_POLY_INLINE FLINT_WARN_UNUSED int
 gr_poly_zero(gr_poly_t poly, gr_ctx_t ctx)
 {
     _gr_poly_set_length(poly, 0, ctx);
     return GR_SUCCESS;
 }
 
-WARN_UNUSED_RESULT int gr_poly_one(gr_poly_t poly, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_neg_one(gr_poly_t poly, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_gen(gr_poly_t poly, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_one(gr_poly_t poly, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_neg_one(gr_poly_t poly, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_gen(gr_poly_t poly, gr_ctx_t ctx);
 
 int gr_poly_write(gr_stream_t out, const gr_poly_t poly, const char * x, gr_ctx_t ctx);
 int gr_poly_print(const gr_poly_t poly, gr_ctx_t ctx);
@@ -88,305 +88,305 @@ truth_t gr_poly_is_one(const gr_poly_t poly, gr_ctx_t ctx);
 truth_t gr_poly_is_gen(const gr_poly_t poly, gr_ctx_t ctx);
 truth_t gr_poly_is_scalar(const gr_poly_t poly, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_poly_set_scalar(gr_poly_t poly, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_set_si(gr_poly_t poly, slong x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_set_ui(gr_poly_t poly, ulong x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_set_fmpz(gr_poly_t poly, const fmpz_t x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_set_fmpq(gr_poly_t poly, const fmpq_t x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_set_scalar(gr_poly_t poly, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_set_si(gr_poly_t poly, slong x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_set_ui(gr_poly_t poly, ulong x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_set_fmpz(gr_poly_t poly, const fmpz_t x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_set_fmpq(gr_poly_t poly, const fmpq_t x, gr_ctx_t ctx);
 
 /* todo: test */
-WARN_UNUSED_RESULT int gr_poly_set_fmpz_poly(gr_poly_t res, const fmpz_poly_t src, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_set_fmpq_poly(gr_poly_t res, const fmpq_poly_t src, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_set_gr_poly_other(gr_poly_t res, const gr_poly_t x, gr_ctx_t x_ctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_set_fmpz_poly(gr_poly_t res, const fmpz_poly_t src, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_set_fmpq_poly(gr_poly_t res, const fmpq_poly_t src, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_set_gr_poly_other(gr_poly_t res, const gr_poly_t x, gr_ctx_t x_ctx, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_poly_set_coeff_scalar(gr_poly_t poly, slong n, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_set_coeff_si(gr_poly_t poly, slong n, slong x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_set_coeff_ui(gr_poly_t poly, slong n, ulong x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_set_coeff_fmpz(gr_poly_t poly, slong n, const fmpz_t x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_set_coeff_fmpq(gr_poly_t poly, slong n, const fmpq_t x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_set_coeff_scalar(gr_poly_t poly, slong n, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_set_coeff_si(gr_poly_t poly, slong n, slong x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_set_coeff_ui(gr_poly_t poly, slong n, ulong x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_set_coeff_fmpz(gr_poly_t poly, slong n, const fmpz_t x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_set_coeff_fmpq(gr_poly_t poly, slong n, const fmpq_t x, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_poly_get_coeff_scalar(gr_ptr res, const gr_poly_t poly, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_get_coeff_scalar(gr_ptr res, const gr_poly_t poly, slong n, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_poly_neg(gr_poly_t res, const gr_poly_t src, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_neg(gr_poly_t res, const gr_poly_t src, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_add(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_add(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_add(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_add(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_sub(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_sub(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_sub(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_sub(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_mul(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_mul(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_mul(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_mul(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_mullow_generic(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, slong n, gr_ctx_t ctx);
-GR_POLY_INLINE WARN_UNUSED_RESULT int _gr_poly_mullow(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, slong len, gr_ctx_t ctx) { return GR_POLY_BINARY_TRUNC_OP(ctx, POLY_MULLOW)(res, poly1, len1, poly2, len2, len, ctx); }
-WARN_UNUSED_RESULT int gr_poly_mullow(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_mul_scalar(gr_poly_t res, const gr_poly_t poly, gr_srcptr c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_mullow_generic(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, slong n, gr_ctx_t ctx);
+GR_POLY_INLINE FLINT_WARN_UNUSED int _gr_poly_mullow(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, slong len, gr_ctx_t ctx) { return GR_POLY_BINARY_TRUNC_OP(ctx, POLY_MULLOW)(res, poly1, len1, poly2, len2, len, ctx); }
+FLINT_WARN_UNUSED int gr_poly_mullow(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_mul_scalar(gr_poly_t res, const gr_poly_t poly, gr_srcptr c, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_mul_karatsuba(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_mul_karatsuba(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_mul_karatsuba(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_mul_karatsuba(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, gr_ctx_t ctx);
 
 
 /* powering */
 
-WARN_UNUSED_RESULT int _gr_poly_pow_series_ui_binexp(gr_ptr res, gr_srcptr f, slong flen, ulong exp, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_pow_series_ui_binexp(gr_poly_t res, const gr_poly_t poly, ulong exp, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_pow_series_ui_binexp(gr_ptr res, gr_srcptr f, slong flen, ulong exp, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_pow_series_ui_binexp(gr_poly_t res, const gr_poly_t poly, ulong exp, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_pow_series_ui(gr_ptr res, gr_srcptr f, slong flen, ulong exp, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_pow_series_ui(gr_poly_t res, const gr_poly_t poly, ulong exp, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_pow_series_ui(gr_ptr res, gr_srcptr f, slong flen, ulong exp, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_pow_series_ui(gr_poly_t res, const gr_poly_t poly, ulong exp, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_pow_ui_binexp(gr_ptr res, gr_srcptr f, slong flen, ulong exp, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_pow_ui_binexp(gr_poly_t res, const gr_poly_t poly, ulong exp, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_pow_ui_binexp(gr_ptr res, gr_srcptr f, slong flen, ulong exp, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_pow_ui_binexp(gr_poly_t res, const gr_poly_t poly, ulong exp, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_pow_ui(gr_ptr res, gr_srcptr f, slong flen, ulong exp, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_pow_ui(gr_poly_t res, const gr_poly_t poly, ulong exp, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_pow_ui(gr_ptr res, gr_srcptr f, slong flen, ulong exp, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_pow_ui(gr_poly_t res, const gr_poly_t poly, ulong exp, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_poly_pow_fmpz(gr_poly_t res, const gr_poly_t poly, const fmpz_t exp, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_pow_fmpz(gr_poly_t res, const gr_poly_t poly, const fmpz_t exp, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_pow_series_fmpq_recurrence(gr_ptr h, gr_srcptr f, slong flen, const fmpq_t exp, slong len, int precomp, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_pow_series_fmpq_recurrence(gr_poly_t res, const gr_poly_t poly, const fmpq_t exp, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_pow_series_fmpq_recurrence(gr_ptr h, gr_srcptr f, slong flen, const fmpq_t exp, slong len, int precomp, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_pow_series_fmpq_recurrence(gr_poly_t res, const gr_poly_t poly, const fmpq_t exp, slong len, gr_ctx_t ctx);
 
 /* shifting */
 
-WARN_UNUSED_RESULT int _gr_poly_shift_left(gr_ptr res, gr_srcptr poly, slong len, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_shift_left(gr_poly_t res, const gr_poly_t poly, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_shift_right(gr_ptr res, gr_srcptr poly, slong len, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_shift_right(gr_poly_t res, const gr_poly_t poly, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_shift_left(gr_ptr res, gr_srcptr poly, slong len, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_shift_left(gr_poly_t res, const gr_poly_t poly, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_shift_right(gr_ptr res, gr_srcptr poly, slong len, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_shift_right(gr_poly_t res, const gr_poly_t poly, slong n, gr_ctx_t ctx);
 
 /* division */
 
-WARN_UNUSED_RESULT int gr_poly_div_scalar(gr_poly_t res, const gr_poly_t poly, gr_srcptr c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_div_scalar(gr_poly_t res, const gr_poly_t poly, gr_srcptr c, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_poly_inv(gr_poly_t res, const gr_poly_t poly, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_inv(gr_poly_t res, const gr_poly_t poly, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_divrem_basecase_preinv1(gr_ptr Q, gr_ptr R, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_srcptr invB, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_divrem_basecase_noinv(gr_ptr Q, gr_ptr R, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_divrem_basecase(gr_ptr Q, gr_ptr R, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_divrem_basecase(gr_poly_t Q, gr_poly_t R, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_divrem_basecase_preinv1(gr_ptr Q, gr_ptr R, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_srcptr invB, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_divrem_basecase_noinv(gr_ptr Q, gr_ptr R, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_divrem_basecase(gr_ptr Q, gr_ptr R, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_divrem_basecase(gr_poly_t Q, gr_poly_t R, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_divrem_divconquer_preinv1(gr_ptr Q, gr_ptr R, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_srcptr invB, slong cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_divrem_divconquer_noinv(gr_ptr Q, gr_ptr R, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, slong cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_divrem_divconquer(gr_ptr Q, gr_ptr R, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, slong cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_divrem_divconquer(gr_poly_t Q, gr_poly_t R, const gr_poly_t A, const gr_poly_t B, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_divrem_divconquer_preinv1(gr_ptr Q, gr_ptr R, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_srcptr invB, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_divrem_divconquer_noinv(gr_ptr Q, gr_ptr R, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_divrem_divconquer(gr_ptr Q, gr_ptr R, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_divrem_divconquer(gr_poly_t Q, gr_poly_t R, const gr_poly_t A, const gr_poly_t B, slong cutoff, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_divrem_newton(gr_ptr Q, gr_ptr R, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_divrem_newton(gr_poly_t Q, gr_poly_t R, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_divrem_newton(gr_ptr Q, gr_ptr R, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_divrem_newton(gr_poly_t Q, gr_poly_t R, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
 
-GR_POLY_INLINE WARN_UNUSED_RESULT int _gr_poly_divrem(gr_ptr Q, gr_ptr R, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx) { return GR_POLY_BINARY_BINARY_OP(ctx, POLY_DIVREM)(Q, R, A, lenA, B, lenB, ctx); }
-WARN_UNUSED_RESULT int _gr_poly_divrem_generic(gr_ptr Q, gr_ptr R, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_divrem(gr_poly_t Q, gr_poly_t R, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
+GR_POLY_INLINE FLINT_WARN_UNUSED int _gr_poly_divrem(gr_ptr Q, gr_ptr R, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx) { return GR_POLY_BINARY_BINARY_OP(ctx, POLY_DIVREM)(Q, R, A, lenA, B, lenB, ctx); }
+FLINT_WARN_UNUSED int _gr_poly_divrem_generic(gr_ptr Q, gr_ptr R, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_divrem(gr_poly_t Q, gr_poly_t R, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_div_divconquer_preinv1(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_srcptr invB, slong cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_div_divconquer_noinv(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, slong cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_div_divconquer(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, slong cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_div_divconquer(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_div_divconquer_preinv1(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_srcptr invB, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_div_divconquer_noinv(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_div_divconquer(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_div_divconquer(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, slong cutoff, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_div_basecase_preinv1(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_srcptr invB, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_div_basecase_noinv(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_div_basecase(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_div_basecase(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_div_basecase_preinv1(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_srcptr invB, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_div_basecase_noinv(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_div_basecase(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_div_basecase(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_div_newton(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_div_newton(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_div_newton(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_div_newton(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
 
-GR_POLY_INLINE WARN_UNUSED_RESULT int _gr_poly_div(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx) { return GR_POLY_BINARY_OP(ctx, POLY_DIV)(Q, A, lenA, B, lenB, ctx); }
-WARN_UNUSED_RESULT int _gr_poly_div_generic(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_div(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
+GR_POLY_INLINE FLINT_WARN_UNUSED int _gr_poly_div(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx) { return GR_POLY_BINARY_OP(ctx, POLY_DIV)(Q, A, lenA, B, lenB, ctx); }
+FLINT_WARN_UNUSED int _gr_poly_div_generic(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_div(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_rem(gr_ptr R, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_rem(gr_poly_t R, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_rem(gr_ptr R, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_rem(gr_poly_t R, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
 
 
 /* todo: div with fast divisibility checking; rem; divexact */
 
-WARN_UNUSED_RESULT int _gr_poly_inv_series_newton(gr_ptr Qinv, gr_srcptr Q, slong Qlen, slong len, slong cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_inv_series_newton(gr_poly_t Qinv, const gr_poly_t Q, slong len, slong cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_inv_series_basecase_preinv1(gr_ptr res, gr_srcptr A, slong Alen, gr_srcptr Ainv, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_inv_series_basecase_generic(gr_ptr Qinv, gr_srcptr Q, slong Qlen, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_inv_series_basecase(gr_poly_t Qinv, const gr_poly_t Q, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_inv_series_newton(gr_ptr Qinv, gr_srcptr Q, slong Qlen, slong len, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_inv_series_newton(gr_poly_t Qinv, const gr_poly_t Q, slong len, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_inv_series_basecase_preinv1(gr_ptr res, gr_srcptr A, slong Alen, gr_srcptr Ainv, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_inv_series_basecase_generic(gr_ptr Qinv, gr_srcptr Q, slong Qlen, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_inv_series_basecase(gr_poly_t Qinv, const gr_poly_t Q, slong len, gr_ctx_t ctx);
 
-GR_POLY_INLINE WARN_UNUSED_RESULT int _gr_poly_inv_series_basecase(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx) { return GR_POLY_UNARY_TRUNC_OP(ctx, POLY_INV_SERIES_BASECASE)(res, f, flen, len, ctx); }
-GR_POLY_INLINE WARN_UNUSED_RESULT int _gr_poly_inv_series(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx) { return GR_POLY_UNARY_TRUNC_OP(ctx, POLY_INV_SERIES)(res, f, flen, len, ctx); }
+GR_POLY_INLINE FLINT_WARN_UNUSED int _gr_poly_inv_series_basecase(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx) { return GR_POLY_UNARY_TRUNC_OP(ctx, POLY_INV_SERIES_BASECASE)(res, f, flen, len, ctx); }
+GR_POLY_INLINE FLINT_WARN_UNUSED int _gr_poly_inv_series(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx) { return GR_POLY_UNARY_TRUNC_OP(ctx, POLY_INV_SERIES)(res, f, flen, len, ctx); }
 
-WARN_UNUSED_RESULT int _gr_poly_inv_series_generic(gr_ptr Qinv, gr_srcptr Q, slong Qlen, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_inv_series(gr_poly_t Qinv, const gr_poly_t Q, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_inv_series_generic(gr_ptr Qinv, gr_srcptr Q, slong Qlen, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_inv_series(gr_poly_t Qinv, const gr_poly_t Q, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_div_series_newton(gr_ptr res, gr_srcptr B, slong Blen, gr_srcptr A, slong Alen, slong len, slong cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_div_series_newton(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, slong len, slong cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_div_series_divconquer(gr_ptr res, gr_srcptr B, slong Blen, gr_srcptr A, slong Alen, slong len, slong cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_div_series_divconquer(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, slong len, slong cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_div_series_basecase_generic(gr_ptr Q, gr_srcptr A, slong Alen, gr_srcptr B, slong Blen, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_div_series_basecase(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_div_series_basecase_preinv1(gr_ptr Q, gr_srcptr A, slong Alen, gr_srcptr B, slong Blen, gr_srcptr Binv, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_div_series_basecase_noinv(gr_ptr Q, gr_srcptr A, slong Alen, gr_srcptr B, slong Blen, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_div_series_invmul(gr_ptr Q, gr_srcptr A, slong Alen, gr_srcptr B, slong Blen, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_div_series_invmul(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_div_series_newton(gr_ptr res, gr_srcptr B, slong Blen, gr_srcptr A, slong Alen, slong len, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_div_series_newton(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, slong len, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_div_series_divconquer(gr_ptr res, gr_srcptr B, slong Blen, gr_srcptr A, slong Alen, slong len, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_div_series_divconquer(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, slong len, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_div_series_basecase_generic(gr_ptr Q, gr_srcptr A, slong Alen, gr_srcptr B, slong Blen, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_div_series_basecase(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_div_series_basecase_preinv1(gr_ptr Q, gr_srcptr A, slong Alen, gr_srcptr B, slong Blen, gr_srcptr Binv, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_div_series_basecase_noinv(gr_ptr Q, gr_srcptr A, slong Alen, gr_srcptr B, slong Blen, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_div_series_invmul(gr_ptr Q, gr_srcptr A, slong Alen, gr_srcptr B, slong Blen, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_div_series_invmul(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, slong len, gr_ctx_t ctx);
 
-GR_POLY_INLINE WARN_UNUSED_RESULT int _gr_poly_div_series_basecase(gr_ptr res, gr_srcptr f, slong flen, gr_srcptr g, slong glen, slong len, gr_ctx_t ctx) { return GR_POLY_BINARY_TRUNC_OP(ctx, POLY_DIV_SERIES_BASECASE)(res, f, flen, g, glen, len, ctx); }
-GR_POLY_INLINE WARN_UNUSED_RESULT int _gr_poly_div_series(gr_ptr res, gr_srcptr f, slong flen, gr_srcptr g, slong glen, slong len, gr_ctx_t ctx) { return GR_POLY_BINARY_TRUNC_OP(ctx, POLY_DIV_SERIES)(res, f, flen, g, glen, len, ctx); }
+GR_POLY_INLINE FLINT_WARN_UNUSED int _gr_poly_div_series_basecase(gr_ptr res, gr_srcptr f, slong flen, gr_srcptr g, slong glen, slong len, gr_ctx_t ctx) { return GR_POLY_BINARY_TRUNC_OP(ctx, POLY_DIV_SERIES_BASECASE)(res, f, flen, g, glen, len, ctx); }
+GR_POLY_INLINE FLINT_WARN_UNUSED int _gr_poly_div_series(gr_ptr res, gr_srcptr f, slong flen, gr_srcptr g, slong glen, slong len, gr_ctx_t ctx) { return GR_POLY_BINARY_TRUNC_OP(ctx, POLY_DIV_SERIES)(res, f, flen, g, glen, len, ctx); }
 
-WARN_UNUSED_RESULT int _gr_poly_div_series_generic(gr_ptr Q, gr_srcptr A, slong Alen, gr_srcptr B, slong Blen, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_div_series(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_div_series_generic(gr_ptr Q, gr_srcptr A, slong Alen, gr_srcptr B, slong Blen, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_div_series(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_divexact_basecase_bidirectional(gr_ptr Q, gr_srcptr A, slong Alen, gr_srcptr B, slong Blen, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_divexact_basecase_bidirectional(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_divexact_bidirectional(gr_ptr Q, gr_srcptr A, slong Alen, gr_srcptr B, slong Blen, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_divexact_bidirectional(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_divexact_basecase_noinv(gr_ptr Q, gr_srcptr A, slong Alen, gr_srcptr B, slong Blen, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_divexact_basecase(gr_ptr Q, gr_srcptr A, slong Alen, gr_srcptr B, slong Blen, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_divexact_basecase(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_divexact_basecase_bidirectional(gr_ptr Q, gr_srcptr A, slong Alen, gr_srcptr B, slong Blen, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_divexact_basecase_bidirectional(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_divexact_bidirectional(gr_ptr Q, gr_srcptr A, slong Alen, gr_srcptr B, slong Blen, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_divexact_bidirectional(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_divexact_basecase_noinv(gr_ptr Q, gr_srcptr A, slong Alen, gr_srcptr B, slong Blen, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_divexact_basecase(gr_ptr Q, gr_srcptr A, slong Alen, gr_srcptr B, slong Blen, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_divexact_basecase(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
 
-GR_POLY_INLINE WARN_UNUSED_RESULT int _gr_poly_divexact(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx) { return GR_POLY_BINARY_OP(ctx, POLY_DIVEXACT)(Q, A, lenA, B, lenB, ctx); }
-WARN_UNUSED_RESULT int _gr_poly_divexact_generic(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_divexact(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
+GR_POLY_INLINE FLINT_WARN_UNUSED int _gr_poly_divexact(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx) { return GR_POLY_BINARY_OP(ctx, POLY_DIVEXACT)(Q, A, lenA, B, lenB, ctx); }
+FLINT_WARN_UNUSED int _gr_poly_divexact_generic(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_divexact(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
 
 
-WARN_UNUSED_RESULT int _gr_poly_divexact_series_basecase_noinv(gr_ptr Q, gr_srcptr A, slong Alen, gr_srcptr B, slong Blen, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_divexact_series_basecase(gr_ptr Q, gr_srcptr A, slong Alen, gr_srcptr B, slong Blen, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_divexact_series_basecase(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_divexact_series_basecase_noinv(gr_ptr Q, gr_srcptr A, slong Alen, gr_srcptr B, slong Blen, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_divexact_series_basecase(gr_ptr Q, gr_srcptr A, slong Alen, gr_srcptr B, slong Blen, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_divexact_series_basecase(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_sqrt_series_newton(gr_ptr res, gr_srcptr f, slong flen, slong len, slong cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_sqrt_series_newton(gr_poly_t res, const gr_poly_t f, slong len, slong cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_sqrt_series_basecase(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_sqrt_series_basecase(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_sqrt_series_miller(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_sqrt_series_miller(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
-GR_POLY_INLINE WARN_UNUSED_RESULT int _gr_poly_sqrt_series(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx) { return GR_POLY_UNARY_TRUNC_OP(ctx, POLY_SQRT_SERIES)(res, f, flen, len, ctx); }
-WARN_UNUSED_RESULT int _gr_poly_sqrt_series_generic(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_sqrt_series(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_sqrt_series_newton(gr_ptr res, gr_srcptr f, slong flen, slong len, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_sqrt_series_newton(gr_poly_t res, const gr_poly_t f, slong len, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_sqrt_series_basecase(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_sqrt_series_basecase(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_sqrt_series_miller(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_sqrt_series_miller(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
+GR_POLY_INLINE FLINT_WARN_UNUSED int _gr_poly_sqrt_series(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx) { return GR_POLY_UNARY_TRUNC_OP(ctx, POLY_SQRT_SERIES)(res, f, flen, len, ctx); }
+FLINT_WARN_UNUSED int _gr_poly_sqrt_series_generic(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_sqrt_series(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_rsqrt_series_newton(gr_ptr res, gr_srcptr f, slong flen, slong len, slong cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_rsqrt_series_newton(gr_poly_t res, const gr_poly_t f, slong len, slong cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_rsqrt_series_basecase(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_rsqrt_series_basecase(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_rsqrt_series_miller(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_rsqrt_series_miller(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
-GR_POLY_INLINE WARN_UNUSED_RESULT int _gr_poly_rsqrt_series(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx) { return GR_POLY_UNARY_TRUNC_OP(ctx, POLY_RSQRT_SERIES)(res, f, flen, len, ctx); }
-WARN_UNUSED_RESULT int _gr_poly_rsqrt_series_generic(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_rsqrt_series(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_rsqrt_series_newton(gr_ptr res, gr_srcptr f, slong flen, slong len, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_rsqrt_series_newton(gr_poly_t res, const gr_poly_t f, slong len, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_rsqrt_series_basecase(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_rsqrt_series_basecase(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_rsqrt_series_miller(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_rsqrt_series_miller(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
+GR_POLY_INLINE FLINT_WARN_UNUSED int _gr_poly_rsqrt_series(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx) { return GR_POLY_UNARY_TRUNC_OP(ctx, POLY_RSQRT_SERIES)(res, f, flen, len, ctx); }
+FLINT_WARN_UNUSED int _gr_poly_rsqrt_series_generic(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_rsqrt_series(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_evaluate_rectangular(gr_ptr res, gr_srcptr poly, slong len, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_evaluate_rectangular(gr_ptr res, const gr_poly_t poly, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_evaluate_rectangular(gr_ptr res, gr_srcptr poly, slong len, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_evaluate_rectangular(gr_ptr res, const gr_poly_t poly, gr_srcptr x, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_evaluate_modular(gr_ptr res, gr_srcptr poly, slong len, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_evaluate_modular(gr_ptr res, const gr_poly_t poly, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_evaluate_modular(gr_ptr res, gr_srcptr poly, slong len, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_evaluate_modular(gr_ptr res, const gr_poly_t poly, gr_srcptr x, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_evaluate_horner(gr_ptr res, gr_srcptr poly, slong len, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_evaluate_horner(gr_ptr res, const gr_poly_t poly, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_evaluate_horner(gr_ptr res, gr_srcptr poly, slong len, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_evaluate_horner(gr_ptr res, const gr_poly_t poly, gr_srcptr x, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_evaluate(gr_ptr res, gr_srcptr poly, slong len, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_evaluate(gr_ptr res, const gr_poly_t poly, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_evaluate(gr_ptr res, gr_srcptr poly, slong len, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_evaluate(gr_ptr res, const gr_poly_t poly, gr_srcptr x, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_evaluate_other_horner(gr_ptr res, gr_srcptr f, slong len, const gr_srcptr x, gr_ctx_t x_ctx, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_evaluate_other_horner(gr_ptr res, const gr_poly_t f, gr_srcptr a, gr_ctx_t a_ctx, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_evaluate_other_rectangular(gr_ptr res, gr_srcptr f, slong len, const gr_srcptr x, gr_ctx_t x_ctx, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_evaluate_other_rectangular(gr_ptr res, const gr_poly_t f, gr_srcptr a, gr_ctx_t a_ctx, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_evaluate_other(gr_ptr res, gr_srcptr f, slong len, const gr_srcptr x, gr_ctx_t x_ctx, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_evaluate_other(gr_ptr res, const gr_poly_t f, gr_srcptr a, gr_ctx_t a_ctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_evaluate_other_horner(gr_ptr res, gr_srcptr f, slong len, const gr_srcptr x, gr_ctx_t x_ctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_evaluate_other_horner(gr_ptr res, const gr_poly_t f, gr_srcptr a, gr_ctx_t a_ctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_evaluate_other_rectangular(gr_ptr res, gr_srcptr f, slong len, const gr_srcptr x, gr_ctx_t x_ctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_evaluate_other_rectangular(gr_ptr res, const gr_poly_t f, gr_srcptr a, gr_ctx_t a_ctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_evaluate_other(gr_ptr res, gr_srcptr f, slong len, const gr_srcptr x, gr_ctx_t x_ctx, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_evaluate_other(gr_ptr res, const gr_poly_t f, gr_srcptr a, gr_ctx_t a_ctx, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_taylor_shift_horner(gr_ptr res, gr_srcptr poly, slong len, gr_srcptr c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_taylor_shift_horner(gr_poly_t res, const gr_poly_t f, gr_srcptr c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_taylor_shift_divconquer(gr_ptr res, gr_srcptr poly, slong len, gr_srcptr c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_taylor_shift_divconquer(gr_poly_t res, const gr_poly_t f, gr_srcptr c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_taylor_shift_convolution(gr_ptr res, gr_srcptr poly, slong len, gr_srcptr c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_taylor_shift_convolution(gr_poly_t res, const gr_poly_t f, gr_srcptr c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_taylor_shift_generic(gr_ptr res, gr_srcptr poly, slong len, gr_srcptr c, gr_ctx_t ctx);
-GR_POLY_INLINE WARN_UNUSED_RESULT int _gr_poly_taylor_shift(gr_ptr res, gr_srcptr f, slong len, gr_srcptr c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP(ctx, POLY_TAYLOR_SHIFT)(res, f, len, c, ctx); }
-WARN_UNUSED_RESULT int _gr_poly_taylor_shift(gr_ptr res, gr_srcptr poly, slong len, gr_srcptr c, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_taylor_shift(gr_poly_t res, const gr_poly_t f, gr_srcptr c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_taylor_shift_horner(gr_ptr res, gr_srcptr poly, slong len, gr_srcptr c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_taylor_shift_horner(gr_poly_t res, const gr_poly_t f, gr_srcptr c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_taylor_shift_divconquer(gr_ptr res, gr_srcptr poly, slong len, gr_srcptr c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_taylor_shift_divconquer(gr_poly_t res, const gr_poly_t f, gr_srcptr c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_taylor_shift_convolution(gr_ptr res, gr_srcptr poly, slong len, gr_srcptr c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_taylor_shift_convolution(gr_poly_t res, const gr_poly_t f, gr_srcptr c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_taylor_shift_generic(gr_ptr res, gr_srcptr poly, slong len, gr_srcptr c, gr_ctx_t ctx);
+GR_POLY_INLINE FLINT_WARN_UNUSED int _gr_poly_taylor_shift(gr_ptr res, gr_srcptr f, slong len, gr_srcptr c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP(ctx, POLY_TAYLOR_SHIFT)(res, f, len, c, ctx); }
+FLINT_WARN_UNUSED int _gr_poly_taylor_shift(gr_ptr res, gr_srcptr poly, slong len, gr_srcptr c, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_taylor_shift(gr_poly_t res, const gr_poly_t f, gr_srcptr c, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_compose_horner(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_compose_horner(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_compose_divconquer(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_compose_divconquer(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_compose(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_compose(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_compose_horner(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_compose_horner(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_compose_divconquer(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_compose_divconquer(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_compose(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_compose(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_compose_series_horner(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_compose_series_horner(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_compose_series_brent_kung(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_compose_series_brent_kung(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_compose_series_divconquer(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_compose_series_divconquer(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_compose_series(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_compose_series(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_compose_series_horner(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_compose_series_horner(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_compose_series_brent_kung(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_compose_series_brent_kung(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_compose_series_divconquer(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_compose_series_divconquer(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_compose_series(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_compose_series(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, slong n, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_revert_series_lagrange(gr_ptr res, gr_srcptr f, slong flen, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_revert_series_lagrange(gr_poly_t res, const gr_poly_t f, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_revert_series_lagrange_fast(gr_ptr res, gr_srcptr f, slong flen, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_revert_series_lagrange_fast(gr_poly_t res, const gr_poly_t f, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_revert_series_newton(gr_ptr res, gr_srcptr f, slong flen, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_revert_series_newton(gr_poly_t res, const gr_poly_t f, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_revert_series(gr_ptr res, gr_srcptr f, slong flen, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_revert_series(gr_poly_t res, const gr_poly_t f, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_revert_series_lagrange(gr_ptr res, gr_srcptr f, slong flen, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_revert_series_lagrange(gr_poly_t res, const gr_poly_t f, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_revert_series_lagrange_fast(gr_ptr res, gr_srcptr f, slong flen, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_revert_series_lagrange_fast(gr_poly_t res, const gr_poly_t f, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_revert_series_newton(gr_ptr res, gr_srcptr f, slong flen, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_revert_series_newton(gr_poly_t res, const gr_poly_t f, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_revert_series(gr_ptr res, gr_srcptr f, slong flen, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_revert_series(gr_poly_t res, const gr_poly_t f, slong n, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_derivative(gr_ptr res, gr_srcptr poly, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_derivative(gr_poly_t res, const gr_poly_t poly, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_derivative(gr_ptr res, gr_srcptr poly, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_derivative(gr_poly_t res, const gr_poly_t poly, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_nth_derivative(gr_ptr res, gr_srcptr poly, ulong n, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_nth_derivative(gr_poly_t res, const gr_poly_t poly, ulong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_nth_derivative(gr_ptr res, gr_srcptr poly, ulong n, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_nth_derivative(gr_poly_t res, const gr_poly_t poly, ulong n, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_integral(gr_ptr res, gr_srcptr poly, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_integral(gr_poly_t res, const gr_poly_t poly, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_integral(gr_ptr res, gr_srcptr poly, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_integral(gr_poly_t res, const gr_poly_t poly, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_make_monic(gr_ptr res, gr_srcptr poly, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_make_monic(gr_poly_t res, const gr_poly_t src, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_make_monic(gr_ptr res, gr_srcptr poly, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_make_monic(gr_poly_t res, const gr_poly_t src, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT truth_t _gr_poly_is_monic(gr_srcptr poly, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT truth_t gr_poly_is_monic(const gr_poly_t res, gr_ctx_t ctx);
+FLINT_WARN_UNUSED truth_t _gr_poly_is_monic(gr_srcptr poly, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED truth_t gr_poly_is_monic(const gr_poly_t res, gr_ctx_t ctx);
 
 /* GCD, resultant */
 
-WARN_UNUSED_RESULT int _gr_poly_hgcd(gr_ptr r, slong * sgn, gr_ptr * M, slong * lenM, gr_ptr A, slong * lenA, gr_ptr B, slong * lenB, gr_srcptr a, slong lena, gr_srcptr b, slong lenb, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_hgcd(gr_ptr r, slong * sgn, gr_ptr * M, slong * lenM, gr_ptr A, slong * lenA, gr_ptr B, slong * lenB, gr_srcptr a, slong lena, gr_srcptr b, slong lenb, slong cutoff, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_gcd_hgcd(gr_ptr G, slong * _lenG, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, slong inner_cutoff, slong cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_gcd_hgcd(gr_poly_t G, const gr_poly_t A, const gr_poly_t B, slong inner_cutoff, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_gcd_hgcd(gr_ptr G, slong * _lenG, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, slong inner_cutoff, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_gcd_hgcd(gr_poly_t G, const gr_poly_t A, const gr_poly_t B, slong inner_cutoff, slong cutoff, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_gcd_euclidean(gr_ptr G, slong * lenG, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_gcd_euclidean(gr_poly_t G, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_gcd_generic(gr_ptr G, slong * lenG, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
-GR_POLY_INLINE WARN_UNUSED_RESULT int _gr_poly_gcd(gr_ptr G, slong * lenG, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx) { return GR_POLY_GCD_OP(ctx, POLY_GCD)(G, lenG, A, lenA, B, lenB, ctx); }
-WARN_UNUSED_RESULT int gr_poly_gcd(gr_poly_t G, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_gcd_euclidean(gr_ptr G, slong * lenG, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_gcd_euclidean(gr_poly_t G, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_gcd_generic(gr_ptr G, slong * lenG, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
+GR_POLY_INLINE FLINT_WARN_UNUSED int _gr_poly_gcd(gr_ptr G, slong * lenG, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx) { return GR_POLY_GCD_OP(ctx, POLY_GCD)(G, lenG, A, lenA, B, lenB, ctx); }
+FLINT_WARN_UNUSED int gr_poly_gcd(gr_poly_t G, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_xgcd_euclidean(slong * lenG, gr_ptr G, gr_ptr S, gr_ptr T, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_xgcd_euclidean(gr_poly_t G, gr_poly_t S, gr_poly_t T, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_xgcd_euclidean(slong * lenG, gr_ptr G, gr_ptr S, gr_ptr T, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_xgcd_euclidean(gr_poly_t G, gr_poly_t S, gr_poly_t T, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_xgcd_hgcd(slong * Glen, gr_ptr G, gr_ptr S, gr_ptr T, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, slong hgcd_cutoff, slong cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_xgcd_hgcd(gr_poly_t G, gr_poly_t S, gr_poly_t T, const gr_poly_t A, const gr_poly_t B, slong hgcd_cutoff, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_xgcd_hgcd(slong * Glen, gr_ptr G, gr_ptr S, gr_ptr T, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, slong hgcd_cutoff, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_xgcd_hgcd(gr_poly_t G, gr_poly_t S, gr_poly_t T, const gr_poly_t A, const gr_poly_t B, slong hgcd_cutoff, slong cutoff, gr_ctx_t ctx);
 
-GR_POLY_INLINE WARN_UNUSED_RESULT int _gr_poly_xgcd(slong * Glen, gr_ptr G, gr_ptr S, gr_ptr T, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx) { return GR_POLY_XGCD_OP(ctx, POLY_XGCD)(Glen, G, S, T, A, lenA, B, lenB, ctx); }
-WARN_UNUSED_RESULT int _gr_poly_xgcd_generic(slong * Glen, gr_ptr G, gr_ptr S, gr_ptr T, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_xgcd_wrapper(gr_method_poly_xgcd_op _xgcd_op, gr_poly_t G, gr_poly_t S, gr_poly_t T, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_xgcd(gr_poly_t G, gr_poly_t S, gr_poly_t T, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
+GR_POLY_INLINE FLINT_WARN_UNUSED int _gr_poly_xgcd(slong * Glen, gr_ptr G, gr_ptr S, gr_ptr T, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx) { return GR_POLY_XGCD_OP(ctx, POLY_XGCD)(Glen, G, S, T, A, lenA, B, lenB, ctx); }
+FLINT_WARN_UNUSED int _gr_poly_xgcd_generic(slong * Glen, gr_ptr G, gr_ptr S, gr_ptr T, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_xgcd_wrapper(gr_method_poly_xgcd_op _xgcd_op, gr_poly_t G, gr_poly_t S, gr_poly_t T, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_xgcd(gr_poly_t G, gr_poly_t S, gr_poly_t T, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_resultant_euclidean(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_resultant_euclidean(gr_ptr r, const gr_poly_t f, const gr_poly_t g, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_resultant_euclidean(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_resultant_euclidean(gr_ptr r, const gr_poly_t f, const gr_poly_t g, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_resultant_hgcd(gr_ptr res, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, slong inner_cutoff, slong cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_resultant_hgcd(gr_ptr r, const gr_poly_t f, const gr_poly_t g, slong inner_cutoff, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_resultant_hgcd(gr_ptr res, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, slong inner_cutoff, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_resultant_hgcd(gr_ptr r, const gr_poly_t f, const gr_poly_t g, slong inner_cutoff, slong cutoff, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_resultant_sylvester(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_resultant_sylvester(gr_ptr r, const gr_poly_t f, const gr_poly_t g, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_resultant_sylvester(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_resultant_sylvester(gr_ptr r, const gr_poly_t f, const gr_poly_t g, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_resultant_small(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_resultant_small(gr_ptr r, const gr_poly_t f, const gr_poly_t g, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_resultant_small(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_resultant_small(gr_ptr r, const gr_poly_t f, const gr_poly_t g, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_resultant(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_resultant(gr_ptr r, const gr_poly_t f, const gr_poly_t g, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_resultant(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_resultant(gr_ptr r, const gr_poly_t f, const gr_poly_t g, gr_ctx_t ctx);
 
 /* Multipoint evaluation/interpolation */
 
 gr_ptr * _gr_poly_tree_alloc(slong len, gr_ctx_t ctx);
 void _gr_poly_tree_free(gr_ptr * tree, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_tree_build(gr_ptr * tree, gr_srcptr roots, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_tree_build(gr_ptr * tree, gr_srcptr roots, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_evaluate_vec_fast_precomp(gr_ptr vs, gr_srcptr poly, slong plen, gr_ptr * tree, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_evaluate_vec_fast_precomp(gr_ptr vs, gr_srcptr poly, slong plen, gr_ptr * tree, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_evaluate_vec_fast(gr_ptr ys, gr_srcptr poly, slong plen, gr_srcptr xs, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_evaluate_vec_fast(gr_vec_t ys, const gr_poly_t poly, const gr_vec_t xs, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_evaluate_vec_fast(gr_ptr ys, gr_srcptr poly, slong plen, gr_srcptr xs, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_evaluate_vec_fast(gr_vec_t ys, const gr_poly_t poly, const gr_vec_t xs, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_evaluate_vec_iter(gr_ptr ys, gr_srcptr poly, slong plen, gr_srcptr xs, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_evaluate_vec_iter(gr_vec_t ys, const gr_poly_t poly, const gr_vec_t xs, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_evaluate_vec_iter(gr_ptr ys, gr_srcptr poly, slong plen, gr_srcptr xs, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_evaluate_vec_iter(gr_vec_t ys, const gr_poly_t poly, const gr_vec_t xs, gr_ctx_t ctx);
 
 /* Squarefree factorization */
 
@@ -397,51 +397,51 @@ int gr_poly_squarefree_part(gr_poly_t res, const gr_poly_t poly, gr_ctx_t ctx);
 
 typedef int ((*gr_poly_roots_op)(gr_vec_t, gr_vec_t, const gr_poly_t, int, gr_ctx_ptr));
 #define GR_POLY_ROOTS_OP(ctx, NAME) (((gr_poly_roots_op *) ctx->methods)[GR_METHOD_ ## NAME])
-GR_POLY_INLINE WARN_UNUSED_RESULT int gr_poly_roots(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, int flags, gr_ctx_t ctx) { return GR_POLY_ROOTS_OP(ctx, POLY_ROOTS)(roots, mult, poly, flags, ctx); }
+GR_POLY_INLINE FLINT_WARN_UNUSED int gr_poly_roots(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, int flags, gr_ctx_t ctx) { return GR_POLY_ROOTS_OP(ctx, POLY_ROOTS)(roots, mult, poly, flags, ctx); }
 
 typedef int ((*gr_poly_roots_op_other)(gr_vec_t, gr_vec_t, const gr_poly_t, gr_ctx_ptr, int, gr_ctx_ptr));
 #define GR_POLY_ROOTS_OP_OTHER(ctx, NAME) (((gr_poly_roots_op_other *) ctx->methods)[GR_METHOD_ ## NAME])
-GR_POLY_INLINE WARN_UNUSED_RESULT int gr_poly_roots_other(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, gr_ctx_t poly_ctx, int flags, gr_ctx_t ctx) { return GR_POLY_ROOTS_OP_OTHER(ctx, POLY_ROOTS_OTHER)(roots, mult, poly, poly_ctx, flags, ctx); }
+GR_POLY_INLINE FLINT_WARN_UNUSED int gr_poly_roots_other(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, gr_ctx_t poly_ctx, int flags, gr_ctx_t ctx) { return GR_POLY_ROOTS_OP_OTHER(ctx, POLY_ROOTS_OTHER)(roots, mult, poly, poly_ctx, flags, ctx); }
 
-WARN_UNUSED_RESULT int _gr_poly_asin_series(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_asin_series(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_asinh_series(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_asinh_series(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_acos_series(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_acos_series(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_acosh_series(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_acosh_series(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_atan_series(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_atan_series(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_atanh_series(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_atanh_series(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_asin_series(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_asin_series(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_asinh_series(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_asinh_series(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_acos_series(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_acos_series(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_acosh_series(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_acosh_series(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_atan_series(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_atan_series(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_atanh_series(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_atanh_series(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_log_series(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_log_series(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_log1p_series(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_log1p_series(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_log_series(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_log_series(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_log1p_series(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_log1p_series(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_exp_series_basecase(gr_ptr f, gr_srcptr h, slong hlen, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_exp_series_basecase(gr_poly_t f, const gr_poly_t h, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_exp_series_basecase_mul(gr_ptr f, gr_srcptr h, slong hlen, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_exp_series_basecase_mul(gr_poly_t f, const gr_poly_t h, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_exp_series_newton(gr_ptr f, gr_ptr g, gr_srcptr h, slong hlen, slong n, slong cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_exp_series_newton(gr_poly_t f, const gr_poly_t h, slong n, slong cutoff, gr_ctx_t ctx);
-GR_POLY_INLINE WARN_UNUSED_RESULT int _gr_poly_exp_series(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx) { return GR_POLY_UNARY_TRUNC_OP(ctx, POLY_EXP_SERIES)(res, f, flen, len, ctx); }
-WARN_UNUSED_RESULT int _gr_poly_exp_series_generic(gr_ptr f, gr_srcptr h, slong hlen, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_exp_series(gr_poly_t f, const gr_poly_t h, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_exp_series_basecase(gr_ptr f, gr_srcptr h, slong hlen, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_exp_series_basecase(gr_poly_t f, const gr_poly_t h, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_exp_series_basecase_mul(gr_ptr f, gr_srcptr h, slong hlen, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_exp_series_basecase_mul(gr_poly_t f, const gr_poly_t h, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_exp_series_newton(gr_ptr f, gr_ptr g, gr_srcptr h, slong hlen, slong n, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_exp_series_newton(gr_poly_t f, const gr_poly_t h, slong n, slong cutoff, gr_ctx_t ctx);
+GR_POLY_INLINE FLINT_WARN_UNUSED int _gr_poly_exp_series(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx) { return GR_POLY_UNARY_TRUNC_OP(ctx, POLY_EXP_SERIES)(res, f, flen, len, ctx); }
+FLINT_WARN_UNUSED int _gr_poly_exp_series_generic(gr_ptr f, gr_srcptr h, slong hlen, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_exp_series(gr_poly_t f, const gr_poly_t h, slong n, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_sin_cos_series_basecase(gr_ptr s, gr_ptr c, gr_srcptr h, slong hlen, slong n, int times_pi, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_sin_cos_series_basecase(gr_poly_t s, gr_poly_t c, const gr_poly_t h, slong n, int times_pi, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_sin_cos_series_tangent(gr_ptr s, gr_ptr c, gr_srcptr h, slong hlen, slong n, int times_pi, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_sin_cos_series_tangent(gr_poly_t s, gr_poly_t c, const gr_poly_t h, slong n, int times_pi, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_sin_cos_series_basecase(gr_ptr s, gr_ptr c, gr_srcptr h, slong hlen, slong n, int times_pi, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_sin_cos_series_basecase(gr_poly_t s, gr_poly_t c, const gr_poly_t h, slong n, int times_pi, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_sin_cos_series_tangent(gr_ptr s, gr_ptr c, gr_srcptr h, slong hlen, slong n, int times_pi, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_sin_cos_series_tangent(gr_poly_t s, gr_poly_t c, const gr_poly_t h, slong n, int times_pi, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_tan_series_basecase(gr_ptr f, gr_srcptr h, slong hlen, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_tan_series_basecase(gr_poly_t f, const gr_poly_t h, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_tan_series_newton(gr_ptr f, gr_srcptr h, slong hlen, slong n, slong cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_tan_series_newton(gr_poly_t f, const gr_poly_t h, slong n, slong cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_poly_tan_series(gr_ptr f, gr_srcptr h, slong hlen, slong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_tan_series(gr_poly_t f, const gr_poly_t h, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_tan_series_basecase(gr_ptr f, gr_srcptr h, slong hlen, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_tan_series_basecase(gr_poly_t f, const gr_poly_t h, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_tan_series_newton(gr_ptr f, gr_srcptr h, slong hlen, slong n, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_tan_series_newton(gr_poly_t f, const gr_poly_t h, slong n, slong cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_poly_tan_series(gr_ptr f, gr_srcptr h, slong hlen, slong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_poly_tan_series(gr_poly_t f, const gr_poly_t h, slong n, gr_ctx_t ctx);
 
 /* Test functions */
 

--- a/src/gr_special.h
+++ b/src/gr_special.h
@@ -24,7 +24,7 @@
 extern "C" {
 #endif
 
-#define GR_SPECIAL_DEF GR_SPECIAL_INLINE WARN_UNUSED_RESULT
+#define GR_SPECIAL_DEF GR_SPECIAL_INLINE FLINT_WARN_UNUSED
 
 GR_SPECIAL_DEF int gr_pi(gr_ptr res, gr_ctx_t ctx) { return GR_CONSTANT_OP(ctx, PI)(res, ctx); }
 GR_SPECIAL_DEF int gr_euler(gr_ptr res, gr_ctx_t ctx) { return GR_CONSTANT_OP(ctx, EULER)(res, ctx); }
@@ -252,12 +252,12 @@ GR_SPECIAL_DEF int gr_zeta_nzeros(gr_ptr res, gr_srcptr t, gr_ctx_t ctx) { retur
 
 #ifdef DIRICHLET_H
 
-WARN_UNUSED_RESULT int gr_dirichlet_chi_fmpz(gr_ptr res, const dirichlet_group_t G, const dirichlet_char_t chi, const fmpz_t n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_dirichlet_chi_vec(gr_ptr res, const dirichlet_group_t G, const dirichlet_char_t chi, slong len, gr_ctx_t ctx);  /* todo: wrap, test */
-WARN_UNUSED_RESULT int gr_dirichlet_l(gr_ptr res, const dirichlet_group_t G, const dirichlet_char_t chi, gr_srcptr s, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_dirichlet_l_all(gr_vec_t res, const dirichlet_group_t G, gr_srcptr s, gr_ctx_t ctx);  /* todo: wrap, test */
-WARN_UNUSED_RESULT int gr_dirichlet_hardy_theta(gr_ptr res, const dirichlet_group_t G, const dirichlet_char_t chi, gr_srcptr t, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_dirichlet_hardy_z(gr_ptr res, const dirichlet_group_t G, const dirichlet_char_t chi, gr_srcptr t, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_dirichlet_chi_fmpz(gr_ptr res, const dirichlet_group_t G, const dirichlet_char_t chi, const fmpz_t n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_dirichlet_chi_vec(gr_ptr res, const dirichlet_group_t G, const dirichlet_char_t chi, slong len, gr_ctx_t ctx);  /* todo: wrap, test */
+FLINT_WARN_UNUSED int gr_dirichlet_l(gr_ptr res, const dirichlet_group_t G, const dirichlet_char_t chi, gr_srcptr s, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_dirichlet_l_all(gr_vec_t res, const dirichlet_group_t G, gr_srcptr s, gr_ctx_t ctx);  /* todo: wrap, test */
+FLINT_WARN_UNUSED int gr_dirichlet_hardy_theta(gr_ptr res, const dirichlet_group_t G, const dirichlet_char_t chi, gr_srcptr t, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_dirichlet_hardy_z(gr_ptr res, const dirichlet_group_t G, const dirichlet_char_t chi, gr_srcptr t, gr_ctx_t ctx);
 
 #endif
 
@@ -332,80 +332,80 @@ GR_SPECIAL_DEF int gr_weierstrass_sigma(gr_ptr res, gr_srcptr z, gr_srcptr tau, 
 
 /* generic implementations */
 
-WARN_UNUSED_RESULT int gr_generic_exp(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_expm1(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_exp2(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_exp10(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_log(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_log1p(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_log2(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_log10(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_sin(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_cos(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_sin_cos(gr_ptr res1, gr_ptr res2, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_tan(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_asin(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_asinh(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_atan(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_atanh(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_exp(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_expm1(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_exp2(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_exp10(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_log(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_log1p(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_log2(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_log10(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_sin(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_cos(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_sin_cos(gr_ptr res1, gr_ptr res2, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_tan(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_asin(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_asinh(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_atan(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_atanh(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_acot(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_asec(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_acsc(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_acoth(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_asech(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_acsch(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_acot(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_asec(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_acsc(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_acoth(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_asech(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_acsch(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_fac(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_fac_fmpz(gr_ptr res, const fmpz_t n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_fac_ui(gr_ptr res, ulong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_fac_vec(gr_ptr res, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_fac(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_fac_fmpz(gr_ptr res, const fmpz_t n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_fac_ui(gr_ptr res, ulong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_fac_vec(gr_ptr res, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_rfac(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_rfac_fmpz(gr_ptr res, const fmpz_t n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_rfac_ui(gr_ptr res, ulong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_rfac_vec(gr_ptr res, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_rfac(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_rfac_fmpz(gr_ptr res, const fmpz_t n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_rfac_ui(gr_ptr res, ulong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_rfac_vec(gr_ptr res, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_rising(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_rising_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_falling(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_falling_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_rising(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_rising_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_falling(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_falling_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_bin(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_bin_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_bin_uiui(gr_ptr res, ulong x, ulong y, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_bin_vec(gr_ptr res, gr_srcptr x, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_bin_ui_vec(gr_ptr res, ulong x, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_bin(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_bin_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_bin_uiui(gr_ptr res, ulong x, ulong y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_bin_vec(gr_ptr res, gr_srcptr x, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_bin_ui_vec(gr_ptr res, ulong x, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_doublefac(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_doublefac_ui(gr_ptr res, ulong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_doublefac(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_doublefac_ui(gr_ptr res, ulong n, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_harmonic(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_harmonic_ui(gr_ptr res, ulong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_harmonic(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_harmonic_ui(gr_ptr res, ulong n, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_beta(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_beta(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_fib2_fmpz(gr_ptr v, gr_ptr u, const fmpz_t n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_fib_fmpz(gr_ptr res, const fmpz_t n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_fib_ui(gr_ptr res, ulong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_fib_vec(gr_ptr res, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_fib2_fmpz(gr_ptr v, gr_ptr u, const fmpz_t n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_fib_fmpz(gr_ptr res, const fmpz_t n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_fib_ui(gr_ptr res, ulong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_fib_vec(gr_ptr res, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_bellnum_fmpz(gr_ptr res, const fmpz_t n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_bellnum_ui(gr_ptr res, ulong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_bellnum_vec(gr_ptr res, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_bellnum_fmpz(gr_ptr res, const fmpz_t n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_bellnum_ui(gr_ptr res, ulong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_bellnum_vec(gr_ptr res, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_partitions_fmpz(gr_ptr res, const fmpz_t n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_partitions_ui(gr_ptr res, ulong n, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_partitions_vec(gr_ptr res, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_partitions_fmpz(gr_ptr res, const fmpz_t n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_partitions_ui(gr_ptr res, ulong n, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_partitions_vec(gr_ptr res, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_chebyshev_t2_fmpz(gr_ptr a, gr_ptr b, const fmpz_t n, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_chebyshev_t_fmpz(gr_ptr y, const fmpz_t n, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_chebyshev_u2_fmpz(gr_ptr a, gr_ptr b, const fmpz_t n, gr_srcptr x, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_generic_chebyshev_u_fmpz(gr_ptr y, const fmpz_t n, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_chebyshev_t2_fmpz(gr_ptr a, gr_ptr b, const fmpz_t n, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_chebyshev_t_fmpz(gr_ptr y, const fmpz_t n, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_chebyshev_u2_fmpz(gr_ptr a, gr_ptr b, const fmpz_t n, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_chebyshev_u_fmpz(gr_ptr y, const fmpz_t n, gr_srcptr x, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_erfcx(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_erfcx(gr_ptr res, gr_srcptr x, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_hilbert_class_poly(gr_ptr res, slong D, gr_srcptr x, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_generic_hilbert_class_poly(gr_ptr res, slong D, gr_srcptr x, gr_ctx_t ctx);
 
 #ifdef __cplusplus
 }

--- a/src/gr_special.h
+++ b/src/gr_special.h
@@ -250,15 +250,13 @@ GR_SPECIAL_DEF int gr_zeta_nzeros(gr_ptr res, gr_srcptr t, gr_ctx_t ctx) { retur
 
 /* todo: backlund_s, etc */
 
-#ifdef DIRICHLET_H
-
+#if defined(DIRICHLET_H)
 FLINT_WARN_UNUSED int gr_dirichlet_chi_fmpz(gr_ptr res, const dirichlet_group_t G, const dirichlet_char_t chi, const fmpz_t n, gr_ctx_t ctx);
 FLINT_WARN_UNUSED int gr_dirichlet_chi_vec(gr_ptr res, const dirichlet_group_t G, const dirichlet_char_t chi, slong len, gr_ctx_t ctx);  /* todo: wrap, test */
 FLINT_WARN_UNUSED int gr_dirichlet_l(gr_ptr res, const dirichlet_group_t G, const dirichlet_char_t chi, gr_srcptr s, gr_ctx_t ctx);
 FLINT_WARN_UNUSED int gr_dirichlet_l_all(gr_vec_t res, const dirichlet_group_t G, gr_srcptr s, gr_ctx_t ctx);  /* todo: wrap, test */
 FLINT_WARN_UNUSED int gr_dirichlet_hardy_theta(gr_ptr res, const dirichlet_group_t G, const dirichlet_char_t chi, gr_srcptr t, gr_ctx_t ctx);
 FLINT_WARN_UNUSED int gr_dirichlet_hardy_z(gr_ptr res, const dirichlet_group_t G, const dirichlet_char_t chi, gr_srcptr t, gr_ctx_t ctx);
-
 #endif
 
 GR_SPECIAL_DEF int gr_jacobi_theta(gr_ptr res1, gr_ptr res2, gr_ptr res3, gr_ptr res4, gr_srcptr z, gr_srcptr tau, gr_ctx_t ctx) { return GR_QUATERNARY_BINARY_OP(ctx, JACOBI_THETA)(res1, res2, res3, res4, z, tau, ctx); }

--- a/src/gr_special.h
+++ b/src/gr_special.h
@@ -21,7 +21,7 @@
 #include "gr.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 #define GR_SPECIAL_DEF GR_SPECIAL_INLINE WARN_UNUSED_RESULT

--- a/src/gr_types.h
+++ b/src/gr_types.h
@@ -1,0 +1,170 @@
+/*
+    Copyright (C) 2024 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef GR_TYPES_H
+#define GR_TYPES_H
+
+#include "flint.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* truth *********************************************************************/
+
+typedef enum
+{
+    T_TRUE,
+    T_FALSE,
+    T_UNKNOWN
+}
+truth_t;
+
+/* function ******************************************************************/
+
+typedef int (* gr_funcptr)(void);
+
+/* streams *******************************************************************/
+
+typedef struct
+{
+    FLINT_FILE * fp;
+    char * s;
+    slong len;
+    slong alloc;
+}
+gr_stream_struct;
+
+typedef gr_stream_struct gr_stream_t[1];
+
+/* general contexts **********************************************************/
+
+typedef void * gr_ctx_ptr;
+
+/* large enough to hold any context data we want to store inline */
+#define GR_CTX_STRUCT_DATA_BYTES (6 * sizeof(ulong))
+
+typedef struct
+{
+    char data[GR_CTX_STRUCT_DATA_BYTES];
+    ulong which_ring;
+    slong sizeof_elem;
+    gr_funcptr * methods;
+    ulong size_limit;
+}
+gr_ctx_struct;
+
+typedef gr_ctx_struct gr_ctx_t[1];
+
+/* general elements **********************************************************/
+
+typedef void * gr_ptr;
+typedef const void * gr_srcptr;
+
+typedef struct
+{
+    gr_ptr entries;
+    slong alloc;
+    slong length;
+}
+gr_vec_struct;
+
+typedef gr_vec_struct gr_vec_t[1];
+
+/* identifications of structures *********************************************/
+
+typedef enum
+{
+    GR_CTX_FMPZ, GR_CTX_FMPQ, GR_CTX_FMPZI,
+    GR_CTX_FMPZ_MOD, GR_CTX_NMOD, GR_CTX_NMOD8, GR_CTX_NMOD32, GR_CTX_MPN_MOD,
+    GR_CTX_FQ, GR_CTX_FQ_NMOD, GR_CTX_FQ_ZECH,
+    GR_CTX_NF,
+    GR_CTX_REAL_ALGEBRAIC_QQBAR, GR_CTX_COMPLEX_ALGEBRAIC_QQBAR,
+    GR_CTX_REAL_ALGEBRAIC_CA, GR_CTX_COMPLEX_ALGEBRAIC_CA,
+    GR_CTX_RR_CA, GR_CTX_CC_CA,
+    GR_CTX_COMPLEX_EXTENDED_CA,
+    GR_CTX_RR_ARB, GR_CTX_CC_ACB,
+    GR_CTX_REAL_FLOAT_ARF, GR_CTX_COMPLEX_FLOAT_ACF,
+    GR_CTX_FMPZ_POLY, GR_CTX_FMPQ_POLY, GR_CTX_GR_POLY,
+    GR_CTX_FMPZ_MPOLY, GR_CTX_GR_MPOLY,
+    GR_CTX_FMPZ_MPOLY_Q,
+    GR_CTX_GR_SERIES, GR_CTX_SERIES_MOD_GR_POLY,
+    GR_CTX_GR_MAT,
+    GR_CTX_GR_VEC,
+    GR_CTX_PSL2Z, GR_CTX_DIRICHLET_GROUP, GR_CTX_PERM,
+    GR_CTX_FEXPR,
+    GR_CTX_UNKNOWN_DOMAIN,
+    GR_CTX_WHICH_STRUCTURE_TAB_SIZE
+}
+gr_which_structure;
+
+/* vector context ************************************************************/
+
+typedef struct
+{
+    gr_ctx_struct * base_ring;
+    int all_sizes;
+    slong n;
+}
+vector_ctx_t;
+
+/* matrix context ************************************************************/
+
+typedef struct
+{
+    gr_ctx_struct * base_ring;
+    int all_sizes;
+    slong nrows;
+    slong ncols;
+}
+matrix_ctx_t;
+
+/* polynomial context ********************************************************/
+
+typedef struct
+{
+    gr_ctx_struct * base_ring;
+    slong degree_limit;
+    char * var;
+}
+polynomial_ctx_t;
+
+/* series context ************************************************************/
+
+typedef struct
+{
+    gr_ctx_struct * base_ring;
+    slong n;
+    char * var;
+}
+series_mod_ctx_t;
+
+typedef struct
+{
+    slong prec;     /* default approximate truncation */
+}
+gr_series_ctx_struct;
+
+typedef gr_series_ctx_struct gr_series_ctx_t[1];
+
+typedef struct
+{
+    gr_ctx_struct * base_ring;
+    gr_series_ctx_struct sctx;
+    char * var;
+}
+series_ctx_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GR_TYPES_H */

--- a/src/gr_types.h
+++ b/src/gr_types.h
@@ -200,6 +200,10 @@ gr_mpoly_struct;
 
 typedef gr_mpoly_struct gr_mpoly_t[1];
 
+/* widely used macros ********************************************************/
+
+#define GR_ENTRY(vec, i, size) ((void *) (((char *) (vec)) + ((i) * (size))))
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/gr_types.h
+++ b/src/gr_types.h
@@ -213,6 +213,9 @@ typedef gr_mpoly_struct gr_mpoly_t[1];
 
 #define GR_CTX_DATA_AS_PTR(ctx) (*(void **) (&(ctx)->data))
 
+#define GR_MUST_SUCCEED(expr) do { if ((expr) != GR_SUCCESS) { flint_throw(FLINT_ERROR, "GR_MUST_SUCCEED failure: %s", __FILE__); } } while (0)
+#define GR_IGNORE(expr) do { int ___unused = (expr); (void) ___unused; } while (0)
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/gr_types.h
+++ b/src/gr_types.h
@@ -18,6 +18,13 @@
 extern "C" {
 #endif
 
+/* constants *****************************************************************/
+
+#define GR_SUCCESS 0
+#define GR_DOMAIN 1
+#define GR_UNABLE 2
+#define GR_TEST_FAIL 4
+
 /* truth *********************************************************************/
 
 typedef enum

--- a/src/gr_types.h
+++ b/src/gr_types.h
@@ -116,7 +116,18 @@ typedef struct
 }
 vector_ctx_t;
 
-/* matrix context ************************************************************/
+/* matrices ******************************************************************/
+
+typedef struct
+{
+    gr_ptr entries;
+    slong r;
+    slong c;
+    gr_ptr * rows;
+}
+gr_mat_struct;
+
+typedef gr_mat_struct gr_mat_t[1];
 
 typedef struct
 {
@@ -127,7 +138,18 @@ typedef struct
 }
 matrix_ctx_t;
 
-/* polynomial context ********************************************************/
+/* polynomials ***************************************************************/
+
+/* fixme: compatible with flint polys but not with arb, ... */
+typedef struct
+{
+    gr_ptr coeffs;
+    slong alloc;
+    slong length;
+}
+gr_poly_struct;
+
+typedef gr_poly_struct gr_poly_t[1];
 
 typedef struct
 {
@@ -162,6 +184,21 @@ typedef struct
     char * var;
 }
 series_ctx_t;
+
+/* multivariate polynomials **************************************************/
+
+typedef struct
+{
+    gr_ptr coeffs;
+    ulong * exps;
+    slong length;
+    flint_bitcnt_t bits;    /* number of bits per exponent */
+    slong coeffs_alloc;     /* abs size in mp_limb_t units */
+    slong exps_alloc;       /* abs size in ulong units */
+}
+gr_mpoly_struct;
+
+typedef gr_mpoly_struct gr_mpoly_t[1];
 
 #ifdef __cplusplus
 }

--- a/src/gr_types.h
+++ b/src/gr_types.h
@@ -211,6 +211,8 @@ typedef gr_mpoly_struct gr_mpoly_t[1];
 
 #define GR_ENTRY(vec, i, size) ((void *) (((char *) (vec)) + ((i) * (size))))
 
+#define GR_CTX_DATA_AS_PTR(ctx) (*(void **) (&(ctx)->data))
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/gr_vec.h
+++ b/src/gr_vec.h
@@ -21,7 +21,7 @@
 #include "gr.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 void gr_vec_init(gr_vec_t vec, slong len, gr_ctx_t ctx);

--- a/src/gr_vec.h
+++ b/src/gr_vec.h
@@ -18,7 +18,7 @@
 #define GR_VEC_INLINE static inline
 #endif
 
-#include "gr.h"
+#include "gr_types.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -49,109 +49,109 @@ GR_VEC_INLINE slong gr_vec_length(const gr_vec_t vec, gr_ctx_t FLINT_UNUSED(ctx)
 
 void gr_vec_fit_length(gr_vec_t vec, slong len, gr_ctx_t ctx);
 void gr_vec_set_length(gr_vec_t vec, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_vec_set(gr_vec_t res, const gr_vec_t src, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_vec_append(gr_vec_t vec, gr_srcptr f, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_vec_set(gr_vec_t res, const gr_vec_t src, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int gr_vec_append(gr_vec_t vec, gr_srcptr f, gr_ctx_t ctx);
 
 int _gr_vec_write(gr_stream_t out, gr_srcptr vec, slong len, gr_ctx_t ctx);
 int gr_vec_write(gr_stream_t out, const gr_vec_t vec, gr_ctx_t ctx);
 int _gr_vec_print(gr_srcptr vec, slong len, gr_ctx_t ctx);
 int gr_vec_print(const gr_vec_t vec, gr_ctx_t ctx);
 
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_zero(gr_ptr vec, slong len, gr_ctx_t ctx) { return GR_VEC_CONSTANT_OP(ctx, VEC_ZERO)(vec, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_set(gr_ptr res, gr_srcptr src, slong len, gr_ctx_t ctx) { return GR_VEC_OP(ctx, VEC_SET)(res, src, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_neg(gr_ptr res, gr_srcptr src, slong len, gr_ctx_t ctx) { return GR_VEC_OP(ctx, VEC_NEG)(res, src, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_zero(gr_ptr vec, slong len, gr_ctx_t ctx) { return GR_VEC_CONSTANT_OP(ctx, VEC_ZERO)(vec, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_set(gr_ptr res, gr_srcptr src, slong len, gr_ctx_t ctx) { return GR_VEC_OP(ctx, VEC_SET)(res, src, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_neg(gr_ptr res, gr_srcptr src, slong len, gr_ctx_t ctx) { return GR_VEC_OP(ctx, VEC_NEG)(res, src, len, ctx); }
 
 typedef int ((*gr_method_vec_normalise_op)(slong *, gr_srcptr, slong, gr_ctx_ptr));
 typedef slong ((*gr_method_vec_normalise_weak_op)(gr_srcptr, slong, gr_ctx_ptr));
 #define GR_VEC_NORMALISE_OP(ctx, NAME) (((gr_method_vec_normalise_op *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_VEC_NORMALISE_WEAK_OP(ctx, NAME) (((gr_method_vec_normalise_weak_op *) ctx->methods)[GR_METHOD_ ## NAME])
 
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_normalise(slong * res, gr_srcptr vec, slong len, gr_ctx_t ctx) { return GR_VEC_NORMALISE_OP(ctx, VEC_NORMALISE)(res, vec, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT slong _gr_vec_normalise_weak(gr_srcptr vec, slong len, gr_ctx_t ctx) { return GR_VEC_NORMALISE_WEAK_OP(ctx, VEC_NORMALISE_WEAK)(vec, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_normalise(slong * res, gr_srcptr vec, slong len, gr_ctx_t ctx) { return GR_VEC_NORMALISE_OP(ctx, VEC_NORMALISE)(res, vec, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED slong _gr_vec_normalise_weak(gr_srcptr vec, slong len, gr_ctx_t ctx) { return GR_VEC_NORMALISE_WEAK_OP(ctx, VEC_NORMALISE_WEAK)(vec, len, ctx); }
 
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_add(gr_ptr res, gr_srcptr src1, gr_srcptr src2, slong len, gr_ctx_t ctx) { return GR_VEC_VEC_OP(ctx, VEC_ADD)(res, src1, src2, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_sub(gr_ptr res, gr_srcptr src1, gr_srcptr src2, slong len, gr_ctx_t ctx) { return GR_VEC_VEC_OP(ctx, VEC_SUB)(res, src1, src2, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_mul(gr_ptr res, gr_srcptr src1, gr_srcptr src2, slong len, gr_ctx_t ctx) { return GR_VEC_VEC_OP(ctx, VEC_MUL)(res, src1, src2, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_div(gr_ptr res, gr_srcptr src1, gr_srcptr src2, slong len, gr_ctx_t ctx) { return GR_VEC_VEC_OP(ctx, VEC_DIV)(res, src1, src2, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_divexact(gr_ptr res, gr_srcptr src1, gr_srcptr src2, slong len, gr_ctx_t ctx) { return GR_VEC_VEC_OP(ctx, VEC_DIVEXACT)(res, src1, src2, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_pow(gr_ptr res, gr_srcptr src1, gr_srcptr src2, slong len, gr_ctx_t ctx) { return GR_VEC_VEC_OP(ctx, VEC_POW)(res, src1, src2, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_add(gr_ptr res, gr_srcptr src1, gr_srcptr src2, slong len, gr_ctx_t ctx) { return GR_VEC_VEC_OP(ctx, VEC_ADD)(res, src1, src2, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_sub(gr_ptr res, gr_srcptr src1, gr_srcptr src2, slong len, gr_ctx_t ctx) { return GR_VEC_VEC_OP(ctx, VEC_SUB)(res, src1, src2, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_mul(gr_ptr res, gr_srcptr src1, gr_srcptr src2, slong len, gr_ctx_t ctx) { return GR_VEC_VEC_OP(ctx, VEC_MUL)(res, src1, src2, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_div(gr_ptr res, gr_srcptr src1, gr_srcptr src2, slong len, gr_ctx_t ctx) { return GR_VEC_VEC_OP(ctx, VEC_DIV)(res, src1, src2, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_divexact(gr_ptr res, gr_srcptr src1, gr_srcptr src2, slong len, gr_ctx_t ctx) { return GR_VEC_VEC_OP(ctx, VEC_DIVEXACT)(res, src1, src2, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_pow(gr_ptr res, gr_srcptr src1, gr_srcptr src2, slong len, gr_ctx_t ctx) { return GR_VEC_VEC_OP(ctx, VEC_POW)(res, src1, src2, len, ctx); }
 
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_add_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP(ctx, VEC_ADD_SCALAR)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_sub_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP(ctx, VEC_SUB_SCALAR)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_mul_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP(ctx, VEC_MUL_SCALAR)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_div_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP(ctx, VEC_DIV_SCALAR)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_divexact_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP(ctx, VEC_DIVEXACT_SCALAR)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_pow_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP(ctx, VEC_POW_SCALAR)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_add_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP(ctx, VEC_ADD_SCALAR)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_sub_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP(ctx, VEC_SUB_SCALAR)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_mul_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP(ctx, VEC_MUL_SCALAR)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_div_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP(ctx, VEC_DIV_SCALAR)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_divexact_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP(ctx, VEC_DIVEXACT_SCALAR)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_pow_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP(ctx, VEC_POW_SCALAR)(vec1, vec2, len, c, ctx); }
 
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_add_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_SI(ctx, VEC_ADD_SCALAR_SI)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_sub_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_SI(ctx, VEC_SUB_SCALAR_SI)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_mul_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_SI(ctx, VEC_MUL_SCALAR_SI)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_div_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_SI(ctx, VEC_DIV_SCALAR_SI)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_divexact_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_SI(ctx, VEC_DIVEXACT_SCALAR_SI)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_pow_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_SI(ctx, VEC_POW_SCALAR_SI)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_add_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_SI(ctx, VEC_ADD_SCALAR_SI)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_sub_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_SI(ctx, VEC_SUB_SCALAR_SI)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_mul_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_SI(ctx, VEC_MUL_SCALAR_SI)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_div_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_SI(ctx, VEC_DIV_SCALAR_SI)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_divexact_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_SI(ctx, VEC_DIVEXACT_SCALAR_SI)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_pow_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_SI(ctx, VEC_POW_SCALAR_SI)(vec1, vec2, len, c, ctx); }
 
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_add_scalar_ui(gr_ptr vec1, gr_srcptr vec2, slong len, ulong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_UI(ctx, VEC_ADD_SCALAR_UI)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_sub_scalar_ui(gr_ptr vec1, gr_srcptr vec2, slong len, ulong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_UI(ctx, VEC_SUB_SCALAR_UI)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_mul_scalar_ui(gr_ptr vec1, gr_srcptr vec2, slong len, ulong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_UI(ctx, VEC_MUL_SCALAR_UI)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_div_scalar_ui(gr_ptr vec1, gr_srcptr vec2, slong len, ulong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_UI(ctx, VEC_DIV_SCALAR_UI)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_divexact_scalar_ui(gr_ptr vec1, gr_srcptr vec2, slong len, ulong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_UI(ctx, VEC_DIVEXACT_SCALAR_UI)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_pow_scalar_ui(gr_ptr vec1, gr_srcptr vec2, slong len, ulong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_UI(ctx, VEC_POW_SCALAR_UI)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_add_scalar_ui(gr_ptr vec1, gr_srcptr vec2, slong len, ulong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_UI(ctx, VEC_ADD_SCALAR_UI)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_sub_scalar_ui(gr_ptr vec1, gr_srcptr vec2, slong len, ulong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_UI(ctx, VEC_SUB_SCALAR_UI)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_mul_scalar_ui(gr_ptr vec1, gr_srcptr vec2, slong len, ulong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_UI(ctx, VEC_MUL_SCALAR_UI)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_div_scalar_ui(gr_ptr vec1, gr_srcptr vec2, slong len, ulong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_UI(ctx, VEC_DIV_SCALAR_UI)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_divexact_scalar_ui(gr_ptr vec1, gr_srcptr vec2, slong len, ulong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_UI(ctx, VEC_DIVEXACT_SCALAR_UI)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_pow_scalar_ui(gr_ptr vec1, gr_srcptr vec2, slong len, ulong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_UI(ctx, VEC_POW_SCALAR_UI)(vec1, vec2, len, c, ctx); }
 
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_add_scalar_fmpz(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpz_t c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_FMPZ(ctx, VEC_ADD_SCALAR_FMPZ)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_sub_scalar_fmpz(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpz_t c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_FMPZ(ctx, VEC_SUB_SCALAR_FMPZ)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_mul_scalar_fmpz(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpz_t c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_FMPZ(ctx, VEC_MUL_SCALAR_FMPZ)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_div_scalar_fmpz(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpz_t c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_FMPZ(ctx, VEC_DIV_SCALAR_FMPZ)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_divexact_scalar_fmpz(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpz_t c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_FMPZ(ctx, VEC_DIVEXACT_SCALAR_FMPZ)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_pow_scalar_fmpz(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpz_t c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_FMPZ(ctx, VEC_POW_SCALAR_FMPZ)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_add_scalar_fmpz(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpz_t c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_FMPZ(ctx, VEC_ADD_SCALAR_FMPZ)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_sub_scalar_fmpz(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpz_t c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_FMPZ(ctx, VEC_SUB_SCALAR_FMPZ)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_mul_scalar_fmpz(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpz_t c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_FMPZ(ctx, VEC_MUL_SCALAR_FMPZ)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_div_scalar_fmpz(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpz_t c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_FMPZ(ctx, VEC_DIV_SCALAR_FMPZ)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_divexact_scalar_fmpz(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpz_t c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_FMPZ(ctx, VEC_DIVEXACT_SCALAR_FMPZ)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_pow_scalar_fmpz(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpz_t c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_FMPZ(ctx, VEC_POW_SCALAR_FMPZ)(vec1, vec2, len, c, ctx); }
 
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_add_scalar_fmpq(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpq_t c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_FMPQ(ctx, VEC_ADD_SCALAR_FMPQ)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_sub_scalar_fmpq(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpq_t c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_FMPQ(ctx, VEC_SUB_SCALAR_FMPQ)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_mul_scalar_fmpq(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpq_t c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_FMPQ(ctx, VEC_MUL_SCALAR_FMPQ)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_div_scalar_fmpq(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpq_t c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_FMPQ(ctx, VEC_DIV_SCALAR_FMPQ)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_divexact_scalar_fmpq(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpq_t c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_FMPQ(ctx, VEC_DIVEXACT_SCALAR_FMPQ)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_pow_scalar_fmpq(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpq_t c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_FMPQ(ctx, VEC_POW_SCALAR_FMPQ)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_add_scalar_fmpq(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpq_t c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_FMPQ(ctx, VEC_ADD_SCALAR_FMPQ)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_sub_scalar_fmpq(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpq_t c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_FMPQ(ctx, VEC_SUB_SCALAR_FMPQ)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_mul_scalar_fmpq(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpq_t c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_FMPQ(ctx, VEC_MUL_SCALAR_FMPQ)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_div_scalar_fmpq(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpq_t c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_FMPQ(ctx, VEC_DIV_SCALAR_FMPQ)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_divexact_scalar_fmpq(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpq_t c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_FMPQ(ctx, VEC_DIVEXACT_SCALAR_FMPQ)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_pow_scalar_fmpq(gr_ptr vec1, gr_srcptr vec2, slong len, const fmpq_t c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_FMPQ(ctx, VEC_POW_SCALAR_FMPQ)(vec1, vec2, len, c, ctx); }
 
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_scalar_add_vec(gr_ptr vec1, gr_srcptr c, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_SCALAR_VEC_OP(ctx, SCALAR_ADD_VEC)(vec1, c, vec2, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_scalar_sub_vec(gr_ptr vec1, gr_srcptr c, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_SCALAR_VEC_OP(ctx, SCALAR_SUB_VEC)(vec1, c, vec2, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_scalar_mul_vec(gr_ptr vec1, gr_srcptr c, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_SCALAR_VEC_OP(ctx, SCALAR_MUL_VEC)(vec1, c, vec2, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_scalar_div_vec(gr_ptr vec1, gr_srcptr c, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_SCALAR_VEC_OP(ctx, SCALAR_DIV_VEC)(vec1, c, vec2, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_scalar_divexact_vec(gr_ptr vec1, gr_srcptr c, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_SCALAR_VEC_OP(ctx, SCALAR_DIVEXACT_VEC)(vec1, c, vec2, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_scalar_pow_vec(gr_ptr vec1, gr_srcptr c, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_SCALAR_VEC_OP(ctx, SCALAR_POW_VEC)(vec1, c, vec2, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_scalar_add_vec(gr_ptr vec1, gr_srcptr c, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_SCALAR_VEC_OP(ctx, SCALAR_ADD_VEC)(vec1, c, vec2, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_scalar_sub_vec(gr_ptr vec1, gr_srcptr c, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_SCALAR_VEC_OP(ctx, SCALAR_SUB_VEC)(vec1, c, vec2, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_scalar_mul_vec(gr_ptr vec1, gr_srcptr c, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_SCALAR_VEC_OP(ctx, SCALAR_MUL_VEC)(vec1, c, vec2, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_scalar_div_vec(gr_ptr vec1, gr_srcptr c, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_SCALAR_VEC_OP(ctx, SCALAR_DIV_VEC)(vec1, c, vec2, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_scalar_divexact_vec(gr_ptr vec1, gr_srcptr c, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_SCALAR_VEC_OP(ctx, SCALAR_DIVEXACT_VEC)(vec1, c, vec2, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_scalar_pow_vec(gr_ptr vec1, gr_srcptr c, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_SCALAR_VEC_OP(ctx, SCALAR_POW_VEC)(vec1, c, vec2, len, ctx); }
 
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_add_other(gr_ptr vec1, gr_srcptr vec2, gr_srcptr vec3, gr_ctx_t ctx3, slong len, gr_ctx_t ctx) { return GR_VEC_OP_OTHER(ctx, VEC_ADD_OTHER)(vec1, vec2, vec3, ctx3, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_sub_other(gr_ptr vec1, gr_srcptr vec2, gr_srcptr vec3, gr_ctx_t ctx3, slong len, gr_ctx_t ctx) { return GR_VEC_OP_OTHER(ctx, VEC_SUB_OTHER)(vec1, vec2, vec3, ctx3, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_mul_other(gr_ptr vec1, gr_srcptr vec2, gr_srcptr vec3, gr_ctx_t ctx3, slong len, gr_ctx_t ctx) { return GR_VEC_OP_OTHER(ctx, VEC_MUL_OTHER)(vec1, vec2, vec3, ctx3, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_div_other(gr_ptr vec1, gr_srcptr vec2, gr_srcptr vec3, gr_ctx_t ctx3, slong len, gr_ctx_t ctx) { return GR_VEC_OP_OTHER(ctx, VEC_DIV_OTHER)(vec1, vec2, vec3, ctx3, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_divexact_other(gr_ptr vec1, gr_srcptr vec2, gr_srcptr vec3, gr_ctx_t ctx3, slong len, gr_ctx_t ctx) { return GR_VEC_OP_OTHER(ctx, VEC_DIVEXACT_OTHER)(vec1, vec2, vec3, ctx3, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_pow_other(gr_ptr vec1, gr_srcptr vec2, gr_srcptr vec3, gr_ctx_t ctx3, slong len, gr_ctx_t ctx) { return GR_VEC_OP_OTHER(ctx, VEC_POW_OTHER)(vec1, vec2, vec3, ctx3, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_add_other(gr_ptr vec1, gr_srcptr vec2, gr_srcptr vec3, gr_ctx_t ctx3, slong len, gr_ctx_t ctx) { return GR_VEC_OP_OTHER(ctx, VEC_ADD_OTHER)(vec1, vec2, vec3, ctx3, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_sub_other(gr_ptr vec1, gr_srcptr vec2, gr_srcptr vec3, gr_ctx_t ctx3, slong len, gr_ctx_t ctx) { return GR_VEC_OP_OTHER(ctx, VEC_SUB_OTHER)(vec1, vec2, vec3, ctx3, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_mul_other(gr_ptr vec1, gr_srcptr vec2, gr_srcptr vec3, gr_ctx_t ctx3, slong len, gr_ctx_t ctx) { return GR_VEC_OP_OTHER(ctx, VEC_MUL_OTHER)(vec1, vec2, vec3, ctx3, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_div_other(gr_ptr vec1, gr_srcptr vec2, gr_srcptr vec3, gr_ctx_t ctx3, slong len, gr_ctx_t ctx) { return GR_VEC_OP_OTHER(ctx, VEC_DIV_OTHER)(vec1, vec2, vec3, ctx3, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_divexact_other(gr_ptr vec1, gr_srcptr vec2, gr_srcptr vec3, gr_ctx_t ctx3, slong len, gr_ctx_t ctx) { return GR_VEC_OP_OTHER(ctx, VEC_DIVEXACT_OTHER)(vec1, vec2, vec3, ctx3, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_pow_other(gr_ptr vec1, gr_srcptr vec2, gr_srcptr vec3, gr_ctx_t ctx3, slong len, gr_ctx_t ctx) { return GR_VEC_OP_OTHER(ctx, VEC_POW_OTHER)(vec1, vec2, vec3, ctx3, len, ctx); }
 
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_other_add_vec(gr_ptr vec1, gr_srcptr vec2, gr_ctx_t ctx2, gr_srcptr vec3, slong len, gr_ctx_t ctx) { return GR_OTHER_OP_VEC(ctx, OTHER_ADD_VEC)(vec1, vec2, ctx2, vec3, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_other_sub_vec(gr_ptr vec1, gr_srcptr vec2, gr_ctx_t ctx2, gr_srcptr vec3, slong len, gr_ctx_t ctx) { return GR_OTHER_OP_VEC(ctx, OTHER_SUB_VEC)(vec1, vec2, ctx2, vec3, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_other_mul_vec(gr_ptr vec1, gr_srcptr vec2, gr_ctx_t ctx2, gr_srcptr vec3, slong len, gr_ctx_t ctx) { return GR_OTHER_OP_VEC(ctx, OTHER_MUL_VEC)(vec1, vec2, ctx2, vec3, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_other_div_vec(gr_ptr vec1, gr_srcptr vec2, gr_ctx_t ctx2, gr_srcptr vec3, slong len, gr_ctx_t ctx) { return GR_OTHER_OP_VEC(ctx, OTHER_DIV_VEC)(vec1, vec2, ctx2, vec3, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_other_divexact_vec(gr_ptr vec1, gr_srcptr vec2, gr_ctx_t ctx2, gr_srcptr vec3, slong len, gr_ctx_t ctx) { return GR_OTHER_OP_VEC(ctx, OTHER_DIVEXACT_VEC)(vec1, vec2, ctx2, vec3, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_other_pow_vec(gr_ptr vec1, gr_srcptr vec2, gr_ctx_t ctx2, gr_srcptr vec3, slong len, gr_ctx_t ctx) { return GR_OTHER_OP_VEC(ctx, OTHER_POW_VEC)(vec1, vec2, ctx2, vec3, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_other_add_vec(gr_ptr vec1, gr_srcptr vec2, gr_ctx_t ctx2, gr_srcptr vec3, slong len, gr_ctx_t ctx) { return GR_OTHER_OP_VEC(ctx, OTHER_ADD_VEC)(vec1, vec2, ctx2, vec3, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_other_sub_vec(gr_ptr vec1, gr_srcptr vec2, gr_ctx_t ctx2, gr_srcptr vec3, slong len, gr_ctx_t ctx) { return GR_OTHER_OP_VEC(ctx, OTHER_SUB_VEC)(vec1, vec2, ctx2, vec3, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_other_mul_vec(gr_ptr vec1, gr_srcptr vec2, gr_ctx_t ctx2, gr_srcptr vec3, slong len, gr_ctx_t ctx) { return GR_OTHER_OP_VEC(ctx, OTHER_MUL_VEC)(vec1, vec2, ctx2, vec3, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_other_div_vec(gr_ptr vec1, gr_srcptr vec2, gr_ctx_t ctx2, gr_srcptr vec3, slong len, gr_ctx_t ctx) { return GR_OTHER_OP_VEC(ctx, OTHER_DIV_VEC)(vec1, vec2, ctx2, vec3, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_other_divexact_vec(gr_ptr vec1, gr_srcptr vec2, gr_ctx_t ctx2, gr_srcptr vec3, slong len, gr_ctx_t ctx) { return GR_OTHER_OP_VEC(ctx, OTHER_DIVEXACT_VEC)(vec1, vec2, ctx2, vec3, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_other_pow_vec(gr_ptr vec1, gr_srcptr vec2, gr_ctx_t ctx2, gr_srcptr vec3, slong len, gr_ctx_t ctx) { return GR_OTHER_OP_VEC(ctx, OTHER_POW_VEC)(vec1, vec2, ctx2, vec3, len, ctx); }
 
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_add_scalar_other(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t cctx, gr_ctx_t ctx) { return GR_VEC_OP_SCALAR_OTHER(ctx, VEC_ADD_SCALAR_OTHER)(vec1, vec2, len, c, cctx, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_sub_scalar_other(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t cctx, gr_ctx_t ctx) { return GR_VEC_OP_SCALAR_OTHER(ctx, VEC_SUB_SCALAR_OTHER)(vec1, vec2, len, c, cctx, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_mul_scalar_other(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t cctx, gr_ctx_t ctx) { return GR_VEC_OP_SCALAR_OTHER(ctx, VEC_MUL_SCALAR_OTHER)(vec1, vec2, len, c, cctx, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_div_scalar_other(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t cctx, gr_ctx_t ctx) { return GR_VEC_OP_SCALAR_OTHER(ctx, VEC_DIV_SCALAR_OTHER)(vec1, vec2, len, c, cctx, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_divexact_scalar_other(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t cctx, gr_ctx_t ctx) { return GR_VEC_OP_SCALAR_OTHER(ctx, VEC_DIVEXACT_SCALAR_OTHER)(vec1, vec2, len, c, cctx, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_pow_scalar_other(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t cctx, gr_ctx_t ctx) { return GR_VEC_OP_SCALAR_OTHER(ctx, VEC_POW_SCALAR_OTHER)(vec1, vec2, len, c, cctx, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_add_scalar_other(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t cctx, gr_ctx_t ctx) { return GR_VEC_OP_SCALAR_OTHER(ctx, VEC_ADD_SCALAR_OTHER)(vec1, vec2, len, c, cctx, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_sub_scalar_other(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t cctx, gr_ctx_t ctx) { return GR_VEC_OP_SCALAR_OTHER(ctx, VEC_SUB_SCALAR_OTHER)(vec1, vec2, len, c, cctx, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_mul_scalar_other(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t cctx, gr_ctx_t ctx) { return GR_VEC_OP_SCALAR_OTHER(ctx, VEC_MUL_SCALAR_OTHER)(vec1, vec2, len, c, cctx, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_div_scalar_other(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t cctx, gr_ctx_t ctx) { return GR_VEC_OP_SCALAR_OTHER(ctx, VEC_DIV_SCALAR_OTHER)(vec1, vec2, len, c, cctx, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_divexact_scalar_other(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t cctx, gr_ctx_t ctx) { return GR_VEC_OP_SCALAR_OTHER(ctx, VEC_DIVEXACT_SCALAR_OTHER)(vec1, vec2, len, c, cctx, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_pow_scalar_other(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t cctx, gr_ctx_t ctx) { return GR_VEC_OP_SCALAR_OTHER(ctx, VEC_POW_SCALAR_OTHER)(vec1, vec2, len, c, cctx, ctx); }
 
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_scalar_other_add_vec(gr_ptr vec1, gr_srcptr c, gr_ctx_t cctx, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_SCALAR_OTHER_OP_VEC(ctx, SCALAR_OTHER_ADD_VEC)(vec1, c, cctx, vec2, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_scalar_other_sub_vec(gr_ptr vec1, gr_srcptr c, gr_ctx_t cctx, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_SCALAR_OTHER_OP_VEC(ctx, SCALAR_OTHER_SUB_VEC)(vec1, c, cctx, vec2, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_scalar_other_mul_vec(gr_ptr vec1, gr_srcptr c, gr_ctx_t cctx, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_SCALAR_OTHER_OP_VEC(ctx, SCALAR_OTHER_MUL_VEC)(vec1, c, cctx, vec2, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_scalar_other_div_vec(gr_ptr vec1, gr_srcptr c, gr_ctx_t cctx, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_SCALAR_OTHER_OP_VEC(ctx, SCALAR_OTHER_DIV_VEC)(vec1, c, cctx, vec2, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_scalar_other_divexact_vec(gr_ptr vec1, gr_srcptr c, gr_ctx_t cctx, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_SCALAR_OTHER_OP_VEC(ctx, SCALAR_OTHER_DIVEXACT_VEC)(vec1, c, cctx, vec2, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_scalar_other_pow_vec(gr_ptr vec1, gr_srcptr c, gr_ctx_t cctx, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_SCALAR_OTHER_OP_VEC(ctx, SCALAR_OTHER_POW_VEC)(vec1, c, cctx, vec2, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_scalar_other_add_vec(gr_ptr vec1, gr_srcptr c, gr_ctx_t cctx, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_SCALAR_OTHER_OP_VEC(ctx, SCALAR_OTHER_ADD_VEC)(vec1, c, cctx, vec2, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_scalar_other_sub_vec(gr_ptr vec1, gr_srcptr c, gr_ctx_t cctx, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_SCALAR_OTHER_OP_VEC(ctx, SCALAR_OTHER_SUB_VEC)(vec1, c, cctx, vec2, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_scalar_other_mul_vec(gr_ptr vec1, gr_srcptr c, gr_ctx_t cctx, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_SCALAR_OTHER_OP_VEC(ctx, SCALAR_OTHER_MUL_VEC)(vec1, c, cctx, vec2, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_scalar_other_div_vec(gr_ptr vec1, gr_srcptr c, gr_ctx_t cctx, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_SCALAR_OTHER_OP_VEC(ctx, SCALAR_OTHER_DIV_VEC)(vec1, c, cctx, vec2, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_scalar_other_divexact_vec(gr_ptr vec1, gr_srcptr c, gr_ctx_t cctx, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_SCALAR_OTHER_OP_VEC(ctx, SCALAR_OTHER_DIVEXACT_VEC)(vec1, c, cctx, vec2, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_scalar_other_pow_vec(gr_ptr vec1, gr_srcptr c, gr_ctx_t cctx, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_SCALAR_OTHER_OP_VEC(ctx, SCALAR_OTHER_POW_VEC)(vec1, c, cctx, vec2, len, ctx); }
 
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_mul_scalar_2exp_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_SI(ctx, VEC_MUL_SCALAR_2EXP_SI)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_mul_scalar_2exp_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_SI(ctx, VEC_MUL_SCALAR_2EXP_SI)(vec1, vec2, len, c, ctx); }
 
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_addmul_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP(ctx, VEC_ADDMUL_SCALAR)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_submul_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP(ctx, VEC_SUBMUL_SCALAR)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_addmul_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_SI(ctx, VEC_ADDMUL_SCALAR_SI)(vec1, vec2, len, c, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_submul_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_SI(ctx, VEC_SUBMUL_SCALAR_SI)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_addmul_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP(ctx, VEC_ADDMUL_SCALAR)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_submul_scalar(gr_ptr vec1, gr_srcptr vec2, slong len, gr_srcptr c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP(ctx, VEC_SUBMUL_SCALAR)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_addmul_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_SI(ctx, VEC_ADDMUL_SCALAR_SI)(vec1, vec2, len, c, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_submul_scalar_si(gr_ptr vec1, gr_srcptr vec2, slong len, slong c, gr_ctx_t ctx) { return GR_VEC_SCALAR_OP_SI(ctx, VEC_SUBMUL_SCALAR_SI)(vec1, vec2, len, c, ctx); }
 
 GR_VEC_INLINE truth_t _gr_vec_equal(gr_srcptr vec1, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_VEC_VEC_PREDICATE(ctx, VEC_EQUAL)(vec1, vec2, len, ctx); }
 GR_VEC_INLINE truth_t _gr_vec_is_zero(gr_srcptr vec, slong len, gr_ctx_t ctx) { return GR_VEC_PREDICATE(ctx, VEC_IS_ZERO)(vec, len, ctx); }
@@ -169,36 +169,36 @@ typedef int ((*gr_method_vec_dot_fmpz_op)(gr_ptr, gr_srcptr, int, gr_srcptr, con
 #define GR_VEC_DOT_UI_OP(ctx, NAME) (((gr_method_vec_dot_ui_op *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_VEC_DOT_FMPZ_OP(ctx, NAME) (((gr_method_vec_dot_fmpz_op *) ctx->methods)[GR_METHOD_ ## NAME])
 
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_sum(gr_ptr res, gr_srcptr vec, slong len, gr_ctx_t ctx) { return GR_VEC_REDUCE_OP(ctx, VEC_SUM)(res, vec, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_product(gr_ptr res, gr_srcptr vec, slong len, gr_ctx_t ctx) { return GR_VEC_REDUCE_OP(ctx, VEC_PRODUCT)(res, vec, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_sum(gr_ptr res, gr_srcptr vec, slong len, gr_ctx_t ctx) { return GR_VEC_REDUCE_OP(ctx, VEC_SUM)(res, vec, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_product(gr_ptr res, gr_srcptr vec, slong len, gr_ctx_t ctx) { return GR_VEC_REDUCE_OP(ctx, VEC_PRODUCT)(res, vec, len, ctx); }
 
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_dot(gr_ptr res, gr_srcptr initial, int subtract, gr_srcptr vec1, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_VEC_DOT_OP(ctx, VEC_DOT)(res, initial, subtract, vec1, vec2, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_dot_rev(gr_ptr res, gr_srcptr initial, int subtract, gr_srcptr vec1, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_VEC_DOT_OP(ctx, VEC_DOT_REV)(res, initial, subtract, vec1, vec2, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_dot_si(gr_ptr res, gr_srcptr initial, int subtract, gr_srcptr vec1, const slong * vec2, slong len, gr_ctx_t ctx) { return GR_VEC_DOT_SI_OP(ctx, VEC_DOT_SI)(res, initial, subtract, vec1, vec2, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_dot_ui(gr_ptr res, gr_srcptr initial, int subtract, gr_srcptr vec1, const ulong * vec2, slong len, gr_ctx_t ctx) { return GR_VEC_DOT_UI_OP(ctx, VEC_DOT_UI)(res, initial, subtract, vec1, vec2, len, ctx); }
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_dot_fmpz(gr_ptr res, gr_srcptr initial, int subtract, gr_srcptr vec1, const fmpz * vec2, slong len, gr_ctx_t ctx) { return GR_VEC_DOT_FMPZ_OP(ctx, VEC_DOT_FMPZ)(res, initial, subtract, vec1, vec2, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_dot(gr_ptr res, gr_srcptr initial, int subtract, gr_srcptr vec1, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_VEC_DOT_OP(ctx, VEC_DOT)(res, initial, subtract, vec1, vec2, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_dot_rev(gr_ptr res, gr_srcptr initial, int subtract, gr_srcptr vec1, gr_srcptr vec2, slong len, gr_ctx_t ctx) { return GR_VEC_DOT_OP(ctx, VEC_DOT_REV)(res, initial, subtract, vec1, vec2, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_dot_si(gr_ptr res, gr_srcptr initial, int subtract, gr_srcptr vec1, const slong * vec2, slong len, gr_ctx_t ctx) { return GR_VEC_DOT_SI_OP(ctx, VEC_DOT_SI)(res, initial, subtract, vec1, vec2, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_dot_ui(gr_ptr res, gr_srcptr initial, int subtract, gr_srcptr vec1, const ulong * vec2, slong len, gr_ctx_t ctx) { return GR_VEC_DOT_UI_OP(ctx, VEC_DOT_UI)(res, initial, subtract, vec1, vec2, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_dot_fmpz(gr_ptr res, gr_srcptr initial, int subtract, gr_srcptr vec1, const fmpz * vec2, slong len, gr_ctx_t ctx) { return GR_VEC_DOT_FMPZ_OP(ctx, VEC_DOT_FMPZ)(res, initial, subtract, vec1, vec2, len, ctx); }
 
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_reciprocals(gr_ptr res, slong len, gr_ctx_t ctx) { return GR_UNARY_OP_SI(ctx, VEC_RECIPROCALS)(res, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_reciprocals(gr_ptr res, slong len, gr_ctx_t ctx) { return GR_UNARY_OP_SI(ctx, VEC_RECIPROCALS)(res, len, ctx); }
 
-GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_set_powers(gr_ptr res, gr_srcptr x, slong len, gr_ctx_t ctx) { return GR_VEC_OP(ctx, VEC_SET_POWERS)(res, x, len, ctx); }
+GR_VEC_INLINE FLINT_WARN_UNUSED int _gr_vec_set_powers(gr_ptr res, gr_srcptr x, slong len, gr_ctx_t ctx) { return GR_VEC_OP(ctx, VEC_SET_POWERS)(res, x, len, ctx); }
 
 /* todo: could allow overloading this as well */
 /* todo: worth warning about unused result? */
-WARN_UNUSED_RESULT int _gr_vec_randtest(gr_ptr res, flint_rand_t state, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_vec_randtest(gr_ptr res, flint_rand_t state, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_vec_sum_bsplit_parallel(gr_ptr res, gr_srcptr vec, slong len, slong basecase_cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_vec_sum_bsplit(gr_ptr res, gr_srcptr vec, slong len, slong basecase_cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_vec_sum_parallel(gr_ptr res, gr_srcptr vec, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_vec_sum_serial(gr_ptr res, gr_srcptr vec, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_vec_sum_generic(gr_ptr res, gr_srcptr vec, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_vec_sum_bsplit_parallel(gr_ptr res, gr_srcptr vec, slong len, slong basecase_cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_vec_sum_bsplit(gr_ptr res, gr_srcptr vec, slong len, slong basecase_cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_vec_sum_parallel(gr_ptr res, gr_srcptr vec, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_vec_sum_serial(gr_ptr res, gr_srcptr vec, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_vec_sum_generic(gr_ptr res, gr_srcptr vec, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_vec_product_bsplit_parallel(gr_ptr res, gr_srcptr vec, slong len, slong basecase_cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_vec_product_bsplit(gr_ptr res, gr_srcptr vec, slong len, slong basecase_cutoff, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_vec_product_parallel(gr_ptr res, gr_srcptr vec, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_vec_product_serial(gr_ptr res, gr_srcptr vec, slong len, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int _gr_vec_product_generic(gr_ptr res, gr_srcptr vec, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_vec_product_bsplit_parallel(gr_ptr res, gr_srcptr vec, slong len, slong basecase_cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_vec_product_bsplit(gr_ptr res, gr_srcptr vec, slong len, slong basecase_cutoff, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_vec_product_parallel(gr_ptr res, gr_srcptr vec, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_vec_product_serial(gr_ptr res, gr_srcptr vec, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_vec_product_generic(gr_ptr res, gr_srcptr vec, slong len, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_vec_step(gr_ptr vec, gr_srcptr start, gr_srcptr step, slong len, gr_ctx_t ctx);
+FLINT_WARN_UNUSED int _gr_vec_step(gr_ptr vec, gr_srcptr start, gr_srcptr step, slong len, gr_ctx_t ctx);
 
 #ifdef __cplusplus
 }

--- a/src/gr_vec.h
+++ b/src/gr_vec.h
@@ -18,7 +18,7 @@
 #define GR_VEC_INLINE static inline
 #endif
 
-#include "gr_types.h"
+#include "gr.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/mpn_mod.h
+++ b/src/mpn_mod.h
@@ -18,11 +18,8 @@
 #define MPN_MOD_INLINE static inline
 #endif
 
-#include "flint.h"
 #include "mpn_extras.h"
-#include "gr.h"
-#include "gr_poly.h"
-#include "gr_mat.h"
+#include "gr_types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/mpn_mod/ctx.c
+++ b/src/mpn_mod/ctx.c
@@ -11,6 +11,7 @@
 
 #include "fmpz.h"
 #include "mpn_mod.h"
+#include "gr.h"
 
 int _mpn_mod_methods_initialized = 0;
 

--- a/src/mpn_mod/mat_det.c
+++ b/src/mpn_mod/mat_det.c
@@ -10,6 +10,7 @@
 */
 
 #include "mpn_mod.h"
+#include "gr_mat.h"
 
 int
 mpn_mod_mat_det(mp_ptr res, const gr_mat_t A, gr_ctx_t ctx)

--- a/src/mpn_mod/mat_lu.c
+++ b/src/mpn_mod/mat_lu.c
@@ -10,6 +10,7 @@
 */
 
 #include "mpn_mod.h"
+#include "gr_mat.h"
 
 /* todo: retune this when arithmetic is more optimized */
 

--- a/src/mpn_mod/mat_mul.c
+++ b/src/mpn_mod/mat_mul.c
@@ -11,6 +11,7 @@
 
 #include "thread_support.h"
 #include "mpn_mod.h"
+#include "gr_mat.h"
 
 /* todo: retune this when arithmetic is more optimized */
 

--- a/src/mpn_mod/mat_mul_multi_mod.c
+++ b/src/mpn_mod/mat_mul_multi_mod.c
@@ -18,6 +18,7 @@
 #include "nmod.h"
 #include "nmod_mat.h"
 #include "mpn_mod.h"
+#include "gr_mat.h"
 
 typedef struct {
     slong m;

--- a/src/mpn_mod/mat_mul_waksman.c
+++ b/src/mpn_mod/mat_mul_waksman.c
@@ -12,6 +12,7 @@
 */
 
 #include "mpn_mod.h"
+#include "gr_mat.h"
 
 /* compute c += (a1 + b1) * (a2 + b2) */
 /* val0, val1, val2 are scratch space */

--- a/src/mpn_mod/mat_nonsingular_solve_tri.c
+++ b/src/mpn_mod/mat_nonsingular_solve_tri.c
@@ -10,6 +10,7 @@
 */
 
 #include "mpn_mod.h"
+#include "gr_mat.h"
 
 static const int mpn_mod_mat_solve_tri_cutoff[MPN_MOD_MAX_LIMBS + 1] =
 {

--- a/src/nf.h
+++ b/src/nf.h
@@ -12,37 +12,13 @@
 #ifndef NF_H
 #define NF_H
 
-#include "fmpz.h"
-#include "fmpz_poly.h"
-#include "fmpq_poly.h"
+#include "nf_types.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-typedef struct {
-   fmpq_poly_t pol;  /* defining polynomial */
-   union {
-      /* insert any precomputed inverse for zz case here */
-      fmpz_preinvn_t qq; /* precomputed inverse for leading coeff of num(pol), QQ case */
-   } pinv;
-   union { /* powers of the generator mod pol */
-      fmpq_poly_powers_precomp_t qq;
-      fmpz_poly_powers_precomp_t zz;
-   } powers;
-   fmpq_poly_t traces; /* S_k = sum_i \theta_i^k for k = 0, 1, 2, ..., (n-1) */
-   ulong flag;       /* 1 = pol monic over ZZ, 2, = linear, 4 = quadratic field */
-} nf_struct;
-
-typedef nf_struct nf_t[1];
-
 #define NF_POWERS_CUTOFF 30 /* maximum length of pol where we precompute powers */
-
-#define NF_GENERIC 0
-#define NF_MONIC 1
-#define NF_LINEAR 2
-#define NF_QUADRATIC 4
-#define NF_GAUSSIAN 8
 
 /******************************************************************************
 

--- a/src/nf.h
+++ b/src/nf.h
@@ -18,8 +18,6 @@
 extern "C" {
 #endif
 
-#define NF_POWERS_CUTOFF 30 /* maximum length of pol where we precompute powers */
-
 /******************************************************************************
 
     Initialisation

--- a/src/nf/clear.c
+++ b/src/nf/clear.c
@@ -11,6 +11,8 @@
 */
 
 #include "fmpz.h"
+#include "fmpz_poly.h"
+#include "fmpq_poly.h"
 #include "nf.h"
 
 void nf_clear(nf_t nf)

--- a/src/nf/init.c
+++ b/src/nf/init.c
@@ -11,6 +11,8 @@
 */
 
 #include "fmpz.h"
+#include "fmpz_poly.h"
+#include "fmpq_poly.h"
 #include "nf.h"
 
 void nf_init(nf_t nf, const fmpq_poly_t pol)

--- a/src/nf/init_randtest.c
+++ b/src/nf/init_randtest.c
@@ -10,6 +10,8 @@
 */
 
 #include "fmpz.h"
+#include "fmpz_poly.h"
+#include "fmpq_poly.h"
 #include "nf.h"
 
 void nf_init_randtest(nf_t nf, flint_rand_t state,

--- a/src/nf/print.c
+++ b/src/nf/print.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpq_poly.h"
 #include "nf.h"
 
 void nf_print(const nf_t nf)

--- a/src/nf/test/t-init_clear.c
+++ b/src/nf/test/t-init_clear.c
@@ -1,6 +1,6 @@
 /*
     Copyright (C) 2013 William Hart
-                  2019 Vincent Delecroix
+    Copyright (C) 2019 Vincent Delecroix
 
     This file is part of FLINT.
 
@@ -11,6 +11,8 @@
 */
 
 #include "test_helpers.h"
+#include "fmpz.h"
+#include "fmpq_poly.h"
 #include "nf.h"
 
 TEST_FUNCTION_START(nf_init_clear, state)

--- a/src/nf_elem.h
+++ b/src/nf_elem.h
@@ -18,39 +18,14 @@
 #define NF_ELEM_INLINE static inline
 #endif
 
-#include "fmpq.h"
-#include "fmpq_types.h"
 #include "fmpz_mod_types.h"
-#include "nf.h"
+#include "fmpq.h"
+#include "fmpq_poly.h"
+#include "nf_types.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
-
-typedef struct /* element of a linear number field */
-{
-   fmpz_t num;
-   fmpz_t den;
-} lnf_elem_struct;
-
-typedef lnf_elem_struct lnf_elem_t[1];
-
-typedef struct /* element of a quadratic number field */
-{
-   fmpz num[3]; /* extra coeff for delayed reduction */
-   fmpz_t den;
-} qnf_elem_struct;
-
-typedef qnf_elem_struct qnf_elem_t[1];
-
-typedef union /* element in a number field (specified by an nf_t) */
-{
-   fmpq_poly_t elem; /* general case */
-   lnf_elem_t lelem; /* linear number field */
-   qnf_elem_t qelem; /* quadratic number field */
-} nf_elem_struct;
-
-typedef nf_elem_struct nf_elem_t[1];
 
 #define NF_ELEM_NUMREF(xxx) fmpq_poly_numref((xxx)->elem)
 #define NF_ELEM_DENREF(xxx) fmpq_poly_denref((xxx)->elem)

--- a/src/nf_elem/mul.c
+++ b/src/nf_elem/mul.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpz_vec.h"
+#include "fmpz_poly.h"
 #include "nf_elem.h"
 
 void _nf_elem_mul_gaussian(fmpz * anum, fmpz * aden,

--- a/src/nf_elem/reduce.c
+++ b/src/nf_elem/reduce.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpz_vec.h"
+#include "fmpz_poly.h"
 #include "nf_elem.h"
 
 void _nf_elem_reduce(nf_elem_t a, const nf_t nf)

--- a/src/nf_elem/test/t-add_sub.c
+++ b/src/nf_elem/test/t-add_sub.c
@@ -1,6 +1,6 @@
 /*
     Copyright (C) 2013 William Hart
-                  2020 Julian Rüth
+    Copyright (C) 2020 Julian Rüth
 
     This file is part of FLINT.
 
@@ -11,6 +11,7 @@
 */
 
 #include "test_helpers.h"
+#include "nf.h"
 #include "nf_elem.h"
 
 TEST_FUNCTION_START(nf_elem_add_sub, state)

--- a/src/nf_elem/test/t-norm_div.c
+++ b/src/nf_elem/test/t-norm_div.c
@@ -10,6 +10,7 @@
 */
 
 #include "test_helpers.h"
+#include "fmpz_poly.h"
 #include "nf.h"
 #include "nf_elem.h"
 

--- a/src/nf_types.h
+++ b/src/nf_types.h
@@ -26,6 +26,8 @@ extern "C" {
 #define NF_QUADRATIC 4
 #define NF_GAUSSIAN 8
 
+#define NF_POWERS_CUTOFF 30 /* maximum length of pol where we precompute powers */
+
 /* number field **************************************************************/
 
 typedef struct

--- a/src/nf_types.h
+++ b/src/nf_types.h
@@ -1,0 +1,83 @@
+/*
+    Copyright (C) 2024 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef NF_TYPES_H
+#define NF_TYPES_H
+
+#include "fmpq_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* macros ********************************************************************/
+
+#define NF_GENERIC 0
+#define NF_MONIC 1
+#define NF_LINEAR 2
+#define NF_QUADRATIC 4
+#define NF_GAUSSIAN 8
+
+/* number field **************************************************************/
+
+typedef struct
+{
+   fmpq_poly_t pol;  /* defining polynomial */
+   union {
+      /* insert any precomputed inverse for zz case here */
+      fmpz_preinvn_t qq; /* precomputed inverse for leading coeff of num(pol), QQ case */
+   } pinv;
+   union { /* powers of the generator mod pol */
+      fmpq_poly_powers_precomp_t qq;
+      fmpz_poly_powers_precomp_t zz;
+   } powers;
+   fmpq_poly_t traces; /* S_k = sum_i \theta_i^k for k = 0, 1, 2, ..., (n-1) */
+   ulong flag;       /* 1 = pol monic over ZZ, 2, = linear, 4 = quadratic field */
+}
+nf_struct;
+
+typedef nf_struct nf_t[1];
+
+/* number field element ******************************************************/
+
+typedef struct /* element of a linear number field */
+{
+   fmpz_t num;
+   fmpz_t den;
+}
+lnf_elem_struct;
+
+typedef lnf_elem_struct lnf_elem_t[1];
+
+typedef struct /* element of a quadratic number field */
+{
+   fmpz num[3]; /* extra coeff for delayed reduction */
+   fmpz_t den;
+}
+qnf_elem_struct;
+
+typedef qnf_elem_struct qnf_elem_t[1];
+
+typedef union /* element in a number field (specified by an nf_t) */
+{
+   fmpq_poly_t elem; /* general case */
+   lnf_elem_t lelem; /* linear number field */
+   qnf_elem_t qelem; /* quadratic number field */
+}
+nf_elem_struct;
+
+typedef nf_elem_struct nf_elem_t[1];
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NF_TYPES_H */

--- a/src/qqbar.h
+++ b/src/qqbar.h
@@ -413,12 +413,12 @@ int qqbar_express_in_field(fmpq_poly_t res, const qqbar_t alpha, const qqbar_t x
 
 void qqbar_get_quadratic(fmpz_t res_a, fmpz_t res_b, fmpz_t res_c, fmpz_t res_q, const qqbar_t x, int factoring);
 
-#ifdef FEXPR_H
-
 void qqbar_get_fexpr_repr(fexpr_t res, const qqbar_t x);
 void qqbar_get_fexpr_root_nearest(fexpr_t res, const qqbar_t x);
 void qqbar_get_fexpr_root_indexed(fexpr_t res, const qqbar_t x);
 int qqbar_get_fexpr_formula(fexpr_t res, const qqbar_t x, ulong flags);
+
+int qqbar_set_fexpr(qqbar_t res, const fexpr_t expr);
 
 #define QQBAR_FORMULA_GAUSSIANS    1
 #define QQBAR_FORMULA_QUADRATICS   2
@@ -436,11 +436,6 @@ int qqbar_get_fexpr_formula(fexpr_t res, const qqbar_t x, ulong flags);
 #define QQBAR_FORMULA_AUTO_FORM       0
 
 #define QQBAR_FORMULA_ALL ((2 * QQBAR_FORMULA_SEPARATION - 1) | QQBAR_FORMULA_AUTO_FORM)
-
-
-int qqbar_set_fexpr(qqbar_t res, const fexpr_t expr);
-
-#endif
 
 /* Internal functions */
 

--- a/src/qqbar.h
+++ b/src/qqbar.h
@@ -22,21 +22,10 @@
 extern "C" {
 #endif
 
-#include "fmpz_types.h"
 #include "fmpq_types.h"
 #include "mpoly_types.h"
-#include "acb.h"
-
-typedef struct
-{
-    fmpz_poly_struct poly;
-    acb_struct enclosure;
-}
-qqbar_struct;
-
-typedef qqbar_struct qqbar_t[1];
-typedef qqbar_struct * qqbar_ptr;
-typedef const qqbar_struct * qqbar_srcptr;
+#include "arf.h"
+#include "ca_types.h"
 
 #define QQBAR_POLY(x) (&((x)->poly))
 #define QQBAR_COEFFS(x) ((&((x)->poly))->coeffs)

--- a/src/qqbar/abs.c
+++ b/src/qqbar/abs.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "arb.h"
 #include "qqbar.h"
 
 /* todo: might be worth it to detect p/q * root of unity */

--- a/src/qqbar/abs2.c
+++ b/src/qqbar/abs2.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "arb.h"
 #include "qqbar.h"
 
 /* todo: might be worth it to detect p/q * root of unity */

--- a/src/qqbar/acb_lindep.c
+++ b/src/qqbar/acb_lindep.c
@@ -12,6 +12,7 @@
 #include "fmpz_vec.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
+#include "acb.h"
 #include "qqbar.h"
 
 int

--- a/src/qqbar/acot_pi.c
+++ b/src/qqbar/acot_pi.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "arb.h"
 #include "qqbar.h"
 
 int

--- a/src/qqbar/affine_transform.c
+++ b/src/qqbar/affine_transform.c
@@ -10,9 +10,10 @@
 */
 
 #include "fmpz_vec.h"
+#include "fmpz_poly.h"
 #include "fmpq.h"
 #include "fmpq_poly.h"
-#include "arb_fmpz_poly.h"
+#include "acb.h"
 #include "qqbar.h"
 
 static void

--- a/src/qqbar/asin_pi.c
+++ b/src/qqbar/asin_pi.c
@@ -10,6 +10,7 @@
 */
 
 #include "ulong_extras.h"
+#include "arb.h"
 #include "qqbar.h"
 
 void best_rational_fast(slong * p, ulong * q, double x, slong N);

--- a/src/qqbar/atan_pi.c
+++ b/src/qqbar/atan_pi.c
@@ -9,15 +9,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include <math.h>
 #include "ulong_extras.h"
+#include "arb.h"
 #include "qqbar.h"
-
-#ifdef __GNUC__
-# define fabs __builtin_fabs
-# define floor __builtin_floor
-#else
-# include <math.h>
-#endif
 
 void
 best_rational_fast(slong * p, ulong * q, double x, slong N)

--- a/src/qqbar/cache_enclosure.c
+++ b/src/qqbar/cache_enclosure.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/ceil.c
+++ b/src/qqbar/ceil.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/clear.c
+++ b/src/qqbar/clear.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpz_poly.h"
+#include "acb.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/cmp_im.c
+++ b/src/qqbar/cmp_im.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
 #include "qqbar.h"
 
 int

--- a/src/qqbar/cmp_re.c
+++ b/src/qqbar/cmp_re.c
@@ -11,6 +11,7 @@
 
 #include "fmpq.h"
 #include "fmpz_poly.h"
+#include "acb.h"
 #include "qqbar.h"
 
 int

--- a/src/qqbar/cmpabs.c
+++ b/src/qqbar/cmpabs.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
 #include "qqbar.h"
 
 int

--- a/src/qqbar/cmpabs_im.c
+++ b/src/qqbar/cmpabs_im.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "arb.h"
 #include "qqbar.h"
 
 static int

--- a/src/qqbar/cmpabs_re.c
+++ b/src/qqbar/cmpabs_re.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "arb.h"
 #include "qqbar.h"
 
 static int

--- a/src/qqbar/composed_op.c
+++ b/src/qqbar/composed_op.c
@@ -9,9 +9,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_poly.h"
 #include "fmpz_poly_factor.h"
 #include "fmpq_poly.h"
 #include "arb_fmpz_poly.h"
+#include "acb.h"
 #include "qqbar.h"
 
 #define OP_ADD 0

--- a/src/qqbar/conj.c
+++ b/src/qqbar/conj.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpz_poly.h"
+#include "acb.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/cos_pi.c
+++ b/src/qqbar/cos_pi.c
@@ -11,6 +11,7 @@
 
 #include "fmpq.h"
 #include "fmpz_poly.h"
+#include "acb.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/enclosure_raw.c
+++ b/src/qqbar/enclosure_raw.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_poly.h"
+#include "acb.h"
 #include "arb_fmpz_poly.h"
 #include "qqbar.h"
 

--- a/src/qqbar/equal.c
+++ b/src/qqbar/equal.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpz_poly.h"
+#include "acb.h"
 #include "qqbar.h"
 
 int

--- a/src/qqbar/equal_fmpq_poly_val.c
+++ b/src/qqbar/equal_fmpq_poly_val.c
@@ -9,8 +9,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_poly.h"
 #include "fmpq_poly.h"
 #include "arb_fmpz_poly.h"
+#include "acb.h"
 #include "qqbar.h"
 
 /* Algorithm based on Cohen section 4.5.1 */

--- a/src/qqbar/evaluate_fmpq_poly.c
+++ b/src/qqbar/evaluate_fmpq_poly.c
@@ -9,13 +9,15 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "fmpz.h"
 #include "fmpz_vec.h"
+#include "fmpz_poly.h"
 #include "fmpq_mat.h"
+#include "fmpq.h"
 #include "fmpq_poly.h"
 #include "nf.h"
 #include "nf_elem.h"
 #include "arb_fmpz_poly.h"
+#include "acb.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/express_in_field.c
+++ b/src/qqbar/express_in_field.c
@@ -11,6 +11,7 @@
 
 #include "fmpq.h"
 #include "fmpq_poly.h"
+#include "acb.h"
 #include "qqbar.h"
 
 int

--- a/src/qqbar/floor.c
+++ b/src/qqbar/floor.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/fmpq_root_ui.c
+++ b/src/qqbar/fmpq_root_ui.c
@@ -9,8 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "fmpq.h"
 #include "fmpz_poly.h"
+#include "fmpq.h"
+#include "acb.h"
 #include "qqbar.h"
 
 static int

--- a/src/qqbar/get_acb.c
+++ b/src/qqbar/get_acb.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
 #include "qqbar.h"
 
 /* Todo: could special-case quadratics, in particular Gaussian rationals */

--- a/src/qqbar/get_arb.c
+++ b/src/qqbar/get_arb.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/get_arb_im.c
+++ b/src/qqbar/get_arb_im.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/get_arb_re.c
+++ b/src/qqbar/get_arb_re.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/get_fexpr.c
+++ b/src/qqbar/get_fexpr.c
@@ -10,12 +10,13 @@
 */
 
 #include <stdio.h>
+#include "ulong_extras.h"
 #include "fmpq.h"
 #include "fmpq_poly.h"
 #include "arb_fmpz_poly.h"
 #include "acb_poly.h"
+#include "fexpr.h"
 #include "fexpr_builtin.h"
-#include "ulong_extras.h"
 #include "qqbar.h"
 
 static ulong _deflation(const fmpz * poly, slong len)

--- a/src/qqbar/get_quadratic.c
+++ b/src/qqbar/get_quadratic.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpz_factor.h"
+#include "arb.h"
 #include "qqbar.h"
 
 /* Write |n| = A * B^2

--- a/src/qqbar/guess.c
+++ b/src/qqbar/guess.c
@@ -9,9 +9,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_poly.h"
 #include "fmpz_poly_factor.h"
 #include "fmpz_lll.h"
 #include "arb_fmpz_poly.h"
+#include "acb.h"
 #include "qqbar.h"
 
 #define QQBAR_GUESS_TRY_SMALLER 1

--- a/src/qqbar/i.c
+++ b/src/qqbar/i.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpz_poly.h"
+#include "acb.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/im.c
+++ b/src/qqbar/im.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "arb.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/init.c
+++ b/src/qqbar/init.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpz_poly.h"
+#include "acb.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/inlines.c
+++ b/src/qqbar/inlines.c
@@ -10,4 +10,5 @@
 */
 
 #define QQBAR_INLINES_C
+
 #include "qqbar.h"

--- a/src/qqbar/inv.c
+++ b/src/qqbar/inv.c
@@ -9,7 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_poly.h"
 #include "arb_fmpz_poly.h"
+#include "acb.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/mul_2exp_si.c
+++ b/src/qqbar/mul_2exp_si.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpz_poly.h"
+#include "acb.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/neg.c
+++ b/src/qqbar/neg.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpz_poly.h"
+#include "acb.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/phi.c
+++ b/src/qqbar/phi.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpz_poly.h"
+#include "acb.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/pow.c
+++ b/src/qqbar/pow.c
@@ -11,9 +11,10 @@
 
 #include "ulong_extras.h"
 #include "fmpz_vec.h"
+#include "fmpz_poly.h"
 #include "fmpq.h"
-#include "fmpz_poly_factor.h"
 #include "arb_fmpz_poly.h"
+#include "acb.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/print.c
+++ b/src/qqbar/print.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/printn.c
+++ b/src/qqbar/printn.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/randtest.c
+++ b/src/qqbar/randtest.c
@@ -11,6 +11,8 @@
 */
 
 #include "fmpq.h"
+#include "fmpz_poly.h"
+#include "acb.h"
 #include "arb_fmpz_poly.h"
 #include "qqbar.h"
 

--- a/src/qqbar/re.c
+++ b/src/qqbar/re.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/root_of_unity.c
+++ b/src/qqbar/root_of_unity.c
@@ -11,6 +11,7 @@
 
 #include "fmpz_poly.h"
 #include "fmpq.h"
+#include "acb.h"
 #include "qqbar.h"
 
 int

--- a/src/qqbar/root_ui.c
+++ b/src/qqbar/root_ui.c
@@ -10,8 +10,10 @@
 */
 
 #include "fmpz_vec.h"
+#include "fmpz_poly.h"
 #include "fmpz_poly_factor.h"
 #include "fmpq.h"
+#include "acb.h"
 #include "arb_fmpz_poly.h"
 #include "qqbar.h"
 

--- a/src/qqbar/roots_fmpz_poly.c
+++ b/src/qqbar/roots_fmpz_poly.c
@@ -11,8 +11,10 @@
 
 #include <stdlib.h>
 #include "fmpq.h"
+#include "fmpz_poly.h"
 #include "fmpz_poly_factor.h"
 #include "arb_fmpz_poly.h"
+#include "acb.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/roots_poly_squarefree.c
+++ b/src/qqbar/roots_poly_squarefree.c
@@ -10,10 +10,11 @@
 */
 
 #include <stdlib.h>
-#include "qqbar.h"
+#include "fmpz_poly.h"
+#include "fmpz_poly_factor.h"
 #include "acb_poly.h"
 #include "arb_fmpz_poly.h"
-#include "fmpz_poly_factor.h"
+#include "qqbar.h"
 
 /*
 We convert an annihilating polynomial over QQbar to an annihilating polynomial

--- a/src/qqbar/set.c
+++ b/src/qqbar/set.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpz_poly.h"
+#include "acb.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/set_fexpr.c
+++ b/src/qqbar/set_fexpr.c
@@ -9,20 +9,14 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include <string.h>
+#include <math.h>
 #include "fmpq.h"
 #include "fmpz_poly.h"
-#include "qqbar.h"
 #include "fexpr.h"
 #include "fexpr_builtin.h"
-
-#ifdef __GNUC__
-# define fabs __builtin_fabs
-# define strchr __builtin_strchr
-# define strlen __builtin_strlen
-#else
-# include <math.h>
-# include <string.h>
-#endif
+#include "acb.h"
+#include "qqbar.h"
 
 int qqbar_set_fexpr(qqbar_t res, const fexpr_t expr);
 

--- a/src/qqbar/set_fmpq.c
+++ b/src/qqbar/set_fmpq.c
@@ -11,6 +11,7 @@
 
 #include "fmpz_poly.h"
 #include "fmpq.h"
+#include "acb.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/set_fmpz.c
+++ b/src/qqbar/set_fmpz.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpz_poly.h"
+#include "acb.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/sgn_im.c
+++ b/src/qqbar/sgn_im.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
 #include "qqbar.h"
 
 int

--- a/src/qqbar/sgn_re.c
+++ b/src/qqbar/sgn_re.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "acb.h"
 #include "qqbar.h"
 
 int

--- a/src/qqbar/swap.c
+++ b/src/qqbar/swap.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "fmpz_poly.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/tan_pi.c
+++ b/src/qqbar/tan_pi.c
@@ -10,6 +10,7 @@
 */
 
 #include "ulong_extras.h"
+#include "arb.h"
 #include "qqbar.h"
 
 int

--- a/src/qqbar/test/t-cmp_im.c
+++ b/src/qqbar/test/t-cmp_im.c
@@ -10,6 +10,7 @@
 */
 
 #include "test_helpers.h"
+#include "arb.h"
 #include "qqbar.h"
 
 TEST_FUNCTION_START(qqbar_cmp_im, state)

--- a/src/qqbar/test/t-exp_pi_i.c
+++ b/src/qqbar/test/t-exp_pi_i.c
@@ -11,6 +11,7 @@
 
 #include "test_helpers.h"
 #include "fmpq.h"
+#include "acb.h"
 #include "qqbar.h"
 
 TEST_FUNCTION_START(qqbar_exp_pi_i, state)

--- a/src/qqbar/validate_enclosure.c
+++ b/src/qqbar/validate_enclosure.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_poly.h"
+#include "acb.h"
 #include "arb_fmpz_poly.h"
 #include "qqbar.h"
 

--- a/src/qqbar/write.c
+++ b/src/qqbar/write.c
@@ -10,6 +10,7 @@
 */
 
 #include "calcium.h"
+#include "acb.h"
 #include "qqbar.h"
 
 /* Todo: document, unify and generalize. This is currently only


### PR DESCRIPTION
Perhaps these headers should be split in some other ways. For instance, I pushed `qqbar_t` into `ca_types.h`, which perhaps is not the most fitting.

- Converted `WARN_UNUSED_RESULT` to `FLINT_WARN_UNUSED`.
- Reduced a lot of inclusions in headers.

A multithreaded build now takes around 2% less time to build than before.

Will squash when it seems to be okay.