### PR TITLE
Refactor FLINT randstate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,6 +323,14 @@ check_c_source_compiles([[#include <gmp.h>
   #endif
   void main(){};]] LONG_LONG_LIMB)
 
+if(LONG_LONG_LIMB)
+    set(ULONG "unsigned long long int")
+    set(SLONG "long long int")
+else()
+    set(ULONG "unsigned long int")
+    set(SLONG "long int")
+endif()
+
 # Populate headers
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/CMake/cmake_config.h.in

--- a/configure.ac
+++ b/configure.ac
@@ -926,8 +926,15 @@ fi
 ################################################################################
 
 FLINT_CHECK_GMP_H(6,2,1)
-FLINT_GMP_LONG_LONG_LIMB([gmpcompat_h_in="gmpcompat-longlong.h.in"],
-                         [gmpcompat_h_in="gmpcompat.h.in"])
+FLINT_GMP_LONG_LONG_LIMB([SLONG="long long int"
+                          ULONG="unsigned long long int"
+                          gmpcompat_h_in="gmpcompat-longlong.h.in"],
+                         [SLONG="long int"
+                          ULONG="unsigned long int"
+                          gmpcompat_h_in="gmpcompat.h.in"])
+
+AC_SUBST(SLONG)
+AC_SUBST(ULONG)
 
 AC_CONFIG_LINKS([src/gmpcompat.h:src/$gmpcompat_h_in],[],[gmpcompat_h_in="$gmpcompat_h_in"])
 AC_SUBST(GMPCOMPAT_H_IN, $gmpcompat_h_in)

--- a/doc/source/flint.rst
+++ b/doc/source/flint.rst
@@ -149,31 +149,25 @@ Allocation Functions
 Random Numbers
 ------------------
 
-.. type:: flint_rand_s
+.. type:: flint_rand_struct
 
-    A structure holding the state of a flint pseudo random number generator.
+    A structure holding the state of the FLINT pseudo random number generator.
 
 .. type:: flint_rand_t
 
-    An array of length 1 of :type:`flint_rand_s`.
+    An array of length 1 of :type:`flint_rand_struct`.
 
-.. function:: flint_rand_s * flint_rand_alloc(void)
+.. function:: void flint_rand_init(flint_rand_t state)
+              void flint_rand_clear(flint_rand_t state)
 
-    Allocates a ``flint_rand_t`` object to be used like a heap-allocated
-    ``flint_rand_t`` in external libraries.
-    The random state is not initialised.
+    Initialises or clears a :type:`flint_rand_t`:.
 
-.. function:: void flint_rand_free(flint_rand_s * state)
+.. function:: flint_rand_struct * flint_rand_alloc(void)
+              void flint_rand_free(flint_rand_s * state)
 
-    Frees a random state object as allocated using :func:`flint_rand_alloc`.
-
-.. function:: void flint_randinit(flint_rand_t state)
-
-    Initialize a :type:`flint_rand_t`.
-
-.. function:: void flint_randclear(flint_rand_t state)
-
-    Free all memory allocated by :func:`flint_rand_init`.
+    Allocates or frees a memory block to be used as a heap-allocated
+    :type:`flint_rand_t`:, such as use in external libraries. The random state
+    is not initialised, nor is it cleared.
 
 Thread functions
 -----------------------

--- a/examples/radix.c
+++ b/examples/radix.c
@@ -122,7 +122,7 @@ int main(void)
     flint_free(b);
     fmpz_mod_ctx_clear(ctx);
 
-    flint_randclear(state);
+    FLINT_TEST_CLEANUP(state);
 
     return 0;
 }

--- a/src/acb_dft/profile/p-convol.c
+++ b/src/acb_dft/profile/p-convol.c
@@ -72,7 +72,7 @@ int main(int argc, char *argv[])
     if (out == CSV)
         flint_printf("# %-12s, %7s, %7s, %7s\n","name", "prec", "len", "factor", "time");
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     for (j = 0; j < nj; j++)
     {

--- a/src/acb_dft/profile/p-dft.c
+++ b/src/acb_dft/profile/p-dft.c
@@ -73,7 +73,7 @@ int main(int argc, char *argv[])
     if (out == CSV)
         flint_printf("# %-12s, %7s, %7s, %7s\n","name", "prec", "len", "factor", "time");
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     for (j = 0; j < nj; j++)
     {

--- a/src/acb_dirichlet/profile/p-vec.c
+++ b/src/acb_dirichlet/profile/p-vec.c
@@ -115,7 +115,7 @@ int main(int argc, char *argv[])
 
     nr = 20;
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     rand = flint_malloc(nr * sizeof(ulong));
 
@@ -207,7 +207,7 @@ int main(int argc, char *argv[])
     }
 
     flint_free(rand);
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     flint_cleanup();
     return 0;

--- a/src/acb_theta/profile/p-ql_a0.c
+++ b/src/acb_theta/profile/p-ql_a0.c
@@ -37,7 +37,7 @@ int main(int argc, char * argv[])
     pstep = atol(argv[2]);
     pmax = atol(argv[3]);
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     /* Profile with different number of steps on reduced input */
     for (prec = pstep; prec <= pmax; prec += pstep)
@@ -114,7 +114,7 @@ int main(int argc, char * argv[])
         arb_clear(test);
     }
 
-    flint_randclear(state);
+    flint_rand_clear(state);
     flint_cleanup();
     return 0;
 }

--- a/src/acb_theta/profile/p-ql_a0_split.c
+++ b/src/acb_theta/profile/p-ql_a0_split.c
@@ -36,7 +36,7 @@ int main(int argc, char * argv[])
     cstep = atol(argv[3]);
     cmax = atol(argv[4]);
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     /* Profile with different splittings on reduced input */
     for (c = cstep; c <= cmax; c += cstep)
@@ -143,7 +143,7 @@ int main(int argc, char * argv[])
         arb_clear(test);
     }
 
-    flint_randclear(state);
+    flint_rand_clear(state);
     flint_cleanup();
     return 0;
 }

--- a/src/acb_theta/profile/p-ql_a0_steps.c
+++ b/src/acb_theta/profile/p-ql_a0_steps.c
@@ -37,7 +37,7 @@ int main(int argc, char * argv[])
     pstep = atol(argv[2]);
     pmax = atol(argv[3]);
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     /* Profile with different number of steps on reduced input */
     for (prec = pstep; prec <= pmax; prec += pstep)
@@ -127,7 +127,7 @@ int main(int argc, char * argv[])
         arb_clear(test);
     }
 
-    flint_randclear(state);
+    flint_rand_clear(state);
     flint_cleanup();
     return 0;
 }

--- a/src/acb_theta/profile/p-siegel_reduce.c
+++ b/src/acb_theta/profile/p-siegel_reduce.c
@@ -42,7 +42,7 @@ int main(int argc, char * argv[])
     dstep = atol(argv[4]);
     dmax = atol(argv[5]);
 
-    flint_randinit(state);
+    flint_rand_init(state);
     acb_mat_init(tau, g, g);
     acb_mat_init(w, g, g);
     arb_init(r);
@@ -76,7 +76,7 @@ int main(int argc, char * argv[])
         }
     }
 
-    flint_randclear(state);
+    flint_rand_clear(state);
     acb_mat_clear(tau);
     acb_mat_clear(w);
     arb_clear(r);

--- a/src/acb_theta/ql_all.c
+++ b/src/acb_theta/ql_all.c
@@ -159,7 +159,7 @@ acb_theta_ql_all_red(acb_ptr th, acb_srcptr z, const acb_mat_t tau, slong prec)
     int hasz = !_acb_vec_is_zero(z, g);
     int res;
 
-    flint_randinit(state);
+    flint_rand_init(state);
     d = _arb_vec_init(n);
     d0 = _arb_vec_init(n);
     acb_mat_init(tau_mid, g, g);
@@ -219,7 +219,7 @@ acb_theta_ql_all_red(acb_ptr th, acb_srcptr z, const acb_mat_t tau, slong prec)
         }
     }
 
-    flint_randclear(state);
+    flint_rand_clear(state);
     _arb_vec_clear(d, n);
     _arb_vec_clear(d0, n);
     acb_mat_clear(tau_mid);
@@ -247,7 +247,7 @@ acb_theta_ql_all_sqr_red(acb_ptr th2, acb_srcptr z, const acb_mat_t tau, slong p
     slong j, k;
     int res;
 
-    flint_randinit(state);
+    flint_rand_init(state);
     acb_mat_init(w, g, g);
     x = _acb_vec_init(g);
     d = _arb_vec_init(n);
@@ -288,7 +288,7 @@ acb_theta_ql_all_sqr_red(acb_ptr th2, acb_srcptr z, const acb_mat_t tau, slong p
         acb_theta_ql_dupl(th2, th, th, d0, d0, g, prec);
     }
 
-    flint_randclear(state);
+    flint_rand_clear(state);
     acb_mat_clear(w);
     _acb_vec_clear(x, g);
     _arb_vec_clear(d, n);

--- a/src/acb_theta/transform_sqrtdet.c
+++ b/src/acb_theta/transform_sqrtdet.c
@@ -56,7 +56,7 @@ acb_theta_transform_sqrtdet(acb_t res, const acb_mat_t tau, slong prec)
     slong k, j, nb_neg, nb_pos;
     int success = 0;
 
-    flint_randinit(state);
+    flint_rand_init(state);
     acb_mat_init(A, g, g);
     acb_mat_init(B, g, g);
     acb_mat_init(C, g, g);
@@ -169,7 +169,7 @@ acb_theta_transform_sqrtdet(acb_t res, const acb_mat_t tau, slong prec)
         acb_union(res, res, z, prec);
     }
 
-    flint_randclear(state);
+    flint_rand_clear(state);
     acb_mat_clear(A);
     acb_mat_clear(B);
     acb_mat_clear(C);

--- a/src/dlog/profile/p-precomp.c
+++ b/src/dlog/profile/p-precomp.c
@@ -115,7 +115,7 @@ int main(int argc, char *argv[])
         flint_abort();
     }
 
-    flint_randinit(state);
+    flint_rand_init(state);
     for (nbits = 10; nbits <= 40; nbits += 5)
     {
 
@@ -170,7 +170,7 @@ int main(int argc, char *argv[])
             }
         }
     }
-    flint_randclear(state);
+    flint_rand_clear(state);
     flint_cleanup();
     flint_printf("PASS\n");
     return 0;

--- a/src/dlog/profile/p-vec.c
+++ b/src/dlog/profile/p-vec.c
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
     p = flint_malloc(np * sizeof(nmod_t));
     a = flint_malloc(np * sizeof(ulong));
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     if (argc < 2)
         out = LOG;
@@ -137,7 +137,7 @@ int main(int argc, char *argv[])
 
     flint_free(p);
     flint_free(a);
-    flint_randclear(state);
+    flint_rand_clear(state);
     flint_cleanup();
     flint_printf("PASS\n");
     return 0;

--- a/src/dlog/rho.c
+++ b/src/dlog/rho.c
@@ -74,7 +74,7 @@ dlog_rho(const dlog_rho_t t, ulong b)
     ulong x[2], e[2], f[2], g;
     flint_rand_t state;
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     do {
 
@@ -105,7 +105,7 @@ dlog_rho(const dlog_rho_t t, ulong b)
 
     } while (e[0] == e[1] && f[0] == f[1]);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     /* e = f * log(b) */
     e[0] = nmod_sub(e[0], e[1], t->n);

--- a/src/fft/profile/p-mul_mfa_truncate_sqrt2.c
+++ b/src/fft/profile/p-mul_mfa_truncate_sqrt2.c
@@ -56,7 +56,7 @@ main(void)
        flint_free(i1);
     }
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     flint_printf("done\n");
     return 0;

--- a/src/fft/profile/p-mul_truncate_sqrt2.c
+++ b/src/fft/profile/p-mul_truncate_sqrt2.c
@@ -56,7 +56,7 @@ main(void)
        flint_free(i1);
     }
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     flint_printf("done\n");
     return 0;

--- a/src/fft/tune/tune-fft.c
+++ b/src/fft/tune/tune-fft.c
@@ -170,7 +170,7 @@ main(void)
 
     flint_printf("#define FFT_MULMOD_2EXPP1_CUTOFF %wd\n\n", ((mp_limb_t) 1 << best_d)*best_w/(2*FLINT_BITS));
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     flint_printf("#endif\n");
     return 0;

--- a/src/fft_small/profile/p-nmod_poly_divrem.c
+++ b/src/fft_small/profile/p-nmod_poly_divrem.c
@@ -100,7 +100,7 @@ int main(void)
     ulong an, bn, n, i, nreps;
     ulong nmax = 1000000;
 
-    flint_randinit(state);
+    flint_rand_init(state);
     mpn_ctx_init(R, UWORD(0x0003f00000000001));
 
     flint_set_num_threads(8);
@@ -224,7 +224,7 @@ int main(void)
     }
 
     mpn_ctx_clear(R);
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     return 0;
 }

--- a/src/fft_small/profile/p-nmod_poly_mul.c
+++ b/src/fft_small/profile/p-nmod_poly_mul.c
@@ -101,7 +101,7 @@ int main(void)
     ulong an, bn, zn, i, nreps;
     ulong zn_max = 10000000;
 
-    flint_randinit(state);
+    flint_rand_init(state);
     mpn_ctx_init(R, UWORD(0x0003f00000000001));
 
     //flint_set_num_threads(8);
@@ -181,7 +181,7 @@ int main(void)
     }
 
     mpn_ctx_clear(R);
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     return 0;
 }

--- a/src/flint.h.in
+++ b/src/flint.h.in
@@ -24,8 +24,8 @@
 # include <sys/param.h>
 #endif
 
-#include <limits.h>
 #include <gmp.h>
+#include <limits.h>
 #ifdef BUILDING_FLINT
 # include "config.h"
 #else
@@ -92,9 +92,9 @@ FLINT_DLL extern char flint_version[];
 struct __FLINT_FILE;
 typedef struct __FLINT_FILE FLINT_FILE;
 
-#define ulong mp_limb_t
-#define slong mp_limb_signed_t
-#define flint_bitcnt_t ulong
+typedef @ULONG@ ulong;
+typedef @SLONG@ slong;
+typedef @ULONG@ flint_bitcnt_t;
 
 #if FLINT_WANT_ASSERT
 # define FLINT_ASSERT(param) assert(param)
@@ -127,6 +127,7 @@ typedef struct __FLINT_FILE FLINT_FILE;
 # define FLINT_UNREACHABLE __builtin_unreachable()
 # define FLINT_RETURNS_NONNULL __attribute__((returns_nonnull))
 # define FLINT_MALLOC __attribute__((malloc))
