### PR TITLE
Fix crash in fmpz_poly_sub_fmpz

### DIFF
--- a/src/fmpz_poly/sub.c
+++ b/src/fmpz_poly/sub.c
@@ -75,7 +75,7 @@ void fmpz_poly_si_sub(fmpz_poly_t res, slong c, const fmpz_poly_t poly)
 
         if (c < 0)
             fmpz_sub_ui(res->coeffs + 0, res->coeffs + 0, -c);
-         else
+        else
             fmpz_add_ui(res->coeffs + 0, res->coeffs + 0, c);
 
         _fmpz_poly_normalise(res);
@@ -87,7 +87,7 @@ void fmpz_poly_sub_fmpz(fmpz_poly_t res, const fmpz_poly_t poly, fmpz_t c)
     if (poly->length == 0)
     {
         fmpz_poly_set_fmpz(res, c);
-        fmpz_neg(res->coeffs + 0, res->coeffs + 0);
+        fmpz_poly_neg(res, res);
     }
     else
     {


### PR DESCRIPTION
If `poly` is a zero polynomial and `c` the value zero then
the `fmpz_neg` can crash (it definitely does in Nemo).

Discovered via extended ring conformance tests in Nemo. See also https://github.com/Nemocas/Nemo.jl/pull/1930
