### PR TITLE
sd fft no blocks

### DIFF
--- a/src/fft_small.h
+++ b/src/fft_small.h
@@ -139,7 +139,7 @@ int fft_small_mulmod_satisfies_bounds(ulong n);
 
     with the special case j_bits = j_r = 0 for j = 0.
     The first SD_FFT_CTX_W2TAB_INIT tables are stored consecutively to ease the
-    lookup of small indices, which must currently be at least 4.
+    lookup of small indices, which must currently be at least max(4, LG_BLK_SZ).
 */
 
 /* for the fft look up of powers of w */

--- a/src/fft_small.h
+++ b/src/fft_small.h
@@ -240,7 +240,7 @@ FLINT_FORCE_INLINE void sd_fft_ctx_fit_depth(sd_fft_ctx_t Q, ulong depth)
 #if FLINT_USES_PTHREAD
     ulong tdepth = (ulong)atomic_load_explicit(&Q->w2tab_depth, memory_order_relaxed);
 #else
-    ulong tdepth = (ulong)Q->w2tab_depth);
+    ulong tdepth = (ulong)Q->w2tab_depth;
 #endif
     if (FLINT_UNLIKELY(tdepth < depth))
         sd_fft_ctx_fit_depth_with_lock(Q, depth);

--- a/src/fft_small.h
+++ b/src/fft_small.h
@@ -237,7 +237,11 @@ void sd_fft_ctx_fit_depth_with_lock(sd_fft_ctx_t Q, ulong k);
 
 FLINT_FORCE_INLINE void sd_fft_ctx_fit_depth(sd_fft_ctx_t Q, ulong depth)
 {
-    ulong tdepth = atomic_load_explicit(&Q->w2tab_depth, memory_order_relaxed);
+#if FLINT_USES_PTHREAD
+    ulong tdepth = (ulong)atomic_load_explicit(&Q->w2tab_depth, memory_order_relaxed);
+#else
+    ulong tdepth = (ulong)Q->w2tab_depth);
+#endif
     if (FLINT_UNLIKELY(tdepth < depth))
         sd_fft_ctx_fit_depth_with_lock(Q, depth);
 }

--- a/src/fft_small.h
+++ b/src/fft_small.h
@@ -15,6 +15,10 @@
 #include "longlong.h"
 #include "machine_vectors.h"
 
+#if FLINT_USES_PTHREAD
+#include <pthread.h>
+#endif
+
 #define LG_BLK_SZ 8
 #define BLK_SZ 256
 
@@ -180,6 +184,9 @@ typedef struct {
     ulong primitive_root;
     volatile ulong w2tab_depth;
     double* w2tab[SD_FFT_CTX_W2TAB_SIZE];
+#if FLINT_USES_PTHREAD
+    pthread_mutex_t mutex;
+#endif
 } sd_fft_ctx_struct;
 
 typedef sd_fft_ctx_struct sd_fft_ctx_t[1];
@@ -221,7 +228,13 @@ void sd_ifft_trunc(sd_fft_ctx_t Q, double* d, ulong L, ulong trunc);
 /* sd_fft_ctx.c */
 void sd_fft_ctx_clear(sd_fft_ctx_t Q);
 void sd_fft_ctx_init_prime(sd_fft_ctx_t Q, ulong pp);
-void sd_fft_ctx_fit_depth(sd_fft_ctx_t Q, ulong k);
+void sd_fft_ctx_fit_depth_with_lock(sd_fft_ctx_t Q, ulong k);
+
+FLINT_FORCE_INLINE void sd_fft_ctx_fit_depth(sd_fft_ctx_t Q, ulong depth)
+{
+    if (FLINT_UNLIKELY(Q->w2tab_depth < depth))
+        sd_fft_ctx_fit_depth_with_lock(Q, depth);
+}
 
 void sd_fft_ctx_point_mul(const sd_fft_ctx_t Q,
                             double* a, const double* b, ulong m_, ulong depth);

--- a/src/fft_small/fmpz_poly_mul.c
+++ b/src/fft_small/fmpz_poly_mul.c
@@ -179,7 +179,7 @@ static void _mod(
     }
 
     for (i = an; i < atrunc; i++)
-        sd_fft_ctx_set_index(abuf, i, 0);
+        abuf[i] = 0;
 }
 
 
@@ -329,18 +329,15 @@ typedef struct {
 static void extra_func(void* varg)
 {
     s1worker_struct* X = (s1worker_struct*) varg;
-    sd_fft_lctx_t Q;
+    sd_fft_ctx_struct* Q = X->ffts + X->ioff;
 
-    sd_fft_lctx_init(Q, X->ffts + X->ioff, X->depth);
-    _mod(X->bbuf, X->btrunc, X->b, X->bn, X->bbits, X->ffts + X->ioff);
-    sd_fft_lctx_fft_trunc(Q, X->bbuf, X->depth, X->btrunc, X->ztrunc);
-    sd_fft_lctx_clear(Q, X->ffts + X->ioff);
+    _mod(X->bbuf, X->btrunc, X->b, X->bn, X->bbits, Q);
+    sd_fft_trunc(Q, X->bbuf, X->depth, X->btrunc, X->ztrunc);
 }
 
 static void s1worker_func(void* varg)
 {
     s1worker_struct* X = (s1worker_struct*) varg;
-    sd_fft_lctx_t Q;
     ulong i, m;
     thread_pool_handle* handles = NULL;
     slong nworkers = 0;
@@ -353,8 +350,7 @@ static void s1worker_func(void* varg)
         ulong ioff = i + X->offset;
         double* abuf = X->abuf + X->stride*i;
         double* bbuf = X->bbuf;
-
-        sd_fft_lctx_init(Q, X->ffts + ioff, X->depth);
+        sd_fft_ctx_struct* Q = X->ffts + ioff;
 
         if (!X->squaring)
         {
@@ -365,13 +361,13 @@ static void s1worker_func(void* varg)
             }
             else
             {
-                _mod(bbuf, X->btrunc, X->b, X->bn, X->bbits, X->ffts + ioff);
-                sd_fft_lctx_fft_trunc(Q, bbuf, X->depth, X->btrunc, X->ztrunc);
+                _mod(bbuf, X->btrunc, X->b, X->bn, X->bbits, Q);
+                sd_fft_trunc(Q, bbuf, X->depth, X->btrunc, X->ztrunc);
             }
         }
 
-        _mod(abuf, X->atrunc, X->a, X->an, X->abits, X->ffts + ioff);
-        sd_fft_lctx_fft_trunc(Q, abuf, X->depth, X->atrunc, X->ztrunc);
+        _mod(abuf, X->atrunc, X->a, X->an, X->abits, Q);
+        sd_fft_trunc(Q, abuf, X->depth, X->atrunc, X->ztrunc);
 
         if (!X->squaring)
         {
@@ -380,17 +376,15 @@ static void s1worker_func(void* varg)
         }
 
         ulong cop = X->np == 1 ? 1 : *crt_data_co_prime_red(X->crts + X->np - 1, ioff);
-        NMOD_RED2(m, cop >> (FLINT_BITS - X->depth), cop << X->depth, X->ffts[ioff].mod);
-        m = nmod_inv(m, X->ffts[ioff].mod);
+        NMOD_RED2(m, cop >> (FLINT_BITS - X->depth), cop << X->depth, Q->mod);
+        m = nmod_inv(m, Q->mod);
 
         if (X->squaring)
-            sd_fft_lctx_point_sqr(Q, abuf, m, X->depth);
+            sd_fft_ctx_point_sqr(Q, abuf, m, X->depth);
         else
-            sd_fft_lctx_point_mul(Q, abuf, bbuf, m, X->depth);
+            sd_fft_ctx_point_mul(Q, abuf, bbuf, m, X->depth);
 
-        sd_fft_lctx_ifft_trunc(Q, abuf, X->depth, X->ztrunc);
-
-        sd_fft_lctx_clear(Q, X->ffts + ioff);
+        sd_ifft_trunc(Q, abuf, X->depth, X->ztrunc);
     }
 
     flint_give_back_threads(handles, nworkers);

--- a/src/fft_small/profile/p-sd_fft.c
+++ b/src/fft_small/profile/p-sd_fft.c
@@ -94,7 +94,7 @@ void profile_v2_fft(sd_fft_ctx_t Q, ulong minL, ulong maxL)
     timeit_stop(timer);
     flint_printf("depth %wu setup: %wd ms\n", maxL, timer->wall);
 
