### PR TITLE
Configure and flint-mparam for meteorlake

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -113,16 +113,16 @@ define(X86_PATTERN,
 [[i?86*-*-* | k[5-8]*-*-* | pentium*-*-* | athlon-*-* | viac3*-*-* | geode*-*-* | atom-*-*]])
 
 define(X86_64_PATTERN,
-[[athlon64-*-* | k8-*-* | k10-*-* | bobcat-*-* | jaguar*-*-* | bulldozer*-*-* | piledriver*-*-* | steamroller*-*-* | excavator*-*-* | zen*-*-* | pentium4-*-* | atom-*-* | silvermont-*-* | goldmont-*-* | tremont-*-* | core2-*-* | corei*-*-* | x86_64-*-* | nano-*-* | nehalem*-*-* | westmere*-*-* | sandybridge*-*-* | ivybridge*-*-* | haswell*-*-* | broadwell*-*-* | skylake*-*-* | kabylake*-*-* | icelake*-*-* | tigerlake*-*-* | rocketlake*-*-* | alderlake*-*-* | raptorlake*-*-* | x86_64v[1234]-*-*]])
+[[athlon64-*-* | k8-*-* | k10-*-* | bobcat-*-* | jaguar*-*-* | bulldozer*-*-* | piledriver*-*-* | steamroller*-*-* | excavator*-*-* | zen*-*-* | pentium4-*-* | atom-*-* | silvermont-*-* | goldmont-*-* | tremont-*-* | core2-*-* | corei*-*-* | x86_64-*-* | nano-*-* | nehalem*-*-* | westmere*-*-* | sandybridge*-*-* | ivybridge*-*-* | haswell*-*-* | broadwell*-*-* | skylake*-*-* | kabylake*-*-* | icelake*-*-* | tigerlake*-*-* | rocketlake*-*-* | alderlake*-*-* | raptorlake*-*-* | meteorlake*-*-* | x86_64v[1234]-*-*]])
 
 define(X86_64_ADX_PATTERN,
-[[zen[1234]-*-* | coreibwl-*-* | broadwell-*-* | skylake-*-* | skylake_server-*-* | cannonlake-*-* | kabylake-*-* | icelake-*-* | icelake_server-*-* | rocketlake-*-* | tigerlake-*-* | alderlake-*-* | raptorlake-*-* | knightslanding-*-* | sapphirerapids-*-* | cometlake-*-*]])
+[[zen[1234]-*-* | coreibwl-*-* | broadwell-*-* | skylake-*-* | skylake_server-*-* | cannonlake-*-* | kabylake-*-* | icelake-*-* | icelake_server-*-* | rocketlake-*-* | tigerlake-*-* | alderlake-*-* | raptorlake-*-* | meteorlake-*-* | knightslanding-*-* | sapphirerapids-*-* | cometlake-*-*]])
 
 define(ARM64_PATTERN,
 [[armcortexa53-*-* | armcortexa53neon-*-* | armcortexa55-*-* | armcortexa55neon-*-* | armcortexa57-*-* | armcortexa57neon-*-* | armcortexa7[2-9]-*-* | armcortexa7[2-9]neon-*-* | armexynosm1-*-* | armthunderx-*-* | armxgene1-*-* | aarch64*-*-* | applem[1-9]*-*-* | armv8*-*-*]])
 
 define(SLOW_VROUNDPD_PATTERN,
-[[haswell* | broadwell* | skylake* | kabylake* | icelake* | tigerlake* | rocketlake* | alderlake* | raptorlake*]])
+[[haswell* | broadwell* | skylake* | kabylake* | icelake* | tigerlake* | rocketlake* | alderlake* | raptorlake* | meteorlake*]])
 
 define(FAST_VROUNDPD_PATTERN,
 [[znver[2-4]* | sandybridge* | ivybridge*]])

--- a/config/config.guess
+++ b/config/config.guess
@@ -955,6 +955,7 @@ main ()
           else if (model == 0xa7) cpu_64bit = 1, cpu_avx=1, modelstr = "rocketlake"; /* Rocket Lake S */
           else if (model == 0xba) cpu_64bit = 1, cpu_avx=1, modelstr = "raptorlake"; /* Raptor Lake */
           else if (model == 0xb7) cpu_64bit = 1, cpu_avx=1, modelstr = "raptorlake"; /* Raptor Lake */
+          else if (model == 0xaa) cpu_64bit = 1, cpu_avx=1, modelstr = "meteorlake"; /* Meteor Lake H, U */
           else                    cpu_64bit = 1,            modelstr = "nehalem";    /* default */
 
           if (strcmp (modelstr, "haswell") == 0 ||

--- a/config/config.sub
+++ b/config/config.sub
@@ -102,7 +102,7 @@ itanium | itanium2)
   test_cpu=ia64 ;;
 pentium | pentiummmx | pentiumpro | pentium[234m] | k[567] | k6[23] | geode | athlon | viac3*)
   test_cpu=i386 ;;
