### PR TITLE
Add missing `transpose` functions, delegate a bunch of them to `gr`

### DIFF
--- a/doc/source/acb_mat.rst
+++ b/doc/source/acb_mat.rst
@@ -251,12 +251,12 @@ Transpose
 .. function:: void acb_mat_transpose(acb_mat_t dest, const acb_mat_t src)
 
     Sets *dest* to the exact transpose *src*. The operands must have
-    compatible dimensions. Aliasing is allowed.
+    compatible dimensions. Aliasing is allowed for square matrices.
 
 .. function:: void acb_mat_conjugate_transpose(acb_mat_t dest, const acb_mat_t src)
 
     Sets *dest* to the conjugate transpose of *src*. The operands must have
-    compatible dimensions. Aliasing is allowed.
+    compatible dimensions. Aliasing is allowed for square matrices.
 
 .. function:: void acb_mat_conjugate(acb_mat_t dest, const acb_mat_t src)
 

--- a/doc/source/arb_mat.rst
+++ b/doc/source/arb_mat.rst
@@ -264,7 +264,7 @@ Transpose
 .. function:: void arb_mat_transpose(arb_mat_t dest, const arb_mat_t src)
 
     Sets *dest* to the exact transpose *src*. The operands must have
-    compatible dimensions. Aliasing is allowed.
+    compatible dimensions. Aliasing is allowed for square matrices.
 
 Norms
 -------------------------------------------------------------------------------

--- a/doc/source/bool_mat.rst
+++ b/doc/source/bool_mat.rst
@@ -165,7 +165,7 @@ Transpose
 .. function:: void bool_mat_transpose(bool_mat_t dest, const bool_mat_t src)
 
     Sets *dest* to the transpose of *src*. The operands must have
-    compatible dimensions. Aliasing is allowed.
+    compatible dimensions. Aliasing is allowed for square matrices.
 
 
 Arithmetic

--- a/doc/source/ca_mat.rst
+++ b/doc/source/ca_mat.rst
@@ -199,7 +199,8 @@ Conjugate and transpose
 
 .. function:: void ca_mat_transpose(ca_mat_t res, const ca_mat_t A, ca_ctx_t ctx)
 
-    Sets *res* to the transpose of *A*.
+    Sets *res* to the transpose of *A*. The operands must have
+    compatible dimensions. Aliasing is allowed for square matrices.
 
 .. function:: void ca_mat_conj(ca_mat_t res, const ca_mat_t A, ca_ctx_t ctx)
 

--- a/doc/source/d_mat.rst
+++ b/doc/source/d_mat.rst
@@ -100,7 +100,7 @@ Transpose
 .. function:: void d_mat_transpose(d_mat_t B, const d_mat_t A)
 
     Sets `B` to `A^T`, the transpose of `A`. Dimensions must be compatible.
-    `A` and `B` are allowed to be the same object if `A` is a square matrix.
+    Aliasing is allowed for square matrices.
 
 
 Matrix multiplication

--- a/doc/source/fmpq_mat.rst
+++ b/doc/source/fmpq_mat.rst
@@ -110,7 +110,7 @@ Basic assignment
 .. function:: void fmpq_mat_transpose(fmpq_mat_t rop, const fmpq_mat_t op)
 
     Sets the matrix ``rop`` to the transpose of the matrix ``op``,
-    assuming that their dimensions are compatible.
+    assuming that their dimensions are compatible. Aliasing is allowed for square matrices.
 
 .. function:: void fmpq_mat_swap_rows(fmpq_mat_t mat, slong * perm, slong r, slong s)
 

--- a/doc/source/fmpz_mat.rst
+++ b/doc/source/fmpz_mat.rst
@@ -386,7 +386,7 @@ Transpose
 .. function:: void fmpz_mat_transpose(fmpz_mat_t B, const fmpz_mat_t A)
 
     Sets `B` to `A^T`, the transpose of `A`. Dimensions must be compatible.
-    `A` and `B` are allowed to be the same object if `A` is a square matrix.
+    Aliasing is allowed for square matrices.
 
 
 

--- a/doc/source/fmpz_mod_mat.rst
+++ b/doc/source/fmpz_mod_mat.rst
@@ -160,7 +160,8 @@ Set and transpose
 
 .. function:: void fmpz_mod_mat_transpose(fmpz_mod_mat_t B, const fmpz_mod_mat_t A, const fmpz_mod_ctx_t ctx)
 
-    Set ``B`` to the transpose of ``A``.
+    Sets ``B`` to the transpose of ``A``. Dimensions must be compatible.
+    Aliasing is allowed for square matrices.
 
 
 Conversions

--- a/doc/source/fmpz_poly_mat.rst
+++ b/doc/source/fmpz_poly_mat.rst
@@ -227,7 +227,8 @@ Transpose
 
 .. function:: void fmpz_poly_mat_transpose(fmpz_poly_mat_t B, const fmpz_poly_mat_t A)
 
-    Sets `B` to `A^t`.
+    Sets `B` to `A^t`. The operands must have compatible dimensions.
+    Aliasing is allowed for square matrices.
 
 
 

