### PR TITLE
flint_test_clear

### DIFF
--- a/examples/fq_poly.c
+++ b/examples/fq_poly.c
@@ -158,7 +158,7 @@ int main(void)
         fmpz_clear(p);
     }
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/examples/radix.c
+++ b/examples/radix.c
@@ -122,7 +122,7 @@ int main(void)
     flint_free(b);
     fmpz_mod_ctx_clear(ctx);
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/aprcl/profile/p-is_prime_aprcl.c
+++ b/src/aprcl/profile/p-is_prime_aprcl.c
@@ -760,5 +760,7 @@ int main(void)
         flint_free(ns);
     }
 
+    FLINT_TEST_CLEAR(state)
+
     return 0;
 }

--- a/src/aprcl/profile/p-is_prime_aprcl_big.c
+++ b/src/aprcl/profile/p-is_prime_aprcl_big.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "flint.h"
 #include "profiler.h"
 #include "fmpz.h"
 #include "aprcl.h"
@@ -418,6 +419,8 @@ int main(void)
 
         fmpz_clear(n);
     }
+
+    FLINT_TEST_CLEAR(state)
 
     return 0;
 }

--- a/src/fft/profile/p-mul_mfa_truncate_sqrt2.c
+++ b/src/fft/profile/p-mul_mfa_truncate_sqrt2.c
@@ -55,7 +55,7 @@ main(void)
        flint_free(i1);
     }
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 
     flint_printf("done\n");
     return 0;

--- a/src/fft/profile/p-mul_truncate_sqrt2.c
+++ b/src/fft/profile/p-mul_truncate_sqrt2.c
@@ -55,7 +55,7 @@ main(void)
        flint_free(i1);
     }
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 
     flint_printf("done\n");
     return 0;

--- a/src/fft/tune/tune-fft.c
+++ b/src/fft/tune/tune-fft.c
@@ -169,8 +169,9 @@ main(void)
 
     flint_printf("#define FFT_MULMOD_2EXPP1_CUTOFF %wd\n\n", ((mp_limb_t) 1 << best_d)*best_w/(2*FLINT_BITS));
 
-    flint_rand_clear(state);
-
     flint_printf("#endif\n");
+
+    FLINT_TEST_CLEAR(state);
+
     return 0;
 }

--- a/src/flint.h.in
+++ b/src/flint.h.in
@@ -351,7 +351,7 @@ FLINT_INLINE ulong n_randint(flint_rand_t state, ulong limit)
    FLINT_GC_INIT(); \
    flint_rand_init(xxx)
 
-#define FLINT_TEST_CLEANUP(xxx) \
+#define FLINT_TEST_CLEAR(xxx) \
    flint_rand_clear(xxx); \
    flint_cleanup_master();
 

--- a/src/fmpz/profile/p-addmul.c
+++ b/src/fmpz/profile/p-addmul.c
@@ -77,7 +77,7 @@ sample_new(void * arg, ulong count)
     _fmpz_vec_clear(res, ntests);
     _fmpz_vec_clear(a, ntests);
     _fmpz_vec_clear(b, ntests);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 void
@@ -111,7 +111,7 @@ sample_old(void * arg, ulong count)
     _fmpz_vec_clear(res, ntests);
     _fmpz_vec_clear(a, ntests);
     _fmpz_vec_clear(b, ntests);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 slong sizes[] = { 10, 30, 60, 62, 64, 66, 80, 128, 160, 256, 512, 1024, 4096, 0 };

--- a/src/fmpz/profile/p-aors_ui.c
+++ b/src/fmpz/profile/p-aors_ui.c
@@ -439,7 +439,7 @@ sample_add_new(void * arg, ulong count)
     _fmpz_vec_clear(res, ntests);
     _fmpz_vec_clear(a, ntests);
     flint_free(b);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 void
@@ -474,7 +474,7 @@ sample_add_old(void * arg, ulong count)
     _fmpz_vec_clear(res, ntests);
     _fmpz_vec_clear(a, ntests);
     flint_free(b);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 void
@@ -509,7 +509,7 @@ sample_sub_new(void * arg, ulong count)
     _fmpz_vec_clear(res, ntests);
     _fmpz_vec_clear(a, ntests);
     flint_free(b);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 void
@@ -544,7 +544,7 @@ sample_sub_old(void * arg, ulong count)
     _fmpz_vec_clear(res, ntests);
     _fmpz_vec_clear(a, ntests);
     flint_free(b);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 

--- a/src/fmpz/profile/p-div_qr.c
+++ b/src/fmpz/profile/p-div_qr.c
@@ -50,7 +50,7 @@ void sample_ndiv_qr(void * arg, ulong count)
     fmpz_clear(b);
     fmpz_clear(nmax);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 void sample_fdiv_qr(void * arg, ulong count)
@@ -90,7 +90,7 @@ void sample_fdiv_qr(void * arg, ulong count)
     fmpz_clear(b);
     fmpz_clear(nmax);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 void sample_cdiv_qr(void * arg, ulong count)
