### PR TITLE
Use `cp -pRP` instead of `cp -a` in make

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -59,7 +59,8 @@ STRIP:=@STRIP@
 RM_F:=rm -f
 RM_RF:=rm -rf
 CP:=cp
-CP_A:=cp -a
+# `cp -a` is not supported on all systems, but `cp -pRP` seems to be POSIX.
+CP_A:=cp -pRP
 GDB:=gdb
 
 STATIC:=@STATIC@


### PR DESCRIPTION
The latter is not supported by POSIX, and causes installation failures for some systems.

Solves #2135.

@barracuda156 can you verify that this works on your system?