### PR TITLE
Compute the sum of powers and the sum of divisors of an integer

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -446,6 +446,8 @@ David Berghaus
 Matthias Gessinger
 
   Graeffe transforms.
+  Sums of powers and sums of divisors of integers.
+  Aliquot sequences.
 
 Erik Postma
 

--- a/dev/check_examples.sh
+++ b/dev/check_examples.sh
@@ -298,6 +298,23 @@ then
     fi
     echo "PASS"
     exit 0
+elif test "$1" = "aliquot";
+then
+    echo -n "aliquot...."
+    res=$($2/aliquot)
+    if test "$?" != "0";
+    then
+        echo "FAIL"
+        exit 1
+    fi
+    echo "$res" | perl -0ne 'if (/\b117 : 179931895322\b/) { $found=1; last } END { exit !$found }'
+    if test "$?" != "0";
+    then
+        echo "FAIL"
+        exit 2
+    fi
+    echo "PASS"
+    exit 0
 else
     exit 3
 fi

--- a/doc/source/fmpz.rst
+++ b/doc/source/fmpz.rst
@@ -960,10 +960,8 @@ Basic arithmetic
     Assumes that `m \neq 0`, raises an ``abort`` signal otherwise.
 
 .. function:: void fmpz_sum_powers_horner(fmpz_t f, const fmpz_t g, ulong e)
-
-.. function:: void fmpz_sum_powers_div(fmpz_t f, const fmpz_t g, ulong e)
-
-.. function:: void fmpz_sum_powers(fmpz_t f, const fmpz_t g, ulong e)
+              void fmpz_sum_powers_div(fmpz_t f, const fmpz_t g, ulong e)
+	      void fmpz_sum_powers(fmpz_t f, const fmpz_t g, ulong e)
 
    Sets `f` to the sum of powers of `g`, starting at `g^0 = 1` up to and
    including `p^e`.

--- a/doc/source/fmpz.rst
+++ b/doc/source/fmpz.rst
@@ -959,6 +959,29 @@ Basic arithmetic
 
     Assumes that `m \neq 0`, raises an ``abort`` signal otherwise.
 
+.. function:: void fmpz_sum_powers_horner(fmpz_t f, const fmpz_t g, ulong e)
+
+.. function:: void fmpz_sum_powers_div(fmpz_t f, const fmpz_t g, ulong e)
+
+.. function:: void fmpz_sum_powers(fmpz_t f, const fmpz_t g, ulong e)
+
+   Sets `f` to the sum of powers of g, starting at `g^0 = 1` up to and
+   including `p^e`.
+
+   The `horner` method uses a horner-style method to evaluate the sum.
+
+   The `div` method uses polynomial division to evaluate the sum with a
+   single exponentiation and a single division.
+
+.. function:: void fmpz_sum_divisors(fmpz_t f, const fmpz_t g)
+
+   Sets `f` to the sum of divisors of `g`, including 1 and `g` itself.
+
+.. function:: void fmpz_sum_divisors_proper(fmpz_t f, const fmpz_t g)
+
+   Sets `f` to the sum of proper divisors of `g`, including 1 but excluding
+   `g` itself.
+
 .. function:: slong fmpz_clog(const fmpz_t x, const fmpz_t b)
               slong fmpz_clog_ui(const fmpz_t x, ulong b)
 

--- a/doc/source/fmpz.rst
+++ b/doc/source/fmpz.rst
@@ -965,10 +965,11 @@ Basic arithmetic
 
 .. function:: void fmpz_sum_powers(fmpz_t f, const fmpz_t g, ulong e)
 
-   Sets `f` to the sum of powers of g, starting at `g^0 = 1` up to and
+   Sets `f` to the sum of powers of `g`, starting at `g^0 = 1` up to and
    including `p^e`.
 
-   The `horner` method uses a horner-style method to evaluate the sum.
+   The `horner` method uses a horner-style method to evaluate the sum
+   iteratively.
 
    The `div` method uses polynomial division to evaluate the sum with a
    single exponentiation and a single division.

