### PR TITLE
Fix GR context bug in `_gr_gr_series_mod_gen`

### DIFF
--- a/src/gr/series_mod.c
+++ b/src/gr/series_mod.c
@@ -159,7 +159,7 @@ static int _gr_gr_series_mod_one(gr_poly_t res, gr_ctx_t ctx)
 
 static int _gr_gr_series_mod_gen(gr_poly_t res, gr_ctx_t ctx)
 {
-    return (SERIES_MOD_N(ctx) <= 1) ? gr_poly_zero(res, ctx) : gr_poly_gen(res, SERIES_MOD_ELEM_CTX(ctx));
+    return (SERIES_MOD_N(ctx) <= 1) ? gr_poly_zero(res, SERIES_MOD_ELEM_CTX(ctx)) : gr_poly_gen(res, SERIES_MOD_ELEM_CTX(ctx));
 }
 
 static int _gr_gr_series_mod_set(gr_poly_t res, const gr_poly_t x, gr_ctx_t ctx)


### PR DESCRIPTION
I presume it should be like this, the old way caused a crash in one of my tests.

(I'll contribute that test soon, but without this fix it would fail CI.)