### PR TITLE
Fix docstrings of various `lu` functions

### DIFF
--- a/doc/source/fmpz_mod_mat.rst
+++ b/doc/source/fmpz_mod_mat.rst
@@ -320,7 +320,7 @@ LU decomposition
 
 .. function:: slong fmpz_mod_mat_lu(slong * P, fmpz_mod_mat_t A, int rank_check, const fmpz_mod_ctx_t ctx)
 
-    Computes a generalised LU decomposition `LU = PA` of a given
+    Computes a generalised LU decomposition `PLU = A` of a given
     matrix `A`, returning the rank of `A`.
 
     If `A` is a nonsingular square matrix, it will be overwritten with

--- a/doc/source/fq_default_mat.rst
+++ b/doc/source/fq_default_mat.rst
@@ -313,7 +313,7 @@ LU decomposition
 
 .. function:: slong fq_default_mat_lu(slong * P, fq_default_mat_t A, int rank_check, const fq_default_ctx_t ctx)
 
-    Computes a generalised LU decomposition `LU = PA` of a given
+    Computes a generalised LU decomposition `PLU = A` of a given
     matrix `A`, returning the rank of `A`.
 
     If `A` is a nonsingular square matrix, it will be overwritten with

--- a/doc/source/fq_mat.rst
+++ b/doc/source/fq_mat.rst
@@ -337,7 +337,7 @@ LU decomposition
 
 .. function:: slong fq_mat_lu(slong * P, fq_mat_t A, int rank_check, const fq_ctx_t ctx)
 
-    Computes a generalised LU decomposition `LU = PA` of a given
+    Computes a generalised LU decomposition `PLU = A` of a given
     matrix `A`, returning the rank of `A`.
 
     If `A` is a nonsingular square matrix, it will be overwritten with

--- a/doc/source/fq_nmod_mat.rst
+++ b/doc/source/fq_nmod_mat.rst
@@ -336,7 +336,7 @@ LU decomposition
 
 .. function:: slong fq_nmod_mat_lu(slong * P, fq_nmod_mat_t A, int rank_check, const fq_nmod_ctx_t ctx)
 
-    Computes a generalised LU decomposition `LU = PA` of a given
+    Computes a generalised LU decomposition `PLU = A` of a given
     matrix `A`, returning the rank of `A`.
 
     If `A` is a nonsingular square matrix, it will be overwritten with

--- a/doc/source/fq_zech_mat.rst
+++ b/doc/source/fq_zech_mat.rst
@@ -303,7 +303,7 @@ LU decomposition
 
 .. function:: slong fq_zech_mat_lu(slong * P, fq_zech_mat_t A, int rank_check, const fq_zech_ctx_t ctx)
 
-    Computes a generalised LU decomposition `LU = PA` of a given
+    Computes a generalised LU decomposition `PLU = A` of a given
     matrix `A`, returning the rank of `A`.
 
     If `A` is a nonsingular square matrix, it will be overwritten with

--- a/doc/source/nmod_mat.rst
+++ b/doc/source/nmod_mat.rst
@@ -593,7 +593,7 @@ LU decomposition
               slong nmod_mat_lu_classical_delayed(slong * P, nmod_mat_t A, int rank_check)
               slong nmod_mat_lu_recursive(slong * P, nmod_mat_t A, int rank_check)
 
-    Computes a generalised LU decomposition `LU = PA` of a given
+    Computes a generalised LU decomposition `PLU = A` of a given
     matrix `A`, returning the rank of `A`.
 
     If `A` is a nonsingular square matrix, it will be overwritten with


### PR DESCRIPTION
The tests also compute `P * (L*U)` and compare it with `A`. For all other types, this was already correct, just for the various finite fields not.