### PR TITLE
 fmpz_mat_snf_kannan_bachem can take any matrix

### DIFF
--- a/doc/source/fmpz_mat.rst
+++ b/doc/source/fmpz_mat.rst
@@ -1328,7 +1328,7 @@ Smith normal form
 .. function:: void fmpz_mat_snf_kannan_bachem(fmpz_mat_t S, const fmpz_mat_t A)
 
     Computes an integer matrix ``S`` such that ``S`` is the unique Smith
-    normal form of the diagonal matrix ``A``. The algorithm used here is due
+    normal form of the matrix ``A``. The algorithm used here is due
     to Kannan and Bachem [KanBac1979]_
 
     Aliasing of ``S`` and ``A`` is allowed. The size of ``S`` must be


### PR DESCRIPTION
There is an extra "diagonal" there, probably just a cut and paste typo. The function takes any matrix