@@ -130,7 +130,7 @@ void sample_cdiv_qr(void * arg, ulong count)
     fmpz_clear(b);
     fmpz_clear(nmax);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 void sample_tdiv_qr(void * arg, ulong count)
@@ -170,7 +170,7 @@ void sample_tdiv_qr(void * arg, ulong count)
     fmpz_clear(b);
     fmpz_clear(nmax);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/fmpz/profile/p-fdiv_qr_preinvn.c
+++ b/src/fmpz/profile/p-fdiv_qr_preinvn.c
@@ -66,7 +66,7 @@ void sample(void * arg, ulong count)
    fmpz_clear(b);
    fmpz_clear(c);
    fmpz_clear(r);
-   flint_rand_clear(state);
+   FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/fmpz/profile/p-fmma.c
+++ b/src/fmpz/profile/p-fmma.c
@@ -103,7 +103,7 @@ void sample_small(void * arg, ulong count)
     fmpz_clear(c);
     fmpz_clear(d);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 void sample_small_old(void * arg, ulong count)
@@ -136,7 +136,7 @@ void sample_small_old(void * arg, ulong count)
     fmpz_clear(c);
     fmpz_clear(d);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 void sample_small_zeros(void * arg, ulong count)
@@ -170,7 +170,7 @@ void sample_small_zeros(void * arg, ulong count)
     fmpz_clear(c);
     fmpz_clear(d);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 void sample_small_zeros_old(void * arg, ulong count)
@@ -204,7 +204,7 @@ void sample_small_zeros_old(void * arg, ulong count)
     fmpz_clear(c);
     fmpz_clear(d);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 void sample_big_zeros(void * arg, ulong count)
@@ -238,7 +238,7 @@ void sample_big_zeros(void * arg, ulong count)
     fmpz_clear(c);
     fmpz_clear(d);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 void sample_big_zeros_old(void * arg, ulong count)
@@ -272,7 +272,7 @@ void sample_big_zeros_old(void * arg, ulong count)
     fmpz_clear(c);
     fmpz_clear(d);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/fmpz/profile/p-gcd.c
+++ b/src/fmpz/profile/p-gcd.c
@@ -105,7 +105,7 @@ sample_new(void * arg, ulong count)
     fmpz_clear(a);
     fmpz_clear(b);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 void
@@ -135,7 +135,7 @@ sample_old(void * arg, ulong count)
     fmpz_clear(a);
     fmpz_clear(b);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 int

--- a/src/fmpz/profile/p-gcd3.c
+++ b/src/fmpz/profile/p-gcd3.c
@@ -178,7 +178,7 @@ sample_new(void * arg, ulong count)
     fmpz_clear(a);
     fmpz_clear(b);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 void
@@ -210,7 +210,7 @@ sample_old(void * arg, ulong count)
     fmpz_clear(a);
     fmpz_clear(b);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 int

--- a/src/fmpz/profile/p-mul.c
+++ b/src/fmpz/profile/p-mul.c
@@ -77,7 +77,7 @@ sample_new(void * arg, ulong count)
     _fmpz_vec_clear(res, ntests);
     _fmpz_vec_clear(a, ntests);
     _fmpz_vec_clear(b, ntests);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 void
@@ -111,7 +111,7 @@ sample_old(void * arg, ulong count)
     _fmpz_vec_clear(res, ntests);
     _fmpz_vec_clear(a, ntests);
     _fmpz_vec_clear(b, ntests);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 slong sizes[] = { 10, 30, 60, 62, 64, 66, 80, 128, 160, 256, 512, 1024, 4096, 0 };

--- a/src/fmpz/profile/p-mul_2exp.c
+++ b/src/fmpz/profile/p-mul_2exp.c
@@ -69,9 +69,9 @@ sample_new(void * arg, ulong count)
         prof_stop();
     }
 
-    flint_rand_clear(state);
     fmpz_clear(res);
     fmpz_clear(a);
+    FLINT_TEST_CLEAR(state);
 }
 
 void
@@ -97,9 +97,9 @@ sample_old(void * arg, ulong count)
         prof_stop();
     }
 
-    flint_rand_clear(state);
     fmpz_clear(res);
     fmpz_clear(a);
+    FLINT_TEST_CLEAR(state);
 }
 
 int

--- a/src/fmpz/profile/p-mul_ui.c
+++ b/src/fmpz/profile/p-mul_ui.c
@@ -70,9 +70,9 @@ sample_new(void * arg, ulong count)
         prof_stop();
     }
 
-    flint_rand_clear(state);
     fmpz_clear(res);
     fmpz_clear(a);
+    FLINT_TEST_CLEAR(state);
 }
 
 void
@@ -99,9 +99,9 @@ sample_old(void * arg, ulong count)
         prof_stop();
     }
 
-    flint_rand_clear(state);
     fmpz_clear(res);
     fmpz_clear(a);
+    FLINT_TEST_CLEAR(state);
 }
 
 int

--- a/src/fmpz/profile/p-xgcd.c
+++ b/src/fmpz/profile/p-xgcd.c
@@ -44,7 +44,7 @@ void sample_xgcd_small(void * arg, ulong count)
     fmpz_clear(b);
     fmpz_clear(nmax);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 void sample_xgcd_mixed(void * arg, ulong count)
