### PR TITLE
Recognize when generic univariate polynomial rings are UFDs

### DIFF
--- a/src/fmpz_mod_mat/minpoly.c
+++ b/src/fmpz_mod_mat/minpoly.c
@@ -28,5 +28,6 @@ void fmpz_mod_mat_minpoly(fmpz_mod_poly_t p, const fmpz_mod_mat_t X,
         flint_throw(FLINT_ERROR, "Exception (fmpz_mod_mat_minpoly). Non-square matrix.\n");
 
     _gr_ctx_init_fmpz_mod_from_ref(gr_ctx, ctx);
+    GR_MUST_SUCCEED(gr_ctx_set_is_field(gr_ctx, T_TRUE));
     GR_MUST_SUCCEED(gr_mat_minpoly_field((gr_poly_struct *) p, (const gr_mat_struct *) X, gr_ctx));
 }

--- a/src/gr/polynomial.c
+++ b/src/gr/polynomial.c
@@ -80,6 +80,12 @@ polynomial_ctx_is_integral_domain(gr_ctx_t ctx)
 }
 
 truth_t
+polynomial_ctx_is_unique_factorization_domain(gr_ctx_t ctx)
+{
+    return gr_ctx_is_unique_factorization_domain(POLYNOMIAL_ELEM_CTX(ctx));
+}
+
+truth_t
 polynomial_ctx_is_threadsafe(gr_ctx_t ctx)
 {
     return gr_ctx_is_threadsafe(POLYNOMIAL_ELEM_CTX(ctx));
@@ -616,7 +622,6 @@ polynomial_gcd(gr_poly_t res, const gr_poly_t x, const gr_poly_t y, const gr_ctx
     return gr_poly_gcd(res, x, y, POLYNOMIAL_ELEM_CTX(ctx));
 }
 
-
 int _gr_poly_methods_initialized = 0;
 
 gr_static_method_table _gr_poly_methods;
@@ -629,6 +634,7 @@ gr_method_tab_input _gr_poly_methods_input[] =
     {GR_METHOD_CTX_IS_RING,     (gr_funcptr) polynomial_ctx_is_ring},
     {GR_METHOD_CTX_IS_COMMUTATIVE_RING, (gr_funcptr) polynomial_ctx_is_commutative_ring},
     {GR_METHOD_CTX_IS_INTEGRAL_DOMAIN,  (gr_funcptr) polynomial_ctx_is_integral_domain},
+    {GR_METHOD_CTX_IS_UNIQUE_FACTORIZATION_DOMAIN,  (gr_funcptr) polynomial_ctx_is_unique_factorization_domain},
     {GR_METHOD_CTX_IS_FIELD,            (gr_funcptr) gr_generic_ctx_predicate_false},
     {GR_METHOD_CTX_IS_THREADSAFE,       (gr_funcptr) polynomial_ctx_is_threadsafe},
     {GR_METHOD_CTX_SET_GEN_NAME,        (gr_funcptr) _gr_gr_poly_ctx_set_gen_name},

--- a/src/gr_poly/gcd.c
+++ b/src/gr_poly/gcd.c
@@ -41,6 +41,9 @@ gr_poly_gcd(gr_poly_t G, const gr_poly_t A,
     if (A->length == 0 && B->length == 0)
         return gr_poly_zero(G, ctx);
 
+    if (gr_ctx_is_field(ctx) != T_TRUE)
+        return GR_UNABLE;
+
     if (A->length == 0)
         return gr_poly_make_monic(G, B, ctx);
 


### PR DESCRIPTION
Also fix `gr_poly_gcd` to bail out when the base ring is not a field since
it computes a monic gcd.
