### PR TITLE
Precise bounds calculation for nfixed_mat_mul

### DIFF
--- a/doc/source/nfloat.rst
+++ b/doc/source/nfloat.rst
@@ -467,7 +467,8 @@ intermediate results (including rounding errors) lie in `(-1,1)`.
     indicate the offset in number of limbs between consecutive entries
     and may be negative.
 
-.. function:: void _nfixed_mat_mul_classical(nn_ptr C, nn_srcptr A, nn_srcptr B, slong m, slong n, slong p, slong nlimbs)
+.. function:: void _nfixed_mat_mul_classical_precise(nn_ptr C, nn_srcptr A, nn_srcptr B, slong m, slong n, slong p, slong nlimbs)
+              void _nfixed_mat_mul_classical(nn_ptr C, nn_srcptr A, nn_srcptr B, slong m, slong n, slong p, slong nlimbs)
               void _nfixed_mat_mul_waksman(nn_ptr C, nn_srcptr A, nn_srcptr B, slong m, slong n, slong p, slong nlimbs)
               void _nfixed_mat_mul_strassen(nn_ptr C, nn_srcptr A, nn_srcptr B, slong m, slong n, slong p, slong cutoff, slong nlimbs)
               void _nfixed_mat_mul(nn_ptr C, nn_srcptr A, nn_srcptr B, slong m, slong n, slong p, slong nlimbs)
@@ -475,3 +476,24 @@ intermediate results (including rounding errors) lie in `(-1,1)`.
     Matrix multiplication using various algorithms.
     The *strassen* variant takes a *cutoff* parameter specifying where
     to switch from basecase multiplication to Strassen multiplication.
+    The *classical_precise* version computes with one extra limb of
+    internal precision; this is only intended for testing purposes.
+
+.. function:: void _nfixed_mat_mul_bound_classical(double * bound, double * error, slong m, slong n, slong p, double A, double B, slong nlimbs)
+              void _nfixed_mat_mul_bound_waksman(double * bound, double * error, slong m, slong n, slong p, double A, double B, slong nlimbs)
+              void _nfixed_mat_mul_bound_strassen(double * bound, double * error, slong m, slong n, slong p, double A, double B, slong cutoff, slong nlimbs)
+              void _nfixed_mat_mul_bound(double * bound, double * error, slong m, slong n, slong p, double A, double B, slong nlimbs)
+              void _nfixed_complex_mat_mul_bound(double * bound, double * error, slong m, slong n, slong p, double A, double B, double C, double D, slong nlimbs)
+
+    For the respective matrix multiplication algorithm, computes bounds
+    for a size `m \times n \times p` product at precision *nlimbs*
+    given entrywise bounds *A* and *B*.
+
+    The *bound* output is set to a bound for the entries in all intermediate
+    variables of the computation. This should be < 1 to
+    ensure correctness. The *error* output is set to a bound for the
+    output error, measured in ulp.
+    The caller can assume that the computed bounds are nondecreasing
+    functions of *A* and *B*.
+
+    For complex multiplication, the entrywise bounds are for `A+Bi` and `C+Di`.

--- a/src/nfloat.h
+++ b/src/nfloat.h
@@ -590,10 +590,18 @@ void _nfixed_dot_6(nn_ptr res, nn_srcptr x, slong xstride, nn_srcptr y, slong ys
 void _nfixed_dot_7(nn_ptr res, nn_srcptr x, slong xstride, nn_srcptr y, slong ystride, slong len);
 void _nfixed_dot_8(nn_ptr res, nn_srcptr x, slong xstride, nn_srcptr y, slong ystride, slong len);
 
+void _nfixed_mat_mul_classical_precise(nn_ptr C, nn_srcptr A, nn_srcptr B, slong m, slong n, slong p, slong nlimbs);
 void _nfixed_mat_mul_classical(nn_ptr C, nn_srcptr A, nn_srcptr B, slong m, slong n, slong p, slong nlimbs);
 void _nfixed_mat_mul_waksman(nn_ptr C, nn_srcptr A, nn_srcptr B, slong m, slong n, slong p, slong nlimbs);
 void _nfixed_mat_mul_strassen(nn_ptr C, nn_srcptr A, nn_srcptr B, slong m, slong n, slong p, slong cutoff, slong nlimbs);
 void _nfixed_mat_mul(nn_ptr C, nn_srcptr A, nn_srcptr B, slong m, slong n, slong p, slong nlimbs);
+
+void _nfixed_mat_mul_bound_classical(double * bound, double * error, slong m, slong n, slong p, double A, double B, slong nlimbs);
+void _nfixed_mat_mul_bound_waksman(double * bound, double * error, slong m, slong n, slong p, double A, double B, slong nlimbs);
+void _nfixed_mat_mul_bound_strassen(double * bound, double * error, slong m, slong n, slong p, double A, double B, slong cutoff, slong nlimbs);
+void _nfixed_mat_mul_bound(double * bound, double * error, slong m, slong n, slong p, double A, double B, slong nlimbs);
+void _nfixed_complex_mat_mul_bound(double * bound, double * error, slong m, slong n, slong p, double A, double B, double C, double D, slong nlimbs);
+
 
 #ifdef __cplusplus
 }

