### PR TITLE
Specialize addmul, submul for nfloat

### DIFF
--- a/doc/source/nfloat.rst
+++ b/doc/source/nfloat.rst
@@ -252,6 +252,8 @@ These methods are interchangeable with their ``gr`` counterparts.
               int nfloat_add(nfloat_ptr res, nfloat_srcptr x, nfloat_srcptr y, gr_ctx_t ctx)
               int nfloat_sub(nfloat_ptr res, nfloat_srcptr x, nfloat_srcptr y, gr_ctx_t ctx)
               int nfloat_mul(nfloat_ptr res, nfloat_srcptr x, nfloat_srcptr y, gr_ctx_t ctx)
+              int nfloat_submul(nfloat_ptr res, nfloat_srcptr x, nfloat_srcptr y, gr_ctx_t ctx)
+              int nfloat_addmul(nfloat_ptr res, nfloat_srcptr x, nfloat_srcptr y, gr_ctx_t ctx)
 
 .. function:: int nfloat_mul_2exp_si(nfloat_ptr res, nfloat_srcptr x, slong y, gr_ctx_t ctx)
 
@@ -303,6 +305,8 @@ code for reduced overhead.
               int _nfloat_vec_sub(nfloat_ptr res, nfloat_srcptr x, nfloat_srcptr y, slong len, gr_ctx_t ctx)
               int _nfloat_vec_mul(nfloat_ptr res, nfloat_srcptr x, nfloat_srcptr y, slong len, gr_ctx_t ctx)
               int _nfloat_vec_mul_scalar(nfloat_ptr res, nfloat_srcptr x, slong len, nfloat_srcptr y, gr_ctx_t ctx)
+              int _nfloat_vec_addmul_scalar(nfloat_ptr res, nfloat_srcptr x, slong len, nfloat_srcptr y, gr_ctx_t ctx)
+              int _nfloat_vec_submul_scalar(nfloat_ptr res, nfloat_srcptr x, slong len, nfloat_srcptr y, gr_ctx_t ctx)
 
 .. function:: int _nfloat_vec_dot(nfloat_ptr res, nfloat_srcptr initial, int subtract, nfloat_srcptr x, nfloat_srcptr y, slong len, gr_ctx_t ctx)
               int _nfloat_vec_dot_rev(nfloat_ptr res, nfloat_srcptr initial, int subtract, nfloat_srcptr x, nfloat_srcptr y, slong len, gr_ctx_t ctx)

