### PR TITLE
[flint-3.1] Fix typo in configure.ac with debug and ntl enabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -520,7 +520,7 @@ then
         )
         if test "$enable_debug" = "yes";
         then
-            if "$ac_cv_prog_cxx_g" = "yes";
+            if test "$ac_cv_prog_cxx_g" = "yes";
             then
                 CXXFLAGS="-g $CXXFLAGS"
             else


### PR DESCRIPTION
Otherwise `configure` would literally run `yes` when `--with-ntl` is passed but `--disable-debug` isn't, leading to an infinite loop. CI tests NTL, but [does so with debug disabled](https://github.com/flintlib/flint/blob/flint-3.1/.github/workflows/CI.yml#L131). Typo introduced in 2c0fb476271cc977769095c7b14cc162a059093d.