+# define FLINT_DEPRECATED __attribute__((deprecated))
 #else
 # define __attribute__(x)
 # if defined(_MSC_VER)
@@ -149,6 +150,7 @@ typedef struct __FLINT_FILE FLINT_FILE;
 # define FLINT_CONSTANT_P(x) 0
 # define FLINT_RETURNS_NONNULL
 # define FLINT_MALLOC
+# define FLINT_DEPRECATED
 #endif
 
 #if defined(__cplusplus)
@@ -270,18 +272,21 @@ FLINT_CONST double flint_test_multiplier(void);
 
 typedef struct
 {
-    gmp_randstate_t gmp_state;
-    int gmp_init;
-    mp_limb_t __randval;
-    mp_limb_t __randval2;
-} flint_rand_s;
+    void * __gmp_state;
+    ulong __randval;
+    ulong __randval2;
+}
+flint_rand_struct;
 
-typedef flint_rand_s flint_rand_t[1];
+typedef flint_rand_struct flint_rand_t[1];
+
+/* Assumes that flint_rand_init has been called for state */
+#define FLINT_RAND_GMP_STATE_IS_INITIALISED(state) ((state)->__gmp_state != NULL)
 
 FLINT_INLINE
-void flint_randinit(flint_rand_t state)
+void flint_rand_init(flint_rand_t state)
 {
-   state->gmp_init = 0;
+    state->__gmp_state = NULL;
 #if FLINT64
     state->__randval = UWORD(13845646450878251009);
     state->__randval2 = UWORD(13142370077570254774);
@@ -292,48 +297,36 @@ void flint_randinit(flint_rand_t state)
 }
 
 FLINT_INLINE
-void flint_randseed(flint_rand_t state, ulong seed1, ulong seed2)
+void flint_rand_set_seed(flint_rand_t state, ulong seed1, ulong seed2)
 {
-   state->__randval = seed1;
-   state->__randval2 = seed2;
+    state->__randval = seed1;
+    state->__randval2 = seed2;
 }
 
 FLINT_INLINE
-void flint_get_randseed(ulong * seed1, ulong * seed2, flint_rand_t state)
+void flint_rand_get_seed(ulong * seed1, ulong * seed2, flint_rand_t state)
 {
-   *seed1 = state->__randval;
-   *seed2 = state->__randval2;
+    *seed1 = state->__randval;
+    *seed2 = state->__randval2;
 }
 
-
-FLINT_INLINE
-void _flint_rand_init_gmp(flint_rand_t state)
-{
-    if (!state->gmp_init)
-    {
-        gmp_randinit_default(state->gmp_state);
-        state->gmp_init = 1;
-    }
-}
+void _flint_rand_init_gmp_state(flint_rand_t);
+void _flint_rand_clear_gmp_state(flint_rand_t);
 
 FLINT_INLINE
-void flint_randclear(flint_rand_t state)
+void flint_rand_clear(flint_rand_t state)
 {
-    if (state->gmp_init)
-        gmp_randclear(state->gmp_state);
+    if (FLINT_RAND_GMP_STATE_IS_INITIALISED(state))
+        _flint_rand_clear_gmp_state(state);
 }
 
-FLINT_INLINE
-flint_rand_s * flint_rand_alloc(void)
-{
-    return (flint_rand_s *) flint_malloc(sizeof(flint_rand_s));
-}
-
-FLINT_INLINE
-void flint_rand_free(flint_rand_s * state)
-{
-    flint_free(state);
-}
+FLINT_DEPRECATED void flint_randinit(flint_rand_t);
+FLINT_DEPRECATED void flint_randclear(flint_rand_t);
+FLINT_DEPRECATED void flint_randseed(flint_rand_t, ulong, ulong);
+FLINT_DEPRECATED void flint_get_randseed(ulong *, ulong *, flint_rand_t);
+FLINT_DEPRECATED void _flint_rand_init_gmp(flint_rand_t);
+FLINT_DEPRECATED flint_rand_struct * flint_rand_alloc(void);
+FLINT_DEPRECATED void flint_rand_free(flint_rand_struct * state);
 
 /* defined in ulong_extras, but used throughout the test code */
 ulong n_randlimb(flint_rand_t);
@@ -357,10 +350,10 @@ FLINT_INLINE ulong n_randint(flint_rand_t state, ulong limit)
 #define FLINT_TEST_INIT(xxx) \
    flint_rand_t xxx; \
    FLINT_GC_INIT(); \
-   flint_randinit(xxx)
+   flint_rand_init(xxx)
 
 #define FLINT_TEST_CLEANUP(xxx) \
-   flint_randclear(xxx); \
+   flint_rand_clear(xxx); \
    flint_cleanup_master();
 
 /* comparison macros *********************************************************/
@@ -380,9 +373,9 @@ FLINT_INLINE ulong n_randint(flint_rand_t state, ulong limit)
 
 /* Beware when using the unsigned return value in signed arithmetic */
 FLINT_FORCE_INLINE
-mp_limb_t FLINT_BIT_COUNT(mp_limb_t x)
+flint_bitcnt_t FLINT_BIT_COUNT(ulong x)
 {
-   mp_limb_t zeros = FLINT_BITS;
+   flint_bitcnt_t zeros = FLINT_BITS;
    if (x) zeros = flint_clz(x);
    return FLINT_BITS - zeros;
 }
@@ -487,8 +480,8 @@ FLINT_INLINE slong flint_mul_sizes(slong x, slong y)
 
 typedef struct
 {
-   mp_limb_t n;
-   mp_limb_t ninv;
+   ulong n;
+   ulong ninv;
    flint_bitcnt_t norm;
 }
 nmod_t;

--- a/src/fmpq/profile/p-reconstruct_fmpz_2.c
+++ b/src/fmpq/profile/p-reconstruct_fmpz_2.c
@@ -118,7 +118,7 @@ main(void)
     flint_printf("\n");
     fflush(stdout);
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
 printf("---- balanced ----\n");
 
@@ -184,7 +184,7 @@ printf("---- imbalanced ----\n");
     profile_it(state,   4, 40000,20000,60000,1);
 
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     flint_cleanup_master();
     return 0;

--- a/src/fmpq_poly/test/t-gegenbauer_c.c
+++ b/src/fmpq_poly/test/t-gegenbauer_c.c
@@ -36,10 +36,10 @@ TEST_FUNCTION_START(fmpq_poly_gegenbauer_c, state)
     fmpq_set_si(rats, 0, 1);
     for (d = 1; d < 16; d++)
         fmpq_set_si(rats + d, 1, d);
-    flint_randinit(rand_state);
+    flint_rand_init(rand_state);
     for (d = 16; d < NRATS; d++)
         fmpq_randtest_not_zero(rats + d, rand_state, 32);
-    flint_randclear(rand_state);
+    flint_rand_clear(rand_state);
 
     for (d = 0; d < NRATS; d++)
     {

--- a/src/fmpz/profile/p-addmul.c
+++ b/src/fmpz/profile/p-addmul.c
@@ -76,7 +76,7 @@ sample_new(void * arg, ulong count)
     _fmpz_vec_clear(res, ntests);
     _fmpz_vec_clear(a, ntests);
     _fmpz_vec_clear(b, ntests);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 void
@@ -110,7 +110,7 @@ sample_old(void * arg, ulong count)
     _fmpz_vec_clear(res, ntests);
     _fmpz_vec_clear(a, ntests);
     _fmpz_vec_clear(b, ntests);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 slong sizes[] = { 10, 30, 60, 62, 64, 66, 80, 128, 160, 256, 512, 1024, 4096, 0 };

--- a/src/fmpz/profile/p-aors_ui.c
+++ b/src/fmpz/profile/p-aors_ui.c
@@ -438,7 +438,7 @@ sample_add_new(void * arg, ulong count)
     _fmpz_vec_clear(res, ntests);
     _fmpz_vec_clear(a, ntests);
     flint_free(b);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 void
@@ -473,7 +473,7 @@ sample_add_old(void * arg, ulong count)
     _fmpz_vec_clear(res, ntests);
     _fmpz_vec_clear(a, ntests);
     flint_free(b);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 void
@@ -508,7 +508,7 @@ sample_sub_new(void * arg, ulong count)
     _fmpz_vec_clear(res, ntests);
     _fmpz_vec_clear(a, ntests);
     flint_free(b);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 void
@@ -543,7 +543,7 @@ sample_sub_old(void * arg, ulong count)
     _fmpz_vec_clear(res, ntests);
     _fmpz_vec_clear(a, ntests);
     flint_free(b);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 

--- a/src/fmpz/profile/p-crt.c
+++ b/src/fmpz/profile/p-crt.c
@@ -124,7 +124,7 @@ benchmark(slong num_primes, slong prime_bits)
     fmpz_t res;
     slong k;
 
-    flint_randinit(state);
+    flint_rand_init(state);
     primes = flint_malloc(num_primes * sizeof(mp_limb_t));
     residues = flint_malloc(num_primes * sizeof(mp_limb_t));
     fmpz_init(res);

--- a/src/fmpz/profile/p-div_qr.c
+++ b/src/fmpz/profile/p-div_qr.c
@@ -51,7 +51,7 @@ void sample_ndiv_qr(void * arg, ulong count)
     fmpz_clear(b);
     fmpz_clear(nmax);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 void sample_fdiv_qr(void * arg, ulong count)
@@ -91,7 +91,7 @@ void sample_fdiv_qr(void * arg, ulong count)
     fmpz_clear(b);
     fmpz_clear(nmax);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 void sample_cdiv_qr(void * arg, ulong count)
@@ -131,7 +131,7 @@ void sample_cdiv_qr(void * arg, ulong count)
     fmpz_clear(b);
     fmpz_clear(nmax);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 void sample_tdiv_qr(void * arg, ulong count)
@@ -171,7 +171,7 @@ void sample_tdiv_qr(void * arg, ulong count)
     fmpz_clear(b);
     fmpz_clear(nmax);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 int main(void)
@@ -214,7 +214,7 @@ int main(void)
         flint_rand_t state;
         timeit_t timer;
 
-        flint_randinit(state);
+        flint_rand_init(state);
 
         as = _fmpz_vec_init(len);
         bs = _fmpz_vec_init(len);
@@ -250,7 +250,7 @@ int main(void)
         _fmpz_vec_clear(as, len);
         _fmpz_vec_clear(bs, len);
 
-        flint_randclear(state);
+        flint_rand_clear(state);
     }
 
     return 0;

--- a/src/fmpz/profile/p-fdiv_qr_preinvn.c
+++ b/src/fmpz/profile/p-fdiv_qr_preinvn.c
@@ -67,7 +67,7 @@ void sample(void * arg, ulong count)
    fmpz_clear(b);
    fmpz_clear(c);
    fmpz_clear(r);
-   flint_randclear(state);
+   flint_rand_clear(state);
 }
 
 int main(void)

--- a/src/fmpz/profile/p-fmma.c
+++ b/src/fmpz/profile/p-fmma.c
@@ -103,7 +103,7 @@ void sample_small(void * arg, ulong count)
     fmpz_clear(c);
     fmpz_clear(d);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 void sample_small_old(void * arg, ulong count)
@@ -136,7 +136,7 @@ void sample_small_old(void * arg, ulong count)
     fmpz_clear(c);
     fmpz_clear(d);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 void sample_small_zeros(void * arg, ulong count)
@@ -170,7 +170,7 @@ void sample_small_zeros(void * arg, ulong count)
     fmpz_clear(c);
     fmpz_clear(d);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 void sample_small_zeros_old(void * arg, ulong count)
@@ -204,7 +204,7 @@ void sample_small_zeros_old(void * arg, ulong count)
     fmpz_clear(c);
     fmpz_clear(d);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 void sample_big_zeros(void * arg, ulong count)
@@ -238,7 +238,7 @@ void sample_big_zeros(void * arg, ulong count)
     fmpz_clear(c);
     fmpz_clear(d);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 void sample_big_zeros_old(void * arg, ulong count)
@@ -272,7 +272,7 @@ void sample_big_zeros_old(void * arg, ulong count)
     fmpz_clear(c);
     fmpz_clear(d);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 int main(void)

--- a/src/fmpz/profile/p-gcd.c
+++ b/src/fmpz/profile/p-gcd.c
@@ -105,7 +105,7 @@ sample_new(void * arg, ulong count)
     fmpz_clear(a);
     fmpz_clear(b);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 void
@@ -135,7 +135,7 @@ sample_old(void * arg, ulong count)
     fmpz_clear(a);
     fmpz_clear(b);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 int

--- a/src/fmpz/profile/p-gcd3.c
+++ b/src/fmpz/profile/p-gcd3.c
@@ -178,7 +178,7 @@ sample_new(void * arg, ulong count)
     fmpz_clear(a);
     fmpz_clear(b);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 void
@@ -210,7 +210,7 @@ sample_old(void * arg, ulong count)
     fmpz_clear(a);
     fmpz_clear(b);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 int

--- a/src/fmpz/profile/p-mul.c
+++ b/src/fmpz/profile/p-mul.c
@@ -77,7 +77,7 @@ sample_new(void * arg, ulong count)
     _fmpz_vec_clear(res, ntests);
     _fmpz_vec_clear(a, ntests);
     _fmpz_vec_clear(b, ntests);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 void
@@ -111,7 +111,7 @@ sample_old(void * arg, ulong count)
     _fmpz_vec_clear(res, ntests);
     _fmpz_vec_clear(a, ntests);
     _fmpz_vec_clear(b, ntests);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 slong sizes[] = { 10, 30, 60, 62, 64, 66, 80, 128, 160, 256, 512, 1024, 4096, 0 };

--- a/src/fmpz/profile/p-mul_2exp.c
+++ b/src/fmpz/profile/p-mul_2exp.c
@@ -69,7 +69,7 @@ sample_new(void * arg, ulong count)
         prof_stop();
     }
 
-    flint_randclear(state);
+    flint_rand_clear(state);
     fmpz_clear(res);
     fmpz_clear(a);
 }
@@ -97,7 +97,7 @@ sample_old(void * arg, ulong count)
         prof_stop();
     }
 
-    flint_randclear(state);
+    flint_rand_clear(state);
     fmpz_clear(res);
     fmpz_clear(a);
 }

--- a/src/fmpz/profile/p-mul_ui.c
+++ b/src/fmpz/profile/p-mul_ui.c
@@ -69,7 +69,7 @@ sample_new(void * arg, ulong count)
         prof_stop();
     }
 
-    flint_randclear(state);
+    flint_rand_clear(state);
     fmpz_clear(res);
     fmpz_clear(a);
 }
@@ -98,7 +98,7 @@ sample_old(void * arg, ulong count)
         prof_stop();
     }
 
-    flint_randclear(state);
+    flint_rand_clear(state);
     fmpz_clear(res);
     fmpz_clear(a);
 }

