### PR TITLE
Sorting functions

### DIFF
--- a/doc/source/flint.rst
+++ b/doc/source/flint.rst
@@ -503,3 +503,20 @@ Exceptions
 
     Sets the :func:`flint_throw` function use ``func`` instead of a private
     throw function.
+
+Sorting and searching
+-----------------------------------------------
+
+.. function:: void flint_merge_sort(void * buf, slong len, slong size, int (* cmp) (const void *, const void *, void *), void * data)
+              void flint_sort(void * buf, slong len, slong size, int (* cmp) (const void *, const void *, void *), void * data)
+
+    Sorts an array *buf* with *len* elements of size *size* according to the
+    comparison function *cmp*. The comparison function takes as arguments
+    pointers to the two elements being compared and a pointer to arbitrary data
+    passed to the sorting function. It must return an `int` less than, equal to
+    or greater than zero according to whether the first element is strictly
+    smaller than, equal to, or strictly larger than the second.
+
+    The ``merge_sort`` version uses a simple implementation of the merge sort
+    algorithm. The generic version uses the system's ``qsort_r`` (or equivalent)
+    function when detected and falls back to ``flint_merge_sort`` otherwise.

--- a/doc/source/gr_vec.rst
+++ b/doc/source/gr_vec.rst
@@ -205,6 +205,30 @@ Dot products
 
     Sets *res* to `c \pm \sum_{i=0}^{n-1} a_i b_{n-1-i}`.
 
+Sorting and searching
+--------------------------------------------------------------------------------
+
+.. function:: truth_t _gr_vec_contains(gr_srcptr vec, slong len, gr_srcptr x, gr_ctx_t ctx)
+              truth_t gr_vec_contains(const gr_vec_t vec, gr_srcptr x, gr_ctx_t ctx);
+
+.. function:: int _gr_vec_sort(gr_ptr vec, slong len, gr_ctx_t ctx)
+              int gr_vec_sort(gr_vec_t dest, const gr_vec_t src, gr_ctx_t ctx)
+
+    Sorts the entries in increasing order. The underscore version works
+    in-place; when it returns a status code other than `GR_SUCCESS`, the vector
+    may not be sorted but still contains some permutation of the original
+    entries.
+
+.. function:: void _gr_vec_permute(gr_ptr vec, slong * perm, slong len, gr_ctx_t ctx)
+              int gr_vec_permute(gr_vec_t dest, gr_vec_t src, slong * perm, gr_ctx_t ctx)
+
+    Applies a permutation to a vector. The underscore version works in-place and
+    overwrites `perm`.
+
+.. function:: void _gr_vec_shuffle(gr_ptr vec, flint_rand_t state, slong len, gr_ctx_t ctx)
+
+    Applies a uniform random permutation.
+
 Other functions
 --------------------------------------------------------------------------------
 

--- a/src/flint.h.in
+++ b/src/flint.h.in
@@ -354,6 +354,11 @@ FLINT_INLINE ulong n_randint(flint_rand_t state, ulong limit)
 #define FLINT_SGN(x) ((0 < (slong)(x)) - ((slong)(x) < 0))
 #define FLINT_SWAP(T, x, y) do { T _swap_t = (x); (x) = (y); (y) = _swap_t; } while(0)
 
+/* sorting *******************************************************************/
+
+void flint_merge_sort(void * buf, slong len, slong size, int (* cmp) (const void *, const void *, void *), void * data);
+void flint_sort(void * buf, slong len, slong size, int (* cmp) (const void *, const void *, void *), void * data);
+
 /* allocation macros *********************************************************/
 
 #define FLINT_ARRAY_ALLOC(n, T) (T *) flint_malloc((n)*sizeof(T))

