### PR TITLE
Fix name conflicts with `small` macro from `rpcndr`

### DIFF
--- a/src/qsieve.h
+++ b/src/qsieve.h
@@ -24,7 +24,7 @@
 extern "C" {
 #endif
 
-// rpcndr.h (included via windows.h) defines a `small` macro, which leads to conflicts
+/* Windows systems may define `small` macro, which leads to conflicts */
 #undef small
 
 #define QS_DEBUG 0 /* level of debug information printed, 0 = none */

--- a/src/qsieve.h
+++ b/src/qsieve.h
@@ -24,6 +24,9 @@
 extern "C" {
 #endif
 
+// rpcndr.h (included via windows.h) defines a `small` macro, which leads to conflicts
+#undef small
+
 #define QS_DEBUG 0 /* level of debug information printed, 0 = none */
 
 #define BITS_ADJUST 25 /* add to sieve entries to compensate approximations */


### PR DESCRIPTION
On Windows, if you include `windows.h` then you get the following error

```
C:/Users/Tobia/.conda/envs/sage-dev/Library/include\flint/qsieve.h(66): error C2059: syntax error: 'type'
C:/Users/Tobia/.conda/envs/sage-dev/Library/include\flint/qsieve.h(69): error C2059: syntax error: '}'
```

since `small` is defined as a macro (see eg https://stackoverflow.com/questions/27793470/why-does-small-give-an-error-about-char). To fix this, `small` is undefined before its used as a variable name.