### PR TITLE
Allow emscripten builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,10 +12,6 @@
 
 cmake_minimum_required(VERSION 3.22)
 
-if(NOT WIN32)
-    message(FATAL_ERROR "Detected system is not Windows.  Please use the Autotools configuration along with the Makefile instead as it is more up-to-date.  Read INSTALL.md.")
-endif()
-
 include(CheckCCompilerFlag)
 include(CheckCSourceRuns)
 include(CheckIPOSupported)
@@ -31,6 +27,11 @@ project(flint
   DESCRIPTION "Fast Library for Number Theory"
   HOMEPAGE_URL https://flintlib.org/
   LANGUAGES C CXX)
+
+if(NOT WIN32 AND NOT EMSCRIPTEN)
+    message(STATUS "CMAKE_SYSTEM_NAME: ${EMSCRIPTEN}")
+    message(FATAL_ERROR "Detected system is not Windows.  Please use the Autotools configuration along with the Makefile instead as it is more up-to-date.  Read INSTALL.md.")
+endif()
 
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/configure.ac" CONFIGURE_CONTENTS)
 foreach(version in MAJOR MINOR PATCH)


### PR DESCRIPTION
Hi All,

First of all, excellent library. I'm using it in our model counter [Ganak](https://github.com/meelgroup/ganak), that won the [model counting competition last year](https://mccompetition.org/). The weights can be any polynomial! Yay! I wanna build my counter as an online tool, and it's working already, but I want FLINT to be also inside, would be fun. To do that, I need to compile FLINT with emscripten, easiest is emsdk. This is actually really easy usually. For the 3.2.1 release, I can simply:

```
mkdir build && cd build
emcmake cmake -DCMAKE_INSTALL_PREFIX=$EMINSTALL -DBUILD_SHARED_LIBS=OFF -DENABLE_ARCH=NO ..
emmake make -j12
emmake make install
```

Done! Yay. And that works 100% fine. 

But for the `main` branch, firstly, you now check for Windows. This patch checks that it's also not EMSCIRPTEN. I had to move the  check lower, because some parameters, including EMSCIRPTEN, are not initialized before the `project()` call. Actually, I'm not even sure it's standards-compliant to check for WIN32 that early. Anyway. This chanege allows me to configure with emscripten, via simple:

```
mkdir build && cd build
emcmake cmake -DCMAKE_INSTALL_PREFIX=$EMINSTALL -DBUILD_SHARED_LIBS=OFF ..
```

Building is kinda messed up, due to some bug that I guess you are aware of, or probably will be soon, since it seems to break this build, but probably at least a few others:

```
$ emmake make
make: make
[  0%] Building C object CMakeFiles/flint.dir/src/generic_files/clz_tab.c.o
[  0%] Building C object CMakeFiles/flint.dir/src/generic_files/exception.c.o
/home/soos/development/flint/src/generic_files/exception.c:57:16: error: incompatible function pointer types assigning to 'void (*)(void) __attribute__((noreturn))' from 'void (*)(void)' [-Wincompatible-function-pointer-types]
   57 |     abort_func = func;
      |                ^ ~~~~
/home/soos/development/flint/src/generic_files/exception.c:75:16: error: incompatible function pointer types assigning to 'void (*)(flint_err_t, const char *, va_list) __attribute__((noreturn))' (aka 'void (*)(flint_err_t, const char *, void *) __attribute__((noreturn))') from 'void (*)(flint_err_t, const char *, va_list)' (aka 'void (*)(flint_err_t, const char *, void *)') [-Wincompatible-function-pointer-types]
   75 |     throw_func = func;
      |                ^ ~~~~
2 errors generated.
make[2]: *** [CMakeFiles/flint.dir/build.make:95: CMakeFiles/flint.dir/src/generic_files/exception.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:87: CMakeFiles/flint.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
emmake: error: 'make' failed (returned 2)
```

Anyway. I guess that will be fixed. However, this PR at least fixes the issue with the configuration with emscripten. I hope this makes sense!

Mate