--- a/examples/aliquot.c
+++ b/examples/aliquot.c
@@ -1,0 +1,47 @@
+/*
+    Copyright (C) 2024 Matthias Gessinger
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <flint/fmpz.h>
+#include <flint/profiler.h>
+
+int
+main(int argc, char * argv[])
+{
+	fmpz_t n;
+	ulong num_iterations = 0;
+
+	fmpz_init_set_si(n, 138);
+
+	flint_printf("Computing aliquot sequence\n");
+	flint_printf("%3wu : ", 0);
+	fmpz_print(n);
+	flint_printf("\n");
+
+	TIMEIT_ONCE_START
+
+	while (!fmpz_is_one(n))
+	{
+		fmpz_sum_divisors_proper(n, n);
+		num_iterations++;
+
+		flint_printf("%3wu : ", num_iterations);
+		fmpz_print(n);
+		flint_printf("\n");
+	}
+
+	flint_printf("Sequence terminated after %wu iterations.\n", num_iterations);
+
+	TIMEIT_ONCE_STOP
+	SHOW_MEMORY_USAGE
+
+	fmpz_clear(n);
+	return 0;
+}

--- a/examples/aliquot.c
+++ b/examples/aliquot.c
@@ -15,33 +15,33 @@
 int
 main(int argc, char * argv[])
 {
-	fmpz_t n;
-	ulong num_iterations = 0;
+    fmpz_t n;
+    ulong num_iterations = 0;
 
-	fmpz_init_set_si(n, 138);
+    fmpz_init_set_si(n, 138);
 
-	flint_printf("Computing aliquot sequence\n");
-	flint_printf("%3wu : ", 0);
-	fmpz_print(n);
-	flint_printf("\n");
+    flint_printf("Computing aliquot sequence\n");
+    flint_printf("%3wu : ", 0);
+    fmpz_print(n);
+    flint_printf("\n");
 
-	TIMEIT_ONCE_START
+    TIMEIT_ONCE_START
 
-	while (!fmpz_is_one(n))
-	{
-		fmpz_sum_divisors_proper(n, n);
-		num_iterations++;
+    while (!fmpz_is_one(n))
+    {
+        fmpz_sum_divisors_proper(n, n);
+        num_iterations++;
 
-		flint_printf("%3wu : ", num_iterations);
-		fmpz_print(n);
-		flint_printf("\n");
-	}
+        flint_printf("%3wu : ", num_iterations);
+        fmpz_print(n);
+        flint_printf("\n");
+    }
 
-	flint_printf("Sequence terminated after %wu iterations.\n", num_iterations);
+    flint_printf("Sequence terminated after %wu iterations.\n", num_iterations);
 
-	TIMEIT_ONCE_STOP
-	SHOW_MEMORY_USAGE
+    TIMEIT_ONCE_STOP
+    SHOW_MEMORY_USAGE
 
-	fmpz_clear(n);
-	return 0;
+    fmpz_clear(n);
+    return 0;
 }

--- a/src/fmpz.h
+++ b/src/fmpz.h
@@ -378,6 +378,13 @@ void fmpz_pow_ui(fmpz_t f, const fmpz_t g, ulong exp);
 void fmpz_ui_pow_ui(fmpz_t x, ulong b, ulong e);
 int fmpz_pow_fmpz(fmpz_t a, const fmpz_t b, const fmpz_t e);
 
+void fmpz_sum_powers(fmpz_t f, const fmpz_t g, ulong exp);
+void fmpz_sum_powers_horner(fmpz_t f, const fmpz_t g, ulong exp);
+void fmpz_sum_powers_div(fmpz_t f, const fmpz_t g, ulong exp);
+
+void fmpz_sum_divisors(fmpz_t f, const fmpz_t g);
+void fmpz_sum_divisors_proper(fmpz_t f, const fmpz_t g);
+
 void fmpz_sqrt(fmpz_t f, const fmpz_t g);
 void fmpz_sqrtrem(fmpz_t f, fmpz_t r, const fmpz_t g);
 
@@ -439,10 +446,6 @@ slong fmpz_flog_ui(const fmpz_t x, ulong b);
 
 double fmpz_get_d_2exp(slong * exp, const fmpz_t f);
 void fmpz_set_d_2exp(fmpz_t f, double m, slong exp);
-
-void fmpz_sum_powers_horner(fmpz_t f, const fmpz_t g, ulong exp);
-void fmpz_sum_powers_div(fmpz_t f, const fmpz_t g, ulong exp);
-void fmpz_sum_powers(fmpz_t f, const fmpz_t g, ulong exp);
 
 #if FLINT_HAVE_FFT_SMALL
 #define MPZ_WANT_FLINT_DIVISION(a, b) (mpz_size(b) >= 1250 && mpz_size(a) - mpz_size(b) >= 1250)

--- a/src/fmpz.h
+++ b/src/fmpz.h
@@ -440,6 +440,10 @@ slong fmpz_flog_ui(const fmpz_t x, ulong b);
 double fmpz_get_d_2exp(slong * exp, const fmpz_t f);
 void fmpz_set_d_2exp(fmpz_t f, double m, slong exp);
 
+void fmpz_sum_powers_horner(fmpz_t f, const fmpz_t g, ulong exp);
+void fmpz_sum_powers_div(fmpz_t f, const fmpz_t g, ulong exp);
+void fmpz_sum_powers(fmpz_t f, const fmpz_t g, ulong exp);
+
 #if FLINT_HAVE_FFT_SMALL
 #define MPZ_WANT_FLINT_DIVISION(a, b) (mpz_size(b) >= 1250 && mpz_size(a) - mpz_size(b) >= 1250)
 #else

--- a/src/fmpz/sum_divisors.c
+++ b/src/fmpz/sum_divisors.c
@@ -64,12 +64,12 @@ fmpz_sum_divisors(fmpz_t f, const fmpz_t g)
 void
 fmpz_sum_divisors_proper(fmpz_t f, const fmpz_t g)
 {
-	fmpz_t temp;
-	fmpz_init(temp);
+    fmpz_t temp;
+    fmpz_init(temp);
 
-	fmpz_sum_divisors(temp, g);
+    fmpz_sum_divisors(temp, g);
 
-	fmpz_sub(f, temp, g);
+    fmpz_sub(f, temp, g);
 
-	fmpz_clear(temp);
+    fmpz_clear(temp);
 }

--- a/src/fmpz/sum_divisors.c
+++ b/src/fmpz/sum_divisors.c
@@ -1,0 +1,75 @@
+/*
+    Copyright (C) 2024 Matthias Gessinger
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz.h"
+#include "fmpz_factor.h"
+
+void
+fmpz_sum_divisors(fmpz_t f, const fmpz_t g)
+{
+    fmpz_factor_t factors;
+    fmpz * temp;
+    ulong exp;
+    ulong i;
+
+    fmpz * p;
+
+    if (fmpz_is_zero(g) || fmpz_is_pm1(g))
+    {
+        fmpz_set(f, g);
+    }
+    else
+    {
+        fmpz_factor_init(factors);
+
+        fmpz_factor(factors, g);
+        i = 0;
+
+        temp = factors->p + i;
+        exp = factors->exp[i];
+
+        fmpz_sum_powers(temp, temp, exp);
+
+        for (i = 1; i < factors->num; i++)
+        {
+            p = factors->p + i;
+            exp = factors->exp[i];
+
+            fmpz_sum_powers(p, p, exp);
+
+            fmpz_mul(temp, temp, p);
+        }
+
+        if (factors->sign == -1)
+        {
+            fmpz_neg(f, temp);
+        }
+        else
+        {
+            fmpz_swap(f, temp);
+        }
+
+        fmpz_factor_clear(factors);
+    }
+}
+
+void
+fmpz_sum_divisors_proper(fmpz_t f, const fmpz_t g)
+{
+	fmpz_t temp;
+	fmpz_init(temp);
+
+	fmpz_sum_divisors(temp, g);
+
+	fmpz_sub(f, temp, g);
+
+	fmpz_clear(temp);
+}

--- a/src/fmpz/sum_divisors.c
+++ b/src/fmpz/sum_divisors.c
@@ -18,7 +18,7 @@ fmpz_sum_divisors(fmpz_t f, const fmpz_t g)
     fmpz_factor_t factors;
     fmpz * temp;
     ulong exp;
-    ulong i;
+    slong i;
 
     fmpz * p;
 

--- a/src/fmpz/sum_powers.c
+++ b/src/fmpz/sum_powers.c
@@ -14,55 +14,79 @@
 void
 fmpz_sum_powers_horner(fmpz_t f, const fmpz_t g, ulong exp)
 {
-    fmpz_t t;
-    fmpz_init_set_ui(t, 1);
+	fmpz_t t;
 
-    for (ulong i = 1; i < exp; i++)
-    {
-        fmpz_mul(t, t, g);
-        fmpz_add_ui(t, t, 1);
-    }
+	if (exp == 0 || fmpz_is_zero(g))
+	{
+		fmpz_one(f);
+	}
+	else if (fmpz_is_one(g))
+	{
+		fmpz_set_ui(f, exp + 1);
+	}
+	else
+	{
+		fmpz_init_set_ui(t, 1);
 
-    fmpz_swap(f, t);
-    fmpz_clear(t);
+		for (ulong i = 1; i <= exp; i++)
+		{
+			fmpz_mul(t, t, g);
+			fmpz_add_ui(t, t, 1);
+		}
+
+		fmpz_swap(f, t);
+		fmpz_clear(t);
+	}
 }
 
 void
 fmpz_sum_powers_div(fmpz_t f, const fmpz_t g, ulong exp)
 {
-    fmpz_t t;
-    fmpz_init(t);
+	fmpz_t t;
 
-    // t = g^(e + 1) - 1
-    fmpz_pow_ui(t, g, exp + 1);
-    fmpz_sub_ui(t, t, 1);
+	if (exp == 0 || fmpz_is_zero(g))
+	{
+		fmpz_one(f);
+	}
+	else if (fmpz_is_one(g))
+	{
+		fmpz_set_ui(f, exp + 1);
+	}
+	else
+	{
+		fmpz_init(t);
 
-    // f = g - 1
-    fmpz_sub_ui(f, g, 1);
+		// t = g - 1
+		fmpz_sub_ui(t, g, 1);
 
-    // f = (g^(e + 1) - 1) / (g - 1)
-    fmpz_tdiv(f, t, g);
+		// f = g^(e + 1) - 1
+		fmpz_pow_ui(f, g, exp + 1);
+		fmpz_sub_ui(f, f, 1);
 
-    fmpz_clear(t);
+		// f = (g^(e + 1) - 1) / (g - 1)
+		fmpz_tdiv_q(f, f, t);
+
+		fmpz_clear(t);
+	}
 }
 
 void
 fmpz_sum_powers(fmpz_t f, const fmpz_t g, ulong exp)
 {
-    if (exp == 0)
-    {
-        fmpz_zero(f);
-    }
-    else if (exp == 1)
-    {
-        fmpz_add_ui(f, g, 1);
-    }
-    else if (exp <= 100)
-    {
-        _fmpz_sum_powers_horner(f, g, exp);
-    }
-    else
-    {
-        _fmpz_sum_powers_div(f, g, exp);
-    }
+	if (exp == 0 || fmpz_is_zero(g))
+	{
+		fmpz_one(f);
+	}
+	else if (exp == 1)
+	{
+		fmpz_add_ui(f, g, 1);
+	}
+	else if (exp <= 100)
+	{
+		fmpz_sum_powers_horner(f, g, exp);
+	}
+	else
+	{
+		fmpz_sum_powers_div(f, g, exp);
+	}
 }

--- a/src/fmpz/sum_powers.c
+++ b/src/fmpz/sum_powers.c
@@ -1,0 +1,68 @@
+/*
+    Copyright (C) 2024 Matthias Gessinger
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz.h"
+
+void
+fmpz_sum_powers_horner(fmpz_t f, const fmpz_t g, ulong exp)
+{
+    fmpz_t t;
+    fmpz_init_set_ui(t, 1);
+
+    for (ulong i = 1; i < exp; i++)
+    {
+        fmpz_mul(t, t, g);
+        fmpz_add_ui(t, t, 1);
+    }
+
+    fmpz_swap(f, t);
+    fmpz_clear(t);
+}
+
+void
+fmpz_sum_powers_div(fmpz_t f, const fmpz_t g, ulong exp)
+{
+    fmpz_t t;
+    fmpz_init(t);
+
+    // t = g^(e + 1) - 1
+    fmpz_pow_ui(t, g, exp + 1);
+    fmpz_sub_ui(t, t, 1);
+
+    // f = g - 1
+    fmpz_sub_ui(f, g, 1);
+
+    // f = (g^(e + 1) - 1) / (g - 1)
+    fmpz_tdiv(f, t, g);
+
+    fmpz_clear(t);
+}
+
+void
+fmpz_sum_powers(fmpz_t f, const fmpz_t g, ulong exp)
+{
+    if (exp == 0)
+    {
+        fmpz_zero(f);
+    }
+    else if (exp == 1)
+    {
+        fmpz_add_ui(f, g, 1);
+    }
+    else if (exp <= 100)
+    {
+        _fmpz_sum_powers_horner(f, g, exp);
+    }
+    else
+    {
+        _fmpz_sum_powers_div(f, g, exp);
+    }
+}

--- a/src/fmpz/sum_powers.c
+++ b/src/fmpz/sum_powers.c
@@ -14,79 +14,79 @@
 void
 fmpz_sum_powers_horner(fmpz_t f, const fmpz_t g, ulong exp)
 {
-	fmpz_t t;
+    fmpz_t t;
 
-	if (exp == 0 || fmpz_is_zero(g))
-	{
-		fmpz_one(f);
-	}
-	else if (fmpz_is_one(g))
-	{
-		fmpz_set_ui(f, exp + 1);
-	}
-	else
-	{
-		fmpz_init_set_ui(t, 1);
+    if (exp == 0 || fmpz_is_zero(g))
+    {
+        fmpz_one(f);
+    }
+    else if (fmpz_is_one(g))
+    {
+        fmpz_set_ui(f, exp + 1);
+    }
+    else
+    {
+        fmpz_init_set_ui(t, 1);
 
-		for (ulong i = 1; i <= exp; i++)
-		{
-			fmpz_mul(t, t, g);
-			fmpz_add_ui(t, t, 1);
-		}
+        for (ulong i = 1; i <= exp; i++)
+        {
+            fmpz_mul(t, t, g);
+            fmpz_add_ui(t, t, 1);
+        }
 
-		fmpz_swap(f, t);
-		fmpz_clear(t);
-	}
+        fmpz_swap(f, t);
+        fmpz_clear(t);
+    }
 }
 
 void
 fmpz_sum_powers_div(fmpz_t f, const fmpz_t g, ulong exp)
 {
-	fmpz_t t;
+    fmpz_t t;
 
-	if (exp == 0 || fmpz_is_zero(g))
-	{
-		fmpz_one(f);
-	}
-	else if (fmpz_is_one(g))
-	{
-		fmpz_set_ui(f, exp + 1);
-	}
-	else
-	{
-		fmpz_init(t);
+    if (exp == 0 || fmpz_is_zero(g))
+    {
+        fmpz_one(f);
+    }
+    else if (fmpz_is_one(g))
+    {
+        fmpz_set_ui(f, exp + 1);
+    }
+    else
+    {
+        fmpz_init(t);
 
-		// t = g - 1
-		fmpz_sub_ui(t, g, 1);
+        /* t = g - 1 */
+        fmpz_sub_ui(t, g, 1);
 
