### PR TITLE
Update release CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           cd doc/build
           mv html doc
-          cp latex/Flint.pdf doc
+          cp latex/flint.pdf doc
           tar -czvf doc.tar.gz doc
 
       - name: "Setup SSH key"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
           cd doc
           make html SPHINXOPTS="-W -j auto"
 
-      - name: "Build pdf documentation"
+      - name: "Build PDF documentation"
         uses: dante-ev/latex-action@latest
         with:
           root_file:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       - id: get-tag_name
         run: |
           echo "tag_name=${TAG_NAME}"
-          echo "tag_name=${TAG_NAME}" >>  $GITHUB_OUTPUT
+          echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
 
       - name: "Record FLINT version"
         id: get-version
@@ -88,7 +88,7 @@ jobs:
         run: dev/make_dist.sh ${FLINT_VERSION}
 
       - name: "Upload source archive as artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           name: flint
@@ -103,7 +103,7 @@ jobs:
       TAG_NAME: ${{ needs.version_and_tag.outputs.tag_name }}
     steps:
       - name: "Download archive from previous job"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: flint
 
@@ -162,7 +162,7 @@ jobs:
 
     steps:
       - name: "Download archive from previous job"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: flint
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,6 +206,37 @@ jobs:
         run: |
           gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/notes.md" --title "$SUBJECT" --target $GITHUB_SHA flint-${FLINT_VERSION}.{tar.gz,tar.xz,zip}
 
+      - if: env.TAG_NAME != 'nightly'
+        name: "Setup for PDF documentation"
+        run: |
+          sudo apt-get install -y python3-sphinx
+          sphinx-build --version
+
+      - if: env.TAG_NAME != 'nightly'
+        name: "Build PDF documentation"
+        uses: dante-ev/latex-action@latest
+        with:
+          root_file:
+          compiler:
+          args:
+          entrypoint: doc/entrypoint.sh
+
+      - if: env.TAG_NAME != 'nightly'
+        name: "Setup SSH key"
+        uses: shimataro/ssh-key-action@v2.7.0
+        with:
+          key: ${{ secrets.SSH_KEY }}
+          name: id_ed25519
+          known_hosts: ${{ secrets.KNOWN_HOSTS }}
+
+      - if: env.TAG_NAME != 'nightly'
+        name: "Upload to website"
+        run: |
+          # Push documentation and tarballs to server
+          mv doc/build/latex/flint.pdf flint-${FLINT_VERSION}.pdf
+          for ext in pdf tar.gz zip; do
+            scp flint-${FLINT_VERSION}.$ext wbhart@opal6.opalstack.com:~/apps/flintlib_org/download/
+          # Rebuild the website
+          ssh -t wbhart@opal6.opalstack.com 'cd ~/flintwebpage && python3 downloads.py ~/apps/flintlib_org && python3 build.py ~/apps/flintlib_org'
+
 # TODO: we could / should perhaps also test `make install` ?
-# TODO: also trigger a documentation build and upload the result?
-# TODO: if desired, we could e.g. also upload the archive to a server via scp

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    = -j=auto
 SPHINXBUILD   = sphinx-build
-SPHINXPROJ    = Flint
+SPHINXPROJ    = flint
 SOURCEDIR     = source
 BUILDDIR      = build
 

--- a/doc/source/bug_reporting.rst
+++ b/doc/source/bug_reporting.rst
@@ -12,7 +12,7 @@ email with your bug report to the FLINT devel list
 https://groups.google.com/group/flint-devel.
 
 
-If possible please include details of your system, how Flint was
+If possible please include details of your system, how FLINT was
 complied/installed, the versions of GMP and MPFR as well as precise details of
 how to replicate the bug.
 

--- a/doc/source/calcium.rst
+++ b/doc/source/calcium.rst
@@ -25,10 +25,10 @@ The Calcium modules use two kinds of predicate functions:
   decide). The return value is a :type:`truth_t` (``T_TRUE``,
   ``T_FALSE`` or ``T_UNKNOWN``).
 
-Flint, Arb and Antic extras
+FLINT, Arb and Antic extras
 -------------------------------------------------------------------------------
 
-Here we collect various utility methods for Flint, Arb and Antic
+Here we collect various utility methods for FLINT, Arb and Antic
 types that are missing in those libraries. Some of these functions
 may be migrated upstream in the future.
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -21,9 +21,9 @@ sys.path.append(os.path.abspath('../../src/python'))
 
 # -- Project information -----------------------------------------------------
 