--- a/src/fmpz/profile/p-xgcd.c
+++ b/src/fmpz/profile/p-xgcd.c
@@ -45,7 +45,7 @@ void sample_xgcd_small(void * arg, ulong count)
     fmpz_clear(b);
     fmpz_clear(nmax);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 void sample_xgcd_mixed(void * arg, ulong count)
@@ -80,7 +80,7 @@ void sample_xgcd_mixed(void * arg, ulong count)
     fmpz_clear(b);
     fmpz_clear(nmax);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 void sample_xgcd_big(void * arg, ulong count)
@@ -115,7 +115,7 @@ void sample_xgcd_big(void * arg, ulong count)
     fmpz_clear(b);
     fmpz_clear(nmax);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 void sample_xgcd_canonical_bezout_small(void * arg, ulong count)
@@ -150,7 +150,7 @@ void sample_xgcd_canonical_bezout_small(void * arg, ulong count)
     fmpz_clear(b);
     fmpz_clear(nmax);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 void sample_xgcd_canonical_bezout_mixed(void * arg, ulong count)
@@ -185,7 +185,7 @@ void sample_xgcd_canonical_bezout_mixed(void * arg, ulong count)
     fmpz_clear(b);
     fmpz_clear(nmax);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 void sample_xgcd_canonical_bezout_big(void * arg, ulong count)
@@ -220,7 +220,7 @@ void sample_xgcd_canonical_bezout_big(void * arg, ulong count)
     fmpz_clear(b);
     fmpz_clear(nmax);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 int main(void)

--- a/src/fmpz/rand.c
+++ b/src/fmpz/rand.c
@@ -27,8 +27,11 @@ fmpz_randbits_unsigned(fmpz_t f, flint_rand_t state, flint_bitcnt_t bits)
     else
     {
         mpz_ptr mf = _fmpz_promote(f);
-        _flint_rand_init_gmp(state);
-        mpz_urandomb(mf, state->gmp_state, bits);
+
+        if (!FLINT_RAND_GMP_STATE_IS_INITIALISED(state))
+            _flint_rand_init_gmp_state(state);
+
+        mpz_urandomb(mf, state->__gmp_state, bits);
         mpz_setbit(mf, bits - 1);
         _fmpz_demote_val(f);
     }
@@ -57,8 +60,10 @@ fmpz_randm(fmpz_t f, flint_rand_t state, const fmpz_t m)
     {
         mpz_ptr mf = _fmpz_promote(f);
 
-        _flint_rand_init_gmp(state);
-        mpz_urandomm(mf, state->gmp_state, COEFF_TO_PTR(*m));
+        if (!FLINT_RAND_GMP_STATE_IS_INITIALISED(state))
+            _flint_rand_init_gmp_state(state);
+
+        mpz_urandomm(mf, state->__gmp_state, COEFF_TO_PTR(*m));
         if (sgn < 0)
             mpz_neg(mf, mf);
         _fmpz_demote_val(f);
@@ -121,8 +126,10 @@ fmpz_randtest_unsigned(fmpz_t f, flint_rand_t state, flint_bitcnt_t bits)
     {
         mpz_ptr mf = _fmpz_promote(f);
 
-        _flint_rand_init_gmp(state);
-        mpz_rrandomb(mf, state->gmp_state, bits);
+        if (!FLINT_RAND_GMP_STATE_IS_INITIALISED(state))
+            _flint_rand_init_gmp_state(state);
+
+        mpz_rrandomb(mf, state->__gmp_state, bits);
         _fmpz_demote_val(f);
     }
 }

--- a/src/fmpz/test/t-get_mpz.c
+++ b/src/fmpz/test/t-get_mpz.c
@@ -17,6 +17,9 @@ TEST_FUNCTION_START(fmpz_get_mpz, state)
 {
     int i, result;
 
+    if (!FLINT_RAND_GMP_STATE_IS_INITIALISED(state))
+        _flint_rand_init_gmp_state(state);
+
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a;
@@ -28,8 +31,7 @@ TEST_FUNCTION_START(fmpz_get_mpz, state)
 
         bits = n_randint(state, 200) + 1;
 
-        _flint_rand_init_gmp(state);
-        mpz_rrandomb(b, state->gmp_state, bits);
+        mpz_rrandomb(b, state->__gmp_state, bits);
 
         if (n_randint(state, 2))
             mpz_neg(b, b);

--- a/src/fmpz/test/t-set.c
+++ b/src/fmpz/test/t-set.c
@@ -17,6 +17,9 @@ TEST_FUNCTION_START(fmpz_set, state)
 {
     int i, result;
 
+    if (!FLINT_RAND_GMP_STATE_IS_INITIALISED(state))
+        _flint_rand_init_gmp_state(state);
+
     for (i = 0; i < 10000 * flint_test_multiplier(); i++)
     {
         fmpz_t a, b;
@@ -28,8 +31,7 @@ TEST_FUNCTION_START(fmpz_set, state)
 
         bits = n_randint(state, 200) + 1;
 
-        _flint_rand_init_gmp(state);
-        mpz_rrandomb(c, state->gmp_state, bits);
+        mpz_rrandomb(c, state->__gmp_state, bits);
 
         if (n_randint(state, 2))
             mpz_neg(c, c);

--- a/src/fmpz_factor/factor_smooth.c
+++ b/src/fmpz_factor/factor_smooth.c
@@ -219,7 +219,7 @@ int fmpz_factor_smooth(fmpz_factor_t factor, const fmpz_t n,
                 flint_rand_t state;
 
                 fmpz_init(f);
-                flint_randinit(state);
+                flint_rand_init(state);
 
                 /* currently only tuning values up to factors of 100 bits */
                 bits = FLINT_MIN(bits, 100);
@@ -268,7 +268,7 @@ int fmpz_factor_smooth(fmpz_factor_t factor, const fmpz_t n,
                     }
                 }
 
-                flint_randclear(state);
+                flint_rand_clear(state);
                 fmpz_clear(f);
             }
         }

--- a/src/fmpz_factor/profile/p-factor_pp1.c
+++ b/src/fmpz_factor/profile/p-factor_pp1.c
@@ -56,7 +56,7 @@ int main(void)
          flint_printf("Factor not found!\n");
    } while(1);
 
-   flint_randclear(state);
+   flint_rand_clear(state);
 
    fmpz_clear(n);
    fmpz_clear(p);

--- a/src/fmpz_lll/profile/p-lll.c
+++ b/src/fmpz_lll/profile/p-lll.c
@@ -83,7 +83,7 @@ sample(void *arg, ulong count)
     fmpz_mat_clear(D);
     fmpq_clear(delta);
     fmpq_clear(eta);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 int

--- a/src/fmpz_mat/hnf.c
+++ b/src/fmpz_mat/hnf.c
@@ -46,10 +46,10 @@ fmpz_mat_hnf(fmpz_mat_t H, const fmpz_mat_t A)
     else {
         flint_rand_t state;
 
-        flint_randinit(state);
+        flint_rand_init(state);
 
         fmpz_mat_hnf_pernet_stein(H, A, state);
 
-        flint_randclear(state);
+        flint_rand_clear(state);
     }
 }

--- a/src/fmpz_mat/hnf_transform.c
+++ b/src/fmpz_mat/hnf_transform.c
@@ -64,7 +64,7 @@ fmpz_mat_hnf_transform(fmpz_mat_t H, fmpz_mat_t U, const fmpz_mat_t A)
         _fmpz_mat_hnf_transform_naive(H, U, A);
     else
     {
-        flint_randinit(state);
+        flint_rand_init(state);
         p = n_randprime(state, NMOD_MAT_OPTIMAL_MODULUS_BITS, 1);
         nmod_mat_init(Amod, m, n, p);
 
@@ -73,7 +73,7 @@ fmpz_mat_hnf_transform(fmpz_mat_t H, fmpz_mat_t U, const fmpz_mat_t A)
 
         nmod_mat_clear(Amod);
 
-        flint_randclear(state);
+        flint_rand_clear(state);
 
         if (r == n) /* Full column rank */
             fmpz_mat_hnf_minors_transform(H, U, A);

--- a/src/fmpz_mat/profile/p-det.c
+++ b/src/fmpz_mat/profile/p-det.c
@@ -57,7 +57,7 @@ void sample(void * arg, ulong count)
     fmpz_mat_clear(A);
     fmpz_clear(d);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 int main(void)

--- a/src/fmpz_mat/profile/p-mul.c
+++ b/src/fmpz_mat/profile/p-mul.c
@@ -80,9 +80,9 @@ compare_two(int parameters, int alg1, int alg2)
     int randtest;
 
     flint_rand_t state, state1, state2;
-    flint_randinit(state);
-    flint_randinit(state1);
-    flint_randinit(state2);
+    flint_rand_init(state);
+    flint_rand_init(state1);
+    flint_rand_init(state2);
 
     flint_printf("A = %s\n", names[alg1]);
     flint_printf("B = %s\n\n", names[alg2]);
@@ -128,9 +128,9 @@ compare_two(int parameters, int alg1, int alg2)
         flint_printf("%4wd %4wd %4wd   %5wd %5wd   %d   %6.8f  %6.8f     %.3f\n", m, n, k, bits1, bits2, randtest, t1, t2, t1 / t2);
     }
 
-    flint_randclear(state);
-    flint_randclear(state1);
-    flint_randclear(state2);
+    flint_rand_clear(state);
+    flint_rand_clear(state1);
+    flint_rand_clear(state2);
 }
 
 int main(int argc, char * argv[])

--- a/src/fmpz_mat/profile/p-sqr.c
+++ b/src/fmpz_mat/profile/p-sqr.c
@@ -58,7 +58,7 @@ void sample(void * arg, ulong count)
     fmpz_mat_clear(B);
     fmpz_mat_clear(C);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 int main(void)