--- a/src/generic_files/sort.c
+++ b/src/generic_files/sort.c
@@ -1,0 +1,71 @@
+/*
+   Copyright (C) 2025 Marc Mezzarobba
+
+   This file is part of FLINT.
+
+   FLINT is free software: you can redistribute it and/or modify it under
+   the terms of the GNU Lesser General Public License (LGPL) as published
+   by the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#define _GNU_SOURCE
+#include <stdlib.h>
+#include <string.h>
+
+#include "flint.h"
+
+typedef int (* cmp_t) (const void *, const void *, void *);
+
+static void
+merge_sort(unsigned char * buf0, unsigned char * alt0, slong len, slong size,
+           cmp_t cmp, void * data)
+{
+    if (len <= 1)
+        return;
+
+    slong l0 = len / 2;
+    slong l1 = len - l0;
+
+    unsigned char * buf1 = buf0 + l0 * size;
+    unsigned char * alt1 = alt0 + l0 * size;
+
+    merge_sort(alt0, buf0, l0, size, cmp, data);
+    merge_sort(alt1, buf1, l1, size, cmp, data);
+
+    slong i0 = 0, i1 = 0;
+
+    for (slong k = 0; k < len; k++)
+    {
+        unsigned char * elt;
+
+        if (i1 >= l1 || (i0 < l0 && cmp(alt0 + i0 * size,
+                                        alt1 + i1 * size, data) <= 0))
+            elt = alt0 + i0++ * size;
+        else
+            elt = alt1 + i1++ * size;
+
+        memcpy(buf0 + k * size, elt, size);
+    }
+}
+
+void
+flint_merge_sort(void * buf, slong len, slong size,
+                 cmp_t cmp, void * data)
+{
+    unsigned char * alt = flint_malloc(len * size);
+    memcpy(alt, buf, len * size);
+    merge_sort(buf, alt, len, size, cmp, data);
+    flint_free(alt);
+}
+
+void
+flint_sort(void * buf, slong len, slong size,
+           cmp_t cmp, void * data)
+{
+#ifdef __GLIBC__
+    qsort_r(buf, len, size, cmp, data);
+#else
+    flint_merge_sort(buf, len, size, cmp, data);
+#endif
+}

--- a/src/gr_vec.h
+++ b/src/gr_vec.h
@@ -52,6 +52,21 @@ void gr_vec_set_length(gr_vec_t vec, slong len, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_vec_set(gr_vec_t res, const gr_vec_t src, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_vec_append(gr_vec_t vec, gr_srcptr f, gr_ctx_t ctx);
 
+truth_t _gr_vec_contains(gr_srcptr vec, slong len, gr_srcptr x, gr_ctx_t ctx);
+
+GR_VEC_INLINE truth_t
+gr_vec_contains(const gr_vec_t vec, gr_srcptr x, gr_ctx_t ctx)
+{
+    return _gr_vec_contains(vec->entries, vec->length, x, ctx);
+}
+
+WARN_UNUSED_RESULT int _gr_vec_sort(gr_ptr vec, slong len, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_vec_sort(gr_vec_t dest, const gr_vec_t src, gr_ctx_t ctx);
+
+void _gr_vec_permute(gr_ptr vec, slong * perm, slong len, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_vec_permute(gr_vec_t dest, gr_vec_t src, slong * perm, gr_ctx_t ctx);
+void _gr_vec_shuffle(gr_ptr vec, flint_rand_t state, slong len, gr_ctx_t ctx);
+
 int _gr_vec_write(gr_stream_t out, gr_srcptr vec, slong len, gr_ctx_t ctx);
 int gr_vec_write(gr_stream_t out, const gr_vec_t vec, gr_ctx_t ctx);
 int _gr_vec_print(gr_srcptr vec, slong len, gr_ctx_t ctx);

--- a/src/gr_vec/contains.c
+++ b/src/gr_vec/contains.c
@@ -1,0 +1,28 @@
+/*
+    Copyright (C) 2025 Marc Mezzarobba
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "gr.h"
+
+truth_t
+_gr_vec_contains(gr_srcptr vec, slong len, gr_srcptr x, gr_ctx_t ctx)
+{
+    truth_t contains = T_FALSE;
+
+    for (slong i = 0; i < len; i++)
+    {
+        gr_srcptr y = GR_ENTRY(vec, i, ctx->sizeof_elem);
+        contains = truth_or(contains, gr_equal(x, y, ctx));
+        if (contains == T_TRUE)
+            break;
+    }
+
+    return contains;
+}

--- a/src/gr_vec/permute.c
+++ b/src/gr_vec/permute.c
@@ -1,0 +1,49 @@
+/*
+   Copyright (C) 2025 Marc Mezzarobba
+
+   This file is part of FLINT.
+
+   FLINT is free software: you can redistribute it and/or modify it under
+   the terms of the GNU Lesser General Public License (LGPL) as published
+   by the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+   */
+
+#include "gr_vec.h"
+#include "perm.h"
+
+void
+_gr_vec_permute(gr_ptr vec, slong * perm, slong len, gr_ctx_t ctx)
+{
+    for (slong base = 0; base < len; base++)
+    {
+        slong k = base;
+        while (perm[k] != k)
+        {
+            gr_swap(GR_ENTRY(vec, base, ctx->sizeof_elem),
+                    GR_ENTRY(vec, k, ctx->sizeof_elem),
+                    ctx);
+            FLINT_SWAP(slong, perm[k], k);
+        }
+    }
+}
+
+int
+gr_vec_permute(gr_vec_t dest, gr_vec_t src, slong * perm, gr_ctx_t ctx)
+{
+    if (dest != src)
+    {
+        int status = gr_vec_set(dest, src, ctx);
+        if (status != GR_SUCCESS)
+            return status;
+    }
+
+    slong * _perm = _perm_init(src->length);
+    _perm_set(_perm, perm, src->length);
+
+    _gr_vec_permute(dest->entries, _perm, dest->length, ctx);
+
+    _perm_clear(_perm);
+
+    return GR_SUCCESS;
+}

