### PR TITLE
Final header reduction

### DIFF
--- a/src/acb.h
+++ b/src/acb.h
@@ -826,184 +826,29 @@ acb_indeterminate(acb_t x)
     arb_indeterminate(acb_imagref(x));
 }
 
-ACB_INLINE acb_ptr
-_acb_vec_entry_ptr(acb_ptr vec, slong i)
-{
-    return vec + i;
-}
+acb_ptr _acb_vec_entry_ptr(acb_ptr vec, slong i);
 
-ACB_INLINE void
-_acb_vec_zero(acb_ptr A, slong n)
-{
-    slong i;
-    for (i = 0; i < n; i++)
-        acb_zero(A + i);
-}
-
-ACB_INLINE int
-_acb_vec_is_zero(acb_srcptr vec, slong len)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        if (!acb_is_zero(vec + i))
-            return 0;
-    return 1;
-}
-
-ACB_INLINE void
-_acb_vec_set(acb_ptr res, acb_srcptr vec, slong len)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        acb_set(res + i, vec + i);
-}
-
-ACB_INLINE void
-_acb_vec_set_round(acb_ptr res, acb_srcptr vec, slong len, slong prec)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        acb_set_round(res + i, vec + i, prec);
-}
-
-ACB_INLINE void
-_acb_vec_swap(acb_ptr res, acb_ptr vec, slong len)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        acb_swap(res + i, vec + i);
-}
-
-ACB_INLINE void
-_acb_vec_neg(acb_ptr res, acb_srcptr vec, slong len)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        acb_neg(res + i, vec + i);
-}
-
-ACB_INLINE void
-_acb_vec_add(acb_ptr res, acb_srcptr vec1, acb_srcptr vec2, slong len, slong prec)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        acb_add(res + i, vec1 + i, vec2 + i, prec);
-}
-
-ACB_INLINE void
-_acb_vec_sub(acb_ptr res, acb_srcptr vec1, acb_srcptr vec2, slong len, slong prec)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        acb_sub(res + i, vec1 + i, vec2 + i, prec);
-}
-
-ACB_INLINE void
-_acb_vec_scalar_submul(acb_ptr res, acb_srcptr vec, slong len, const acb_t c, slong prec)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        acb_submul(res + i, vec + i, c, prec);
-}
-
-ACB_INLINE void
-_acb_vec_scalar_addmul(acb_ptr res, acb_srcptr vec, slong len, const acb_t c, slong prec)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        acb_addmul(res + i, vec + i, c, prec);
-}
-
-ACB_INLINE void
-_acb_vec_scalar_mul(acb_ptr res, acb_srcptr vec, slong len, const acb_t c, slong prec)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        acb_mul(res + i, vec + i, c, prec);
-}
-
-ACB_INLINE void
-_acb_vec_scalar_mul_ui(acb_ptr res, acb_srcptr vec, slong len, ulong c, slong prec)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        acb_mul_ui(res + i, vec + i, c, prec);
-}
-
-ACB_INLINE void
-_acb_vec_scalar_mul_2exp_si(acb_ptr res, acb_srcptr vec, slong len, slong c)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        acb_mul_2exp_si(res + i, vec + i, c);
-}
-
-ACB_INLINE void
-_acb_vec_scalar_mul_onei(acb_ptr res, acb_srcptr vec, slong len)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        acb_mul_onei(res + i, vec + i);
-}
-
-ACB_INLINE void
-_acb_vec_scalar_div_ui(acb_ptr res, acb_srcptr vec, slong len, ulong c, slong prec)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        acb_div_ui(res + i, vec + i, c, prec);
-}
-
-ACB_INLINE void
-_acb_vec_scalar_div(acb_ptr res, acb_srcptr vec, slong len, const acb_t c, slong prec)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        acb_div(res + i, vec + i, c, prec);
-}
-
-ACB_INLINE void
-_acb_vec_scalar_mul_arb(acb_ptr res, acb_srcptr vec, slong len, const arb_t c, slong prec)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        acb_mul_arb(res + i, vec + i, c, prec);
-}
-
-ACB_INLINE void
-_acb_vec_scalar_div_arb(acb_ptr res, acb_srcptr vec, slong len, const arb_t c, slong prec)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-    {
-        arb_div(acb_realref(res + i), acb_realref(vec + i), c, prec);
-        arb_div(acb_imagref(res + i), acb_imagref(vec + i), c, prec);
-    }
-}
-
-ACB_INLINE void
-_acb_vec_scalar_mul_fmpz(acb_ptr res, acb_srcptr vec, slong len, const fmpz_t c, slong prec)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        acb_mul_fmpz(res + i, vec + i, c, prec);
-}
-
-ACB_INLINE void
-_acb_vec_scalar_div_fmpz(acb_ptr res, acb_srcptr vec, slong len, const fmpz_t c, slong prec)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        acb_div_fmpz(res + i, vec + i, c, prec);
-}
-
-ACB_INLINE void
-_acb_vec_sqr(acb_ptr res, acb_srcptr vec, slong len, slong prec)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        acb_sqr(res + i, vec + i, prec);
-}
+void _acb_vec_zero(acb_ptr A, slong n);
+int _acb_vec_is_zero(acb_srcptr vec, slong len);
+void _acb_vec_set(acb_ptr res, acb_srcptr vec, slong len);
+void _acb_vec_set_round(acb_ptr res, acb_srcptr vec, slong len, slong prec);
+void _acb_vec_swap(acb_ptr res, acb_ptr vec, slong len);
+void _acb_vec_neg(acb_ptr res, acb_srcptr vec, slong len);
+void _acb_vec_add(acb_ptr res, acb_srcptr vec1, acb_srcptr vec2, slong len, slong prec);
+void _acb_vec_sub(acb_ptr res, acb_srcptr vec1, acb_srcptr vec2, slong len, slong prec);
+void _acb_vec_scalar_submul(acb_ptr res, acb_srcptr vec, slong len, const acb_t c, slong prec);
+void _acb_vec_scalar_addmul(acb_ptr res, acb_srcptr vec, slong len, const acb_t c, slong prec);
+void _acb_vec_scalar_mul(acb_ptr res, acb_srcptr vec, slong len, const acb_t c, slong prec);
+void _acb_vec_scalar_mul_ui(acb_ptr res, acb_srcptr vec, slong len, ulong c, slong prec);
+void _acb_vec_scalar_mul_2exp_si(acb_ptr res, acb_srcptr vec, slong len, slong c);
+void _acb_vec_scalar_mul_onei(acb_ptr res, acb_srcptr vec, slong len);
+void _acb_vec_scalar_div_ui(acb_ptr res, acb_srcptr vec, slong len, ulong c, slong prec);
+void _acb_vec_scalar_div(acb_ptr res, acb_srcptr vec, slong len, const acb_t c, slong prec);
+void _acb_vec_scalar_mul_arb(acb_ptr res, acb_srcptr vec, slong len, const arb_t c, slong prec);
+void _acb_vec_scalar_div_arb(acb_ptr res, acb_srcptr vec, slong len, const arb_t c, slong prec);
+void _acb_vec_scalar_mul_fmpz(acb_ptr res, acb_srcptr vec, slong len, const fmpz_t c, slong prec);
+void _acb_vec_scalar_div_fmpz(acb_ptr res, acb_srcptr vec, slong len, const fmpz_t c, slong prec);
+void _acb_vec_sqr(acb_ptr res, acb_srcptr vec, slong len, slong prec);
 
 #ifdef FLINT_HAVE_FILE
 void acb_fprint(FILE * file, const acb_t x);
@@ -1053,152 +898,23 @@ acb_is_real(const acb_t x)
     return arb_is_zero(acb_imagref(x));
 }
 
-ACB_INLINE int
-_acb_vec_is_real(acb_srcptr v, slong len)
-{
-    slong i;
-
-    for (i = 0; i < len; i++)
-    {
-        if (!acb_is_real(v + i))
-            return 0;
-    }
-
-    return 1;
-}
-
-ACB_INLINE int
-_acb_vec_is_finite(acb_srcptr vec, slong len)
-{
-    return _arb_vec_is_finite((arb_srcptr) vec, 2 * len);
-}
-
-ACB_INLINE int
-_acb_vec_equal(acb_srcptr vec1, acb_srcptr vec2, slong len)
-{
-    slong i;
-
-    for (i = 0; i < len; i++)
-    {
-        if (!acb_equal(vec1 + i, vec2 + i))
-            return 0;
-    }
-    return 1;
-}
-
-ACB_INLINE int
-_acb_vec_overlaps(acb_srcptr vec1, acb_srcptr vec2, slong len)
-{
-    slong i;
-
-    for (i = 0; i < len; i++)
-    {
-        if (!acb_overlaps(vec1 + i, vec2 + i))
-            return 0;
-    }
-
-    return 1;
-}
-
-ACB_INLINE int
-_acb_vec_contains(acb_srcptr vec1, acb_srcptr vec2, slong len)
-{
-    slong i;
-
-    for (i = 0; i < len; i++)
-    {
-        if (!acb_contains(vec1 + i, vec2 + i))
-            return 0;
-    }
-
-    return 1;
-}
-
-ACB_INLINE void
-_acb_vec_get_real(arb_ptr re, acb_srcptr vec, slong len)
-{
-    slong i;
-
-    for (i = 0; i < len; i++)
-    {
-        arb_set(re + i, acb_realref(vec + i));
-    }
-}
-
-ACB_INLINE void
-_acb_vec_get_imag(arb_ptr im, acb_srcptr vec, slong len)
-{
-    slong i;
-
-    for (i = 0; i < len; i++)
-    {
-        arb_set(im + i, acb_imagref(vec + i));
-    }
-}
-
-ACB_INLINE void
-_acb_vec_set_real_imag(acb_ptr vec, arb_srcptr re, arb_srcptr im, slong len)
-{
-    slong i;
-
-    for (i = 0; i < len; i++)
-    {
-        acb_set_arb_arb(vec + i, re + i, im + i);
-    }
-}
-
-ACB_INLINE slong
-_acb_vec_bits(acb_srcptr vec, slong len)
-{
-    return _arb_vec_bits((arb_srcptr) vec, 2 * len);
-}
+int _acb_vec_is_real(acb_srcptr v, slong len);
+int _acb_vec_is_finite(acb_srcptr vec, slong len);
+int _acb_vec_equal(acb_srcptr vec1, acb_srcptr vec2, slong len);
+int _acb_vec_overlaps(acb_srcptr vec1, acb_srcptr vec2, slong len);
+int _acb_vec_contains(acb_srcptr vec1, acb_srcptr vec2, slong len);
+void _acb_vec_get_real(arb_ptr re, acb_srcptr vec, slong len);
+void _acb_vec_get_imag(arb_ptr im, acb_srcptr vec, slong len);
+void _acb_vec_set_real_imag(acb_ptr vec, arb_srcptr re, arb_srcptr im, slong len);
+slong _acb_vec_bits(acb_srcptr vec, slong len);
 
 void _acb_vec_set_powers(acb_ptr xs, const acb_t x, slong len, slong prec);
 
-ACB_INLINE void
-_acb_vec_add_error_arf_vec(acb_ptr res, arf_srcptr err, slong len)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        acb_add_error_arf(res + i, err + i);
-}
-
-ACB_INLINE void
-_acb_vec_add_error_mag_vec(acb_ptr res, mag_srcptr err, slong len)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-    {
-        mag_add(arb_radref(acb_realref(res + i)),
-            arb_radref(acb_realref(res + i)), err + i);
-        mag_add(arb_radref(acb_imagref(res + i)),
-            arb_radref(acb_imagref(res + i)), err + i);
-    }
-}
-
-ACB_INLINE void
-_acb_vec_indeterminate(acb_ptr vec, slong len)
-{
-    _arb_vec_indeterminate((arb_ptr) vec, 2 * len);
-}
-
-ACB_INLINE void
-_acb_vec_trim(acb_ptr res, acb_srcptr vec, slong len)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        acb_trim(res + i, vec + i);
-}
-
-ACB_INLINE int
-_acb_vec_get_unique_fmpz_vec(fmpz * res,  acb_srcptr vec, slong len)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        if (!acb_get_unique_fmpz(res + i, vec + i))
-            return 0;
-    return 1;
-}
+void _acb_vec_add_error_arf_vec(acb_ptr res, arf_srcptr err, slong len);
+void _acb_vec_add_error_mag_vec(acb_ptr res, mag_srcptr err, slong len);
+void _acb_vec_indeterminate(acb_ptr vec, slong len);
+void _acb_vec_trim(acb_ptr res, acb_srcptr vec, slong len);
+int _acb_vec_get_unique_fmpz_vec(fmpz * res,  acb_srcptr vec, slong len);
 
 /* sort complex numbers in a nice-to-display order */
 void _acb_vec_sort_pretty(acb_ptr vec, slong len);
@@ -1213,17 +929,8 @@ acb_allocated_bytes(const acb_t x)
     return arb_allocated_bytes(acb_realref(x)) + arb_allocated_bytes(acb_imagref(x));
 }
 
-ACB_INLINE slong
-_acb_vec_allocated_bytes(acb_srcptr vec, slong len)
-{
-    return _arb_vec_allocated_bytes((arb_srcptr) vec, 2 * len);
-}
-
-ACB_INLINE double
-_acb_vec_estimate_allocated_bytes(slong len, slong prec)
-{
-    return 2 * _arb_vec_estimate_allocated_bytes(len, prec);
-}
+slong _acb_vec_allocated_bytes(acb_srcptr vec, slong len);
+double _acb_vec_estimate_allocated_bytes(slong len, slong prec);
 
 #ifdef __cplusplus
 }

--- a/src/acb/vec.c
+++ b/src/acb/vec.c
@@ -1,0 +1,172 @@
+/*
+    Copyright (C) 2012 Fredrik Johansson
+    Copyright (C) 2024 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "acb.h"
+
+acb_ptr _acb_vec_entry_ptr(acb_ptr vec, slong i)
+{
+    return vec + i;
+}
+
+void _acb_vec_get_real(arb_ptr re, acb_srcptr vec, slong len)
+{
+    slong i;
+
+    for (i = 0; i < len; i++)
+        arb_set(re + i, acb_realref(vec + i));
+}
+
+void _acb_vec_get_imag(arb_ptr im, acb_srcptr vec, slong len)
+{
+    slong i;
+
+    for (i = 0; i < len; i++)
+        arb_set(im + i, acb_imagref(vec + i));
+}
+
+void _acb_vec_set_real_imag(acb_ptr vec, arb_srcptr re, arb_srcptr im, slong len)
+{
+    slong i;
+
+    for (i = 0; i < len; i++)
+        acb_set_arb_arb(vec + i, re + i, im + i);
+}
+
+slong _acb_vec_bits(acb_srcptr vec, slong len)
+{
+    return _arb_vec_bits((arb_srcptr) vec, 2 * len);
+}
+
+slong _acb_vec_allocated_bytes(acb_srcptr vec, slong len)
+{
+    return _arb_vec_allocated_bytes((arb_srcptr) vec, 2 * len);
+}
+
+double _acb_vec_estimate_allocated_bytes(slong len, slong prec)
+{
+    return 2 * _arb_vec_estimate_allocated_bytes(len, prec);
+}
+
+void _acb_vec_scalar_mul_2exp_si(acb_ptr res, acb_srcptr vec, slong len, slong c)
+{
+    slong i;
+    for (i = 0; i < len; i++)
+        acb_mul_2exp_si(res + i, vec + i, c);
+}
+
+#define IS_OP(func_name, T, OP) \
+int func_name(T ap, slong len)  \
+{                               \
+    slong ix;                   \
+                                \
+    for (ix = 0; ix < len; ix++)\
+        if (!OP(ap + ix))       \
+            return 0;           \
+                                \
+    return 1;                   \
+}
+
+IS_OP(_acb_vec_is_zero,   acb_srcptr, acb_is_zero)
+IS_OP(_acb_vec_is_real,   acb_srcptr, acb_is_real)
+IS_OP(_acb_vec_is_finite, acb_srcptr, acb_is_finite)
+
+#define SET_OP_1(func_name, T, OP) \
+void func_name(T ap, slong len) \
+{                               \
+    slong ix;                   \
+                                \
+    for (ix = 0; ix < len; ix++)\
+        OP(ap + ix);            \
+}
+
+SET_OP_1(_acb_vec_zero,          acb_ptr, acb_zero)
+SET_OP_1(_acb_vec_indeterminate, acb_ptr, acb_indeterminate)
+
+#define SET_OP(func_name, S, T, OP) \
+void func_name(S ap, T bp, slong len) \
+{                               \
+    slong ix;                   \
+                                \
+    for (ix = 0; ix < len; ix++)\
+        OP(ap + ix, bp + ix);   \
+}
+
+SET_OP(_acb_vec_set,               acb_ptr, acb_srcptr, acb_set)
+SET_OP(_acb_vec_swap,              acb_ptr, acb_ptr,    acb_swap)
+SET_OP(_acb_vec_neg,               acb_ptr, acb_srcptr, acb_neg)
+SET_OP(_acb_vec_trim,              acb_ptr, acb_srcptr, acb_trim)
+SET_OP(_acb_vec_add_error_arf_vec, acb_ptr, arf_srcptr, acb_add_error_arf)
+SET_OP(_acb_vec_add_error_mag_vec, acb_ptr, mag_srcptr, acb_add_error_mag)
+SET_OP(_acb_vec_scalar_mul_onei,   acb_ptr, acb_srcptr, acb_mul_onei)
+
+#define SET_PREC_OP(func_name, S, T, OP) \
+void func_name(S ap, T bp, slong len, slong prec) \
+{                               \
+    slong ix;                   \
+                                \
+    for (ix = 0; ix < len; ix++)\
+        OP(ap + ix, bp + ix, prec); \
+}
+
+SET_PREC_OP(_acb_vec_set_round, acb_ptr, acb_srcptr, acb_set_round)
+SET_PREC_OP(_acb_vec_sqr,       acb_ptr, acb_srcptr, acb_sqr)
+
+#define AORS_OP(func_name, S, T, OP) \
+void func_name(S rp, T ap, T bp, slong len, slong prec) \
+{                               \
+    slong ix;                   \
+                                \
+    for (ix = 0; ix < len; ix++)\
+        OP(rp + ix, ap + ix, bp + ix, prec); \
+}
+
+AORS_OP(_acb_vec_add, acb_ptr, acb_srcptr, acb_add)
+AORS_OP(_acb_vec_sub, acb_ptr, acb_srcptr, acb_sub)
+
+#define SCALAR_OP(func_name, S, T, U, OP) \
+void func_name(S rp, T ap, slong len, U b, slong prec) \
+{                               \
+    slong ix;                   \
+                                \
+    for (ix = 0; ix < len; ix++)\
+        OP(rp + ix, ap + ix, b, prec); \
+}
+
+SCALAR_OP(_acb_vec_scalar_mul_ui,   acb_ptr, acb_srcptr, ulong,        acb_mul_ui)
+SCALAR_OP(_acb_vec_scalar_mul_fmpz, acb_ptr, acb_srcptr, const fmpz_t, acb_mul_fmpz)
+SCALAR_OP(_acb_vec_scalar_mul_arb,  acb_ptr, acb_srcptr, const arb_t,  acb_mul_arb)
+SCALAR_OP(_acb_vec_scalar_mul,      acb_ptr, acb_srcptr, const acb_t,  acb_mul)
+
+SCALAR_OP(_acb_vec_scalar_div_ui,   acb_ptr, acb_srcptr, ulong,        acb_div_ui)
+SCALAR_OP(_acb_vec_scalar_div_fmpz, acb_ptr, acb_srcptr, const fmpz_t, acb_div_fmpz)
+SCALAR_OP(_acb_vec_scalar_div_arb,  acb_ptr, acb_srcptr, const arb_t,  acb_div_arb)
+SCALAR_OP(_acb_vec_scalar_div,      acb_ptr, acb_srcptr, const acb_t,  acb_div)
+
+SCALAR_OP(_acb_vec_scalar_addmul,   acb_ptr, acb_srcptr, const acb_t, acb_addmul)
+SCALAR_OP(_acb_vec_scalar_submul,   acb_ptr, acb_srcptr, const acb_t, acb_submul)
+
+#define COMPARISON_OP(func_name, S, T, OP) \
+int func_name(S ap, T bp, slong len)\
+{                                   \
+    slong ix;                       \
+                                    \
+    for (ix = 0; ix < len; ix++)    \
+        if (!OP(ap + ix, bp + ix))  \
+            return 0;               \
+                                    \
+    return 1;                       \
+}
+
+COMPARISON_OP(_acb_vec_equal,               acb_srcptr, acb_srcptr, acb_equal)
+COMPARISON_OP(_acb_vec_overlaps,            acb_srcptr, acb_srcptr, acb_overlaps)
+COMPARISON_OP(_acb_vec_contains,            acb_srcptr, acb_srcptr, acb_contains)
+COMPARISON_OP(_acb_vec_get_unique_fmpz_vec, fmpz *,     acb_srcptr, acb_get_unique_fmpz)

--- a/src/arb.h
+++ b/src/arb.h
@@ -638,241 +638,45 @@ arb_sqr(arb_t res, const arb_t val, slong prec)
 
 /* vector functions */
 
-ARB_INLINE arb_ptr
-_arb_vec_entry_ptr(arb_ptr vec, slong i)
-{
-    return vec + i;
-}
+arb_ptr _arb_vec_entry_ptr(arb_ptr vec, slong i);
 
-ARB_INLINE void
-_arb_vec_zero(arb_ptr A, slong n)
-{
-    slong i;
-    for (i = 0; i < n; i++)
-        arb_zero(A + i);
-}
+void _arb_vec_zero(arb_ptr A, slong n);
+void _arb_vec_indeterminate(arb_ptr vec, slong len);
 
-ARB_INLINE int
-_arb_vec_is_zero(arb_srcptr vec, slong len)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        if (!arb_is_zero(vec + i))
-            return 0;
-    return 1;
-}
+int _arb_vec_is_zero(arb_srcptr vec, slong len);
+int _arb_vec_is_finite(arb_srcptr x, slong len);
 
-ARB_INLINE int
-_arb_vec_is_finite(arb_srcptr x, slong len)
-{
-    slong i;
+int _arb_vec_equal(arb_srcptr vec1, arb_srcptr vec2, slong len);
+int _arb_vec_overlaps(arb_srcptr vec1, arb_srcptr vec2, slong len);
+int _arb_vec_contains(arb_srcptr vec1, arb_srcptr vec2, slong len);
 
-    for (i = 0; i < len; i++)
-        if (!arb_is_finite(x + i))
-            return 0;
+void _arb_vec_set(arb_ptr res, arb_srcptr vec, slong len);
+void _arb_vec_swap(arb_ptr res, arb_ptr vec, slong len);
+void _arb_vec_neg(arb_ptr B, arb_srcptr A, slong n);
 
-    return 1;
-}
+void _arb_vec_set_round(arb_ptr res, arb_srcptr vec, slong len, slong prec);
 