--- a/src/nfloat.h
+++ b/src/nfloat.h
@@ -303,6 +303,8 @@ int _nfloat_sub_n(nfloat_ptr res, nn_srcptr xd, slong xexp, int xsgnbit, nn_srcp
 int nfloat_add(nfloat_ptr res, nfloat_srcptr x, nfloat_srcptr y, gr_ctx_t ctx);
 int nfloat_sub(nfloat_ptr res, nfloat_srcptr x, nfloat_srcptr y, gr_ctx_t ctx);
 int nfloat_mul(nfloat_ptr res, nfloat_srcptr x, nfloat_srcptr y, gr_ctx_t ctx);
+int nfloat_addmul(nfloat_ptr res, nfloat_srcptr x, nfloat_srcptr y, gr_ctx_t ctx);
+int nfloat_submul(nfloat_ptr res, nfloat_srcptr x, nfloat_srcptr y, gr_ctx_t ctx);
 
 int nfloat_mul_2exp_si(nfloat_ptr res, nfloat_srcptr x, slong y, gr_ctx_t ctx);
 
@@ -344,6 +346,8 @@ int _nfloat_vec_add(nfloat_ptr res, nfloat_srcptr x, nfloat_srcptr y, slong len,
 int _nfloat_vec_sub(nfloat_ptr res, nfloat_srcptr x, nfloat_srcptr y, slong len, gr_ctx_t ctx);
 int _nfloat_vec_mul(nfloat_ptr res, nfloat_srcptr x, nfloat_srcptr y, slong len, gr_ctx_t ctx);
 int _nfloat_vec_mul_scalar(nfloat_ptr res, nfloat_srcptr x, slong len, nfloat_srcptr y, gr_ctx_t ctx);
+int _nfloat_vec_addmul_scalar(nfloat_ptr res, nfloat_srcptr x, slong len, nfloat_srcptr y, gr_ctx_t ctx);
+int _nfloat_vec_submul_scalar(nfloat_ptr res, nfloat_srcptr x, slong len, nfloat_srcptr y, gr_ctx_t ctx);
 
 int _nfloat_vec_dot(nfloat_ptr res, nfloat_srcptr initial, int subtract, nfloat_srcptr x, nfloat_srcptr y, slong len, gr_ctx_t ctx);
 int _nfloat_vec_dot_rev(nfloat_ptr res, nfloat_srcptr initial, int subtract, nfloat_srcptr x, nfloat_srcptr y, slong len, gr_ctx_t ctx);

--- a/src/nfloat/ctx.c
+++ b/src/nfloat/ctx.c
@@ -87,8 +87,10 @@ gr_method_tab_input _nfloat_methods_input[] =
     {GR_METHOD_MUL_SI,          (gr_funcptr) nfloat_mul_si},
     {GR_METHOD_MUL_FMPZ,        (gr_funcptr) nfloat_mul_fmpz},
     {GR_METHOD_MUL_TWO,         (gr_funcptr) nfloat_mul_two},
+*/
     {GR_METHOD_ADDMUL,          (gr_funcptr) nfloat_addmul},
     {GR_METHOD_SUBMUL,          (gr_funcptr) nfloat_submul},
+/*
     {GR_METHOD_SQR,             (gr_funcptr) nfloat_sqr},
 */
     {GR_METHOD_DIV,             (gr_funcptr) nfloat_div},
@@ -163,6 +165,8 @@ gr_method_tab_input _nfloat_methods_input[] =
     {GR_METHOD_VEC_SUB,                 (gr_funcptr) _nfloat_vec_sub},
     {GR_METHOD_VEC_MUL,                 (gr_funcptr) _nfloat_vec_mul},
     {GR_METHOD_VEC_MUL_SCALAR,          (gr_funcptr) _nfloat_vec_mul_scalar},
+    {GR_METHOD_VEC_ADDMUL_SCALAR,          (gr_funcptr) _nfloat_vec_addmul_scalar},
+    {GR_METHOD_VEC_SUBMUL_SCALAR,          (gr_funcptr) _nfloat_vec_submul_scalar},
     {GR_METHOD_VEC_DOT,         (gr_funcptr) _nfloat_vec_dot},
     {GR_METHOD_VEC_DOT_REV,     (gr_funcptr) _nfloat_vec_dot_rev},
 /*

--- a/src/nfloat/profile/p-vs_arf.c
+++ b/src/nfloat/profile/p-vs_arf.c
@@ -40,10 +40,10 @@ int main()
     int which;
     slong i, n;
     slong prec;
-    double __, t, arf_tadd = 0.0, arf_tmul = 0.0, arf_tmul_scalar = 0.0, arf_tsum = 0.0, arf_tprod = 0.0, arf_tdot = 0.0;
-    double nfloat_tadd = 0.0, nfloat_tmul = 0.0, nfloat_tmul_scalar = 0.0, nfloat_tsum = 0.0, nfloat_tprod = 0.0, nfloat_tdot = 0.0;
+    double __, t, arf_tadd = 0.0, arf_tmul = 0.0, arf_tmul_scalar = 0.0, arf_taddmul_scalar = 0.0, arf_tsum = 0.0, arf_tprod = 0.0, arf_tdot = 0.0;
+    double nfloat_tadd = 0.0, nfloat_tmul = 0.0, nfloat_tmul_scalar = 0.0, nfloat_taddmul_scalar = 0.0, nfloat_tsum = 0.0, nfloat_tprod = 0.0, nfloat_tdot = 0.0;
 
-    flint_printf("                   _gr_vec_add          _gr_vec_mul          _gr_vec_mul_scalar   _gr_vec_sum          _gr_vec_product      _gr_vec_dot\n");
+    flint_printf("                   _gr_vec_add          _gr_vec_mul       _gr_vec_mul_scalar  _gr_vec_addmul_scalar  _gr_vec_sum          _gr_vec_product      _gr_vec_dot\n");
 
     for (prec = 64; prec <= 2048; prec = prec < 256 ? prec + 64 : prec * 2)
     {
@@ -107,6 +107,12 @@ int main()
                 (void) __;
 
                 TIMEIT_START
+                GR_MUST_SUCCEED(_gr_vec_addmul_scalar(vec3, vec1, n, x, ctx));
+                TIMEIT_STOP_VALUES(__, t)
+                if (which == 0) arf_taddmul_scalar = t; else nfloat_taddmul_scalar = t;
+                (void) __;
+
+                TIMEIT_START
                 GR_MUST_SUCCEED(_gr_vec_sum(x, vec1, n, ctx));
                 TIMEIT_STOP_VALUES(__, t)
                 if (which == 0) arf_tsum = t; else nfloat_tsum = t;
@@ -131,10 +137,11 @@ int main()
             }
 
             flint_printf("n = %4wd   ", n);
-            flint_printf("     %.3e (%.3fx)   %.3e (%.3fx)   %.3e (%.3fx)   %.3e (%.3fx)   %.3e (%.3fx)   %.3e (%.3fx)\n",
+            flint_printf("     %.3e (%.3fx)   %.3e (%.3fx)   %.3e (%.3fx)   %.3e (%.3fx)   %.3e (%.3fx)   %.3e (%.3fx)   %.3e (%.3fx)\n",
                 nfloat_tadd, arf_tadd / nfloat_tadd,
                 nfloat_tmul, arf_tmul / nfloat_tmul,
                 nfloat_tmul_scalar, arf_tmul_scalar / nfloat_tmul_scalar,
+                nfloat_taddmul_scalar, arf_taddmul_scalar / nfloat_taddmul_scalar,
                 nfloat_tsum, arf_tsum / nfloat_tsum,
                 nfloat_tprod, arf_tprod / nfloat_tprod,
                 nfloat_tdot, arf_tdot / nfloat_tdot);

--- a/src/nfloat/test/main.c
+++ b/src/nfloat/test/main.c
@@ -12,6 +12,7 @@
 /* Include functions *********************************************************/
 
 #include "t-add_sub_n.c"
+#include "t-addmul_submul.c"
 #include "t-nfloat.c"
 
 /* Array of test functions ***************************************************/
@@ -19,6 +20,7 @@
 test_struct tests[] =
 {
     TEST_FUNCTION(add_sub_n),
+    TEST_FUNCTION(addmul_submul),
     TEST_FUNCTION(nfloat),
 };
 

--- a/src/nfloat/test/t-add_sub_n.c
+++ b/src/nfloat/test/t-add_sub_n.c
@@ -92,6 +92,5 @@ TEST_FUNCTION_START(add_sub_n, state)
         gr_ctx_clear(ctx);
     }
 
-
     TEST_FUNCTION_END(state);
 }

