### PR TITLE
Fix division by zero in `monomials_deflate.c`.

### DIFF
--- a/src/mpoly/monomials_deflate.c
+++ b/src/mpoly/monomials_deflate.c
@@ -36,12 +36,18 @@ void mpoly_monomials_deflate(ulong * Aexps, flint_bitcnt_t Abits,
         for (j = 0; j < nvars; j++)
         {
             fmpz_sub(exps + j, exps + j, shift + j);
-            /* stride + j is allowed to be zero */
-            if (!fmpz_is_zero(exps + j))
+            /* stride + j is allowed to be zero, if it is then exps + j is
+               assumed to be zero, and the quotient is defined as zero */
+            if (!fmpz_is_zero(exps + j) && !fmpz_is_zero(stride + j))
             {
                 FLINT_ASSERT(fmpz_divisible(exps + j, stride + j));
                 fmpz_divexact(exps + j, exps + j, stride + j);
             }
+            else
+            {
+                fmpz_zero(exps + j);
+            }
+
         }
         FLINT_ASSERT(Abits >= mpoly_exp_bits_required_ffmpz(exps, mctx));
         mpoly_set_monomial_ffmpz(Aexps + NA*i, exps, Abits, mctx);


### PR DESCRIPTION
The documentation for `fmpz_mpoly_deflate` (and similar) states

> If any `stride[v]` is zero, the corresponding numerator `e - shift[v]` is assumed to
> be zero, and the quotient is defined as zero. This allows the function to undo the
> operation performed by `fmpz_mpoly_inflate()` when possible.

The previous comment and if-statement did not align, meaning that the denominator was not being checked leading to divisions by zero when `stride[v]` is 0.

Here is a MWE
```c
#include "flint/fmpz_mpoly.h"

int main(void) {
    fmpz_mpoly_ctx_t ctx;
    fmpz_mpoly_t x, res;
    fmpz *stride, *shift;

    const char *vars = "x";

    fmpz_mpoly_ctx_init(ctx, 1, ORD_LEX);
    fmpz_mpoly_init(x, ctx);
    fmpz_mpoly_init(res, ctx);

    fmpz_mpoly_gen(x, 0, ctx);

    stride = flint_malloc(ctx->minfo->nvars * sizeof(fmpz));
    shift = flint_malloc(ctx->minfo->nvars * sizeof(fmpz));
    for (int i = 0; i < ctx->minfo->nvars; i++) {
      fmpz_init(stride + i);
      fmpz_init(shift + i);
    }

    fmpz_mpoly_print_pretty(x, &vars, ctx); flint_printf("\n");

    // Division by zero here
    fmpz_mpoly_deflate(res, x, shift, stride, ctx);

    fmpz_mpoly_print_pretty(res, &vars, ctx); flint_printf("\n");

    for (int i = 0; i < ctx->minfo->nvars; i++) {
      fmpz_clear(stride + i);
      fmpz_clear(shift + i);
    }
    flint_free(stride);
    flint_free(shift);

    fmpz_mpoly_clear(x, ctx);
    fmpz_mpoly_ctx_clear(ctx);
    return 0;
}
```
Without this patch:
```
~/ λ gcc scratch.c -lflint
~/ λ ./a.out
x
Exception (fmpz_divexact). Division by zero.
aborted (core dumped)
```
With:
```
~/ λ gcc scratch.c -lflint
~/ λ ./a.out
x
1
```

From python-flint here: https://github.com/flintlib/python-flint/pull/216#issuecomment-2335957311