### PR TITLE
Good enclosure for exponential and trigonometric integrals

### DIFF
--- a/examples/integrals.c
+++ b/examples/integrals.c
@@ -732,11 +732,22 @@ scaled_bessel_select_N(arb_t N, ulong k, slong prec)
     arb_mul_2exp_si(N, N, e);
 }
 
+/* f(z) = Si(z) */
+int
+f_si(acb_ptr res, const acb_t z, void * param, slong order, slong prec)
+{
+    if (order > 1)
+        flint_abort();  /* Would be needed for Taylor method. */
+
+    acb_hypgeom_si(res, z, prec);
+    return 0;
+}
+
 /* ------------------------------------------------------------------------- */
 /*  Main test program                                                        */
 /* ------------------------------------------------------------------------- */
 
-#define NUM_INTEGRALS 37
+#define NUM_INTEGRALS 38
 
 const char * descr[NUM_INTEGRALS] =
 {
@@ -777,6 +788,7 @@ const char * descr[NUM_INTEGRALS] =
     "int_0^{inf} exp(-x) I_0(x/15)^{15} dx   (using domain truncation)",
     "int_{-1-i}^{-1+i} 1/sqrt(x) dx",
     "int_0^{inf} 1/gamma(x) dx   (using domain truncation)",
+    "int_0^{1000} Si(x) dx",
 };
 
 int main(int argc, char *argv[])
@@ -1272,6 +1284,13 @@ int main(int argc, char *argv[])
                 acb_calc_integrate(s, f_rgamma, NULL, a, b, goal, tol, options, prec);
                 arb_add_error_2exp_si(acb_realref(s), -goal);
                 break;
+
+            case 37:
+                acb_zero(a);
+                acb_set_ui(b, 1000);
+                acb_calc_integrate(s, f_si, NULL, a, b, goal, tol, options, prec);
+                break;
+
 
             default:
                 abort();

--- a/src/acb_hypgeom/chi.c
+++ b/src/acb_hypgeom/chi.c
@@ -113,20 +113,27 @@ acb_hypgeom_chi_2f3(acb_t res, const acb_t z, slong prec);
 static void
 acb_hypgeom_chi_prop_error(mag_t err, const acb_t z)
 {
-    mag_t t, u;
+    if (acb_is_exact(z))
+    {
+        mag_zero(err);
+    }
+    else
+    {
+        mag_t t, u;
 
-    mag_init(t);
-    mag_init(u);
+        mag_init(t);
+        mag_init(u);
 
-    arb_get_mag(t, acb_realref(z));
-    mag_cosh(t, t);
-    acb_get_mag_lower(u, z);
-    mag_div(t, t, u);
-    mag_hypot(u, arb_radref(acb_realref(z)), arb_radref(acb_imagref(z)));
-    mag_mul(err, t, u);
+        arb_get_mag(t, acb_realref(z));
+        mag_cosh(t, t);
+        acb_get_mag_lower(u, z);
+        mag_div(t, t, u);
+        mag_hypot(u, arb_radref(acb_realref(z)), arb_radref(acb_imagref(z)));
+        mag_mul(err, t, u);
 
-    mag_clear(t);
-    mag_clear(u);
+        mag_clear(t);
+        mag_clear(u);
+    }
 }
 
 void