-ARB_INLINE int
-_arb_vec_equal(arb_srcptr vec1, arb_srcptr vec2, slong len)
-{
-    slong i;
+void _arb_vec_sub(arb_ptr C, arb_srcptr A, arb_srcptr B, slong n, slong prec);
+void _arb_vec_add(arb_ptr C, arb_srcptr A, arb_srcptr B, slong n, slong prec);
 
-    for (i = 0; i < len; i++)
-    {
-        if (!arb_equal(vec1 + i, vec2 + i))
-            return 0;
-    }
-    return 1;
-}
-
-ARB_INLINE int
-_arb_vec_overlaps(arb_srcptr vec1, arb_srcptr vec2, slong len)
-{
-    slong i;
-
-    for (i = 0; i < len; i++)
-    {
-        if (!arb_overlaps(vec1 + i, vec2 + i))
-            return 0;
-    }
-
-    return 1;
-}
-
-ARB_INLINE int
-_arb_vec_contains(arb_srcptr vec1, arb_srcptr vec2, slong len)
-{
-    slong i;
-
-    for (i = 0; i < len; i++)
-    {
-        if (!arb_contains(vec1 + i, vec2 + i))
-            return 0;
-    }
-
-    return 1;
-}
-
-ARB_INLINE void
-_arb_vec_set(arb_ptr res, arb_srcptr vec, slong len)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        arb_set(res + i, vec + i);
-}
-
-ARB_INLINE void
-_arb_vec_set_round(arb_ptr res, arb_srcptr vec, slong len, slong prec)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        arb_set_round(res + i, vec + i, prec);
-}
-
-ARB_INLINE void
-_arb_vec_swap(arb_ptr res, arb_ptr vec, slong len)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        arb_swap(res + i, vec + i);
-}
-
-ARB_INLINE void
-_arb_vec_neg(arb_ptr B, arb_srcptr A, slong n)
-{
-    slong i;
-    for (i = 0; i < n; i++)
-        arb_neg(B + i, A + i);
-}
-
-ARB_INLINE void
-_arb_vec_sub(arb_ptr C, arb_srcptr A,
-    arb_srcptr B, slong n, slong prec)
-{
-    slong i;
-    for (i = 0; i < n; i++)
-        arb_sub(C + i, A + i, B + i, prec);
-}
-
-ARB_INLINE void
-_arb_vec_add(arb_ptr C, arb_srcptr A,
-    arb_srcptr B, slong n, slong prec)
-{
-    slong i;
-    for (i = 0; i < n; i++)
-        arb_add(C + i, A + i, B + i, prec);
-}
-
-ARB_INLINE void
-_arb_vec_scalar_mul(arb_ptr res, arb_srcptr vec,
-    slong len, const arb_t c, slong prec)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        arb_mul(res + i, vec + i, c, prec);
-}
-
-ARB_INLINE void
-_arb_vec_scalar_div(arb_ptr res, arb_srcptr vec,
-    slong len, const arb_t c, slong prec)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        arb_div(res + i, vec + i, c, prec);
-}
-
-ARB_INLINE void
-_arb_vec_scalar_mul_fmpz(arb_ptr res, arb_srcptr vec,
-    slong len, const fmpz_t c, slong prec)
-{
-    slong i;
-    arf_t t;
-    arf_init(t);
-    arf_set_fmpz(t, c);
-    for (i = 0; i < len; i++)
-        arb_mul_arf(res + i, vec + i, t, prec);
-    arf_clear(t);
-}
-
-ARB_INLINE void
-_arb_vec_scalar_mul_2exp_si(arb_ptr res, arb_srcptr src, slong len, slong c)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        arb_mul_2exp_si(res + i, src + i, c);
-}
-
-ARB_INLINE void
-_arb_vec_scalar_addmul(arb_ptr res, arb_srcptr vec,
-    slong len, const arb_t c, slong prec)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        arb_addmul(res + i, vec + i, c, prec);
-}
+void _arb_vec_scalar_mul(arb_ptr res, arb_srcptr vec, slong len, const arb_t c, slong prec);
+void _arb_vec_scalar_mul_fmpz(arb_ptr res, arb_srcptr vec, slong len, const fmpz_t c, slong prec);
+void _arb_vec_scalar_mul_2exp_si(arb_ptr res, arb_srcptr src, slong len, slong c);
+void _arb_vec_scalar_div(arb_ptr res, arb_srcptr vec, slong len, const arb_t c, slong prec);
+void _arb_vec_scalar_addmul(arb_ptr res, arb_srcptr vec, slong len, const arb_t c, slong prec);
 
 void _arb_vec_get_mag(mag_t bound, arb_srcptr vec, slong len);
 
-ARB_INLINE slong
-_arb_vec_bits(arb_srcptr x, slong len)
-{
-    slong i, b, c;
-
-    b = 0;
-    for (i = 0; i < len; i++)
-    {
-        c = arb_bits(x + i);
-        b = FLINT_MAX(b, c);
-    }
-
-    return b;
-}
+slong _arb_vec_bits(arb_srcptr x, slong len);
 
 void _arb_vec_set_powers(arb_ptr xs, const arb_t x, slong len, slong prec);
 
-ARB_INLINE void
-_arb_vec_add_error_arf_vec(arb_ptr res, arf_srcptr err, slong len)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        arb_add_error_arf(res + i, err + i);
-}
+void _arb_vec_add_error_arf_vec(arb_ptr res, arf_srcptr err, slong len);
+void _arb_vec_add_error_mag_vec(arb_ptr res, mag_srcptr err, slong len);
 
-ARB_INLINE void
-_arb_vec_add_error_mag_vec(arb_ptr res, mag_srcptr err, slong len)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        mag_add(arb_radref(res + i), arb_radref(res + i), err + i);
-}
+void _arb_vec_trim(arb_ptr res, arb_srcptr vec, slong len);
 
-ARB_INLINE void
-_arb_vec_indeterminate(arb_ptr vec, slong len)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        arb_indeterminate(vec + i);
-}
-
-ARB_INLINE void
-_arb_vec_trim(arb_ptr res, arb_srcptr vec, slong len)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        arb_trim(res + i, vec + i);
-}
-
-ARB_INLINE int
-_arb_vec_get_unique_fmpz_vec(fmpz * res,  arb_srcptr vec, slong len)
-{
-    slong i;
-    for (i = 0; i < len; i++)
-        if (!arb_get_unique_fmpz(res + i, vec + i))
-            return 0;
-    return 1;
-}
+int _arb_vec_get_unique_fmpz_vec(fmpz * res,  arb_srcptr vec, slong len);
 
 /* arctangent implementation */
 
@@ -1081,31 +885,9 @@ arb_allocated_bytes(const arb_t x)
     return arf_allocated_bytes(arb_midref(x)) + mag_allocated_bytes(arb_radref(x));
 }
 
-ARB_INLINE slong
-_arb_vec_allocated_bytes(arb_srcptr vec, slong len)
-{
-    slong i, size;
+slong _arb_vec_allocated_bytes(arb_srcptr vec, slong len);
 
-    size = len * sizeof(arb_struct);
-
-    for (i = 0; i < len; i++)
-        size += arb_allocated_bytes(vec + i);
-
-    return size;
-}
-
-ARB_INLINE double
-_arb_vec_estimate_allocated_bytes(slong len, slong prec)
-{
-    double size;
-
-    size = len * (double) sizeof(arb_struct);
-
-    if (prec > ARF_NOPTR_LIMBS * FLINT_BITS)
-        size += len * (double) ((prec + FLINT_BITS - 1) / FLINT_BITS) * sizeof(ulong);
-
-    return size;
-}
+double _arb_vec_estimate_allocated_bytes(slong len, slong prec);
 
 int arb_load_str(arb_t res, const char * data);
 char * arb_dump_str(const arb_t x);

--- a/src/arb/vec.c
+++ b/src/arb/vec.c
@@ -1,0 +1,170 @@
+/*
+    Copyright (C) 2012 Fredrik Johansson
+    Copyright (C) 2024 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "arb.h"
+
+arb_ptr _arb_vec_entry_ptr(arb_ptr vec, slong i)
+{
+    return vec + i;
+}
+
+void _arb_vec_scalar_mul_fmpz(arb_ptr res, arb_srcptr vec, slong len, const fmpz_t c, slong prec)
+{
+    slong i;
+    arf_t t;
+    arf_init(t);
+    arf_set_fmpz(t, c);
+    for (i = 0; i < len; i++)
+        arb_mul_arf(res + i, vec + i, t, prec);
+    arf_clear(t);
+}
+
+void _arb_vec_scalar_mul_2exp_si(arb_ptr res, arb_srcptr src, slong len, slong c)
+{
+    slong i;
+    for (i = 0; i < len; i++)
+        arb_mul_2exp_si(res + i, src + i, c);
+}
+
+slong _arb_vec_bits(arb_srcptr x, slong len)
+{
+    slong i, b, c;
+
+    b = 0;
+    for (i = 0; i < len; i++)
+    {
+        c = arb_bits(x + i);
+        b = FLINT_MAX(b, c);
+    }
+
+    return b;
+}
+
+slong _arb_vec_allocated_bytes(arb_srcptr vec, slong len)
+{
+    slong i, size;
+
+    size = len * sizeof(arb_struct);
+
+    for (i = 0; i < len; i++)
+        size += arb_allocated_bytes(vec + i);
+
+    return size;
+}
+
+double _arb_vec_estimate_allocated_bytes(slong len, slong prec)
+{
+    double size;
+
+    size = len * (double) sizeof(arb_struct);
+
+    if (prec > ARF_NOPTR_LIMBS * FLINT_BITS)
+        size += len * (double) ((prec + FLINT_BITS - 1) / FLINT_BITS) * sizeof(ulong);
+
+    return size;
+}
+
+#define IS_OP(func_name, T, OP) \
+int func_name(T ap, slong len)  \
+{                               \
+    slong ix;                   \
+                                \
+    for (ix = 0; ix < len; ix++)\
+        if (!OP(ap + ix))       \
+            return 0;           \
+                                \
+    return 1;                   \
+}
+
+IS_OP(_arb_vec_is_zero,   arb_srcptr, arb_is_zero)
+IS_OP(_arb_vec_is_finite, arb_srcptr, arb_is_finite)
+
+#define SET_OP_1(func_name, T, OP) \
+void func_name(T ap, slong len) \
+{                               \
+    slong ix;                   \
+                                \
+    for (ix = 0; ix < len; ix++)\
+        OP(ap + ix);            \
+}
+
+SET_OP_1(_arb_vec_zero,          arb_ptr, arb_zero)
+SET_OP_1(_arb_vec_indeterminate, arb_ptr, arb_indeterminate)
+
+#define SET_OP(func_name, S, T, OP) \
+void func_name(S ap, T bp, slong len) \
+{                               \
+    slong ix;                   \
+                                \
+    for (ix = 0; ix < len; ix++)\
+        OP(ap + ix, bp + ix);   \
+}
+
+SET_OP(_arb_vec_set,               arb_ptr, arb_srcptr, arb_set)
+SET_OP(_arb_vec_swap,              arb_ptr, arb_ptr,    arb_swap)
+SET_OP(_arb_vec_neg,               arb_ptr, arb_srcptr, arb_neg)
+SET_OP(_arb_vec_trim,              arb_ptr, arb_srcptr, arb_trim)
+SET_OP(_arb_vec_add_error_arf_vec, arb_ptr, arf_srcptr, arb_add_error_arf)
+SET_OP(_arb_vec_add_error_mag_vec, arb_ptr, mag_srcptr, arb_add_error_mag)
+
+#define SET_PREC_OP(func_name, S, T, OP) \
+void func_name(S ap, T bp, slong len, slong prec) \
+{                               \
+    slong ix;                   \
+                                \
+    for (ix = 0; ix < len; ix++)\
+        OP(ap + ix, bp + ix, prec); \
+}
+
+SET_PREC_OP(_arb_vec_set_round, arb_ptr, arb_srcptr, arb_set_round)
+
+#define AORS_OP(func_name, S, T, OP) \
+void func_name(S rp, T ap, T bp, slong len, slong prec) \
+{                               \
+    slong ix;                   \
+                                \
+    for (ix = 0; ix < len; ix++)\
+        OP(rp + ix, ap + ix, bp + ix, prec); \
+}
+
+AORS_OP(_arb_vec_add, arb_ptr, arb_srcptr, arb_add)
+AORS_OP(_arb_vec_sub, arb_ptr, arb_srcptr, arb_sub)
+
+#define SCALAR_OP(func_name, S, T, U, OP) \
+void func_name(S rp, T ap, slong len, U b, slong prec) \
+{                               \
+    slong ix;                   \
+                                \
+    for (ix = 0; ix < len; ix++)\
+        OP(rp + ix, ap + ix, b, prec); \
+}
+
+SCALAR_OP(_arb_vec_scalar_mul,      arb_ptr, arb_srcptr, const arb_t,  arb_mul)
+SCALAR_OP(_arb_vec_scalar_div,      arb_ptr, arb_srcptr, const arb_t,  arb_div)
+SCALAR_OP(_arb_vec_scalar_addmul,   arb_ptr, arb_srcptr, const arb_t, arb_addmul)
+
+#define COMPARISON_OP(func_name, S, T, OP) \
+int func_name(S ap, T bp, slong len)\
+{                                   \
+    slong ix;                       \
+                                    \
+    for (ix = 0; ix < len; ix++)    \
+        if (!OP(ap + ix, bp + ix))  \
+            return 0;               \
+                                    \
+    return 1;                       \
+}
+
+COMPARISON_OP(_arb_vec_equal,               arb_srcptr, arb_srcptr, arb_equal)
+COMPARISON_OP(_arb_vec_overlaps,            arb_srcptr, arb_srcptr, arb_overlaps)
+COMPARISON_OP(_arb_vec_contains,            arb_srcptr, arb_srcptr, arb_contains)
+COMPARISON_OP(_arb_vec_get_unique_fmpz_vec, fmpz *,     arb_srcptr, arb_get_unique_fmpz)

--- a/src/fmpz_mpoly.h
+++ b/src/fmpz_mpoly.h
@@ -153,27 +153,18 @@ int fmpz_mpoly_print_pretty(const fmpz_mpoly_t A, const char ** x, const fmpz_mp
 
 /*  Basic manipulation *******************************************************/
 
