### PR TITLE
MSVC: support building as static library

### DIFF
--- a/CMake/cmake_config.h.in
+++ b/CMake/cmake_config.h.in
@@ -31,7 +31,9 @@
 #endif
 
 #ifdef _MSC_VER
-# if defined(FLINT_BUILD_DLL)
+# if defined(FLINT_STATIC_BUILD)
+#  define FLINT_DLL
+# elif defined(FLINT_BUILD_DLL)
 #  define FLINT_DLL __declspec(dllexport)
 # else
 #  define FLINT_DLL __declspec(dllimport)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,11 +423,15 @@ target_include_directories(flint PUBLIC
     ${PThreads_INCLUDE_DIRS}
 )
 
-if(BUILD_SHARED_LIBS AND MSVC)
-    # Export all functions automatically (except global data)
-    set_target_properties(flint PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
-    # Export flint's global data that are marked manually
-    target_compile_definitions(flint PRIVATE "FLINT_BUILD_DLL")
+if(MSVC)
+    if (BUILD_SHARED_LIBS)
+        # Export all functions automatically (except global data)
+        set_target_properties(flint PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+        # Export flint's global data that are marked manually
+        target_compile_definitions(flint PRIVATE "FLINT_BUILD_DLL")
+    else()
+        target_compile_definitions(flint PUBLIC "FLINT_STATIC_BUILD")
+    endif()
 endif()
 
 if (HAS_FLAG_MPOPCNT)


### PR DESCRIPTION
Adds support for building flint as a static library using cmake.

Workaround for https://github.com/flintlib/flint/issues/2164 and might be the preferred option anyway in certain settings.