--- a/src/gr_vec/shuffle.c
+++ b/src/gr_vec/shuffle.c
@@ -1,0 +1,24 @@
+/*
+   Copyright (C) 2025 Marc Mezzarobba
+
+   This file is part of FLINT.
+
+   FLINT is free software: you can redistribute it and/or modify it under
+   the terms of the GNU Lesser General Public License (LGPL) as published
+   by the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+   */
+
+#include "gr_vec.h"
+#include "perm.h"
+
+void
+_gr_vec_shuffle(gr_ptr vec, flint_rand_t state, slong len, gr_ctx_t ctx)
+{
+    slong * perm = _perm_init(len);
+    _perm_randtest(perm, len, state);
+
+    _gr_vec_permute(vec, perm, len, ctx);
+
+    _perm_clear(perm);
+}

--- a/src/gr_vec/sort.c
+++ b/src/gr_vec/sort.c
@@ -1,0 +1,52 @@
+/*
+    Copyright (C) 2025 Marc Mezzarobba
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "gr_vec.h"
+
+typedef struct
+{
+    gr_ctx_struct * gr_ctx;
+    int status;
+}
+cmp_ctx_struct;
+
+static int
+cmp(const void * x, const void * y, void * ctx)
+{
+    int res;
+    cmp_ctx_struct * cmp_ctx = ctx;
+    int status = gr_cmp(&res, x, y, cmp_ctx->gr_ctx);
+    if (status != GR_SUCCESS)
+        res = 0;
+    cmp_ctx->status |= status;
+    return res;
+}
+
+int
+_gr_vec_sort(gr_ptr vec, slong len, gr_ctx_t ctx)
+{
+    cmp_ctx_struct cmp_ctx = { .gr_ctx = ctx, .status = GR_SUCCESS };
+    flint_sort(vec, len, ctx->sizeof_elem, cmp, &cmp_ctx);
+    return cmp_ctx.status;
+}
+
+int
+gr_vec_sort(gr_vec_t dest, const gr_vec_t src, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+
+    if (dest != src)
+        status |= gr_vec_set(dest, src, ctx);
+
+    status |= _gr_vec_sort(dest->entries, dest->length, ctx);
+
+    return status;
+}

--- a/src/gr_vec/test/main.c
+++ b/src/gr_vec/test/main.c
@@ -11,14 +11,18 @@
 
 /* Include functions *********************************************************/
 
+#include "t-permute.c"
 #include "t-product.c"
+#include "t-sort.c"
 #include "t-sum.c"
 
 /* Array of test functions ***************************************************/
 
 test_struct tests[] =
 {
+    TEST_FUNCTION(gr_vec_permute),
     TEST_FUNCTION(gr_vec_product),
+    TEST_FUNCTION(gr_vec_sort),
     TEST_FUNCTION(gr_vec_sum)
 };
 

