### PR TITLE
Minor doc fixes (one requires verification)

### DIFF
--- a/doc/source/fmpz_mod.rst
+++ b/doc/source/fmpz_mod.rst
@@ -42,7 +42,7 @@ Arithmetic
 --------------------------------------------------------------------------------
 
 Unless specified otherwise all functions here expect their relevant arguments to be in the canonical range `[0,n)`.
-Comparison of elements against each other or against zero can be accomplished with func::fmpz_equal or func::fmpz_is_zero without a context.
+Comparison of elements against each other or against zero can be accomplished with :func:`fmpz_equal` or :func:`fmpz_is_zero` without a context.
 
 .. function:: int fmpz_mod_is_canonical(const fmpz_t a, const fmpz_mod_ctx_t ctx)
 

--- a/doc/source/fmpz_mod_poly.rst
+++ b/doc/source/fmpz_mod_poly.rst
@@ -1909,7 +1909,7 @@ Berlekamp-Massey Algorithm
 
 .. function:: const fmpz * fmpz_mod_berlekamp_massey_points(const fmpz_mod_berlekamp_massey_t B)
 
-    Return a pointer the array of points stored in ``B``. This may be ``NULL`` if func::fmpz_mod_berlekamp_massey_point_count returns ``0``.
+    Return a pointer the array of points stored in ``B``. This may be ``NULL`` if :func:`fmpz_mod_berlekamp_massey_point_count` returns ``0``.
 
 .. function:: const fmpz_mod_poly_struct * fmpz_mod_berlekamp_massey_V_poly(const fmpz_mod_berlekamp_massey_t B)
 

--- a/doc/source/longlong.rst
+++ b/doc/source/longlong.rst
@@ -80,7 +80,7 @@ Division
 .. macro:: udiv_qrnnd(q, r, n1, n0, d)
 
     Computes the non-negative integers `q` and `r` in `d q + r = n_1 B + n_0`,
-    where `B = 2^{\mathtt{FLINT\_BITS}}`. Assumes that `d < n_1`.
+    where `B = 2^{\mathtt{FLINT\_BITS}}`. Assumes that `n_1 < d`.
 
 .. macro:: sdiv_qrnnd(quotient, remainder, high_numerator, low_numerator, denominator)
 
@@ -89,4 +89,4 @@ Division
 .. macro:: udiv_qrnnd_preinv(q, r, n1, n0, d, di)
 
     Works like ``udiv_qrnnd``, but takes a precomputed inverse ``di`` as 
-    computed by ::func::`n_preinvert_limb`.
+    computed by :func:`n_preinvert_limb`.


### PR DESCRIPTION
These are minor doc fixes.

One of these fixes needs verification (@albinahlback  ?). The current doc says that for udiv_qrnnd, the input should satisfy `d < n_1`, but after seeing several use cases of this function, including its test file, it seems that this is a typo: should it rather be `n_1 < d`? I have not checked this carefully, but conjectured the answer is yes and modified the doc in this direction.