### PR TITLE
Add `gr_mat_companion` to construct companion matrices

### DIFF
--- a/doc/source/gr_mat.rst
+++ b/doc/source/gr_mat.rst
@@ -710,6 +710,24 @@ Minimal polynomial
     Compute the minimal polynomial of the matrix *mat*.
     The algorithm assumes that the coefficient ring is a field.
 
+Companion matrix
+-------------------------------------------------------------------------------
+
+.. function:: int _gr_mat_companion(gr_mat_t res, gr_srcptr poly, gr_ctx_t ctx)
+              int gr_mat_companion(gr_mat_t res, const gr_poly_t poly, gr_ctx_t ctx)
+
+    Sets the *n* by *n* matrix *res* to the companion matrix of the polynomial
+    *poly* which must have degree *n*.
+    The underscore method reads `n + 1` input coefficients.
+    The algorithm assumes that the leading coefficient of *poly* is invertible.
+
+.. function:: int _gr_mat_companion_fraction(gr_mat_t res_num, gr_ptr res_den, gr_srcptr poly, gr_ctx_t ctx)
+              int gr_mat_companion_fraction(gr_mat_t res_num, gr_ptr res_den, const gr_poly_t poly, gr_ctx_t ctx)
+
+    Sets the *n* by *n* matrix *res_num* and the polynomial *res_den* so that
+    the fraction is the companion matrix of the polynomial *poly* which must
+    have degree *n*. The underscore method reads `n + 1` input coefficients.
+
 Similarity transformations
 -------------------------------------------------------------------------------
 

--- a/src/acb_mat/companion.c
+++ b/src/acb_mat/companion.c
@@ -9,41 +9,31 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
+#include "gr_mat.h"
 #include "acb_poly.h"
 #include "acb_mat.h"
 
 void
 _acb_mat_companion(acb_mat_t A, acb_srcptr poly, slong prec)
 {
-    slong i, j, n;
-    acb_t c;
-
-    n = acb_mat_nrows(A);
-
-    if (n == 0)
-        return;
-
-    for (i = 0; i < n - 1; i++)
-        for (j = 0; j < n; j++)
-            acb_set_ui(acb_mat_entry(A, i, j), (i + 1) == j);
-
-    acb_init(c);
-    acb_inv(c, poly + n, prec);
-    acb_neg(c, c);
-    for (j = 0; j < n; j++)
-        acb_mul(acb_mat_entry(A, n - 1, j), poly + j, c, prec);
-    acb_clear(c);
+    int status;
+    gr_ctx_t ctx;
+    gr_ctx_init_complex_acb(ctx, prec);
+    status = _gr_mat_companion((gr_mat_struct *) A, (gr_srcptr) poly, ctx);
+    gr_ctx_clear(ctx);
+    if (status != GR_SUCCESS)
+        acb_mat_indeterminate(A);
 }
 
 void
 acb_mat_companion(acb_mat_t A, const acb_poly_t poly, slong prec)
 {
-    slong n = acb_mat_nrows(A);
-
-    if (n != acb_poly_degree(poly) || n != acb_mat_ncols(A))
-    {
-        flint_throw(FLINT_ERROR, "acb_mat_companion: incompatible dimensions!\n");
-    }
-
-    _acb_mat_companion(A, poly->coeffs, prec);
+    int status;
+    gr_ctx_t ctx;
+    gr_ctx_init_complex_acb(ctx, prec);
+    status = gr_mat_companion((gr_mat_struct *) A, (const gr_poly_struct *) poly, ctx);
+    gr_ctx_clear(ctx);
+    if (status != GR_SUCCESS)
+        acb_mat_indeterminate(A);
 }

--- a/src/arb_mat/companion.c
+++ b/src/arb_mat/companion.c
@@ -9,41 +9,31 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gr.h"
+#include "gr_mat.h"
 #include "arb_poly.h"
 #include "arb_mat.h"
 
 void
 _arb_mat_companion(arb_mat_t A, arb_srcptr poly, slong prec)
 {
-    slong i, j, n;
-    arb_t c;
-
-    n = arb_mat_nrows(A);
-
-    if (n == 0)
-        return;
-
-    for (i = 0; i < n - 1; i++)
-        for (j = 0; j < n; j++)
-            arb_set_ui(arb_mat_entry(A, i, j), (i + 1) == j);
-
-    arb_init(c);
-    arb_inv(c, poly + n, prec);
-    arb_neg(c, c);
-    for (j = 0; j < n; j++)
-        arb_mul(arb_mat_entry(A, n - 1, j), poly + j, c, prec);
-    arb_clear(c);
+    int status;
+    gr_ctx_t ctx;
+    gr_ctx_init_real_arb(ctx, prec);
+    status = _gr_mat_companion((gr_mat_struct *) A, (gr_srcptr) poly, ctx);
+    gr_ctx_clear(ctx);
+    if (status != GR_SUCCESS)
+        arb_mat_indeterminate(A);
 }
 
 void
 arb_mat_companion(arb_mat_t A, const arb_poly_t poly, slong prec)
 {
-    slong n = arb_mat_nrows(A);
-
-    if (n != arb_poly_degree(poly) || n != arb_mat_ncols(A))
-    {
-        flint_throw(FLINT_ERROR, "arb_mat_companion: incompatible dimensions!\n");
-    }
-
-    _arb_mat_companion(A, poly->coeffs, prec);
+    int status;
+    gr_ctx_t ctx;
+    gr_ctx_init_real_arb(ctx, prec);
+    status = gr_mat_companion((gr_mat_struct *) A, (const gr_poly_struct *) poly, ctx);
+    gr_ctx_clear(ctx);
+    if (status != GR_SUCCESS)
+        arb_mat_indeterminate(A);
 }

