### PR TITLE
build: reduce build requirements on gmp and mpfr

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -978,7 +978,15 @@ fi
 # check GMP
 ################################################################################
 
-FLINT_CHECK_GMP_H(6,2,1)
+AS_IF([test "$enable_gmp_internals" = "yes"], [
+	FLINT_CHECK_GMP_H(6,2,1)
+	GMP_REQUIREMENT="6.2.1"
+], [
+	dnl Dependency on mpn_zero_p
+	FLINT_CHECK_GMP_H(6,1,0)
+	GMP_REQUIREMENT="6.1.0"
+])
+AC_SUBST([GMP_REQUIREMENT])
 FLINT_GMP_LONG_LONG_LIMB([SLONG="long long int"
                           ULONG="unsigned long long int"
                           gmpcompat_h_in="gmpcompat-longlong.h.in"],
@@ -1001,7 +1009,8 @@ AC_SUBST(GMPCOMPAT_H_IN, $gmpcompat_h_in)
 # check MPFR
 ################################################################################
 
-FLINT_CHECK_MPFR_H(4,1,0)
+dnl Dependency on mpfr_rootn_ui
+FLINT_CHECK_MPFR_H(4,0,0)
 
 ################################################################################
 # check ABI

--- a/flint.pc.in
+++ b/flint.pc.in
@@ -7,6 +7,6 @@ Name: @PACKAGE_NAME@
 Description: Fast Library for Number Theory
 Version: @PACKAGE_VERSION@
 URL: https://flintlib.org/
-Requires: gmp >= 6.2.1 mpfr >= 4.1.0
+Requires: gmp >= @GMP_REQUIREMENT@ mpfr >= 4.0.0
 Cflags: -I${includedir}
 Libs: -L${libdir} -lflint


### PR DESCRIPTION
Systems like openSUSE Leap 15.6 have gmp-6.1.2 and mpfr-4.0.2, so I located the minimum viable versions for flint and adjusted configure.ac.