@@ -79,7 +79,7 @@ void sample_xgcd_mixed(void * arg, ulong count)
     fmpz_clear(b);
     fmpz_clear(nmax);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 void sample_xgcd_big(void * arg, ulong count)
@@ -114,7 +114,7 @@ void sample_xgcd_big(void * arg, ulong count)
     fmpz_clear(b);
     fmpz_clear(nmax);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 void sample_xgcd_canonical_bezout_small(void * arg, ulong count)
@@ -149,7 +149,7 @@ void sample_xgcd_canonical_bezout_small(void * arg, ulong count)
     fmpz_clear(b);
     fmpz_clear(nmax);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 void sample_xgcd_canonical_bezout_mixed(void * arg, ulong count)
@@ -184,7 +184,7 @@ void sample_xgcd_canonical_bezout_mixed(void * arg, ulong count)
     fmpz_clear(b);
     fmpz_clear(nmax);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 void sample_xgcd_canonical_bezout_big(void * arg, ulong count)
@@ -219,7 +219,7 @@ void sample_xgcd_canonical_bezout_big(void * arg, ulong count)
     fmpz_clear(b);
     fmpz_clear(nmax);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/fmpz_factor/profile/p-factor_pp1.c
+++ b/src/fmpz_factor/profile/p-factor_pp1.c
@@ -55,7 +55,7 @@ int main(void)
          flint_printf("Factor not found!\n");
    } while(1);
 
-   flint_rand_clear(state);
+   FLINT_TEST_CLEAR(state);
 
    fmpz_clear(n);
    fmpz_clear(p);

--- a/src/fmpz_lll/profile/p-lll.c
+++ b/src/fmpz_lll/profile/p-lll.c
@@ -82,7 +82,7 @@ sample(void *arg, ulong count)
     fmpz_mat_clear(D);
     fmpq_clear(delta);
     fmpq_clear(eta);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 int

--- a/src/fmpz_mat/profile/p-big_mul.c
+++ b/src/fmpz_mat/profile/p-big_mul.c
@@ -237,6 +237,6 @@ int main(void)
         fmpz_mat_clear(C);
     }
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
     return 0;
 }

--- a/src/fmpz_mat/profile/p-det.c
+++ b/src/fmpz_mat/profile/p-det.c
@@ -56,7 +56,7 @@ void sample(void * arg, ulong count)
     fmpz_mat_clear(A);
     fmpz_clear(d);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/fmpz_mat/profile/p-mul_blas_v_mul.c
+++ b/src/fmpz_mat/profile/p-mul_blas_v_mul.c
@@ -93,7 +93,7 @@ int main(void)
         fmpz_mat_clear(D);
     }
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
     return 0;
 }
 

--- a/src/fmpz_mat/profile/p-mul_double_word.c
+++ b/src/fmpz_mat/profile/p-mul_double_word.c
@@ -98,6 +98,6 @@ int main(void)
         fmpz_mat_clear(E);
     }
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
     return 0;
 }

--- a/src/fmpz_mat/profile/p-mul_double_word_v_mul_multi_mod.c
+++ b/src/fmpz_mat/profile/p-mul_double_word_v_mul_multi_mod.c
@@ -100,6 +100,6 @@ int main(void)
         fmpz_mat_clear(D);
     }
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
     return 0;
 }

--- a/src/fmpz_mat/profile/p-mul_multi_mod.c
+++ b/src/fmpz_mat/profile/p-mul_multi_mod.c
@@ -84,6 +84,6 @@ int main(void)
         fmpz_mat_clear(E);
     }
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
     return 0;
 }

--- a/src/fmpz_mat/profile/p-mul_small.c
+++ b/src/fmpz_mat/profile/p-mul_small.c
@@ -164,6 +164,6 @@ int main(void)
         fmpz_mat_clear(D);
     }
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
     return 0;
 }

--- a/src/fmpz_mat/profile/p-mul_small_v_mul_multi_mod.c
+++ b/src/fmpz_mat/profile/p-mul_small_v_mul_multi_mod.c
@@ -96,6 +96,6 @@ int main(void)
         fmpz_mat_clear(D);
     }
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
     return 0;
 }

--- a/src/fmpz_mat/profile/p-sqr.c
+++ b/src/fmpz_mat/profile/p-sqr.c
@@ -57,7 +57,7 @@ void sample(void * arg, ulong count)
     fmpz_mat_clear(B);
     fmpz_mat_clear(C);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/fmpz_mod_poly/profile/p-gcd.c
+++ b/src/fmpz_mod_poly/profile/p-gcd.c
@@ -227,7 +227,7 @@ main(void)
         }
     }
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/fmpz_mod_poly/profile/p-invert.c
+++ b/src/fmpz_mod_poly/profile/p-invert.c
@@ -75,7 +75,7 @@ main(void)
     fmpz_clear(one);
     fmpz_mod_ctx_clear(ctx);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/fmpz_mod_poly/profile/p-minpoly.c