-		// f = g^(e + 1) - 1
-		fmpz_pow_ui(f, g, exp + 1);
-		fmpz_sub_ui(f, f, 1);
+        /* f = g^(e + 1) - 1 */
+        fmpz_pow_ui(f, g, exp + 1);
+        fmpz_sub_ui(f, f, 1);
 
-		// f = (g^(e + 1) - 1) / (g - 1)
-		fmpz_tdiv_q(f, f, t);
+        /* f = (g^(e + 1) - 1) / (g - 1) */
+        fmpz_tdiv_q(f, f, t);
 
-		fmpz_clear(t);
-	}
+        fmpz_clear(t);
+    }
 }
 
 void
 fmpz_sum_powers(fmpz_t f, const fmpz_t g, ulong exp)
 {
-	if (exp == 0 || fmpz_is_zero(g))
-	{
-		fmpz_one(f);
-	}
-	else if (exp == 1)
-	{
-		fmpz_add_ui(f, g, 1);
-	}
-	else if (exp <= 100)
-	{
-		fmpz_sum_powers_horner(f, g, exp);
-	}
-	else
-	{
-		fmpz_sum_powers_div(f, g, exp);
-	}
+    if (exp == 0 || fmpz_is_zero(g))
+    {
+        fmpz_one(f);
+    }
+    else if (exp == 1)
+    {
+        fmpz_add_ui(f, g, 1);
+    }
+    else if (exp <= 100)
+    {
+        fmpz_sum_powers_horner(f, g, exp);
+    }
+    else
+    {
+        fmpz_sum_powers_div(f, g, exp);
+    }
 }