@@ -154,60 +161,59 @@ acb_hypgeom_chi(acb_t res, const acb_t z, slong prec)
     else
     {
         double asymp_accuracy, a, b, absz, cancellation, rlog2 = 1.4426950408889634;
+        slong wp;
+        int use_asymp;
+        acb_t m;
+        mag_t err;
+        /* since we don't have a special case for real z */
+        int pure_real = arb_is_zero(acb_imagref(z));
 
         a = arf_get_d(arb_midref(acb_realref(z)), ARF_RND_DOWN);
         b = arf_get_d(arb_midref(acb_imagref(z)), ARF_RND_DOWN);
         a = fabs(a);
         b = fabs(b);
+        absz = sqrt(a * a + b * b);
 
         if (a <= 1.0 && b <= 1.0)
         {
-            acb_hypgeom_chi_2f3(res, z, prec);
-            return;
+            use_asymp = 0;
         }
-
-        if (a > prec || b > prec)
+        else if (a > prec || b > prec)
         {
-            acb_hypgeom_chi_asymp(res, z, prec);
-            return;
-        }
-
-        absz = sqrt(a * a + b * b);
-        asymp_accuracy = absz * rlog2 * 0.999 - 5;
-
-        if (asymp_accuracy > prec)
-        {
-            acb_hypgeom_chi_asymp(res, z, prec);
+            use_asymp = 1;
         }
         else
         {
-            acb_t m;
-            mag_t err;
-            slong wp;
-            /* since we don't have a special case for real z */
-            int pure_real = arb_is_zero(acb_imagref(z));
+            asymp_accuracy = absz * rlog2 * 0.999 - 5;
+            use_asymp = asymp_accuracy > prec;
+        }
 
-            acb_init(m);
-            mag_init(err);
+        acb_init(m);
+        mag_init(err);
 
+        /* assumes that we already handled the branch cut */
+        acb_hypgeom_chi_prop_error(err, z);
+        acb_get_mid(m, z);
+
+        if (use_asymp)
+        {
+            acb_hypgeom_chi_asymp(res, m, prec);
+        }
+        else
+        {
             /* terms grow to ~ exp(|z|), sum is ~ exp(|re(z)|) */
             cancellation = (absz - a) * rlog2;
             wp = prec + FLINT_MAX(0, cancellation);
             wp = wp * 1.001 + 5;
-
-            /* assumes that we already handled the branch cut */
-            acb_hypgeom_chi_prop_error(err, z);
-            acb_get_mid(m, z);
-
             acb_hypgeom_chi_2f3(res, m, wp);
-
-            if (pure_real)
-                arb_add_error_mag(acb_realref(res), err);
-            else
-                acb_add_error_mag(res, err);
-
-            acb_clear(m);
-            mag_clear(err);
         }
+
+        if (pure_real)
+            arb_add_error_mag(acb_realref(res), err);
+        else
+            acb_add_error_mag(res, err);
+
+        acb_clear(m);
+        mag_clear(err);
     }
 }

--- a/src/acb_hypgeom/chi.c
+++ b/src/acb_hypgeom/chi.c
@@ -206,6 +206,7 @@ acb_hypgeom_chi(acb_t res, const acb_t z, slong prec)
             wp = prec + FLINT_MAX(0, cancellation);
             wp = wp * 1.001 + 5;
             acb_hypgeom_chi_2f3(res, m, wp);
+            acb_set_round(res, res, prec);
         }
 
         if (pure_real)

--- a/src/acb_hypgeom/ci.c
+++ b/src/acb_hypgeom/ci.c
@@ -271,6 +271,7 @@ acb_hypgeom_ci(acb_t res, const acb_t z, slong prec)
             wp = prec + FLINT_MAX(0, cancellation);
             wp = wp * 1.001 + 5;
             acb_hypgeom_ci_2f3(res, m, wp);
+            acb_set_round(res, res, prec);
         }
 
         acb_add_error_mag(res, err);

--- a/src/acb_hypgeom/ci.c
+++ b/src/acb_hypgeom/ci.c
@@ -171,20 +171,27 @@ acb_hypgeom_chi_2f3(acb_t res, const acb_t z, slong prec)
 static void
 acb_hypgeom_ci_prop_error(mag_t err, const acb_t z)
 {
-    mag_t t, u;
+    if (acb_is_exact(z))
+    {
+        mag_zero(err);
+    }
+    else
+    {
+        mag_t t, u;
 
-    mag_init(t);
-    mag_init(u);
+        mag_init(t);
+        mag_init(u);
 
-    arb_get_mag(t, acb_imagref(z));
-    mag_cosh(t, t);
-    acb_get_mag_lower(u, z);
-    mag_div(t, t, u);
-    mag_hypot(u, arb_radref(acb_realref(z)), arb_radref(acb_imagref(z)));
-    mag_mul(err, t, u);
+        arb_get_mag(t, acb_imagref(z));
+        mag_cosh(t, t);
+        acb_get_mag_lower(u, z);
+        mag_div(t, t, u);
+        mag_hypot(u, arb_radref(acb_realref(z)), arb_radref(acb_imagref(z)));
+        mag_mul(err, t, u);
 
-    mag_clear(t);
-    mag_clear(u);
+        mag_clear(t);
+        mag_clear(u);
+    }
 }
 
 void
