### PR TITLE
Port some modular composition methods to generics

### DIFF
--- a/doc/source/gr_poly.rst
+++ b/doc/source/gr_poly.rst
@@ -300,6 +300,56 @@ Division with remainder
 
     Versions of the *divrem* functions which output only the remainder.
 
+Division with remainder with full precomputed inverse
+--------------------------------------------------------------------------------
+
+.. function:: int _gr_poly_div_newton_n_preinv(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr FLINT_UNUSED(B), slong lenB, gr_srcptr Binv, slong lenBinv, gr_ctx_t ctx)
+
+    Notionally computes polynomials `Q` and `R` such that `A = BQ + R` with
+    `\operatorname{len}(R)` less than ``lenB``, where ``A`` is of length ``lenA``
+    and ``B`` is of length ``lenB``, but return only `Q`.
+
+    We require that `Q` have space for ``lenA - lenB + 1`` coefficients
+    and assume that the leading coefficient of `B` is a unit. Furthermore, we
+    assume that `Binv` is the inverse of the reverse of `B` mod `x^{\operatorname{len}(B)}`.
+
+    The algorithm used is to reverse the polynomials and divide the
+    resulting power series, then reverse the result.
+
+.. function:: int gr_poly_div_newton_n_preinv(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, const gr_poly_t Binv, gr_ctx_t ctx)
+
+    Notionally computes `Q` and `R` such that `A = BQ + R` with
+    `\operatorname{len}(R) < \operatorname{len}(B)`, but returns only `Q`.
+
+    We assume that the leading coefficient of `B` is a unit and that `Binv` is
+    the inverse of the reverse of `B` mod `x^{\operatorname{len}(B)}`.
+
+    It is required that the length of `A` is less than or equal to
+    2*the length of `B` - 2.
+
+    The algorithm used is to reverse the polynomials and divide the
+    resulting power series, then reverse the result.
+
+.. function:: int _gr_poly_divrem_newton_n_preinv(gr_ptr Q, gr_ptr R, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_srcptr Binv, slong lenBinv, gr_ctx_t ctx)
+
+    Computes `Q` and `R` such that `A = BQ + R` with `\operatorname{len}(R)` less
+    than ``lenB``, where `A` is of length ``lenA`` and `B` is of
+    length ``lenB``. We require that `Q` have space for
+    ``lenA - lenB + 1`` coefficients. Furthermore, we assume that `Binv` is
+    the inverse of the reverse of `B` mod `x^{\operatorname{len}(B)}`. The algorithm
+    used is to call :func:`_gr_poly_div_newton_n_preinv` and then multiply out
+    and compute the remainder.
+
+.. function:: int gr_poly_divrem_newton_n_preinv(gr_poly_t Q, gr_poly_t R, const gr_poly_t A, const gr_poly_t B, const gr_poly_t Binv, gr_ctx_t ctx)
+
+    Computes `Q` and `R` such that `A = BQ + R` with `\operatorname{len}(R) <
+    \operatorname{len}(B)`.  We assume `Binv` is the inverse of the reverse of `B`
+    mod `x^{\operatorname{len}(B)}`.
+
+    It is required (not checked) that the length of `A` is less than or equal to
+    2*the length of `B` - 2.
+
+
 Power series division
 --------------------------------------------------------------------------------
 
@@ -786,6 +836,111 @@ Power series special functions
               int gr_poly_tan_series_newton(gr_poly_t f, const gr_poly_t h, slong n, slong cutoff, gr_ctx_t ctx)
               int _gr_poly_tan_series(gr_ptr f, gr_srcptr h, slong hlen, slong n, gr_ctx_t ctx)
               int gr_poly_tan_series(gr_poly_t f, const gr_poly_t h, slong n, gr_ctx_t ctx)
+
+Modular arithmetic and composition
+--------------------------------------------------------------------------------
+
+.. function:: int _gr_poly_mulmod(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_srcptr f, slong lenf, gr_ctx_t ctx)
+
+    Sets ``res`` to the remainder of the product of ``poly1``
+    and ``poly2`` upon polynomial division by ``f``.
+
+    It is required that ``len1 + len2 - lenf > 0``, which is
+    equivalent to requiring that the result will actually be
+    reduced. Otherwise, simply use ``_fq_poly_mul`` instead.
+
+    Aliasing of ``f`` and ``res`` is not permitted.
+
+.. function:: int gr_poly_mulmod(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, const gr_poly_t f, gr_ctx_t ctx)
+
+    Sets ``res`` to the remainder of the product of ``poly1``
+    and ``poly2`` upon polynomial division by ``f``.
+
+.. function:: int _gr_poly_mulmod_preinv(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_srcptr f, slong lenf, gr_srcptr finv, slong lenfinv, gr_ctx_t ctx)
+
+    Sets ``res`` to the remainder of the product of ``poly1``
+    and ``poly2`` upon polynomial division by ``f``.
+
+    It is required that ``finv`` is the inverse of the reverse of
+    ``f`` mod ``x^lenf``.
+
+    Aliasing of ``res`` with any of the inputs is not permitted.
+
+.. function:: int gr_poly_mulmod_preinv(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, const gr_poly_t f, const gr_poly_t finv, gr_ctx_t ctx)
+
+    Sets ``res`` to the remainder of the product of ``poly1``
+    and ``poly2`` upon polynomial division by ``f``. ``finv``
+    is the inverse of the reverse of ``f``.
+
+.. function:: int _gr_poly_compose_mod_horner(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, gr_srcptr poly3, slong len3, gr_ctx_t ctx)
+              int gr_poly_compose_mod_horner(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, const gr_poly_t poly3, gr_ctx_t ctx)
+              int _gr_poly_compose_mod_brent_kung(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, gr_srcptr poly3, slong len3, gr_ctx_t ctx)
+              int gr_poly_compose_mod_brent_kung(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, const gr_poly_t poly3, gr_ctx_t ctx)
+              int _gr_poly_compose_mod(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, gr_srcptr poly3, slong len3, gr_ctx_t ctx)
+              int gr_poly_compose_mod(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, const gr_poly_t poly3, gr_ctx_t ctx)
+
+    Sets ``res`` to the composition `f(g)` modulo `h` where *f*, *g*
+    and *h* are given by *poly1*, *poly2* and *poly3*.
+
+    The underscore methods require that the lengths are nonzero
+    and that the length of `g` is one less than the length of `h` (possibly
+    with zero padding). We also require that the length of `f` is less than
+    the length of `h`. The underscore methods do not support aliasing.
+
+.. function:: int _gr_poly_compose_mod_horner_preinv(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, gr_srcptr poly3, slong len3, gr_srcptr poly3inv, slong inv3len, gr_ctx_t ctx)
+              int gr_poly_compose_mod_horner_preinv(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, const gr_poly_t poly3, const gr_poly_t poly3inv, gr_ctx_t ctx)
+              int _gr_poly_compose_mod_brent_kung_preinv(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, gr_srcptr poly3, slong len3, gr_srcptr poly3inv, slong inv3len, gr_ctx_t ctx)
+              int gr_poly_compose_mod_brent_kung_preinv(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, const gr_poly_t poly3, const gr_poly_t poly3inv, gr_ctx_t ctx)
+              int _gr_poly_compose_mod_preinv(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, gr_srcptr poly3, slong len3, gr_srcptr poly3inv, slong inv3len, gr_ctx_t ctx)
+              int gr_poly_compose_mod_preinv(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, const gr_poly_t poly3, const gr_poly_t poly3inv, gr_ctx_t ctx)
+
+    Versions accepting an additional precomputed argument ``poly3inv``
+    representing the inverse of the reverse of ``poly3``.
+
+.. function:: int _gr_poly_reduce_matrix_mod_poly(gr_mat_t A, const gr_mat_t B, const gr_poly_t f, gr_ctx_t ctx)
+
+    Sets the ith row of ``A`` to the reduction of the ith row of `B` modulo
+    `f` for `i=1,\ldots,\sqrt{\deg(f)}`. We require `B` to be at least
+    a `\sqrt{\deg(f)}\times \deg(f)` matrix and `f` to be nonzero.
+
+.. function:: int _gr_poly_precompute_matrix(gr_mat_t A, gr_srcptr f, gr_srcptr g, slong leng, gr_srcptr ginv, slong lenginv, gr_ctx_t ctx)
+
+    Sets the ith row of ``A`` to `f^i` modulo `g` for
+    `i=1,\ldots,\sqrt{\deg(g)}`. We require `A` to be a
+    `\sqrt{\deg(g)}\times \deg(g)` matrix. We require ``ginv`` to
+    be the inverse of the reverse of ``g`` and `g` to be nonzero.
+
+.. function:: int gr_poly_precompute_matrix(gr_mat_t A, const gr_poly_t f, const gr_poly_t g, const gr_poly_t ginv, gr_ctx_t ctx)
+
+    Sets the ith row of ``A`` to `f^i` modulo `g` for
+    `i=1,\ldots,\sqrt{\deg(g)}`. We require `A` to be a
+    `\sqrt{\deg(g)}\times \deg(g)` matrix. We require ``ginv`` to
+    be the inverse of the reverse of ``g``.
+
+.. function:: int _gr_poly_compose_mod_brent_kung_precomp_preinv(gr_ptr res, gr_srcptr f, slong lenf, const gr_mat_t A, gr_srcptr h, slong lenh, gr_srcptr hinv, slong lenhinv, gr_ctx_t ctx)
+
+    Sets ``res`` to the composition `f(g)` modulo `h`. We require
+    that `h` is nonzero. We require that the ith row of `A` contains
+    `g^i` for `i=1,\ldots,\sqrt{\deg(h)}`, i.e. `A` is a
+    `\sqrt{\deg(h)}\times \deg(h)` matrix. We also require that the
+    length of `f` is less than the length of `h`. Furthermore, we
+    require ``hinv`` to be the inverse of the reverse of ``h``.
+    The output is not allowed to be aliased with any of the inputs.
+
+    The algorithm used is the Brent-Kung matrix algorithm.
+
+.. function:: int gr_poly_compose_mod_brent_kung_precomp_preinv(gr_poly_t res, const gr_poly_t f, const gr_mat_t A, const gr_poly_t h, const gr_poly_t hinv, gr_ctx_t ctx)
+
+    Sets ``res`` to the composition `f(g)` modulo `h`. We require
+    that the ith row of `A` contains `g^i` for
+    `i=1,\ldots,\sqrt{\deg(h)}`, i.e. `A` is a `\sqrt{\deg(h)}\times
+    \deg(h)` matrix. We require that `h` is nonzero and that `f` has
+    smaller degree than `h`. Furthermore, we require ``hinv`` to be
+    the inverse of the reverse of ``h``. This version of Brent-Kung
+    modular composition is particularly useful if one has to perform
+    several modular composition of the form `f(g)` modulo `h` for
+    fixed `g` and `h`.
+
 
 Test functions
 -------------------------------------------------------------------------------

--- a/src/fmpz_mod_poly/compose_mod.c
+++ b/src/fmpz_mod_poly/compose_mod.c
@@ -10,84 +10,28 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "fmpz.h"
-#include "fmpz_vec.h"
-#include "fmpz_mod.h"
+#include "gr.h"
+#include "gr_poly.h"
 #include "fmpz_mod_poly.h"
 
 void
-_fmpz_mod_poly_compose_mod(fmpz * res, const fmpz * f, slong lenf, const fmpz * g,
-                                       const fmpz * h, slong lenh, const fmpz_mod_ctx_t ctx)
+_fmpz_mod_poly_compose_mod(fmpz * res, const fmpz * poly1, slong len1,
+                              const fmpz * poly2, const fmpz * poly3, slong len3,
+                                                                    const fmpz_mod_ctx_t ctx)
 {
-    if (lenh < 12 || lenf >= lenh)
-        _fmpz_mod_poly_compose_mod_horner(res, f, lenf, g, h, lenh, ctx);
-    else
-        _fmpz_mod_poly_compose_mod_brent_kung(res, f, lenf, g, h, lenh, ctx);
+    gr_ctx_t gr_ctx;
+    _gr_ctx_init_fmpz_mod_from_ref(gr_ctx, ctx);
+    GR_MUST_SUCCEED(_gr_poly_compose_mod(res, poly1, len1, poly2, poly3, len3, gr_ctx));
 }
 
-void
-fmpz_mod_poly_compose_mod(fmpz_mod_poly_t res, const fmpz_mod_poly_t poly1,
-                  const fmpz_mod_poly_t poly2, const fmpz_mod_poly_t poly3,
-                                                      const fmpz_mod_ctx_t ctx)
+void fmpz_mod_poly_compose_mod(fmpz_mod_poly_t res,
+                     const fmpz_mod_poly_t poly1, const fmpz_mod_poly_t poly2,
+                         const fmpz_mod_poly_t poly3, const fmpz_mod_ctx_t ctx)
 {
-    fmpz_t inv3;
-    slong len1 = poly1->length;
-    slong len2 = poly2->length;
-    slong len3 = poly3->length;
-    slong len = len3 - 1;
-    slong vec_len = FLINT_MAX(len3 - 1, len2);
-
-    fmpz * ptr2;
-
-    if (len3 == 0)
-    {
-        flint_throw(FLINT_ERROR, "(fmpz_mod_poly_compose_mod):"
-                "Division by zero.\n");
-    }
-
-    if (len1 == 0 || len3 == 1)
-    {
-        fmpz_mod_poly_zero(res, ctx);
-        return;
-    }
-
-    if (len1 == 1)
-    {
-        fmpz_mod_poly_set(res, poly1, ctx);
-        return;
-    }
-
-    if (res == poly3 || res == poly1)
-    {
-        fmpz_mod_poly_t tmp;
-        fmpz_mod_poly_init(tmp, ctx);
-        fmpz_mod_poly_compose_mod(tmp, poly1, poly2, poly3, ctx);
-        fmpz_mod_poly_swap(tmp, res, ctx);
-        fmpz_mod_poly_clear(tmp, ctx);
-        return;
-    }
-
-    ptr2 = _fmpz_vec_init(vec_len);
-
-    if (len2 <= len)
-    {
-        _fmpz_vec_set(ptr2, poly2->coeffs, len2);
-        _fmpz_vec_zero(ptr2 + len2, len - len2);
-    }
-    else
-    {
-        fmpz_init(inv3);
-        fmpz_invmod(inv3, poly3->coeffs + len, fmpz_mod_ctx_modulus(ctx));
-        _fmpz_mod_poly_rem(ptr2, poly2->coeffs, len2,
-                         poly3->coeffs, len3, inv3, ctx);
-        fmpz_clear(inv3);
-    }
-
-    fmpz_mod_poly_fit_length(res, len, ctx);
-    _fmpz_mod_poly_compose_mod(res->coeffs, poly1->coeffs, len1,
-                         ptr2, poly3->coeffs, len3, ctx);
-    _fmpz_mod_poly_set_length(res, len);
-    _fmpz_mod_poly_normalise(res);
-
-    _fmpz_vec_clear(ptr2, vec_len);
+    gr_ctx_t gr_ctx;
+    _gr_ctx_init_fmpz_mod_from_ref(gr_ctx, ctx);
+    GR_MUST_SUCCEED(gr_poly_compose_mod((gr_poly_struct *) res,
+        (const gr_poly_struct *) poly1,
+        (const gr_poly_struct *) poly2,
+        (const gr_poly_struct *) poly3, gr_ctx));
 }

--- a/src/fmpz_mod_poly/compose_mod_brent_kung.c
+++ b/src/fmpz_mod_poly/compose_mod_brent_kung.c
@@ -10,13 +10,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "ulong_extras.h"
-#include "fmpz.h"
-#include "fmpz_vec.h"
-#include "fmpz_mat.h"
-#include "fmpz_mod.h"
-#include "fmpz_mod_vec.h"
-#include "fmpz_mod_mat.h"
+#include "gr.h"
+#include "gr_poly.h"
 #include "fmpz_mod_poly.h"
 
 void
@@ -24,140 +19,19 @@ _fmpz_mod_poly_compose_mod_brent_kung(fmpz * res, const fmpz * poly1, slong len1
                               const fmpz * poly2, const fmpz * poly3, slong len3,
                                                                     const fmpz_mod_ctx_t ctx)
 {
-    fmpz_mod_mat_t A, B, C;
-    fmpz * t, * h, * tmp;
-    slong i, n, m;
-
-    n = len3 - 1;
-
-    if (len3 == 1)
-        return;
-
-    if (len1 == 1)
-    {
-        fmpz_set(res, poly1);
-        return;
-    }
-
-    if (len3 == 2)
-    {
-        _fmpz_mod_poly_evaluate_fmpz(res, poly1, len1, poly2, ctx);
-        return;
-    }
-
-    m = n_sqrt(n) + 1;
-
-    fmpz_mod_mat_init(A, m, n, ctx);
-    fmpz_mod_mat_init(B, m, m, ctx);
-    fmpz_mod_mat_init(C, m, n, ctx);
-
-    h = _fmpz_vec_init(2 * n - 1);
-    t = _fmpz_vec_init(2 * n - 1);
-
-    /* Set rows of B to the segments of poly1 */
-    for (i = 0; i < len1 / m; i++)
-        _fmpz_vec_set(fmpz_mod_mat_row(B, i), poly1 + i * m, m);
-
-    _fmpz_vec_set(fmpz_mod_mat_row(B, i), poly1 + i * m, len1 % m);
-
-    /* Set rows of A to powers of poly2 */
-    fmpz_one(fmpz_mod_mat_row(A, 0));
-    _fmpz_vec_set(fmpz_mod_mat_row(A, 1), poly2, n);
-    tmp = _fmpz_vec_init(2 * n - 1);
-    for (i = 2; i < m; i++)
-    {
-        _fmpz_mod_poly_mulmod(tmp, fmpz_mod_mat_row(A, i - 1), n, poly2, n, poly3, len3, ctx);
-        _fmpz_vec_set(fmpz_mod_mat_row(A, i), tmp, n);
-    }
-    _fmpz_vec_clear(tmp, 2 * n - 1);
-
-    fmpz_mod_mat_mul(C, B, A, ctx);
-
-    /* Evaluate block composition using the Horner scheme */
-    _fmpz_vec_set(res, fmpz_mod_mat_row(C, m - 1), n);
-    _fmpz_mod_poly_mulmod(h, fmpz_mod_mat_row(A, m - 1), n, poly2, n, poly3, len3, ctx);
-
-    for (i = m - 2; i >= 0; i--)
-    {
-        _fmpz_mod_poly_mulmod(t, res, n, h, n, poly3, len3, ctx);
-        _fmpz_mod_poly_add(res, t, n, fmpz_mod_mat_row(C, i), n, ctx);
-    }
-
-    _fmpz_vec_clear(h, 2 * n - 1);
-    _fmpz_vec_clear(t, 2 * n - 1);
-
-    fmpz_mod_mat_clear(A, ctx);
-    fmpz_mod_mat_clear(B, ctx);
-    fmpz_mod_mat_clear(C, ctx);
+    gr_ctx_t gr_ctx;
+    _gr_ctx_init_fmpz_mod_from_ref(gr_ctx, ctx);
+    GR_MUST_SUCCEED(_gr_poly_compose_mod_brent_kung(res, poly1, len1, poly2, poly3, len3, gr_ctx));
 }
 
 void fmpz_mod_poly_compose_mod_brent_kung(fmpz_mod_poly_t res,
                      const fmpz_mod_poly_t poly1, const fmpz_mod_poly_t poly2,
                          const fmpz_mod_poly_t poly3, const fmpz_mod_ctx_t ctx)
 {
-    slong len1 = poly1->length;
-    slong len2 = poly2->length;
-    slong len3 = poly3->length;
-    slong len = len3 - 1;
-    slong vec_len = FLINT_MAX(len3 - 1, len2);
-
-    fmpz * ptr2;
-    fmpz_t inv3;
-
-    if (len3 == 0)
-    {
-        flint_throw(FLINT_ERROR, "(fmpz_mod_poly_compose_mod_brent_kung): Division by zero\n");
-    }
-
-    if (len1 >= len3)
-    {
-        flint_throw(FLINT_ERROR, "(fmpz_mod_poly_compose_mod_brent_kung): "
-                "The degree of the first polynomial must be smaller than that of the modulus\n");
-    }
-
-    if (len1 == 0 || len3 == 1)
-    {
-        fmpz_mod_poly_zero(res, ctx);
-        return;
-    }
-
-    if (len1 == 1)
-    {
-        fmpz_mod_poly_set(res, poly1, ctx);
-        return;
-    }
-
-    if (res == poly3 || res == poly1)
-    {
-        fmpz_mod_poly_t tmp;
-        fmpz_mod_poly_init(tmp, ctx);
-        fmpz_mod_poly_compose_mod_brent_kung(tmp, poly1, poly2, poly3, ctx);
-        fmpz_mod_poly_swap(tmp, res, ctx);
-        fmpz_mod_poly_clear(tmp, ctx);
-        return;
-    }
-
-    ptr2 = _fmpz_vec_init(vec_len);
-
-    if (len2 <= len)
-    {
-        _fmpz_vec_set(ptr2, poly2->coeffs, len2);
-        _fmpz_vec_zero(ptr2 + len2, vec_len - len2);
-    }
-    else
-    {
-        fmpz_init(inv3);
-        fmpz_invmod(inv3, poly3->coeffs + len, fmpz_mod_ctx_modulus(ctx));
-        _fmpz_mod_poly_rem(ptr2, poly2->coeffs, len2,
-                         poly3->coeffs, len3, inv3, ctx);
-        fmpz_clear(inv3);
-    }
-
-    fmpz_mod_poly_fit_length(res, len, ctx);
-    _fmpz_mod_poly_compose_mod_brent_kung(res->coeffs, poly1->coeffs, len1,
-                         ptr2, poly3->coeffs, len3, ctx);
-    _fmpz_mod_poly_set_length(res, len);
-    _fmpz_mod_poly_normalise(res);
-
-    _fmpz_vec_clear(ptr2, vec_len);
+    gr_ctx_t gr_ctx;
+    _gr_ctx_init_fmpz_mod_from_ref(gr_ctx, ctx);
+    GR_MUST_SUCCEED(gr_poly_compose_mod_brent_kung((gr_poly_struct *) res,
+        (const gr_poly_struct *) poly1,
+        (const gr_poly_struct *) poly2,
+        (const gr_poly_struct *) poly3, gr_ctx));
 }