--- a/src/fmpz_mod_mpoly/sqrt_heap.c
+++ b/src/fmpz_mod_mpoly/sqrt_heap.c
@@ -121,7 +121,7 @@ static int _fmpz_mod_mpoly_sqrt_heap1(
     FLINT_ASSERT(mpoly_words_per_exp(bits, mctx) == 1);
     mpoly_get_cmpmask(&cmpmask, 1, bits, mctx);
 
-    flint_randinit(heuristic_state);
+    flint_rand_init(heuristic_state);
 
     /* alloc array of heap nodes which can be chained together */
     next_loc = 2*n_sqrt(Alen) + 4;   /* something bigger than heap can ever be */
@@ -310,7 +310,7 @@ static int _fmpz_mod_mpoly_sqrt_heap1(
 
 cleanup:
 
-    flint_randclear(heuristic_state);
+    flint_rand_clear(heuristic_state);
 
     Q->coeffs = Qcoeffs;
     Q->exps = Qexps;
@@ -386,7 +386,7 @@ static int _fmpz_mod_mpoly_sqrt_heap(
     cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
     mpoly_get_cmpmask(cmpmask, N, bits, mctx);
 
-    flint_randinit(heuristic_state);
+    flint_rand_init(heuristic_state);
 
     /* alloc array of heap nodes which can be chained together */
     next_loc = 2*sqrt(Alen) + 4;   /* something bigger than heap can ever be */
@@ -631,7 +631,7 @@ FLINT_ASSERT(fmpz_mod_is_canonical(Acoeffs + 0, fctx));
 
 cleanup:
 
-    flint_randclear(heuristic_state);
+    flint_rand_clear(heuristic_state);
 
     Q->coeffs = Qcoeffs;
     Q->exps = Qexps;

--- a/src/fmpz_mod_mpoly_factor/factor.c
+++ b/src/fmpz_mod_mpoly_factor/factor.c
@@ -72,7 +72,7 @@ static int _factor_irred_compressed(
 
     Abits = A->bits;
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     if (nvars < 2)
     {
@@ -220,7 +220,7 @@ static int _factor_irred_compressed(
         fmpz_mod_mpoly_factor_clear(lcAf, ctx);
     }
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
 #if FLINT_WANT_ASSERT
     if (success)

--- a/src/fmpz_mod_mpoly_factor/gcd_algo.c
+++ b/src/fmpz_mod_mpoly_factor/gcd_algo.c
@@ -142,7 +142,7 @@ static void _set_estimates(
     slong ignore_limit;
     int * ignore;
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     ignore = FLINT_ARRAY_ALLOC(nvars, int);
     alphas  = _fmpz_vec_init(nvars);
@@ -235,7 +235,7 @@ cleanup:
     flint_free(Aevals);
     flint_free(Bevals);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     return;
 }
@@ -805,7 +805,7 @@ static int _try_zippel(
 
     FLINT_ASSERT(m >= 2);
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     fmpz_mod_mpoly_ctx_init(lctx, m, ORD_LEX, fmpz_mod_ctx_modulus(ctx->ffinfo));
 
@@ -894,7 +894,7 @@ cleanup:
     fmpz_mod_mpoly_clear(Bbarc, lctx);
 
     fmpz_mod_mpoly_ctx_clear(lctx);
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     return success;
 }

--- a/src/fmpz_mod_mpoly_factor/gcd_hensel.c
+++ b/src/fmpz_mod_mpoly_factor/gcd_hensel.c
@@ -44,7 +44,7 @@ int fmpz_mod_mpolyl_gcd_hensel_smprime(
     FLINT_ASSERT(B->bits == bits);
     FLINT_ASSERT(ctx->minfo->ord == ORD_LEX);
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     Hdegs  = FLINT_ARRAY_ALLOC(n + 1, slong);
 
@@ -374,7 +374,7 @@ got_alpha:
 
 cleanup:
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     flint_free(Hdegs);
 

--- a/src/fmpz_mod_mpoly_factor/gcd_zippel2.c
+++ b/src/fmpz_mod_mpoly_factor/gcd_zippel2.c
@@ -655,7 +655,7 @@ int fmpz_mod_mpolyl_gcd_zippel2_smprime(
 
     betas = _fmpz_vec_init(nvars);
     alphas = _fmpz_vec_init(nvars);
-    flint_randinit(state);
+    flint_rand_init(state);
 
     beta_caches = FLINT_ARRAY_ALLOC(nvars, fmpz_mod_poly_struct);
     alpha_caches = FLINT_ARRAY_ALLOC(nvars, fmpz_mod_poly_struct);
@@ -1242,7 +1242,7 @@ cleanup:
     _fmpz_vec_clear(betas, nvars);
     _fmpz_vec_clear(alphas, nvars);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     for (i = 0; i < nvars; i++)
     {

--- a/src/fmpz_mod_mpoly_factor/test/t-gcd_hensel.c
+++ b/src/fmpz_mod_mpoly_factor/test/t-gcd_hensel.c
@@ -74,7 +74,7 @@ int compute_gcd(
     FLINT_ASSERT(!fmpz_mod_mpoly_is_zero(B, ctx));
     FLINT_ASSERT(ctx->minfo->nvars >= 3);
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     wbits = FLINT_MAX(A->bits, B->bits);
 
@@ -141,7 +141,7 @@ cleanup:
 
     fmpz_mod_mpoly_ctx_clear(lctx);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     flint_free(perm);
     flint_free(shift);

--- a/src/fmpz_mod_mpoly_factor/test/t-gcd_zippel.c
+++ b/src/fmpz_mod_mpoly_factor/test/t-gcd_zippel.c
@@ -73,7 +73,7 @@ int compute_gcd(
     FLINT_ASSERT(!fmpz_mod_mpoly_is_zero(B, ctx));
     FLINT_ASSERT(ctx->minfo->nvars >= 2);
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     wbits = FLINT_MAX(A->bits, B->bits);
 
@@ -138,7 +138,7 @@ cleanup:
 
     fmpz_mod_mpoly_ctx_clear(lctx);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     flint_free(perm);
     flint_free(shift);

--- a/src/fmpz_mod_mpoly_factor/test/t-gcd_zippel2.c
+++ b/src/fmpz_mod_mpoly_factor/test/t-gcd_zippel2.c
@@ -79,7 +79,7 @@ int compute_gcd(
     FLINT_ASSERT(!fmpz_mod_mpoly_is_zero(B, ctx));
     FLINT_ASSERT(ctx->minfo->nvars >= 3);
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     wbits = FLINT_MAX(A->bits, B->bits);
 
@@ -160,7 +160,7 @@ cleanup:
 
     fmpz_mod_mpoly_ctx_clear(lctx);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     flint_free(perm);
     flint_free(shift);

--- a/src/fmpz_mod_poly/find_distinct_nonzero_roots.c
+++ b/src/fmpz_mod_poly/find_distinct_nonzero_roots.c
@@ -163,7 +163,7 @@ int fmpz_mod_poly_find_distinct_nonzero_roots(
         goto cleanup1;
     }
 
-    flint_randinit(randstate);
+    flint_rand_init(randstate);
     fmpz_mod_poly_init(t, ctx);
     fmpz_mod_poly_init(t2, ctx);
     fmpz_mod_poly_init(f, ctx);
@@ -231,7 +231,7 @@ int fmpz_mod_poly_find_distinct_nonzero_roots(
 
 cleanup:
 
-    flint_randclear(randstate);
+    flint_rand_clear(randstate);
     fmpz_mod_poly_clear(t, ctx);
     fmpz_mod_poly_clear(t2, ctx);
     fmpz_mod_poly_clear(f, ctx);

--- a/src/fmpz_mod_poly/profile/p-gcd.c
+++ b/src/fmpz_mod_poly/profile/p-gcd.c
@@ -228,7 +228,7 @@ main(void)
         }
     }
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     return 0;
 }

--- a/src/fmpz_mod_poly/profile/p-invert.c
+++ b/src/fmpz_mod_poly/profile/p-invert.c
@@ -76,7 +76,7 @@ main(void)
     fmpz_clear(one);
     fmpz_mod_ctx_clear(ctx);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     return 0;
 }

--- a/src/fmpz_mod_poly/profile/p-mul.c
+++ b/src/fmpz_mod_poly/profile/p-mul.c
@@ -67,7 +67,7 @@ main(void)
     fmpz_clear(N);
     fmpz_mod_ctx_clear(ctx);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     return 0;
 }

--- a/src/fmpz_mod_poly/profile/p-tree.c
+++ b/src/fmpz_mod_poly/profile/p-tree.c
@@ -70,7 +70,7 @@ main(void)
     fmpz_clear(N);
     fmpz_mod_ctx_clear(ctx);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     return 0;
 }

--- a/src/fmpz_mod_poly_factor/factor_berlekamp.c
+++ b/src/fmpz_mod_poly_factor/factor_berlekamp.c
@@ -269,12 +269,12 @@ fmpz_mod_poly_factor_berlekamp(fmpz_mod_poly_factor_t factors,
     fmpz_mod_poly_factor_squarefree(sq_free, v, ctx);
 
     /* run Berlekamp algorithm for all squarefree factors */
-    flint_randinit(r);
+    flint_rand_init(r);
     for (i = 0; i < sq_free->num; i++)
     {
         __fmpz_mod_poly_factor_berlekamp(factors, r, sq_free->poly + i, ctx);
     }
-    flint_randclear(r);
+    flint_rand_clear(r);
 
     /* compute multiplicities of factors in f */
     for (i = 0; i < factors->num; i++)

--- a/src/fmpz_mod_poly_factor/factor_equal_deg.c
+++ b/src/fmpz_mod_poly_factor/factor_equal_deg.c
@@ -246,7 +246,7 @@ static void _fmpz_mod_poly_factor_equal_deg_via_trace(
 
     res->num = 0;
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     fmpz_init(halfp);
     fmpz_sub_ui(halfp, p, 1);
@@ -445,7 +445,7 @@ cleanup:
     fmpz_mod_poly_clear(tr, ctx);
     fmpz_mod_poly_clear(finv, ctx);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
     fmpz_clear(halfp);
 
     return;

--- a/src/fmpz_mod_poly_factor/profile/p-factor_equal_deg.c
+++ b/src/fmpz_mod_poly_factor/profile/p-factor_equal_deg.c
@@ -25,7 +25,7 @@ int main(void)
     fmpz_mod_poly_factor_t f;
     timeit_t timer;
 
-    flint_randinit(state);
+    flint_rand_init(state);
     fmpz_init_set_ui(p, 1);
     fmpz_init(t);
     fmpz_mod_ctx_init(ctx, p);
@@ -102,7 +102,7 @@ int main(void)
     fmpz_mod_ctx_clear(ctx);
     fmpz_clear(p);
     fmpz_clear(t);
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     return 0;
 }

--- a/src/fmpz_mod_poly_factor/roots.c
+++ b/src/fmpz_mod_poly_factor/roots.c
@@ -181,7 +181,7 @@ void fmpz_mod_poly_roots(fmpz_mod_poly_factor_t r, const fmpz_mod_poly_t f,
     fmpz_sub_ui(p2, p2, 1);
     fmpz_fdiv_q_2exp(p2, p2, 1);
 
-    flint_randinit(randstate);
+    flint_rand_init(randstate);
 
     for (i = 0; i < FLINT_BITS + 3; i++)
         fmpz_mod_poly_init(t + i, ctx);
@@ -208,7 +208,7 @@ void fmpz_mod_poly_roots(fmpz_mod_poly_factor_t r, const fmpz_mod_poly_t f,
 
     fmpz_clear(p2);
 
-    flint_randclear(randstate);
+    flint_rand_clear(randstate);
 
     for (i = 0; i < FLINT_BITS + 3; i++)
         fmpz_mod_poly_clear(t + i, ctx);

--- a/src/fmpz_mpoly/sqrt_heap.c
+++ b/src/fmpz_mpoly/sqrt_heap.c
@@ -175,7 +175,7 @@ slong _fmpz_mpoly_sqrt_heap1(
     FLINT_ASSERT(mpoly_words_per_exp(bits, mctx) == 1);
     mpoly_get_cmpmask(&maskhi, 1, bits, mctx);
 
-    flint_randinit(heuristic_state);
+    flint_rand_init(heuristic_state);
 
     mpz_init(r);
     mpz_init(acc);
@@ -555,7 +555,7 @@ slong _fmpz_mpoly_sqrt_heap1(
 
 cleanup:
 
-    flint_randclear(heuristic_state);
+    flint_rand_clear(heuristic_state);
 
     mpz_clear(r);
     mpz_clear(acc);
@@ -630,7 +630,7 @@ slong _fmpz_mpoly_sqrt_heap(
     cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
     mpoly_get_cmpmask(cmpmask, N, bits, mctx);
 
-    flint_randinit(heuristic_state);
+    flint_rand_init(heuristic_state);
 
     mpz_init(r);
     mpz_init(acc);
@@ -1065,7 +1065,7 @@ slong _fmpz_mpoly_sqrt_heap(
 
 cleanup:
 
-    flint_randclear(heuristic_state);
+    flint_rand_clear(heuristic_state);
 
     mpz_clear(r);
     mpz_clear(acc);

--- a/src/fmpz_mpoly_factor/factor.c
+++ b/src/fmpz_mpoly_factor/factor.c
@@ -129,7 +129,7 @@ static int _factor_irred_compressed(
 
     Abits = A->bits;
 
-    flint_randinit(state);
+    flint_rand_init(state);
     fmpz_poly_init(u);
     fmpz_poly_factor_init(uf);
     fmpz_mpoly_init(lcA, ctx);
@@ -336,7 +336,7 @@ done_alpha:
 
 cleanup:
 
-    flint_randclear(state);
+    flint_rand_clear(state);
     fmpz_poly_clear(u);
     fmpz_poly_factor_clear(uf);
     fmpz_mpoly_clear(lcA, ctx);

--- a/src/fmpz_mpoly_factor/gcd_algo.c
+++ b/src/fmpz_mpoly_factor/gcd_algo.c
@@ -250,7 +250,7 @@ void _set_estimates(
     slong ignore_limit;
     int * ignore;
 
-    flint_randinit(randstate);
+    flint_rand_init(randstate);
 
     ignore = (int *) flint_malloc(ctx->minfo->nvars*sizeof(int));
     alpha = (mp_limb_t *) flint_malloc(ctx->minfo->nvars*sizeof(mp_limb_t));
@@ -351,7 +351,7 @@ cleanup:
     flint_free(Aevals);
     flint_free(Bevals);
 
-    flint_randclear(randstate);
+    flint_rand_clear(randstate);
 
     return;
 }
@@ -991,7 +991,7 @@ static int _try_zippel(
     FLINT_ASSERT(A->length > 0);
     FLINT_ASSERT(B->length > 0);
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     fmpz_mpoly_ctx_init(lctx, m, ORD_LEX);
 
@@ -1082,7 +1082,7 @@ cleanup:
 
     fmpz_mpoly_ctx_clear(lctx);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     return success;
 }

--- a/src/fmpz_mpoly_factor/gcd_hensel.c
+++ b/src/fmpz_mpoly_factor/gcd_hensel.c
@@ -47,7 +47,7 @@ int fmpz_mpolyl_gcd_hensel(
     FLINT_ASSERT(B->bits == bits);
     FLINT_ASSERT(ctx->minfo->ord == ORD_LEX);
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     Hdegs  = FLINT_ARRAY_ALLOC(n + 1, slong);
 
@@ -385,7 +385,7 @@ got_alpha:
 
 cleanup:
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     flint_free(Hdegs);
 

--- a/src/fmpz_mpoly_factor/gcd_zippel2.c
+++ b/src/fmpz_mpoly_factor/gcd_zippel2.c
@@ -1570,7 +1570,7 @@ int fmpz_mpolyl_gcd_zippel2(
                                          B->exps, B->length, bits, ctx->minfo);
 
 
-    flint_randinit(randstate);
+    flint_rand_init(randstate);
     fmpz_init(p);
     fmpz_init(pm1); /* p - 1 */
     fmpz_init(subprod);
@@ -2430,7 +2430,7 @@ cleanup:
     fmpz_clear(subprod);
     fmpz_clear(pm1);
     fmpz_clear(p);
-    flint_randclear(randstate);
+    flint_rand_clear(randstate);
 
     FLINT_ASSERT(G->bits == bits);
     FLINT_ASSERT(Abar->bits == bits);

--- a/src/fmpz_mpoly_factor/test/t-gcd_zippel.c
+++ b/src/fmpz_mpoly_factor/test/t-gcd_zippel.c
@@ -86,7 +86,7 @@ int compute_gcd(
         stride[i] = 1;
     }
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     wbits = FLINT_MAX(A->bits, B->bits);
 
@@ -151,7 +151,7 @@ cleanup:
 
     fmpz_mpoly_ctx_clear(lctx);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     flint_free(perm);
     flint_free(shift);

--- a/src/fmpz_poly/profile/p-compose.c
+++ b/src/fmpz_poly/profile/p-compose.c
@@ -142,7 +142,7 @@ main(void)
         flint_printf("\n");
     }
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     return 0;
 }

--- a/src/fmpz_poly/profile/p-div_preinv.c
+++ b/src/fmpz_poly/profile/p-div_preinv.c
@@ -97,7 +97,7 @@ void sample(void * arg, ulong count)
    fmpz_poly_clear(q);
    fmpz_poly_clear(r);
 
-   flint_randclear(state);
+   flint_rand_clear(state);
 }
 
 int main(void)

--- a/src/fmpz_poly/profile/p-gcd.c
+++ b/src/fmpz_poly/profile/p-gcd.c
@@ -84,7 +84,7 @@ void sample(void * arg, ulong count)
    fmpz_poly_clear(c);
    fmpz_poly_clear(g);
 
-   flint_randclear(state);
+   flint_rand_clear(state);
 }
 
 int main(void)

--- a/src/fmpz_poly/profile/p-mul.c
+++ b/src/fmpz_poly/profile/p-mul.c
@@ -214,7 +214,7 @@ main(void)
         }
     }
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     return 0;
 }

--- a/src/fmpz_poly/profile/p-mul_triangle.c
+++ b/src/fmpz_poly/profile/p-mul_triangle.c
@@ -245,7 +245,7 @@ main(void)
         }
     }
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     return 0;
 }

--- a/src/fmpz_poly/profile/p-pow.c
+++ b/src/fmpz_poly/profile/p-pow.c
@@ -117,7 +117,7 @@ main(void)
     fmpz_poly_clear(f);
     fmpz_poly_clear(g);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     return 0;
 }

--- a/src/fmpz_poly/profile/p-pow_binomial.c
+++ b/src/fmpz_poly/profile/p-pow_binomial.c
@@ -81,7 +81,7 @@ main(void)
     fmpz_poly_clear(f);
     fmpz_poly_clear(g);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     return 0;
 }

--- a/src/fmpz_poly/profile/p-rem_powers_precomp.c
+++ b/src/fmpz_poly/profile/p-rem_powers_precomp.c
@@ -97,7 +97,7 @@ void sample(void * arg, ulong count)
    fmpz_poly_clear(q);
    fmpz_poly_clear(r);
 
-   flint_randclear(state);
+   flint_rand_clear(state);
 }
 
 int main(void)

--- a/src/fmpz_poly/profile/p-taylor_shift.c
+++ b/src/fmpz_poly/profile/p-taylor_shift.c
@@ -25,7 +25,7 @@ main(int argc, char * argv[])
     double incbits, inclen;
     flint_rand_t state;
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     fmpz_poly_init(f);
     fmpz_poly_init(g);
@@ -136,7 +136,7 @@ main(int argc, char * argv[])
     fmpz_clear(c);
     fmpz_clear(d);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
     flint_cleanup();
     return 0;
 }

--- a/src/fmpzi/profile/p-gcd.c
+++ b/src/fmpzi/profile/p-gcd.c
@@ -59,7 +59,7 @@ int main(void)
     ulong a_bits, b_bits, g_bits;
     flint_rand_t state;
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     for (a_bits = 100000; a_bits < 10000000; a_bits += 1 + a_bits/2)
     for (b_bits = a_bits; b_bits < 10000000; b_bits += 1 + b_bits/2)
@@ -74,7 +74,7 @@ int main(void)
         flint_printf("\n");
     }
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     return 0;
 }