@@ -221,55 +228,54 @@ acb_hypgeom_ci(acb_t res, const acb_t z, slong prec)
     else
     {
         double asymp_accuracy, a, b, absz, cancellation, rlog2 = 1.4426950408889634;
+        slong wp;
+        int use_asymp;
+        acb_t m;
+        mag_t err;
 
         a = arf_get_d(arb_midref(acb_realref(z)), ARF_RND_DOWN);
         b = arf_get_d(arb_midref(acb_imagref(z)), ARF_RND_DOWN);
         a = fabs(a);
         b = fabs(b);
+        absz = sqrt(a * a + b * b);
 
         if (a <= 1.0 && b <= 1.0)
         {
-            acb_hypgeom_ci_2f3(res, z, prec);
-            return;
+            use_asymp = 0;
         }
-
-        if (a > prec || b > prec)
+        else if (a > prec || b > prec)
         {
-            acb_hypgeom_ci_asymp(res, z, prec);
-            return;
-        }
-
-        absz = sqrt(a * a + b * b);
-        asymp_accuracy = absz * rlog2 * 0.999 - 5;
-
-        if (asymp_accuracy > prec)
-        {
-            acb_hypgeom_ci_asymp(res, z, prec);
+            use_asymp = 1;
         }
         else
         {
-            acb_t m;
-            mag_t err;
-            slong wp;
+            asymp_accuracy = absz * rlog2 * 0.999 - 5;
+            use_asymp = asymp_accuracy > prec;
+        }
 
-            acb_init(m);
-            mag_init(err);
+        acb_init(m);
+        mag_init(err);
 
+        /* assumes that we already handled the branch cut */
+        acb_hypgeom_ci_prop_error(err, z);
+        acb_get_mid(m, z);
+
+        if (use_asymp)
+        {
+            acb_hypgeom_ci_asymp(res, m, prec);
+        }
+        else
+        {
             /* terms grow to ~ exp(|z|), sum is ~ exp(|im(z)|) */
             cancellation = (absz - b) * rlog2;
             wp = prec + FLINT_MAX(0, cancellation);
             wp = wp * 1.001 + 5;
-
-            /* assumes that we already handled the branch cut */
-            acb_hypgeom_ci_prop_error(err, z);
-            acb_get_mid(m, z);
-
             acb_hypgeom_ci_2f3(res, m, wp);
-
-            acb_add_error_mag(res, err);
-
-            acb_clear(m);
-            mag_clear(err);
         }
+
+        acb_add_error_mag(res, err);
+
+        acb_clear(m);
+        mag_clear(err);
     }
 }

--- a/src/acb_hypgeom/ei.c
+++ b/src/acb_hypgeom/ei.c
@@ -128,34 +128,41 @@ acb_hypgeom_ei_2f2(acb_t res, const acb_t z, slong prec)
 static void
 acb_hypgeom_ei_prop_error(mag_t err, const acb_t z)
 {
-    mag_t t, u;
-    arf_t x;
-
-    mag_init(t);
-    mag_init(u);
-    arf_init(x);
-
-    arb_get_ubound_arf(x, acb_realref(z), MAG_BITS);
-
-    if (arf_sgn(x) >= 0)
+    if (acb_is_exact(z))
     {
-        arf_get_mag(t, x);
-        mag_exp(t, t);
+        mag_zero(err);
     }
     else
     {
-        arf_get_mag_lower(t, x);
-        mag_expinv(t, t);
+        mag_t t, u;
+        arf_t x;
+
+        mag_init(t);
+        mag_init(u);
+        arf_init(x);
+
+        arb_get_ubound_arf(x, acb_realref(z), MAG_BITS);
+
+        if (arf_sgn(x) >= 0)
+        {
+            arf_get_mag(t, x);
+            mag_exp(t, t);
+        }
+        else
+        {
+            arf_get_mag_lower(t, x);
+            mag_expinv(t, t);
+        }
+
+        acb_get_mag_lower(u, z);
+        mag_div(t, t, u);
+        mag_hypot(u, arb_radref(acb_realref(z)), arb_radref(acb_imagref(z)));
+        mag_mul(err, t, u);
+
+        mag_clear(t);
+        mag_clear(u);
+        arf_clear(x);
     }
-
-    acb_get_mag_lower(u, z);
-    mag_div(t, t, u);
-    mag_hypot(u, arb_radref(acb_realref(z)), arb_radref(acb_imagref(z)));
-    mag_mul(err, t, u);
-
-    mag_clear(t);
-    mag_clear(u);
-    arf_clear(x);
 }
 
 void