--- a/src/fmpz/test/main.c
+++ b/src/fmpz/test/main.c
@@ -193,6 +193,7 @@
 #include "t-sum_powers_horner.c"
 #include "t-sum_powers_div.c"
 #include "t-sum_powers.c"
+#include "t-sum_divisors.c"
 
 /* Array of test functions ***************************************************/
 
@@ -365,7 +366,8 @@ test_struct tests[] =
     TEST_FUNCTION(fmpz_xor),
     TEST_FUNCTION(fmpz_sum_powers_horner),
     TEST_FUNCTION(fmpz_sum_powers_div),
-    TEST_FUNCTION(fmpz_sum_powers)
+    TEST_FUNCTION(fmpz_sum_powers),
+    TEST_FUNCTION(fmpz_sum_divisors)
 };
 
 /* main function *************************************************************/

--- a/src/fmpz/test/main.c
+++ b/src/fmpz/test/main.c
@@ -190,6 +190,8 @@
 #include "t-xgcd_canonical_bezout.c"
 #include "t-xgcd_partial.c"
 #include "t-xor.c"
+#include "t-sum_powers_horner.c"
+#include "t-sum_powers_div.c"
 #include "t-sum_powers.c"
 
 /* Array of test functions ***************************************************/
@@ -360,7 +362,9 @@ test_struct tests[] =
     TEST_FUNCTION(fmpz_xgcd),
     TEST_FUNCTION(fmpz_xgcd_canonical_bezout),
     TEST_FUNCTION(fmpz_xgcd_partial),
-    TEST_FUNCTION(fmpz_xor)
+    TEST_FUNCTION(fmpz_xor),
+    TEST_FUNCTION(fmpz_sum_powers_horner),
+    TEST_FUNCTION(fmpz_sum_powers_div),
     TEST_FUNCTION(fmpz_sum_powers)
 };
 

--- a/src/fmpz/test/main.c
+++ b/src/fmpz/test/main.c
@@ -190,6 +190,7 @@
 #include "t-xgcd_canonical_bezout.c"
 #include "t-xgcd_partial.c"
 #include "t-xor.c"
+#include "t-sum_powers.c"
 
 /* Array of test functions ***************************************************/
 
@@ -360,6 +361,7 @@ test_struct tests[] =
     TEST_FUNCTION(fmpz_xgcd_canonical_bezout),
     TEST_FUNCTION(fmpz_xgcd_partial),
     TEST_FUNCTION(fmpz_xor)
+    TEST_FUNCTION(fmpz_sum_powers)
 };
 
 /* main function *************************************************************/

--- a/src/fmpz/test/main.c
+++ b/src/fmpz/test/main.c
@@ -176,6 +176,10 @@
 #include "t-submul.c"
 #include "t-submul_si.c"
 #include "t-submul_ui.c"
+#include "t-sum_powers_horner.c"
+#include "t-sum_powers_div.c"
+#include "t-sum_powers.c"
+#include "t-sum_divisors.c"
 #include "t-swap.c"
 #include "t-tdiv_q_2exp.c"
 #include "t-tdiv_q.c"
@@ -190,10 +194,6 @@
 #include "t-xgcd_canonical_bezout.c"
 #include "t-xgcd_partial.c"
 #include "t-xor.c"
-#include "t-sum_powers_horner.c"
-#include "t-sum_powers_div.c"
-#include "t-sum_powers.c"
-#include "t-sum_divisors.c"
 
 /* Array of test functions ***************************************************/
 
@@ -350,6 +350,10 @@ test_struct tests[] =
     TEST_FUNCTION(fmpz_submul),
     TEST_FUNCTION(fmpz_submul_si),
     TEST_FUNCTION(fmpz_submul_ui),
+    TEST_FUNCTION(fmpz_sum_powers_horner),
+    TEST_FUNCTION(fmpz_sum_powers_div),
+    TEST_FUNCTION(fmpz_sum_powers),
+    TEST_FUNCTION(fmpz_sum_divisors),
     TEST_FUNCTION(fmpz_swap),
     TEST_FUNCTION(fmpz_tdiv_q_2exp),
     TEST_FUNCTION(fmpz_tdiv_q),
@@ -363,11 +367,7 @@ test_struct tests[] =
     TEST_FUNCTION(fmpz_xgcd),
     TEST_FUNCTION(fmpz_xgcd_canonical_bezout),
     TEST_FUNCTION(fmpz_xgcd_partial),
-    TEST_FUNCTION(fmpz_xor),
-    TEST_FUNCTION(fmpz_sum_powers_horner),
-    TEST_FUNCTION(fmpz_sum_powers_div),
-    TEST_FUNCTION(fmpz_sum_powers),
-    TEST_FUNCTION(fmpz_sum_divisors)
+    TEST_FUNCTION(fmpz_xor)
 };
 
 /* main function *************************************************************/

--- a/src/fmpz/test/t-sum_divisors.c
+++ b/src/fmpz/test/t-sum_divisors.c
@@ -1,0 +1,120 @@
+/*
+    Copyright (C) 2024 Matthias Gessinger
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "ulong_extras.h"
+#include "fmpz.h"
+
+void _fmpz_sum_divisors_naive(fmpz_t f, fmpz_t g)
+{
+	fmpz_t sqrt, temp1, temp2, temp3, out;
+
+	fmpz_init(sqrt);
+	fmpz_init(temp1);
+	fmpz_init(temp2);
+	fmpz_init(temp3);
+	fmpz_init(out);
+
+	int is_neg = fmpz_cmp_ui(g, 0) < 1;
+
+	fmpz_abs(f, g);
+	fmpz_sqrt(sqrt, f);
+
+	fmpz_set_si(temp1, 1);
+	while (fmpz_cmp(temp1, sqrt) != 1)
+	{
+		fmpz_tdiv_qr(temp3, temp2, f, temp1);
+
+		if (fmpz_is_zero(temp2))
+		{
+			fmpz_add(out, out, temp3);
+
+			if (fmpz_cmp(temp1, temp3) != 0)
+			{
+				fmpz_add(out, out, temp1);
+			}
+		}
+
+		fmpz_add_si(temp1, temp1, 1);
+	}
+
+	if (is_neg)
+	{
+		fmpz_neg(f, out);
+	}
+	else
+	{
+		fmpz_set(f, out);
+	}
+
+	fmpz_clear(out);
+	fmpz_clear(temp1);
+	fmpz_clear(temp2);
+	fmpz_clear(temp3);
+	fmpz_clear(sqrt);
+}
+
+TEST_FUNCTION_START(fmpz_sum_divisors, state)
+{
+	int i, result;
+
+	for (i = 0; i < 1000 * flint_test_multiplier(); i++)
+	{
+		fmpz_t a, b, c;
+		int aliasing;
+
+		fmpz_init(a);
+		fmpz_init(b);
+		fmpz_init(c);
+
+		fmpz_randtest(a, state, 32);
+
+		aliasing = n_randint(state, 2);
+
+		/* The reference result */
+		_fmpz_sum_divisors_naive(c, a);
+
+		/* general function */
+		if (aliasing == 1)
+		{
+			fmpz_sum_divisors(a, a);
+			fmpz_set(b, a);
+		}
+		else
+		{
+			fmpz_sum_divisors(b, a);
+		}
+
+		result = (fmpz_cmp(c, b) == 0);
+
+		if (!result)
+		{
+			flint_printf("FAIL:\n");
+
+			flint_printf("Expected: ");
+			fmpz_print(c);
+			flint_printf("\n");
+
+			flint_printf("Actual: ");
+			fmpz_print(b);
+			flint_printf("\n");
+
+			fflush(stdout);
+			flint_abort();
+		}
+
+		fmpz_clear(a);
+		fmpz_clear(b);
+		fmpz_clear(c);
+	}
+
+	TEST_FUNCTION_END(state);
+}