-void fmpz_mpoly_gen(fmpz_mpoly_t poly, slong i,
-                                                   const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_gen(fmpz_mpoly_t poly, slong i, const fmpz_mpoly_ctx_t ctx);
 
-int fmpz_mpoly_is_gen(const fmpz_mpoly_t poly,
-                                          slong k, const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_is_gen(const fmpz_mpoly_t poly, slong k, const fmpz_mpoly_ctx_t ctx);
 
-void _fmpz_mpoly_set(fmpz * poly1, ulong * exps1,
-                    const fmpz * poly2, const ulong * exps2, slong n, slong N);
+void _fmpz_mpoly_set(fmpz * poly1, ulong * exps1, const fmpz * poly2, const ulong * exps2, slong n, slong N);
+void fmpz_mpoly_set(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_set(fmpz_mpoly_t A, const fmpz_mpoly_t B,
-                                                   const fmpz_mpoly_ctx_t ctx);
-
-int _fmpz_mpoly_equal(fmpz * poly1, ulong * exps1,
-                    const fmpz * poly2, const ulong * exps2, slong n, slong N);
-
-int fmpz_mpoly_equal(const fmpz_mpoly_t A, const fmpz_mpoly_t B,
-                                                   const fmpz_mpoly_ctx_t ctx);
+int _fmpz_mpoly_equal(fmpz * poly1, ulong * exps1, const fmpz * poly2, const ulong * exps2, slong n, slong N);
+int fmpz_mpoly_equal(const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
 
 FMPZ_MPOLY_INLINE
-void fmpz_mpoly_swap(fmpz_mpoly_t A,
-                                fmpz_mpoly_t B, const fmpz_mpoly_ctx_t FLINT_UNUSED(ctx))
+void fmpz_mpoly_swap(fmpz_mpoly_t A, fmpz_mpoly_t B, const fmpz_mpoly_ctx_t FLINT_UNUSED(ctx))
 {
     FLINT_SWAP(fmpz_mpoly_struct, *A, *B);
 }
@@ -194,20 +185,13 @@ slong fmpz_mpoly_max_bits(const fmpz_mpoly_t A);
 
 /* Constants *****************************************************************/
 
-int fmpz_mpoly_is_fmpz(const fmpz_mpoly_t A,
-                                                   const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_is_fmpz(const fmpz_mpoly_t A, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_get_fmpz(fmpz_t c, const fmpz_mpoly_t A,
-                                                   const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_get_fmpz(fmpz_t c, const fmpz_mpoly_t A, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_set_fmpz(fmpz_mpoly_t A,
-                                   const fmpz_t c, const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_set_ui(fmpz_mpoly_t A,
-                                          ulong c, const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_set_si(fmpz_mpoly_t A,
-                                          slong c, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_set_si(fmpz_mpoly_t A, slong c, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_set_ui(fmpz_mpoly_t A, ulong c, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_set_fmpz(fmpz_mpoly_t A, const fmpz_t c, const fmpz_mpoly_ctx_t ctx);
 
 FMPZ_MPOLY_INLINE
 void fmpz_mpoly_zero(fmpz_mpoly_t A, const fmpz_mpoly_ctx_t ctx)
@@ -221,14 +205,9 @@ void fmpz_mpoly_one(fmpz_mpoly_t A, const fmpz_mpoly_ctx_t ctx)
     fmpz_mpoly_set_ui(A, UWORD(1), ctx);
 }
 
-int fmpz_mpoly_equal_fmpz(const fmpz_mpoly_t A,
-                                   const fmpz_t c, const fmpz_mpoly_ctx_t ctx);
-
-int fmpz_mpoly_equal_ui(const fmpz_mpoly_t A,
-                                          ulong c, const fmpz_mpoly_ctx_t ctx);
-
-int fmpz_mpoly_equal_si(const fmpz_mpoly_t A,
-                                          slong c, const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_equal_si(const fmpz_mpoly_t A, slong c, const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_equal_ui(const fmpz_mpoly_t A, ulong c, const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_equal_fmpz(const fmpz_mpoly_t A, const fmpz_t c, const fmpz_mpoly_ctx_t ctx);
 
 FMPZ_MPOLY_INLINE
 int fmpz_mpoly_is_zero(const fmpz_mpoly_t A, const fmpz_mpoly_ctx_t FLINT_UNUSED(ctx))
@@ -262,86 +241,49 @@ void fmpz_mpoly_used_vars(int * used, const fmpz_mpoly_t A, const fmpz_mpoly_ctx
 
 /* Coefficients **************************************************************/
 
-void fmpz_mpoly_get_coeff_fmpz_monomial(fmpz_t c,
-                          const fmpz_mpoly_t A, const fmpz_mpoly_t M,
-                                                   const fmpz_mpoly_ctx_t ctx);
+slong fmpz_mpoly_get_coeff_si_fmpz(const fmpz_mpoly_t A, fmpz * const * exp, const fmpz_mpoly_ctx_t ctx);
+ulong fmpz_mpoly_get_coeff_ui_fmpz(const fmpz_mpoly_t A, fmpz * const * exp, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_get_coeff_fmpz_fmpz(fmpz_t c, const fmpz_mpoly_t A, fmpz * const * exp, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_set_coeff_fmpz_monomial(fmpz_mpoly_t A,
-                                  const fmpz_t c, const fmpz_mpoly_t M,
-                                                   const fmpz_mpoly_ctx_t ctx);
+slong fmpz_mpoly_get_coeff_si_ui(const fmpz_mpoly_t A, const ulong * exp, const fmpz_mpoly_ctx_t ctx);
+ulong fmpz_mpoly_get_coeff_ui_ui(const fmpz_mpoly_t A, const ulong * exp, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_get_coeff_fmpz_ui(fmpz_t c, const fmpz_mpoly_t A, const ulong * exp, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_get_coeff_fmpz_fmpz(fmpz_t c, const fmpz_mpoly_t A,
-                               fmpz * const * exp, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_get_coeff_fmpz_monomial(fmpz_t c, const fmpz_mpoly_t A, const fmpz_mpoly_t M, const fmpz_mpoly_ctx_t ctx);
 
-ulong fmpz_mpoly_get_coeff_ui_fmpz(           const fmpz_mpoly_t A,
-                               fmpz * const * exp, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_set_coeff_si_ui(fmpz_mpoly_t A, const slong c, const ulong * exp, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_set_coeff_ui_ui(fmpz_mpoly_t A, const ulong c, const ulong * exp, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_set_coeff_fmpz_ui(fmpz_mpoly_t A, const fmpz_t c, const ulong * exp, const fmpz_mpoly_ctx_t ctx);
 
-slong fmpz_mpoly_get_coeff_si_fmpz(           const fmpz_mpoly_t A,
-                               fmpz * const * exp, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_set_coeff_si_fmpz(fmpz_mpoly_t A, const slong c, fmpz * const * exp, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_set_coeff_ui_fmpz(fmpz_mpoly_t A, const ulong c, fmpz * const * exp, const fmpz_mpoly_ctx_t ctx);
+void _fmpz_mpoly_set_coeff_fmpz_fmpz(fmpz_mpoly_t A, const fmpz_t c, const fmpz * exp, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_set_coeff_fmpz_fmpz(fmpz_mpoly_t A, const fmpz_t c, fmpz * const * exp, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_get_coeff_fmpz_ui(fmpz_t c, const fmpz_mpoly_t A,
-                                const ulong * exp, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_set_coeff_fmpz_monomial(fmpz_mpoly_t A, const fmpz_t c, const fmpz_mpoly_t M, const fmpz_mpoly_ctx_t ctx);
 
-ulong fmpz_mpoly_get_coeff_ui_ui(           const fmpz_mpoly_t A,
-                                const ulong * exp, const fmpz_mpoly_ctx_t ctx);
-
-slong fmpz_mpoly_get_coeff_si_ui(           const fmpz_mpoly_t A,
-                                const ulong * exp, const fmpz_mpoly_ctx_t ctx);
-
-void _fmpz_mpoly_set_coeff_fmpz_fmpz(fmpz_mpoly_t A,
-                 const fmpz_t c, const fmpz * exp, const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_set_coeff_fmpz_fmpz(fmpz_mpoly_t A,
-               const fmpz_t c, fmpz * const * exp, const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_set_coeff_ui_fmpz(fmpz_mpoly_t A,
-                const ulong c, fmpz * const * exp, const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_set_coeff_si_fmpz(fmpz_mpoly_t A,
-                const slong c, fmpz * const * exp, const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_set_coeff_fmpz_ui(fmpz_mpoly_t A,
-                const fmpz_t c, const ulong * exp, const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_set_coeff_ui_ui(fmpz_mpoly_t A,
-                 const ulong c, const ulong * exp, const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_set_coeff_si_ui(fmpz_mpoly_t A,
-                 const slong c, const ulong * exp, const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_get_coeff_vars_ui(fmpz_mpoly_t C,
-             const fmpz_mpoly_t A, const slong * vars, const ulong * exps,
-                                     slong length, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_get_coeff_vars_ui(fmpz_mpoly_t C, const fmpz_mpoly_t A, const slong * vars, const ulong * exps, slong length, const fmpz_mpoly_ctx_t ctx);
 
 /* conversion ****************************************************************/
 
-int fmpz_mpoly_is_fmpz_poly(const fmpz_mpoly_t A, slong var,
-                                                   const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_is_fmpz_poly(const fmpz_mpoly_t A, slong var, const fmpz_mpoly_ctx_t ctx);
 
-int fmpz_mpoly_get_fmpz_poly(fmpz_poly_t A, const fmpz_mpoly_t B,
-                                        slong var, const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_get_fmpz_poly(fmpz_poly_t A, const fmpz_mpoly_t B, slong var, const fmpz_mpoly_ctx_t ctx);
 
-void _fmpz_mpoly_set_fmpz_poly(fmpz_mpoly_t A, flint_bitcnt_t Abits,
-      const fmpz * Bcoeffs, slong Blen, slong var, const fmpz_mpoly_ctx_t ctx);
+void _fmpz_mpoly_set_fmpz_poly(fmpz_mpoly_t A, flint_bitcnt_t Abits, const fmpz * Bcoeffs, slong Blen, slong var, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_set_fmpz_poly(fmpz_mpoly_t A, const fmpz_poly_t B, slong v, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_set_fmpz_poly(fmpz_mpoly_t A, const fmpz_poly_t B,
-                                          slong v, const fmpz_mpoly_ctx_t ctx);
-
-void _fmpz_mpoly_set_fmpz_poly_one_var(fmpz_mpoly_t A,
-                        flint_bitcnt_t Aminbits, fmpz * Acoeffs, slong Adeg,
-                                                   const fmpz_mpoly_ctx_t ctx);
+void _fmpz_mpoly_set_fmpz_poly_one_var(fmpz_mpoly_t A, flint_bitcnt_t Aminbits, fmpz * Acoeffs, slong Adeg, const fmpz_mpoly_ctx_t ctx);
 
 void fmpz_mpoly_set_gen_fmpz_poly(fmpz_mpoly_t res, slong var, const fmpz_poly_t pol, const fmpz_mpoly_ctx_t ctx);
 
 /* comparison ****************************************************************/
 
-int fmpz_mpoly_cmp(const fmpz_mpoly_t A, const fmpz_mpoly_t B,
-                                                   const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_cmp(const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
 
 /* container operations ******************************************************/
 
-int fmpz_mpoly_is_canonical(const fmpz_mpoly_t A,
-                                                   const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_is_canonical(const fmpz_mpoly_t A, const fmpz_mpoly_ctx_t ctx);
 
 FMPZ_MPOLY_INLINE
 slong fmpz_mpoly_length(const fmpz_mpoly_t A, const fmpz_mpoly_ctx_t FLINT_UNUSED(ctx))
@@ -362,300 +304,145 @@ void fmpz_mpoly_set_term_coeff_si(fmpz_mpoly_t A, slong i, slong c, const fmpz_m
 int fmpz_mpoly_term_exp_fits_ui(const fmpz_mpoly_t A, slong i, const fmpz_mpoly_ctx_t ctx);
 int fmpz_mpoly_term_exp_fits_si(const fmpz_mpoly_t A, slong i, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_get_term_exp_fmpz(fmpz ** exp, const fmpz_mpoly_t A,
-                                          slong i, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_get_term_exp_si(slong * exp, const fmpz_mpoly_t A, slong i, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_get_term_exp_ui(ulong * exp, const fmpz_mpoly_t A, slong i, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_get_term_exp_fmpz(fmpz ** exp, const fmpz_mpoly_t A, slong i, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_get_term_exp_ui(ulong * exp, const fmpz_mpoly_t A,
-                                          slong i, const fmpz_mpoly_ctx_t ctx);
+slong fmpz_mpoly_get_term_var_exp_si(const fmpz_mpoly_t A, slong i, slong var, const fmpz_mpoly_ctx_t ctx);
+ulong fmpz_mpoly_get_term_var_exp_ui(const fmpz_mpoly_t A, slong i, slong var, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_get_term_exp_si(slong * exp, const fmpz_mpoly_t A,
-                                          slong i, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_get_term(fmpz_mpoly_t M, const fmpz_mpoly_t A, slong i, const fmpz_mpoly_ctx_t ctx);
 
-ulong fmpz_mpoly_get_term_var_exp_ui(const fmpz_mpoly_t A, slong i,
-                                        slong var, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_get_term_monomial(fmpz_mpoly_t M, const fmpz_mpoly_t A, slong i, const fmpz_mpoly_ctx_t ctx);
 
-slong fmpz_mpoly_get_term_var_exp_si(const fmpz_mpoly_t A, slong i,
-                                        slong var, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_set_term_exp_ui(fmpz_mpoly_t A, slong i, const ulong * exp, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_set_term_exp_fmpz(fmpz_mpoly_t A, slong i, fmpz * const * exp, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_set_term_exp_fmpz(fmpz_mpoly_t A,
-                      slong i, fmpz * const * exp, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_push_term_si_ui(fmpz_mpoly_t A, slong c, const ulong * exp, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_push_term_si_fmpz(fmpz_mpoly_t A, slong c, fmpz *const *exp, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_push_term_si_ffmpz(fmpz_mpoly_t A, slong c, const fmpz *exp, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_set_term_exp_ui(fmpz_mpoly_t A,
-                       slong i, const ulong * exp, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_push_term_ui_ui(fmpz_mpoly_t A, ulong c, const ulong * exp, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_push_term_ui_fmpz(fmpz_mpoly_t A, ulong c, fmpz *const *exp, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_push_term_ui_ffmpz(fmpz_mpoly_t A, ulong c, const fmpz *exp, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_get_term(fmpz_mpoly_t M, const fmpz_mpoly_t A,
-                                          slong i, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_push_term_fmpz_ui(fmpz_mpoly_t A, const fmpz_t c, const ulong * exp, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_push_term_fmpz_fmpz(fmpz_mpoly_t A, const fmpz_t c, fmpz * const * exp, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_push_term_fmpz_ffmpz(fmpz_mpoly_t A, const fmpz_t c, const fmpz *exp, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_get_term_monomial(fmpz_mpoly_t M, const fmpz_mpoly_t A,
-                                          slong i, const fmpz_mpoly_ctx_t ctx);
+void _fmpz_mpoly_push_exp_ui(fmpz_mpoly_t A, const ulong * exp, const fmpz_mpoly_ctx_t ctx);
+void _fmpz_mpoly_push_exp_ffmpz(fmpz_mpoly_t A, const fmpz * exp, const fmpz_mpoly_ctx_t ctx);
+void _fmpz_mpoly_push_exp_pfmpz(fmpz_mpoly_t A, fmpz * const * exp, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_push_term_fmpz_fmpz(fmpz_mpoly_t A,
-               const fmpz_t c, fmpz * const * exp, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_combine_like_terms(fmpz_mpoly_t A, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_push_term_fmpz_ffmpz(fmpz_mpoly_t A, const fmpz_t c,
-                                    const fmpz *exp, const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_push_term_ui_fmpz(fmpz_mpoly_t A, ulong c, fmpz *const *exp,
-                                  const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_push_term_ui_ffmpz(fmpz_mpoly_t A, ulong c,
-                                    const fmpz *exp, const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_push_term_si_fmpz(fmpz_mpoly_t A, slong c, fmpz *const *exp,
-                                  const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_push_term_si_ffmpz(fmpz_mpoly_t A, slong c,
-                                    const fmpz *exp, const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_push_term_fmpz_ui(fmpz_mpoly_t A,
-                const fmpz_t c, const ulong * exp, const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_push_term_ui_ui(fmpz_mpoly_t A,
-                       ulong c, const ulong * exp, const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_push_term_si_ui(fmpz_mpoly_t A,
-                       slong c, const ulong * exp, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_reverse(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
 
 void fmpz_mpoly_sort_terms(fmpz_mpoly_t A, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_combine_like_terms(fmpz_mpoly_t A,
-                                                   const fmpz_mpoly_ctx_t ctx);
+void _fmpz_mpoly_radix_sort1(fmpz_mpoly_t A, slong left, slong right, flint_bitcnt_t pos, ulong cmpmask, ulong totalmask);
+void _fmpz_mpoly_radix_sort(fmpz_mpoly_t A, slong left, slong right, flint_bitcnt_t pos, slong N, ulong * cmpmask);
 
-void fmpz_mpoly_reverse(fmpz_mpoly_t A, const fmpz_mpoly_t B,
-                                                   const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_assert_canonical(const fmpz_mpoly_t A,
-                                                   const fmpz_mpoly_ctx_t ctx);
-
-void _fmpz_mpoly_radix_sort1(fmpz_mpoly_t A, slong left, slong right,
-                              flint_bitcnt_t pos, ulong cmpmask, ulong totalmask);
-
-void _fmpz_mpoly_radix_sort(fmpz_mpoly_t A, slong left, slong right,
-                                    flint_bitcnt_t pos, slong N, ulong * cmpmask);
-
-void _fmpz_mpoly_push_exp_ffmpz(fmpz_mpoly_t A,
-                                 const fmpz * exp, const fmpz_mpoly_ctx_t ctx);
-
-void _fmpz_mpoly_push_exp_pfmpz(fmpz_mpoly_t A,
-                               fmpz * const * exp, const fmpz_mpoly_ctx_t ctx);
-
-void _fmpz_mpoly_push_exp_ui(fmpz_mpoly_t A,
-                                const ulong * exp, const fmpz_mpoly_ctx_t ctx);
-
+void fmpz_mpoly_assert_canonical(const fmpz_mpoly_t A, const fmpz_mpoly_ctx_t ctx);
 
 /* Random generation *********************************************************/
 
-void fmpz_mpoly_randtest_bound(fmpz_mpoly_t A, flint_rand_t state,
-                        slong length, flint_bitcnt_t coeff_bits, ulong exp_bound,
-                                                   const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_randtest_bound(fmpz_mpoly_t A, flint_rand_t state, slong length, flint_bitcnt_t coeff_bits, ulong exp_bound, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_randtest_bounds(fmpz_mpoly_t A, flint_rand_t state, slong length, flint_bitcnt_t coeff_bits, ulong * exp_bounds, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_randtest_bounds(fmpz_mpoly_t A, flint_rand_t state,
-                     slong length, flint_bitcnt_t coeff_bits, ulong * exp_bounds,
-                                                   const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_randtest_bits(fmpz_mpoly_t A, flint_rand_t state,
-                   slong length, flint_bitcnt_t coeff_bits, flint_bitcnt_t exp_bits,
-                                                   const fmpz_mpoly_ctx_t ctx);
-
+void fmpz_mpoly_randtest_bits(fmpz_mpoly_t A, flint_rand_t state, slong length, flint_bitcnt_t coeff_bits, flint_bitcnt_t exp_bits, const fmpz_mpoly_ctx_t ctx);
 
 /* Addition/Subtraction ******************************************************/
 
-void fmpz_mpoly_add_fmpz(fmpz_mpoly_t A, const fmpz_mpoly_t B,
-                                   const fmpz_t c, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_add_si(fmpz_mpoly_t A, const fmpz_mpoly_t B, slong c, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_add_ui(fmpz_mpoly_t A, const fmpz_mpoly_t B, ulong c, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_add_fmpz(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_t c, const fmpz_mpoly_ctx_t ctx);
+slong _fmpz_mpoly_add(fmpz * poly1, ulong * exps1, const fmpz * poly2, const ulong * exps2, slong len2, const fmpz * poly3, const ulong * exps3, slong len3, slong N, const ulong * cmpmask);
+void fmpz_mpoly_add(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_add_ui(fmpz_mpoly_t A, const fmpz_mpoly_t B,
-                                          ulong c, const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_add_si(fmpz_mpoly_t A, const fmpz_mpoly_t B,
-                                          slong c, const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_sub_fmpz(fmpz_mpoly_t A, const fmpz_mpoly_t B,
-                                   const fmpz_t c, const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_sub_ui(fmpz_mpoly_t A, const fmpz_mpoly_t B,
-                                          ulong c, const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_sub_si(fmpz_mpoly_t A, const fmpz_mpoly_t B,
-                                          slong c, const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_add(fmpz_mpoly_t A, const fmpz_mpoly_t B,
-                             const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx);
-
-slong _fmpz_mpoly_add(fmpz * poly1, ulong * exps1,
-                 const fmpz * poly2, const ulong * exps2, slong len2,
-                 const fmpz * poly3, const ulong * exps3, slong len3, slong N,
-                                                        const ulong * cmpmask);
-
-void fmpz_mpoly_sub(fmpz_mpoly_t A, const fmpz_mpoly_t B,
-                             const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx);
-
-slong _fmpz_mpoly_sub(fmpz * poly1, ulong * exps1,
-                 const fmpz * poly2, const ulong * exps2, slong len2,
-                 const fmpz * poly3, const ulong * exps3, slong len3, slong N,
-                                                        const ulong * cmpmask);
-
+void fmpz_mpoly_sub_si(fmpz_mpoly_t A, const fmpz_mpoly_t B, slong c, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_sub_ui(fmpz_mpoly_t A, const fmpz_mpoly_t B, ulong c, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_sub_fmpz(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_t c, const fmpz_mpoly_ctx_t ctx);
+slong _fmpz_mpoly_sub(fmpz * poly1, ulong * exps1, const fmpz * poly2, const ulong * exps2, slong len2, const fmpz * poly3, const ulong * exps3, slong len3, slong N, const ulong * cmpmask);
+void fmpz_mpoly_sub(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx);
 
 /* Scalar operations *********************************************************/
 
-void fmpz_mpoly_neg(fmpz_mpoly_t A, const fmpz_mpoly_t B,
-                                                   const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_neg(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_scalar_mul_fmpz(fmpz_mpoly_t A,
-             const fmpz_mpoly_t B, const fmpz_t c, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_scalar_mul_si(fmpz_mpoly_t A, const fmpz_mpoly_t B, slong c, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_scalar_mul_ui(fmpz_mpoly_t A, const fmpz_mpoly_t B, ulong c, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_scalar_mul_fmpz(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_t c, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_scalar_mul_si(fmpz_mpoly_t A,
-                    const fmpz_mpoly_t B, slong c, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_scalar_fmma(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_t c, const fmpz_mpoly_t D, const fmpz_t e, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_scalar_mul_ui(fmpz_mpoly_t A,
-                    const fmpz_mpoly_t B, ulong c, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_scalar_divexact_si(fmpz_mpoly_t A, const fmpz_mpoly_t B, slong c, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_scalar_divexact_ui(fmpz_mpoly_t A, const fmpz_mpoly_t B, ulong c, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_scalar_divexact_fmpz(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_t c, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_scalar_fmma(fmpz_mpoly_t A, const fmpz_mpoly_t B,
-                         const fmpz_t c, const fmpz_mpoly_t D, const fmpz_t e,
-                                                   const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_scalar_divexact_fmpz(fmpz_mpoly_t A,
-             const fmpz_mpoly_t B, const fmpz_t c, const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_scalar_divexact_si(fmpz_mpoly_t A,
-                    const fmpz_mpoly_t B, slong c, const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_scalar_divexact_ui(fmpz_mpoly_t A,
-                    const fmpz_mpoly_t B, ulong c, const fmpz_mpoly_ctx_t ctx);
-
-int fmpz_mpoly_scalar_divides_fmpz(fmpz_mpoly_t A,
-             const fmpz_mpoly_t B, const fmpz_t c, const fmpz_mpoly_ctx_t ctx);
-
-int fmpz_mpoly_scalar_divides_si(fmpz_mpoly_t A,
-                    const fmpz_mpoly_t B, slong c, const fmpz_mpoly_ctx_t ctx);
-
-int fmpz_mpoly_scalar_divides_ui(fmpz_mpoly_t A,
-                    const fmpz_mpoly_t B, ulong c, const fmpz_mpoly_ctx_t ctx);
-
+int fmpz_mpoly_scalar_divides_si(fmpz_mpoly_t A, const fmpz_mpoly_t B, slong c, const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_scalar_divides_ui(fmpz_mpoly_t A, const fmpz_mpoly_t B, ulong c, const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_scalar_divides_fmpz(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_t c, const fmpz_mpoly_ctx_t ctx);
 
 /* Differentiation/Integration ***********************************************/
 
-void fmpz_mpoly_derivative(fmpz_mpoly_t A,
-                  const fmpz_mpoly_t B, slong var, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_derivative(fmpz_mpoly_t A, const fmpz_mpoly_t B, slong var, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_integral(fmpz_mpoly_t A, fmpz_t scale,
-                  const fmpz_mpoly_t B, slong var, const fmpz_mpoly_ctx_t ctx);
-
+void fmpz_mpoly_integral(fmpz_mpoly_t A, fmpz_t scale, const fmpz_mpoly_t B, slong var, const fmpz_mpoly_ctx_t ctx);
 
 /* Evaluation ****************************************************************/
 
 int _fmpz_pow_ui_is_not_feasible(flint_bitcnt_t bbits, ulong e);
-
 int _fmpz_pow_fmpz_is_not_feasible(flint_bitcnt_t bbits, const fmpz_t e);
 
-int fmpz_mpoly_evaluate_all_fmpz(fmpz_t ev, const fmpz_mpoly_t A,
-                              fmpz * const * vals, const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_evaluate_all_fmpz(fmpz_t ev, const fmpz_mpoly_t A, fmpz * const * vals, const fmpz_mpoly_ctx_t ctx);
+ulong fmpz_mpoly_evaluate_all_nmod(const fmpz_mpoly_t A, const ulong * alphas, const fmpz_mpoly_ctx_t ctx, nmod_t fpctx);
+void fmpz_mpoly_evaluate_all_fmpz_mod(fmpz_t ev, const fmpz_mpoly_t A, const fmpz * alphas, const fmpz_mpoly_ctx_t ctx, const fmpz_mod_ctx_t fpctx);
 
-ulong fmpz_mpoly_evaluate_all_nmod(const fmpz_mpoly_t A,
-           const ulong * alphas, const fmpz_mpoly_ctx_t ctx, nmod_t fpctx);
+int fmpz_mpoly_evaluate_one_fmpz(fmpz_mpoly_t A, const fmpz_mpoly_t B, slong var, const fmpz_t val, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_evaluate_all_fmpz_mod(fmpz_t ev,
-                        const fmpz_mpoly_t A, const fmpz * alphas,
-                       const fmpz_mpoly_ctx_t ctx, const fmpz_mod_ctx_t fpctx);
+int fmpz_mpoly_compose_fmpz_poly(fmpz_poly_t A, const fmpz_mpoly_t B, fmpz_poly_struct * const * C, const fmpz_mpoly_ctx_t ctxB);
 
-int fmpz_mpoly_evaluate_one_fmpz(fmpz_mpoly_t A,
-                           const fmpz_mpoly_t B, slong var, const fmpz_t val,
-                                                   const fmpz_mpoly_ctx_t ctx);
+void _fmpz_mpoly_compose_mat(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mat_t M, const fmpz_mpoly_ctx_t ctxB, const fmpz_mpoly_ctx_t ctxAC);
 
-int fmpz_mpoly_compose_fmpz_poly(fmpz_poly_t A,
-                         const fmpz_mpoly_t B, fmpz_poly_struct * const * C,
-                                                  const fmpz_mpoly_ctx_t ctxB);
+int fmpz_mpoly_compose_fmpz_mpoly_geobucket(fmpz_mpoly_t A, const fmpz_mpoly_t B, fmpz_mpoly_struct * const * C, const fmpz_mpoly_ctx_t ctxB, const fmpz_mpoly_ctx_t ctxAC);
+int fmpz_mpoly_compose_fmpz_mpoly_horner(fmpz_mpoly_t A, const fmpz_mpoly_t B, fmpz_mpoly_struct * const * C, const fmpz_mpoly_ctx_t ctxB, const fmpz_mpoly_ctx_t ctxAC);
+int fmpz_mpoly_compose_fmpz_mpoly(fmpz_mpoly_t A, const fmpz_mpoly_t B, fmpz_mpoly_struct * const * C, const fmpz_mpoly_ctx_t ctxB, const fmpz_mpoly_ctx_t ctxAC);
 
-void _fmpz_mpoly_compose_mat(fmpz_mpoly_t A,
-                            const fmpz_mpoly_t B, const fmpz_mat_t M,
-                    const fmpz_mpoly_ctx_t ctxB, const fmpz_mpoly_ctx_t ctxAC);
-
-int fmpz_mpoly_compose_fmpz_mpoly_geobucket(fmpz_mpoly_t A,
-                   const fmpz_mpoly_t B, fmpz_mpoly_struct * const * C,
-                    const fmpz_mpoly_ctx_t ctxB, const fmpz_mpoly_ctx_t ctxAC);
-
-int fmpz_mpoly_compose_fmpz_mpoly_horner(fmpz_mpoly_t A,
-                   const fmpz_mpoly_t B, fmpz_mpoly_struct * const * C,
-                    const fmpz_mpoly_ctx_t ctxB, const fmpz_mpoly_ctx_t ctxAC);
-
-int fmpz_mpoly_compose_fmpz_mpoly(fmpz_mpoly_t A,
-                   const fmpz_mpoly_t B, fmpz_mpoly_struct * const * C,
-                    const fmpz_mpoly_ctx_t ctxB, const fmpz_mpoly_ctx_t ctxAC);
-
-void fmpz_mpoly_compose_fmpz_mpoly_gen(fmpz_mpoly_t A,
-                             const fmpz_mpoly_t B, const slong * c,
-                    const fmpz_mpoly_ctx_t ctxB, const fmpz_mpoly_ctx_t ctxAC);
-
+void fmpz_mpoly_compose_fmpz_mpoly_gen(fmpz_mpoly_t A, const fmpz_mpoly_t B, const slong * c, const fmpz_mpoly_ctx_t ctxB, const fmpz_mpoly_ctx_t ctxAC);
 
 /* Multiplication ************************************************************/
 
-void fmpz_mpoly_mul(fmpz_mpoly_t A,
-       const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_mul(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_mul_monomial(fmpz_mpoly_t A, const fmpz_mpoly_t B,
-                             const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_mul_monomial(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_mul_johnson(fmpz_mpoly_t A,
-       const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_mul_heap_threaded(fmpz_mpoly_t A,
-       const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx);
-
-int fmpz_mpoly_mul_array(fmpz_mpoly_t A,
-       const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx);
-
-int fmpz_mpoly_mul_array_threaded(fmpz_mpoly_t A,
-       const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx);
-
-int fmpz_mpoly_mul_dense(fmpz_mpoly_t A,
-       const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx);
-
-slong _fmpz_mpoly_mul_johnson(fmpz ** poly1, ulong ** exp1, slong * alloc,
-                 const fmpz * poly2, const ulong * exp2, slong len2,
-                 const fmpz * poly3, const ulong * exp3, slong len3,
-                             flint_bitcnt_t bits, slong N, const ulong * cmpmask);
-
-void _fmpz_mpoly_mul_johnson_maxfields(fmpz_mpoly_t A,
-                                 const fmpz_mpoly_t B, fmpz * maxBfields,
-                                 const fmpz_mpoly_t C, fmpz * maxCfields,
-                                                   const fmpz_mpoly_ctx_t ctx);
+void _fmpz_mpoly_mul_johnson_maxfields(fmpz_mpoly_t A, const fmpz_mpoly_t B, fmpz * maxBfields, const fmpz_mpoly_t C, fmpz * maxCfields, const fmpz_mpoly_ctx_t ctx);
+slong _fmpz_mpoly_mul_johnson(fmpz ** poly1, ulong ** exp1, slong * alloc, const fmpz * poly2, const ulong * exp2, slong len2, const fmpz * poly3, const ulong * exp3, slong len3, flint_bitcnt_t bits, slong N, const ulong * cmpmask);
+void fmpz_mpoly_mul_johnson(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx);
 
 void _fmpz_mpoly_mul_heap_threaded_pool_maxfields(fmpz_mpoly_t A,
            const fmpz_mpoly_t B, fmpz * maxBfields,
            const fmpz_mpoly_t C, fmpz * maxCfields, const fmpz_mpoly_ctx_t ctx,
                         const thread_pool_handle * handles, slong num_handles);
+void fmpz_mpoly_mul_heap_threaded(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx);
 
-int _fmpz_mpoly_mul_array_DEG(fmpz_mpoly_t A,
-                                 const fmpz_mpoly_t B, fmpz * maxBfields,
-                                 const fmpz_mpoly_t C, fmpz * maxCfields,
-                                                   const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_mul_array(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_mul_array_threaded(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx);
 
-int _fmpz_mpoly_mul_array_LEX(fmpz_mpoly_t A,
-                                 const fmpz_mpoly_t B, fmpz * maxBfields,
-                                 const fmpz_mpoly_t C, fmpz * maxCfields,
-                                                   const fmpz_mpoly_ctx_t ctx);
+int _fmpz_mpoly_mul_dense(fmpz_mpoly_t P, const fmpz_mpoly_t A, fmpz * maxAfields, const fmpz_mpoly_t B, fmpz * maxBfields, const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_mul_dense(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_t C, const fmpz_mpoly_ctx_t ctx);
 
-int _fmpz_mpoly_mul_array_threaded_pool_DEG(fmpz_mpoly_t A,
-           const fmpz_mpoly_t B, fmpz * maxBfields,
-           const fmpz_mpoly_t C, fmpz * maxCfields, const fmpz_mpoly_ctx_t ctx,
-                        const thread_pool_handle * handles, slong num_handles);
+int _fmpz_mpoly_mul_array_DEG(fmpz_mpoly_t A, const fmpz_mpoly_t B, fmpz * maxBfields, const fmpz_mpoly_t C, fmpz * maxCfields, const fmpz_mpoly_ctx_t ctx);
+int _fmpz_mpoly_mul_array_LEX(fmpz_mpoly_t A, const fmpz_mpoly_t B, fmpz * maxBfields, const fmpz_mpoly_t C, fmpz * maxCfields, const fmpz_mpoly_ctx_t ctx);
 
-int _fmpz_mpoly_mul_array_threaded_pool_LEX(fmpz_mpoly_t A,
-           const fmpz_mpoly_t B, fmpz * maxBfields,
-           const fmpz_mpoly_t C, fmpz * maxCfields, const fmpz_mpoly_ctx_t ctx,
-                        const thread_pool_handle * handles, slong num_handles);
-
-int _fmpz_mpoly_mul_dense(fmpz_mpoly_t P,
-                                 const fmpz_mpoly_t A, fmpz * maxAfields,
-                                 const fmpz_mpoly_t B, fmpz * maxBfields,
-                                                   const fmpz_mpoly_ctx_t ctx);
+int _fmpz_mpoly_mul_array_threaded_pool_DEG(fmpz_mpoly_t A, const fmpz_mpoly_t B, fmpz * maxBfields, const fmpz_mpoly_t C, fmpz * maxCfields, const fmpz_mpoly_ctx_t ctx, const thread_pool_handle * handles, slong num_handles);
+int _fmpz_mpoly_mul_array_threaded_pool_LEX(fmpz_mpoly_t A, const fmpz_mpoly_t B, fmpz * maxBfields, const fmpz_mpoly_t C, fmpz * maxCfields, const fmpz_mpoly_ctx_t ctx, const thread_pool_handle * handles, slong num_handles);
 
 /* Powering ******************************************************************/
 
-int fmpz_mpoly_pow_fmpz(fmpz_mpoly_t A, const fmpz_mpoly_t B,
-                                  const fmpz_t k, const fmpz_mpoly_ctx_t ctx);
-
-int fmpz_mpoly_pow_ui(fmpz_mpoly_t A, const fmpz_mpoly_t B,
-                                          ulong k, const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_pow_ui(fmpz_mpoly_t A, const fmpz_mpoly_t B, ulong k, const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_pow_fmpz(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_t k, const fmpz_mpoly_ctx_t ctx);
 
 /* Division ******************************************************************/
 
@@ -677,41 +464,39 @@ int _fmpz_mpoly_divides_heap_threaded_pool(fmpz_mpoly_t Q,
 #endif
 
 slong _fmpz_mpoly_divides_array(fmpz ** poly1, ulong ** exp1,
-         slong * alloc, const fmpz * poly2, const ulong * exp2, slong len2,
-                        const fmpz * poly3, const ulong * exp3, slong len3,
-                                         slong * mults, slong num, slong bits);
+        slong * alloc, const fmpz * poly2, const ulong * exp2, slong len2,
+        const fmpz * poly3, const ulong * exp3, slong len3,
+        slong * mults, slong num, slong bits);
 
 int fmpz_mpoly_divides_array(fmpz_mpoly_t poly1,
-                  const fmpz_mpoly_t poly2, const fmpz_mpoly_t poly3,
-                                                   const fmpz_mpoly_ctx_t ctx);
-
+        const fmpz_mpoly_t poly2, const fmpz_mpoly_t poly3,
+        const fmpz_mpoly_ctx_t ctx);
 
 int mpoly_divides_select_exps(fmpz_mpoly_t S, fmpz_mpoly_ctx_t zctx,
-                                slong nworkers, ulong * Aexp, slong Alen,
-                                   ulong * Bexp, slong Blen, flint_bitcnt_t bits);
+        slong nworkers, ulong * Aexp, slong Alen,
+        ulong * Bexp, slong Blen, flint_bitcnt_t bits);
 
 slong _fmpz_mpoly_divides_monagan_pearce(fmpz ** poly1,
-                      ulong ** exp1, slong * alloc, const fmpz * poly2,
-                    const ulong * exp2, slong len2, const fmpz * poly3,
-                    const ulong * exp3, slong len3, flint_bitcnt_t bits, slong N,
-                                                        const ulong * cmpmask);
+        ulong ** exp1, slong * alloc, const fmpz * poly2,
+        const ulong * exp2, slong len2, const fmpz * poly3,
+        const ulong * exp3, slong len3, flint_bitcnt_t bits, slong N,
+        const ulong * cmpmask);
 
 void fmpz_mpoly_divrem(fmpz_mpoly_t Q, fmpz_mpoly_t R,
        const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
 
 void fmpz_mpoly_quasidivrem(fmpz_t scale, fmpz_mpoly_t Q,
-     fmpz_mpoly_t R, const fmpz_mpoly_t A, const fmpz_mpoly_t B,
-                                                   const fmpz_mpoly_ctx_t ctx);
+        fmpz_mpoly_t R, const fmpz_mpoly_t A, const fmpz_mpoly_t B,
+        const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_div(fmpz_mpoly_t Q, const fmpz_mpoly_t A,
-                             const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_div(fmpz_mpoly_t Q, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
 
 void fmpz_mpoly_quasidiv(fmpz_t scale, fmpz_mpoly_t Q,
        const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
 
 void fmpz_mpoly_divrem_ideal(fmpz_mpoly_struct ** Q,
-     fmpz_mpoly_t R, const fmpz_mpoly_t A, fmpz_mpoly_struct * const * B,
-                                        slong len, const fmpz_mpoly_ctx_t ctx);
+        fmpz_mpoly_t R, const fmpz_mpoly_t A, fmpz_mpoly_struct * const * B,
+        slong len, const fmpz_mpoly_ctx_t ctx);
 
 void fmpz_mpoly_quasidivrem_ideal(fmpz_t scale,
      fmpz_mpoly_struct ** Q, fmpz_mpoly_t R, const fmpz_mpoly_t A,
@@ -733,69 +518,64 @@ slong _fmpz_mpoly_div_monagan_pearce(fmpz ** polyq,
                        slong len3, slong bits, slong N, const ulong * cmpmask);
 
 void fmpz_mpoly_div_monagan_pearce(fmpz_mpoly_t q,
-                     const fmpz_mpoly_t poly2, const fmpz_mpoly_t poly3,
-                                                   const fmpz_mpoly_ctx_t ctx);
+        const fmpz_mpoly_t poly2, const fmpz_mpoly_t poly3,
+        const fmpz_mpoly_ctx_t ctx);
 
 slong _fmpz_mpoly_divrem_monagan_pearce(slong * lenr,
-  fmpz ** polyq, ulong ** expq, slong * allocq, fmpz ** polyr,
-                  ulong ** expr, slong * allocr, const fmpz * poly2,
-   const ulong * exp2, slong len2, const fmpz * poly3, const ulong * exp3,
-                       slong len3, slong bits, slong N, const ulong * cmpmask);
+        fmpz ** polyq, ulong ** expq, slong * allocq, fmpz ** polyr,
+        ulong ** expr, slong * allocr, const fmpz * poly2,
+        const ulong * exp2, slong len2, const fmpz * poly3, const ulong * exp3,
+        slong len3, slong bits, slong N, const ulong * cmpmask);
 
 void fmpz_mpoly_divrem_monagan_pearce(fmpz_mpoly_t q, fmpz_mpoly_t r,
-                  const fmpz_mpoly_t poly2, const fmpz_mpoly_t poly3,
-                                                   const fmpz_mpoly_ctx_t ctx);
+        const fmpz_mpoly_t poly2, const fmpz_mpoly_t poly3,
+        const fmpz_mpoly_ctx_t ctx);
 
 slong _fmpz_mpoly_divrem_array(slong * lenr,
-       fmpz ** polyq, ulong ** expq, slong * allocq,
-              fmpz ** polyr, ulong ** expr, slong * allocr,
-                const fmpz * poly2, const ulong * exp2, slong len2,
+        fmpz ** polyq, ulong ** expq, slong * allocq,
+        fmpz ** polyr, ulong ** expr, slong * allocr,
+        const fmpz * poly2, const ulong * exp2, slong len2,
         const fmpz * poly3, const ulong * exp3, slong len3, slong * mults,
-                                                        slong num, slong bits);
+        slong num, slong bits);
 
 int fmpz_mpoly_divrem_array(fmpz_mpoly_t q, fmpz_mpoly_t r,
-                    const fmpz_mpoly_t poly2, const fmpz_mpoly_t poly3,
-                                                   const fmpz_mpoly_ctx_t ctx);
+        const fmpz_mpoly_t poly2, const fmpz_mpoly_t poly3,
+        const fmpz_mpoly_ctx_t ctx);
 
 void fmpz_mpoly_quasidivrem_heap(fmpz_t scale,
-                        fmpz_mpoly_t q, fmpz_mpoly_t r,
-                  const fmpz_mpoly_t poly2, const fmpz_mpoly_t poly3,
-                                                   const fmpz_mpoly_ctx_t ctx);
+        fmpz_mpoly_t q, fmpz_mpoly_t r,
+        const fmpz_mpoly_t poly2, const fmpz_mpoly_t poly3,
+        const fmpz_mpoly_ctx_t ctx);
 
 void fmpz_mpoly_quasidiv_heap(fmpz_t scale, fmpz_mpoly_t q,
-                  const fmpz_mpoly_t poly2, const fmpz_mpoly_t poly3,
-                                                   const fmpz_mpoly_ctx_t ctx);
+        const fmpz_mpoly_t poly2, const fmpz_mpoly_t poly3,
+        const fmpz_mpoly_ctx_t ctx);
 
 slong
 _fmpz_mpoly_divrem_ideal_monagan_pearce(fmpz_mpoly_struct ** polyq,
-       fmpz ** polyr, ulong ** expr, slong * allocr, const fmpz * poly2,
-          const ulong * exp2, slong len2, fmpz_mpoly_struct * const * poly3,
-                        ulong * const * exp3, slong len, slong N, slong bits,
-                            const fmpz_mpoly_ctx_t ctx, const ulong * cmpmask);
+        fmpz ** polyr, ulong ** expr, slong * allocr, const fmpz * poly2,
+        const ulong * exp2, slong len2, fmpz_mpoly_struct * const * poly3,
+        ulong * const * exp3, slong len, slong N, slong bits,
+        const fmpz_mpoly_ctx_t ctx, const ulong * cmpmask);
 
 void
 fmpz_mpoly_divrem_ideal_monagan_pearce(fmpz_mpoly_struct ** q, fmpz_mpoly_t r,
-    const fmpz_mpoly_t poly2, fmpz_mpoly_struct * const * poly3, slong len,
-                                                   const fmpz_mpoly_ctx_t ctx);
+        const fmpz_mpoly_t poly2, fmpz_mpoly_struct * const * poly3, slong len,
+        const fmpz_mpoly_ctx_t ctx);
 
 void
 fmpz_mpoly_quasidivrem_ideal_heap(fmpz_t scale,
-                                 fmpz_mpoly_struct ** q, fmpz_mpoly_t r,
-                const fmpz_mpoly_t poly2, fmpz_mpoly_struct * const * poly3,
-                                        slong len, const fmpz_mpoly_ctx_t ctx);
+        fmpz_mpoly_struct ** q, fmpz_mpoly_t r,
+        const fmpz_mpoly_t poly2, fmpz_mpoly_struct * const * poly3,
+        slong len, const fmpz_mpoly_ctx_t ctx);
 
 /* Square root ***************************************************************/
 
-slong _fmpz_mpoly_sqrt_heap(fmpz ** polyq, ulong ** expq,
-           slong * allocq, const fmpz * poly2, const ulong * exp2, slong len2,
-                       flint_bitcnt_t bits, const mpoly_ctx_t mctx, int check);
-
-int fmpz_mpoly_sqrt_heap(fmpz_mpoly_t q, const fmpz_mpoly_t poly2,
-                                        const fmpz_mpoly_ctx_t ctx, int check);
+slong _fmpz_mpoly_sqrt_heap(fmpz ** polyq, ulong ** expq, slong * allocq, const fmpz * poly2, const ulong * exp2, slong len2, flint_bitcnt_t bits, const mpoly_ctx_t mctx, int check);
+int fmpz_mpoly_sqrt_heap(fmpz_mpoly_t q, const fmpz_mpoly_t poly2, const fmpz_mpoly_ctx_t ctx, int check);
 
 FMPZ_MPOLY_INLINE
-int fmpz_mpoly_sqrt(fmpz_mpoly_t q, const fmpz_mpoly_t poly2,
-                                                    const fmpz_mpoly_ctx_t ctx)
+int fmpz_mpoly_sqrt(fmpz_mpoly_t q, const fmpz_mpoly_t poly2, const fmpz_mpoly_ctx_t ctx)
 {
     return fmpz_mpoly_sqrt_heap(q, poly2, ctx, 1);
 }
@@ -813,59 +593,36 @@ int fmpz_mpoly_is_square(const fmpz_mpoly_t poly2, const fmpz_mpoly_ctx_t ctx)
 
 /* GCD ***********************************************************************/
 
-void fmpz_mpoly_term_content(fmpz_mpoly_t M, const fmpz_mpoly_t A,
-                                                   const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_term_content(fmpz_mpoly_t M, const fmpz_mpoly_t A, const fmpz_mpoly_ctx_t ctx);
 
 void fmpz_mpoly_primitive_part(fmpz_mpoly_t res, const fmpz_mpoly_t f, const fmpz_mpoly_ctx_t ctx);
 
-int fmpz_mpoly_content_vars(fmpz_mpoly_t g, const fmpz_mpoly_t A,
-                  slong * vars, slong vars_length, const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_content_vars(fmpz_mpoly_t g, const fmpz_mpoly_t A, slong * vars, slong vars_length, const fmpz_mpoly_ctx_t ctx);
 
-int fmpz_mpoly_gcd(fmpz_mpoly_t G,
-       const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_deflation(fmpz * shift, fmpz * stride, const fmpz_mpoly_t A, const fmpz_mpoly_ctx_t ctx);
 
-int fmpz_mpoly_gcd_cofactors(fmpz_mpoly_t G,
-                fmpz_mpoly_t Abar, fmpz_mpoly_t Bbar, const fmpz_mpoly_t A,
-                             const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_deflate(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz * shift, const fmpz * stride, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_inflate(fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz * shift, const fmpz * stride, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_deflation(fmpz * shift, fmpz * stride,
-                             const fmpz_mpoly_t A, const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_gcd_cofactors(fmpz_mpoly_t G, fmpz_mpoly_t Abar, fmpz_mpoly_t Bbar, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_deflate(fmpz_mpoly_t A, const fmpz_mpoly_t B,
-          const fmpz * shift, const fmpz * stride, const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_inflate(fmpz_mpoly_t A, const fmpz_mpoly_t B,
-          const fmpz * shift, const fmpz * stride, const fmpz_mpoly_ctx_t ctx);
-
-int fmpz_mpoly_gcd_hensel(fmpz_mpoly_t G,
-       const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
-
-int fmpz_mpoly_gcd_brown(fmpz_mpoly_t G,
-       const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
-
-int fmpz_mpoly_gcd_subresultant(fmpz_mpoly_t G,
-       const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
-
-int fmpz_mpoly_gcd_zippel(fmpz_mpoly_t G,
-       const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
-
-int fmpz_mpoly_gcd_zippel2(fmpz_mpoly_t G,
-       const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_gcd_hensel(fmpz_mpoly_t G, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_gcd_brown(fmpz_mpoly_t G, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_gcd_subresultant(fmpz_mpoly_t G, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_gcd_zippel(fmpz_mpoly_t G, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_gcd_zippel2(fmpz_mpoly_t G, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_gcd(fmpz_mpoly_t G, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx);
 
 /* Univariates ***************************************************************/
 
 void fmpz_mpoly_univar_init(fmpz_mpoly_univar_t A, const fmpz_mpoly_ctx_t FLINT_UNUSED(ctx));
-
 void fmpz_mpoly_univar_clear(fmpz_mpoly_univar_t A, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_univar_fit_length(fmpz_mpoly_univar_t A,
-                                     slong length, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_univar_fit_length(fmpz_mpoly_univar_t A, slong length, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_univar_print_pretty(const fmpz_mpoly_univar_t A,
-                                  const char ** x, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_univar_print_pretty(const fmpz_mpoly_univar_t A, const char ** x, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_univar_assert_canonical(fmpz_mpoly_univar_t A,
-                                                   const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_univar_assert_canonical(fmpz_mpoly_univar_t A, const fmpz_mpoly_ctx_t ctx);
 
 FMPZ_MPOLY_INLINE
 void fmpz_mpoly_univar_zero(fmpz_mpoly_univar_t A, const fmpz_mpoly_ctx_t FLINT_UNUSED(ctx))
@@ -985,31 +742,24 @@ int fmpz_mpoly_vec_is_autoreduced(const fmpz_mpoly_vec_t G, const fmpz_mpoly_ctx
 
 ******************************************************************************/
 
-void mpoly_void_ring_init_fmpz_mpoly_ctx(mpoly_void_ring_t R,
-                                                   const fmpz_mpoly_ctx_t ctx);
+void mpoly_void_ring_init_fmpz_mpoly_ctx(mpoly_void_ring_t R, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_pow_fps(fmpz_mpoly_t A, const fmpz_mpoly_t B,
-                                          ulong k, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_pow_fps(fmpz_mpoly_t A, const fmpz_mpoly_t B, ulong k, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpolyl_lead_coeff(fmpz_mpoly_t c, const fmpz_mpoly_t A,
-                                   slong num_vars, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpolyl_lead_coeff(fmpz_mpoly_t c, const fmpz_mpoly_t A, slong num_vars, const fmpz_mpoly_ctx_t ctx);
 
-int fmpz_mpolyl_content(fmpz_mpoly_t g, const fmpz_mpoly_t A,
-                                   slong num_vars, const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpolyl_content(fmpz_mpoly_t g, const fmpz_mpoly_t A, slong num_vars, const fmpz_mpoly_ctx_t ctx);
 
 void _fmpz_mpoly_to_fmpz_poly_deflate(fmpz_poly_t A,
-                         const fmpz_mpoly_t B, slong var, const ulong * Bshift,
-                            const ulong * Bstride, const fmpz_mpoly_ctx_t ctx);
+        const fmpz_mpoly_t B, slong var, const ulong * Bshift,
+        const ulong * Bstride, const fmpz_mpoly_ctx_t ctx);
 
 void _fmpz_mpoly_from_fmpz_poly_inflate(fmpz_mpoly_t A,
-       flint_bitcnt_t Abits, const fmpz_poly_t B, slong var, const ulong * Ashift,
-                            const ulong * Astride, const fmpz_mpoly_ctx_t ctx);
+        flint_bitcnt_t Abits, const fmpz_poly_t B, slong var, const ulong * Ashift,
+        const ulong * Astride, const fmpz_mpoly_ctx_t ctx);
 
-int fmpz_mpoly_repack_bits(fmpz_mpoly_t A, const fmpz_mpoly_t B,
-                                flint_bitcnt_t Abits, const fmpz_mpoly_ctx_t ctx);
-
-int fmpz_mpoly_repack_bits_inplace(fmpz_mpoly_t A, flint_bitcnt_t Abits,
-                                                   const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_repack_bits(fmpz_mpoly_t A, const fmpz_mpoly_t B, flint_bitcnt_t Abits, const fmpz_mpoly_ctx_t ctx);
+int fmpz_mpoly_repack_bits_inplace(fmpz_mpoly_t A, flint_bitcnt_t Abits, const fmpz_mpoly_ctx_t ctx);
 
 typedef struct _fmpz_mpoly_stripe_struct
 {
@@ -1028,7 +778,6 @@ typedef struct _fmpz_mpoly_stripe_struct
 } fmpz_mpoly_stripe_struct;
 
 typedef fmpz_mpoly_stripe_struct fmpz_mpoly_stripe_t[1];
-
 
 /* mpolyd ********************************************************************/
 
@@ -1059,30 +808,24 @@ void fmpz_pow_cache_init(fmpz_pow_cache_t T, const fmpz_t val);
 
 void fmpz_pow_cache_clear(fmpz_pow_cache_t T);
 
-int fmpz_pow_cache_mulpow_ui(fmpz_t a, const fmpz_t b, ulong k,
-                                                          fmpz_pow_cache_t T);
-
-int fmpz_pow_cache_mulpow_fmpz(fmpz_t a, const fmpz_t b, const fmpz_t k,
-                                                          fmpz_pow_cache_t T);
+int fmpz_pow_cache_mulpow_ui(fmpz_t a, const fmpz_t b, ulong k, fmpz_pow_cache_t T);
+int fmpz_pow_cache_mulpow_fmpz(fmpz_t a, const fmpz_t b, const fmpz_t k, fmpz_pow_cache_t T);
 
 /*****************************************************************************/
 
 void fmpz_mpoly_to_mpoly_perm_deflate_threaded_pool(
-                                fmpz_mpoly_t A, const fmpz_mpoly_ctx_t lctx,
-                            const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx,
-               const slong * perm, const ulong * shift, const ulong * stride,
-                        const thread_pool_handle * handles, slong num_handles);
+        fmpz_mpoly_t A, const fmpz_mpoly_ctx_t lctx,
+        const fmpz_mpoly_t B, const fmpz_mpoly_ctx_t ctx,
+        const slong * perm, const ulong * shift, const ulong * stride,
+        const thread_pool_handle * handles, slong num_handles);
 
 void fmpz_mpoly_from_mpoly_perm_inflate(
-               fmpz_mpoly_t A, flint_bitcnt_t Abits, const fmpz_mpoly_ctx_t ctx,
-                          const fmpz_mpoly_t B,  const fmpz_mpoly_ctx_t lctx,
-                const slong * perm, const ulong * shift, const ulong * stride);
+        fmpz_mpoly_t A, flint_bitcnt_t Abits, const fmpz_mpoly_ctx_t ctx,
+        const fmpz_mpoly_t B,  const fmpz_mpoly_ctx_t lctx,
+        const slong * perm, const ulong * shift, const ulong * stride);
 
-void fmpz_mpoly_height(fmpz_t max,
-                             const fmpz_mpoly_t A, const fmpz_mpoly_ctx_t FLINT_UNUSED(ctx));
-
-void fmpz_mpoly_heights(fmpz_t max, fmpz_t sum,
-                             const fmpz_mpoly_t A, const fmpz_mpoly_ctx_t FLINT_UNUSED(ctx));
+void fmpz_mpoly_height(fmpz_t max, const fmpz_mpoly_t A, const fmpz_mpoly_ctx_t FLINT_UNUSED(ctx));
+void fmpz_mpoly_heights(fmpz_t max, fmpz_t sum, const fmpz_mpoly_t A, const fmpz_mpoly_ctx_t FLINT_UNUSED(ctx));
 
 /* geobuckets ****************************************************************/
 
@@ -1095,140 +838,68 @@ typedef struct fmpz_mpoly_geobucket
 
 typedef fmpz_mpoly_geobucket_struct fmpz_mpoly_geobucket_t[1];
 
-void fmpz_mpoly_geobucket_init(fmpz_mpoly_geobucket_t B,
-                                                   const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_geobucket_init(fmpz_mpoly_geobucket_t B, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_geobucket_clear(fmpz_mpoly_geobucket_t B, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_geobucket_clear(fmpz_mpoly_geobucket_t B,
-                                                   const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_geobucket_empty(fmpz_mpoly_t p, fmpz_mpoly_geobucket_t B, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_geobucket_empty(fmpz_mpoly_t p,
-                         fmpz_mpoly_geobucket_t B, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_geobucket_fit_length(fmpz_mpoly_geobucket_t B, slong i, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_geobucket_fit_length(fmpz_mpoly_geobucket_t B,
-                                          slong i, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_geobucket_set(fmpz_mpoly_geobucket_t B, fmpz_mpoly_t p, const fmpz_mpoly_ctx_t ctx);
 
-void fmpz_mpoly_geobucket_set(fmpz_mpoly_geobucket_t B,
-                                   fmpz_mpoly_t p, const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_geobucket_add(fmpz_mpoly_geobucket_t B,
-                                   fmpz_mpoly_t p, const fmpz_mpoly_ctx_t ctx);
-
-void fmpz_mpoly_geobucket_sub(fmpz_mpoly_geobucket_t B,
-                                   fmpz_mpoly_t p, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_geobucket_add(fmpz_mpoly_geobucket_t B, fmpz_mpoly_t p, const fmpz_mpoly_ctx_t ctx);
+void fmpz_mpoly_geobucket_sub(fmpz_mpoly_geobucket_t B, fmpz_mpoly_t p, const fmpz_mpoly_ctx_t ctx);
 
 /* Helpers for array methods *************************************************/
 
-void _fmpz_mpoly_mul_array_chunked_DEG(fmpz_mpoly_t P,
-                             const fmpz_mpoly_t A, const fmpz_mpoly_t B,
-                                       ulong degb, const fmpz_mpoly_ctx_t ctx);
+void _fmpz_mpoly_mul_array_chunked_DEG(fmpz_mpoly_t P, const fmpz_mpoly_t A, const fmpz_mpoly_t B, ulong degb, const fmpz_mpoly_ctx_t ctx);
+void _fmpz_mpoly_mul_array_chunked_LEX(fmpz_mpoly_t P, const fmpz_mpoly_t A, const fmpz_mpoly_t B, const ulong * mults, const fmpz_mpoly_ctx_t ctx);
 
-void _fmpz_mpoly_mul_array_chunked_LEX(fmpz_mpoly_t P,
-                             const fmpz_mpoly_t A, const fmpz_mpoly_t B,
-                              const ulong * mults, const fmpz_mpoly_ctx_t ctx);
+void _fmpz_mpoly_addmul_array1_slong1(ulong * poly1, const slong * poly2, const ulong * exp2, slong len2, const slong * poly3, const ulong * exp3, slong len3);
+void _fmpz_mpoly_addmul_array1_slong2(ulong * poly1, const slong * poly2, const ulong * exp2, slong len2, const slong * poly3, const ulong * exp3, slong len3);
+void _fmpz_mpoly_addmul_array1_slong(ulong * poly1, const slong * poly2, const ulong * exp2, slong len2, const slong * poly3, const ulong * exp3, slong len3);
 
-void _fmpz_mpoly_addmul_array1_slong1(ulong * poly1,
-                 const slong * poly2, const ulong * exp2, slong len2,
-                          const slong * poly3, const ulong * exp3, slong len3);
+void _fmpz_mpoly_addmul_array1_fmpz(fmpz * poly1, const fmpz * poly2, const ulong * exp2, slong len2, const fmpz * poly3, const ulong * exp3, slong len3);
 
-void _fmpz_mpoly_addmul_array1_slong(ulong * poly1,
-                 const slong * poly2, const ulong * exp2, slong len2,
-                          const slong * poly3, const ulong * exp3, slong len3);
+void _fmpz_mpoly_submul_array1_slong1(ulong * poly1, const slong * poly2, const ulong * exp2, slong len2, const slong * poly3, const ulong * exp3, slong len3);
+void _fmpz_mpoly_submul_array1_slong2(ulong * poly1, const slong * poly2, const ulong * exp2, slong len2, const slong * poly3, const ulong * exp3, slong len3);
+void _fmpz_mpoly_submul_array1_slong(ulong * poly1, const slong * poly2, const ulong * exp2, slong len2, const slong * poly3, const ulong * exp3, slong len3);
 
-void _fmpz_mpoly_addmul_array1_slong2(ulong * poly1,
-                 const slong * poly2, const ulong * exp2, slong len2,
-                          const slong * poly3, const ulong * exp3, slong len3);
+void _fmpz_mpoly_submul_array1_fmpz(fmpz * poly1, const fmpz * poly2, const ulong * exp2, slong len2, const fmpz * poly3, const ulong * exp3, slong len3);
 
-void _fmpz_mpoly_addmul_array1_fmpz(fmpz * poly1,
-                 const fmpz * poly2, const ulong * exp2, slong len2,
-                           const fmpz * poly3, const ulong * exp3, slong len3);
+void _fmpz_mpoly_submul_array1_slong2_1(ulong * poly1, slong d, const ulong exp2, const slong * poly3, const ulong * exp3, slong len3);
+void _fmpz_mpoly_submul_array1_slong_1(ulong * poly1, slong d, const ulong exp2, const slong * poly3, const ulong * exp3, slong len3);
 
-void _fmpz_mpoly_submul_array1_slong(ulong * poly1,
-                  const slong * poly2, const ulong * exp2, slong len2,
-                          const slong * poly3, const ulong * exp3, slong len3);
+void _fmpz_mpoly_submul_array1_fmpz_1(fmpz * poly1, const fmpz_t d, ulong exp2, const fmpz * poly3, const ulong * exp3, slong len3);
 
-void _fmpz_mpoly_submul_array1_slong2(ulong * poly1,
-                  const slong * poly2, const ulong * exp2, slong len2,
-                          const slong * poly3, const ulong * exp3, slong len3);
+slong fmpz_mpoly_append_array_sm1_LEX(fmpz_mpoly_t P, slong Plen, ulong * coeff_array, const ulong * mults, slong num, slong array_size, slong top);
+slong fmpz_mpoly_append_array_sm2_LEX(fmpz_mpoly_t P, slong Plen, ulong * coeff_array, const ulong * mults, slong num, slong array_size, slong top);
+slong fmpz_mpoly_append_array_sm3_LEX(fmpz_mpoly_t P, slong Plen, ulong * coeff_array, const ulong * mults, slong num, slong array_size, slong top);
 
-void _fmpz_mpoly_submul_array1_slong1(ulong * poly1,
-                 const slong * poly2, const ulong * exp2, slong len2,
-                          const slong * poly3, const ulong * exp3, slong len3);
+slong fmpz_mpoly_append_array_fmpz_LEX(fmpz_mpoly_t P, slong Plen, fmpz * coeff_array, const ulong * mults, slong num, slong array_size, slong top);
 
-void _fmpz_mpoly_submul_array1_fmpz(fmpz * poly1,
-                 const fmpz * poly2, const ulong * exp2, slong len2,
-                           const fmpz * poly3, const ulong * exp3, slong len3);
+slong fmpz_mpoly_append_array_sm1_DEGLEX(fmpz_mpoly_t P, slong Plen, ulong * coeff_array, slong top, slong nvars, slong degb);
+slong fmpz_mpoly_append_array_sm2_DEGLEX(fmpz_mpoly_t P, slong Plen, ulong * coeff_array, slong top, slong nvars, slong degb);
+slong fmpz_mpoly_append_array_sm3_DEGLEX(fmpz_mpoly_t P, slong Plen, ulong * coeff_array, slong top, slong nvars, slong degb);
 
-void _fmpz_mpoly_submul_array1_slong_1(ulong * poly1,
-                          slong d, const ulong exp2,
-                          const slong * poly3, const ulong * exp3, slong len3);
+slong fmpz_mpoly_append_array_fmpz_DEGLEX(fmpz_mpoly_t P, slong Plen, fmpz * coeff_array, slong top, slong nvars, slong degb);
 
-void _fmpz_mpoly_submul_array1_slong2_1(ulong * poly1,
-                           slong d, const ulong exp2,
-                          const slong * poly3, const ulong * exp3, slong len3);
+slong fmpz_mpoly_append_array_sm1_DEGREVLEX(fmpz_mpoly_t P, slong Plen, ulong * coeff_array, slong top, slong nvars, slong degb);
+slong fmpz_mpoly_append_array_sm2_DEGREVLEX(fmpz_mpoly_t P, slong Plen, ulong * coeff_array, slong top, slong nvars, slong degb);
+slong fmpz_mpoly_append_array_sm3_DEGREVLEX(fmpz_mpoly_t P, slong Plen, ulong * coeff_array, slong top, slong nvars, slong degb);
+slong fmpz_mpoly_append_array_fmpz_DEGREVLEX(fmpz_mpoly_t P, slong Plen, fmpz * coeff_array, slong top, slong nvars, slong degb);
 
-void _fmpz_mpoly_submul_array1_fmpz_1(fmpz * poly1,
-                          const fmpz_t d, ulong exp2,
-                           const fmpz * poly3, const ulong * exp3, slong len3);
+slong _fmpz_mpoly_from_ulong_array1(fmpz ** poly1, ulong ** exp1, slong * alloc, ulong * poly2, const slong * mults, slong num, slong bits, slong k);
+slong _fmpz_mpoly_from_ulong_array2(fmpz ** poly1, ulong ** exp1, slong * alloc, ulong * poly2, const slong * mults, slong num, slong bits, slong k);
+slong _fmpz_mpoly_from_ulong_array(fmpz ** poly1, ulong ** exp1, slong * alloc, ulong * poly2, const slong * mults, slong num, slong bits, slong k);
 
-slong fmpz_mpoly_append_array_sm1_LEX(fmpz_mpoly_t P,
-                        slong Plen, ulong * coeff_array,
-                  const ulong * mults, slong num, slong array_size, slong top);
-slong fmpz_mpoly_append_array_sm2_LEX(fmpz_mpoly_t P,
-                        slong Plen, ulong * coeff_array,
-                  const ulong * mults, slong num, slong array_size, slong top);
-slong fmpz_mpoly_append_array_sm3_LEX(fmpz_mpoly_t P,
-                         slong Plen, ulong * coeff_array,
-                  const ulong * mults, slong num, slong array_size, slong top);
-slong fmpz_mpoly_append_array_fmpz_LEX(fmpz_mpoly_t P,
-                        slong Plen, fmpz * coeff_array,
-                  const ulong * mults, slong num, slong array_size, slong top);
+slong _fmpz_mpoly_from_fmpz_array(fmpz ** poly1, ulong ** exp1, slong * alloc, fmpz * poly2, const slong * mults, slong num, slong bits, slong k);
 
-slong fmpz_mpoly_append_array_sm1_DEGLEX(fmpz_mpoly_t P,
-          slong Plen, ulong * coeff_array, slong top, slong nvars, slong degb);
-slong fmpz_mpoly_append_array_sm2_DEGLEX(fmpz_mpoly_t P,
-          slong Plen, ulong * coeff_array, slong top, slong nvars, slong degb);
-slong fmpz_mpoly_append_array_sm3_DEGLEX(fmpz_mpoly_t P,
-          slong Plen, ulong * coeff_array, slong top, slong nvars, slong degb);
-slong fmpz_mpoly_append_array_fmpz_DEGLEX(fmpz_mpoly_t P,
-           slong Plen, fmpz * coeff_array, slong top, slong nvars, slong degb);
+void _fmpz_mpoly_to_ulong_array1(ulong * p, const fmpz * coeffs, const ulong * exps, slong len);
+void _fmpz_mpoly_to_ulong_array2(ulong * p, const fmpz * coeffs, const ulong * exps, slong len);
+void _fmpz_mpoly_to_ulong_array(ulong * p, const fmpz * coeffs, const ulong * exps, slong len);
 
-slong fmpz_mpoly_append_array_sm1_DEGREVLEX(fmpz_mpoly_t P,
-          slong Plen, ulong * coeff_array, slong top, slong nvars, slong degb);
-slong fmpz_mpoly_append_array_sm2_DEGREVLEX(fmpz_mpoly_t P,
-          slong Plen, ulong * coeff_array, slong top, slong nvars, slong degb);
-slong fmpz_mpoly_append_array_sm3_DEGREVLEX(fmpz_mpoly_t P,
-          slong Plen, ulong * coeff_array, slong top, slong nvars, slong degb);
-slong fmpz_mpoly_append_array_fmpz_DEGREVLEX(fmpz_mpoly_t P,
-           slong Plen, fmpz * coeff_array, slong top, slong nvars, slong degb);
-
-slong _fmpz_mpoly_from_ulong_array(fmpz ** poly1,
-                         ulong ** exp1, slong * alloc, ulong * poly2,
-                          const slong * mults, slong num, slong bits, slong k);
-
-slong _fmpz_mpoly_from_ulong_array2(fmpz ** poly1,
-                         ulong ** exp1, slong * alloc, ulong * poly2,
-                          const slong * mults, slong num, slong bits, slong k);
-
-slong _fmpz_mpoly_from_ulong_array1(fmpz ** poly1,
-                         ulong ** exp1, slong * alloc, ulong * poly2,
-                          const slong * mults, slong num, slong bits, slong k);
-
-slong _fmpz_mpoly_from_fmpz_array(fmpz ** poly1,
-                         ulong ** exp1, slong * alloc, fmpz * poly2,
-                          const slong * mults, slong num, slong bits, slong k);
-
-void _fmpz_mpoly_to_ulong_array2(ulong * p, const fmpz * coeffs,
-                                                const ulong * exps, slong len);
-
-void _fmpz_mpoly_to_ulong_array1(ulong * p, const fmpz * coeffs,
-                                                const ulong * exps, slong len);
-
-void _fmpz_mpoly_to_ulong_array(ulong * p, const fmpz * coeffs,
-                                                const ulong * exps, slong len);
-
-void _fmpz_mpoly_to_fmpz_array(fmpz * p, const fmpz * coeffs,
-                                                const ulong * exps, slong len);
-
+void _fmpz_mpoly_to_fmpz_array(fmpz * p, const fmpz * coeffs, const ulong * exps, slong len);
 
 /* Misc arithmetic - has nothing to do with mpoly, should be moved out *******/
 

--- a/src/mpoly.h
+++ b/src/mpoly.h
@@ -26,25 +26,7 @@ extern "C" {
 #endif
 
 /* choose m so that (m + 1)/(n - m) ~= la/lb, i.e. m = (n*la - lb)/(la + lb) */
-FLINT_FORCE_INLINE slong mpoly_divide_threads(slong n, double la, double lb)
-{
-    double m_double = (n*la - lb)/(la + lb);
-    slong m = m_double + (2*m_double > n ? -0.5 : 0.5);
-
-    /* input must satisfy */
-    FLINT_ASSERT(n > 0);
-
-    if (m <= 0)
-        m = 0;
-
-    if (m >= n - 1)
-        m = n - 1;
-
-    /* output must satisfy */
-    FLINT_ASSERT(m >= 0);
-    FLINT_ASSERT(m < n);
-    return m;
-}
+slong mpoly_divide_threads(slong n, double la, double lb);
 
 #ifdef _MSC_VER
 # define DECLSPEC_IMPORT __declspec(dllimport)
@@ -324,34 +306,8 @@ void mpoly_monomial_msub_mp(ulong * exp1, const ulong * exp2, ulong scalar,
     __gmpn_submul_1(exp1, exp3, N, scalar);
 }
 
-FLINT_FORCE_INLINE
-void mpoly_monomial_msub_ui_array(ulong * exp1, const ulong * exp2,
-                                     const ulong * scalar, slong scalar_limbs,
-                                                   const ulong * exp3, slong N)
-{
-    slong i;
-    for (i = 0; i < N; i++)
-        exp1[i] = exp2[i];
-    FLINT_ASSERT(scalar_limbs <= N);
-    for (i = 0; i < scalar_limbs; i++)
-    {
-        FLINT_ASSERT(N > i);
-        __gmpn_submul_1(exp1 + i, exp3, N - i, scalar[i]);
-    }
-}
-
-FLINT_FORCE_INLINE
-void mpoly_monomial_madd_ui_array(ulong * exp1, const ulong * exp2,
-                                     const ulong * scalar, slong scalar_limbs,
-                                                   const ulong * exp3, slong N)
-{
-    slong i;
-    for (i = 0; i < N; i++)
-        exp1[i] = exp2[i];
-    FLINT_ASSERT(scalar_limbs <= N);
-    for (i = 0; i < scalar_limbs; i++)
-        __gmpn_addmul_1(exp1 + i, exp3, N - i, scalar[i]);
-}
+void mpoly_monomial_msub_ui_array(ulong * exp1, const ulong * exp2, const ulong * scalar, slong scalar_limbs, const ulong * exp3, slong N);
+void mpoly_monomial_madd_ui_array(ulong * exp1, const ulong * exp2, const ulong * scalar, slong scalar_limbs, const ulong * exp3, slong N);
 
 FLINT_FORCE_INLINE
 void mpoly_monomial_madd_fmpz(ulong * exp1, const ulong * exp2,
@@ -360,8 +316,7 @@ void mpoly_monomial_madd_fmpz(ulong * exp1, const ulong * exp2,
     if (COEFF_IS_MPZ(*scalar))
     {
         zz_ptr mpz = FMPZ_TO_ZZ(*scalar);
-        mpoly_monomial_madd_ui_array(exp1, exp2,
-                                           mpz->ptr, mpz->size, exp3, N);
+        mpoly_monomial_madd_ui_array(exp1, exp2, mpz->ptr, mpz->size, exp3, N);
     }
     else
     {
@@ -396,20 +351,7 @@ ulong mpoly_monomial_max1(ulong exp2, ulong exp3, flint_bitcnt_t bits, ulong mas
     return exp1;
 }
 
-FLINT_FORCE_INLINE
-void mpoly_monomial_max(ulong * exp1, const ulong * exp2, const ulong * exp3,
-                                      flint_bitcnt_t bits, slong N, ulong mask)
-{
-    ulong s, m;
-    slong i;
-    for (i = 0; i < N; i++)
-    {
-        s = mask + exp2[i] - exp3[i];
-        m = mask & s;
-        m = m - (m >> (bits - 1));
-        exp1[i] = exp3[i] + (s & m);
-    }
-}
+void mpoly_monomial_max(ulong * exp1, const ulong * exp2, const ulong * exp3, flint_bitcnt_t bits, slong N, ulong mask);
 
 FLINT_FORCE_INLINE
 ulong mpoly_monomial_min1(ulong exp2, ulong exp3, flint_bitcnt_t bits, ulong mask)
@@ -422,70 +364,10 @@ ulong mpoly_monomial_min1(ulong exp2, ulong exp3, flint_bitcnt_t bits, ulong mas
     return exp1;
 }
 
-FLINT_FORCE_INLINE
-void mpoly_monomial_min(ulong * exp1, const ulong * exp2, const ulong * exp3,
-                                      flint_bitcnt_t bits, slong N, ulong mask)
-{
-    ulong s, m;
-    slong i;
-    for (i = 0; i < N; i++)
-    {
-        s = mask + exp2[i] - exp3[i];
-        m = mask & s;
-        m = m - (m >> (bits - 1));
-        exp1[i] = exp2[i] - (s & m);
-    }
-}
+void mpoly_monomial_min(ulong * exp1, const ulong * exp2, const ulong * exp3, flint_bitcnt_t bits, slong N, ulong mask);
 
-FLINT_FORCE_INLINE
-void mpoly_monomial_max_mp(ulong * exp1, const ulong * exp2, const ulong * exp3,
-                                                  flint_bitcnt_t bits, slong N)
-{
-    slong i;
-    flint_bitcnt_t j;
-    for (i = 0; i < N; i += bits/FLINT_BITS)
-    {
-        const ulong * t = exp2;
-        for (j = bits/FLINT_BITS - 1; (slong) j >= 0; j--)
-        {
-            if (exp3[i + j] != exp2[i + j])
-            {
-                if (exp3[i + j] > exp2[i + j])
-                    t = exp3;
-                break;
-            }
-        }
-        for (j = 0; j < bits/FLINT_BITS; j++)
-        {
-            exp1[i + j] = t[i + j];
-        }
-    }
-}
-
-FLINT_FORCE_INLINE
-void mpoly_monomial_min_mp(ulong * exp1, const ulong * exp2, const ulong * exp3,
-                                                     flint_bitcnt_t bits, slong N)
-{
-    slong i;
-    flint_bitcnt_t j;
-    for (i = 0; i < N; i += bits/FLINT_BITS)
-    {
-        const ulong * t = exp2;
-        for (j = bits/FLINT_BITS - 1; (slong) j >= 0; j--)
-        {
-            if (exp3[i + j] != exp2[i + j])
-            {
-                if (exp3[i + j] < exp2[i + j])
-                    t = exp3;
-                break;
-            }
-        }
-        for (j = 0; j < bits/FLINT_BITS; j++)
-        {
-            exp1[i + j] = t[i + j];
-        }
-    }
-}
+void mpoly_monomial_max_mp(ulong * exp1, const ulong * exp2, const ulong * exp3, flint_bitcnt_t bits, slong N);
+void mpoly_monomial_min_mp(ulong * exp1, const ulong * exp2, const ulong * exp3, flint_bitcnt_t bits, slong N);
 
 FLINT_FORCE_INLINE
 int mpoly_monomial_overflows(ulong * exp2, slong N, ulong mask)
@@ -714,10 +596,8 @@ int mpoly_monomial_equal(const ulong * exp2, const ulong * exp3, slong N)
    slong i;
 
    for (i = 0; i < N; i++)
-   {
       if (exp2[i] != exp3[i])
          return 0;
-   }
 
    return 1;
 }
@@ -957,11 +837,9 @@ ulong _mpoly_bidegree(const ulong * Aexps, flint_bitcnt_t Abits,
 
 /* generators ****************************************************************/
 
-void mpoly_gen_fields_ui(ulong * exp, slong var,
-                                                       const mpoly_ctx_t mctx);
+void mpoly_gen_fields_ui(ulong * exp, slong var, const mpoly_ctx_t mctx);
 
-void mpoly_gen_fields_fmpz(fmpz * exp, slong var,
-                                                       const mpoly_ctx_t mctx);
+void mpoly_gen_fields_fmpz(fmpz * exp, slong var, const mpoly_ctx_t mctx);
 
 flint_bitcnt_t mpoly_gen_bits_required(slong FLINT_UNUSED(var), const mpoly_ctx_t FLINT_UNUSED(mctx));
 
@@ -980,8 +858,7 @@ void mpoly_gen_monomial_offset_shift_sp(ulong * mexp, slong * offset,
 void mpoly_gen_monomial_sp(ulong * oneexp, slong var,
                                      flint_bitcnt_t bits, const mpoly_ctx_t mctx);
 
-slong mpoly_gen_offset_mp(slong var,
-                                     flint_bitcnt_t bits, const mpoly_ctx_t mctx);
+slong mpoly_gen_offset_mp(slong var, flint_bitcnt_t bits, const mpoly_ctx_t mctx);
 
 slong mpoly_gen_monomial_offset_mp(ulong * mexp, slong var,
                                      flint_bitcnt_t bits, const mpoly_ctx_t mctx);
@@ -1383,24 +1260,8 @@ int mpoly_parse_parse(mpoly_parse_t E, void * res, const char * s, slong len);
    assumes there are l1 "coefficients" in a list of len1 exponents.
    Note this doesn't currently mask the relevant bits.
 */
-MPOLY_INLINE
 void mpoly_main_variable_terms1(slong * i1, slong * n1, const ulong * exp1,
-                          slong l1, slong len1, slong k, slong FLINT_UNUSED(num), slong bits)
-{
-   slong i, j = 0;
-   slong shift = bits*(k - 1);
-
-   i1[0] = 0;
-   for (i = 0; i < l1 - 1; i++)
-   {
-      while (j < len1 && (l1 - i - 1) == (slong) (exp1[j] >> shift))
-         j++;
-
-      i1[i + 1] = j;
-      n1[i] = j - i1[i];
-   }
-   n1[l1 - 1] = len1 - j;
-}
+        slong l1, slong len1, slong k, slong FLINT_UNUSED(num), slong bits);
 
 #ifdef __cplusplus
 }

--- a/src/mpoly/misc.c
+++ b/src/mpoly/misc.c
@@ -1,0 +1,165 @@
+/*
+    Copyright (C) 2016-2017 William Hart
+    Copyright (C) 2017-2020 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "mpoly.h"
+
+/* choose m so that (m + 1)/(n - m) ~= la/lb, i.e. m = (n*la - lb)/(la + lb) */
+slong mpoly_divide_threads(slong n, double la, double lb)
+{
+    double m_double = (n*la - lb)/(la + lb);
+    slong m = m_double + (2*m_double > n ? -0.5 : 0.5);
+
+    /* input must satisfy */
+    FLINT_ASSERT(n > 0);
+
+    if (m <= 0)
+        m = 0;
+
+    if (m >= n - 1)
+        m = n - 1;
+
+    /* output must satisfy */
+    FLINT_ASSERT(m >= 0);
+    FLINT_ASSERT(m < n);
+    return m;
+}
+
+void mpoly_monomial_msub_ui_array(
+        ulong * exp1, const ulong * exp2,
+        const ulong * scalar, slong scalar_limbs,
+        const ulong * exp3, slong N)
+{
+    slong i;
+
+    /* TODO: Check if exp1 == exp2? */
+    for (i = 0; i < N; i++)
+        exp1[i] = exp2[i];
+
+    FLINT_ASSERT(scalar_limbs <= N);
+
+    for (i = 0; i < scalar_limbs; i++)
+    {
+        FLINT_ASSERT(N > i);
+        __gmpn_submul_1(exp1 + i, exp3, N - i, scalar[i]);
+    }
+}
+
+void mpoly_monomial_madd_ui_array(
+        ulong * exp1, const ulong * exp2,
+        const ulong * scalar, slong scalar_limbs,
+        const ulong * exp3, slong N)
+{
+    slong i;
+
+    /* TODO: Check if exp1 == exp2? */
+    for (i = 0; i < N; i++)
+        exp1[i] = exp2[i];
+
+    FLINT_ASSERT(scalar_limbs <= N);
+
+    for (i = 0; i < scalar_limbs; i++)
+        __gmpn_addmul_1(exp1 + i, exp3, N - i, scalar[i]);
+}
+
+void mpoly_monomial_max(ulong * exp1, const ulong * exp2, const ulong * exp3,
+        flint_bitcnt_t bits, slong N, ulong mask)
+{
+    ulong s, m;
+    slong i;
+    for (i = 0; i < N; i++)
+    {
+        s = mask + exp2[i] - exp3[i];
+        m = mask & s;
+        m = m - (m >> (bits - 1));
+        exp1[i] = exp3[i] + (s & m);
+    }
+}
+
+void mpoly_monomial_min(ulong * exp1, const ulong * exp2, const ulong * exp3,
+        flint_bitcnt_t bits, slong N, ulong mask)
+{
+    ulong s, m;
+    slong i;
+    for (i = 0; i < N; i++)
+    {
+        s = mask + exp2[i] - exp3[i];
+        m = mask & s;
+        m = m - (m >> (bits - 1));
+        exp1[i] = exp2[i] - (s & m);
+    }
+}
+
+void mpoly_monomial_max_mp(ulong * exp1, const ulong * exp2, const ulong * exp3,
+        flint_bitcnt_t bits, slong N)
+{
+    slong i;
+    flint_bitcnt_t j;
+    for (i = 0; i < N; i += bits/FLINT_BITS)
+    {
+        const ulong * t = exp2;
+        for (j = bits/FLINT_BITS - 1; (slong) j >= 0; j--)
+        {
+            if (exp3[i + j] != exp2[i + j])
+            {
+                if (exp3[i + j] > exp2[i + j])
+                    t = exp3;
+                break;
+            }
+        }
+        for (j = 0; j < bits/FLINT_BITS; j++)
+        {
+            exp1[i + j] = t[i + j];
+        }
+    }
+}
+
+void mpoly_monomial_min_mp(ulong * exp1, const ulong * exp2, const ulong * exp3,
+        flint_bitcnt_t bits, slong N)
+{
+    slong i;
+    flint_bitcnt_t j;
+    for (i = 0; i < N; i += bits/FLINT_BITS)
+    {
+        const ulong * t = exp2;
+        for (j = bits/FLINT_BITS - 1; (slong) j >= 0; j--)
+        {
+            if (exp3[i + j] != exp2[i + j])
+            {
+                if (exp3[i + j] < exp2[i + j])
+                    t = exp3;
+                break;
+            }
+        }
+        for (j = 0; j < bits/FLINT_BITS; j++)
+        {
+            exp1[i + j] = t[i + j];
+        }
+    }
+}
+
+void mpoly_main_variable_terms1(slong * i1, slong * n1, const ulong * exp1,
+        slong l1, slong len1, slong k, slong FLINT_UNUSED(num), slong bits)
+{
+    slong i, j = 0;
+    slong shift = bits*(k - 1);
+
+    i1[0] = 0;
+    for (i = 0; i < l1 - 1; i++)
+    {
+        while (j < len1 && (l1 - i - 1) == (slong) (exp1[j] >> shift))
+            j++;
+
+        i1[i + 1] = j;
+        n1[i] = j - i1[i];
+    }
+    n1[l1 - 1] = len1 - j;
+}

--- a/src/nmod_mpoly.h
+++ b/src/nmod_mpoly.h
@@ -120,23 +120,16 @@ typedef struct
 
 typedef nmod_poly_stack_struct nmod_poly_stack_t[1];
 
-void nmod_poly_stack_init(nmod_poly_stack_t S, flint_bitcnt_t bits,
-                                                   const nmod_mpoly_ctx_t ctx);
-
+void nmod_poly_stack_init(nmod_poly_stack_t S, flint_bitcnt_t bits, const nmod_mpoly_ctx_t ctx);
 void nmod_poly_stack_clear(nmod_poly_stack_t S);
 
-void nmod_poly_stack_set_ctx(nmod_poly_stack_t S,
-                                                   const nmod_mpoly_ctx_t ctx);
+void nmod_poly_stack_set_ctx(nmod_poly_stack_t S, const nmod_mpoly_ctx_t ctx);
 
-n_poly_struct ** nmod_poly_stack_fit_request_poly(
-                                                 nmod_poly_stack_t S, slong k);
+n_poly_struct ** nmod_poly_stack_fit_request_poly(nmod_poly_stack_t S, slong k);
 
-nmod_mpolyun_struct ** nmod_poly_stack_fit_request_mpolyun(
-                                                 nmod_poly_stack_t S, slong k);
+nmod_mpolyun_struct ** nmod_poly_stack_fit_request_mpolyun(nmod_poly_stack_t S, slong k);
 
-nmod_mpolyn_struct ** nmod_poly_stack_fit_request_mpolyn(
-                                                 nmod_poly_stack_t S, slong k);
-
+nmod_mpolyn_struct ** nmod_poly_stack_fit_request_mpolyn(nmod_poly_stack_t S, slong k);
 
 FLINT_FORCE_INLINE
 n_poly_struct ** nmod_poly_stack_request_poly(nmod_poly_stack_t S, slong k)
@@ -240,11 +233,9 @@ slong nmod_poly_stack_size_mpolyn(const nmod_poly_stack_t S)
 
 /* Context object ************************************************************/
 
-void nmod_mpoly_ctx_init(nmod_mpoly_ctx_t ctx,
-                         slong nvars, const ordering_t ord, ulong modulus);
+void nmod_mpoly_ctx_init(nmod_mpoly_ctx_t ctx, slong nvars, const ordering_t ord, ulong modulus);
 
-void nmod_mpoly_ctx_init_rand(nmod_mpoly_ctx_t ctx, flint_rand_t state,
-                                           slong max_nvars, ulong modulus);
+void nmod_mpoly_ctx_init_rand(nmod_mpoly_ctx_t ctx, flint_rand_t state, slong max_nvars, ulong modulus);
 
 void nmod_mpoly_ctx_clear(nmod_mpoly_ctx_t ctx);
 
@@ -270,7 +261,6 @@ ulong nmod_mpoly_ctx_modulus(const nmod_mpoly_ctx_t ctx)
 
 /*  Memory management ********************************************************/
 
-
 NMOD_MPOLY_INLINE
 void nmod_mpoly_init(nmod_mpoly_t A, const nmod_mpoly_ctx_t FLINT_UNUSED(ctx))
 {
@@ -282,6 +272,11 @@ void nmod_mpoly_init(nmod_mpoly_t A, const nmod_mpoly_ctx_t FLINT_UNUSED(ctx))
     A->exps_alloc = 0;
 }
 
+void nmod_mpoly_init2(nmod_mpoly_t A, slong alloc, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_init3(nmod_mpoly_t A, slong alloc, flint_bitcnt_t bits, const nmod_mpoly_ctx_t ctx);
+
+void nmod_mpoly_realloc(nmod_mpoly_t A, slong alloc, const nmod_mpoly_ctx_t ctx);
+
 NMOD_MPOLY_INLINE
 void nmod_mpoly_clear(nmod_mpoly_t A, const nmod_mpoly_ctx_t FLINT_UNUSED(ctx))
 {
@@ -292,23 +287,10 @@ void nmod_mpoly_clear(nmod_mpoly_t A, const nmod_mpoly_ctx_t FLINT_UNUSED(ctx))
         flint_free(A->exps);
 }
 
-void nmod_mpoly_init2(nmod_mpoly_t A, slong alloc,
-                                                   const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_fit_length(nmod_mpoly_t A, slong length, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_init3(nmod_mpoly_t A, slong alloc,
-                              flint_bitcnt_t bits, const nmod_mpoly_ctx_t ctx);
-
-void nmod_mpoly_realloc(nmod_mpoly_t A,
-                                      slong alloc, const nmod_mpoly_ctx_t ctx);
-
-void nmod_mpoly_fit_length(nmod_mpoly_t A, slong length,
-                                                   const nmod_mpoly_ctx_t ctx);
-
-void nmod_mpoly_fit_length_fit_bits(nmod_mpoly_t A,
-                   slong len, flint_bitcnt_t bits, const nmod_mpoly_ctx_t ctx);
-
-void nmod_mpoly_fit_length_reset_bits(nmod_mpoly_t A,
-                   slong len, flint_bitcnt_t bits, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_fit_length_fit_bits(nmod_mpoly_t A, slong len, flint_bitcnt_t bits, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_fit_length_reset_bits(nmod_mpoly_t A, slong len, flint_bitcnt_t bits, const nmod_mpoly_ctx_t ctx);
 
 NMOD_MPOLY_INLINE
 void _nmod_mpoly_fit_length(
@@ -334,8 +316,7 @@ void _nmod_mpoly_fit_length(
 }
 
 NMOD_MPOLY_INLINE
-void _nmod_mpoly_set_length(nmod_mpoly_t A, slong newlen,
-                                                    const nmod_mpoly_ctx_t FLINT_UNUSED(ctx))
+void _nmod_mpoly_set_length(nmod_mpoly_t A, slong newlen, const nmod_mpoly_ctx_t FLINT_UNUSED(ctx))
 {
     FLINT_ASSERT(newlen <= A->coeffs_alloc);
     FLINT_ASSERT(mpoly_words_per_exp(A->bits, ctx->minfo)*newlen <= A->exps_alloc);
@@ -343,15 +324,13 @@ void _nmod_mpoly_set_length(nmod_mpoly_t A, slong newlen,
 }
 
 NMOD_MPOLY_INLINE
-void nmod_mpoly_truncate(nmod_mpoly_t A, slong newlen,
-                                                   const nmod_mpoly_ctx_t FLINT_UNUSED(ctx))
+void nmod_mpoly_truncate(nmod_mpoly_t A, slong newlen, const nmod_mpoly_ctx_t FLINT_UNUSED(ctx))
 {
     if (A->length > newlen)
     {
         A->length = newlen;
     }
 }
-
 
 /* Input/output **************************************************************/
 
@@ -369,17 +348,13 @@ int nmod_mpoly_print_pretty(const nmod_mpoly_t A, const char ** x, const nmod_mp
 
 /*  Basic manipulation *******************************************************/
 
-void nmod_mpoly_gen(nmod_mpoly_t A, slong var,
-                                                   const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_gen(nmod_mpoly_t A, slong var, const nmod_mpoly_ctx_t ctx);
 
-int nmod_mpoly_is_gen(const nmod_mpoly_t A,
-                                        slong var, const nmod_mpoly_ctx_t ctx);
+int nmod_mpoly_is_gen(const nmod_mpoly_t A, slong var, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_set(nmod_mpoly_t A, const nmod_mpoly_t B,
-                                                   const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_set(nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx);
 
-int nmod_mpoly_equal(const nmod_mpoly_t A, const nmod_mpoly_t B,
-                                                   const nmod_mpoly_ctx_t ctx);
+int nmod_mpoly_equal(const nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx);
 
 NMOD_MPOLY_INLINE
 void nmod_mpoly_swap(nmod_mpoly_t A, nmod_mpoly_t B, const nmod_mpoly_ctx_t FLINT_UNUSED(ctx))
@@ -389,17 +364,12 @@ void nmod_mpoly_swap(nmod_mpoly_t A, nmod_mpoly_t B, const nmod_mpoly_ctx_t FLIN
 
 /* Constants *****************************************************************/
 
-int nmod_mpoly_is_ui(const nmod_mpoly_t A,
-                                                   const nmod_mpoly_ctx_t ctx);
+int nmod_mpoly_is_ui(const nmod_mpoly_t A, const nmod_mpoly_ctx_t ctx);
 
-ulong nmod_mpoly_get_ui(const nmod_mpoly_t A,
-                                                   const nmod_mpoly_ctx_t ctx);
+ulong nmod_mpoly_get_ui(const nmod_mpoly_t A, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_set_ui(nmod_mpoly_t A, ulong c,
-                                                   const nmod_mpoly_ctx_t ctx);
-
-void nmod_mpoly_set_fmpz(nmod_mpoly_t A, const fmpz_t c,
-                                                   const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_set_ui(nmod_mpoly_t A, ulong c, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_set_fmpz(nmod_mpoly_t A, const fmpz_t c, const nmod_mpoly_ctx_t ctx);
 
 NMOD_MPOLY_INLINE
 void nmod_mpoly_zero(nmod_mpoly_t A, const nmod_mpoly_ctx_t ctx)
@@ -413,8 +383,7 @@ void nmod_mpoly_one(nmod_mpoly_t A, const nmod_mpoly_ctx_t ctx)
     nmod_mpoly_set_ui(A, UWORD(1), ctx);
 }
 
-int nmod_mpoly_equal_ui(const nmod_mpoly_t A,
-                                          ulong c, const nmod_mpoly_ctx_t ctx);
+int nmod_mpoly_equal_ui(const nmod_mpoly_t A, ulong c, const nmod_mpoly_ctx_t ctx);
 
 NMOD_MPOLY_INLINE
 int nmod_mpoly_is_zero(const nmod_mpoly_t A, const nmod_mpoly_ctx_t FLINT_UNUSED(ctx))
@@ -447,33 +416,24 @@ void nmod_mpoly_used_vars(int * used, const nmod_mpoly_t A, const nmod_mpoly_ctx
 
 /* Coefficients **************************************************************/
 
-ulong nmod_mpoly_get_coeff_ui_monomial(const nmod_mpoly_t A,
-                             const nmod_mpoly_t M, const nmod_mpoly_ctx_t ctx);
+ulong nmod_mpoly_get_coeff_ui_monomial(const nmod_mpoly_t A, const nmod_mpoly_t M, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_set_coeff_ui_monomial(nmod_mpoly_t A, ulong c,
-                             const nmod_mpoly_t M, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_set_coeff_ui_monomial(nmod_mpoly_t A, ulong c, const nmod_mpoly_t M, const nmod_mpoly_ctx_t ctx);
 
-ulong nmod_mpoly_get_coeff_ui_fmpz(const nmod_mpoly_t A,
-                               fmpz * const * exp, const nmod_mpoly_ctx_t ctx);
+ulong nmod_mpoly_get_coeff_ui_ui(const nmod_mpoly_t A, const ulong * exp, const nmod_mpoly_ctx_t ctx);
+ulong nmod_mpoly_get_coeff_ui_fmpz(const nmod_mpoly_t A, fmpz * const * exp, const nmod_mpoly_ctx_t ctx);
 
-ulong nmod_mpoly_get_coeff_ui_ui(const nmod_mpoly_t A,
-                                const ulong * exp, const nmod_mpoly_ctx_t ctx);
+void _nmod_mpoly_set_coeff_ui_fmpz(nmod_mpoly_t A, ulong c, const fmpz * exp, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_set_coeff_ui_fmpz(nmod_mpoly_t A, ulong c, fmpz * const * exp, const nmod_mpoly_ctx_t ctx);
 
-void _nmod_mpoly_set_coeff_ui_fmpz(nmod_mpoly_t A,
-                        ulong c, const fmpz * exp, const nmod_mpoly_ctx_t ctx);
-
-void nmod_mpoly_set_coeff_ui_fmpz(nmod_mpoly_t A,
-                      ulong c, fmpz * const * exp, const nmod_mpoly_ctx_t ctx);
-
-void nmod_mpoly_set_coeff_ui_ui(nmod_mpoly_t A,
-                       ulong c, const ulong * exp, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_set_coeff_ui_ui(nmod_mpoly_t A, ulong c, const ulong * exp, const nmod_mpoly_ctx_t ctx);
 
 void nmod_mpoly_get_coeff_vars_ui(nmod_mpoly_t C,
-                 const nmod_mpoly_t A, const slong * vars, const ulong * exps,
-                                     slong length, const nmod_mpoly_ctx_t ctx);
+        const nmod_mpoly_t A, const slong * vars, const ulong * exps,
+        slong length, const nmod_mpoly_ctx_t ctx);
 
-NMOD_MPOLY_INLINE ulong nmod_mpoly_leadcoeff(
-                                    nmod_mpoly_t A, const nmod_mpoly_ctx_t FLINT_UNUSED(ctx))
+NMOD_MPOLY_INLINE
+ulong nmod_mpoly_leadcoeff(nmod_mpoly_t A, const nmod_mpoly_ctx_t FLINT_UNUSED(ctx))
 {
     FLINT_ASSERT(A->length > 0);
     return A->coeffs[0];
@@ -481,35 +441,24 @@ NMOD_MPOLY_INLINE ulong nmod_mpoly_leadcoeff(
 
 /* conversion ****************************************************************/
 
-int nmod_mpoly_is_nmod_poly(const nmod_mpoly_t A,
-                                        slong var, const nmod_mpoly_ctx_t ctx);
+int nmod_mpoly_is_nmod_poly(const nmod_mpoly_t A, slong var, const nmod_mpoly_ctx_t ctx);
 
-int nmod_mpoly_get_n_poly(n_poly_t A, const nmod_mpoly_t B,
-                                        slong var, const nmod_mpoly_ctx_t ctx);
+int nmod_mpoly_get_n_poly(n_poly_t A, const nmod_mpoly_t B, slong var, const nmod_mpoly_ctx_t ctx);
 
-int nmod_mpoly_get_nmod_poly(nmod_poly_t A, const nmod_mpoly_t B,
-                                        slong var, const nmod_mpoly_ctx_t ctx);
+int nmod_mpoly_get_nmod_poly(nmod_poly_t A, const nmod_mpoly_t B, slong var, const nmod_mpoly_ctx_t ctx);
 
-void _nmod_mpoly_set_nmod_poly(nmod_mpoly_t A, flint_bitcnt_t Abits,
-                                        const ulong * Bcoeffs, slong Blen,
-                                        slong var, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_set_n_poly_mod(nmod_mpoly_t A, const n_poly_t B, slong var, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_set_n_poly_mod(nmod_mpoly_t A, const n_poly_t B,
-                                        slong var, const nmod_mpoly_ctx_t ctx);
-
-void nmod_mpoly_set_nmod_poly(nmod_mpoly_t A, const nmod_poly_t B,
-                                        slong var, const nmod_mpoly_ctx_t ctx);
+void _nmod_mpoly_set_nmod_poly(nmod_mpoly_t A, flint_bitcnt_t Abits, const ulong * Bcoeffs, slong Blen, slong var, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_set_nmod_poly(nmod_mpoly_t A, const nmod_poly_t B, slong var, const nmod_mpoly_ctx_t ctx);
 
 /* comparison ****************************************************************/
 
-int nmod_mpoly_cmp(const nmod_mpoly_t A, const nmod_mpoly_t B,
-                                                   const nmod_mpoly_ctx_t ctx);
-
+int nmod_mpoly_cmp(const nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx);
 
 /* container operations ******************************************************/
 
-int nmod_mpoly_is_canonical(const nmod_mpoly_t A,
-                                                   const nmod_mpoly_ctx_t ctx);
+int nmod_mpoly_is_canonical(const nmod_mpoly_t A, const nmod_mpoly_ctx_t ctx);
 
 NMOD_MPOLY_INLINE
 slong nmod_mpoly_length(const nmod_mpoly_t A, const nmod_mpoly_ctx_t FLINT_UNUSED(ctx))
@@ -517,81 +466,47 @@ slong nmod_mpoly_length(const nmod_mpoly_t A, const nmod_mpoly_ctx_t FLINT_UNUSE
     return A->length;
 }
 
-void nmod_mpoly_resize(nmod_mpoly_t A, slong new_length,
-                                                   const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_resize(nmod_mpoly_t A, slong new_length, const nmod_mpoly_ctx_t ctx);
 
-ulong nmod_mpoly_get_term_coeff_ui(const nmod_mpoly_t A, slong i,
-                                                   const nmod_mpoly_ctx_t FLINT_UNUSED(ctx));
+ulong nmod_mpoly_get_term_coeff_ui(const nmod_mpoly_t A, slong i, const nmod_mpoly_ctx_t FLINT_UNUSED(ctx));
 
-void nmod_mpoly_set_term_coeff_ui(nmod_mpoly_t A, slong i, ulong c,
-                                                   const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_set_term_coeff_ui(nmod_mpoly_t A, slong i, ulong c, const nmod_mpoly_ctx_t ctx);
 
 int nmod_mpoly_term_exp_fits_ui(const nmod_mpoly_t A, slong i, const nmod_mpoly_ctx_t ctx);
 int nmod_mpoly_term_exp_fits_si(const nmod_mpoly_t A, slong i, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_get_term_exp_fmpz(fmpz ** exp, const nmod_mpoly_t A,
-                                          slong i, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_get_term_exp_si(slong * exp, const nmod_mpoly_t A, slong i, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_get_term_exp_ui(ulong * exp, const nmod_mpoly_t A, slong i, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_get_term_exp_fmpz(fmpz ** exp, const nmod_mpoly_t A, slong i, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_get_term_exp_ui(ulong * exp, const nmod_mpoly_t A,
-                                          slong i, const nmod_mpoly_ctx_t ctx);
+slong nmod_mpoly_get_term_var_exp_si(const nmod_mpoly_t A, slong i, slong var, const nmod_mpoly_ctx_t ctx);
+ulong nmod_mpoly_get_term_var_exp_ui(const nmod_mpoly_t A, slong i, slong var, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_get_term_exp_si(slong * exp, const nmod_mpoly_t A,
-                                          slong i, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_set_term_exp_ui(nmod_mpoly_t A, slong i, const ulong * exp, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_set_term_exp_fmpz(nmod_mpoly_t A, slong i, fmpz * const * exp, const nmod_mpoly_ctx_t ctx);
 
-ulong nmod_mpoly_get_term_var_exp_ui(const nmod_mpoly_t A, slong i,
-                                        slong var, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_get_term(nmod_mpoly_t M, const nmod_mpoly_t A, slong i, const nmod_mpoly_ctx_t ctx);
 
-slong nmod_mpoly_get_term_var_exp_si(const nmod_mpoly_t A, slong i,
-                                        slong var, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_get_term_monomial(nmod_mpoly_t M, const nmod_mpoly_t A, slong i, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_set_term_exp_fmpz(nmod_mpoly_t A, slong i,
-                               fmpz * const * exp, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_push_term_ui_ui(nmod_mpoly_t A, ulong c, const ulong * exp, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_push_term_ui_fmpz(nmod_mpoly_t A, ulong c, fmpz * const * exp, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_push_term_ui_ffmpz(nmod_mpoly_t A, ulong c, const fmpz * exp, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_set_term_exp_ui(nmod_mpoly_t A, slong i,
-                                const ulong * exp, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_sort_terms(nmod_mpoly_t A, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_get_term(nmod_mpoly_t M, const nmod_mpoly_t A,
-                                          slong i, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_combine_like_terms(nmod_mpoly_t A, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_get_term_monomial(nmod_mpoly_t M, const nmod_mpoly_t A,
-                                          slong i, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_reverse(nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_push_term_ui_fmpz(nmod_mpoly_t A, ulong c,
-                               fmpz * const * exp, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_assert_canonical(const nmod_mpoly_t A, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_push_term_ui_ffmpz(nmod_mpoly_t A, ulong c,
-                               const fmpz * exp, const nmod_mpoly_ctx_t ctx);
+void _nmod_mpoly_radix_sort1(nmod_mpoly_t A, slong left, slong right, flint_bitcnt_t pos, ulong cmpmask, ulong totalmask);
+void _nmod_mpoly_radix_sort(nmod_mpoly_t A, slong left, slong right, flint_bitcnt_t pos, slong N, ulong * cmpmask);
 
-void nmod_mpoly_push_term_ui_ui(nmod_mpoly_t A, ulong c,
-                                const ulong * exp, const nmod_mpoly_ctx_t ctx);
-
-void nmod_mpoly_sort_terms(nmod_mpoly_t A,
-                                                   const nmod_mpoly_ctx_t ctx);
-
-void nmod_mpoly_combine_like_terms(nmod_mpoly_t A,
-                                                   const nmod_mpoly_ctx_t ctx);
-
-void nmod_mpoly_reverse(nmod_mpoly_t A, const nmod_mpoly_t B,
-                                                   const nmod_mpoly_ctx_t ctx);
-
-void nmod_mpoly_assert_canonical(const nmod_mpoly_t A,
-                                                   const nmod_mpoly_ctx_t ctx);
-
-void _nmod_mpoly_radix_sort1(nmod_mpoly_t A, slong left, slong right,
-                              flint_bitcnt_t pos, ulong cmpmask, ulong totalmask);
-
-void _nmod_mpoly_radix_sort(nmod_mpoly_t A, slong left, slong right,
-                                    flint_bitcnt_t pos, slong N, ulong * cmpmask);
-
-void _nmod_mpoly_push_exp_ffmpz(nmod_mpoly_t A,
-                                 const fmpz * exp, const nmod_mpoly_ctx_t ctx);
-
-void _nmod_mpoly_push_exp_pfmpz(nmod_mpoly_t A,
-                               fmpz * const * exp, const nmod_mpoly_ctx_t ctx);
-
-void _nmod_mpoly_push_exp_ui(nmod_mpoly_t A,
-                                const ulong * exp, const nmod_mpoly_ctx_t ctx);
-
+void _nmod_mpoly_push_exp_ui(nmod_mpoly_t A, const ulong * exp, const nmod_mpoly_ctx_t ctx);
+void _nmod_mpoly_push_exp_ffmpz(nmod_mpoly_t A, const fmpz * exp, const nmod_mpoly_ctx_t ctx);
+void _nmod_mpoly_push_exp_pfmpz(nmod_mpoly_t A, fmpz * const * exp, const nmod_mpoly_ctx_t ctx);
 
 /* Random generation *********************************************************/
 
@@ -604,203 +519,110 @@ void nmod_mpoly_randtest_bound(nmod_mpoly_t A, flint_rand_t state,
 void nmod_mpoly_randtest_bits(nmod_mpoly_t A, flint_rand_t state,
                slong length, flint_bitcnt_t exp_bits, const nmod_mpoly_ctx_t ctx);
 
-ulong _nmod_mpoly_get_term_ui_fmpz(const nmod_mpoly_t poly,
-                                 const fmpz * exp, const nmod_mpoly_ctx_t ctx);
+ulong _nmod_mpoly_get_term_ui_fmpz(const nmod_mpoly_t poly, const fmpz * exp, const nmod_mpoly_ctx_t ctx);
+ulong nmod_mpoly_get_term_ui_fmpz(const nmod_mpoly_t poly, fmpz * const * exp, const nmod_mpoly_ctx_t ctx);
+ulong nmod_mpoly_get_term_ui_ui(const nmod_mpoly_t poly, const ulong * exp, const nmod_mpoly_ctx_t ctx);
 
-ulong nmod_mpoly_get_term_ui_fmpz(const nmod_mpoly_t poly,
-                               fmpz * const * exp, const nmod_mpoly_ctx_t ctx);
+void _nmod_mpoly_max_degrees(ulong * max_degs, const ulong * exps, slong len, slong bits, slong n, int deg, int rev, slong N);
+void nmod_mpoly_max_degrees(ulong * max_degs, const nmod_mpoly_t poly, const nmod_mpoly_ctx_t ctx);
 
-ulong nmod_mpoly_get_term_ui_ui(const nmod_mpoly_t poly,
-                                const ulong * exp, const nmod_mpoly_ctx_t ctx);
-
-void _nmod_mpoly_max_degrees(ulong * max_degs, const ulong * exps,
-                    slong len, slong bits, slong n, int deg, int rev, slong N);
-
-void nmod_mpoly_max_degrees(ulong * max_degs,
-                          const nmod_mpoly_t poly, const nmod_mpoly_ctx_t ctx);
-
-void nmod_mpoly_set_nmod(nmod_mpoly_t poly,
-                                   const nmod_t c, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_set_nmod(nmod_mpoly_t poly, const nmod_t c, const nmod_mpoly_ctx_t ctx);
 
 
-ulong nmod_mpoly_get_coeff_ui(nmod_t x,
-                 const nmod_mpoly_t poly, slong n, const nmod_mpoly_ctx_t ctx);
+ulong nmod_mpoly_get_coeff_ui(nmod_t x, const nmod_mpoly_t poly, slong n, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_set_coeff_ui(nmod_mpoly_t poly,
-                          slong n, ulong x, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_set_coeff_ui(nmod_mpoly_t poly, slong n, ulong x, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_get_monomial(ulong * exps, const nmod_mpoly_t poly,
-                                          slong n, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_get_monomial(ulong * exps, const nmod_mpoly_t poly, slong n, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_set_monomial(nmod_mpoly_t poly,
-                      slong n, const ulong * exps, const nmod_mpoly_ctx_t ctx);
-
+void nmod_mpoly_set_monomial(nmod_mpoly_t poly, slong n, const ulong * exps, const nmod_mpoly_ctx_t ctx);
 
 /* Addition/Subtraction ******************************************************/
 
-void nmod_mpoly_add_ui(nmod_mpoly_t A, const nmod_mpoly_t B,
-                                          ulong c, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_add_ui(nmod_mpoly_t A, const nmod_mpoly_t B, ulong c, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_add(nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_t C, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_sub_ui(nmod_mpoly_t A, const nmod_mpoly_t B,
-                                          ulong c, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_sub_ui(nmod_mpoly_t A, const nmod_mpoly_t B, ulong c, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_sub(nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_t C, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_add(nmod_mpoly_t A, const nmod_mpoly_t B,
-                             const nmod_mpoly_t C, const nmod_mpoly_ctx_t ctx);
-
-void nmod_mpoly_sub(nmod_mpoly_t A, const nmod_mpoly_t B,
-                             const nmod_mpoly_t C, const nmod_mpoly_ctx_t ctx);
-
-slong _nmod_mpoly_add(ulong * coeff1,       ulong * exp1,
-                const ulong * coeff2, const ulong * exp2, slong len2,
-                const ulong * coeff3, const ulong * exp3, slong len3,
-                                  slong N, const ulong * cmpmask, nmod_t fctx);
-
-slong _nmod_mpoly_sub(ulong * coeff1,       ulong * exp1,
-                    const ulong * coeff2, const ulong * exp2, slong len2,
-                    const ulong * coeff3, const ulong * exp3, slong len3,
-                                  slong N, const ulong * cmpmask, nmod_t fctx);
-
+slong _nmod_mpoly_add(ulong * coeff1, ulong * exp1, const ulong * coeff2, const ulong * exp2, slong len2, const ulong * coeff3, const ulong * exp3, slong len3, slong N, const ulong * cmpmask, nmod_t fctx);
+slong _nmod_mpoly_sub(ulong * coeff1, ulong * exp1, const ulong * coeff2, const ulong * exp2, slong len2, const ulong * coeff3, const ulong * exp3, slong len3, slong N, const ulong * cmpmask, nmod_t fctx);
 
 /* Scalar operations *********************************************************/
 
-void nmod_mpoly_neg(nmod_mpoly_t A, const nmod_mpoly_t B,
-                                                   const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_neg(nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_scalar_mul_ui(nmod_mpoly_t A,
-                const nmod_mpoly_t B, ulong c, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_scalar_mul_ui(nmod_mpoly_t A, const nmod_mpoly_t B, ulong c, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_make_monic(nmod_mpoly_t A, const nmod_mpoly_t B,
-                                                    const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_make_monic(nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx);
 
 void nmod_mpoly_scalar_mul_nmod_invertible(nmod_mpoly_t A,
-                const nmod_mpoly_t B, ulong c, const nmod_mpoly_ctx_t ctx);
+        const nmod_mpoly_t B, ulong c, const nmod_mpoly_ctx_t ctx);
 
 void nmod_mpoly_scalar_addmul_ui(nmod_mpoly_t A,
-                        const nmod_mpoly_t B, const nmod_mpoly_t C, ulong d,
-                                                   const nmod_mpoly_ctx_t ctx);
+        const nmod_mpoly_t B, const nmod_mpoly_t C, ulong d,
+        const nmod_mpoly_ctx_t ctx);
 
 /* Differention **************************************************************/
 
-void nmod_mpoly_derivative(nmod_mpoly_t A,
-                  const nmod_mpoly_t B, slong var, const nmod_mpoly_ctx_t ctx);
-
+void nmod_mpoly_derivative(nmod_mpoly_t A, const nmod_mpoly_t B, slong var, const nmod_mpoly_ctx_t ctx);
 
 /* Evaluation ****************************************************************/
 
+int _ff_poly_pow_ui_is_not_feasible(slong length, ulong e);
 int _ff_poly_pow_fmpz_is_not_feasible(slong length, const fmpz_t e);
 
-int _ff_poly_pow_ui_is_not_feasible(slong length, ulong e);
+ulong _nmod_mpoly_eval_all_ui(const ulong * Acoeffs, const ulong * Aexps, slong Alen, flint_bitcnt_t Abits, const ulong * alphas, const mpoly_ctx_t mctx, nmod_t mod);
+ulong nmod_mpoly_evaluate_all_ui(const nmod_mpoly_t A, const ulong * vals, const nmod_mpoly_ctx_t ctx);
 
-ulong _nmod_mpoly_eval_all_ui(const ulong * Acoeffs,
-                 const ulong * Aexps, slong Alen, flint_bitcnt_t Abits,
-                 const ulong * alphas, const mpoly_ctx_t mctx, nmod_t mod);
+void nmod_mpoly_evaluate_one_ui(nmod_mpoly_t A, const nmod_mpoly_t B, slong var, ulong val, const nmod_mpoly_ctx_t ctx);
 
-ulong nmod_mpoly_evaluate_all_ui(const nmod_mpoly_t A,
-                               const ulong * vals, const nmod_mpoly_ctx_t ctx);
+int nmod_mpoly_compose_nmod_poly(nmod_poly_t A, const nmod_mpoly_t B, nmod_poly_struct * const * C, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_evaluate_one_ui(nmod_mpoly_t A, const nmod_mpoly_t B,
-                             slong var, ulong val, const nmod_mpoly_ctx_t ctx);
+void _nmod_mpoly_compose_mat(nmod_mpoly_t A, const nmod_mpoly_t B, const fmpz_mat_t M, const nmod_mpoly_ctx_t ctxB, const nmod_mpoly_ctx_t ctxAC);
 
-int nmod_mpoly_compose_nmod_poly(nmod_poly_t A,
-                        const nmod_mpoly_t B, nmod_poly_struct * const * C,
-                                                   const nmod_mpoly_ctx_t ctx);
+int nmod_mpoly_compose_nmod_mpoly_geobucket(nmod_mpoly_t A, const nmod_mpoly_t B, nmod_mpoly_struct * const * C, const nmod_mpoly_ctx_t ctxB, const nmod_mpoly_ctx_t ctxAC);
+int nmod_mpoly_compose_nmod_mpoly_horner(nmod_mpoly_t A, const nmod_mpoly_t B, nmod_mpoly_struct * const * C, const nmod_mpoly_ctx_t ctxB, const nmod_mpoly_ctx_t ctxAC);
+int nmod_mpoly_compose_nmod_mpoly(nmod_mpoly_t A, const nmod_mpoly_t B, nmod_mpoly_struct * const * C, const nmod_mpoly_ctx_t ctxB, const nmod_mpoly_ctx_t ctxAC);
 
-void _nmod_mpoly_compose_mat(nmod_mpoly_t A,
-                            const nmod_mpoly_t B, const fmpz_mat_t M,
-                    const nmod_mpoly_ctx_t ctxB, const nmod_mpoly_ctx_t ctxAC);
-
-int nmod_mpoly_compose_nmod_mpoly_geobucket(nmod_mpoly_t A,
-                    const nmod_mpoly_t B, nmod_mpoly_struct * const * C,
-                    const nmod_mpoly_ctx_t ctxB, const nmod_mpoly_ctx_t ctxAC);
-
-int nmod_mpoly_compose_nmod_mpoly_horner(nmod_mpoly_t A,
-                    const nmod_mpoly_t B, nmod_mpoly_struct * const * C,
-                    const nmod_mpoly_ctx_t ctxB, const nmod_mpoly_ctx_t ctxAC);
-
-int nmod_mpoly_compose_nmod_mpoly(nmod_mpoly_t A,
-                    const nmod_mpoly_t B, nmod_mpoly_struct * const * C,
-                    const nmod_mpoly_ctx_t ctxB, const nmod_mpoly_ctx_t ctxAC);
-
-void nmod_mpoly_compose_nmod_mpoly_gen(nmod_mpoly_t A,
-                    const nmod_mpoly_t B, const slong * c,
-                    const nmod_mpoly_ctx_t ctxB, const nmod_mpoly_ctx_t ctxAC);
-
+void nmod_mpoly_compose_nmod_mpoly_gen(nmod_mpoly_t A, const nmod_mpoly_t B, const slong * c, const nmod_mpoly_ctx_t ctxB, const nmod_mpoly_ctx_t ctxAC);
 
 /* Multiplication ************************************************************/
 
-void nmod_mpoly_mul(nmod_mpoly_t A,
-       const nmod_mpoly_t B, const nmod_mpoly_t C, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_mul(nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_t C, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_mul_johnson(nmod_mpoly_t A,
-       const nmod_mpoly_t B, const nmod_mpoly_t C, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_mul_johnson(nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_t C, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_mul_heap_threaded(nmod_mpoly_t A,
-       const nmod_mpoly_t B, const nmod_mpoly_t C, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_mul_heap_threaded(nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_t C, const nmod_mpoly_ctx_t ctx);
 
-int nmod_mpoly_mul_array(nmod_mpoly_t A,
-       const nmod_mpoly_t B, const nmod_mpoly_t C, const nmod_mpoly_ctx_t ctx);
+int nmod_mpoly_mul_array(nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_t C, const nmod_mpoly_ctx_t ctx);
+int nmod_mpoly_mul_array_threaded(nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_t C, const nmod_mpoly_ctx_t ctx);
 
-int nmod_mpoly_mul_array_threaded(nmod_mpoly_t A,
-       const nmod_mpoly_t B, const nmod_mpoly_t C, const nmod_mpoly_ctx_t ctx);
+int _nmod_mpoly_mul_dense(nmod_mpoly_t P, const nmod_mpoly_t A, fmpz * maxAfields, const nmod_mpoly_t B, fmpz * maxBfields, const nmod_mpoly_ctx_t ctx);
+int nmod_mpoly_mul_dense(nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_t C, const nmod_mpoly_ctx_t ctx);
 
-int nmod_mpoly_mul_dense(nmod_mpoly_t A,
-       const nmod_mpoly_t B, const nmod_mpoly_t C, const nmod_mpoly_ctx_t ctx);
+slong _nmod_mpoly_mul_johnson(nmod_mpoly_t A, const ulong * coeff2, const ulong * exp2, slong len2, const ulong * coeff3, const ulong * exp3, slong len3, flint_bitcnt_t bits, slong N, const ulong * cmpmask, nmod_t fctx);
 
-slong _nmod_mpoly_mul_johnson(nmod_mpoly_t A,
-                 const ulong * coeff2, const ulong * exp2, slong len2,
-                 const ulong * coeff3, const ulong * exp3, slong len3,
-             flint_bitcnt_t bits, slong N, const ulong * cmpmask, nmod_t fctx);
-
-void _nmod_mpoly_mul_johnson_maxfields(nmod_mpoly_t A,
-                                 const nmod_mpoly_t B, fmpz * maxBfields,
-                                 const nmod_mpoly_t C, fmpz * maxCfields,
-                                                   const nmod_mpoly_ctx_t ctx);
+void _nmod_mpoly_mul_johnson_maxfields(nmod_mpoly_t A, const nmod_mpoly_t B, fmpz * maxBfields, const nmod_mpoly_t C, fmpz * maxCfields, const nmod_mpoly_ctx_t ctx);
 
 void _nmod_mpoly_mul_heap_threaded_pool_maxfields(nmod_mpoly_t A,
-           const nmod_mpoly_t B, fmpz * maxBfields,
-           const nmod_mpoly_t C, fmpz * maxCfields, const nmod_mpoly_ctx_t ctx,
-                        const thread_pool_handle * handles, slong num_handles);
+        const nmod_mpoly_t B, fmpz * maxBfields,
+        const nmod_mpoly_t C, fmpz * maxCfields, const nmod_mpoly_ctx_t ctx,
+        const thread_pool_handle * handles, slong num_handles);
 
-int _nmod_mpoly_mul_array_DEG(nmod_mpoly_t A,
-                                 const nmod_mpoly_t B, fmpz * maxBfields,
-                                 const nmod_mpoly_t C, fmpz * maxCfields,
-                                                   const nmod_mpoly_ctx_t ctx);
+int _nmod_mpoly_mul_array_DEG(nmod_mpoly_t A, const nmod_mpoly_t B, fmpz * maxBfields, const nmod_mpoly_t C, fmpz * maxCfields, const nmod_mpoly_ctx_t ctx);
+int _nmod_mpoly_mul_array_LEX(nmod_mpoly_t A, const nmod_mpoly_t B, fmpz * maxBfields, const nmod_mpoly_t C, fmpz * maxCfields, const nmod_mpoly_ctx_t ctx);
 
-int _nmod_mpoly_mul_array_LEX(nmod_mpoly_t A,
-                                 const nmod_mpoly_t B, fmpz * maxBfields,
-                                 const nmod_mpoly_t C, fmpz * maxCfields,
-                                                   const nmod_mpoly_ctx_t ctx);
-
-int _nmod_mpoly_mul_array_threaded_pool_DEG(nmod_mpoly_t A,
-           const nmod_mpoly_t B, fmpz * maxBfields,
-           const nmod_mpoly_t C, fmpz * maxCfields, const nmod_mpoly_ctx_t ctx,
-                        const thread_pool_handle * handles, slong num_handles);
-
-int _nmod_mpoly_mul_array_threaded_pool_LEX(nmod_mpoly_t A,
-           const nmod_mpoly_t B, fmpz * maxBfields,
-           const nmod_mpoly_t C, fmpz * maxCfields, const nmod_mpoly_ctx_t ctx,
-                        const thread_pool_handle * handles, slong num_handles);
-
-int _nmod_mpoly_mul_dense(nmod_mpoly_t P,
-                                 const nmod_mpoly_t A, fmpz * maxAfields,
-                                 const nmod_mpoly_t B, fmpz * maxBfields,
-                                                   const nmod_mpoly_ctx_t ctx);
+int _nmod_mpoly_mul_array_threaded_pool_DEG(nmod_mpoly_t A, const nmod_mpoly_t B, fmpz * maxBfields, const nmod_mpoly_t C, fmpz * maxCfields, const nmod_mpoly_ctx_t ctx, const thread_pool_handle * handles, slong num_handles);
+int _nmod_mpoly_mul_array_threaded_pool_LEX(nmod_mpoly_t A, const nmod_mpoly_t B, fmpz * maxBfields, const nmod_mpoly_t C, fmpz * maxCfields, const nmod_mpoly_ctx_t ctx, const thread_pool_handle * handles, slong num_handles);
 
 /* Powering ******************************************************************/
 
-void _nmod_mpoly_pow_rmul(nmod_mpoly_t A, const ulong * Bcoeffs,
-                            const ulong * Bexps, slong Blen, ulong k, slong N,
-                            const ulong * cmpmask, nmod_t mod, nmod_mpoly_t T);
+void _nmod_mpoly_pow_rmul(nmod_mpoly_t A, const ulong * Bcoeffs, const ulong * Bexps, slong Blen, ulong k, slong N, const ulong * cmpmask, nmod_t mod, nmod_mpoly_t T);
+void nmod_mpoly_pow_rmul(nmod_mpoly_t A, const nmod_mpoly_t B, ulong k, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_pow_rmul(nmod_mpoly_t A, const nmod_mpoly_t B,
-                                          ulong k, const nmod_mpoly_ctx_t ctx);
-
-int nmod_mpoly_pow_fmpz(nmod_mpoly_t A, const nmod_mpoly_t B,
-                                   const fmpz_t k, const nmod_mpoly_ctx_t ctx);
-
-int nmod_mpoly_pow_ui(nmod_mpoly_t A, const nmod_mpoly_t B,
-                                          ulong k, const nmod_mpoly_ctx_t ctx);
-
+int nmod_mpoly_pow_ui(nmod_mpoly_t A, const nmod_mpoly_t B, ulong k, const nmod_mpoly_ctx_t ctx);
+int nmod_mpoly_pow_fmpz(nmod_mpoly_t A, const nmod_mpoly_t B, const fmpz_t k, const nmod_mpoly_ctx_t ctx);
 
 /* Division ******************************************************************/
 
@@ -1005,11 +827,8 @@ typedef nmod_mpoly_stripe_struct nmod_mpoly_stripe_t[1];
 
 /* Univariates ***************************************************************/
 
-void nmod_mpoly_univar_init(nmod_mpoly_univar_t A,
-                                                   const nmod_mpoly_ctx_t ctx);
-
-void nmod_mpoly_univar_clear(nmod_mpoly_univar_t A,
-                                                   const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_univar_init(nmod_mpoly_univar_t A, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_univar_clear(nmod_mpoly_univar_t A, const nmod_mpoly_ctx_t ctx);
 
 void nmod_mpoly_univar_fit_length(nmod_mpoly_univar_t A,
                                      slong length, const nmod_mpoly_ctx_t ctx);
@@ -1091,66 +910,28 @@ int nmod_mpoly_discriminant(nmod_mpoly_t R,
 
 /* Helpers for array methods *************************************************/
 
-void _nmod_mpoly_mul_array_chunked_LEX(nmod_mpoly_t P,
-                             const nmod_mpoly_t A, const nmod_mpoly_t B,
-                              const ulong * mults, const nmod_mpoly_ctx_t ctx);
+void _nmod_mpoly_mul_array_chunked_LEX(nmod_mpoly_t P, const nmod_mpoly_t A, const nmod_mpoly_t B, const ulong * mults, const nmod_mpoly_ctx_t ctx);
+void _nmod_mpoly_mul_array_chunked_DEG(nmod_mpoly_t P, const nmod_mpoly_t A, const nmod_mpoly_t B, ulong degb, const nmod_mpoly_ctx_t ctx);
 
-void _nmod_mpoly_mul_array_chunked_DEG(nmod_mpoly_t P,
-                             const nmod_mpoly_t A, const nmod_mpoly_t B,
-                                       ulong degb, const nmod_mpoly_ctx_t ctx);
+void _nmod_mpoly_addmul_array1_ulong1(ulong * poly1, const ulong * poly2, const ulong * exp2, slong len2, const ulong * poly3, const ulong * exp3, slong len3);
+void _nmod_mpoly_addmul_array1_ulong2(ulong * poly1, const ulong * poly2, const ulong * exp2, slong len2, const ulong * poly3, const ulong * exp3, slong len3);
+void _nmod_mpoly_addmul_array1_ulong3(ulong * poly1, const ulong * poly2, const ulong * exp2, slong len2, const ulong * poly3, const ulong * exp3, slong len3);
 
-void _nmod_mpoly_addmul_array1_ulong1(ulong * poly1,
-                          const ulong * poly2, const ulong * exp2, slong len2,
-                          const ulong * poly3, const ulong * exp3, slong len3);
+slong nmod_mpoly_append_array_sm1_LEX(nmod_mpoly_t P, slong Plen, ulong * coeff_array, const ulong * mults, slong num, slong array_size, slong top, const nmod_mpoly_ctx_t ctx);
+slong nmod_mpoly_append_array_sm2_LEX(nmod_mpoly_t P, slong Plen, ulong * coeff_array, const ulong * mults, slong num, slong array_size, slong top, const nmod_mpoly_ctx_t ctx);
+slong nmod_mpoly_append_array_sm3_LEX(nmod_mpoly_t P, slong Plen, ulong * coeff_array, const ulong * mults, slong num, slong array_size, slong top, const nmod_mpoly_ctx_t ctx);
 
-void _nmod_mpoly_addmul_array1_ulong2(ulong * poly1,
-                          const ulong * poly2, const ulong * exp2, slong len2,
-                          const ulong * poly3, const ulong * exp3, slong len3);
+slong nmod_mpoly_append_array_sm1_DEGLEX(nmod_mpoly_t P, slong Plen, ulong * coeff_array, slong top, slong nvars, slong degb, const nmod_mpoly_ctx_t ctx);
+slong nmod_mpoly_append_array_sm2_DEGLEX(nmod_mpoly_t P, slong Plen, ulong * coeff_array, slong top, slong nvars, slong degb, const nmod_mpoly_ctx_t ctx);
+slong nmod_mpoly_append_array_sm3_DEGLEX(nmod_mpoly_t P, slong Plen, ulong * coeff_array, slong top, slong nvars, slong degb, const nmod_mpoly_ctx_t ctx);
 
-void _nmod_mpoly_addmul_array1_ulong3(ulong * poly1,
-                          const ulong * poly2, const ulong * exp2, slong len2,
-                          const ulong * poly3, const ulong * exp3, slong len3);
-
-slong nmod_mpoly_append_array_sm1_LEX(nmod_mpoly_t P, slong Plen,
-         ulong * coeff_array, const ulong * mults, slong num, slong array_size,
-                                        slong top, const nmod_mpoly_ctx_t ctx);
-
-slong nmod_mpoly_append_array_sm2_LEX(nmod_mpoly_t P, slong Plen,
-         ulong * coeff_array, const ulong * mults, slong num, slong array_size,
-                                        slong top, const nmod_mpoly_ctx_t ctx);
-
-slong nmod_mpoly_append_array_sm3_LEX(nmod_mpoly_t P, slong Plen,
-         ulong * coeff_array, const ulong * mults, slong num, slong array_size,
-                                        slong top, const nmod_mpoly_ctx_t ctx);
-
-slong nmod_mpoly_append_array_sm1_DEGLEX(nmod_mpoly_t P, slong Plen,
-                     ulong * coeff_array, slong top, slong nvars, slong degb,
-                                                   const nmod_mpoly_ctx_t ctx);
-
-slong nmod_mpoly_append_array_sm2_DEGLEX(nmod_mpoly_t P, slong Plen,
-                     ulong * coeff_array, slong top, slong nvars, slong degb,
-                                                   const nmod_mpoly_ctx_t ctx);
-
-slong nmod_mpoly_append_array_sm3_DEGLEX(nmod_mpoly_t P, slong Plen,
-                     ulong * coeff_array, slong top, slong nvars, slong degb,
-                                                   const nmod_mpoly_ctx_t ctx);
-
-slong nmod_mpoly_append_array_sm1_DEGREVLEX(nmod_mpoly_t P, slong Plen,
-                     ulong * coeff_array, slong top, slong nvars, slong degb,
-                                                   const nmod_mpoly_ctx_t ctx);
-
-slong nmod_mpoly_append_array_sm2_DEGREVLEX(nmod_mpoly_t P, slong Plen,
-                     ulong * coeff_array, slong top, slong nvars, slong degb,
-                                                   const nmod_mpoly_ctx_t ctx);
-
-slong nmod_mpoly_append_array_sm3_DEGREVLEX(nmod_mpoly_t P, slong Plen,
-                     ulong * coeff_array, slong top, slong nvars, slong degb,
-                                                   const nmod_mpoly_ctx_t ctx);
+slong nmod_mpoly_append_array_sm1_DEGREVLEX(nmod_mpoly_t P, slong Plen, ulong * coeff_array, slong top, slong nvars, slong degb, const nmod_mpoly_ctx_t ctx);
+slong nmod_mpoly_append_array_sm2_DEGREVLEX(nmod_mpoly_t P, slong Plen, ulong * coeff_array, slong top, slong nvars, slong degb, const nmod_mpoly_ctx_t ctx);
+slong nmod_mpoly_append_array_sm3_DEGREVLEX(nmod_mpoly_t P, slong Plen, ulong * coeff_array, slong top, slong nvars, slong degb, const nmod_mpoly_ctx_t ctx);
 
 /* mpolyd ********************************************************************/
 
 void nmod_mpolyd_ctx_init(nmod_mpolyd_ctx_t dctx, slong nvars);
-
 void nmod_mpolyd_ctx_clear(nmod_mpolyd_ctx_t dctx);
 
 FLINT_FORCE_INLINE void nmod_mpolyd_swap(nmod_mpolyd_t poly1, nmod_mpolyd_t poly2)
@@ -1160,20 +941,19 @@ FLINT_FORCE_INLINE void nmod_mpolyd_swap(nmod_mpolyd_t poly1, nmod_mpolyd_t poly
 
 int nmod_mpolyd_set_degbounds(nmod_mpolyd_t A, slong * bounds);
 
-int nmod_mpolyd_set_degbounds_perm(nmod_mpolyd_t A,
-                                 const nmod_mpolyd_ctx_t dctx, slong * bounds);
+int nmod_mpolyd_set_degbounds_perm(nmod_mpolyd_t A, const nmod_mpolyd_ctx_t dctx, slong * bounds);
 
 void nmod_mpoly_convert_to_nmod_mpolyd(
-                                  nmod_mpolyd_t A, const nmod_mpolyd_ctx_t dctx,
-                             const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx);
+        nmod_mpolyd_t A, const nmod_mpolyd_ctx_t dctx,
+        const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx);
 
 void nmod_mpoly_convert_to_nmod_mpolyd_degbound(
-                                  nmod_mpolyd_t A, const nmod_mpolyd_ctx_t dctx,
-                             const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx);
+        nmod_mpolyd_t A, const nmod_mpolyd_ctx_t dctx,
+        const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx);
 
 void nmod_mpoly_convert_from_nmod_mpolyd(
-                                 nmod_mpoly_t A, const nmod_mpoly_ctx_t ctx,
-                          const nmod_mpolyd_t B, const nmod_mpolyd_ctx_t dctx);
+        nmod_mpoly_t A, const nmod_mpoly_ctx_t ctx,
+        const nmod_mpolyd_t B, const nmod_mpolyd_ctx_t dctx);
 
 void nmod_mpolyd_init(nmod_mpolyd_t poly, slong nvars);
 
@@ -1194,9 +974,7 @@ slong nmod_mpolyd_length(const nmod_mpolyd_t A);
 
 /* mpolyu ********************************************************************/
 
-void nmod_mpolyu_init(nmod_mpolyu_t A, flint_bitcnt_t bits,
-                                                   const nmod_mpoly_ctx_t FLINT_UNUSED(ctx));
-
+void nmod_mpolyu_init(nmod_mpolyu_t A, flint_bitcnt_t bits, const nmod_mpoly_ctx_t FLINT_UNUSED(ctx));
 void nmod_mpolyu_clear(nmod_mpolyu_t A, const nmod_mpoly_ctx_t uctx);
 
 FLINT_FORCE_INLINE
@@ -1235,7 +1013,6 @@ nmod_mpoly_struct * _nmod_mpolyu_get_coeff(nmod_mpolyu_t A,
                                        ulong pow, const nmod_mpoly_ctx_t uctx);
 
 void nmod_mpolyu_shift_right(nmod_mpolyu_t A, ulong s);
-
 void nmod_mpolyu_shift_left(nmod_mpolyu_t A, ulong s);
 
 int nmod_mpolyu_content_mpoly(nmod_mpoly_t g,
@@ -1386,15 +1163,13 @@ slong nmod_mpolyn_lastdeg(nmod_mpolyn_t A, const nmod_mpoly_ctx_t FLINT_UNUSED(c
 
 slong nmod_mpolyun_lastdeg(nmod_mpolyun_t A, const nmod_mpoly_ctx_t FLINT_UNUSED(ctx));
 
-void nmod_mpolyun_set(nmod_mpolyun_t A, const nmod_mpolyun_t B,
-                                                   const nmod_mpoly_ctx_t ctx);
+void nmod_mpolyun_set(nmod_mpolyun_t A, const nmod_mpolyun_t B, const nmod_mpoly_ctx_t ctx);
 
 void nmod_mpolyn_one(nmod_mpolyn_t A, const nmod_mpoly_ctx_t ctx);
 
 void nmod_mpolyun_one(nmod_mpolyun_t A, const nmod_mpoly_ctx_t ctx);
 
-ulong nmod_mpolyun_leadcoeff_last(nmod_mpolyun_t A,
-                                                   const nmod_mpoly_ctx_t ctx);
+ulong nmod_mpolyun_leadcoeff_last(nmod_mpolyun_t A, const nmod_mpoly_ctx_t ctx);
 
 void nmod_mpolyn_set_mod(nmod_mpolyn_t FLINT_UNUSED(A), const nmod_t FLINT_UNUSED(mod));
 
@@ -1412,11 +1187,9 @@ void nmod_mpolyn_scalar_mul_nmod(
 void nmod_mpolyun_scalar_mul_nmod(nmod_mpolyun_t A, ulong c,
                                                    const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpolyn_mul_last(nmod_mpolyn_t A, n_poly_t b,
-                                                   const nmod_mpoly_ctx_t ctx);
+void nmod_mpolyn_mul_last(nmod_mpolyn_t A, n_poly_t b, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpolyun_mul_last(nmod_mpolyun_t A, n_poly_t b,
-                                                   const nmod_mpoly_ctx_t ctx);
+void nmod_mpolyun_mul_last(nmod_mpolyun_t A, n_poly_t b, const nmod_mpoly_ctx_t ctx);
 
 int nmod_mpolyn_equal(
     const nmod_mpolyn_t A,
@@ -1458,31 +1231,31 @@ int nmod_mpolyn_divides_threaded_pool(nmod_mpolyn_t Q,
 #endif
 
 int nmod_mpolyun_divides(nmod_mpolyun_t Q, const nmod_mpolyun_t A,
-                           const nmod_mpolyun_t B, const nmod_mpoly_ctx_t ctx);
+        const nmod_mpolyun_t B, const nmod_mpoly_ctx_t ctx);
 
 void nmod_mpoly_to_mpolyun_perm_deflate_threaded_pool(
-                nmod_mpolyun_t A, const nmod_mpoly_ctx_t uctx,
-                const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx,
-                const slong * perm, const ulong * shift, const ulong * stride,
-                        const thread_pool_handle * handles, slong num_handles);
+        nmod_mpolyun_t A, const nmod_mpoly_ctx_t uctx,
+        const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx,
+        const slong * perm, const ulong * shift, const ulong * stride,
+        const thread_pool_handle * handles, slong num_handles);
 
 void nmod_mpoly_to_mpolyn_perm_deflate_threaded_pool(nmod_mpolyn_t A,
-  const nmod_mpoly_ctx_t nctx, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx,
-                 const slong * perm, const ulong * shift, const ulong * stride,
-                        const thread_pool_handle * FLINT_UNUSED(handles), slong FLINT_UNUSED(num_handles));
+        const nmod_mpoly_ctx_t nctx, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx,
+        const slong * perm, const ulong * shift, const ulong * stride,
+        const thread_pool_handle * FLINT_UNUSED(handles), slong FLINT_UNUSED(num_handles));
 
 void nmod_mpoly_from_mpolyun_perm_inflate(nmod_mpoly_t A,
-     flint_bitcnt_t Abits, const nmod_mpoly_ctx_t ctx, const nmod_mpolyun_t B,
+        flint_bitcnt_t Abits, const nmod_mpoly_ctx_t ctx, const nmod_mpolyun_t B,
         const nmod_mpoly_ctx_t uctx, const slong * perm, const ulong * shift,
-                                                        const ulong * stride);
+        const ulong * stride);
 
 void nmod_mpoly_from_mpolyn_perm_inflate(nmod_mpoly_t A,
-                        flint_bitcnt_t Abits, const nmod_mpoly_ctx_t ctx,
-                        const nmod_mpolyn_t B, const nmod_mpoly_ctx_t nctx,
-                const slong * perm, const ulong * shift, const ulong * stride);
+        flint_bitcnt_t Abits, const nmod_mpoly_ctx_t ctx,
+        const nmod_mpolyn_t B, const nmod_mpoly_ctx_t nctx,
+        const slong * perm, const ulong * shift, const ulong * stride);
 
-NMOD_MPOLY_INLINE ulong nmod_mpolyun_leadcoeff(
-                                  nmod_mpolyun_t A, const nmod_mpoly_ctx_t ctx)
+NMOD_MPOLY_INLINE
+ulong nmod_mpolyun_leadcoeff(nmod_mpolyun_t A, const nmod_mpoly_ctx_t ctx)
 {
     FLINT_ASSERT(A->length > 0);
     return nmod_mpolyn_leadcoeff(A->coeffs + 0, ctx);
@@ -1495,49 +1268,48 @@ NMOD_MPOLY_INLINE n_poly_struct * nmod_mpolyun_leadcoeff_poly(
     return nmod_mpolyn_leadcoeff_poly(A->coeffs + 0, ctx);
 }
 
-
 /* GCD ***********************************************************************/
 
 int mpoly_gcd_get_use_first(slong rGdeg, slong Adeg, slong Bdeg,
                                                                slong gammadeg);
 
 int nmod_mpoly_gcd_get_use_new(slong rGdeg, slong Adeg, slong Bdeg,
-             slong gammadeg, slong degxAB, slong degyAB, slong numABgamma,
-             const n_polyun_t G, const n_polyun_t Abar, const n_polyun_t Bbar);
+        slong gammadeg, slong degxAB, slong degyAB, slong numABgamma,
+        const n_polyun_t G, const n_polyun_t Abar, const n_polyun_t Bbar);
 
 void nmod_mpolyu_setform_mpolyun(nmod_mpolyu_t A, nmod_mpolyun_t B,
-                                                   const nmod_mpoly_ctx_t ctx);
+        const nmod_mpoly_ctx_t ctx);
 
 int nmod_mpolyn_gcd_brown_smprime_bivar(
-               nmod_mpolyn_t G, nmod_mpolyn_t Abar, nmod_mpolyn_t Bbar,
-               nmod_mpolyn_t A, nmod_mpolyn_t B, const nmod_mpoly_ctx_t ctx,
-                                                         nmod_poly_stack_t Sp);
+        nmod_mpolyn_t G, nmod_mpolyn_t Abar, nmod_mpolyn_t Bbar,
+        nmod_mpolyn_t A, nmod_mpolyn_t B, const nmod_mpoly_ctx_t ctx,
+        nmod_poly_stack_t Sp);
 
 int nmod_mpolyn_gcd_brown_smprime(nmod_mpolyn_t G,
-                                  nmod_mpolyn_t Abar, nmod_mpolyn_t Bbar,
-                                 nmod_mpolyn_t A, nmod_mpolyn_t B, slong var,
-                         const nmod_mpoly_ctx_t ctx, const mpoly_gcd_info_t I,
-                                                         nmod_poly_stack_t Sp);
+        nmod_mpolyn_t Abar, nmod_mpolyn_t Bbar,
+        nmod_mpolyn_t A, nmod_mpolyn_t B, slong var,
+        const nmod_mpoly_ctx_t ctx, const mpoly_gcd_info_t I,
+        nmod_poly_stack_t Sp);
 
 int nmod_mpolyn_gcd_brown_smprime_threaded_pool(nmod_mpolyn_t G,
-                                nmod_mpolyn_t Abar, nmod_mpolyn_t Bbar,
-                               nmod_mpolyn_t A, nmod_mpolyn_t B, slong var,
-                         const nmod_mpoly_ctx_t ctx, const mpoly_gcd_info_t I,
-                        const thread_pool_handle * handles, slong num_workers);
+        nmod_mpolyn_t Abar, nmod_mpolyn_t Bbar,
+        nmod_mpolyn_t A, nmod_mpolyn_t B, slong var,
+        const nmod_mpoly_ctx_t ctx, const mpoly_gcd_info_t I,
+        const thread_pool_handle * handles, slong num_workers);
 
 int nmod_mpolyn_gcd_brown_lgprime(nmod_mpolyn_t G,
-                                 nmod_mpolyn_t Abar, nmod_mpolyn_t Bbar,
-                                 nmod_mpolyn_t A, nmod_mpolyn_t B, slong var,
-                                                   const nmod_mpoly_ctx_t ctx);
+        nmod_mpolyn_t Abar, nmod_mpolyn_t Bbar,
+        nmod_mpolyn_t A, nmod_mpolyn_t B, slong var,
+        const nmod_mpoly_ctx_t ctx);
 
 nmod_gcds_ret_t nmod_mpolyu_gcds_zippel(nmod_mpolyu_t G,
-                           nmod_mpolyu_t A, nmod_mpolyu_t B, nmod_mpolyu_t f,
-                                        slong var, const nmod_mpoly_ctx_t ctx,
-                                     flint_rand_t randstate, slong * degbound);
+        nmod_mpolyu_t A, nmod_mpolyu_t B, nmod_mpolyu_t f,
+        slong var, const nmod_mpoly_ctx_t ctx,
+        flint_rand_t randstate, slong * degbound);
 
 int nmod_mpolyu_gcdp_zippel(nmod_mpolyu_t G, nmod_mpolyu_t Abar,
-             nmod_mpolyu_t Bbar, nmod_mpolyu_t A, nmod_mpolyu_t B, slong var,
-                           const nmod_mpoly_ctx_t ctx, flint_rand_t randstate);
+        nmod_mpolyu_t Bbar, nmod_mpolyu_t A, nmod_mpolyu_t B, slong var,
+        const nmod_mpoly_ctx_t ctx, flint_rand_t randstate);
 
 void nmod_mpoly_to_mpolyl_perm_deflate(
     nmod_mpoly_t A,
@@ -1593,13 +1365,13 @@ int nmod_mpolyl_gcd_hensel_medprime(
     const nmod_mpoly_ctx_t smctx);
 
 void _nmod_mpoly_monomial_evals_cache(n_poly_t E,
-                    const ulong * Aexps, flint_bitcnt_t Abits, slong Alen,
-                    const ulong * betas, slong start, slong stop,
-                                          const mpoly_ctx_t mctx, nmod_t mod);
+        const ulong * Aexps, flint_bitcnt_t Abits, slong Alen,
+        const ulong * betas, slong start, slong stop,
+        const mpoly_ctx_t mctx, nmod_t mod);
 
 void _nmod_mpoly_monomial_evals2_cache(n_polyun_t E,
-          const ulong * Aexps, flint_bitcnt_t Abits, slong Alen,
-          const ulong * betas, slong m, const mpoly_ctx_t ctx, nmod_t mod);
+        const ulong * Aexps, flint_bitcnt_t Abits, slong Alen,
+        const ulong * betas, slong m, const mpoly_ctx_t ctx, nmod_t mod);
 
 /* interp ********************************************************************/
 
@@ -1671,26 +1443,17 @@ typedef struct nmod_mpoly_geobucket
 
 typedef nmod_mpoly_geobucket_struct nmod_mpoly_geobucket_t[1];
 
-void nmod_mpoly_geobucket_init(nmod_mpoly_geobucket_t B,
-                                                   const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_geobucket_init(nmod_mpoly_geobucket_t B, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_geobucket_clear(nmod_mpoly_geobucket_t B, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_geobucket_clear(nmod_mpoly_geobucket_t B,
-                                                   const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_geobucket_empty(nmod_mpoly_t p, nmod_mpoly_geobucket_t B, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_geobucket_empty(nmod_mpoly_t p,
-                         nmod_mpoly_geobucket_t B, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_geobucket_fit_length(nmod_mpoly_geobucket_t B, slong i, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_geobucket_fit_length(nmod_mpoly_geobucket_t B,
-                                          slong i, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_geobucket_set(nmod_mpoly_geobucket_t B, nmod_mpoly_t p, const nmod_mpoly_ctx_t ctx);
 
-void nmod_mpoly_geobucket_set(nmod_mpoly_geobucket_t B,
-                                   nmod_mpoly_t p, const nmod_mpoly_ctx_t ctx);
-
-void nmod_mpoly_geobucket_add(nmod_mpoly_geobucket_t B,
-                                   nmod_mpoly_t p, const nmod_mpoly_ctx_t ctx);
-
-void nmod_mpoly_geobucket_sub(nmod_mpoly_geobucket_t B,
-                                   nmod_mpoly_t p, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_geobucket_add(nmod_mpoly_geobucket_t B, nmod_mpoly_t p, const nmod_mpoly_ctx_t ctx);
+void nmod_mpoly_geobucket_sub(nmod_mpoly_geobucket_t B, nmod_mpoly_t p, const nmod_mpoly_ctx_t ctx);
 
 /******************************************************************************
 

--- a/src/qsieve/block_lanczos.c
+++ b/src/qsieve/block_lanczos.c
@@ -731,27 +731,27 @@ uint64_t * block_lanczos(flint_rand_t state, slong nrows,
 	   two numbers  */
 
 	vsize = FLINT_MAX(nrows, ncols);
-	v[0] = (uint64_t *)flint_malloc(vsize * sizeof(uint64_t));
-	v[1] = (uint64_t *)flint_malloc(vsize * sizeof(uint64_t));
-	v[2] = (uint64_t *)flint_malloc(vsize * sizeof(uint64_t));
-	vnext = (uint64_t *)flint_malloc(vsize * sizeof(uint64_t));
-	x = (uint64_t *)flint_malloc(vsize * sizeof(uint64_t));
-	v0 = (uint64_t *)flint_malloc(vsize * sizeof(uint64_t));
-	scratch = (uint64_t *)flint_malloc(FLINT_MAX(vsize, 256 * 8) * sizeof(uint64_t));
+	v[0] = flint_malloc(vsize * sizeof(uint64_t));
+	v[1] = flint_calloc(vsize, sizeof(uint64_t));
+	v[2] = flint_calloc(vsize, sizeof(uint64_t));
+	vnext = flint_malloc(vsize * sizeof(uint64_t));
+	x = flint_malloc(vsize * sizeof(uint64_t));
+	v0 = flint_malloc(vsize * sizeof(uint64_t));
+	scratch = flint_malloc(FLINT_MAX(vsize, 256 * 8) * sizeof(uint64_t));
 
 	/* allocate all the 64x64 variables */
 
-	winv[0] = (uint64_t *)flint_malloc(64 * sizeof(uint64_t));
-	winv[1] = (uint64_t *)flint_malloc(64 * sizeof(uint64_t));
-	winv[2] = (uint64_t *)flint_malloc(64 * sizeof(uint64_t));
-	vt_a_v[0] = (uint64_t *)flint_malloc(64 * sizeof(uint64_t));
-	vt_a_v[1] = (uint64_t *)flint_malloc(64 * sizeof(uint64_t));
-	vt_a2_v[0] = (uint64_t *)flint_malloc(64 * sizeof(uint64_t));
-	vt_a2_v[1] = (uint64_t *)flint_malloc(64 * sizeof(uint64_t));
-	d = (uint64_t *)flint_malloc(64 * sizeof(uint64_t));
-	e = (uint64_t *)flint_malloc(64 * sizeof(uint64_t));
-	f = (uint64_t *)flint_malloc(64 * sizeof(uint64_t));
-	f2 = (uint64_t *)flint_malloc(64 * sizeof(uint64_t));
+	winv[0] = flint_malloc(64 * sizeof(uint64_t));
+	winv[1] = flint_calloc(64, sizeof(uint64_t));
+	winv[2] = flint_calloc(64, sizeof(uint64_t));
+	vt_a_v[0] = flint_malloc(64 * sizeof(uint64_t));
+	vt_a_v[1] = flint_calloc(64, sizeof(uint64_t));
+	vt_a2_v[0] = flint_malloc(64 * sizeof(uint64_t));
+	vt_a2_v[1] = flint_calloc(64, sizeof(uint64_t));
+	d = flint_malloc(64 * sizeof(uint64_t));
+	e = flint_malloc(64 * sizeof(uint64_t));
+	f = flint_malloc(64 * sizeof(uint64_t));
+	f2 = flint_malloc(64 * sizeof(uint64_t));
 
 	/* The iterations computes v[0], vt_a_v[0],
 	   vt_a2_v[0], s[0] and winv[0]. Subscripts larger
@@ -759,16 +759,9 @@ uint64_t * block_lanczos(flint_rand_t state, slong nrows,
 	   quantities, which start off empty (except for
 	   the past version of s[], which contains all
 	   the column indices */
-
-	memset(v[1], 0, vsize * sizeof(uint64_t));
-	memset(v[2], 0, vsize * sizeof(uint64_t));
-	for (i = 0; i < 64; i++) {
+	for (i = 0; i < 64; i++)
 		s[1][i] = i;
-		vt_a_v[1][i] = 0;
-		vt_a2_v[1][i] = 0;
-		winv[1][i] = 0;
-		winv[2][i] = 0;
-	}
+
 	dim0 = 0;
 	dim1 = 64;
 	mask1 = (uint64_t)(-1);


### PR DESCRIPTION
I believe this is the final header reduction PR that I will make. The compile time per file has been reduced quite a lot over time and there is not much more that can be done without actually splitting headers (such as a specialized header for `arb` memory management etc., which of course poses a lot of problems). Some minor work can still be pursued, but the effect will be minimal, such as with this one. For instance, one could remove `gmp.h` inclusion from `arf.h`, but that yields a minimal effect on the compile time.

I think I'm satisfied with this, and I will continue with trying to templatize and optimize tests.