### PR TITLE
nmod_vec_dot_product enhancements (including avx2 for small moduli)

### DIFF
--- a/src/arith/stirling2.c
+++ b/src/arith/stirling2.c
@@ -537,7 +537,7 @@ stirling_2_nmod(const unsigned int * divtab, ulong n, ulong k, nmod_t mod)
     nn_ptr t, u;
     slong i, bin_len, pow_len;
     ulong s1, s2, bden, bd;
-    int bound_limbs;
+    dot_params_t params;
     TMP_INIT;
     TMP_START;
 
@@ -575,13 +575,13 @@ stirling_2_nmod(const unsigned int * divtab, ulong n, ulong k, nmod_t mod)
     for (i = 1; i < bin_len; i += 2)
         t[i] = nmod_neg(t[i], mod);
 
-    bound_limbs = _nmod_vec_dot_bound_limbs(bin_len, mod);
-    s1 = _nmod_vec_dot(t, u, bin_len, mod, bound_limbs);
+    params = _nmod_vec_dot_params(bin_len, mod);
+    s1 = _nmod_vec_dot(t, u, bin_len, mod, params);
 
     if (pow_len > bin_len)
     {
-        bound_limbs = _nmod_vec_dot_bound_limbs(pow_len - bin_len, mod);
-        s2 = _nmod_vec_dot_rev(u + bin_len, t + k - pow_len + 1, pow_len - bin_len, mod, bound_limbs);
+        params = _nmod_vec_dot_params(pow_len - bin_len, mod);
+        s2 = _nmod_vec_dot_rev(u + bin_len, t + k - pow_len + 1, pow_len - bin_len, mod, params);
         if (k % 2)
             s1 = nmod_sub(s1, s2, mod);
         else

--- a/src/fq_nmod_mpoly/fq_nmod_embed.c
+++ b/src/fq_nmod_mpoly/fq_nmod_embed.c
@@ -352,12 +352,12 @@ void bad_n_fq_embed_lg_to_sm(
     slong smd = fq_nmod_ctx_degree(emb->smctx);
     slong lgd = fq_nmod_ctx_degree(emb->lgctx);
     slong i;
-    int nlimbs = _nmod_vec_dot_bound_limbs(lgd, emb->lgctx->mod);
+    const dot_params_t params = _nmod_vec_dot_params(lgd, emb->lgctx->mod);
 
     n_poly_fit_length(out, lgd);
     for (i = 0; i < lgd; i++)
         out->coeffs[i] = _nmod_vec_dot(emb->lg_to_sm_mat->rows[i], in, lgd,
-                                                      emb->lgctx->mod, nlimbs);
+                                                      emb->lgctx->mod, params);
     FLINT_ASSERT(lgd/smd == emb->h->length - 1);
     out->length = emb->h->length - 1;
     _n_fq_poly_normalise(out, smd);
@@ -438,7 +438,7 @@ void bad_n_fq_embed_sm_to_lg(
     slong smd = fq_nmod_ctx_degree(emb->smctx);
     slong lgd = fq_nmod_ctx_degree(emb->lgctx);
     slong i;
-    int nlimbs = _nmod_vec_dot_bound_limbs(lgd, emb->lgctx->mod);
+    const dot_params_t params = _nmod_vec_dot_params(lgd, emb->lgctx->mod);
     n_poly_stack_t St;  /* TODO: pass the stack in */
     n_fq_poly_struct * q, * in_red;
 
@@ -454,7 +454,7 @@ void bad_n_fq_embed_sm_to_lg(
 
     for (i = 0; i < lgd; i++)
         out[i] = _nmod_vec_dot(emb->sm_to_lg_mat->rows[i], in_red->coeffs,
-                                  smd*in_red->length, emb->lgctx->mod, nlimbs);
+                                  smd*in_red->length, emb->lgctx->mod, params);
 
     n_poly_stack_give_back(St, 2);
 
@@ -544,11 +544,11 @@ void bad_n_fq_embed_sm_elem_to_lg(
     slong smd = fq_nmod_ctx_degree(emb->smctx);
     slong lgd = fq_nmod_ctx_degree(emb->lgctx);
     slong i;
-    int nlimbs = _nmod_vec_dot_bound_limbs(smd, emb->lgctx->mod);
+    const dot_params_t params = _nmod_vec_dot_params(smd, emb->lgctx->mod);
 
     for (i = 0; i < lgd; i++)
         out[i] = _nmod_vec_dot(emb->sm_to_lg_mat->rows[i], in, smd,
-                                                      emb->lgctx->mod, nlimbs);
+                                                      emb->lgctx->mod, params);
 }
 
 void bad_fq_nmod_embed_sm_elem_to_lg(
@@ -559,7 +559,7 @@ void bad_fq_nmod_embed_sm_elem_to_lg(
     slong smd = fq_nmod_ctx_degree(emb->smctx);
     slong lgd = fq_nmod_ctx_degree(emb->lgctx);
     slong i;
-    int nlimbs = _nmod_vec_dot_bound_limbs(smd, emb->lgctx->mod);
+    const dot_params_t params = _nmod_vec_dot_params(smd, emb->lgctx->mod);
 
     FLINT_ASSERT(in->length <= smd);
 
@@ -568,7 +568,7 @@ void bad_fq_nmod_embed_sm_elem_to_lg(
     for (i = 0; i < lgd; i++)
     {
         out->coeffs[i] = _nmod_vec_dot(emb->sm_to_lg_mat->rows[i],
-                              in->coeffs, in->length, emb->lgctx->mod, nlimbs);
+                              in->coeffs, in->length, emb->lgctx->mod, params);
     }
 
     out->length = lgd;

--- a/src/fq_nmod_mpoly_factor/n_bpoly_fq_factor_lgprime.c
+++ b/src/fq_nmod_mpoly_factor/n_bpoly_fq_factor_lgprime.c
@@ -190,11 +190,10 @@ static void _lattice(
     n_bpoly_t Q, R, dg;
     n_bpoly_struct * ld;
     nmod_mat_t M, T1, T2;
-    int nlimbs;
     ulong * trow;
     slong lift_order = lift_alpha_pow->length - 1;
 
-    nlimbs = _nmod_vec_dot_bound_limbs(r, ctx->mod);
+    const dot_params_t params = _nmod_vec_dot_params(r, ctx->mod);
     trow = (ulong *) flint_malloc(r*sizeof(ulong));
     n_bpoly_init(Q);
     n_bpoly_init(R);
@@ -243,7 +242,7 @@ static void _lattice(
 
             for (i = 0; i < d; i++)
                 nmod_mat_entry(M, (j - starts[k])*deg + l, i) =
-                         _nmod_vec_dot(trow, N->rows[i], r, ctx->mod, nlimbs);
+                         _nmod_vec_dot(trow, N->rows[i], r, ctx->mod, params);
         }
 
         nmod_mat_init_nullspace_tr(T1, M);

--- a/src/fq_nmod_mpoly_factor/n_bpoly_fq_factor_smprime.c
+++ b/src/fq_nmod_mpoly_factor/n_bpoly_fq_factor_smprime.c
@@ -957,10 +957,9 @@ static void _lattice(
     n_fq_bpoly_t Q, R, dg;
     n_fq_bpoly_struct * ld;
     nmod_mat_t M, T1, T2;
-    int nlimbs;
     ulong * trow;
 
-    nlimbs = _nmod_vec_dot_bound_limbs(r, ctx->mod);
+    const dot_params_t params = _nmod_vec_dot_params(r, ctx->mod);
     trow = (ulong *) flint_malloc(r*sizeof(ulong));
     n_fq_bpoly_init(Q);
     n_fq_bpoly_init(R);
@@ -985,20 +984,20 @@ static void _lattice(
         nmod_mat_init(M, d*(lift_order - CLD[k]), nrows, ctx->modulus->mod.n);
 
         for (j = CLD[k]; j < lift_order; j++)
-        for (l = 0; l < d; l++)
-        {
-            for (i = 0; i < r; i++)
+            for (l = 0; l < d; l++)
             {
-                if (k >= ld[i].length || j >= ld[i].coeffs[k].length)
-                    trow[i] = 0;
-                else
-                    trow[i] = ld[i].coeffs[k].coeffs[d*j + l];
-            }
+                for (i = 0; i < r; i++)
+                {
+                    if (k >= ld[i].length || j >= ld[i].coeffs[k].length)
+                        trow[i] = 0;
+                    else
+                        trow[i] = ld[i].coeffs[k].coeffs[d*j + l];
+                }
 
-            for (i = 0; i < nrows; i++)
-                nmod_mat_entry(M, (j - CLD[k])*d + l, i) =
-                          _nmod_vec_dot(trow, N->rows[i], r, ctx->mod, nlimbs);
-        }
+                for (i = 0; i < nrows; i++)
+                    nmod_mat_entry(M, (j - CLD[k])*d + l, i) =
+                              _nmod_vec_dot(trow, N->rows[i], r, ctx->mod, params);
+            }
 
         nmod_mat_init_nullspace_tr(T1, M);
 

--- a/src/fq_zech_mpoly_factor/bpoly_factor_smprime.c
+++ b/src/fq_zech_mpoly_factor/bpoly_factor_smprime.c
@@ -496,10 +496,9 @@ static void _lattice(
     fq_zech_bpoly_t Q, R, dg;
     fq_zech_bpoly_struct * ld;
     nmod_mat_t M, T1, T2;
-    int nlimbs;
     ulong * trow;
 
-    nlimbs = _nmod_vec_dot_bound_limbs(r, fq_zech_ctx_mod(ctx));
+    const dot_params_t params = _nmod_vec_dot_params(r, fq_zech_ctx_mod(ctx));
     trow = (ulong *) flint_malloc(r*sizeof(ulong));
     fq_zech_bpoly_init(Q, ctx);
     fq_zech_bpoly_init(R, ctx);
@@ -549,7 +548,7 @@ static void _lattice(
 
             for (i = 0; i < d; i++)
                 nmod_mat_entry(M, (j - starts[k])*deg + l, i) =
-              _nmod_vec_dot(trow, N->rows[i], r, fq_zech_ctx_mod(ctx), nlimbs);
+              _nmod_vec_dot(trow, N->rows[i], r, fq_zech_ctx_mod(ctx), params);
         }
 
         nmod_mat_init_nullspace_tr(T1, M);

--- a/src/gr/nmod.c
+++ b/src/gr/nmod.c
@@ -861,9 +861,34 @@ __gr_nmod_vec_dot(ulong * res, const ulong * initial, int subtract, const ulong 
     dot_params_t params;
     nmod_t mod;
 
-    mod = NMOD_CTX(ctx);
-    params = _nmod_vec_dot_params(len, mod);
-    NMOD_VEC_DOT(s, i, len, vec1[i], vec2[i], mod, params);
+    if (len <= 1)
+    {
+        if (len == 2)   /* todo: fmma */
+        {
+            mod = NMOD_CTX(ctx);
+            s = nmod_mul(vec1[0], vec2[0], mod);
+            s = nmod_addmul(s, vec1[1], vec2[1], mod);
+        }
+        else if (len == 1)
+        {
+            mod = NMOD_CTX(ctx);
+            s = nmod_mul(vec1[0], vec2[0], mod);
+        }
+        else
+        {
+            if (initial == NULL)
+                _gr_nmod_zero(res, ctx);
+            else
+                _gr_nmod_set(res, initial, ctx);
+            return GR_SUCCESS;
+        }
+    }
+    else 
+    {
+        mod = NMOD_CTX(ctx);
+        params = _nmod_vec_dot_params(len, mod);
+        NMOD_VEC_DOT(s, i, len, vec1[i], vec2[i], mod, params);
+    }
 
     if (initial == NULL)
     {
@@ -891,9 +916,34 @@ __gr_nmod_vec_dot_rev(ulong * res, const ulong * initial, int subtract, const ul
     dot_params_t params;
     nmod_t mod;
 
-    mod = NMOD_CTX(ctx);
-    params = _nmod_vec_dot_params(len, mod);
-    NMOD_VEC_DOT(s, i, len, vec1[i], vec2[len - 1 - i], mod, params);
+    if (len <= 1)
+    {
+        if (len == 2)   /* todo: fmma */
+        {
+            mod = NMOD_CTX(ctx);
+            s = nmod_mul(vec1[0], vec2[1], mod);
+            s = nmod_addmul(s, vec1[1], vec2[0], mod);
+        }
+        else if (len == 1)
+        {
+            mod = NMOD_CTX(ctx);
+            s = nmod_mul(vec1[0], vec2[0], mod);
+        }
+        else
+        {
+            if (initial == NULL)
+                _gr_nmod_zero(res, ctx);
+            else
+                _gr_nmod_set(res, initial, ctx);
+            return GR_SUCCESS;
+        }
+    }
+    else
+    {
+        mod = NMOD_CTX(ctx);
+        params = _nmod_vec_dot_params(len, mod);
+        NMOD_VEC_DOT(s, i, len, vec1[i], vec2[len - 1 - i], mod, params);
+    }
 
     if (initial == NULL)
     {

--- a/src/gr/nmod.c
+++ b/src/gr/nmod.c
@@ -861,48 +861,9 @@ __gr_nmod_vec_dot(ulong * res, const ulong * initial, int subtract, const ulong 
     dot_params_t params;
     nmod_t mod;
 
-    if (len <= 1)
-    {
-        if (len == 2)   /* todo: fmma */
-        {
-            mod = NMOD_CTX(ctx);
-            s = nmod_mul(vec1[0], vec2[0], mod);
-            s = nmod_addmul(s, vec1[1], vec2[1], mod);
-        }
-        else if (len == 1)
-        {
-            mod = NMOD_CTX(ctx);
-            s = nmod_mul(vec1[0], vec2[0], mod);
-        }
-        else
-        {
-            if (initial == NULL)
-                _gr_nmod_zero(res, ctx);
-            else
-                _gr_nmod_set(res, initial, ctx);
-            return GR_SUCCESS;
-        }
-    }
-    else
-    {
-        mod = NMOD_CTX(ctx);
-
-        if (len <= 16)
-        {
-            if (mod.n <= UWORD(1) << (FLINT_BITS / 2 - 2))
-                params.method = _DOT1;
-            if (mod.n <= UWORD(1) << (FLINT_BITS - 2))
-                params.method = _DOT2;
-            else
-                params.method = _DOT3;
-        }
-        else
-        {
-            params = _nmod_vec_dot_params(len, mod);
-        }
-
-        NMOD_VEC_DOT(s, i, len, vec1[i], vec2[i], mod, params);
-    }
+    mod = NMOD_CTX(ctx);
+    params = _nmod_vec_dot_params(len, mod);
+    NMOD_VEC_DOT(s, i, len, vec1[i], vec2[i], mod, params);
 
     if (initial == NULL)
     {
@@ -930,48 +891,9 @@ __gr_nmod_vec_dot_rev(ulong * res, const ulong * initial, int subtract, const ul
     dot_params_t params;
     nmod_t mod;
 
-    if (len <= 1)
-    {
-        if (len == 2)   /* todo: fmma */
-        {
-            mod = NMOD_CTX(ctx);
-            s = nmod_mul(vec1[0], vec2[1], mod);
-            s = nmod_addmul(s, vec1[1], vec2[0], mod);
-        }
-        else if (len == 1)
-        {
-            mod = NMOD_CTX(ctx);
-            s = nmod_mul(vec1[0], vec2[0], mod);
-        }
-        else
-        {
-            if (initial == NULL)
-                _gr_nmod_zero(res, ctx);
-            else
-                _gr_nmod_set(res, initial, ctx);
-            return GR_SUCCESS;
-        }
-    }
-    else
-    {
-        mod = NMOD_CTX(ctx);
-
-        if (len <= 16)
-        {
-            if (mod.n <= UWORD(1) << (FLINT_BITS / 2 - 2))
-                params.method = _DOT1;
-            if (mod.n <= UWORD(1) << (FLINT_BITS - 2))
-                params.method = _DOT2;
-            else
-                params.method = _DOT3;
-        }
-        else
-        {
-            params = _nmod_vec_dot_params(len, mod);
-        }
-
-        NMOD_VEC_DOT(s, i, len, vec1[i], vec2[len - 1 - i], mod, params);
-    }
+    mod = NMOD_CTX(ctx);
+    params = _nmod_vec_dot_params(len, mod);
+    NMOD_VEC_DOT(s, i, len, vec1[i], vec2[len - 1 - i], mod, params);
 
     if (initial == NULL)
     {

--- a/src/gr/nmod.c
+++ b/src/gr/nmod.c
@@ -858,7 +858,7 @@ __gr_nmod_vec_dot(ulong * res, const ulong * initial, int subtract, const ulong 
 {
     slong i;
     ulong s;
-    int nlimbs;
+    dot_params_t params;
     nmod_t mod;
 
     if (len <= 1)
@@ -890,18 +890,18 @@ __gr_nmod_vec_dot(ulong * res, const ulong * initial, int subtract, const ulong 
         if (len <= 16)
         {
             if (mod.n <= UWORD(1) << (FLINT_BITS / 2 - 2))
-                nlimbs = 1;
+                params.method = _DOT1;
             if (mod.n <= UWORD(1) << (FLINT_BITS - 2))
-                nlimbs = 2;
+                params.method = _DOT2;
             else
-                nlimbs = 3;
+                params.method = _DOT3;
         }
         else
         {
-            nlimbs = _nmod_vec_dot_bound_limbs(len, mod);
+            params = _nmod_vec_dot_params(len, mod);
         }
 
-        NMOD_VEC_DOT(s, i, len, vec1[i], vec2[i], mod, nlimbs);
+        NMOD_VEC_DOT(s, i, len, vec1[i], vec2[i], mod, params);
     }
 
     if (initial == NULL)
@@ -927,7 +927,7 @@ __gr_nmod_vec_dot_rev(ulong * res, const ulong * initial, int subtract, const ul
 {
     slong i;
     ulong s;
-    int nlimbs;
+    dot_params_t params;
     nmod_t mod;
 
     if (len <= 1)
@@ -959,18 +959,18 @@ __gr_nmod_vec_dot_rev(ulong * res, const ulong * initial, int subtract, const ul
         if (len <= 16)
         {
             if (mod.n <= UWORD(1) << (FLINT_BITS / 2 - 2))
-                nlimbs = 1;
+                params.method = _DOT1;
             if (mod.n <= UWORD(1) << (FLINT_BITS - 2))
-                nlimbs = 2;
+                params.method = _DOT2;
             else
-                nlimbs = 3;
+                params.method = _DOT3;
         }
         else
         {
-            nlimbs = _nmod_vec_dot_bound_limbs(len, mod);
+            params = _nmod_vec_dot_params(len, mod);
         }
 
-        NMOD_VEC_DOT(s, i, len, vec1[i], vec2[len - 1 - i], mod, nlimbs);
+        NMOD_VEC_DOT(s, i, len, vec1[i], vec2[len - 1 - i], mod, params);
     }
 
     if (initial == NULL)

--- a/src/gr/nmod.c
+++ b/src/gr/nmod.c
@@ -856,39 +856,22 @@ _gr_nmod_vec_product(ulong * res, const ulong * vec, slong len, gr_ctx_t ctx)
 int
 __gr_nmod_vec_dot(ulong * res, const ulong * initial, int subtract, const ulong * vec1, const ulong * vec2, slong len, gr_ctx_t ctx)
 {
-    slong i;
     ulong s;
     dot_params_t params;
     nmod_t mod;
 
-    if (len <= 1)
+    if (len == 0)
     {
-        if (len == 2)   /* todo: fmma */
-        {
-            mod = NMOD_CTX(ctx);
-            s = nmod_mul(vec1[0], vec2[0], mod);
-            s = nmod_addmul(s, vec1[1], vec2[1], mod);
-        }
-        else if (len == 1)
-        {
-            mod = NMOD_CTX(ctx);
-            s = nmod_mul(vec1[0], vec2[0], mod);
-        }
+        if (initial == NULL)
+            _gr_nmod_zero(res, ctx);
         else
-        {
-            if (initial == NULL)
-                _gr_nmod_zero(res, ctx);
-            else
-                _gr_nmod_set(res, initial, ctx);
-            return GR_SUCCESS;
-        }
+            _gr_nmod_set(res, initial, ctx);
+        return GR_SUCCESS;
     }
-    else 
-    {
-        mod = NMOD_CTX(ctx);
-        params = _nmod_vec_dot_params(len, mod);
-        NMOD_VEC_DOT(s, i, len, vec1[i], vec2[i], mod, params);
-    }
+
+    mod = NMOD_CTX(ctx);
+    params = _nmod_vec_dot_params(len, mod);
+    s = _nmod_vec_dot(vec1, vec2, len, mod, params);
 
     if (initial == NULL)
     {
@@ -911,39 +894,22 @@ __gr_nmod_vec_dot(ulong * res, const ulong * initial, int subtract, const ulong 
 int
 __gr_nmod_vec_dot_rev(ulong * res, const ulong * initial, int subtract, const ulong * vec1, const ulong * vec2, slong len, gr_ctx_t ctx)
 {
-    slong i;
     ulong s;
     dot_params_t params;
     nmod_t mod;
 
-    if (len <= 1)
+    if (len == 0)
     {
-        if (len == 2)   /* todo: fmma */
-        {
-            mod = NMOD_CTX(ctx);
-            s = nmod_mul(vec1[0], vec2[1], mod);
-            s = nmod_addmul(s, vec1[1], vec2[0], mod);
-        }
-        else if (len == 1)
-        {
-            mod = NMOD_CTX(ctx);
-            s = nmod_mul(vec1[0], vec2[0], mod);
-        }
+        if (initial == NULL)
+            _gr_nmod_zero(res, ctx);
         else
-        {
-            if (initial == NULL)
-                _gr_nmod_zero(res, ctx);
-            else
-                _gr_nmod_set(res, initial, ctx);
-            return GR_SUCCESS;
-        }
+            _gr_nmod_set(res, initial, ctx);
+        return GR_SUCCESS;
     }
-    else
-    {
-        mod = NMOD_CTX(ctx);
-        params = _nmod_vec_dot_params(len, mod);
-        NMOD_VEC_DOT(s, i, len, vec1[i], vec2[len - 1 - i], mod, params);
-    }
+
+    mod = NMOD_CTX(ctx);
+    params = _nmod_vec_dot_params(len, mod);
+    s = _nmod_vec_dot_rev(vec1, vec2, len, mod, params);
 
     if (initial == NULL)
     {

--- a/src/gr/nmod32.c
+++ b/src/gr/nmod32.c
@@ -10,7 +10,7 @@
 */
 
 #include "fmpz.h"
-#include "fmpq.h"
+//#include "fmpq.h"
 #include "nmod.h"
 #include "nmod_vec.h"
 #include "gr.h"
@@ -430,10 +430,8 @@ _nmod32_vec_dot(nmod32_t res, const nmod32_t initial, int subtract, const nmod32
 
     {
         ulong ss;
-        int nlimbs;
-
-        nlimbs = _nmod_vec_dot_bound_limbs(len, NMOD32_CTX(ctx));
-        NMOD_VEC_DOT(ss, i, len, (ulong) vec1[i], (ulong) vec2[i], NMOD32_CTX(ctx), nlimbs);
+        const dot_params_t params = _nmod_vec_dot_params(len, NMOD32_CTX(ctx));
+        NMOD_VEC_DOT(ss, i, len, (ulong) vec1[i], (ulong) vec2[i], NMOD32_CTX(ctx), params);
         s = n_addmod(s, ss, n);
     }
 
@@ -477,10 +475,9 @@ _nmod32_vec_dot_rev(nmod32_t res, const nmod32_t initial, int subtract, const nm
 
     {
         ulong ss;
-        int nlimbs;
 
-        nlimbs = _nmod_vec_dot_bound_limbs(len, NMOD32_CTX(ctx));
-        NMOD_VEC_DOT(ss, i, len, (ulong) vec1[i], (ulong) vec2[len - 1 - i], NMOD32_CTX(ctx), nlimbs);
+        const dot_params_t params = _nmod_vec_dot_params(len, NMOD32_CTX(ctx));
+        NMOD_VEC_DOT(ss, i, len, (ulong) vec1[i], (ulong) vec2[len - 1 - i], NMOD32_CTX(ctx), params);
         s = n_addmod(s, ss, n);
     }
 

--- a/src/gr/nmod8.c
+++ b/src/gr/nmod8.c
@@ -10,7 +10,7 @@
 */
 
 #include "fmpz.h"
-#include "fmpq.h"
+//#include "fmpq.h"
 #include "nmod.h"
 #include "nmod_vec.h"
 #include "gr.h"
@@ -440,10 +440,9 @@ _nmod8_vec_dot(nmod8_t res, const nmod8_t initial, int subtract, const nmod8_str
     else
     {
         ulong ss;
-        int nlimbs;
 
-        nlimbs = _nmod_vec_dot_bound_limbs(len, NMOD8_CTX(ctx));
-        NMOD_VEC_DOT(ss, i, len, (ulong) vec1[i], (ulong) vec2[i], NMOD8_CTX(ctx), nlimbs);
+        const dot_params_t params = _nmod_vec_dot_params(len, NMOD8_CTX(ctx));
+        NMOD_VEC_DOT(ss, i, len, (ulong) vec1[i], (ulong) vec2[i], NMOD8_CTX(ctx), params);
         s = n_addmod(s, ss, n);
     }
 
@@ -504,10 +503,9 @@ _nmod8_vec_dot_rev(nmod8_t res, const nmod8_t initial, int subtract, const nmod8
     else
     {
         ulong ss;
-        int nlimbs;
 
-        nlimbs = _nmod_vec_dot_bound_limbs(len, NMOD8_CTX(ctx));
-        NMOD_VEC_DOT(ss, i, len, (ulong) vec1[i], (ulong) vec2[len - 1 - i], NMOD8_CTX(ctx), nlimbs);
+        const dot_params_t params = _nmod_vec_dot_params(len, NMOD8_CTX(ctx));
+        NMOD_VEC_DOT(ss, i, len, (ulong) vec1[i], (ulong) vec2[len - 1 - i], NMOD8_CTX(ctx), params);
         s = n_addmod(s, ss, n);
     }
 

--- a/src/machine_vectors.h
+++ b/src/machine_vectors.h
@@ -1150,10 +1150,10 @@ FLINT_FORCE_INLINE vec2d vec2d_reduce_0n_to_pmhn(vec2d a, vec2d n) {
 FLINT_FORCE_INLINE vec2d vec2d_reduce_pm1n_to_pmhn(vec2d a, vec2d n) {
     vec2d halfn = vec2d_half(n);
     vec2d t = vec2d_add(a, n);
-    
+
     vec2n condition_a = vcgtq_f64(a, halfn);
     vec2n condition_t = vcltq_f64(t, halfn);
-    
+
     return vbslq_f64(condition_a, vec2d_sub(a, n), vbslq_f64(condition_t, t, a));
 }
 
@@ -1509,18 +1509,18 @@ FLINT_FORCE_INLINE vec2n vec2n_sub(vec2n a, vec2n b) {
 FLINT_FORCE_INLINE vec2n vec2n_addmod(vec2n a, vec2n b, vec2n n) {
     vec2n nmb = vec2n_sub(n, b);
     vec2n sum = vec2n_sub(a, nmb);
-    
+
     vec2n mask = vcgtq_u64(nmb, a);
-    
+
     return vec2n_add(sum, vandq_u64(n, mask));
 }
 
 // (a + b) % n for n < 2^63
 FLINT_FORCE_INLINE vec2n vec2n_addmod_limited(vec2n a, vec2n b, vec2n n) {
     vec2n s = vec2n_add(a, b);
-    
+
     vec2n mask = vcgeq_u64(s, n);
-    
+
     return vec2n_sub(s, vandq_u64(n, mask));
 }
 

--- a/src/machine_vectors.h
+++ b/src/machine_vectors.h
@@ -550,6 +550,15 @@ FLINT_FORCE_INLINE vec4d vec4n_convert_limited_vec4d(vec4n a) {
     return _mm256_sub_pd(_mm256_or_pd(_mm256_castsi256_pd(a), t), t);
 }
 
+// horizontal sum
+FLINT_FORCE_INLINE ulong vec4n_horizontal_sum(vec4n a) {
+    vec4n a_hi = _mm256_shuffle_epi32(a, 14);  // 14 == 0b00001110
+    vec4n sum_lo = _mm256_add_epi64(a, a_hi);
+    vec2n sum_hi = _mm256_extracti128_si256(sum_lo, 1);
+    vec2n sum = _mm_add_epi64(_mm256_castsi256_si128(sum_lo), sum_hi);
+    return (ulong) _mm_cvtsi128_si64(sum);
+}
+
 
 /* vec8d -- AVX2 ***********************************************************/
 

--- a/src/n_poly.h
+++ b/src/n_poly.h
@@ -357,7 +357,7 @@ void n_poly_mod_addmul_linear(n_poly_t A, const n_poly_t B,
 void n_poly_mod_scalar_addmul_nmod(n_poly_t A, const n_poly_t B,
                                    const n_poly_t C, ulong d0, nmod_t ctx);
 
-ulong _n_poly_eval_pow(n_poly_t P, n_poly_t alphapow, int nlimbs,
+ulong _n_poly_eval_pow(n_poly_t P, n_poly_t alphapow, dot_params_t params,
                                                                    nmod_t ctx);
 
 ulong n_poly_mod_eval_pow(n_poly_t P, n_poly_t alphapow,

--- a/src/n_poly/n_poly_mod.c
+++ b/src/n_poly/n_poly_mod.c
@@ -1030,7 +1030,7 @@ ulong n_poly_mod_remove(n_poly_t f, const n_poly_t p, nmod_t ctx)
     return i;
 }
 
-ulong _n_poly_eval_pow(n_poly_t P, n_poly_t alphapow, int nlimbs, nmod_t ctx)
+ulong _n_poly_eval_pow(n_poly_t P, n_poly_t alphapow, dot_params_t params, nmod_t ctx)
 {
     ulong * Pcoeffs = P->coeffs;
     slong Plen = P->length;
@@ -1049,15 +1049,15 @@ ulong _n_poly_eval_pow(n_poly_t P, n_poly_t alphapow, int nlimbs, nmod_t ctx)
             alpha_powers[k] = nmod_mul(alpha_powers[k - 1], alpha_powers[1], ctx);
     }
 
-    NMOD_VEC_DOT(res, k, Plen, Pcoeffs[k], alpha_powers[k], ctx, nlimbs);
+    NMOD_VEC_DOT(res, k, Plen, Pcoeffs[k], alpha_powers[k], ctx, params);
 
     return res;
 }
 
 ulong n_poly_mod_eval_pow(n_poly_t P, n_poly_t alphapow, nmod_t ctx)
 {
-    int nlimbs = _nmod_vec_dot_bound_limbs(P->length, ctx);
-    return _n_poly_eval_pow(P, alphapow, nlimbs, ctx);
+    const dot_params_t params = _nmod_vec_dot_params(P->length, ctx);
+    return _n_poly_eval_pow(P, alphapow, params, ctx);
 }
 
 void n_poly_mod_eval2_pow(

--- a/src/nmod.h
+++ b/src/nmod.h
@@ -185,6 +185,15 @@ ulong nmod_addmul(ulong a, ulong b, ulong c, nmod_t mod)
        (r) = nmod_addmul((r), (a), (b), (mod)); \
     } while (0)
 
+// TODO doc  a*b + c*d
+NMOD_INLINE
+ulong nmod_fmma(ulong a, ulong b, ulong c, ulong d, nmod_t mod)
+{
+    a = nmod_mul(a, b, mod);
+    NMOD_ADDMUL(a, c, d, mod);
+    return a;
+}
+
 NMOD_INLINE
 ulong nmod_inv(ulong a, nmod_t mod)
 {

--- a/src/nmod_mat/charpoly.c
+++ b/src/nmod_mat/charpoly.c
@@ -45,14 +45,13 @@ _nmod_mat_charpoly_berkowitz(nn_ptr cp, const nmod_mat_t mat, nmod_t mod)
     {
         slong i, k, t;
         nn_ptr a, A, s;
-        int nlimbs;
         TMP_INIT;
 
         TMP_START;
         a = TMP_ALLOC(sizeof(ulong) * (n * n));
         A = a + (n - 1) * n;
 
-        nlimbs = _nmod_vec_dot_bound_limbs(n, mod);
+        const dot_params_t params = _nmod_vec_dot_params(n, mod);
 
         _nmod_vec_zero(cp, n + 1);
         cp[0] = nmod_neg(nmod_mat_entry(mat, 0, 0), mod);
@@ -71,17 +70,17 @@ _nmod_mat_charpoly_berkowitz(nn_ptr cp, const nmod_mat_t mat, nmod_t mod)
                 for (i = 0; i <= t; i++)
                 {
                     s = a + k * n + i;
-                    s[0] = _nmod_vec_dot(mat->rows[i], a + (k - 1) * n, t + 1, mod, nlimbs);
+                    s[0] = _nmod_vec_dot(mat->rows[i], a + (k - 1) * n, t + 1, mod, params);
                 }
 
                 A[k] = a[k * n + t];
             }
 
-            A[t] = _nmod_vec_dot(mat->rows[t], a + (t - 1) * n, t + 1, mod, nlimbs);
+            A[t] = _nmod_vec_dot(mat->rows[t], a + (t - 1) * n, t + 1, mod, params);
 
             for (k = 0; k <= t; k++)
             {
-                cp[k] = nmod_sub(cp[k], _nmod_vec_dot_rev(A, cp, k, mod, nlimbs), mod);
+                cp[k] = nmod_sub(cp[k], _nmod_vec_dot_rev(A, cp, k, mod, params), mod);
                 cp[k] = nmod_sub(cp[k], A[k], mod);
             }
         }
@@ -117,7 +116,6 @@ void nmod_mat_charpoly_danilevsky(nmod_poly_t p, const nmod_mat_t M)
    ulong h;
    nmod_poly_t b;
    nmod_mat_t M2;
-   int num_limbs;
    TMP_INIT;
 
    if (M->r != M->c)
@@ -142,7 +140,7 @@ void nmod_mat_charpoly_danilevsky(nmod_poly_t p, const nmod_mat_t M)
    TMP_START;
 
    i = 1;
-   num_limbs = _nmod_vec_dot_bound_limbs(n, p->mod);
+   const dot_params_t params = _nmod_vec_dot_params(n, p->mod);
    nmod_poly_one(p);
    nmod_poly_init(b, p->mod.n);
    nmod_mat_init_set(M2, M);
@@ -226,7 +224,7 @@ void nmod_mat_charpoly_danilevsky(nmod_poly_t p, const nmod_mat_t M)
          for (k = 1; k <= n - i; k++)
             T[k - 1] = A[k - 1][j - 1];
 
-         A[n - i - 1][j - 1] = _nmod_vec_dot(T, W, n - i, p->mod, num_limbs);
+         A[n - i - 1][j - 1] = _nmod_vec_dot(T, W, n - i, p->mod, params);
       }
 
       for (j = n - i; j <= n - 1; j++)
@@ -234,13 +232,13 @@ void nmod_mat_charpoly_danilevsky(nmod_poly_t p, const nmod_mat_t M)
          for (k = 1; k <= n - i; k++)
             T[k - 1] = A[k - 1][j - 1];
 
-         A[n - i - 1][j - 1] = n_addmod(_nmod_vec_dot(T, W, n - i, p->mod, num_limbs), W[j], p->mod.n);
+         A[n - i - 1][j - 1] = n_addmod(_nmod_vec_dot(T, W, n - i, p->mod, params), W[j], p->mod.n);
       }
 
       for (k = 1; k <= n - i; k++)
          T[k - 1] = A[k - 1][j - 1];
 
-      A[n - i - 1][n - 1] = _nmod_vec_dot(T, W, n - i, p->mod, num_limbs);
+      A[n - i - 1][n - 1] = _nmod_vec_dot(T, W, n - i, p->mod, params);
 
       i++;
    }

--- a/src/nmod_mat/lu.c
+++ b/src/nmod_mat/lu.c
@@ -17,7 +17,7 @@ slong
 nmod_mat_lu(slong * P, nmod_mat_t A, int rank_check)
 {
     slong nrows, ncols, n, cutoff;
-    int nlimbs, bits;
+    int bits;
     nrows = A->r;
     ncols = A->c;
 
@@ -46,9 +46,12 @@ nmod_mat_lu(slong * P, nmod_mat_t A, int rank_check)
                 return nmod_mat_lu_recursive(P, A, rank_check);
         }
 
-        nlimbs = _nmod_vec_dot_bound_limbs(n, A->mod);
+        const dot_params_t params = _nmod_vec_dot_params(n, A->mod);
 
-        if (nlimbs <= 1 || (nlimbs == 2 && n >= 12) || (nlimbs == 3 && n >= 20))
+        // TODO thresholds to re-examine after dot product changes
+        if (params.method <= _DOT1                        // <= 0,1 limb
+                || (params.method <= _DOT2 && n >= 12)    // <= 2 limbs (n >= 12 if exactly 2)
+                || (params.method > _DOT2 && n >= 20))    // == 3 limbs && n >= 20
             return nmod_mat_lu_classical_delayed(P, A, rank_check);
         else
             return nmod_mat_lu_classical(P, A, rank_check);

--- a/src/nmod_mat/lu_classical_delayed.c
+++ b/src/nmod_mat/lu_classical_delayed.c
@@ -430,15 +430,15 @@ slong
 nmod_mat_lu_classical_delayed(slong * P, nmod_mat_t A, int rank_check)
 {
     slong nrows, ncols;
-    int nlimbs;
 
     nrows = A->r;
     ncols = A->c;
-    nlimbs = _nmod_vec_dot_bound_limbs(FLINT_MIN(nrows, ncols), A->mod);
+    const dot_params_t params = _nmod_vec_dot_params(FLINT_MIN(nrows, ncols), A->mod);
 
-    if (nlimbs <= 1)
+    // TODO cases to re-examine after dot product changes?
+    if (params.method <= _DOT1)
         return nmod_mat_lu_classical_delayed_1(P, A, rank_check);
-    else if (nlimbs <= 2)
+    else if (params.method <= _DOT2)
         return nmod_mat_lu_classical_delayed_2(P, A, rank_check);
     else
         return nmod_mat_lu_classical_delayed_3(P, A, rank_check);

--- a/src/nmod_mat/mul_classical.c
+++ b/src/nmod_mat/mul_classical.c
@@ -24,7 +24,7 @@ with op = -1, computes D = C - A*B
 
 static inline void
 _nmod_mat_addmul_basic_op(nn_ptr * D, nn_ptr * const C, nn_ptr * const A,
-    nn_ptr * const B, slong m, slong k, slong n, int op, nmod_t mod, int nlimbs)
+    nn_ptr * const B, slong m, slong k, slong n, int op, nmod_t mod, dot_params_t params)
 {
     slong i, j;
     ulong c;
@@ -33,7 +33,7 @@ _nmod_mat_addmul_basic_op(nn_ptr * D, nn_ptr * const C, nn_ptr * const A,
     {
         for (j = 0; j < n; j++)
         {
-            c = _nmod_vec_dot_ptr(A[i], B, j, k, mod, nlimbs);
+            c = _nmod_vec_dot_ptr(A[i], B, j, k, mod, params);
 
             if (op == 1)
                 c = nmod_add(C[i][j], c, mod);
@@ -47,7 +47,7 @@ _nmod_mat_addmul_basic_op(nn_ptr * D, nn_ptr * const C, nn_ptr * const A,
 
 static inline void
 _nmod_mat_addmul_transpose_op(nn_ptr * D, const nn_ptr * C, const nn_ptr * A,
-    const nn_ptr * B, slong m, slong k, slong n, int op, nmod_t mod, int nlimbs)
+    const nn_ptr * B, slong m, slong k, slong n, int op, nmod_t mod, dot_params_t params)
 {
     nn_ptr tmp;
     ulong c;
@@ -63,7 +63,7 @@ _nmod_mat_addmul_transpose_op(nn_ptr * D, const nn_ptr * C, const nn_ptr * A,
     {
         for (j = 0; j < n; j++)
         {
-            c = _nmod_vec_dot(A[i], tmp + j*k, k, mod, nlimbs);
+            c = _nmod_vec_dot(A[i], tmp + j*k, k, mod, params);
 
             if (op == 1)
                 c = nmod_add(C[i][j], c, mod);
@@ -77,7 +77,7 @@ _nmod_mat_addmul_transpose_op(nn_ptr * D, const nn_ptr * C, const nn_ptr * A,
     flint_free(tmp);
 }
 
-/* Assumes nlimbs = 1 */
+/* Assumes nlimbs = 1 <-> params.method <= _DOT1 */
 static void
 _nmod_mat_addmul_packed_op(nn_ptr * D, const nn_ptr * C, const nn_ptr * A,
     const nn_ptr * B, slong M, slong N, slong K, int op, nmod_t mod)
@@ -164,7 +164,6 @@ _nmod_mat_mul_classical_op(nmod_mat_t D, const nmod_mat_t C,
                                 const nmod_mat_t A, const nmod_mat_t B, int op)
 {
     slong m, k, n;
-    int nlimbs;
     nmod_t mod;
 
     mod = A->mod;
@@ -181,9 +180,12 @@ _nmod_mat_mul_classical_op(nmod_mat_t D, const nmod_mat_t C,
         return;
     }
 
-    nlimbs = _nmod_vec_dot_bound_limbs(k, mod);
+    dot_params_t params = _nmod_vec_dot_params(k, mod);
 
-    if (nlimbs == 1 && m > 10 && k > 10 && n > 10)
+    // TODO cases to re-examine after dot product changes?
+    if (params.method == _DOT0)
+        return;
+    if (params.method == _DOT1 && m > 10 && k > 10 && n > 10)
     {
         _nmod_mat_addmul_packed_op(D->rows, (op == 0) ? NULL : C->rows,
             A->rows, B->rows, m, k, n, op, D->mod);
@@ -193,18 +195,18 @@ _nmod_mat_mul_classical_op(nmod_mat_t D, const nmod_mat_t C,
         || k < NMOD_MAT_MUL_TRANSPOSE_CUTOFF)
     {
         if ((mod.n & (mod.n - 1)) == 0)
-            nlimbs = 1;
+            params.method = _DOT1; // TODO
 
         _nmod_mat_addmul_basic_op(D->rows, (op == 0) ? NULL : C->rows,
-            A->rows, B->rows, m, k, n, op, D->mod, nlimbs);
+            A->rows, B->rows, m, k, n, op, D->mod, params);
     }
     else
     {
         if ((mod.n & (mod.n - 1)) == 0)
-            nlimbs = 1;
+            params.method = _DOT1; // TODO
 
         _nmod_mat_addmul_transpose_op(D->rows, (op == 0) ? NULL : C->rows,
-            A->rows, B->rows, m, k, n, op, D->mod, nlimbs);
+            A->rows, B->rows, m, k, n, op, D->mod, params);
     }
 }
 

--- a/src/nmod_mat/mul_classical.c
+++ b/src/nmod_mat/mul_classical.c
@@ -180,7 +180,7 @@ _nmod_mat_mul_classical_op(nmod_mat_t D, const nmod_mat_t C,
         return;
     }
 
-    dot_params_t params = _nmod_vec_dot_params(k, mod);
+    const dot_params_t params = _nmod_vec_dot_params(k, mod);
 
     // TODO vec_dot changes --> thresholds to re-examine
     if (params.method == _DOT1 && m > 10 && k > 10 && n > 10)

--- a/src/nmod_mat/mul_classical.c
+++ b/src/nmod_mat/mul_classical.c
@@ -171,7 +171,7 @@ _nmod_mat_mul_classical_op(nmod_mat_t D, const nmod_mat_t C,
     k = A->c;
     n = B->c;
 
-    if (k == 0)
+    if (k == 0 || mod.n == 1)  // covers params.method == _DOT0
     {
         if (op == 0)
             nmod_mat_zero(D);
@@ -182,9 +182,7 @@ _nmod_mat_mul_classical_op(nmod_mat_t D, const nmod_mat_t C,
 
     dot_params_t params = _nmod_vec_dot_params(k, mod);
 
-    // TODO cases to re-examine after dot product changes?
-    if (params.method == _DOT0)
-        return;
+    // TODO vec_dot changes --> thresholds to re-examine
     if (params.method == _DOT1 && m > 10 && k > 10 && n > 10)
     {
         _nmod_mat_addmul_packed_op(D->rows, (op == 0) ? NULL : C->rows,

--- a/src/nmod_mat/mul_classical.c
+++ b/src/nmod_mat/mul_classical.c
@@ -77,7 +77,7 @@ _nmod_mat_addmul_transpose_op(nn_ptr * D, const nn_ptr * C, const nn_ptr * A,
     flint_free(tmp);
 }
 
-/* Assumes nlimbs = 1 <-> params.method <= _DOT1 */
+/* Assumes nlimbs = 1 */
 static void
 _nmod_mat_addmul_packed_op(nn_ptr * D, const nn_ptr * C, const nn_ptr * A,
     const nn_ptr * B, slong M, slong N, slong K, int op, nmod_t mod)
@@ -194,17 +194,11 @@ _nmod_mat_mul_classical_op(nmod_mat_t D, const nmod_mat_t C,
         || n < NMOD_MAT_MUL_TRANSPOSE_CUTOFF
         || k < NMOD_MAT_MUL_TRANSPOSE_CUTOFF)
     {
-        if ((mod.n & (mod.n - 1)) == 0)
-            params.method = _DOT1; // TODO
-
         _nmod_mat_addmul_basic_op(D->rows, (op == 0) ? NULL : C->rows,
             A->rows, B->rows, m, k, n, op, D->mod, params);
     }
     else
     {
-        if ((mod.n & (mod.n - 1)) == 0)
-            params.method = _DOT1; // TODO
-
         _nmod_mat_addmul_transpose_op(D->rows, (op == 0) ? NULL : C->rows,
             A->rows, B->rows, m, k, n, op, D->mod, params);
     }

--- a/src/nmod_mat/mul_classical_threaded.c
+++ b/src/nmod_mat/mul_classical_threaded.c
@@ -438,9 +438,6 @@ _nmod_mat_mul_classical_threaded_pool_op(nmod_mat_t D, const nmod_mat_t C,
     }
     else
     {
-        if ((mod.n & (mod.n - 1)) == 0)
-            params.method = _DOT1;
-
         _nmod_mat_addmul_transpose_threaded_pool_op(D->rows, (op == 0) ? NULL : C->rows,
             A->rows, B->rows, m, k, n, op, D->mod, params, threads, num_threads);
     }

--- a/src/nmod_mat/mul_classical_threaded.c
+++ b/src/nmod_mat/mul_classical_threaded.c
@@ -26,7 +26,7 @@ with op = -1, computes D = C - A*B
 
 static inline void
 _nmod_mat_addmul_basic_op(nn_ptr * D, nn_ptr * const C, nn_ptr * const A,
-    nn_ptr * const B, slong m, slong k, slong n, int op, nmod_t mod, int nlimbs)
+    nn_ptr * const B, slong m, slong k, slong n, int op, nmod_t mod, dot_params_t params)
 {
     slong i, j;
     ulong c;
@@ -35,7 +35,7 @@ _nmod_mat_addmul_basic_op(nn_ptr * D, nn_ptr * const C, nn_ptr * const A,
     {
         for (j = 0; j < n; j++)
         {
-            c = _nmod_vec_dot_ptr(A[i], B, j, k, mod, nlimbs);
+            c = _nmod_vec_dot_ptr(A[i], B, j, k, mod, params);
 
             if (op == 1)
                 c = nmod_add(C[i][j], c, mod);
@@ -55,7 +55,7 @@ typedef struct
     slong k;
     slong m;
     slong n;
-    slong nlimbs;
+    dot_params_t params;
     const nn_ptr * A;
     const nn_ptr * C;
     nn_ptr * D;
@@ -76,7 +76,7 @@ _nmod_mat_addmul_transpose_worker(void * arg_ptr)
     slong k = arg.k;
     slong m = arg.m;
     slong n = arg.n;
-    slong nlimbs = arg.nlimbs;
+    dot_params_t params = arg.params;
     const nn_ptr * A = arg.A;
     const nn_ptr * C = arg.C;
     nn_ptr * D = arg.D;
@@ -114,7 +114,7 @@ _nmod_mat_addmul_transpose_worker(void * arg_ptr)
         {
             for (j = jstart ; j < jend; j++)
             {
-                c = _nmod_vec_dot(A[i], tmp + j*k, k, mod, nlimbs);
+                c = _nmod_vec_dot(A[i], tmp + j*k, k, mod, params);
 
                 if (op == 1)
                     c = nmod_add(C[i][j], c, mod);
@@ -130,7 +130,7 @@ _nmod_mat_addmul_transpose_worker(void * arg_ptr)
 static inline void
 _nmod_mat_addmul_transpose_threaded_pool_op(nn_ptr * D, const nn_ptr * C,
                             const nn_ptr * A, const nn_ptr * B, slong m,
-                          slong k, slong n, int op, nmod_t mod, int nlimbs,
+                          slong k, slong n, int op, nmod_t mod, dot_params_t params,
                                thread_pool_handle * threads, slong num_threads)
 {
     nn_ptr tmp;
@@ -164,7 +164,7 @@ _nmod_mat_addmul_transpose_threaded_pool_op(nn_ptr * D, const nn_ptr * C,
         args[i].k       = k;
         args[i].m       = m;
         args[i].n       = n;
-        args[i].nlimbs  = nlimbs;
+        args[i].params  = params;
         args[i].A       = A;
         args[i].C       = C;
         args[i].D       = D;
@@ -312,7 +312,7 @@ _nmod_mat_addmul_packed_worker(void * arg_ptr)
     }
 }
 
-/* Assumes nlimbs = 1 */
+/* Assumes nlimbs = 1  <->  params.method <= _DOT1 */
 static void
 _nmod_mat_addmul_packed_threaded_pool_op(nn_ptr * D,
       const nn_ptr * C, const nn_ptr * A, const nn_ptr * B,
@@ -420,7 +420,6 @@ _nmod_mat_mul_classical_threaded_pool_op(nmod_mat_t D, const nmod_mat_t C,
                                thread_pool_handle * threads, slong num_threads)
 {
     slong m, k, n;
-    int nlimbs;
     nmod_t mod;
 
     mod = A->mod;
@@ -428,9 +427,11 @@ _nmod_mat_mul_classical_threaded_pool_op(nmod_mat_t D, const nmod_mat_t C,
     k = A->c;
     n = B->c;
 
-    nlimbs = _nmod_vec_dot_bound_limbs(k, mod);
+    dot_params_t params = _nmod_vec_dot_params(k, mod);
 
-    if (nlimbs == 1 && m > 10 && k > 10 && n > 10)
+    if (params.method == _DOT0)
+        return;
+    if (params.method == _DOT1 && m > 10 && k > 10 && n > 10)
     {
         _nmod_mat_addmul_packed_threaded_pool_op(D->rows, (op == 0) ? NULL : C->rows,
             A->rows, B->rows, m, k, n, op, D->mod, threads, num_threads);
@@ -438,10 +439,10 @@ _nmod_mat_mul_classical_threaded_pool_op(nmod_mat_t D, const nmod_mat_t C,
     else
     {
         if ((mod.n & (mod.n - 1)) == 0)
-            nlimbs = 1;
+            params.method = _DOT1;
 
         _nmod_mat_addmul_transpose_threaded_pool_op(D->rows, (op == 0) ? NULL : C->rows,
-            A->rows, B->rows, m, k, n, op, D->mod, nlimbs, threads, num_threads);
+            A->rows, B->rows, m, k, n, op, D->mod, params, threads, num_threads);
     }
 }
 
@@ -466,10 +467,10 @@ _nmod_mat_mul_classical_threaded_op(nmod_mat_t D, const nmod_mat_t C,
         || A->c < NMOD_MAT_MUL_TRANSPOSE_CUTOFF
         || B->c < NMOD_MAT_MUL_TRANSPOSE_CUTOFF)
     {
-        slong nlimbs = _nmod_vec_dot_bound_limbs(A->c, D->mod);
+        dot_params_t params = _nmod_vec_dot_params(A->c, D->mod);
 
         _nmod_mat_addmul_basic_op(D->rows, (op == 0) ? NULL : C->rows,
-            A->rows, B->rows, A->r, A->c, B->c, op, D->mod, nlimbs);
+            A->rows, B->rows, A->r, A->c, B->c, op, D->mod, params);
 
         return;
     }

--- a/src/nmod_mat/mul_nmod_vec.c
+++ b/src/nmod_mat/mul_nmod_vec.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "nmod.h"
 #include "nmod_vec.h"
 #include "nmod_mat.h"
 

--- a/src/nmod_mat/mul_nmod_vec.c
+++ b/src/nmod_mat/mul_nmod_vec.c
@@ -18,16 +18,11 @@ void nmod_mat_mul_nmod_vec(
     const nmod_mat_t A,
     const ulong * b, slong blen)
 {
-    nmod_t mod = A->mod;
-    slong i, j;
-    slong len = FLINT_MIN(A->c, blen);
-    const dot_params_t params = _nmod_vec_dot_params(len, mod);
+    const slong len = FLINT_MIN(A->c, blen);
+    const dot_params_t params = _nmod_vec_dot_params(len, A->mod);
 
-    for (i = A->r - 1; i >= 0; i--)
-    {
-        const ulong * Ai = A->rows[i];
-        NMOD_VEC_DOT(c[i], j, len, Ai[j], b[j], mod, params);
-    }
+    for (slong i = 0; i < A->r; i++)
+        c[i] = _nmod_vec_dot(A->rows[i], b, len, A->mod, params);
 }
 
 void nmod_mat_mul_nmod_vec_ptr(

--- a/src/nmod_mat/mul_nmod_vec.c
+++ b/src/nmod_mat/mul_nmod_vec.c
@@ -21,12 +21,12 @@ void nmod_mat_mul_nmod_vec(
     nmod_t mod = A->mod;
     slong i, j;
     slong len = FLINT_MIN(A->c, blen);
-    int nlimbs = _nmod_vec_dot_bound_limbs(len, mod);
+    const dot_params_t params = _nmod_vec_dot_params(len, mod);
 
     for (i = A->r - 1; i >= 0; i--)
     {
         const ulong * Ai = A->rows[i];
-        NMOD_VEC_DOT(c[i], j, len, Ai[j], b[j], mod, nlimbs);
+        NMOD_VEC_DOT(c[i], j, len, Ai[j], b[j], mod, params);
     }
 }
 

--- a/src/nmod_mat/solve_tril.c
+++ b/src/nmod_mat/solve_tril.c
@@ -16,7 +16,6 @@
 void
 nmod_mat_solve_tril_classical(nmod_mat_t X, const nmod_mat_t L, const nmod_mat_t B, int unit)
 {
-    int nlimbs;
     slong i, j, n, m;
     nmod_t mod;
     nn_ptr inv, tmp;
@@ -34,7 +33,7 @@ nmod_mat_solve_tril_classical(nmod_mat_t X, const nmod_mat_t L, const nmod_mat_t
     else
         inv = NULL;
 
-    nlimbs = _nmod_vec_dot_bound_limbs(n, mod);
+    const dot_params_t params = _nmod_vec_dot_params(n, mod);
     tmp = _nmod_vec_init(n);
 
     for (i = 0; i < m; i++)
@@ -45,7 +44,7 @@ nmod_mat_solve_tril_classical(nmod_mat_t X, const nmod_mat_t L, const nmod_mat_t
         for (j = 0; j < n; j++)
         {
             ulong s;
-            s = _nmod_vec_dot(L->rows[j], tmp, j, mod, nlimbs);
+            s = _nmod_vec_dot(L->rows[j], tmp, j, mod, params);
             s = nmod_sub(nmod_mat_entry(B, j, i), s, mod);
             if (!unit)
                 s = n_mulmod2_preinv(s, inv[j], mod.n, mod.ninv);

--- a/src/nmod_mat/solve_triu.c
+++ b/src/nmod_mat/solve_triu.c
@@ -16,7 +16,6 @@
 void
 nmod_mat_solve_triu_classical(nmod_mat_t X, const nmod_mat_t U, const nmod_mat_t B, int unit)
 {
-    int nlimbs;
     slong i, j, n, m;
     nmod_t mod;
     nn_ptr inv, tmp;
@@ -34,7 +33,7 @@ nmod_mat_solve_triu_classical(nmod_mat_t X, const nmod_mat_t U, const nmod_mat_t
     else
         inv = NULL;
 
-    nlimbs = _nmod_vec_dot_bound_limbs(n, mod);
+    const dot_params_t params = _nmod_vec_dot_params(n, mod);
     tmp = _nmod_vec_init(n);
 
     for (i = 0; i < m; i++)
@@ -46,7 +45,7 @@ nmod_mat_solve_triu_classical(nmod_mat_t X, const nmod_mat_t U, const nmod_mat_t
         {
             ulong s;
             s = _nmod_vec_dot(U->rows[j] + j + 1,
-                              tmp + j + 1, n - j - 1, mod, nlimbs);
+                              tmp + j + 1, n - j - 1, mod, params);
             s = nmod_sub(nmod_mat_entry(B, j, i), s, mod);
             if (!unit)
                 s = n_mulmod2_preinv(s, inv[j], mod.n, mod.ninv);

--- a/src/nmod_mpoly/interp.c
+++ b/src/nmod_mpoly/interp.c
@@ -393,7 +393,7 @@ int nmod_mpolyn_interp_crt_sm_bpoly(
     const nmod_mpoly_ctx_t ctx)
 {
     int changed = 0;
-    int nlimbs = _nmod_vec_dot_bound_limbs(modulus->length, ctx->mod);
+    const dot_params_t params = _nmod_vec_dot_params(modulus->length, ctx->mod);
     slong N = mpoly_words_per_exp(F->bits, ctx->minfo);
     slong off0, shift0, off1, shift1;
     n_poly_struct * Acoeffs = A->coeffs;
@@ -440,7 +440,7 @@ int nmod_mpolyn_interp_crt_sm_bpoly(
             /* F term ok, A term ok */
             mpoly_monomial_set(Texps + N*Ti, Fexps + N*Fi, N);
 
-            v = _n_poly_eval_pow(Fcoeffs + Fi, alphapow, nlimbs, ctx->mod);
+            v = _n_poly_eval_pow(Fcoeffs + Fi, alphapow, params, ctx->mod);
             v = nmod_sub(Acoeffs[Ai].coeffs[ai], v, ctx->mod);
             if (v != 0)
             {
@@ -495,7 +495,7 @@ int nmod_mpolyn_interp_crt_sm_bpoly(
             /* F term ok, Aterm missing */
             mpoly_monomial_set(Texps + N*Ti, Fexps + N*Fi, N);
 
-            v = _n_poly_eval_pow(Fcoeffs + Fi, alphapow, nlimbs, ctx->mod);
+            v = _n_poly_eval_pow(Fcoeffs + Fi, alphapow, params, ctx->mod);
             if (v != 0)
             {
                 changed = 1;

--- a/src/nmod_mpoly_factor/n_bpoly_mod_factor_lgprime.c
+++ b/src/nmod_mpoly_factor/n_bpoly_mod_factor_lgprime.c
@@ -641,11 +641,10 @@ static void _lattice(
     n_bpoly_t Q, R, dg;
     n_bpoly_struct * ld;
     nmod_mat_t M, T1, T2;
-    int nlimbs;
     ulong * trow;
     slong lift_order = lift_alpha_pow->length - 1;
 
-    nlimbs = _nmod_vec_dot_bound_limbs(r, ctx);
+    const dot_params_t params = _nmod_vec_dot_params(r, ctx);
     trow = (ulong *) flint_malloc(r*sizeof(ulong));
     n_bpoly_init(Q);
     n_bpoly_init(R);
@@ -683,7 +682,7 @@ static void _lattice(
 
             for (i = 0; i < d; i++)
                 nmod_mat_entry(M, j - starts[k], i) =
-                             _nmod_vec_dot(trow, N->rows[i], r, ctx, nlimbs);
+                             _nmod_vec_dot(trow, N->rows[i], r, ctx, params);
         }
 
         nmod_mat_init_nullspace_tr(T1, M);

--- a/src/nmod_mpoly_factor/n_bpoly_mod_factor_smprime.c
+++ b/src/nmod_mpoly_factor/n_bpoly_mod_factor_smprime.c
@@ -1090,10 +1090,9 @@ static void _lattice(
     n_bpoly_t Q, R, dg;
     n_bpoly_struct * ld;
     nmod_mat_t M, T1, T2;
-    int nlimbs;
     ulong * trow;
 
-    nlimbs = _nmod_vec_dot_bound_limbs(r, ctx);
+    const dot_params_t params = _nmod_vec_dot_params(r, ctx);
     trow = FLINT_ARRAY_ALLOC(r, ulong);
     n_bpoly_init(Q);
     n_bpoly_init(R);
@@ -1134,7 +1133,7 @@ static void _lattice(
 
             for (i = 0; i < nrows; i++)
                 nmod_mat_entry(M, j - lower, i) =
-                             _nmod_vec_dot(trow, N->rows[i], r, ctx, nlimbs);
+                             _nmod_vec_dot(trow, N->rows[i], r, ctx, params);
         }
 
         nmod_mat_init_nullspace_tr(T1, M);

--- a/src/nmod_poly/div_series.c
+++ b/src/nmod_poly/div_series.c
@@ -20,7 +20,6 @@ _nmod_poly_div_series_basecase_preinv1(nn_ptr Qinv, nn_srcptr P, slong Plen,
                                 nn_srcptr Q, slong Qlen, slong n, ulong q, nmod_t mod)
 {
     slong i, j, l;
-    int nlimbs;
     ulong s;
 
     Plen = FLINT_MIN(Plen, n);
@@ -35,13 +34,13 @@ _nmod_poly_div_series_basecase_preinv1(nn_ptr Qinv, nn_srcptr P, slong Plen,
     {
         Qinv[0] = nmod_mul(q, P[0], mod);
 
-        nlimbs = _nmod_vec_dot_bound_limbs(FLINT_MIN(n, Qlen), mod);
+        const dot_params_t params = _nmod_vec_dot_params(FLINT_MIN(n, Qlen), mod);
 
         for (i = 1; i < n; i++)
         {
             l = FLINT_MIN(i, Qlen - 1);
 
-            NMOD_VEC_DOT(s, j, l, Q[j + 1], Qinv[i - 1 - j], mod, nlimbs);
+            NMOD_VEC_DOT(s, j, l, Q[j + 1], Qinv[i - 1 - j], mod, params);
 
             if (i < Plen)
                 s = nmod_sub(P[i], s, mod);

--- a/src/nmod_poly/divides.c
+++ b/src/nmod_poly/divides.c
@@ -129,7 +129,7 @@ static int
 _nmod_poly_mullow_classical_check(nn_srcptr p, nn_srcptr poly1, slong len1,
                             nn_srcptr poly2, slong n, nmod_t mod)
 {
-    slong i, j, bits, log_len, nlimbs, n1;
+    slong i, j, bits, log_len, n1;
     ulong c;
 
     len1 = FLINT_MIN(len1, n);
@@ -140,6 +140,7 @@ _nmod_poly_mullow_classical_check(nn_srcptr p, nn_srcptr poly1, slong len1,
     if (n == 1)
         return p[0] == nmod_mul(poly1[0], poly2[0], mod);
 
+    // TODO could what is below make more direct use of nmod_vec_dot?
     log_len = FLINT_BIT_COUNT(n);
     bits = FLINT_BITS - (slong) mod.norm;
     bits = 2 * bits + log_len;
@@ -160,10 +161,11 @@ _nmod_poly_mullow_classical_check(nn_srcptr p, nn_srcptr poly1, slong len1,
         }
     } else
     {
+        dot_params_t params = {_DOT2, 0};
         if (bits <= 2 * FLINT_BITS)
-            nlimbs = 2;
+            params.method = _DOT2;
         else
-            nlimbs = 3;
+            params.method = _DOT3;
 
         for (i = 0; i < n; i++)
         {
@@ -171,7 +173,7 @@ _nmod_poly_mullow_classical_check(nn_srcptr p, nn_srcptr poly1, slong len1,
 
             c = _nmod_vec_dot_rev(poly1,
                     poly2 + i - n1,
-                    n1 + 1, mod, nlimbs);
+                    n1 + 1, mod, params);
 
             if (p[i] != c)
                 return 0;

--- a/src/nmod_poly/inv_series.c
+++ b/src/nmod_poly/inv_series.c
@@ -30,15 +30,13 @@ _nmod_poly_inv_series_basecase_preinv1(nn_ptr Qinv, nn_srcptr Q, slong Qlen, slo
     else
     {
         slong i, j, l;
-        int nlimbs;
         ulong s;
-
-        nlimbs = _nmod_vec_dot_bound_limbs(FLINT_MIN(n, Qlen), mod);
+        const dot_params_t params = _nmod_vec_dot_params(FLINT_MIN(n, Qlen), mod);
 
         for (i = 1; i < n; i++)
         {
             l = FLINT_MIN(i, Qlen - 1);
-            NMOD_VEC_DOT(s, j, l, Q[j + 1], Qinv[i - 1 - j], mod, nlimbs);
+            NMOD_VEC_DOT(s, j, l, Q[j + 1], Qinv[i - 1 - j], mod, params);
 
             if (q == 1)
                 Qinv[i] = nmod_neg(s, mod);

--- a/src/nmod_poly/inv_series.c
+++ b/src/nmod_poly/inv_series.c
@@ -31,7 +31,7 @@ _nmod_poly_inv_series_basecase_preinv1(nn_ptr Qinv, nn_srcptr Q, slong Qlen, slo
     {
         slong i, l;
         ulong s;
-        const dot_params_t params = _nmod_vec_dot_params(FLINT_MIN(n, Qlen), mod);
+        const dot_params_t params = _nmod_vec_dot_params(FLINT_MIN(n, Qlen) - 1, mod);
 
         for (i = 1; i < n; i++)
         {

--- a/src/nmod_poly/inv_series.c
+++ b/src/nmod_poly/inv_series.c
@@ -36,8 +36,6 @@ _nmod_poly_inv_series_basecase_preinv1(nn_ptr Qinv, nn_srcptr Q, slong Qlen, slo
         for (i = 1; i < n; i++)
         {
             l = FLINT_MIN(i, Qlen - 1);
-            //NMOD_VEC_DOT(s, j, l, Q[j + 1], Qinv[i - 1 - j], mod, params);
-            // FIXME macro more efficient for small l ?
             s = _nmod_vec_dot_rev(Q+1, Qinv + i-l, l, mod, params);
 
             if (q == 1)

--- a/src/nmod_poly/inv_series.c
+++ b/src/nmod_poly/inv_series.c
@@ -29,14 +29,16 @@ _nmod_poly_inv_series_basecase_preinv1(nn_ptr Qinv, nn_srcptr Q, slong Qlen, slo
     }
     else
     {
-        slong i, j, l;
+        slong i, l;
         ulong s;
         const dot_params_t params = _nmod_vec_dot_params(FLINT_MIN(n, Qlen), mod);
 
         for (i = 1; i < n; i++)
         {
             l = FLINT_MIN(i, Qlen - 1);
-            NMOD_VEC_DOT(s, j, l, Q[j + 1], Qinv[i - 1 - j], mod, params);
+            //NMOD_VEC_DOT(s, j, l, Q[j + 1], Qinv[i - 1 - j], mod, params);
+            // FIXME macro more efficient for small l ?
+            s = _nmod_vec_dot_rev(Q+1, Qinv + i-l, l, mod, params);
 
             if (q == 1)
                 Qinv[i] = nmod_neg(s, mod);

--- a/src/nmod_poly/mul_classical.c
+++ b/src/nmod_poly/mul_classical.c
@@ -20,7 +20,7 @@ void
 _nmod_poly_mul_classical(nn_ptr res, nn_srcptr poly1,
                          slong len1, nn_srcptr poly2, slong len2, nmod_t mod)
 {
-    slong i, j, bits, log_len, nlimbs, n1, n2;
+    slong i, j, bits, log_len, n1, n2;
     int squaring;
     ulong c;
 
@@ -38,6 +38,7 @@ _nmod_poly_mul_classical(nn_ptr res, nn_srcptr poly1,
 
     squaring = (poly1 == poly2 && len1 == len2);
 
+    // TODO could what is below make more direct use of nmod_vec_dot?
     log_len = FLINT_BIT_COUNT(len2);
     bits = FLINT_BITS - (slong) mod.norm;
     bits = 2 * bits + log_len;
@@ -82,10 +83,11 @@ _nmod_poly_mul_classical(nn_ptr res, nn_srcptr poly1,
         return;
     }
 
+    dot_params_t params = {_DOT2, 0};
     if (bits <= 2 * FLINT_BITS)
-        nlimbs = 2;
+        params.method = _DOT2;
     else
-        nlimbs = 3;
+        params.method = _DOT3;
 
     if (squaring)
     {
@@ -94,7 +96,7 @@ _nmod_poly_mul_classical(nn_ptr res, nn_srcptr poly1,
             n1 = FLINT_MAX(0, i - len1 + 1);
             n2 = FLINT_MIN(len1 - 1, (i + 1) / 2 - 1);
 
-            c = _nmod_vec_dot_rev(poly1 + n1, poly1 + i - n2, n2 - n1 + 1, mod, nlimbs);
+            c = _nmod_vec_dot_rev(poly1 + n1, poly1 + i - n2, n2 - n1 + 1, mod, params);
             c = nmod_add(c, c, mod);
 
             if (i % 2 == 0 && i / 2 < len1)
@@ -112,7 +114,7 @@ _nmod_poly_mul_classical(nn_ptr res, nn_srcptr poly1,
 
             res[i] = _nmod_vec_dot_rev(poly1 + i - n2,
                                        poly2 + i - n1,
-                                       n1 + n2 - i + 1, mod, nlimbs);
+                                       n1 + n2 - i + 1, mod, params);
         }
     }
 }

--- a/src/nmod_poly/mul_classical.c
+++ b/src/nmod_poly/mul_classical.c
@@ -38,12 +38,9 @@ _nmod_poly_mul_classical(nn_ptr res, nn_srcptr poly1,
 
     squaring = (poly1 == poly2 && len1 == len2);
 
-    // TODO could what is below make more direct use of nmod_vec_dot?
-    log_len = FLINT_BIT_COUNT(len2);
-    bits = FLINT_BITS - (slong) mod.norm;
-    bits = 2 * bits + log_len;
+    const dot_params_t params = _nmod_vec_dot_params(FLINT_MIN(len1, len2), mod);
 
-    if (bits <= FLINT_BITS)
+    if (params.method <= _DOT1)
     {
         flint_mpn_zero(res, len1 + len2 - 1);
 
@@ -82,12 +79,6 @@ _nmod_poly_mul_classical(nn_ptr res, nn_srcptr poly1,
         res[len1 + len2 - 2] = nmod_mul(poly1[len1 - 1], poly2[len2 - 1], mod);
         return;
     }
-
-    dot_params_t params = {_DOT2, 0};
-    if (bits <= 2 * FLINT_BITS)
-        params.method = _DOT2;
-    else
-        params.method = _DOT3;
 
     if (squaring)
     {

--- a/src/nmod_poly/mul_classical.c
+++ b/src/nmod_poly/mul_classical.c
@@ -20,7 +20,7 @@ void
 _nmod_poly_mul_classical(nn_ptr res, nn_srcptr poly1,
                          slong len1, nn_srcptr poly2, slong len2, nmod_t mod)
 {
-    slong i, j, bits, log_len, n1, n2;
+    slong i, j, n1, n2;
     int squaring;
     ulong c;
 

--- a/src/nmod_vec.h
+++ b/src/nmod_vec.h
@@ -527,9 +527,21 @@ ulong _nmod_vec_dot2_split_ptr(nn_srcptr vec1, const nn_ptr * vec2, slong offset
 
 #define _NMOD_VEC_DOT_SHORT3(fixedlen,expr1,expr2)               \
         {                                                        \
-            ulong res = nmod_mul((expr1), (expr2), mod); i++;    \
-            for (slong j = 0; j < fixedlen-1; j++, i++)          \
-                res = nmod_addmul(res, (expr1), (expr2), mod);   \
+            ulong t2zz = UWORD(0);                               \
+            ulong t1zz, t0zz;                                    \
+            umul_ppmm(t1zz, t0zz, (expr1), (expr2)); i++;        \
+            for (slong j = 0; j < fixedlen - 1; j++, i++)        \
+            {                                                    \
+                ulong s0zz, s1zz;                                \
+                umul_ppmm(s1zz, s0zz, (expr1), (expr2));         \
+                add_sssaaaaaa(t2zz, t1zz, t0zz,                  \
+                                t2zz, t1zz, t0zz,                \
+                                UWORD(0), s1zz, s0zz);           \
+            }                                                    \
+                                                                 \
+            NMOD_RED(t2zz, t2zz, mod);                           \
+            ulong res;                                           \
+            NMOD_RED3(res, t2zz, t1zz, t0zz, mod);               \
             return res;                                          \
         }                                                        \
 

--- a/src/nmod_vec.h
+++ b/src/nmod_vec.h
@@ -141,7 +141,6 @@ typedef struct
 } dot_params_t;
 
 // compute dot parameters
-int _nmod_vec_dot_bound_limbs(slong len, nmod_t mod);
 dot_params_t _nmod_vec_dot_params(ulong len, nmod_t mod);
 
 // _DOT1   (1 limb)

--- a/src/nmod_vec.h
+++ b/src/nmod_vec.h
@@ -123,7 +123,9 @@ typedef enum
     _DOT0 = 0,           /* len == 0 || mod.n == 1 */
     _DOT_POW2 = 1,       /* modulus is a power of 2, computations performed on 1 limb */
     _DOT1 = 2,           /* 1 limb */
-    _DOT2_SPLIT = 3,  /* 2 limbs, modulus < ~2**30.5 (FLINT_BITS == 64 only) */
+#if (FLINT_BITS == 64)
+    _DOT2_SPLIT = 3,     /* 2 limbs, modulus < ~2**30.5 (FLINT_BITS == 64 only) */
+#endif  // FLINT_BITS == 64
     _DOT2_HALF = 4,      /* 2 limbs, modulus < 2**(FLINT_BITS/2) */
     _DOT2 = 5,           /* 2 limbs */
     _DOT3_ACC = 6,       /* 3 limbs, modulus < 2**62.5 allowing accumulation in 2 limbs */

--- a/src/nmod_vec.h
+++ b/src/nmod_vec.h
@@ -411,11 +411,54 @@ do                                                                    \
     NMOD_RED3(res, t2zz, t1zz, t0zz, mod);                            \
 } while(0);
 
+
+#if (FLINT_BITS == 64)
+
+#define NMOD_VEC_DOT(res, i, len, expr1, expr2, mod, params)          \
+do                                                                    \
+{                                                                     \
+    res = UWORD(0);   /* covers _DOT0 */                              \
+    if (params.method == _DOT1 || params.method == _DOT_POW2)         \
+        _NMOD_VEC_DOT1(res, i, len, expr1, expr2, mod)                \
+    else if (params.method == _DOT2_SPLIT)                            \
+        _NMOD_VEC_DOT2_SPLIT(res, i, len, expr1, expr2, mod,          \
+                params.pow2_precomp)                                  \
+    else if (params.method == _DOT2_HALF)                             \
+        _NMOD_VEC_DOT2_HALF(res, i, len, expr1, expr2, mod)           \
+    else if (params.method == _DOT2)                                  \
+        _NMOD_VEC_DOT2(res, i, len, expr1, expr2, mod)                \
+    else if (params.method == _DOT3_ACC)                              \
+        _NMOD_VEC_DOT3_ACC(res, i, len, expr1, expr2, mod)            \
+    else if (params.method == _DOT3)                                  \
+        _NMOD_VEC_DOT3(res, i, len, expr1, expr2, mod)                \
+} while(0);
+
+#else  // FLINT_BITS == 64
+
+#define NMOD_VEC_DOT(res, i, len, expr1, expr2, mod, params)          \
+do                                                                    \
+{                                                                     \
+    res = UWORD(0);   /* covers _DOT0 */                              \
+    if (params.method == _DOT1 || params.method == _DOT_POW2)         \
+        _NMOD_VEC_DOT1(res, i, len, expr1, expr2, mod)                \
+    else if (params.method == _DOT2_HALF)                             \
+        _NMOD_VEC_DOT2_HALF(res, i, len, expr1, expr2, mod)           \
+    else if (params.method == _DOT2)                                  \
+        _NMOD_VEC_DOT2(res, i, len, expr1, expr2, mod)                \
+    else if (params.method == _DOT3_ACC)                              \
+        _NMOD_VEC_DOT3_ACC(res, i, len, expr1, expr2, mod)            \
+    else if (params.method == _DOT3)                                  \
+        _NMOD_VEC_DOT3(res, i, len, expr1, expr2, mod)                \
+} while(0);
+
+#endif  // FLINT_BITS == 64
+
+
 // warning: interface different from other _NMOD_VEC_DOT macros
 // * only supports len <= 4
 // * i must be already initialized at the first wanted value
 // * returns the result
-#define NMOD_VEC_DOT_SHORT(i, expr1, expr2, len, mod, method)           \
+#define _NMOD_VEC_DOT_SHORT(i, expr1, expr2, len, mod, method)          \
 {                                                                       \
     if (method <= _DOT1 || method == _DOT_POW2)                         \
     {                                                                   \
@@ -519,50 +562,8 @@ do                                                                    \
             return nmod_mul((expr1), (expr2), mod);                     \
         return 0;                                                       \
     }                                                                   \
-}                                                                       \
+}  while(0);                                                            \
 
-
-
-#if (FLINT_BITS == 64)
-
-#define NMOD_VEC_DOT(res, i, len, expr1, expr2, mod, params)          \
-do                                                                    \
-{                                                                     \
-    res = UWORD(0);   /* covers _DOT0 */                              \
-    if (params.method == _DOT1 || params.method == _DOT_POW2)         \
-        _NMOD_VEC_DOT1(res, i, len, expr1, expr2, mod)                \
-    else if (params.method == _DOT2_SPLIT)                            \
-        _NMOD_VEC_DOT2_SPLIT(res, i, len, expr1, expr2, mod,          \
-                params.pow2_precomp)                                  \
-    else if (params.method == _DOT2_HALF)                             \
-        _NMOD_VEC_DOT2_HALF(res, i, len, expr1, expr2, mod)           \
-    else if (params.method == _DOT2)                                  \
-        _NMOD_VEC_DOT2(res, i, len, expr1, expr2, mod)                \
-    else if (params.method == _DOT3_ACC)                              \
-        _NMOD_VEC_DOT3_ACC(res, i, len, expr1, expr2, mod)            \
-    else if (params.method == _DOT3)                                  \
-        _NMOD_VEC_DOT3(res, i, len, expr1, expr2, mod)                \
-} while(0);
-
-#else  // FLINT_BITS == 64
-
-#define NMOD_VEC_DOT(res, i, len, expr1, expr2, mod, params)          \
-do                                                                    \
-{                                                                     \
-    res = UWORD(0);   /* covers _DOT0 */                              \
-    if (params.method == _DOT1 || params.method == _DOT_POW2)         \
-        _NMOD_VEC_DOT1(res, i, len, expr1, expr2, mod)                \
-    else if (params.method == _DOT2_HALF)                             \
-        _NMOD_VEC_DOT2_HALF(res, i, len, expr1, expr2, mod)           \
-    else if (params.method == _DOT2)                                  \
-        _NMOD_VEC_DOT2(res, i, len, expr1, expr2, mod)                \
-    else if (params.method == _DOT3_ACC)                              \
-        _NMOD_VEC_DOT3_ACC(res, i, len, expr1, expr2, mod)            \
-    else if (params.method == _DOT3)                                  \
-        _NMOD_VEC_DOT3(res, i, len, expr1, expr2, mod)                \
-} while(0);
-
-#endif  // FLINT_BITS == 64
 
 /* dot functions: specific algorithms */
 ulong _nmod_vec_dot_pow2(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod);
@@ -601,7 +602,7 @@ NMOD_VEC_INLINE ulong _nmod_vec_dot(nn_srcptr vec1, nn_srcptr vec2, slong len, n
     if (len <= 4)
     {
         slong i = 0;
-        NMOD_VEC_DOT_SHORT(i, vec1[i], vec2[i], len, mod, params.method);
+        _NMOD_VEC_DOT_SHORT(i, vec1[i], vec2[i], len, mod, params.method);
     }
 
     if (params.method == _DOT1)
@@ -636,7 +637,7 @@ NMOD_VEC_INLINE ulong _nmod_vec_dot_rev(nn_srcptr vec1, nn_srcptr vec2, slong le
     if (len <= 4)
     {
         slong i = 0;
-        NMOD_VEC_DOT_SHORT(i, vec1[i], vec2[len-1-i], len, mod, params.method);
+        _NMOD_VEC_DOT_SHORT(i, vec1[i], vec2[len-1-i], len, mod, params.method);
     }
 
     if (params.method == _DOT1)
@@ -671,7 +672,7 @@ NMOD_VEC_INLINE ulong _nmod_vec_dot_ptr(nn_srcptr vec1, const nn_ptr * vec2, slo
     if (len <= 4)
     {
         slong i = 0;
-        NMOD_VEC_DOT_SHORT(i, vec1[i], vec2[i][offset], len, mod, params.method);
+        _NMOD_VEC_DOT_SHORT(i, vec1[i], vec2[i][offset], len, mod, params.method);
     }
 
     if (params.method == _DOT1)

--- a/src/nmod_vec.h
+++ b/src/nmod_vec.h
@@ -157,8 +157,8 @@ FLINT_FORCE_INLINE dot_params_t _nmod_vec_dot_params(ulong len, nmod_t mod)
 //    {
 //        if (mod.n <= UWORD(1) << (FLINT_BITS / 2))
 //        {
-//            if ((mod.n & (mod.n - 1)) == 0
-//                    || mod.n <= UWORD(1) << (FLINT_BITS / 2 - 2))
+//            if (mod.n <= UWORD(1) << (FLINT_BITS / 2 - 2)
+//                    || (mod.n & (mod.n - 1)) == 0)
 //                return (dot_params_t) {_DOT1, UWORD(0)};
 //
 //#if (FLINT_BITS == 64)

--- a/src/nmod_vec.h
+++ b/src/nmod_vec.h
@@ -395,6 +395,7 @@ ulong _nmod_vec_dot2_split_rev(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t
 
 NMOD_VEC_INLINE ulong _nmod_vec_dot(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, dot_params_t params)
 {
+    // FIXME handle short products
     if (len <= 2 && params.method > _DOT1)
     {
         if (len == 2)

--- a/src/nmod_vec.h
+++ b/src/nmod_vec.h
@@ -343,7 +343,7 @@ ulong _nmod_vec_dot2_split_ptr(nn_srcptr vec1, const nn_ptr * vec2, slong offset
             return res;                                      \
         }                                                    \
 
-// * supports 1 <= len <= 11, requires method==DOT0|DOT1|DOT2|DOT3|DOT_POW2
+// * supports 1 <= len <= 11, requires method==DOT1|DOT2|DOT3|DOT_POW2
 // * i must be already initialized at the first wanted value
 #define _NMOD_VEC_DOT_SHORT(i, expr1, expr2, len, mod, method)          \
 {                                                                       \

--- a/src/nmod_vec.h
+++ b/src/nmod_vec.h
@@ -254,6 +254,9 @@ FLINT_FORCE_INLINE dot_params_t _nmod_vec_dot_params(ulong len, nmod_t mod)
 
 #undef _FIXED_LEN_MOD_BOUNDS
 
+int _nmod_vec_dot_bound_limbs(slong len, nmod_t mod);
+int _nmod_vec_dot_bound_limbs_from_params(slong len, nmod_t mod, dot_params_t params);
+
 
 /* ------ dot product, specific algorithms ------ */
 

--- a/src/nmod_vec.h
+++ b/src/nmod_vec.h
@@ -161,11 +161,12 @@ FLINT_FORCE_INLINE dot_params_t _nmod_vec_dot_params(ulong len, nmod_t mod)
         }
     // short dot products: k limbs  <=>  n <= ceil(2**(32*k) / sqrt(len))
     // we use only _DOT1, _DOT2, _DOT3 in that case
-    if (len <= 10)
-    { // TODO 32 bits
+    if (len <= 11)
+    {
         if ((mod.n & (mod.n - 1)) == 0)  // power of 2
             return (dot_params_t) {_DOT1, UWORD(0)};
 #if FLINT_BITS == 64
+        _FIXED_LEN_MOD_BOUNDS(11, 1294981365,  5561902608746059656);
         _FIXED_LEN_MOD_BOUNDS(10, 1358187914,  5833372668713515885);
         _FIXED_LEN_MOD_BOUNDS( 9, 1431655766,  6148914691236517206);
         _FIXED_LEN_MOD_BOUNDS( 8, 1518500250,  6521908912666391107);
@@ -176,6 +177,7 @@ FLINT_FORCE_INLINE dot_params_t _nmod_vec_dot_params(ulong len, nmod_t mod)
         _FIXED_LEN_MOD_BOUNDS( 3, 2479700525, 10650232656628343402);
         _FIXED_LEN_MOD_BOUNDS( 2, 3037000500, 13043817825332782213);
 #else  // FLINT_BITS == 64
+        _FIXED_LEN_MOD_BOUNDS(11, 19760, 1294981365);
         _FIXED_LEN_MOD_BOUNDS(10, 20725, 1358187914);
         _FIXED_LEN_MOD_BOUNDS( 9, 21846, 1431655766);
         _FIXED_LEN_MOD_BOUNDS( 8, 23171, 1518500250);
@@ -193,7 +195,7 @@ FLINT_FORCE_INLINE dot_params_t _nmod_vec_dot_params(ulong len, nmod_t mod)
     }
 #undef _FIXED_LEN_MOD_BOUNDS
 
-// sage: for ell in range(1,11):
+// sage: for ell in range(1,12):
 // ....:     n0 = ceil(2**16 / sqrt(ell))
 // ....:     n1 = ceil(2**32 / sqrt(ell))
 // ....:     n2 = ceil(2**64 / sqrt(ell))
@@ -209,6 +211,8 @@ FLINT_FORCE_INLINE dot_params_t _nmod_vec_dot_params(ulong len, nmod_t mod)
 //  8: 23171  ||  1518500250  ||  6521908912666391107
 //  9: 21846  ||  1431655766  ||  6148914691236517206
 // 10: 20725  ||  1358187914  ||  5833372668713515885
+// 11: 19760  ||  1294981365  ||  5561902608746059656
+
 
     if (mod.n <= UWORD(1) << (FLINT_BITS / 2)) // implies <= 2 limbs
     {
@@ -567,6 +571,7 @@ ulong _nmod_vec_dot2_split_ptr(nn_srcptr vec1, const nn_ptr * vec2, slong offset
         _NMOD_VEC_DOT_SHORT1(8, expr1, expr2)                           \
         _NMOD_VEC_DOT_SHORT1(9, expr1, expr2)                           \
         _NMOD_VEC_DOT_SHORT1(10, expr1, expr2)                          \
+        _NMOD_VEC_DOT_SHORT1(11, expr1, expr2)                          \
         return 0;                                                       \
     }                                                                   \
                                                                         \
@@ -583,6 +588,7 @@ ulong _nmod_vec_dot2_split_ptr(nn_srcptr vec1, const nn_ptr * vec2, slong offset
         _NMOD_VEC_DOT_SHORT2(8, expr1, expr2)                           \
         _NMOD_VEC_DOT_SHORT2(9, expr1, expr2)                           \
         _NMOD_VEC_DOT_SHORT2(10, expr1, expr2)                          \
+        _NMOD_VEC_DOT_SHORT2(11, expr1, expr2)                          \
         return 0;                                                       \
     }                                                                   \
                                                                         \
@@ -599,14 +605,17 @@ ulong _nmod_vec_dot2_split_ptr(nn_srcptr vec1, const nn_ptr * vec2, slong offset
         _NMOD_VEC_DOT_SHORT3(8, expr1, expr2)                           \
         _NMOD_VEC_DOT_SHORT3(9, expr1, expr2)                           \
         _NMOD_VEC_DOT_SHORT3(10, expr1, expr2)                          \
+        _NMOD_VEC_DOT_SHORT3(11, expr1, expr2)                          \
         return 0;                                                       \
     }                                                                   \
 }  while(0);                                                            \
 
 FLINT_FORCE_INLINE ulong _nmod_vec_dot(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, dot_params_t params)
 {
+    if (params.method == _DOT0)
+        return UWORD(0);
     // handle short products
-    if (len <= 10)
+    if (len <= 11)
     {
         slong i = 0;
         _NMOD_VEC_DOT_SHORT(i, vec1[i], vec2[i], len, mod, params.method);
@@ -641,7 +650,7 @@ FLINT_FORCE_INLINE ulong _nmod_vec_dot(nn_srcptr vec1, nn_srcptr vec2, slong len
 
 FLINT_FORCE_INLINE ulong _nmod_vec_dot_rev(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, dot_params_t params)
 {
-    if (len <= 10)
+    if (len <= 11)
     {
         slong i = 0;
         _NMOD_VEC_DOT_SHORT(i, vec1[i], vec2[len-1-i], len, mod, params.method);
@@ -676,7 +685,7 @@ FLINT_FORCE_INLINE ulong _nmod_vec_dot_rev(nn_srcptr vec1, nn_srcptr vec2, slong
 
 FLINT_FORCE_INLINE ulong _nmod_vec_dot_ptr(nn_srcptr vec1, const nn_ptr * vec2, slong offset, slong len, nmod_t mod, dot_params_t params)
 {
-    if (len <= 10)
+    if (len <= 11)
     {
         slong i = 0;
         _NMOD_VEC_DOT_SHORT(i, vec1[i], vec2[i][offset], len, mod, params.method);

--- a/src/nmod_vec.h
+++ b/src/nmod_vec.h
@@ -155,6 +155,7 @@ do                                                                    \
 } while(0);
 
 // _DOT2_SPLIT   (2 limbs, splitting at 56 bits, 8-unrolling)
+#if (FLINT_BITS == 64)
 #define _NMOD_VEC_DOT2_SPLIT(res, i, len, expr1, expr2, mod, pow2_precomp) \
 do                                                    \
 {                                                     \
@@ -182,6 +183,7 @@ do                                                    \
     res = pow2_precomp * dp_hi + dp_lo;               \
     NMOD_RED(res, res, mod);                          \
 } while(0);
+#endif  // FLINT_BITS == 64
 
 // _DOT2_HALF   (two limbs, modulus < 2**32)
 // mod.n is too close to 2**32 to accumulate in some ulong
@@ -326,6 +328,9 @@ do                                                                    \
     NMOD_RED3(res, t2zz, t1zz, t0zz, mod);                            \
 } while(0);
 
+
+#if (FLINT_BITS == 64)
+
 #define NMOD_VEC_DOT(res, i, len, expr1, expr2, mod, params)          \
 do                                                                    \
 {                                                                     \
@@ -345,6 +350,25 @@ do                                                                    \
         _NMOD_VEC_DOT3(res, i, len, expr1, expr2, mod)                \
 } while(0);
 
+#else  // FLINT_BITS == 64
+
+#define NMOD_VEC_DOT(res, i, len, expr1, expr2, mod, params)          \
+do                                                                    \
+{                                                                     \
+    res = UWORD(0);   /* covers _DOT0 */                              \
+    if (params.method == _DOT1 || params.method == _DOT_POW2)         \
+        _NMOD_VEC_DOT1(res, i, len, expr1, expr2, mod)                \
+    else if (params.method == _DOT2_HALF)                             \
+        _NMOD_VEC_DOT2_HALF(res, i, len, expr1, expr2, mod)           \
+    else if (params.method == _DOT2)                                  \
+        _NMOD_VEC_DOT2(res, i, len, expr1, expr2, mod)                \
+    else if (params.method == _DOT3_ACC)                              \
+        _NMOD_VEC_DOT3_ACC(res, i, len, expr1, expr2, mod)            \
+    else if (params.method == _DOT3)                                  \
+        _NMOD_VEC_DOT3(res, i, len, expr1, expr2, mod)                \
+} while(0);
+
+#endif  // FLINT_BITS == 64
 
 ulong _nmod_vec_dot(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, dot_params_t);
 ulong _nmod_vec_dot_rev(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, dot_params_t);

--- a/src/nmod_vec.h
+++ b/src/nmod_vec.h
@@ -142,10 +142,6 @@ typedef enum
 // 2 limbs <=>  _DOT1 < method <= _DOT2
 // 3 limbs <=>  _DOT2 < method
 
-// TODO note (for documentation): if params has been computed for some given len and mod, algorithms
-// ensure it can be used safely for smaller lengths and same mod
-// (e.g. in particular algorithms handle len == 0 even when the method is e.g. _DOT1)
-
 typedef struct
 {
     dot_method_t method;

--- a/src/nmod_vec.h
+++ b/src/nmod_vec.h
@@ -1,6 +1,7 @@
 /*
     Copyright (C) 2010 William Hart
     Copyright (C) 2021 Fredrik Johansson
+    Copyright (C) 2024 Vincent Neiger
 
     This file is part of FLINT.
 
@@ -108,187 +109,239 @@ void _nmod_vec_scalar_mul_nmod_shoup(nn_ptr res, nn_srcptr vec, slong len, ulong
 
 void _nmod_vec_scalar_addmul_nmod(nn_ptr res, nn_srcptr vec, slong len, ulong c, nmod_t mod);
 
-int _nmod_vec_dot_bound_limbs(slong len, nmod_t mod);
-
+/* -------------------- dot product ----------------------- */
+/* more comments in nmod_vec/dot.c */
 
 #define DOT_SPLIT_BITS 56
 #define DOT_SPLIT_MASK UWORD(72057594037927935) // (1L << DOT_SPLIT_BITS) - 1
 
-// new general dot macro
-#define NMOD_VEC_DOT(res, i, len, expr1, expr2, mod, nlimbs)          \
+typedef enum
+{
+    _DOT0 = 0,           /* len == 0 || mod.n == 1 */
+    _DOT1 = 1,           /* 1 limb */
+    _DOT2_32_SPLIT = 2,  /* 2 limbs, modulus < ~2**30.5 (FLINT_BITS == 64 only) */
+    _DOT2_HALF = 3,      /* 2 limbs, modulus < 2**(FLINT_BITS/2) */
+    _DOT2 = 4,           /* 2 limbs */
+    _DOT3_ACC = 5,       /* 3 limbs, modulus < 2**62.5 allowing accumulation in 2 limbs */
+    _DOT3 = 6            /* 3 limbs, modulus >= 2**62.5 */
+} dot_method_t;
+// > 1 limb <-> method > _DOT1   |   > 2 limbs <-> method > _DOT2
+
+typedef struct
+{
+    dot_method_t method;
+    ulong pow2_precomp;  /* for splitting: (1L << 56) % mod.n */
+} dot_params_t;
+
+// compute dot parameters
+dot_params_t _nmod_vec_dot_params(ulong len, nmod_t mod);
+
+// _DOT1   (1 limb)
+#define _NMOD_VEC_DOT1(res, i, len, expr1, expr2, mod)                \
 do                                                                    \
 {                                                                     \
-    if (nlimbs == 1)                                                  \
-    {                                                                 \
-        res = UWORD(0);                                               \
-        for (i = 0; i < (len); i++)                                   \
-            res += (expr1) * (expr2);                                 \
-        NMOD_RED(res, res, mod);                                      \
-    }                                                                 \
-    else if (mod.n <= UWORD(1515531528) && (len) <= WORD(134744072))  \
-    {                                                                 \
-        ulong dp_lo = 0;                                              \
-        unsigned int dp_hi = 0;                                       \
-                                                                      \
-        for (i = 0; i+7 < (len); )                                    \
-        {                                                             \
-            dp_lo += (expr1) * (expr2); i++;                          \
-            dp_lo += (expr1) * (expr2); i++;                          \
-            dp_lo += (expr1) * (expr2); i++;                          \
-            dp_lo += (expr1) * (expr2); i++;                          \
-            dp_lo += (expr1) * (expr2); i++;                          \
-            dp_lo += (expr1) * (expr2); i++;                          \
-            dp_lo += (expr1) * (expr2); i++;                          \
-            dp_lo += (expr1) * (expr2); i++;                          \
-                                                                      \
-            dp_hi += dp_lo >> DOT_SPLIT_BITS;                         \
-            dp_lo &= DOT_SPLIT_MASK;                                  \
-        }                                                             \
-                                                                      \
-        for ( ; i < (len); i++)                                       \
-            dp_lo += (expr1) * (expr2);                               \
-                                                                      \
-        unsigned int red_pow;                                         \
-        NMOD_RED(red_pow, (UWORD(1) << DOT_SPLIT_BITS), mod);         \
-        res = (ulong)red_pow * dp_hi + dp_lo;                         \
-        NMOD_RED(res, res, mod);                                      \
-    }                                                                 \
-    else if (mod.n <= (UWORD(1) << (FLINT_BITS / 2)))                 \
-    {                                                                 \
-        ulong s0zz = UWORD(0);                                        \
-        ulong s1zz = UWORD(0);                                        \
-        for (i = 0; i < (len); i++)                                   \
-        {                                                             \
-            const ulong prodzz = (expr1) * (expr2);                   \
-            add_ssaaaa(s1zz, s0zz, s1zz, s0zz, 0, prodzz);            \
-        }                                                             \
-        NMOD2_RED2(res, s1zz, s0zz, mod);                             \
-    }                                                                 \
-    else if (nlimbs == 2)                                             \
-    {                                                                 \
-        ulong u0zz = UWORD(0);                                        \
-        ulong u1zz = UWORD(0);                                        \
-                                                                      \
-        for (i = 0; i+7 < (len); )                                    \
-        {                                                             \
-            ulong s0zz, s1zz;                                         \
-            umul_ppmm(s1zz, s0zz, (expr1), (expr2));                  \
-            add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);           \
-            i++;                                                      \
-            umul_ppmm(s1zz, s0zz, (expr1), (expr2));                  \
-            add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);           \
-            i++;                                                      \
-            umul_ppmm(s1zz, s0zz, (expr1), (expr2));                  \
-            add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);           \
-            i++;                                                      \
-            umul_ppmm(s1zz, s0zz, (expr1), (expr2));                  \
-            add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);           \
-            i++;                                                      \
-            umul_ppmm(s1zz, s0zz, (expr1), (expr2));                  \
-            add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);           \
-            i++;                                                      \
-            umul_ppmm(s1zz, s0zz, (expr1), (expr2));                  \
-            add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);           \
-            i++;                                                      \
-            umul_ppmm(s1zz, s0zz, (expr1), (expr2));                  \
-            add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);           \
-            i++;                                                      \
-            umul_ppmm(s1zz, s0zz, (expr1), (expr2));                  \
-            add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);           \
-            i++;                                                      \
-        }                                                             \
-        for ( ; i < (len); i++)                                       \
-        {                                                             \
-            ulong s0zz, s1zz;                                         \
-            umul_ppmm(s1zz, s0zz, (expr1), (expr2));                  \
-            add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);           \
-        }                                                             \
-                                                                      \
-        NMOD2_RED2(res, u1zz, u0zz, mod);                             \
-    }                                                                 \
-    else if (nlimbs == 3)                                             \
-    {                                                                 \
-        ulong t2zz = UWORD(0);                                        \
-        ulong t1zz = UWORD(0);                                        \
-        ulong t0zz = UWORD(0);                                        \
-                                                                      \
-        /* we can accumulate 8 terms if n == mod.n is such that */    \
-        /*      8 * (n-1)**2 < 2**128, this is equivalent to    */    \
-        /*      n <= ceil(sqrt(2**125)) = 6521908912666391107   */    \
-        if (mod.n <= 6521908912666391107L)                            \
-        {                                                             \
-            for (i = 0; i+7 < (len); )                                \
-            {                                                         \
-                ulong s0zz, s1zz;                                     \
-                ulong u0zz = UWORD(0);                                \
-                ulong u1zz = UWORD(0);                                \
-                umul_ppmm(s1zz, s0zz, (expr1), (expr2));              \
-                add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);       \
-                i++;                                                  \
-                umul_ppmm(s1zz, s0zz, (expr1), (expr2));              \
-                add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);       \
-                i++;                                                  \
-                umul_ppmm(s1zz, s0zz, (expr1), (expr2));              \
-                add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);       \
-                i++;                                                  \
-                umul_ppmm(s1zz, s0zz, (expr1), (expr2));              \
-                add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);       \
-                i++;                                                  \
-                umul_ppmm(s1zz, s0zz, (expr1), (expr2));              \
-                add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);       \
-                i++;                                                  \
-                umul_ppmm(s1zz, s0zz, (expr1), (expr2));              \
-                add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);       \
-                i++;                                                  \
-                umul_ppmm(s1zz, s0zz, (expr1), (expr2));              \
-                add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);       \
-                i++;                                                  \
-                umul_ppmm(s1zz, s0zz, (expr1), (expr2));              \
-                add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);       \
-                i++;                                                  \
-                add_sssaaaaaa(t2zz, t1zz, t0zz,                       \
-                              t2zz, t1zz, t0zz,                       \
-                              UWORD(0), u1zz, u0zz);                  \
-            }                                                         \
-                                                                      \
-            ulong s0zz, s1zz;                                         \
-            ulong u0zz = UWORD(0);                                    \
-            ulong u1zz = UWORD(0);                                    \
-            for ( ; i < (len); i++)                                   \
-            {                                                         \
-                umul_ppmm(s1zz, s0zz, (expr1), (expr2));              \
-                add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);       \
-            }                                                         \
-                                                                      \
-            add_sssaaaaaa(t2zz, t1zz, t0zz,                           \
-                          t2zz, t1zz, t0zz,                           \
-                          UWORD(0), u1zz, u0zz);                      \
-        }                                                             \
-        else                                                          \
-        {                                                             \
-            for (i = 0; i < (len); i++)                               \
-            {                                                         \
-                ulong s0zz, s1zz;                                     \
-                umul_ppmm(s1zz, s0zz, (expr1), (expr2));              \
-                add_sssaaaaaa(t2zz, t1zz, t0zz,                       \
-                              t2zz, t1zz, t0zz,                       \
-                              UWORD(0), s1zz, s0zz);                  \
-            }                                                         \
-        }                                                             \
-                                                                      \
-        NMOD_RED(t2zz, t2zz, mod);                                    \
-        NMOD_RED3(res, t2zz, t1zz, t0zz, mod);                        \
-    }                                                                 \
-    else   /* nlimbs == 0 */                                          \
-    {                                                                 \
-        res = UWORD(0);                                               \
-    }                                                                 \
+    res = UWORD(0);                                                   \
+    for (i = 0; i < (len); i++)                                       \
+        res += (expr1) * (expr2);                                     \
+    NMOD_RED(res, res, mod);                                          \
 } while(0);
 
-ulong _nmod_vec_dot(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, int nlimbs);
-ulong _nmod_vec_dot_rev(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, int nlimbs);
+// _DOT2_32_SPLIT   (2 limbs, splitting at 56 bits, 8-unrolling)
+#define _NMOD_VEC_DOT2_32_SPLIT(res, i, len, expr1, expr2, mod, pow2_precomp) \
+do                                                    \
+{                                                     \
+    ulong dp_lo = 0;                                  \
+    ulong dp_hi = 0;                                  \
+                                                      \
+    for (i = 0; i+7 < (len); )                        \
+    {                                                 \
+        dp_lo += (expr1) * (expr2); i++;              \
+        dp_lo += (expr1) * (expr2); i++;              \
+        dp_lo += (expr1) * (expr2); i++;              \
+        dp_lo += (expr1) * (expr2); i++;              \
+        dp_lo += (expr1) * (expr2); i++;              \
+        dp_lo += (expr1) * (expr2); i++;              \
+        dp_lo += (expr1) * (expr2); i++;              \
+        dp_lo += (expr1) * (expr2); i++;              \
+                                                      \
+        dp_hi += dp_lo >> DOT_SPLIT_BITS;             \
+        dp_lo &= DOT_SPLIT_MASK;                      \
+    }                                                 \
+                                                      \
+    for ( ; i < (len); i++)                           \
+        dp_lo += (expr1) * (expr2);                   \
+                                                      \
+    res = pow2_precomp * dp_hi + dp_lo;               \
+    NMOD_RED(res, res, mod);                          \
+} while(0);
 
-ulong _nmod_vec_dot_ptr(nn_srcptr vec1, const nn_ptr * vec2, slong offset, slong len, nmod_t mod, int nlimbs);
+// _DOT2_HALF   (two limbs, modulus < 2**32)
+// mod.n is too close to 2**32 to accumulate in some ulong
+// still interesting: a bit faster than _NMOD_VEC_DOT2
+#define _NMOD_VEC_DOT2_HALF(res, i, len, expr1, expr2, mod)           \
+do                                                                    \
+{                                                                     \
+    ulong s0zz = UWORD(0);                                            \
+    ulong s1zz = UWORD(0);                                            \
+    for (i = 0; i < (len); i++)                                       \
+    {                                                                 \
+        const ulong prodzz = (expr1) * (expr2);                       \
+        add_ssaaaa(s1zz, s0zz, s1zz, s0zz, 0, prodzz);                \
+    }                                                                 \
+    NMOD2_RED2(res, s1zz, s0zz, mod);                                 \
+} while(0);
+
+// _DOT2   (two limbs, general)
+// 8-unroll: requires  8 * (mod.n - 1)**2 < 2**128
+#define _NMOD_VEC_DOT2(res, i, len, expr1, expr2, mod)                \
+do                                                                    \
+{                                                                     \
+    ulong u0zz = UWORD(0);                                            \
+    ulong u1zz = UWORD(0);                                            \
+                                                                      \
+    for (i = 0; i+7 < (len); )                                        \
+    {                                                                 \
+        ulong s0zz, s1zz;                                             \
+        umul_ppmm(s1zz, s0zz, (expr1), (expr2));                      \
+        add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);               \
+        i++;                                                          \
+        umul_ppmm(s1zz, s0zz, (expr1), (expr2));                      \
+        add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);               \
+        i++;                                                          \
+        umul_ppmm(s1zz, s0zz, (expr1), (expr2));                      \
+        add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);               \
+        i++;                                                          \
+        umul_ppmm(s1zz, s0zz, (expr1), (expr2));                      \
+        add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);               \
+        i++;                                                          \
+        umul_ppmm(s1zz, s0zz, (expr1), (expr2));                      \
+        add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);               \
+        i++;                                                          \
+        umul_ppmm(s1zz, s0zz, (expr1), (expr2));                      \
+        add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);               \
+        i++;                                                          \
+        umul_ppmm(s1zz, s0zz, (expr1), (expr2));                      \
+        add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);               \
+        i++;                                                          \
+        umul_ppmm(s1zz, s0zz, (expr1), (expr2));                      \
+        add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);               \
+        i++;                                                          \
+    }                                                                 \
+    for ( ; i < (len); i++)                                           \
+    {                                                                 \
+        ulong s0zz, s1zz;                                             \
+        umul_ppmm(s1zz, s0zz, (expr1), (expr2));                      \
+        add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);               \
+    }                                                                 \
+                                                                      \
+    NMOD2_RED2(res, u1zz, u0zz, mod);                                 \
+} while(0);
+
+// _DOT3_ACC   (three limbs, delayed accumulations)
+// 8-unroll: requires  8 * (mod.n - 1)**2 < 2**128
+#define _NMOD_VEC_DOT3_ACC(res, i, len, expr1, expr2, mod)            \
+do                                                                    \
+{                                                                     \
+    ulong t2zz = UWORD(0);                                            \
+    ulong t1zz = UWORD(0);                                            \
+    ulong t0zz = UWORD(0);                                            \
+                                                                      \
+    for (i = 0; i+7 < (len); )                                        \
+    {                                                                 \
+        ulong s0zz, s1zz;                                             \
+        ulong u0zz = UWORD(0);                                        \
+        ulong u1zz = UWORD(0);                                        \
+        umul_ppmm(s1zz, s0zz, (expr1), (expr2));                      \
+        add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);               \
+        i++;                                                          \
+        umul_ppmm(s1zz, s0zz, (expr1), (expr2));                      \
+        add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);               \
+        i++;                                                          \
+        umul_ppmm(s1zz, s0zz, (expr1), (expr2));                      \
+        add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);               \
+        i++;                                                          \
+        umul_ppmm(s1zz, s0zz, (expr1), (expr2));                      \
+        add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);               \
+        i++;                                                          \
+        umul_ppmm(s1zz, s0zz, (expr1), (expr2));                      \
+        add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);               \
+        i++;                                                          \
+        umul_ppmm(s1zz, s0zz, (expr1), (expr2));                      \
+        add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);               \
+        i++;                                                          \
+        umul_ppmm(s1zz, s0zz, (expr1), (expr2));                      \
+        add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);               \
+        i++;                                                          \
+        umul_ppmm(s1zz, s0zz, (expr1), (expr2));                      \
+        add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);               \
+        i++;                                                          \
+        add_sssaaaaaa(t2zz, t1zz, t0zz,                               \
+                        t2zz, t1zz, t0zz,                             \
+                        UWORD(0), u1zz, u0zz);                        \
+    }                                                                 \
+                                                                      \
+    ulong s0zz, s1zz;                                                 \
+    ulong u0zz = UWORD(0);                                            \
+    ulong u1zz = UWORD(0);                                            \
+    for ( ; i < (len); i++)                                           \
+    {                                                                 \
+        umul_ppmm(s1zz, s0zz, (expr1), (expr2));                      \
+        add_ssaaaa(u1zz, u0zz, u1zz, u0zz, s1zz, s0zz);               \
+    }                                                                 \
+                                                                      \
+    add_sssaaaaaa(t2zz, t1zz, t0zz,                                   \
+                    t2zz, t1zz, t0zz,                                 \
+                    UWORD(0), u1zz, u0zz);                            \
+                                                                      \
+    NMOD_RED(t2zz, t2zz, mod);                                        \
+    NMOD_RED3(res, t2zz, t1zz, t0zz, mod);                            \
+} while(0);
+
+// _DOT3   (three limbs, general)
+// mod.n is too close to 2**64 to accumulate in two words
+#define _NMOD_VEC_DOT3(res, i, len, expr1, expr2, mod)                \
+do                                                                    \
+{                                                                     \
+    ulong t2zz = UWORD(0);                                            \
+    ulong t1zz = UWORD(0);                                            \
+    ulong t0zz = UWORD(0);                                            \
+    for (i = 0; i < (len); i++)                                       \
+    {                                                                 \
+        ulong s0zz, s1zz;                                             \
+        umul_ppmm(s1zz, s0zz, (expr1), (expr2));                      \
+        add_sssaaaaaa(t2zz, t1zz, t0zz,                               \
+                        t2zz, t1zz, t0zz,                             \
+                        UWORD(0), s1zz, s0zz);                        \
+    }                                                                 \
+                                                                      \
+    NMOD_RED(t2zz, t2zz, mod);                                        \
+    NMOD_RED3(res, t2zz, t1zz, t0zz, mod);                            \
+} while(0);
+
+#define NMOD_VEC_DOT(res, i, len, expr1, expr2, mod, params)          \
+do                                                                    \
+{                                                                     \
+    res = UWORD(0);   /* covers _DOT0 */                              \
+    if (params.method == _DOT1)                                       \
+        _NMOD_VEC_DOT1(res, i, len, expr1, expr2, mod)                \
+    else if (params.method == _DOT2_32_SPLIT)                         \
+        _NMOD_VEC_DOT2_32_SPLIT(res, i, len, expr1, expr2, mod,       \
+                params.pow2_precomp)                                  \
+    else if (params.method == _DOT2_HALF)                             \
+        _NMOD_VEC_DOT2_HALF(res, i, len, expr1, expr2, mod)           \
+    else if (params.method == _DOT2)                                  \
+        _NMOD_VEC_DOT2(res, i, len, expr1, expr2, mod)                \
+    else if (params.method == _DOT3_ACC)                              \
+        _NMOD_VEC_DOT3_ACC(res, i, len, expr1, expr2, mod)            \
+    else if (params.method == _DOT3)                                  \
+        _NMOD_VEC_DOT3(res, i, len, expr1, expr2, mod)                \
+} while(0);
+
+
+ulong _nmod_vec_dot(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, dot_params_t);
+ulong _nmod_vec_dot_rev(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, dot_params_t);
+
+ulong _nmod_vec_dot_ptr(nn_srcptr vec1, const nn_ptr * vec2, slong offset, slong len, nmod_t mod, dot_params_t);
 
 /* some IO functions */
 #ifdef FLINT_HAVE_FILE

--- a/src/nmod_vec/dot.c
+++ b/src/nmod_vec/dot.c
@@ -12,6 +12,7 @@
 
 #include "nmod.h"
 #include "nmod_vec.h"
+#include "machine_vectors.h"
 
 
 dot_params_t _nmod_vec_dot_params(ulong len, nmod_t mod)
@@ -72,9 +73,90 @@ dot_params_t _nmod_vec_dot_params(ulong len, nmod_t mod)
 ulong
 _nmod_vec_dot(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, dot_params_t params)
 {
-    ulong res;
+    ulong res = UWORD(0);   /* covers _DOT0 */
     slong i;
-    NMOD_VEC_DOT(res, i, len, vec1[i], vec2[i], mod, params);
+
+    if (params.method == _DOT1)
+#if defined(__AVX2__)
+    {
+        vec4n dp = vec4n_zero();
+
+        slong i = 0;
+        for ( ; i+31 < len; i += 32)
+        {
+            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+ 0), vec4n_load_unaligned(vec2+i+ 0)));
+            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+ 4), vec4n_load_unaligned(vec2+i+ 4)));
+            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+ 8), vec4n_load_unaligned(vec2+i+ 8)));
+            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+12), vec4n_load_unaligned(vec2+i+12)));
+            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+16), vec4n_load_unaligned(vec2+i+16)));
+            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+20), vec4n_load_unaligned(vec2+i+20)));
+            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+24), vec4n_load_unaligned(vec2+i+24)));
+            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+28), vec4n_load_unaligned(vec2+i+28)));
+        }
+
+        for ( ; i + 3 < len; i += 4)
+            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i), vec4n_load_unaligned(vec2+i)));
+
+        res = dp[0] + dp[1] + dp[2] + dp[3];
+
+        for (; i < len; i++)
+            res += vec1[i] * vec2[i];
+
+        NMOD_RED(res, res, mod);
+    }
+#else // if defined(__AVX2__)
+        _NMOD_VEC_DOT1(res, i, len, vec1[i], vec2[i], mod)
+#endif // if defined(__AVX2__)
+    else if (params.method == _DOT2_32_SPLIT)
+#if defined(__AVX2__)
+    {
+        const vec4n low_bits = vec4n_set_n(DOT_SPLIT_MASK);
+        vec4n dp_lo = vec4n_zero();
+        vec4n dp_hi = vec4n_zero();
+
+        slong i = 0;
+        for ( ; i+31 < len; i += 32)
+        {
+            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+ 0), vec4n_load_unaligned(vec2+i+ 0)));
+            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+ 4), vec4n_load_unaligned(vec2+i+ 4)));
+            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+ 8), vec4n_load_unaligned(vec2+i+ 8)));
+            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+12), vec4n_load_unaligned(vec2+i+12)));
+            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+16), vec4n_load_unaligned(vec2+i+16)));
+            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+20), vec4n_load_unaligned(vec2+i+20)));
+            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+24), vec4n_load_unaligned(vec2+i+24)));
+            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+28), vec4n_load_unaligned(vec2+i+28)));
+
+            dp_hi = vec4n_add(dp_hi, vec4n_bit_shift_right(dp_lo, DOT_SPLIT_BITS));
+            dp_lo = vec4n_bit_and(dp_lo, low_bits);
+        }
+
+        for ( ; i + 3 < len; i += 4)
+            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i), vec4n_load_unaligned(vec2+i)));
+
+        dp_hi = vec4n_add(dp_hi, vec4n_bit_shift_right(dp_lo, DOT_SPLIT_BITS));
+        dp_lo = vec4n_bit_and(dp_lo, low_bits);
+
+        ulong hsum_lo = dp_lo[0] + dp_lo[1] + dp_lo[2] + dp_lo[3];
+        const ulong hsum_hi = dp_hi[0] + dp_hi[1] + dp_hi[2] + dp_hi[3] + (hsum_lo >> DOT_SPLIT_BITS);
+        hsum_lo &= DOT_SPLIT_MASK;
+
+        for (; i < len; i++)
+            hsum_lo += vec1[i] * vec2[i];
+
+        NMOD_RED(res, params.pow2_precomp * hsum_hi + hsum_lo, mod);
+    }
+#else // if defined(__AVX2__)
+        _NMOD_VEC_DOT2_32_SPLIT(res, i, len, vec1[i], vec2[i], mod, params.pow2_precomp)
+#endif // if defined(__AVX2__)
+    else if (params.method == _DOT2_HALF)
+        _NMOD_VEC_DOT2_HALF(res, i, len, vec1[i], vec2[i], mod)
+    else if (params.method == _DOT2)
+        _NMOD_VEC_DOT2(res, i, len, vec1[i], vec2[i], mod)
+    else if (params.method == _DOT3_ACC)
+        _NMOD_VEC_DOT3_ACC(res, i, len, vec1[i], vec2[i], mod)
+    else if (params.method == _DOT3)
+        _NMOD_VEC_DOT3(res, i, len, vec1[i], vec2[i], mod)
+
     return res;
 }
 
@@ -99,9 +181,7 @@ nmod_fmma(ulong a, ulong b, ulong c, ulong d, nmod_t mod)
 ulong
 _nmod_vec_dot_rev(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, dot_params_t params)
 {
-    ulong res;
-    slong i;
-
+    // FIXME advantage of this? (if yes, no similar advantage in non-rev version?)
     if (len <= 2 && params.method > _DOT1)
     {
         if (len == 2)
@@ -111,11 +191,94 @@ _nmod_vec_dot_rev(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, dot_par
         return 0;
     }
 
-    NMOD_VEC_DOT(res, i, len, vec1[i], vec2[len - 1 - i], mod, params);
+    ulong res = UWORD(0);   /* covers _DOT0 */
+    slong i;
+
+    if (params.method == _DOT1)
+#if defined(__AVX2__)
+    {
+        vec4n dp = vec4n_zero();
+
+        slong i = 0;
+        for ( ; i+31 < len; i += 32)
+        {
+            const ulong ii = len - 32 - i; // >= 0
+            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+ 0), vec4n_permute_3_2_1_0(vec4n_load_unaligned(vec2+ii+28))));
+            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+ 4), vec4n_permute_3_2_1_0(vec4n_load_unaligned(vec2+ii+24))));
+            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+ 8), vec4n_permute_3_2_1_0(vec4n_load_unaligned(vec2+ii+20))));
+            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+12), vec4n_permute_3_2_1_0(vec4n_load_unaligned(vec2+ii+16))));
+            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+16), vec4n_permute_3_2_1_0(vec4n_load_unaligned(vec2+ii+12))));
+            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+20), vec4n_permute_3_2_1_0(vec4n_load_unaligned(vec2+ii+ 8))));
+            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+24), vec4n_permute_3_2_1_0(vec4n_load_unaligned(vec2+ii+ 4))));
+            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+28), vec4n_permute_3_2_1_0(vec4n_load_unaligned(vec2+ii+ 0))));
+        }
+
+        for ( ; i + 3 < len; i += 4)
+            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i), vec4n_permute_3_2_1_0(vec4n_load_unaligned(vec2+len-4-i))));
+
+        res = dp[0] + dp[1] + dp[2] + dp[3];
+
+        for (; i < len; i++)
+            res += vec1[i] * vec2[len-1-i];
+
+        NMOD_RED(res, res, mod);
+    }
+#else // if defined(__AVX2__)
+        _NMOD_VEC_DOT1(res, i, len, vec1[i], vec2[len-1-i], mod)
+#endif // if defined(__AVX2__)
+    else if (params.method == _DOT2_32_SPLIT)
+#if defined(__AVX2__)
+    {
+        const vec4n low_bits = vec4n_set_n(DOT_SPLIT_MASK);
+        vec4n dp_lo = vec4n_zero();
+        vec4n dp_hi = vec4n_zero();
+
+        slong i = 0;
+        for ( ; i+31 < len; i += 32)
+        {
+            const ulong ii = len - 32 - i; // >= 0
+            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+ 0), vec4n_permute_3_2_1_0(vec4n_load_unaligned(vec2+ii+28))));
+            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+ 4), vec4n_permute_3_2_1_0(vec4n_load_unaligned(vec2+ii+24))));
+            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+ 8), vec4n_permute_3_2_1_0(vec4n_load_unaligned(vec2+ii+20))));
+            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+12), vec4n_permute_3_2_1_0(vec4n_load_unaligned(vec2+ii+16))));
+            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+16), vec4n_permute_3_2_1_0(vec4n_load_unaligned(vec2+ii+12))));
+            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+20), vec4n_permute_3_2_1_0(vec4n_load_unaligned(vec2+ii+ 8))));
+            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+24), vec4n_permute_3_2_1_0(vec4n_load_unaligned(vec2+ii+ 4))));
+            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+28), vec4n_permute_3_2_1_0(vec4n_load_unaligned(vec2+ii+ 0))));
+
+            dp_hi = vec4n_add(dp_hi, vec4n_bit_shift_right(dp_lo, DOT_SPLIT_BITS));
+            dp_lo = vec4n_bit_and(dp_lo, low_bits);
+        }
+
+        for ( ; i + 3 < len; i += 4)
+            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i), vec4n_permute_3_2_1_0(vec4n_load_unaligned(vec2+len-4-i))));
+
+        dp_hi = vec4n_add(dp_hi, vec4n_bit_shift_right(dp_lo, DOT_SPLIT_BITS));
+        dp_lo = vec4n_bit_and(dp_lo, low_bits);
+
+        ulong hsum_lo = dp_lo[0] + dp_lo[1] + dp_lo[2] + dp_lo[3];
+        const ulong hsum_hi = dp_hi[0] + dp_hi[1] + dp_hi[2] + dp_hi[3] + (hsum_lo >> DOT_SPLIT_BITS);
+        hsum_lo &= DOT_SPLIT_MASK;
+
+        for (; i < len; i++)
+            hsum_lo += vec1[i] * vec2[len-1-i];
+
+        NMOD_RED(res, params.pow2_precomp * hsum_hi + hsum_lo, mod);
+    }
+#else // if defined(__AVX2__)
+        _NMOD_VEC_DOT2_32_SPLIT(res, i, len, vec1[i], vec2[len-1-i], mod, params.pow2_precomp)
+#endif // if defined(__AVX2__)
+    else if (params.method == _DOT2_HALF)
+        _NMOD_VEC_DOT2_HALF(res, i, len, vec1[i], vec2[len-1-i], mod)
+    else if (params.method == _DOT2)
+        _NMOD_VEC_DOT2(res, i, len, vec1[i], vec2[len-1-i], mod)
+    else if (params.method == _DOT3_ACC)
+        _NMOD_VEC_DOT3_ACC(res, i, len, vec1[i], vec2[len-1-i], mod)
+    else if (params.method == _DOT3)
+        _NMOD_VEC_DOT3(res, i, len, vec1[i], vec2[len-1-i], mod)
+
     return res;
 }
