### PR TITLE
Add `gr_poly_coeff_ptr` and deprecate `gr_poly_entry_ptr`

### DIFF
--- a/doc/source/gr_poly.rst
+++ b/doc/source/gr_poly.rst
@@ -82,8 +82,14 @@ Memory management
 
 .. function:: void gr_poly_clear(gr_poly_t poly, gr_ctx_t ctx)
 
+.. function:: gr_ptr gr_poly_coeff_ptr(gr_poly_t poly, slong i, gr_ctx_t ctx)
+              gr_srcptr gr_poly_coeff_srcptr(const gr_poly_t poly, slong i, gr_ctx_t ctx)
+
 .. function:: gr_ptr gr_poly_entry_ptr(gr_poly_t poly, slong i, gr_ctx_t ctx)
               gr_srcptr gr_poly_entry_srcptr(const gr_poly_t poly, slong i, gr_ctx_t ctx)
+
+    These functions are deprecated aliases of :func:`gr_poly_coeff_ptr` and
+    :func:`gr_poly_coeff_srcptr`; use those functions instead.
 
 .. function:: slong gr_poly_length(const gr_poly_t poly, gr_ctx_t ctx)
 

--- a/src/gr/polynomial.c
+++ b/src/gr/polynomial.c
@@ -250,23 +250,23 @@ polynomial_set_interval_mid_rad(gr_poly_t res, const gr_poly_t m, const gr_poly_
         {
             if (i < mlen && i < rlen)
             {
-                status |= gr_set_interval_mid_rad(gr_poly_entry_ptr(res, i, cctx),
-                        gr_poly_entry_srcptr(m, i, cctx),
-                        gr_poly_entry_srcptr(r, i, cctx), cctx);
+                status |= gr_set_interval_mid_rad(gr_poly_coeff_ptr(res, i, cctx),
+                        gr_poly_coeff_srcptr(m, i, cctx),
+                        gr_poly_coeff_srcptr(r, i, cctx), cctx);
             }
             else if (i < mlen)
             {
-                status |= gr_set(gr_poly_entry_ptr(res, i, cctx),
-                            gr_poly_entry_srcptr(m, i, cctx), cctx);
+                status |= gr_set(gr_poly_coeff_ptr(res, i, cctx),
+                            gr_poly_coeff_srcptr(m, i, cctx), cctx);
             }
             else if (i < rlen)
             {
                 if (zero == NULL)
                     zero = gr_heap_init(cctx);
 
-                status |= gr_set_interval_mid_rad(gr_poly_entry_ptr(res, i, cctx),
+                status |= gr_set_interval_mid_rad(gr_poly_coeff_ptr(res, i, cctx),
                         zero,
-                        gr_poly_entry_srcptr(r, i, cctx), cctx);
+                        gr_poly_coeff_srcptr(r, i, cctx), cctx);
             }
         }
 

--- a/src/gr/series.c
+++ b/src/gr/series.c
@@ -562,7 +562,7 @@ gr_series_coeff_is_zero(const gr_series_t x, slong i, gr_series_ctx_t sctx, gr_c
     if (i < 0)
         return T_TRUE;
 
-    return gr_is_zero(gr_poly_entry_srcptr(&x->poly, i, cctx), cctx);
+    return gr_is_zero(gr_poly_coeff_srcptr(&x->poly, i, cctx), cctx);
 }
 
 int
@@ -665,9 +665,9 @@ gr_series_div(gr_series_t res, const gr_series_t x, const gr_series_t y, gr_seri
         {
             gr_poly_t xb, yb;
 
-            xb->coeffs = (gr_ptr) gr_poly_entry_srcptr(&x->poly, val, cctx);
+            xb->coeffs = (gr_ptr) gr_poly_coeff_srcptr(&x->poly, val, cctx);
             xb->length = xlen;
-            yb->coeffs = (gr_ptr) gr_poly_entry_srcptr(&y->poly, val, cctx);
+            yb->coeffs = (gr_ptr) gr_poly_coeff_srcptr(&y->poly, val, cctx);
             yb->length = ylen;
 
             status |= gr_poly_div_series(t, xb, yb, len + 1, cctx);
@@ -703,9 +703,9 @@ gr_series_div(gr_series_t res, const gr_series_t x, const gr_series_t y, gr_seri
     {
         gr_poly_t xb, yb;
 
-        xb->coeffs = (gr_ptr) gr_poly_entry_srcptr(&x->poly, val, cctx);
+        xb->coeffs = (gr_ptr) gr_poly_coeff_srcptr(&x->poly, val, cctx);
         xb->length = xlen;
-        yb->coeffs = (gr_ptr) gr_poly_entry_srcptr(&y->poly, val, cctx);
+        yb->coeffs = (gr_ptr) gr_poly_coeff_srcptr(&y->poly, val, cctx);
         yb->length = ylen;
 
         if (x == res || y == res)

--- a/src/gr_generic/poly_factor.c
+++ b/src/gr_generic/poly_factor.c
@@ -36,7 +36,7 @@ gr_generic_poly_factor_roots(
 
     int status = GR_SUCCESS;
 
-    gr_ptr lc = gr_poly_entry_ptr(poly, poly->length - 1, ctx);
+    gr_ptr lc = gr_poly_coeff_ptr(poly, poly->length - 1, ctx);
     if (gr_is_zero(lc, ctx) != T_FALSE)
     {
         status = GR_UNABLE;

--- a/src/gr_mat/test/t-companion.c
+++ b/src/gr_mat/test/t-companion.c
@@ -36,14 +36,14 @@ TEST_FUNCTION_START(gr_mat_companion, state)
         do {
             status |= gr_poly_randtest(f, state, 1 + n_randint(state, 8), ctx);
             n = gr_poly_length(f, ctx) - 1;
-        } while (n < 0 || gr_is_invertible(gr_poly_entry_srcptr(f, n, ctx), ctx) != T_TRUE);
+        } while (n < 0 || gr_is_invertible(gr_poly_coeff_srcptr(f, n, ctx), ctx) != T_TRUE);
 
         gr_mat_init(A, n, n, ctx);
         status |= gr_mat_randtest(A, state, ctx);
         status |= gr_mat_companion(A, f, ctx);
         status |= gr_mat_charpoly(g, A, ctx);
 
-        status |= gr_poly_scalar_mul(g, gr_poly_entry_srcptr(f, n, ctx), g, ctx);
+        status |= gr_poly_scalar_mul(g, gr_poly_coeff_srcptr(f, n, ctx), g, ctx);
 
         if (gr_poly_equal(g, f, ctx) == T_FALSE)
         {

--- a/src/gr_poly.h
+++ b/src/gr_poly.h
@@ -30,11 +30,23 @@ void gr_poly_init2(gr_poly_t poly, slong len, gr_ctx_t ctx);
 void gr_poly_clear(gr_poly_t poly, gr_ctx_t ctx);
 
 GR_POLY_INLINE gr_ptr
+gr_poly_coeff_ptr(gr_poly_t poly, slong i, gr_ctx_t ctx)
+{
+    return GR_ENTRY(poly->coeffs, i, ctx->sizeof_elem);
+}
+/* deprecated old function name */
+GR_POLY_INLINE gr_ptr
 gr_poly_entry_ptr(gr_poly_t poly, slong i, gr_ctx_t ctx)
 {
     return GR_ENTRY(poly->coeffs, i, ctx->sizeof_elem);
 }
 
+GR_POLY_INLINE gr_srcptr
+gr_poly_coeff_srcptr(const gr_poly_t poly, slong i, gr_ctx_t ctx)
+{
+    return GR_ENTRY(poly->coeffs, i, ctx->sizeof_elem);
+}
+/* deprecated old function name */
 GR_POLY_INLINE gr_srcptr
 gr_poly_entry_srcptr(const gr_poly_t poly, slong i, gr_ctx_t ctx)
 {

--- a/src/gr_poly/add.c
+++ b/src/gr_poly/add.c
@@ -43,8 +43,8 @@ gr_poly_add(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, gr_ctx_
     int status;
     slong max = FLINT_MAX(poly1->length, poly2->length);
 
-    FLINT_ASSERT(poly1->length == 0 || gr_is_zero(gr_poly_entry_srcptr(poly1, poly1->length - 1, ctx), ctx) != T_TRUE);
-    FLINT_ASSERT(poly2->length == 0 || gr_is_zero(gr_poly_entry_srcptr(poly2, poly2->length - 1, ctx), ctx) != T_TRUE);
+    FLINT_ASSERT(poly1->length == 0 || gr_is_zero(gr_poly_coeff_srcptr(poly1, poly1->length - 1, ctx), ctx) != T_TRUE);
+    FLINT_ASSERT(poly2->length == 0 || gr_is_zero(gr_poly_coeff_srcptr(poly2, poly2->length - 1, ctx), ctx) != T_TRUE);
 
     gr_poly_fit_length(res, max, ctx);
 

--- a/src/gr_poly/add_scalar.c
+++ b/src/gr_poly/add_scalar.c
@@ -37,7 +37,7 @@ gr_poly_add_scalar(gr_poly_t res, const gr_poly_t poly, gr_srcptr c, gr_ctx_t ct
     }
 
     if (gr_is_zero(c, ctx) != T_TRUE) {
-        gr_ptr constant_coeff = gr_poly_entry_ptr(res, 0, ctx);
+        gr_ptr constant_coeff = gr_poly_coeff_ptr(res, 0, ctx);
         status |= gr_add(constant_coeff, constant_coeff, c, ctx);
         if (len == 1 && gr_is_zero(constant_coeff, ctx) == T_TRUE) {
             _gr_poly_set_length(res, 0, ctx);
@@ -72,7 +72,7 @@ gr_poly_add_ui(gr_poly_t res, const gr_poly_t poly, ulong c, gr_ctx_t ctx)
     }
 
     if (c != 0) {
-        gr_ptr constant_coeff = gr_poly_entry_ptr(res, 0, ctx);
+        gr_ptr constant_coeff = gr_poly_coeff_ptr(res, 0, ctx);
         status |= gr_add_ui(constant_coeff, constant_coeff, c, ctx);
         if (len == 1 && gr_is_zero(constant_coeff, ctx) == T_TRUE) {
             _gr_poly_set_length(res, 0, ctx);
@@ -107,7 +107,7 @@ gr_poly_add_si(gr_poly_t res, const gr_poly_t poly, slong c, gr_ctx_t ctx)
     }
 
     if (c != 0) {
-        gr_ptr constant_coeff = gr_poly_entry_ptr(res, 0, ctx);
+        gr_ptr constant_coeff = gr_poly_coeff_ptr(res, 0, ctx);
         status |= gr_add_si(constant_coeff, constant_coeff, c, ctx);
         if (len == 1 && gr_is_zero(constant_coeff, ctx) == T_TRUE) {
             _gr_poly_set_length(res, 0, ctx);
@@ -142,7 +142,7 @@ gr_poly_add_fmpz(gr_poly_t res, const gr_poly_t poly, const fmpz_t c, gr_ctx_t c
     }
 
     if (!fmpz_is_zero(c)) {
-        gr_ptr constant_coeff = gr_poly_entry_ptr(res, 0, ctx);
+        gr_ptr constant_coeff = gr_poly_coeff_ptr(res, 0, ctx);
         status |= gr_add_fmpz(constant_coeff, constant_coeff, c, ctx);
         if (len == 1 && gr_is_zero(constant_coeff, ctx) == T_TRUE) {
             _gr_poly_set_length(res, 0, ctx);
@@ -177,7 +177,7 @@ gr_poly_add_fmpq(gr_poly_t res, const gr_poly_t poly, const fmpq_t c, gr_ctx_t c
     }
 
     if (!fmpq_is_zero(c)) {
-        gr_ptr constant_coeff = gr_poly_entry_ptr(res, 0, ctx);
+        gr_ptr constant_coeff = gr_poly_coeff_ptr(res, 0, ctx);
         status |= gr_add_fmpq(constant_coeff, constant_coeff, c, ctx);
         if (len == 1 && gr_is_zero(constant_coeff, ctx) == T_TRUE) {
             _gr_poly_set_length(res, 0, ctx);

--- a/src/gr_poly/canonical_associate.c
+++ b/src/gr_poly/canonical_associate.c
@@ -41,7 +41,7 @@ gr_poly_canonical_associate(gr_poly_t ux, gr_poly_t u,
         FLINT_ASSERT(len == ux->length);
 
         GR_TMP_INIT(c, ctx);
-        lc = gr_poly_entry_ptr(ux, len - 1, ctx);
+        lc = gr_poly_coeff_ptr(ux, len - 1, ctx);
         status |= gr_canonical_associate(lc, c, lc, ctx);
         status |= _gr_vec_mul_scalar(ux->coeffs, ux->coeffs, len - 1, c, ctx);
         _gr_poly_normalise(ux, ctx);

--- a/src/gr_poly/clear.c
+++ b/src/gr_poly/clear.c
@@ -13,7 +13,7 @@
 
 void gr_poly_clear(gr_poly_t poly, gr_ctx_t ctx)
 {
-    FLINT_ASSERT(poly->length == 0 || gr_is_zero(gr_poly_entry_srcptr(poly,poly->length - 1, ctx), ctx) != T_TRUE);
+    FLINT_ASSERT(poly->length == 0 || gr_is_zero(gr_poly_coeff_srcptr(poly,poly->length - 1, ctx), ctx) != T_TRUE);
 
     if (poly->coeffs != NULL)
     {

--- a/src/gr_poly/divrem.c
+++ b/src/gr_poly/divrem.c
@@ -50,8 +50,8 @@ gr_poly_divrem(gr_poly_t Q, gr_poly_t R,
     gr_ptr q, r;
     int status = GR_SUCCESS;
 
-    FLINT_ASSERT(lenA == 0 || gr_is_zero(gr_poly_entry_srcptr(A, lenA - 1, ctx), ctx) != T_TRUE);
-    FLINT_ASSERT(lenB == 0 || gr_is_zero(gr_poly_entry_srcptr(B, lenB - 1, ctx), ctx) != T_TRUE);
+    FLINT_ASSERT(lenA == 0 || gr_is_zero(gr_poly_coeff_srcptr(A, lenA - 1, ctx), ctx) != T_TRUE);
+    FLINT_ASSERT(lenB == 0 || gr_is_zero(gr_poly_coeff_srcptr(B, lenB - 1, ctx), ctx) != T_TRUE);
 
     if (lenB == 0)
         return GR_DOMAIN;

--- a/src/gr_poly/equal.c
+++ b/src/gr_poly/equal.c
@@ -35,8 +35,8 @@ gr_poly_equal(const gr_poly_t poly1, const gr_poly_t poly2, gr_ctx_t ctx)
     slong len1 = poly1->length;
     slong len2 = poly2->length;
 
-    FLINT_ASSERT(len1 == 0 || gr_is_zero(gr_poly_entry_srcptr(poly1, len1 - 1, ctx), ctx) != T_TRUE);
-    FLINT_ASSERT(len2 == 0 || gr_is_zero(gr_poly_entry_srcptr(poly2, len2 - 1, ctx), ctx) != T_TRUE);
+    FLINT_ASSERT(len1 == 0 || gr_is_zero(gr_poly_coeff_srcptr(poly1, len1 - 1, ctx), ctx) != T_TRUE);
+    FLINT_ASSERT(len2 == 0 || gr_is_zero(gr_poly_coeff_srcptr(poly2, len2 - 1, ctx), ctx) != T_TRUE);
 
     if (len1 >= len2)
         return _gr_poly_equal(poly1->coeffs, len1, poly2->coeffs, len2, ctx);

--- a/src/gr_poly/factor_squarefree.c
+++ b/src/gr_poly/factor_squarefree.c
@@ -103,7 +103,7 @@ gr_poly_factor_squarefree(gr_ptr c, gr_vec_t fac, gr_vec_t exp, const gr_poly_t 
             status |= gr_poly_sub(s, w, t1, ctx);
 
             /* check if polynomial is proper */
-            if (s->length != 0 && gr_is_zero(gr_poly_entry_ptr(s, s->length - 1, ctx), ctx) != T_FALSE)
+            if (s->length != 0 && gr_is_zero(gr_poly_coeff_ptr(s, s->length - 1, ctx), ctx) != T_FALSE)
             {
                 status = GR_UNABLE;
                 goto cleanup;

--- a/src/gr_poly/mul.c
+++ b/src/gr_poly/mul.c
@@ -25,8 +25,8 @@ gr_poly_mul(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, gr_ctx_
     slong len_out;
     int status;
 
-    FLINT_ASSERT(poly1->length == 0 || gr_is_zero(gr_poly_entry_srcptr(poly1, poly1->length - 1, ctx), ctx) != T_TRUE);
-    FLINT_ASSERT(poly2->length == 0 || gr_is_zero(gr_poly_entry_srcptr(poly2, poly2->length - 1, ctx), ctx) != T_TRUE);
+    FLINT_ASSERT(poly1->length == 0 || gr_is_zero(gr_poly_coeff_srcptr(poly1, poly1->length - 1, ctx), ctx) != T_TRUE);
+    FLINT_ASSERT(poly2->length == 0 || gr_is_zero(gr_poly_coeff_srcptr(poly2, poly2->length - 1, ctx), ctx) != T_TRUE);
 
     if (poly1->length == 0 || poly2->length == 0)
         return gr_poly_zero(res, ctx);

--- a/src/gr_poly/sub.c
+++ b/src/gr_poly/sub.c
@@ -43,8 +43,8 @@ gr_poly_sub(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, gr_ctx_
     int status;
     slong max = FLINT_MAX(poly1->length, poly2->length);
 
-    FLINT_ASSERT(poly1->length == 0 || gr_is_zero(gr_poly_entry_srcptr(poly1, poly1->length - 1, ctx), ctx) != T_TRUE);
-    FLINT_ASSERT(poly2->length == 0 || gr_is_zero(gr_poly_entry_srcptr(poly2, poly2->length - 1, ctx), ctx) != T_TRUE);
+    FLINT_ASSERT(poly1->length == 0 || gr_is_zero(gr_poly_coeff_srcptr(poly1, poly1->length - 1, ctx), ctx) != T_TRUE);
+    FLINT_ASSERT(poly2->length == 0 || gr_is_zero(gr_poly_coeff_srcptr(poly2, poly2->length - 1, ctx), ctx) != T_TRUE);
 
     gr_poly_fit_length(res, max, ctx);
 

--- a/src/gr_poly/sub_scalar.c
+++ b/src/gr_poly/sub_scalar.c
@@ -38,7 +38,7 @@ gr_poly_sub_scalar(gr_poly_t res, const gr_poly_t poly, gr_srcptr c, gr_ctx_t ct
     }
 
     if (gr_is_zero(c, ctx) != T_TRUE) {
-        gr_ptr constant_coeff = gr_poly_entry_ptr(res, 0, ctx);
+        gr_ptr constant_coeff = gr_poly_coeff_ptr(res, 0, ctx);
         status |= gr_sub(constant_coeff, constant_coeff, c, ctx);
         if (len == 1 && gr_is_zero(constant_coeff, ctx) == T_TRUE) {
             _gr_poly_set_length(res, 0, ctx);
@@ -74,7 +74,7 @@ gr_poly_sub_ui(gr_poly_t res, const gr_poly_t poly, ulong c, gr_ctx_t ctx)
     }
 
     if (c != 0) {
-        gr_ptr constant_coeff = gr_poly_entry_ptr(res, 0, ctx);
+        gr_ptr constant_coeff = gr_poly_coeff_ptr(res, 0, ctx);
         status |= gr_sub_ui(constant_coeff, constant_coeff, c, ctx);
         if (len == 1 && gr_is_zero(constant_coeff, ctx) == T_TRUE) {
             _gr_poly_set_length(res, 0, ctx);
@@ -110,7 +110,7 @@ gr_poly_sub_si(gr_poly_t res, const gr_poly_t poly, slong c, gr_ctx_t ctx)
     }
 
     if (c != 0) {
-        gr_ptr constant_coeff = gr_poly_entry_ptr(res, 0, ctx);
+        gr_ptr constant_coeff = gr_poly_coeff_ptr(res, 0, ctx);
         status |= gr_sub_si(constant_coeff, constant_coeff, c, ctx);
         if (len == 1 && gr_is_zero(constant_coeff, ctx) == T_TRUE) {
             _gr_poly_set_length(res, 0, ctx);
@@ -146,7 +146,7 @@ gr_poly_sub_fmpz(gr_poly_t res, const gr_poly_t poly, const fmpz_t c, gr_ctx_t c
     }
 
     if (!fmpz_is_zero(c)) {
-        gr_ptr constant_coeff = gr_poly_entry_ptr(res, 0, ctx);
+        gr_ptr constant_coeff = gr_poly_coeff_ptr(res, 0, ctx);
         status |= gr_sub_fmpz(constant_coeff, constant_coeff, c, ctx);
         if (len == 1 && gr_is_zero(constant_coeff, ctx) == T_TRUE) {
             _gr_poly_set_length(res, 0, ctx);
@@ -182,7 +182,7 @@ gr_poly_sub_fmpq(gr_poly_t res, const gr_poly_t poly, const fmpq_t c, gr_ctx_t c
     }
 
     if (!fmpq_is_zero(c)) {
-        gr_ptr constant_coeff = gr_poly_entry_ptr(res, 0, ctx);
+        gr_ptr constant_coeff = gr_poly_coeff_ptr(res, 0, ctx);
         status |= gr_sub_fmpq(constant_coeff, constant_coeff, c, ctx);
         if (len == 1 && gr_is_zero(constant_coeff, ctx) == T_TRUE) {
             _gr_poly_set_length(res, 0, ctx);

--- a/src/gr_poly/test/t-compose_mod.c
+++ b/src/gr_poly/test/t-compose_mod.c
@@ -108,7 +108,7 @@ test_compose_mod(flint_rand_t state, int which)
             else
                 status |= gr_poly_mul(F, F, B, ctx);
             status |= gr_poly_rem(F, F, C, ctx);
-            status |= gr_poly_mul_scalar(G, F, gr_poly_entry_ptr(A, i, ctx), ctx);
+            status |= gr_poly_mul_scalar(G, F, gr_poly_coeff_ptr(A, i, ctx), ctx);
             status |= gr_poly_add(E, E, G, ctx);
         }
 

--- a/src/gr_poly/test/t-compose_series.c
+++ b/src/gr_poly/test/t-compose_series.c
@@ -110,7 +110,7 @@ test_compose_series(flint_rand_t state, int which)
                 status |= gr_poly_one(E, ctx);
             else
                 status |= gr_poly_mullow(E, E, B, n, ctx);
-            status |= gr_poly_mul_scalar(F, E, gr_poly_entry_ptr(A, i, ctx), ctx);
+            status |= gr_poly_mul_scalar(F, E, gr_poly_coeff_ptr(A, i, ctx), ctx);
             status |= gr_poly_add(D, D, F, ctx);
         }
 


### PR DESCRIPTION
Similarly `gr_poly_entry_srcptr` -> `gr_poly_coeff_srcptr`. The old functions are kept (to preserve their symbols in the library) with code comments and documentation saying that they are deprecated.

Follow-up to https://github.com/flintlib/flint/pull/2299#issuecomment-2886134018