### PR TITLE
Add msolve to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -198,7 +198,11 @@ jobs:
         run: |
           ./autogen.sh
           ./configure
-          make 
+
+      - name: "Build msolve"
+        working-directory: ./msolve
+        run: |
+          $MAKE
           make check
 
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -203,7 +203,11 @@ jobs:
         working-directory: ./msolve
         run: |
           $MAKE
-          make check
+
+      - name: "Check msolve"
+        working-directory: ./msolve
+        run: |
+          $MAKE check
 
 
   ##############################################################################

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -185,13 +185,13 @@ jobs:
           $MAKE check
 
       - name: "Check msolve"
+        run: |
           git clone https://github.com/algebraic-solving/msolve
           cd msolve
           ./autogen.sh
           ./configure
           $MAKE
           $MAKE check
-
 
 
   ##############################################################################

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -195,8 +195,8 @@ jobs:
           cd msolve
           ./autogen.sh
           ./configure
-          $MAKE
-          $MAKE check
+          make 
+          make check
 
 
   ##############################################################################

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -189,9 +189,9 @@ jobs:
           sudo make install
           sudo ldconfig
 
-      - name: "Check msolve"
+      - name: "Fetch msolve"
         run: |
-          git clone https://github.com/algebraic-solving/msolve
+          git clone --depth=1 https://github.com/algebraic-solving/msolve
           cd msolve
           ./autogen.sh
           ./configure

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -184,6 +184,11 @@ jobs:
         run: |
           $MAKE check
 
+      - name: "Install"
+        run: |
+          sudo make install
+          sudo ldconfig
+
       - name: "Check msolve"
         run: |
           git clone https://github.com/algebraic-solving/msolve

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -136,7 +136,7 @@ jobs:
   # ubuntu gcc with assert
   ##############################################################################
   ubuntu-gcc-assert:
-    name: Ubuntu GCC with NTL (assert, x2)
+    name: Ubuntu GCC with NTL and checking msolve (assert, x2)
 
     runs-on: ubuntu-24.04
 
@@ -182,6 +182,14 @@ jobs:
 
       - name: "Check"
         run: |
+          $MAKE check
+
+      - name: "Check msolve"
+          git clone https://github.com/algebraic-solving/msolve
+          cd msolve
+          ./autogen.sh
+          ./configure
+          $MAKE
           $MAKE check
 
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -192,7 +192,10 @@ jobs:
       - name: "Fetch msolve"
         run: |
           git clone --depth=1 https://github.com/algebraic-solving/msolve
-          cd msolve
+
+      - name: "Configure msolve"
+        working-directory: ./msolve
+        run: |
           ./autogen.sh
           ./configure
           make 


### PR DESCRIPTION
As per #2261 .

This adds, in one of the workflow runners, the compilation of msolve and its `make check`.