### PR TITLE
(Partially) fix profile calls to openblas's threads when not available

### DIFF
--- a/src/fmpz_mat/profile/p-mul_blas_v_mul.c
+++ b/src/fmpz_mat/profile/p-mul_blas_v_mul.c
@@ -13,6 +13,7 @@
 
 #if FLINT_USES_BLAS
 #include <cblas.h>
+#include "longlong.h"  // for FLINT_BIT_COUNT
 #include "fmpz_mat.h"
 #include "profiler.h"
 
@@ -26,7 +27,7 @@ int main(void)
     FLINT_TEST_INIT(state);
 
     flint_set_num_threads(8);
-    openblas_set_num_threads(8);
+    //openblas_set_num_threads(8);
 
     for (dim = 50; dim <= 3000; dim += 2 + dim/4)
     {

--- a/src/nmod_mat/profile/p-mul.c
+++ b/src/nmod_mat/profile/p-mul.c
@@ -113,8 +113,8 @@ int main(void)
             {
                 double min_old, min_new, min_ratio = 100;
 
-#if FLINT_HAVE_BLAS
-                openblas_set_num_threads(blas_num);
+#if FLINT_USES_BLAS
+                //openblas_set_num_threads(blas_num);
 #endif
 
                 flint_printf("[flint %wd, blas %wd]: (", flint_num, blas_num);


### PR DESCRIPTION
This comments out two calls to `openblas_set_num_threads` in profile files: this function is not necessarily available even when Flint was compiled with BLAS (this is at least the case when using a BLAS library other than OpenBLAS). This resulted in `make profile` not going through.