--- a/doc/source/fq_default_mat.rst
+++ b/doc/source/fq_default_mat.rst
@@ -261,6 +261,16 @@ Comparison
 
 
 
+Transpose
+--------------------------------------------------------------------------------
+
+
+.. function:: void fq_default_mat_transpose(fq_default_mat_t B, const fq_default_mat_t A, const fq_default_ctx_t ctx)
+
+    Sets `B` to `A^T`, the transpose of `A`. Dimensions must be compatible.
+    Aliasing is allowed for square matrices.
+
+
 
 Addition and subtraction
 --------------------------------------------------------------------------------

--- a/doc/source/fq_mat.rst
+++ b/doc/source/fq_mat.rst
@@ -258,6 +258,16 @@ Comparison
 
 
 
+Transpose
+--------------------------------------------------------------------------------
+
+
+.. function:: void fq_mat_transpose(fq_mat_t B, const fq_mat_t A, const fq_ctx_t ctx)
+
+    Sets `B` to `A^T`, the transpose of `A`. Dimensions must be compatible.
+    Aliasing is allowed for square matrices.
+
+
 
 Addition and subtraction
 --------------------------------------------------------------------------------

--- a/doc/source/fq_nmod_mat.rst
+++ b/doc/source/fq_nmod_mat.rst
@@ -257,6 +257,16 @@ Comparison
 
 
 
+Transpose
+--------------------------------------------------------------------------------
+
+
+.. function:: void fq_nmod_mat_transpose(fq_nmod_mat_t B, const fq_nmod_mat_t A, const fq_nmod_ctx_t ctx)
+
+    Sets `B` to `A^T`, the transpose of `A`. Dimensions must be compatible.
+    Aliasing is allowed for square matrices.
+
+
 
 Addition and subtraction
 --------------------------------------------------------------------------------

--- a/doc/source/fq_zech_mat.rst
+++ b/doc/source/fq_zech_mat.rst
@@ -235,6 +235,16 @@ Comparison
 
 
 
+Transpose
+--------------------------------------------------------------------------------
+
+
+.. function:: void fq_zech_mat_transpose(fq_zech_mat_t B, const fq_zech_mat_t A, const fq_zech_ctx_t ctx)
+
+    Sets `B` to `A^T`, the transpose of `A`. Dimensions must be compatible.
+    Aliasing is allowed for square matrices.
+
+
 
 Addition and subtraction
 --------------------------------------------------------------------------------

--- a/doc/source/gr_mat.rst
+++ b/doc/source/gr_mat.rst
@@ -174,9 +174,10 @@ Basic row, column and entry operations
 
 .. function:: int gr_mat_concat_vertical(gr_mat_t res, const gr_mat_t mat1, const gr_mat_t mat2, gr_ctx_t ctx)
 
-.. function:: int gr_mat_transpose(gr_mat_t B, const gr_mat_t A, gr_ctx_t ctx)
+.. function:: int gr_mat_transpose(gr_mat_t res, const gr_mat_t mat, gr_ctx_t ctx)
 
-    Sets *B* to the transpose of *A*.
+    Sets ``res`` to the transpose of ``mat``. Dimensions must be compatible.
+    Aliasing is allowed for square matrices.
 
 .. function:: int gr_mat_swap_rows(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx)
 

--- a/doc/source/nmod_mat.rst
+++ b/doc/source/nmod_mat.rst
@@ -262,7 +262,7 @@ Transposition and permutations
 .. function:: void nmod_mat_transpose(nmod_mat_t B, const nmod_mat_t A)
 
     Sets `B` to the transpose of `A`. Dimensions must be compatible.
-    `B` and `A` may be the same object if and only if the matrix is square.
+    Aliasing is allowed for square matrices.
 
 .. function:: void nmod_mat_swap_rows(nmod_mat_t mat, slong * perm, slong r, slong s)
 

--- a/doc/source/nmod_poly_mat.rst
+++ b/doc/source/nmod_poly_mat.rst
@@ -219,6 +219,17 @@ Basic comparison and properties
     than its degree, this entry is first resized to the appropriate length,
     with intervening coefficients being set to zero.
 
+
+
+Transposition
+--------------------------------------------------------------------------------
+
+.. function:: void nmod_poly_mat_transpose(nmod_poly_mat_t B, const nmod_poly_mat_t A)
+
+    Sets `B` to the transpose of `A`. Dimensions must be compatible.
+    Aliasing is allowed for square matrices.
+
+
 Norms
 --------------------------------------------------------------------------------
 

--- a/doc/source/padic_mat.rst
+++ b/doc/source/padic_mat.rst
@@ -226,7 +226,8 @@ Transpose
 
 .. function:: void padic_mat_transpose(padic_mat_t B, const padic_mat_t A)
 
-    Sets `B` to `A^t`.
+    Sets `B` to `A^t`.Dimensions must be compatible.
+    Aliasing is allowed for square matrices.
 
 
 Addition and subtraction

--- a/src/fmpq_mat/transpose.c
+++ b/src/fmpq_mat/transpose.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2011 Sebastian Pancratz
+    Copyright (C) 2025 Lars Göttgens
 
     This file is part of FLINT.
 
@@ -9,25 +10,14 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "fmpq.h"
 #include "fmpq_mat.h"
