### PR TITLE
Wrap arb_poly_init and arb_poly_clear to fix signature

### DIFF
--- a/src/acb_modular/hilbert_class_poly.c
+++ b/src/acb_modular/hilbert_class_poly.c
@@ -90,13 +90,13 @@ merge(arb_poly_t res, const arb_poly_t a, const arb_poly_t b, work_t * work)
 }
 
 static void
-init(arb_poly_t * x, void * args)
+init(arb_poly_t x, void * args)
 {
     arb_poly_init(x);
 }
 
 static void
-clear(arb_poly_t * x, void * args)
+clear(arb_poly_t x, void * args)
 {
     arb_poly_clear(x);
 }

--- a/src/acb_modular/hilbert_class_poly.c
+++ b/src/acb_modular/hilbert_class_poly.c
@@ -89,6 +89,18 @@ merge(arb_poly_t res, const arb_poly_t a, const arb_poly_t b, work_t * work)
     arb_poly_mul(res, a, b, work->prec);
 }
 
+static void
+init(arb_poly_t * x, void * args)
+{
+    arb_poly_init(x);
+}
+
+static void
+clear(arb_poly_t * x, void * args)
+{
+    arb_poly_clear(x);
+}
+
 int
 _acb_modular_hilbert_class_poly(fmpz_poly_t res, slong D,
         const slong * qbf, slong qbf_len, slong prec)
@@ -112,8 +124,8 @@ _acb_modular_hilbert_class_poly(fmpz_poly_t res, slong D,
         (bsplit_basecase_func_t) basecase,
         (bsplit_merge_func_t) merge,
         sizeof(arb_poly_struct),
-        (bsplit_init_func_t) arb_poly_init,
-        (bsplit_clear_func_t) arb_poly_clear,
+        (bsplit_init_func_t) init,
+        (bsplit_clear_func_t) clear,
         &work, 0, qbf_len, 1, -1, 0);
 
 /*    bsplit(pol, sqrtD, qbf, 0, qbf_len, prec); */


### PR DESCRIPTION
The signatures expected by flint_parallel_binary_splitting do not match arb_poly_init and arb_poly_clear so make dummy functions of the correct signature and pass those instead.

This otherwise crashes with a bad function pointer cast in WASM.

From https://github.com/flintlib/python-flint/pull/262#issuecomment-2909928759