--- a/src/fmpz_mod_poly/compose_mod_brent_kung_precomp_preinv.c
+++ b/src/fmpz_mod_poly/compose_mod_brent_kung_precomp_preinv.c
@@ -59,7 +59,7 @@ _fmpz_mod_poly_compose_mod_brent_kung_precomp_preinv(fmpz * res,
     _gr_ctx_init_fmpz_mod_from_ref(gr_ctx, ctx);
     GR_MUST_SUCCEED(_gr_poly_compose_mod_brent_kung_precomp_preinv(res,
         poly1, len1, (gr_mat_struct *) A, poly3, len3,
-        poly3, len3inv, gr_ctx));
+        poly3inv, len3inv, gr_ctx));
 }
 
 void fmpz_mod_poly_compose_mod_brent_kung_precomp_preinv(fmpz_mod_poly_t res,

--- a/src/fmpz_mod_poly/compose_mod_brent_kung_precomp_preinv.c
+++ b/src/fmpz_mod_poly/compose_mod_brent_kung_precomp_preinv.c
@@ -12,43 +12,18 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "ulong_extras.h"
-#include "fmpz.h"
-#include "fmpz_vec.h"
-#include "fmpz_mat.h"
-#include "fmpz_mod.h"
-#include "fmpz_mod_vec.h"
-#include "fmpz_mod_mat.h"
+#include "gr.h"
+#include "gr_poly.h"
 #include "fmpz_mod_poly.h"
 
 void
 _fmpz_mod_poly_reduce_matrix_mod_poly(fmpz_mat_t A, const fmpz_mat_t B,
                             const fmpz_mod_poly_t f, const fmpz_mod_ctx_t ctx)
 {
-    fmpz * tmp1, *tmp2;
-    slong n = f->length - 1;
-    slong i, m = n_sqrt(n) + 1;
-
-    fmpz_t invf;
-    fmpz_init(invf);
-    fmpz_invmod(invf, f->coeffs + n, fmpz_mod_ctx_modulus(ctx));
-
-    fmpz_mat_init(A, m, n);
-
-    tmp1 = _fmpz_vec_init(2 * (B->c) - n);
-    tmp2 = tmp1 + (B->c - n);
-
-    fmpz_one(fmpz_mat_entry(A, 0, 0));
-
-    for (i= 1; i < m; i++)
-    {
-        _fmpz_mod_poly_divrem(tmp1, tmp2, fmpz_mod_mat_row(B, i), B->c, f->coeffs,
-                                   f->length, invf, ctx);
-        _fmpz_vec_set(fmpz_mat_row(A, i), tmp2, n);
-    }
-
-    _fmpz_vec_clear(tmp1, 2*(B->c) - n);
-    fmpz_clear(invf);
+    gr_ctx_t gr_ctx;
+    _gr_ctx_init_fmpz_mod_from_ref(gr_ctx, ctx);
+    GR_MUST_SUCCEED(_gr_poly_reduce_matrix_mod_poly((gr_mat_struct *) A,
+        (const gr_mat_struct *) B, (const gr_poly_struct *) f, gr_ctx));
 }
 
 void
@@ -56,23 +31,10 @@ _fmpz_mod_poly_precompute_matrix(fmpz_mat_t A, const fmpz * poly1,
                           const fmpz * poly2, slong len2, const fmpz * poly2inv,
                           slong len2inv, const fmpz_mod_ctx_t ctx)
 {
-    /* Set rows of A to powers of poly1 */
-    slong n, m;
-    fmpz ** Arows;
-
-    n = len2 - 1;
-
-    m = n_sqrt(n) + 1;
-
-    slong i;
-    Arows = flint_malloc(sizeof(fmpz *) * A->r);
-    for (i = 0; i < A->r; i++)
-        Arows[i] = fmpz_mat_row(A, i);
-
-    _fmpz_mod_poly_powers_mod_preinv_naive(Arows, poly1, n, m,
-                                            poly2, len2, poly2inv, len2inv, ctx);
-
-    flint_free(Arows);
+    gr_ctx_t gr_ctx;
+    _gr_ctx_init_fmpz_mod_from_ref(gr_ctx, ctx);
+    GR_MUST_SUCCEED(_gr_poly_precompute_matrix((gr_mat_struct *) A,
+        poly1, poly2, len2, poly2inv, len2inv, gr_ctx));
 }
 
 void
@@ -80,52 +42,12 @@ fmpz_mod_poly_precompute_matrix(fmpz_mat_t A, const fmpz_mod_poly_t poly1,
                   const fmpz_mod_poly_t poly2, const fmpz_mod_poly_t poly2inv,
                                                       const fmpz_mod_ctx_t ctx)
 {
-    slong len1 = poly1->length;
-    slong len2 = poly2->length;
-    slong len = len2 - 1;
-    slong vec_len = FLINT_MAX(len2 - 1, len1);
-    slong m = n_sqrt(len) + 1;
-
-    fmpz * ptr;
-    fmpz_t inv2;
-
-    if (len2 == 0)
-    {
-        flint_throw(FLINT_ERROR, "(fmpz_mod_poly_precompute_matrix): Division by zero.\n");
-    }
-
-    if (A->r != m || A->c != len)
-    {
-        flint_throw(FLINT_ERROR, "(fmpz_mod_poly_precompute_matrix): Wrong dimensions.\n");
-    }
-
-    if (len2 == 1)
-    {
-        fmpz_mat_zero(A);
-
-        return;
-    }
-
-    ptr = _fmpz_vec_init(vec_len);
-
-    if (len1 <= len)
-    {
-        _fmpz_vec_set(ptr, poly1->coeffs, len1);
-        _fmpz_vec_zero(ptr + len1, vec_len - len1);
-    }
-    else
-    {
-        fmpz_init(inv2);
-        fmpz_invmod(inv2, poly2->coeffs + len, fmpz_mod_ctx_modulus(ctx));
-        _fmpz_mod_poly_rem(ptr, poly1->coeffs, len1,
-                         poly2->coeffs, len2, inv2, ctx);
-        fmpz_clear(inv2);
-    }
-
-    _fmpz_mod_poly_precompute_matrix (A, ptr, poly2->coeffs, len2,
-                poly2inv->coeffs, poly2inv->length, ctx);
-
-    _fmpz_vec_clear(ptr, vec_len);
+    gr_ctx_t gr_ctx;
+    _gr_ctx_init_fmpz_mod_from_ref(gr_ctx, ctx);
+    GR_MUST_SUCCEED(gr_poly_precompute_matrix((gr_mat_struct *) A,
+        (const gr_poly_struct *) poly1,
+        (const gr_poly_struct *) poly2,
+        (const gr_poly_struct *) poly2inv, gr_ctx));
 }
 
 void
@@ -133,61 +55,11 @@ _fmpz_mod_poly_compose_mod_brent_kung_precomp_preinv(fmpz * res,
          const fmpz * poly1, slong len1, const fmpz_mat_t A, const fmpz * poly3,
          slong len3, const fmpz * poly3inv, slong len3inv, const fmpz_mod_ctx_t ctx)
 {
-    fmpz_mod_mat_t B, C;
-    fmpz * t, * h;
-    slong i, n, m;
-
-    n = len3 - 1;
-
-    if (len3 == 1)
-        return;
-
-    if (len1 == 1)
-    {
-        fmpz_set(res, poly1);
-
-        return;
-    }
-
-    if (len3 == 2)
-    {
-        _fmpz_mod_poly_evaluate_fmpz(res, poly1, len1, fmpz_mod_mat_row(A, 1), ctx);
-        return;
-    }
-
-    m = n_sqrt(n) + 1;
-
-    fmpz_mod_mat_init(B, m, m, ctx);
-    fmpz_mod_mat_init(C, m, n, ctx);
-
-    h = _fmpz_vec_init(n);
-    t = _fmpz_vec_init(n);
-
-    /* Set rows of B to the segments of poly1 */
-    for (i = 0; i < len1 / m; i++)
-        _fmpz_vec_set(fmpz_mod_mat_row(B, i), poly1 + i * m, m);
-
-    _fmpz_vec_set(fmpz_mod_mat_row(B, i), poly1 + i * m, len1 % m);
-
-    fmpz_mod_mat_mul(C, B, A, ctx);
-
-    /* Evaluate block composition using the Horner scheme */
-    _fmpz_vec_set(res, fmpz_mod_mat_row(C, m - 1), n);
-    _fmpz_mod_poly_mulmod_preinv(h, fmpz_mod_mat_row(A, m - 1), n, fmpz_mod_mat_row(A, 1), n, poly3,
-                                 len3, poly3inv, len3inv, ctx);
-
-    for (i = m - 2; i >= 0; i--)
-    {
-        _fmpz_mod_poly_mulmod_preinv(t, res, n, h, n, poly3, len3,
-                                     poly3inv, len3inv, ctx);
-        _fmpz_mod_poly_add(res, t, n, fmpz_mod_mat_row(C, i), n, ctx);
-    }
-
-    _fmpz_vec_clear(h, n);
-    _fmpz_vec_clear(t, n);
-
-    fmpz_mod_mat_clear(B, ctx);
-    fmpz_mod_mat_clear(C, ctx);
+    gr_ctx_t gr_ctx;
+    _gr_ctx_init_fmpz_mod_from_ref(gr_ctx, ctx);
+    GR_MUST_SUCCEED(_gr_poly_compose_mod_brent_kung_precomp_preinv(res,
+        poly1, len1, (gr_mat_struct *) A, poly3, len3,
+        poly3, len3inv, gr_ctx));
 }
 
 void fmpz_mod_poly_compose_mod_brent_kung_precomp_preinv(fmpz_mod_poly_t res,
@@ -195,56 +67,12 @@ void fmpz_mod_poly_compose_mod_brent_kung_precomp_preinv(fmpz_mod_poly_t res,
                   const fmpz_mod_poly_t poly3, const fmpz_mod_poly_t poly3inv,
                                                       const fmpz_mod_ctx_t ctx)
 {
-    slong len1 = poly1->length;
-    slong len3 = poly3->length;
-    slong len = len3 - 1;
-
-    if (len3 == 0)
-    {
-        flint_throw(FLINT_ERROR, "(fmpz_mod_poly_compose_mod_brent_kung_precomp_preinv): "
-                     "Division by zero\n");
-    }
-
-    if (len1 >= len3)
-    {
-        flint_throw(FLINT_ERROR, "(fmpz_mod_poly_compose_mod_brent_kung_precomp_preinv): "
-               "The degree of the first polynomial must be smaller than that of the modulus\n");
-    }
-
-    if (len1 == 0 || len3 == 1)
-    {
-        fmpz_mod_poly_zero(res, ctx);
-
-        return;
-    }
-
-    if (len1 == 1)
-    {
-        fmpz_mod_poly_set(res, poly1, ctx);
-
-        return;
-    }
-
-    if (res == poly3 || res == poly1 || res == poly3inv)
-    {
-        fmpz_mod_poly_t tmp;
-
-        fmpz_mod_poly_init(tmp, ctx);
-
-        fmpz_mod_poly_compose_mod_brent_kung_precomp_preinv(tmp, poly1, A,
-                                                         poly3, poly3inv, ctx);
-        fmpz_mod_poly_swap(tmp, res, ctx);
-        fmpz_mod_poly_clear(tmp, ctx);
-
-        return;
-    }
-
-    fmpz_mod_poly_fit_length(res, len, ctx);
-
-    _fmpz_mod_poly_compose_mod_brent_kung_precomp_preinv(res->coeffs,
-             poly1->coeffs, len1, A, poly3->coeffs, len3,
-             poly3inv->coeffs, poly3inv->length, ctx);
-
-    _fmpz_mod_poly_set_length(res, len);
-    _fmpz_mod_poly_normalise(res);
+    gr_ctx_t gr_ctx;
+    _gr_ctx_init_fmpz_mod_from_ref(gr_ctx, ctx);
+    GR_MUST_SUCCEED(gr_poly_compose_mod_brent_kung_precomp_preinv(
+        (gr_poly_struct *) res,
+        (const gr_poly_struct *) poly1,
+        (const gr_mat_struct *) A,
+        (const gr_poly_struct *) poly3,
+        (const gr_poly_struct *) poly3inv, gr_ctx));
 }

--- a/src/fmpz_mod_poly/compose_mod_brent_kung_preinv.c
+++ b/src/fmpz_mod_poly/compose_mod_brent_kung_preinv.c
@@ -1,8 +1,6 @@
 /*
     Copyright (C) 2011 Fredrik Johansson
     Copyright (C) 2012 Lina Kulakova
-    Copyright (C) 2013 Martin Lee
-    Copyright (C) 2020 William Hart
 
     This file is part of FLINT.
 
@@ -12,162 +10,29 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "ulong_extras.h"
-#include "fmpz.h"
-#include "fmpz_vec.h"
-#include "fmpz_mat.h"
-#include "fmpz_mod.h"
-#include "fmpz_mod_mat.h"
-#include "fmpz_mod_vec.h"
+#include "gr.h"
+#include "gr_poly.h"
 #include "fmpz_mod_poly.h"
 
 void
-_fmpz_mod_poly_compose_mod_brent_kung_preinv(fmpz * res, const fmpz * poly1,
-                 slong len1, const fmpz * poly2, const fmpz * poly3, slong len3,
-                 const fmpz * poly3inv, slong len3inv, const fmpz_mod_ctx_t ctx)
+_fmpz_mod_poly_compose_mod_brent_kung_preinv(fmpz * res, const fmpz * poly1, slong len1,
+                              const fmpz * poly2, const fmpz * poly3, slong len3,
+                              const fmpz * poly3inv, slong len3inv, const fmpz_mod_ctx_t ctx)
 {
-    fmpz_mod_mat_t A, B, C;
-    fmpz * t, * h;
-    slong i, n, m;
-
-    n = len3 - 1;
-
-    if (len3 == 1)
-        return;
-
-    if (len1 == 1)
-    {
-        fmpz_set(res, poly1);
-        return;
-    }
-
-    if (len3 == 2)
-    {
-        _fmpz_mod_poly_evaluate_fmpz(res, poly1, len1, poly2, ctx);
-        return;
-    }
-
-    m = n_sqrt(n) + 1;
-
-    fmpz_mod_mat_init(A, m, n, ctx);
-    fmpz_mod_mat_init(B, m, m, ctx);
-    fmpz_mod_mat_init(C, m, n, ctx);
-
-    h = _fmpz_vec_init(2 * n - 1);
-    t = _fmpz_vec_init(2 * n - 1);
-
-    /* Set rows of B to the segments of poly1 */
-    for (i = 0; i < len1 / m; i++)
-        _fmpz_vec_set(fmpz_mod_mat_row(B, i), poly1 + i * m, m);
-
-    _fmpz_vec_set(fmpz_mod_mat_row(B, i), poly1 + i * m, len1 % m);
-
-    /* Set rows of A to powers of poly2 */
-    {
-        fmpz ** Arows;
-        slong i;
-        Arows = flint_malloc(sizeof(fmpz *) * A->r);
-        for (i = 0; i < A->r; i++)
-            Arows[i] = fmpz_mod_mat_row(A, i);
-
-        _fmpz_mod_poly_powers_mod_preinv_naive(Arows, poly2, n,
-                                             m, poly3, len3, poly3inv, len3inv, ctx);
-        flint_free(Arows);
-    }
-
-    fmpz_mod_mat_mul(C, B, A, ctx);
-
-    /* Evaluate block composition using the Horner scheme */
-    _fmpz_vec_set(res, fmpz_mod_mat_row(C, m - 1), n);
-    _fmpz_mod_poly_mulmod_preinv(h, fmpz_mod_mat_row(A, m - 1), n, poly2, n, poly3, len3,
-                                 poly3inv, len3inv, ctx);
-
-    for (i = m - 2; i >= 0; i--)
-    {
-        _fmpz_mod_poly_mulmod_preinv(t, res, n, h, n, poly3, len3,
-                                     poly3inv, len3inv, ctx);
-        _fmpz_mod_poly_add(res, t, n, fmpz_mod_mat_row(C, i), n, ctx);
-    }
-
-    _fmpz_vec_clear(h, 2 * n - 1);
-    _fmpz_vec_clear(t, 2 * n - 1);
-
-    fmpz_mod_mat_clear(A, ctx);
-    fmpz_mod_mat_clear(B, ctx);
-    fmpz_mod_mat_clear(C, ctx);
+    gr_ctx_t gr_ctx;
+    _gr_ctx_init_fmpz_mod_from_ref(gr_ctx, ctx);
+    GR_MUST_SUCCEED(_gr_poly_compose_mod_brent_kung_preinv(res, poly1, len1, poly2, poly3, len3, poly3inv, len3inv, gr_ctx));
 }
 
-void
-fmpz_mod_poly_compose_mod_brent_kung_preinv(fmpz_mod_poly_t res,
-                    const fmpz_mod_poly_t poly1, const fmpz_mod_poly_t poly2,
-                    const fmpz_mod_poly_t poly3, const fmpz_mod_poly_t poly3inv,
-                                                      const fmpz_mod_ctx_t ctx)
+void fmpz_mod_poly_compose_mod_brent_kung_preinv(fmpz_mod_poly_t res,
+                     const fmpz_mod_poly_t poly1, const fmpz_mod_poly_t poly2,
+                         const fmpz_mod_poly_t poly3, const fmpz_mod_poly_t poly3inv, const fmpz_mod_ctx_t ctx)
 {
-    slong len1 = poly1->length;
-    slong len2 = poly2->length;
-    slong len3 = poly3->length;
-    slong len = len3 - 1;
-
-    fmpz * ptr2;
-    fmpz_t inv3;
-
-    if (len3 == 0)
-    {
-        flint_throw(FLINT_ERROR, "(fmpz_mod_poly_compose_mod_brent_kung preinv): "
-                     "Division by zero\n");
-    }
-
-    if (len1 >= len3)
-    {
-        flint_throw(FLINT_ERROR, "(fmpz_mod_poly_compose_mod_brent_kung_preinv): "
-               "The degree of the first polynomial must be smaller than that of the modulus\n");
-    }
-
-    if (len1 == 0 || len3 == 1)
-    {
-        fmpz_mod_poly_zero(res, ctx);
-        return;
-    }
-
-    if (len1 == 1)
-    {
-        fmpz_mod_poly_set(res, poly1, ctx);
-        return;
-    }
-
-    if (res == poly3 || res == poly1 || res == poly3inv)
-    {
-        fmpz_mod_poly_t tmp;
-        fmpz_mod_poly_init(tmp, ctx);
-        fmpz_mod_poly_compose_mod_brent_kung_preinv(tmp, poly1, poly2,
-                                                    poly3, poly3inv, ctx);
-        fmpz_mod_poly_swap(tmp, res, ctx);
-        fmpz_mod_poly_clear(tmp, ctx);
-        return;
-    }
-
-    ptr2 = _fmpz_vec_init(len);
-
-    if (len2 <= len)
-    {
-        _fmpz_vec_set(ptr2, poly2->coeffs, len2);
-        _fmpz_vec_zero(ptr2 + len2, len - len2);
-    }
-    else
-    {
-        fmpz_init(inv3);
-        fmpz_invmod(inv3, poly3->coeffs + len, fmpz_mod_ctx_modulus(ctx));
-        _fmpz_mod_poly_rem(ptr2, poly2->coeffs, len2,
-                         poly3->coeffs, len3, inv3, ctx);
-        fmpz_clear(inv3);
-    }
-
-    fmpz_mod_poly_fit_length(res, len, ctx);
-    _fmpz_mod_poly_compose_mod_brent_kung_preinv(res->coeffs,
-             poly1->coeffs, len1, ptr2, poly3->coeffs, len3,
-             poly3inv->coeffs, poly3inv->length, ctx);
-    _fmpz_mod_poly_set_length(res, len);
-    _fmpz_mod_poly_normalise(res);
-
-    _fmpz_vec_clear(ptr2, len);
+    gr_ctx_t gr_ctx;
+    _gr_ctx_init_fmpz_mod_from_ref(gr_ctx, ctx);
+    GR_MUST_SUCCEED(gr_poly_compose_mod_brent_kung_preinv((gr_poly_struct *) res,
+        (const gr_poly_struct *) poly1,
+        (const gr_poly_struct *) poly2,
+        (const gr_poly_struct *) poly3,
+        (const gr_poly_struct *) poly3inv, gr_ctx));
 }

--- a/src/fmpz_mod_poly/compose_mod_horner.c
+++ b/src/fmpz_mod_poly/compose_mod_horner.c
@@ -10,113 +10,28 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "fmpz.h"
-#include "fmpz_vec.h"
-#include "fmpz_mod.h"
+#include "gr.h"
+#include "gr_poly.h"
 #include "fmpz_mod_poly.h"
 
 void
-_fmpz_mod_poly_compose_mod_horner(fmpz * res, const fmpz * f, slong lenf, const fmpz * g,
-                                              const fmpz * h, slong lenh, const fmpz_mod_ctx_t ctx)
+_fmpz_mod_poly_compose_mod_horner(fmpz * res, const fmpz * poly1, slong len1,
+                              const fmpz * poly2, const fmpz * poly3, slong len3,
+                                                                    const fmpz_mod_ctx_t ctx)
 {
-    slong i, len;
-    fmpz * t;
-
-    if (lenh == 1)
-        return;
-
-    if (lenf == 1)
-    {
-        fmpz_set(res, f);
-        return;
-    }
-
-    if (lenh == 2)
-    {
-        _fmpz_mod_poly_evaluate_fmpz(res, f, lenf, g, ctx);
-        return;
-    }
-
-    len = lenh - 1;
-    i = lenf - 1;
-    t = _fmpz_vec_init(2 * lenh - 3);
-
-    _fmpz_mod_poly_scalar_mul_fmpz(res, g, len, f + i, ctx);
-    i--;
-    if (i >= 0)
-        fmpz_mod_add(res, res, f + i, ctx);
-
-    while (i > 0)
-    {
-        i--;
-        _fmpz_mod_poly_mulmod(t, res, len, g, len, h, lenh, ctx);
-        _fmpz_mod_poly_add(res, t, len, f + i, 1, ctx);
-    }
-
-    _fmpz_vec_clear(t, 2 * lenh - 3);
+    gr_ctx_t gr_ctx;
+    _gr_ctx_init_fmpz_mod_from_ref(gr_ctx, ctx);
+    GR_MUST_SUCCEED(_gr_poly_compose_mod_horner(res, poly1, len1, poly2, poly3, len3, gr_ctx));
 }
 
 void fmpz_mod_poly_compose_mod_horner(fmpz_mod_poly_t res,
                      const fmpz_mod_poly_t poly1, const fmpz_mod_poly_t poly2,
                          const fmpz_mod_poly_t poly3, const fmpz_mod_ctx_t ctx)
 {
-    fmpz_t inv3;
-    slong len1 = poly1->length;
-    slong len2 = poly2->length;
-    slong len3 = poly3->length;
-    slong len = len3 - 1;
-    slong vec_len = FLINT_MAX(len3 - 1, len2);
-
-    fmpz * ptr2;
-
-    if (len3 == 0)
-    {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_mod_poly_compose_mod_horner). Division by zero \n");
-    }
-
-    if (len1 == 0 || len3 == 1)
-    {
-        fmpz_mod_poly_zero(res, ctx);
-        return;
-    }
-
-    if (len1 == 1)
-    {
-        fmpz_mod_poly_set(res, poly1, ctx);
-        return;
-    }
-
-    if (res == poly3 || res == poly1)
-    {
-        fmpz_mod_poly_t tmp;
-        fmpz_mod_poly_init(tmp, ctx);
-        fmpz_mod_poly_compose_mod_horner(tmp, poly1, poly2, poly3, ctx);
-        fmpz_mod_poly_swap(tmp, res, ctx);
-        fmpz_mod_poly_clear(tmp, ctx);
-        return;
-    }
-
-    ptr2 = _fmpz_vec_init(vec_len);
-
-    if (len2 <= len3 - 1)
-    {
-        _fmpz_vec_set(ptr2, poly2->coeffs, len2);
-        _fmpz_vec_zero(ptr2 + len2, vec_len - len2);
-    }
-    else
-    {
-        fmpz_init(inv3);
-        fmpz_invmod(inv3, poly3->coeffs + len, fmpz_mod_ctx_modulus(ctx));
-        _fmpz_mod_poly_rem(ptr2, poly2->coeffs, len2,
-                         poly3->coeffs, len3, inv3, ctx);
-        fmpz_clear(inv3);
-    }
-
-    fmpz_mod_poly_fit_length(res, len, ctx);
-    _fmpz_mod_poly_compose_mod_horner(res->coeffs, poly1->coeffs, len1,
-                         ptr2, poly3->coeffs, len3, ctx);
-    _fmpz_mod_poly_set_length(res, len);
-    _fmpz_mod_poly_normalise(res);
-
-    _fmpz_vec_clear(ptr2, vec_len);
+    gr_ctx_t gr_ctx;
+    _gr_ctx_init_fmpz_mod_from_ref(gr_ctx, ctx);
+    GR_MUST_SUCCEED(gr_poly_compose_mod_horner((gr_poly_struct *) res,
+        (const gr_poly_struct *) poly1,
+        (const gr_poly_struct *) poly2,
+        (const gr_poly_struct *) poly3, gr_ctx));
 }

--- a/src/fq_poly_templates/compose_mod.c
+++ b/src/fq_poly_templates/compose_mod.c
@@ -13,21 +13,20 @@
 
 #ifdef T
 
+#include "gr.h"
+#include "gr_mat.h"
 #include "templates.h"
 
-#include "ulong_extras.h"
 void
 _TEMPLATE(T, poly_compose_mod) (TEMPLATE(T, struct) * res,
-                                const TEMPLATE(T, struct) * f, slong lenf,
-                                const TEMPLATE(T, struct) * g,
-                                const TEMPLATE(T, struct) * h, slong lenh,
+                                const TEMPLATE(T, struct) * poly1, slong len1,
+                                const TEMPLATE(T, struct) * poly2,
+                                const TEMPLATE(T, struct) * poly3, slong len3,
                                 const TEMPLATE(T, ctx_t) ctx)
 {
-    if (lenh < TEMPLATE(CAP_T, COMPOSE_MOD_LENH_CUTOFF) || lenf >= lenh)
-        _TEMPLATE(T, poly_compose_mod_horner) (res, f, lenf, g, h, lenh, ctx);
-    else
-        _TEMPLATE(T, poly_compose_mod_brent_kung) (res, f, lenf, g, h, lenh,
-                                                   ctx);
+    gr_ctx_t gr_ctx;
+    TEMPLATE3(_gr_ctx_init, T, from_ref)(gr_ctx, ctx);
+    GR_MUST_SUCCEED(_gr_poly_compose_mod(res, poly1, len1, poly2, poly3, len3, gr_ctx));
 }
 
 void
@@ -37,66 +36,12 @@ TEMPLATE(T, poly_compose_mod) (TEMPLATE(T, poly_t) res,
                                const TEMPLATE(T, poly_t) poly3,
                                const TEMPLATE(T, ctx_t) ctx)
 {
-    TEMPLATE(T, t) inv3;
-    slong len1 = poly1->length;
-    slong len2 = poly2->length;
-    slong len3 = poly3->length;
-    slong len = len3 - 1;
-    slong vec_len = FLINT_MAX(len3 - 1, len2);
-
-    TEMPLATE(T, struct) * ptr2;
-
-    if (len3 == 0)
-    {
-        flint_throw(FLINT_ERROR, "(%s): Division by zero\n", __func__);
-    }
-
-    if (len1 == 0 || len3 == 1)
-    {
-        TEMPLATE(T, poly_zero) (res, ctx);
-        return;
-    }
-
-    if (len1 == 1)
-    {
-        TEMPLATE(T, poly_set) (res, poly1, ctx);
-        return;
-    }
-
-    if (res == poly3 || res == poly1)
-    {
-        TEMPLATE(T, poly_t) tmp;
-        TEMPLATE(T, poly_init) (tmp, ctx);
-        TEMPLATE(T, poly_compose_mod) (tmp, poly1, poly2, poly3, ctx);
-        TEMPLATE(T, poly_swap) (tmp, res, ctx);
-        TEMPLATE(T, poly_clear) (tmp, ctx);
-        return;
-    }
-
-    ptr2 = _TEMPLATE(T, vec_init) (vec_len, ctx);
-
-    if (len2 <= len)
-    {
-        _TEMPLATE(T, vec_set) (ptr2, poly2->coeffs, len2, ctx);
-        _TEMPLATE(T, vec_zero) (ptr2 + len2, len - len2, ctx);
-    }
-    else
-    {
-        TEMPLATE(T, init) (inv3, ctx);
-        TEMPLATE(T, inv) (inv3, poly3->coeffs + len, ctx);
-        _TEMPLATE(T, poly_rem) (ptr2, poly2->coeffs, len2,
-                                poly3->coeffs, len3, inv3, ctx);
-        TEMPLATE(T, clear) (inv3, ctx);
-    }
-
-    TEMPLATE(T, poly_fit_length) (res, len, ctx);
-    _TEMPLATE(T, poly_compose_mod) (res->coeffs,
-                                    poly1->coeffs, len1, ptr2, poly3->coeffs,
-                                    len3, ctx);
-    _TEMPLATE(T, poly_set_length) (res, len, ctx);
-    _TEMPLATE(T, poly_normalise) (res, ctx);
-
-    _TEMPLATE(T, vec_clear) (ptr2, vec_len, ctx);
+    gr_ctx_t gr_ctx;
+    TEMPLATE3(_gr_ctx_init, T, from_ref)(gr_ctx, ctx);
+    GR_MUST_SUCCEED(gr_poly_compose_mod((gr_poly_struct *) res,
+            (const gr_poly_struct *) poly1,
+            (const gr_poly_struct *) poly2,
+            (const gr_poly_struct *) poly3, gr_ctx));
 }
 
 

