### PR TITLE
a more reasonable sorting of complex numbers

### DIFF
--- a/src/acb/vec_sort_pretty.c
+++ b/src/acb/vec_sort_pretty.c
@@ -25,24 +25,14 @@ int acb_cmp_pretty(const acb_t a, const acb_t b)
     arb_t t, u, v;
     int res;
     arb_init(t);
-    arb_init(u);
-    arb_init(v);
-    arb_abs(u, acb_imagref(a));
-    arb_abs(v, acb_imagref(b));
-    arb_sub(t, u, v, MAG_BITS);
+    arb_sub(t, acb_realref(a), acb_realref(b), MAG_BITS);
     res = 0;
     if (arb_contains_zero(t))
     {
-        arb_sub(t, acb_realref(a), acb_realref(b), MAG_BITS);
-        res = arb_is_positive(t) ? 1 : -1;
+        arb_sub(t, acb_imagref(a), acb_imagref(b), MAG_BITS);
     }
-    else
-    {
-        res = arb_is_positive(t) ? 1 : -1;
-    }
+    res = arb_is_positive(t) ? 1 : -1;
     arb_clear(t);
-    arb_clear(u);
-    arb_clear(v);
     return res;
 }
 


### PR DESCRIPTION
In the current sorting, we have `z < conjugate(z)` and `conjugate(z) < z`.

I propose sorting on the real part; if they overlap, use the imaginary part.

Note that in the library, `_acb_vec_sort_pretty` is used to sort polynomials' roots, which are multisets of non-overlapping balls.
Therefore, we will obtain a predictable and stable sorting with the new comparison function.

PS: this will break some tests at Sagemath, as the roots will now come in a different order, but this is how I got into this rabbit hole.