### PR TITLE
Update fmpz.rst

### DIFF
--- a/doc/source/fmpz.rst
+++ b/doc/source/fmpz.rst
@@ -315,7 +315,7 @@ Conversion
 
 .. function:: ulong fmpz_get_nmod(const fmpz_t f, nmod_t mod)
 
-    Returns `f \mod n`.
+    Returns `f` modulo the integer given by `mod`.
 
 .. function:: double fmpz_get_d(const fmpz_t f)
 


### PR DESCRIPTION
`fmpz_get_nmod(f, mod)` should refer to `f mod mod` instead of `f mod n`. But that sounds silly, so I rephrased it slightly.