### PR TITLE
Add `gr_poly_scalar_mul`

### DIFF
--- a/doc/source/gr_poly.rst
+++ b/doc/source/gr_poly.rst
@@ -159,13 +159,14 @@ Arithmetic
               int gr_poly_mullow(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, slong len, gr_ctx_t ctx)
 
 .. function:: int gr_poly_mul_scalar(gr_poly_t res, const gr_poly_t poly, gr_srcptr c, gr_ctx_t ctx)
+              int gr_poly_scalar_mul(gr_poly_t res, gr_srcptr c, const gr_poly_t poly, gr_ctx_t ctx)
               int gr_poly_mul_ui(gr_poly_t res, const gr_poly_t poly, ulong c, gr_ctx_t ctx)
               int gr_poly_mul_si(gr_poly_t res, const gr_poly_t poly, slong c, gr_ctx_t ctx)
               int gr_poly_mul_fmpz(gr_poly_t res, const gr_poly_t poly, const fmpz c, gr_ctx_t ctx)
               int gr_poly_mul_fmpq(gr_poly_t res, const gr_poly_t poly, const fmpq c, gr_ctx_t ctx)
     
-    Sets *res* to *poly* multiplied by the scalar *c* which must be
-    an element of or coercible to the coefficient ring.
+    Sets *res* to *poly* multiplied by the scalar *c* (or the scalar *c* multiplied by *poly*)
+    which must be an element of or coercible to the coefficient ring.
 
 .. function:: int _gr_poly_mul_karatsuba(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ctx_t ctx)
               int gr_poly_mul_karatsuba(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, gr_ctx_t ctx)

--- a/src/gr/polynomial.c
+++ b/src/gr/polynomial.c
@@ -416,17 +416,17 @@ polynomial_mul(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, gr_c
 }
 
 int