-project = u'Flint'
-copyright = u'2009-2023, The Flint development team'
-author = u'The Flint development team'
+project = u'FLINT'
+copyright = u'2009-2025, The FLINT development team'
+author = u'The FLINT development team'
 
 # The full version, including alpha/beta/rc tags
 with open("../../VERSION") as f:
@@ -134,7 +134,7 @@ html_static_path = ['_static']
 # -- Options for HTMLHelp output ---------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'Flintdoc'
+htmlhelp_basename = 'flintdoc'
 
 
 # -- Options for LaTeX output ------------------------------------------------
@@ -164,8 +164,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'Flint.tex', u'Flint Documentation',
-     u'The Flint development team', 'manual'),
+    (master_doc, 'flint.tex', u'FLINT Documentation',
+     u'The FLINT development team', 'manual'),
 ]
 
 
@@ -174,7 +174,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'flint', u'Flint Documentation',
+    (master_doc, 'flint', u'FLINT Documentation',
      [author], 1)
 ]
 
@@ -185,8 +185,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'Flint', u'Flint Documentation',
-     author, 'Flint', 'One line description of project.',
+    (master_doc, 'FLINT', u'FLINT Documentation',
+     author, 'FLINT', 'One line description of project.',
      'Miscellaneous'),
 ]
 

--- a/doc/source/fexpr.rst
+++ b/doc/source/fexpr.rst
@@ -46,7 +46,7 @@ to a dedicated data structure (e.g. polynomials) internally
 and (optionally) convert the final result back to a symbolic expression.
 
 Symbolic expressions do not allow embedding arbitrary binary objects
-such as Flint/Arb/Antic/Calcium types as atoms.
+such as FLINT/Arb/Antic/Calcium types as atoms.
 This is done on purpose to make symbolic expressions easy to use
 as a data exchange format.
 To embed an object in an expression, one has the following options:

--- a/doc/source/flint.rst
+++ b/doc/source/flint.rst
@@ -179,7 +179,7 @@ Thread functions
 .. function:: int flint_get_num_threads(void)
 
     When called at the global level, this function returns one more than the
-    number of worker threads in the Flint thread pool, i.e. it returns the
+    number of worker threads in the FLINT thread pool, i.e. it returns the
     number of workers in the thread pool plus one for the master thread.
 
     In general, this function returns one more than the number of additional
@@ -194,7 +194,7 @@ Thread functions
     Restricts the number of worker threads that can be started by the current
     thread to ``num_workers``. This function can be called from any thread.
 
-    Assumes that the Flint thread pool is already set up.
+    Assumes that the FLINT thread pool is already set up.
 
     The function returns the old number of worker threads that can be started.
 

--- a/doc/source/fmpz.rst
+++ b/doc/source/fmpz.rst
@@ -182,7 +182,7 @@ Types, macros and constants
 
    This function is for internal use. The resulting ``fmpz`` will be backed by
    an ``mpz_t`` that can be passed to GMP, but the ``fmpz`` will be in an
-   inconsistent state with respect to the other Flint ``fmpz`` functions such as
+   inconsistent state with respect to the other FLINT ``fmpz`` functions such as
    ``fmpz_is_zero``, etc.
 
    **Note:** Requires that ``gmp.h`` has been included before any FLINT

--- a/doc/source/fmpz_mpoly_q.rst
+++ b/doc/source/fmpz_mpoly_q.rst
@@ -4,7 +4,7 @@
 ===============================================================================
 
 An :type:`fmpz_mpoly_q_t` represents an element of 
-`\mathbb{Q}(x_1,\ldots,x_n)` for fixed *n* as a pair of Flint 
+`\mathbb{Q}(x_1,\ldots,x_n)` for fixed *n* as a pair of FLINT 
 multivariate polynomials (:type:`fmpz_mpoly_t`).
 Instances are always kept in canonical form by ensuring that the GCD
 of numerator and denominator is 1 and that the coefficient

--- a/doc/source/fmpz_poly.rst
+++ b/doc/source/fmpz_poly.rst
@@ -151,7 +151,7 @@ Memory management
     This function sets the uninitialised polynomial ``trunc`` to the low
     `n` coefficients of ``poly``, or to ``poly`` if the latter doesn't
     have `n` coefficients. The polynomial ``trunc`` not be cleared or used
-    as the output of any Flint functions.
+    as the output of any FLINT functions.
 
 .. function:: void fmpz_poly_attach_shift(fmpz_poly_t trunc, const fmpz_poly_t poly, slong n)
 
@@ -159,7 +159,7 @@ Memory management
     high coefficients of ``poly``, i.e. the coefficients not among the low
     `n` coefficients of ``poly``. If the latter doesn't have `n`
     coefficients ``trunc`` is set to the zero polynomial. The polynomial