--- a/src/fq/ctx_init.c
+++ b/src/fq/ctx_init.c
@@ -121,7 +121,7 @@ fq_ctx_init(fq_ctx_t ctx, const fmpz_t p, slong d, const char * var)
 
     ctx->is_conway = 0;
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     fmpz_mod_ctx_init(ctxp, p);
     fmpz_mod_poly_init2(poly, d + 1, ctxp);
@@ -131,7 +131,7 @@ fq_ctx_init(fq_ctx_t ctx, const fmpz_t p, slong d, const char * var)
 
     fmpz_mod_poly_clear(poly, ctxp);
     fmpz_mod_ctx_clear(ctxp);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 /* FIXME: Test super big primes? */

--- a/src/fq_embed/embed.c
+++ b/src/fq_embed/embed.c
@@ -43,7 +43,7 @@ void _fq_embed_gens_naive(fq_t gen_sub,
     fq_poly_init(fact, sup_ctx);
     fq_poly_set_fmpz_mod_poly(modulus, fq_ctx_modulus(sub_ctx), sup_ctx);
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     /* Get one linear factor of sub_ctx->modulus in sup_ctx */
     while (fq_poly_degree(modulus, sup_ctx) != 1)
@@ -53,6 +53,8 @@ void _fq_embed_gens_naive(fq_t gen_sub,
         };
         fq_poly_set(modulus, fact, sup_ctx);
     }
+
+    flint_rand_clear(state);
 
     fq_gen(gen_sub, sub_ctx);
     fq_set(gen_sup, modulus->coeffs, sup_ctx);

--- a/src/fq_embed_templates/embed.c
+++ b/src/fq_embed_templates/embed.c
@@ -46,7 +46,7 @@ void _TEMPLATE(T, embed_gens_naive)(TEMPLATE(T, t) gen_sub,
 				    TEMPLATE(T, ctx_modulus)(sub_ctx),
 				    sup_ctx);
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     /* Get one linear factor of sub_ctx->modulus in sup_ctx */
     while (TEMPLATE(T, poly_degree)(modulus, sup_ctx) != 1)
@@ -57,6 +57,8 @@ void _TEMPLATE(T, embed_gens_naive)(TEMPLATE(T, t) gen_sub,
         };
         TEMPLATE(T, poly_set)(modulus, fact, sup_ctx);
     }
+
+    flint_rand_clear(state);
 
     TEMPLATE(T, gen)(gen_sub, sub_ctx);
     TEMPLATE(T, set)(gen_sup, modulus->coeffs, sup_ctx);

--- a/src/fq_nmod/ctx_init.c
+++ b/src/fq_nmod/ctx_init.c
@@ -65,7 +65,7 @@ void fq_nmod_ctx_init_ui(fq_nmod_ctx_t ctx, ulong p, slong d, const char *var)
 
         ctx->is_conway = 0;
 
-        flint_randinit(state);
+        flint_rand_init(state);
 
         nmod_poly_init2(poly, p, d + 1);
         nmod_poly_randtest_sparse_irreducible(poly, state, d + 1);
@@ -73,7 +73,7 @@ void fq_nmod_ctx_init_ui(fq_nmod_ctx_t ctx, ulong p, slong d, const char *var)
         fq_nmod_ctx_init_modulus(ctx, poly, var);
 
         nmod_poly_clear(poly);
-        flint_randclear(state);
+        flint_rand_clear(state);
     }
 }
 

--- a/src/fq_nmod_mpoly/gcd.c
+++ b/src/fq_nmod_mpoly/gcd.c
@@ -257,7 +257,7 @@ void mpoly_gcd_info_set_estimates_fq_nmod_mpoly(
     slong ignore_limit;
     int * ignore;
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     ignore = FLINT_ARRAY_ALLOC(nvars, int);
     alpha  = FLINT_ARRAY_ALLOC(nvars, fq_nmod_struct);
@@ -354,7 +354,7 @@ cleanup:
     flint_free(alpha);
     flint_free(Aevals);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     return;
 }
@@ -379,7 +379,7 @@ void mpoly_gcd_info_set_estimates_fq_nmod_mpoly_lgprime(
     bad_fq_nmod_mpoly_embed_chooser_t embc;
     bad_fq_nmod_embed_struct * cur_emb;
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     cur_emb = bad_fq_nmod_mpoly_embed_chooser_init(embc, lgctx, smctx, state);
 
@@ -483,7 +483,7 @@ cleanup:
 
     bad_fq_nmod_mpoly_embed_chooser_clear(embc, lgctx, smctx, state);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     return;
 }
@@ -935,7 +935,7 @@ static int _try_zippel(
     FLINT_ASSERT(A->length > 0);
     FLINT_ASSERT(B->length > 0);
 
-    flint_randinit(randstate);
+    flint_rand_init(randstate);
 
     /* uctx is context for Fq[y_1,...,y_{m-1}]*/
     fq_nmod_mpoly_ctx_init(uctx, m - 1, ORD_LEX, ctx->fqctx);
@@ -1026,7 +1026,7 @@ cleanup:
 
     fq_nmod_mpoly_ctx_clear(uctx);
 
-    flint_randclear(randstate);
+    flint_rand_clear(randstate);
 
     return success;
 }