--- a/src/nfloat/test/t-addmul_submul.c
+++ b/src/nfloat/test/t-addmul_submul.c
@@ -1,0 +1,91 @@
+/*
+    Copyright (C) 2024 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "fmpq.h"
+#include "arf.h"
+#include "gr.h"
+#include "gr_vec.h"
+#include "gr_generic.h"
+#include "nfloat.h"
+
+TEST_FUNCTION_START(addmul_submul, state)
+{
+    gr_ctx_t ctx;
+    slong i, len, iter, reps, prec;
+    gr_ptr x, y, r1, r2;
+
+    /* test that addmul and submul specializations match the trivial
+       algorithm */
+    for (prec = FLINT_BITS; prec <= NFLOAT_MAX_LIMBS * FLINT_BITS; prec += FLINT_BITS)
+    {
+        GR_MUST_SUCCEED(nfloat_ctx_init(ctx, prec, 0));
+
+        reps = (prec <= 256 ? 1000 : 10) * flint_test_multiplier();
+
+        for (iter = 0; iter < reps; iter++)
+        {
+            len = n_randint(state, 4);
+
+            x = gr_heap_init_vec(len, ctx);
+            y = gr_heap_init(ctx);
+            r1 = gr_heap_init_vec(len, ctx);
+            r2 = gr_heap_init_vec(len, ctx);
+
+            GR_IGNORE(_gr_vec_randtest(x, state, len, ctx));
+            GR_IGNORE(gr_randtest(y, state, ctx));
+            GR_IGNORE(_gr_vec_randtest(r1, state, len, ctx));
+            GR_IGNORE(_gr_vec_set(r2, r1, len, ctx));
+
+            if (n_randint(state, 2))
+            {
+                GR_MUST_SUCCEED(_gr_vec_addmul_scalar(r1, x, len, y, ctx));
+
+                if (n_randint(state, 2))
+                    for (i = 0; i < len; i++)
+                        GR_MUST_SUCCEED(gr_addmul(GR_ENTRY(r2, i, ctx->sizeof_elem), 
+                                                  GR_ENTRY(x, i, ctx->sizeof_elem), y, ctx));
+                else
+                    GR_MUST_SUCCEED(gr_generic_vec_scalar_addmul(r2, x, len, y, ctx));
+            }
+            else
+            {
+                GR_MUST_SUCCEED(_gr_vec_submul_scalar(r1, x, len, y, ctx));
+
+                if (n_randint(state, 2))
+                    for (i = 0; i < len; i++)
+                        GR_MUST_SUCCEED(gr_submul(GR_ENTRY(r2, i, ctx->sizeof_elem), 
+                                              GR_ENTRY(x, i, ctx->sizeof_elem), y, ctx));
+                else
+                    GR_MUST_SUCCEED(gr_generic_vec_scalar_submul(r2, x, len, y, ctx));
+            }
+
+            if (_gr_vec_equal(r1, r2, len, ctx) != T_TRUE)
+            {
+                flint_printf("FAIL: %wd\n", prec / FLINT_BITS);
+                flint_printf("x = "); _gr_vec_print(x, len, ctx); flint_printf("\n\n");
+                flint_printf("y = "); gr_println(y, ctx);
+                flint_printf("r1 = "); _gr_vec_print(r1, len, ctx); flint_printf("\n\n");
+                flint_printf("r2 = "); _gr_vec_print(r2, len, ctx); flint_printf("\n\n");
+                flint_abort();
+            }
+
+            gr_heap_clear_vec(x, len, ctx);
+            gr_heap_clear(y, ctx);
+            gr_heap_clear_vec(r1, len, ctx);
+            gr_heap_clear_vec(r2, len, ctx);
+        }
+        
+        gr_ctx_clear(ctx);
+    }
+
+    TEST_FUNCTION_END(state);
+}


