### PR TITLE
src/flint.h.in: fix "noreturn" attribute in C23 mode

### DIFF
--- a/src/flint.h.in
+++ b/src/flint.h.in
@@ -156,12 +156,10 @@ typedef const ulong * nn_srcptr;
 # define FLINT_DEPRECATED
 #endif
 
-#if defined(__cplusplus)
+#if defined(__cplusplus) || ( __STDC_VERSION__ >= 202300L )
 # define FLINT_NORETURN [[noreturn]]
-#elif __STDC_VERSION__ < 202300L
-# define FLINT_NORETURN _Noreturn
 #else
-# define FLINT_NORETURN noreturn
+# define FLINT_NORETURN _Noreturn
 #endif
 
 #if FLINT_USES_TLS


### PR DESCRIPTION
C23 uses `[[noreturn]]` for this, just like C++.

This fixes the build with the forthcoming GCC 15, which will use C23 by default (https://bugs.gentoo.org/944848).