### PR TITLE
Have gr_divexact over a gr_poly ring dispatch to gr_poly_divexact

### DIFF
--- a/src/gr/fmpz.c
+++ b/src/gr/fmpz.c
@@ -970,6 +970,15 @@ _gr_fmpz_poly_mullow(fmpz * res,
     return GR_SUCCESS;
 }
 
+int
+_gr_fmpz_poly_divexact2(fmpz * res,
+    const fmpz * poly1, slong len1,
+    const fmpz * poly2, slong len2, gr_ctx_t ctx)
+{
+    _fmpz_poly_divexact(res, poly1, len1, poly2, len2);
+    return GR_SUCCESS;
+}
+
 /* defined in gr/fmpz_poly.c */
 int _gr_fmpz_poly_factor(fmpz_poly_t c, gr_vec_t factors, gr_vec_t exponents, gr_srcptr x, int flags, gr_ctx_t ctx);
 
@@ -1194,6 +1203,7 @@ gr_method_tab_input _fmpz_methods_input[] =
     {GR_METHOD_VEC_DOT,         (gr_funcptr) _gr_fmpz_vec_dot},
     {GR_METHOD_VEC_DOT_REV,     (gr_funcptr) _gr_fmpz_vec_dot_rev},
     {GR_METHOD_POLY_MULLOW,     (gr_funcptr) _gr_fmpz_poly_mullow},
+    {GR_METHOD_POLY_DIVEXACT,   (gr_funcptr) _gr_fmpz_poly_divexact2},
     {GR_METHOD_POLY_FACTOR,     (gr_funcptr) _gr_fmpz_poly_factor},
     {GR_METHOD_POLY_ROOTS,      (gr_funcptr) _gr_fmpz_roots_gr_poly},
     {GR_METHOD_POLY_ROOTS_OTHER,(gr_funcptr) _gr_fmpz_roots_gr_poly_other},

--- a/src/gr/polynomial.c
+++ b/src/gr/polynomial.c
@@ -560,6 +560,12 @@ polynomial_div(gr_poly_t res, const gr_poly_t x, const gr_poly_t y, const gr_ctx
 }
 
 int
+polynomial_divexact(gr_poly_t res, const gr_poly_t x, const gr_poly_t y, const gr_ctx_t ctx)
+{
+    return gr_poly_divexact(res, x, y, POLYNOMIAL_ELEM_CTX(ctx));
+}
+
+int
 polynomial_euclidean_div(gr_poly_t res, const gr_poly_t x, const gr_poly_t y, const gr_ctx_t ctx)
 {
     gr_poly_t r;
@@ -707,6 +713,7 @@ gr_method_tab_input _gr_poly_methods_input[] =
     {GR_METHOD_POW_SI,      (gr_funcptr) polynomial_pow_si},
     {GR_METHOD_POW_FMPZ,    (gr_funcptr) polynomial_pow_fmpz},
     {GR_METHOD_DIV,         (gr_funcptr) polynomial_div},
+    {GR_METHOD_DIVEXACT,    (gr_funcptr) polynomial_divexact},
     {GR_METHOD_INV,         (gr_funcptr) polynomial_inv},
 
     {GR_METHOD_EUCLIDEAN_DIV,         (gr_funcptr) polynomial_euclidean_div},


### PR DESCRIPTION
This should somewhat speed up fraction field arithmetic over ``gr_poly`` rings, among other things.

Sample benchmark:

```
#include "gr.h"
#include "gr_poly.h"
#include "profiler.h"

int main()
{
    gr_ctx_t R, Rx, Rxy, Rxyz;
    gr_ptr f, g, h;

    gr_ctx_init_fmpzi(R);
    gr_ctx_init_gr_poly(Rx, R);
    GR_MUST_SUCCEED(gr_ctx_set_gen_name(Rx, "x"));
    gr_ctx_init_gr_poly(Rxy, Rx);
    GR_MUST_SUCCEED(gr_ctx_set_gen_name(Rxy, "y"));
    gr_ctx_init_gr_poly(Rxyz, Rxy);
    GR_MUST_SUCCEED(gr_ctx_set_gen_name(Rxyz, "z"));

    f = gr_heap_init(Rxyz);
    g = gr_heap_init(Rxyz);
    h = gr_heap_init(Rxyz);

    GR_MUST_SUCCEED(gr_set_str(f, "(1+I+x+2*y+3*z)^10", Rxyz));
    GR_MUST_SUCCEED(gr_set_str(g, "(1+I-x+2*y-3*z)^10", Rxyz));
    GR_MUST_SUCCEED(gr_mul(h, f, g, Rxyz));

    TIMEIT_START
    GR_MUST_SUCCEED(gr_divexact(f, h, g, Rxyz));
    TIMEIT_STOP
    TIMEIT_START
    GR_MUST_SUCCEED(gr_gcd(f, h, g, Rxyz));
    TIMEIT_STOP
}
```

Before:

    cpu/wall(s): 0.00129 0.00129
    cpu/wall(s): 0.00864 0.00863

After:

    cpu/wall(s): 0.000745 0.000744
    cpu/wall(s): 0.00825 0.00825
