### PR TITLE
Do not use inline assembly for big aors_n on ARM

### DIFF
--- a/src/longlong.h
+++ b/src/longlong.h
@@ -122,43 +122,19 @@ flint_bitcnt_t FLINT_BIT_COUNT(ulong x)
     (s1) = (a1) + (b1) + ((ulong) (s0) < __t0); \
   } while (0)
 
+# define sub_ddmmss(s1, s0, a1, a0, b1, b0) \
+  do { \
+    ulong __t0 = (a0); \
+    (s0) = (a0) - (b0); \
+    (s1) = (a1) - (b1) - ((ulong) (s0) > __t0); \
+  } while (0)
+
 # define add_sssaaaaaa(s2, s1, s0, a2, a1, a0, b2, b1, b0) \
   do { \
     ulong __t1, __t2; \
     add_ssaaaa(__t1, s0, (ulong) 0, a0, (ulong) 0, b0); \
     add_ssaaaa(__t2, s1, (ulong) 0, a1, (ulong) 0, b1); \
     add_ssaaaa(s2, s1, (a2) + (b2), s1, __t2, __t1); \
-  } while (0)
-
-# define add_ssssaaaaaaaa(s3, s2, s1, s0, a3, a2, a1, a0, b3, b2, b1, b0) \
-  do { \
-    ulong __t3; \
-    add_sssaaaaaa(__t3, s1, s0, (ulong) 0, a1, a0, (ulong) 0, b1, b0); \
-    add_ssaaaa(s3, s2, a3, a2, b3, b2); \
-    add_ssaaaa(s3, s2, s3, s2, (ulong) 0, __t3); \
-  } while (0)
-
-#define add_sssssaaaaaaaaaa(s4, s3, s2, s1, s0, a4, a3, a2, a1, a0, b4, b3, b2, b1, b0) \
-  do { \
-    ulong __t4 = 0; \
-    add_ssssaaaaaaaa(__t4, s2, s1, s0, (ulong) 0, a2, a1, a0, (ulong) 0, b2, b1, b0); \
-    add_ssaaaa(s4, s3, a4, a3, b4, b3); \
-    add_ssaaaa(s4, s3, s4, s3, (ulong) 0, __t4); \
-  } while (0)
-
-#define add_ssssssaaaaaaaaaaaa(s5, s4, s3, s2, s1, s0, a5, a4, a3, a2, a1, a0, b5, b4, b3, b2, b1, b0) \
-  do { \
-    ulong __t5 = 0; \
-    add_sssssaaaaaaaaaa(__t5, s3, s2, s1, s0, (ulong) 0, a3, a2, a1, a0, (ulong) 0, b3, b2, b1, b0); \
-    add_ssaaaa(s5, s4, a5, a4, b5, b4); \
-    add_ssaaaa(s5, s4, s5, s4, (ulong) 0, __t5); \
-  } while (0)
-
-# define sub_ddmmss(s1, s0, a1, a0, b1, b0) \
-  do { \
-    ulong __t0 = (a0); \
-    (s0) = (a0) - (b0); \
-    (s1) = (a1) - (b1) - ((ulong) (s0) > __t0); \
   } while (0)
 
 # define sub_dddmmmsss(d2, d1, d0, m2, m1, m0, s2, s1, s0) \
@@ -168,37 +144,61 @@ flint_bitcnt_t FLINT_BIT_COUNT(ulong x)
     sub_ddmmss(__t2, d1, (ulong) 0, m1, (ulong) 0, s1); \
     sub_ddmmss(d2, d1, (m2) - (s2), d1, -__t2, -__t1); \
   } while (0)
+#endif
 