-
-
 
 
 

--- a/src/nmod_vec/dot.c
+++ b/src/nmod_vec/dot.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2011, 2021 Fredrik Johansson
+    Copyright (C) 2024 Vincent Neiger
 
     This file is part of FLINT.
 
@@ -12,37 +13,78 @@
 #include "nmod.h"
 #include "nmod_vec.h"
 
-ulong
-_nmod_vec_dot(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, int nlimbs)
-{
-    ulong res;
-    slong i;
-    NMOD_VEC_DOT(res, i, len, vec1[i], vec2[i], mod, nlimbs);
-    return res;
-}
 
-int
-_nmod_vec_dot_bound_limbs(slong len, nmod_t mod)
+dot_params_t _nmod_vec_dot_params(ulong len, nmod_t mod)
 {
     ulong t2, t1, t0, u1, u0;
+
+    dot_params_t params = {_DOT0, UWORD(0)};
 
     umul_ppmm(t1, t0, mod.n - 1, mod.n - 1);
     umul_ppmm(t2, t1, t1, len);
     umul_ppmm(u1, u0, t0, len);
     add_ssaaaa(t2, t1, t2, t1, UWORD(0), u1);
 
-    if (t2 != 0) return 3;
-    if (t1 != 0) return 2;
-    return (u0 != 0);
+    // TODO handle power of 2 case? (do not return DOT1 directly; special flag?)
+
+    if (t2 != 0) // three limbs
+    {
+        /* we can accumulate 8 terms if n == mod.n is such that        */
+        /*      8 * (n-1)**2 < 2**(2*FLINT_BITS), this is equivalent to    */
+        /*      n <= ceil(sqrt(2**(2*FLINT_BITS-3)))                     */
+#if (FLINT_BITS == 64)
+        if (mod.n <= UWORD(6521908912666391107))
+#else
+        if (mod.n <= UWORD(1518500250))
+#endif
+            params.method = _DOT3_ACC;
+        else
+            params.method = _DOT3;
+    }
+
+    else if (t1 != 0) // two limbs
+    {
+#if (FLINT_BITS == 64)
+        if (mod.n <= UWORD(1515531528) && len <= WORD(380368697)) // see end of file
+        {
+            params.method = _DOT2_32_SPLIT;
+            NMOD_RED(params.pow2_precomp, (1L << DOT_SPLIT_BITS), mod);
+        }
+        else
+#endif
+        if (mod.n <= (UWORD(1) << (FLINT_BITS / 2)))
+            params.method = _DOT2_HALF;
+        else
+            params.method = _DOT2;
+    }
+
+    // single limb
+    else if (u0 != 0)
+        params.method = _DOT1;
+
+    // remaining case: u0 == 0
+    // <=> mod.n == 1 or len == 0
+    // => dot product is zero, _DOT0 already set
+
+    return params;
+}
+
+ulong
+_nmod_vec_dot(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, dot_params_t params)
+{
+    ulong res;
+    slong i;
+    NMOD_VEC_DOT(res, i, len, vec1[i], vec2[i], mod, params);
+    return res;
 }
 
 ulong
 _nmod_vec_dot_ptr(nn_srcptr vec1, const nn_ptr * vec2, slong offset,
-                            slong len, nmod_t mod, int nlimbs)
+                            slong len, nmod_t mod, dot_params_t params)
 {
     ulong res;
     slong i;
-    NMOD_VEC_DOT(res, i, len, vec1[i], vec2[i][offset], mod, nlimbs);
+    NMOD_VEC_DOT(res, i, len, vec1[i], vec2[i][offset], mod, params);
     return res;
 }
 