--- a/src/fq_poly_templates/compose_mod_brent_kung.c
+++ b/src/fq_poly_templates/compose_mod_brent_kung.c
@@ -13,161 +13,35 @@
 
 #ifdef T
 
+#include "gr.h"
+#include "gr_mat.h"
 #include "templates.h"
 
 void
-_TEMPLATE(T, poly_compose_mod_brent_kung) (
-    TEMPLATE(T, struct) * res,
-    const TEMPLATE(T, struct) * poly1, slong len1,
-    const TEMPLATE(T, struct) * poly2,
-    const TEMPLATE(T, struct) * poly3, slong len3,
-    const TEMPLATE(T, ctx_t) ctx)
+_TEMPLATE(T, poly_compose_mod_brent_kung) (TEMPLATE(T, struct) * res,
+                                const TEMPLATE(T, struct) * poly1, slong len1,
+                                const TEMPLATE(T, struct) * poly2,
+                                const TEMPLATE(T, struct) * poly3, slong len3,
+                                const TEMPLATE(T, ctx_t) ctx)
 {
-    TEMPLATE(T, mat_t) A, B, C;
-    TEMPLATE(T, struct) * t, *h, *tmp;
-    slong i, n, m;
-
-    n = len3 - 1;
-
-    if (len3 == 1)
-        return;
-
-    if (len1 == 1)
-    {
-        TEMPLATE(T, set) (res, poly1, ctx);
-        return;
-    }
-
-    if (len3 == 2)
-    {
-        _TEMPLATE(T, TEMPLATE(poly_evaluate, T)) (res, poly1, len1, poly2,
-                                                  ctx);
-        return;
-    }
-
-    m = n_sqrt(n) + 1;
-
-    TEMPLATE(T, mat_init) (A, m, n, ctx);
-    TEMPLATE(T, mat_init) (B, m, m, ctx);
-    TEMPLATE(T, mat_init) (C, m, n, ctx);
-
-    h = _TEMPLATE(T, vec_init) (2 * n - 1, ctx);
-    t = _TEMPLATE(T, vec_init) (2 * n - 1, ctx);
-
-    /* Set rows of B to the segments of poly1 */
-    for (i = 0; i < len1 / m; i++)
-        _TEMPLATE(T, vec_set) (TEMPLATE(T, mat_entry) (B, i, 0), poly1 + i * m, m, ctx);
-
-    _TEMPLATE(T, vec_set) (TEMPLATE(T, mat_entry) (B, i, 0), poly1 + i * m, len1 % m, ctx);
-
-    /* Set rows of A to powers of poly2 */
-    TEMPLATE(T, one) (TEMPLATE(T, mat_entry) (A, 0, 0), ctx);
-    _TEMPLATE(T, vec_set) (TEMPLATE(T, mat_entry) (A, 1, 0), poly2, n, ctx);
-    tmp = _TEMPLATE(T, vec_init) (2 * n - 1, ctx);
-    for (i = 2; i < m; i++)
-    {
-        _TEMPLATE(T, poly_mulmod) (tmp, TEMPLATE(T, mat_entry) (A, i - 1, 0), n, poly2, n, poly3,
-                                   len3, ctx);
-        _TEMPLATE(T, vec_set) (TEMPLATE(T, mat_entry) (A, i, 0), tmp, n, ctx);
-    }
-    _TEMPLATE(T, vec_clear) (tmp, 2 * n - 1, ctx);
-
-    TEMPLATE(T, mat_mul) (C, B, A, ctx);
-
-    /* Evaluate block composition using the Horner scheme */
-    _TEMPLATE(T, vec_set) (res, TEMPLATE(T, mat_entry) (C, m - 1, 0), n, ctx);
-    _TEMPLATE(T, poly_mulmod) (h, TEMPLATE(T, mat_entry) (A, m - 1, 0), n, poly2, n, poly3, len3,
-                               ctx);
-
-    for (i = m - 2; i >= 0; i--)
-    {
-        _TEMPLATE(T, poly_mulmod) (t, res, n, h, n, poly3, len3, ctx);
-        _TEMPLATE(T, poly_add) (res, t, n, TEMPLATE(T, mat_entry) (C, i, 0), n, ctx);
-    }
-
-    _TEMPLATE(T, vec_clear) (h, 2 * n - 1, ctx);
-    _TEMPLATE(T, vec_clear) (t, 2 * n - 1, ctx);
-
-    TEMPLATE(T, mat_clear) (A, ctx);
-    TEMPLATE(T, mat_clear) (B, ctx);
-    TEMPLATE(T, mat_clear) (C, ctx);
+    gr_ctx_t gr_ctx;
+    TEMPLATE3(_gr_ctx_init, T, from_ref)(gr_ctx, ctx);
+    GR_MUST_SUCCEED(_gr_poly_compose_mod_brent_kung(res, poly1, len1, poly2, poly3, len3, gr_ctx));
 }
 
 void
 TEMPLATE(T, poly_compose_mod_brent_kung) (TEMPLATE(T, poly_t) res,
-                                          const TEMPLATE(T, poly_t) poly1,
-                                          const TEMPLATE(T, poly_t) poly2,
-                                          const TEMPLATE(T, poly_t) poly3,
-                                          const TEMPLATE(T, ctx_t) ctx)
+                               const TEMPLATE(T, poly_t) poly1,
+                               const TEMPLATE(T, poly_t) poly2,
+                               const TEMPLATE(T, poly_t) poly3,
+                               const TEMPLATE(T, ctx_t) ctx)
 {
-    slong len1 = poly1->length;
-    slong len2 = poly2->length;
-    slong len3 = poly3->length;
-    slong len = len3 - 1;
-    slong vec_len = FLINT_MAX(len3 - 1, len2);
-
-    TEMPLATE(T, struct) * ptr2;
-    TEMPLATE(T, t) inv3;
-
-    if (len3 == 0)
-    {
-        flint_throw(FLINT_ERROR, "(%s): Division by zero\n", __func__);
-    }
-
-    if (len1 >= len3)
-    {
-        flint_throw(FLINT_ERROR, "(%s): The degree of the first polynomial must "
-                "be smaller than that of the modulus\n", __func__);
-    }
-
-    if (len1 == 0 || len3 == 1)
-    {
-        TEMPLATE(T, poly_zero) (res, ctx);
-        return;
-    }
-
-    if (len1 == 1)
-    {
-        TEMPLATE(T, poly_set) (res, poly1, ctx);
-        return;
-    }
-
-    if (res == poly3 || res == poly1)
-    {
-        TEMPLATE(T, poly_t) tmp;
-        TEMPLATE(T, poly_init) (tmp, ctx);
-        TEMPLATE(T, poly_compose_mod_brent_kung) (tmp, poly1, poly2, poly3,
-                                                  ctx);
-        TEMPLATE(T, poly_swap) (tmp, res, ctx);
-        TEMPLATE(T, poly_clear) (tmp, ctx);
-        return;
-    }
-
-    ptr2 = _TEMPLATE(T, vec_init) (vec_len, ctx);
-
-    if (len2 <= len)
-    {
-        _TEMPLATE(T, vec_set) (ptr2, poly2->coeffs, len2, ctx);
-        _TEMPLATE(T, vec_zero) (ptr2 + len2, vec_len - len2, ctx);
-    }
-    else
-    {
-        TEMPLATE(T, init) (inv3, ctx);
-        TEMPLATE(T, inv) (inv3, poly3->coeffs + len, ctx);
-        _TEMPLATE(T, poly_rem) (ptr2, poly2->coeffs, len2,
-                                poly3->coeffs, len3, inv3, ctx);
-        TEMPLATE(T, clear) (inv3, ctx);
-    }
-
-    TEMPLATE(T, poly_fit_length) (res, len, ctx);
-    _TEMPLATE(T, poly_compose_mod_brent_kung) (res->coeffs, poly1->coeffs,
-                                               len1, ptr2, poly3->coeffs, len3,
-                                               ctx);
-    _TEMPLATE(T, poly_set_length) (res, len, ctx);
-    _TEMPLATE(T, poly_normalise) (res, ctx);
-
-    _TEMPLATE(T, vec_clear) (ptr2, vec_len, ctx);
+    gr_ctx_t gr_ctx;
+    TEMPLATE3(_gr_ctx_init, T, from_ref)(gr_ctx, ctx);
+    GR_MUST_SUCCEED(gr_poly_compose_mod_brent_kung((gr_poly_struct *) res,
+            (const gr_poly_struct *) poly1,
+            (const gr_poly_struct *) poly2,
+            (const gr_poly_struct *) poly3, gr_ctx));
 }
-
 
 #endif

--- a/src/fq_poly_templates/compose_mod_brent_kung_precomp_preinv.c
+++ b/src/fq_poly_templates/compose_mod_brent_kung_precomp_preinv.c
@@ -13,9 +13,9 @@
 
 #ifdef T
 
+#include "gr.h"
+#include "gr_mat.h"
 #include "templates.h"
-
-#include "ulong_extras.h"
 
 void
 _TEMPLATE(T, poly_reduce_matrix_mod_poly) (TEMPLATE(T, mat_t) A,
@@ -23,19 +23,10 @@ _TEMPLATE(T, poly_reduce_matrix_mod_poly) (TEMPLATE(T, mat_t) A,
                                            const TEMPLATE(T, poly_t) f,
                                            const TEMPLATE(T, ctx_t) ctx)
 {
-    slong n = f->length - 1;
-    slong i, m = n_sqrt(n) + 1;
-    TEMPLATE(T, t) invf;
-
-    TEMPLATE(T, mat_init) (A, m, n, ctx);
-
-    TEMPLATE(T, one) (TEMPLATE(T, mat_entry) (A, 0, 0), ctx);
-    TEMPLATE(T, init) (invf, ctx);
-    TEMPLATE(T, inv) (invf, f->coeffs + (f->length - 1), ctx);
-    for (i = 1; i < m; i++)
-        _TEMPLATE(T, poly_rem) (TEMPLATE(T, mat_entry) (A, i, 0), TEMPLATE(T, mat_entry) (B, i, 0), B->c, f->coeffs,
-                                f->length, invf, ctx);
-    TEMPLATE(T, clear) (invf, ctx);
+    gr_ctx_t gr_ctx;
+    TEMPLATE3(_gr_ctx_init, T, from_ref)(gr_ctx, ctx);
+    GR_MUST_SUCCEED(_gr_poly_reduce_matrix_mod_poly((gr_mat_struct *) A,
+        (const gr_mat_struct *) B, (const gr_poly_struct *) f, gr_ctx));
 }
 
 void
@@ -46,19 +37,10 @@ _TEMPLATE(T, poly_precompute_matrix) (
     const TEMPLATE(T, struct) * poly2inv, slong len2inv,
     const TEMPLATE(T, ctx_t) ctx)
 {
-    /* Set rows of A to powers of poly1 */
-    slong i, n, m;
-
-    n = len2 - 1;
-
-    m = n_sqrt(n) + 1;
-
-    TEMPLATE(T, one) (TEMPLATE(T, mat_entry) (A, 0, 0), ctx);
-    _TEMPLATE(T, vec_set) (TEMPLATE(T, mat_entry) (A, 1, 0), poly1, n, ctx);
-    for (i = 2; i < m; i++)
-        _TEMPLATE(T, poly_mulmod_preinv) (TEMPLATE(T, mat_entry) (A, i, 0), TEMPLATE(T, mat_entry) (A, i - 1, 0),
-                                          n, poly1, n, poly2, len2,
-                                          poly2inv, len2inv, ctx);
+    gr_ctx_t gr_ctx;
+    TEMPLATE3(_gr_ctx_init, T, from_ref)(gr_ctx, ctx);
+    GR_MUST_SUCCEED(_gr_poly_precompute_matrix((gr_mat_struct *) A,
+        poly1, poly2, len2, poly2inv, len2inv, gr_ctx));
 }
 
 void
@@ -68,51 +50,12 @@ TEMPLATE(T, poly_precompute_matrix) (TEMPLATE(T, mat_t) A,
                                      const TEMPLATE(T, poly_t) poly2inv,
                                      const TEMPLATE(T, ctx_t) ctx)
 {
-    slong len1 = poly1->length;
-    slong len2 = poly2->length;
-    slong len = len2 - 1;
-    slong m = n_sqrt(len) + 1;
-
-    TEMPLATE(T, struct) * ptr1;
-
-    if (len2 == 0)
-    {
-        flint_throw(FLINT_ERROR, "(%s): Division by zero.\n", __func__);
-    }
-
-    if (A->r != m || A->c != len)
-    {
-        flint_throw(FLINT_ERROR, "(%s): Wrong dimensions.\n", __func__);
-    }
-
-    if (len2 == 1)
-    {
-        TEMPLATE(T, mat_zero) (A, ctx);
-        return;
-    }
-
-    ptr1 = _TEMPLATE(T, vec_init) (len, ctx);
-
-    if (len1 <= len)
-    {
-        _TEMPLATE(T, vec_set) (ptr1, poly1->coeffs, len1, ctx);
-        _TEMPLATE(T, vec_zero) (ptr1 + len1, len - len1, ctx);
-    }
-    else
-    {
-        TEMPLATE(T, t) inv2;
-        TEMPLATE(T, init) (inv2, ctx);
-        TEMPLATE(T, inv) (inv2, poly2->coeffs + len2 - 1, ctx);
-        _TEMPLATE(T, poly_rem) (ptr1, poly1->coeffs, len1,
-                                poly2->coeffs, len2, inv2, ctx);
-        TEMPLATE(T, clear) (inv2, ctx);
-    }
-
-    _TEMPLATE(T, poly_precompute_matrix) (A, ptr1, poly2->coeffs, len2,
-                                          poly2inv->coeffs, poly2inv->length,
-                                          ctx);
-
-    _TEMPLATE(T, vec_clear) (ptr1, len, ctx);
+    gr_ctx_t gr_ctx;
+    TEMPLATE3(_gr_ctx_init, T, from_ref)(gr_ctx, ctx);
+    GR_MUST_SUCCEED(gr_poly_precompute_matrix((gr_mat_struct *) A,
+        (const gr_poly_struct *) poly1,
+        (const gr_poly_struct *) poly2,
+        (const gr_poly_struct *) poly2inv, gr_ctx));
 }
 
 void
@@ -124,64 +67,11 @@ _TEMPLATE(T, poly_compose_mod_brent_kung_precomp_preinv) (
     const TEMPLATE(T, struct) * poly3inv, slong len3inv,
     const TEMPLATE(T, ctx_t) ctx)
 {
-    TEMPLATE(T, mat_t) B, C;
-    TEMPLATE(T, struct) * t, *h;
-    slong i, n, m;
-
-    n = len3 - 1;
-
-    if (len3 == 1)
-        return;
-
-    if (len1 == 1)
-    {
-        TEMPLATE(T, set) (res, poly1, ctx);
-        return;
-    }
-
-    if (len3 == 2)
-    {
-        _TEMPLATE3(T, poly_evaluate, T) (res, poly1, len1,
-                                         TEMPLATE(T, mat_entry) (A, 1, 0),
-                                         ctx);
-        return;
-    }
-
-    m = n_sqrt(n) + 1;
-
-    /* TODO check A */
-
-    TEMPLATE(T, mat_init) (B, m, m, ctx);
-    TEMPLATE(T, mat_init) (C, m, n, ctx);
-
-    h = _TEMPLATE(T, vec_init) (n, ctx);
-    t = _TEMPLATE(T, vec_init) (n, ctx);
-
-    /* Set rows of B to the segments of poly1 */
-    for (i = 0; i < len1 / m; i++)
-        _TEMPLATE(T, vec_set) (TEMPLATE(T, mat_entry) (B, i, 0), poly1 + i * m, m, ctx);
-
-    _TEMPLATE(T, vec_set) (TEMPLATE(T, mat_entry) (B, i, 0), poly1 + i * m, len1 % m, ctx);
-
-    TEMPLATE(T, mat_mul) (C, B, A, ctx);
-
-    /* Evaluate block composition using the Horner scheme */
-    _TEMPLATE(T, vec_set) (res, TEMPLATE(T, mat_entry) (C, m - 1, 0), n, ctx);
-    _TEMPLATE(T, poly_mulmod_preinv) (h, TEMPLATE(T, mat_entry) (A, m - 1, 0), n, TEMPLATE(T, mat_entry) (A, 1, 0), n,
-                                      poly3, len3, poly3inv, len3inv, ctx);
-
-    for (i = m - 2; i >= 0; i--)
-    {
-        _TEMPLATE(T, poly_mulmod_preinv) (t, res, n, h, n, poly3, len3,
-                                          poly3inv, len3inv, ctx);
-        _TEMPLATE(T, poly_add) (res, t, n, TEMPLATE(T, mat_entry) (C, i, 0), n, ctx);
-    }
-
-    _TEMPLATE(T, vec_clear) (h, n, ctx);
-    _TEMPLATE(T, vec_clear) (t, n, ctx);
-
-    TEMPLATE(T, mat_clear) (B, ctx);
-    TEMPLATE(T, mat_clear) (C, ctx);
+    gr_ctx_t gr_ctx;
+    TEMPLATE3(_gr_ctx_init, T, from_ref)(gr_ctx, ctx);
+    GR_MUST_SUCCEED(_gr_poly_compose_mod_brent_kung_precomp_preinv(res,
+        poly1, len1, (const gr_mat_struct *) A,
+        poly3, len3, poly3inv, len3inv, gr_ctx));
 }
 
 void
@@ -191,56 +81,14 @@ TEMPLATE(T, poly_compose_mod_brent_kung_precomp_preinv) (
     const TEMPLATE(T, poly_t) poly3, const TEMPLATE(T, poly_t) poly3inv,
     const TEMPLATE(T, ctx_t) ctx)
 {
-    slong len1 = poly1->length;
-    slong len3 = poly3->length;
-    slong len = len3 - 1;
-
-    if (len3 == 0)
-    {
-        flint_throw(FLINT_ERROR, "(%s): Division by zero.\n", __func__);
-    }
-
-    if (len1 >= len3)
-    {
-        flint_throw(FLINT_ERROR, "(%s): The degree of the first polynomial must be smaller than that of the modulus.\n", __func__);
-    }
-
-    if (len1 == 0 || len3 == 1)
-    {
-        TEMPLATE(T, poly_zero) (res, ctx);
-        return;
-    }
-
-    if (len1 == 1)
-    {
-        TEMPLATE(T, poly_set) (res, poly1, ctx);
-        return;
-    }
-
-    if (res == poly3 || res == poly1 || res == poly3inv)
-    {
-        TEMPLATE(T, poly_t) tmp;
-        TEMPLATE(T, poly_init) (tmp, ctx);
-        TEMPLATE(T, poly_compose_mod_brent_kung_precomp_preinv) (tmp, poly1, A,
-                                                                 poly3,
-                                                                 poly3inv,
-                                                                 ctx);
-        TEMPLATE(T, poly_swap) (tmp, res, ctx);
-        TEMPLATE(T, poly_clear) (tmp, ctx);
-        return;
-    }
-
-    TEMPLATE(T, poly_fit_length) (res, len, ctx);
-    _TEMPLATE(T, poly_compose_mod_brent_kung_precomp_preinv) (res->coeffs,
-                                                              poly1->coeffs,
-                                                              len1, A,
-                                                              poly3->coeffs,
-                                                              len3,
-                                                              poly3inv->coeffs,
-                                                              poly3inv->length,
-                                                              ctx);
-    res->length = len;
-    _TEMPLATE(T, poly_normalise) (res, ctx);
-
+    gr_ctx_t gr_ctx;
+    TEMPLATE3(_gr_ctx_init, T, from_ref)(gr_ctx, ctx);
+    GR_MUST_SUCCEED(gr_poly_compose_mod_brent_kung_precomp_preinv(
+        (gr_poly_struct *) res,
+        (const gr_poly_struct *) poly1,
+        (gr_mat_struct *) A,
+        (const gr_poly_struct *) poly3,
+        (const gr_poly_struct *) poly3inv, gr_ctx));
 }
+
 #endif

--- a/src/fq_poly_templates/compose_mod_brent_kung_preinv.c
+++ b/src/fq_poly_templates/compose_mod_brent_kung_preinv.c
@@ -1,7 +1,6 @@
 /*
     Copyright (C) 2011 Fredrik Johansson
     Copyright (C) 2012 Lina Kulakova
-    Copyright (C) 2013 Martin Lee
     Copyright (C) 2013 Mike Hansen
 
     This file is part of FLINT.
@@ -14,167 +13,38 @@
 
 #ifdef T
 
+#include "gr.h"
+#include "gr_mat.h"
 #include "templates.h"
 
 void
-_TEMPLATE(T, poly_compose_mod_brent_kung_preinv) (
-    TEMPLATE(T, struct) * res,
-    const TEMPLATE(T, struct) * poly1, slong len1,
-    const TEMPLATE(T, struct) * poly2,
-    const TEMPLATE(T, struct) * poly3, slong len3,
-    const TEMPLATE(T, struct) * poly3inv, slong len3inv,
-    const TEMPLATE(T, ctx_t) ctx)
+_TEMPLATE(T, poly_compose_mod_brent_kung_preinv) (TEMPLATE(T, struct) * res,
+                                const TEMPLATE(T, struct) * poly1, slong len1,
+                                const TEMPLATE(T, struct) * poly2,
+                                const TEMPLATE(T, struct) * poly3, slong len3,
+                                const TEMPLATE(T, struct) * poly3inv, slong len3inv,
+                                const TEMPLATE(T, ctx_t) ctx)
 {
-    TEMPLATE(T, mat_t) A, B, C;
-    TEMPLATE(T, struct) * t, *h, *tmp;
-    slong i, n, m;
-
-    n = len3 - 1;
-
-    if (len3 == 1)
-        return;
-
-    if (len1 == 1)
-    {
-        TEMPLATE(T, set) (res, poly1, ctx);
-        return;
-    }
-
-    if (len3 == 2)
-    {
-        _TEMPLATE(T, TEMPLATE(poly_evaluate, T)) (res, poly1, len1, poly2,
-                                                  ctx);
-        return;
-    }
-
-    m = n_sqrt(n) + 1;
-
-    TEMPLATE(T, mat_init) (A, m, n, ctx);
-    TEMPLATE(T, mat_init) (B, m, m, ctx);
-    TEMPLATE(T, mat_init) (C, m, n, ctx);
-
-    h = _TEMPLATE(T, vec_init) (2 * n - 1, ctx);
-    t = _TEMPLATE(T, vec_init) (2 * n - 1, ctx);
-
-    /* Set rows of B to the segments of poly1 */
-    for (i = 0; i < len1 / m; i++)
-        _TEMPLATE(T, vec_set) (TEMPLATE(T, mat_entry) (B, i, 0), poly1 + i * m, m, ctx);
-
-    _TEMPLATE(T, vec_set) (TEMPLATE(T, mat_entry) (B, i, 0), poly1 + i * m, len1 % m, ctx);
-
-    /* Set rows of A to powers of poly2 */
-    TEMPLATE(T, one) (TEMPLATE(T, mat_entry) (A, 0, 0), ctx);
-    _TEMPLATE(T, vec_set) (TEMPLATE(T, mat_entry) (A, 1, 0), poly2, n, ctx);
-    tmp = _TEMPLATE(T, vec_init) (2 * n - 1, ctx);
-    for (i = 2; i < m; i++)
-    {
-        _TEMPLATE(T, poly_mulmod_preinv) (tmp, TEMPLATE(T, mat_entry) (A, i - 1, 0), n, poly2, n,
-                                          poly3, len3, poly3inv, len3inv, ctx);
-        _TEMPLATE(T, vec_set) (TEMPLATE(T, mat_entry) (A, i, 0), tmp, n, ctx);
-    }
-    _TEMPLATE(T, vec_clear) (tmp, 2 * n - 1, ctx);
-
-    TEMPLATE(T, mat_mul) (C, B, A, ctx);
-
-    /* Evaluate block composition using the Horner scheme */
-    _TEMPLATE(T, vec_set) (res, TEMPLATE(T, mat_entry) (C, m - 1, 0), n, ctx);
-    _TEMPLATE(T, poly_mulmod_preinv) (h, TEMPLATE(T, mat_entry) (A, m - 1, 0), n, poly2, n, poly3,
-                                      len3, poly3inv, len3inv, ctx);
-
-    for (i = m - 2; i >= 0; i--)
-    {
-        _TEMPLATE(T, poly_mulmod_preinv) (t, res, n, h, n, poly3, len3,
-                                          poly3inv, len3inv, ctx);
-        _TEMPLATE(T, poly_add) (res, t, n, TEMPLATE(T, mat_entry) (C, i, 0), n, ctx);
-    }
-
-    _TEMPLATE(T, vec_clear) (h, 2 * n - 1, ctx);
-    _TEMPLATE(T, vec_clear) (t, 2 * n - 1, ctx);
-
-    TEMPLATE(T, mat_clear) (A, ctx);
-    TEMPLATE(T, mat_clear) (B, ctx);
-    TEMPLATE(T, mat_clear) (C, ctx);
+    gr_ctx_t gr_ctx;
+    TEMPLATE3(_gr_ctx_init, T, from_ref)(gr_ctx, ctx);
+    GR_MUST_SUCCEED(_gr_poly_compose_mod_brent_kung_preinv(res, poly1, len1, poly2, poly3, len3, poly3inv, len3inv, gr_ctx));
 }
 
 void
