### PR TITLE
Correct signature of gr_ctx_clear to have void return type

### DIFF
--- a/doc/source/gr.rst
+++ b/doc/source/gr.rst
@@ -246,7 +246,7 @@ Context operations
     Return ``sizeof(type)`` where ``type`` is the underlying C
     type for elements of *ctx*.
 
-.. function:: int gr_ctx_clear(gr_ctx_t ctx)
+.. function:: void gr_ctx_clear(gr_ctx_t ctx)
 
     Clears the context object *ctx*, freeing any memory
     allocated by this object.

--- a/doc/source/gr_generic.rst
+++ b/doc/source/gr_generic.rst
@@ -20,7 +20,7 @@
               void gr_generic_sub(void)
               void gr_generic_mul(void)
 
-.. function:: int gr_generic_ctx_clear(gr_ctx_t ctx)
+.. function:: void gr_generic_ctx_clear(gr_ctx_t ctx)
 
 .. function:: void gr_generic_set_shallow(gr_ptr res, gr_srcptr x, const gr_ctx_t ctx)
 

--- a/src/gr.h
+++ b/src/gr.h
@@ -740,6 +740,7 @@ GR_INLINE slong gr_ctx_sizeof_elem(gr_ctx_t ctx)
 typedef void ((*gr_method_init_clear_op)(gr_ptr, gr_ctx_ptr));
 typedef void ((*gr_method_swap_op)(gr_ptr, gr_ptr, gr_ctx_ptr));
 typedef int ((*gr_method_ctx)(gr_ctx_ptr));
+typedef void ((*gr_method_ctx_void_op)(gr_ctx_ptr));
 typedef truth_t ((*gr_method_ctx_predicate)(gr_ctx_ptr));
 typedef int ((*gr_method_ctx_set_si)(gr_ctx_ptr, slong));
 typedef int ((*gr_method_ctx_get_si)(slong *, gr_ctx_ptr));
@@ -836,6 +837,7 @@ typedef int ((*gr_method_set_fexpr_op)(gr_ptr, fexpr_vec_t, gr_vec_t, const fexp
 
 /* Macros to retrieve methods (with correct call signature) from context object. */
 #define GR_CTX_OP(ctx, NAME) (((gr_method_ctx *) ctx->methods)[GR_METHOD_ ## NAME])
+#define GR_CTX_VOID_OP(ctx, NAME) (((gr_method_ctx_void_op *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_CTX_STREAM(ctx, NAME) (((gr_method_ctx_stream *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_CTX_PREDICATE(ctx, NAME) (((gr_method_ctx_predicate *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_CTX_SET_SI(ctx, NAME) (((gr_method_ctx_set_si *) ctx->methods)[GR_METHOD_ ## NAME])
@@ -933,7 +935,7 @@ typedef int ((*gr_method_set_fexpr_op)(gr_ptr, fexpr_vec_t, gr_vec_t, const fexp
 
 /* Wrappers to call methods. */
 
-GR_INLINE int gr_ctx_clear(gr_ctx_t ctx) { return GR_CTX_OP(ctx, CTX_CLEAR)(ctx); }
+GR_INLINE void gr_ctx_clear(gr_ctx_t ctx) { GR_CTX_VOID_OP(ctx, CTX_CLEAR)(ctx); }
 GR_INLINE int gr_ctx_write(gr_stream_t out, gr_ctx_t ctx) { return GR_CTX_STREAM(ctx, CTX_WRITE)(out, ctx); }
 
 GR_INLINE truth_t gr_ctx_is_ring(gr_ctx_t ctx) { return GR_CTX_PREDICATE(ctx, CTX_IS_RING)(ctx); }

--- a/src/gr_generic.h
+++ b/src/gr_generic.h
@@ -84,7 +84,7 @@ truth_t gr_generic_ctx_predicate(gr_ctx_t ctx);
 truth_t gr_generic_ctx_predicate_true(gr_ctx_t ctx);
 truth_t gr_generic_ctx_predicate_false(gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_ctx_clear(gr_ctx_t ctx);
+void gr_generic_ctx_clear(gr_ctx_t ctx);
 
 void gr_generic_set_shallow(gr_ptr res, gr_srcptr x, const gr_ctx_t ctx);
 

--- a/src/gr_generic/generic.c
+++ b/src/gr_generic/generic.c
@@ -22,10 +22,9 @@
 #include "gr_poly.h"
 #include "gr_special.h"
 
-int
+void
 gr_generic_ctx_clear(gr_ctx_t ctx)
 {
-    return GR_SUCCESS;
 }
 
 truth_t gr_generic_ctx_predicate(gr_ctx_t ctx)


### PR DESCRIPTION
As discovered in https://github.com/flintlib/python-flint/pull/262#issuecomment-2908087394 ``gr_ctx_clear`` was declared to return ``int`` but implementations return ``void``. This discrepancy is harmless on most architectures but fails on WASM. This patch changes the return type to ``void`` which is the intended behavior (this method is assumed to never require error handling).