--- a/src/fq_nmod_mpoly/gcd_hensel.c
+++ b/src/fq_nmod_mpoly/gcd_hensel.c
@@ -68,7 +68,7 @@ int fq_nmod_mpolyl_gcd_hensel_smprime(
     FLINT_ASSERT(B->bits == bits);
     FLINT_ASSERT(ctx->minfo->ord == ORD_LEX);
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     tmp = FLINT_ARRAY_ALLOC(d*(N_FQ_MUL_INV_ITCH + 1), mp_limb_t);
     q = tmp + d*N_FQ_MUL_INV_ITCH;
@@ -390,7 +390,7 @@ got_alpha:
 
 cleanup:
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     flint_free(tmp);
 

--- a/src/fq_nmod_mpoly/gcd_zippel2.c
+++ b/src/fq_nmod_mpoly/gcd_zippel2.c
@@ -676,7 +676,7 @@ int fq_nmod_mpolyl_gcd_zippel_smprime(
         fq_nmod_init(alphas + i, ctx->fqctx);
     }
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     Aevals = FLINT_ARRAY_ALLOC(nvars + 1, fq_nmod_mpoly_struct);
     Bevals = FLINT_ARRAY_ALLOC(nvars + 1, fq_nmod_mpoly_struct);
@@ -1308,7 +1308,7 @@ cleanup:
     }
     flint_free(betas);
     flint_free(alphas);
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     for (i = 0; i < nvars; i++)
     {
@@ -1523,7 +1523,7 @@ int fq_nmod_mpolyl_gcd_zippel_lgprime(
         fq_nmod_init(alphas + i, smctx->fqctx);
     }
 
-    flint_randinit(state);
+    flint_rand_init(state);
     cur_emb = bad_fq_nmod_mpoly_embed_chooser_init(embc, lgctx, smctx, state);
     lgd = fq_nmod_ctx_degree(lgctx->fqctx);
     n_poly_init2(tmp, lgd);
@@ -2372,7 +2372,7 @@ cleanup:
     n_fq_poly_clear(alphapow);
     fq_nmod_clear(start_alpha, smctx->fqctx);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     for (i = 0; i < nvars; i++)
     {

--- a/src/fq_nmod_mpoly/mpolyn_gcd_brown.c
+++ b/src/fq_nmod_mpoly/mpolyn_gcd_brown.c
@@ -599,7 +599,7 @@ int fq_nmod_mpolyn_gcd_brown_lgprime_bivar(
 
     fq_nmod_poly_one(modulus, ctx->fqctx);
 
-    flint_randinit(randstate);
+    flint_rand_init(randstate);
     cur_emb = bad_fq_nmod_mpoly_embed_chooser_init(embc, ectx, ctx, randstate);
 
     /*
@@ -777,7 +777,7 @@ cleanup:
 
     bad_fq_nmod_mpoly_embed_chooser_clear(embc, ectx, ctx, randstate);
 
-    flint_randclear(randstate);
+    flint_rand_clear(randstate);
 
     return success;
 }
@@ -868,7 +868,7 @@ int fq_nmod_mpolyn_gcd_brown_lgprime(
 
     fq_nmod_poly_one(modulus, ctx->fqctx);
 
-    flint_randinit(randstate);
+    flint_rand_init(randstate);
     cur_emb = bad_fq_nmod_mpoly_embed_chooser_init(embc, ectx, ctx, randstate);
 
     /*
@@ -1054,7 +1054,7 @@ cleanup:
 
     bad_fq_nmod_mpoly_embed_chooser_clear(embc, ectx, ctx, randstate);
 
-    flint_randclear(randstate);
+    flint_rand_clear(randstate);
 
     return success;
 }

--- a/src/fq_nmod_mpoly/sqrt_heap.c
+++ b/src/fq_nmod_mpoly/sqrt_heap.c
@@ -142,7 +142,7 @@ static int _fq_nmod_mpoly_sqrt_heap(
     cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
     mpoly_get_cmpmask(cmpmask, N, bits, mctx);
 
-    flint_randinit(heuristic_state);
+    flint_rand_init(heuristic_state);
 
     /* alloc array of heap nodes which can be chained together */
     next_loc = 2*sqrt(Alen) + 4;   /* something bigger than heap can ever be */
@@ -363,7 +363,7 @@ static int _fq_nmod_mpoly_sqrt_heap(
 
 cleanup:
 
-    flint_randclear(heuristic_state);
+    flint_rand_clear(heuristic_state);
 
     Q->coeffs = Qcoeffs;
     Q->exps = Qexps;

--- a/src/fq_nmod_mpoly_factor/factor.c
+++ b/src/fq_nmod_mpoly_factor/factor.c
@@ -277,7 +277,7 @@ static int _factor_irred_compressed(
 
     Abits = A->bits;
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     strides = FLINT_ARRAY_ALLOC(2*nvars, ulong);
     texps = strides + nvars;
@@ -538,7 +538,7 @@ static int _factor_irred_compressed(
 
 cleanup:
 
-    flint_randclear(state);
+    flint_rand_clear(state);
     flint_free(strides);
     flint_free(perm);
 

--- a/src/fq_nmod_poly_factor/profile/p-roots.c
+++ b/src/fq_nmod_poly_factor/profile/p-roots.c
@@ -30,7 +30,7 @@ int main(int argc, char *argv[])
         flint_rand_t randstate;
         timeit_t timer;
 
-        flint_randinit(randstate);
+        flint_rand_init(randstate);
 
         p = UWORD(1) << (SMALL_FMPZ_BITCOUNT_MAX);
         p = n_nextprime(p, 1);
@@ -75,7 +75,7 @@ int main(int argc, char *argv[])
         fq_nmod_poly_clear(f, ctx);
         fq_nmod_ctx_clear(ctx);
 
-        flint_randclear(randstate);
+        flint_rand_clear(randstate);
     }
 
     flint_cleanup_master();

--- a/src/fq_poly_factor_templates/factor_berlekamp.c
+++ b/src/fq_poly_factor_templates/factor_berlekamp.c
@@ -294,13 +294,13 @@ TEMPLATE(T, poly_factor_berlekamp) (TEMPLATE(T, poly_factor_t) factors,
     TEMPLATE(T, poly_factor_squarefree) (sq_free, v, ctx);
 
     /* run Berlekamp algorithm for all squarefree factors */
-    flint_randinit(r);
+    flint_rand_init(r);
     for (i = 0; i < sq_free->num; i++)
     {
         __TEMPLATE(T, poly_factor_berlekamp) (factors, r, sq_free->poly + i,
                                               ctx);
     }
-    flint_randclear(r);
+    flint_rand_clear(r);
 
     /* compute multiplicities of factors in f */
     for (i = 0; i < factors->num; i++)

--- a/src/fq_poly_factor_templates/factor_equal_deg.c
+++ b/src/fq_poly_factor_templates/factor_equal_deg.c
@@ -36,14 +36,14 @@ TEMPLATE(T, poly_factor_equal_deg) (TEMPLATE(T, poly_factor_t) factors,
 
         TEMPLATE(T, poly_init) (f, ctx);
 
-        flint_randinit(state);
+        flint_rand_init(state);
 
         while (!TEMPLATE(T, poly_factor_equal_deg_prob)
                (f, state, pol, d, ctx))
         {
         };
 
-        flint_randclear(state);
+        flint_rand_clear(state);
 
         TEMPLATE(T, poly_init) (g, ctx);
         TEMPLATE(T, poly_init) (r, ctx);

--- a/src/fq_poly_factor_templates/factor_split_single.c
+++ b/src/fq_poly_factor_templates/factor_split_single.c
@@ -28,7 +28,7 @@ TEMPLATE(T, poly_factor_split_single) (TEMPLATE(T, poly_t) linfactor,
         slong deflation;
         TEMPLATE(T, poly_t) pol;
 
-        flint_randinit(state);
+        flint_rand_init(state);
         TEMPLATE(T, poly_init) (pol, ctx);
         TEMPLATE(T, poly_set) (linfactor, input, ctx);
         deflation = TEMPLATE(T, poly_deflation) (input, ctx);
@@ -68,7 +68,7 @@ TEMPLATE(T, poly_factor_split_single) (TEMPLATE(T, poly_t) linfactor,
             }
         }
 
-        flint_randclear(state);
+        flint_rand_clear(state);
         TEMPLATE(T, poly_clear) (pol, ctx);
     }
 }

--- a/src/fq_poly_factor_templates/roots.c
+++ b/src/fq_poly_factor_templates/roots.c
@@ -272,7 +272,7 @@ void TEMPLATE(T, poly_roots)(
     else
         fmpz_zero(q2);
 
-    flint_randinit(randstate);
+    flint_rand_init(randstate);
 
     for (i = 0; i < FLINT_BITS + 3; i++)
         TEMPLATE(T, poly_init)(t + i, ctx);
@@ -298,7 +298,7 @@ void TEMPLATE(T, poly_roots)(
 
     fmpz_clear(q2);
 
-    flint_randclear(randstate);
+    flint_rand_clear(randstate);
 
     for (i = 0; i < FLINT_BITS + 3; i++)
         TEMPLATE(T, poly_clear)(t + i, ctx);

--- a/src/fq_templates/sqrt.c
+++ b/src/fq_templates/sqrt.c
@@ -50,12 +50,12 @@ int TEMPLATE(T, sqrt)(TEMPLATE(T, t) rop, const TEMPLATE(T, t) op,
         {
             flint_rand_t state;
 
-            flint_randinit(state);
+            flint_rand_init(state);
 
             while (TEMPLATE(T, is_square)(z, ctx))
                 TEMPLATE(T, rand)(z, state, ctx);
 
-            flint_randclear(state);
+            flint_rand_clear(state);
         }
 
         TEMPLATE(T, ctx_order)(ord, ctx);

--- a/src/fq_zech/ctx.c
+++ b/src/fq_zech/ctx.c
@@ -96,7 +96,7 @@ fq_zech_ctx_init_random_ui(fq_zech_ctx_t ctx, ulong p, slong d, const char * var
 
     fq_nmod_ctx = flint_malloc(sizeof(fq_nmod_ctx_struct));
 
-    flint_randinit(state);
+    flint_rand_init(state);
     nmod_poly_init(poly, p);
 
     poly->coeffs = tmp_coeffs;

--- a/src/generic_files/random.c
+++ b/src/generic_files/random.c
@@ -1,0 +1,65 @@
+/*
+    Copyright (C) 2024 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <gmp.h>
+#include "flint.h"
+
+void _flint_rand_init_gmp_state(flint_rand_t state)
+{
+    FLINT_ASSERT(state->__gmp_state == NULL);
+    state->__gmp_state = flint_malloc(sizeof(__gmp_randstate_struct));
+    gmp_randinit_default(state->__gmp_state);
+}
+
+void _flint_rand_clear_gmp_state(flint_rand_t state)
+{
+    FLINT_ASSERT(state->__gmp_state != NULL);
+    gmp_randclear(state->__gmp_state);
+    flint_free(state->__gmp_state);
+}
+
+/* NOTE: The following functions are deprecated, and only exists for
+   backwards-compatibility. */
+void flint_randinit(flint_rand_t state)
+{
+    flint_rand_init(state);
+}
+
+void flint_randclear(flint_rand_t state)
+{
+    flint_rand_clear(state);
+}
+
+void flint_randseed(flint_rand_t state, ulong s0, ulong s1)
+{
+    flint_rand_set_seed(state, s0, s1);
+}
+
+void flint_get_randseed(ulong * s0, ulong * s1, flint_rand_t state)
+{
+    flint_rand_get_seed(s0, s1, state);
+}
+
+void _flint_rand_init_gmp(flint_rand_t state)
+{
+    if (state->__gmp_state == NULL)
+        _flint_rand_init_gmp_state(state);
+}
+
+flint_rand_struct * flint_rand_alloc(void)
+{
+    return (flint_rand_struct *) flint_malloc(sizeof(flint_rand_struct));
+}
+
+void flint_rand_free(flint_rand_struct * state)
+{
+    flint_free(state);
+}

--- a/src/gr/test_ring.c
+++ b/src/gr/test_ring.c
@@ -3704,7 +3704,7 @@ gr_test_ring(gr_ctx_t R, slong iters, int test_flags)
         flint_printf("-------------------------------------------------------------------------------\n");
     }
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     /* if (gr_ctx_is_ring(R) != T_TRUE)
         flint_abort(); */
@@ -3828,7 +3828,7 @@ gr_test_ring(gr_ctx_t R, slong iters, int test_flags)
 
     gr_test_iter(R, state, "mat_mul_classical: associative", gr_test_mat_mul_classical_associative, iters, test_flags);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     if (test_flags & GR_TEST_VERBOSE)
     {
@@ -3857,7 +3857,7 @@ gr_test_multiplicative_group(gr_ctx_t R, slong iters, int test_flags)
         flint_printf("-------------------------------------------------------------------------------\n");
     }
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     /* if (gr_ctx_is_multiplicative_group(R) != T_TRUE)
         flint_abort(); */
@@ -3891,7 +3891,7 @@ gr_test_multiplicative_group(gr_ctx_t R, slong iters, int test_flags)
 
     gr_test_iter(R, state, "get_set_fexpr", gr_test_get_set_fexpr, iters, test_flags);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     if (test_flags & GR_TEST_VERBOSE)
     {
@@ -3921,7 +3921,7 @@ gr_test_floating_point(gr_ctx_t R, slong iters, int test_flags)
         flint_printf("-------------------------------------------------------------------------------\n");
     }
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     /* if (gr_ctx_is_ring(R) != T_TRUE)
         flint_abort(); */
@@ -3949,7 +3949,7 @@ gr_test_floating_point(gr_ctx_t R, slong iters, int test_flags)
     gr_test_iter(R, state, "vec_mul", gr_test_vec_mul, vec_iters, test_flags);
     gr_test_iter(R, state, "vec_mul_scalar", gr_test_vec_mul_scalar, vec_iters, test_flags);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     if (test_flags & GR_TEST_VERBOSE)
     {

--- a/src/gr_poly/tune/cutoffs.c
+++ b/src/gr_poly/tune/cutoffs.c
@@ -262,7 +262,7 @@ get_profile(gr_ctx_t ctx, slong len)
     gr_poly_init(C, ctx);
     gr_poly_init(D, ctx);
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     SETUP
 
@@ -280,7 +280,7 @@ get_profile(gr_ctx_t ctx, slong len)
 
     printf("len %ld : %f\n", len, tbase / tnew);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     gr_poly_clear(A, ctx);
     gr_poly_clear(B, ctx);

--- a/src/mpfr_mat/randtest.c
+++ b/src/mpfr_mat/randtest.c
@@ -21,9 +21,10 @@ mpfr_mat_randtest(mpfr_mat_t mat, flint_rand_t state)
     r = mat->r;
     c = mat->c;
 
-    _flint_rand_init_gmp(state);
+    if (!FLINT_RAND_GMP_STATE_IS_INITIALISED(state))
+        _flint_rand_init_gmp_state(state);
 
     for (i = 0; i < r; i++)
         for (j = 0; j < c; j++)
-            mpfr_urandomb(mpfr_mat_entry(mat, i, j), state->gmp_state);
+            mpfr_urandomb(mpfr_mat_entry(mat, i, j), state->__gmp_state);
 }

--- a/src/mpfr_vec/randtest.c
+++ b/src/mpfr_vec/randtest.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "mpfr_vec.h"
 
 void
@@ -17,8 +16,9 @@ _mpfr_vec_randtest(mpfr_ptr f, flint_rand_t state, slong len)
 {
     slong i;
 
-    _flint_rand_init_gmp(state);
+    if (!FLINT_RAND_GMP_STATE_IS_INITIALISED(state))
+        _flint_rand_init_gmp_state(state);
 
     for (i = 0; i < len; i++)
-        mpfr_urandomb(f + i, state->gmp_state);
+        mpfr_urandomb(f + i, state->__gmp_state);
 }

--- a/src/mpn_extras/profile/p-mul_n.c
+++ b/src/mpn_extras/profile/p-mul_n.c
@@ -23,7 +23,7 @@ int main(void)
     slong i, n;
     double t1, t2, FLINT_SET_BUT_UNUSED(__);
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     {
         for (i = 0; i < MAXN; i++)
@@ -56,7 +56,7 @@ int main(void)
         }
     }
 
-    flint_randclear(state);
+    flint_rand_clear(state);
     flint_cleanup_master();
     return 0;
 }

--- a/src/mpn_extras/profile/p-mulmod_preinvn.c
+++ b/src/mpn_extras/profile/p-mulmod_preinvn.c
@@ -113,7 +113,7 @@ void sample(void * arg, ulong count)
     /* don't init r2 */
 
     gmp_randclear(st);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 int main(void)

--- a/src/mpn_extras/random.c
+++ b/src/mpn_extras/random.c
@@ -9,16 +9,19 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "mpn_extras.h"
 
 void flint_mpn_rrandom(mp_ptr rp, flint_rand_t state, mp_size_t n)
 {
     __mpz_struct str;
+
     str._mp_d = rp;
     str._mp_alloc = n;
     str._mp_size = n;
-    _flint_rand_init_gmp(state);
+
+    if (!FLINT_RAND_GMP_STATE_IS_INITIALISED(state))
+        _flint_rand_init_gmp_state(state);
+
     FLINT_ASSERT(n >= 1);
     /* Randomly generate numbers where the top limb has the highest bit
        set or not. TODO: do we want this function to generate
@@ -26,17 +29,21 @@ void flint_mpn_rrandom(mp_ptr rp, flint_rand_t state, mp_size_t n)
        that be a separate function? The documentation does not specify
        precisely what this function does. */
     if (n_randint(state, 2))
-        mpz_rrandomb(&str, state->gmp_state, FLINT_BITS * n);
+        mpz_rrandomb(&str, state->__gmp_state, FLINT_BITS * n);
     else
-        mpz_rrandomb(&str, state->gmp_state, FLINT_BITS * n - n_randint(state, FLINT_BITS));
+        mpz_rrandomb(&str, state->__gmp_state, FLINT_BITS * n - n_randint(state, FLINT_BITS));
 }
 
 void flint_mpn_urandomb(mp_ptr rp, flint_rand_t state, flint_bitcnt_t n)
 {
     __mpz_struct str;
+
     str._mp_d = rp;
     str._mp_alloc = (n + FLINT_BITS - 1)/FLINT_BITS;
     str._mp_size = (n + FLINT_BITS - 1)/FLINT_BITS;
-    _flint_rand_init_gmp(state);
-    mpz_urandomb(&str, state->gmp_state, n);
+
+    if (!FLINT_RAND_GMP_STATE_IS_INITIALISED(state))
+        _flint_rand_init_gmp_state(state);
+
+    mpz_urandomb(&str, state->__gmp_state, n);
 }

--- a/src/mpn_mod/profile/p-karatsuba.c
+++ b/src/mpn_mod/profile/p-karatsuba.c
@@ -106,7 +106,7 @@ int main()
     flint_rand_t state;
     slong bits, m1, m2, m3;
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     for (bits = 65; bits <= 1024; bits++)
     {
@@ -124,5 +124,5 @@ int main()
     }
 
     fmpz_clear(p);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }

--- a/src/mpn_mod/profile/p-mat_mul.c
+++ b/src/mpn_mod/profile/p-mat_mul.c
@@ -139,7 +139,7 @@ int main()
     flint_rand_t state;
     slong bits;
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     /* flint_set_num_threads(8); */
 
@@ -153,5 +153,5 @@ int main()
     }
 
     fmpz_clear(p);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }

--- a/src/mpn_mod/profile/p-mat_vs_fmpz_mod.c
+++ b/src/mpn_mod/profile/p-mat_vs_fmpz_mod.c
@@ -65,7 +65,7 @@ int main()
     slong i;
     slong bits_tab[] = { 80, 128, 180, 256, 512, 1024, };
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     gr_mat_t A, B, C;
     gr_mat_t A2, B2, C2;
@@ -170,6 +170,6 @@ int main()
     }
 
     fmpz_clear(p);
-    flint_randclear(state);
+    flint_rand_clear(state);
     return 0;
 }

--- a/src/mpn_mod/profile/p-poly_mullow.c
+++ b/src/mpn_mod/profile/p-poly_mullow.c
@@ -224,7 +224,7 @@ int main()
     flint_rand_t state;
     slong bits;
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     for (bits = 1; bits <= 100; bits++)
     {
@@ -243,5 +243,5 @@ int main()
     }
 
     fmpz_clear(p);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }

--- a/src/mpn_mod/profile/p-poly_vs_fmpz_mod.c
+++ b/src/mpn_mod/profile/p-poly_vs_fmpz_mod.c
@@ -57,7 +57,7 @@ int main()
     slong i;
     slong bits_tab[] = { 80, 128, 180, 256, 512, 1024, };
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     gr_ptr A, B, C, Q, R;
     gr_ptr A2, B2, C2, Q2, R2;
@@ -175,6 +175,6 @@ int main()
     }
 
     fmpz_clear(p);
-    flint_randclear(state);
+    flint_rand_clear(state);
     return 0;
 }

--- a/src/mpoly/compression.c
+++ b/src/mpoly/compression.c
@@ -337,7 +337,7 @@ void mpoly_compression_set(
     if (one_total != M->nvars)
         M->is_perm = 0;
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     sum_deg = 1;
     overflowed = 0;
@@ -357,5 +357,5 @@ void mpoly_compression_set(
     M->is_irred = _mpoly_test_irreducible(M->exps, nvars, Alen,
                                                    M->mvars, state, tries);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }

--- a/src/mpoly/profile/p-test_irreducible.c
+++ b/src/mpoly/profile/p-test_irreducible.c
@@ -23,7 +23,7 @@ main(void)
     timeit_t timer;
     flint_rand_t state;
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     flint_printf("------------------------------\n");
     total_time = 0;
@@ -115,7 +115,7 @@ main(void)
     }
     flint_printf("irreducible time: %wd ms\n\n", total_time);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     return 0;
 }

--- a/src/mpoly/test_irreducible.c
+++ b/src/mpoly/test_irreducible.c
@@ -979,7 +979,7 @@ int mpoly_test_irreducible(
     if (Abits > FLINT_BITS || Alen < 2)
         return 0;
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     uexps = FLINT_ARRAY_ALLOC(n*Alen, slong);
     max_exps = FLINT_ARRAY_ALLOC(n, slong);
@@ -1013,7 +1013,7 @@ int mpoly_test_irreducible(
 
     result = _mpoly_test_irreducible(uexps, n, Alen, n, state, tries);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
     flint_free(max_exps);
     flint_free(uexps);
 

--- a/src/nf_elem/profile/p-mul.c
+++ b/src/nf_elem/profile/p-mul.c
@@ -66,7 +66,7 @@ void sample(void * arg, ulong count)
    nf_t nf;
    nf_elem_t a, b, c;
 
-   flint_randinit(state);
+   flint_rand_init(state);
 
    scale = 100;
    if (length >= 50) scale = 10;
@@ -113,7 +113,7 @@ void sample(void * arg, ulong count)
 
    fmpq_poly_clear(pol);
 
-   flint_randclear(state);
+   flint_rand_clear(state);
 }
 
 int main(void)

--- a/src/nf_elem/profile/p-norm.c
+++ b/src/nf_elem/profile/p-norm.c
@@ -67,7 +67,7 @@ void sample(void * arg, ulong count)
    nf_elem_t a;
    fmpq_t norm;
 
-   flint_randinit(state);
+   flint_rand_init(state);
 
    scale = 100;
    if (length >= 50) scale = 10;
@@ -109,7 +109,7 @@ void sample(void * arg, ulong count)
 
    fmpq_poly_clear(pol);
 
-   flint_randclear(state);
+   flint_rand_clear(state);
 }
 
 int main(void)