-TEMPLATE(T, poly_compose_mod_brent_kung_preinv) (
-    TEMPLATE(T, poly_t) res,
-    const TEMPLATE(T, poly_t) poly1,
-    const TEMPLATE(T, poly_t) poly2,
-    const TEMPLATE(T, poly_t) poly3,
-    const TEMPLATE(T, poly_t) poly3inv,
-    const TEMPLATE(T, ctx_t) ctx)
+TEMPLATE(T, poly_compose_mod_brent_kung_preinv) (TEMPLATE(T, poly_t) res,
+                               const TEMPLATE(T, poly_t) poly1,
+                               const TEMPLATE(T, poly_t) poly2,
+                               const TEMPLATE(T, poly_t) poly3,
+                               const TEMPLATE(T, poly_t) poly3inv,
+                               const TEMPLATE(T, ctx_t) ctx)
 {
-    slong len1 = poly1->length;
-    slong len2 = poly2->length;
-    slong len3 = poly3->length;
-    slong len3inv = poly3inv->length;
-    slong len = len3 - 1;
-    slong vec_len = FLINT_MAX(len3 - 1, len2);
-
-    TEMPLATE(T, struct) * ptr2;
-    TEMPLATE(T, t) inv3;
-
-    if (len3 == 0)
-    {
-        flint_throw(FLINT_ERROR, "(%s): Division by zero\n", __func__);
-    }
-
-    if (len1 >= len3)
-    {
-        flint_throw(FLINT_ERROR, "(%s): The degree of the first polynomial must be smaller than that of the modulus\n", __func__);
-    }
-
-    if (len1 == 0 || len3 == 1)
-    {
-        TEMPLATE(T, poly_zero) (res, ctx);
-        return;
-    }
-
-    if (len1 == 1)
-    {
-        TEMPLATE(T, poly_set) (res, poly1, ctx);
-        return;
-    }
-
-    if (res == poly3 || res == poly1)
-    {
-        TEMPLATE(T, poly_t) tmp;
-        TEMPLATE(T, poly_init) (tmp, ctx);
-        TEMPLATE(T, poly_compose_mod_brent_kung_preinv) (tmp, poly1, poly2,
-                                                         poly3, poly3inv, ctx);
-        TEMPLATE(T, poly_swap) (tmp, res, ctx);
-        TEMPLATE(T, poly_clear) (tmp, ctx);
-        return;
-    }
-
-    ptr2 = _TEMPLATE(T, vec_init) (vec_len, ctx);
-
-    if (len2 <= len)
-    {
-        _TEMPLATE(T, vec_set) (ptr2, poly2->coeffs, len2, ctx);
-        _TEMPLATE(T, vec_zero) (ptr2 + len2, vec_len - len2, ctx);
-    }
-    else
-    {
-        TEMPLATE(T, init) (inv3, ctx);
-        TEMPLATE(T, inv) (inv3, poly3->coeffs + len, ctx);
-        _TEMPLATE(T, poly_rem) (ptr2, poly2->coeffs, len2,
-                                poly3->coeffs, len3, inv3, ctx);
-        TEMPLATE(T, clear) (inv3, ctx);
-    }
-
-    TEMPLATE(T, poly_fit_length) (res, len, ctx);
-    _TEMPLATE(T, poly_compose_mod_brent_kung_preinv) (res->coeffs,
-                                                      poly1->coeffs, len1,
-                                                      ptr2, poly3->coeffs,
-                                                      len3, poly3inv->coeffs,
-                                                      len3inv, ctx);
-    _TEMPLATE(T, poly_set_length) (res, len, ctx);
-    _TEMPLATE(T, poly_normalise) (res, ctx);
-
-    _TEMPLATE(T, vec_clear) (ptr2, vec_len, ctx);
+    gr_ctx_t gr_ctx;
+    TEMPLATE3(_gr_ctx_init, T, from_ref)(gr_ctx, ctx);
+    GR_MUST_SUCCEED(gr_poly_compose_mod_brent_kung_preinv((gr_poly_struct *) res,
+            (const gr_poly_struct *) poly1,
+            (const gr_poly_struct *) poly2,
+            (const gr_poly_struct *) poly3,
+            (const gr_poly_struct *) poly3inv, gr_ctx));
 }
-
 
 #endif

--- a/src/fq_poly_templates/compose_mod_horner.c
+++ b/src/fq_poly_templates/compose_mod_horner.c
@@ -13,124 +13,35 @@
 
 #ifdef T
 
+#include "gr.h"
+#include "gr_mat.h"
 #include "templates.h"
 
-#include "ulong_extras.h"
 void
-_TEMPLATE(T, poly_compose_mod_horner) (
-    TEMPLATE(T, struct) * res,
-    const TEMPLATE(T, struct) * f, slong lenf,
-    const TEMPLATE(T, struct) * g,
-    const TEMPLATE(T, struct) * h, slong lenh,
-    const TEMPLATE(T, ctx_t) ctx)
+_TEMPLATE(T, poly_compose_mod_horner) (TEMPLATE(T, struct) * res,
+                                const TEMPLATE(T, struct) * poly1, slong len1,
+                                const TEMPLATE(T, struct) * poly2,
+                                const TEMPLATE(T, struct) * poly3, slong len3,
+                                const TEMPLATE(T, ctx_t) ctx)
 {
-    slong i, len;
-    TEMPLATE(T, struct) * t;
-
-    if (lenh == 1)
-        return;
-
-    if (lenf == 1)
-    {
-        TEMPLATE(T, set) (res, f, ctx);
-        return;
-    }
-
-    if (lenh == 2)
-    {
-        _TEMPLATE(T, TEMPLATE(poly_evaluate, T)) (res, f, lenf, g, ctx);
-        return;
-    }
-
-    len = lenh - 1;
-    i = lenf - 1;
-    t = _TEMPLATE(T, vec_init) (2 * lenh - 3, ctx);
-
-    _TEMPLATE(T, TEMPLATE(poly_scalar_mul, T)) (res, g, len, f + i, ctx);
-    i--;
-    if (i >= 0)
-    {
-        TEMPLATE(T, add) (res, res, f + i, ctx);
-    }
-
-    while (i > 0)
-    {
-        i--;
-        _TEMPLATE(T, poly_mulmod) (t, res, len, g, len, h, lenh, ctx);
-        _TEMPLATE(T, poly_add) (res, t, len, f + i, 1, ctx);
-    }
-
-    _TEMPLATE(T, vec_clear) (t, 2 * lenh - 3, ctx);
+    gr_ctx_t gr_ctx;
+    TEMPLATE3(_gr_ctx_init, T, from_ref)(gr_ctx, ctx);
+    GR_MUST_SUCCEED(_gr_poly_compose_mod_horner(res, poly1, len1, poly2, poly3, len3, gr_ctx));
 }
 
 void
 TEMPLATE(T, poly_compose_mod_horner) (TEMPLATE(T, poly_t) res,
-                                      const TEMPLATE(T, poly_t) poly1,
-                                      const TEMPLATE(T, poly_t) poly2,
-                                      const TEMPLATE(T, poly_t) poly3,
-                                      const TEMPLATE(T, ctx_t) ctx)
+                               const TEMPLATE(T, poly_t) poly1,
+                               const TEMPLATE(T, poly_t) poly2,
+                               const TEMPLATE(T, poly_t) poly3,
+                               const TEMPLATE(T, ctx_t) ctx)
 {
-    TEMPLATE(T, t) inv3;
-    slong len1 = poly1->length;
-    slong len2 = poly2->length;
-    slong len3 = poly3->length;
-    slong len = len3 - 1;
-    slong vec_len = FLINT_MAX(len3 - 1, len2);
-
-    TEMPLATE(T, struct) * ptr2;
-
-    if (len3 == 0)
-    {
-        flint_throw(FLINT_ERROR, "(%s): Division by zero\n", __func__);
-    }
-
-    if (len1 == 0 || len3 == 1)
-    {
-        TEMPLATE(T, poly_zero) (res, ctx);
-        return;
-    }
-
-    if (len1 == 1)
-    {
-        TEMPLATE(T, poly_set) (res, poly1, ctx);
-        return;
-    }
-
-    if (res == poly3 || res == poly1)
-    {
-        TEMPLATE(T, poly_t) tmp;
-        TEMPLATE(T, poly_init) (tmp, ctx);
-        TEMPLATE(T, poly_compose_mod_horner) (tmp, poly1, poly2, poly3, ctx);
-        TEMPLATE(T, poly_swap) (tmp, res, ctx);
-        TEMPLATE(T, poly_clear) (tmp, ctx);
-        return;
-    }
-
-    ptr2 = _TEMPLATE(T, vec_init) (vec_len, ctx);
-
-    if (len2 <= len3 - 1)
-    {
-        _TEMPLATE(T, vec_set) (ptr2, poly2->coeffs, len2, ctx);
-        _TEMPLATE(T, vec_zero) (ptr2 + len2, vec_len - len2, ctx);
-    }
-    else
-    {
-        TEMPLATE(T, init) (inv3, ctx);
-        TEMPLATE(T, inv) (inv3, poly3->coeffs + len, ctx);
-        _TEMPLATE(T, poly_rem) (ptr2, poly2->coeffs, len2,
-                                poly3->coeffs, len3, inv3, ctx);
-        TEMPLATE(T, clear) (inv3, ctx);
-    }
-
-    TEMPLATE(T, poly_fit_length) (res, len, ctx);
-    _TEMPLATE(T, poly_compose_mod_horner) (res->coeffs,
-                                           poly1->coeffs, len1,
-                                           ptr2, poly3->coeffs, len3, ctx);
-    _TEMPLATE(T, poly_set_length) (res, len, ctx);
-    _TEMPLATE(T, poly_normalise) (res, ctx);
-
-    _TEMPLATE(T, vec_clear) (ptr2, vec_len, ctx);
+    gr_ctx_t gr_ctx;
+    TEMPLATE3(_gr_ctx_init, T, from_ref)(gr_ctx, ctx);
+    GR_MUST_SUCCEED(gr_poly_compose_mod_horner((gr_poly_struct *) res,
+            (const gr_poly_struct *) poly1,
+            (const gr_poly_struct *) poly2,
+            (const gr_poly_struct *) poly3, gr_ctx));
 }
-
 
 #endif

--- a/src/fq_poly_templates/compose_mod_horner_preinv.c
+++ b/src/fq_poly_templates/compose_mod_horner_preinv.c
@@ -13,133 +13,38 @@
 
 #ifdef T
 
+#include "gr.h"
+#include "gr_mat.h"
 #include "templates.h"
 
-#include "ulong_extras.h"
 void
-_TEMPLATE(T, poly_compose_mod_horner_preinv) (
-    TEMPLATE(T, struct) * res,
-    const TEMPLATE(T, struct) * f, slong lenf,
-    const TEMPLATE(T, struct) * g,
-    const TEMPLATE(T, struct) * h, slong lenh,
-    const TEMPLATE(T, struct) * hinv, slong lenhinv,
-    const TEMPLATE(T, ctx_t) ctx)
+_TEMPLATE(T, poly_compose_mod_horner_preinv) (TEMPLATE(T, struct) * res,
+                                const TEMPLATE(T, struct) * poly1, slong len1,
+                                const TEMPLATE(T, struct) * poly2,
+                                const TEMPLATE(T, struct) * poly3, slong len3,
+                                const TEMPLATE(T, struct) * poly3inv, slong len3inv,
+                                const TEMPLATE(T, ctx_t) ctx)
 {
-    slong i, len;
-    TEMPLATE(T, struct) * t;
-
-    if (lenh == 1)
-        return;
-
-    if (lenf == 1)
-    {
-        TEMPLATE(T, set) (res, f, ctx);
-        return;
-    }
-
-    if (lenh == 2)
-    {
-        _TEMPLATE(T, TEMPLATE(poly_evaluate, T)) (res, f, lenf, g, ctx);
-        return;
-    }
-
-    len = lenh - 1;
-    i = lenf - 1;
-    t = _TEMPLATE(T, vec_init) (2 * lenh - 3, ctx);
-
-    _TEMPLATE(T, TEMPLATE(poly_scalar_mul, T)) (res, g, len, f + i, ctx);
-    i--;
-    if (i >= 0)
-    {
-        TEMPLATE(T, add) (res, res, f + i, ctx);
-    }
-
-    while (i > 0)
-    {
-        i--;
-        _TEMPLATE(T, poly_mulmod_preinv) (t, res, len, g, len, h, lenh, hinv,
-                                          lenhinv, ctx);
-        _TEMPLATE(T, poly_add) (res, t, len, f + i, 1, ctx);
-    }
-
-    _TEMPLATE(T, vec_clear) (t, 2 * lenh - 3, ctx);
+    gr_ctx_t gr_ctx;
+    TEMPLATE3(_gr_ctx_init, T, from_ref)(gr_ctx, ctx);
+    GR_MUST_SUCCEED(_gr_poly_compose_mod_horner_preinv(res, poly1, len1, poly2, poly3, len3, poly3inv, len3inv, gr_ctx));
 }
 
 void
-TEMPLATE(T, poly_compose_mod_horner_preinv) (
-    TEMPLATE(T, poly_t) res,
-    const TEMPLATE(T, poly_t) poly1,
-    const TEMPLATE(T, poly_t) poly2,
-    const TEMPLATE(T, poly_t) poly3,
-    const TEMPLATE(T, poly_t) poly3inv,
-    const TEMPLATE(T, ctx_t) ctx)
+TEMPLATE(T, poly_compose_mod_horner_preinv) (TEMPLATE(T, poly_t) res,
+                               const TEMPLATE(T, poly_t) poly1,
+                               const TEMPLATE(T, poly_t) poly2,
+                               const TEMPLATE(T, poly_t) poly3,
+                               const TEMPLATE(T, poly_t) poly3inv,
+                               const TEMPLATE(T, ctx_t) ctx)
 {
-    TEMPLATE(T, t) inv3;
-    slong len1 = poly1->length;
-    slong len2 = poly2->length;
-    slong len3 = poly3->length;
-    slong len3inv = poly3inv->length;
-    slong len = len3 - 1;
-    slong vec_len = FLINT_MAX(len3 - 1, len2);
-
-    TEMPLATE(T, struct) * ptr2;
-
-    if (len3 == 0)
-    {
-        flint_throw(FLINT_ERROR, "(%s): Division by zero\n", __func__);
-    }
-
-    if (len1 == 0 || len3 == 1)
-    {
-        TEMPLATE(T, poly_zero) (res, ctx);
-        return;
-    }
-
-    if (len1 == 1)
-    {
-        TEMPLATE(T, poly_set) (res, poly1, ctx);
-        return;
-    }
-
-    if (res == poly3 || res == poly1)
-    {
-        TEMPLATE(T, poly_t) tmp;
-        TEMPLATE(T, poly_init) (tmp, ctx);
-        TEMPLATE(T, poly_compose_mod_horner_preinv) (tmp, poly1, poly2, poly3,
-                                                     poly3inv, ctx);
-        TEMPLATE(T, poly_swap) (tmp, res, ctx);
-        TEMPLATE(T, poly_clear) (tmp, ctx);
-        return;
-    }
-
-    ptr2 = _TEMPLATE(T, vec_init) (vec_len, ctx);
-
-    if (len2 <= len3 - 1)
-    {
-        _TEMPLATE(T, vec_set) (ptr2, poly2->coeffs, len2, ctx);
-        _TEMPLATE(T, vec_zero) (ptr2 + len2, vec_len - len2, ctx);
-    }
-    else
-    {
-        TEMPLATE(T, init) (inv3, ctx);
-        TEMPLATE(T, inv) (inv3, poly3->coeffs + len, ctx);
-        _TEMPLATE(T, poly_rem) (ptr2, poly2->coeffs, len2,
-                                poly3->coeffs, len3, inv3, ctx);
-        TEMPLATE(T, clear) (inv3, ctx);
-    }
-
-    TEMPLATE(T, poly_fit_length) (res, len, ctx);
-    _TEMPLATE(T, poly_compose_mod_horner_preinv) (res->coeffs,
-                                                  poly1->coeffs, len1,
-                                                  ptr2,
-                                                  poly3->coeffs, len3,
-                                                  poly3inv->coeffs, len3inv,
-                                                  ctx);
-    _TEMPLATE(T, poly_set_length) (res, len, ctx);
-    _TEMPLATE(T, poly_normalise) (res, ctx);
-
-    _TEMPLATE(T, vec_clear) (ptr2, vec_len, ctx);
+    gr_ctx_t gr_ctx;
+    TEMPLATE3(_gr_ctx_init, T, from_ref)(gr_ctx, ctx);
+    GR_MUST_SUCCEED(gr_poly_compose_mod_horner_preinv((gr_poly_struct *) res,
+            (const gr_poly_struct *) poly1,
+            (const gr_poly_struct *) poly2,
+            (const gr_poly_struct *) poly3,
+            (const gr_poly_struct *) poly3inv, gr_ctx));
 }
-
 
 #endif

--- a/src/fq_poly_templates/compose_mod_preinv.c
+++ b/src/fq_poly_templates/compose_mod_preinv.c
@@ -13,100 +13,38 @@
 
 #ifdef T
 
+#include "gr.h"
+#include "gr_mat.h"
 #include "templates.h"
 
-#include "ulong_extras.h"
 void
-_TEMPLATE(T, poly_compose_mod_preinv) (
-    TEMPLATE(T, struct) * res,
-    const TEMPLATE(T, struct) * f, slong lenf,
-    const TEMPLATE(T, struct) * g,
-    const TEMPLATE(T, struct) * h, slong lenh,
-    const TEMPLATE(T, struct) * hinv, slong lenhinv,
-    const TEMPLATE(T, ctx_t) ctx)
+_TEMPLATE(T, poly_compose_mod_preinv) (TEMPLATE(T, struct) * res,
+                                const TEMPLATE(T, struct) * poly1, slong len1,
+                                const TEMPLATE(T, struct) * poly2,
+                                const TEMPLATE(T, struct) * poly3, slong len3,
+                                const TEMPLATE(T, struct) * poly3inv, slong len3inv,
+                                const TEMPLATE(T, ctx_t) ctx)
 {
-    if (lenh < TEMPLATE(CAP_T, COMPOSE_MOD_PREINV_LENH_CUTOFF) || lenf >= lenh)
-        _TEMPLATE(T, poly_compose_mod_horner_preinv) (res, f, lenf, g, h, lenh,
-                                                      hinv, lenhinv, ctx);
-    else
-        _TEMPLATE(T, poly_compose_mod_brent_kung_preinv) (res, f, lenf, g, h,
-                                                          lenh, hinv, lenhinv,
-                                                          ctx);
+    gr_ctx_t gr_ctx;
+    TEMPLATE3(_gr_ctx_init, T, from_ref)(gr_ctx, ctx);
+    GR_MUST_SUCCEED(_gr_poly_compose_mod_preinv(res, poly1, len1, poly2, poly3, len3, poly3inv, len3inv, gr_ctx));
 }
 
 void
 TEMPLATE(T, poly_compose_mod_preinv) (TEMPLATE(T, poly_t) res,
-                                      const TEMPLATE(T, poly_t) poly1,
-                                      const TEMPLATE(T, poly_t) poly2,
-                                      const TEMPLATE(T, poly_t) poly3,
-                                      const TEMPLATE(T, poly_t) poly3inv,
-                                      const TEMPLATE(T, ctx_t) ctx)
+                               const TEMPLATE(T, poly_t) poly1,
+                               const TEMPLATE(T, poly_t) poly2,
+                               const TEMPLATE(T, poly_t) poly3,
+                               const TEMPLATE(T, poly_t) poly3inv,
+                               const TEMPLATE(T, ctx_t) ctx)
 {
-    TEMPLATE(T, t) inv3;
-    slong len1 = poly1->length;
-    slong len2 = poly2->length;
-    slong len3 = poly3->length;
-    slong len3inv = poly3inv->length;
-    slong len = len3 - 1;
-    slong vec_len = FLINT_MAX(len3 - 1, len2);
-
-    TEMPLATE(T, struct) * ptr2;
-
-    if (len3 == 0)
-    {
-        flint_throw(FLINT_ERROR, "(%s): Division by zero\n", __func__);
-    }
-
-    if (len1 == 0 || len3 == 1)
-    {
-        TEMPLATE(T, poly_zero) (res, ctx);
-        return;
-    }
-
-    if (len1 == 1)
-    {
-        TEMPLATE(T, poly_set) (res, poly1, ctx);
-        return;
-    }
-
-    if (res == poly3 || res == poly1)
-    {
-        TEMPLATE(T, poly_t) tmp;
-        TEMPLATE(T, poly_init) (tmp, ctx);
-        TEMPLATE(T, poly_compose_mod_preinv) (tmp, poly1, poly2, poly3,
-                                              poly3inv, ctx);
-        TEMPLATE(T, poly_swap) (tmp, res, ctx);
-        TEMPLATE(T, poly_clear) (tmp, ctx);
-        return;
-    }
-
-    ptr2 = _TEMPLATE(T, vec_init) (vec_len, ctx);
-
-    if (len2 <= len)
-    {
-        _TEMPLATE(T, vec_set) (ptr2, poly2->coeffs, len2, ctx);
-        _TEMPLATE(T, vec_zero) (ptr2 + len2, len - len2, ctx);
-    }
-    else
-    {
-        TEMPLATE(T, init) (inv3, ctx);
-        TEMPLATE(T, inv) (inv3, poly3->coeffs + len, ctx);
-        _TEMPLATE(T, poly_rem) (ptr2, poly2->coeffs, len2,
-                                poly3->coeffs, len3, inv3, ctx);
-        TEMPLATE(T, clear) (inv3, ctx);
-    }
-
-    TEMPLATE(T, poly_fit_length) (res, len, ctx);
-    _TEMPLATE(T, poly_compose_mod_preinv) (res->coeffs,
-                                           poly1->coeffs, len1,
-                                           ptr2,
-                                           poly3->coeffs, len3,
-                                           poly3inv->coeffs, len3inv, ctx);
-    _TEMPLATE(T, poly_set_length) (res, len, ctx);
-    _TEMPLATE(T, poly_normalise) (res, ctx);
-
-    _TEMPLATE(T, vec_clear) (ptr2, vec_len, ctx);
+    gr_ctx_t gr_ctx;
+    TEMPLATE3(_gr_ctx_init, T, from_ref)(gr_ctx, ctx);
+    GR_MUST_SUCCEED(gr_poly_compose_mod_preinv((gr_poly_struct *) res,
+            (const gr_poly_struct *) poly1,
+            (const gr_poly_struct *) poly2,
+            (const gr_poly_struct *) poly3,
+            (const gr_poly_struct *) poly3inv, gr_ctx));
 }
-
 
 #endif