--- a/src/fmpz/test/t-sum_divisors.c
+++ b/src/fmpz/test/t-sum_divisors.c
@@ -15,106 +15,98 @@
 
 void _fmpz_sum_divisors_naive(fmpz_t f, fmpz_t g)
 {
-	fmpz_t sqrt, temp1, temp2, temp3, out;
+    fmpz_t sqrt, temp1, temp2, temp3, out;
 
-	fmpz_init(sqrt);
-	fmpz_init(temp1);
-	fmpz_init(temp2);
-	fmpz_init(temp3);
-	fmpz_init(out);
+    fmpz_init(sqrt);
+    fmpz_init(temp1);
+    fmpz_init(temp2);
+    fmpz_init(temp3);
+    fmpz_init(out);
 
-	int is_neg = fmpz_cmp_ui(g, 0) < 1;
+    int is_neg = fmpz_cmp_ui(g, 0) < 1;
 
-	fmpz_abs(f, g);
-	fmpz_sqrt(sqrt, f);
+    fmpz_abs(f, g);
+    fmpz_sqrt(sqrt, f);
 
-	fmpz_set_si(temp1, 1);
-	while (fmpz_cmp(temp1, sqrt) != 1)
-	{
-		fmpz_tdiv_qr(temp3, temp2, f, temp1);
+    fmpz_set_si(temp1, 1);
+    while (fmpz_cmp(temp1, sqrt) != 1)
+    {
+        fmpz_tdiv_qr(temp3, temp2, f, temp1);
 
-		if (fmpz_is_zero(temp2))
-		{
-			fmpz_add(out, out, temp3);
+        if (fmpz_is_zero(temp2))
+        {
+            fmpz_add(out, out, temp3);
 
-			if (fmpz_cmp(temp1, temp3) != 0)
-			{
-				fmpz_add(out, out, temp1);
-			}
-		}
+            if (fmpz_cmp(temp1, temp3) != 0)
+            {
+                fmpz_add(out, out, temp1);
+            }
+        }
 
-		fmpz_add_si(temp1, temp1, 1);
-	}
+        fmpz_add_si(temp1, temp1, 1);
+    }
 
-	if (is_neg)
-	{
-		fmpz_neg(f, out);
-	}
-	else
-	{
-		fmpz_set(f, out);
-	}
+    if (is_neg)
+    {
+        fmpz_neg(f, out);
+    }
+    else
+    {
+        fmpz_set(f, out);
+    }
 
-	fmpz_clear(out);
-	fmpz_clear(temp1);
-	fmpz_clear(temp2);
-	fmpz_clear(temp3);
-	fmpz_clear(sqrt);
+    fmpz_clear(out);
+    fmpz_clear(temp1);
+    fmpz_clear(temp2);
+    fmpz_clear(temp3);
+    fmpz_clear(sqrt);
 }
 
 TEST_FUNCTION_START(fmpz_sum_divisors, state)
 {
-	int i, result;
+    int i, result;
 
-	for (i = 0; i < 1000 * flint_test_multiplier(); i++)
-	{
-		fmpz_t a, b, c;
-		int aliasing;
+    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
+    {
+        fmpz_t a, b, c;
+        int aliasing;
 
-		fmpz_init(a);
-		fmpz_init(b);
-		fmpz_init(c);
+        fmpz_init(a);
+        fmpz_init(b);
+        fmpz_init(c);
 
-		fmpz_randtest(a, state, 32);
+        fmpz_randtest(a, state, 32);
 
-		aliasing = n_randint(state, 2);
+        aliasing = n_randint(state, 2);
 
-		/* The reference result */
-		_fmpz_sum_divisors_naive(c, a);
+        /* The reference result */
+        _fmpz_sum_divisors_naive(c, a);
 
-		/* general function */
-		if (aliasing == 1)
-		{
-			fmpz_sum_divisors(a, a);
-			fmpz_set(b, a);
-		}
-		else
-		{
-			fmpz_sum_divisors(b, a);
-		}
+        /* general function */
+        if (aliasing == 1)
+        {
+            fmpz_sum_divisors(a, a);
+            fmpz_set(b, a);
+        }
+        else
+        {
+            fmpz_sum_divisors(b, a);
+        }
 
-		result = (fmpz_cmp(c, b) == 0);
+        result = (fmpz_cmp(c, b) == 0);
 
-		if (!result)
-		{
-			flint_printf("FAIL:\n");
+        if (!result)
+        {
+            TEST_FUNCTION_FAIL(
+                "Expected: %{fmpz}\n"
+                "Got: %{fmpz}\n",
+                c, b);
+        }
 
-			flint_printf("Expected: ");
-			fmpz_print(c);
-			flint_printf("\n");
+        fmpz_clear(a);
+        fmpz_clear(b);
+        fmpz_clear(c);
+    }
 
-			flint_printf("Actual: ");
-			fmpz_print(b);
-			flint_printf("\n");
-
-			fflush(stdout);
-			flint_abort();
-		}
-
-		fmpz_clear(a);
-		fmpz_clear(b);
-		fmpz_clear(c);
-	}
-
-	TEST_FUNCTION_END(state);
+    TEST_FUNCTION_END(state);
 }

--- a/src/fmpz/test/t-sum_powers.c
+++ b/src/fmpz/test/t-sum_powers.c
@@ -67,18 +67,10 @@ TEST_FUNCTION_START(fmpz_sum_powers, state)
 
         if (!result)
         {
-            flint_printf("FAIL:\n");
-
-            flint_printf("Expected: ");
-            fmpz_print(c);
-            flint_printf("\n");
-
-            flint_printf("Actual: ");
-            fmpz_print(b);
-            flint_printf("\n");
-
-            fflush(stdout);
-            flint_abort();
+            TEST_FUNCTION_FAIL(
+                "Expected: %{fmpz}\n"
+                "Got: %{fmpz}\n",
+                c, b);
         }
 
         fmpz_clear(a);

