### PR TITLE
Linear algebra tuning for nfloat + cmpabs

### DIFF
--- a/doc/source/nfloat.rst
+++ b/doc/source/nfloat.rst
@@ -324,6 +324,10 @@ Matrix functions
 
     Different implementations of matrix multiplication.
 
+.. function:: int nfloat_mat_nonsingular_solve_tril(gr_mat_t X, const gr_mat_t L, const gr_mat_t B, int unit, gr_ctx_t ctx)
+              int nfloat_mat_nonsingular_solve_triu(gr_mat_t X, const gr_mat_t L, const gr_mat_t B, int unit, gr_ctx_t ctx)
+              int nfloat_mat_lu(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx)
+
 Internal functions
 -------------------------------------------------------------------------------
 
@@ -417,3 +421,6 @@ real pairs.
               int nfloat_complex_mat_mul_block(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, slong min_block_size, gr_ctx_t ctx)
               int nfloat_complex_mat_mul_reorder(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx)
               int nfloat_complex_mat_mul(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx)
+              int nfloat_complex_mat_nonsingular_solve_tril(gr_mat_t X, const gr_mat_t L, const gr_mat_t B, int unit, gr_ctx_t ctx)
+              int nfloat_complex_mat_nonsingular_solve_triu(gr_mat_t X, const gr_mat_t L, const gr_mat_t B, int unit, gr_ctx_t ctx)
+              int nfloat_complex_mat_lu(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx)

--- a/src/gr/acf.c
+++ b/src/gr/acf.c
@@ -686,6 +686,11 @@ _gr_acf_cmpabs(int * res, const acf_t x, const acf_t y, const gr_ctx_t ctx)
             return _gr_arf_cmpabs(res, a, c, ctx);
         if (arf_is_zero(c))
             return _gr_arf_cmpabs(res, a, d, ctx);
+        if (arf_is_zero(a))
+        {
+            *res = -1;
+            return GR_SUCCESS;
+        }
     }
 
     if (arf_is_zero(a))
@@ -696,20 +701,10 @@ _gr_acf_cmpabs(int * res, const acf_t x, const acf_t y, const gr_ctx_t ctx)
             return _gr_arf_cmpabs(res, b, d, ctx);
     }
 
-    if (arf_is_zero(c))
+    if (arf_is_zero(c) && arf_is_zero(d))
     {
-        if (arf_is_zero(a))
-            return _gr_arf_cmpabs(res, b, d, ctx);
-        if (arf_is_zero(b))
-            return _gr_arf_cmpabs(res, a, d, ctx);
-    }
-
-    if (arf_is_zero(d))
-    {
-        if (arf_is_zero(a))
-            return _gr_arf_cmpabs(res, b, c, ctx);
-        if (arf_is_zero(b))
-            return _gr_arf_cmpabs(res, a, c, ctx);
+        *res = 1;
+        return GR_SUCCESS;
     }
 
     if (ARF_IS_LAGOM(a) && ARF_IS_LAGOM(b) && ARF_IS_LAGOM(c) && ARF_IS_LAGOM(d))

--- a/src/gr/acf.c
+++ b/src/gr/acf.c
@@ -666,13 +666,149 @@ _gr_acf_cmp(int * res, const acf_t x, const acf_t y, const gr_ctx_t ctx)
     return GR_SUCCESS;
 }
 