--- a/src/nfloat/test/main.c
+++ b/src/nfloat/test/main.c
@@ -17,6 +17,9 @@
 #include "t-mat_mul.c"
 #include "t-nfixed_dot.c"
 #include "t-nfixed_mat_mul.c"
+#include "t-nfixed_mat_mul_classical.c"
+#include "t-nfixed_mat_mul_strassen.c"
+#include "t-nfixed_mat_mul_waksman.c"
 #include "t-nfloat.c"
 #include "t-nfloat_complex.c"
 
@@ -30,6 +33,9 @@ test_struct tests[] =
     TEST_FUNCTION(mat_mul),
     TEST_FUNCTION(nfixed_dot),
     TEST_FUNCTION(nfixed_mat_mul),
+    TEST_FUNCTION(nfixed_mat_mul_classical),
+    TEST_FUNCTION(nfixed_mat_mul_strassen),
+    TEST_FUNCTION(nfixed_mat_mul_waksman),
     TEST_FUNCTION(nfloat),
     TEST_FUNCTION(nfloat_complex),
 };

--- a/src/nfloat/test/t-nfixed_mat_mul_classical.c
+++ b/src/nfloat/test/t-nfixed_mat_mul_classical.c
@@ -17,7 +17,7 @@
 #include "gr_special.h"
 #include "nfloat.h"
 