@@ -183,61 +190,60 @@ acb_hypgeom_ei(acb_t res, const acb_t z, slong prec)
     else
     {
         double asymp_accuracy, a, asigned, b, absz, cancellation, rlog2 = 1.4426950408889634;
+        slong wp;
+        int use_asymp;
+        acb_t m;
+        mag_t err;
+        /* since we don't have a special case for real z */
+        int pure_real = arb_is_zero(acb_imagref(z));
 
         a = arf_get_d(arb_midref(acb_realref(z)), ARF_RND_DOWN);
         b = arf_get_d(arb_midref(acb_imagref(z)), ARF_RND_DOWN);
         asigned = a;
         a = fabs(a);
         b = fabs(b);
+        absz = sqrt(a * a + b * b);
 
         if (a <= 1.0 && b <= 1.0)
         {
-            acb_hypgeom_ei_2f2(res, z, prec);
-            return;
+            use_asymp = 0;
         }
-
-        if (a > prec || b > prec)
+        else if (a > prec || b > prec)
         {
-            acb_hypgeom_ei_asymp(res, z, prec);
-            return;
-        }
-
-        absz = sqrt(a * a + b * b);
-        asymp_accuracy = absz * rlog2 * 0.999 - 5;
-
-        if (asymp_accuracy > prec)
-        {
-            acb_hypgeom_ei_asymp(res, z, prec);
+            use_asymp = 1;
         }
         else
         {
-            acb_t m;
-            mag_t err;
-            slong wp;
-            /* since we don't have a special case for real z */
-            int pure_real = arb_is_zero(acb_imagref(z));
+            asymp_accuracy = absz * rlog2 * 0.999 - 5;
+            use_asymp = asymp_accuracy > prec;
+        }
 
-            acb_init(m);
-            mag_init(err);
+        acb_init(m);
+        mag_init(err);
 
+        /* assumes that we already handled the branch cut */
+        acb_hypgeom_ei_prop_error(err, z);
+        acb_get_mid(m, z);
+
+        if (use_asymp)
+        {
+            acb_hypgeom_ei_asymp(res, m, prec);
+        }
+        else
+        {
             /* terms grow to ~ exp(|z|), sum is ~ exp(re(z)) */
             cancellation = (absz - asigned) * rlog2;
             wp = prec + FLINT_MAX(0, cancellation);
             wp = wp * 1.001 + 5;
-
-            /* assumes that we already handled the branch cut */
-            acb_hypgeom_ei_prop_error(err, z);
-            acb_get_mid(m, z);
-
             acb_hypgeom_ei_2f2(res, m, wp);
-
-            if (pure_real)
-                arb_add_error_mag(acb_realref(res), err);
-            else
-                acb_add_error_mag(res, err);
-
-            acb_clear(m);
-            mag_clear(err);
         }
+
+        if (pure_real)
+            arb_add_error_mag(acb_realref(res), err);
+        else
+            acb_add_error_mag(res, err);
+
+        acb_clear(m);
+        mag_clear(err);
     }
 }

--- a/src/acb_hypgeom/ei.c
+++ b/src/acb_hypgeom/ei.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include <math.h>
 #include "acb.h"
 #include "acb_hypgeom.h"
 
@@ -120,11 +121,123 @@ acb_hypgeom_ei_2f2(acb_t res, const acb_t z, slong prec)
     acb_clear(t);
 }
 