+++ b/src/fmpz_mod_poly/profile/p-minpoly.c
@@ -156,7 +156,7 @@ int main(void)
     for (i=0; i<NUMEX; ++i)
         fmpz_mod_ctx_clear(primes+i);
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/fmpz_mod_poly/profile/p-mul.c
+++ b/src/fmpz_mod_poly/profile/p-mul.c
@@ -66,7 +66,7 @@ main(void)
     fmpz_clear(N);
     fmpz_mod_ctx_clear(ctx);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/fmpz_mod_poly/profile/p-tree.c
+++ b/src/fmpz_mod_poly/profile/p-tree.c
@@ -69,7 +69,7 @@ main(void)
     fmpz_clear(N);
     fmpz_mod_ctx_clear(ctx);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/fmpz_mod_poly_factor/profile/p-factor.c
+++ b/src/fmpz_mod_poly_factor/profile/p-factor.c
@@ -362,7 +362,7 @@ int main(void)
     mpz_clear(curr);
     fmpz_clear(p);
     fmpz_mod_ctx_clear(ctx);
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/fmpz_mpoly/profile/p-univar.c
+++ b/src/fmpz_mpoly/profile/p-univar.c
@@ -236,6 +236,6 @@ int main(int argc, char *argv[])
         fmpz_mpoly_ctx_clear(ctx);
     }
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
     return 0;
 }

--- a/src/fmpz_poly/profile/p-compose.c
+++ b/src/fmpz_poly/profile/p-compose.c
@@ -141,7 +141,7 @@ main(void)
         flint_printf("\n");
     }
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/fmpz_poly/profile/p-div_preinv.c
+++ b/src/fmpz_poly/profile/p-div_preinv.c
@@ -96,7 +96,7 @@ void sample(void * arg, ulong count)
    fmpz_poly_clear(q);
    fmpz_poly_clear(r);
 
-   flint_rand_clear(state);
+   FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/fmpz_poly/profile/p-gcd.c
+++ b/src/fmpz_poly/profile/p-gcd.c
@@ -83,7 +83,7 @@ void sample(void * arg, ulong count)
    fmpz_poly_clear(c);
    fmpz_poly_clear(g);
 
-   flint_rand_clear(state);
+   FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/fmpz_poly/profile/p-mul.c
+++ b/src/fmpz_poly/profile/p-mul.c
@@ -213,7 +213,7 @@ main(void)
         }
     }
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/fmpz_poly/profile/p-mul_triangle.c
+++ b/src/fmpz_poly/profile/p-mul_triangle.c
@@ -244,7 +244,7 @@ main(void)
         }
     }
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/fmpz_poly/profile/p-pow.c
+++ b/src/fmpz_poly/profile/p-pow.c
@@ -116,7 +116,7 @@ main(void)
     fmpz_poly_clear(f);
     fmpz_poly_clear(g);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/fmpz_poly/profile/p-pow_binomial.c
+++ b/src/fmpz_poly/profile/p-pow_binomial.c
@@ -80,7 +80,7 @@ main(void)
     fmpz_poly_clear(f);
     fmpz_poly_clear(g);
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/fmpz_poly/profile/p-rem_powers_precomp.c
+++ b/src/fmpz_poly/profile/p-rem_powers_precomp.c
@@ -96,7 +96,7 @@ void sample(void * arg, ulong count)
    fmpz_poly_clear(q);
    fmpz_poly_clear(r);
 
-   flint_rand_clear(state);
+   FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/fmpz_poly_factor/profile/p-factor_quadratic_cubic.c
+++ b/src/fmpz_poly_factor/profile/p-factor_quadratic_cubic.c
@@ -338,7 +338,7 @@ main(void)
         flint_printf(" %06wu", tab[10][i]);
     printf("\n");
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
 
     flint_printf("factors found: %wd\n", omega);
     return 0;

--- a/src/fq/profile/p-inv.c
+++ b/src/fq/profile/p-inv.c
@@ -63,7 +63,7 @@ main(void)
 
     flint_printf ( " cpu = %wd ms, wall = %wd ms \n " , cpu , wall );
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 

--- a/src/fq/profile/p-mul.c
+++ b/src/fq/profile/p-mul.c
@@ -41,7 +41,7 @@ main(void)
     fq_randtest_not_zero(a,state,ctx);
     fq_randtest_not_zero(b,state,ctx);
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 