@@ -55,12 +97,12 @@ nmod_fmma(ulong a, ulong b, ulong c, ulong d, nmod_t mod)
 }
 
 ulong
-_nmod_vec_dot_rev(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, int nlimbs)
+_nmod_vec_dot_rev(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, dot_params_t params)
 {
     ulong res;
     slong i;
 
-    if (len <= 2 && nlimbs >= 2)
+    if (len <= 2 && params.method > _DOT1)
     {
         if (len == 2)
             return nmod_fmma(vec1[0], vec2[1], vec1[1], vec2[0], mod);
@@ -69,6 +111,111 @@ _nmod_vec_dot_rev(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, int nli
         return 0;
     }
 
-    NMOD_VEC_DOT(res, i, len, vec1[i], vec2[len - 1 - i], mod, nlimbs);
+    NMOD_VEC_DOT(res, i, len, vec1[i], vec2[len - 1 - i], mod, params);
     return res;
 }
+
+
+
+
+
+
+/*----------------------------------------*/
+/* notes concerning the different methods */
+/*----------------------------------------*/
+
+// Why no vectorization in the general NMOD_VEC_DOT macro?
+// attempts at vectorized versions (2024-06-16, for methods _DOT1,
+// _DOT2_32_SPLIT) did not show an advantage except in "regular" cases where
+// memory accesses are fast (typically, expr = v[i] or expr = v[len - 1 -i]).
+// For these, there is dedicated code anyway.
+
+// 2024-06-16 _DOT2_HALF is slightly faster than _DOT2
+// 2024-06-16 _DOT3_ACC is slightly faster than _DOT3
+
+/*---------------------------------------------*/
+/* dot product for small modulus via splitting */
+/*---------------------------------------------*/
+
+// in short: with current DOT_SPLIT_BITS value 56,
+// -> modulus n up to about 2**30.5
+//       (more precisely, n <= 1515531528)
+// -> length of dot product up to at least 380368697
+//       (more precisely, len * (n-1)**3 < 2**120 + 2**56 - 2**112)
+
+// APPROACH:
+//
+// Let n = mod.n, s = DOT_SPLIT_BITS
+// As input, take pow2_precomp == 2**s % n
+//
+// -> avoiding modular reductions altogether, compute dp_lo and dp_hi such that
+// the dot product without modular reduction is dp  =  dp_lo + 2**s * dp_hi
+// -> finally, compute (dp_lo + pow2_precomp * dp_hi)  %  n
+// -> done through repeating this: accumulate a few terms,
+// move higher bits to dp_hi and keep lower ones in dp_lo
+
+// PARAMETER CONSTRAINTS:
+//
+// 2024-06-16: currently, the code accumulates 8 terms as this showed slightly better performance
+//
+// -> constraint (C0-8):
+// if we accumulate 8 terms (each a product of two integers reduced modulo n)
+// on top of an s-bit integer, we require
+//     2**s - 1 + 8 * (n-1)**2  <  2**64
+// so one can take any modulus with
+//     n <= 1 + floor(sqrt(2**61 - 2**(s-3)))
+// in particular, n-1 < 2**30.5, (n-1)**2 < 2**61, (n-1)**3 < 2**91.5
+//
+// -> constraint (C0-4):
+// similarly, if we accumulate 4 terms on top of an s-bit integer, we require
+//     2**s - 1 + 4 * (n-1)**2  <  2**64
+// so one can take any modulus with
+//     n <= 1 + floor(sqrt(2**62 - 2**(s-2)))
+// in particular, n-1 < 2**30.5, (n-1)**2 < 2**61, (n-1)**3 < 2**91.5
+//
+// -> constraint (C1):
+// in the above representation of dp we will use a ulong for dp_hi,
+// so we require      len * (n-1)**2 <= 2**s * (2**64 - 1)
+// which is less restrictive than the below (C2)
+//
+// -> constraint (C2):
+// for dp_lo + pow2_precomp * dp_hi to fit in a single word, we require
+//      2**s - 1 + (n-1) dp_hi < 2**64.
+// Since dp_hi <= len * (n-1)**2 / 2**s, it suffices to ensure
+//     len * (n-1)**3 < 2**s * (2**64 + 1 - 2**s)
+//
+// sage: for s in range(40,64):
+// ....:     nmax8 = 1 + floor(sqrt(2**61 - 2**(s-3)))             # (C0-8)
+// ....:     nmax4 = 1 + floor(sqrt(2**62 - 2**(s-2)))             # (C0-4)
+// ....:     lenmax4 = floor(2**s * (2**64 - 1) / (nmax4-1)**2)     # (C1)
+// ....:     lenmax4_bis = ceil(2**s * (2**64 + 1 - 2**s) / (nmax4-1)**3) - 1       # (C2)
+// ....:     lenmax8 = floor(2**s * (2**64 - 1) / (nmax8-1)**2)     # (C1)
+// ....:     lenmax8_bis = ceil(2**s * (2**64 + 1 - 2**s) / (nmax8-1)**3) - 1       # (C2)
+// ....:     print(f"{s}\t{nmax.nbits()}\t{nmax8}\t{lenmax8_bis}\t{nmax4}\t{lenmax4_bis}")
+// ....:
+// s       nbits   nmax8          (C2) for nmax8    nmax4           (C2) for nmax4
+// 40      31      1518500205      5792             2147483584      2048
+// 41      31      1518500160      11585            2147483520      4096
+// 42      31      1518500069      23170            2147483392      8192
+// 43      31      1518499888      46340            2147483136      16384
+// 44      31      1518499526      92681            2147482624      32768
+// 45      31      1518498802      185363           2147481600      65536
+// 46      31      1518497354      370728           2147479552      131072
+// 47      31      1518494458      741458           2147475456      262145
+// 48      31      1518488665      1482921          2147467264      524292
+// 49      31      1518477080      2965866          2147450880      1048592
+// 50      31      1518453909      5931822          2147418111      2097216
+// 51      31      1518407566      11864007         2147352572      4194560
+// 52      31      1518314875      23729463         2147221488      8389632
+// 53      31      1518129478      47464722         2146959296      16781313
+// 54      31      1517758614      94952640         2146434816      33570828
+// 55      31      1517016615      189998167        2145385471      67174496
+// 56      31      1515531528      380368697        2143285240      134480642
+// 57      31      1512556978      762233438        2139078592      269490216
+// 58      31      1506590261      1530504392       2130640379      541115017
+// 59      31      1494585366      3085595597       2113662895      1090922784
+// 60      31      1470281545      6273201268       2079292102      2217911575
+// 61      31      1420426920      12986760413      2008787014      4591513178
+// 62      31      1315059793      28054608908      1859775394      9918802104
+// 63      31      1073741825      68719476736      1518500250      24296004047
+

--- a/src/nmod_vec/dot.c
+++ b/src/nmod_vec/dot.c
@@ -78,103 +78,258 @@ dot_params_t _nmod_vec_dot_params(ulong len, nmod_t mod)
     return params;
 }
 