-    ``trunc`` not be cleared or used as the output of any Flint functions.
+    ``trunc`` not be cleared or used as the output of any FLINT functions.
 
 
 Polynomial parameters
@@ -2303,14 +2303,14 @@ Evaluation
 
     Evaluate ``(poly, n)`` at the double `d`. No attempt is made to do this
     efficiently or in a numerically stable way. It is currently only used in
-    Flint for quick and dirty evaluations of polynomials with all coefficients
+    FLINT for quick and dirty evaluations of polynomials with all coefficients
     positive.
 
 .. function:: double fmpz_poly_evaluate_horner_d(const fmpz_poly_t poly, double d)
 
     Evaluate ``poly`` at the double `d`. No attempt is made to do this
     efficiently or in a numerically stable way. It is currently only used in
-    Flint for quick and dirty evaluations of polynomials with all coefficients
+    FLINT for quick and dirty evaluations of polynomials with all coefficients
     positive.
 
 .. function:: double _fmpz_poly_evaluate_horner_d_2exp(slong * exp, const fmpz * poly, slong n, double d)
@@ -2318,7 +2318,7 @@ Evaluation
     Evaluate ``(poly, n)`` at the double `d`. Return the result as a double
     and an exponent ``exp`` combination. No attempt is made to do this
     efficiently or in a numerically stable way. It is currently only used in
-    Flint for quick and dirty evaluations of polynomials with all coefficients
+    FLINT for quick and dirty evaluations of polynomials with all coefficients
     positive.
 
 .. function:: double fmpz_poly_evaluate_horner_d_2exp(slong * exp, const fmpz_poly_t poly, double d)
@@ -2326,7 +2326,7 @@ Evaluation
     Evaluate ``poly`` at the double `d`. Return the result as a double
     and an exponent ``exp`` combination. No attempt is made to do this
     efficiently or in a numerically stable way. It is currently only used in
-    Flint for quick and dirty evaluations of polynomials with all coefficients
+    FLINT for quick and dirty evaluations of polynomials with all coefficients
     positive.
 
 .. function:: double _fmpz_poly_evaluate_horner_d_2exp2(slong * exp, const fmpz * poly, slong n, double d, slong dexp)
@@ -2334,7 +2334,7 @@ Evaluation
     Evaluate ``poly`` at ``d*2^dexp``. Return the result as a double
     and an exponent ``exp`` combination. No attempt is made to do this
     efficiently or in a numerically stable way. It is currently only used in
-    Flint for quick and dirty evaluations of polynomials with all coefficients
+    FLINT for quick and dirty evaluations of polynomials with all coefficients
     positive.
 
 

--- a/doc/source/gr_mat.rst
+++ b/doc/source/gr_mat.rst
@@ -29,9 +29,9 @@ Type compatibility
 -------------------------------------------------------------------------------
 
 The ``gr_mat`` type has the same data layout as most
-Flint, Arb and Calcium matrix types.
+FLINT, Arb and Calcium matrix types.
 Methods in this module can therefore be mixed freely with
-methods in the corresponding Flint, Arb and Calcium modules
+methods in the corresponding FLINT, Arb and Calcium modules
 when the underlying coefficient type is the same.
 
 It is not directly compatible with the ``nmod_mat`` type,

--- a/doc/source/history.rst
+++ b/doc/source/history.rst
@@ -789,7 +789,7 @@ List of removals
 -------------------------------------------------------------------------------
 
 * Fix a bug in generator of finite field in characteristic 2
-* Allow Flint to work with GMP 6.1.2 and 6.2.0 interchangeably
+* Allow FLINT to work with GMP 6.1.2 and 6.2.0 interchangeably
 * Fix some old license headers
 
 2020-07-31 -- FLINT 2.6.2
@@ -2344,7 +2344,7 @@ Calcium version history
   * Special functions: ca_erf, ca_erfi, ca_erfc, with algebraic relations.
   * Special functions: ca_gamma (incomplete simplification algorithms).
 
-* New utils_flint module for Flint utilities
+* New utils_flint module for FLINT utilities
 
   * Vectors of multivariate polynomials.
   * Construction of elementary symmetric polynomials.
@@ -2491,7 +2491,7 @@ Arb version history
 2021-07-25 -- Arb 2.20.0
 -------------------------------------------------------------------------------
 
-* Flint 2.8 support.
+* FLINT 2.8 support.
 * Change arb_get_str with ARB_STR_NO_RADIUS: [+/- 1.20e-15] now prints as 0e-14.
 * Uniformly distributed random number functions arf_urandom, arb_urandom
   (contributed by Albin Ahlbäck).