--- a/src/fq/profile/p-reduce.c
+++ b/src/fq/profile/p-reduce.c
@@ -83,7 +83,7 @@ main(int argc, char** argv)
     fq_clear(c, ctx);
     fq_ctx_clear(ctx);
     fmpz_clear(p);
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/fq_mat_templates/profile/p-mul.c
+++ b/src/fq_mat_templates/profile/p-mul.c
@@ -111,7 +111,7 @@ main(int argc, char** argv)
     TEMPLATE(T, ctx_clear)(ctx);
     fmpz_clear(p);
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/fq_nmod_poly/profile/p-factor_kaltofen_shoup_vs_fq_poly.c
+++ b/src/fq_nmod_poly/profile/p-factor_kaltofen_shoup_vs_fq_poly.c
@@ -146,7 +146,7 @@ main(int argc, char** argv)
     fmpz_clear(p);
     fmpz_clear(temp);
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/fq_nmod_poly/profile/p-mul_univariate.c
+++ b/src/fq_nmod_poly/profile/p-mul_univariate.c
@@ -101,7 +101,7 @@ main(int argc, char** argv)
     fq_nmod_ctx_clear(ctx);
     fmpz_clear(temp);
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/fq_poly/profile/p-compose_mod.c
+++ b/src/fq_poly/profile/p-compose_mod.c
@@ -111,7 +111,7 @@ main(int argc, char** argv)
     fq_ctx_clear(ctx);
     fmpz_clear(p);
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/fq_poly/profile/p-compose_mod_preinv.c
+++ b/src/fq_poly/profile/p-compose_mod_preinv.c
@@ -114,7 +114,7 @@ main(int argc, char** argv)
     fq_ctx_clear(ctx);
     fmpz_clear(p);
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/fq_poly/profile/p-mul_univariate.c
+++ b/src/fq_poly/profile/p-mul_univariate.c
@@ -103,7 +103,7 @@ main(int argc, char** argv)
     fmpz_clear(p);
     fmpz_clear(temp);
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/fq_poly/profile/p-mulmod.c
+++ b/src/fq_poly/profile/p-mulmod.c
@@ -86,7 +86,7 @@ sample(void *arg, ulong count)
     fq_poly_clear(d, ctx);
     fq_poly_clear(dinv, ctx);
     fq_ctx_clear(ctx);
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 int

--- a/src/fq_poly_templates/profile/p-factor_xnpxp1.c
+++ b/src/fq_poly_templates/profile/p-factor_xnpxp1.c
@@ -64,7 +64,7 @@ main(int argc, char** argv)
     fmpz_clear(p);
     fmpz_clear(temp);
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/fq_poly_templates/profile/p-is_irreducible.c
+++ b/src/fq_poly_templates/profile/p-is_irreducible.c
@@ -106,7 +106,7 @@ main(int argc, char** argv)
     fmpz_clear(p);
     fmpz_clear(temp);
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/fq_poly_templates/profile/p-iterated_frobenius.c
+++ b/src/fq_poly_templates/profile/p-iterated_frobenius.c
@@ -173,7 +173,7 @@ main(int argc, char** argv)
     fmpz_clear(p);
     fmpz_clear(q);
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/fq_poly_templates/profile/p-iterated_frobenius_table.c
+++ b/src/fq_poly_templates/profile/p-iterated_frobenius_table.c
@@ -161,7 +161,7 @@ get_timings(double* s, slong degree, flint_bitcnt_t bits, slong length)
 
     flint_free(h);
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
 
     return s[0] > s[1];
 }

--- a/src/fq_poly_templates/profile/p-mullow.c
+++ b/src/fq_poly_templates/profile/p-mullow.c
@@ -113,7 +113,7 @@ main(int argc, char** argv)
     fmpz_clear(p);
     fmpz_clear(temp);
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/fq_poly_templates/profile/p-sqr.c
+++ b/src/fq_poly_templates/profile/p-sqr.c
@@ -108,7 +108,7 @@ main(int argc, char** argv)
     fmpz_clear(p);
     fmpz_clear(temp);
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/fq_zech_poly/profile/p-factor_kaltofen_shoup_vs_fq_nmod_poly.c
+++ b/src/fq_zech_poly/profile/p-factor_kaltofen_shoup_vs_fq_nmod_poly.c
@@ -136,7 +136,7 @@ main(int argc, char** argv)
     fq_nmod_ctx_clear(ctxn);
     fmpz_clear(temp);
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/fq_zech_poly/profile/p-factor_vs_fq_nmod.c
+++ b/src/fq_zech_poly/profile/p-factor_vs_fq_nmod.c
@@ -128,7 +128,7 @@ main(int argc, char** argv)
     fq_nmod_ctx_clear(ctx);
     fq_zech_ctx_clear(ctx_zech);
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/mpn_extras/profile/p-mulmod_preinvn.c
+++ b/src/mpn_extras/profile/p-mulmod_preinvn.c
@@ -110,7 +110,7 @@ void sample(void * arg, ulong count)
     /* don't init r2 */
 
     gmp_randclear(st);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/nmod_poly/profile/p-evaluate_mat.c
+++ b/src/nmod_poly/profile/p-evaluate_mat.c
@@ -79,6 +79,6 @@ main(void)
         nmod_mat_clear(C);
     }
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
     return 0;
 }

--- a/src/nmod_poly/profile/p-gcd.c
+++ b/src/nmod_poly/profile/p-gcd.c
@@ -126,6 +126,6 @@ int main(void)
     }
     flint_printf("]\n");
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
     return 0;
 }

--- a/src/nmod_poly/profile/p-mul.c
+++ b/src/nmod_poly/profile/p-mul.c
@@ -64,7 +64,7 @@ void sample(void * arg, ulong count)
    nmod_poly_clear(a);
    nmod_poly_clear(b);
    nmod_poly_clear(c);
