### PR TITLE
Two small vector optimizations

### DIFF
--- a/src/fmpz_vec/add.c
+++ b/src/fmpz_vec/add.c
@@ -12,10 +12,24 @@
 #include "fmpz.h"
 #include "fmpz_vec.h"
 
+static void
+_fmpz_add_inline(fmpz_t z, const fmpz_t x, const fmpz_t y)
+{
+    fmpz f, g;
+
+    f = *x;
+    g = *y;
+
+    if (!COEFF_IS_MPZ(f) && !COEFF_IS_MPZ(g))
+        fmpz_set_si(z, f + g);
+    else
+        fmpz_add(z, x, y);
+}
+
 void
 _fmpz_vec_add(fmpz * res, const fmpz * vec1, const fmpz * vec2, slong len2)
 {
     slong i;
     for (i = 0; i < len2; i++)
-        fmpz_add(res + i, vec1 + i, vec2 + i);
+        _fmpz_add_inline(res + i, vec1 + i, vec2 + i);
 }

--- a/src/fmpz_vec/sub.c
+++ b/src/fmpz_vec/sub.c
@@ -12,10 +12,24 @@
 #include "fmpz.h"
 #include "fmpz_vec.h"
 
+static void
+_fmpz_sub_inline(fmpz_t z, const fmpz_t x, const fmpz_t y)
+{
+    fmpz f, g;
+
+    f = *x;
+    g = *y;
+
+    if (!COEFF_IS_MPZ(f) && !COEFF_IS_MPZ(g))
+        fmpz_set_si(z, f - g);
+    else
+        fmpz_sub(z, x, y);
+}
+
 void
 _fmpz_vec_sub(fmpz * res, const fmpz * vec1, const fmpz * vec2, slong len2)
 {
     slong i;
     for (i = 0; i < len2; i++)
-        fmpz_sub(res + i, vec1 + i, vec2 + i);
+        _fmpz_sub_inline(res + i, vec1 + i, vec2 + i);
 }

--- a/src/gr/nmod.c
+++ b/src/gr/nmod.c
@@ -654,6 +654,17 @@ _gr_nmod_vec_sub(ulong * res, const ulong * vec1, const ulong * vec2, slong len,
     return GR_SUCCESS;
 }
 
+int
+_gr_nmod_vec_mul(ulong * res, const ulong * vec1, const ulong * vec2, slong len, gr_ctx_t ctx)
+{
+    slong i;
+    nmod_t mod = NMOD_CTX(ctx);
+
+    for (i = 0; i < len; i++)
+        res[i] = nmod_mul(vec1[i], vec2[i], mod);
+
+    return GR_SUCCESS;
+}
 
 static inline void _nmod_vec_scalar_mul_nmod_fullword_inline(nn_ptr res, nn_srcptr vec,
                                slong len, ulong c, nmod_t mod)
@@ -1451,6 +1462,7 @@ gr_method_tab_input __gr_nmod_methods_input[] =
     {GR_METHOD_VEC_NEG,         (gr_funcptr) _gr_nmod_vec_neg},
     {GR_METHOD_VEC_ADD,         (gr_funcptr) _gr_nmod_vec_add},
     {GR_METHOD_VEC_SUB,         (gr_funcptr) _gr_nmod_vec_sub},
+    {GR_METHOD_VEC_MUL,         (gr_funcptr) _gr_nmod_vec_mul},
     {GR_METHOD_VEC_MUL_SCALAR,      (gr_funcptr) _gr_nmod_vec_mul_scalar},
     {GR_METHOD_VEC_MUL_SCALAR_SI,   (gr_funcptr) _gr_nmod_vec_mul_scalar_si},
     {GR_METHOD_VEC_MUL_SCALAR_UI,   (gr_funcptr) _gr_nmod_vec_mul_scalar_ui},

--- a/src/gr/nmod32.c
+++ b/src/gr/nmod32.c
@@ -398,6 +398,18 @@ _nmod32_vec_sub(nmod32_struct * res, const nmod32_struct * vec1, const nmod32_st
     return GR_SUCCESS;
 }
 
+int
+_nmod32_vec_mul(nmod32_struct * res, const nmod32_struct * vec1, const nmod32_struct * vec2, slong len, gr_ctx_t ctx)
+{
+    slong i;
+    nmod_t mod = NMOD32_CTX(ctx);
+
+    for (i = 0; i < len; i++)
+        res[i] = nmod_mul(vec1[i], vec2[i], mod);
+
+    return GR_SUCCESS;
+}
+
 /* todo: overflow checks */
 int
 _nmod32_vec_dot(nmod32_t res, const nmod32_t initial, int subtract, const nmod32_struct * vec1, const nmod32_struct * vec2, slong len, gr_ctx_t ctx)
@@ -558,6 +570,7 @@ gr_method_tab_input _nmod32_methods_input[] =
     {GR_METHOD_VEC_NEG,         (gr_funcptr) _nmod32_vec_neg},
     {GR_METHOD_VEC_ADD,         (gr_funcptr) _nmod32_vec_add},
     {GR_METHOD_VEC_SUB,         (gr_funcptr) _nmod32_vec_sub},
+    {GR_METHOD_VEC_MUL,         (gr_funcptr) _nmod32_vec_mul},
     {GR_METHOD_VEC_DOT,         (gr_funcptr) _nmod32_vec_dot},
     {GR_METHOD_VEC_DOT_REV,     (gr_funcptr) _nmod32_vec_dot_rev},
     {GR_METHOD_MAT_MUL,         (gr_funcptr) _nmod32_mat_mul},

--- a/src/gr/nmod8.c
+++ b/src/gr/nmod8.c
@@ -392,6 +392,18 @@ _nmod8_vec_sub(nmod8_struct * res, const nmod8_struct * vec1, const nmod8_struct
 }
 
 int
+_nmod8_vec_mul(nmod8_struct * res, const nmod8_struct * vec1, const nmod8_struct * vec2, slong len, gr_ctx_t ctx)
+{
+    slong i;
+    nmod_t mod = NMOD8_CTX(ctx);
+
+    for (i = 0; i < len; i++)
+        res[i] = nmod_mul(vec1[i], vec2[i], mod);
+
+    return GR_SUCCESS;
+}
+
+int
 _nmod8_vec_dot(nmod8_t res, const nmod8_t initial, int subtract, const nmod8_struct * vec1, const nmod8_struct * vec2, slong len, gr_ctx_t ctx)
 {
     slong i;
@@ -586,6 +598,7 @@ gr_method_tab_input _nmod8_methods_input[] =
     {GR_METHOD_VEC_NEG,         (gr_funcptr) _nmod8_vec_neg},
     {GR_METHOD_VEC_ADD,         (gr_funcptr) _nmod8_vec_add},
     {GR_METHOD_VEC_SUB,         (gr_funcptr) _nmod8_vec_sub},
+    {GR_METHOD_VEC_MUL,         (gr_funcptr) _nmod8_vec_mul},
     {GR_METHOD_VEC_DOT,         (gr_funcptr) _nmod8_vec_dot},
     {GR_METHOD_VEC_DOT_REV,     (gr_funcptr) _nmod8_vec_dot_rev},
     {GR_METHOD_MAT_MUL,         (gr_funcptr) _nmod8_mat_mul},


### PR DESCRIPTION
* Overload ``_gr_vec_mul`` for nmod types

* Optimize ``_fmpz_vec_add``/``sub`` for small coefficients by inlining (this was already done for ``_gr_vec_add``/``sub`` and gives a 2x speedup)