@@ -2542,7 +2542,7 @@ Arb version history
 
 * General
 
-  * Flint 2.6 support.
+  * FLINT 2.6 support.
   * Several build system improvements (contributed by Isuru Fernando).
   * Changed arf_get_mpfr to return an MPFR underflow/overflow result
     (rounding to 0 or infinity with the right sign and MPFR overflow flags)

--- a/doc/source/introduction.rst
+++ b/doc/source/introduction.rst
@@ -3,7 +3,7 @@
 **Introduction**
 ===============================================================================
 
-What is Flint?
+What is FLINT?
 -------------------------------------------------------------------------------
 
 FLINT is a C library of functions for doing basic arithmetic in support of
@@ -28,7 +28,7 @@ FLINT was rewritten as FLINT 2 by William Hart, Fredrik Johansson and
 Sebastian Pancratz. Many other substantial contributions have been made
 by other authors, e.g. Tom Bachmann, Mike Hansen, Daniel Schultz and Andy
 Novocin. There have been a great number of other contributors, listed on
-the main Flint website and the contributors section of this documentation.
+the main FLINT website and the contributors section of this documentation.
 
 Requirements
 -------------------------------------------------------------------------------
@@ -46,7 +46,7 @@ this support has been dropped.
 It is also required that the platform provide a ``uint64_t`` type if a
 native 64 bit type is not available. Full C99 compliance is not required.
 
-Structure of Flint
+Structure of FLINT
 -----------------------------------------------------------------------------
 
 FLINT is supplied as a set of modules, ``fmpz``, ``fmpz_poly``, etc.,

--- a/doc/source/introduction_calcium.rst
+++ b/doc/source/introduction_calcium.rst
@@ -149,7 +149,7 @@ will not be tied to a particular programming language
 ecosystem: C is uniquely easy to interface from
 almost any other language.
 The second most important reason is familiarity: Calcium follows
-the design of Flint and Arb
+the design of FLINT and Arb
 (coding style, naming, module layout, memory management,
 test code, etc.) which has proved to work quite well for
 libraries of this type.
@@ -159,7 +159,7 @@ benefit from
 optimizations that are natural in C such as in-place operations
 and fine-grained manual memory management. However, the performance
 aspect should not be overemphasized: Calcium will spend
-most of its time in Flint and Arb kernel functions
+most of its time in FLINT and Arb kernel functions
 and this would probably still be true even if it were written
 in a slower language.
 

--- a/doc/source/qqbar.rst
+++ b/doc/source/qqbar.rst
@@ -823,7 +823,7 @@ Symbolic expressions and conversion to radicals
       small factors from *c*. This is a tradeoff that provides pretty
       output in most cases while avoiding extreme worst-case slowdown.
       The smooth factorization guarantees finding all small factors
-      (up to some trial division limit determined internally by Flint),
+      (up to some trial division limit determined internally by FLINT),
       but large factors are only found heuristically.
 
 .. function:: int qqbar_set_fexpr(qqbar_t res, const fexpr_t expr)

--- a/doc/source/threading.rst
+++ b/doc/source/threading.rst
@@ -26,7 +26,7 @@ multivariate polynomial algorithms are threaded in FLINT.
 Writing threaded functions in FLINT
 -----------------------------------
 
-Flint uses a custom thread pool for threading. This involves creating a worker
+FLINT uses a custom thread pool for threading. This involves creating a worker
 function, requesting threads from the thread pool, starting the threads,
 waiting for them to finish, then giving the threads back to the pool. Simple
 examples of this include ``fmpz_mod_mat_mul_classical_threaded`` and
@@ -65,7 +65,7 @@ Note that if ``flint_get_num_threads()`` returns ``n`` then the number of worker
 can be started is ``n - 1`` (in addition to the thread the function is already
 running in). For this reason our documentation often distinguishes number of
 workers and number of threads. Please refer to the thread pool interface and
-Flint threading interface documentation to see the exact specification.
+FLINT threading interface documentation to see the exact specification.
 
 Functional parallel programming helpers
 ---------------------------------------


### PR DESCRIPTION
This should push PDF documentation and tarballs of new tags to our website, and rebuild the website.  Hence, new releases should automatically appear on the website.

@edgarcosta Perhaps you could look at `release.yml` and check if it looks okay?  I assume that `flint-${FLINT_VERSION}.$ext`, such as `flint-3.1.3.tar.gz` exists in the topdir at this stage.  I don't really understand if it is available at that stage or not, and I cannot really try this without triggering a new release, I think.