-   flint_rand_clear(state);
+   FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/nmod_poly/profile/p-mulmod.c
+++ b/src/nmod_poly/profile/p-mulmod.c
@@ -89,7 +89,7 @@ void sample(void * arg, ulong count)
    nmod_poly_clear(c);
    nmod_poly_clear(d);
    nmod_poly_clear(dinv);
-   flint_rand_clear(state);
+   FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/nmod_poly_factor/profile/p-factor.c
+++ b/src/nmod_poly_factor/profile/p-factor.c
@@ -330,6 +330,6 @@ int main(void)
         }
     }
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
     return 0;
 }

--- a/src/nmod_vec/profile/p-add.c
+++ b/src/nmod_vec/profile/p-add.c
@@ -96,7 +96,7 @@ void sample(void * arg, ulong unused)
         _nmod_vec_clear(vec2);
     }
 
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
 int main(int argc, char ** argv)

--- a/src/nmod_vec/profile/p-add_sub_neg.c
+++ b/src/nmod_vec/profile/p-add_sub_neg.c
@@ -78,9 +78,9 @@ void sample(void * arg, ulong count)
       break;
    }
 
-   flint_rand_clear(state);
    _nmod_vec_clear(vec1);
    _nmod_vec_clear(vec2);
+   FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/nmod_vec/profile/p-mul.c
+++ b/src/nmod_vec/profile/p-mul.c
@@ -66,9 +66,9 @@ void sample(void * arg, ulong count)
       break;
    }
 
-   flint_rand_clear(state);
    _nmod_vec_clear(vec1);
    _nmod_vec_clear(vec2);
+   FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/nmod_vec/profile/p-reduce.c
+++ b/src/nmod_vec/profile/p-reduce.c
@@ -46,9 +46,9 @@ void sample(void * arg, ulong count)
    }
    prof_stop();
 
-   flint_rand_clear(state);
    _nmod_vec_clear(vec);
    _nmod_vec_clear(vec2);
+   FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/nmod_vec/profile/p-scalar_addmul.c
+++ b/src/nmod_vec/profile/p-scalar_addmul.c
@@ -51,9 +51,9 @@ void sample(void * arg, ulong count)
 	  prof_stop();
    }
 
-   flint_rand_clear(state);
    _nmod_vec_clear(vec);
    _nmod_vec_clear(vec2);
+   FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/nmod_vec/profile/p-scalar_mul.c
+++ b/src/nmod_vec/profile/p-scalar_mul.c
@@ -49,9 +49,9 @@ void sample(void * arg, ulong count)
 	  prof_stop();
    }
 
-   flint_rand_clear(state);
    _nmod_vec_clear(vec);
    _nmod_vec_clear(vec2);
+   FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/padic/profile/p-exp_balanced_2.c
+++ b/src/padic/profile/p-exp_balanced_2.c
@@ -96,7 +96,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     padic_ctx_clear(ctx);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/padic/profile/p-exp_balanced_p.c
+++ b/src/padic/profile/p-exp_balanced_p.c
@@ -96,7 +96,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     padic_ctx_clear(ctx);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/padic/profile/p-exp_rectangular.c
+++ b/src/padic/profile/p-exp_rectangular.c
@@ -96,7 +96,7 @@ for (l = 0; l < FLINT_MIN(17, len); l++)
 
     fmpz_clear(p);
     padic_ctx_clear(ctx);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/padic/profile/p-inv.c
+++ b/src/padic/profile/p-inv.c
@@ -93,7 +93,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     padic_ctx_clear(ctx);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/padic/profile/p-log_balanced.c
+++ b/src/padic/profile/p-log_balanced.c
@@ -107,7 +107,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     padic_ctx_clear(ctx);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/padic/profile/p-log_rectangular.c
+++ b/src/padic/profile/p-log_rectangular.c
@@ -107,7 +107,7 @@ for (l = 0; l < FLINT_MIN(16, len); l++)
 
     fmpz_clear(p);
     padic_ctx_clear(ctx);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/padic/profile/p-mul.c
+++ b/src/padic/profile/p-mul.c
@@ -97,7 +97,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     padic_ctx_clear(ctx);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/padic/profile/p-sqrt.c
+++ b/src/padic/profile/p-sqrt.c
@@ -97,7 +97,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     padic_ctx_clear(ctx);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/padic/profile/p-teichmuller.c
+++ b/src/padic/profile/p-teichmuller.c
@@ -85,7 +85,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     padic_ctx_clear(ctx);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/profile/p-invert_limb.c
+++ b/src/profile/p-invert_limb.c
@@ -60,8 +60,8 @@ void sample(void * arg, ulong count)
       if (sum == 0) flint_printf("\r");
    }
 
-   flint_rand_clear(state);
    flint_free(array);
+   FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/profile/p-udiv_qrnnd.c
+++ b/src/profile/p-udiv_qrnnd.c
@@ -45,8 +45,8 @@ void sample(void * arg, ulong count)
          if (array[j] == 0) flint_printf("\r");
    }
 
-   flint_rand_clear(state);
    flint_free(array);