### PR DESCRIPTION
Adds ``nfloat_addmul``, ``nfloat_submul`` and ``_nfloat_vec_addmul_scalar`` and ``_nfloat_vec_submul_scalar`` with partially inlined code for speed.

The accuracy is identical to doing a ``mul`` followed by an ``add``; it would be nice to have something with increased accuracy, or with better speed when the product is much smaller than the sum, but I can't be bothered with all the extra addition code to implement something like that right now.

```
$ build/nfloat/profile/p-vs_arf 
                   _gr_vec_add          _gr_vec_mul       _gr_vec_mul_scalar  _gr_vec_addmul_scalar  _gr_vec_sum          _gr_vec_product      _gr_vec_dot
prec = 64
n =   10        3.180e-08 (3.994x)   1.820e-08 (7.363x)   1.470e-08 (9.320x)   3.600e-08 (7.639x)   4.610e-08 (2.625x)   3.260e-08 (3.681x)   2.440e-08 (2.078x)
n =  100        2.910e-07 (4.502x)   1.480e-07 (9.122x)   1.130e-07 (12.212x)   3.290e-07 (8.207x)   4.780e-07 (2.782x)   3.910e-07 (3.581x)   1.790e-07 (2.168x)
prec = 128
n =   10        4.340e-08 (4.770x)   2.880e-08 (5.069x)   2.560e-08 (5.820x)   5.970e-08 (5.980x)   4.790e-08 (3.841x)   4.070e-08 (3.243x)   3.710e-08 (1.779x)
n =  100        3.950e-07 (5.190x)   2.560e-07 (5.664x)   2.160e-07 (6.852x)   5.570e-07 (6.607x)   6.010e-07 (3.594x)   5.360e-07 (2.817x)   3.160e-07 (1.608x)
prec = 192
n =   10        5.410e-08 (4.362x)   5.850e-08 (2.889x)   6.020e-08 (2.841x)   8.160e-08 (5.380x)   5.540e-08 (3.971x)   6.230e-08 (2.440x)   7.570e-08 (2.391x)
n =  100        4.960e-07 (4.839x)   5.650e-07 (2.973x)   5.820e-07 (2.938x)   7.810e-07 (5.698x)   5.840e-07 (4.418x)   7.140e-07 (2.577x)   6.810e-07 (2.452x)
prec = 256
n =   10        6.380e-08 (3.981x)   7.590e-08 (2.477x)   7.370e-08 (2.578x)   1.080e-07 (4.296x)   5.940e-08 (3.788x)   7.280e-08 (2.321x)   1.020e-07 (2.000x)
n =  100        5.800e-07 (4.345x)   7.440e-07 (2.540x)   7.200e-07 (2.667x)   1.050e-06 (4.495x)   6.570e-07 (4.018x)   8.860e-07 (2.291x)   9.330e-07 (2.058x)
prec = 512
n =   10        1.320e-07 (2.053x)   1.620e-07 (2.006x)   1.610e-07 (2.025x)   2.570e-07 (2.377x)   9.830e-08 (2.370x)   1.450e-07 (1.993x)   2.500e-07 (1.448x)
n =  100        1.280e-06 (2.117x)   1.620e-06 (2.068x)   1.650e-06 (2.067x)   2.580e-06 (2.508x)   1.140e-06 (2.500x)   1.680e-06 (2.095x)   2.430e-06 (1.477x)
prec = 1024
n =   10        1.810e-07 (1.801x)   7.550e-07 (1.391x)   7.560e-07 (1.323x)   8.880e-07 (1.543x)   1.310e-07 (1.992x)   7.240e-07 (1.298x)   8.360e-07 (1.256x)
n =  100        1.700e-06 (1.859x)   7.820e-06 (1.432x)   7.780e-06 (1.427x)   9.040e-06 (1.670x)   1.500e-06 (2.227x)   8.280e-06 (1.389x)   8.250e-06 (1.309x)
prec = 2048
n =   10        2.420e-07 (1.620x)   2.520e-06 (1.254x)   2.520e-06 (1.258x)   2.740e-06 (1.325x)   1.820e-07 (1.874x)   2.320e-06 (1.263x)   2.650e-06 (1.147x)
n =  100        2.660e-06 (1.553x)   2.710e-05 (1.295x)   2.520e-05 (1.484x)   2.670e-05 (1.607x)   2.110e-06 (2.014x)   2.620e-05 (1.397x)   2.580e-05 (1.194x)
```