### PR TITLE
Allow evaluating deflated Riemann zeta function and derivatives on small intervals containing 1

### DIFF
--- a/src/acb_poly/test/t-zeta_cpx_series.c
+++ b/src/acb_poly/test/t-zeta_cpx_series.c
@@ -83,5 +83,62 @@ TEST_FUNCTION_START(acb_poly_zeta_cpx_series, state)
         _acb_vec_clear(z2, len);
     }
 
+    /* check deflations around 1 */
+    for (iter = 0; iter < 100 * 0.1 * flint_test_multiplier(); iter++)
+    {
+        acb_t s1, s2, a;
+        acb_ptr z1, z2;
+        slong i, len, prec;
+        int deflate;
+
+        acb_init(s1);
+        acb_init(s2);
+        acb_init(a);
+
+        acb_one(a);
+
+        prec = 2 + n_randint(state, 300);
+        len = 1 + n_randint(state, 20);
+        deflate = 1;
+
+        acb_randtest(s1, state, 300, 2);
+        acb_mul_2exp_si(s1, s1, -(slong) n_randint(state, 100));
+
+        acb_zero(s2);
+        arb_get_mag(arb_radref(acb_realref(s2)), acb_realref(s1));
+        arb_get_mag(arb_radref(acb_imagref(s2)), acb_imagref(s1));
+
+        acb_add_ui(s1, s1, 1, prec);
+        acb_add_ui(s2, s2, 1, prec);
+
+        z1 = _acb_vec_init(len);
+        z2 = _acb_vec_init(len);
+
+        _acb_poly_zeta_cpx_series(z1, s1, a, deflate, len, prec);
+        _acb_poly_zeta_cpx_series(z2, s2, a, deflate, len, prec);
+
+        for (i = 0; i < len; i++)
+        {
+            if (!acb_overlaps(z1 + i, z2 + i))
+            {
+                flint_printf("FAIL: overlap (deflation)\n\n");
+                flint_printf("iter = %wd\n", iter);
+                flint_printf("deflate = %d, len = %wd, i = %wd\n\n", deflate, len, i);
+                flint_printf("s1 = "); acb_printd(s1, prec / 3.33); flint_printf("\n\n");
+                flint_printf("s2 = "); acb_printd(s2, prec / 3.33); flint_printf("\n\n");
+                flint_printf("a = "); acb_printd(a, prec / 3.33); flint_printf("\n\n");
+                flint_printf("z1 = "); acb_printd(z1 + i, prec / 3.33); flint_printf("\n\n");
+                flint_printf("z2 = "); acb_printd(z2 + i, prec / 3.33); flint_printf("\n\n");
+                flint_abort();
+            }
+        }
+
+        acb_clear(a);
+        acb_clear(s1);
+        acb_clear(s2);
+        _acb_vec_clear(z1, len);
+        _acb_vec_clear(z2, len);
+    }
+
     TEST_FUNCTION_END(state);
 }


### PR DESCRIPTION
Previously deflation of $\zeta(s) - 1/(s-1)$ only handled when $s = 1$ exactly; now small (complex) intervals containing 1 work too.

Requested by @Joel-Dahne in #1395.

Only done for Hurwitz zeta with parameter $a = 1$ (ordinary Riemann zeta) in this PR; I think the same bound should be valid (needs checking) for $1 \le a \le 2$ and one could get to $0 < a \le 1$ and Dirichlet L-functions from there with a shift. For complex $a$ one would need to work out some reasonable bound for the generalized Stieltjes constants.