-ulong
-_nmod_vec_dot(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, dot_params_t params)
+ulong _nmod_vec_dot_pow2(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod)
 {
-    ulong res = UWORD(0);   /* covers _DOT0 */
-    slong i;
+    ulong res = UWORD(0);
+    for (slong i = 0; i < len; i++)
+        res += vec1[i] * vec2[i];
+    NMOD_RED(res, res, mod);
+    return res;
+}
 
-#if (defined(__AVX2__) && FLINT_BITS == 64)
-    if (params.method == _DOT1
-        || (params.method == _DOT_POW2 && mod.n < (UWORD(1) << (FLINT_BITS / 2))))
+#if defined(__AVX2__)
+ulong _nmod_vec_dot1(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod)
+{
+    vec4n dp = vec4n_zero();
+
+    slong i = 0;
+    for ( ; i+31 < len; i += 32)
     {
-        vec4n dp = vec4n_zero();
-
-        slong i = 0;
-        for ( ; i+31 < len; i += 32)
-        {
-            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+ 0), vec4n_load_unaligned(vec2+i+ 0)));
-            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+ 4), vec4n_load_unaligned(vec2+i+ 4)));
-            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+ 8), vec4n_load_unaligned(vec2+i+ 8)));
-            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+12), vec4n_load_unaligned(vec2+i+12)));
-            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+16), vec4n_load_unaligned(vec2+i+16)));
-            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+20), vec4n_load_unaligned(vec2+i+20)));
-            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+24), vec4n_load_unaligned(vec2+i+24)));
-            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+28), vec4n_load_unaligned(vec2+i+28)));
-        }
-
-        for ( ; i + 3 < len; i += 4)
-            dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i), vec4n_load_unaligned(vec2+i)));
-
-        res = vec4n_horizontal_sum(dp);
-
-        for (; i < len; i++)
-            res += vec1[i] * vec2[i];
-
-        NMOD_RED(res, res, mod);
+        dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+ 0), vec4n_load_unaligned(vec2+i+ 0)));
+        dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+ 4), vec4n_load_unaligned(vec2+i+ 4)));
+        dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+ 8), vec4n_load_unaligned(vec2+i+ 8)));
+        dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+12), vec4n_load_unaligned(vec2+i+12)));
+        dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+16), vec4n_load_unaligned(vec2+i+16)));
+        dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+20), vec4n_load_unaligned(vec2+i+20)));
+        dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+24), vec4n_load_unaligned(vec2+i+24)));
+        dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i+28), vec4n_load_unaligned(vec2+i+28)));
     }