+/* ignores ctx, so we can pass in the acf context */
+int
+_gr_arf_cmpabs(int * res, const arf_t x, const arf_t y, const gr_ctx_t ctx);
+
+#include "double_extras.h"
+
 int
 _gr_acf_cmpabs(int * res, const acf_t x, const acf_t y, const gr_ctx_t ctx)
 {
-    if (!arf_is_zero(acf_imagref(x)) || !arf_is_zero(acf_imagref(y)))
-        return GR_UNABLE;
+    arf_srcptr a = acf_realref(x);
+    arf_srcptr b = acf_imagref(x);
+    arf_srcptr c = acf_realref(y);
+    arf_srcptr d = acf_imagref(y);
 
-    *res = arf_cmpabs(acf_realref(x), acf_realref(y));
+    if (arf_is_zero(b))
+    {
+        if (arf_is_zero(d))
+            return _gr_arf_cmpabs(res, a, c, ctx);
+        if (arf_is_zero(c))
+            return _gr_arf_cmpabs(res, a, d, ctx);
+    }
+
+    if (arf_is_zero(a))
+    {
+        if (arf_is_zero(d))
+            return _gr_arf_cmpabs(res, b, c, ctx);
+        if (arf_is_zero(c))
+            return _gr_arf_cmpabs(res, b, d, ctx);
+    }
+
+    if (arf_is_zero(c))
+    {
+        if (arf_is_zero(a))
+            return _gr_arf_cmpabs(res, b, d, ctx);
+        if (arf_is_zero(b))
+            return _gr_arf_cmpabs(res, a, d, ctx);
+    }
+
+    if (arf_is_zero(d))
+    {
+        if (arf_is_zero(a))
+            return _gr_arf_cmpabs(res, b, c, ctx);
+        if (arf_is_zero(b))
+            return _gr_arf_cmpabs(res, a, c, ctx);
+    }
+
+    if (ARF_IS_LAGOM(a) && ARF_IS_LAGOM(b) && ARF_IS_LAGOM(c) && ARF_IS_LAGOM(d))
+    {
+        slong aexp, bexp, cexp, dexp, xexp, yexp, exp;
+
+        aexp = arf_is_zero(a) ? WORD_MIN : ARF_EXP(a);
+        bexp = arf_is_zero(b) ? WORD_MIN : ARF_EXP(b);
+        cexp = arf_is_zero(c) ? WORD_MIN : ARF_EXP(c);
+        dexp = arf_is_zero(d) ? WORD_MIN : ARF_EXP(d);
+
+        /* 0.5 * 2^xexp <= |x| < sqrt(2) * 2^xexp */
+        xexp = FLINT_MAX(aexp, bexp);
+        /* 0.5 * 2^yexp <= |y| < sqrt(2) * 2^yexp */
+        yexp = FLINT_MAX(cexp, dexp);
+
+        if (xexp + 2 < yexp)
+        {
+            *res = -1;
+            return GR_SUCCESS;
+        }
+
+        if (xexp > yexp + 2)
+        {
+            *res = 1;
+            return GR_SUCCESS;
+        }
+
+        exp = FLINT_MAX(xexp, yexp);
+
+        double tt, xx = 0.0, yy = 0.0;
+        nn_srcptr xp;
+        slong xn;
+
+        if (aexp >= exp - 53)
+        {
+            ARF_GET_MPN_READONLY(xp, xn, a);
+            tt = d_mul_2exp_inrange(xp[xn - 1], aexp - exp - FLINT_BITS);
+            xx += tt * tt;
+        }
+
+        if (bexp >= exp - 53)
+        {
+            ARF_GET_MPN_READONLY(xp, xn, b);
+            tt = d_mul_2exp_inrange(xp[xn - 1], bexp - exp - FLINT_BITS);
+            xx += tt * tt;
+        }
+
+        if (cexp >= exp - 53)
+        {
+            ARF_GET_MPN_READONLY(xp, xn, c);
+            tt = d_mul_2exp_inrange(xp[xn - 1], cexp - exp - FLINT_BITS);
+            yy += tt * tt;
+        }
+
+        if (dexp >= exp - 53)
+        {
+            ARF_GET_MPN_READONLY(xp, xn, d);
+            tt = d_mul_2exp_inrange(xp[xn - 1], dexp - exp - FLINT_BITS);
+            yy += tt * tt;
+        }
+
+        if (xx < yy * 0.999999)
+        {
+            *res = -1;
+            return GR_SUCCESS;
+        }
+
+        if (xx * 0.999999 > yy)
+        {
+            *res = 1;
+            return GR_SUCCESS;
+        }
+    }
+
+    arf_struct s[5];
+
+    arf_init(s + 0);
+    arf_init(s + 1);
+    arf_init(s + 2);
+    arf_init(s + 3);
+    arf_init(s + 4);
+
+    arf_mul(s + 0, a, a, ARF_PREC_EXACT, ARF_RND_DOWN);
+    arf_mul(s + 1, b, b, ARF_PREC_EXACT, ARF_RND_DOWN);
+    arf_mul(s + 2, c, c, ARF_PREC_EXACT, ARF_RND_DOWN);
+    arf_mul(s + 3, d, d, ARF_PREC_EXACT, ARF_RND_DOWN);
+    arf_neg(s + 2, s + 2);
+    arf_neg(s + 3, s + 3);
+    arf_sum(s + 4, s, 4, 30, ARF_RND_DOWN);
+
+    *res = arf_sgn(s + 4);
+
+    arf_clear(s + 0);
+    arf_clear(s + 1);
+    arf_clear(s + 2);
+    arf_clear(s + 3);
+    arf_clear(s + 4);
+
     return GR_SUCCESS;
 }
 