+   FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/profile/p-udiv_qrnnd_preinv.c
+++ b/src/profile/p-udiv_qrnnd_preinv.c
@@ -48,8 +48,8 @@ void sample(void * arg, ulong count)
       if (q + r == 0) flint_printf("\r");
    }
 
-   flint_rand_clear(state);
    flint_free(array);
+   FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/qadic/profile/p-exp_balanced.c
+++ b/src/qadic/profile/p-exp_balanced.c
@@ -104,7 +104,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     qadic_ctx_clear(ctx);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/qadic/profile/p-exp_rectangular.c
+++ b/src/qadic/profile/p-exp_rectangular.c
@@ -104,7 +104,7 @@ for (l = 0; l < FLINT_MIN(16, len); l++)
 
     fmpz_clear(p);
     qadic_ctx_clear(ctx);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/qadic/profile/p-frobenius.c
+++ b/src/qadic/profile/p-frobenius.c
@@ -104,7 +104,7 @@ for (l = 0; l < FLINT_MIN(16, len); l++)
 
     fmpz_clear(p);
     qadic_ctx_clear(ctx);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/qadic/profile/p-inv.c
+++ b/src/qadic/profile/p-inv.c
@@ -104,7 +104,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     qadic_ctx_clear(ctx);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/qadic/profile/p-log_balanced.c
+++ b/src/qadic/profile/p-log_balanced.c
@@ -107,7 +107,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     qadic_ctx_clear(ctx);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/qadic/profile/p-log_rectangular.c
+++ b/src/qadic/profile/p-log_rectangular.c
@@ -107,7 +107,7 @@ for (l = 0; l < FLINT_MIN(16, len); l++)
 
     fmpz_clear(p);
     qadic_ctx_clear(ctx);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/qadic/profile/p-mul.c
+++ b/src/qadic/profile/p-mul.c
@@ -118,7 +118,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     qadic_ctx_clear(ctx);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/qadic/profile/p-norm_analytic.c
+++ b/src/qadic/profile/p-norm_analytic.c
@@ -108,7 +108,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     qadic_ctx_clear(ctx);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/qadic/profile/p-norm_resultant.c
+++ b/src/qadic/profile/p-norm_resultant.c
@@ -108,7 +108,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     qadic_ctx_clear(ctx);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/qadic/profile/p-sqrt.c
+++ b/src/qadic/profile/p-sqrt.c
@@ -115,7 +115,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     qadic_ctx_clear(ctx);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/qadic/profile/p-teichmuller.c
+++ b/src/qadic/profile/p-teichmuller.c
@@ -96,7 +96,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     qadic_ctx_clear(ctx);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/qadic/profile/p-trace.c
+++ b/src/qadic/profile/p-trace.c
@@ -105,7 +105,7 @@ for (l = 0; l < len; l++)
 
     fmpz_clear(p);
     qadic_ctx_clear(ctx);
-    flint_rand_clear(state);
+    FLINT_TEST_CLEAR(state);
 }
 
     flint_printf("Output as a list:\n");

--- a/src/test_helpers.h
+++ b/src/test_helpers.h
@@ -129,7 +129,7 @@ int TEMPLATE5(test, T, label1, T, label2)(void)         \
 }
 
 #define TEST_FUNCTION_END_SKIPPED(state)                \
-    FLINT_TEST_CLEAR(state);                          \
+    FLINT_TEST_CLEAR(state);                            \
     if (_label_len_ < 54)                               \
         printf("%.*s(" _YELLOW_B "SKIPPED" _RESET ")\n", \
                 54, _test_io_string_);                  \

--- a/src/test_helpers.h
+++ b/src/test_helpers.h
@@ -115,7 +115,7 @@ int TEMPLATE5(test, T, label1, T, label2)(void)         \
 
 #define TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable) \
     _end_time_ = clock();                               \