-    else if (params.method == _DOT_POW2)  // cannot use avx 32-bit mul
-        _NMOD_VEC_DOT1(res, i, len, vec1[i], vec2[i], mod)
-#else // if (defined(__AVX2__) && FLINT_BITS == 64)
-    if (params.method == _DOT1 || params.method == _DOT_POW2)
-        _NMOD_VEC_DOT1(res, i, len, vec1[i], vec2[i], mod)
-#endif // if (defined(__AVX2__) && FLINT_BITS == 64)
+
+    for ( ; i + 3 < len; i += 4)
+        dp = vec4n_add(dp, vec4n_mul(vec4n_load_unaligned(vec1+i), vec4n_load_unaligned(vec2+i)));
+
+    ulong res = vec4n_horizontal_sum(dp);
+
+    for (; i < len; i++)
+        res += vec1[i] * vec2[i];
+
+    NMOD_RED(res, res, mod);
+    return res;
+}
+#else  // if defined(__AVX2__)
+ulong _nmod_vec_dot1(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod)
+{
+    ulong res = UWORD(0);
+    for (slong i = 0; i < len; i++)
+        res += vec1[i] * vec2[i];
+    NMOD_RED(res, res, mod);
+    return res;
+}
+#endif  // if defined(__AVX2__)
 
 #if FLINT_BITS == 64
