### PR TITLE
Inline code in _gr_fmpz_set

### DIFF
--- a/src/gr/fmpz.c
+++ b/src/gr/fmpz.c
@@ -247,7 +247,17 @@ _gr_fmpz_equal(const fmpz_t x, const fmpz_t y, const gr_ctx_t ctx)
 int
 _gr_fmpz_set(fmpz_t res, const fmpz_t x, const gr_ctx_t ctx)
 {
-    fmpz_set(res, x);
+    if (res == x)
+        return GR_SUCCESS;
+
+    if (!COEFF_IS_MPZ(*x))
+    {
+        _fmpz_demote(res);
+        *res = *x;
+    }
+    else
+        mpz_set(_fmpz_promote(res), COEFF_TO_PTR(*x));
+
     return GR_SUCCESS;
 }
 


### PR DESCRIPTION
In #2203 we noticed a small speed regression when converting ``fmpz_mat_transpose`` to generics.

It turns out that this has a simple explanation: the double function call overhead ``_gr_fmpz_set`` -> ``fmpz_set``. When the operation is inlined in ``_gr_fmpz_set``, ``fmpz_mat_transpose`` now runs exactly as fast as the previous non-generic code (and slightly faster than the original ``fmpz_mat_transpose`` did with the old matrix representation in FLINT 3.1).

We should do this inlining in more of the ``gr_fmpz`` methods, but currently this isn't urgent since we don't use a lot of generics in the ``fmpz`` modules yet.