--- a/src/nf_elem/profile/p-trace.c
+++ b/src/nf_elem/profile/p-trace.c
@@ -67,7 +67,7 @@ void sample(void * arg, ulong count)
    nf_elem_t a;
    fmpq_t norm;
 
-   flint_randinit(state);
+   flint_rand_init(state);
 
    scale = 1000;
    if (length >= 50) scale = 100;
@@ -109,7 +109,7 @@ void sample(void * arg, ulong count)
 
    fmpq_poly_clear(pol);
 
-   flint_randclear(state);
+   flint_rand_clear(state);
 }
 
 int main(void)

--- a/src/nmod_mat/profile/p-lu.c
+++ b/src/nmod_mat/profile/p-lu.c
@@ -34,7 +34,7 @@ void sample(void * arg, ulong count)
     ulong i;
     flint_rand_t state;
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     nmod_mat_init(A, params->n, params->n, params->modulus);
     nmod_mat_init(LU, params->n, params->n, params->modulus);
@@ -74,7 +74,7 @@ void sample(void * arg, ulong count)
     nmod_mat_clear(LU);
     _perm_clear(P);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 slong bits_tab[] = { 5, 14, 15, 25, 30, 31, 32, 33, 60, 61, 62, 63, 64, 0 };

--- a/src/nmod_mat/profile/p-mul.c
+++ b/src/nmod_mat/profile/p-mul.c
@@ -38,7 +38,7 @@ void sample(void * arg, ulong count)
     ulong i;
     flint_rand_t state;
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     nmod_mat_init(A, params->dim_m, params->dim_k, params->modulus);
     nmod_mat_init(B, params->dim_k, params->dim_n, params->modulus);
@@ -71,7 +71,7 @@ void sample(void * arg, ulong count)
     nmod_mat_clear(B);
     nmod_mat_clear(C);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 int main(void)

--- a/src/nmod_mpoly/gcd.c
+++ b/src/nmod_mpoly/gcd.c
@@ -359,7 +359,7 @@ static void _set_estimates(
     slong ignore_limit;
     int * ignore;
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     ignore = FLINT_ARRAY_ALLOC(nvars, int);
     alpha  = FLINT_ARRAY_ALLOC(nvars, mp_limb_t);
@@ -452,7 +452,7 @@ cleanup:
     flint_free(Aevals);
     flint_free(Bevals);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     return;
 }
@@ -480,7 +480,7 @@ static void _set_estimates_medprime(
     if (max_degree < 2)
         return;
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     fq_zech_ctx_init_ui(medctx, smctx->mod.n, 1, "#");
 
@@ -576,7 +576,7 @@ cleanup:
 
     fq_zech_ctx_clear(medctx);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     return;
 }
@@ -600,7 +600,7 @@ static void _set_estimates_lgprime(
     fq_nmod_mpoly_ctx_t lgctx;
     slong d;
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     d = WORD(20)/(FLINT_BIT_COUNT(smctx->mod.n));
     d = FLINT_MAX(WORD(2), d);
@@ -693,7 +693,7 @@ cleanup:
 
     fq_nmod_mpoly_ctx_clear(lgctx);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     return;
 }
@@ -1131,7 +1131,7 @@ static int _try_zippel(
     FLINT_ASSERT(A->length > 0);
     FLINT_ASSERT(B->length > 0);
 
-    flint_randinit(randstate);
+    flint_rand_init(randstate);
 
     /* uctx is context for Z[y_1,...,y_{m-1}]*/
     nmod_mpoly_ctx_init(uctx, m - 1, ORD_LEX, ctx->mod.n);
@@ -1221,7 +1221,7 @@ cleanup:
 
     nmod_mpoly_ctx_clear(uctx);
 
-    flint_randclear(randstate);
+    flint_rand_clear(randstate);
 
     return success;
 }

--- a/src/nmod_mpoly/gcd_hensel.c
+++ b/src/nmod_mpoly/gcd_hensel.c
@@ -69,7 +69,7 @@ int nmod_mpolyl_gcd_hensel_smprime(
     FLINT_ASSERT(B->bits == bits);
     FLINT_ASSERT(ctx->minfo->ord == ORD_LEX);
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     Hdegs  = FLINT_ARRAY_ALLOC(n + 1, slong);
 
@@ -394,7 +394,7 @@ got_alpha:
 
 cleanup:
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     flint_free(Hdegs);
 
@@ -491,7 +491,7 @@ int nmod_mpolyl_gcd_hensel_medprime(
     fq_zech_mpoly_init(A, ctx);
     fq_zech_mpoly_init(B, ctx);
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     Hdegs  = FLINT_ARRAY_ALLOC(n + 1, slong);
 
@@ -844,7 +844,7 @@ cleanup:
     fq_zech_mpoly_clear(A, ctx);
     fq_zech_mpoly_clear(B, ctx);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     flint_free(Hdegs);
 

--- a/src/nmod_mpoly/gcd_zippel2.c
+++ b/src/nmod_mpoly/gcd_zippel2.c
@@ -593,7 +593,7 @@ int nmod_mpolyl_gcd_zippel_smprime(
 
     betas = FLINT_ARRAY_ALLOC(nvars, mp_limb_t);
     alphas = FLINT_ARRAY_ALLOC(nvars, mp_limb_t);
-    flint_randinit(state);
+    flint_rand_init(state);
 
     Aevals = FLINT_ARRAY_ALLOC(nvars + 1, nmod_mpoly_struct);
     Bevals = FLINT_ARRAY_ALLOC(nvars + 1, nmod_mpoly_struct);
@@ -1155,7 +1155,7 @@ cleanup:
 
     flint_free(betas);
     flint_free(alphas);
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     for (i = 0; i < nvars; i++)
     {
@@ -1262,7 +1262,7 @@ int nmod_mpolyl_gcd_zippel_lgprime(
     FLINT_ASSERT(gammadegs[0] == 0);
     FLINT_ASSERT(gammadegs[1] == 0);
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     lgd = WORD(20)/(FLINT_BIT_COUNT(smctx->mod.n));
     lgd = FLINT_MAX(WORD(2), lgd);
@@ -2172,7 +2172,7 @@ cleanup:
         fq_nmod_clear(betas + i, lgctx->fqctx);
     }
     flint_free(alphas);
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     for (i = 0; i < nvars; i++)
     {

--- a/src/nmod_mpoly/sqrt_heap.c
+++ b/src/nmod_mpoly/sqrt_heap.c
@@ -175,7 +175,7 @@ static int _nmod_mpoly_sqrt_heap1(
     FLINT_ASSERT(mpoly_words_per_exp(bits, mctx) == 1);
     mpoly_get_cmpmask(&maskhi, 1, bits, mctx);
 
-    flint_randinit(heuristic_state);
+    flint_rand_init(heuristic_state);
 
     /* alloc array of heap nodes which can be chained together */
     next_loc = 2*n_sqrt(Alen) + 4;   /* something bigger than heap can ever be */
@@ -345,7 +345,7 @@ static int _nmod_mpoly_sqrt_heap1(
 
 cleanup:
 
-    flint_randclear(heuristic_state);
+    flint_rand_clear(heuristic_state);
 
     Q->coeffs = Qcoeffs;
     Q->exps = Qexps;
@@ -406,7 +406,7 @@ static int _nmod_mpoly_sqrt_heap(
     cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
     mpoly_get_cmpmask(cmpmask, N, bits, mctx);
 
-    flint_randinit(heuristic_state);
+    flint_rand_init(heuristic_state);
 
     /* alloc array of heap nodes which can be chained together */
     next_loc = 2*sqrt(Alen) + 4;   /* something bigger than heap can ever be */
@@ -629,7 +629,7 @@ static int _nmod_mpoly_sqrt_heap(
 
 cleanup:
 
-    flint_randclear(heuristic_state);
+    flint_rand_clear(heuristic_state);
 
     Q->coeffs = Qcoeffs;
     Q->exps = Qexps;

--- a/src/nmod_mpoly_factor/factor.c
+++ b/src/nmod_mpoly_factor/factor.c
@@ -275,7 +275,7 @@ static int _factor_irred_compressed(
 
     Abits = A->bits;
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     strides = FLINT_ARRAY_ALLOC(2*nvars, ulong);
     texps = strides + nvars;
@@ -550,7 +550,7 @@ static int _factor_irred_compressed(
 
 cleanup:
 
-    flint_randclear(state);
+    flint_rand_clear(state);
     flint_free(strides);
     flint_free(perm);
 

--- a/src/nmod_mpoly_factor/test/t-gcd_zippel.c
+++ b/src/nmod_mpoly_factor/test/t-gcd_zippel.c
@@ -72,7 +72,7 @@ int compute_gcd(
     FLINT_ASSERT(!nmod_mpoly_is_zero(B, ctx));
     FLINT_ASSERT(ctx->minfo->nvars >= 2);
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     wbits = FLINT_MAX(A->bits, B->bits);
 
@@ -136,7 +136,7 @@ cleanup:
 
     nmod_mpoly_ctx_clear(lctx);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     flint_free(perm);
     flint_free(shift);

--- a/src/nmod_poly/find_distinct_nonzero_roots.c
+++ b/src/nmod_poly/find_distinct_nonzero_roots.c
@@ -90,7 +90,7 @@ int nmod_poly_find_distinct_nonzero_roots(
     if (P->coeffs[0] == 0)
         return 0;
 
-    flint_randinit(randstate);
+    flint_rand_init(randstate);
     nmod_poly_init_mod(t, P->mod);
     nmod_poly_init_mod(t2, P->mod);
     nmod_poly_init_mod(f, P->mod);
@@ -155,7 +155,7 @@ int nmod_poly_find_distinct_nonzero_roots(
 
 cleanup:
 
-    flint_randclear(randstate);
+    flint_rand_clear(randstate);
     nmod_poly_clear(t);
     nmod_poly_clear(t2);
     nmod_poly_clear(f);

--- a/src/nmod_poly/profile/p-gcd.c
+++ b/src/nmod_poly/profile/p-gcd.c
@@ -127,6 +127,6 @@ int main(void)
     }
     flint_printf("]\n");
 
-    flint_randclear(state);
+    flint_rand_clear(state);
     return 0;
 }

--- a/src/nmod_poly/profile/p-mul.c
+++ b/src/nmod_poly/profile/p-mul.c
@@ -65,7 +65,7 @@ void sample(void * arg, ulong count)
    nmod_poly_clear(a);
    nmod_poly_clear(b);
    nmod_poly_clear(c);
-   flint_randclear(state);
+   flint_rand_clear(state);
 }
 
 int main(void)

--- a/src/nmod_poly/profile/p-mulmod.c
+++ b/src/nmod_poly/profile/p-mulmod.c
@@ -90,7 +90,7 @@ void sample(void * arg, ulong count)
    nmod_poly_clear(c);
    nmod_poly_clear(d);
    nmod_poly_clear(dinv);
-   flint_randclear(state);
+   flint_rand_clear(state);
 }
 
 int main(void)

--- a/src/nmod_poly_factor/factor_berlekamp.c
+++ b/src/nmod_poly_factor/factor_berlekamp.c
@@ -231,9 +231,9 @@ nmod_poly_factor_berlekamp(nmod_poly_factor_t factors, const nmod_poly_t f)
 {
     flint_rand_t r;
 
-    flint_randinit(r);
+    flint_rand_init(r);
 
     __nmod_poly_factor_berlekamp(factors, r, f);
 
-    flint_randclear(r);
+    flint_rand_clear(r);
 }

--- a/src/nmod_poly_factor/factor_equal_deg.c
+++ b/src/nmod_poly_factor/factor_equal_deg.c
@@ -30,12 +30,12 @@ nmod_poly_factor_equal_deg(nmod_poly_factor_t factors,
 
         nmod_poly_init_mod(f, pol->mod);
 
-        flint_randinit(state);
+        flint_rand_init(state);
 
         while (!nmod_poly_factor_equal_deg_prob(f, state, pol, d))
            ;
 
-        flint_randclear(state);
+        flint_rand_clear(state);
 
         nmod_poly_init_mod(g, pol->mod);
         nmod_poly_divexact(g, pol, f);

--- a/src/nmod_poly_factor/profile/p-factor.c
+++ b/src/nmod_poly_factor/profile/p-factor.c
@@ -331,6 +331,6 @@ int main(void)
         }
     }
 
-    flint_randclear(state);
+    flint_rand_clear(state);
     return 0;
 }

--- a/src/nmod_poly_factor/profile/p-roots.c
+++ b/src/nmod_poly_factor/profile/p-roots.c
@@ -27,7 +27,7 @@ int main(int argc, char *argv[])
         timeit_t timer;
         ulong p = n_nextprime(UWORD(1) << (SMALL_FMPZ_BITCOUNT_MAX), 1);
 
-        flint_randinit(state);
+        flint_rand_init(state);
 
         nmod_poly_init(f, p);
         nmod_poly_init(g, p);
@@ -62,7 +62,7 @@ int main(int argc, char *argv[])
         nmod_poly_clear(g);
         nmod_poly_clear(f);
 
-        flint_randclear(state);
+        flint_rand_clear(state);
     }
 
     flint_cleanup_master();

--- a/src/nmod_poly_factor/roots.c
+++ b/src/nmod_poly_factor/roots.c
@@ -174,7 +174,7 @@ void nmod_poly_roots(nmod_poly_factor_t r, const nmod_poly_t f,
         return;
     }
 
-    flint_randinit(randstate);
+    flint_rand_init(randstate);
 
     for (i = 0; i < FLINT_BITS + 3; i++)
         nmod_poly_init_mod(t + i, f->mod);
@@ -197,7 +197,7 @@ void nmod_poly_roots(nmod_poly_factor_t r, const nmod_poly_t f,
         _nmod_poly_push_roots(r, t + 0, 1, t + 1, t + 2, t + 3, randstate);
     }
 
-    flint_randclear(randstate);
+    flint_rand_clear(randstate);
 
     for (i = 0; i < FLINT_BITS + 3; i++)
         nmod_poly_clear(t + i);

--- a/src/nmod_vec/profile/p-add.c
+++ b/src/nmod_vec/profile/p-add.c
@@ -96,7 +96,7 @@ void sample(void * arg, ulong unused)
         _nmod_vec_clear(vec2);
     }
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
 int main(int argc, char ** argv)

--- a/src/nmod_vec/profile/p-add_sub_neg.c
+++ b/src/nmod_vec/profile/p-add_sub_neg.c
@@ -79,7 +79,7 @@ void sample(void * arg, ulong count)
       break;
    }
 
-   flint_randclear(state);
+   flint_rand_clear(state);
    _nmod_vec_clear(vec1);
    _nmod_vec_clear(vec2);
 }

--- a/src/nmod_vec/profile/p-mul.c
+++ b/src/nmod_vec/profile/p-mul.c
@@ -67,7 +67,7 @@ void sample(void * arg, ulong count)
       break;
    }
 
-   flint_randclear(state);
+   flint_rand_clear(state);
    _nmod_vec_clear(vec1);
    _nmod_vec_clear(vec2);
 }

--- a/src/nmod_vec/profile/p-reduce.c
+++ b/src/nmod_vec/profile/p-reduce.c
@@ -47,7 +47,7 @@ void sample(void * arg, ulong count)
    }
    prof_stop();
 
-   flint_randclear(state);
+   flint_rand_clear(state);
    _nmod_vec_clear(vec);
    _nmod_vec_clear(vec2);
 }