-    else if (params.method == _DOT2_SPLIT)
 #if defined(__AVX2__)
+ulong _nmod_vec_dot2_split(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, ulong pow2_precomp)
+{
+    const vec4n low_bits = vec4n_set_n(DOT_SPLIT_MASK);
+    vec4n dp_lo = vec4n_zero();
+    vec4n dp_hi = vec4n_zero();
+
+    slong i = 0;
+    for ( ; i+31 < len; i += 32)
     {
-        const vec4n low_bits = vec4n_set_n(DOT_SPLIT_MASK);
-        vec4n dp_lo = vec4n_zero();
-        vec4n dp_hi = vec4n_zero();
-
-        slong i = 0;
-        for ( ; i+31 < len; i += 32)
-        {
-            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+ 0), vec4n_load_unaligned(vec2+i+ 0)));
-            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+ 4), vec4n_load_unaligned(vec2+i+ 4)));
-            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+ 8), vec4n_load_unaligned(vec2+i+ 8)));
-            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+12), vec4n_load_unaligned(vec2+i+12)));
-            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+16), vec4n_load_unaligned(vec2+i+16)));
-            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+20), vec4n_load_unaligned(vec2+i+20)));
-            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+24), vec4n_load_unaligned(vec2+i+24)));
-            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+28), vec4n_load_unaligned(vec2+i+28)));
-
-            dp_hi = vec4n_add(dp_hi, vec4n_bit_shift_right(dp_lo, DOT_SPLIT_BITS));
-            dp_lo = vec4n_bit_and(dp_lo, low_bits);
-        }
-
-        for ( ; i + 3 < len; i += 4)
-            dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i), vec4n_load_unaligned(vec2+i)));
+        dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+ 0), vec4n_load_unaligned(vec2+i+ 0)));
+        dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+ 4), vec4n_load_unaligned(vec2+i+ 4)));
+        dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+ 8), vec4n_load_unaligned(vec2+i+ 8)));
+        dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+12), vec4n_load_unaligned(vec2+i+12)));
+        dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+16), vec4n_load_unaligned(vec2+i+16)));
+        dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+20), vec4n_load_unaligned(vec2+i+20)));
+        dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+24), vec4n_load_unaligned(vec2+i+24)));
+        dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i+28), vec4n_load_unaligned(vec2+i+28)));
 
         dp_hi = vec4n_add(dp_hi, vec4n_bit_shift_right(dp_lo, DOT_SPLIT_BITS));
         dp_lo = vec4n_bit_and(dp_lo, low_bits);