--- a/src/gr/test_ring.c
+++ b/src/gr/test_ring.c
@@ -2904,7 +2904,7 @@ gr_test_ordered_ring_cmpabs(gr_ctx_t R, flint_rand_t state, int test_flags)
         status = GR_TEST_FAIL;
     }
 
-    if (status & GR_DOMAIN && !(status & GR_UNABLE))
+    if (gr_ctx_is_ordered_ring(R) == T_TRUE && (status & GR_DOMAIN && !(status & GR_UNABLE)))
     {
         status = GR_TEST_FAIL;
     }
@@ -4315,10 +4315,9 @@ gr_test_ring(gr_ctx_t R, slong iters, int test_flags)
     gr_test_iter(R, state, "pow: ui/si/fmpz/fmpq", gr_test_pow_type_variants, iters, test_flags & (~GR_TEST_ALWAYS_ABLE));
 
     if (gr_ctx_is_ordered_ring(R) == T_TRUE)
-    {
         gr_test_iter(R, state, "ordered_ring_cmp", gr_test_ordered_ring_cmp, iters, test_flags);
-        gr_test_iter(R, state, "ordered_ring_cmpabs", gr_test_ordered_ring_cmpabs, iters, test_flags);
-    }
+
+    gr_test_iter(R, state, "ordered_ring_cmpabs", gr_test_ordered_ring_cmpabs, iters, test_flags);
 
     gr_test_iter(R, state, "numerator_denominator", gr_test_numerator_denominator, iters, test_flags);
     gr_test_iter(R, state, "complex_parts", gr_test_complex_parts, iters, test_flags);