--- a/src/nmod_vec/profile/p-scalar_addmul.c
+++ b/src/nmod_vec/profile/p-scalar_addmul.c
@@ -52,7 +52,7 @@ void sample(void * arg, ulong count)
 	  prof_stop();
    }
 
-   flint_randclear(state);
+   flint_rand_clear(state);
    _nmod_vec_clear(vec);
    _nmod_vec_clear(vec2);
 }

--- a/src/nmod_vec/profile/p-scalar_mul.c
+++ b/src/nmod_vec/profile/p-scalar_mul.c
@@ -50,7 +50,7 @@ void sample(void * arg, ulong count)
 	  prof_stop();
    }
 
-   flint_randclear(state);
+   flint_rand_clear(state);
    _nmod_vec_clear(vec);
    _nmod_vec_clear(vec2);
 }

--- a/src/padic/profile/p-exp_balanced_2.c
+++ b/src/padic/profile/p-exp_balanced_2.c
@@ -97,7 +97,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     padic_ctx_clear(ctx);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/padic/profile/p-exp_balanced_p.c
+++ b/src/padic/profile/p-exp_balanced_p.c
@@ -97,7 +97,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     padic_ctx_clear(ctx);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/padic/profile/p-exp_rectangular.c
+++ b/src/padic/profile/p-exp_rectangular.c
@@ -97,7 +97,7 @@ for (l = 0; l < FLINT_MIN(17, len); l++)
 
     fmpz_clear(p);
     padic_ctx_clear(ctx);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/padic/profile/p-inv.c
+++ b/src/padic/profile/p-inv.c
@@ -94,7 +94,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     padic_ctx_clear(ctx);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/padic/profile/p-log_balanced.c
+++ b/src/padic/profile/p-log_balanced.c
@@ -108,7 +108,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     padic_ctx_clear(ctx);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/padic/profile/p-log_rectangular.c
+++ b/src/padic/profile/p-log_rectangular.c
@@ -108,7 +108,7 @@ for (l = 0; l < FLINT_MIN(16, len); l++)
 
     fmpz_clear(p);
     padic_ctx_clear(ctx);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/padic/profile/p-mul.c
+++ b/src/padic/profile/p-mul.c
@@ -98,7 +98,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     padic_ctx_clear(ctx);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/padic/profile/p-sqrt.c
+++ b/src/padic/profile/p-sqrt.c
@@ -98,7 +98,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     padic_ctx_clear(ctx);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/padic/profile/p-teichmuller.c
+++ b/src/padic/profile/p-teichmuller.c
@@ -86,7 +86,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     padic_ctx_clear(ctx);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/profile/p-invert_limb.c
+++ b/src/profile/p-invert_limb.c
@@ -61,7 +61,7 @@ void sample(void * arg, ulong count)
       if (sum == 0) flint_printf("\r");
    }
 
-   flint_randclear(state);
+   flint_rand_clear(state);
    flint_free(array);
 }
 

--- a/src/profile/p-udiv_qrnnd.c
+++ b/src/profile/p-udiv_qrnnd.c
@@ -46,7 +46,7 @@ void sample(void * arg, ulong count)
          if (array[j] == 0) flint_printf("\r");
    }
 
-   flint_randclear(state);
+   flint_rand_clear(state);
    flint_free(array);
 }
 

--- a/src/profile/p-udiv_qrnnd_preinv.c
+++ b/src/profile/p-udiv_qrnnd_preinv.c
@@ -49,7 +49,7 @@ void sample(void * arg, ulong count)
       if (q + r == 0) flint_printf("\r");
    }
 
-   flint_randclear(state);
+   flint_rand_clear(state);
    flint_free(array);
 }
 

--- a/src/python/flint_ctypes.py
+++ b/src/python/flint_ctypes.py
@@ -107,11 +107,12 @@ def _handle_error(ctx, status, rstr, *args):
 
 
 class flint_rand_struct(ctypes.Structure):
-    # todo: use the real size
-    _fields_ = [('data', c_slong * 16)]
+    _fields_ = [('__gmp_state', ctypes.c_void_p),
+                ('__randval', c_ulong),
+                ('__randval2', c_ulong)]
 
 _flint_rand = flint_rand_struct()
-libflint.flint_randinit(ctypes.byref(_flint_rand))
+libflint.flint_rand_init(ctypes.byref(_flint_rand))
 
 class fmpz_struct(ctypes.Structure):
     _fields_ = [('val', c_slong)]

--- a/src/qadic/ctx_init.c
+++ b/src/qadic/ctx_init.c
@@ -101,14 +101,14 @@ void qadic_ctx_init(qadic_ctx_t ctx, const fmpz_t p, slong d,
         if (_qadic_ctx_init_conway_ui(ctx, *p, d, min, max, var, mode))
             return;
 
-    flint_randinit(state);
+    flint_rand_init(state);
 
     fmpz_mod_ctx_init(ctxp, p);
     fmpz_mod_poly_init2(poly, d + 1, ctxp);
 
     fmpz_mod_poly_randtest_sparse_irreducible(poly, state, d + 1, ctxp);
 
-    flint_randclear(state);
+    flint_rand_clear(state);
 
     /* Find number of non-zero coefficients */
     ctx->len = 1;

--- a/src/qadic/profile/p-exp_balanced.c
+++ b/src/qadic/profile/p-exp_balanced.c
@@ -105,7 +105,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     qadic_ctx_clear(ctx);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/qadic/profile/p-exp_rectangular.c
+++ b/src/qadic/profile/p-exp_rectangular.c
@@ -105,7 +105,7 @@ for (l = 0; l < FLINT_MIN(16, len); l++)
 
     fmpz_clear(p);
     qadic_ctx_clear(ctx);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/qadic/profile/p-frobenius.c
+++ b/src/qadic/profile/p-frobenius.c
@@ -105,7 +105,7 @@ for (l = 0; l < FLINT_MIN(16, len); l++)
 
     fmpz_clear(p);
     qadic_ctx_clear(ctx);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/qadic/profile/p-inv.c
+++ b/src/qadic/profile/p-inv.c
@@ -105,7 +105,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     qadic_ctx_clear(ctx);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/qadic/profile/p-log_balanced.c
+++ b/src/qadic/profile/p-log_balanced.c
@@ -108,7 +108,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     qadic_ctx_clear(ctx);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/qadic/profile/p-log_rectangular.c
+++ b/src/qadic/profile/p-log_rectangular.c
@@ -108,7 +108,7 @@ for (l = 0; l < FLINT_MIN(16, len); l++)
 
     fmpz_clear(p);
     qadic_ctx_clear(ctx);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/qadic/profile/p-mul.c
+++ b/src/qadic/profile/p-mul.c
@@ -119,7 +119,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     qadic_ctx_clear(ctx);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/qadic/profile/p-norm_analytic.c
+++ b/src/qadic/profile/p-norm_analytic.c
@@ -109,7 +109,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     qadic_ctx_clear(ctx);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/qadic/profile/p-norm_resultant.c
+++ b/src/qadic/profile/p-norm_resultant.c
@@ -109,7 +109,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     qadic_ctx_clear(ctx);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/qadic/profile/p-sqrt.c
+++ b/src/qadic/profile/p-sqrt.c
@@ -116,7 +116,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     qadic_ctx_clear(ctx);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/qadic/profile/p-teichmuller.c
+++ b/src/qadic/profile/p-teichmuller.c
@@ -97,7 +97,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     qadic_ctx_clear(ctx);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/qadic/profile/p-trace.c
+++ b/src/qadic/profile/p-trace.c
@@ -106,7 +106,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     qadic_ctx_clear(ctx);
-    flint_randclear(state);
+    flint_rand_clear(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/qsieve/factor.c
+++ b/src/qsieve/factor.c
@@ -329,7 +329,7 @@ void qsieve_factor(fmpz_factor_t factors, const fmpz_t n)
                     flint_printf("\nBlock Lanczos\n");
 #endif
 
-                    flint_randinit(state); /* initialise the random generator */
+                    flint_rand_init(state); /* initialise the random generator */
 
                     do /* repeat block lanczos until it succeeds */
                     {
@@ -345,7 +345,7 @@ void qsieve_factor(fmpz_factor_t factors, const fmpz_t n)
                             count++;
                     }
 
-                    flint_randclear(state); /* clean up random state */
+                    flint_rand_clear(state); /* clean up random state */
 
     /**************************************************************************
         SQUARE ROOT:

--- a/src/ulong_extras/factor_pp1.c
+++ b/src/ulong_extras/factor_pp1.c
@@ -221,7 +221,7 @@ mp_limb_t n_factor_pp1_wrapper(mp_limb_t n)
    B1 = n_factor_pp1_table[bits - 31][0];
    count = n_factor_pp1_table[bits - 31][1];
 
-   flint_randinit(state);
+   flint_rand_init(state);
 
    for (i = 0; i < count; i++)
    {
@@ -229,11 +229,11 @@ mp_limb_t n_factor_pp1_wrapper(mp_limb_t n)
        factor = n_factor_pp1(n, B1, n_randint(state, n - 3) + 3);
        if (factor != 0)
        {
-           flint_randclear(state);
+           flint_rand_clear(state);
            return factor;
        }
    }
 
-   flint_randclear(state);
+   flint_rand_clear(state);
    return 0;
 }

--- a/src/ulong_extras/profile/p-factor.c
+++ b/src/ulong_extras/profile/p-factor.c
@@ -83,7 +83,7 @@ int main(void)
 		  i, max/(double)ITERS);
    }
 
-   flint_randclear(state);
+   flint_rand_clear(state);
    flint_free(params.composites);
    return 0;
 }

--- a/src/ulong_extras/profile/p-gcd.c
+++ b/src/ulong_extras/profile/p-gcd.c
@@ -74,7 +74,7 @@ int main(void)
 						i, i, max/(double)ITERS);
 	}
 
-   flint_randclear(state);
+   flint_rand_clear(state);
    flint_free(params.rnums1);
    flint_free(params.rnums2);
    return 0;

--- a/src/ulong_extras/profile/p-is_probabprime_BPSW.c
+++ b/src/ulong_extras/profile/p-is_probabprime_BPSW.c
@@ -42,7 +42,7 @@ void sample(void * arg, ulong count)
       if (!res) flint_printf("Error\n");
    }
 
-   flint_randclear(state);
+   flint_rand_clear(state);
 }
 
 int main(void)

--- a/src/ulong_extras/profile/p-lll_mod_preinv.c
+++ b/src/ulong_extras/profile/p-lll_mod_preinv.c
@@ -65,7 +65,7 @@ void sample(void * arg, ulong count)
 
    if (r == UWORD(9879875897)) flint_abort();
 
-   flint_randclear(state);
+   flint_rand_clear(state);
    flint_free(arr);
    flint_free(arr2);
 }

--- a/src/ulong_extras/profile/p-mod2_precomp.c
+++ b/src/ulong_extras/profile/p-mod2_precomp.c
@@ -45,7 +45,7 @@ void sample(void * arg, ulong count)
 
    if (r == 0) flint_abort();
 
-   flint_randclear(state);
+   flint_rand_clear(state);
    flint_free(array);
 }
 

--- a/src/ulong_extras/profile/p-mod2_preinv.c
+++ b/src/ulong_extras/profile/p-mod2_preinv.c
@@ -107,7 +107,7 @@ void sample(void * arg, ulong count)
 
    if (r == UWORD(9879875897)) flint_abort();
 
-   flint_randclear(state);
+   flint_rand_clear(state);
    flint_free(arr);
 }
 

--- a/src/ulong_extras/profile/p-mod_precomp.c
+++ b/src/ulong_extras/profile/p-mod_precomp.c
@@ -43,7 +43,7 @@ void sample(void * arg, ulong count)
       prof_stop();
    }
 
-   flint_randclear(state);
+   flint_rand_clear(state);
    flint_free(array);
 }
 

--- a/src/ulong_extras/profile/p-mulmod2_preinv.c
+++ b/src/ulong_extras/profile/p-mulmod2_preinv.c
@@ -42,7 +42,7 @@ void sample(void * arg, ulong count)
       prof_stop();
    }
 
-   flint_randclear(state);
+   flint_rand_clear(state);
    flint_free(array);
 }
 

--- a/src/ulong_extras/profile/p-mulmod_precomp.c
+++ b/src/ulong_extras/profile/p-mulmod_precomp.c
@@ -43,7 +43,7 @@ void sample(void * arg, ulong count)
       prof_stop();
    }
 
-   flint_randclear(state);
+   flint_rand_clear(state);
    flint_free(array);
 }
 


### PR DESCRIPTION
* Rename `flint_rand_s` to `flint_rand_struct`,

* Replace fields `gmp_state` and `gmp_init` in `flint_rand_s` by `void * __gmp_state`,

* Rename the following functions:
  ```
  flint_randinit     -> flint_rand_init      (different content)
  flint_randclear    -> flint_rand_clear     (different content)
  flint_randseed     -> flint_rand_set_seed
  flint_get_randseed -> flint_rand_get_seed
  ```
* Remove `_flint_rand_init_gmp` and replace with the two new functions `_flint_rand_init_gmp_state` and `_flint_rand_clear_gmp_state`.

  NOTE: The new init-function for the GMP-state assumes that `__gmp_state` *is not* initialized, and the new clear-function assumes that `__gmp_state` *is* initialized. To help with this, a new macro `FLINT_RAND_GMP_STATE_IS_INITIALISED(state)` can be utilized to check whether the GMP-state is initialized in `state`, assuming that `state` has been initialized via `flint_rand_init`.

* Typedef `ulong` and `slong` to proper primitive C type instead of relying on GMP's `mp_limb_t` and `mp_limb_signed_t`.