### PR TITLE
Add `gr_mat_randsimilar`

### DIFF
--- a/doc/source/gr.rst
+++ b/doc/source/gr.rst
@@ -373,6 +373,10 @@ Random elements
     Typically the distribution is non-uniform in order to
     find corner cases more easily in test code.
 
+.. function:: int gr_randtest_invertible(gr_ptr res, flint_rand_t state, gr_ctx_t ctx)
+
+    Sets *res* to a random invertible element of the domain *ctx*.
+
 .. function:: int gr_randtest_not_zero(gr_ptr res, flint_rand_t state, gr_ctx_t ctx)
 
     Sets *res* to a random nonzero element of the domain *ctx*.

--- a/doc/source/gr_mat.rst
+++ b/doc/source/gr_mat.rst
@@ -861,6 +861,12 @@ Random matrices
 
     This operation only makes sense over integral domains (currently not checked).
 
+.. function:: int gr_mat_randsimilar(gr_mat_t mat, flint_rand_t state, slong opcount, gr_ctx_t ctx)
+
+    Randomises *mat* in-place by conjugating by elementary row/column
+    operations. More precisely, at most *opcount* conjugations by random
+    elementary row/column operations will be performed.
+
 Special matrices
 -------------------------------------------------------------------------------
 

--- a/src/gr.h
+++ b/src/gr.h
@@ -123,6 +123,7 @@ typedef enum
 
     GR_METHOD_RANDTEST,
     GR_METHOD_RANDTEST_NOT_ZERO,
+    GR_METHOD_RANDTEST_INVERTIBLE,
     GR_METHOD_RANDTEST_SMALL,
 
     GR_METHOD_ZERO,
