### PR TITLE
Use __ARM_ACLE to guard inclusion of arm_acle.h

### DIFF
--- a/src/ulong_extras/revbin.c
+++ b/src/ulong_extras/revbin.c
@@ -19,7 +19,7 @@
 # define HAVE_RBIT 1
 #endif
 
-#if defined(__GNUC__) && FLINT64 && defined(__ARM_ACLE) && HAVE_RBIT
+#if FLINT64 && __ARM_ACLE && HAVE_RBIT
 # include <arm_acle.h>
 ulong
 n_revbin(ulong n, ulong b)

--- a/src/ulong_extras/revbin.c
+++ b/src/ulong_extras/revbin.c
@@ -19,7 +19,7 @@
 # define HAVE_RBIT 1
 #endif
 
-#if defined(__GNUC__) && FLINT64 && HAVE_RBIT
+#if defined(__GNUC__) && FLINT64 && defined(__ARM_ACLE) && HAVE_RBIT
 # include <arm_acle.h>
 ulong
 n_revbin(ulong n, ulong b)


### PR DESCRIPTION
When trying to build FLINT v3.2.0 with julia's BinaryBuilder (to produce the julia package `FLINT_jll.jl` that is a dependency of `Nemo.jl`), the build for `aarch64-linux-gnu` failed with the following error message:
```
[23:35:30] /workspace/srcdir/flint-3.2.0/src/ulong_extras/revbin.c: In function ‘n_revbin’:
[23:35:30] /workspace/srcdir/flint-3.2.0/src/ulong_extras/revbin.c:29:9: error: implicit declaration of function ‘__rbitll’ [-Werror=implicit-function-declaration]
[23:35:30]      n = __rbitll(n);
[23:35:30]          ^~~~~~~~
```
(full log at https://buildkite.com/julialang/yggdrasil/builds/18605#01958cb4-1ad1-4dac-87ea-34869cf00fad/689-11246)

This could be due to BinaryBuilder.jl using very old compilers for maximum compatibility of produced libraries; the above error was produced with GCC v6.

https://github.com/flintlib/flint/pull/2245 added a check wether the `arm_acle.h` header contains the `rbit` instruction. However, it does not check if the `arm_acle.h` header even exists in the first place.
According to https://github.com/ARM-software/acle/releases/download/r2024Q4/acle-2024Q4.pdf, Section 3.5.1, one can test this by checking for ` __ARM_ACLE` (as this PR does).

Adding the patch from this PR to the BinaryBuilder.jl script fixed the above build failure, so I thought it would be good to upstream this.
