### PR TITLE
Two minor doc fixes

### DIFF
--- a/doc/source/arb_poly.rst
+++ b/doc/source/arb_poly.rst
@@ -318,8 +318,6 @@ Arithmetic
 
 .. function:: void arb_poly_mullow_classical(arb_poly_t C, const arb_poly_t A, const arb_poly_t B, slong n, slong prec)
 
-.. function:: void arb_poly_mullow_ztrunc(arb_poly_t C, const arb_poly_t A, const arb_poly_t B, slong n, slong prec)
-
 .. function:: void arb_poly_mullow_block(arb_poly_t C, const arb_poly_t A, const arb_poly_t B, slong n, slong prec)
 
 .. function:: void arb_poly_mullow(arb_poly_t C, const arb_poly_t A, const arb_poly_t B, slong n, slong prec)

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -27,7 +27,7 @@ Use the following checklist regarding code style:
 
 * Try to keep names and function arguments consistent with existing code.
 * Follow the conventions regarding types, aliasing rules, etc. described
-  in :ref:`issues` and in ``code_conventions.txt``.
+  in :ref:`issues` and in ``code_conventions.md``.
 * Use basic FLINT constants, types and functions: ``FLINT_BITS``, ``flint_malloc``/``flint_free``, ``flint_abort``, ``flint_printf``, etc.
 * Complex macros should be avoided.
 * Indentation is four spaces.

--- a/doc/source/portability.rst
+++ b/doc/source/portability.rst
@@ -12,7 +12,7 @@ respectively. These are guaranteed to be the same size as GMP's
 ``mp_limb_t`` and ``mp_limb_signed_t`` types, respectively.
 
 A full list of types provided by FLINT is available in
-``code_conventions.txt`` in the top-level source tree.
+``code_conventions.md`` in the top-level source tree.
 
 As FLINT supports Windows 64 on which the FLINT ``ulong`` and
 ``slong`` types are 64 bits, whilst ``unsigned long`` and

--- a/src/arb_poly.h
+++ b/src/arb_poly.h
@@ -239,14 +239,6 @@ arb_poly_scalar_div(arb_poly_t res, const arb_poly_t poly, const arb_t c, slong 
     _arb_poly_normalise(res);
 }
 
-void _arb_poly_mullow_ztrunc(arb_ptr res,
-    arb_srcptr poly1, slong len1,
-    arb_srcptr poly2, slong len2, slong n, slong prec);
-
-void arb_poly_mullow_ztrunc(arb_poly_t res, const arb_poly_t poly1,
-                                            const arb_poly_t poly2,
-                                                slong n, slong prec);
-
 void _arb_poly_mullow_classical(arb_ptr res,
     arb_srcptr poly1, slong len1,
     arb_srcptr poly2, slong len2, slong n, slong prec);


### PR DESCRIPTION
- `code_conventions.txt` → `.md`
- remove prototype of non-existing function `arb_poly_mullow_ztrunc`