@@ -955,6 +956,7 @@ GR_INLINE void _gr_length(gr_srcptr x, gr_ctx_t ctx) { _GR_GET_SI_OP(ctx, LENGTH
 
 GR_INLINE WARN_UNUSED_RESULT int gr_randtest(gr_ptr x, flint_rand_t state, gr_ctx_t ctx) { return GR_RANDTEST(ctx, RANDTEST)(x, state, ctx); }
 GR_INLINE WARN_UNUSED_RESULT int gr_randtest_not_zero(gr_ptr x, flint_rand_t state, gr_ctx_t ctx) { return GR_RANDTEST(ctx, RANDTEST_NOT_ZERO)(x, state, ctx); }
+GR_INLINE WARN_UNUSED_RESULT int gr_randtest_invertible(gr_ptr x, flint_rand_t state, gr_ctx_t ctx) { return GR_RANDTEST(ctx, RANDTEST_INVERTIBLE)(x, state, ctx); }
 GR_INLINE WARN_UNUSED_RESULT int gr_randtest_small(gr_ptr x, flint_rand_t state, gr_ctx_t ctx) { return GR_RANDTEST(ctx, RANDTEST_SMALL)(x, state, ctx); }
 GR_INLINE /* todo: warn? */ int gr_write(gr_stream_t out, gr_srcptr x, gr_ctx_t ctx) { return GR_STREAM_IN(ctx, WRITE)(out, x, ctx); }
 GR_INLINE /* todo: warn? */ int gr_write_n(gr_stream_t out, gr_srcptr x, slong n, gr_ctx_t ctx) { return GR_STREAM_IN_SI(ctx, WRITE_N)(out, x, n, ctx); }

--- a/src/gr_generic/generic.c
+++ b/src/gr_generic/generic.c
@@ -117,6 +117,36 @@ int gr_generic_randtest_not_zero(gr_ptr x, flint_rand_t state, gr_ctx_t ctx)
     return GR_UNABLE;
 }
 
+int gr_generic_randtest_invertible(gr_ptr x, flint_rand_t state, gr_ctx_t ctx)
+{
+    slong i;
+    truth_t is_invertible;
+    int status = GR_SUCCESS;
+
+    for (i = 0; i < 5; i++)
+    {
+        status |= gr_randtest(x, state, ctx);
+
+        is_invertible = gr_is_invertible(x, ctx);
+        if (is_invertible == T_TRUE)
+            return GR_SUCCESS;
+    }
+
+    for (i = 0; i < 5; i++)
+    {
+        status |= gr_randtest_small(x, state, ctx);
+
+        is_invertible = gr_is_invertible(x, ctx);
+        if (is_invertible == T_TRUE)
+            return GR_SUCCESS;
+    }
+
+    /* unused */
+    (void) status;
+
+    return n_randint(state, 2) ? gr_one(x, ctx) : gr_neg_one(x, ctx);
+}
+
 int gr_generic_randtest_small(gr_ptr x, flint_rand_t state, gr_ctx_t ctx)
 {
     int status = GR_SUCCESS;
@@ -2620,6 +2650,7 @@ const gr_method_tab_input _gr_generic_methods[] =
 
     {GR_METHOD_RANDTEST,                (gr_funcptr) gr_generic_randtest},
     {GR_METHOD_RANDTEST_NOT_ZERO,       (gr_funcptr) gr_generic_randtest_not_zero},
+    {GR_METHOD_RANDTEST_INVERTIBLE,     (gr_funcptr) gr_generic_randtest_invertible},
     {GR_METHOD_RANDTEST_SMALL,          (gr_funcptr) gr_generic_randtest_small},
 
     {GR_METHOD_GENS,                    (gr_funcptr) gr_generic_gens},

--- a/src/gr_mat.h
+++ b/src/gr_mat.h
@@ -103,6 +103,7 @@ WARN_UNUSED_RESULT int gr_mat_randtest(gr_mat_t mat, flint_rand_t state, gr_ctx_
 WARN_UNUSED_RESULT int gr_mat_randops(gr_mat_t mat, flint_rand_t state, slong count, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mat_randpermdiag(int * parity, gr_mat_t mat, flint_rand_t state, gr_ptr diag, slong n, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mat_randrank(gr_mat_t mat, flint_rand_t state, slong rank, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_mat_randsimilar(gr_mat_t mat, flint_rand_t state, slong opcount, gr_ctx_t ctx);
 
 GR_MAT_INLINE truth_t
 gr_mat_is_empty(const gr_mat_t mat, gr_ctx_t FLINT_UNUSED(ctx))

--- a/src/gr_mat/randsimilar.c
+++ b/src/gr_mat/randsimilar.c
@@ -1,0 +1,74 @@
+/*
+    Copyright (C) 2025 Ricardo Buring
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "gr.h"
+#include "gr_vec.h"
+#include "gr_mat.h"
+
+int
+gr_mat_randsimilar(gr_mat_t mat, flint_rand_t state, slong opcount, gr_ctx_t ctx)
+{
+    slong c, i, j;
+    slong m = mat->r;
+    slong n = mat->c;
+    slong sz = ctx->sizeof_elem;
+    gr_mat_t W1, W2;
+    gr_ptr x;
+    int status = GR_SUCCESS;
+
+    if (n != m)
+        return GR_DOMAIN;
+
+    if (n <= 1)
+        return GR_SUCCESS;
+
+    GR_TMP_INIT(x, ctx);
+
+    /* Conjugate by random elementary operations. */
+    for (c = 0; c < opcount; c++)
+    {
+        switch (n_randint(state, 3)) {
+            case 0: {
+                /* Swap row i and row j, swap column i and column j. */
+                if ((i = n_randint(state, n)) == (j = n_randint(state, n)))
+                    continue;
+                status |= gr_mat_swap_rows(mat, NULL, i, j, ctx);
+                status |= gr_mat_swap_cols(mat, NULL, i, j, ctx);
+            } break;
+            case 1: {
+                /* For a random invertible x, scale row i by x, scale column i by the inverse of x. */
+                i = n_randint(state, n);
+                status |= gr_randtest_invertible(x, state, ctx);
+                status |= _gr_vec_mul_scalar(GR_MAT_ENTRY(mat, i, 0, sz), GR_MAT_ENTRY(mat, i, 0, sz), mat->c, x, ctx);
+                gr_mat_window_init(W1, mat, 0, i, n, i + 1, ctx);
+                status |= gr_inv(x, x, ctx);
+                status |= gr_mat_mul_scalar(W1, W1, x, ctx);
+            } break;
+            case 2: {
+                /* For a random x, add x times row j to row i, subtract x times column i from column j. */
+                if ((i = n_randint(state, n)) == (j = n_randint(state, n)))
+                    continue;
+                status |= gr_randtest(x, state, ctx);
+                status |= _gr_vec_addmul_scalar(GR_MAT_ENTRY(mat, i, 0, sz), GR_MAT_ENTRY(mat, j, 0, sz), mat->c, x, ctx);
+                gr_mat_window_init(W1, mat, 0, j, n, j + 1, ctx);
+                gr_mat_window_init(W2, mat, 0, i, n, i + 1, ctx);
+                status |= gr_mat_submul_scalar(W1, W2, x, ctx);
+            } break;
+            default: {
+                /* Cannot happen. */
+            } break;
+        }
+    }
+
+    GR_TMP_CLEAR(x, ctx);
+
+    return status;
+}

--- a/src/gr_mat/test/main.c
+++ b/src/gr_mat/test/main.c
@@ -45,6 +45,7 @@
 #include "t-pow_scalar.c"
 #include "t-properties.c"
 #include "t-randrank.c"
+#include "t-randsimilar.c"
 #include "t-rank.c"
 #include "t-rank_fflu.c"
 #include "t-rank_lu.c"
@@ -100,6 +101,7 @@ test_struct tests[] =
     TEST_FUNCTION(gr_mat_pow_scalar),
     TEST_FUNCTION(gr_mat_properties),
     TEST_FUNCTION(gr_mat_randrank),
+    TEST_FUNCTION(gr_mat_randsimilar),
     TEST_FUNCTION(gr_mat_rank),
     TEST_FUNCTION(gr_mat_rank_fflu),
     TEST_FUNCTION(gr_mat_rank_lu),

--- a/src/gr_mat/test/t-randsimilar.c
+++ b/src/gr_mat/test/t-randsimilar.c
@@ -1,0 +1,67 @@
+/*
+    Copyright (C) 2025 Ricardo Buring
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "gr_poly.h"
+#include "gr_mat.h"
+
+TEST_FUNCTION_START(gr_mat_randsimilar, state)
+{
+    slong iter;
+
+    /* Check that random similarity transformations preserve the characteristic polynomial. */
+    for (iter = 0; iter < 10000; iter++)
+    {
+        gr_ctx_t ctx;
+        gr_mat_t A;
+        gr_poly_t f, g;
+        slong n, rank, randops_count, randsimilar_opcount;
+        int status = GR_SUCCESS;
+
+        gr_ctx_init_random(ctx, state);
+
+        if (gr_ctx_is_integral_domain(ctx) == T_TRUE)
+        {
+            n = n_randint(state, 6);
+            rank = n_randint(state, n + 1);
+            randops_count = n_randint(state, 8);
+            randsimilar_opcount = n_randint(state, 8);
+
+            gr_mat_init(A, n, n, ctx);
+            gr_poly_init(f, ctx);
+            gr_poly_init(g, ctx);
+
+            status |= gr_mat_randrank(A, state, rank, ctx);
+            status |= gr_mat_randops(A, state, randops_count, ctx);
+            status |= gr_mat_charpoly(f, A, ctx);
+            status |= gr_mat_randsimilar(A, state, randsimilar_opcount, ctx);
+            status |= gr_mat_charpoly(g, A, ctx);
+
+            if (gr_poly_equal(f, g, ctx) == T_FALSE)
+            {
+                flint_printf("FAIL:\n");
+                gr_ctx_println(ctx);
+                flint_printf("A: "); gr_mat_print(A, ctx); flint_printf("\n");
+                flint_printf("f: "); gr_poly_print(f, ctx); flint_printf("\n");
+                flint_printf("g: "); gr_poly_print(g, ctx); flint_printf("\n");
+                flint_abort();
+            }
+
+            gr_poly_clear(g, ctx);
+            gr_poly_clear(f, ctx);
+            gr_mat_clear(A, ctx);
+        }
+
+        gr_ctx_clear(ctx);
+    }
+
+    TEST_FUNCTION_END(state);
+}


### PR DESCRIPTION
Randomize a matrix in-place by conjugating by elementary row/column operations.

I would like to add this because `gr_mat_randops` (applied to the identity) is not always usable to achieve the same goal, namely when inverses can't be computed (and even if we could, it would be inefficient).

As a point for discussion, I suppose the case `Swap row i and row j, swap column i and column j` could be omitted, due to https://proofwiki.org/wiki/Exchange_of_Rows_as_Sequence_of_Other_Elementary_Row_Operations