### PR TITLE
vector bit shift: change srl to srli

### DIFF
--- a/src/machine_vectors.h
+++ b/src/machine_vectors.h
@@ -758,7 +758,7 @@ FLINT_FORCE_INLINE vec8n vec8n_set_n(ulong a) {
 }
 
 FLINT_FORCE_INLINE vec4n vec4n_bit_shift_right(vec4n a, ulong b) {
-    return _mm256_srl_epi64(a, _mm_set_epi32(0,0,0,b));
+    return _mm256_srli_epi64(a, b);
 }
 
 FLINT_FORCE_INLINE vec8n vec8n_bit_shift_right(vec8n a, ulong b) {


### PR DESCRIPTION
For bit shifting each 64-bit word of a 256 bit vector `a` (and of 512 bit vectors emulated via two 256 ones), all shifted by the same amount `b`, the current code uses
```_mm256_srl_epi64(a, _mm_set_epi32(0,0,0,b));```
It should be slightly faster to directly use 
```_mm256_srli_epi64(a, b);```
as this avoids the "set" and the srli variant is more efficient than srl.