-    minL = n_max(minL, n_clog2(Q->blk_sz) + 1);
+    minL = n_max(minL, LG_BLK_SZ + 1);
     for (ulong L = minL+1; L <= maxL; L++)
     {
         double fft_time, ifft_time;
@@ -105,22 +105,22 @@ void profile_v2_fft(sd_fft_ctx_t Q, ulong minL, ulong maxL)
         ulong otrunc = n_pow2(L-1);
         while (otrunc < n_pow2(L))
         {
-            otrunc = n_round_up(1+1+(EXP_FAC+1)*otrunc/EXP_FAC, Q->blk_sz);
+            otrunc = n_round_up(1+1+(EXP_FAC+1)*otrunc/EXP_FAC, BLK_SZ);
             otrunc = n_min(otrunc, n_pow2(L));
-            ulong itrunc = n_round_up(otrunc/2, Q->blk_sz);
+            ulong itrunc = n_round_up(otrunc/2, BLK_SZ);
             for (ulong i = 0; i < n_pow2(L); i++)
-                sd_fft_ctx_set_index(data, i, 0);
+                data[i] = 0;
             ulong nreps = 1 + 300000000/(otrunc*n_clog2(otrunc));
 
             timeit_start(timer);
             for (ulong i = 0; i < nreps; i++)
-                sd_fft_ctx_fft_trunc(Q, data, L, itrunc, otrunc);
+                sd_fft_trunc(Q, data, L, itrunc, otrunc);
             timeit_stop(timer);
             fft_time = timer->wall;
 
             timeit_start(timer);
             for (ulong i = 0; i < nreps; i++)
-                sd_fft_ctx_ifft_trunc(Q, data, L, otrunc);
+                sd_ifft_trunc(Q, data, L, otrunc);
             timeit_stop(timer);
             ifft_time = timer->wall;
 
@@ -138,7 +138,7 @@ int main(void)
     sd_fft_ctx_t Q;
     sd_fft_ctx_init_prime(Q, UWORD(0x0003f00000000001));
     flint_printf("--- v2 fft/ifft gflops ---\n");
-    profile_v2_fft(Q, 10, 20);
+    profile_v2_fft(Q, 9, 20);
     sd_fft_ctx_clear(Q);
 
     return 0;

--- a/src/fft_small/sd_fft.c
+++ b/src/fft_small/sd_fft.c
@@ -1020,7 +1020,7 @@ void sd_fft_trunc(
         new_itrunc = n_cdiv(itrunc, BLK_SZ);
         new_otrunc = n_cdiv(otrunc, BLK_SZ);
         /* this isn't very clever */
-        for (int i = 0; i < ((-itrunc)&(BLK_SZ-1)); i++)
+        for (int i = 0; i < ((-(int)itrunc)&(BLK_SZ-1)); i++)
             d[itrunc+i] = 0.0;
 
         sd_fft_trunc_internal(Q, d, 1, L - LG_BLK_SZ, 0, new_itrunc, new_otrunc);
@@ -1028,7 +1028,7 @@ void sd_fft_trunc(
     }
 
     /* neither is this */
-    for (int i = itrunc; i < n_pow2(L); i++)
+    for (int i = itrunc; i < (1<<L); i++)
         d[i] = 0;
 
     /* L=8 reads from w2tab[7] */

--- a/src/fft_small/sd_fft.c
+++ b/src/fft_small/sd_fft.c
@@ -168,123 +168,345 @@
 #define _RADIX_4_FORWARD_PARAM_J_IS_NZ(...) RADIX_4_FORWARD_PARAM_J_IS_NZ(__VA_ARGS__)
 #define _RADIX_4_FORWARD_MOTH_J_IS_NZ(...)  RADIX_4_FORWARD_MOTH_J_IS_NZ(__VA_ARGS__)
 
-/**************** basecase transform of size BLK_SZ **************************/
-/*
-    The basecases below 4 are disabled because the fft is expected to be
-    produced in the slightly-worse-than-bit-reversed order of basecase_4.
-*/
-#define DEFINE_IT(j_is_0) \
-FLINT_FORCE_INLINE void CAT(sd_fft_basecase_4, j_is_0)( \
-    const sd_fft_ctx_t Q, \
-    double* X, \
-    ulong j_r, \
-    ulong j_bits) \
+#define LENGTH4_ANY_J(T, x0, x1, x2, x3, n, ninv, w2, w, iw) \
 { \
-    vec4d n    = vec4d_set_d(Q->p); \
-    vec4d ninv = vec4d_set_d(Q->pinv); \
-    vec4d w, w2, iw; \
-    vec4d x0, x1, x2, x3, y0, y1, y2, y3, u, v; \
- \
-    /* will abuse the fact that Q->w2tab[0] points to consecutive entries */ \
-    FLINT_ASSERT(SD_FFT_CTX_W2TAB_INIT >= 4); \
- \
-    x0 = vec4d_load(X+0); \
-    x0 = vec4d_reduce_to_pm1n(x0, n, ninv); \
-    x1 = vec4d_load(X+4); \
-    x2 = vec4d_load(X+8); \
-    x3 = vec4d_load(X+12); \
- \
-    if (j_is_0) \
-    { \
-        iw = vec4d_set_d(Q->w2tab[0][1]); \
- \
-        x2 = vec4d_reduce_to_pm1n(x2, n, ninv); \
-        x3 = vec4d_reduce_to_pm1n(x3, n, ninv); \
-        y0 = vec4d_add(x0, x2); \
-        y1 = vec4d_add(x1, x3); \
-        y2 = vec4d_sub(x0, x2); \
-        y3 = vec4d_sub(x1, x3); \
-        y1 = vec4d_reduce_to_pm1n(y1, n, ninv); \
-        y3 = vec4d_mulmod(y3, iw, n, ninv); \
-        x0 = vec4d_add(y0, y1); \
-        x1 = vec4d_sub(y0, y1); \
-        x2 = vec4d_add(y2, y3); \
-        x3 = vec4d_sub(y2, y3); \
-    } \
-    else \
-    { \
-        w  = vec4d_set_d(Q->w2tab[1+j_bits][2*j_r]); \
-        w2 = vec4d_set_d(Q->w2tab[0+j_bits][j_r]); \
-        iw = vec4d_set_d(Q->w2tab[1+j_bits][2*j_r+1]); \
- \
-        x2 = vec4d_mulmod(x2, w2, n, ninv); \
-        x3 = vec4d_mulmod(x3, w2, n, ninv); \
-        y0 = vec4d_add(x0, x2); \
-        y1 = vec4d_add(x1, x3); \
-        y2 = vec4d_sub(x0, x2); \
-        y3 = vec4d_sub(x1, x3); \
-        y1 = vec4d_mulmod(y1, w, n, ninv); \
-        y3 = vec4d_mulmod(y3, iw, n, ninv); \
-        x0 = vec4d_add(y0, y1); \
-        x1 = vec4d_sub(y0, y1); \
-        x2 = vec4d_add(y2, y3); \
-        x3 = vec4d_sub(y2, y3); \
-    } \
- \
-    if (j_is_0) \
-    { \
-        u = vec4d_load_aligned(Q->w2tab[0] + 0); \
-        v = vec4d_load_aligned(Q->w2tab[0] + 4); \
-        w2 = u; \
-    } \
-    else \
-    { \
-        u  = vec4d_load_aligned(Q->w2tab[3+j_bits] + 8*j_r + 0); \
-        v  = vec4d_load_aligned(Q->w2tab[3+j_bits] + 8*j_r + 4); \
-        w2 = vec4d_load_aligned(Q->w2tab[2+j_bits] + 4*j_r + 0); \
-    } \
-    w  = vec4d_unpack_lo_permute_0_2_1_3(u, v); \
-    iw = vec4d_unpack_hi_permute_0_2_1_3(u, v); \
- \
-    VEC4D_TRANSPOSE(x0, x1, x2, x3, x0, x1, x2, x3); \
- \
-    x0 = vec4d_reduce_to_pm1n(x0, n, ninv); \
-    x2 = vec4d_mulmod(x2, w2, n, ninv); \
-    x3 = vec4d_mulmod(x3, w2, n, ninv); \
-    y0 = vec4d_add(x0, x2); \
-    y1 = vec4d_add(x1, x3); \
-    y2 = vec4d_sub(x0, x2); \
-    y3 = vec4d_sub(x1, x3); \
-    y1 = vec4d_mulmod(y1, w, n, ninv); \
-    y3 = vec4d_mulmod(y3, iw, n, ninv); \
-    x0 = vec4d_add(y0, y1); \
-    x1 = vec4d_sub(y0, y1); \
-    x2 = vec4d_add(y2, y3); \
-    x3 = vec4d_sub(y2, y3); \
- \
-    /* another VEC4D_TRANSPOSE here would put the output in bit-reversed */ \
-    /* but this slow down is not necessary */ \
- \
-    vec4d_store(X+0, x0); \
-    vec4d_store(X+4, x1); \
-    vec4d_store(X+8, x2); \
-    vec4d_store(X+12, x3); \
+    T X0 = x0, X1 = x1, X2 = x2, X3 = x3, Y0, Y1, Y2, Y3; \
+    X0 = CAT(T, reduce_to_pm1n)(X0, n, ninv); \
+    X2 = CAT(T, mulmod)(X2, w2, n, ninv); \
+    X3 = CAT(T, mulmod)(X3, w2, n, ninv); \
+    Y0 = CAT(T, add)(X0, X2); \
+    Y1 = CAT(T, add)(X1, X3); \
+    Y2 = CAT(T, sub)(X0, X2); \
+    Y3 = CAT(T, sub)(X1, X3); \
+    Y1 = CAT(T, mulmod)(Y1, w, n, ninv); \
+    Y3 = CAT(T, mulmod)(Y3, iw, n, ninv); \
+    x0 = CAT(T, add)(Y0, Y1); \
+    x1 = CAT(T, sub)(Y0, Y1); \
+    x2 = CAT(T, add)(Y2, Y3); \
+    x3 = CAT(T, sub)(Y2, Y3); \
 }
 
-DEFINE_IT(0)
-DEFINE_IT(1)
-#undef DEFINE_IT
+#define LENGTH4_ZERO_J(T, x0, x1, x2, x3, n, ninv, e14) \
+{ \
+    T X0 = x0, X1 = x1, X2 = x2, X3 = x3, Y0, Y1, Y2, Y3; \
+    X0 = CAT(T, reduce_to_pm1n)(X0, n, ninv); \
+    X2 = CAT(T, reduce_to_pm1n)(X2, n, ninv); \
+    X3 = CAT(T, reduce_to_pm1n)(X3, n, ninv); \
+    Y0 = CAT(T, add)(X0, X2); \
+    Y1 = CAT(T, add)(X1, X3); \
+    Y2 = CAT(T, sub)(X0, X2); \
+    Y3 = CAT(T, sub)(X1, X3); \
+    Y1 = CAT(T, reduce_to_pm1n)(Y1, n, ninv); \
+    Y3 = CAT(T, mulmod)(Y3, e14, n, ninv); \
+    x0 = CAT(T, add)(Y0, Y1); \
+    x1 = CAT(T, sub)(Y0, Y1); \
+    x2 = CAT(T, add)(Y2, Y3); \
+    x3 = CAT(T, sub)(Y2, Y3); \
+}
+
+#define LENGTH8_ANY_J(T, x0, x1, x2, x3, x4, x5, x6, x7, n, ninv, w2, w, iw, ww0, ww1, ww2, ww3) \
+{ \
+    T X0 = x0, X1 = x1, X2 = x2, X3 = x3, X4 = x4, X5 = x5, X6 = x6, X7 = x7; \
+    T Y0, Y1, Y2, Y3, Y4, Y5, Y6, Y7, Z0, Z1, Z2, Z3, Z4, Z5, Z6, Z7; \
+    X0 = CAT(T, reduce_to_pm1n)(X0, n, ninv); \
+    X1 = CAT(T, reduce_to_pm1n)(X1, n, ninv); \
+    X4 = CAT(T, mulmod)(X4, w2, n, ninv); \
+    X5 = CAT(T, mulmod)(X5, w2, n, ninv); \
+    X6 = CAT(T, mulmod)(X6, w2, n, ninv); \
+    X7 = CAT(T, mulmod)(X7, w2, n, ninv); \
+    Y0 = CAT(T, add)(X0, X4); \
+    Y1 = CAT(T, add)(X1, X5); \
+    Y2 = CAT(T, add)(X2, X6); \
+    Y3 = CAT(T, add)(X3, X7); \
+    Y4 = CAT(T, sub)(X0, X4); \
+    Y5 = CAT(T, sub)(X1, X5); \
+    Y6 = CAT(T, sub)(X2, X6); \
+    Y7 = CAT(T, sub)(X3, X7); \
+    Y2 = CAT(T, mulmod)(Y2, w, n, ninv); \
+    Y3 = CAT(T, mulmod)(Y3, w, n, ninv); \
+    Y6 = CAT(T, mulmod)(Y6, iw, n, ninv); \
+    Y7 = CAT(T, mulmod)(Y7, iw, n, ninv); \
+    Z0 = CAT(T, add)(Y0, Y2); \
+    Z1 = CAT(T, add)(Y1, Y3); \
+    Z2 = CAT(T, sub)(Y0, Y2); \
+    Z3 = CAT(T, sub)(Y1, Y3); \
+    Z4 = CAT(T, add)(Y4, Y6); \
+    Z5 = CAT(T, add)(Y5, Y7); \
+    Z6 = CAT(T, sub)(Y4, Y6); \
+    Z7 = CAT(T, sub)(Y5, Y7); \
+    Z0 = CAT(T, reduce_to_pm1n)(Z0, n, ninv); \
+    Z1 = CAT(T, mulmod)(Z1, ww0, n, ninv); \
+    Z2 = CAT(T, reduce_to_pm1n)(Z2, n, ninv); \
+    Z3 = CAT(T, mulmod)(Z3, ww1, n, ninv); \
+    Z4 = CAT(T, reduce_to_pm1n)(Z4, n, ninv); \
+    Z5 = CAT(T, mulmod)(Z5, ww2, n, ninv); \
+    Z6 = CAT(T, reduce_to_pm1n)(Z6, n, ninv); \
+    Z7 = CAT(T, mulmod)(Z7, ww3, n, ninv); \
+    x0 = CAT(T, add)(Z0, Z1); \
+    x1 = CAT(T, sub)(Z0, Z1); \
+    x2 = CAT(T, add)(Z2, Z3); \
+    x3 = CAT(T, sub)(Z2, Z3); \
+    x4 = CAT(T, add)(Z4, Z5); \
+    x5 = CAT(T, sub)(Z4, Z5); \
+    x6 = CAT(T, add)(Z6, Z7); \
+    x7 = CAT(T, sub)(Z6, Z7); \
+}
+
+#define LENGTH8_ZERO_J(T, x0, x1, x2, x3, x4, x5, x6, x7, n, ninv, e14, e18, e38) \
+{ \
+    T X0 = x0, X1 = x1, X2 = x2, X3 = x3, X4 = x4, X5 = x5, X6 = x6, X7 = x7; \
+    T Y0, Y1, Y2, Y3, Y4, Y5, Y6, Y7, Z0, Z1, Z2, Z3, Z4, Z5, Z6, Z7; \
+    Y0 = CAT(T, reduce_to_pm1n)(CAT(T, add)(X0, X4), n, ninv); \
+    Y1 = CAT(T, reduce_to_pm1n)(CAT(T, add)(X1, X5), n, ninv); \
+    Y2 = CAT(T, reduce_to_pm1n)(CAT(T, add)(X2, X6), n, ninv); \
+    Y3 = CAT(T, reduce_to_pm1n)(CAT(T, add)(X3, X7), n, ninv); \
+    Y4 = CAT(T, reduce_to_pm1n)(CAT(T, sub)(X0, X4), n, ninv); \
+    Y5 = CAT(T, reduce_to_pm1n)(CAT(T, sub)(X1, X5), n, ninv); \
+    Y6 = CAT(T, reduce_to_pm1n)(CAT(T, sub)(X2, X6), n, ninv); \
+    Y7 = CAT(T, reduce_to_pm1n)(CAT(T, sub)(X3, X7), n, ninv); \
+    Z0 = CAT(T, add)(Y0, Y2); \
+    Z1 = CAT(T, add)(Y1, Y3); \
+    Z2 = CAT(T, sub)(Y0, Y2); \
+    Z3 = CAT(T, sub)(Y1, Y3); \
+    Y6 = CAT(T, mulmod)(e14, Y6, n, ninv); \
+    Y7 = CAT(T, mulmod)(e14, Y7, n, ninv); \
+    Z4 = CAT(T, add)(Y4, Y6); \
+    Z5 = CAT(T, add)(Y5, Y7); \
+    Z6 = CAT(T, sub)(Y4, Y6); \
+    Z7 = CAT(T, sub)(Y5, Y7); \
+    x0 = CAT(T, add)(Z0, Z1); \
+    x1 = CAT(T, sub)(Z0, Z1); \
+    Z3 = CAT(T, mulmod)(e14, Z3, n, ninv); \
+    Z5 = CAT(T, mulmod)(e18, Z5, n, ninv); \
+    Z7 = CAT(T, mulmod)(e38, Z7, n, ninv); \
+    x2 = CAT(T, add)(Z2, Z3); \
+    x3 = CAT(T, sub)(Z2, Z3); \
+    x4 = CAT(T, add)(Z4, Z5); \
+    x5 = CAT(T, sub)(Z4, Z5); \
+    x6 = CAT(T, add)(Z6, Z7); \
+    x7 = CAT(T, sub)(Z6, Z7); \
+}
+
+
+/**************** basecase transform of size 2^m **********************/
+/* template<int m, bool j_is_zero> sd_fft_basecase(Q, X, j_r, j_bits) */
+
+static void sd_fft_basecase_0_1(const sd_fft_ctx_t FLINT_UNUSED(Q), double* FLINT_UNUSED(X))
+{
+}
+
+
+static void sd_fft_basecase_1_1(const sd_fft_ctx_t Q, double* X)
+{
+    double n    = Q->p;
+    double ninv = Q->pinv;
+    double x0 = vec1d_reduce_to_pm1n(X[0], n, ninv);
+    double x1 = vec1d_reduce_to_pm1n(X[1], n, ninv);
+    X[0] = vec1d_add(x0, x1);
+    X[1] = vec1d_sub(x0, x1);
+}
+
+
+static void sd_fft_basecase_2_1(const sd_fft_ctx_t Q, double* X)
+{
+    LENGTH4_ZERO_J(vec1d, X[0], X[1], X[2], X[3], Q->p, Q->pinv, Q->w2tab[1][0])
+}
+
+
+static void sd_fft_basecase_3_1(const sd_fft_ctx_t Q, double* X)
+{
+    LENGTH8_ZERO_J(vec1d, X[0], X[1], X[2], X[3], X[4], X[5], X[6], X[7], Q->p, Q->pinv,
+                   Q->w2tab[1][0], Q->w2tab[2][0], Q->w2tab[2][1])
+}
+
+
+/* missing final transpose gives length >= 16 a worse-than-bit-reversed order */
+static void sd_fft_basecase_4_1(const sd_fft_ctx_t Q, double* X)
+{
+    vec4d n    = vec4d_set_d(Q->p);
+    vec4d ninv = vec4d_set_d(Q->pinv);
+    vec4d w, w2, iw, u, v;
+
+    vec4d x0 = vec4d_load(X+4*0);
+    vec4d x1 = vec4d_load(X+4*1);
+    vec4d x2 = vec4d_load(X+4*2);
+    vec4d x3 = vec4d_load(X+4*3);
+
+    FLINT_ASSERT(SD_FFT_CTX_W2TAB_INIT >= 4); /* Q.w2tab[0] points to consecutive entries */
+    iw = vec4d_set_d(Q->w2tab[0][1]);
+    LENGTH4_ZERO_J(vec4d, x0,x1,x2,x3, n,ninv, iw);
+
+    u = vec4d_load_aligned(&Q->w2tab[0][0]);
+    v = vec4d_load_aligned(&Q->w2tab[0][4]);
+    w2 = u;
+    w  = vec4d_unpack_lo_permute_0_2_1_3(u, v);
+    iw = vec4d_unpack_hi_permute_0_2_1_3(u, v);
+    VEC4D_TRANSPOSE(x0,x1,x2,x3, x0,x1,x2,x3);
+    LENGTH4_ANY_J(vec4d, x0,x1,x2,x3, n,ninv, w2, w,iw);
+
+    /* transpose_4x4(x0,x1,x2,x3, x0,x1,x2,x3) */ /* skipped */
+    vec4d_store(X+4*0, x0);
+    vec4d_store(X+4*1, x1);
+    vec4d_store(X+4*2, x2);
+    vec4d_store(X+4*3, x3);
+}
+
+static void sd_fft_basecase_4_0(const sd_fft_ctx_t Q, double* X, ulong j_r, ulong j_bits)
+{
+    vec4d n    = vec4d_set_d(Q->p);
+    vec4d ninv = vec4d_set_d(Q->pinv);
+    vec4d w, w2, iw, u, v;
+
+    vec4d x0 = vec4d_load(X+4*0);
+    vec4d x1 = vec4d_load(X+4*1);
+    vec4d x2 = vec4d_load(X+4*2);
+    vec4d x3 = vec4d_load(X+4*3);
+
+    w2 = vec4d_set_d(Q->w2tab[0+j_bits][1*j_r+0]);
+    w  = vec4d_set_d(Q->w2tab[1+j_bits][2*j_r+0]);
+    iw = vec4d_set_d(Q->w2tab[1+j_bits][2*j_r+1]);
+    LENGTH4_ANY_J(vec4d, x0,x1,x2,x3, n,ninv, w2, w,iw);
+
+    u  = vec4d_load_aligned(&Q->w2tab[3+j_bits][8*j_r+0]);
+    v  = vec4d_load_aligned(&Q->w2tab[3+j_bits][8*j_r+4]);
+    w2 = vec4d_load_aligned(&Q->w2tab[2+j_bits][4*j_r+0]);
+    w  = vec4d_unpack_lo_permute_0_2_1_3(u, v);
+    iw = vec4d_unpack_hi_permute_0_2_1_3(u, v);
+    VEC4D_TRANSPOSE(x0,x1,x2,x3, x0,x1,x2,x3);
+    LENGTH4_ANY_J(vec4d, x0,x1,x2,x3, n,ninv, w2, w,iw);
+
+    /* transpose_4x4(x0,x1,x2,x3, x0,x1,x2,x3) */ /* skipped */
+    vec4d_store(X+4*0, x0);
+    vec4d_store(X+4*1, x1);
+    vec4d_store(X+4*2, x2);
+    vec4d_store(X+4*3, x3);
+}
+
+/*
+The length 32 transform can be broken up as
+   (a) 8 transforms of length 4 within columns, followed by 4 transforms of length 8 in the rows, or
+   (b) 4 transforms of length 8 within columns, followed by 8 transforms of length 4 in the rows
+Since the length 16 basecase is missing the final 4x4 transpose, so the output
+is worse than bit-reversed. If the length 32 transform used a order different from 16's,
+then we will have a problem at a higher level since it would be difficult to keep track
+of what basecase happened to have be used. Therefore, the length 16 and 32 basecases
+should produce the same order, and this is easier with (b).
+*/
+static void sd_fft_basecase_5_1(const sd_fft_ctx_t Q, double* X)
+{
+    vec4d n    = vec4d_set_d(Q->p);
+    vec4d ninv = vec4d_set_d(Q->pinv);
+    vec4d u, v, w0, ww0, ww1, www2, www3;
+
+    vec4d x0 = vec4d_load(X+4*0);
+    vec4d x1 = vec4d_load(X+4*1);
+    vec4d x2 = vec4d_load(X+4*2);
+    vec4d x3 = vec4d_load(X+4*3);
+    vec4d x4 = vec4d_load(X+4*4);
+    vec4d x5 = vec4d_load(X+4*5);
+    vec4d x6 = vec4d_load(X+4*6);
+    vec4d x7 = vec4d_load(X+4*7);
+
+    ww1  = vec4d_set_d(Q->w2tab[1][0]);
+    www2 = vec4d_set_d(Q->w2tab[2][0]);
+    www3 = vec4d_set_d(Q->w2tab[2][1]);
+    LENGTH8_ZERO_J(vec4d, x0,x1,x2,x3,x4,x5,x6,x7, n,ninv, ww1, www2,www3);
+
+    VEC4D_TRANSPOSE(x0,x1,x2,x3, x0,x1,x2,x3);
+    VEC4D_TRANSPOSE(x4,x5,x6,x7, x4,x5,x6,x7);
+
+    /* j = 0, 1, 2, 3 */
+    w0  = vec4d_set_d4(Q->w2tab[0][0], Q->w2tab[0+(1)][1*(0)+0], Q->w2tab[0+(2)][1*(0)+0], Q->w2tab[0+(2)][1*(1)+0]);
+    ww0 = vec4d_set_d4(Q->w2tab[0][0], Q->w2tab[1+(1)][2*(0)+0], Q->w2tab[1+(2)][2*(0)+0], Q->w2tab[1+(2)][2*(1)+0]);
+    ww1 = vec4d_set_d4(Q->w2tab[1][0], Q->w2tab[1+(1)][2*(0)+1], Q->w2tab[1+(2)][2*(0)+1], Q->w2tab[1+(2)][2*(1)+1]);
+    LENGTH4_ANY_J(vec4d, x0,x1,x2,x3, n,ninv, w0,ww0,ww1);
+
+    /* j = 4, 5, 6, 7 */
+    w0 = vec4d_set_d4(Q->w2tab[0+(3)][1*(0)+0], Q->w2tab[0+(3)][1*(1)+0], Q->w2tab[0+(3)][1*(2)+0], Q->w2tab[0+(3)][1*(3)+0]);
+    u  = vec4d_load_aligned(&Q->w2tab[1+(3)][2*(0)+0]);
+    v  = vec4d_load_aligned(&Q->w2tab[1+(3)][2*(0)+4]);
+    ww0 = vec4d_unpack_lo_permute_0_2_1_3(u, v);
+    ww1 = vec4d_unpack_hi_permute_0_2_1_3(u, v);
+    LENGTH4_ANY_J(vec4d, x4,x5,x6,x7, n,ninv, w0,ww0,ww1);
+
+    /* transpose_4x4(x0,x1,x2,x3, x0,x1,x2,x3); */ /* skipped */
+    /* transpose_4x4(x4,x5,x6,x7, x4,x5,x6,x7); */
+    vec4d_store(X+4*0, x0);
+    vec4d_store(X+4*1, x1);
+    vec4d_store(X+4*2, x2);
+    vec4d_store(X+4*3, x3);
+    vec4d_store(X+4*4, x4);
+    vec4d_store(X+4*5, x5);
+    vec4d_store(X+4*6, x6);
+    vec4d_store(X+4*7, x7);
+}
+
+static void sd_fft_basecase_5_0(const sd_fft_ctx_t Q, double* X, ulong j_r, ulong j_bits)
+{
+    vec4d n    = vec4d_set_d(Q->p);
+    vec4d ninv = vec4d_set_d(Q->pinv);
+    vec4d u, v, w0, ww0, ww1, www0, www1, www2, www3;
+
+    vec4d x0 = vec4d_load(X+4*0);
+    vec4d x1 = vec4d_load(X+4*1);
+    vec4d x2 = vec4d_load(X+4*2);
+    vec4d x3 = vec4d_load(X+4*3);
+    vec4d x4 = vec4d_load(X+4*4);
+    vec4d x5 = vec4d_load(X+4*5);
+    vec4d x6 = vec4d_load(X+4*6);
+    vec4d x7 = vec4d_load(X+4*7);
+
+    w0   = vec4d_set_d(Q->w2tab[0+j_bits][1*j_r+0]);
+    ww0  = vec4d_set_d(Q->w2tab[1+j_bits][2*j_r+0]);
+    ww1  = vec4d_set_d(Q->w2tab[1+j_bits][2*j_r+1]);
+    www0 = vec4d_set_d(Q->w2tab[2+j_bits][4*j_r+0]);
+    www1 = vec4d_set_d(Q->w2tab[2+j_bits][4*j_r+1]);
+    www2 = vec4d_set_d(Q->w2tab[2+j_bits][4*j_r+2]);
+    www3 = vec4d_set_d(Q->w2tab[2+j_bits][4*j_r+3]);
+    LENGTH8_ANY_J(vec4d, x0,x1,x2,x3,x4,x5,x6,x7, n,ninv, w0, ww0,ww1, www0,www1,www2,www3);
+
+    VEC4D_TRANSPOSE(x0,x1,x2,x3, x0,x1,x2,x3);
+    VEC4D_TRANSPOSE(x4,x5,x6,x7, x4,x5,x6,x7);
+
+    /* j = 8*j+0, 8*j+1, 8*j+2, 8*j+3 */
+    w0 = vec4d_load_aligned(&Q->w2tab[0+(3+j_bits)][1*(8*j_r+0)+0]);
+    u  = vec4d_load_aligned(&Q->w2tab[1+(3+j_bits)][2*(8*j_r+0)+0]);
+    v  = vec4d_load_aligned(&Q->w2tab[1+(3+j_bits)][2*(8*j_r+0)+4]);
+    ww0 = vec4d_unpack_lo_permute_0_2_1_3(u, v);
+    ww1 = vec4d_unpack_hi_permute_0_2_1_3(u, v);
+    LENGTH4_ANY_J(vec4d, x0,x1,x2,x3,n,ninv, w0, ww0, ww1);
+
+    /* j = 8*j+4, 8*j+5, 8*j+6, 8*j+7 */
+    w0 = vec4d_load_aligned(&Q->w2tab[0+(3+j_bits)][1*(8*j_r+4)+0]);
+    u  = vec4d_load_aligned(&Q->w2tab[1+(3+j_bits)][2*(8*j_r+4)+0]);
+    v  = vec4d_load_aligned(&Q->w2tab[1+(3+j_bits)][2*(8*j_r+4)+4]);
+    ww0 = vec4d_unpack_lo_permute_0_2_1_3(u, v);
+    ww1 = vec4d_unpack_hi_permute_0_2_1_3(u, v);
+    LENGTH4_ANY_J(vec4d, x4,x5,x6,x7,n,ninv, w0, ww0, ww1);
+
+    /* transpose_4x4(x0,x1,x2,x3, x0,x1,x2,x3); */ /* skipped */
+    /* transpose_4x4(x4,x5,x6,x7, x4,x5,x6,x7); */
+    vec4d_store(X+4*0, x0);
+    vec4d_store(X+4*1, x1);
+    vec4d_store(X+4*2, x2);
+    vec4d_store(X+4*3, x3);
+    vec4d_store(X+4*4, x4);
+    vec4d_store(X+4*5, x5);
+    vec4d_store(X+4*6, x6);
+    vec4d_store(X+4*7, x7);
+}
+
 
 /* use with n = m-2 and m >= 6 */
 #define EXTEND_BASECASE(n, m) \
-static void CAT3(sd_fft_basecase, m, 1)(const sd_fft_ctx_t Q, double* X, ulong FLINT_UNUSED(j_r), ulong FLINT_UNUSED(j_bits)) \
+static void CAT3(sd_fft_basecase, m, 1)(const sd_fft_ctx_t Q, double* X) \
 { \
     ulong l = n_pow2(m - 2); \
     _RADIX_4_FORWARD_PARAM_J_IS_Z(VECND, Q) \
     ulong i = 0; do { \
         _RADIX_4_FORWARD_MOTH_J_IS_Z(VECND, X+0*l+i, X+1*l+i, X+2*l+i, X+3*l+i) \
     } while (i += N, i < l); \
-    CAT3(sd_fft_basecase, n, 1)(Q, X+0*l, 0, 0); \
+    CAT3(sd_fft_basecase, n, 1)(Q, X+0*l); \
     CAT3(sd_fft_basecase, n, 0)(Q, X+1*l, 0, 1); \
     CAT3(sd_fft_basecase, n, 0)(Q, X+2*l, 0, 2); \
     CAT3(sd_fft_basecase, n, 0)(Q, X+3*l, 1, 2); \
@@ -302,37 +524,51 @@ static void CAT3(sd_fft_basecase, m, 0)(const sd_fft_ctx_t Q, double* X, ulong j
     CAT3(sd_fft_basecase, n, 0)(Q, X+3*l, 4*j_r+3, j_bits+2); \
 }
 EXTEND_BASECASE(4, 6)
+EXTEND_BASECASE(5, 7)
 EXTEND_BASECASE(6, 8)
+EXTEND_BASECASE(7, 9)
 #undef EXTEND_BASECASE
 
 /* parameter 1: j can be zero */
-static void sd_fft_base_1(const sd_fft_ctx_t Q, double* x, ulong j)
+static void sd_fft_base_8_1(const sd_fft_ctx_t Q, double* x, ulong j)
 {
     ulong j_bits, j_r;
 
     FLINT_ASSERT(8 == LG_BLK_SZ);
-    FLINT_ASSERT(256 == BLK_SZ);
 
     SET_J_BITS_AND_J_R(j_bits, j_r, j);
 
     if (FLINT_UNLIKELY(j == 0))
-        sd_fft_basecase_8_1(Q, x, j_r, j_bits);
+        sd_fft_basecase_8_1(Q, x);
     else
         sd_fft_basecase_8_0(Q, x, j_r, j_bits);
 }
 
 /* parameter 0: j cannot be zero */
-static void sd_fft_base_0(const sd_fft_ctx_t Q, double* x, ulong j)
+static void sd_fft_base_8_0(const sd_fft_ctx_t Q, double* x, ulong j)
 {
     ulong j_bits, j_r;
 
     FLINT_ASSERT(j != 0);
     FLINT_ASSERT(8 == LG_BLK_SZ);
-    FLINT_ASSERT(256 == BLK_SZ);
 
     SET_J_BITS_AND_J_R(j_bits, j_r, j);
 
     sd_fft_basecase_8_0(Q, x, j_r, j_bits);
+}
+
+static void sd_fft_base_9_1(const sd_fft_ctx_t Q, double* x, ulong j)
+{
+    ulong j_bits, j_r;
+
+    FLINT_ASSERT(8 == LG_BLK_SZ);
+
+    SET_J_BITS_AND_J_R(j_bits, j_r, j);
+
+    if (FLINT_UNLIKELY(j == 0))
+        sd_fft_basecase_9_1(Q, x);
+    else
+        sd_fft_basecase_9_0(Q, x, j_r, j_bits);
 }
 
 
@@ -423,7 +659,7 @@ DEFINE_IT(4, 4)
 
 /************************ the recursive stuff ********************************/
 
-static void sd_fft_main_block(
+static void sd_fft_no_trunc_block(
     const sd_fft_ctx_t Q,
     double* x,
     ulong S, /* stride */
@@ -439,13 +675,13 @@ static void sd_fft_main_block(
 
         ulong l2 = n_pow2(k2);
         ulong a = 0; do {
-            sd_fft_main_block(Q, x + BLK_SZ*(a*S), S<<k2, k1, j);
+            sd_fft_no_trunc_block(Q, x + BLK_SZ*(a*S), S<<k2, k1, j);
         } while (a++, a < l2);
 
-        // row ffts
+        /* row ffts */
         ulong l1 = n_pow2(k1);
         ulong b = 0; do {
-            sd_fft_main_block(Q, x + BLK_SZ*((b<<k2)*S), S, k2, (j<<k1) + b);
+            sd_fft_no_trunc_block(Q, x + BLK_SZ*((b<<k2)*S), S, k2, (j<<k1) + b);
         } while (b++, b < l1);
 
         return;
@@ -493,7 +729,7 @@ static void sd_fft_main_block(
         /* row ffts */
         ulong l1 = n_pow2(k1);
         ulong b = 0; do {
-            sd_fft_main_block(Q, x + BLK_SZ*((b<<k2)*S), S, k2, (j<<k1) + b);
+            sd_fft_no_trunc_block(Q, x + BLK_SZ*((b<<k2)*S), S, k2, (j<<k1) + b);
         } while (b++, b < l1);
     }
     else if (k == 1)
@@ -519,7 +755,7 @@ static void sd_fft_main_block(
 
 
 
-void sd_fft_main(
+void sd_fft_no_trunc_internal(
     const sd_fft_ctx_t Q,
     double* x,
     ulong S,    /* stride */
@@ -534,13 +770,13 @@ void sd_fft_main(
         /* column ffts */
         ulong l2 = n_pow2(k2);
         ulong a = 0; do {
-            sd_fft_main_block(Q, x + BLK_SZ*(a*S), S<<k2, k1, j);
+            sd_fft_no_trunc_block(Q, x + BLK_SZ*(a*S), S<<k2, k1, j);
         } while (a++, a < l2);
 
         /* row ffts */
         ulong l1 = n_pow2(k1);
         ulong b = 0; do {
-            sd_fft_main(Q, x + BLK_SZ*(b*(S<<k2)), S, k2, (j<<k1) + b);
+            sd_fft_no_trunc_internal(Q, x + BLK_SZ*(b*(S<<k2)), S, k2, (j<<k1) + b);
         } while (b++, b < l1);
 
         return;
@@ -548,23 +784,20 @@ void sd_fft_main(
 
     if (k == 2)
     {
-        // k1 = 2; k2 = 0
-        sd_fft_main_block(Q, x, S, 2, j);
-        sd_fft_base_1(Q, x + BLK_SZ*(S*0), 4*j + 0);
-        sd_fft_base_0(Q, x + BLK_SZ*(S*1), 4*j + 1);
-        sd_fft_base_0(Q, x + BLK_SZ*(S*2), 4*j + 2);
-        sd_fft_base_0(Q, x + BLK_SZ*(S*3), 4*j + 3);
+        /* k1 = 2; k2 = 0 */
+        sd_fft_no_trunc_block(Q, x, S, 2, j);
+        sd_fft_base_8_1(Q, x + BLK_SZ*(S*0), 4*j + 0);
+        sd_fft_base_8_0(Q, x + BLK_SZ*(S*1), 4*j + 1);
+        sd_fft_base_8_0(Q, x + BLK_SZ*(S*2), 4*j + 2);
+        sd_fft_base_8_0(Q, x + BLK_SZ*(S*3), 4*j + 3);
     }
     else if (k == 1)
     {
-        // k1 = 1; k2 = 0
-        sd_fft_main_block(Q, x, S, 1, j);
-        sd_fft_base_1(Q, x + BLK_SZ*(S*0), 2*j + 0);
-        sd_fft_base_0(Q, x + BLK_SZ*(S*1), 2*j + 1);
+        sd_fft_base_9_1(Q, x, j);
     }
     else
     {
-        sd_fft_base_1(Q, x, j);
+        sd_fft_base_8_1(Q, x, j);
     }
 }
 
@@ -572,8 +805,8 @@ void sd_fft_main(
 static void sd_fft_trunc_block(
     const sd_fft_ctx_t Q,
     double* x,
-    ulong S, // stride
-    ulong k, // transform length 2^k
+    ulong S,
+    ulong k, /* transform length 2^k */
     ulong j,
     ulong itrunc,
     ulong otrunc)
@@ -617,7 +850,7 @@ static void sd_fft_trunc_block(
 
     if (itrunc == otrunc && otrunc == n_pow2(k))
     {
-        sd_fft_main_block(Q, x, S, k, j);
+        sd_fft_no_trunc_block(Q, x, S, k, j);
         return;
     }
 
@@ -750,20 +983,20 @@ static void sd_fft_trunc_internal(
     if (k == 2)
     {
         sd_fft_trunc_block(Q, x, S, 2, j, itrunc, otrunc);
-                        sd_fft_base_1(Q, x + BLK_SZ*(S*0), 4*j + 0);
-        if (otrunc > 1) sd_fft_base_0(Q, x + BLK_SZ*(S*1), 4*j + 1);
-        if (otrunc > 2) sd_fft_base_0(Q, x + BLK_SZ*(S*2), 4*j + 2);
-        if (otrunc > 3) sd_fft_base_0(Q, x + BLK_SZ*(S*3), 4*j + 3);
+                        sd_fft_base_8_1(Q, x + BLK_SZ*(S*0), 4*j + 0);
+        if (otrunc > 1) sd_fft_base_8_0(Q, x + BLK_SZ*(S*1), 4*j + 1);
+        if (otrunc > 2) sd_fft_base_8_0(Q, x + BLK_SZ*(S*2), 4*j + 2);
+        if (otrunc > 3) sd_fft_base_8_0(Q, x + BLK_SZ*(S*3), 4*j + 3);
     }
     else if (k == 1)
     {
         sd_fft_trunc_block(Q, x, S, 1, j, itrunc, otrunc);
-                        sd_fft_base_1(Q, x + BLK_SZ*(S*0), 2*j + 0);
-        if (otrunc > 1) sd_fft_base_0(Q, x + BLK_SZ*(S*1), 2*j + 1);
+                        sd_fft_base_8_1(Q, x + BLK_SZ*(S*0), 2*j + 0);
+        if (otrunc > 1) sd_fft_base_8_0(Q, x + BLK_SZ*(S*1), 2*j + 1);
     }
     else
     {
-        sd_fft_base_1(Q, x, j);
+        sd_fft_base_8_1(Q, x, j);
     }
 }
 
@@ -802,37 +1035,15 @@ void sd_fft_trunc(
     FLINT_ASSERT(LG_BLK_SZ <= SD_FFT_CTX_W2TAB_INIT);
 
     switch (L) {
-      case 8: sd_fft_base_1(Q, d, 0); break;
-      default: flint_printf("sd_fft_trunc: L=%wud not supported yet", L); flint_abort();
+        case 0: sd_fft_basecase_0_1(Q, d); break;
+        case 1: sd_fft_basecase_1_1(Q, d); break;
+        case 2: sd_fft_basecase_2_1(Q, d); break;
+        case 3: sd_fft_basecase_3_1(Q, d); break;
+        case 4: sd_fft_basecase_4_1(Q, d); break;
+        case 5: sd_fft_basecase_5_1(Q, d); break;
+        case 6: sd_fft_basecase_6_1(Q, d); break;
+        case 7: sd_fft_basecase_7_1(Q, d); break;
+        case 8: sd_fft_basecase_8_1(Q, d); break;
+        default: FLINT_ASSERT(0);
     }
 }
-
-
-
-
-#undef RADIX_2_FORWARD_PARAM_J_IS_Z
-#undef RADIX_2_FORWARD_MOTH_J_IS_Z
-#undef RADIX_2_FORWARD_PARAM_J_IS_NZ
-#undef RADIX_2_FORWARD_MOTH_J_IS_NZ
-#undef RADIX_2_FORWARD_MOTH_TRUNC_2_1_J_IS_Z
-#undef RADIX_2_FORWARD_MOTH_TRUNC_2_1_J_IS_NZ
-#undef RADIX_4_FORWARD_PARAM_J_IS_Z
-#undef RADIX_4_FORWARD_MOTH_J_IS_Z
-#undef RADIX_4_FORWARD_PARAM_J_IS_NZ
-#undef RADIX_4_FORWARD_MOTH_J_IS_NZ
-
-
-#undef _RADIX_2_FORWARD_PARAM_J_IS_Z
-#undef _RADIX_2_FORWARD_MOTH_J_IS_Z
-#undef _RADIX_2_FORWARD_PARAM_J_IS_NZ
-#undef _RADIX_2_FORWARD_MOTH_J_IS_NZ
-#undef _RADIX_2_FORWARD_MOTH_TRUNC_2_1_J_IS_Z
-#undef _RADIX_2_FORWARD_MOTH_TRUNC_2_1_J_IS_NZ
-#undef _RADIX_4_FORWARD_PARAM_J_IS_Z
-#undef _RADIX_4_FORWARD_MOTH_J_IS_Z
-#undef _RADIX_4_FORWARD_PARAM_J_IS_NZ
-#undef _RADIX_4_FORWARD_MOTH_J_IS_NZ
-
-#undef N
-#undef VECND
-#undef VECNOP

--- a/src/fft_small/sd_fft.c
+++ b/src/fft_small/sd_fft.c
@@ -797,6 +797,7 @@ void sd_fft_no_trunc_internal(
     }
     else
     {
+        /* currently unreachable because all ffts are called with k > 0 */
         sd_fft_base_8_1(Q, x, j);
     }
 }
@@ -952,6 +953,12 @@ static void sd_fft_trunc_internal(
         return;
     }
 
+    if (itrunc == otrunc && otrunc == n_pow2(k))
+    {
+        sd_fft_no_trunc_internal(Q, x, S, k, j);
+        return;
+    }
+
     if (k > 2)
     {
         ulong k1 = k/2;
@@ -996,6 +1003,7 @@ static void sd_fft_trunc_internal(
     }
     else
     {
+        /* currently unreachable for the same reason */
         sd_fft_base_8_1(Q, x, j);
     }
 }

--- a/src/fft_small/sd_fft_ctx.c
+++ b/src/fft_small/sd_fft_ctx.c
@@ -30,7 +30,6 @@ void sd_fft_ctx_init_prime(sd_fft_ctx_t Q, ulong pp)
     if (!fft_small_mulmod_satisfies_bounds(pp))
         flint_throw(FLINT_ERROR, "FFT prime %wu does not satisfy bounds for arithmetic", pp);
 
-    Q->blk_sz = BLK_SZ;
     Q->p = pp;
     Q->pinv = 1.0/Q->p;
     nmod_init(&Q->mod, pp);
@@ -72,7 +71,7 @@ void sd_fft_ctx_init_prime(sd_fft_ctx_t Q, ulong pp)
         Q->w2tab[k] = NULL;
 
 #if FLINT_WANT_ASSERT
-    for (k = 1; k < SD_FFT_CTX_INIT_DEPTH; k++)
+    for (k = 1; k < SD_FFT_CTX_W2TAB_INIT; k++)
     {
         ulong ww = nmod_pow_ui(Q->primitive_root, (Q->mod.n - 1)>>(k + 1), Q->mod);
         for (i = 0; i < n_pow2(k-1); i++)

--- a/src/fft_small/sd_fft_ctx.c
+++ b/src/fft_small/sd_fft_ctx.c
@@ -70,6 +70,10 @@ void sd_fft_ctx_init_prime(sd_fft_ctx_t Q, ulong pp)
     for ( ; k < SD_FFT_CTX_W2TAB_SIZE; k++)
         Q->w2tab[k] = NULL;
 
+#if FLINT_USES_PTHREAD
+    pthread_mutex_init(&Q->mutex, NULL);
+#endif
+
 #if FLINT_WANT_ASSERT
     for (k = 1; k < SD_FFT_CTX_W2TAB_INIT; k++)
     {
@@ -83,8 +87,12 @@ void sd_fft_ctx_init_prime(sd_fft_ctx_t Q, ulong pp)
 #endif
 }
 
-void sd_fft_ctx_fit_depth(sd_fft_ctx_t Q, ulong depth)
+void sd_fft_ctx_fit_depth_with_lock(sd_fft_ctx_t Q, ulong depth)
 {
+#if FLINT_USES_PTHREAD
+    pthread_mutex_lock(&Q->mutex);
+#endif
+
     ulong k = Q->w2tab_depth;
     while (k < depth)
     {
@@ -133,4 +141,9 @@ void sd_fft_ctx_fit_depth(sd_fft_ctx_t Q, ulong depth)
         k++;
         Q->w2tab_depth = k;
     }
+
+
+#if FLINT_USES_PTHREAD
+    pthread_mutex_unlock(&Q->mutex);
+#endif
 }

--- a/src/fft_small/sd_fft_ctx.c
+++ b/src/fft_small/sd_fft_ctx.c
@@ -17,7 +17,7 @@ void sd_fft_ctx_clear(sd_fft_ctx_t Q)
 {
     ulong k;
     flint_aligned_free(Q->w2tab[0]);
-    for (k = SD_FFT_CTX_INIT_DEPTH; k < FLINT_BITS; k++)
+    for (k = SD_FFT_CTX_W2TAB_INIT; k < SD_FFT_CTX_W2TAB_SIZE; k++)
         flint_aligned_free(Q->w2tab[k]);
 }
 
@@ -40,18 +40,18 @@ void sd_fft_ctx_init_prime(sd_fft_ctx_t Q, ulong pp)
     ninv = Q->pinv;
 
     /*
-        fill wtab to a depth of SD_FFT_CTX_INIT_DEPTH:
-        2^(SD_FFT_CTX_INIT_DEPTH-1) entries: 1, e(1/4), e(1/8), e(3/8), ...
+        fill wtab to a depth of SD_FFT_CTX_W2TAB_INIT:
+        2^(SD_FFT_CTX_W2TAB_INIT-1) entries: 1, e(1/4), e(1/8), e(3/8), ...
 
         Q->w2tab[j] is itself a table of length 2^(j-1) containing 2^(j+1) st
         roots of unity.
     */
-    N = n_pow2(SD_FFT_CTX_INIT_DEPTH - 1);
+    N = n_pow2(SD_FFT_CTX_W2TAB_INIT - 1);
     t = (double*) flint_aligned_alloc(4096, n_round_up(N*sizeof(double), 4096));
 
     Q->w2tab[0] = t;
     t[0] = 1;
-    for (k = 1, l = 1; k < SD_FFT_CTX_INIT_DEPTH; k++, l *= 2)
+    for (k = 1, l = 1; k < SD_FFT_CTX_W2TAB_INIT; k++, l *= 2)
     {
         ulong ww = nmod_pow_ui(Q->primitive_root, (Q->mod.n - 1)>>(k + 1), Q->mod);
         double w = vec1d_set_d(vec1d_reduce_0n_to_pmhn(ww, n));
@@ -68,7 +68,7 @@ void sd_fft_ctx_init_prime(sd_fft_ctx_t Q, ulong pp)
     Q->w2tab_depth = k;
 
     /* the rest of the tables are uninitialized */
-    for ( ; k < FLINT_BITS; k++)
+    for ( ; k < SD_FFT_CTX_W2TAB_SIZE; k++)
         Q->w2tab[k] = NULL;
 
 #if FLINT_WANT_ASSERT
@@ -101,8 +101,8 @@ void sd_fft_ctx_fit_depth(sd_fft_ctx_t Q, ulong depth)
 
         /* The first few tables are stored consecutively, so vec16 is ok. */
         off = 0;
-        l = n_pow2(SD_FFT_CTX_INIT_DEPTH - 1);
-        for (j = SD_FFT_CTX_INIT_DEPTH - 1; j < k; j++)
+        l = n_pow2(SD_FFT_CTX_W2TAB_INIT - 1);
+        for (j = SD_FFT_CTX_W2TAB_INIT - 1; j < k; j++)
         {
             i = 0; do {
                 vec8d x0 = vec8d_load_aligned(t + i + 0);

--- a/src/fft_small/sd_fft_ctx.c
+++ b/src/fft_small/sd_fft_ctx.c
@@ -68,7 +68,11 @@ void sd_fft_ctx_init_prime(sd_fft_ctx_t Q, ulong pp)
         } while (i += 1, i < l);
     }
 
+#if FLINT_USES_PTHREAD
     atomic_init(&Q->w2tab_depth, (unsigned int)k);
+#else
+    Q->w2tab_depth = (unsigned int)k;
+#endif
 
     /* the rest of the tables are uninitialized */
     for ( ; k < SD_FFT_CTX_W2TAB_SIZE; k++)

--- a/src/fft_small/sd_ifft.c
+++ b/src/fft_small/sd_ifft.c
@@ -78,7 +78,7 @@
 /* the legal functions must be implemented */
 #define DEFINE_IT(nn, zz, ff) \
 static void CAT4(radix_2_moth_inv_trunc_block, nn, zz, ff)( \
-    const sd_fft_lctx_t FLINT_UNUSED(Q), \
+    const sd_fft_ctx_t FLINT_UNUSED(Q), \
     ulong FLINT_UNUSED(j), \
     double* FLINT_UNUSED(X0), double* FLINT_UNUSED(X1)) \
 { \
@@ -101,13 +101,13 @@ DEFINE_IT(2,2,1)
 
 /* {x0, x1} = {2*x0 - w*x1, x0 - w*x1} */
 static void radix_2_moth_inv_trunc_block_1_2_1(
-    const sd_fft_lctx_t Q,
+    const sd_fft_ctx_t Q,
     ulong j,
     double* X0, double* X1)
 {
     VECND n    = VECNOP(set_d)(Q->p);
     VECND ninv = VECNOP(set_d)(Q->pinv);
-    VECND w = VECNOP(set_d)(sd_fft_lctx_w2(Q, j));
+    VECND w = VECNOP(set_d)(sd_fft_ctx_w2(Q, j));
     VECND c = VECNOP(set_d)(2);
     ulong i = 0; do {
         VECND a, b, u, v;
@@ -126,13 +126,13 @@ static void radix_2_moth_inv_trunc_block_1_2_1(
 
 /* {x0} = {2*x0 - w*x1} */
 static void radix_2_moth_inv_trunc_block_1_2_0(
-    const sd_fft_lctx_t Q,
+    const sd_fft_ctx_t Q,
     ulong j,
     double* X0, double* X1)
 {
     VECND n    = VECNOP(set_d)(Q->p);
     VECND ninv = VECNOP(set_d)(Q->pinv);
-    VECND w = VECNOP(set_d)(sd_fft_lctx_w2(Q, j));
+    VECND w = VECNOP(set_d)(sd_fft_ctx_w2(Q, j));
     VECND c = VECNOP(set_d)(2);
     ulong i = 0; do {
         VECND a, b, u;
@@ -148,7 +148,7 @@ static void radix_2_moth_inv_trunc_block_1_2_0(
 
 /* {x0, x1} = {2*x0, x0} */
 static void radix_2_moth_inv_trunc_block_1_1_1(
-    const sd_fft_lctx_t Q,
+    const sd_fft_ctx_t Q,
     ulong FLINT_UNUSED(j),
     double* X0, double* X1)
 {
@@ -167,7 +167,7 @@ static void radix_2_moth_inv_trunc_block_1_1_1(
 
 /* {x0} = {2*x0} */
 static void radix_2_moth_inv_trunc_block_1_1_0(
-    const sd_fft_lctx_t Q,
+    const sd_fft_ctx_t Q,
     ulong FLINT_UNUSED(j),
     double* X0, double* FLINT_UNUSED(X1))
 {
@@ -185,13 +185,13 @@ static void radix_2_moth_inv_trunc_block_1_1_0(
 
 /* {x0} = {(x0 + w*x1)/2} */
 static void radix_2_moth_inv_trunc_block_0_2_1(
-    const sd_fft_lctx_t Q,
+    const sd_fft_ctx_t Q,
     ulong j,
     double* X0, double* X1)
 {
     VECND n    = VECNOP(set_d)(Q->p);
     VECND ninv = VECNOP(set_d)(Q->pinv);
-    VECND w = VECNOP(set_d)(sd_fft_lctx_w2(Q, j));
+    VECND w = VECNOP(set_d)(sd_fft_ctx_w2(Q, j));
     VECND c = VECNOP(set_d)(vec1d_fnmadd(0.5, Q->p, 0.5));
     ulong i = 0; do {
         VECND a, b;
@@ -207,7 +207,7 @@ static void radix_2_moth_inv_trunc_block_0_2_1(
 
 /* {x0} = {(x0)/2} */
 static void radix_2_moth_inv_trunc_block_0_1_1(
-    const sd_fft_lctx_t Q,
+    const sd_fft_ctx_t Q,
     ulong FLINT_UNUSED(j),
     double* X0, double* FLINT_UNUSED(X1))
 {
@@ -303,7 +303,7 @@ static void radix_2_moth_inv_trunc_block_0_1_1(
 */
 #define DEFINE_IT(j_is_0) \
 FLINT_FORCE_INLINE void sd_ifft_basecase_4_##j_is_0(\
-    const sd_fft_lctx_t Q, double* X, ulong j_mr, ulong j_bits) \
+    const sd_fft_ctx_t Q, double* X, ulong j_mr, ulong j_bits) \
 { \
     vec4d n    = vec4d_set_d(Q->p); \
     vec4d ninv = vec4d_set_d(Q->pinv); \
@@ -395,7 +395,7 @@ DEFINE_IT(1)
 
 /* use with n = m-2 and m >= 6 */
 #define EXTEND_BASECASE(n, m) \
-void CAT3(sd_ifft_basecase, m, 1)(const sd_fft_lctx_t Q, double* X, ulong FLINT_UNUSED(j_mr), ulong FLINT_UNUSED(j_bits)) \
+void CAT3(sd_ifft_basecase, m, 1)(const sd_fft_ctx_t Q, double* X, ulong FLINT_UNUSED(j_mr), ulong FLINT_UNUSED(j_bits)) \
 { \
     ulong l = n_pow2(m - 2); \
     FLINT_ASSERT(j_bits == 0); \
@@ -411,7 +411,7 @@ void CAT3(sd_ifft_basecase, m, 1)(const sd_fft_lctx_t Q, double* X, ulong FLINT_
         FLINT_ASSERT(i == l); \
     } \
 } \
-void CAT3(sd_ifft_basecase, m, 0)(const sd_fft_lctx_t Q, double* X, ulong j_mr, ulong j_bits) \
+void CAT3(sd_ifft_basecase, m, 0)(const sd_fft_ctx_t Q, double* X, ulong j_mr, ulong j_bits) \
 { \
     ulong l = n_pow2(m - 2); \
     FLINT_ASSERT(j_bits != 0); \
@@ -433,10 +433,10 @@ EXTEND_BASECASE(6, 8)
 #undef EXTEND_BASECASE
 
 /* parameter 1: j can be zero */
-void sd_ifft_base_1(const sd_fft_lctx_t Q, ulong I, ulong j)
+void sd_ifft_base_1(const sd_fft_ctx_t Q, double* d, ulong I, ulong j)
 {
     ulong j_bits, j_mr;
-    double* x = sd_fft_lctx_blk_index(Q, I);
+    double* x = sd_fft_ctx_blk_index(d, I);
 
     SET_J_BITS_AND_J_MR(j_bits, j_mr, j);
 
@@ -447,10 +447,10 @@ void sd_ifft_base_1(const sd_fft_lctx_t Q, ulong I, ulong j)
 }
 
 /* parameter 0: j cannot be zero */
-void sd_ifft_base_0(const sd_fft_lctx_t Q, ulong I, ulong j)
+void sd_ifft_base_0(const sd_fft_ctx_t Q, double* d, ulong I, ulong j)
 {
     ulong j_bits, j_mr;
-    double* x = sd_fft_lctx_blk_index(Q, I);
+    double* x = sd_fft_ctx_blk_index(d, I);
 
     FLINT_ASSERT(j != 0);
 
@@ -499,7 +499,7 @@ k = 2, n = 3, z = 4, f = true
 [          -r               r         1   r*w^3]
 */
 static void radix_4_moth_inv_trunc_block_3_4_1(
-    const sd_fft_lctx_t Q,
+    const sd_fft_ctx_t Q,
     ulong j, ulong j_bits,
     double* X0, double* X1, double* X2, double* X3)
 {
@@ -554,7 +554,7 @@ k = 2, n = 3, z = 4, f = false
 [(r + 1)//w^2   (-r + 1)//w^2   -2//w^2    -r*w]
 */
 static void radix_4_moth_inv_trunc_block_3_4_0(
-    const sd_fft_lctx_t Q,
+    const sd_fft_ctx_t Q,
     ulong j, ulong j_bits,
     double* X0, double* X1, double* X2, double* X3)
 {
@@ -616,7 +616,7 @@ k = 2, n = 3, z = 3, f = true
                                 -r*(x0 - x1)             +   x2  }
 */
 static void radix_4_moth_inv_trunc_block_3_3_1(
-    const sd_fft_lctx_t Q,
+    const sd_fft_ctx_t Q,
     ulong j, ulong j_bits,
     double* X0, double* X1, double* X2, double* X3)
 {
@@ -666,7 +666,7 @@ k = 2, n = 3, z = 3, f = false
                      -w^-2*(2*x2 - r*v - u)}
 */
 static void radix_4_moth_inv_trunc_block_3_3_0(
-    const sd_fft_lctx_t Q,
+    const sd_fft_ctx_t Q,
     ulong j, ulong j_bits,
     double* X0, double* X1, double* X2, double* FLINT_UNUSED(X3))
 {
@@ -708,7 +708,7 @@ k = 2, n = 2, z = 4, f = true
 [1//2*r + 1//2   -1//2*r + 1//2   -1//2*w^2   -1//2*r*w^3]
 */
 static void radix_4_moth_inv_trunc_block_2_4_1(
-    const sd_fft_lctx_t Q,
+    const sd_fft_ctx_t Q,
     ulong j, ulong j_bits,
     double* X0, double* X1, double* X2, double* X3)
 {
@@ -759,7 +759,7 @@ k = 2, n = 2, z = 4, f = false
 [2//w   -2//w      0   -w^2]
 */
 static void radix_4_moth_inv_trunc_block_2_4_0(
-    const sd_fft_lctx_t Q,
+    const sd_fft_ctx_t Q,
     ulong j, ulong j_bits,
     double* X0, double* X1, double* X2, double* X3)
 {
@@ -800,7 +800,7 @@ k = 2, n = 2, z = 2, f = true
 {x0, x1, x2} = {2*(x0 + x1), 2*w^-1*(x0 - x1), (x0+x1)/2 + (x0-x1)*i/2}
 */
 static void radix_4_moth_inv_trunc_block_2_2_1(
-    const sd_fft_lctx_t Q,
+    const sd_fft_ctx_t Q,
     ulong j, ulong j_bits,
     double* X0, double* X1, double* X2, double* FLINT_UNUSED(X3))
 {
@@ -836,7 +836,7 @@ k = 2, n = 2, z = 2, f = 0
 {x0, x1} = {2*(x0 + x1), 2*w^-1*(x0 - x1)}
 */
 static void radix_4_moth_inv_trunc_block_2_2_0(
-    const sd_fft_lctx_t Q,
+    const sd_fft_ctx_t Q,
     ulong j, ulong j_bits,
     double* X0, double* X1, double* FLINT_UNUSED(X2), double* FLINT_UNUSED(X3))
 {
@@ -867,7 +867,7 @@ k = 2, n = 1, z = 4, f = true
 [1   -1//2*w      0   -1//2*w^3]
 */
 static void radix_4_moth_inv_trunc_block_1_4_1(
-    const sd_fft_lctx_t Q,
+    const sd_fft_ctx_t Q,
     ulong j, ulong j_bits,
     double* X0, double* X1, double* X2, double* X3)
 {
@@ -907,7 +907,7 @@ k = 2, n = 1, z = 4, f = false
 [4   -w   -w^2   -w^3]
 */
 static void radix_4_moth_inv_trunc_block_1_4_0(
-    const sd_fft_lctx_t Q,
+    const sd_fft_ctx_t Q,
     ulong j, ulong j_bits,
     double* X0, double* X1, double* X2, double* X3)
 {
@@ -942,7 +942,7 @@ k = 2, n = 1, z = 1, f = true
 [1]
 */
 static void radix_4_moth_inv_trunc_block_1_1_1(
-    const sd_fft_lctx_t Q,
+    const sd_fft_ctx_t Q,
     ulong FLINT_UNUSED(j), ulong FLINT_UNUSED(j_bits),
     double* X0, double* X1, double* FLINT_UNUSED(X2), double* FLINT_UNUSED(X3))
 {
@@ -964,7 +964,7 @@ k = 2, n = 1, z = 1, f = false
 [4]
 */
 static void radix_4_moth_inv_trunc_block_1_1_0(
-    const sd_fft_lctx_t Q,
+    const sd_fft_ctx_t Q,
     ulong FLINT_UNUSED(j), ulong FLINT_UNUSED(j_bits),
     double* X0, double* FLINT_UNUSED(X1), double* FLINT_UNUSED(X2), double* FLINT_UNUSED(X3))
 {
@@ -985,7 +985,7 @@ k = 2, n = 0, z = 4, f = true
 [1//4   1//4*w   1//4*w^2   1//4*w^3]
 */
 static void radix_4_moth_inv_trunc_block_0_4_1(
-    const sd_fft_lctx_t Q,
+    const sd_fft_ctx_t Q,
     ulong j, ulong j_bits,
     double* X0, double* X1, double* X2, double* X3)
 {
@@ -1014,8 +1014,9 @@ static void radix_4_moth_inv_trunc_block_0_4_1(
 
 /************************ the recursive stuff ********************************/
 
-void sd_ifft_main_block(
-    const sd_fft_lctx_t Q,
+static void sd_ifft_main_block(
+    const sd_fft_ctx_t Q,
+    double* d,
     ulong I, /* starting index */
     ulong S, /* stride */
     ulong k, /* BLK_SZ transforms each of length 2^k */
@@ -1031,13 +1032,13 @@ void sd_ifft_main_block(
         /* row ffts */
         ulong l1 = n_pow2(k1);
         ulong b = 0; do {
-            sd_ifft_main_block(Q, I + (b<<k2)*S, S, k2, (j<<k1) + b);
+            sd_ifft_main_block(Q, d, I + (b<<k2)*S, S, k2, (j<<k1) + b);
         } while (b++, b < l1);
 
         /* column ffts */
         ulong l2 = n_pow2(k2);
         ulong a = 0; do {
-            sd_ifft_main_block(Q, I + a*S, S<<k2, k1, j);
+            sd_ifft_main_block(Q, d, I + a*S, S<<k2, k1, j);
         } while (a++, a < l2);
 
         return;
@@ -1047,10 +1048,10 @@ void sd_ifft_main_block(
 
     if (k == 2)
     {
-        double* X0 = sd_fft_lctx_blk_index(Q, I + S*0);
-        double* X1 = sd_fft_lctx_blk_index(Q, I + S*1);
-        double* X2 = sd_fft_lctx_blk_index(Q, I + S*2);
-        double* X3 = sd_fft_lctx_blk_index(Q, I + S*3);
+        double* X0 = sd_fft_ctx_blk_index(d, I + S*0);
+        double* X1 = sd_fft_ctx_blk_index(d, I + S*1);
+        double* X2 = sd_fft_ctx_blk_index(d, I + S*2);
+        double* X3 = sd_fft_ctx_blk_index(d, I + S*3);
         if (FLINT_UNLIKELY(j_bits == 0))
         {
             _RADIX_4_REVERSE_PARAM_J_IS_Z(VECND, Q)
@@ -1068,8 +1069,8 @@ void sd_ifft_main_block(
     }
     else if (k == 1)
     {
-        double* X0 = sd_fft_lctx_blk_index(Q, I + S*0);
-        double* X1 = sd_fft_lctx_blk_index(Q, I + S*1);
+        double* X0 = sd_fft_ctx_blk_index(d, I + S*0);
+        double* X1 = sd_fft_ctx_blk_index(d, I + S*1);
         if (FLINT_UNLIKELY(j_bits == 0))
         {
             _RADIX_2_REVERSE_PARAM_J_IS_Z(VECND, Q)
@@ -1087,8 +1088,9 @@ void sd_ifft_main_block(
     }
 }
 
-void sd_ifft_main(
-    const sd_fft_lctx_t Q,
+static void sd_ifft_main(
+    const sd_fft_ctx_t Q,
+    double* d,
     ulong I, /* starting index */
     ulong S, /* stride */
     ulong k, /* transform length BLK_SZ*2^k */
@@ -1101,12 +1103,12 @@ void sd_ifft_main(
 
         ulong l1 = n_pow2(k1);
         ulong b = 0; do {
-            sd_ifft_main(Q, I + b*(S<<k2), S, k2, (j<<k1) + b);
+            sd_ifft_main(Q, d, I + b*(S<<k2), S, k2, (j<<k1) + b);
         } while (b++, b < l1);
 
         ulong l2 = n_pow2(k2);
         ulong a = 0; do {
-            sd_ifft_main_block(Q, I + a*S, S<<k2, k1, j);
+            sd_ifft_main_block(Q, d, I + a*S, S<<k2, k1, j);
         } while (a++, a < l2);
 
         return;
@@ -1115,27 +1117,28 @@ void sd_ifft_main(
     if (k == 2)
     {
         /* k1 = 2; k2 = 0 */
-        sd_ifft_base_1(Q, I + S*0, 4*j+0);
-        sd_ifft_base_0(Q, I + S*1, 4*j+1);
-        sd_ifft_base_0(Q, I + S*2, 4*j+2);
-        sd_ifft_base_0(Q, I + S*3, 4*j+3);
-        sd_ifft_main_block(Q, I, S, 2, j);
+        sd_ifft_base_1(Q, d, I + S*0, 4*j+0);
+        sd_ifft_base_0(Q, d, I + S*1, 4*j+1);
+        sd_ifft_base_0(Q, d, I + S*2, 4*j+2);
+        sd_ifft_base_0(Q, d, I + S*3, 4*j+3);
+        sd_ifft_main_block(Q, d, I, S, 2, j);
     }
     else if (k == 1)
     {
         /* k1 = 1; k2 = 0 */
-        sd_ifft_base_1(Q, I + S*0, 2*j+0);
-        sd_ifft_base_0(Q, I + S*1, 2*j+1);
-        sd_ifft_main_block(Q, I, S, 1, j);
+        sd_ifft_base_1(Q, d, I + S*0, 2*j+0);
+        sd_ifft_base_0(Q, d, I + S*1, 2*j+1);
+        sd_ifft_main_block(Q, d, I, S, 1, j);
     }
     else
     {
-        sd_ifft_base_1(Q, I, j);
+        sd_ifft_base_1(Q, d, I, j);
     }
 }
 
-void sd_ifft_trunc_block(
-    const sd_fft_lctx_t Q,
+static void sd_ifft_trunc_block(
+    const sd_fft_ctx_t Q,
+    double* d,
     ulong I, /* starting index */
     ulong S, /* stride */
     ulong k, /* BLK_SZ transforms each of length 2^k */
@@ -1151,7 +1154,7 @@ void sd_ifft_trunc_block(
 
     if (!f && z == n && n == n_pow2(k))
     {
-        sd_ifft_main_block(Q, I, S, k, j);
+        sd_ifft_main_block(Q, d, I, S, k, j);
         return;
     }
 
@@ -1159,21 +1162,21 @@ void sd_ifft_trunc_block(
     {
 #define IT(nn, zz, ff) CAT4(radix_4_moth_inv_trunc_block, nn, zz, ff)
 #define LOOKUP_IT(nn, zz, ff) tab[(ulong)(ff) + 2*((zz)-1 + 4*(nn))]
-        static void (*tab[5*4*2])(const sd_fft_lctx_t, ulong, ulong, double*, double*, double*, double*) =
+        static void (*tab[5*4*2])(const sd_fft_ctx_t, ulong, ulong, double*, double*, double*, double*) =
             {IT(0,1,0),IT(0,1,1), IT(0,2,0),IT(0,2,1), IT(0,3,0),IT(0,3,1), IT(0,4,0),IT(0,4,1),
              IT(1,1,0),IT(1,1,1), IT(1,2,0),IT(1,2,1), IT(1,3,0),IT(1,3,1), IT(1,4,0),IT(1,4,1),
              IT(2,1,0),IT(2,1,1), IT(2,2,0),IT(2,2,1), IT(2,3,0),IT(2,3,1), IT(2,4,0),IT(2,4,1),
              IT(3,1,0),IT(3,1,1), IT(3,2,0),IT(3,2,1), IT(3,3,0),IT(3,3,1), IT(3,4,0),IT(3,4,1),
              IT(4,1,0),IT(4,1,1), IT(4,2,0),IT(4,2,1), IT(4,3,0),IT(4,3,1), IT(4,4,0),IT(4,4,1)};
 
-        static void (*fxn)(const sd_fft_lctx_t, ulong, ulong, double*, double*, double*, double*);
+        static void (*fxn)(const sd_fft_ctx_t, ulong, ulong, double*, double*, double*, double*);
         fxn = LOOKUP_IT(n,z,f);
         if (FLINT_LIKELY(fxn != NULL))
         {
-            fxn(Q, j, n_nbits(j), sd_fft_lctx_blk_index(Q, I + S*0),
-                                  sd_fft_lctx_blk_index(Q, I + S*1),
-                                  sd_fft_lctx_blk_index(Q, I + S*2),
-                                  sd_fft_lctx_blk_index(Q, I + S*3));
+            fxn(Q, j, n_nbits(j), sd_fft_ctx_blk_index(d, I + S*0),
+                                  sd_fft_ctx_blk_index(d, I + S*1),
+                                  sd_fft_ctx_blk_index(d, I + S*2),
+                                  sd_fft_ctx_blk_index(d, I + S*3));
             return;
         }
 #undef LOOKUP_IT
@@ -1197,19 +1200,19 @@ void sd_ifft_trunc_block(
 
         /* complete rows */
         for (ulong b = 0; b < n1; b++)
-            sd_ifft_main_block(Q, I + b*(S << k2), S, k2, (j << k1) + b);
+            sd_ifft_main_block(Q, d, I + b*(S << k2), S, k2, (j << k1) + b);
 
         /* rightmost columns */
         for (ulong a = n2; a < z2p; a++)
-            sd_ifft_trunc_block(Q, I + a*S, S << k2, k1, j, z1 + (a < mp), n1, fp);
+            sd_ifft_trunc_block(Q, d, I + a*S, S << k2, k1, j, z1 + (a < mp), n1, fp);
 
         /* last partial row */
         if (fp)
-            sd_ifft_trunc_block(Q, I + n1*(S << k2), S, k2, (j << k1) + n1, z2p, n2, f);
+            sd_ifft_trunc_block(Q, d, I + n1*(S << k2), S, k2, (j << k1) + n1, z2p, n2, f);
 
         /* leftmost columns */
         for (ulong a = 0; a < n2; a++)
-            sd_ifft_trunc_block(Q, I + a*S, S << k2, k1, j, z1 + (a < m), n1 + 1, 0);
+            sd_ifft_trunc_block(Q, d, I + a*S, S << k2, k1, j, z1 + (a < m), n1 + 1, 0);
 
         return;
     }
@@ -1218,13 +1221,13 @@ void sd_ifft_trunc_block(
     {
 #define IT(nn, zz, ff) CAT4(radix_2_moth_inv_trunc_block, nn, zz, ff)
 #define LOOKUP_IT(nn, zz, ff) tab[(ulong)(ff) + 2*((zz)-1 + 2*(nn))]
-        static void (*tab[3*2*2*2])(const sd_fft_lctx_t, ulong, double*, double*) =
+        static void (*tab[3*2*2*2])(const sd_fft_ctx_t, ulong, double*, double*) =
             {IT(0,1,0),IT(0,1,1), IT(0,2,0),IT(0,2,1),
              IT(1,1,0),IT(1,1,1), IT(1,2,0),IT(1,2,1),
              IT(2,1,0),IT(2,1,1), IT(2,2,0),IT(2,2,1)};
 
-        LOOKUP_IT(n, z, f)(Q, j, sd_fft_lctx_blk_index(Q, I + S*0),
-                                 sd_fft_lctx_blk_index(Q, I + S*1));
+        LOOKUP_IT(n, z, f)(Q, j, sd_fft_ctx_blk_index(d, I + S*0),
+                                 sd_fft_ctx_blk_index(d, I + S*1));
         return;
 #undef LOOKUP_IT
 #undef IT
@@ -1232,8 +1235,9 @@ void sd_ifft_trunc_block(
 }
 
 
-void sd_ifft_trunc(
-    const sd_fft_lctx_t Q,
+static void sd_ifft_trunc_internal(
+    const sd_fft_ctx_t Q,
+    double* d,
     ulong I, // starting index
     ulong S, // stride
     ulong k, // transform length 2^(k + LG_BLK_SZ)
@@ -1264,42 +1268,70 @@ void sd_ifft_trunc(
 
         /* complete rows */
         for (ulong b = 0; b < n1; b++)
-            sd_ifft_main(Q, I + b*(S << k2), S, k2, (j << k1) + b);
+            sd_ifft_main(Q, d, I + b*(S << k2), S, k2, (j << k1) + b);
 
         /* rightmost columns */
         for (ulong a = n2; a < z2p; a++)
-            sd_ifft_trunc_block(Q, I + a*S, S << k2, k1, j, z1 + (a < mp), n1, fp);
+            sd_ifft_trunc_block(Q, d, I + a*S, S << k2, k1, j, z1 + (a < mp), n1, fp);
 
         /* last partial row */
         if (fp)
-            sd_ifft_trunc(Q, I + n1*(S << k2), S, k2, (j << k1) + n1, z2p, n2, f);
+            sd_ifft_trunc_internal(Q, d, I + n1*(S << k2), S, k2, (j << k1) + n1, z2p, n2, f);
 
         /* leftmost columns */
         for (ulong a = 0; a < n2; a++)
-            sd_ifft_trunc_block(Q, I + a*S, S << k2, k1, j, z1 + (a < m), n1 + 1, 0);
+            sd_ifft_trunc_block(Q, d, I + a*S, S << k2, k1, j, z1 + (a < m), n1 + 1, 0);
 
         return;
     }
 
     if (k == 2)
     {
-                   sd_ifft_base_1(Q, I + S*0, 4*j+0);
-        if (n > 1) sd_ifft_base_0(Q, I + S*1, 4*j+1);
-        if (n > 2) sd_ifft_base_0(Q, I + S*2, 4*j+2);
-        if (n > 3) sd_ifft_base_0(Q, I + S*3, 4*j+3);
-        sd_ifft_trunc_block(Q, I, S, 2, j, z, n, f);
-        if (f) sd_ifft_trunc(Q, I + S*n, S, 0, 4*j+n, 1, 0, f);
+                   sd_ifft_base_1(Q, d, I + S*0, 4*j+0);
+        if (n > 1) sd_ifft_base_0(Q, d, I + S*1, 4*j+1);
+        if (n > 2) sd_ifft_base_0(Q, d, I + S*2, 4*j+2);
+        if (n > 3) sd_ifft_base_0(Q, d, I + S*3, 4*j+3);
+        sd_ifft_trunc_block(Q, d, I, S, 2, j, z, n, f);
+        if (f) sd_ifft_trunc_internal(Q, d, I + S*n, S, 0, 4*j+n, 1, 0, f);
     }
     else if (k == 1)
     {
-                   sd_ifft_base_1(Q, I + S*0, 2*j+0);
-        if (n > 1) sd_ifft_base_0(Q, I + S*1, 2*j+1);
-        sd_ifft_trunc_block(Q, I, S, 1, j, z, n, f);
-        if (f) sd_ifft_trunc(Q, I + S*n, S, 0, 2*j+n, 1, 0, f);
+                   sd_ifft_base_1(Q, d, I + S*0, 2*j+0);
+        if (n > 1) sd_ifft_base_0(Q, d, I + S*1, 2*j+1);
+        sd_ifft_trunc_block(Q, d, I, S, 1, j, z, n, f);
+        if (f) sd_ifft_trunc_internal(Q, d, I + S*n, S, 0, 2*j+n, 1, 0, f);
     }
     else
     {
         FLINT_ASSERT(!f);
-        sd_ifft_base_1(Q, I, j);
+        sd_ifft_base_1(Q, d, I, j);
     }
 }
+
+
+/********************* interface functions ***********************/
+
+void sd_ifft_trunc(
+    sd_fft_ctx_t Q,
+    double* d,
+    ulong L,    /* convolution length 2^L */
+    ulong trunc)
+{
+    FLINT_ASSERT(trunc <= n_pow2(L));
+
+    if (L > LG_BLK_SZ)
+    {
+        ulong new_trunc = n_cdiv(trunc, BLK_SZ);
+
+        sd_fft_ctx_fit_depth(Q, L);
+
+        sd_ifft_trunc_internal(Q, d, 0, 1, L - LG_BLK_SZ, 0, new_trunc, new_trunc, 0);
+        return;
+    }
+
+    switch (L) {
+        case 8: sd_ifft_base_1(Q, d, 0, 0); break;
+        default: flint_printf("sd_ifft_trunc: L=%wud not supported yet", L); flint_abort();
+    }
+}
+

--- a/src/fft_small/sd_ifft.c
+++ b/src/fft_small/sd_ifft.c
@@ -1431,6 +1431,12 @@ static void sd_ifft_trunc_internal(
     FLINT_ASSERT(1 <= BLK_SZ*z && BLK_SZ*z <= n_pow2(k+LG_BLK_SZ));
     FLINT_ASSERT(1 <= BLK_SZ*n+f && BLK_SZ*n+f <= n_pow2(k+LG_BLK_SZ));
 
+    if (!f && z == n && n == n_pow2(k))
+    {
+        sd_ifft_no_trunc_internal(Q, x, S, k, j);
+        return;
+    }
+
     if (k > 2)
     {
         ulong k1 = k/2;

--- a/src/fft_small/test/t-sd_fft.c
+++ b/src/fft_small/test/t-sd_fft.c
@@ -43,8 +43,8 @@ void test_sd_fft_trunc(sd_fft_ctx_t Q, ulong minL, ulong maxL, ulong ireps, flin
                 X[i] = n_randint(state, Q->mod.n);
 
             /* output of fft_trunc is supposed to be eval_poly */
-            ulong itrunc = 1 + n_randint(state, Xn);
-            ulong otrunc = 1 + n_randint(state, Xn);
+            ulong itrunc = rep == 0 ? Xn : 1 + n_randint(state, Xn);
+            ulong otrunc = rep == 0 ? Xn : 1 + n_randint(state, Xn);
 
             for (i = 0; i < itrunc; i++)
                 data[i] = X[i];
@@ -66,7 +66,7 @@ void test_sd_fft_trunc(sd_fft_ctx_t Q, ulong minL, ulong maxL, ulong ireps, flin
             }
 
             /* output of ifft_trunc is supposed to be 2^L*input */
-            ulong trunc = 1 + n_randint(state, Xn);
+            ulong trunc = rep == 0 ? Xn : 1 + n_randint(state, Xn);
             for (i = 0; i < trunc; i++)
                 data[i] = X[i];
 

--- a/src/fft_small/test/t-sd_fft.c
+++ b/src/fft_small/test/t-sd_fft.c
@@ -23,10 +23,10 @@ vec1d vec1d_eval_poly_mod(const vec1d* a, ulong an, const vec1d b, const vec1d n
     return vec1d_reduce_to_pm1n(x, n, ninv);
 }
 
-void test_v2_fft(sd_fft_ctx_t Q, ulong minL, ulong maxL, ulong ireps, flint_rand_t state)
+void test_sd_fft_trunc(sd_fft_ctx_t Q, ulong minL, ulong maxL, ulong ireps, flint_rand_t state)
 {
     ulong irepmul = 10;
-    minL = n_max(minL, LG_BLK_SZ);
+    minL = n_max(minL, LG_BLK_SZ); /* TODO */
 
     for (ulong L = minL; L <= maxL; L++)
     {
@@ -39,25 +39,25 @@ void test_v2_fft(sd_fft_ctx_t Q, ulong minL, ulong maxL, ulong ireps, flint_rand
         ulong nreps = ireps + irepmul*L;
         for (ulong rep = 0; rep < nreps; rep++)
         {
-            // randomize input data
+            /* randomize input data */
             for (i = 0; i < Xn; i++)
-                X[i] = i + 1;
+                X[i] = n_randint(state, Q->mod.n);
 
-            // output of fft_trunc is supposed to be eval_poly
-            ulong itrunc = n_round_up(1 + n_randint(state, Xn), Q->blk_sz);
-            ulong otrunc = n_round_up(1 + n_randint(state, Xn) , Q->blk_sz);
+            /* output of fft_trunc is supposed to be eval_poly */
+            ulong itrunc = n_round_up(1 + n_randint(state, Xn), BLK_SZ);    /* TODO */
+            ulong otrunc = n_round_up(1 + n_randint(state, Xn), BLK_SZ);
 
             for (i = 0; i < itrunc; i++)
-                sd_fft_ctx_set_index(data, i, X[i]);
+                data[i] = X[i];
 
-            sd_fft_ctx_fft_trunc(Q, data, L, itrunc, otrunc);
+            sd_fft_trunc(Q, data, L, itrunc, otrunc);
 
-            for (int check_reps = 0; check_reps < 3; check_reps++)
+            for (int check_reps = 0; check_reps < 2+50/L; check_reps++)
             {
                 i = n_randint(state, otrunc);
                 double point = sd_fft_ctx_w(Q, i);
                 double y = vec1d_eval_poly_mod(X, itrunc, point, Q->p, Q->pinv);
-                if (!vec1d_same_mod(y, sd_fft_ctx_get_fft_index(data, i), Q->p, Q->pinv))
+                if (!vec1d_same_mod(y, data[sd_fft_ctx_trunc_index(L, i)], Q->p, Q->pinv))
                 {
                     flint_printf("FAIL: fft error at index %wu\nitrunc: %wu\n"
                                            "otrunc: %wu\n", i, itrunc, otrunc);
@@ -67,19 +67,19 @@ void test_v2_fft(sd_fft_ctx_t Q, ulong minL, ulong maxL, ulong ireps, flint_rand
             }
 
             /* output of ifft_trunc is supposed to be 2^L*input */
-            ulong trunc = n_round_up(1 + n_randint(state, Xn), Q->blk_sz);
+            ulong trunc = n_round_up(1 + n_randint(state, Xn), BLK_SZ); /* TODO */
             for (i = 0; i < trunc; i++)
-                sd_fft_ctx_set_index( data, i, X[i]);
+                data[i] = X[i];
 
-            sd_fft_ctx_fft_trunc(Q, data, L, trunc, trunc);
-            sd_fft_ctx_ifft_trunc(Q, data, L, trunc);
+            sd_fft_trunc(Q, data, L, trunc, trunc);
+            sd_ifft_trunc(Q, data, L, trunc);
 
-            for (int check_reps = 0; check_reps < 3; check_reps++)
+            for (int check_reps = 0; check_reps < 2+50/L; check_reps++)
             {
                 i = n_randint(state, trunc);
                 double m = vec1d_reduce_0n_to_pmhn(nmod_pow_ui(2, L, Q->mod), Q->p);
                 double y = vec1d_mulmod(X[i], m, Q->p, Q->pinv);
-                if (!vec1d_same_mod(y, sd_fft_ctx_get_index(data, i), Q->p, Q->pinv))
+                if (!vec1d_same_mod(y, data[i], Q->p, Q->pinv))
                 {
                     flint_printf("FAIL: ifft error at index %wu\n"
                                       "trunc: %wu\ndepth: %wu\n", i, trunc, L);
@@ -99,7 +99,7 @@ TEST_FUNCTION_START(sd_fft, state)
     {
         sd_fft_ctx_t Q;
         sd_fft_ctx_init_prime(Q, UWORD(0x0003f00000000001));
-        test_v2_fft(Q, 10, 19, 20, state);
+        test_sd_fft_trunc(Q, 0, 19, 20, state);
         sd_fft_ctx_clear(Q);
     }
 

--- a/src/mpn_mod/poly_mullow_fft_small.c
+++ b/src/mpn_mod/poly_mullow_fft_small.c
@@ -117,7 +117,7 @@ static void _mod(
         aI[j] = (double) nmod_set_mpn(a + (i + j) * nlimbs, nlimbs, mod);
 
     for (i = an; i < atrunc; i++)
-        sd_fft_ctx_set_index(abuf, i, 0);
+        abuf[i] = 0;
 }
 
 #define DEFINE_IT(NP, N, M) \
@@ -223,18 +223,15 @@ typedef struct {
 static void extra_func(void* varg)
 {
     s1worker_struct* X = (s1worker_struct*) varg;
-    sd_fft_lctx_t Q;
+    sd_fft_ctx_struct* Q = X->ffts + X->ioff;
 
-    sd_fft_lctx_init(Q, X->ffts + X->ioff, X->depth);
     _mod(X->bbuf, X->btrunc, X->b, X->bn, X->nlimbs, X->ffts + X->ioff);
-    sd_fft_lctx_fft_trunc(Q, X->bbuf, X->depth, X->btrunc, X->ztrunc);
-    sd_fft_lctx_clear(Q, X->ffts + X->ioff);
+    sd_fft_trunc(Q, X->bbuf, X->depth, X->btrunc, X->ztrunc);
 }
 
 static void s1worker_func(void* varg)
 {
     s1worker_struct* X = (s1worker_struct*) varg;
-    sd_fft_lctx_t Q;
     ulong i, m;
     thread_pool_handle* handles = NULL;
     slong nworkers = 0;
@@ -247,8 +244,7 @@ static void s1worker_func(void* varg)
         ulong ioff = i + X->offset;
         double* abuf = X->abuf + X->stride*i;
         double* bbuf = X->bbuf;
-
-        sd_fft_lctx_init(Q, X->ffts + ioff, X->depth);
+        sd_fft_ctx_struct* Q = X->ffts + ioff;
 
         if (!X->squaring)
         {
@@ -259,13 +255,13 @@ static void s1worker_func(void* varg)
             }
             else
             {
-                _mod(bbuf, X->btrunc, X->b, X->bn, X->nlimbs, X->ffts + ioff);
-                sd_fft_lctx_fft_trunc(Q, bbuf, X->depth, X->btrunc, X->ztrunc);
+                _mod(bbuf, X->btrunc, X->b, X->bn, X->nlimbs, Q);
+                sd_fft_trunc(Q, bbuf, X->depth, X->btrunc, X->ztrunc);
             }
         }
 
-        _mod(abuf, X->atrunc, X->a, X->an, X->nlimbs, X->ffts + ioff);
-        sd_fft_lctx_fft_trunc(Q, abuf, X->depth, X->atrunc, X->ztrunc);
+        _mod(abuf, X->atrunc, X->a, X->an, X->nlimbs, Q);
+        sd_fft_trunc(Q, abuf, X->depth, X->atrunc, X->ztrunc);
 
         if (!X->squaring)
         {
@@ -274,17 +270,15 @@ static void s1worker_func(void* varg)
         }
 
         ulong cop = X->np == 1 ? 1 : *crt_data_co_prime_red(X->crts + X->np - 1, ioff);
-        NMOD_RED2(m, cop >> (FLINT_BITS - X->depth), cop << X->depth, X->ffts[ioff].mod);
-        m = nmod_inv(m, X->ffts[ioff].mod);
+        NMOD_RED2(m, cop >> (FLINT_BITS - X->depth), cop << X->depth, Q->mod);
+        m = nmod_inv(m, Q->mod);
 
         if (X->squaring)
-            sd_fft_lctx_point_sqr(Q, abuf, m, X->depth);
+            sd_fft_ctx_point_sqr(Q, abuf, m, X->depth);
         else
-            sd_fft_lctx_point_mul(Q, abuf, bbuf, m, X->depth);
+            sd_fft_ctx_point_mul(Q, abuf, bbuf, m, X->depth);
 
-        sd_fft_lctx_ifft_trunc(Q, abuf, X->depth, X->ztrunc);
-
-        sd_fft_lctx_clear(Q, X->ffts + ioff);
+        sd_ifft_trunc(Q, abuf, X->depth, X->ztrunc);
     }
 
     flint_give_back_threads(handles, nworkers);


### PR DESCRIPTION
sd stands for scalar double, and now, true to its name, the fft data is just a plain array of doubles.

By the way, the sd_fft_ctx_fit_depth function was previously called in the now-defunct sd_fft_lctx constructor. This fit_depth function was not thread safe before, and maybe its uses didn't demand thread safety. Now, it is moved to a place where it definitely needs to be thread safe. Everything is a lot simpler now.