### PR TITLE
Fix ENABLE_AVX2=OFF for CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ set(CMAKE_REQUIRED_LIBRARIES gmp::gmp)
 if(HAS_FLAG_ARCH)
     set(CMAKE_REQUIRED_FLAGS "-march=${ENABLE_ARCH}")
 endif()
-if(HAS_FLAG_AVX2)
+if(ENABLE_AVX2)
     set(CMAKE_REQUIRED_FLAGS "${avx2_flag}")
 endif()
 check_c_source_compiles([[


### PR DESCRIPTION
It assumed that fft_small was available on some systems where AVX2 was available, but the user had turned off AVX2.

Fixes #2266 