--- a/src/gr_poly.h
+++ b/src/gr_poly.h
@@ -463,8 +463,11 @@ WARN_UNUSED_RESULT int gr_poly_mulmod(gr_poly_t res, const gr_poly_t poly1, cons
 WARN_UNUSED_RESULT int _gr_poly_mulmod_preinv(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_srcptr f, slong lenf, gr_srcptr finv, slong lenfinv, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_mulmod_preinv(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, const gr_poly_t f, const gr_poly_t finv, gr_ctx_t ctx);
 
+/* boilerplate */
 typedef int ((*_gr_method_compose_mod_op)(gr_ptr, gr_srcptr, slong, gr_srcptr, gr_srcptr, slong, gr_ctx_t));
 WARN_UNUSED_RESULT int gr_poly_compose_mod_wrapper(_gr_method_compose_mod_op _compose_mod, gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, const gr_poly_t poly3, gr_ctx_t ctx);
+typedef int ((*_gr_method_compose_mod_preinv_op)(gr_ptr, gr_srcptr, slong, gr_srcptr, gr_srcptr, slong, gr_srcptr, slong, gr_ctx_t));
+WARN_UNUSED_RESULT int gr_poly_compose_mod_preinv_wrapper(_gr_method_compose_mod_preinv_op _compose_mod, gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, const gr_poly_t poly3, const gr_poly_t poly3inv, gr_ctx_t ctx);
 
 WARN_UNUSED_RESULT int _gr_poly_compose_mod_horner(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, gr_srcptr poly3, slong len3, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_compose_mod_horner(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, const gr_poly_t poly3, gr_ctx_t ctx);
@@ -473,8 +476,12 @@ WARN_UNUSED_RESULT int gr_poly_compose_mod_brent_kung(gr_poly_t res, const gr_po
 WARN_UNUSED_RESULT int _gr_poly_compose_mod(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, gr_srcptr poly3, slong len3, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_compose_mod(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, const gr_poly_t poly3, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_compose_mod_horner_preinv(gr_ptr res, gr_srcptr f, slong lenf, gr_srcptr g, gr_srcptr h, slong lenh, gr_srcptr hinv, slong lenhinv, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int _gr_poly_compose_mod_horner_preinv(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, gr_srcptr poly3, slong len3, gr_srcptr poly3inv, slong inv3len, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_compose_mod_horner_preinv(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, const gr_poly_t poly3, const gr_poly_t poly3inv, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int _gr_poly_compose_mod_brent_kung_preinv(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, gr_srcptr poly3, slong len3, gr_srcptr poly3inv, slong inv3len, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_poly_compose_mod_brent_kung_preinv(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, const gr_poly_t poly3, const gr_poly_t poly3inv, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int _gr_poly_compose_mod_preinv(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, gr_srcptr poly3, slong len3, gr_srcptr poly3inv, slong inv3len, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_poly_compose_mod_preinv(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, const gr_poly_t poly3, const gr_poly_t poly3inv, gr_ctx_t ctx);
 
 /* Test functions */
 

--- a/src/gr_poly.h
+++ b/src/gr_poly.h
@@ -200,6 +200,11 @@ WARN_UNUSED_RESULT int gr_poly_div(gr_poly_t Q, const gr_poly_t A, const gr_poly
 WARN_UNUSED_RESULT int _gr_poly_rem(gr_ptr R, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_rem(gr_poly_t R, const gr_poly_t A, const gr_poly_t B, gr_ctx_t ctx);
 
+WARN_UNUSED_RESULT int _gr_poly_div_newton_n_preinv(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr FLINT_UNUSED(B), slong lenB, gr_srcptr Binv, slong lenBinv, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_poly_div_newton_n_preinv(gr_poly_t Q, const gr_poly_t A, const gr_poly_t B, const gr_poly_t Binv, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int _gr_poly_divrem_newton_n_preinv(gr_ptr Q, gr_ptr R, gr_srcptr A, slong lenA, gr_srcptr B, slong lenB, gr_srcptr Binv, slong lenBinv, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_poly_divrem_newton_n_preinv(gr_poly_t Q, gr_poly_t R, const gr_poly_t A, const gr_poly_t B, const gr_poly_t Binv, gr_ctx_t ctx);
+
 
 /* todo: div with fast divisibility checking; rem; divexact */
 
@@ -449,6 +454,27 @@ WARN_UNUSED_RESULT int _gr_poly_tan_series_newton(gr_ptr f, gr_srcptr h, slong h
 WARN_UNUSED_RESULT int gr_poly_tan_series_newton(gr_poly_t f, const gr_poly_t h, slong n, slong cutoff, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int _gr_poly_tan_series(gr_ptr f, gr_srcptr h, slong hlen, slong n, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_tan_series(gr_poly_t f, const gr_poly_t h, slong n, gr_ctx_t ctx);
+
+/* Modular arithmetic and composition */
+
+WARN_UNUSED_RESULT int _gr_poly_mulmod(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_srcptr f, slong lenf, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_poly_mulmod(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, const gr_poly_t f, gr_ctx_t ctx);
+
+WARN_UNUSED_RESULT int _gr_poly_mulmod_preinv(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_srcptr f, slong lenf, gr_srcptr finv, slong lenfinv, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_poly_mulmod_preinv(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, const gr_poly_t f, const gr_poly_t finv, gr_ctx_t ctx);
+
+typedef int ((*_gr_method_compose_mod_op)(gr_ptr, gr_srcptr, slong, gr_srcptr, gr_srcptr, slong, gr_ctx_t));
+WARN_UNUSED_RESULT int gr_poly_compose_mod_wrapper(_gr_method_compose_mod_op _compose_mod, gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, const gr_poly_t poly3, gr_ctx_t ctx);
+
+WARN_UNUSED_RESULT int _gr_poly_compose_mod_horner(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, gr_srcptr poly3, slong len3, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_poly_compose_mod_horner(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, const gr_poly_t poly3, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int _gr_poly_compose_mod_brent_kung(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, gr_srcptr poly3, slong len3, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_poly_compose_mod_brent_kung(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, const gr_poly_t poly3, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int _gr_poly_compose_mod(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, gr_srcptr poly3, slong len3, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_poly_compose_mod(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, const gr_poly_t poly3, gr_ctx_t ctx);
+
+WARN_UNUSED_RESULT int _gr_poly_compose_mod_horner_preinv(gr_ptr res, gr_srcptr f, slong lenf, gr_srcptr g, gr_srcptr h, slong lenh, gr_srcptr hinv, slong lenhinv, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_poly_compose_mod_horner_preinv(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, const gr_poly_t poly3, const gr_poly_t poly3inv, gr_ctx_t ctx);
 
 /* Test functions */
 

--- a/src/gr_poly.h
+++ b/src/gr_poly.h
@@ -483,6 +483,12 @@ WARN_UNUSED_RESULT int gr_poly_compose_mod_brent_kung_preinv(gr_poly_t res, cons
 WARN_UNUSED_RESULT int _gr_poly_compose_mod_preinv(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, gr_srcptr poly3, slong len3, gr_srcptr poly3inv, slong inv3len, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_compose_mod_preinv(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, const gr_poly_t poly3, const gr_poly_t poly3inv, gr_ctx_t ctx);
 
+WARN_UNUSED_RESULT int _gr_poly_reduce_matrix_mod_poly(gr_mat_t A, const gr_mat_t B, const gr_poly_t f, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int _gr_poly_precompute_matrix(gr_mat_t A, gr_srcptr poly1, gr_srcptr poly2, slong len2, gr_srcptr poly2inv, slong len2inv, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_poly_precompute_matrix(gr_mat_t A, const gr_poly_t poly1, const gr_poly_t poly2, const gr_poly_t poly2inv, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int _gr_poly_compose_mod_brent_kung_precomp_preinv(gr_ptr res, gr_srcptr poly1, slong len1, const gr_mat_t A, gr_srcptr poly3, slong len3, gr_srcptr poly3inv, slong len3inv, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_poly_compose_mod_brent_kung_precomp_preinv(gr_poly_t res, const gr_poly_t poly1, const gr_mat_t A, const gr_poly_t poly3, const gr_poly_t poly3inv, gr_ctx_t ctx);
+
 /* Test functions */
 
 void _gr_poly_test_mullow(gr_method_poly_binary_trunc_op mullow_impl, gr_method_poly_binary_trunc_op mullow_ref, flint_rand_t state, slong iters, slong maxn, gr_ctx_t ctx);

--- a/src/gr_poly/compose_mod.c
+++ b/src/gr_poly/compose_mod.c
@@ -1,0 +1,99 @@
+/*
+    Copyright (C) 2011, 2025 Fredrik Johansson
+    Copyright (C) 2012 Lina Kulakova
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "ulong_extras.h"
+#include "gr.h"
+#include "gr_vec.h"
+#include "gr_mat.h"
+#include "gr_poly.h"
+
+int
+_gr_poly_compose_mod(
+    gr_ptr res,
+    gr_srcptr poly1, slong len1,
+    gr_srcptr poly2,
+    gr_srcptr poly3, slong len3,
+    gr_ctx_t ctx)
+{
+    /* todo: ring-specific tuning */
+    if (len3 < 6 || len1 >= len3)
+        return _gr_poly_compose_mod_horner(res, poly1, len1, poly2, poly3, len3, ctx);
+    else
+        return _gr_poly_compose_mod_brent_kung(res, poly1, len1, poly2, poly3, len3, ctx);
+}
+
+int
+gr_poly_compose_mod_wrapper(_gr_method_compose_mod_op _compose_mod, gr_poly_t res,
+                                      const gr_poly_t poly1,
+                                      const gr_poly_t poly2,
+                                      const gr_poly_t poly3,
+                                      gr_ctx_t ctx)
+{
+    slong len1 = poly1->length;
+    slong len2 = poly2->length;
+    slong len3 = poly3->length;
+    slong len = len3 - 1;
+    slong vec_len = FLINT_MAX(len3 - 1, len2);
+    gr_ptr ptr2;
+    slong sz = ctx->sizeof_elem;
+    int status = GR_SUCCESS;
+
+    if (len3 == 0)
+        return GR_DOMAIN;
+
+    if (len1 == 0 || len3 == 1)
+        return gr_poly_zero(res, ctx);
+
+    if (len1 == 1)
+        return gr_poly_set(res, poly1, ctx);
+
+    if (res == poly3 || res == poly1)
+    {
+        gr_poly_t tmp;
+        gr_poly_init(tmp, ctx);
+        status = gr_poly_compose_mod_wrapper(_compose_mod, tmp, poly1, poly2, poly3, ctx);
+        gr_poly_swap(tmp, res, ctx);
+        gr_poly_clear(tmp, ctx);
+        return status;
+    }
+
+    GR_TMP_INIT_VEC(ptr2, vec_len, ctx);
+
+    if (len2 <= len3 - 1)
+    {
+        status |= _gr_vec_set(ptr2, poly2->coeffs, len2, ctx);
+        status |= _gr_vec_zero(GR_ENTRY(ptr2, len2, sz), vec_len - len2, ctx);
+    }
+    else
+    {
+        status |= _gr_poly_rem(ptr2, poly2->coeffs, len2, poly3->coeffs, len3, ctx);
+    }
+
+    gr_poly_fit_length(res, len, ctx);
+    status |= _compose_mod(res->coeffs, poly1->coeffs, len1, ptr2, poly3->coeffs, len3, ctx);
+    _gr_poly_set_length(res, len, ctx);
+    _gr_poly_normalise(res, ctx);
+
+    GR_TMP_CLEAR_VEC(ptr2, vec_len, ctx);
+    return status;
+}
+
+int
+gr_poly_compose_mod(gr_poly_t res,
+                      const gr_poly_t poly1,
+                      const gr_poly_t poly2,
+                      const gr_poly_t poly3,
+                      gr_ctx_t ctx)
+{
+    return gr_poly_compose_mod_wrapper(_gr_poly_compose_mod, res, poly1, poly2, poly3, ctx);
+}

--- a/src/gr_poly/compose_mod_brent_kung.c
+++ b/src/gr_poly/compose_mod_brent_kung.c
@@ -26,7 +26,7 @@ _gr_poly_compose_mod_brent_kung(
     gr_ctx_t ctx)
 {
     gr_mat_t A, B, C;
-    gr_ptr t, h, tmp;
+    gr_ptr t, h;
     slong i, n, m;
     int status = GR_SUCCESS;
     slong sz = ctx->sizeof_elem;
@@ -52,10 +52,8 @@ _gr_poly_compose_mod_brent_kung(
     gr_mat_init(B, m, m, ctx);
     gr_mat_init(C, m, n, ctx);
 
-    /* TODO: merge allocations */
-    GR_TMP_INIT_VEC(h, 2 * n - 1, ctx);
-    GR_TMP_INIT_VEC(t, 2 * n - 1, ctx);
-    GR_TMP_INIT_VEC(tmp, 2 * n - 1, ctx);
+    GR_TMP_INIT_VEC(h, 2 * n, ctx);
+    t = GR_ENTRY(h, n, sz);
 
     /* Set rows of B to the segments of poly1 */
     for (i = 0; i < len1 / m; i++)
@@ -71,16 +69,15 @@ _gr_poly_compose_mod_brent_kung(
     {
         /* Assume that squaring is better. XXX: this depends on the ring. */
 #if 1
-        status |= _gr_poly_mulmod(tmp, gr_mat_entry_srcptr(A, (i + 1) / 2, 0, ctx), n,
+        status |= _gr_poly_mulmod(gr_mat_entry_ptr(A, i, 0, ctx),
+                    gr_mat_entry_srcptr(A, (i + 1) / 2, 0, ctx), n,
                     gr_mat_entry_srcptr(A, i / 2, 0, ctx), n, poly3, len3, ctx);
 #else
-        status |= _gr_poly_mulmod(tmp, gr_mat_entry_srcptr(A, i - 1, 0, ctx), n,
+        status |= _gr_poly_mulmod(gr_mat_entry_ptr(A, i, 0, ctx),
+                    gr_mat_entry_srcptr(A, i - 1, 0, ctx), n,
                     poly2, n, poly3, len3, ctx);
 #endif
-        status |= _gr_vec_set(gr_mat_entry_ptr(A, i, 0, ctx), tmp, n, ctx);
     }
-
-    GR_TMP_CLEAR_VEC(tmp, 2 * n - 1, ctx);
 
     status |= gr_mat_mul(C, B, A, ctx);
 
@@ -94,8 +91,7 @@ _gr_poly_compose_mod_brent_kung(
         status |= _gr_poly_add(res, t, n, gr_mat_entry_srcptr(C, i, 0, ctx), n, ctx);
     }
 
-    GR_TMP_CLEAR_VEC(h, 2 * n - 1, ctx);
-    GR_TMP_CLEAR_VEC(t, 2 * n - 1, ctx);
+    GR_TMP_CLEAR_VEC(h, 2 * n, ctx);
 
     gr_mat_clear(A, ctx);
     gr_mat_clear(B, ctx);

--- a/src/gr_poly/compose_mod_brent_kung.c
+++ b/src/gr_poly/compose_mod_brent_kung.c
@@ -1,0 +1,109 @@
+/*
+    Copyright (C) 2011, 2025 Fredrik Johansson
+    Copyright (C) 2012 Lina Kulakova
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "ulong_extras.h"
+#include "gr.h"
+#include "gr_vec.h"
+#include "gr_mat.h"
+#include "gr_poly.h"
+
+int
+_gr_poly_compose_mod_brent_kung(
+    gr_ptr res,
+    gr_srcptr poly1, slong len1,
+    gr_srcptr poly2,
+    gr_srcptr poly3, slong len3,
+    gr_ctx_t ctx)
+{
+    gr_mat_t A, B, C;
+    gr_ptr t, h, tmp;
+    slong i, n, m;
+    int status = GR_SUCCESS;
+    slong sz = ctx->sizeof_elem;
+
+    n = len3 - 1;
+
+    if (len3 == 1)
+        return status;
+
+    if (len1 == 1)
+        return gr_set(res, poly1, ctx);
+
+    if (len3 == 2)
+        return _gr_poly_evaluate(res, poly1, len1, poly2, ctx);
+
+    /* Limitation of Brent-Kung */
+    if (len1 >= len3)
+        return GR_UNABLE;
+
+    m = n_sqrt(n) + 1;
+
+    gr_mat_init(A, m, n, ctx);
+    gr_mat_init(B, m, m, ctx);
+    gr_mat_init(C, m, n, ctx);
+
+    /* TODO: merge allocations */
+    GR_TMP_INIT_VEC(h, 2 * n - 1, ctx);
+    GR_TMP_INIT_VEC(t, 2 * n - 1, ctx);
+    GR_TMP_INIT_VEC(tmp, 2 * n - 1, ctx);
+
+    /* Set rows of B to the segments of poly1 */
+    for (i = 0; i < len1 / m; i++)
+        status |= _gr_vec_set(gr_mat_entry_ptr(B, i, 0, ctx), GR_ENTRY(poly1, i * m, sz), m, ctx);
+
+    status |= _gr_vec_set(gr_mat_entry_ptr(B, i, 0, ctx), GR_ENTRY(poly1, i * m, sz), len1 % m, ctx);
+
+    /* Set rows of A to powers of poly2 */
+    status |= gr_one(gr_mat_entry_ptr(A, 0, 0, ctx), ctx);
+    status |= _gr_vec_set(gr_mat_entry_ptr(A, 1, 0, ctx), poly2, n, ctx);
+
+    for (i = 2; i < m; i++)
+    {
+        /* Assume that squaring is better. XXX: this depends on the ring. */
+        status |= _gr_poly_mulmod(tmp, gr_mat_entry_srcptr(A, i - 1, 0, ctx), n, poly2, n, poly3, len3, ctx);
+        status |= _gr_vec_set(gr_mat_entry_ptr(A, i, 0, ctx), tmp, n, ctx);
+    }
+
+    GR_TMP_CLEAR_VEC(tmp, 2 * n - 1, ctx);
+
+    status |= gr_mat_mul(C, B, A, ctx);
+
+    /* Evaluate block composition using the Horner scheme */
+    status |= _gr_vec_set(res, gr_mat_entry_srcptr(C, m - 1, 0, ctx), n, ctx);
+    status |= _gr_poly_mulmod(h, gr_mat_entry_srcptr(A, m - 1, 0, ctx), n, poly2, n, poly3, len3, ctx);
+
+    for (i = m - 2; i >= 0; i--)
+    {
+        status |= _gr_poly_mulmod(t, res, n, h, n, poly3, len3, ctx);
+        status |= _gr_poly_add(res, t, n, gr_mat_entry_srcptr(C, i, 0, ctx), n, ctx);
+    }
+
+    GR_TMP_CLEAR_VEC(h, 2 * n - 1, ctx);
+    GR_TMP_CLEAR_VEC(t, 2 * n - 1, ctx);
+
+    gr_mat_clear(A, ctx);
+    gr_mat_clear(B, ctx);
+    gr_mat_clear(C, ctx);
+
+    return status;
+}
+
+int
+gr_poly_compose_mod_brent_kung(gr_poly_t res,
+                                      const gr_poly_t poly1,
+                                      const gr_poly_t poly2,
+                                      const gr_poly_t poly3,
+                                      gr_ctx_t ctx)
+{
+    return gr_poly_compose_mod_wrapper(_gr_poly_compose_mod_brent_kung, res, poly1, poly2, poly3, ctx);
+}

--- a/src/gr_poly/compose_mod_brent_kung_precomp_preinv.c
+++ b/src/gr_poly/compose_mod_brent_kung_precomp_preinv.c
@@ -1,0 +1,234 @@
+/*
+    Copyright (C) 2011, 2025 Fredrik Johansson
+    Copyright (C) 2013 Martin Lee
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "ulong_extras.h"
+#include "gr.h"
+#include "gr_vec.h"
+#include "gr_mat.h"
+#include "gr_poly.h"
+
+int
+_gr_poly_reduce_matrix_mod_poly(gr_mat_t A,
+                                           const gr_mat_t B,
+                                           const gr_poly_t f,
+                                           gr_ctx_t ctx)
+{
+    slong n = f->length - 1;
+    slong i, m = n_sqrt(n) + 1;
+    int status = GR_SUCCESS;
+
+    gr_mat_init(A, m, n, ctx);
+
+    /* todo: use a rem_preinv or at least preinv1 method for divisions */
+    /* gr_inv(invf, f->coeffs + (f->length - 1), ctx); */
+
+    status |= gr_one(gr_mat_entry_ptr(A, 0, 0, ctx), ctx);
+    for (i = 1; i < m; i++)
+        status |= _gr_poly_rem(gr_mat_entry_ptr(A, i, 0, ctx),
+                                gr_mat_entry_srcptr(B, i, 0, ctx),
+                                B->c, f->coeffs, f->length, ctx);
+
+    return status;
+}
+
+int
+_gr_poly_precompute_matrix(
+    gr_mat_t A,
+    gr_srcptr poly1,
+    gr_srcptr poly2, slong len2,
+    gr_srcptr poly2inv, slong len2inv,
+    gr_ctx_t ctx)
+{
+    /* Set rows of A to powers of poly1 */
+    slong i, n, m;
+    int status = GR_SUCCESS;
+
+    n = len2 - 1;
+
+    /* XXX: why not just read A->r? */
+    m = n_sqrt(n) + 1;
+
+    status |= gr_one(gr_mat_entry_ptr(A, 0, 0, ctx), ctx);
+    status |= _gr_vec_set(gr_mat_entry_ptr(A, 1, 0, ctx), poly1, n, ctx);
+    for (i = 2; i < m; i++)
+        status |= _gr_poly_mulmod_preinv(gr_mat_entry_ptr(A, i, 0, ctx),
+                gr_mat_entry_srcptr(A, (i + 1) / 2, 0, ctx), n,
+                gr_mat_entry_srcptr(A, i / 2, 0, ctx), n, poly2, len2,
+                                          poly2inv, len2inv, ctx);
+
+    return status;
+}
+
+int
+gr_poly_precompute_matrix(gr_mat_t A,
+                                     const gr_poly_t poly1,
+                                     const gr_poly_t poly2,
+                                     const gr_poly_t poly2inv,
+                                     gr_ctx_t ctx)
+{
+    slong len1 = poly1->length;
+    slong len2 = poly2->length;
+    slong len = len2 - 1;
+    int status = GR_SUCCESS;
+    slong sz = ctx->sizeof_elem;
+    slong m = n_sqrt(len) + 1;
+    gr_ptr ptr1;
+
+    /* Division by zero */
+    if (len2 == 0)
+        return GR_DOMAIN;
+
+    /* Wrong dimensions */
+    if (A->r != m || A->c != len)
+        return GR_DOMAIN;
+
+    if (len2 == 1)
+        return gr_mat_zero(A, ctx);
+
+    GR_TMP_INIT_VEC(ptr1, len, ctx);
+
+    if (len1 <= len)
+    {
+        status |= _gr_vec_set(ptr1, poly1->coeffs, len1, ctx);
+        status |= _gr_vec_zero(GR_ENTRY(ptr1, len1, sz), len - len1, ctx);
+    }
+    else
+    {
+        status |= _gr_poly_rem(ptr1, poly1->coeffs, len1, poly2->coeffs, len2, ctx);
+    }
+
+    status |= _gr_poly_precompute_matrix(A, ptr1, poly2->coeffs, len2,
+                                          poly2inv->coeffs, poly2inv->length,
+                                          ctx);
+
+    GR_TMP_CLEAR_VEC(ptr1, len, ctx);
+
+    return status;
+}
+
+int
+_gr_poly_compose_mod_brent_kung_precomp_preinv(
+    gr_ptr res,
+    gr_srcptr poly1, slong len1,
+    const gr_mat_t A,
+    gr_srcptr poly3, slong len3,
+    gr_srcptr poly3inv, slong len3inv,
+    gr_ctx_t ctx)
+{
+    gr_mat_t B, C;
+    gr_ptr t, h;
+    slong i, n, m;
+    int status = GR_SUCCESS;
+    slong sz = ctx->sizeof_elem;
+
+    n = len3 - 1;
+
+    if (len3 == 1)
+        return status;
+
+    if (len1 == 1)
+        return gr_set(res, poly1, ctx);
+
+    if (len3 == 2)
+        return _gr_poly_evaluate(res, poly1, len1, gr_mat_entry_srcptr(A, 1, 0, ctx), ctx);
+
+    /* Limitation of Brent-Kung */
+    if (len1 >= len3)
+        return GR_UNABLE;
+
+    m = n_sqrt(n) + 1;
+
+    /* TODO check A */
+
+    gr_mat_init(B, m, m, ctx);
+    gr_mat_init(C, m, n, ctx);
+
+    GR_TMP_INIT_VEC(h, 2 * n, ctx);
+    t = GR_ENTRY(h, n, sz);
+
+    /* Set rows of B to the segments of poly1 */
+    for (i = 0; i < len1 / m; i++)
+        status |= _gr_vec_set(gr_mat_entry_ptr(B, i, 0, ctx), GR_ENTRY(poly1, i * m, sz), m, ctx);
+
+    status |= _gr_vec_set(gr_mat_entry_ptr(B, i, 0, ctx), GR_ENTRY(poly1, i * m, sz), len1 % m, ctx);
+
+    status |= gr_mat_mul(C, B, A, ctx);
+
+    /* Evaluate block composition using the Horner scheme */
+    status |= _gr_vec_set(res, gr_mat_entry_srcptr(C, m - 1, 0, ctx), n, ctx);
+    status |= _gr_poly_mulmod_preinv(h, gr_mat_entry_srcptr(A, m - 1, 0, ctx), n,
+                                        gr_mat_entry_srcptr(A, 1, 0, ctx), n,
+                                      poly3, len3, poly3inv, len3inv, ctx);
+
+    for (i = m - 2; i >= 0; i--)
+    {
+        status |= _gr_poly_mulmod_preinv(t, res, n, h, n, poly3, len3,
+                                          poly3inv, len3inv, ctx);
+        status |= _gr_poly_add(res, t, n, gr_mat_entry_srcptr(C, i, 0, ctx), n, ctx);
+    }
+
+    GR_TMP_CLEAR_VEC(h, 2 * n, ctx);
+
+    gr_mat_clear(B, ctx);
+    gr_mat_clear(C, ctx);
+
+    return status;
+}
+
+int
+gr_poly_compose_mod_brent_kung_precomp_preinv(
+    gr_poly_t res,
+    const gr_poly_t poly1, const gr_mat_t A,
+    const gr_poly_t poly3, const gr_poly_t poly3inv,
+    gr_ctx_t ctx)
+{
+    slong len1 = poly1->length;
+    slong len3 = poly3->length;
+    slong len = len3 - 1;
+    int status;
+
+    if (len3 == 0)
+        return GR_DOMAIN;
+
+    if (len1 == 0 || len3 == 1)
+        return gr_poly_zero(res, ctx);
+
+    if (len1 == 1)
+        return gr_poly_set(res, poly1, ctx);
+
+    if (res == poly3 || res == poly1 || res == poly3inv)
+    {
+        gr_poly_t tmp;
+        gr_poly_init(tmp, ctx);
+        status = gr_poly_compose_mod_brent_kung_precomp_preinv(tmp, poly1, A,
+                                                                 poly3,
+                                                                 poly3inv,
+                                                                 ctx);
+        gr_poly_swap(tmp, res, ctx);
+        gr_poly_clear(tmp, ctx);
+        return status;
+    }
+
+    gr_poly_fit_length(res, len, ctx);
+    status = _gr_poly_compose_mod_brent_kung_precomp_preinv(res->coeffs,
+                                                              poly1->coeffs,
+                                                              len1, A,
+                                                              poly3->coeffs,
+                                                              len3,
+                                                              poly3inv->coeffs,
+                                                              poly3inv->length,
+                                                              ctx);
+    _gr_poly_set_length(res, len, ctx);
+    _gr_poly_normalise(res, ctx);
+    return status;
+}

--- a/src/gr_poly/compose_mod_brent_kung_preinv.c
+++ b/src/gr_poly/compose_mod_brent_kung_preinv.c
@@ -18,11 +18,12 @@
 #include "gr_poly.h"
 
 int
-_gr_poly_compose_mod_brent_kung(
+_gr_poly_compose_mod_brent_kung_preinv(
     gr_ptr res,
     gr_srcptr poly1, slong len1,
     gr_srcptr poly2,
     gr_srcptr poly3, slong len3,
+    gr_srcptr poly3inv, slong len3inv,
     gr_ctx_t ctx)
 {
     gr_mat_t A, B, C;
@@ -71,11 +72,11 @@ _gr_poly_compose_mod_brent_kung(
     {
         /* Assume that squaring is better. XXX: this depends on the ring. */
 #if 1
-        status |= _gr_poly_mulmod(tmp, gr_mat_entry_srcptr(A, (i + 1) / 2, 0, ctx), n,
-                    gr_mat_entry_srcptr(A, i / 2, 0, ctx), n, poly3, len3, ctx);
+        status |= _gr_poly_mulmod_preinv(tmp, gr_mat_entry_srcptr(A, (i + 1) / 2, 0, ctx), n,
+                    gr_mat_entry_srcptr(A, i / 2, 0, ctx), n, poly3, len3, poly3inv, len3inv, ctx);
 #else
-        status |= _gr_poly_mulmod(tmp, gr_mat_entry_srcptr(A, i - 1, 0, ctx), n,
-                    poly2, n, poly3, len3, ctx);
+        status |= _gr_poly_mulmod_preinv(tmp, gr_mat_entry_srcptr(A, i - 1, 0, ctx), n,
+                    poly2, n, poly3, len3, poly3inv, len3inv, ctx);
 #endif
         status |= _gr_vec_set(gr_mat_entry_ptr(A, i, 0, ctx), tmp, n, ctx);
     }
@@ -86,11 +87,11 @@ _gr_poly_compose_mod_brent_kung(
 
     /* Evaluate block composition using the Horner scheme */
     status |= _gr_vec_set(res, gr_mat_entry_srcptr(C, m - 1, 0, ctx), n, ctx);
-    status |= _gr_poly_mulmod(h, gr_mat_entry_srcptr(A, m - 1, 0, ctx), n, poly2, n, poly3, len3, ctx);
+    status |= _gr_poly_mulmod_preinv(h, gr_mat_entry_srcptr(A, m - 1, 0, ctx), n, poly2, n, poly3, len3, poly3inv, len3inv, ctx);
 
     for (i = m - 2; i >= 0; i--)
     {
-        status |= _gr_poly_mulmod(t, res, n, h, n, poly3, len3, ctx);
+        status |= _gr_poly_mulmod_preinv(t, res, n, h, n, poly3, len3, poly3inv, len3inv, ctx);
         status |= _gr_poly_add(res, t, n, gr_mat_entry_srcptr(C, i, 0, ctx), n, ctx);
     }
 
@@ -105,11 +106,12 @@ _gr_poly_compose_mod_brent_kung(
 }
 
 int
-gr_poly_compose_mod_brent_kung(gr_poly_t res,
+gr_poly_compose_mod_brent_kung_preinv(gr_poly_t res,
                                       const gr_poly_t poly1,
                                       const gr_poly_t poly2,
                                       const gr_poly_t poly3,
+                                      const gr_poly_t poly3inv,
                                       gr_ctx_t ctx)
 {
-    return gr_poly_compose_mod_wrapper(_gr_poly_compose_mod_brent_kung, res, poly1, poly2, poly3, ctx);
+    return gr_poly_compose_mod_preinv_wrapper(_gr_poly_compose_mod_brent_kung_preinv, res, poly1, poly2, poly3, poly3inv, ctx);
 }

--- a/src/gr_poly/compose_mod_horner.c
+++ b/src/gr_poly/compose_mod_horner.c
@@ -1,0 +1,67 @@
+/*
+    Copyright (C) 2011, 2025 Fredrik Johansson
+    Copyright (C) 2012 Lina Kulakova
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "gr_vec.h"
+#include "gr_poly.h"
+
+int
+_gr_poly_compose_mod_horner(gr_ptr res,
+    gr_srcptr f, slong lenf,
+    gr_srcptr g,
+    gr_srcptr h, slong lenh,
+    gr_ctx_t ctx)
+{
+    slong i, len;
+    gr_ptr t;
+    int status = GR_SUCCESS;
+    slong sz = ctx->sizeof_elem;
+
+    if (lenh == 1)
+        return status;
+
+    if (lenf == 1)
+        return gr_set(res, f, ctx);
+
+    if (lenh == 2)
+        return _gr_poly_evaluate(res, f, lenf, g, ctx);
+
+    len = lenh - 1;
+    i = lenf - 1;
+    GR_TMP_INIT_VEC(t, 2 * lenh - 3, ctx);
+
+    status |= _gr_vec_mul_scalar(res, g, len, GR_ENTRY(f, i, sz), ctx);
+    i--;
+    if (i >= 0)
+        status |= gr_add(res, res, GR_ENTRY(f, i, sz), ctx);
+
+    while (i > 0)
+    {
+        i--;
+        status |= _gr_poly_mulmod(t, res, len, g, len, h, lenh, ctx);
+        status |= _gr_poly_add(res, t, len, GR_ENTRY(f, i, sz), 1, ctx);
+    }
+
+    GR_TMP_CLEAR_VEC(t, 2 * lenh - 3, ctx);
+
+    return status;
+}
+
+int
+gr_poly_compose_mod_horner(gr_poly_t res,
+                                      const gr_poly_t poly1,
+                                      const gr_poly_t poly2,
+                                      const gr_poly_t poly3,
+                                      gr_ctx_t ctx)
+{
+    return gr_poly_compose_mod_wrapper(_gr_poly_compose_mod_horner, res, poly1, poly2, poly3, ctx);
+}

--- a/src/gr_poly/compose_mod_horner.c
+++ b/src/gr_poly/compose_mod_horner.c
@@ -37,7 +37,7 @@ _gr_poly_compose_mod_horner(gr_ptr res,
 
     len = lenh - 1;
     i = lenf - 1;
-    GR_TMP_INIT_VEC(t, 2 * lenh - 3, ctx);
+    GR_TMP_INIT_VEC(t, len, ctx);
 
     status |= _gr_vec_mul_scalar(res, g, len, GR_ENTRY(f, i, sz), ctx);
     i--;
@@ -51,7 +51,7 @@ _gr_poly_compose_mod_horner(gr_ptr res,
         status |= _gr_poly_add(res, t, len, GR_ENTRY(f, i, sz), 1, ctx);
     }
 
-    GR_TMP_CLEAR_VEC(t, 2 * lenh - 3, ctx);
+    GR_TMP_CLEAR_VEC(t, len, ctx);
 
     return status;
 }

--- a/src/gr_poly/compose_mod_horner_preinv.c
+++ b/src/gr_poly/compose_mod_horner_preinv.c
@@ -38,7 +38,7 @@ _gr_poly_compose_mod_horner_preinv(gr_ptr res,
 
     len = lenh - 1;
     i = lenf - 1;
-    GR_TMP_INIT_VEC(t, 2 * lenh - 3, ctx);
+    GR_TMP_INIT_VEC(t, len, ctx);
 
     status |= _gr_vec_mul_scalar(res, g, len, GR_ENTRY(f, i, sz), ctx);
     i--;
@@ -52,7 +52,7 @@ _gr_poly_compose_mod_horner_preinv(gr_ptr res,
         status |= _gr_poly_add(res, t, len, GR_ENTRY(f, i, sz), 1, ctx);
     }
 
-    GR_TMP_CLEAR_VEC(t, 2 * lenh - 3, ctx);
+    GR_TMP_CLEAR_VEC(t, len, ctx);
 
     return status;
 }

--- a/src/gr_poly/compose_mod_horner_preinv.c
+++ b/src/gr_poly/compose_mod_horner_preinv.c
@@ -65,53 +65,5 @@ gr_poly_compose_mod_horner_preinv(gr_poly_t res,
                                       const gr_poly_t poly3inv,
                                       gr_ctx_t ctx)
 {
-    slong len1 = poly1->length;
-    slong len2 = poly2->length;
-    slong len3 = poly3->length;
-    slong len3inv = poly3inv->length;
-    slong len = len3 - 1;
-    slong vec_len = FLINT_MAX(len3 - 1, len2);
-    gr_ptr ptr2;
-    slong sz = ctx->sizeof_elem;
-    int status = GR_SUCCESS;
-
-    if (len3 == 0)
-        return GR_DOMAIN;
-
-    if (len1 == 0 || len3 == 1)
-        return gr_poly_zero(res, ctx);
-
-    if (len1 == 1)
-        return gr_poly_set(res, poly1, ctx);
-
-    if (res == poly3 || res == poly1)
-    {
-        gr_poly_t tmp;
-        gr_poly_init(tmp, ctx);
-        status = gr_poly_compose_mod_horner_preinv(tmp, poly1, poly2, poly3, poly3inv, ctx);
-        gr_poly_swap(tmp, res, ctx);
-        gr_poly_clear(tmp, ctx);
-        return status;
-    }
-
-    GR_TMP_INIT_VEC(ptr2, vec_len, ctx);
-
-    if (len2 <= len3 - 1)
-    {
-        status |= _gr_vec_set(ptr2, poly2->coeffs, len2, ctx);
-        status |= _gr_vec_zero(GR_ENTRY(ptr2, len2, sz), vec_len - len2, ctx);
-    }
-    else
-    {
-        /* todo: take advantage of preinv */
-        status |= _gr_poly_rem(ptr2, poly2->coeffs, len2, poly3->coeffs, len3, ctx);
-    }
-
-    gr_poly_fit_length(res, len, ctx);
-    status |= _gr_poly_compose_mod_horner_preinv(res->coeffs, poly1->coeffs, len1, ptr2, poly3->coeffs, len3, poly3inv->coeffs, len3inv, ctx);
-    _gr_poly_set_length(res, len, ctx);
-    _gr_poly_normalise(res, ctx);
-
-    GR_TMP_CLEAR_VEC(ptr2, vec_len, ctx);
-    return status;
+    return gr_poly_compose_mod_preinv_wrapper(_gr_poly_compose_mod_horner_preinv, res, poly1, poly2, poly3, poly3inv, ctx);
 }

--- a/src/gr_poly/compose_mod_horner_preinv.c
+++ b/src/gr_poly/compose_mod_horner_preinv.c
@@ -1,0 +1,117 @@
+/*
+    Copyright (C) 2011, 2025 Fredrik Johansson
+    Copyright (C) 2012 Lina Kulakova
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "gr_vec.h"
+#include "gr_poly.h"
+
+int
+_gr_poly_compose_mod_horner_preinv(gr_ptr res,
+    gr_srcptr f, slong lenf,
+    gr_srcptr g,
+    gr_srcptr h, slong lenh,
+    gr_srcptr hinv, slong lenhinv,
+    gr_ctx_t ctx)
+{
+    slong i, len;
+    gr_ptr t;
+    int status = GR_SUCCESS;
+    slong sz = ctx->sizeof_elem;
+
+    if (lenh == 1)
+        return status;
+
+    if (lenf == 1)
+        return gr_set(res, f, ctx);
+
+    if (lenh == 2)
+        return _gr_poly_evaluate(res, f, lenf, g, ctx);
+
+    len = lenh - 1;
+    i = lenf - 1;
+    GR_TMP_INIT_VEC(t, 2 * lenh - 3, ctx);
+
+    status |= _gr_vec_mul_scalar(res, g, len, GR_ENTRY(f, i, sz), ctx);
+    i--;
+    if (i >= 0)
+        status |= gr_add(res, res, GR_ENTRY(f, i, sz), ctx);
+
+    while (i > 0)
+    {
+        i--;
+        status |= _gr_poly_mulmod_preinv(t, res, len, g, len, h, lenh, hinv, lenhinv, ctx);
+        status |= _gr_poly_add(res, t, len, GR_ENTRY(f, i, sz), 1, ctx);
+    }
+
+    GR_TMP_CLEAR_VEC(t, 2 * lenh - 3, ctx);
+
+    return status;
+}
+
+int
+gr_poly_compose_mod_horner_preinv(gr_poly_t res,
+                                      const gr_poly_t poly1,
+                                      const gr_poly_t poly2,
+                                      const gr_poly_t poly3,
+                                      const gr_poly_t poly3inv,
+                                      gr_ctx_t ctx)
+{
+    slong len1 = poly1->length;
+    slong len2 = poly2->length;
+    slong len3 = poly3->length;
+    slong len3inv = poly3inv->length;
+    slong len = len3 - 1;
+    slong vec_len = FLINT_MAX(len3 - 1, len2);
+    gr_ptr ptr2;
+    slong sz = ctx->sizeof_elem;
+    int status = GR_SUCCESS;
+
+    if (len3 == 0)
+        return GR_DOMAIN;
+
+    if (len1 == 0 || len3 == 1)
+        return gr_poly_zero(res, ctx);
+
+    if (len1 == 1)
+        return gr_poly_set(res, poly1, ctx);
+
+    if (res == poly3 || res == poly1)
+    {
+        gr_poly_t tmp;
+        gr_poly_init(tmp, ctx);
+        status = gr_poly_compose_mod_horner_preinv(tmp, poly1, poly2, poly3, poly3inv, ctx);
+        gr_poly_swap(tmp, res, ctx);
+        gr_poly_clear(tmp, ctx);
+        return status;
+    }
+
+    GR_TMP_INIT_VEC(ptr2, vec_len, ctx);
+
+    if (len2 <= len3 - 1)
+    {
+        status |= _gr_vec_set(ptr2, poly2->coeffs, len2, ctx);
+        status |= _gr_vec_zero(GR_ENTRY(ptr2, len2, sz), vec_len - len2, ctx);
+    }
+    else
+    {
+        /* todo: take advantage of preinv */
+        status |= _gr_poly_rem(ptr2, poly2->coeffs, len2, poly3->coeffs, len3, ctx);
+    }
+
+    gr_poly_fit_length(res, len, ctx);
+    status |= _gr_poly_compose_mod_horner_preinv(res->coeffs, poly1->coeffs, len1, ptr2, poly3->coeffs, len3, poly3inv->coeffs, len3inv, ctx);
+    _gr_poly_set_length(res, len, ctx);
+    _gr_poly_normalise(res, ctx);
+
+    GR_TMP_CLEAR_VEC(ptr2, vec_len, ctx);
+    return status;
+}

--- a/src/gr_poly/compose_mod_preinv.c
+++ b/src/gr_poly/compose_mod_preinv.c
@@ -60,7 +60,7 @@ gr_poly_compose_mod_preinv_wrapper(_gr_method_compose_mod_preinv_op _compose_mod
     if (len1 == 1)
         return gr_poly_set(res, poly1, ctx);
 
-    if (res == poly3 || res == poly1)
+    if (res == poly3 || res == poly1 || res == poly3inv)
     {
         gr_poly_t tmp;
         gr_poly_init(tmp, ctx);

--- a/src/gr_poly/div_newton_n_preinv.c
+++ b/src/gr_poly/div_newton_n_preinv.c
@@ -66,6 +66,9 @@ gr_poly_div_newton_n_preinv(gr_poly_t Q,
     if (Alen < Blen)
         return gr_poly_zero(Q, ctx);
 
+    if (Alen > 2 * Blen - 2)
+        return GR_UNABLE;
+
     Qlen = Alen - Blen + 1;
 
     if (Q == A || Q == B)

--- a/src/gr_poly/div_newton_n_preinv.c
+++ b/src/gr_poly/div_newton_n_preinv.c
@@ -28,13 +28,20 @@ _gr_poly_div_newton_n_preinv(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr FLINT_
 
     lenQ = lenA - lenB + 1;
 
-    Arev = GR_TMP_ALLOC(lenQ * sz);
-    _gr_vec_reverse_shallow(Arev, GR_ENTRY(A, lenA - lenQ, sz), lenQ, ctx);
+    if (lenBinv == 0)  /* fallback if the caller failed to invert B */
+    {
+        status = _gr_vec_zero(Q, lenQ, ctx);
+    }
+    else
+    {
+        Arev = GR_TMP_ALLOC(lenQ * sz);
+        _gr_vec_reverse_shallow(Arev, GR_ENTRY(A, lenA - lenQ, sz), lenQ, ctx);
 
-    status |= _gr_poly_mullow(Q, Arev, lenQ, Binv, FLINT_MIN(lenQ, lenBinv), lenQ, ctx);
-    status |= _gr_poly_reverse(Q, Q, lenQ, lenQ, ctx);
+        status |= _gr_poly_mullow(Q, Arev, lenQ, Binv, FLINT_MIN(lenQ, lenBinv), lenQ, ctx);
+        status |= _gr_poly_reverse(Q, Q, lenQ, lenQ, ctx);
 
-    GR_TMP_FREE(Arev, lenQ * sz);
+        GR_TMP_FREE(Arev, lenQ * sz);
+    }
 
     return status;
 }

--- a/src/gr_poly/div_newton_n_preinv.c
+++ b/src/gr_poly/div_newton_n_preinv.c
@@ -1,0 +1,81 @@
+/*
+    Copyright (C) 2011 William Hart
+    Copyright (C) 2011 Sebastian Pancratz
+    Copyright (C) 2013 Martin Lee
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "gr_vec.h"
+#include "gr_poly.h"
+
+void
+_gr_vec_reverse_shallow(gr_ptr res, gr_srcptr vec, slong len, gr_ctx_t ctx);
+
+int
+_gr_poly_div_newton_n_preinv(gr_ptr Q, gr_srcptr A, slong lenA, gr_srcptr FLINT_UNUSED(B), slong lenB, gr_srcptr Binv, slong lenBinv, gr_ctx_t ctx)
+{
+    slong sz = ctx->sizeof_elem;
+    int status = GR_SUCCESS;
+    slong lenQ;
+    gr_ptr Arev;
+
+    lenQ = lenA - lenB + 1;
+
+    Arev = GR_TMP_ALLOC(lenQ * sz);
+    _gr_vec_reverse_shallow(Arev, GR_ENTRY(A, lenA - lenQ, sz), lenQ, ctx);
+
+    status |= _gr_poly_mullow(Q, Arev, lenQ, Binv, FLINT_MIN(lenQ, lenBinv), lenQ, ctx);
+    status |= _gr_poly_reverse(Q, Q, lenQ, lenQ, ctx);
+
+    GR_TMP_FREE(Arev, lenQ * sz);
+
+    return status;
+}
+
+int
+gr_poly_div_newton_n_preinv(gr_poly_t Q,
+                                       const gr_poly_t A,
+                                       const gr_poly_t B,
+                                       const gr_poly_t Binv,
+                                       gr_ctx_t ctx)
+{
+    slong Alen, Blen, Qlen;
+    int status = GR_SUCCESS;
+    slong lenBinv = Binv->length;
+
+    Alen = A->length;
+    Blen = B->length;
+
+    if (Blen == 0)
+        return GR_DOMAIN;
+
+    if (Alen < Blen)
+        return gr_poly_zero(Q, ctx);
+
+    Qlen = Alen - Blen + 1;
+
+    if (Q == A || Q == B)
+    {
+        gr_poly_t t;
+        gr_poly_init2(t, Qlen, ctx);
+        status = _gr_poly_div_newton_n_preinv(t->coeffs, A->coeffs, Alen, B->coeffs, Blen, Binv->coeffs, lenBinv, ctx);
+        gr_poly_swap(Q, t, ctx);
+        gr_poly_clear(t, ctx);
+    }
+    else
+    {
+        gr_poly_fit_length(Q, Qlen, ctx);
+        status = _gr_poly_div_newton_n_preinv(Q->coeffs, A->coeffs, A->length, B->coeffs, B->length, Binv->coeffs, lenBinv, ctx);
+    }
+
+    _gr_poly_set_length(Q, Qlen, ctx);
+    _gr_poly_normalise(Q, ctx);
+    return status;
+}

--- a/src/gr_poly/div_newton_n_preinv.c
+++ b/src/gr_poly/div_newton_n_preinv.c
@@ -71,7 +71,7 @@ gr_poly_div_newton_n_preinv(gr_poly_t Q,
 
     Qlen = Alen - Blen + 1;
 
-    if (Q == A || Q == B)
+    if (Q == A || Q == B || Q == Binv)
     {
         gr_poly_t t;
         gr_poly_init2(t, Qlen, ctx);

--- a/src/gr_poly/divrem_newton_n_preinv.c
+++ b/src/gr_poly/divrem_newton_n_preinv.c
@@ -1,0 +1,109 @@
+/*
+    Copyright (C) 2011 William Hart
+    Copyright (C) 2013 Martin Lee
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "gr_vec.h"
+#include "gr_poly.h"
+
+int
+_gr_poly_divrem_newton_n_preinv(
+    gr_ptr Q,
+    gr_ptr R,
+    gr_srcptr A, slong lenA,
+    gr_srcptr B, slong lenB,
+    gr_srcptr Binv, slong lenBinv,
+    gr_ctx_t ctx)
+{
+    slong lenQ = lenA - lenB + 1;
+    int status = GR_SUCCESS;
+
+    status |= _gr_poly_div_newton_n_preinv(Q, A, lenA, B, lenB, Binv, lenBinv, ctx);
+
+    if (lenB > 1)
+    {
+        status |= _gr_poly_mullow(R, Q, lenQ, B, lenB - 1, lenB - 1, ctx);
+        status |= _gr_vec_sub(R, A, R, lenB - 1, ctx);
+    }
+
+    return status;
+}
+
+int
+gr_poly_divrem_newton_n_preinv(gr_poly_t Q,
+                                          gr_poly_t R,
+                                          const gr_poly_t A,
+                                          const gr_poly_t B,
+                                          const gr_poly_t Binv,
+                                          gr_ctx_t ctx)
+{
+    slong lenA = A->length, lenB = B->length, lenBinv = Binv->length;
+    gr_ptr q, r;
+    int status = GR_SUCCESS;
+
+    if (lenB == 0)
+        return GR_DOMAIN;
+
+    if (lenA < lenB)
+    {
+        status |= gr_poly_set(R, A, ctx);
+        status |= gr_poly_zero(Q, ctx);
+        return status;
+    }
+
+    if (lenA > 2 * lenB - 2)
+        return GR_UNABLE;
+
+    if (Q == A || Q == B || Q == Binv)
+    {
+        GR_TMP_INIT_VEC(q, lenA - lenB + 1, ctx);
+    }
+    else
+    {
+        gr_poly_fit_length(Q, lenA - lenB + 1, ctx);
+        q = Q->coeffs;
+    }
+
+    if (R == A || R == B || R == Binv)
+    {
+        GR_TMP_INIT_VEC(r, lenB - 1, ctx);
+    }
+    else
+    {
+        gr_poly_fit_length(R, lenB - 1, ctx);
+        r = R->coeffs;
+    }
+
+    status |= _gr_poly_divrem_newton_n_preinv(q, r, A->coeffs, lenA,
+                                               B->coeffs, lenB, Binv->coeffs,
+                                               lenBinv, ctx);
+
+    if (Q == A || Q == B || Q == Binv)
+    {
+        GR_TMP_CLEAR_VEC(Q->coeffs, Q->alloc, ctx);
+        Q->coeffs = q;
+        Q->alloc = lenA - lenB + 1;
+    }
+
+    if (R == A || R == B || R == Binv)
+    {
+        GR_TMP_CLEAR_VEC(R->coeffs, R->alloc, ctx);
+        R->coeffs = r;
+        R->alloc = lenB - 1;
+    }
+
+    _gr_poly_set_length(Q, lenA - lenB + 1, ctx);
+    _gr_poly_set_length(R, lenB - 1, ctx);
+    _gr_poly_normalise(Q, ctx);
+    _gr_poly_normalise(R, ctx);
+
+    return status;
+}

--- a/src/gr_poly/divrem_newton_n_preinv.c
+++ b/src/gr_poly/divrem_newton_n_preinv.c
@@ -45,7 +45,9 @@ gr_poly_divrem_newton_n_preinv(gr_poly_t Q,
                                           const gr_poly_t Binv,
                                           gr_ctx_t ctx)
 {
-    slong lenA = A->length, lenB = B->length, lenBinv = Binv->length;
+    slong lenA = A->length, lenB = B->length, lenQ = lenA - lenB + 1;
+    slong lenBinv = Binv->length;
+    gr_poly_t tQ, tR;
     gr_ptr q, r;
     int status = GR_SUCCESS;
 
@@ -64,17 +66,19 @@ gr_poly_divrem_newton_n_preinv(gr_poly_t Q,
 
     if (Q == A || Q == B || Q == Binv)
     {
-        GR_TMP_INIT_VEC(q, lenA - lenB + 1, ctx);
+        gr_poly_init2(tQ, lenQ, ctx);
+        q = tQ->coeffs;
     }
     else
     {
-        gr_poly_fit_length(Q, lenA - lenB + 1, ctx);
+        gr_poly_fit_length(Q, lenQ, ctx);
         q = Q->coeffs;
     }
 
     if (R == A || R == B || R == Binv)
     {
-        GR_TMP_INIT_VEC(r, lenB - 1, ctx);
+        gr_poly_init2(tR, lenB - 1, ctx);
+        r = tR->coeffs;
     }
     else
     {
@@ -82,22 +86,22 @@ gr_poly_divrem_newton_n_preinv(gr_poly_t Q,
         r = R->coeffs;
     }
 
-    status |= _gr_poly_divrem_newton_n_preinv(q, r, A->coeffs, lenA,
-                                               B->coeffs, lenB, Binv->coeffs,
-                                               lenBinv, ctx);
+    status |= _gr_poly_divrem_newton_n_preinv(q, r, A->coeffs, lenA, B->coeffs, lenB, Binv->coeffs, lenBinv, ctx);
 
     if (Q == A || Q == B || Q == Binv)
     {
-        GR_TMP_CLEAR_VEC(Q->coeffs, Q->alloc, ctx);
-        Q->coeffs = q;
-        Q->alloc = lenA - lenB + 1;
+        gr_poly_swap(tQ, Q, ctx);
+        gr_poly_clear(tQ, ctx);
+    }
+    else
+    {
+        _gr_poly_set_length(Q, lenQ, ctx);
     }
 
     if (R == A || R == B || R == Binv)
     {
-        GR_TMP_CLEAR_VEC(R->coeffs, R->alloc, ctx);
-        R->coeffs = r;
-        R->alloc = lenB - 1;
+        gr_poly_swap(tR, R, ctx);
+        gr_poly_clear(tR, ctx);
     }
 
     _gr_poly_set_length(Q, lenA - lenB + 1, ctx);

--- a/src/gr_poly/mulmod.c
+++ b/src/gr_poly/mulmod.c
@@ -1,0 +1,89 @@
+/*
+    Copyright (C) 2011 Fredrik Johansson
+    Copyright (C) 2012 Lina Kulakova
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "gr_vec.h"
+#include "gr_poly.h"
+
+int
+_gr_poly_mulmod(gr_ptr res, gr_srcptr poly1, slong len1,
+                           gr_srcptr poly2, slong len2,
+                           gr_srcptr f, slong lenf,
+                           gr_ctx_t ctx)
+{
+    gr_ptr T, Q;
+    slong lenT, lenQ;
+    slong sz = ctx->sizeof_elem;
+    int status = GR_SUCCESS;
+
+    lenT = len1 + len2 - 1;
+    lenQ = lenT - lenf + 1;
+
+    GR_TMP_INIT_VEC(T, lenT + lenQ, ctx);
+    Q = GR_ENTRY(T, lenT, sz);
+
+    status |= _gr_poly_mul(T, poly1, len1, poly2, len2, ctx);
+    status |= _gr_poly_divrem(Q, res, T, lenT, f, lenf, ctx);
+
+    GR_TMP_CLEAR_VEC(T, lenT + lenQ, ctx);
+
+    return status;
+}
+
+int
+gr_poly_mulmod(gr_poly_t res,
+                          const gr_poly_t poly1,
+                          const gr_poly_t poly2,
+                          const gr_poly_t f,
+                          gr_ctx_t ctx)
+{
+    slong len1, len2, lenf;
+    gr_ptr fcoeffs;
+    int status = GR_SUCCESS;
+
+    lenf = f->length;
+    len1 = poly1->length;
+    len2 = poly2->length;
+
+    if (lenf == 0)
+        return GR_DOMAIN;
+
+    if (lenf == 1 || len1 == 0 || len2 == 0)
+        return gr_poly_zero(res, ctx);
+
+    if (len1 + len2 - lenf > 0)
+    {
+        if (f == res)
+        {
+            GR_TMP_INIT_VEC(fcoeffs, lenf, ctx);
+            status |= _gr_vec_set(fcoeffs, f->coeffs, lenf, ctx);
+        }
+        else
+            fcoeffs = f->coeffs;
+
+        gr_poly_fit_length(res, len1 + len2 - 1, ctx);
+        status |= _gr_poly_mulmod(res->coeffs,
+                                   poly1->coeffs, len1,
+                                   poly2->coeffs, len2, fcoeffs, lenf, ctx);
+
+        if (f == res)
+            GR_TMP_CLEAR_VEC(fcoeffs, lenf, ctx);
+
+        _gr_poly_set_length(res, lenf - 1, ctx);
+        _gr_poly_normalise(res, ctx);
+        return status;
+    }
+    else
+    {
+        return gr_poly_mul(res, poly1, poly2, ctx);
+    }
+}

--- a/src/gr_poly/mulmod_preinv.c
+++ b/src/gr_poly/mulmod_preinv.c
@@ -1,0 +1,122 @@
+/*
+    Copyright (C) 2011 Fredrik Johansson
+    Copyright (C) 2012 Lina Kulakova
+    Copyright (C) 2013 Martin Lee
+    Copyright (C) 2013 Mike Hansen
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "gr_vec.h"
+#include "gr_poly.h"
+
+int
+_gr_poly_mulmod_preinv(
+    gr_ptr res,
+    gr_srcptr poly1, slong len1,
+    gr_srcptr poly2, slong len2,
+    gr_srcptr f, slong lenf,
+    gr_srcptr finv, slong lenfinv,
+    gr_ctx_t ctx)
+{
+    gr_ptr T, Q;
+    slong lenT, lenQ;
+    int status = GR_SUCCESS;
+    slong sz = ctx->sizeof_elem;
+
+    lenT = len1 + len2 - 1;
+    lenQ = lenT - lenf + 1;
+
+    /* FIXME: should not require that poly1 and poly2 are already reduced */
+    if (len1 >= lenf || len2 >= lenf)
+        return GR_UNABLE;
+
+    if (len1 + len2 > lenf) /* reduction necessary */
+    {
+        GR_TMP_INIT_VEC(T, lenT + lenQ, ctx);
+        Q = GR_ENTRY(T, lenT, sz);
+
+        status |= _gr_poly_mul(T, poly1, len1, poly2, len2, ctx);
+        status |= _gr_poly_divrem_newton_n_preinv(Q, res, T, lenT, f, lenf,
+                                               finv, lenfinv, ctx);
+        GR_TMP_CLEAR_VEC(T, lenT + lenQ, ctx);
+    }
+    else /* just use mul */
+    {
+        status |= _gr_poly_mul(res, poly1, len1, poly2, len2, ctx);
+        if (lenT < lenf - 1)
+            status |= _gr_vec_zero(GR_ENTRY(res, lenT, sz), lenf - lenT - 1, ctx);
+    }
+
+    return status;
+}
+
+int
+gr_poly_mulmod_preinv(gr_poly_t res,
+                                 const gr_poly_t poly1,
+                                 const gr_poly_t poly2,
+                                 const gr_poly_t f,
+                                 const gr_poly_t finv,
+                                 gr_ctx_t ctx)
+{
+    slong len1, len2, lenf;
+    gr_ptr fcoeffs, coeffs1, coeffs2;
+    int status = GR_SUCCESS;
+
+    lenf = f->length;
+    len1 = poly1->length;
+    len2 = poly2->length;
+
+    if (lenf == 0)
+        return GR_DOMAIN;
+
+    if (lenf == 1 || len1 == 0 || len2 == 0)
+        return gr_poly_zero(res, ctx);
+
+    if (f == res)
+    {
+        GR_TMP_INIT_VEC(fcoeffs, lenf, ctx);
+        status |= _gr_vec_set(fcoeffs, f->coeffs, lenf, ctx);
+    }
+    else
+        fcoeffs = f->coeffs;
+
+    if (poly1 == res)
+    {
+        GR_TMP_INIT_VEC(coeffs1, len1, ctx);
+        status |= _gr_vec_set(coeffs1, poly1->coeffs, len1, ctx);
+    }
+    else
+        coeffs1 = poly1->coeffs;
+
+    if (poly2 == res)
+    {
+        GR_TMP_INIT_VEC(coeffs2, len2, ctx);
+        status |= _gr_vec_set(coeffs2, poly2->coeffs, len2, ctx);
+    }
+    else
+        coeffs2 = poly2->coeffs;
+
+     gr_poly_fit_length(res, lenf - 1, ctx);
+     status |= _gr_poly_mulmod_preinv(res->coeffs, coeffs1, len1,
+                                      coeffs2, len2,
+                                      fcoeffs, lenf, finv->coeffs,
+                                      finv->length, ctx);
+    if (f == res)
+        GR_TMP_CLEAR_VEC(fcoeffs, lenf, ctx);
+
+    if (poly1 == res)
+        GR_TMP_CLEAR_VEC(coeffs1, len1, ctx);
+
+    if (poly2 == res)
+        GR_TMP_CLEAR_VEC(coeffs2, len2, ctx);
+
+    _gr_poly_set_length(res, lenf - 1, ctx);
+    _gr_poly_normalise(res, ctx);
+    return status;
+}

--- a/src/gr_poly/test/main.c
+++ b/src/gr_poly/test/main.c
@@ -24,10 +24,12 @@
 #include "t-div_divconquer.c"
 #include "t-divexact.c"
 #include "t-div_newton.c"
+#include "t-div_newton_n_preinv.c"
 #include "t-divrem_basecase.c"
 #include "t-divrem.c"
 #include "t-divrem_divconquer.c"
 #include "t-divrem_newton.c"
+#include "t-divrem_newton_n_preinv.c"
 #include "t-div_series.c"
 #include "t-evaluate.c"
 #include "t-evaluate_horner.c"
@@ -92,10 +94,12 @@ test_struct tests[] =
     TEST_FUNCTION(gr_poly_div_divconquer),
     TEST_FUNCTION(gr_poly_divexact),
     TEST_FUNCTION(gr_poly_div_newton),
+    TEST_FUNCTION(gr_poly_div_newton_n_preinv),
     TEST_FUNCTION(gr_poly_divrem_basecase),
     TEST_FUNCTION(gr_poly_divrem),
     TEST_FUNCTION(gr_poly_divrem_divconquer),
     TEST_FUNCTION(gr_poly_divrem_newton),
+    TEST_FUNCTION(gr_poly_divrem_newton_n_preinv),
     TEST_FUNCTION(gr_poly_div_series),
     TEST_FUNCTION(gr_poly_evaluate),
     TEST_FUNCTION(gr_poly_evaluate_horner),

--- a/src/gr_poly/test/main.c
+++ b/src/gr_poly/test/main.c
@@ -16,6 +16,7 @@
 #include "t-compose_divconquer.c"
 #include "t-compose_horner.c"
 #include "t-compose_mod.c"
+#include "t-compose_mod_precomp_preinv.c"
 #include "t-compose_mod_preinv.c"
 #include "t-compose_series.c"
 #include "t-div_basecase.c"
@@ -83,6 +84,7 @@ test_struct tests[] =
     TEST_FUNCTION(gr_poly_compose_divconquer),
     TEST_FUNCTION(gr_poly_compose_horner),
     TEST_FUNCTION(gr_poly_compose_mod),
+    TEST_FUNCTION(gr_poly_compose_mod_precomp_preinv),
     TEST_FUNCTION(gr_poly_compose_mod_preinv),
     TEST_FUNCTION(gr_poly_compose_series),
     TEST_FUNCTION(gr_poly_div_basecase),

--- a/src/gr_poly/test/main.c
+++ b/src/gr_poly/test/main.c
@@ -15,6 +15,8 @@
 #include "t-compose.c"
 #include "t-compose_divconquer.c"
 #include "t-compose_horner.c"
+#include "t-compose_mod.c"
+#include "t-compose_mod_preinv.c"
 #include "t-compose_series.c"
 #include "t-div_basecase.c"
 #include "t-div.c"
@@ -45,6 +47,8 @@
 #include "t-make_monic.c"
 #include "t-mul_karatsuba.c"
 #include "t-mul_toom33.c"
+#include "t-mulmod.c"
+#include "t-mulmod_preinv.c"
 #include "t-nth_derivative.c"
 #include "t-pow_series_fmpq.c"
 #include "t-pow_series_ui.c"
@@ -78,6 +82,8 @@ test_struct tests[] =
     TEST_FUNCTION(gr_poly_compose),
     TEST_FUNCTION(gr_poly_compose_divconquer),
     TEST_FUNCTION(gr_poly_compose_horner),
+    TEST_FUNCTION(gr_poly_compose_mod),
+    TEST_FUNCTION(gr_poly_compose_mod_preinv),
     TEST_FUNCTION(gr_poly_compose_series),
     TEST_FUNCTION(gr_poly_div_basecase),
     TEST_FUNCTION(gr_poly_div),
@@ -108,6 +114,8 @@ test_struct tests[] =
     TEST_FUNCTION(gr_poly_make_monic),
     TEST_FUNCTION(gr_poly_mul_karatsuba),
     TEST_FUNCTION(gr_poly_mul_toom33),
+    TEST_FUNCTION(gr_poly_mulmod),
+    TEST_FUNCTION(gr_poly_mulmod_preinv),
     TEST_FUNCTION(gr_poly_nth_derivative),
     TEST_FUNCTION(gr_poly_pow_series_fmpq),
     TEST_FUNCTION(gr_poly_pow_series_ui),

--- a/src/gr_poly/test/t-compose_mod.c
+++ b/src/gr_poly/test/t-compose_mod.c
@@ -1,0 +1,154 @@
+/*
+    Copyright (C) 2023, 2025 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "ulong_extras.h"
+#include "gr_poly.h"
+
+int
+test_compose_mod(flint_rand_t state, int which)
+{
+    gr_ctx_t ctx;
+    gr_poly_t A, B, C, D, E, F, G;
+    int status = GR_SUCCESS;
+
+    while (1)
+    {
+        gr_ctx_init_random(ctx, state);
+        if (gr_ctx_is_finite(ctx) == T_TRUE || gr_ctx_has_real_prec(ctx) == T_TRUE)
+            break;
+        gr_ctx_clear(ctx);
+    }
+
+    gr_poly_init(A, ctx);
+    gr_poly_init(B, ctx);
+    gr_poly_init(C, ctx);
+    gr_poly_init(D, ctx);
+    gr_poly_init(E, ctx);
+    gr_poly_init(F, ctx);
+    gr_poly_init(G, ctx);
+
+    GR_MUST_SUCCEED(gr_poly_randtest(A, state, 1 + n_randint(state, 15), ctx));
+    GR_MUST_SUCCEED(gr_poly_randtest(B, state, 1 + n_randint(state, 15), ctx));
+    GR_MUST_SUCCEED(gr_poly_randtest(C, state, 1 + n_randint(state, 15), ctx));
+    GR_MUST_SUCCEED(gr_poly_randtest(D, state, 1 + n_randint(state, 15), ctx));
+
+    switch (which)
+    {
+        case 0:
+            status |= gr_poly_compose_mod_horner(D, A, B, C, ctx);
+            break;
+        case 1:
+            status |= gr_poly_set(D, A, ctx);
+            status |= gr_poly_compose_mod_horner(D, D, B, C, ctx);
+            break;
+        case 2:
+            status |= gr_poly_set(D, B, ctx);
+            status |= gr_poly_compose_mod_horner(D, A, D, C, ctx);
+            break;
+        case 3:
+            status |= gr_poly_set(D, C, ctx);
+            status |= gr_poly_compose_mod_horner(D, A, B, D, ctx);
+            break;
+
+        case 4:
+            status |= gr_poly_compose_mod_brent_kung(D, A, B, C, ctx);
+            break;
+        case 5:
+            status |= gr_poly_set(D, A, ctx);
+            status |= gr_poly_compose_mod_brent_kung(D, D, B, C, ctx);
+            break;
+        case 6:
+            status |= gr_poly_set(D, B, ctx);
+            status |= gr_poly_compose_mod_brent_kung(D, A, D, C, ctx);
+            break;
+        case 7:
+            status |= gr_poly_set(D, C, ctx);
+            status |= gr_poly_compose_mod_brent_kung(D, A, B, D, ctx);
+            break;
+
+        case 8:
+            status |= gr_poly_compose_mod(D, A, B, C, ctx);
+            break;
+        case 9:
+            status |= gr_poly_set(D, A, ctx);
+            status |= gr_poly_compose_mod(D, D, B, C, ctx);
+            break;
+        case 10:
+            status |= gr_poly_set(D, B, ctx);
+            status |= gr_poly_compose_mod(D, A, D, C, ctx);
+            break;
+        case 11:
+            status |= gr_poly_set(D, C, ctx);
+            status |= gr_poly_compose_mod(D, A, B, D, ctx);
+            break;
+
+
+        default:
+            flint_abort();
+    }
+
+    if (status == GR_SUCCESS)
+    {
+        /* compare with naive composition */
+        slong i;
+
+        for (i = 0; i < A->length; i++)
+        {
+            if (i == 0)
+                status |= gr_poly_one(F, ctx);
+            else
+                status |= gr_poly_mul(F, F, B, ctx);
+            status |= gr_poly_rem(F, F, C, ctx);
+            status |= gr_poly_mul_scalar(G, F, gr_poly_entry_ptr(A, i, ctx), ctx);
+            status |= gr_poly_add(E, E, G, ctx);
+        }
+
+        status |= gr_poly_rem(E, E, C, ctx);
+
+        if (status == GR_SUCCESS && gr_poly_equal(D, E, ctx) == T_FALSE)
+        {
+            flint_printf("FAIL\n\n");
+            flint_printf("which = %d\n\n", which);
+            gr_ctx_println(ctx);
+            flint_printf("A = "); gr_poly_print(A, ctx); flint_printf("\n");
+            flint_printf("B = "); gr_poly_print(B, ctx); flint_printf("\n");
+            flint_printf("C = "); gr_poly_print(C, ctx); flint_printf("\n");
+            flint_printf("D = "); gr_poly_print(D, ctx); flint_printf("\n");
+            flint_printf("E = "); gr_poly_print(E, ctx); flint_printf("\n");
+            flint_abort();
+        }
+    }
+
+    gr_poly_clear(A, ctx);
+    gr_poly_clear(B, ctx);
+    gr_poly_clear(C, ctx);
+    gr_poly_clear(D, ctx);
+    gr_poly_clear(E, ctx);
+    gr_poly_clear(F, ctx);
+    gr_poly_clear(G, ctx);
+
+    gr_ctx_clear(ctx);
+
+    return status;
+}
+
+TEST_FUNCTION_START(gr_poly_compose_mod, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
+    {
+        test_compose_mod(state, n_randint(state, 12));
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/gr_poly/test/t-compose_mod_precomp_preinv.c
+++ b/src/gr_poly/test/t-compose_mod_precomp_preinv.c
@@ -1,0 +1,117 @@
+/*
+    Copyright (C) 2023, 2025 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "ulong_extras.h"
+#include "gr_mat.h"
+#include "gr_poly.h"
+
+int
+test_compose_mod_precomp_preinv(flint_rand_t state, int which)
+{
+    gr_ctx_t ctx;
+    gr_poly_t A, B, C, D, E, Cinv;
+    gr_mat_t M;
+    int status = GR_SUCCESS;
+
+    while (1)
+    {
+        gr_ctx_init_random(ctx, state);
+        if (gr_ctx_is_finite(ctx) == T_TRUE || gr_ctx_has_real_prec(ctx) == T_TRUE)
+            break;
+        gr_ctx_clear(ctx);
+    }
+
+    gr_poly_init(A, ctx);
+    gr_poly_init(B, ctx);
+    gr_poly_init(C, ctx);
+    gr_poly_init(D, ctx);
+    gr_poly_init(E, ctx);
+    gr_poly_init(Cinv, ctx);
+
+    GR_MUST_SUCCEED(gr_poly_randtest(A, state, 1 + n_randint(state, 15), ctx));
+    GR_MUST_SUCCEED(gr_poly_randtest(B, state, 1 + n_randint(state, 15), ctx));
+    GR_MUST_SUCCEED(gr_poly_randtest(C, state, 1 + n_randint(state, 15), ctx));
+    GR_MUST_SUCCEED(gr_poly_randtest(D, state, 1 + n_randint(state, 15), ctx));
+    GR_MUST_SUCCEED(gr_poly_randtest(Cinv, state, 1 + n_randint(state, 15), ctx));
+
+    status |= gr_poly_reverse(Cinv, C, C->length, ctx);
+    status |= gr_poly_inv_series(Cinv, Cinv, C->length, ctx);
+
+    if (C->length != 0)
+    {
+        gr_mat_init(M, n_sqrt(C->length-1) + 1, C->length - 1, ctx);
+        status |= gr_poly_precompute_matrix(M, B, C, Cinv, ctx);
+        status |= gr_poly_rem(A, A, C, ctx);
+
+        switch (which)
+        {
+            case 0:
+                status |= gr_poly_compose_mod_brent_kung_precomp_preinv(D, A, M, C, Cinv, ctx);
+                break;
+            case 1:
+                status |= gr_poly_set(D, A, ctx);
+                status |= gr_poly_compose_mod_brent_kung_precomp_preinv(D, D, M, C, Cinv, ctx);
+                break;
+            case 2:
+                status |= gr_poly_set(D, C, ctx);
+                status |= gr_poly_compose_mod_brent_kung_precomp_preinv(D, A, M, D, Cinv, ctx);
+                break;
+            case 3:
+                status |= gr_poly_set(D, Cinv, ctx);
+                status |= gr_poly_compose_mod_brent_kung_precomp_preinv(D, A, M, C, D, ctx);
+                break;
+
+            default:
+                flint_abort();
+        }
+
+            status |= gr_poly_compose_mod(E, A, B, C, ctx);
+
+        if (status == GR_SUCCESS && gr_poly_equal(D, E, ctx) == T_FALSE)
+        {
+            flint_printf("FAIL\n\n");
+            flint_printf("which = %d\n\n", which);
+            gr_ctx_println(ctx);
+            flint_printf("A = "); gr_poly_print(A, ctx); flint_printf("\n");
+            flint_printf("B = "); gr_poly_print(B, ctx); flint_printf("\n");
+            flint_printf("C = "); gr_poly_print(C, ctx); flint_printf("\n");
+            flint_printf("D = "); gr_poly_print(D, ctx); flint_printf("\n");
+            flint_printf("E = "); gr_poly_print(E, ctx); flint_printf("\n");
+            flint_abort();
+        }
+
+        gr_mat_clear(M, ctx);
+    }
+
+    gr_poly_clear(A, ctx);
+    gr_poly_clear(B, ctx);
+    gr_poly_clear(C, ctx);
+    gr_poly_clear(D, ctx);
+    gr_poly_clear(E, ctx);
+    gr_poly_clear(Cinv, ctx);
+
+    gr_ctx_clear(ctx);
+
+    return status;
+}
+
+TEST_FUNCTION_START(gr_poly_compose_mod_precomp_preinv, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
+    {
+        test_compose_mod_precomp_preinv(state, n_randint(state, 4));
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/gr_poly/test/t-compose_mod_preinv.c
+++ b/src/gr_poly/test/t-compose_mod_preinv.c
@@ -1,0 +1,109 @@
+/*
+    Copyright (C) 2023, 2025 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "ulong_extras.h"
+#include "gr_poly.h"
+
+int
+test_compose_mod_preinv(flint_rand_t state, int which)
+{
+    gr_ctx_t ctx;
+    gr_poly_t A, B, C, D, E, Cinv;
+    int status = GR_SUCCESS;
+
+    while (1)
+    {
+        gr_ctx_init_random(ctx, state);
+        if (gr_ctx_is_finite(ctx) == T_TRUE || gr_ctx_has_real_prec(ctx) == T_TRUE)
+            break;
+        gr_ctx_clear(ctx);
+    }
+
+    gr_poly_init(A, ctx);
+    gr_poly_init(B, ctx);
+    gr_poly_init(C, ctx);
+    gr_poly_init(D, ctx);
+    gr_poly_init(E, ctx);
+    gr_poly_init(Cinv, ctx);
+
+    GR_MUST_SUCCEED(gr_poly_randtest(A, state, 1 + n_randint(state, 15), ctx));
+    GR_MUST_SUCCEED(gr_poly_randtest(B, state, 1 + n_randint(state, 15), ctx));
+    GR_MUST_SUCCEED(gr_poly_randtest(C, state, 1 + n_randint(state, 15), ctx));
+    GR_MUST_SUCCEED(gr_poly_randtest(D, state, 1 + n_randint(state, 15), ctx));
+    GR_MUST_SUCCEED(gr_poly_randtest(Cinv, state, 1 + n_randint(state, 15), ctx));
+
+    status |= gr_poly_reverse(Cinv, C, C->length, ctx);
+    status |= gr_poly_inv_series(Cinv, Cinv, C->length, ctx);
+
+    switch (which)
+    {
+        case 0:
+            status |= gr_poly_compose_mod_horner_preinv(D, A, B, C, Cinv, ctx);
+            break;
+        case 1:
+            status |= gr_poly_set(D, A, ctx);
+            status |= gr_poly_compose_mod_horner_preinv(D, D, B, C, Cinv, ctx);
+            break;
+        case 2:
+            status |= gr_poly_set(D, B, ctx);
+            status |= gr_poly_compose_mod_horner_preinv(D, A, D, C, Cinv, ctx);
+            break;
+        case 3:
+            status |= gr_poly_set(D, C, ctx);
+            status |= gr_poly_compose_mod_horner_preinv(D, A, B, D, Cinv, ctx);
+            break;
+        default:
+            flint_abort();
+    }
+
+    if (status == GR_SUCCESS)
+    {
+        status |= gr_poly_compose_mod_horner(E, A, B, C, ctx);
+        status |= gr_poly_rem(E, E, C, ctx);
+
+        if (status == GR_SUCCESS && gr_poly_equal(D, E, ctx) == T_FALSE)
+        {
+            flint_printf("FAIL\n\n");
+            flint_printf("which = %d\n\n", which);
+            gr_ctx_println(ctx);
+            flint_printf("A = "); gr_poly_print(A, ctx); flint_printf("\n");
+            flint_printf("B = "); gr_poly_print(B, ctx); flint_printf("\n");
+            flint_printf("C = "); gr_poly_print(C, ctx); flint_printf("\n");
+            flint_printf("D = "); gr_poly_print(D, ctx); flint_printf("\n");
+            flint_printf("E = "); gr_poly_print(E, ctx); flint_printf("\n");
+            flint_abort();
+        }
+    }
+
+    gr_poly_clear(A, ctx);
+    gr_poly_clear(B, ctx);
+    gr_poly_clear(C, ctx);
+    gr_poly_clear(D, ctx);
+    gr_poly_clear(E, ctx);
+    gr_poly_clear(Cinv, ctx);
+
+    gr_ctx_clear(ctx);
+
+    return status;
+}
+
+TEST_FUNCTION_START(gr_poly_compose_mod_preinv, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
+    {
+        test_compose_mod(state, n_randint(state, 4));
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/gr_poly/test/t-compose_mod_preinv.c
+++ b/src/gr_poly/test/t-compose_mod_preinv.c
@@ -61,6 +61,40 @@ test_compose_mod_preinv(flint_rand_t state, int which)
             status |= gr_poly_set(D, C, ctx);
             status |= gr_poly_compose_mod_horner_preinv(D, A, B, D, Cinv, ctx);
             break;
+
+        case 4:
+            status |= gr_poly_compose_mod_brent_kung_preinv(D, A, B, C, Cinv, ctx);
+            break;
+        case 5:
+            status |= gr_poly_set(D, A, ctx);
+            status |= gr_poly_compose_mod_brent_kung_preinv(D, D, B, C, Cinv, ctx);
+            break;
+        case 6:
+            status |= gr_poly_set(D, B, ctx);
+            status |= gr_poly_compose_mod_brent_kung_preinv(D, A, D, C, Cinv, ctx);
+            break;
+        case 7:
+            status |= gr_poly_set(D, C, ctx);
+            status |= gr_poly_compose_mod_brent_kung_preinv(D, A, B, D, Cinv, ctx);
+            break;
+
+        case 8:
+            status |= gr_poly_compose_mod_preinv(D, A, B, C, Cinv, ctx);
+            break;
+        case 9:
+            status |= gr_poly_set(D, A, ctx);
+            status |= gr_poly_compose_mod_preinv(D, D, B, C, Cinv, ctx);
+            break;
+        case 10:
+            status |= gr_poly_set(D, B, ctx);
+            status |= gr_poly_compose_mod_preinv(D, A, D, C, Cinv, ctx);
+            break;
+        case 11:
+            status |= gr_poly_set(D, C, ctx);
+            status |= gr_poly_compose_mod_preinv(D, A, B, D, Cinv, ctx);
+            break;
+
+
         default:
             flint_abort();
     }
@@ -102,7 +136,7 @@ TEST_FUNCTION_START(gr_poly_compose_mod_preinv, state)
 
     for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
     {
-        test_compose_mod(state, n_randint(state, 4));
+        test_compose_mod_preinv(state, n_randint(state, 12));
     }
 
     TEST_FUNCTION_END(state);

--- a/src/gr_poly/test/t-compose_mod_preinv.c
+++ b/src/gr_poly/test/t-compose_mod_preinv.c
@@ -61,39 +61,51 @@ test_compose_mod_preinv(flint_rand_t state, int which)
             status |= gr_poly_set(D, C, ctx);
             status |= gr_poly_compose_mod_horner_preinv(D, A, B, D, Cinv, ctx);
             break;
-
         case 4:
+            status |= gr_poly_set(D, Cinv, ctx);
+            status |= gr_poly_compose_mod_horner_preinv(D, A, B, C, D, ctx);
+            break;
+
+        case 5:
             status |= gr_poly_compose_mod_brent_kung_preinv(D, A, B, C, Cinv, ctx);
             break;
-        case 5:
+        case 6:
             status |= gr_poly_set(D, A, ctx);
             status |= gr_poly_compose_mod_brent_kung_preinv(D, D, B, C, Cinv, ctx);
             break;
-        case 6:
+        case 7:
             status |= gr_poly_set(D, B, ctx);
             status |= gr_poly_compose_mod_brent_kung_preinv(D, A, D, C, Cinv, ctx);
             break;
-        case 7:
+        case 8:
             status |= gr_poly_set(D, C, ctx);
             status |= gr_poly_compose_mod_brent_kung_preinv(D, A, B, D, Cinv, ctx);
             break;
+        case 9:
+            status |= gr_poly_set(D, Cinv, ctx);
+            status |= gr_poly_compose_mod_brent_kung_preinv(D, A, B, C, D, ctx);
+            break;
 
-        case 8:
+
+        case 10:
             status |= gr_poly_compose_mod_preinv(D, A, B, C, Cinv, ctx);
             break;
-        case 9:
+        case 11:
             status |= gr_poly_set(D, A, ctx);
             status |= gr_poly_compose_mod_preinv(D, D, B, C, Cinv, ctx);
             break;
-        case 10:
+        case 12:
             status |= gr_poly_set(D, B, ctx);
             status |= gr_poly_compose_mod_preinv(D, A, D, C, Cinv, ctx);
             break;
-        case 11:
+        case 13:
             status |= gr_poly_set(D, C, ctx);
             status |= gr_poly_compose_mod_preinv(D, A, B, D, Cinv, ctx);
             break;
-
+        case 14:
+            status |= gr_poly_set(D, Cinv, ctx);
+            status |= gr_poly_compose_mod_preinv(D, A, B, C, D, ctx);
+            break;
 
         default:
             flint_abort();
@@ -136,7 +148,7 @@ TEST_FUNCTION_START(gr_poly_compose_mod_preinv, state)
 
     for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
     {
-        test_compose_mod_preinv(state, n_randint(state, 12));
+        test_compose_mod_preinv(state, n_randint(state, 15));
     }
 
     TEST_FUNCTION_END(state);

--- a/src/gr_poly/test/t-div.c
+++ b/src/gr_poly/test/t-div.c
@@ -45,7 +45,7 @@ TEST_FUNCTION_START(gr_poly_div, state)
         }
 
         /* test aliasing */
-        switch (n_randint(state, 4))
+        switch (n_randint(state, 5))
         {
             case 0:
                 status |= gr_poly_set(Q, A, ctx);
@@ -55,11 +55,11 @@ TEST_FUNCTION_START(gr_poly_div, state)
                 status |= gr_poly_set(Q, B, ctx);
                 status |= gr_poly_div(Q, A, B, ctx);
                 break;
-            case 3:
+            case 2:
                 status |= gr_poly_set(A, B, ctx);
                 status |= gr_poly_div(Q, A, A, ctx);
                 break;
-            case 4:
+            case 3:
                 status |= gr_poly_set(A, B, ctx);
                 status |= gr_poly_set(Q, A, ctx);
                 status |= gr_poly_div(Q, Q, Q, ctx);

--- a/src/gr_poly/test/t-div_basecase.c
+++ b/src/gr_poly/test/t-div_basecase.c
@@ -45,7 +45,7 @@ TEST_FUNCTION_START(gr_poly_div_basecase, state)
         }
 
         /* test aliasing */
-        switch (n_randint(state, 4))
+        switch (n_randint(state, 5))
         {
             case 0:
                 status |= gr_poly_set(Q, A, ctx);
@@ -55,11 +55,11 @@ TEST_FUNCTION_START(gr_poly_div_basecase, state)
                 status |= gr_poly_set(Q, B, ctx);
                 status |= gr_poly_div_basecase(Q, A, B, ctx);
                 break;
-            case 3:
+            case 2:
                 status |= gr_poly_set(A, B, ctx);
                 status |= gr_poly_div_basecase(Q, A, A, ctx);
                 break;
-            case 4:
+            case 3:
                 status |= gr_poly_set(A, B, ctx);
                 status |= gr_poly_set(Q, A, ctx);
                 status |= gr_poly_div_basecase(Q, Q, Q, ctx);

--- a/src/gr_poly/test/t-div_divconquer.c
+++ b/src/gr_poly/test/t-div_divconquer.c
@@ -47,7 +47,7 @@ TEST_FUNCTION_START(gr_poly_div_divconquer, state)
         }
 
         /* test aliasing */
-        switch (n_randint(state, 4))
+        switch (n_randint(state, 5))
         {
             case 0:
                 status |= gr_poly_set(Q, A, ctx);
@@ -57,11 +57,11 @@ TEST_FUNCTION_START(gr_poly_div_divconquer, state)
                 status |= gr_poly_set(Q, B, ctx);
                 status |= gr_poly_div_divconquer(Q, A, B, cutoff, ctx);
                 break;
-            case 3:
+            case 2:
                 status |= gr_poly_set(A, B, ctx);
                 status |= gr_poly_div_divconquer(Q, A, A, cutoff, ctx);
                 break;
-            case 4:
+            case 3:
                 status |= gr_poly_set(A, B, ctx);
                 status |= gr_poly_set(Q, A, ctx);
                 status |= gr_poly_div_divconquer(Q, Q, Q, cutoff, ctx);

--- a/src/gr_poly/test/t-div_newton.c
+++ b/src/gr_poly/test/t-div_newton.c
@@ -45,7 +45,7 @@ TEST_FUNCTION_START(gr_poly_div_newton, state)
         }
 
         /* test aliasing */
-        switch (n_randint(state, 4))
+        switch (n_randint(state, 5))
         {
             case 0:
                 status |= gr_poly_set(Q, A, ctx);
@@ -55,11 +55,11 @@ TEST_FUNCTION_START(gr_poly_div_newton, state)
                 status |= gr_poly_set(Q, B, ctx);
                 status |= gr_poly_div_newton(Q, A, B, ctx);
                 break;
-            case 3:
+            case 2:
                 status |= gr_poly_set(A, B, ctx);
                 status |= gr_poly_div_newton(Q, A, A, ctx);
                 break;
-            case 4:
+            case 3:
                 status |= gr_poly_set(A, B, ctx);
                 status |= gr_poly_set(Q, A, ctx);
                 status |= gr_poly_div_newton(Q, Q, Q, ctx);

--- a/src/gr_poly/test/t-div_newton_n_preinv.c
+++ b/src/gr_poly/test/t-div_newton_n_preinv.c
@@ -43,7 +43,6 @@ TEST_FUNCTION_START(gr_poly_div_newton_n_preinv, state)
         /* different aliasing cases */
         switch (n_randint(state, 4))
         {
-/*
             case 0:
                 status |= gr_poly_set(Q, A, ctx);
                 status |= gr_poly_div_newton_n_preinv(Q, Q, B, Binv, ctx);
@@ -56,7 +55,6 @@ TEST_FUNCTION_START(gr_poly_div_newton_n_preinv, state)
                 status |= gr_poly_set(Q, Binv, ctx);
                 status |= gr_poly_div_newton_n_preinv(Q, A, B, Q, ctx);
                 break;
-*/
             default:
                 status |= gr_poly_div_newton_n_preinv(Q, A, B, Binv, ctx);
                 break;

--- a/src/gr_poly/test/t-div_newton_n_preinv.c
+++ b/src/gr_poly/test/t-div_newton_n_preinv.c
@@ -1,0 +1,90 @@
+/*
+    Copyright (C) 2023, 2025 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "ulong_extras.h"
+#include "gr_poly.h"
+
+TEST_FUNCTION_START(gr_poly_div_newton_n_preinv, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 1000; iter++)
+    {
+        int status;
+        gr_ctx_t ctx;
+        gr_poly_t A, B, Binv, Q, Q2;
+
+        gr_ctx_init_random(ctx, state);
+
+        gr_poly_init(A, ctx);
+        gr_poly_init(B, ctx);
+        gr_poly_init(Binv, ctx);
+        gr_poly_init(Q, ctx);
+        gr_poly_init(Q2, ctx);
+
+        status = GR_SUCCESS;
+
+        status |= gr_poly_randtest(A, state, 1 + n_randint(state, 6), ctx);
+        status |= gr_poly_randtest(B, state, 1 + n_randint(state, 6), ctx);
+        status |= gr_poly_randtest(Q, state, 1 + n_randint(state, 6), ctx);
+
+        status |= gr_poly_reverse(Binv, B, B->length, ctx);
+        status |= gr_poly_inv_series(Binv, Binv, B->length, ctx);
+
+        /* different aliasing cases */
+        switch (n_randint(state, 4))
+        {
+/*
+            case 0:
+                status |= gr_poly_set(Q, A, ctx);
+                status |= gr_poly_div_newton_n_preinv(Q, Q, B, Binv, ctx);
+                break;
+            case 1:
+                status |= gr_poly_set(Q, B, ctx);
+                status |= gr_poly_div_newton_n_preinv(Q, A, Q, Binv, ctx);
+                break;
+            case 2:
+                status |= gr_poly_set(Q, Binv, ctx);
+                status |= gr_poly_div_newton_n_preinv(Q, A, B, Q, ctx);
+                break;
+*/
+            default:
+                status |= gr_poly_div_newton_n_preinv(Q, A, B, Binv, ctx);
+                break;
+        }
+
+        if (status == GR_SUCCESS)
+        {
+            status |= gr_poly_div(Q2, A, B, ctx);
+
+            if (status == GR_SUCCESS && (gr_poly_equal(Q, Q2, ctx) == T_FALSE))
+            {
+                flint_printf("FAIL\n\n");
+                flint_printf("A = "); gr_poly_print(A, ctx); flint_printf("\n");
+                flint_printf("B = "); gr_poly_print(B, ctx); flint_printf("\n");
+                flint_printf("Q = "); gr_poly_print(Q, ctx); flint_printf("\n");
+                flint_printf("Q2 = "); gr_poly_print(Q2, ctx); flint_printf("\n");
+                flint_abort();
+            }
+        }
+
+        gr_poly_clear(A, ctx);
+        gr_poly_clear(B, ctx);
+        gr_poly_clear(Binv, ctx);
+        gr_poly_clear(Q, ctx);
+        gr_poly_clear(Q2, ctx);
+
+        gr_ctx_clear(ctx);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/gr_poly/test/t-divrem_newton_n_preinv.c
+++ b/src/gr_poly/test/t-divrem_newton_n_preinv.c
@@ -1,0 +1,114 @@
+/*
+    Copyright (C) 2023, 2025 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "ulong_extras.h"
+#include "gr_poly.h"
+
+TEST_FUNCTION_START(gr_poly_divrem_newton_n_preinv, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 1000; iter++)
+    {
+        int status;
+        gr_ctx_t ctx;
+        gr_poly_t A, B, Binv, Q, R, Q2, R2;
+
+        gr_ctx_init_random(ctx, state);
+
+        gr_poly_init(A, ctx);
+        gr_poly_init(B, ctx);
+        gr_poly_init(Binv, ctx);
+        gr_poly_init(Q, ctx);
+        gr_poly_init(R, ctx);
+        gr_poly_init(Q2, ctx);
+        gr_poly_init(R2, ctx);
+
+        status = GR_SUCCESS;
+
+        status |= gr_poly_randtest(A, state, 1 + n_randint(state, 6), ctx);
+        status |= gr_poly_randtest(B, state, 1 + n_randint(state, 6), ctx);
+        status |= gr_poly_randtest(Q, state, 1 + n_randint(state, 6), ctx);
+        status |= gr_poly_randtest(R, state, 1 + n_randint(state, 6), ctx);
+
+        if (n_randint(state, 3) == 0)
+        {
+            status |= gr_poly_mul(A, A, B, ctx);
+            status |= gr_poly_add(A, A, R, ctx);
+        }
+
+        status |= gr_poly_reverse(Binv, B, B->length, ctx);
+        status |= gr_poly_inv_series(Binv, Binv, B->length, ctx);
+
+        /* different aliasing cases */
+        switch (n_randint(state, 7))
+        {
+            case 0:
+                status |= gr_poly_set(Q, A, ctx);
+                status |= gr_poly_divrem_newton_n_preinv(Q, R, Q, B, Binv, ctx);
+                break;
+            case 1:
+                status |= gr_poly_set(R, A, ctx);
+                status |= gr_poly_divrem_newton_n_preinv(Q, R, R, B, Binv, ctx);
+                break;
+            case 2:
+                status |= gr_poly_set(Q, B, ctx);
+                status |= gr_poly_divrem_newton_n_preinv(Q, R, A, Q, Binv, ctx);
+                break;
+            case 3:
+                status |= gr_poly_set(R, B, ctx);
+                status |= gr_poly_divrem_newton_n_preinv(Q, R, A, R, Binv, ctx);
+                break;
+            case 4:
+                status |= gr_poly_set(Q, Binv, ctx);
+                status |= gr_poly_divrem_newton_n_preinv(Q, R, A, B, Q, ctx);
+                break;
+            case 5:
+                status |= gr_poly_set(R, Binv, ctx);
+                status |= gr_poly_divrem_newton_n_preinv(Q, R, A, B, R, ctx);
+                break;
+            default:
+                status |= gr_poly_divrem_newton_n_preinv(Q, R, A, B, Binv, ctx);
+                break;
+        }
+
+        if (status == GR_SUCCESS)
+        {
+            status |= gr_poly_divrem(Q2, R2, A, B, ctx);
+
+            if (status == GR_SUCCESS && (gr_poly_equal(Q, Q2, ctx) == T_FALSE ||
+                gr_poly_equal(R, R2, ctx) == T_FALSE))
+            {
+                flint_printf("FAIL\n\n");
+                flint_printf("A = "); gr_poly_print(A, ctx); flint_printf("\n");
+                flint_printf("B = "); gr_poly_print(B, ctx); flint_printf("\n");
+                flint_printf("Q = "); gr_poly_print(Q, ctx); flint_printf("\n");
+                flint_printf("R = "); gr_poly_print(R, ctx); flint_printf("\n");
+                flint_printf("Q2 = "); gr_poly_print(Q2, ctx); flint_printf("\n");
+                flint_printf("R2 = "); gr_poly_print(R2, ctx); flint_printf("\n");
+                flint_abort();
+            }
+        }
+
+        gr_poly_clear(A, ctx);
+        gr_poly_clear(B, ctx);
+        gr_poly_clear(Binv, ctx);
+        gr_poly_clear(Q, ctx);
+        gr_poly_clear(R, ctx);
+        gr_poly_clear(Q2, ctx);
+        gr_poly_clear(R2, ctx);
+
+        gr_ctx_clear(ctx);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/gr_poly/test/t-mulmod.c
+++ b/src/gr_poly/test/t-mulmod.c
@@ -1,0 +1,99 @@
+/*
+    Copyright (C) 2009 William Hart
+    Copyright (C) 2010, 2011 Sebastian Pancratz
+    Copyright (C) 2012 Lina Kulakova
+    Copyright (C) 2013 Mike Hansen
+    Copyright (C) 2025 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "ulong_extras.h"
+#include "gr_poly.h"
+
+TEST_FUNCTION_START(gr_poly_mulmod, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 1000; iter++)
+    {
+        int status;
+        gr_ctx_t ctx;
+        gr_poly_t a, b, res1, res2, f;
+
+        while (1)
+        {
+            gr_ctx_init_random(ctx, state);
+            if (gr_ctx_is_finite(ctx) == T_TRUE || gr_ctx_has_real_prec(ctx) == T_TRUE)
+                break;
+            gr_ctx_clear(ctx);
+        }
+
+        gr_poly_init(a, ctx);
+        gr_poly_init(b, ctx);
+        gr_poly_init(res1, ctx);
+        gr_poly_init(res2, ctx);
+        gr_poly_init(f, ctx);
+
+        status = GR_SUCCESS;
+
+        status |= gr_poly_randtest(a, state, 1 + n_randint(state, 20), ctx);
+        status |= gr_poly_randtest(b, state, 1 + n_randint(state, 20), ctx);
+        status |= gr_poly_randtest(res1, state, 1 + n_randint(state, 20), ctx);
+        status |= gr_poly_randtest(res2, state, 1 + n_randint(state, 20), ctx);
+        status |= gr_poly_randtest(f, state, 1 + n_randint(state, 20), ctx);
+
+        /* test aliasing */
+        switch (n_randint(state, 4))
+        {
+            case 0:
+                status |= gr_poly_set(res1, a, ctx);
+                status |= gr_poly_mulmod(res1, res1, b, f, ctx);
+                break;
+            case 1:
+                status |= gr_poly_set(res1, b, ctx);
+                status |= gr_poly_mulmod(res1, a, res1, f, ctx);
+                break;
+            case 2:
+                status |= gr_poly_set(res1, f, ctx);
+                status |= gr_poly_mulmod(res1, a, b, res1, ctx);
+                break;
+            default:
+                status |= gr_poly_mulmod(res1, a, b, f, ctx);
+                break;
+        }
+
+        if (status == GR_SUCCESS)
+        {
+            status |= gr_poly_mul(res2, a, b, ctx);
+            status |= gr_poly_rem(res2, res2, f, ctx);
+
+            if (status == GR_SUCCESS && gr_poly_equal(res1, res2, ctx) == T_FALSE)
+            {
+                flint_printf("FAIL\n\n");
+                flint_printf("a = "); gr_poly_print(a, ctx); flint_printf("\n");
+                flint_printf("b = "); gr_poly_print(b, ctx); flint_printf("\n");
+                flint_printf("f = "); gr_poly_print(f, ctx); flint_printf("\n");
+                flint_printf("res1 = "); gr_poly_print(res1, ctx); flint_printf("\n");
+                flint_printf("res2 = "); gr_poly_print(res2, ctx); flint_printf("\n");
+                flint_abort();
+            }
+        }
+
+        gr_poly_clear(a, ctx);
+        gr_poly_clear(b, ctx);
+        gr_poly_clear(res1, ctx);
+        gr_poly_clear(res2, ctx);
+        gr_poly_clear(f, ctx);
+
+        gr_ctx_clear(ctx);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/gr_poly/test/t-mulmod_preinv.c
+++ b/src/gr_poly/test/t-mulmod_preinv.c
@@ -1,0 +1,105 @@
+/*
+    Copyright (C) 2009 William Hart
+    Copyright (C) 2010, 2011 Sebastian Pancratz
+    Copyright (C) 2012 Lina Kulakova
+    Copyright (C) 2013 Mike Hansen
+    Copyright (C) 2025 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "ulong_extras.h"
+#include "gr_poly.h"
+
+TEST_FUNCTION_START(gr_poly_mulmod_preinv, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 1000; iter++)
+    {
+        int status;
+        gr_ctx_t ctx;
+        gr_poly_t a, b, res1, res2, f, finv;
+
+        while (1)
+        {
+            gr_ctx_init_random(ctx, state);
+            if (gr_ctx_is_finite(ctx) == T_TRUE || gr_ctx_has_real_prec(ctx) == T_TRUE)
+                break;
+            gr_ctx_clear(ctx);
+        }
+
+        gr_poly_init(a, ctx);
+        gr_poly_init(b, ctx);
+        gr_poly_init(res1, ctx);
+        gr_poly_init(res2, ctx);
+        gr_poly_init(f, ctx);
+        gr_poly_init(finv, ctx);
+
+        status = GR_SUCCESS;
+
+        status |= gr_poly_randtest(a, state, 1 + n_randint(state, 20), ctx);
+        status |= gr_poly_randtest(b, state, 1 + n_randint(state, 20), ctx);
+        status |= gr_poly_randtest(res1, state, 1 + n_randint(state, 20), ctx);
+        status |= gr_poly_randtest(res2, state, 1 + n_randint(state, 20), ctx);
+        status |= gr_poly_randtest(f, state, 1 + n_randint(state, 20), ctx);
+        status |= gr_poly_randtest(finv, state, 1 + n_randint(state, 20), ctx);
+
+        status |= gr_poly_reverse(finv, f, f->length, ctx);
+        status |= gr_poly_inv_series(finv, finv, f->length, ctx);
+
+        /* test aliasing */
+        switch (n_randint(state, 4))
+        {
+            case 0:
+                status |= gr_poly_set(res1, a, ctx);
+                status |= gr_poly_mulmod_preinv(res1, res1, b, f, finv, ctx);
+                break;
+            case 1:
+                status |= gr_poly_set(res1, b, ctx);
+                status |= gr_poly_mulmod_preinv(res1, a, res1, f, finv, ctx);
+                break;
+            case 2:
+                status |= gr_poly_set(res1, f, ctx);
+                status |= gr_poly_mulmod_preinv(res1, a, b, res1, finv, ctx);
+                break;
+            default:
+                status |= gr_poly_mulmod_preinv(res1, a, b, f, finv, ctx);
+                break;
+        }
+
+        if (status == GR_SUCCESS)
+        {
+            status |= gr_poly_mul(res2, a, b, ctx);
+            status |= gr_poly_rem(res2, res2, f, ctx);
+
+            if (status == GR_SUCCESS && gr_poly_equal(res1, res2, ctx) == T_FALSE)
+            {
+                flint_printf("FAIL\n\n");
+                flint_printf("a = "); gr_poly_print(a, ctx); flint_printf("\n");
+                flint_printf("b = "); gr_poly_print(b, ctx); flint_printf("\n");
+                flint_printf("f = "); gr_poly_print(f, ctx); flint_printf("\n");
+                flint_printf("res1 = "); gr_poly_print(res1, ctx); flint_printf("\n");
+                flint_printf("res2 = "); gr_poly_print(res2, ctx); flint_printf("\n");
+                flint_abort();
+            }
+        }
+
+        gr_poly_clear(a, ctx);
+        gr_poly_clear(b, ctx);
+        gr_poly_clear(res1, ctx);
+        gr_poly_clear(res2, ctx);
+        gr_poly_clear(f, ctx);
+        gr_poly_clear(finv, ctx);
+
+        gr_ctx_clear(ctx);
+    }
+
+    TEST_FUNCTION_END(state);
+}


### PR DESCRIPTION
Adds the following methods (plus underscore version) and replaces the counterparts in ``fmpz_mod_poly`` and ``fq_poly_templates`` with wrappers:

* gr_poly_mulmod
* gr_poly_mulmod_preinv
* gr_poly_compose_mod_horner
* gr_poly_compose_mod_brent_kung
* gr_poly_compose_mod
* gr_poly_compose_mod_horner_preinv
* gr_poly_compose_mod_brent_kung_preinv
* gr_poly_compose_mod_preinv
* _gr_poly_reduce_matrix_mod_poly
* gr_poly_precompute_matrix
* gr_poly_compose_mod_brent_kung_precomp_preinv

All have been ported from ``fq_poly_templates``, with a few minor optimizations.

There are some interfaces I would like to change, and some of the methods need clearer specifications, in particular with respect to error handling. However, my goal for now is just to keep the ``fq_poly`` conventions to facilitate porting the polynomial factorization code to generics.

Note: this PR decreases the library size though here is a net + lines of code since some legacy functions and their tests can't be removed yet. Once the factorization code is ported to generics we will be able to remove more code.