--- a/src/fmpz/test/t-sum_powers.c
+++ b/src/fmpz/test/t-sum_powers.c
@@ -1,0 +1,89 @@
+/*
+    Copyright (C) 2024 Matthias Gessinger
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "ulong_extras.h"
+#include "fmpz.h"
+
+void _sum_powers_naive(fmpz_t f, const fmpz_t g, ulong exp);
+{
+	fmpz_t t;
+	fmpz_init(t);
+
+	fmpz_zero(f);
+
+	for (ulong i = 0; i < exp; i++)
+	{
+		fmpz_pow_ui(t, g, i);
+		fmpz_add(f, f, t);
+	}
+
+	fmpz_clear(t);
+}
+
+TEST_FUNCTION_START(fmpz_sum_powers, state)
+{
+	int i, result;
+
+	for (i = 0; i < 1000 * flint_test_multiplier(); i++)
+	{
+		fmpz_t a, b, c;
+		ulong exp;
+		int aliasing;
+
+		fmpz_init(a);
+		fmpz_init(b);
+		fmpz_init(c);
+
+		fmpz_randtest(a, state, 200);
+		fmpz_randtest(b, state, 200);
+
+		exp = n_randint(state, 1<<10);
+
+		aliasing = n_randint(state, 2);
+
+		if (aliasing == 1)
+		{
+			fmpz_sum_powers(a, a, exp);
+			fmpz_set(b, a);
+		}
+		else
+		{
+			fmpz_sum_powers(b, a, exp);
+		}
+
+		_fmpz_sum_powers_naive(c, a, exp);
+
+		result = fmpz_cmp(c, b);
+
+		if (!result)
+		{
+			flint_printf("FAIL:\n");
+
+			flint_printf("Expected: ");
+			fmpz_print(c);
+			flint_printf("\n");
+
+			flint_printf("Actual: ");
+			fmpz_print(b);
+			flint_printf("\n");
+
+			fflush(stdout);
+			flint_abort();
+		}
+
+		fmpz_clear(a);
+		fmpz_clear(b);
+		fmpz_clear(c);
+	}
+
+	TEST_FUNCTION_END(state);
+}

--- a/src/fmpz/test/t-sum_powers.c
+++ b/src/fmpz/test/t-sum_powers.c
@@ -15,76 +15,76 @@
 
 void _fmpz_sum_powers_naive(fmpz_t f, const fmpz_t g, ulong exp)
 {
-	fmpz_t t;
-	fmpz_init(t);
+    fmpz_t t;
+    fmpz_init(t);
 
-	fmpz_zero(f);
+    fmpz_zero(f);
 
-	for (ulong i = 0; i <= exp; i++)
-	{
-		fmpz_pow_ui(t, g, i);
-		fmpz_add(f, f, t);
-	}
+    for (ulong i = 0; i <= exp; i++)
+    {
+        fmpz_pow_ui(t, g, i);
+        fmpz_add(f, f, t);
+    }
 
-	fmpz_clear(t);
+    fmpz_clear(t);
 }
 
 TEST_FUNCTION_START(fmpz_sum_powers, state)
 {
-	int i, result;
+    int i, result;
 
-	for (i = 0; i < 1000 * flint_test_multiplier(); i++)
-	{
-		fmpz_t a, b, c;
-		ulong exp;
-		int aliasing;
+    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
+    {
+        fmpz_t a, b, c;
+        ulong exp;
+        int aliasing;
 
-		fmpz_init(a);
-		fmpz_init(b);
-		fmpz_init(c);
+        fmpz_init(a);
+        fmpz_init(b);
+        fmpz_init(c);
 
-		fmpz_randtest(a, state, 100);
+        fmpz_randtest(a, state, 100);
 
-		exp = n_randint(state, 250);
+        exp = n_randint(state, 250);
 
-		aliasing = n_randint(state, 2);
+        aliasing = n_randint(state, 2);
 
-		/* The reference result */
-		_fmpz_sum_powers_naive(c, a, exp);
+        /* The reference result */
+        _fmpz_sum_powers_naive(c, a, exp);
 
-		/* general function */
-		if (aliasing == 1)
-		{
-			fmpz_sum_powers(a, a, exp);
-			fmpz_set(b, a);
-		}
-		else
-		{
-			fmpz_sum_powers(b, a, exp);
-		}
+        /* general function */
+        if (aliasing == 1)
+        {
+            fmpz_sum_powers(a, a, exp);
+            fmpz_set(b, a);
+        }
+        else
+        {
+            fmpz_sum_powers(b, a, exp);
+        }
 
-		result = (fmpz_cmp(c, b) == 0);
+        result = (fmpz_cmp(c, b) == 0);
 
-		if (!result)
-		{
-			flint_printf("FAIL in general method:\n");
+        if (!result)
+        {
+            flint_printf("FAIL:\n");
 
-			flint_printf("Expected: ");
-			fmpz_print(c);
-			flint_printf("\n");
+            flint_printf("Expected: ");
+            fmpz_print(c);
+            flint_printf("\n");
 
-			flint_printf("Actual: ");
-			fmpz_print(b);
-			flint_printf("\n");
+            flint_printf("Actual: ");
+            fmpz_print(b);
+            flint_printf("\n");
 
-			fflush(stdout);
-			flint_abort();
-		}
+            fflush(stdout);
+            flint_abort();
+        }
 
-		fmpz_clear(a);
-		fmpz_clear(b);
-		fmpz_clear(c);
-	}
+        fmpz_clear(a);
+        fmpz_clear(b);
+        fmpz_clear(c);
+    }
 
-	TEST_FUNCTION_END(state);
+    TEST_FUNCTION_END(state);
 }