+#include "gr.h"
+#include "gr_mat.h"
 
-void fmpq_mat_transpose(fmpq_mat_t rop, const fmpq_mat_t op)
+void
+fmpq_mat_transpose(fmpq_mat_t B, const fmpq_mat_t A)
 {
-    slong i, j;
-
-    if (rop == op)
-    {
-        for (i = 0; i < rop->r; i++)
-            for (j = 0; j < i; j++)
-                fmpq_swap(fmpq_mat_entry(rop, i, j),
-                          fmpq_mat_entry(rop, j, i));
-    }
-    else
-    {
-        for (i = 0; i < rop->r; i++)
-            for (j = 0; j < rop->c; j++)
-                fmpq_set(fmpq_mat_entry(rop, i, j),
-                         fmpq_mat_entry(op, j, i));
-    }
+    gr_ctx_t gr_ctx;
+    gr_ctx_init_fmpq(gr_ctx);
+    GR_MUST_SUCCEED(gr_mat_transpose((gr_mat_struct *) B, (const gr_mat_struct *) A, gr_ctx));
 }

--- a/src/fmpz_mat/test/t-transpose.c
+++ b/src/fmpz_mat/test/t-transpose.c
@@ -47,7 +47,7 @@ TEST_FUNCTION_START(fmpz_mat_transpose, state)
     }
 
     /* Self-transpose */
-    for (rep = 0; rep < 1000; rep++)
+    for (rep = 0; rep < 100 * flint_test_multiplier(); rep++)
     {
         fmpz_mat_t A, B;
 

--- a/src/fmpz_mat/transpose.c
+++ b/src/fmpz_mat/transpose.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2010 Fredrik Johansson
+    Copyright (C) 2025 Lars Göttgens
 
     This file is part of FLINT.
 
@@ -9,29 +10,14 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "fmpz.h"
 #include "fmpz_mat.h"
+#include "gr.h"
+#include "gr_mat.h"
 
 void
 fmpz_mat_transpose(fmpz_mat_t B, const fmpz_mat_t A)
 {
-    slong i, j;
-
-    if (B->r != A->c || B->c != A->r)
-    {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_mat_transpose). Incompatible dimensions.\n");
-    }
-
-    if (A == B)  /* In-place, guaranteed to be square */
-    {
-        for (i = 0; i < A->r - 1; i++)
-            for (j = i + 1; j < A->c; j++)
-                FLINT_SWAP(fmpz, *fmpz_mat_entry(B, i, j), *fmpz_mat_entry(B, j, i));
-    }
-    else  /* Not aliased; general case */
-    {
-        for (i = 0; i < B->r; i++)
-            for (j = 0; j < B->c; j++)
-                fmpz_set(fmpz_mat_entry(B, i, j), fmpz_mat_entry(A, j, i));
-    }
+    gr_ctx_t gr_ctx;
+    gr_ctx_init_fmpz(gr_ctx);
+    GR_MUST_SUCCEED(gr_mat_transpose((gr_mat_struct *)B, (const gr_mat_struct *) A, gr_ctx));
 }

--- a/src/fmpz_mod_mat/test/main.c
+++ b/src/fmpz_mod_mat/test/main.c
@@ -37,6 +37,7 @@
 #include "t-solve_triu.c"
 #include "t-sqr.c"
 #include "t-trace.c"
+#include "t-transpose.c"
 #include "t-window_init_clear.c"
 
 /* Array of test functions ***************************************************/
@@ -69,6 +70,7 @@ test_struct tests[] =
     TEST_FUNCTION(fmpz_mod_mat_solve_triu),
     TEST_FUNCTION(fmpz_mod_mat_sqr),
     TEST_FUNCTION(fmpz_mod_mat_trace),
+    TEST_FUNCTION(fmpz_mod_mat_transpose),
     TEST_FUNCTION(fmpz_mod_mat_window_init_clear)
 };
 