-polynomial_mul_other(gr_poly_t res, const gr_poly_t f, gr_srcptr x, gr_ctx_t x_ctx, gr_ctx_t ctx)
+polynomial_mul_other(gr_poly_t res, const gr_poly_t poly, gr_srcptr x, gr_ctx_t x_ctx, gr_ctx_t ctx)
 {
     if (x_ctx == POLYNOMIAL_ELEM_CTX(ctx))
     {
-        return gr_poly_mul_scalar(res, f, x, x_ctx);
+        return gr_poly_mul_scalar(res, poly, x, x_ctx);
     }
-    else if (x_ctx->which_ring == GR_CTX_GR_POLY && 
+    else if (x_ctx->which_ring == GR_CTX_GR_POLY &&
         POLYNOMIAL_ELEM_CTX(x_ctx) == POLYNOMIAL_ELEM_CTX(ctx) &&
         !strcmp(POLYNOMIAL_CTX(x_ctx)->var, POLYNOMIAL_CTX(ctx)->var))
     {
-        return polynomial_mul(res, f, x, ctx);
+        return polynomial_mul(res, poly, x, ctx);
     }
     else
     {
@@ -436,7 +436,34 @@ polynomial_mul_other(gr_poly_t res, const gr_poly_t f, gr_srcptr x, gr_ctx_t x_c
         polynomial_init(t, ctx);
         status = polynomial_set_other(t, x, x_ctx, ctx);
         if (status == GR_SUCCESS)
-            status = polynomial_mul(res, f, t, ctx);
+            status = polynomial_mul(res, poly, t, ctx);
+        polynomial_clear(t, ctx);
+        return status;
+    }
+}
+
+int
+polynomial_other_mul(gr_poly_t res, gr_srcptr x, gr_ctx_t x_ctx, const gr_poly_t poly, gr_ctx_t ctx)
+{
+    if (x_ctx == POLYNOMIAL_ELEM_CTX(ctx))
+    {
+        return gr_poly_scalar_mul(res, x, poly, x_ctx);
+    }
+    else if (x_ctx->which_ring == GR_CTX_GR_POLY &&
+        POLYNOMIAL_ELEM_CTX(x_ctx) == POLYNOMIAL_ELEM_CTX(ctx) &&
+        !strcmp(POLYNOMIAL_CTX(x_ctx)->var, POLYNOMIAL_CTX(ctx)->var))
+    {
+        return polynomial_mul(res, x, poly, ctx);
+    }
+    else
+    {
+        gr_poly_t t;
+        int status = GR_SUCCESS;
+
+        polynomial_init(t, ctx);
+        status = polynomial_set_other(t, x, x_ctx, ctx);
+        if (status == GR_SUCCESS)
+            status = polynomial_mul(res, t, poly, ctx);
         polynomial_clear(t, ctx);
         return status;
     }
@@ -601,6 +628,7 @@ gr_method_tab_input _gr_poly_methods_input[] =
     {GR_METHOD_SUB,         (gr_funcptr) polynomial_sub},
     {GR_METHOD_MUL,         (gr_funcptr) polynomial_mul},
     {GR_METHOD_MUL_OTHER,   (gr_funcptr) polynomial_mul_other},
+    {GR_METHOD_OTHER_MUL,   (gr_funcptr) polynomial_other_mul},
     {GR_METHOD_MUL_UI,      (gr_funcptr) polynomial_mul_ui},
     {GR_METHOD_MUL_SI,      (gr_funcptr) polynomial_mul_si},
     {GR_METHOD_MUL_FMPZ,    (gr_funcptr) polynomial_mul_fmpz},

--- a/src/gr_poly.h
+++ b/src/gr_poly.h
@@ -121,6 +121,7 @@ WARN_UNUSED_RESULT int _gr_poly_mullow_generic(gr_ptr res, gr_srcptr poly1, slon
 GR_POLY_INLINE WARN_UNUSED_RESULT int _gr_poly_mullow(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, slong len, gr_ctx_t ctx) { return GR_POLY_BINARY_TRUNC_OP(ctx, POLY_MULLOW)(res, poly1, len1, poly2, len2, len, ctx); }
 WARN_UNUSED_RESULT int gr_poly_mullow(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, slong n, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_mul_scalar(gr_poly_t res, const gr_poly_t poly, gr_srcptr c, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_poly_scalar_mul(gr_poly_t res, gr_srcptr c, const gr_poly_t poly, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_mul_ui(gr_poly_t res, const gr_poly_t poly, ulong c, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_mul_si(gr_poly_t res, const gr_poly_t poly, slong c, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_mul_fmpz(gr_poly_t res, const gr_poly_t poly, const fmpz_t c, gr_ctx_t ctx);

--- a/src/gr_poly/mul_scalar.c
+++ b/src/gr_poly/mul_scalar.c
@@ -34,6 +34,26 @@ gr_poly_mul_scalar(gr_poly_t res, const gr_poly_t poly, gr_srcptr c, gr_ctx_t ct
 }
 
 int
+gr_poly_scalar_mul(gr_poly_t res, gr_srcptr c, const gr_poly_t poly, gr_ctx_t ctx)
+{
+    int status;
+    slong len = poly->length;
+
+    if (len == 0 || gr_is_zero(c, ctx) == T_TRUE)
+        return gr_poly_zero(res, ctx);
+
+    if (res != poly)
+    {
+        gr_poly_fit_length(res, len, ctx);
+        _gr_poly_set_length(res, len, ctx);
+    }
+
+    status = _gr_scalar_mul_vec(res->coeffs, c, poly->coeffs, len, ctx);
+    _gr_poly_normalise(res, ctx);
+    return status;
+}
+
+int
 gr_poly_mul_ui(gr_poly_t res, const gr_poly_t poly, ulong c, gr_ctx_t ctx)
 {
     int status;


### PR DESCRIPTION
Also implement `GR_METHOD_OTHER_MUL` for `gr_poly`.

I was thinking of adding `gr_poly_mul_other` as mentioned in https://github.com/flintlib/flint/issues/2159#issuecomment-2590222995 but I'm not sure how it should be done (or how useful it would be), since it would not have the polynomial ring context as input but only the base ring context. For example if the other is also a polynomial then it would not be possible to check if the variable names match (a check which is currently done in the methods `gr_mul_other` and `gr_other_mul` implemented for `gr_poly`).

- Closes https://github.com/flintlib/flint/issues/2159