--- a/src/fmpz/test/t-sum_powers_div.c
+++ b/src/fmpz/test/t-sum_powers_div.c
@@ -15,76 +15,76 @@
 
 void _fmpz_sum_powers_naive_div(fmpz_t f, const fmpz_t g, ulong exp)
 {
-	fmpz_t t;
-	fmpz_init(t);
+    fmpz_t t;
+    fmpz_init(t);
 
-	fmpz_zero(f);
+    fmpz_zero(f);
 
-	for (ulong i = 0; i <= exp; i++)
-	{
-		fmpz_pow_ui(t, g, i);
-		fmpz_add(f, f, t);
-	}
+    for (ulong i = 0; i <= exp; i++)
+    {
+        fmpz_pow_ui(t, g, i);
+        fmpz_add(f, f, t);
+    }
 
-	fmpz_clear(t);
+    fmpz_clear(t);
 }
 
 TEST_FUNCTION_START(fmpz_sum_powers_div, state)
 {
-	int i, result;
+    int i, result;
 
-	for (i = 0; i < 1000 * flint_test_multiplier(); i++)
-	{
-		fmpz_t a, b, c;
-		ulong exp;
-		int aliasing;
+    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
+    {
+        fmpz_t a, b, c;
+        ulong exp;
+        int aliasing;
 
-		fmpz_init(a);
-		fmpz_init(b);
-		fmpz_init(c);
+        fmpz_init(a);
+        fmpz_init(b);
+        fmpz_init(c);
 
-		fmpz_randtest(a, state, 100);
+        fmpz_randtest(a, state, 100);
 
-		exp = n_randint(state, 250);
+        exp = n_randint(state, 250);
 
-		aliasing = n_randint(state, 2);
+        aliasing = n_randint(state, 2);
 
-		/* The reference result */
-		_fmpz_sum_powers_naive_div(c, a, exp);
+        /* The reference result */
+        _fmpz_sum_powers_naive_div(c, a, exp);
 
-		/* polynomial division method */
-		if (aliasing == 1)
-		{
-			fmpz_sum_powers_div(a, a, exp);
-			fmpz_set(b, a);
-		}
-		else
-		{
-			fmpz_sum_powers_div(b, a, exp);
-		}
+        /* polynomial division method */
+        if (aliasing == 1)
+        {
+            fmpz_sum_powers_div(a, a, exp);
+            fmpz_set(b, a);
+        }
+        else
+        {
+            fmpz_sum_powers_div(b, a, exp);
+        }
 
-		result = (fmpz_cmp(c, b) == 0);
+        result = (fmpz_cmp(c, b) == 0);
 
-		if (!result)
-		{
-			flint_printf("FAIL in polynomial division method:\n");
+        if (!result)
+        {
+            flint_printf("FAIL:\n");
 
-			flint_printf("Expected: ");
-			fmpz_print(c);
-			flint_printf("\n");
+            flint_printf("Expected: ");
+            fmpz_print(c);
+            flint_printf("\n");
 
-			flint_printf("Actual: ");
-			fmpz_print(b);
-			flint_printf("\n");
+            flint_printf("Actual: ");
+            fmpz_print(b);
+            flint_printf("\n");
 
-			fflush(stdout);
-			flint_abort();
-		}
+            fflush(stdout);
+            flint_abort();
+        }
 
-		fmpz_clear(a);
-		fmpz_clear(b);
-		fmpz_clear(c);
-	}
+        fmpz_clear(a);
+        fmpz_clear(b);
+        fmpz_clear(c);
+    }
 
-	TEST_FUNCTION_END(state);
+    TEST_FUNCTION_END(state);
 }

--- a/src/fmpz/test/t-sum_powers_div.c
+++ b/src/fmpz/test/t-sum_powers_div.c
@@ -67,18 +67,10 @@ TEST_FUNCTION_START(fmpz_sum_powers_div, state)
 
         if (!result)
         {
-            flint_printf("FAIL:\n");
-
-            flint_printf("Expected: ");
-            fmpz_print(c);
-            flint_printf("\n");
-
-            flint_printf("Actual: ");
-            fmpz_print(b);
-            flint_printf("\n");
-
-            fflush(stdout);
-            flint_abort();
+            TEST_FUNCTION_FAIL(
+                "Expected: %{fmpz}\n"
+                "Got: %{fmpz}\n",
+                c, b);
         }
 
         fmpz_clear(a);

--- a/src/fmpz/test/t-sum_powers_div.c
+++ b/src/fmpz/test/t-sum_powers_div.c
@@ -13,7 +13,7 @@
 #include "ulong_extras.h"
 #include "fmpz.h"
 
-void _fmpz_sum_powers_naive(fmpz_t f, const fmpz_t g, ulong exp)
+void _fmpz_sum_powers_naive_div(fmpz_t f, const fmpz_t g, ulong exp)
 {
 	fmpz_t t;
 	fmpz_init(t);
@@ -29,7 +29,7 @@ void _fmpz_sum_powers_naive(fmpz_t f, const fmpz_t g, ulong exp)
 	fmpz_clear(t);
 }
 