--- a/src/nfloat.h
+++ b/src/nfloat.h
@@ -458,6 +458,11 @@ int nfloat_mat_mul_waksman(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ct
 int nfloat_mat_mul_block(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, slong min_block_size, gr_ctx_t ctx);
 int nfloat_mat_mul(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
 
+int nfloat_mat_nonsingular_solve_tril(gr_mat_t X, const gr_mat_t L, const gr_mat_t B, int unit, gr_ctx_t ctx);
+int nfloat_mat_nonsingular_solve_triu(gr_mat_t X, const gr_mat_t L, const gr_mat_t B, int unit, gr_ctx_t ctx);
+int nfloat_mat_lu(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx);
+
+
 /* Complex numbers */
 /* Note: we use the same context data for real and complex rings
    (only which_ring and sizeof_elem differ). This allows us to call
@@ -568,6 +573,10 @@ int nfloat_complex_mat_mul_waksman(gr_mat_t C, const gr_mat_t A, const gr_mat_t 
 int nfloat_complex_mat_mul_block(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, slong min_block_size, gr_ctx_t ctx);
 int nfloat_complex_mat_mul_reorder(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
 int nfloat_complex_mat_mul(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
+
+int nfloat_complex_mat_nonsingular_solve_tril(gr_mat_t X, const gr_mat_t L, const gr_mat_t B, int unit, gr_ctx_t ctx);
+int nfloat_complex_mat_nonsingular_solve_triu(gr_mat_t X, const gr_mat_t L, const gr_mat_t B, int unit, gr_ctx_t ctx);
+int nfloat_complex_mat_lu(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx);
 
 #ifdef __cplusplus
 }

--- a/src/nfloat/complex.c
+++ b/src/nfloat/complex.c
@@ -1566,6 +1566,11 @@ nfloat_complex_cmpabs(int * res, nfloat_complex_srcptr x, nfloat_complex_srcptr 
             return nfloat_cmpabs(res, a, c, ctx);
         if (NFLOAT_IS_ZERO(c))
             return nfloat_cmpabs(res, a, d, ctx);
+        if (NFLOAT_IS_ZERO(a))
+        {
+            *res = -1;
+            return GR_SUCCESS;
+        }
     }
 
     if (NFLOAT_IS_ZERO(a))
@@ -1576,20 +1581,10 @@ nfloat_complex_cmpabs(int * res, nfloat_complex_srcptr x, nfloat_complex_srcptr 
             return nfloat_cmpabs(res, b, d, ctx);
     }
 
-    if (NFLOAT_IS_ZERO(c))
+    if (NFLOAT_IS_ZERO(c) && NFLOAT_IS_ZERO(d))
     {
-        if (NFLOAT_IS_ZERO(a))
-            return nfloat_cmpabs(res, b, d, ctx);
-        if (NFLOAT_IS_ZERO(b))
-            return nfloat_cmpabs(res, a, d, ctx);
-    }
-
-    if (NFLOAT_IS_ZERO(d))
-    {
-        if (NFLOAT_IS_ZERO(a))
-            return nfloat_cmpabs(res, b, c, ctx);
-        if (NFLOAT_IS_ZERO(b))
-            return nfloat_cmpabs(res, a, c, ctx);
+        *res = 1;
+        return GR_SUCCESS;
     }
 
     aexp = NFLOAT_EXP(a);

--- a/src/nfloat/complex.c
+++ b/src/nfloat/complex.c
@@ -15,6 +15,7 @@
 #include "gr_generic.h"
 #include "acf.h"
 #include "acb.h"
+#include "mag.h"
 #include "nfloat.h"
 
 static int
@@ -1542,17 +1543,146 @@ nfloat_complex_cmp(int * res, nfloat_complex_srcptr x, nfloat_complex_srcptr y, 
     return nfloat_cmp(res, NFLOAT_COMPLEX_RE(x, ctx), NFLOAT_COMPLEX_RE(y, ctx), ctx);
 }
 
+#include "double_extras.h"
+
 int
 nfloat_complex_cmpabs(int * res, nfloat_complex_srcptr x, nfloat_complex_srcptr y, gr_ctx_t ctx)
 {
+    nfloat_srcptr a, b, c, d;
+    slong aexp, bexp, cexp, dexp, xexp, yexp, exp;
+    slong xn = NFLOAT_CTX_NLIMBS(ctx);
+
     if (NFLOAT_CTX_HAS_INF_NAN(ctx))
         return GR_UNABLE;
 
-    if (!NFLOAT_IS_ZERO(NFLOAT_COMPLEX_IM(x, ctx)) ||
-        !NFLOAT_IS_ZERO(NFLOAT_COMPLEX_IM(y, ctx)))
-        return GR_UNABLE;
+    a = NFLOAT_COMPLEX_RE(x, ctx);
+    b = NFLOAT_COMPLEX_IM(x, ctx);
+    c = NFLOAT_COMPLEX_RE(y, ctx);
+    d = NFLOAT_COMPLEX_IM(y, ctx);
 
-    return nfloat_cmpabs(res, NFLOAT_COMPLEX_RE(x, ctx), NFLOAT_COMPLEX_RE(y, ctx), ctx);
+    if (NFLOAT_IS_ZERO(b))
+    {
+        if (NFLOAT_IS_ZERO(d))
+            return nfloat_cmpabs(res, a, c, ctx);
+        if (NFLOAT_IS_ZERO(c))
+            return nfloat_cmpabs(res, a, d, ctx);
+    }
+
+    if (NFLOAT_IS_ZERO(a))
+    {
+        if (NFLOAT_IS_ZERO(d))
+            return nfloat_cmpabs(res, b, c, ctx);
+        if (NFLOAT_IS_ZERO(c))
+            return nfloat_cmpabs(res, b, d, ctx);
+    }
+
+    if (NFLOAT_IS_ZERO(c))
+    {
+        if (NFLOAT_IS_ZERO(a))
+            return nfloat_cmpabs(res, b, d, ctx);
+        if (NFLOAT_IS_ZERO(b))
+            return nfloat_cmpabs(res, a, d, ctx);
+    }
+
+    if (NFLOAT_IS_ZERO(d))
+    {
+        if (NFLOAT_IS_ZERO(a))
+            return nfloat_cmpabs(res, b, c, ctx);
+        if (NFLOAT_IS_ZERO(b))
+            return nfloat_cmpabs(res, a, c, ctx);
+    }
+
+    aexp = NFLOAT_EXP(a);
+    bexp = NFLOAT_EXP(b);
+    cexp = NFLOAT_EXP(c);
+    dexp = NFLOAT_EXP(d);
+
+    /* 0.5 * 2^xexp <= |x| < sqrt(2) * 2^xexp */
+    xexp = FLINT_MAX(aexp, bexp);
+    /* 0.5 * 2^yexp <= |y| < sqrt(2) * 2^yexp */
+    yexp = FLINT_MAX(cexp, dexp);
+
+    if (xexp + 2 < yexp)
+    {
+        *res = -1;
+        return GR_SUCCESS;
+    }
+
+    if (xexp > yexp + 2)
+    {
+        *res = 1;
+        return GR_SUCCESS;
+    }
+
+    exp = FLINT_MAX(xexp, yexp);
+
+    double tt, xx = 0.0, yy = 0.0;
+
+    if (aexp >= exp - 53)
+    {
+        tt = d_mul_2exp_inrange(NFLOAT_D(a)[xn - 1], aexp - exp - FLINT_BITS);
+        xx += tt * tt;
+    }
+
+    if (bexp >= exp - 53)
+    {
+        tt = d_mul_2exp_inrange(NFLOAT_D(b)[xn - 1], bexp - exp - FLINT_BITS);
+        xx += tt * tt;
+    }
+
+    if (cexp >= exp - 53)
+    {
+        tt = d_mul_2exp_inrange(NFLOAT_D(c)[xn - 1], cexp - exp - FLINT_BITS);
+        yy += tt * tt;
+    }
+
+    if (dexp >= exp - 53)
+    {
+        tt = d_mul_2exp_inrange(NFLOAT_D(d)[xn - 1], dexp - exp - FLINT_BITS);
+        yy += tt * tt;
+    }
+
+    if (xx < yy * 0.999999)
+    {
+        *res = -1;
+        return GR_SUCCESS;
+    }
+
+    if (xx * 0.999999 > yy)
+    {
+        *res = 1;
+        return GR_SUCCESS;
+    }
+
+    arf_struct s[5];
+
+    arf_init(s + 0);
+    arf_init(s + 1);
+    arf_init(s + 2);
+    arf_init(s + 3);
+    arf_init(s + 4);
+
+    nfloat_get_arf(s + 0, a, ctx);
+    nfloat_get_arf(s + 1, b, ctx);
+    nfloat_get_arf(s + 2, c, ctx);
+    nfloat_get_arf(s + 3, d, ctx);
+
+    arf_mul(s + 0, s + 0, s + 0, ARF_PREC_EXACT, ARF_RND_DOWN);
+    arf_mul(s + 1, s + 1, s + 1, ARF_PREC_EXACT, ARF_RND_DOWN);
+    arf_mul(s + 2, s + 2, s + 2, ARF_PREC_EXACT, ARF_RND_DOWN);
+    arf_mul(s + 3, s + 3, s + 3, ARF_PREC_EXACT, ARF_RND_DOWN);
+    arf_neg(s + 2, s + 2);
+    arf_neg(s + 3, s + 3);
+    arf_sum(s + 4, s, 4, 30, ARF_RND_DOWN);
+    *res = arf_sgn(s + 4);
+
+    arf_clear(s + 0);
+    arf_clear(s + 1);
+    arf_clear(s + 2);
+    arf_clear(s + 3);
+    arf_clear(s + 4);
+
+    return GR_SUCCESS;
 }
 
 int
@@ -1794,6 +1924,9 @@ gr_method_tab_input _nfloat_complex_methods_input[] =
     {GR_METHOD_POLY_ROOTS_OTHER,(gr_funcptr) nfloat_complex_poly_roots_other},
 */
     {GR_METHOD_MAT_MUL,         (gr_funcptr) nfloat_complex_mat_mul},
+    {GR_METHOD_MAT_NONSINGULAR_SOLVE_TRIL,  (gr_funcptr) nfloat_complex_mat_nonsingular_solve_tril},
+    {GR_METHOD_MAT_NONSINGULAR_SOLVE_TRIU,  (gr_funcptr) nfloat_complex_mat_nonsingular_solve_triu},
+    {GR_METHOD_MAT_LU,                      (gr_funcptr) nfloat_complex_mat_lu},
     {GR_METHOD_MAT_DET,         (gr_funcptr) gr_mat_det_generic_field},
     {GR_METHOD_MAT_FIND_NONZERO_PIVOT,     (gr_funcptr) gr_mat_find_nonzero_pivot_large_abs},
 

--- a/src/nfloat/ctx.c
+++ b/src/nfloat/ctx.c
@@ -175,6 +175,9 @@ gr_method_tab_input _nfloat_methods_input[] =
     {GR_METHOD_POLY_ROOTS_OTHER,(gr_funcptr) nfloat_poly_roots_other},
 */
     {GR_METHOD_MAT_MUL,         (gr_funcptr) nfloat_mat_mul},
+    {GR_METHOD_MAT_NONSINGULAR_SOLVE_TRIL,  (gr_funcptr) nfloat_mat_nonsingular_solve_tril},
+    {GR_METHOD_MAT_NONSINGULAR_SOLVE_TRIU,  (gr_funcptr) nfloat_mat_nonsingular_solve_triu},
+    {GR_METHOD_MAT_LU,                      (gr_funcptr) nfloat_mat_lu},
     {GR_METHOD_MAT_DET,         (gr_funcptr) gr_mat_det_generic_field},
     {GR_METHOD_MAT_FIND_NONZERO_PIVOT,     (gr_funcptr) gr_mat_find_nonzero_pivot_large_abs},
 

--- a/src/nfloat/mat.c
+++ b/src/nfloat/mat.c
@@ -1,0 +1,156 @@
+/*
+    Copyright (C) 2024 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "gr.h"
+#include "nfloat.h"
+#include "gr_mat.h"
+
+int
+nfloat_mat_nonsingular_solve_tril(gr_mat_t X, const gr_mat_t L,
+                                    const gr_mat_t B, int unit, gr_ctx_t ctx)
+{
+    slong cutoff, prec = NFLOAT_CTX_PREC(ctx);
+
+    if (prec <= 256)
+        cutoff = 96;
+    else if (prec <= 512)
+        cutoff = 16;
+    else if (prec <= 576)
+        cutoff = 32;
+    else if (prec <= 1536)
+        cutoff = 8;
+    else if (prec <= 2176)
+        cutoff = 7;
+    else
+        cutoff = 6;
+
+    if (B->r < cutoff || B->c < cutoff)
+        return gr_mat_nonsingular_solve_tril_classical(X, L, B, unit, ctx);
+    else
+        return gr_mat_nonsingular_solve_tril_recursive(X, L, B, unit, ctx);
+}
+
+int
+nfloat_mat_nonsingular_solve_triu(gr_mat_t X, const gr_mat_t L,
+                                    const gr_mat_t B, int unit, gr_ctx_t ctx)
+{
+    slong cutoff, prec = NFLOAT_CTX_PREC(ctx);
+
+    if (prec <= 256)
+        cutoff = 96;
+    else if (prec <= 512)
+        cutoff = 16;
+    else if (prec <= 576)
+        cutoff = 32;
+    else if (prec <= 1536)
+        cutoff = 8;
+    else if (prec <= 2176)
+        cutoff = 7;
+    else
+        cutoff = 6;
+
+    if (B->r < cutoff || B->c < cutoff)
+        return gr_mat_nonsingular_solve_triu_classical(X, L, B, unit, ctx);
+    else
+        return gr_mat_nonsingular_solve_triu_recursive(X, L, B, unit, ctx);
+}
+
+int
+nfloat_complex_mat_nonsingular_solve_tril(gr_mat_t X, const gr_mat_t L,
+                                    const gr_mat_t B, int unit, gr_ctx_t ctx)
+{
+    slong cutoff, prec = NFLOAT_CTX_PREC(ctx);
+
+    if (prec <= 192)
+        cutoff = 64;
+    else if (prec <= 256)
+        cutoff = 16;
+    else if (prec <= 384)
+        cutoff = 7;
+    else if (prec == 576)
+        cutoff = 16;
+    else
+        cutoff = 6;
+
+    if (B->r < cutoff || B->c < cutoff)
+        return gr_mat_nonsingular_solve_tril_classical(X, L, B, unit, ctx);
+    else
+        return gr_mat_nonsingular_solve_tril_recursive(X, L, B, unit, ctx);
+}
+
+int
+nfloat_complex_mat_nonsingular_solve_triu(gr_mat_t X, const gr_mat_t L,
+                                    const gr_mat_t B, int unit, gr_ctx_t ctx)
+{
+    slong cutoff, prec = NFLOAT_CTX_PREC(ctx);
+
+    if (prec <= 192)
+        cutoff = 64;
+    else if (prec <= 256)
+        cutoff = 16;
+    else if (prec <= 384)
+        cutoff = 7;
+    else if (prec == 576)
+        cutoff = 16;
+    else
+        cutoff = 6;
+
+    if (B->r < cutoff || B->c < cutoff)
+        return gr_mat_nonsingular_solve_triu_classical(X, L, B, unit, ctx);
+    else
+        return gr_mat_nonsingular_solve_triu_recursive(X, L, B, unit, ctx);
+}
+
+int
+nfloat_mat_lu(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx)
+{
+    slong cutoff, prec = NFLOAT_CTX_PREC(ctx);
+
+    if (prec <= 256)
+        cutoff = 32;
+    else if (prec <= 576)
+        cutoff = 28;
+    else if (prec <= 768)
+        cutoff = 16;
+    else if (prec <= 1536)
+        cutoff = 12;
+    else if (prec <= 2560)
+        cutoff = 8;
+    else
+        cutoff = 7;
+
+    if (A->r < cutoff || A->c < cutoff)
+        return gr_mat_lu_classical(rank, P, LU, A, rank_check, ctx);
+    else
+        return gr_mat_lu_recursive(rank, P, LU, A, rank_check, ctx);
+}
+
+int
+nfloat_complex_mat_lu(slong * rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx)
+{
+    slong cutoff, prec = NFLOAT_CTX_PREC(ctx);
+
+    if (prec <= 256)
+        cutoff = 12;
+    else if (prec <= 512)
+        cutoff = 8;
+    else if (prec <= 576)
+        cutoff = 16;
+    else if (prec <= 1024)
+        cutoff = 7;
+    else
+        cutoff = 6;
+
+    if (A->r < cutoff || A->c < cutoff)
+        return gr_mat_lu_classical(rank, P, LU, A, rank_check, ctx);
+    else
+        return gr_mat_lu_recursive(rank, P, LU, A, rank_check, ctx);
+}


### PR DESCRIPTION
* Implement ``gr_cmpabs`` properly for ``nfloat_complex``, ``acf``, ``acb``
* Tuned threshold values for ``nfloat`` and ``nfloat_complex`` linear solving

Speedup ``nfloat`` vs ``arf`` for solving $Ax = b$ using ``gr_mat_nonsingular_solve`` (uniform random entries):

```
prec \ n
           2     4     8    16    32    64   128   256   512  1024 
    64  1.570 2.264 3.115 2.882 3.455 1.780 1.679 1.563 1.478 1.354 
   128  1.496 2.046 2.719 2.702 3.169 1.789 1.643 1.498 1.396 1.262 
   192  1.542 2.191 3.191 3.668 3.466 2.375 1.903 1.638 1.456 1.326 
   256  1.426 1.981 3.292 3.370 3.000 2.186 1.796 1.585 1.365 1.274 
   320  1.472 1.824 2.366 2.398 2.061 1.832 1.704 1.445 1.304 1.218 
   384  1.394 1.803 2.317 2.362 2.013 1.849 1.692 1.455 1.301 1.224 
   448  1.326 1.737 2.251 2.295 2.095 1.907 1.805 1.514 1.332 1.219 
   512  1.455 1.708 2.169 2.347 2.095 1.972 1.835 1.504 1.325 1.233 
   576  1.423 1.720 2.210 2.301 2.031 1.898 1.661 1.413 1.267 1.185 
   640  1.327 1.487 1.600 1.731 1.709 1.797 1.728 1.382 1.250 1.171 
   768  1.326 1.434 1.672 1.645 1.791 1.871 1.718 1.404 1.275 1.183 
  1024  1.398 1.476 1.588 1.691 1.846 2.028 1.789 1.480 1.321 1.206 
  1536  1.308 1.444 1.468 1.544 1.718 1.835 1.714 1.436 1.287 1.175 
  2048  1.217 1.317 1.359 1.494 1.665 1.793 1.600 1.410 1.264 1.174 
  2560  1.202 1.282 1.388 1.525 1.735 1.927 1.680 1.469 1.299 1.195 
  3072  1.169 1.262 1.314 1.477 1.654 1.831 1.594 1.426 1.281 1.179 
  4096  1.145 1.223 1.280 1.423 1.607 1.780 1.543 1.391 1.260 1.178 
```

Speedup ``nfloat_complex`` vs ``acf``:

```
           2     4     8    16    32    64   128   256   512  1024 
    64  1.806 2.333 2.259 2.074 1.899 1.713 1.627 1.641 1.540 1.304 
   128  1.601 2.141 2.183 2.345 2.040 1.874 1.806 1.684 1.472 1.313 
   192  1.901 2.143 3.296 3.693 3.077 2.944 2.777 2.102 1.642 1.580 
   256  1.678 1.990 2.608 3.152 2.714 2.657 2.568 2.178 1.623 1.502 
   320  1.555 1.731 2.429 2.694 2.566 2.641 2.702 2.191 1.634 1.495 
   384  1.622 1.740 2.170 2.414 2.354 2.451 2.638 1.792 1.701 1.498 
   448  1.533 1.734 2.331 2.577 2.436 2.688 2.887 2.407 1.852 1.612 
   512  1.570 1.776 2.033 2.288 2.252 2.533 2.863 2.382 1.857 1.595 
   576  1.504 1.757 2.399 2.375 2.360 2.520 2.525 2.024 1.737 1.526 
   640  1.365 1.446 1.604 1.753 1.956 2.229 2.460 1.997 1.720 1.507 
   768  1.392 1.492 1.800 1.797 2.023 2.333 2.383 1.963 1.687 1.501 
  1024  2.965 1.786 1.881 2.073 2.293 2.646 2.482 2.049 1.724 1.542 
  1536  2.283 1.770 1.832 1.990 2.240 2.418 2.281 1.921 1.674 1.541 
  2048  2.216 2.100 2.064 2.135 2.326 2.534 2.239 1.937 1.636 1.512 
  2560  1.877 2.003 1.906 2.062 2.291 2.544 2.319 2.013 1.750 1.557 
  3072  1.879 1.778 1.797 1.967 2.228 2.455 2.249 1.945 1.720 1.544 
  4096  1.401 1.464 1.597 1.790 2.067 2.327 2.542 2.268 2.013 1.802 
```