### PR TITLE
Remove underscore in front of nfloat_ctx_(set/get)_real_prec

### DIFF
--- a/src/nfloat.h
+++ b/src/nfloat.h
@@ -137,13 +137,13 @@ int nfloat_set(nfloat_ptr res, nfloat_srcptr x, gr_ctx_t ctx);
 truth_t nfloat_equal(nfloat_srcptr x, nfloat_srcptr y, gr_ctx_t ctx);
 
 NFLOAT_INLINE
-int _nfloat_ctx_set_real_prec(gr_ctx_t ctx, slong prec)
+int nfloat_ctx_set_real_prec(gr_ctx_t ctx, slong prec)
 {
     return GR_UNABLE;
 }
 
 NFLOAT_INLINE
-int _nfloat_ctx_get_real_prec(slong * res, gr_ctx_t ctx)
+int nfloat_ctx_get_real_prec(slong * res, gr_ctx_t ctx)
 {
     *res = NFLOAT_CTX_PREC(ctx);
     return GR_SUCCESS;

--- a/src/nfloat/complex.c
+++ b/src/nfloat/complex.c
@@ -1698,8 +1698,8 @@ gr_method_tab_input _nfloat_complex_methods_input[] =
                                 (gr_funcptr) gr_generic_ctx_predicate_false},
 
     {GR_METHOD_CTX_HAS_REAL_PREC, (gr_funcptr) gr_generic_ctx_predicate_true},
-    {GR_METHOD_CTX_SET_REAL_PREC, (gr_funcptr) _nfloat_ctx_set_real_prec},
-    {GR_METHOD_CTX_GET_REAL_PREC, (gr_funcptr) _nfloat_ctx_get_real_prec},
+    {GR_METHOD_CTX_SET_REAL_PREC, (gr_funcptr) nfloat_ctx_set_real_prec},
+    {GR_METHOD_CTX_GET_REAL_PREC, (gr_funcptr) nfloat_ctx_get_real_prec},
 
     {GR_METHOD_INIT,            (gr_funcptr) nfloat_complex_init},
     {GR_METHOD_CLEAR,           (gr_funcptr) nfloat_complex_clear},

--- a/src/nfloat/ctx.c
+++ b/src/nfloat/ctx.c
@@ -39,8 +39,8 @@ gr_method_tab_input _nfloat_methods_input[] =
                                 (gr_funcptr) gr_generic_ctx_predicate_false},
 
     {GR_METHOD_CTX_HAS_REAL_PREC, (gr_funcptr) gr_generic_ctx_predicate_true},
-    {GR_METHOD_CTX_SET_REAL_PREC, (gr_funcptr) _nfloat_ctx_set_real_prec},
-    {GR_METHOD_CTX_GET_REAL_PREC, (gr_funcptr) _nfloat_ctx_get_real_prec},
+    {GR_METHOD_CTX_SET_REAL_PREC, (gr_funcptr) nfloat_ctx_set_real_prec},
+    {GR_METHOD_CTX_GET_REAL_PREC, (gr_funcptr) nfloat_ctx_get_real_prec},
 
     {GR_METHOD_INIT,            (gr_funcptr) nfloat_init},
     {GR_METHOD_CLEAR,           (gr_funcptr) nfloat_clear},


### PR DESCRIPTION
This was mentioned in #2184. It now matches what is in the documentation.