-TEST_FUNCTION_START(fmpz_sum_powers, state)
+TEST_FUNCTION_START(fmpz_sum_powers_div, state)
 {
 	int i, result;
 
@@ -50,24 +50,24 @@ TEST_FUNCTION_START(fmpz_sum_powers, state)
 		aliasing = n_randint(state, 2);
 
 		/* The reference result */
-		_fmpz_sum_powers_naive(c, a, exp);
+		_fmpz_sum_powers_naive_div(c, a, exp);
 
-		/* general function */
+		/* polynomial division method */
 		if (aliasing == 1)
 		{
-			fmpz_sum_powers(a, a, exp);
+			fmpz_sum_powers_div(a, a, exp);
 			fmpz_set(b, a);
 		}
 		else
 		{
-			fmpz_sum_powers(b, a, exp);
+			fmpz_sum_powers_div(b, a, exp);
 		}
 
 		result = (fmpz_cmp(c, b) == 0);
 
 		if (!result)
 		{
-			flint_printf("FAIL in general method:\n");
+			flint_printf("FAIL in polynomial division method:\n");
 
 			flint_printf("Expected: ");
 			fmpz_print(c);

--- a/src/fmpz/test/t-sum_powers_horner.c
+++ b/src/fmpz/test/t-sum_powers_horner.c
@@ -15,76 +15,76 @@
 
 void _fmpz_sum_powers_naive_horner(fmpz_t f, const fmpz_t g, ulong exp)
 {
-	fmpz_t t;
-	fmpz_init(t);
+    fmpz_t t;
+    fmpz_init(t);
 
-	fmpz_zero(f);
+    fmpz_zero(f);
 
-	for (ulong i = 0; i <= exp; i++)
-	{
-		fmpz_pow_ui(t, g, i);
-		fmpz_add(f, f, t);
-	}
+    for (ulong i = 0; i <= exp; i++)
+    {
+        fmpz_pow_ui(t, g, i);
+        fmpz_add(f, f, t);
+    }
 
-	fmpz_clear(t);
+    fmpz_clear(t);
 }
 
 TEST_FUNCTION_START(fmpz_sum_powers_horner, state)
 {
-	int i, result;
+    int i, result;
 
-	for (i = 0; i < 1000 * flint_test_multiplier(); i++)
-	{
-		fmpz_t a, b, c;
-		ulong exp;
-		int aliasing;
+    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
+    {
+        fmpz_t a, b, c;
+        ulong exp;
+        int aliasing;
 
-		fmpz_init(a);
-		fmpz_init(b);
-		fmpz_init(c);
+        fmpz_init(a);
+        fmpz_init(b);
+        fmpz_init(c);
 
-		fmpz_randtest(a, state, 100);
+        fmpz_randtest(a, state, 100);
 
-		exp = n_randint(state, 250);
+        exp = n_randint(state, 250);
 
-		aliasing = n_randint(state, 2);
+        aliasing = n_randint(state, 2);
 
-		/* The reference result */
-		_fmpz_sum_powers_naive_horner(c, a, exp);
+        /* The reference result */
+        _fmpz_sum_powers_naive_horner(c, a, exp);
 
-		/* Horner-style evaluation */
-		if (aliasing == 1)
-		{
-			fmpz_sum_powers_horner(a, a, exp);
-			fmpz_set(b, a);
-		}
-		else
-		{
-			fmpz_sum_powers_horner(b, a, exp);
-		}
+        /* Horner-style evaluation */
+        if (aliasing == 1)
+        {
+            fmpz_sum_powers_horner(a, a, exp);
+            fmpz_set(b, a);
+        }
+        else
+        {
+            fmpz_sum_powers_horner(b, a, exp);
+        }
 
-		result = (fmpz_cmp(c, b) == 0);
+        result = (fmpz_cmp(c, b) == 0);
 
-		if (!result)
-		{
-			flint_printf("FAIL in horner evaluation:\n");
+        if (!result)
+        {
+            flint_printf("FAIL:\n");
 
-			flint_printf("Expected: ");
-			fmpz_print(c);
-			flint_printf("\n");
+            flint_printf("Expected: ");
+            fmpz_print(c);
+            flint_printf("\n");
 
-			flint_printf("Actual: ");
-			fmpz_print(b);
-			flint_printf("\n");
+            flint_printf("Actual: ");
+            fmpz_print(b);
+            flint_printf("\n");
 
-			fflush(stdout);
-			flint_abort();
-		}
+            fflush(stdout);
+            flint_abort();
+        }
 
-		fmpz_clear(a);
-		fmpz_clear(b);
-		fmpz_clear(c);
-	}
+        fmpz_clear(a);
+        fmpz_clear(b);
+        fmpz_clear(c);
+    }
 
-	TEST_FUNCTION_END(state);
+    TEST_FUNCTION_END(state);
 }

--- a/src/fmpz/test/t-sum_powers_horner.c
+++ b/src/fmpz/test/t-sum_powers_horner.c
@@ -13,7 +13,7 @@
 #include "ulong_extras.h"
 #include "fmpz.h"
 
-void _fmpz_sum_powers_naive(fmpz_t f, const fmpz_t g, ulong exp)
+void _fmpz_sum_powers_naive_horner(fmpz_t f, const fmpz_t g, ulong exp)
 {
 	fmpz_t t;
 	fmpz_init(t);
@@ -29,7 +29,7 @@ void _fmpz_sum_powers_naive(fmpz_t f, const fmpz_t g, ulong exp)
 	fmpz_clear(t);
 }
 
-TEST_FUNCTION_START(fmpz_sum_powers, state)
+TEST_FUNCTION_START(fmpz_sum_powers_horner, state)
 {
 	int i, result;
 
@@ -50,24 +50,24 @@ TEST_FUNCTION_START(fmpz_sum_powers, state)
 		aliasing = n_randint(state, 2);
 
 		/* The reference result */
-		_fmpz_sum_powers_naive(c, a, exp);
+		_fmpz_sum_powers_naive_horner(c, a, exp);
 
-		/* general function */
+		/* Horner-style evaluation */
 		if (aliasing == 1)
 		{
-			fmpz_sum_powers(a, a, exp);
+			fmpz_sum_powers_horner(a, a, exp);
 			fmpz_set(b, a);
 		}
 		else
 		{
-			fmpz_sum_powers(b, a, exp);
+			fmpz_sum_powers_horner(b, a, exp);
 		}
 
 		result = (fmpz_cmp(c, b) == 0);
 
 		if (!result)
 		{
-			flint_printf("FAIL in general method:\n");
+			flint_printf("FAIL in horner evaluation:\n");
 
 			flint_printf("Expected: ");
 			fmpz_print(c);

--- a/src/fmpz/test/t-sum_powers_horner.c
+++ b/src/fmpz/test/t-sum_powers_horner.c
@@ -67,18 +67,10 @@ TEST_FUNCTION_START(fmpz_sum_powers_horner, state)
 
         if (!result)
         {
-            flint_printf("FAIL:\n");
-
-            flint_printf("Expected: ");
-            fmpz_print(c);
-            flint_printf("\n");
-
-            flint_printf("Actual: ");
-            fmpz_print(b);
-            flint_printf("\n");
-
-            fflush(stdout);
-            flint_abort();
+            TEST_FUNCTION_FAIL(
+                "Expected: %{fmpz}\n"
+                "Got: %{fmpz}\n",
+                c, b);
         }
 
         fmpz_clear(a);


### PR DESCRIPTION
This pull request was inspired by a recent [Numberphile video](https://www.youtube.com/watch?v=OtYKDzXwDEE).

The main goal of this PR is the method `fmpz_sum_divisors_proper` which computes the sum of all proper divisors of an integer `g`, i.e. all divisors including 1 but excluding `g` itself, without multiplicities (e.g. 4 counts the divisor 2 only once).
It does so by factorizing into primes and then counting multiplicities. Specifically, it uses the following [well-known formula](https://mathworld.wolfram.com/DivisorFunction.html):

Let $k$ be a positive integer with prime factorization $k = p_{1}^{m_1} \dots p_{n}^{m_n}$, where the $p_i$ are pairwise distinct primes. Denote by $S(n, e)$ the sum of powers of $n$ up to and including $n^e$, i.e. $S(n, e) = \sum\limits_{i=1}^{e} n^{i}$.
Then the sum of all divisors of $k$ (not necessarily proper) is equal to $\prod\limits_{i = 1}^{n} S(p_i, m_i)$ where the $p_i$ and $m_i$ are the primes and their multiplicities from the prime factor decomposition of $k$.
If $k$ is negative, then this implementation performs the computation for $\|k\|$ and adds the sign in the end.

To compute this efficiently, this PR implements two methods to evaluate the function $S$.
The first method is a Horner-style evaluation of the polynomial $h_e(x) \coloneqq S(x,e)$. The other method makes use of the identity $h_e(x) \cdot (x - 1) = x^{e+1} - 1$.
Both methods have their benefits and their downsides. Assuming exponentiation is fast, the polynomial division trick executes in near constant time, but it requires a division. The Horner-style method only needs multiplications and small integer additions, but it takes $O(e)$ time. Hence for large values of $e$, the polynomial version will provide slightly better performance. Some quick and dirty testing on my machine shows that for $e \approx 100$ they are roughly equal.
To "hide" this distinction from the user, an additional convenience method picks an algorithm automatically, based on the value of $e$.

To demonstrate the usefulness of this method, a new example program uses the function `fmpz_sum_divisors_proper` to compute the [aliquot sequence](https://oeis.org/wiki/Aliquot_sequences) of 138, which famously blows up to almost 180 billion before collapsing to 1.


To the best of my knowledge, I followed the code style guidelines. I added documentation, and tests are provided for all functions (except for `fmpz_sum_divisors_proper` because all it does is subtract $k$ from `fmpz_sum_divisors`).
An analogue of `fmpz_sum_powers` might also be of interest for other types, like `fmpq_t` or the arb types. Since the interfaces are pretty much identical, implementing similar functions in the other modules should be a trivial task (though it does lead to code duplication - tweaks in one module do not transfer to the other modules - which raises the question: Is there any plan on how to avoid such duplication? Something like templates in C++ or generics in C#. But that is a topic for another time).