--- a/src/gr_vec/test/t-permute.c
+++ b/src/gr_vec/test/t-permute.c
@@ -1,0 +1,67 @@
+/*
+    Copyright (C) 2025 Marc Mezzarobba
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "gr_vec.h"
+#include "perm.h"
+
+TEST_FUNCTION_START(gr_vec_permute, state)
+{
+    for (slong iter = 0; iter < 1000; iter++)
+    {
+        gr_ctx_t ctx;
+        gr_vec_t vec, out;
+
+        gr_ctx_init_random(ctx, state);
+        slong len = n_randint(state, 30);
+        gr_vec_init(vec, len, ctx);
+        gr_vec_init(out, 0, ctx);
+
+        slong * perm = _perm_init(len);
+        _perm_randtest(perm, len, state);
+
+        int status = GR_SUCCESS;
+
+        status |= _gr_vec_randtest(vec->entries, state, len, ctx);
+
+        status |= gr_vec_permute(out, vec, perm, ctx);
+
+        if (status == GR_SUCCESS)
+        {
+            for (slong k = 0; k < len; k++)
+                if (gr_equal(gr_vec_entry_ptr(vec, k, ctx),
+                             gr_vec_entry_ptr(out, perm[k], ctx),
+                             ctx) == T_FALSE)
+                    status = GR_TEST_FAIL;
+        }
+
+        _perm_inv(perm, perm, len);
+        status |= gr_vec_permute(out, out, perm, ctx);
+
+        if (status == GR_SUCCESS &&
+            _gr_vec_equal(out->entries, vec->entries, len, ctx) == T_FALSE)
+            status = GR_TEST_FAIL;
+
+        if (status == GR_TEST_FAIL)
+        {
+            flint_printf("FAIL\n");
+            printf("vec = "); _gr_vec_print(vec->entries, len, ctx); printf("\n");
+            flint_abort();
+        }
+
+        _perm_clear(perm);
+        gr_vec_clear(out, ctx);
+        gr_vec_clear(vec, ctx);
+        gr_ctx_clear(ctx);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/gr_vec/test/t-sort.c
+++ b/src/gr_vec/test/t-sort.c
@@ -1,0 +1,70 @@
+/*
+    Copyright (C) 2025 Marc Mezzarobba
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "gr_vec.h"
+
+TEST_FUNCTION_START(gr_vec_sort, state)
+{
+    for (slong iter = 0; iter < 1000; iter++)
+    {
+        gr_ctx_t ctx;
+        gr_vec_t vec0, vec1, vec2;
+
+        gr_ctx_init_random(ctx, state);
+        slong len = n_randint(state, 30);
+        gr_vec_init(vec0, len, ctx);
+        gr_vec_init(vec1, len, ctx);
+        gr_vec_init(vec2, 0, ctx);
+
+        int status = GR_SUCCESS;
+
+        status |= _gr_vec_randtest(vec0->entries, state, len, ctx);
+
+        status |= gr_vec_set(vec1, vec0, ctx);
+        _gr_vec_shuffle(vec1->entries, state, len, ctx);
+
+        status |= gr_vec_sort(vec2, vec0, ctx);
+        status |= gr_vec_sort(vec1, vec1, ctx);
+
+        if (status == GR_SUCCESS)
+        {
+            if(_gr_vec_equal(vec1->entries, vec2->entries, len, ctx) == T_FALSE)
+                status = GR_TEST_FAIL;
+
+            for (slong i = 0; i < len - 1; i++)
+                if (gr_le(gr_vec_entry_ptr(vec1, i, ctx),
+                          gr_vec_entry_ptr(vec1, i + 1, ctx), ctx) == T_FALSE)
+                    status = GR_TEST_FAIL;
+        }
+
+        for (slong i = 0; i < len - 1; i++)
+            if (_gr_vec_contains(vec0->entries, len,
+                                 gr_vec_entry_ptr(vec1, i, ctx),
+                                 ctx) == T_FALSE)
+                status = GR_TEST_FAIL;
+
+        if (status == GR_TEST_FAIL)
+        {
+            flint_printf("FAIL\n");
+            printf("vec0 = "); _gr_vec_print(vec0, len, ctx); printf("\n");
+            flint_abort();
+        }
+
+        gr_vec_clear(vec2, ctx);
+        gr_vec_clear(vec1, ctx);
+        gr_vec_clear(vec0, ctx);
+        gr_ctx_clear(ctx);
+    }
+
+    TEST_FUNCTION_END(state);
+}
+

--- a/src/test/main.c
+++ b/src/test/main.c
@@ -19,6 +19,7 @@
 #include "t-memory_manager.c"
 #include "t-sdiv_qrnnd.c"
 #include "t-smul_ppmm.c"
+#include "t-sort.c"
 #include "t-sub_dddmmmsss.c"
 #include "t-sub_ddmmss.c"
 #include "t-udiv_qrnnd.c"
@@ -38,6 +39,7 @@ test_struct tests[] =
     TEST_FUNCTION(memory_manager),
     TEST_FUNCTION(sdiv_qrnnd),
     TEST_FUNCTION(smul_ppmm),
+    TEST_FUNCTION(flint_sort),
     TEST_FUNCTION(sub_dddmmmsss),
     TEST_FUNCTION(sub_ddmmss),
     TEST_FUNCTION(udiv_qrnnd),

--- a/src/test/t-sort.c
+++ b/src/test/t-sort.c
@@ -1,0 +1,87 @@
+/*
+    Copyright (C) 2025 Marc Mezzarobba
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "flint.h"
+#include "perm.h"
+
+static int
+cmp_first(const void * _i, const void * _j, void * _imax)
+{
+    const slong * i = _i, * j = _j;
+    slong * imax = _imax;
+    *imax = FLINT_MAX(*imax, FLINT_MAX(*i, *j));
+    return *i - *j;
+}
+
+TEST_FUNCTION_START(flint_sort, state)
+{
+    for (slong i = 0; i < 1000 * flint_test_multiplier(); i++)
+    {
+        slong imax = -1, imax1 = -1;
+
+        slong n = n_randint(state, 10);
+
+        slong * vec = _perm_init(2*n);
+        _perm_randtest(vec, 2*n, state);
+
+        int dup = n_randint(state, 2);
+        if (dup && n > 0)
+        {
+            slong m = n_randint(state, n);
+            _perm_randtest(vec + 2*m, 2*n - 2*m, state);
+
+            for (slong k = 0; k < n; k++)
+                vec[2*k + 1] = k;
+        }
+
+        slong * vec1 = flint_malloc(2*n*sizeof(slong));
+        memcpy(vec1, vec, 2*n*sizeof(slong));
+
+        flint_sort(vec, n, 2*sizeof(slong), cmp_first, &imax);
+        flint_merge_sort(vec1, n, 2*sizeof(slong), cmp_first, &imax1);
+
+        if (n > 0 && memcmp(vec, vec1, 2*sizeof(slong)))
+            TEST_FUNCTION_FAIL("inconsistent results\n");
+
+        if (imax != imax1)
+            TEST_FUNCTION_FAIL("inconsistent data\n");
+
+        for (slong k = 0; k < n - 1; k++)
+        {
+            if (vec[2 * k] > vec[2 * k + 2])
+                TEST_FUNCTION_FAIL("wrong order\n");
+            if (dup && vec[2 * k] == vec[2 * k + 2]
+                    && vec[2 * k + 1] >= vec[2 * k + 3])
+                TEST_FUNCTION_FAIL("stability\n");
+        }
+
+        if (!dup)
+        {
+            flint_merge_sort(vec, 2 * n, sizeof(slong), cmp_first, &imax);
+
+            for (slong k = 0; k < 2 * n; k++)
+            {
+                if (!dup && vec[k] != k)
+                    TEST_FUNCTION_FAIL("missing entry\n");
+            }
+
+            if (imax != 2 * n - 1)
+                TEST_FUNCTION_FAIL("data\n");
+        }
+
+        flint_free(vec1);
+        _perm_clear(vec);
+    }
+
+    TEST_FUNCTION_END(state);
+}
+


### PR DESCRIPTION
Questions:

* should the prototypes of `flint_merge_sort` and `flint_sort` be moved out of
  `flint.h`? where?
* should `gr_vec_permute` take the permutation as a `gr_vec_t` instead of an
  `slong *`?
