### PR TITLE
Install generated headers in out-of-tree builds

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -933,7 +933,7 @@ endif
 ifneq ($(STATIC), 0)
 	$(CP) $(FLINT_DIR)/$(FLINT_LIB_STATIC) $(DESTDIR)$(LIBDIR)
 endif
-	$(CP) $(HEADERS) $(DESTDIR)$(INCLUDEDIR)/flint
+	$(CP) $(HEADERS) $(SRC_DIR)/*.h $(DESTDIR)$(INCLUDEDIR)/flint
 	@echo ""
 	@echo '############################################################'
 	@echo '# NOTE:                                                    #'


### PR DESCRIPTION
Currently, the generated headers (`flint.h` and friends) aren't properly installed when doing an out-of-tree build.