### PR TITLE
Fix arb_div x/y with x = 0 or 0 +/- eps returning nan at high precision

### DIFF
--- a/src/arb/div.c
+++ b/src/arb/div.c
@@ -198,6 +198,15 @@ arb_div_arf(arb_t z, const arb_t x, const arf_t y, slong prec)
         else
             mag_zero(arb_radref(z));
     }
+    else if (arf_is_zero(arb_midref(x)))
+    {
+        /* [0 +/- eps] / y  ->  [0 +/- eps / y] */
+        mag_init(ym);
+        arf_get_mag_lower(ym, y);
+        mag_div(arb_radref(z), arb_radref(x), ym);
+        arf_zero(arb_midref(z));
+        mag_clear(ym);
+    }
     else if (WANT_NEWTON(prec, arb_bits(x), arf_bits(y)))
     {
         arb_div_arf_newton(z, x, y, prec);
@@ -311,6 +320,10 @@ arb_div(arb_t z, const arb_t x, const arb_t y, slong prec)
     else if (arf_is_zero(arb_midref(y))) /* anything / 0 = nan */
     {
         arb_indeterminate(z);
+    }
+    else if (arf_is_zero(arb_midref(x)) && arb_is_finite(y))
+    {
+        arb_div_wide(z, x, y, prec);
     }
     else if (ARB_IS_LAGOM(x) && ARB_IS_LAGOM(y)) /* fast case */
     {

--- a/src/arb/test/t-div.c
+++ b/src/arb/test/t-div.c
@@ -235,5 +235,41 @@ TEST_FUNCTION_START(arb_div, state)
         arb_clear(d);
     }
 
+    /* Check that a bug has been fixed */
+    {
+        arb_t x, y, z;
+        slong prec = 100000;
+
+        arb_init(x);
+        arb_init(y);
+        arb_init(z);
+
+        arb_set_ui(y, 3);
+        arb_inv(y, y, prec);
+        arb_div(z, x, y, prec);
+
+        if (!arb_is_zero(z))
+        {
+            flint_printf("FAIL: 0 / y at high precision\n\n");
+            flint_abort();
+        }
+
+        mag_zero(arb_radref(y));
+        mag_set_d(arb_radref(x), 1e-10);
+
+        arb_div(z, x, y, prec);
+
+        if (!arb_is_finite(z))
+        {
+            flint_printf("FAIL: [0 +/- eps] / y at high precision\n\n");
+            flint_abort();
+        }
+
+        arb_clear(x);
+        arb_clear(y);
+        arb_clear(z);
+
+    }
+
     TEST_FUNCTION_END(state);
 }


### PR DESCRIPTION
Fix (hopefully) a bug reported by @j-kieffer on flint-devel.