-TEST_FUNCTION_START(nfixed_mat_mul, state)
+TEST_FUNCTION_START(nfixed_mat_mul_classical, state)
 {
     slong iter, m, n, p, i, nlimbs;
     nn_ptr A, B, C, D, t;
@@ -43,7 +43,7 @@ TEST_FUNCTION_START(nfixed_mat_mul, state)
         top = 1;
         while (1)
         {
-            _nfixed_mat_mul_bound(&bound, &error, m, n, p, ldexp(1.0, -top), ldexp(1.0, -top), nlimbs);
+            _nfixed_mat_mul_bound_classical(&bound, &error, m, n, p, ldexp(1.0, -top), ldexp(1.0, -top), nlimbs);
             if (bound < 1.0)
                 break;
             top++;
@@ -86,7 +86,7 @@ TEST_FUNCTION_START(nfixed_mat_mul, state)
         }
 
         _nfixed_mat_mul_classical_precise(C, A, B, m, n, p, nlimbs);
-        _nfixed_mat_mul(D, A, B, m, n, p, nlimbs);
+        _nfixed_mat_mul_classical(D, A, B, m, n, p, nlimbs);
 
         for (i = 0; i < m * p; i++)
         {
@@ -94,8 +94,8 @@ TEST_FUNCTION_START(nfixed_mat_mul, state)
 
             if (!flint_mpn_zero_p(t + 2, nlimbs - 1) || t[1] > maxerr)
             {
-                TEST_FUNCTION_FAIL("nlimbs = %wd, m = %wd, n = %wd, p = %wd\n\nt = %{ulong*}, maxerr = %wu\n\nA = %{ulong*}\n\nB = %{ulong*}\n\nC = %{ulong*}\n\nD = %{ulong*}\n\n",
-                    nlimbs, m, n, p,
+                TEST_FUNCTION_FAIL("nlimbs = %wd, m = %wd, n = %wd, p = %wd, top = %d\n\nt = %{ulong*}, maxerr = %wu\n\nA = %{ulong*}\n\nB = %{ulong*}\n\nC = %{ulong*}\n\nD = %{ulong*}\n\n",
+                    nlimbs, m, n, p, top,
                     t, nlimbs + 1, maxerr, A, m * n * (nlimbs + 1), B, n * p * (nlimbs + 1), C, m * p * (nlimbs + 1), D, m * p * (nlimbs + 1));
             }
         }

--- a/src/nfloat/test/t-nfixed_mat_mul_strassen.c
+++ b/src/nfloat/test/t-nfixed_mat_mul_strassen.c
@@ -17,11 +17,12 @@
 #include "gr_special.h"
 #include "nfloat.h"
 
-TEST_FUNCTION_START(nfixed_mat_mul, state)
+TEST_FUNCTION_START(nfixed_mat_mul_strassen, state)
 {
     slong iter, m, n, p, i, nlimbs;
     nn_ptr A, B, C, D, t;
     nn_ptr a;
+    slong cutoff;
 
     slong MAXN = 20;
     slong MINLIMBS = 2;
@@ -29,6 +30,8 @@ TEST_FUNCTION_START(nfixed_mat_mul, state)
 
     for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
     {
+        cutoff = n_randint(state, 6);
+
         m = 1 + n_randint(state, MAXN);
         n = 1 + n_randint(state, MAXN);
         p = 1 + n_randint(state, MAXN);
@@ -43,7 +46,7 @@ TEST_FUNCTION_START(nfixed_mat_mul, state)
         top = 1;
         while (1)
         {
-            _nfixed_mat_mul_bound(&bound, &error, m, n, p, ldexp(1.0, -top), ldexp(1.0, -top), nlimbs);
+            _nfixed_mat_mul_bound_strassen(&bound, &error, m, n, p, ldexp(1.0, -top), ldexp(1.0, -top), cutoff, nlimbs);
             if (bound < 1.0)
                 break;
             top++;
@@ -85,8 +88,8 @@ TEST_FUNCTION_START(nfixed_mat_mul, state)
             flint_mpn_rrandom(a + 1, state, nlimbs);
         }
 
-        _nfixed_mat_mul_classical_precise(C, A, B, m, n, p, nlimbs);
-        _nfixed_mat_mul(D, A, B, m, n, p, nlimbs);
+        _nfixed_mat_mul_classical(C, A, B, m, n, p, nlimbs);
+        _nfixed_mat_mul_strassen(D, A, B, m, n, p, cutoff, nlimbs);
 
         for (i = 0; i < m * p; i++)
         {

--- a/src/nfloat/test/t-nfixed_mat_mul_waksman.c
+++ b/src/nfloat/test/t-nfixed_mat_mul_waksman.c
@@ -17,7 +17,7 @@
 #include "gr_special.h"
 #include "nfloat.h"
 
-TEST_FUNCTION_START(nfixed_mat_mul, state)
+TEST_FUNCTION_START(nfixed_mat_mul_waksman, state)
 {
     slong iter, m, n, p, i, nlimbs;
     nn_ptr A, B, C, D, t;
@@ -43,7 +43,7 @@ TEST_FUNCTION_START(nfixed_mat_mul, state)
         top = 1;
         while (1)
         {
-            _nfixed_mat_mul_bound(&bound, &error, m, n, p, ldexp(1.0, -top), ldexp(1.0, -top), nlimbs);
+            _nfixed_mat_mul_bound_waksman(&bound, &error, m, n, p, ldexp(1.0, -top), ldexp(1.0, -top), nlimbs);
             if (bound < 1.0)
                 break;
             top++;
@@ -86,7 +86,7 @@ TEST_FUNCTION_START(nfixed_mat_mul, state)
         }
 
         _nfixed_mat_mul_classical_precise(C, A, B, m, n, p, nlimbs);
-        _nfixed_mat_mul(D, A, B, m, n, p, nlimbs);
+        _nfixed_mat_mul_waksman(D, A, B, m, n, p, nlimbs);
 
         for (i = 0; i < m * p; i++)
         {


### PR DESCRIPTION
For each of

* ``_nfixed_mat_mul``
* ``_nfixed_mat_mul_classical``
* ``_nfixed_mat_mul_waksman``
* ``_nfixed_mat_mul_strassen``
* ``_nfixed_complex_mat_mul``

we implement a corresponding method that bounds the magnitudes of all intermediate results as well as the final error (in ulps).

The magnitude bound allows one to scale the inputs tightly while guaranteeing |x| < 1 for intermediate results so that no overflow is possible.

Also, thanks to the error bound, it will be possible to use ``nfixed`` methods for ``arb_t`` and ``acb_t`` matrix multiplication (not done in this PR).

@albinahlback This basically SLP error analysis, so you might want to give this code a careful look when you have time.