+/* Bound propagated error |ei(z)-ei(mid(z))| assuming that we
+   are off the branch cut (not checked here).
+   Uses |ei'(z)| = |exp(z)/z| <= exp(re(z))/|z|.
+*/
+static void
+acb_hypgeom_ei_prop_error(mag_t err, const acb_t z)
+{
+    mag_t t, u;
+    arf_t x;
+
+    mag_init(t);
+    mag_init(u);
+    arf_init(x);
+
+    arb_get_ubound_arf(x, acb_realref(z), MAG_BITS);
+
+    if (arf_sgn(x) >= 0)
+    {
+        arf_get_mag(t, x);
+        mag_exp(t, t);
+    }
+    else
+    {
+        arf_get_mag_lower(t, x);
+        mag_expinv(t, t);
+    }
+
+    acb_get_mag_lower(u, z);
+    mag_div(t, t, u);
+    mag_hypot(u, arb_radref(acb_realref(z)), arb_radref(acb_imagref(z)));
+    mag_mul(err, t, u);
+
+    mag_clear(t);
+    mag_clear(u);
+    arf_clear(x);
+}
+
 void
 acb_hypgeom_ei(acb_t res, const acb_t z, slong prec)
 {
-    if (acb_hypgeom_u_use_asymp(z, prec))
-        acb_hypgeom_ei_asymp(res, z, prec);
+    if (!acb_is_finite(z) || acb_contains_zero(z))
+    {
+        acb_indeterminate(res);
+    }
+/* todo -- good real code
+    else if (acb_is_real(z))
+    {
+    }
+*/
+    else if (arb_contains_zero(acb_imagref(z)) &&
+                !arb_is_zero(acb_imagref(z)) &&
+                !arb_is_positive(acb_realref(z)))
+    {
+        /* We straddle the branch cut; do something generic */
+        if (acb_hypgeom_u_use_asymp(z, prec))
+            acb_hypgeom_ei_asymp(res, z, prec);
+        else
+            acb_hypgeom_ei_2f2(res, z, prec);
+    }
     else
-        acb_hypgeom_ei_2f2(res, z, prec);
+    {
+        double asymp_accuracy, a, asigned, b, absz, cancellation, rlog2 = 1.4426950408889634;
+
+        a = arf_get_d(arb_midref(acb_realref(z)), ARF_RND_DOWN);
+        b = arf_get_d(arb_midref(acb_imagref(z)), ARF_RND_DOWN);
+        asigned = a;
+        a = fabs(a);
+        b = fabs(b);
+
+        if (a <= 1.0 && b <= 1.0)
+        {
+            acb_hypgeom_ei_2f2(res, z, prec);
+            return;
+        }
+
+        if (a > prec || b > prec)
+        {
+            acb_hypgeom_ei_asymp(res, z, prec);
+            return;
+        }
+
+        absz = sqrt(a * a + b * b);
+        asymp_accuracy = absz * rlog2 * 0.999 - 5;
+
+        if (asymp_accuracy > prec)
+        {
+            acb_hypgeom_ei_asymp(res, z, prec);
+        }
+        else
+        {
+            acb_t m;
+            mag_t err;
+            slong wp;
+            /* since we don't have a special case for real z */
+            int pure_real = arb_is_zero(acb_imagref(z));
+
+            acb_init(m);
+            mag_init(err);
+
+            /* terms grow to ~ exp(|z|), sum is ~ exp(re(z)) */
+            cancellation = (absz - asigned) * rlog2;
+            wp = prec + FLINT_MAX(0, cancellation);
+            wp = wp * 1.001 + 5;
+
+            /* assumes that we already handled the branch cut */
+            acb_hypgeom_ei_prop_error(err, z);
+            acb_get_mid(m, z);
+
+            acb_hypgeom_ei_2f2(res, m, wp);
+
+            if (pure_real)
+                arb_add_error_mag(acb_realref(res), err);
+            else
+                acb_add_error_mag(res, err);
+
+            acb_clear(m);
+            mag_clear(err);
+        }
+    }
 }

--- a/src/acb_hypgeom/ei.c
+++ b/src/acb_hypgeom/ei.c
@@ -236,6 +236,7 @@ acb_hypgeom_ei(acb_t res, const acb_t z, slong prec)
             wp = prec + FLINT_MAX(0, cancellation);
             wp = wp * 1.001 + 5;
             acb_hypgeom_ei_2f2(res, m, wp);
+            acb_set_round(res, res, prec);
         }
 
         if (pure_real)

--- a/src/acb_hypgeom/si.c
+++ b/src/acb_hypgeom/si.c
@@ -215,6 +215,7 @@ acb_hypgeom_si(acb_t res, const acb_t z, slong prec)
             wp = prec + FLINT_MAX(0, cancellation);
             wp = wp * 1.001 + 5;
             acb_hypgeom_si_1f2(res, m, wp);