-
-        ulong hsum_lo = vec4n_horizontal_sum(dp_lo);
-        const ulong hsum_hi = vec4n_horizontal_sum(dp_hi) + (hsum_lo >> DOT_SPLIT_BITS);
-        hsum_lo &= DOT_SPLIT_MASK;
-
-        for (; i < len; i++)
-            hsum_lo += vec1[i] * vec2[i];
-
-        NMOD_RED(res, params.pow2_precomp * hsum_hi + hsum_lo, mod);
     }
-#else // if defined(__AVX2__)
-        _NMOD_VEC_DOT2_SPLIT(res, i, len, vec1[i], vec2[i], mod, params.pow2_precomp)
-#endif // if defined(__AVX2__)
-#endif // FLINT_BITS == 64
 
-    else if (params.method == _DOT2_HALF)
-        _NMOD_VEC_DOT2_HALF(res, i, len, vec1[i], vec2[i], mod)
-    else if (params.method == _DOT2)
-        _NMOD_VEC_DOT2(res, i, len, vec1[i], vec2[i], mod)
-    else if (params.method == _DOT3_ACC)
-        _NMOD_VEC_DOT3_ACC(res, i, len, vec1[i], vec2[i], mod)
-    else if (params.method == _DOT3)
-        _NMOD_VEC_DOT3(res, i, len, vec1[i], vec2[i], mod)
+    for ( ; i + 3 < len; i += 4)
+        dp_lo = vec4n_add(dp_lo, vec4n_mul(vec4n_load_unaligned(vec1+i), vec4n_load_unaligned(vec2+i)));
 
+    dp_hi = vec4n_add(dp_hi, vec4n_bit_shift_right(dp_lo, DOT_SPLIT_BITS));
+    dp_lo = vec4n_bit_and(dp_lo, low_bits);
+
+    ulong hsum_lo = vec4n_horizontal_sum(dp_lo);
+    const ulong hsum_hi = vec4n_horizontal_sum(dp_hi) + (hsum_lo >> DOT_SPLIT_BITS);
+    hsum_lo &= DOT_SPLIT_MASK;
+
+    for (; i < len; i++)
+        hsum_lo += vec1[i] * vec2[i];
+
+    ulong res;
+    NMOD_RED(res, pow2_precomp * hsum_hi + hsum_lo, mod);
     return res;
 }