-#define sub_ddddmmmmssss(s3, s2, s1, s0, a3, a2, a1, a0, b3, b2, b1, b0)        \
-  do {                                                                          \
-    ulong __t3, __t4;                                                       \
-    sub_dddmmmsss(__t3, s1, s0, (ulong) 0, a1, a0, (ulong) 0, b1, b0);  \
-    sub_ddmmss(__t4, s2, (ulong) 0, a2, (ulong) 0, b2);                 \
-    sub_ddmmss(s3, s2, (a3) - (b3), s2, -__t4, -__t3);                          \
+#if !defined(add_ssssaaaaaaaa)
+# define add_ssssaaaaaaaa(s3, s2, s1, s0, a3, a2, a1, a0, b3, b2, b1, b0) \
+  do { \
+    ulong __t3; \
+    add_sssaaaaaa(__t3, s1, s0, (ulong) 0, a1, a0, (ulong) 0, b1, b0); \
+    add_ssaaaa(s3, s2, a3, a2, b3, b2); \
+    add_ssaaaa(s3, s2, s3, s2, (ulong) 0, __t3); \
   } while (0)
 
-#define sub_dddddmmmmmsssss(s4, s3, s2, s1, s0, a4, a3, a2, a1, a0, b4, b3, b2, b1, b0)         \
-  do {                                                                                          \
-    ulong __t5, __t6;                                                                       \
-    sub_ddddmmmmssss(__t5, s2, s1, s0, (ulong) 0, a2, a1, a0, (ulong) 0, b2, b1, b0);   \
-    sub_ddmmss(__t6, s3, (ulong) 0, a3, (ulong) 0, b3);                                 \
-    sub_ddmmss(s4, s3, (a4) - (b4), s3, -__t6, -__t5);                                          \
+# define sub_ddddmmmmssss(s3, s2, s1, s0, a3, a2, a1, a0, b3, b2, b1, b0) \
+  do { \
+    ulong __t3, __t4; \
+    sub_dddmmmsss(__t3, s1, s0, (ulong) 0, a1, a0, (ulong) 0, b1, b0); \
+    sub_ddmmss(__t4, s2, (ulong) 0, a2, (ulong) 0, b2); \
+    sub_ddmmss(s3, s2, (a3) - (b3), s2, -__t4, -__t3); \
   } while (0)
 
-#define sub_ddddddmmmmmmssssss(s5, s4, s3, s2, s1, s0, a5, a4, a3, a2, a1, a0, b5, b4, b3, b2, b1, b0)      \
-  do {                                                                                                      \
-    ulong __t7, __t8;                                                                                   \
+# define add_sssssaaaaaaaaaa(s4, s3, s2, s1, s0, a4, a3, a2, a1, a0, b4, b3, b2, b1, b0) \
+  do { \
+    ulong __t4 = 0; \
+    add_ssssaaaaaaaa(__t4, s2, s1, s0, (ulong) 0, a2, a1, a0, (ulong) 0, b2, b1, b0); \
+    add_ssaaaa(s4, s3, a4, a3, b4, b3); \
+    add_ssaaaa(s4, s3, s4, s3, (ulong) 0, __t4); \
+  } while (0)
+
+# define sub_dddddmmmmmsssss(s4, s3, s2, s1, s0, a4, a3, a2, a1, a0, b4, b3, b2, b1, b0) \
+  do { \
+    ulong __t5, __t6; \
+    sub_ddddmmmmssss(__t5, s2, s1, s0, (ulong) 0, a2, a1, a0, (ulong) 0, b2, b1, b0); \
+    sub_ddmmss(__t6, s3, (ulong) 0, a3, (ulong) 0, b3); \
+    sub_ddmmss(s4, s3, (a4) - (b4), s3, -__t6, -__t5); \
+  } while (0)
+
+# define add_ssssssaaaaaaaaaaaa(s5, s4, s3, s2, s1, s0, a5, a4, a3, a2, a1, a0, b5, b4, b3, b2, b1, b0) \
+  do { \
+    ulong __t5 = 0; \
+    add_sssssaaaaaaaaaa(__t5, s3, s2, s1, s0, (ulong) 0, a3, a2, a1, a0, (ulong) 0, b3, b2, b1, b0); \
+    add_ssaaaa(s5, s4, a5, a4, b5, b4); \
+    add_ssaaaa(s5, s4, s5, s4, (ulong) 0, __t5); \
+  } while (0)
+
+# define sub_ddddddmmmmmmssssss(s5, s4, s3, s2, s1, s0, a5, a4, a3, a2, a1, a0, b5, b4, b3, b2, b1, b0) \
+  do { \
+    ulong __t7, __t8; \
     sub_dddddmmmmmsssss(__t7, s3, s2, s1, s0, (ulong) 0, a3, a2, a1, a0, (ulong) 0, b3, b2, b1, b0);\
-    sub_ddmmss(__t8, s4, (ulong) 0, a4, (ulong) 0, b4);                                             \
-    sub_ddmmss(s5, s4, (a5) - (b5), s4, -__t8, -__t7);                                                      \
+    sub_ddmmss(__t8, s4, (ulong) 0, a4, (ulong) 0, b4); \
+    sub_ddmmss(s5, s4, (a5) - (b5), s4, -__t8, -__t7); \
   } while (0)
-
 #endif
 
 /* extra wide variants might not have inline asm if there are not enough registers */
 #if !defined(add_sssssssaaaaaaaaaaaaaa)
-
-#define add_sssssssaaaaaaaaaaaaaa(s6, s5, s4, s3, s2, s1, s0, a6, a5, a4, a3, a2, a1, a0, b6, b5, b4, b3, b2, b1, b0) \
+# define add_sssssssaaaaaaaaaaaaaa(s6, s5, s4, s3, s2, s1, s0, a6, a5, a4, a3, a2, a1, a0, b6, b5, b4, b3, b2, b1, b0) \
   do { \
     ulong __t6 = 0; \
     add_ssssssaaaaaaaaaaaa(__t6, s4, s3, s2, s1, s0, (ulong) 0, a4, a3, a2, a1, a0, (ulong) 0, b4, b3, b2, b1, b0); \
@@ -206,7 +206,7 @@ flint_bitcnt_t FLINT_BIT_COUNT(ulong x)
     add_ssaaaa(s6, s5, s6, s5, (ulong) 0, __t6); \
   } while (0)
 
-#define add_ssssssssaaaaaaaaaaaaaaaa(s7, s6, s5, s4, s3, s2, s1, s0, a7, a6, a5, a4, a3, a2, a1, a0, b7, b6, b5, b4, b3, b2, b1, b0) \
+# define add_ssssssssaaaaaaaaaaaaaaaa(s7, s6, s5, s4, s3, s2, s1, s0, a7, a6, a5, a4, a3, a2, a1, a0, b7, b6, b5, b4, b3, b2, b1, b0) \
   do { \
     ulong __t7 = 0; \
     add_sssssssaaaaaaaaaaaaaa(__t7, s5, s4, s3, s2, s1, s0, (ulong) 0, a5, a4, a3, a2, a1, a0, (ulong) 0, b5, b4, b3, b2, b1, b0); \
@@ -214,22 +214,21 @@ flint_bitcnt_t FLINT_BIT_COUNT(ulong x)
     add_ssaaaa(s7, s6, s7, s6, (ulong) 0, __t7); \
   } while (0)
 
-#define sub_dddddddmmmmmmmsssssss(s6, s5, s4, s3, s2, s1, s0, a6, a5, a4, a3, a2, a1, a0, b6, b5, b4, b3, b2, b1, b0)       \
-  do {                                                                                                                      \
-    ulong __t9, __t10;                                                                                                   \
+# define sub_dddddddmmmmmmmsssssss(s6, s5, s4, s3, s2, s1, s0, a6, a5, a4, a3, a2, a1, a0, b6, b5, b4, b3, b2, b1, b0) \
+  do { \
+    ulong __t9, __t10; \
     sub_ddddddmmmmmmssssss(__t9, s4, s3, s2, s1, s0, (ulong) 0, a4, a3, a2, a1, a0, (ulong) 0, b4, b3, b2, b1, b0); \
-    sub_ddmmss(__t10, s5, (ulong) 0, a5, (ulong) 0, b5);                                                             \
-    sub_ddmmss(s6, s5, (a6) - (b6), s5, -__t10, -__t9);                                                                      \
+    sub_ddmmss(__t10, s5, (ulong) 0, a5, (ulong) 0, b5); \
+    sub_ddmmss(s6, s5, (a6) - (b6), s5, -__t10, -__t9); \
   } while (0)
 
-#define sub_ddddddddmmmmmmmmssssssss(s7, s6, s5, s4, s3, s2, s1, s0, a7, a6, a5, a4, a3, a2, a1, a0, b7, b6, b5, b4, b3, b2, b1, b0)        \
-  do {                                                                                                                                      \
-    ulong __t11, __t12;                                                                                                                   \
-    sub_dddddddmmmmmmmsssssss(__t11, s5, s4, s3, s2, s1, s0, (ulong) 0, a5, a4, a3, a2, a1, a0, (ulong) 0, b5, b4, b3, b2, b1, b0);  \
-    sub_ddmmss(__t12, s6, (ulong) 0, a6, (ulong) 0, b6);                                                                             \
-    sub_ddmmss(s7, s6, (a7) - (b7), s6, -__t12, -__t11);                                                                                      \
+# define sub_ddddddddmmmmmmmmssssssss(s7, s6, s5, s4, s3, s2, s1, s0, a7, a6, a5, a4, a3, a2, a1, a0, b7, b6, b5, b4, b3, b2, b1, b0) \
+  do { \
+    ulong __t11, __t12; \
+    sub_dddddddmmmmmmmsssssss(__t11, s5, s4, s3, s2, s1, s0, (ulong) 0, a5, a4, a3, a2, a1, a0, (ulong) 0, b5, b4, b3, b2, b1, b0); \
+    sub_ddmmss(__t12, s6, (ulong) 0, a6, (ulong) 0, b6); \
+    sub_ddmmss(s7, s6, (a7) - (b7), s6, -__t12, -__t11); \
   } while (0)
-
 #endif
 
 

--- a/src/longlong_asm_gcc.h
+++ b/src/longlong_asm_gcc.h
@@ -41,26 +41,26 @@
 # endif
 
 # define add_ssaaaa(s1, s0, a1, a0, b1, b0) \
-  __asm__(_ASM_ADD " %5,%" _ASM_PRE "1\n"   \
-     "\t" _ASM_ADC " %3,%" _ASM_PRE "0"     \
+  __asm__(_ASM_ADD " %5,%" _ASM_PRE "1\n" \
+     "\t" _ASM_ADC " %3,%" _ASM_PRE "0" \
     : "=r" (s1), "=&r" (s0) \
     : "0" ((ulong)(a1)), _ASM_RME ((ulong)(b1)), \
       "%1" ((ulong)(a0)), _ASM_RME ((ulong)(b0)))
 
 # define add_sssaaaaaa(s2, s1, s0, a2, a1, a0, b2, b1, b0) \
-  __asm__(_ASM_ADD " %8,%" _ASM_PRE "2\n"   \
-     "\t" _ASM_ADC " %6,%" _ASM_PRE "1\n"   \
-     "\t" _ASM_ADC " %4,%" _ASM_PRE "0"     \
+  __asm__(_ASM_ADD " %8,%" _ASM_PRE "2\n" \
+     "\t" _ASM_ADC " %6,%" _ASM_PRE "1\n" \
+     "\t" _ASM_ADC " %4,%" _ASM_PRE "0" \
     : "=r" (s2), "=&r" (s1), "=&r" (s0) \
     : "0" ((ulong)(a2)), _ASM_RME ((ulong)(b2)), \
       "1" ((ulong)(a1)), _ASM_RME ((ulong)(b1)), \
       "2" ((ulong)(a0)), _ASM_RME ((ulong)(b0)))
 
 # define add_ssssaaaaaaaa(s3, s2, s1, s0, a3, a2, a1, a0, b3, b2, b1, b0) \
-  __asm__(_ASM_ADD " %11,%" _ASM_PRE "3\n"   \
-     "\t" _ASM_ADC " %9,%" _ASM_PRE "2\n"   \
-     "\t" _ASM_ADC " %7,%" _ASM_PRE "1\n"   \
-     "\t" _ASM_ADC " %5,%" _ASM_PRE "0"     \
+  __asm__(_ASM_ADD " %11,%" _ASM_PRE "3\n" \
+     "\t" _ASM_ADC " %9,%" _ASM_PRE "2\n" \
+     "\t" _ASM_ADC " %7,%" _ASM_PRE "1\n" \
+     "\t" _ASM_ADC " %5,%" _ASM_PRE "0" \
     : "=r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0) \
     : "0" ((ulong)(a3)), _ASM_RME ((ulong)(b3)), \
       "1" ((ulong)(a2)), _ASM_RME ((ulong)(b2)), \
@@ -68,11 +68,11 @@
       "3" ((ulong)(a0)), _ASM_RME ((ulong)(b0)))
 
 # define add_sssssaaaaaaaaaa(s4, s3, s2, s1, s0, a4, a3, a2, a1, a0, b4, b3, b2, b1, b0) \
-  __asm__(_ASM_ADD " %14,%" _ASM_PRE "4\n"   \
-     "\t" _ASM_ADC " %12,%" _ASM_PRE "3\n"   \
-     "\t" _ASM_ADC " %10,%" _ASM_PRE "2\n"   \
-     "\t" _ASM_ADC " %8,%" _ASM_PRE "1\n"   \
-     "\t" _ASM_ADC " %6,%" _ASM_PRE "0"     \
+  __asm__(_ASM_ADD " %14,%" _ASM_PRE "4\n" \
+     "\t" _ASM_ADC " %12,%" _ASM_PRE "3\n" \
+     "\t" _ASM_ADC " %10,%" _ASM_PRE "2\n" \
+     "\t" _ASM_ADC " %8,%" _ASM_PRE "1\n" \
+     "\t" _ASM_ADC " %6,%" _ASM_PRE "0" \
     : "=r" (s4), "=&r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0) \
     : "0" ((ulong)(a4)), _ASM_RME ((ulong)(b4)), \
       "1" ((ulong)(a3)), _ASM_RME ((ulong)(b3)), \
@@ -81,12 +81,12 @@
       "4" ((ulong)(a0)), _ASM_RME ((ulong)(b0)))
 
 # define add_ssssssaaaaaaaaaaaa(s5, s4, s3, s2, s1, s0, a5, a4, a3, a2, a1, a0, b5, b4, b3, b2, b1, b0) \
-  __asm__(_ASM_ADD " %17,%" _ASM_PRE "5\n"   \
-     "\t" _ASM_ADC " %15,%" _ASM_PRE "4\n"   \
-     "\t" _ASM_ADC " %13,%" _ASM_PRE "3\n"   \
-     "\t" _ASM_ADC " %11,%" _ASM_PRE "2\n"   \
-     "\t" _ASM_ADC " %9,%" _ASM_PRE "1\n"   \
-     "\t" _ASM_ADC " %7,%" _ASM_PRE "0"     \
+  __asm__(_ASM_ADD " %17,%" _ASM_PRE "5\n" \
+     "\t" _ASM_ADC " %15,%" _ASM_PRE "4\n" \
+     "\t" _ASM_ADC " %13,%" _ASM_PRE "3\n" \
+     "\t" _ASM_ADC " %11,%" _ASM_PRE "2\n" \
+     "\t" _ASM_ADC " %9,%" _ASM_PRE "1\n" \
+     "\t" _ASM_ADC " %7,%" _ASM_PRE "0" \
     : "=r" (s5), "=&r" (s4), "=&r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0) \
     : "0" ((ulong)(a5)), _ASM_RME ((ulong)(b5)), \
       "1" ((ulong)(a4)), _ASM_RME ((ulong)(b4)), \
@@ -96,26 +96,26 @@
       "5" ((ulong)(a0)), _ASM_RME ((ulong)(b0)))
 
 # define sub_ddmmss(d1, d0, m1, m0, s1, s0) \
-  __asm__(_ASM_SUB " %5,%" _ASM_PRE "1\n"   \
-     "\t" _ASM_SBB " %3,%" _ASM_PRE "0"     \
+  __asm__(_ASM_SUB " %5,%" _ASM_PRE "1\n" \
+     "\t" _ASM_SBB " %3,%" _ASM_PRE "0" \
     : "=r" (d1), "=&r" (d0) \
     : "0" ((ulong)(m1)), _ASM_RME ((ulong)(s1)), \
       "1" ((ulong)(m0)), _ASM_RME ((ulong)(s0)))
 
 # define sub_dddmmmsss(d2, d1, d0, m2, m1, m0, s2, s1, s0) \
-  __asm__(_ASM_SUB " %8,%" _ASM_PRE "2\n"   \
-     "\t" _ASM_SBB " %6,%" _ASM_PRE "1\n"   \
-     "\t" _ASM_SBB " %4,%" _ASM_PRE "0"     \
+  __asm__(_ASM_SUB " %8,%" _ASM_PRE "2\n" \
+     "\t" _ASM_SBB " %6,%" _ASM_PRE "1\n" \
+     "\t" _ASM_SBB " %4,%" _ASM_PRE "0" \
     : "=r" (d2), "=&r" (d1), "=&r" (d0) \
     : "0" ((ulong)(m2)), _ASM_RME ((ulong)(s2)), \
       "1" ((ulong)(m1)), _ASM_RME ((ulong)(s1)), \
       "2" ((ulong)(m0)), _ASM_RME ((ulong)(s0)))
 
 # define sub_ddddmmmmssss(d3, d2, d1, d0, m3, m2, m1, m0, s3, s2, s1, s0) \
-  __asm__(_ASM_SUB " %11,%" _ASM_PRE "3\n"   \
-     "\t" _ASM_SBB " %9,%" _ASM_PRE "2\n"   \
-     "\t" _ASM_SBB " %7,%" _ASM_PRE "1\n"   \
-     "\t" _ASM_SBB " %5,%" _ASM_PRE "0"     \
+  __asm__(_ASM_SUB " %11,%" _ASM_PRE "3\n" \
+     "\t" _ASM_SBB " %9,%" _ASM_PRE "2\n" \
+     "\t" _ASM_SBB " %7,%" _ASM_PRE "1\n" \
+     "\t" _ASM_SBB " %5,%" _ASM_PRE "0" \
     : "=r" (d3), "=&r" (d2), "=&r" (d1), "=&r" (d0) \
     : "0" ((ulong)(m3)), _ASM_RME ((ulong)(s3)), \
       "1" ((ulong)(m2)), _ASM_RME ((ulong)(s2)), \
@@ -123,11 +123,11 @@
       "3" ((ulong)(m0)), _ASM_RME ((ulong)(s0)))
 
 # define sub_dddddmmmmmsssss(d4, d3, d2, d1, d0, m4, m3, m2, m1, m0, s4, s3, s2, s1, s0) \
-  __asm__(_ASM_SUB " %14,%" _ASM_PRE "4\n"   \
-     "\t" _ASM_SBB " %12,%" _ASM_PRE "3\n"   \
-     "\t" _ASM_SBB " %10,%" _ASM_PRE "2\n"   \
-     "\t" _ASM_SBB " %8,%" _ASM_PRE "1\n"   \
-     "\t" _ASM_SBB " %6,%" _ASM_PRE "0"     \
+  __asm__(_ASM_SUB " %14,%" _ASM_PRE "4\n" \
+     "\t" _ASM_SBB " %12,%" _ASM_PRE "3\n" \
+     "\t" _ASM_SBB " %10,%" _ASM_PRE "2\n" \
+     "\t" _ASM_SBB " %8,%" _ASM_PRE "1\n" \
+     "\t" _ASM_SBB " %6,%" _ASM_PRE "0" \
     : "=r" (d4), "=&r" (d3), "=&r" (d2), "=&r" (d1), "=&r" (d0) \
     : "0" ((ulong)(m4)), _ASM_RME ((ulong)(s4)), \
       "1" ((ulong)(m3)), _ASM_RME ((ulong)(s3)), \
@@ -136,12 +136,12 @@
       "4" ((ulong)(m0)), _ASM_RME ((ulong)(s0)))
 
 # define sub_ddddddmmmmmmssssss(d5, d4, d3, d2, d1, d0, m5, m4, m3, m2, m1, m0, s5, s4, s3, s2, s1, s0) \
-  __asm__(_ASM_SUB " %17,%" _ASM_PRE "5\n"   \
-     "\t" _ASM_SBB " %15,%" _ASM_PRE "4\n"   \
-     "\t" _ASM_SBB " %13,%" _ASM_PRE "3\n"   \
-     "\t" _ASM_SBB " %11,%" _ASM_PRE "2\n"   \
-     "\t" _ASM_SBB " %9,%" _ASM_PRE "1\n"   \
-     "\t" _ASM_SBB " %7,%" _ASM_PRE "0"     \
+  __asm__(_ASM_SUB " %17,%" _ASM_PRE "5\n" \
+     "\t" _ASM_SBB " %15,%" _ASM_PRE "4\n" \
+     "\t" _ASM_SBB " %13,%" _ASM_PRE "3\n" \
+     "\t" _ASM_SBB " %11,%" _ASM_PRE "2\n" \
+     "\t" _ASM_SBB " %9,%" _ASM_PRE "1\n" \
+     "\t" _ASM_SBB " %7,%" _ASM_PRE "0" \
     : "=r" (d5), "=&r" (d4), "=&r" (d3), "=&r" (d2), "=&r" (d1), "=&r" (d0) \
     : "0" ((ulong)(m5)), _ASM_RME ((ulong)(s5)), \
       "1" ((ulong)(m4)), _ASM_RME ((ulong)(s4)), \
@@ -154,13 +154,13 @@
 # if FLINT_BITS == 64 && defined (__amd64__)
 
 # define add_sssssssaaaaaaaaaaaaaa(s6, s5, s4, s3, s2, s1, s0, a6, a5, a4, a3, a2, a1, a0, b6, b5, b4, b3, b2, b1, b0) \
-  __asm__(_ASM_ADD " %20,%" _ASM_PRE "6\n"   \
-     "\t" _ASM_ADC " %18,%" _ASM_PRE "5\n"   \
-     "\t" _ASM_ADC " %16,%" _ASM_PRE "4\n"   \
-     "\t" _ASM_ADC " %14,%" _ASM_PRE "3\n"   \
-     "\t" _ASM_ADC " %12,%" _ASM_PRE "2\n"   \
-     "\t" _ASM_ADC " %10,%" _ASM_PRE "1\n"   \
-     "\t" _ASM_ADC " %8,%" _ASM_PRE "0"     \
+  __asm__(_ASM_ADD " %20,%" _ASM_PRE "6\n" \
+     "\t" _ASM_ADC " %18,%" _ASM_PRE "5\n" \
+     "\t" _ASM_ADC " %16,%" _ASM_PRE "4\n" \
+     "\t" _ASM_ADC " %14,%" _ASM_PRE "3\n" \
+     "\t" _ASM_ADC " %12,%" _ASM_PRE "2\n" \
+     "\t" _ASM_ADC " %10,%" _ASM_PRE "1\n" \
+     "\t" _ASM_ADC " %8,%" _ASM_PRE "0" \
     : "=r" (s6), "=&r" (s5), "=&r" (s4), "=&r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0) \
     : "0" ((ulong)(a6)), _ASM_RME ((ulong)(b6)), \
       "1" ((ulong)(a5)), _ASM_RME ((ulong)(b5)), \
@@ -171,14 +171,14 @@
       "6" ((ulong)(a0)), _ASM_RME ((ulong)(b0)))
 
 # define add_ssssssssaaaaaaaaaaaaaaaa(s7, s6, s5, s4, s3, s2, s1, s0, a7, a6, a5, a4, a3, a2, a1, a0, b7, b6, b5, b4, b3, b2, b1, b0) \
-  __asm__(_ASM_ADD " %23,%" _ASM_PRE "7\n"   \
-     "\t" _ASM_ADC " %21,%" _ASM_PRE "6\n"   \
-     "\t" _ASM_ADC " %19,%" _ASM_PRE "5\n"   \
-     "\t" _ASM_ADC " %17,%" _ASM_PRE "4\n"   \
-     "\t" _ASM_ADC " %15,%" _ASM_PRE "3\n"   \
-     "\t" _ASM_ADC " %13,%" _ASM_PRE "2\n"   \
-     "\t" _ASM_ADC " %11,%" _ASM_PRE "1\n"   \
-     "\t" _ASM_ADC " %9,%" _ASM_PRE "0"     \
+  __asm__(_ASM_ADD " %23,%" _ASM_PRE "7\n" \
+     "\t" _ASM_ADC " %21,%" _ASM_PRE "6\n" \
+     "\t" _ASM_ADC " %19,%" _ASM_PRE "5\n" \
+     "\t" _ASM_ADC " %17,%" _ASM_PRE "4\n" \
+     "\t" _ASM_ADC " %15,%" _ASM_PRE "3\n" \
+     "\t" _ASM_ADC " %13,%" _ASM_PRE "2\n" \
+     "\t" _ASM_ADC " %11,%" _ASM_PRE "1\n" \
+     "\t" _ASM_ADC " %9,%" _ASM_PRE "0" \
     : "=r" (s7), "=&r" (s6), "=&r" (s5), "=&r" (s4), "=&r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0) \
     : "0" ((ulong)(a7)), _ASM_RME ((ulong)(b7)), \
       "1" ((ulong)(a6)), _ASM_RME ((ulong)(b6)), \
@@ -190,13 +190,13 @@
       "7" ((ulong)(a0)), _ASM_RME ((ulong)(b0)))
 
 # define sub_dddddddmmmmmmmsssssss(d6, d5, d4, d3, d2, d1, d0, m6, m5, m4, m3, m2, m1, m0, s6, s5, s4, s3, s2, s1, s0) \
-  __asm__(_ASM_SUB " %20,%" _ASM_PRE "6\n"   \
-     "\t" _ASM_SBB " %18,%" _ASM_PRE "5\n"   \
-     "\t" _ASM_SBB " %16,%" _ASM_PRE "4\n"   \
-     "\t" _ASM_SBB " %14,%" _ASM_PRE "3\n"   \
-     "\t" _ASM_SBB " %12,%" _ASM_PRE "2\n"   \
-     "\t" _ASM_SBB " %10,%" _ASM_PRE "1\n"   \
-     "\t" _ASM_SBB " %8,%" _ASM_PRE "0"     \
+  __asm__(_ASM_SUB " %20,%" _ASM_PRE "6\n" \
+     "\t" _ASM_SBB " %18,%" _ASM_PRE "5\n" \
+     "\t" _ASM_SBB " %16,%" _ASM_PRE "4\n" \
+     "\t" _ASM_SBB " %14,%" _ASM_PRE "3\n" \
+     "\t" _ASM_SBB " %12,%" _ASM_PRE "2\n" \
+     "\t" _ASM_SBB " %10,%" _ASM_PRE "1\n" \
+     "\t" _ASM_SBB " %8,%" _ASM_PRE "0" \
     : "=r" (d6), "=&r" (d5), "=&r" (d4), "=&r" (d3), "=&r" (d2), "=&r" (d1), "=&r" (d0) \
     : "0" ((ulong)(m6)), _ASM_RME ((ulong)(s6)), \
       "1" ((ulong)(m5)), _ASM_RME ((ulong)(s5)), \
@@ -207,14 +207,14 @@
       "6" ((ulong)(m0)), _ASM_RME ((ulong)(s0)))
 
 # define sub_ddddddddmmmmmmmmssssssss(d7, d6, d5, d4, d3, d2, d1, d0, m7, m6, m5, m4, m3, m2, m1, m0, s7, s6, s5, s4, s3, s2, s1, s0) \
-  __asm__(_ASM_SUB " %23,%" _ASM_PRE "7\n"   \
-     "\t" _ASM_SBB " %21,%" _ASM_PRE "6\n"   \
-     "\t" _ASM_SBB " %19,%" _ASM_PRE "5\n"   \
-     "\t" _ASM_SBB " %17,%" _ASM_PRE "4\n"   \
-     "\t" _ASM_SBB " %15,%" _ASM_PRE "3\n"   \
-     "\t" _ASM_SBB " %13,%" _ASM_PRE "2\n"   \
-     "\t" _ASM_SBB " %11,%" _ASM_PRE "1\n"   \
-     "\t" _ASM_SBB " %9,%" _ASM_PRE "0"     \
+  __asm__(_ASM_SUB " %23,%" _ASM_PRE "7\n" \
+     "\t" _ASM_SBB " %21,%" _ASM_PRE "6\n" \
+     "\t" _ASM_SBB " %19,%" _ASM_PRE "5\n" \
+     "\t" _ASM_SBB " %17,%" _ASM_PRE "4\n" \
+     "\t" _ASM_SBB " %15,%" _ASM_PRE "3\n" \
+     "\t" _ASM_SBB " %13,%" _ASM_PRE "2\n" \
+     "\t" _ASM_SBB " %11,%" _ASM_PRE "1\n" \
+     "\t" _ASM_SBB " %9,%" _ASM_PRE "0" \
     : "=r" (d7), "=&r" (d6), "=&r" (d5), "=&r" (d4), "=&r" (d3), "=&r" (d2), "=&r" (d1), "=&r" (d0) \
     : "0" ((ulong)(m7)), _ASM_RME ((ulong)(s7)), \
       "1" ((ulong)(m6)), _ASM_RME ((ulong)(s6)), \
@@ -248,7 +248,15 @@
 
 # define add_ssaaaa(s1, s0, a1, a0, b1, b0) \
   __asm__("adds %1,%3,%5\n" \
-        "\tadc %0,%2,%4"    \
+        "\tadc %0,%2,%4" \
+    : "=r" (s1), "=&r" (s0) \
+    : "r" ((ulong)(a1)), "r" ((ulong)(a0)), \
+      "r" ((ulong)(b1)), "rI" ((ulong)(b0)) \
+    : "cc")
+
+# define sub_ddmmss(s1, s0, a1, a0, b1, b0) \
+  __asm__("subs %1,%3,%5\n" \
+        "\tsbc  %0,%2,%4" \
     : "=r" (s1), "=&r" (s0) \
     : "r" ((ulong)(a1)), "r" ((ulong)(a0)), \
       "r" ((ulong)(b1)), "rI" ((ulong)(b0)) \
@@ -257,130 +265,97 @@
 # define add_sssaaaaaa(s2, s1, s0, a2, a1, a0, b2, b1, b0) \
   __asm__("adds %2,%5,%8\n" \
         "\tadcs %1,%4,%7\n" \
-        "\tadc %0,%3,%6"    \
+        "\tadc %0,%3,%6" \
     : "=r" (s2), "=&r" (s1), "=&r" (s0) \
     : "r" ((ulong)(a2)), "r" ((ulong)(a1)), "r" ((ulong)(a0)), \
       "r" ((ulong)(b2)), "r" ((ulong)(b1)), "rI" ((ulong)(b0)) \
-    : "cc")
-
-# define add_ssssaaaaaaaa(s3, s2, s1, s0, a3, a2, a1, a0, b3, b2, b1, b0) \
-  __asm__("adds %3,%7,%11\n"    \
-        "\tadcs %2,%6,%10\n"    \
-        "\tadcs %1,%5,%9\n"     \
-        "\tadc  %0,%4,%8"       \
-    : "=r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0) \
-    : "r" ((ulong)(a3)), "r" ((ulong)(a2)), "r" ((ulong)(a1)), "r" ((ulong)(a0)), \
-      "r" ((ulong)(b3)), "r" ((ulong)(b2)), "r" ((ulong)(b1)), "rI" ((ulong)(b0)) \
-    : "cc")
-
-#define add_sssssaaaaaaaaaa(s4, s3, s2, s1, s0, a4, a3, a2, a1, a0, b4, b3, b2, b1, b0)      \
-  __asm__ ("adds %4,%9,%14\n\tadcs %3,%8,%13\n\tadcs %2,%7,%12\n\tadcs %1,%6,%11\n\tadc %0,%5,%10"\
-       : "=r" (s4), "=&r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0)                        \
-       : "r" ((ulong)(a4)), "r" ((ulong)(a3)), "r" ((ulong)(a2)), "r" ((ulong)(a1)), "r" ((ulong)(a0)), \
-         "r" ((ulong)(b4)), "r" ((ulong)(b3)), "r" ((ulong)(b2)), "r" ((ulong)(b1)), "rI" ((ulong)(b0))                        \
-       : "cc")
-
-#define add_ssssssaaaaaaaaaaaa(s5, s4, s3, s2, s1, s0, a5, a4, a3, a2, a1, a0, b5, b4, b3, b2, b1, b0)      \
-  __asm__ ("adds %5,%11,%17\n\tadcs %4,%10,%16\n\tadcs %3,%9,%15\n\tadcs %2,%8,%14\n\tadcs %1,%7,%13\n\tadc %0,%6,%12"\
-       : "=r" (s5), "=&r" (s4), "=&r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0)                        \
-       : "r" ((ulong)(a5)), "r" ((ulong)(a4)), "r" ((ulong)(a3)), "r" ((ulong)(a2)), "r" ((ulong)(a1)), "r" ((ulong)(a0)), \
-         "r" ((ulong)(b5)), "r" ((ulong)(b4)), "r" ((ulong)(b3)), "r" ((ulong)(b2)), "r" ((ulong)(b1)), "rI" ((ulong)(b0)) \
-       : "cc")
-
-#define add_sssssssaaaaaaaaaaaaaa(s6, s5, s4, s3, s2, s1, s0, a6, a5, a4, a3, a2, a1, a0, b6, b5, b4, b3, b2, b1, b0)      \
-  __asm__ ("adds %6,%13,%20\n\tadcs %5,%12,%19\n\tadcs %4,%11,%18\n\tadcs %3,%10,%17\n\tadcs %2,%9,%16\n\tadcs %1,%8,%15\n\tadc %0,%7,%14"\
-       : "=r" (s6), "=&r" (s5), "=&r" (s4), "=&r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0)                        \
-       : "r" ((ulong)(a6)), "r" ((ulong)(a5)), "r" ((ulong)(a4)), "r" ((ulong)(a3)), "r" ((ulong)(a2)), "r" ((ulong)(a1)), "r" ((ulong)(a0)), \
-         "r" ((ulong)(b6)), "r" ((ulong)(b5)), "r" ((ulong)(b4)), "r" ((ulong)(b3)), "r" ((ulong)(b2)), "r" ((ulong)(b1)), "rI" ((ulong)(b0)) \
-       : "cc")
-
-#define add_ssssssssaaaaaaaaaaaaaaaa(s7, s6, s5, s4, s3, s2, s1, s0, a7, a6, a5, a4, a3, a2, a1, a0, b7, b6, b5, b4, b3, b2, b1, b0)      \
-  __asm__ ("adds %7,%15,%23\n\tadcs %6,%14,%22\n\tadcs %5,%13,%21\n\tadcs %4,%12,%20\n\tadcs %3,%11,%19\n\tadcs %2,%10,%18\n\tadcs %1,%9,%17\n\tadc %0,%8,%16"\
-       : "=r" (s7), "=&r" (s6), "=&r" (s5), "=&r" (s4), "=&r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0)                        \
-       : "r" ((ulong)(a7)), "r" ((ulong)(a6)), "r" ((ulong)(a5)), "r" ((ulong)(a4)), "r" ((ulong)(a3)), "r" ((ulong)(a2)), "r" ((ulong)(a1)), "r" ((ulong)(a0)), \
-         "r" ((ulong)(b7)), "r" ((ulong)(b6)), "r" ((ulong)(b5)), "r" ((ulong)(b4)), "r" ((ulong)(b3)), "r" ((ulong)(b2)), "r" ((ulong)(b1)), "rI" ((ulong)(b0)) \
-       : "cc")
-
-# define sub_ddmmss(s1, s0, a1, a0, b1, b0) \
-  __asm__("subs %1,%3,%5\n" \
-        "\tsbc  %0,%2,%4"   \
-    : "=r" (s1), "=&r" (s0) \
-    : "r" ((ulong)(a1)), "r" ((ulong)(a0)), \
-      "r" ((ulong)(b1)), "rI" ((ulong)(b0)) \
     : "cc")
 
 # define sub_dddmmmsss(s2, s1, s0, a2, a1, a0, b2, b1, b0) \
   __asm__("subs %2,%5,%8\n" \
         "\tsbcs %1,%4,%7\n" \
-        "\tsbc  %0,%3,%6"   \
+        "\tsbc  %0,%3,%6" \
     : "=r" (s2), "=&r" (s1), "=&r" (s0) \
     : "r" ((ulong)(a2)), "r" ((ulong)(a1)), "r" ((ulong)(a0)), \
       "r" ((ulong)(b2)), "r" ((ulong)(b1)), "rI" ((ulong)(b0)) \
     : "cc")
 
-#define add_sssssaaaaaaaaaa(s4, s3, s2, s1, s0, a4, a3, a2, a1, a0, b4, b3, b2, b1, b0)      \
-  __asm__ ("adds %4,%9,%14\n\tadcs %3,%8,%13\n\tadcs %2,%7,%12\n\tadcs %1,%6,%11\n\tadc %0,%5,%10"\
-       : "=r" (s4), "=&r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0)                        \
-       : "r" ((ulong)(a4)), "r" ((ulong)(a3)), "r" ((ulong)(a2)), "r" ((ulong)(a1)), "r" ((ulong)(a0)), \
-         "r" ((ulong)(b4)), "r" ((ulong)(b3)), "r" ((ulong)(b2)), "r" ((ulong)(b1)), "rI" ((ulong)(b0))                        \
+/* ARM (32-bit) only has 16 registers, and has problems with inline assembly
+ * with too many registers.  See issue #2131. */
+# if FLINT_BITS == 64 && defined(__aarch64__)
+# define add_ssssaaaaaaaa(s3, s2, s1, s0, a3, a2, a1, a0, b3, b2, b1, b0) \
+  __asm__("adds %3,%7,%11\n" \
+        "\tadcs %2,%6,%10\n" \
+        "\tadcs %1,%5,%9\n" \
+        "\tadc  %0,%4,%8" \
+    : "=r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0) \
+    : "r" ((ulong)(a3)), "r" ((ulong)(a2)), "r" ((ulong)(a1)), "r" ((ulong)(a0)), \
+      "r" ((ulong)(b3)), "r" ((ulong)(b2)), "r" ((ulong)(b1)), "rI" ((ulong)(b0)) \
+    : "cc")
+
+# define sub_ddddmmmmssss(s3, s2, s1, s0, a3, a2, a1, a0, b3, b2, b1, b0) \
+  __asm__ ("subs %3,%7,%11\n\tsbcs %2,%6,%10\n\tsbcs %1,%5,%9\n\tsbc %0,%4,%8"\
+       : "=r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0) \
+       : "r" ((ulong)(a3)), "r" ((ulong)(a2)), "r" ((ulong)(a1)), "r" ((ulong)(a0)), \
+         "r" ((ulong)(b3)), "r" ((ulong)(b2)), "r" ((ulong)(b1)), "rI" ((ulong)(b0)) \
        : "cc")
 
-#define add_ssssssaaaaaaaaaaaa(s5, s4, s3, s2, s1, s0, a5, a4, a3, a2, a1, a0, b5, b4, b3, b2, b1, b0)      \
+# define add_sssssaaaaaaaaaa(s4, s3, s2, s1, s0, a4, a3, a2, a1, a0, b4, b3, b2, b1, b0) \
+  __asm__ ("adds %4,%9,%14\n\tadcs %3,%8,%13\n\tadcs %2,%7,%12\n\tadcs %1,%6,%11\n\tadc %0,%5,%10"\
+       : "=r" (s4), "=&r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0) \
+       : "r" ((ulong)(a4)), "r" ((ulong)(a3)), "r" ((ulong)(a2)), "r" ((ulong)(a1)), "r" ((ulong)(a0)), \
+         "r" ((ulong)(b4)), "r" ((ulong)(b3)), "r" ((ulong)(b2)), "r" ((ulong)(b1)), "rI" ((ulong)(b0)) \
+       : "cc")
+
+# define sub_dddddmmmmmsssss(s4, s3, s2, s1, s0, a4, a3, a2, a1, a0, b4, b3, b2, b1, b0) \
+  __asm__ ("subs %4,%9,%14\n\tsbcs %3,%8,%13\n\tsbcs %2,%7,%12\n\tsbcs %1,%6,%11\n\tsbc %0,%5,%10"\
+       : "=r" (s4), "=&r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0) \
+       : "r" ((ulong)(a4)), "r" ((ulong)(a3)), "r" ((ulong)(a2)), "r" ((ulong)(a1)), "r" ((ulong)(a0)), \
+         "r" ((ulong)(b4)), "r" ((ulong)(b3)), "r" ((ulong)(b2)), "r" ((ulong)(b1)), "rI" ((ulong)(b0)) \
+       : "cc")
+
+# define add_ssssssaaaaaaaaaaaa(s5, s4, s3, s2, s1, s0, a5, a4, a3, a2, a1, a0, b5, b4, b3, b2, b1, b0) \
   __asm__ ("adds %5,%11,%17\n\tadcs %4,%10,%16\n\tadcs %3,%9,%15\n\tadcs %2,%8,%14\n\tadcs %1,%7,%13\n\tadc %0,%6,%12"\
-       : "=r" (s5), "=&r" (s4), "=&r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0)                        \
+       : "=r" (s5), "=&r" (s4), "=&r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0) \
        : "r" ((ulong)(a5)), "r" ((ulong)(a4)), "r" ((ulong)(a3)), "r" ((ulong)(a2)), "r" ((ulong)(a1)), "r" ((ulong)(a0)), \
          "r" ((ulong)(b5)), "r" ((ulong)(b4)), "r" ((ulong)(b3)), "r" ((ulong)(b2)), "r" ((ulong)(b1)), "rI" ((ulong)(b0)) \
        : "cc")
 
-#define add_sssssssaaaaaaaaaaaaaa(s6, s5, s4, s3, s2, s1, s0, a6, a5, a4, a3, a2, a1, a0, b6, b5, b4, b3, b2, b1, b0)      \
+# define sub_ddddddmmmmmmssssss(s5, s4, s3, s2, s1, s0, a5, a4, a3, a2, a1, a0, b5, b4, b3, b2, b1, b0) \
+  __asm__ ("subs %5,%11,%17\n\tsbcs %4,%10,%16\n\tsbcs %3,%9,%15\n\tsbcs %2,%8,%14\n\tsbcs %1,%7,%13\n\tsbc %0,%6,%12"\
+       : "=r" (s5), "=&r" (s4), "=&r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0) \
+       : "r" ((ulong)(a5)), "r" ((ulong)(a4)), "r" ((ulong)(a3)), "r" ((ulong)(a2)), "r" ((ulong)(a1)), "r" ((ulong)(a0)), \
+         "r" ((ulong)(b5)), "r" ((ulong)(b4)), "r" ((ulong)(b3)), "r" ((ulong)(b2)), "r" ((ulong)(b1)), "rI" ((ulong)(b0)) \
+       : "cc")
+
+# define add_sssssssaaaaaaaaaaaaaa(s6, s5, s4, s3, s2, s1, s0, a6, a5, a4, a3, a2, a1, a0, b6, b5, b4, b3, b2, b1, b0) \
   __asm__ ("adds %6,%13,%20\n\tadcs %5,%12,%19\n\tadcs %4,%11,%18\n\tadcs %3,%10,%17\n\tadcs %2,%9,%16\n\tadcs %1,%8,%15\n\tadc %0,%7,%14"\
-       : "=r" (s6), "=&r" (s5), "=&r" (s4), "=&r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0)                        \
+       : "=r" (s6), "=&r" (s5), "=&r" (s4), "=&r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0) \
        : "r" ((ulong)(a6)), "r" ((ulong)(a5)), "r" ((ulong)(a4)), "r" ((ulong)(a3)), "r" ((ulong)(a2)), "r" ((ulong)(a1)), "r" ((ulong)(a0)), \
          "r" ((ulong)(b6)), "r" ((ulong)(b5)), "r" ((ulong)(b4)), "r" ((ulong)(b3)), "r" ((ulong)(b2)), "r" ((ulong)(b1)), "rI" ((ulong)(b0)) \
        : "cc")
 
-#define add_ssssssssaaaaaaaaaaaaaaaa(s7, s6, s5, s4, s3, s2, s1, s0, a7, a6, a5, a4, a3, a2, a1, a0, b7, b6, b5, b4, b3, b2, b1, b0)      \
+# define sub_dddddddmmmmmmmsssssss(s6, s5, s4, s3, s2, s1, s0, a6, a5, a4, a3, a2, a1, a0, b6, b5, b4, b3, b2, b1, b0) \
+  __asm__ ("subs %6,%13,%20\n\tsbcs %5,%12,%19\n\tsbcs %4,%11,%18\n\tsbcs %3,%10,%17\n\tsbcs %2,%9,%16\n\tsbcs %1,%8,%15\n\tsbc %0,%7,%14"\
+       : "=r" (s6), "=&r" (s5), "=&r" (s4), "=&r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0) \
+       : "r" ((ulong)(a6)), "r" ((ulong)(a5)), "r" ((ulong)(a4)), "r" ((ulong)(a3)), "r" ((ulong)(a2)), "r" ((ulong)(a1)), "r" ((ulong)(a0)), \
+         "r" ((ulong)(b6)), "r" ((ulong)(b5)), "r" ((ulong)(b4)), "r" ((ulong)(b3)), "r" ((ulong)(b2)), "r" ((ulong)(b1)), "rI" ((ulong)(b0)) \
+       : "cc")
+
+# define add_ssssssssaaaaaaaaaaaaaaaa(s7, s6, s5, s4, s3, s2, s1, s0, a7, a6, a5, a4, a3, a2, a1, a0, b7, b6, b5, b4, b3, b2, b1, b0) \
   __asm__ ("adds %7,%15,%23\n\tadcs %6,%14,%22\n\tadcs %5,%13,%21\n\tadcs %4,%12,%20\n\tadcs %3,%11,%19\n\tadcs %2,%10,%18\n\tadcs %1,%9,%17\n\tadc %0,%8,%16"\
-       : "=r" (s7), "=&r" (s6), "=&r" (s5), "=&r" (s4), "=&r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0)                        \
+       : "=r" (s7), "=&r" (s6), "=&r" (s5), "=&r" (s4), "=&r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0) \
        : "r" ((ulong)(a7)), "r" ((ulong)(a6)), "r" ((ulong)(a5)), "r" ((ulong)(a4)), "r" ((ulong)(a3)), "r" ((ulong)(a2)), "r" ((ulong)(a1)), "r" ((ulong)(a0)), \
          "r" ((ulong)(b7)), "r" ((ulong)(b6)), "r" ((ulong)(b5)), "r" ((ulong)(b4)), "r" ((ulong)(b3)), "r" ((ulong)(b2)), "r" ((ulong)(b1)), "rI" ((ulong)(b0)) \
        : "cc")
 
-
-#define sub_ddddmmmmssss(s3, s2, s1, s0, a3, a2, a1, a0, b3, b2, b1, b0)      \
-  __asm__ ("subs %3,%7,%11\n\tsbcs %2,%6,%10\n\tsbcs %1,%5,%9\n\tsbc %0,%4,%8"\
-       : "=r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0)                        \
-       : "r" ((ulong)(a3)), "r" ((ulong)(a2)), "r" ((ulong)(a1)), "r" ((ulong)(a0)), \
-         "r" ((ulong)(b3)), "r" ((ulong)(b2)), "r" ((ulong)(b1)), "rI" ((ulong)(b0))                        \
-       : "cc")
-
-#define sub_dddddmmmmmsssss(s4, s3, s2, s1, s0, a4, a3, a2, a1, a0, b4, b3, b2, b1, b0)      \
-  __asm__ ("subs %4,%9,%14\n\tsbcs %3,%8,%13\n\tsbcs %2,%7,%12\n\tsbcs %1,%6,%11\n\tsbc %0,%5,%10"\
-       : "=r" (s4), "=&r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0)                        \
-       : "r" ((ulong)(a4)), "r" ((ulong)(a3)), "r" ((ulong)(a2)), "r" ((ulong)(a1)), "r" ((ulong)(a0)), \
-         "r" ((ulong)(b4)), "r" ((ulong)(b3)), "r" ((ulong)(b2)), "r" ((ulong)(b1)), "rI" ((ulong)(b0))                        \
-       : "cc")
-
-#define sub_ddddddmmmmmmssssss(s5, s4, s3, s2, s1, s0, a5, a4, a3, a2, a1, a0, b5, b4, b3, b2, b1, b0)      \
-  __asm__ ("subs %5,%11,%17\n\tsbcs %4,%10,%16\n\tsbcs %3,%9,%15\n\tsbcs %2,%8,%14\n\tsbcs %1,%7,%13\n\tsbc %0,%6,%12"\
-       : "=r" (s5), "=&r" (s4), "=&r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0)                        \
-       : "r" ((ulong)(a5)), "r" ((ulong)(a4)), "r" ((ulong)(a3)), "r" ((ulong)(a2)), "r" ((ulong)(a1)), "r" ((ulong)(a0)), \
-         "r" ((ulong)(b5)), "r" ((ulong)(b4)), "r" ((ulong)(b3)), "r" ((ulong)(b2)), "r" ((ulong)(b1)), "rI" ((ulong)(b0))                        \
-       : "cc")
-
-#define sub_dddddddmmmmmmmsssssss(s6, s5, s4, s3, s2, s1, s0, a6, a5, a4, a3, a2, a1, a0, b6, b5, b4, b3, b2, b1, b0)      \
-  __asm__ ("subs %6,%13,%20\n\tsbcs %5,%12,%19\n\tsbcs %4,%11,%18\n\tsbcs %3,%10,%17\n\tsbcs %2,%9,%16\n\tsbcs %1,%8,%15\n\tsbc %0,%7,%14"\
-       : "=r" (s6), "=&r" (s5), "=&r" (s4), "=&r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0)                        \
-       : "r" ((ulong)(a6)), "r" ((ulong)(a5)), "r" ((ulong)(a4)), "r" ((ulong)(a3)), "r" ((ulong)(a2)), "r" ((ulong)(a1)), "r" ((ulong)(a0)), \
-         "r" ((ulong)(b6)), "r" ((ulong)(b5)), "r" ((ulong)(b4)), "r" ((ulong)(b3)), "r" ((ulong)(b2)), "r" ((ulong)(b1)), "rI" ((ulong)(b0))                        \
-       : "cc")
-
-#define sub_ddddddddmmmmmmmmssssssss(s7, s6, s5, s4, s3, s2, s1, s0, a7, a6, a5, a4, a3, a2, a1, a0, b7, b6, b5, b4, b3, b2, b1, b0)      \
+# define sub_ddddddddmmmmmmmmssssssss(s7, s6, s5, s4, s3, s2, s1, s0, a7, a6, a5, a4, a3, a2, a1, a0, b7, b6, b5, b4, b3, b2, b1, b0) \
   __asm__ ("subs %7,%15,%23\n\tsbcs %6,%14,%22\n\tsbcs %5,%13,%21\n\tsbcs %4,%12,%20\n\tsbcs %3,%11,%19\n\tsbcs %2,%10,%18\n\tsbcs %1,%9,%17\n\tsbc %0,%8,%16"\
-       : "=r" (s7), "=&r" (s6), "=&r" (s5), "=&r" (s4), "=&r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0)                        \
+       : "=r" (s7), "=&r" (s6), "=&r" (s5), "=&r" (s4), "=&r" (s3), "=&r" (s2), "=&r" (s1), "=&r" (s0) \
        : "r" ((ulong)(a7)), "r" ((ulong)(a6)), "r" ((ulong)(a5)), "r" ((ulong)(a4)), "r" ((ulong)(a3)), "r" ((ulong)(a2)), "r" ((ulong)(a1)), "r" ((ulong)(a0)), \
-         "r" ((ulong)(b7)), "r" ((ulong)(b6)), "r" ((ulong)(b5)), "r" ((ulong)(b4)), "r" ((ulong)(b3)), "r" ((ulong)(b2)), "r" ((ulong)(b1)), "rI" ((ulong)(b0))                        \
+         "r" ((ulong)(b7)), "r" ((ulong)(b6)), "r" ((ulong)(b5)), "r" ((ulong)(b4)), "r" ((ulong)(b3)), "r" ((ulong)(b2)), "r" ((ulong)(b1)), "rI" ((ulong)(b0)) \
        : "cc")
+# endif
 
 # if defined(__arm__)
 #  define umul_ppmm(xh, xl, a, b) \


### PR DESCRIPTION
They only have 16 registers, and this causes compilation errors on GCC.

Solves #2131.