-athlon64 | atom | silvermont | goldmont | tremont | core2 | corei* | opteron | k[89] | k10 | bobcat | jaguar* | bulldozer* | piledriver* | steamroller* | excavator* | zen[1234] | nano | nehalem | westmere | sandybridge | ivybridge | haswell | broadwell | skylake | skylake_server | cannonlake | kabylake | icelake | icelake_server | rocketlake | tigerlake | alderlake | raptorlake | knightslanding | sapphirerapids | cometlake | x86_64v[1234])
+athlon64 | atom | silvermont | goldmont | tremont | core2 | corei* | opteron | k[89] | k10 | bobcat | jaguar* | bulldozer* | piledriver* | steamroller* | excavator* | zen[1234] | nano | nehalem | westmere | sandybridge | ivybridge | haswell | broadwell | skylake | skylake_server | cannonlake | kabylake | icelake | icelake_server | rocketlake | tigerlake | alderlake | raptorlake | meteorlake | knightslanding | sapphirerapids | cometlake | x86_64v[1234])
   test_cpu=x86_64 ;;
 power[2-9] | power1[0-9] | power2sc)
   test_cpu=power ;;

--- a/configure.ac
+++ b/configure.ac
@@ -737,7 +737,7 @@ Please report at <https://github.com/flintlib/flint/issues/>])
         ;;
       meteorlake)
         gcc_cflags_arch="-march=meteorlake"
-        param_path="x86_64/skylake"
+        param_path="x86_64/meteorlake"
         ;;
       knightslanding)
         gcc_cflags_arch="-march=knl"

--- a/configure.ac
+++ b/configure.ac
@@ -732,7 +732,11 @@ Please report at <https://github.com/flintlib/flint/issues/>])
         param_path="x86_64/skylake"
         ;;
       raptorlake)
-        gcc_cflags_arch="-march=alderlake"
+        gcc_cflags_arch="-march=raptorlake"
+        param_path="x86_64/skylake"
+        ;;
+      meteorlake)
+        gcc_cflags_arch="-march=meteorlake"
         param_path="x86_64/skylake"
         ;;
       knightslanding)

--- a/src/mpn_extras/x86_64/broadwell/flint-mparam.h
+++ b/src/mpn_extras/x86_64/broadwell/flint-mparam.h
@@ -31,7 +31,6 @@
 #define FFT_N_NUM 23
 #define FFT_MULMOD_2EXPP1_CUTOFF 128
 
-/* TODO: check this tuning */
 #define FLINT_PREINVERT_LIMB_USE_NATIVE 0
 
 #define FLINT_MULMOD_SHOUP_THRESHOLD 14

--- a/src/mpn_extras/x86_64/meteorlake/flint-mparam.h
+++ b/src/mpn_extras/x86_64/meteorlake/flint-mparam.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2024 Albin Ahlbäck
+    Copyright (C) 2025 Vincent Neiger
 
     This file is part of FLINT.
 
@@ -9,27 +9,30 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+/* parameters found for Intel(R) Core(TM) Ultra 7 165H */
+
 #ifndef FLINT_MPARAM_H
 #define FLINT_MPARAM_H
 
+/* TODO these were taken directly from skylake flint-mparam.h  ----> */
 #define FLINT_FFT_SMALL_MUL_THRESHOLD           1540
 #define FLINT_FFT_SMALL_SQR_THRESHOLD           3080
 
 #define FLINT_FFT_MUL_THRESHOLD                32000
 #define FLINT_FFT_SQR_THRESHOLD                32000
+/* <---- these were taken directly from skylake flint-mparam.h  */
 
 #define FFT_TAB \
-   { {4, 4}, {4, 3}, {3, 2}, {2, 1}, {2, 1} }
+   { { 4, 4 }, { 4, 3 }, { 3, 2 }, { 2, 2 }, { 2, 1 } }
 
 #define MULMOD_TAB \
-   { 4, 4, 4, 4, 4, 3, 3, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2, 1, 1 }
+   { 4, 4, 4, 4, 4, 3, 3, 3, 3, 3, 3, 3, 3, 2, 2, 2, 2, 1, 1 }
 
-#define FFT_N_NUM                                 19
-#define FFT_MULMOD_2EXPP1_CUTOFF                 128
+#define FFT_N_NUM 19
+#define FFT_MULMOD_2EXPP1_CUTOFF 128
 
-#define FLINT_PREINVERT_LIMB_USE_NATIVE 0
+#define FLINT_PREINVERT_LIMB_USE_NATIVE 1
 
-/* verified on Xeon(R) Gold 6244 (cascade lake) */
-#define FLINT_MULMOD_SHOUP_THRESHOLD 23
+#define FLINT_MULMOD_SHOUP_THRESHOLD 0
 
 #endif


### PR DESCRIPTION
This allows Intel's meteorlake CPUs to be identified during configure. This adds corresponding parameters in `meteorlake/flint-mparam.h`.