--- a/src/gr_mat.h
+++ b/src/gr_mat.h
@@ -308,6 +308,11 @@ WARN_UNUSED_RESULT int gr_mat_charpoly_generic(gr_poly_t cp, const gr_mat_t mat,
 WARN_UNUSED_RESULT int _gr_mat_charpoly(gr_ptr res, const gr_mat_t mat, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mat_charpoly(gr_poly_t res, const gr_mat_t mat, gr_ctx_t ctx);
 
+WARN_UNUSED_RESULT int _gr_mat_companion(gr_mat_t res, gr_srcptr poly, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_mat_companion(gr_mat_t res, const gr_poly_t poly, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int _gr_mat_companion_fraction(gr_mat_t res_num, gr_ptr res_den, gr_srcptr poly, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_mat_companion_fraction(gr_mat_t res_num, gr_ptr res_den, const gr_poly_t poly, gr_ctx_t ctx);
+
 WARN_UNUSED_RESULT int gr_mat_hessenberg(gr_mat_t res, const gr_mat_t mat, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mat_hessenberg_gauss(gr_mat_t res, const gr_mat_t mat, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mat_hessenberg_householder(gr_mat_t res, const gr_mat_t mat, gr_ctx_t ctx);

--- a/src/gr_mat/companion.c
+++ b/src/gr_mat/companion.c
@@ -1,0 +1,85 @@
+/*
+    Copyright (C) 2025 Ricardo Buring
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "gr_poly.h"
+#include "gr_vec.h"
+#include "gr_mat.h"
+
+int
+_gr_mat_companion(gr_mat_t res, gr_srcptr poly, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    slong n = gr_mat_nrows(res, ctx);
+    slong sz = ctx->sizeof_elem;
+    gr_ptr c;
+    gr_mat_t W;
+
+    if (n == 0)
+        return status;
+
+    gr_mat_window_init(W, res, 0, 0, n - 1, 1, ctx);
+    status |= gr_mat_zero(W, ctx);
+    gr_mat_window_init(W, res, 0, 1, n - 1, n, ctx);
+    status |= gr_mat_one(W, ctx);
+
+    GR_TMP_INIT(c, ctx);
+    status |= gr_inv(c, GR_ENTRY(poly, n, sz), ctx);
+    status |= gr_neg(c, c, ctx);
+    status |= _gr_vec_mul_scalar(gr_mat_entry_ptr(res, n - 1, 0, ctx), poly, n, c, ctx);
+    GR_TMP_CLEAR(c, ctx);
+
+    return status;
+}
+
+int
+gr_mat_companion(gr_mat_t res, const gr_poly_t poly, gr_ctx_t ctx)
+{
+    slong n = gr_mat_nrows(res, ctx);
+
+    if (n != gr_poly_length(poly, ctx) - 1 || n != gr_mat_ncols(res, ctx))
+        return GR_DOMAIN;
+
+    return _gr_mat_companion(res, poly->coeffs, ctx);
+}
+
+int
+_gr_mat_companion_fraction(gr_mat_t res_num, gr_ptr res_den, gr_srcptr poly, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    slong n = gr_mat_nrows(res_num, ctx);
+    slong sz = ctx->sizeof_elem;
+    gr_mat_t W;
+
+    if (n == 0)
+        return gr_one(res_den, ctx);
+
+    status |= gr_set(res_den, GR_ENTRY(poly, n, sz), ctx);
+
+    gr_mat_window_init(W, res_num, 0, 0, n - 1, 1, ctx);
+    status |= gr_mat_zero(W, ctx);
+    gr_mat_window_init(W, res_num, 0, 1, n - 1, n, ctx);
+    status |= gr_mat_set_scalar(W, res_den, ctx);
+
+    status |= _gr_vec_neg(gr_mat_entry_ptr(res_num, n - 1, 0, ctx), poly, n, ctx);
+
+    return status;
+}
+
+int
+gr_mat_companion_fraction(gr_mat_t res_num, gr_ptr res_den, const gr_poly_t poly, gr_ctx_t ctx)
+{
+    slong n = gr_mat_nrows(res_num, ctx);
+
+    if (n != gr_poly_length(poly, ctx) - 1 || n != gr_mat_ncols(res_num, ctx))
+        return GR_DOMAIN;
+
+    return _gr_mat_companion_fraction(res_num, res_den, poly->coeffs, ctx);
+}

--- a/src/gr_mat/test/main.c
+++ b/src/gr_mat/test/main.c
@@ -18,6 +18,7 @@
 #include "t-charpoly_faddeev.c"
 #include "t-charpoly_gauss.c"
 #include "t-charpoly_householder.c"
+#include "t-companion.c"
 #include "t-concat_horizontal.c"
 #include "t-concat_vertical.c"
 #include "t-det_berkowitz.c"
@@ -73,6 +74,7 @@ test_struct tests[] =
     TEST_FUNCTION(gr_mat_charpoly_faddeev),
     TEST_FUNCTION(gr_mat_charpoly_gauss),
     TEST_FUNCTION(gr_mat_charpoly_householder),
+    TEST_FUNCTION(gr_mat_companion),
     TEST_FUNCTION(gr_mat_concat_horizontal),
     TEST_FUNCTION(gr_mat_concat_vertical),
     TEST_FUNCTION(gr_mat_det_berkowitz),

--- a/src/gr_mat/test/t-companion.c
+++ b/src/gr_mat/test/t-companion.c
@@ -1,0 +1,82 @@
+/*
+    Copyright (C) 2025 Ricardo Buring
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "gr_poly.h"
+#include "gr_mat.h"
+
+TEST_FUNCTION_START(gr_mat_companion, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 100 * flint_test_multiplier(); iter++)
+    {
+        int status = GR_SUCCESS;
+        gr_ctx_t ctx;
+        gr_mat_t A, B;
+        gr_poly_t f, g;
+        gr_ptr den;
+        slong n;
+
+        do {
+            gr_ctx_init_random(ctx, state);
+        } while (gr_ctx_is_field(ctx) != T_TRUE);
+
+        gr_poly_init(f, ctx);
+        gr_poly_init(g, ctx);
+
+        do {
+            status |= gr_poly_randtest(f, state, 1 + n_randint(state, 8), ctx);
+            n = gr_poly_length(f, ctx) - 1;
+        } while (n < 0 || gr_is_invertible(gr_poly_entry_srcptr(f, n, ctx), ctx) != T_TRUE);
+
+        gr_mat_init(A, n, n, ctx);
+        status |= gr_mat_randtest(A, state, ctx);
+        status |= gr_mat_companion(A, f, ctx);
+        status |= gr_mat_charpoly(g, A, ctx);
+
+        status |= gr_poly_scalar_mul(g, gr_poly_entry_srcptr(f, n, ctx), g, ctx);
+
+        if (gr_poly_equal(g, f, ctx) == T_FALSE)
+        {
+            flint_printf("FAIL\n");
+            flint_printf("A:\n"), gr_mat_print(A, ctx), flint_printf("\n");
+            flint_printf("f:\n"), gr_poly_print(f, ctx), flint_printf("\n");
+            flint_printf("g:\n"), gr_poly_print(g, ctx), flint_printf("\n");
+            flint_abort();
+        }
+
+        GR_TMP_INIT(den, ctx);
+        gr_mat_init(B, n, n, ctx);
+        status |= gr_mat_randtest(B, state, ctx);
+        status |= gr_mat_companion_fraction(B, den, f, ctx);
+        status |= gr_mat_mul_scalar(A, A, den, ctx);
+
+        if (gr_mat_equal(A, B, ctx) == T_FALSE)
+        {
+            flint_printf("FAIL\n");
+            flint_printf("A:\n"), gr_mat_print(A, ctx), flint_printf("\n");
+            flint_printf("B:\n"), gr_mat_print(B, ctx), flint_printf("\n");
+            flint_printf("f:\n"), gr_poly_print(f, ctx), flint_printf("\n");
+            flint_printf("g:\n"), gr_poly_print(g, ctx), flint_printf("\n");
+            flint_abort();
+        }
+
+        GR_TMP_CLEAR(den, ctx);
+        gr_mat_clear(A, ctx);
+        gr_mat_clear(B, ctx);
+        gr_poly_clear(f, ctx);
+        gr_poly_clear(g, ctx);
+        gr_ctx_clear(ctx);
+    }
+
+    TEST_FUNCTION_END(state);
+}


### PR DESCRIPTION
I would like to apply this to Ore polynomials, but it works for generic polynomials so here it is (with tests).