+            acb_set_round(res, res, prec);
         }
 
         if (pure_imag)

--- a/src/acb_hypgeom/si.c
+++ b/src/acb_hypgeom/si.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2015 Fredrik Johansson
+    Copyright (C) 2015, 2024 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include <math.h>
 #include "acb.h"
 #include "arb_hypgeom.h"
 #include "acb_hypgeom.h"
@@ -80,6 +81,9 @@ acb_hypgeom_si_asymp(acb_t res, const acb_t z, slong prec)
 
     acb_swap(res, t);
 
+    if (!acb_is_finite(res))
+        acb_indeterminate(res);
+
     acb_clear(t);
     acb_clear(u);
     acb_clear(w);
@@ -121,18 +125,97 @@ acb_hypgeom_si_1f2(acb_t res, const acb_t z, slong prec)
     acb_clear(t);
 }
 
+/* Bound propagated error |si(z)-si(mid(z))| using
+   |si'(z)| = |sin(z)/z| <= cosh(|im(z)|)/max(1, |z|).
+*/
+static void
+acb_hypgeom_si_prop_error(mag_t err, const acb_t z)
+{
+    mag_t t, u;
+
+    mag_init(t);
+    mag_init(u);
+
+    arb_get_mag(t, acb_imagref(z));
+    mag_cosh(t, t);
+    acb_get_mag_lower(u, z);
+    if (mag_cmp_2exp_si(u, 0) < 0)
+        mag_one(u);
+    mag_div(t, t, u);
+    mag_hypot(u, arb_radref(acb_realref(z)), arb_radref(acb_imagref(z)));
+    mag_mul(err, t, u);
+
+    mag_clear(t);
+    mag_clear(u);
+}
+
 void
 acb_hypgeom_si(acb_t res, const acb_t z, slong prec)
 {
-    if (acb_is_real(z) && arb_is_finite(acb_realref(z)))
+    if (!acb_is_finite(z))
+    {
+        acb_indeterminate(res);
+    }
+    else if (acb_is_real(z))
     {
         arb_hypgeom_si(acb_realref(res), acb_realref(z), prec);
         arb_zero(acb_imagref(res));
-        return;
     }
-
-    if (acb_hypgeom_u_use_asymp(z, prec))
-        acb_hypgeom_si_asymp(res, z, prec);
     else
-        acb_hypgeom_si_1f2(res, z, prec);
+    {
+        double asymp_accuracy, a, b, absz, cancellation, rlog2 = 1.4426950408889634;
+
+        a = arf_get_d(arb_midref(acb_realref(z)), ARF_RND_DOWN);
+        b = arf_get_d(arb_midref(acb_imagref(z)), ARF_RND_DOWN);
+        a = fabs(a);
+        b = fabs(b);
+
+        if (a <= 1.0 && b <= 1.0)
+        {
+            acb_hypgeom_si_1f2(res, z, prec);
+            return;
+        }
+
+        if (a > prec || b > prec)
+        {
+            acb_hypgeom_si_asymp(res, z, prec);
+            return;
+        }
+
+        absz = sqrt(a * a + b * b);
+        asymp_accuracy = absz * rlog2 * 0.999 - 5;
+
+        if (asymp_accuracy > prec)
+        {
+            acb_hypgeom_si_asymp(res, z, prec);
+        }
+        else
+        {
+            acb_t m;
+            mag_t err;
+            slong wp;
+            int pure_imag = arb_is_zero(acb_realref(z));
+
+            acb_init(m);
+            mag_init(err);
+
+            /* terms grow to ~ exp(|z|), sum is ~ exp(|im(z)|) */
+            cancellation = (absz - b) * rlog2;
+            wp = prec + FLINT_MAX(0, cancellation);
+            wp = wp * 1.001 + 5;
+
+            acb_hypgeom_si_prop_error(err, z);
+            acb_get_mid(m, z);
+
+            acb_hypgeom_si_1f2(res, m, wp);
+
+            if (pure_imag)
+                arb_add_error_mag(acb_imagref(res), err);
+            else
+                acb_add_error_mag(res, err);
+
+            acb_clear(m);
+            mag_clear(err);
+        }
+    }
 }