--- a/src/fmpz_mod_mat/test/t-transpose.c
+++ b/src/fmpz_mod_mat/test/t-transpose.c
@@ -1,0 +1,84 @@
+/*
+    Copyright (C) 2025 Lars Göttgens
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "fmpz_mod_mat.h"
+
+TEST_FUNCTION_START(fmpz_mod_mat_transpose, state)
+{
+    slong m, n, rep;
+
+    /* Rectangular transpose */
+    for (rep = 0; rep < 100 * flint_test_multiplier(); rep++)
+    {
+        fmpz_mod_mat_t A, B, C;
+        fmpz_mod_ctx_t ctx;
+
+        fmpz_mod_ctx_init_rand_bits(ctx, state, 200);
+
+        m = n_randint(state, 20);
+        n = n_randint(state, 20);
+
+        fmpz_mod_mat_init(A, m, n, ctx);
+        fmpz_mod_mat_init(B, n, m, ctx);
+        fmpz_mod_mat_init(C, m, n, ctx);
+
+        fmpz_mod_mat_randtest(A, state, ctx);
+        fmpz_mod_mat_randtest(B, state, ctx);
+
+        fmpz_mod_mat_transpose(B, A, ctx);
+        fmpz_mod_mat_transpose(C, B, ctx);
+
+        if (!fmpz_mod_mat_equal(C, A, ctx))
+        {
+            flint_printf("FAIL: C != A\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        fmpz_mod_mat_clear(A, ctx);
+        fmpz_mod_mat_clear(B, ctx);
+        fmpz_mod_mat_clear(C, ctx);
+        fmpz_mod_ctx_clear(ctx);
+    }
+
+    /* Self-transpose */
+    for (rep = 0; rep < 100 * flint_test_multiplier(); rep++)
+    {
+        fmpz_mod_mat_t A, B;
+        fmpz_mod_ctx_t ctx;
+
+        fmpz_mod_ctx_init_rand_bits(ctx, state, 200);
+        
+        m = n_randint(state, 20);
+
+        fmpz_mod_mat_init(A, m, m, ctx);
+        fmpz_mod_mat_init(B, m, m, ctx);
+
+        fmpz_mod_mat_randtest(A, state, ctx);
+        fmpz_mod_mat_set(B, A, ctx);
+        fmpz_mod_mat_transpose(B, B, ctx);
+        fmpz_mod_mat_transpose(B, B, ctx);
+
+        if (!fmpz_mod_mat_equal(B, A, ctx))
+        {
+            flint_printf("FAIL: B != A\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        fmpz_mod_mat_clear(A, ctx);
+        fmpz_mod_mat_clear(B, ctx);
+        fmpz_mod_ctx_clear(ctx);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/fmpz_poly_mat/test/main.c
+++ b/src/fmpz_poly_mat/test/main.c
@@ -35,6 +35,7 @@
 #include "t-sqrlow.c"
 #include "t-sub.c"
 #include "t-trace.c"
+#include "t-transpose.c"
 #include "t-window_init_clear.c"
 #include "t-zero.c"
 
@@ -66,6 +67,7 @@ test_struct tests[] =
     TEST_FUNCTION(fmpz_poly_mat_sqrlow),
     TEST_FUNCTION(fmpz_poly_mat_sub),
     TEST_FUNCTION(fmpz_poly_mat_trace),
+    TEST_FUNCTION(fmpz_poly_mat_transpose),
     TEST_FUNCTION(fmpz_poly_mat_window_init_clear),
     TEST_FUNCTION(fmpz_poly_mat_zero)
 };

--- a/src/fmpz_poly_mat/test/t-transpose.c
+++ b/src/fmpz_poly_mat/test/t-transpose.c
@@ -1,0 +1,79 @@
+/*
+    Copyright (C) 2025 Lars Göttgens
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "fmpz_poly_mat.h"
+
+TEST_FUNCTION_START(fmpz_poly_mat_transpose, state)
+{
+    slong m, n, rep;
+
+    /* Rectangular transpose */
+    for (rep = 0; rep < 100 * flint_test_multiplier(); rep++)
+    {
+        fmpz_poly_mat_t A, B, C;
+
+        m = n_randint(state, 20);
+        n = n_randint(state, 20);
+
+        fmpz_poly_mat_init(A, m, n);
+        fmpz_poly_mat_init(B, n, m);
+        fmpz_poly_mat_init(C, m, n);
+
+        fmpz_poly_mat_randtest(A, state, 1 + n_randint(state, 10),
+            1 + n_randint(state, 100));
+        fmpz_poly_mat_randtest(B, state, 1 + n_randint(state, 10),
+            1 + n_randint(state, 100));
+
+        fmpz_poly_mat_transpose(B, A);
+        fmpz_poly_mat_transpose(C, B);
+
+        if (!fmpz_poly_mat_equal(C, A))
+        {
+            flint_printf("FAIL: C != A\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        fmpz_poly_mat_clear(A);
+        fmpz_poly_mat_clear(B);
+        fmpz_poly_mat_clear(C);
+    }
+
+    /* Self-transpose */
+    for (rep = 0; rep < 100 * flint_test_multiplier(); rep++)
+    {
+        fmpz_poly_mat_t A, B;
+
+        m = n_randint(state, 20);
+
+        fmpz_poly_mat_init(A, m, m);
+        fmpz_poly_mat_init(B, m, m);
+
+        fmpz_poly_mat_randtest(A, state, 1 + n_randint(state, 10),
+            1 + n_randint(state, 100));
+        fmpz_poly_mat_set(B, A);
+        fmpz_poly_mat_transpose(B, B);
+        fmpz_poly_mat_transpose(B, B);
+
+        if (!fmpz_poly_mat_equal(B, A))
+        {
+            flint_printf("FAIL: B != A\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        fmpz_poly_mat_clear(A);
+        fmpz_poly_mat_clear(B);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/fmpz_poly_mat/transpose.c
+++ b/src/fmpz_poly_mat/transpose.c
@@ -10,31 +10,14 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "fmpz_poly.h"
 #include "fmpz_poly_mat.h"
+#include "gr.h"
+#include "gr_mat.h"
 
 void
 fmpz_poly_mat_transpose(fmpz_poly_mat_t B, const fmpz_poly_mat_t A)
 {
-    slong i, j;
-
-    if (B->r != A->c || B->c != A->r)
-    {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_mat_transpose). Incompatible dimensions.\n");
-    }
-
-    if (A == B)  /* In-place, guaranteed to be square */
-    {
-        for (i = 0; i < A->r - 1; i++)
-            for (j = i + 1; j < A->c; j++)
-                fmpz_poly_swap(fmpz_poly_mat_entry(B, i, j),
-                               fmpz_poly_mat_entry(B, j, i));
-    }
-    else  /* Not aliased; general case */
-    {
-        for (i = 0; i < B->r; i++)
-            for (j = 0; j < B->c; j++)
-                fmpz_poly_set(fmpz_poly_mat_entry(B, i, j),
-                              fmpz_poly_mat_entry(A, j, i));
-    }
+    gr_ctx_t gr_ctx;
+    gr_ctx_init_fmpz_poly(gr_ctx);
+    GR_MUST_SUCCEED(gr_mat_transpose((gr_mat_struct *)B, (const gr_mat_struct *) A, gr_ctx));
 }

--- a/src/fq/mat_templates.c
+++ b/src/fq/mat_templates.c
@@ -72,6 +72,7 @@
 #include "fq_mat_templates/sub.c"
 #include "fq_mat_templates/submul.c"
 #include "fq_mat_templates/swap.c"
+#include "fq_mat_templates/transpose.c"
 #include "fq_mat_templates/vec_mul.c"
 #include "fq_mat_templates/window_clear.c"
 #include "fq_mat_templates/window_init.c"

--- a/src/fq_default_mat.h
+++ b/src/fq_default_mat.h
@@ -26,6 +26,8 @@
 #include "fq_nmod_mat.h"
 #include "fq_zech_mat.h"
 #include "fq_default.h"
+#include "gr.h"
+#include "gr_mat.h"
 
 #ifdef __cplusplus
  extern "C" {
@@ -292,6 +294,19 @@ fq_default_mat_is_square(const fq_default_mat_t mat,
     else
     {
         return fq_mat_is_square(mat->fq, FQ_DEFAULT_CTX_FQ(ctx));
+    }
+}
+
+FQ_DEFAULT_MAT_INLINE void
+fq_default_mat_transpose(fq_default_mat_t B, const fq_default_mat_t A, const fq_default_ctx_t ctx)
+{
+    if (_FQ_DEFAULT_TYPE(ctx) == _FQ_DEFAULT_NMOD)
+    {
+        nmod_mat_transpose(B->nmod, A->nmod);
+    }
+    else
+    {
+        GR_MUST_SUCCEED(gr_mat_transpose((gr_mat_struct *) B, (const gr_mat_struct *) A, FQ_DEFAULT_GR_CTX(ctx)));
     }
 }
 

--- a/src/fq_default_mat/test/main.c
+++ b/src/fq_default_mat/test/main.c
@@ -14,6 +14,7 @@
 #include "t-init.c"
 #include "t-inlines.c"
 #include "t-set_fmpz_mat.c"
+#include "t-transpose.c"
 
 /* Array of test functions ***************************************************/
 
@@ -21,7 +22,8 @@ test_struct tests[] =
 {
     TEST_FUNCTION(fq_default_mat_init),
     TEST_FUNCTION(fq_default_mat_inlines),
-    TEST_FUNCTION(fq_default_mat_set_fmpz_mat)
+    TEST_FUNCTION(fq_default_mat_set_fmpz_mat),
+    TEST_FUNCTION(fq_default_mat_transpose)
 };
 
 /* main function *************************************************************/

--- a/src/fq_default_mat/test/t-transpose.c
+++ b/src/fq_default_mat/test/t-transpose.c
@@ -1,0 +1,83 @@
+/*
+    Copyright (C) 2025 Lars Göttgens
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "fq_default_mat.h"
+
+TEST_FUNCTION_START(fq_default_mat_transpose, state)
+{
+    slong m, n, rep;
+
+    for (rep = 0; rep < 100 * flint_test_multiplier(); rep++)
+    {
+        fq_default_ctx_t ctx;
+        fq_default_mat_t A, B, C;
+
+        fq_default_ctx_init_randtest(ctx, state);
+
+        m = n_randint(state, 20);
+        n = n_randint(state, 20);
+
+        fq_default_mat_init(A, m, n, ctx);
+        fq_default_mat_init(B, n, m, ctx);
+        fq_default_mat_init(C, m, n, ctx);
+
+        fq_default_mat_randtest(A, state, ctx);
+        fq_default_mat_randtest(B, state, ctx);
+
+        fq_default_mat_transpose(B, A, ctx);
+        fq_default_mat_transpose(C, B, ctx);
+
+        if (!fq_default_mat_equal(C, A, ctx))
+        {
+            flint_printf("FAIL: C != A\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        fq_default_mat_clear(A, ctx);
+        fq_default_mat_clear(B, ctx);
+        fq_default_mat_clear(C, ctx);
+        fq_default_ctx_clear(ctx);
+    }
+
+    /* Self-transpose */
+    for (rep = 0; rep < 100 * flint_test_multiplier(); rep++)
+    {
+        fq_default_ctx_t ctx;
+        fq_default_mat_t A, B;
+
+        fq_default_ctx_init_randtest(ctx, state);
+
+        m = n_randint(state, 20);
+
+        fq_default_mat_init(A, m, m, ctx);
+        fq_default_mat_init(B, m, m, ctx);
+
+        fq_default_mat_randtest(A, state, ctx);
+        fq_default_mat_set(B, A, ctx);
+        fq_default_mat_transpose(B, B, ctx);
+        fq_default_mat_transpose(B, B, ctx);
+
+        if (!fq_default_mat_equal(B, A, ctx))
+        {
+            flint_printf("FAIL: B != A\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        fq_default_mat_clear(A, ctx);
+        fq_default_mat_clear(B, ctx);
+        fq_default_ctx_clear(ctx);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/fq_mat/test/main.c
+++ b/src/fq_mat/test/main.c
@@ -35,6 +35,7 @@
 #include "t-solve_tril.c"
 #include "t-solve_triu.c"
 #include "t-submul.c"
+#include "t-transpose.c"
 #include "t-vec_mul.c"
 #include "t-window_init_clear.c"
 #include "t-zero.c"
@@ -67,6 +68,7 @@ test_struct tests[] =
     TEST_FUNCTION(fq_mat_solve_tril),
     TEST_FUNCTION(fq_mat_solve_triu),
     TEST_FUNCTION(fq_mat_submul),
+    TEST_FUNCTION(fq_mat_transpose),
     TEST_FUNCTION(fq_mat_vec_mul),
     TEST_FUNCTION(fq_mat_window_init_clear),
     TEST_FUNCTION(fq_mat_zero)

--- a/src/fq_mat/test/t-transpose.c
+++ b/src/fq_mat/test/t-transpose.c
@@ -1,0 +1,23 @@
+/*
+    Copyright (C) 2025 Lars Göttgens
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fq.h"
+#include "fq_mat.h"
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq
+#define CAP_T FQ
+#include "fq_mat_templates/test/t-transpose.c"
+#undef CAP_T
+#undef T

--- a/src/fq_mat_templates.h
+++ b/src/fq_mat_templates.h
@@ -189,6 +189,9 @@ void TEMPLATE(T, mat_randtriu)(TEMPLATE(T, mat_t) mat, flint_rand_t state,
 
 /* Transpose */
 
+void TEMPLATE(T, mat_transpose)(TEMPLATE(T, mat_t) B, const TEMPLATE(T, mat_t) A,
+                           const TEMPLATE(T, ctx_t) ctx);
+
 /* Addition and subtraction */
 
 void TEMPLATE(T, mat_add)(TEMPLATE(T, mat_t) C,

--- a/src/fq_mat_templates/test/t-transpose.c
+++ b/src/fq_mat_templates/test/t-transpose.c
@@ -1,0 +1,87 @@
+/*
+    Copyright (C) 2025 Lars Göttgens
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#ifdef T
+
+#include "test_helpers.h"
+#include "templates.h"
+
+TEST_TEMPLATE_FUNCTION_START(T, mat_transpose, state)
+{
+    slong m, n, rep;
+
+    /* Rectangular transpose */
+    for (rep = 0; rep < 100 * flint_test_multiplier(); rep++)
+    {
+        TEMPLATE(T, mat_t) A, B, C;
+        TEMPLATE(T, ctx_t) ctx;
+
+        TEMPLATE(T, ctx_init_randtest) (ctx, state, 3);
+
+        m = n_randint(state, 20);
+        n = n_randint(state, 20);
+
+        TEMPLATE(T, mat_init) (A, m, n, ctx);
+        TEMPLATE(T, mat_init) (B, n, m, ctx);
+        TEMPLATE(T, mat_init) (C, m, n, ctx);
+
+        TEMPLATE(T, mat_randtest) (A, state, ctx);
+        TEMPLATE(T, mat_randtest) (B, state, ctx);
+
+        TEMPLATE(T, mat_transpose) (B, A, ctx);
+        TEMPLATE(T, mat_transpose) (C, B, ctx);
+
+        if (!TEMPLATE(T, mat_equal) (C, A, ctx))
+        {
+            flint_printf("FAIL: C != A\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        TEMPLATE(T, mat_clear) (A, ctx);
+        TEMPLATE(T, mat_clear) (B, ctx);
+        TEMPLATE(T, mat_clear) (C, ctx);
+        TEMPLATE(T, ctx_clear) (ctx);
+    }
+
+    /* Self-transpose */
+    for (rep = 0; rep < 100 * flint_test_multiplier(); rep++)
+    {
+        TEMPLATE(T, mat_t) A, B;
+        TEMPLATE(T, ctx_t) ctx;
+
+        TEMPLATE(T, ctx_init_randtest) (ctx, state, 3);
+
+        m = n_randint(state, 20);
+
+        TEMPLATE(T, mat_init) (A, m, m, ctx);
+        TEMPLATE(T, mat_init) (B, m, m, ctx);
+
+        TEMPLATE(T, mat_randtest) (A, state, ctx);
+        TEMPLATE(T, mat_set) (B, A, ctx);
+        TEMPLATE(T, mat_transpose) (B, B, ctx);
+        TEMPLATE(T, mat_transpose) (B, B, ctx);
+
+        if (!TEMPLATE(T, mat_equal) (B, A, ctx))
+        {
+            flint_printf("FAIL: B != A\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        TEMPLATE(T, mat_clear) (A, ctx);
+        TEMPLATE(T, mat_clear) (B, ctx);
+        TEMPLATE(T, ctx_clear) (ctx);
+    }
+
+    TEST_FUNCTION_END(state);
+}
+#endif

--- a/src/fq_mat_templates/transpose.c
+++ b/src/fq_mat_templates/transpose.c
@@ -1,0 +1,26 @@
+/*
+    Copyright (C) 2025 Lars Göttgens
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#ifdef T
+
+#include "gr.h"
+#include "gr_mat.h"
+#include "templates.h"
+void
+TEMPLATE(T, mat_transpose) (TEMPLATE(T, mat_t) B, const TEMPLATE(T, mat_t) A,
+                           const TEMPLATE(T, ctx_t) ctx)
+{
+    gr_ctx_t gr_ctx;
+    TEMPLATE3(_gr_ctx_init, T, from_ref)(gr_ctx, ctx);
+    GR_MUST_SUCCEED(gr_mat_transpose((gr_mat_struct *)B, (const gr_mat_struct *) A, gr_ctx));
+}
+
+#endif

--- a/src/fq_nmod/mat_templates.c
+++ b/src/fq_nmod/mat_templates.c
@@ -73,6 +73,7 @@
 #include "fq_mat_templates/sub.c"
 #include "fq_mat_templates/submul.c"
 #include "fq_mat_templates/swap.c"
+#include "fq_mat_templates/transpose.c"
 #include "fq_mat_templates/vec_mul.c"
 #include "fq_mat_templates/window_clear.c"
 #include "fq_mat_templates/window_init.c"

--- a/src/fq_nmod_mat/test/main.c
+++ b/src/fq_nmod_mat/test/main.c
@@ -35,6 +35,7 @@
 #include "t-solve_tril.c"
 #include "t-solve_triu.c"
 #include "t-submul.c"
+#include "t-transpose.c"
 #include "t-vec_mul.c"
 #include "t-window_init_clear.c"
 #include "t-zero.c"
@@ -67,6 +68,7 @@ test_struct tests[] =
     TEST_FUNCTION(fq_nmod_mat_solve_tril),
     TEST_FUNCTION(fq_nmod_mat_solve_triu),
     TEST_FUNCTION(fq_nmod_mat_submul),
+    TEST_FUNCTION(fq_nmod_mat_transpose),
     TEST_FUNCTION(fq_nmod_mat_vec_mul),
     TEST_FUNCTION(fq_nmod_mat_window_init_clear),
     TEST_FUNCTION(fq_nmod_mat_zero)

--- a/src/fq_nmod_mat/test/t-transpose.c
+++ b/src/fq_nmod_mat/test/t-transpose.c
@@ -1,0 +1,23 @@
+/*
+    Copyright (C) 2025 Lars Göttgens
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fq_nmod.h"
+#include "fq_nmod_mat.h"
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq_nmod
+#define CAP_T FQ_NMOD
+#include "fq_mat_templates/test/t-transpose.c"
+#undef CAP_T
+#undef T

--- a/src/fq_zech/mat_templates.c
+++ b/src/fq_zech/mat_templates.c
@@ -72,6 +72,7 @@
 #include "fq_mat_templates/sub.c"
 #include "fq_mat_templates/submul.c"
 #include "fq_mat_templates/swap.c"
+#include "fq_mat_templates/transpose.c"
 #include "fq_mat_templates/vec_mul.c"
 #include "fq_mat_templates/window_clear.c"
 #include "fq_mat_templates/window_init.c"

--- a/src/fq_zech_mat/test/main.c
+++ b/src/fq_zech_mat/test/main.c
@@ -34,6 +34,7 @@
 #include "t-solve_tril.c"
 #include "t-solve_triu.c"
 #include "t-submul.c"
+#include "t-transpose.c"
 #include "t-vec_mul.c"
 #include "t-window_init_clear.c"
 #include "t-zero.c"
@@ -65,6 +66,7 @@ test_struct tests[] =
     TEST_FUNCTION(fq_zech_mat_solve_tril),
     TEST_FUNCTION(fq_zech_mat_solve_triu),
     TEST_FUNCTION(fq_zech_mat_submul),
+    TEST_FUNCTION(fq_zech_mat_transpose),
     TEST_FUNCTION(fq_zech_mat_vec_mul),
     TEST_FUNCTION(fq_zech_mat_window_init_clear),
     TEST_FUNCTION(fq_zech_mat_zero)

--- a/src/fq_zech_mat/test/t-transpose.c
+++ b/src/fq_zech_mat/test/t-transpose.c
@@ -1,0 +1,23 @@
+/*
+    Copyright (C) 2025 Lars Göttgens
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fq_zech.h"
+#include "fq_zech_mat.h"
+
+#ifdef T
+#undef T
+#endif
+
+#define T fq_zech
+#define CAP_T FQ_ZECH
+#include "fq_mat_templates/test/t-transpose.c"
+#undef CAP_T
+#undef T

--- a/src/nmod_poly_mat.h
+++ b/src/nmod_poly_mat.h
@@ -70,6 +70,8 @@ void nmod_poly_mat_set_nmod_mat(nmod_poly_mat_t pmat, const nmod_mat_t cmat);
 
 void nmod_poly_mat_clear(nmod_poly_mat_t mat);
 
+void nmod_poly_mat_transpose(nmod_poly_mat_t B, const nmod_poly_mat_t A);
+
 /* Truncate, shift *********************************************************/
 
 void nmod_poly_mat_set_trunc(nmod_poly_mat_t res,

--- a/src/nmod_poly_mat/test/main.c
+++ b/src/nmod_poly_mat/test/main.c
@@ -37,6 +37,7 @@
 #include "t-sqr_KS.c"
 #include "t-sub.c"
 #include "t-trace.c"
+#include "t-transpose.c"
 #include "t-window_init_clear.c"
 #include "t-zero.c"
 
@@ -70,6 +71,7 @@ test_struct tests[] =
     TEST_FUNCTION(nmod_poly_mat_sqr_KS),
     TEST_FUNCTION(nmod_poly_mat_sub),
     TEST_FUNCTION(nmod_poly_mat_trace),
+    TEST_FUNCTION(nmod_poly_mat_transpose),
     TEST_FUNCTION(nmod_poly_mat_window_init_clear),
     TEST_FUNCTION(nmod_poly_mat_zero)
 };

--- a/src/nmod_poly_mat/test/t-transpose.c
+++ b/src/nmod_poly_mat/test/t-transpose.c
@@ -1,0 +1,81 @@
+/*
+    Copyright (C) 2025 Lars Göttgens
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "nmod_poly_mat.h"
+
+TEST_FUNCTION_START(nmod_poly_mat_transpose, state)
+{
+    slong m, n, rep;
+
+    /* Rectangular transpose */
+    for (rep = 0; rep < 100 * flint_test_multiplier(); rep++)
+    {
+        nmod_poly_mat_t A, B, C;
+        ulong mod;
+
+        mod = n_randtest_prime(state, 0);
+
+        m = n_randint(state, 20);
+        n = n_randint(state, 20);
+
+        nmod_poly_mat_init(A, m, n, mod);
+        nmod_poly_mat_init(B, n, m, mod);
+        nmod_poly_mat_init(C, m, n, mod);
+
+        nmod_poly_mat_randtest(A, state, 1 + n_randint(state, 10));
+        nmod_poly_mat_randtest(B, state, 1 + n_randint(state, 10));
+
+        nmod_poly_mat_transpose(B, A);
+        nmod_poly_mat_transpose(C, B);
+
+        if (!nmod_poly_mat_equal(C, A))
+        {
+            flint_printf("FAIL: C != A\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        nmod_poly_mat_clear(A);
+        nmod_poly_mat_clear(B);
+        nmod_poly_mat_clear(C);
+    }
+
+    /* Self-transpose */
+    for (rep = 0; rep < 100 * flint_test_multiplier(); rep++)
+    {
+        nmod_poly_mat_t A, B;
+        ulong mod;
+
+        mod = n_randtest_prime(state, 0);
+        m = n_randint(state, 20);
+
+        nmod_poly_mat_init(A, m, m, mod);
+        nmod_poly_mat_init(B, m, m, mod);
+
+        nmod_poly_mat_randtest(A, state, 1 + n_randint(state, 10));
+        nmod_poly_mat_set(B, A);
+        nmod_poly_mat_transpose(B, B);
+        nmod_poly_mat_transpose(B, B);
+
+        if (!nmod_poly_mat_equal(B, A))
+        {
+            flint_printf("FAIL: B != A\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        nmod_poly_mat_clear(A);
+        nmod_poly_mat_clear(B);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/nmod_poly_mat/transpose.c
+++ b/src/nmod_poly_mat/transpose.c
@@ -1,0 +1,37 @@
+/*
+    Copyright (C) 2025 Lars Göttgens
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "nmod_poly.h"
+#include "nmod_poly_mat.h"
+
+void
+nmod_poly_mat_transpose(nmod_poly_mat_t B, const nmod_poly_mat_t A)
+{
+    slong i, j;
+
+    if (B->r != A->c || B->c != A->r)
+    {
+        flint_throw(FLINT_ERROR, "Exception (nmod_poly_mat_transpose). Incompatible dimensions.\n");
+    }
+
+    if (A == B) /* In-place, guaranteed to be square */
+    {
+        for (i = 0; i < A->r - 1; i++)
+            for (j = i + 1; j < A->c; j++)
+                nmod_poly_swap(nmod_poly_mat_entry(A, i, j), nmod_poly_mat_entry(A, j, i));
+    }
+    else /* Not aliased; general case */
+    {
+        for (i = 0; i < B->r; i++)
+            for (j = 0; j < B->c; j++)
+                nmod_poly_set(nmod_poly_mat_entry(B, i, j), nmod_poly_mat_entry(A, j, i));
+    }
+}


### PR DESCRIPTION
Also make their docstrings a bit more uniform. @albinahlback this would be another candidate for https://github.com/flintlib/flint/issues/2094