-    FLINT_TEST_CLEAR(state);                          \
+    FLINT_TEST_CLEAR(state);                            \
     printf("%.*s\n  "                                   \
             "%5" _WORD_FMT "d success, "                \
             "%5" _WORD_FMT "d domain, "                 \

--- a/src/test_helpers.h
+++ b/src/test_helpers.h
@@ -101,7 +101,7 @@ int TEMPLATE5(test, T, label1, T, label2)(void)         \
 
 #define TEST_FUNCTION_END(state)                        \
     _end_time_ = clock();                               \
-    FLINT_TEST_CLEAR(state);                          \
+    FLINT_TEST_CLEAR(state);                            \
     if (_label_len_ < 48)                               \
         printf("%.48s%6.2f   (" _GREEN_B "PASS" _RESET ")\n", \
                 _test_io_string_,                       \

--- a/src/test_helpers.h
+++ b/src/test_helpers.h
@@ -101,7 +101,7 @@ int TEMPLATE5(test, T, label1, T, label2)(void)         \
 
 #define TEST_FUNCTION_END(state)                        \
     _end_time_ = clock();                               \
-    FLINT_TEST_CLEANUP(state);                          \
+    FLINT_TEST_CLEAR(state);                          \
     if (_label_len_ < 48)                               \
         printf("%.48s%6.2f   (" _GREEN_B "PASS" _RESET ")\n", \
                 _test_io_string_,                       \
@@ -115,7 +115,7 @@ int TEMPLATE5(test, T, label1, T, label2)(void)         \
 
 #define TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable) \
     _end_time_ = clock();                               \
-    FLINT_TEST_CLEANUP(state);                          \
+    FLINT_TEST_CLEAR(state);                          \
     printf("%.*s\n  "                                   \
             "%5" _WORD_FMT "d success, "                \
             "%5" _WORD_FMT "d domain, "                 \
@@ -129,7 +129,7 @@ int TEMPLATE5(test, T, label1, T, label2)(void)         \
 }
 
 #define TEST_FUNCTION_END_SKIPPED(state)                \
-    FLINT_TEST_CLEANUP(state);                          \
+    FLINT_TEST_CLEAR(state);                          \
     if (_label_len_ < 54)                               \
         printf("%.*s(" _YELLOW_B "SKIPPED" _RESET ")\n", \
                 54, _test_io_string_);                  \

--- a/src/ulong_extras/profile/p-factor.c
+++ b/src/ulong_extras/profile/p-factor.c
@@ -82,7 +82,7 @@ int main(void)
 		  i, max/(double)ITERS);
    }
 
-   flint_rand_clear(state);
    flint_free(params.composites);
+   FLINT_TEST_CLEAR(state);
    return 0;
 }

--- a/src/ulong_extras/profile/p-factor_pp1.c
+++ b/src/ulong_extras/profile/p-factor_pp1.c
@@ -80,7 +80,7 @@ main(int argc, char** argv)
 	}
     }
 
-    FLINT_TEST_CLEANUP(state);
+    FLINT_TEST_CLEAR(state);
 
     return 0;
 }

--- a/src/ulong_extras/profile/p-gcd.c
+++ b/src/ulong_extras/profile/p-gcd.c
@@ -73,8 +73,8 @@ int main(void)
 						i, i, max/(double)ITERS);
 	}
 
-   flint_rand_clear(state);
    flint_free(params.rnums1);
    flint_free(params.rnums2);
+   FLINT_TEST_CLEAR(state);
    return 0;
 }

--- a/src/ulong_extras/profile/p-is_probabprime_BPSW.c
+++ b/src/ulong_extras/profile/p-is_probabprime_BPSW.c
@@ -41,7 +41,7 @@ void sample(void * arg, ulong count)
       if (!res) flint_printf("Error\n");
    }
 
-   flint_rand_clear(state);
+   FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/ulong_extras/profile/p-lll_mod_preinv.c
+++ b/src/ulong_extras/profile/p-lll_mod_preinv.c
@@ -64,9 +64,9 @@ void sample(void * arg, ulong count)
 
    if (r == UWORD(9879875897)) flint_abort();
 
-   flint_rand_clear(state);
    flint_free(arr);
    flint_free(arr2);
+   FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/ulong_extras/profile/p-mod2_precomp.c
+++ b/src/ulong_extras/profile/p-mod2_precomp.c
@@ -44,8 +44,8 @@ void sample(void * arg, ulong count)
 
    if (r == 0) flint_abort();
 
-   flint_rand_clear(state);
    flint_free(array);
+   FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/ulong_extras/profile/p-mod2_preinv.c
+++ b/src/ulong_extras/profile/p-mod2_preinv.c
@@ -106,8 +106,8 @@ void sample(void * arg, ulong count)
 
    if (r == UWORD(9879875897)) flint_abort();
 
-   flint_rand_clear(state);
    flint_free(arr);
+   FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/ulong_extras/profile/p-mod_precomp.c
+++ b/src/ulong_extras/profile/p-mod_precomp.c
@@ -42,8 +42,8 @@ void sample(void * arg, ulong count)
       prof_stop();
    }
 
-   flint_rand_clear(state);
    flint_free(array);
+   FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/ulong_extras/profile/p-mulmod2_preinv.c
+++ b/src/ulong_extras/profile/p-mulmod2_preinv.c
@@ -41,8 +41,8 @@ void sample(void * arg, ulong count)
       prof_stop();
    }
 
-   flint_rand_clear(state);
    flint_free(array);
+   FLINT_TEST_CLEAR(state);
 }
 
 int main(void)

--- a/src/ulong_extras/profile/p-mulmod_precomp.c
+++ b/src/ulong_extras/profile/p-mulmod_precomp.c
@@ -42,8 +42,8 @@ void sample(void * arg, ulong count)
       prof_stop();
    }
 
-   flint_rand_clear(state);
    flint_free(array);
+   FLINT_TEST_CLEAR(state);
 }
 
 int main(void)


### PR DESCRIPTION
- Change `FLINT_TEST_CLEANUP` into `FLINT_TEST_CLEAR` (to make it more consistent with other functions/macros `xxx_CLEAR` which "close" an `xxx_INIT`)
- Add a few missing `flint_rand_clear` in profile files
- Change many `flint_rand_clear` into `FLINT_TEST_CLEAR` when they were used to close a `FLINT_TEST_INIT`