### PR TITLE
Fix invalid write in _gr_nmod_vec_reciprocals with len == 0

### DIFF
--- a/src/gr/nmod.c
+++ b/src/gr/nmod.c
@@ -939,7 +939,8 @@ _gr_nmod_vec_reciprocals(ulong * res, slong len, gr_ctx_t ctx)
 
     if (len <= 1)
     {
-        res[0] = (mod.n != 1);
+        if (len == 1)
+            res[0] = (mod.n != 1);
         return GR_SUCCESS;
     }
 


### PR DESCRIPTION
Should fix #2180. Credit to @rburing for isolating the bug.