+
+#else  // defined(__AVX2__)
+
+ulong _nmod_vec_dot2_split(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, ulong pow2_precomp)
+{
+    ulong dp_lo = 0;
+    ulong dp_hi = 0;
+
+    slong i = 0;
+    for ( ; i+7 < (len); i += 8)
+    {
+        dp_lo += vec1[i+0] * vec2[i+0]
+               + vec1[i+1] * vec2[i+1]
+               + vec1[i+2] * vec2[i+2]
+               + vec1[i+3] * vec2[i+3]
+               + vec1[i+4] * vec2[i+4]
+               + vec1[i+5] * vec2[i+5]
+               + vec1[i+6] * vec2[i+6]
+               + vec1[i+7] * vec2[i+7];
+
+        dp_hi += dp_lo >> DOT_SPLIT_BITS;
+        dp_lo &= DOT_SPLIT_MASK;
+    }
+
+    for ( ; i < len; i++)
+        dp_lo += vec1[i] * vec2[i];
+
+    ulong res;
+    NMOD_RED(res, pow2_precomp * dp_hi + dp_lo, mod);
+    return res;
+}
+#endif  // defined(__AVX2__)
+#endif  // FLINT_BITS == 64
+
+ulong _nmod_vec_dot2_half(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod)
+{
+    ulong s0 = UWORD(0);
+    ulong s1 = UWORD(0);
+    for (slong i = 0; i < (len); i++)
+    {
+        const ulong prod = vec1[i] * vec2[i];
+        add_ssaaaa(s1, s0, s1, s0, 0, prod);
+    }
+    ulong res;
+    NMOD2_RED2(res, s1, s0, mod);
+    return res;
+}
+
+ulong _nmod_vec_dot2(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod)
+{
+    ulong u0 = UWORD(0);
+    ulong u1 = UWORD(0);
+
+    slong i = 0;
+    for ( ; i+7 < len; i += 8)
+    {
+        ulong s0, s1;
+        umul_ppmm(s1, s0, vec1[i+0], vec2[i+0]);
+        add_ssaaaa(u1, u0, u1, u0, s1, s0);
+        umul_ppmm(s1, s0, vec1[i+1], vec2[i+1]);
+        add_ssaaaa(u1, u0, u1, u0, s1, s0);
+        umul_ppmm(s1, s0, vec1[i+2], vec2[i+2]);
+        add_ssaaaa(u1, u0, u1, u0, s1, s0);
+        umul_ppmm(s1, s0, vec1[i+3], vec2[i+3]);
+        add_ssaaaa(u1, u0, u1, u0, s1, s0);
+        umul_ppmm(s1, s0, vec1[i+4], vec2[i+4]);
+        add_ssaaaa(u1, u0, u1, u0, s1, s0);
+        umul_ppmm(s1, s0, vec1[i+5], vec2[i+5]);
+        add_ssaaaa(u1, u0, u1, u0, s1, s0);
+        umul_ppmm(s1, s0, vec1[i+6], vec2[i+6]);
+        add_ssaaaa(u1, u0, u1, u0, s1, s0);
+        umul_ppmm(s1, s0, vec1[i+7], vec2[i+7]);
+        add_ssaaaa(u1, u0, u1, u0, s1, s0);
+    }
+    for ( ; i < len; i++)
+    {
+        ulong s0, s1;
+        umul_ppmm(s1, s0, vec1[i], vec2[i]);
+        add_ssaaaa(u1, u0, u1, u0, s1, s0);
+    }
+
+    ulong res;
+    NMOD2_RED2(res, u1, u0, mod);
+    return res;
+}
+
+ulong _nmod_vec_dot3(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod)
+{
+    ulong t2 = UWORD(0);
+    ulong t1 = UWORD(0);
+    ulong t0 = UWORD(0);
+    for (slong i = 0; i < len; i++)
+    {
+        ulong s0, s1;
+        umul_ppmm(s1, s0, vec1[i], vec2[i]);
+        add_sssaaaaaa(t2, t1, t0, t2, t1, t0, UWORD(0), s1, s0);
+    }
+
+    NMOD_RED(t2, t2, mod);
+    ulong res;
+    NMOD_RED3(res, t2, t1, t0, mod);
+    return res;
+}
+
+ulong _nmod_vec_dot3_acc(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod)
+{
+    ulong t2 = UWORD(0);
+    ulong t1 = UWORD(0);
+    ulong t0 = UWORD(0);
+
+    slong i = 0;
+    for ( ; i+7 < len; i += 8)
+    {
+        ulong s0, s1;
+        ulong u0 = UWORD(0);
+        ulong u1 = UWORD(0);
+        umul_ppmm(s1, s0, vec1[i+0], vec2[i+0]);
+        add_ssaaaa(u1, u0, u1, u0, s1, s0);
+        umul_ppmm(s1, s0, vec1[i+1], vec2[i+1]);
+        add_ssaaaa(u1, u0, u1, u0, s1, s0);
+        umul_ppmm(s1, s0, vec1[i+2], vec2[i+2]);
+        add_ssaaaa(u1, u0, u1, u0, s1, s0);
+        umul_ppmm(s1, s0, vec1[i+3], vec2[i+3]);
+        add_ssaaaa(u1, u0, u1, u0, s1, s0);
+        umul_ppmm(s1, s0, vec1[i+4], vec2[i+4]);
+        add_ssaaaa(u1, u0, u1, u0, s1, s0);
+        umul_ppmm(s1, s0, vec1[i+5], vec2[i+5]);
+        add_ssaaaa(u1, u0, u1, u0, s1, s0);
+        umul_ppmm(s1, s0, vec1[i+6], vec2[i+6]);
+        add_ssaaaa(u1, u0, u1, u0, s1, s0);
+        umul_ppmm(s1, s0, vec1[i+7], vec2[i+7]);
+        add_ssaaaa(u1, u0, u1, u0, s1, s0);
+        add_sssaaaaaa(t2, t1, t0, t2, t1, t0, UWORD(0), u1, u0);
+    }
+
+    ulong s0, s1;
+    ulong u0 = UWORD(0);
+    ulong u1 = UWORD(0);
+    for ( ; i < len; i++)
+    {
+        umul_ppmm(s1, s0, vec1[i], vec2[i]);
+        add_ssaaaa(u1, u0, u1, u0, s1, s0);
+    }
+
+    add_sssaaaaaa(t2, t1, t0, t2, t1, t0, UWORD(0), u1, u0);
+
+    NMOD_RED(t2, t2, mod);
+    ulong res;
+    NMOD_RED3(res, t2, t1, t0, mod);
+    return res;
+}
+
+
+
+
+
+
+
+
+
+
+
 
 ulong
 _nmod_vec_dot_ptr(nn_srcptr vec1, const nn_ptr * vec2, slong offset,

--- a/src/nmod_vec/dot.c
+++ b/src/nmod_vec/dot.c
@@ -120,8 +120,9 @@ _nmod_vec_dot(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, dot_params_
         _NMOD_VEC_DOT1(res, i, len, vec1[i], vec2[i], mod)
 #endif // if (defined(__AVX2__) && FLINT_BITS == 64)
 
+#if FLINT_BITS == 64
     else if (params.method == _DOT2_SPLIT)
-#if (defined(__AVX2__) && FLINT_BITS == 64)
+#if defined(__AVX2__)
     {
         const vec4n low_bits = vec4n_set_n(DOT_SPLIT_MASK);
         vec4n dp_lo = vec4n_zero();
@@ -158,9 +159,10 @@ _nmod_vec_dot(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, dot_params_
 
         NMOD_RED(res, params.pow2_precomp * hsum_hi + hsum_lo, mod);
     }
-#else // if (defined(__AVX2__) && FLINT_BITS == 64)
+#else // if defined(__AVX2__)
         _NMOD_VEC_DOT2_SPLIT(res, i, len, vec1[i], vec2[i], mod, params.pow2_precomp)
-#endif // if (defined(__AVX2__) && FLINT_BITS == 64)
+#endif // if defined(__AVX2__)
+#endif // FLINT_BITS == 64
 
     else if (params.method == _DOT2_HALF)
         _NMOD_VEC_DOT2_HALF(res, i, len, vec1[i], vec2[i], mod)
@@ -245,8 +247,9 @@ _nmod_vec_dot_rev(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, dot_par
         _NMOD_VEC_DOT1(res, i, len, vec1[i], vec2[len-1-i], mod)
 #endif // if (defined(__AVX2__) && FLINT_BITS == 64)
 
+#if FLINT_BITS == 64
     else if (params.method == _DOT2_SPLIT)
-#if (defined(__AVX2__) && FLINT_BITS == 64)
+#if defined(__AVX2__)
     {
         const vec4n low_bits = vec4n_set_n(DOT_SPLIT_MASK);
         vec4n dp_lo = vec4n_zero();
@@ -284,9 +287,10 @@ _nmod_vec_dot_rev(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, dot_par
 
         NMOD_RED(res, params.pow2_precomp * hsum_hi + hsum_lo, mod);
     }
-#else // if (defined(__AVX2__) && FLINT_BITS == 64)
+#else // if defined(__AVX2__)
         _NMOD_VEC_DOT2_SPLIT(res, i, len, vec1[i], vec2[len-1-i], mod, params.pow2_precomp)
-#endif // if (defined(__AVX2__) && FLINT_BITS == 64)
+#endif // if defined(__AVX2__)
+#endif // FLINT_BITS == 64
 
     else if (params.method == _DOT2_HALF)
         _NMOD_VEC_DOT2_HALF(res, i, len, vec1[i], vec2[len-1-i], mod)

--- a/src/nmod_vec/dot.c
+++ b/src/nmod_vec/dot.c
@@ -613,6 +613,7 @@ ulong _nmod_vec_dot3_acc_ptr(nn_srcptr vec1, const nn_ptr * vec2, slong offset, 
         umul_ppmm(s1, s0, vec1[i+6], vec2[i+6][offset]);
         add_ssaaaa(u1, u0, u1, u0, s1, s0);
         umul_ppmm(s1, s0, vec1[i+7], vec2[i+7][offset]);
+        add_ssaaaa(u1, u0, u1, u0, s1, s0);
         add_sssaaaaaa(t2, t1, t0, t2, t1, t0, UWORD(0), u1, u0);
     }
 

--- a/src/nmod_vec/dot.c
+++ b/src/nmod_vec/dot.c
@@ -14,7 +14,7 @@
 #include "nmod_vec.h"
 
 // currently only vectorized for AVX2
-#if defined(__AVX2__)
+#if (defined(__AVX2__) && FLINT_BITS == 64)
 #   include "machine_vectors.h"
 #endif // if defined(__AVX2__)
 
@@ -84,7 +84,7 @@ _nmod_vec_dot(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, dot_params_
     ulong res = UWORD(0);   /* covers _DOT0 */
     slong i;
 
-#if defined(__AVX2__)
+#if (defined(__AVX2__) && FLINT_BITS == 64)
     if (params.method == _DOT1
         || (params.method == _DOT_POW2 && mod.n < (UWORD(1) << (FLINT_BITS / 2))))
     {
@@ -115,13 +115,13 @@ _nmod_vec_dot(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, dot_params_
     }
     else if (params.method == _DOT_POW2)  // cannot use avx 32-bit mul
         _NMOD_VEC_DOT1(res, i, len, vec1[i], vec2[i], mod)
-#else // if defined(__AVX2__)
+#else // if (defined(__AVX2__) && FLINT_BITS == 64)
     if (params.method == _DOT1 || params.method == _DOT_POW2)
         _NMOD_VEC_DOT1(res, i, len, vec1[i], vec2[i], mod)
-#endif // if defined(__AVX2__)
+#endif // if (defined(__AVX2__) && FLINT_BITS == 64)
 
     else if (params.method == _DOT2_SPLIT)
-#if defined(__AVX2__)
+#if (defined(__AVX2__) && FLINT_BITS == 64)
     {
         const vec4n low_bits = vec4n_set_n(DOT_SPLIT_MASK);
         vec4n dp_lo = vec4n_zero();
@@ -158,9 +158,9 @@ _nmod_vec_dot(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, dot_params_
 
         NMOD_RED(res, params.pow2_precomp * hsum_hi + hsum_lo, mod);
     }
-#else // if defined(__AVX2__)
+#else // if (defined(__AVX2__) && FLINT_BITS == 64)
         _NMOD_VEC_DOT2_SPLIT(res, i, len, vec1[i], vec2[i], mod, params.pow2_precomp)
-#endif // if defined(__AVX2__)
+#endif // if (defined(__AVX2__) && FLINT_BITS == 64)
 
     else if (params.method == _DOT2_HALF)
         _NMOD_VEC_DOT2_HALF(res, i, len, vec1[i], vec2[i], mod)
@@ -208,7 +208,7 @@ _nmod_vec_dot_rev(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, dot_par
     ulong res = UWORD(0);   /* covers _DOT0 */
     slong i;
 
-#if defined(__AVX2__)
+#if (defined(__AVX2__) && FLINT_BITS == 64)
     if (params.method == _DOT1
         || (params.method == _DOT_POW2 && mod.n < (UWORD(1) << (FLINT_BITS / 2))))
     {
@@ -240,13 +240,13 @@ _nmod_vec_dot_rev(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, dot_par
     }
     else if (params.method == _DOT_POW2)  // cannot use avx 32-bit mul
         _NMOD_VEC_DOT1(res, i, len, vec1[i], vec2[len-1-i], mod)
-#else // if defined(__AVX2__)
+#else // if (defined(__AVX2__) && FLINT_BITS == 64)
     if (params.method == _DOT1 || params.method == _DOT_POW2)
         _NMOD_VEC_DOT1(res, i, len, vec1[i], vec2[len-1-i], mod)
-#endif // if defined(__AVX2__)
+#endif // if (defined(__AVX2__) && FLINT_BITS == 64)
 
     else if (params.method == _DOT2_SPLIT)
-#if defined(__AVX2__)
+#if (defined(__AVX2__) && FLINT_BITS == 64)
     {
         const vec4n low_bits = vec4n_set_n(DOT_SPLIT_MASK);
         vec4n dp_lo = vec4n_zero();
@@ -284,9 +284,9 @@ _nmod_vec_dot_rev(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, dot_par
 
         NMOD_RED(res, params.pow2_precomp * hsum_hi + hsum_lo, mod);
     }
-#else // if defined(__AVX2__)
+#else // if (defined(__AVX2__) && FLINT_BITS == 64)
         _NMOD_VEC_DOT2_SPLIT(res, i, len, vec1[i], vec2[len-1-i], mod, params.pow2_precomp)
-#endif // if defined(__AVX2__)
+#endif // if (defined(__AVX2__) && FLINT_BITS == 64)
 
     else if (params.method == _DOT2_HALF)
         _NMOD_VEC_DOT2_HALF(res, i, len, vec1[i], vec2[len-1-i], mod)

--- a/src/nmod_vec/profile/p-dot.c
+++ b/src/nmod_vec/profile/p-dot.c
@@ -376,8 +376,8 @@ int main(int argc, char ** argv)
     const ulong bits[] = {0, 12, 28, 30, 31, 32, 40, 50, 60, 61, 62, 63, 64};
 
     // vector lengths
-    const slong nlens = 14;
-    const ulong lens[] = {1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 100000, 1000000};
+    const slong nlens = 20;
+    const ulong lens[] = {1, 2, 3, 4, 5, 7, 10, 15, 25, 35, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 100000, 1000000};
 
     // bench functions
     const slong nfuns = 12;

--- a/src/nmod_vec/profile/p-dot.c
+++ b/src/nmod_vec/profile/p-dot.c
@@ -455,7 +455,7 @@ int main(int argc, char ** argv)
 
                 printf("%-10ld", b);
                 ulong n;
-                if (b == 232) 
+                if (b == 232)
                     n = UWORD(1) << 32;
                 else if (b == 263)
                     n = UWORD(1) << 63;
@@ -486,7 +486,7 @@ int main(int argc, char ** argv)
 
             printf("%-10ld", b);
             ulong n;
-            if (b == 232) 
+            if (b == 232)
                 n = UWORD(1) << 32;
             else if (b == 263)
                 n = UWORD(1) << 63;
@@ -513,7 +513,7 @@ int main(int argc, char ** argv)
 
         printf("%-10ld", b);
         ulong n;
-        if (b == 232) 
+        if (b == 232)
             n = UWORD(1) << 32;
         else if (b == 263)
             n = UWORD(1) << 63;
@@ -540,7 +540,7 @@ int main(int argc, char ** argv)
 
         printf("%-10ld", b);
         ulong n;
-        if (b == 232) 
+        if (b == 232)
             n = UWORD(1) << 32;
         else if (b == 263)
             n = UWORD(1) << 63;

--- a/src/nmod_vec/profile/p-dot.c
+++ b/src/nmod_vec/profile/p-dot.c
@@ -99,7 +99,8 @@ void time_dot_expr(ulong len, ulong n, flint_rand_t state)
 
     nn_srcptr v1i = v1;
     nn_srcptr v2i = v2;
-    ulong i, FLINT_SET_BUT_UNUSED(res);
+    ulong i;
+    volatile ulong res = 0;  // volatile -> avoid compiler optimizations
 
     TIMEIT_START
     NMOD_VEC_DOT(res, i, len, v1i[9*len - 1 - 9*i], v2i[9*len - 1 - 9*i], mod, params);
@@ -147,7 +148,7 @@ void time_dot_poly_mul(ulong len, ulong n, flint_rand_t state)
 
 void time_dot_poly_inv_series(ulong len, ulong n, flint_rand_t state)
 {
-    if (len > 10000 || n == (UWORD(1) << 63))
+    if (len > 10000 || n % 2 == 0)
     {
         printf("        ");
         return;
@@ -174,7 +175,7 @@ void time_dot_poly_inv_series(ulong len, ulong n, flint_rand_t state)
 
 void time_dot_poly_exp_series(ulong len, ulong n, flint_rand_t state)
 {
-    if (len > 10000 || n == (UWORD(1) << 63))
+    if (len > 10000 || n % 2 == 0)
     {
         printf("        ");
         return;
@@ -262,7 +263,7 @@ void time_dot_mat_mul_vec(ulong len, ulong n, flint_rand_t state)
 
 void time_dot_mat_solve_tril(ulong len, ulong n, flint_rand_t state)
 {
-    if (len > 4000 || n == (UWORD(1) << 63))
+    if (len > 4000 || n % 2 == 0)
     {
         printf("        ");
         return;
@@ -287,7 +288,7 @@ void time_dot_mat_solve_tril(ulong len, ulong n, flint_rand_t state)
 
 void time_dot_mat_solve_tril_vec(ulong len, ulong n, flint_rand_t state)
 {
-    if (len > 10000 || n == (UWORD(1) << 63))
+    if (len > 10000 || n % 2 == 0)
     {
         printf("        ");
         return;
@@ -312,7 +313,7 @@ void time_dot_mat_solve_tril_vec(ulong len, ulong n, flint_rand_t state)
 
 void time_dot_mat_solve_triu(ulong len, ulong n, flint_rand_t state)
 {
-    if (len > 4000 || n == (UWORD(1) << 63))
+    if (len > 4000 || n % 2 == 0)
     {
         printf("        ");
         return;
@@ -337,7 +338,7 @@ void time_dot_mat_solve_triu(ulong len, ulong n, flint_rand_t state)
 
 void time_dot_mat_solve_triu_vec(ulong len, ulong n, flint_rand_t state)
 {
-    if (len > 10000 || n == (UWORD(1)<<63))
+    if (len > 10000 || n % 2 == 0)
     {
         printf("        ");
         return;
@@ -372,8 +373,8 @@ int main(int argc, char ** argv)
     flint_rand_set_seed(state, time(NULL), time(NULL)+129384125L);
 
     // modulus bitsize
-    const slong nbits = 12;
-    const ulong bits[] = {0, 12, 28, 30, 31, 32, 40, 50, 60, 61, 62, 63, 64};
+    const slong nbits = 14;
+    const ulong bits[] = {12, 28, 30, 31, 32, 40, 50, 60, 61, 62, 63, 64, 232, 263};
 
     // vector lengths
     const slong nlens = 20;
@@ -419,7 +420,7 @@ int main(int argc, char ** argv)
         printf("   - fun: id number of the timed function (see below),\n");
         printf("          exception: fun == -1 times all available functions successively\n");
         printf("   - nbits: number of bits for the modulus, chosen as nextprime(2**(nbits-1))\n");
-        printf("          exception: nbits == 0 picks modulus 2**63\n");
+        printf("          exception: nbits == 232 and 263 (moduli 2**32, 2**63)\n");
         printf("   - len: length for the vector, row and column dimension for the matrices\n");
         printf("\nAvailable functions:\n");
         for (slong j = 0; j < nfuns; j++)
@@ -453,7 +454,13 @@ int main(int argc, char ** argv)
                 const slong b = bits[j];
 
                 printf("%-10ld", b);
-                const ulong n = (b==0) ? (UWORD(1) << 63) : n_nextprime(UWORD(1) << (b-1), 0);
+                ulong n;
+                if (b == 232) 
+                    n = UWORD(1) << 32;
+                else if (b == 263)
+                    n = UWORD(1) << 63;
+                else
+                    n = n_nextprime(UWORD(1) << (b-1), 0);
                 for (slong i = 0; i < nlens; i++)
                 {
                     tfun(lens[i], n, state);
@@ -478,7 +485,13 @@ int main(int argc, char ** argv)
             const slong b = bits[j];
 
             printf("%-10ld", b);
-            const ulong n = (b==0) ? (UWORD(1) << 63) : n_nextprime(UWORD(1) << (b-1), 0);
+            ulong n;
+            if (b == 232) 
+                n = UWORD(1) << 32;
+            else if (b == 263)
+                n = UWORD(1) << 63;
+            else
+                n = n_nextprime(UWORD(1) << (b-1), 0);
             for (slong i = 0; i < nlens; i++)
             {
                 tfun(lens[i], n, state);
@@ -499,7 +512,13 @@ int main(int argc, char ** argv)
         printf("\n");
 
         printf("%-10ld", b);
-        const ulong n = (b==0) ? (UWORD(1) << 63) : n_nextprime(UWORD(1) << (b-1), 0);
+        ulong n;
+        if (b == 232) 
+            n = UWORD(1) << 32;
+        else if (b == 263)
+            n = UWORD(1) << 63;
+        else
+            n = n_nextprime(UWORD(1) << (b-1), 0);
         for (slong i = 0; i < nlens; i++)
         {
             tfun(lens[i], n, state);
@@ -520,7 +539,13 @@ int main(int argc, char ** argv)
         printf("\n");
 
         printf("%-10ld", b);
-        const ulong n = (b==0) ? (UWORD(1) << 63) : n_nextprime(UWORD(1) << (b-1), 0);
+        ulong n;
+        if (b == 232) 
+            n = UWORD(1) << 32;
+        else if (b == 263)
+            n = UWORD(1) << 63;
+        else
+            n = n_nextprime(UWORD(1) << (b-1), 0);
 
         tfun(len, n, state);
         printf("\n");

--- a/src/nmod_vec/profile/p-dot.c
+++ b/src/nmod_vec/profile/p-dot.c
@@ -42,7 +42,6 @@ void time_dot(ulong len, ulong n, flint_rand_t state)
 {
     nmod_t mod;
     nmod_init(&mod, n);
-    const dot_params_t params = _nmod_vec_dot_params(len, mod);
 
     nn_ptr v1 = _nmod_vec_init(len);
     _nmod_vec_rand(v1, state, len, mod);
@@ -56,6 +55,7 @@ void time_dot(ulong len, ulong n, flint_rand_t state)
     double FLINT_SET_BUT_UNUSED(tcpu), twall;
 
     TIMEIT_START
+    const dot_params_t params = _nmod_vec_dot_params(len, mod);
     res = _nmod_vec_dot(v1, v2, len, mod, params);
     TIMEIT_STOP_VALUES(tcpu, twall)
 
@@ -69,7 +69,6 @@ void time_dot_rev(ulong len, ulong n, flint_rand_t state)
 {
     nmod_t mod;
     nmod_init(&mod, n);
-    const dot_params_t params = _nmod_vec_dot_params(len, mod);
 
     nn_ptr v1 = _nmod_vec_init(len);
     _nmod_vec_rand(v1, state, len, mod);
@@ -83,6 +82,7 @@ void time_dot_rev(ulong len, ulong n, flint_rand_t state)
     double FLINT_SET_BUT_UNUSED(tcpu), twall;
 
     TIMEIT_START
+    const dot_params_t params = _nmod_vec_dot_params(len, mod);
     res = _nmod_vec_dot_rev(v1, v2, len, mod, params);
     TIMEIT_STOP_VALUES(tcpu, twall)
 
@@ -96,7 +96,6 @@ void time_dot_ptr(ulong len, ulong n, flint_rand_t state)
 {
     nmod_t mod;
     nmod_init(&mod, n);
-    const dot_params_t params = _nmod_vec_dot_params(len, mod);
 
     const ulong offset = UWORD(7);
 
@@ -115,6 +114,7 @@ void time_dot_ptr(ulong len, ulong n, flint_rand_t state)
     double FLINT_SET_BUT_UNUSED(tcpu), twall;
 
     TIMEIT_START
+    const dot_params_t params = _nmod_vec_dot_params(len, mod);
     res = _nmod_vec_dot_ptr(v1, v2, offset, len, mod, params);
     TIMEIT_STOP_VALUES(tcpu, twall)
 
@@ -216,7 +216,6 @@ void time_dot_poly_exp_series(ulong len, ulong n, flint_rand_t state)
     gr_poly_clear(p, ctx);
     gr_poly_clear(res, ctx);
 }
-
 
 /*-------------------------*/
 /* indirect: mat           */

--- a/src/nmod_vec/profile/p-dot.c
+++ b/src/nmod_vec/profile/p-dot.c
@@ -172,7 +172,6 @@ void time_dot_poly_inv_series(ulong len, ulong n, flint_rand_t state)
     _nmod_vec_clear(res);
 }
 
-
 void time_dot_poly_exp_series(ulong len, ulong n, flint_rand_t state)
 {
     if (len > 10000 || n == (UWORD(1) << 63))
@@ -203,7 +202,6 @@ void time_dot_poly_exp_series(ulong len, ulong n, flint_rand_t state)
     gr_poly_clear(p, ctx);
     gr_poly_clear(res, ctx);
 }
-
 
 /*-------------------------*/
 /* indirect: mat           */

--- a/src/nmod_vec/profile/p-dot.c
+++ b/src/nmod_vec/profile/p-dot.c
@@ -49,10 +49,14 @@ void time_dot(ulong len, ulong n, flint_rand_t state)
     nn_ptr v2 = _nmod_vec_init(len);
     _nmod_vec_rand(v2, state, len, mod);
 
+    // store results in volatile variable to avoid that they
+    // are "optimized away" (especially for len <= 4, inlined part)
+    volatile ulong FLINT_SET_BUT_UNUSED(res);
+
     double FLINT_SET_BUT_UNUSED(tcpu), twall;
 
     TIMEIT_START
-    _nmod_vec_dot(v1, v2, len, mod, params);
+    res = _nmod_vec_dot(v1, v2, len, mod, params);
     TIMEIT_STOP_VALUES(tcpu, twall)
 
     printf("%.2e", twall);
@@ -72,10 +76,14 @@ void time_dot_rev(ulong len, ulong n, flint_rand_t state)
     nn_ptr v2 = _nmod_vec_init(len);
     _nmod_vec_rand(v2, state, len, mod);
 
+    // store results in volatile variable to avoid that they
+    // are "optimized away" (especially for len <= 4, inlined part)
+    volatile ulong FLINT_SET_BUT_UNUSED(res);
+
     double FLINT_SET_BUT_UNUSED(tcpu), twall;
 
     TIMEIT_START
-    _nmod_vec_dot_rev(v1, v2, len, mod, params);
+    res = _nmod_vec_dot_rev(v1, v2, len, mod, params);
     TIMEIT_STOP_VALUES(tcpu, twall)
 
     printf("%.2e", twall);
@@ -100,11 +108,14 @@ void time_dot_ptr(ulong len, ulong n, flint_rand_t state)
     for (ulong i = 0; i < len; i++)
         v2[i] = &v2tmp[i] + offset;
 
+    // store results in volatile variable to avoid that they
+    // are "optimized away" (especially for len <= 4, inlined part)
+    volatile ulong FLINT_SET_BUT_UNUSED(res);
 
     double FLINT_SET_BUT_UNUSED(tcpu), twall;
 
     TIMEIT_START
-    _nmod_vec_dot_ptr(v1, v2, offset, len, mod, params);
+    res = _nmod_vec_dot_ptr(v1, v2, offset, len, mod, params);
     TIMEIT_STOP_VALUES(tcpu, twall)
 
     printf("%.2e", twall);
@@ -205,6 +216,7 @@ void time_dot_poly_exp_series(ulong len, ulong n, flint_rand_t state)
     gr_poly_clear(p, ctx);
     gr_poly_clear(res, ctx);
 }
+
 
 /*-------------------------*/
 /* indirect: mat           */

--- a/src/nmod_vec/profile/p-dot.c
+++ b/src/nmod_vec/profile/p-dot.c
@@ -205,7 +205,6 @@ void time_dot_poly_exp_series(ulong len, ulong n, flint_rand_t state)
 }
 
 
-
 /*-------------------------*/
 /* indirect: mat           */
 /*-------------------------*/

--- a/src/nmod_vec/test/main.c
+++ b/src/nmod_vec/test/main.c
@@ -13,7 +13,7 @@
 
 #include "t-add_sub_neg.c"
 #include "t-discrete_log_pohlig_hellman.c"
-#include "t-dot_params.c"
+#include "t-dot_nlimbs.c"
 #include "t-dot.c"
 #include "t-dot_ptr.c"
 #include "t-nmod.c"

--- a/src/nmod_vec/test/main.c
+++ b/src/nmod_vec/test/main.c
@@ -13,7 +13,7 @@
 
 #include "t-add_sub_neg.c"
 #include "t-discrete_log_pohlig_hellman.c"
-#include "t-dot_bound_limbs.c"
+#include "t-dot_params.c"
 #include "t-dot.c"
 #include "t-dot_ptr.c"
 #include "t-nmod.c"
@@ -29,7 +29,7 @@ test_struct tests[] =
 {
     TEST_FUNCTION(nmod_vec_add_sub_neg),
     TEST_FUNCTION(nmod_vec_discrete_log_pohlig_hellman),
-    TEST_FUNCTION(nmod_vec_dot_bound_limbs),
+    TEST_FUNCTION(_nmod_vec_dot_params),
     TEST_FUNCTION(nmod_vec_dot),
     TEST_FUNCTION(nmod_vec_dot_ptr),
     TEST_FUNCTION(nmod_vec_nmod),

--- a/src/nmod_vec/test/t-dot.c
+++ b/src/nmod_vec/test/t-dot.c
@@ -24,7 +24,6 @@ TEST_FUNCTION_START(nmod_vec_dot, state)
         nmod_t mod;
         ulong m, res;
         nn_ptr x, y;
-        int limbs1;
         mpz_t s, t;
         slong j;
 
@@ -39,9 +38,9 @@ TEST_FUNCTION_START(nmod_vec_dot, state)
         _nmod_vec_randtest(x, state, len, mod);
         _nmod_vec_randtest(y, state, len, mod);
 
-        limbs1 = _nmod_vec_dot_bound_limbs(len, mod);
+        const dot_params_t params = _nmod_vec_dot_params(len, mod);
 
-        res = _nmod_vec_dot(x, y, len, mod, limbs1);
+        res = _nmod_vec_dot(x, y, len, mod, params);
 
         mpz_init(s);
         mpz_init(t);
@@ -59,7 +58,7 @@ TEST_FUNCTION_START(nmod_vec_dot, state)
                     "m = %wu\n"
                     "len = %wd\n"
                     "limbs1 = %d\n",
-                    m, len, limbs1);
+                    m, len, params);
 
         mpz_clear(s);
         mpz_clear(t);

--- a/src/nmod_vec/test/t-dot_params.c
+++ b/src/nmod_vec/test/t-dot_params.c
@@ -60,13 +60,13 @@ TEST_FUNCTION_START(_nmod_vec_dot_params, state)
 
         ulong pow2;
         NMOD_RED(pow2, UWORD(1)<<DOT_SPLIT_BITS, mod);
-        if (params.method == _DOT2_32_SPLIT && params.pow2_precomp != pow2)
+        if (params.method == _DOT2_SPLIT && params.pow2_precomp != pow2)
             TEST_FUNCTION_FAIL(
                     "m = %wu\n"
                     "len = %wd\n"
                     "pow2_precomp = %d\n"
                     "actual pow2 = %d\n"
-                    "(method _DOT2_32_SPLIT)\n",
+                    "(method _DOT2_SPLIT)\n",
                     m, len, params.pow2_precomp, pow2, t);
 
         mpz_clear(t);

--- a/src/nmod_vec/test/t-dot_params.c
+++ b/src/nmod_vec/test/t-dot_params.c
@@ -58,6 +58,8 @@ TEST_FUNCTION_START(_nmod_vec_dot_params, state)
                     "bound: %{mpz}\n",
                     m, len, nlimbs1, nlimbs2, t);
 
+// DOT_SPLIT only defined for 64-bit config
+#if (FLINT_BITS == 64)
         ulong pow2;
         NMOD_RED(pow2, UWORD(1)<<DOT_SPLIT_BITS, mod);
         if (params.method == _DOT2_SPLIT && params.pow2_precomp != pow2)
@@ -68,6 +70,7 @@ TEST_FUNCTION_START(_nmod_vec_dot_params, state)
                     "actual pow2 = %d\n"
                     "(method _DOT2_SPLIT)\n",
                     m, len, params.pow2_precomp, pow2, t);
+#endif  // FLINT_BITS == 64
 
         mpz_clear(t);
     }

--- a/src/nmod_vec/test/t-dot_params.c
+++ b/src/nmod_vec/test/t-dot_params.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2011 Fredrik Johansson
+    Copyright (C) 2024 Vincent Neiger
 
     This file is part of FLINT.
 
@@ -14,7 +15,7 @@
 #include "nmod.h"
 #include "nmod_vec.h"
 
-TEST_FUNCTION_START(nmod_vec_dot_bound_limbs, state)
+TEST_FUNCTION_START(_nmod_vec_dot_params, state)
 {
     int i;
 
@@ -23,7 +24,8 @@ TEST_FUNCTION_START(nmod_vec_dot_bound_limbs, state)
         slong len;
         nmod_t mod;
         ulong m;
-        int limbs1, limbs2;
+        int nlimbs1, nlimbs2;
+        dot_params_t params;
         mpz_t t;
 
         len = n_randint(state, 10000) + 1;
@@ -31,22 +33,30 @@ TEST_FUNCTION_START(nmod_vec_dot_bound_limbs, state)
 
         nmod_init(&mod, m);
 
-        limbs1 = _nmod_vec_dot_bound_limbs(len, mod);
+        params = _nmod_vec_dot_params(len, mod);
+        if (params.method == _DOT0)
+            nlimbs1 = 0;
+        else if (params.method == _DOT1)
+            nlimbs1 = 1;
+        else if (params.method > _DOT2)
+            nlimbs1 = 3;
+        else
+            nlimbs1 = 2;
 
         mpz_init2(t, 4*FLINT_BITS);
         flint_mpz_set_ui(t, m-1);
         mpz_mul(t, t, t);
         flint_mpz_mul_ui(t, t, len);
-        limbs2 = mpz_size(t);
+        nlimbs2 = mpz_size(t);
 
-        if (limbs1 != limbs2)
+        if (nlimbs1 != nlimbs2)
             TEST_FUNCTION_FAIL(
                     "m = %wu\n"
                     "len = %wd\n"
-                    "limbs1 = %d\n"
-                    "limbs2 = %d\n"
+                    "nlimbs1 = %d\n"
+                    "nlimbs2 = %d\n"
                     "bound: %{mpz}\n",
-                    m, len, limbs1, limbs2, t);
+                    m, len, nlimbs1, nlimbs2, t);
 
         mpz_clear(t);
     }

--- a/src/nmod_vec/test/t-dot_params.c
+++ b/src/nmod_vec/test/t-dot_params.c
@@ -49,7 +49,9 @@ TEST_FUNCTION_START(_nmod_vec_dot_params, state)
         flint_mpz_mul_ui(t, t, len);
         nlimbs2 = mpz_size(t);
 
-        if (params.method != _DOT_POW2 && nlimbs1 != nlimbs2)
+        const int power_of_two = (mod.n & (mod.n - 1)) == 0;
+
+        if (!power_of_two && nlimbs1 != nlimbs2)
             TEST_FUNCTION_FAIL(
                     "m = %wu\n"
                     "len = %wd\n"

--- a/src/nmod_vec/test/t-dot_params.c
+++ b/src/nmod_vec/test/t-dot_params.c
@@ -49,7 +49,7 @@ TEST_FUNCTION_START(_nmod_vec_dot_params, state)
         flint_mpz_mul_ui(t, t, len);
         nlimbs2 = mpz_size(t);
 
-        if (nlimbs1 != nlimbs2)
+        if (params.method != _DOT_POW2 && nlimbs1 != nlimbs2)
             TEST_FUNCTION_FAIL(
                     "m = %wu\n"
                     "len = %wd\n"
@@ -57,6 +57,17 @@ TEST_FUNCTION_START(_nmod_vec_dot_params, state)
                     "nlimbs2 = %d\n"
                     "bound: %{mpz}\n",
                     m, len, nlimbs1, nlimbs2, t);
+
+        ulong pow2;
+        NMOD_RED(pow2, UWORD(1)<<DOT_SPLIT_BITS, mod);
+        if (params.method == _DOT2_32_SPLIT && params.pow2_precomp != pow2)
+            TEST_FUNCTION_FAIL(
+                    "m = %wu\n"
+                    "len = %wd\n"
+                    "pow2_precomp = %d\n"
+                    "actual pow2 = %d\n"
+                    "(method _DOT2_32_SPLIT)\n",
+                    m, len, params.pow2_precomp, pow2, t);
 
         mpz_clear(t);
     }

--- a/src/nmod_vec/test/t-dot_ptr.c
+++ b/src/nmod_vec/test/t-dot_ptr.c
@@ -24,7 +24,6 @@ TEST_FUNCTION_START(nmod_vec_dot_ptr, state)
         ulong m, res, res2;
         nn_ptr x, y;
         nn_ptr * z;
-        int limbs1;
         slong j, offset;
 
         len = n_randint(state, 1000) + 1;
@@ -43,17 +42,17 @@ TEST_FUNCTION_START(nmod_vec_dot_ptr, state)
         for (j = 0; j < len; j++)
             z[j] = &y[j] + offset;
 
-        limbs1 = _nmod_vec_dot_bound_limbs(len, mod);
+        const dot_params_t params = _nmod_vec_dot_params(len, mod);
 
-        res = _nmod_vec_dot_ptr(x, z, -offset, len, mod, limbs1);
-        res2 = _nmod_vec_dot(x, y, len, mod, limbs1);
+        res = _nmod_vec_dot_ptr(x, z, -offset, len, mod, params);
+        res2 = _nmod_vec_dot(x, y, len, mod, params);
 
         if (res != res2)
             TEST_FUNCTION_FAIL(
                     "m = %wu\n"
                     "len = %wd\n"
-                    "limbs1 = %d\n",
-                    m, len, limbs1);
+                    "method = %d\n",
+                    m, len, params.method);
 
         _nmod_vec_clear(x);
         _nmod_vec_clear(y);


### PR DESCRIPTION
The goal is to introduce the following, for nmod vec's:

1. Good avx2 performance when the modulus is "small". This roughly means moduli with at most 32 bits, but for efficiency reasons the limit would be slightly lower, a bit above 31 bits. Based on draft code, the target of this PR is roughly up to 2**30.5 (trying to go beyond, it is difficult to maintain the same efficiency).

2. Better performance when the dot product fits on 3 limbs but we still have enough room to accumulate a few 2-limb products before using add_sssaaaaaa. Basically the target is to avoid any performance reduction when we are in the region of 50- to 62-bit moduli (depending on the length).

One foreseeable issue is that we do not want more "complex" code (e.g. more branching) to penalize small instances, since this is code which is actually used a lot for small instances. For example an indirect target is to accelerate matrix multiplication or matrix-vector products (when the modulus is close to 32 bits or close to 64 bits): there one computes many dot products of the same type (same length, same modulus), and the new code should avoid any performance decrease for small-ish matrices (e.g. 50x50).

Questions, written here for help and suggestions:

- Regarding benchmarks: measuring the performance of dot products for small lengths is not that trivial, and in fact maybe not that meaningful: what matters the most is the performance within code that uses such products. Apart from matrix multiplication things, could someone suggest a few additional flint routines that could be targeted to get confident that no performance regression is introduced?

- The current flint NMOD_VEC_DOT macro has 4 or 5 cases already (based on number of limbs of the product, but also other things). The new code has a couple more. The plan would be to slightly change the logic, which is currently to compute the number of limbs and use it to separate cases, and then again separate some additional cases within this. One could rather find directly a "case number" ("one limb", "small modulus", "two limbs", "three limbs but room for accumulation", etc.). In my draft experiments, this helps performance for small dot products. This means some code changes here and there. Something that is not clear to me: should a change in `_nmod_vec_dot_bound_limbs` be done via some deprecation? (I'm wondering whether this helper function is considered as, say, "for internal use, subject to change")
 
- In addition, for "small" modulus, the new code would require(*) to compute some integer like 2**56 mod n, i.e. which depends only on the modulus n. Recomputing this for every new dot product seems wasteful for repeated dot products of the same length/modulus, so this computation may as well be incorporated in the new "case distinguishing" approach: if we see we are in the "small modulus case", then compute this number and return it somehow.

(*) the non-avx version should not really require it, but the avx version does.