--- a/src/python/flint_ctypes.py
+++ b/src/python/flint_ctypes.py
@@ -1913,7 +1913,7 @@ class gr_ctx:
     def exp_integral_ei(ctx, x):
         """
             >>> RR.exp_integral_ei(1)
-            [1.89511781635594 +/- 5.11e-15]
+            [1.895117816355937 +/- 6.91e-16]
         """
         return ctx._unary_op(x, libgr.gr_exp_integral_ei, "exp_integral_ei($x)")
 
@@ -1921,6 +1921,10 @@ class gr_ctx:
         """
             >>> RR.sin_integral(1)
             [0.946083070367183 +/- 1.35e-16]
+            >>> CC.sin_integral(CC("(5 +/- 1e-10)*I"))
+            [20.09321183 +/- 5.79e-9]*I
+            >>> CC.sin_integral(CC("10 + (1 +/- 1e-10)*I"))
+            ([1.7002629761 +/- 6.33e-11] + [-0.0667638998 +/- 2.17e-11]*I)
         """
         return ctx._unary_op(x, libgr.gr_sin_integral, "sin_integral($x)")
 
@@ -1934,21 +1938,21 @@ class gr_ctx:
     def sinh_integral(ctx, x):
         """
             >>> RR.sinh_integral(1)
-            [1.05725087537573 +/- 2.77e-15]
+            [1.057250875375728 +/- 6.29e-16]
         """
         return ctx._unary_op(x, libgr.gr_sinh_integral, "sinh_integral($x)")
 
     def cosh_integral(ctx, x):
         """
             >>> RR.cosh_integral(1)
-            [0.837866940980208 +/- 4.78e-16]
+            [0.837866940980208 +/- 3.15e-16]
         """
         return ctx._unary_op(x, libgr.gr_cosh_integral, "cosh_integral($x)")
 
     def log_integral(ctx, x, offset=False):
         """
             >>> RR.log_integral(2)
-            [1.04516378011749 +/- 4.01e-15]
+            [1.04516378011749 +/- 3.31e-15]
             >>> RR.log_integral(2, offset=True)
             0
         """


### PR DESCRIPTION
The exponential and trigonometric integrals Ei(x), Si(x), Ci(x), Shi(x), Chi(x) previously suffered catastrophic cancellation in the transition regime between the convergent and asymptotic series. With this patch, we evaluate at the midpoint using sufficient extra precision to compensate for the cancellation and bound the propagated error using derivatives. A fix was previously in place for Si and Ci for real arguments but not for complex arguments.

Sample behavior before:

```
>>> CC.sin_integral(30+1j)
([1.5633 +/- 5.69e-5] + [-0.0386 +/- 5.17e-5]*I)
>>> CC.sin_integral(CC("30 + (1 +/- 1e-10)*I"))
([+/- 3.37] + [+/- 2.29]*I)
```

After:

```
>>> CC.sin_integral(30+1j)
([1.563272228698903 +/- 5.23e-16] + [-0.03862545356388379 +/- 8.21e-18]*I)
>>> CC.sin_integral(CC("30 + (1 +/- 1e-10)*I"))
([1.56327222870 +/- 6.24e-12] + [-0.03862545356 +/- 9.03e-12]*I)
```

This means that, among other things, numerical integration of these functions is well-behaved (request from Harald Helfgott).

For the added example integral $\int_0^{1000} \text{Si}(x) dx$, we have previously:

```
$ build/examples/integrals -i 37 -prec 333 -verbose 2
I37 = int_0^{1000} Si(x) dx ...
depth 12/666, eval 162650/443889, 1747 leaf intervals
cpu/wall(s): 1.45 1.45
I37 = [1569.795501045061921139041027262939836970542691711052319522220477947810416806610707981954921163519 +/- 5.25e-94]
```

After:

```
$ build/examples/integrals -i 37 -prec 333 -verbose 2
I37 = int_0^{1000} Si(x) dx ...
depth 3/666, eval 798/443889, 4 leaf intervals
cpu/wall(s): 0.017 0.017
I37 = [1569.7955010450619211390410272629398369705426917110523195222204779478104168066107079819549211635186 +/- 1.96e-95]
```