### PR TITLE
do not use find_library() in flint_ctypes

### DIFF
--- a/src/python/flint_ctypes.py
+++ b/src/python/flint_ctypes.py
@@ -3,10 +3,7 @@ import ctypes.util
 import sys
 import functools
 
-libflint_path = ctypes.util.find_library('flint')
-if libflint_path == None:
-    raise ValueError('Could not find libflint.')
-libflint = ctypes.CDLL(libflint_path)
+libflint = ctypes.CDLL("libflint.so")
 libcalcium = libarb = libgr = libflint
 
 T_TRUE = 0


### PR DESCRIPTION
Using find_library(), it seems impossible to use LD_LIBRARY_PATH to load a specific version of libflint when there is one the system library search path. On my system at least, however, specifying the name alone seems to use the normal ld.so/dlopen() search algorithm and works both for an installed library and one in LD_LIBRARY_PATH.

(According to the Python docs, find_library() tries to locate the shared library in a platform-dependent way vaguely similar to the way it is done at _compile_ time. On Linux, it appears to use the ldconfig cache.)
