### PR TITLE
Revise fmpz_mod_mpoly_q

### DIFF
--- a/doc/source/fmpz_mod_mpoly_q.rst
+++ b/doc/source/fmpz_mod_mpoly_q.rst
@@ -1,6 +1,6 @@
-.. _fmpz-mpoly-q:
+.. _fmpz-mod-mpoly-q:
 
-**fmpz_mod_mpoly_q.h** -- multivariate rational functions over Q
+**fmpz_mod_mpoly_q.h** -- multivariate rational functions over Z/mZ
 ===============================================================================
 
 An :type:`fmpz_mod_mpoly_q_t` represents an element of 
@@ -11,8 +11,9 @@ of numerator and denominator is 1 and then normalizing denominator to a monic po
 
 The user must create a multivariate polynomial context
 (:type:`fmpz_mod_mpoly_ctx_t`) specifying the prime number *m* for the field `\mathbb{F}_m` 
-the number of variables *n* and the monomial ordering. It is important to ensure *m* is a prime number
-otherwise undefined behaviour may occur.
+the number of variables *n* and the monomial ordering. The user is responsible
+for verifying that *m* is a prime number;
+if *m* is composite, undefined behaviour may occur.
 
 
 Types and macros
@@ -56,11 +57,13 @@ Assignment
     Swaps the values of *x* and *y* efficiently.
 
 .. function:: void fmpz_mod_mpoly_q_set(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_mod_mpoly_ctx_t ctx)
-              void fmpz_mod_mpoly_q_set_fmpq(fmpz_mod_mpoly_q_t res, const fmpq_t x, const fmpz_mod_mpoly_ctx_t ctx)
+              int fmpz_mod_mpoly_q_set_fmpq(fmpz_mod_mpoly_q_t res, const fmpq_t x, const fmpz_mod_mpoly_ctx_t ctx)
               void fmpz_mod_mpoly_q_set_fmpz(fmpz_mod_mpoly_q_t res, const fmpz_t x, const fmpz_mod_mpoly_ctx_t ctx)
               void fmpz_mod_mpoly_q_set_si(fmpz_mod_mpoly_q_t res, slong x, const fmpz_mod_mpoly_ctx_t ctx)
 
     Sets *res* to the value *x*.
+    The *fmpq* version returns 1 if the denominator of *x* is invertible,
+    otherwise returns 0.
 
 
 Canonicalisation
@@ -160,51 +163,50 @@ Comparisons
 Arithmetic
 -------------------------------------------------------------------------------
 
+The functions below which coerce from an *fmpq* or divide by an integer type
+perform error handling by returning 1 if the denominator is invertible
+and 0 otherwise.
+
 .. function:: void fmpz_mod_mpoly_q_neg(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_mod_mpoly_ctx_t ctx)
 
     Sets *res* to the negation of *x*.
 
 .. function:: void fmpz_mod_mpoly_q_add(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_mod_mpoly_q_t y, const fmpz_mod_mpoly_ctx_t ctx)
-              void fmpz_mod_mpoly_q_add_fmpq(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpq_t y, const fmpz_mod_mpoly_ctx_t ctx)
+              int fmpz_mod_mpoly_q_add_fmpq(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpq_t y, const fmpz_mod_mpoly_ctx_t ctx)
               void fmpz_mod_mpoly_q_add_fmpz(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_t y, const fmpz_mod_mpoly_ctx_t ctx)
+              void fmpz_mod_mpoly_q_add_fmpz_mod(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_t y, const fmpz_mod_mpoly_ctx_t ctx)
               void fmpz_mod_mpoly_q_add_si(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, slong y, const fmpz_mod_mpoly_ctx_t ctx)
 
     Sets *res* to the sum of *x* and *y*. 
 
 .. function:: void fmpz_mod_mpoly_q_sub(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_mod_mpoly_q_t y, const fmpz_mod_mpoly_ctx_t ctx)
-              void fmpz_mod_mpoly_q_sub_fmpq(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpq_t y, const fmpz_mod_mpoly_ctx_t ctx)
+              int fmpz_mod_mpoly_q_sub_fmpq(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpq_t y, const fmpz_mod_mpoly_ctx_t ctx)
               void fmpz_mod_mpoly_q_sub_fmpz(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_t y, const fmpz_mod_mpoly_ctx_t ctx)
+              void fmpz_mod_mpoly_q_sub_fmpz_mod(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_t y, const fmpz_mod_mpoly_ctx_t ctx)
               void fmpz_mod_mpoly_q_sub_si(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, slong y, const fmpz_mod_mpoly_ctx_t ctx)
 
     Sets *res* to the difference of *x* and *y*.
 
 .. function:: void fmpz_mod_mpoly_q_mul(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_mod_mpoly_q_t y, const fmpz_mod_mpoly_ctx_t ctx)
-              void fmpz_mod_mpoly_q_mul_fmpq(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpq_t y, const fmpz_mod_mpoly_ctx_t ctx)
+              int fmpz_mod_mpoly_q_mul_fmpq(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpq_t y, const fmpz_mod_mpoly_ctx_t ctx)
               void fmpz_mod_mpoly_q_mul_fmpz(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_t y, const fmpz_mod_mpoly_ctx_t ctx)
+              void fmpz_mod_mpoly_q_mul_fmpz_mod(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_t y, const fmpz_mod_mpoly_ctx_t ctx)
               void fmpz_mod_mpoly_q_mul_si(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, slong y, const fmpz_mod_mpoly_ctx_t ctx)
 
     Sets *res* to the product of *x* and *y*.
 
 .. function:: void fmpz_mod_mpoly_q_div(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_mod_mpoly_q_t y, const fmpz_mod_mpoly_ctx_t ctx)
-              void fmpz_mod_mpoly_q_div_fmpq(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpq_t y, const fmpz_mod_mpoly_ctx_t ctx)
-              void fmpz_mod_mpoly_q_div_fmpz(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_t y, const fmpz_mod_mpoly_ctx_t ctx)
-              void fmpz_mod_mpoly_q_div_si(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, slong y, const fmpz_mod_mpoly_ctx_t ctx)
+              int fmpz_mod_mpoly_q_div_fmpq(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpq_t y, const fmpz_mod_mpoly_ctx_t ctx)
+              int fmpz_mod_mpoly_q_div_fmpz(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_t y, const fmpz_mod_mpoly_ctx_t ctx)
+              int fmpz_mod_mpoly_q_div_si(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, slong y, const fmpz_mod_mpoly_ctx_t ctx)
 
     Sets *res* to the quotient of *x* and *y*.
-    Division by zero calls *flint_abort*.
 
 .. function:: void fmpz_mod_mpoly_q_inv(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_mod_mpoly_ctx_t ctx)
 
     Sets *res* to the inverse of *x*. Division by zero
     calls *flint_abort*.
 
-Content
--------------------------------------------------------------------------------
-
-.. function:: void _fmpz_mod_mpoly_q_content(fmpz_t num, fmpz_t den, const fmpz_mod_mpoly_t xnum, const fmpz_mod_mpoly_t xden, const fmpz_mod_mpoly_ctx_t ctx)
-              void fmpz_mod_mpoly_q_content(fmpq_t res, const fmpz_mod_mpoly_q_t x, const fmpz_mod_mpoly_ctx_t ctx)
-
-    Sets *res* to the content of the coefficients of *x*.
 
 
 .. raw:: latex

--- a/doc/source/gr_domains.rst
+++ b/doc/source/gr_domains.rst
@@ -378,15 +378,15 @@ Fraction fields
     with monomial ordering *ord*.
     Elements have type :type:`fmpz_mpoly_q_struct`.
 
-.. function:: void gr_ctx_init_fmpz_mod_mpoly_q(gr_ctx_t ctx, slong nvars, const ordering_t ord, const fmpz *mod)
+.. function:: void gr_ctx_init_fmpz_mod_mpoly_q(gr_ctx_t ctx, slong nvars, const ordering_t ord, const fmpz_t mod)
 
     Initializes *ctx* to a ring of sparsely represented multivariate
     fractions in *nvars* variables over the `\mathbb{F}_mod` field,
-    with monomial ordering *ord*, and *mod* being a prime number. In case *mod* is not
-    a prime undefined behavior might occur.
+    with monomial ordering *ord*, and *mod* being a prime number.
+    The user is responsible
+    for verifying that *mod* is a prime number;
+    if *mod* is composite, undefined behaviour may occur.
     Elements have type :type:`fmpz_mod_mpoly_q_struct`.
-    The user is responsible for avoiding rational numbers with denominator
-    divisible by *mod*. It is recommended to provide big enough integer for *mod*.
 
 Symbolic expressions
 -------------------------------------------------------------------------------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -147,6 +147,7 @@ Integers mod n
    fmpz_mod_poly_factor.rst
    fmpz_mod_mpoly.rst
    fmpz_mod_mpoly_factor.rst
+   fmpz_mod_mpoly_q.rst
 
 .. only:: not latex
 

--- a/doc/source/index_integers_mod.rst
+++ b/doc/source/index_integers_mod.rst
@@ -24,3 +24,5 @@
        fmpz_mod_poly_factor.rst
        fmpz_mod_mpoly.rst
        fmpz_mod_mpoly_factor.rst
+       fmpz_mod_mpoly_q.rst
+

--- a/src/fmpz_mod_mpoly_q.h
+++ b/src/fmpz_mod_mpoly_q.h
@@ -44,7 +44,7 @@ void fmpz_mod_mpoly_q_swap(fmpz_mod_mpoly_q_t x, fmpz_mod_mpoly_q_t y, const fmp
 
 void fmpz_mod_mpoly_q_set(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_mod_mpoly_ctx_t ctx);
 
-void fmpz_mod_mpoly_q_set_fmpq(fmpz_mod_mpoly_q_t res, const fmpq_t x, const fmpz_mod_mpoly_ctx_t ctx);
+int fmpz_mod_mpoly_q_set_fmpq(fmpz_mod_mpoly_q_t res, const fmpq_t x, const fmpz_mod_mpoly_ctx_t ctx);
 
 void fmpz_mod_mpoly_q_set_fmpz(fmpz_mod_mpoly_q_t res, const fmpz_t x, const fmpz_mod_mpoly_ctx_t ctx);
 
@@ -72,17 +72,10 @@ fmpz_mod_mpoly_q_is_one(const fmpz_mod_mpoly_q_t x, const fmpz_mod_mpoly_ctx_t c
 }
 
 FMPZ_MOD_MPOLY_Q_INLINE int
-fmpz_mod_mpoly_q_is_fmpz(const fmpz_mod_mpoly_q_t x, const fmpz_mod_mpoly_ctx_t ctx)
+fmpz_mod_mpoly_q_is_fmpz_mod(const fmpz_mod_mpoly_q_t x, const fmpz_mod_mpoly_ctx_t ctx)
 {
     return fmpz_mod_mpoly_is_fmpz(fmpz_mod_mpoly_q_numref(x), ctx) &&
            fmpz_mod_mpoly_is_one(fmpz_mod_mpoly_q_denref(x), ctx);
-}
-
-FMPZ_MOD_MPOLY_Q_INLINE int
-fmpz_mod_mpoly_q_is_fmpq(const fmpz_mod_mpoly_q_t x, const fmpz_mod_mpoly_ctx_t ctx)
-{
-    return fmpz_mod_mpoly_is_fmpz(fmpz_mod_mpoly_q_numref(x), ctx) &&
-           fmpz_mod_mpoly_is_fmpz(fmpz_mod_mpoly_q_denref(x), ctx);
 }
 
 /* Special values */
@@ -140,6 +133,12 @@ _fmpz_mod_mpoly_q_add(fmpz_mod_mpoly_t res_num, fmpz_mod_mpoly_t res_den,
             const fmpz_mod_mpoly_ctx_t ctx);
 
 void
+_fmpz_mod_mpoly_q_add_fmpz_mod(fmpz_mod_mpoly_t res_num, fmpz_mod_mpoly_t res_den,
+            const fmpz_mod_mpoly_t x_num, const fmpz_mod_mpoly_t x_den,
+            const fmpz_t y,
+            const fmpz_mod_mpoly_ctx_t ctx);
+
+void
 _fmpz_mod_mpoly_q_sub(fmpz_mod_mpoly_t res_num, fmpz_mod_mpoly_t res_den,
             const fmpz_mod_mpoly_t x_num, const fmpz_mod_mpoly_t x_den,
             const fmpz_mod_mpoly_t y_num, const fmpz_mod_mpoly_t y_den,
@@ -157,35 +156,20 @@ _fmpz_mod_mpoly_q_div(fmpz_mod_mpoly_t res_num, fmpz_mod_mpoly_t res_den,
             const fmpz_mod_mpoly_t y_num, const fmpz_mod_mpoly_t y_den,
             const fmpz_mod_mpoly_ctx_t ctx);
 
-void
-_fmpz_mod_mpoly_q_add_fmpq(fmpz_mod_mpoly_t res_num, fmpz_mod_mpoly_t res_den,
-            const fmpz_mod_mpoly_t x_num, const fmpz_mod_mpoly_t x_den,
-            const fmpz_t y_num, const fmpz_t y_den,
-            const fmpz_mod_mpoly_ctx_t ctx);
-
-void
-_fmpz_mod_mpoly_q_sub_fmpq(fmpz_mod_mpoly_t res_num, fmpz_mod_mpoly_t res_den,
-            const fmpz_mod_mpoly_t x_num, const fmpz_mod_mpoly_t x_den,
-            const fmpz_t y_num, const fmpz_t y_den,
-            const fmpz_mod_mpoly_ctx_t ctx);
-
-void
-_fmpz_mod_mpoly_q_mul_fmpq(fmpz_mod_mpoly_t res_num, fmpz_mod_mpoly_t res_den,
-            const fmpz_mod_mpoly_t x_num, const fmpz_mod_mpoly_t x_den,
-            const fmpz_t y_num, const fmpz_t y_den,
-            const fmpz_mod_mpoly_ctx_t ctx);
-
+void fmpz_mod_mpoly_q_add_fmpz_mod(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_t y, const fmpz_mod_mpoly_ctx_t ctx);
 void fmpz_mod_mpoly_q_add_fmpz(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_t y, const fmpz_mod_mpoly_ctx_t ctx);
-void fmpz_mod_mpoly_q_add_fmpq(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpq_t y, const fmpz_mod_mpoly_ctx_t ctx);
+int fmpz_mod_mpoly_q_add_fmpq(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpq_t y, const fmpz_mod_mpoly_ctx_t ctx);
 
+void fmpz_mod_mpoly_q_sub_fmpz_mod(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_t y, const fmpz_mod_mpoly_ctx_t ctx);
 void fmpz_mod_mpoly_q_sub_fmpz(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_t y, const fmpz_mod_mpoly_ctx_t ctx);
-void fmpz_mod_mpoly_q_sub_fmpq(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpq_t y, const fmpz_mod_mpoly_ctx_t ctx);
+int fmpz_mod_mpoly_q_sub_fmpq(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpq_t y, const fmpz_mod_mpoly_ctx_t ctx);
 
+void fmpz_mod_mpoly_q_mul_fmpz_mod(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_t y, const fmpz_mod_mpoly_ctx_t ctx);
 void fmpz_mod_mpoly_q_mul_fmpz(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_t y, const fmpz_mod_mpoly_ctx_t ctx);
-void fmpz_mod_mpoly_q_mul_fmpq(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpq_t y, const fmpz_mod_mpoly_ctx_t ctx);
+int fmpz_mod_mpoly_q_mul_fmpq(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpq_t y, const fmpz_mod_mpoly_ctx_t ctx);
 
-void fmpz_mod_mpoly_q_div_fmpz(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_t y, const fmpz_mod_mpoly_ctx_t ctx);
-void fmpz_mod_mpoly_q_div_fmpq(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpq_t y, const fmpz_mod_mpoly_ctx_t ctx);
+int fmpz_mod_mpoly_q_div_fmpz(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_t y, const fmpz_mod_mpoly_ctx_t ctx);
+int fmpz_mod_mpoly_q_div_fmpq(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpq_t y, const fmpz_mod_mpoly_ctx_t ctx);
 
 FMPZ_MOD_MPOLY_Q_INLINE void
 fmpz_mod_mpoly_q_add_si(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, slong c, const fmpz_mod_mpoly_ctx_t ctx)
@@ -214,13 +198,15 @@ fmpz_mod_mpoly_q_mul_si(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, slon
     fmpz_clear(t);
 }
 
-FMPZ_MOD_MPOLY_Q_INLINE void
+FMPZ_MOD_MPOLY_Q_INLINE int
 fmpz_mod_mpoly_q_div_si(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, slong c, const fmpz_mod_mpoly_ctx_t ctx)
 {
     fmpz_t t;
+    int invertible;
     fmpz_init_set_si(t, c);
-    fmpz_mod_mpoly_q_div_fmpz(res, x, t, ctx);
+    invertible = fmpz_mod_mpoly_q_div_fmpz(res, x, t, ctx);
     fmpz_clear(t);
+    return invertible;
 }
 
 /* Polynomial helper functions */
@@ -236,7 +222,7 @@ fmpz_mod_mpoly_gcd_assert_successful(fmpz_mod_mpoly_t res, const fmpz_mod_mpoly_
 
 FMPZ_MOD_MPOLY_Q_INLINE void
 _fmpz_mod_mpoly_q_mpoly_divexact(fmpz_mod_mpoly_t res, const fmpz_mod_mpoly_t x, const fmpz_mod_mpoly_t y, const fmpz_mod_mpoly_ctx_t ctx)
-{    
+{
     fmpz_t g;
     fmpz_init(g);
     

--- a/src/fmpz_mod_mpoly_q/add.c
+++ b/src/fmpz_mod_mpoly_q/add.c
@@ -44,95 +44,61 @@ _fmpz_mod_mpoly_q_add(fmpz_mod_mpoly_t res_num, fmpz_mod_mpoly_t res_den,
         }
         else
         {
-            fmpz_t g;
             fmpz_mod_mpoly_t t;
-
-            fmpz_init(g);
             fmpz_mod_mpoly_init(t, ctx);
 
-            fmpz_mod_set_fmpz(g, x_den->coeffs, ctx->ffinfo);
-            fmpz_mod_inv(g, g, ctx->ffinfo);
-
             fmpz_mod_mpoly_gcd_assert_successful(t, res_num, x_den, ctx);
-            fmpz_mod_mpoly_set(res_den, x_den, ctx);
-            
+
             if (fmpz_mod_mpoly_is_one(t, ctx))
             {
-                fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(res_num, res_num, g, ctx);
-                fmpz_mod_mpoly_make_monic(res_den, res_den, ctx);
-                
-                fmpz_mod_mpoly_clear(t, ctx);
-                fmpz_clear(g);                
-                return;
+                fmpz_mod_mpoly_set(res_den, x_den, ctx);
             }
             else
             {
-                fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(res_num, res_num, g, ctx);
-                fmpz_mod_mpoly_make_monic(res_den, res_den, ctx);
-                fmpz_mod_mpoly_divides(res_num, res_num, t, ctx);
-                fmpz_mod_mpoly_divides(res_den, res_den, t, ctx);
-
-                fmpz_mod_mpoly_clear(t, ctx);
-                fmpz_clear(g);                 
-                return;
+                _fmpz_mod_mpoly_q_mpoly_divexact(res_num, res_num, t, ctx);
+                _fmpz_mod_mpoly_q_mpoly_divexact(res_den, x_den, t, ctx);
             }
+
+            fmpz_mod_mpoly_clear(t, ctx);
+            return;
         }
     }
 
     if (fmpz_mod_mpoly_is_one(x_den, ctx))
     {  
-        fmpz_t g;
-        fmpz_mod_mpoly_t t, u;
-
-        fmpz_init(g);
-        fmpz_mod_mpoly_init(t, ctx);
-        fmpz_mod_mpoly_init(u, ctx);
-
-
-        fmpz_mod_set_fmpz(g, y_den->coeffs, ctx->ffinfo);
-        fmpz_mod_inv(g, g, ctx->ffinfo);
-        
-        fmpz_mod_mpoly_mul(t, x_num, y_den, ctx);
-        fmpz_mod_mpoly_add(res_num, t, y_num, ctx);
-
-        fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(res_num, res_num, g, ctx);
-        fmpz_mod_mpoly_make_monic(res_den, y_den, ctx);
-
-        fmpz_mod_mpoly_gcd_assert_successful(u, res_num, res_den, ctx);
-        fmpz_mod_mpoly_divexact(res_num, res_num, u, ctx);
-        fmpz_mod_mpoly_divexact(res_den, res_den, u, ctx);
-
-        fmpz_mod_mpoly_clear(u, ctx);
-        fmpz_mod_mpoly_clear(t, ctx);
-        fmpz_clear(g);
+        if (res_num == y_num)
+        {
+            fmpz_mod_mpoly_t t;
+            fmpz_mod_mpoly_init(t, ctx);
+            fmpz_mod_mpoly_mul(t, x_num, y_den, ctx);
+            fmpz_mod_mpoly_add(res_num, t, y_num, ctx);
+            fmpz_mod_mpoly_clear(t, ctx);
+        }
+        else
+        {
+            fmpz_mod_mpoly_mul(res_num, x_num, y_den, ctx);
+            fmpz_mod_mpoly_add(res_num, res_num, y_num, ctx);
+        }
+        fmpz_mod_mpoly_set(res_den, y_den, ctx);
         return;
     }
 
     if (fmpz_mod_mpoly_is_one(y_den, ctx))
     {
-        fmpz_t g;
-        fmpz_mod_mpoly_t t, u;
-
-        fmpz_init(g);
-        fmpz_mod_mpoly_init(t, ctx);
-        fmpz_mod_mpoly_init(u, ctx);
-
-        fmpz_mod_set_fmpz(g, x_den->coeffs, ctx->ffinfo);
-        fmpz_mod_inv(g, g, ctx->ffinfo);
-        
-        fmpz_mod_mpoly_mul(t, y_num, x_den, ctx);
-        fmpz_mod_mpoly_add(res_num, t, x_num, ctx);
-
-        fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(res_num, res_num, g, ctx);
-        fmpz_mod_mpoly_make_monic(res_den, x_den, ctx);
-
-        fmpz_mod_mpoly_gcd_assert_successful(u, res_num, res_den, ctx);
-        fmpz_mod_mpoly_divexact(res_num, res_num, u, ctx);
-        fmpz_mod_mpoly_divexact(res_den, res_den, u, ctx);
-
-        fmpz_mod_mpoly_clear(u, ctx);
-        fmpz_mod_mpoly_clear(t, ctx);
-        fmpz_clear(g);
+        if (res_num == x_num)
+        {
+            fmpz_mod_mpoly_t t;
+            fmpz_mod_mpoly_init(t, ctx);
+            fmpz_mod_mpoly_mul(t, y_num, x_den, ctx);
+            fmpz_mod_mpoly_add(res_num, x_num, t, ctx);
+            fmpz_mod_mpoly_clear(t, ctx);
+        }
+        else
+        {
+            fmpz_mod_mpoly_mul(res_num, y_num, x_den, ctx);
+            fmpz_mod_mpoly_add(res_num, x_num, res_num, ctx);
+        }
+        fmpz_mod_mpoly_set(res_den, x_den, ctx);
         return;
     }
 
@@ -147,31 +113,14 @@ _fmpz_mod_mpoly_q_add(fmpz_mod_mpoly_t res_num, fmpz_mod_mpoly_t res_den,
 
         if (fmpz_mod_mpoly_is_one(g, ctx))
         {   
-            fmpz_t g_coeff;
-            
-            fmpz_init(g_coeff);
-
             fmpz_mod_mpoly_mul(t, x_num, y_den, ctx);
             fmpz_mod_mpoly_mul(u, y_num, x_den, ctx);
             fmpz_mod_mpoly_add(res_num, t, u, ctx);
             fmpz_mod_mpoly_mul(res_den, x_den, y_den, ctx);
-                        
-            fmpz_mod_set_fmpz(g_coeff,res_den->coeffs,ctx->ffinfo);
-            fmpz_mod_inv(g_coeff, g_coeff, ctx->ffinfo);
-            
-            fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(res_num, res_num, g_coeff, ctx);
-            fmpz_mod_mpoly_make_monic(res_den, res_den, ctx);
-
-            fmpz_clear(g_coeff);
-
         }
         else
         {
             fmpz_mod_mpoly_t a, b;
-            fmpz_t g_coeff;
-            
-            fmpz_init(g_coeff);
-
             fmpz_mod_mpoly_init(a, ctx);
             fmpz_mod_mpoly_init(b, ctx);
 
@@ -195,19 +144,9 @@ _fmpz_mod_mpoly_q_add(fmpz_mod_mpoly_t res_num, fmpz_mod_mpoly_t res_den,
                 fmpz_mod_mpoly_mul(res_den, g, b, ctx);
             }
 
-            fmpz_mod_set_fmpz(g_coeff,res_den->coeffs,ctx->ffinfo);
-            fmpz_mod_inv(g_coeff, g_coeff, ctx->ffinfo);
-            fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(res_num, res_num, g_coeff, ctx);
-            fmpz_mod_mpoly_make_monic(res_den, res_den, ctx);
-
             fmpz_mod_mpoly_clear(a, ctx);
             fmpz_mod_mpoly_clear(b, ctx);
-            fmpz_clear(g_coeff);
         }
-
-        fmpz_mod_mpoly_gcd_assert_successful(g, res_num, res_den, ctx);
-        fmpz_mod_mpoly_divexact(res_num, res_num, g, ctx);
-        fmpz_mod_mpoly_divexact(res_den, res_den, g, ctx);
 
         fmpz_mod_mpoly_clear(t, ctx);
         fmpz_mod_mpoly_clear(u, ctx);
@@ -217,107 +156,37 @@ _fmpz_mod_mpoly_q_add(fmpz_mod_mpoly_t res_num, fmpz_mod_mpoly_t res_den,
 }
 
 void
-_fmpz_mod_mpoly_q_add_fmpq(fmpz_mod_mpoly_t res_num, fmpz_mod_mpoly_t res_den,
+_fmpz_mod_mpoly_q_add_fmpz_mod(fmpz_mod_mpoly_t res_num, fmpz_mod_mpoly_t res_den,
             const fmpz_mod_mpoly_t x_num, const fmpz_mod_mpoly_t x_den,
-            const fmpz_t y_num, const fmpz_t y_den,
+            const fmpz_t y,
             const fmpz_mod_mpoly_ctx_t ctx)
 {
-    fmpz_t yy, yy_num, yy_den;
-
-    fmpz_init(yy);
-    fmpz_init(yy_num);
-    fmpz_init(yy_den);
-    fmpz_mod_set_fmpz(yy_num, y_num, ctx->ffinfo);
-    fmpz_mod_set_fmpz(yy_den, y_den, ctx->ffinfo);
-
-    if (fmpz_is_zero(yy_den))
-    {
-        flint_throw(FLINT_ERROR, "_fmpz_mpoly_q_add_fmpq: division by zero\n");
-    }
-
-    
-    fmpz_mod_inv(yy_den, yy_den, ctx->ffinfo);
-    fmpz_mod_mul(yy, yy_num, yy_den, ctx->ffinfo);
-
     if (fmpz_mod_mpoly_is_zero(x_num, ctx))
     {
-        fmpz_mod_mpoly_set_fmpz(res_num, yy, ctx);
+        fmpz_mod_mpoly_set_fmpz_mod(res_num, y, ctx);
         fmpz_mod_mpoly_one(res_den, ctx);
-        
-        fmpz_clear(yy_num);
-        fmpz_clear(yy_den);
-        fmpz_clear(yy);
-        return;
     }
-
-    if (fmpz_is_zero(yy))
+    else if (fmpz_is_zero(y))
     {
         fmpz_mod_mpoly_set(res_num, x_num, ctx);
         fmpz_mod_mpoly_set(res_den, x_den, ctx);
-
-        if (!fmpz_mod_mpoly_is_one(res_den, ctx))
-        {
-            fmpz_t g;
-            fmpz_mod_mpoly_t t;
-
-            fmpz_init(g);
-            fmpz_mod_mpoly_init(t, ctx);
-
-            fmpz_mod_set_fmpz(g,res_den->coeffs, ctx->ffinfo);
-            fmpz_mod_mpoly_gcd_assert_successful(t, res_num, res_den, ctx);
-
-            fmpz_mod_inv(g, g, ctx->ffinfo);
-            fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(res_num, res_num, g, ctx);
-            fmpz_mod_mpoly_divexact(res_den, res_den, t, ctx);
-
-            fmpz_mod_mpoly_clear(t, ctx);
-            fmpz_clear(g);
-        }
-
-        fmpz_clear(yy_num);
-        fmpz_clear(yy_den);
-        fmpz_clear(yy);
-        return;
     }
-
-    if (fmpz_mod_mpoly_is_one(x_den, ctx))
+    else if (fmpz_mod_mpoly_is_one(x_den, ctx))
     {
-        fmpz_mod_mpoly_add_fmpz(res_num, x_num, yy, ctx);
-        fmpz_mod_mpoly_one(res_den, ctx);
-
-        fmpz_clear(yy_num);
-        fmpz_clear(yy_den);
-        fmpz_clear(yy);
-        return;
+        fmpz_mod_mpoly_add_fmpz_mod(res_num, x_num, y, ctx);
+        fmpz_mod_mpoly_set(res_den, x_den, ctx);
     }
+    else
+    {
+        fmpz_mod_mpoly_t t;
+        fmpz_mod_mpoly_init(t, ctx);
 
-    fmpz_t g;
-    fmpz_mod_mpoly_t t, u;
+        fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(t, x_den, y, ctx);
+        fmpz_mod_mpoly_add(res_num, x_num, t, ctx);
+        fmpz_mod_mpoly_set(res_den, x_den, ctx);
 
-    fmpz_init(g);
-    fmpz_mod_mpoly_init(t, ctx);
-    fmpz_mod_mpoly_init(u, ctx);
-
-    fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(u, x_den, yy, ctx);
-    fmpz_mod_mpoly_add(res_num, x_num, u, ctx);
-    
-    fmpz_mod_mpoly_set(res_den, x_den, ctx);
-
-    fmpz_mod_set_fmpz(g,res_den->coeffs, ctx->ffinfo);
-    fmpz_mod_mpoly_gcd_assert_successful(t, res_num, res_den, ctx);
-
-    fmpz_mod_inv(g, g, ctx->ffinfo);
-    fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(res_num, res_num, g, ctx);
-    fmpz_mod_mpoly_make_monic(res_den, res_den, ctx);
-    fmpz_mod_mpoly_divexact(res_num, res_num, t, ctx);
-    fmpz_mod_mpoly_divexact(res_den, res_den, t, ctx);
-
-    fmpz_clear(g);
-    fmpz_clear(yy);
-    fmpz_clear(yy_num);
-    fmpz_clear(yy_den);
-    fmpz_mod_mpoly_clear(t, ctx);
-    fmpz_mod_mpoly_clear(u, ctx);
+        fmpz_mod_mpoly_clear(t, ctx);
+    }
 }
 
 void
@@ -330,21 +199,49 @@ fmpz_mod_mpoly_q_add(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const f
 }
 
 void
-fmpz_mod_mpoly_q_add_fmpq(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpq_t y, const fmpz_mod_mpoly_ctx_t ctx)
+fmpz_mod_mpoly_q_add_fmpz_mod(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_t y, const fmpz_mod_mpoly_ctx_t ctx)
 {
-    _fmpz_mod_mpoly_q_add_fmpq(fmpz_mod_mpoly_q_numref(res), fmpz_mod_mpoly_q_denref(res),
+    _fmpz_mod_mpoly_q_add_fmpz_mod(fmpz_mod_mpoly_q_numref(res), fmpz_mod_mpoly_q_denref(res),
                 fmpz_mod_mpoly_q_numref(x), fmpz_mod_mpoly_q_denref(x),
-                fmpq_numref(y), fmpq_denref(y),
-                ctx);
+                y, ctx);
 }
 
 void
 fmpz_mod_mpoly_q_add_fmpz(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_t y, const fmpz_mod_mpoly_ctx_t ctx)
 {
-    fmpz_t one;
-    *one = 1;
-    _fmpz_mod_mpoly_q_add_fmpq(fmpz_mod_mpoly_q_numref(res), fmpz_mod_mpoly_q_denref(res),
-                fmpz_mod_mpoly_q_numref(x), fmpz_mod_mpoly_q_denref(x),
-                y, one,
-                ctx);
+    fmpz_t t;
+    fmpz_init(t);
+    fmpz_mod_set_fmpz(t, y, ctx->ffinfo);
+    fmpz_mod_mpoly_q_add_fmpz_mod(res, x, t, ctx);
+    fmpz_clear(t);
 }
+
+int
+fmpz_mod_mpoly_q_add_fmpq(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpq_t y, const fmpz_mod_mpoly_ctx_t ctx)
+{
+    if (fmpz_is_one(fmpq_denref(y)))
+    {
+        fmpz_mod_mpoly_q_add_fmpz(res, x, fmpq_numref(y), ctx);
+        return 1;
+    }
+    else
+    {
+        fmpz_t t;
+        int invertible;
+        fmpz_init(t);
+
+        fmpz_mod_set_fmpz(t, fmpq_denref(y), ctx->ffinfo);
+        invertible = !fmpz_is_zero(t);
+
+        if (invertible)
+        {
+            fmpz_mod_inv(t, t, ctx->ffinfo);
+            fmpz_mod_mul_fmpz(t, t, fmpq_numref(y), ctx->ffinfo);
+            fmpz_mod_mpoly_q_add_fmpz_mod(res, x, t, ctx);
+        }
+
+        fmpz_clear(t);
+        return invertible;
+    }
+}
+

--- a/src/fmpz_mod_mpoly_q/canonicalise.c
+++ b/src/fmpz_mod_mpoly_q/canonicalise.c
@@ -29,12 +29,10 @@ fmpz_mod_mpoly_q_canonicalise(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_ctx_t
     {
         fmpz_t g;
         fmpz_init(g);
-        fmpz_mod_set_fmpz(g, fmpz_mod_mpoly_q_denref(res)->coeffs, ctx->ffinfo);
 
-        fmpz_mod_inv(g, g, ctx->ffinfo);
+        fmpz_mod_inv(g, fmpz_mod_mpoly_q_denref(res)->coeffs, ctx->ffinfo);
         fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(fmpz_mod_mpoly_q_numref(res), fmpz_mod_mpoly_q_numref(res), g, ctx);
         fmpz_mod_mpoly_one(fmpz_mod_mpoly_q_denref(res), ctx);
-        
 
         fmpz_clear(g);
         return;
@@ -43,13 +41,11 @@ fmpz_mod_mpoly_q_canonicalise(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_ctx_t
     {
         fmpz_t g;
         fmpz_init(g);
-        fmpz_mod_set_fmpz(g, fmpz_mod_mpoly_q_denref(res)->coeffs, ctx->ffinfo);
 
-        fmpz_mod_inv(g, g, ctx->ffinfo);
-
+        fmpz_mod_inv(g, fmpz_mod_mpoly_q_denref(res)->coeffs, ctx->ffinfo);
         fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(fmpz_mod_mpoly_q_numref(res), fmpz_mod_mpoly_q_numref(res), g, ctx);
-        fmpz_mod_mpoly_make_monic(fmpz_mod_mpoly_q_denref(res), fmpz_mod_mpoly_q_denref(res), ctx);
-        
+        fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(fmpz_mod_mpoly_q_denref(res), fmpz_mod_mpoly_q_denref(res), g, ctx);
+
         fmpz_clear(g);
         return;
     }
@@ -66,14 +62,15 @@ fmpz_mod_mpoly_q_canonicalise(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_ctx_t
         _fmpz_mod_mpoly_q_mpoly_divexact(fmpz_mod_mpoly_q_numref(res), fmpz_mod_mpoly_q_numref(res), t, ctx);
         _fmpz_mod_mpoly_q_mpoly_divexact(fmpz_mod_mpoly_q_denref(res), fmpz_mod_mpoly_q_denref(res), t, ctx);
 
-        fmpz_mod_set_fmpz(g, fmpz_mod_mpoly_q_denref(res)->coeffs, ctx->ffinfo);
+        if (!fmpz_is_one(fmpz_mod_mpoly_q_denref(res)->coeffs))
+        {
+            fmpz_mod_inv(g, fmpz_mod_mpoly_q_denref(res)->coeffs, ctx->ffinfo);
+            fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(fmpz_mod_mpoly_q_numref(res), fmpz_mod_mpoly_q_numref(res), g, ctx);
+            fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(fmpz_mod_mpoly_q_denref(res), fmpz_mod_mpoly_q_denref(res), g, ctx);
+        }
 
-        fmpz_mod_inv(g, g, ctx->ffinfo);
-
-        fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(fmpz_mod_mpoly_q_numref(res), fmpz_mod_mpoly_q_numref(res), g, ctx);
-        fmpz_mod_mpoly_make_monic(fmpz_mod_mpoly_q_denref(res), fmpz_mod_mpoly_q_denref(res), ctx);
-        
         fmpz_mod_mpoly_clear(t, ctx);
         fmpz_clear(g);
     }
 }
+

--- a/src/fmpz_mod_mpoly_q/inv.c
+++ b/src/fmpz_mod_mpoly_q/inv.c
@@ -21,13 +21,13 @@ fmpz_mod_mpoly_q_inv(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const f
     fmpz_mod_mpoly_swap(fmpz_mod_mpoly_q_numref(res), fmpz_mod_mpoly_q_denref(res), ctx);
 
     if (!fmpz_is_one(fmpz_mod_mpoly_q_denref(res)->coeffs))
-    {   
+    {
         fmpz_t g;
         fmpz_init(g);
 
         fmpz_mod_inv(g, fmpz_mod_mpoly_q_denref(res)->coeffs, ctx->ffinfo);
         fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(fmpz_mod_mpoly_q_numref(res), fmpz_mod_mpoly_q_numref(res), g, ctx);
-        fmpz_mod_mpoly_make_monic(fmpz_mod_mpoly_q_denref(res), fmpz_mod_mpoly_q_denref(res), ctx);
+        fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(fmpz_mod_mpoly_q_denref(res), fmpz_mod_mpoly_q_denref(res), g, ctx);
     
         fmpz_clear(g);
     }

--- a/src/fmpz_mod_mpoly_q/sub.c
+++ b/src/fmpz_mod_mpoly_q/sub.c
@@ -44,95 +44,61 @@ _fmpz_mod_mpoly_q_sub(fmpz_mod_mpoly_t res_num, fmpz_mod_mpoly_t res_den,
         }
         else
         {
-            fmpz_t g;
             fmpz_mod_mpoly_t t;
-
-            fmpz_init(g);
             fmpz_mod_mpoly_init(t, ctx);
 
-            fmpz_mod_set_fmpz(g, x_den->coeffs, ctx->ffinfo);
-            fmpz_mod_inv(g, g, ctx->ffinfo);
-
             fmpz_mod_mpoly_gcd_assert_successful(t, res_num, x_den, ctx);
-            fmpz_mod_mpoly_set(res_den, x_den, ctx);
-            
+
             if (fmpz_mod_mpoly_is_one(t, ctx))
             {
-                fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(res_num, res_num, g, ctx);
-                fmpz_mod_mpoly_make_monic(res_den, res_den, ctx);
-                
-                fmpz_mod_mpoly_clear(t, ctx);
-                fmpz_clear(g);                
-                return;
+                fmpz_mod_mpoly_set(res_den, x_den, ctx);
             }
             else
             {
-                fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(res_num, res_num, g, ctx);
-                fmpz_mod_mpoly_make_monic(res_den, res_den, ctx);
-                fmpz_mod_mpoly_divides(res_num, res_num, t, ctx);
-                fmpz_mod_mpoly_divides(res_den, res_den, t, ctx);
-
-                
-                fmpz_mod_mpoly_clear(t, ctx);
-                fmpz_clear(g);                 
-                return;
+                _fmpz_mod_mpoly_q_mpoly_divexact(res_num, res_num, t, ctx);
+                _fmpz_mod_mpoly_q_mpoly_divexact(res_den, x_den, t, ctx);
             }
+
+            fmpz_mod_mpoly_clear(t, ctx);
+            return;
         }
     }
 
     if (fmpz_mod_mpoly_is_one(x_den, ctx))
     {  
-        fmpz_t g;
-        fmpz_mod_mpoly_t t, u;
-
-        fmpz_init(g);
-        fmpz_mod_mpoly_init(t, ctx);
-        fmpz_mod_mpoly_init(u, ctx);
-
-        fmpz_mod_set_fmpz(g, y_den->coeffs, ctx->ffinfo);
-        fmpz_mod_inv(g, g, ctx->ffinfo);
-        
-        fmpz_mod_mpoly_mul(t, x_num, y_den, ctx);
-        fmpz_mod_mpoly_sub(res_num, t, y_num, ctx);
-
-        fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(res_num, res_num, g, ctx);
-        fmpz_mod_mpoly_make_monic(res_den, y_den, ctx);
-
-        fmpz_mod_mpoly_gcd_assert_successful(u, res_num, res_den, ctx);
-        fmpz_mod_mpoly_divexact(res_num, res_num, u, ctx);
-        fmpz_mod_mpoly_divexact(res_den, res_den, u, ctx);
-
-        fmpz_mod_mpoly_clear(u, ctx);
-        fmpz_mod_mpoly_clear(t, ctx);
-        fmpz_clear(g);
+        if (res_num == y_num)
+        {
+            fmpz_mod_mpoly_t t;
+            fmpz_mod_mpoly_init(t, ctx);
+            fmpz_mod_mpoly_mul(t, x_num, y_den, ctx);
+            fmpz_mod_mpoly_sub(res_num, t, y_num, ctx);
+            fmpz_mod_mpoly_clear(t, ctx);
+        }
+        else
+        {
+            fmpz_mod_mpoly_mul(res_num, x_num, y_den, ctx);
+            fmpz_mod_mpoly_sub(res_num, res_num, y_num, ctx);
+        }
+        fmpz_mod_mpoly_set(res_den, y_den, ctx);
         return;
     }
 
     if (fmpz_mod_mpoly_is_one(y_den, ctx))
     {
-        fmpz_t g;
-        fmpz_mod_mpoly_t t, u;
-
-        fmpz_init(g);
-        fmpz_mod_mpoly_init(t, ctx);
-        fmpz_mod_mpoly_init(u, ctx);
-
-        fmpz_mod_set_fmpz(g, x_den->coeffs, ctx->ffinfo);
-        fmpz_mod_inv(g, g, ctx->ffinfo);
-        
-        fmpz_mod_mpoly_mul(t, y_num, x_den, ctx);
-        fmpz_mod_mpoly_sub(res_num, x_num, t, ctx);
-
-        fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(res_num, res_num, g, ctx);
-        fmpz_mod_mpoly_make_monic(res_den, x_den, ctx);
-
-        fmpz_mod_mpoly_gcd_assert_successful(u, res_num, res_den, ctx);
-        fmpz_mod_mpoly_divexact(res_num, res_num, u, ctx);
-        fmpz_mod_mpoly_divexact(res_den, res_den, u, ctx);
-
-        fmpz_mod_mpoly_clear(u, ctx);
-        fmpz_mod_mpoly_clear(t, ctx);
-        fmpz_clear(g);
+        if (res_num == x_num)
+        {
+            fmpz_mod_mpoly_t t;
+            fmpz_mod_mpoly_init(t, ctx);
+            fmpz_mod_mpoly_mul(t, y_num, x_den, ctx);
+            fmpz_mod_mpoly_sub(res_num, x_num, t, ctx);
+            fmpz_mod_mpoly_clear(t, ctx);
+        }
+        else
+        {
+            fmpz_mod_mpoly_mul(res_num, y_num, x_den, ctx);
+            fmpz_mod_mpoly_sub(res_num, x_num, res_num, ctx);
+        }
+        fmpz_mod_mpoly_set(res_den, x_den, ctx);
         return;
     }
 
@@ -146,30 +112,15 @@ _fmpz_mod_mpoly_q_sub(fmpz_mod_mpoly_t res_num, fmpz_mod_mpoly_t res_den,
         fmpz_mod_mpoly_gcd_assert_successful(g, x_den, y_den, ctx);
 
         if (fmpz_mod_mpoly_is_one(g, ctx))
-        {   fmpz_t g_coeff;
-            
-            fmpz_init(g_coeff);
-
+        {   
             fmpz_mod_mpoly_mul(t, x_num, y_den, ctx);
             fmpz_mod_mpoly_mul(u, y_num, x_den, ctx);
             fmpz_mod_mpoly_sub(res_num, t, u, ctx);
             fmpz_mod_mpoly_mul(res_den, x_den, y_den, ctx);
-                        
-            fmpz_mod_set_fmpz(g_coeff,res_den->coeffs,ctx->ffinfo);
-            fmpz_mod_inv(g_coeff, g_coeff, ctx->ffinfo);
-            fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(res_num, res_num, g_coeff, ctx);
-            fmpz_mod_mpoly_make_monic(res_den, res_den, ctx);
-
-            fmpz_clear(g_coeff);
-
         }
         else
         {
             fmpz_mod_mpoly_t a, b;
-            fmpz_t g_coeff;
-            
-            fmpz_init(g_coeff);
-
             fmpz_mod_mpoly_init(a, ctx);
             fmpz_mod_mpoly_init(b, ctx);
 
@@ -193,129 +144,15 @@ _fmpz_mod_mpoly_q_sub(fmpz_mod_mpoly_t res_num, fmpz_mod_mpoly_t res_den,
                 fmpz_mod_mpoly_mul(res_den, g, b, ctx);
             }
 
-            fmpz_mod_set_fmpz(g_coeff,res_den->coeffs,ctx->ffinfo);
-            fmpz_mod_inv(g_coeff, g_coeff, ctx->ffinfo);
-            fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(res_num, res_num, g_coeff, ctx);
-            fmpz_mod_mpoly_make_monic(res_den, res_den, ctx);
-
             fmpz_mod_mpoly_clear(a, ctx);
             fmpz_mod_mpoly_clear(b, ctx);
-            fmpz_clear(g_coeff);
         }
 
-        fmpz_mod_mpoly_gcd_assert_successful(g, res_num, res_den, ctx);
-        fmpz_mod_mpoly_divexact(res_num, res_num, g, ctx);
-        fmpz_mod_mpoly_divexact(res_den, res_den, g, ctx);
-
-        fmpz_mod_mpoly_init(t, ctx);
-        fmpz_mod_mpoly_init(u, ctx);
+        fmpz_mod_mpoly_clear(t, ctx);
+        fmpz_mod_mpoly_clear(u, ctx);
         fmpz_mod_mpoly_clear(g, ctx);
         return;
     }
-}
-
-void
-_fmpz_mod_mpoly_q_sub_fmpq(fmpz_mod_mpoly_t res_num, fmpz_mod_mpoly_t res_den,
-            const fmpz_mod_mpoly_t x_num, const fmpz_mod_mpoly_t x_den,
-            const fmpz_t y_num, const fmpz_t y_den,
-            const fmpz_mod_mpoly_ctx_t ctx)
-{
-    fmpz_t yy, yy_num, yy_den;
-
-    fmpz_init(yy);
-    fmpz_init(yy_num);
-    fmpz_init(yy_den);
-    fmpz_mod_set_fmpz(yy_num, y_num, ctx->ffinfo);
-    fmpz_mod_set_fmpz(yy_den, y_den, ctx->ffinfo);
-
-    if (fmpz_is_zero(yy_den))
-    {
-        flint_throw(FLINT_ERROR, "_fmpz_mpoly_q_sub_fmpq: division by zero\n");
-    }
-    
-    fmpz_mod_inv(yy_den, yy_den, ctx->ffinfo);
-    fmpz_mod_mul(yy, yy_num, yy_den, ctx->ffinfo);
-
-    if (fmpz_mod_mpoly_is_zero(x_num, ctx))
-    {
-        fmpz_mod_mpoly_set_fmpz(res_num, yy, ctx);
-        fmpz_mod_mpoly_neg(res_num, res_num, ctx);
-        fmpz_mod_mpoly_one(res_den, ctx);
-
-        fmpz_clear(yy);
-        fmpz_clear(yy_num);
-        fmpz_clear(yy_den);
-        return;
-    }
-
-    if (fmpz_is_zero(yy))
-    {
-        fmpz_mod_mpoly_set(res_num, x_num, ctx);
-        fmpz_mod_mpoly_set(res_den, x_den, ctx);
-
-        if (!fmpz_mod_mpoly_is_one(res_den, ctx))
-        {
-            fmpz_t g;
-            fmpz_mod_mpoly_t t;
-
-            fmpz_init(g);
-            fmpz_mod_mpoly_init(t, ctx);
-
-            fmpz_mod_set_fmpz(g,res_den->coeffs, ctx->ffinfo);
-            fmpz_mod_mpoly_gcd_assert_successful(t, res_num, res_den, ctx);
-
-            fmpz_mod_inv(g, g, ctx->ffinfo);
-            fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(res_num, res_num, g, ctx);
-            fmpz_mod_mpoly_divexact(res_den, res_den, t, ctx);
-
-            fmpz_mod_mpoly_clear(t, ctx);
-            fmpz_clear(g);
-        }
-
-        fmpz_clear(yy_num);
-        fmpz_clear(yy_den);
-        fmpz_clear(yy);
-        return;
-    }
-
-    if (fmpz_mod_mpoly_is_one(x_den, ctx))
-    {
-        fmpz_mod_mpoly_sub_fmpz(res_num, x_num, yy, ctx);
-        fmpz_mod_mpoly_one(res_den, ctx);
-
-        fmpz_clear(yy_num);
-        fmpz_clear(yy_den);
-        fmpz_clear(yy);
-        return;
-    }
-
-    fmpz_t g;
-    fmpz_mod_mpoly_t t, u;
-
-    fmpz_init(g);
-    fmpz_mod_mpoly_init(t, ctx);
-    fmpz_mod_mpoly_init(u, ctx);
-
-    fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(t, x_den, yy, ctx);
-    fmpz_mod_mpoly_sub(res_num, x_num, t, ctx);
-    
-    fmpz_mod_mpoly_set(res_den, x_den, ctx);
-
-    fmpz_mod_set_fmpz(g,res_den->coeffs, ctx->ffinfo);
-    fmpz_mod_mpoly_gcd_assert_successful(u, res_num, res_den, ctx);
-
-    fmpz_mod_inv(g, g, ctx->ffinfo);
-    fmpz_mod_mpoly_scalar_mul_fmpz_mod_invertible(res_num, res_num, g, ctx);
-    fmpz_mod_mpoly_make_monic(res_den, res_den, ctx);
-    fmpz_mod_mpoly_divexact(res_num, res_num, u, ctx);
-    fmpz_mod_mpoly_divexact(res_den, res_den, u, ctx);
-
-    fmpz_clear(g);
-    fmpz_clear(yy);
-    fmpz_clear(yy_num);
-    fmpz_clear(yy_den);
-    fmpz_mod_mpoly_clear(t, ctx);
-    fmpz_mod_mpoly_clear(u, ctx);
 }
 
 void
@@ -328,21 +165,60 @@ fmpz_mod_mpoly_q_sub(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const f
 }
 
 void
-fmpz_mod_mpoly_q_sub_fmpq(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpq_t y, const fmpz_mod_mpoly_ctx_t ctx)
+_fmpz_mod_mpoly_q_add_fmpz_mod(fmpz_mod_mpoly_t res_num, fmpz_mod_mpoly_t res_den,
+            const fmpz_mod_mpoly_t x_num, const fmpz_mod_mpoly_t x_den,
+            const fmpz_t y,
+            const fmpz_mod_mpoly_ctx_t ctx);
+
+void
+fmpz_mod_mpoly_q_sub_fmpz_mod(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_t y, const fmpz_mod_mpoly_ctx_t ctx)
 {
-    _fmpz_mod_mpoly_q_sub_fmpq(fmpz_mod_mpoly_q_numref(res), fmpz_mod_mpoly_q_denref(res),
+    fmpz_t t;
+    fmpz_init(t);
+    fmpz_mod_neg(t, y, ctx->ffinfo);
+    _fmpz_mod_mpoly_q_add_fmpz_mod(fmpz_mod_mpoly_q_numref(res), fmpz_mod_mpoly_q_denref(res),
                 fmpz_mod_mpoly_q_numref(x), fmpz_mod_mpoly_q_denref(x),
-                fmpq_numref(y), fmpq_denref(y),
-                ctx);
+                t, ctx);
+    fmpz_clear(t);
 }
 
 void
 fmpz_mod_mpoly_q_sub_fmpz(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpz_t y, const fmpz_mod_mpoly_ctx_t ctx)
 {
-    fmpz_t one;
-    *one = 1;
-    _fmpz_mod_mpoly_q_sub_fmpq(fmpz_mod_mpoly_q_numref(res), fmpz_mod_mpoly_q_denref(res),
-                fmpz_mod_mpoly_q_numref(x), fmpz_mod_mpoly_q_denref(x),
-                y, one,
-                ctx);
+    fmpz_t t;
+    fmpz_init(t);
+    fmpz_mod_set_fmpz(t, y, ctx->ffinfo);
+    fmpz_mod_neg(t, t, ctx->ffinfo);
+    fmpz_mod_mpoly_q_add_fmpz_mod(res, x, t, ctx);
+    fmpz_clear(t);
 }
+
+int
+fmpz_mod_mpoly_q_sub_fmpq(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t x, const fmpq_t y, const fmpz_mod_mpoly_ctx_t ctx)
+{
+    if (fmpz_is_one(fmpq_denref(y)))
+    {
+        fmpz_mod_mpoly_q_sub_fmpz(res, x, fmpq_numref(y), ctx);
+        return 1;
+    }
+    else
+    {
+        fmpz_t t;
+        int invertible;
+        fmpz_init(t);
+
+        fmpz_mod_set_fmpz(t, fmpq_denref(y), ctx->ffinfo);
+        invertible = !fmpz_is_zero(t);
+
+        if (invertible)
+        {
+            fmpz_mod_inv(t, t, ctx->ffinfo);
+            fmpz_mod_mul_fmpz(t, t, fmpq_numref(y), ctx->ffinfo);
+            fmpz_mod_mpoly_q_sub_fmpz_mod(res, x, t, ctx);
+        }
+
+        fmpz_clear(t);
+        return invertible;
+    }
+}
+

--- a/src/fmpz_mod_mpoly_q/test/t-add.c
+++ b/src/fmpz_mod_mpoly_q/test/t-add.c
@@ -17,7 +17,7 @@ TEST_FUNCTION_START(fmpz_mod_mpoly_q_add, state)
 {
     slong iter;
 
-    for (iter = 0; iter < 100000 * 0.1 * flint_test_multiplier(); iter++)
+    for (iter = 0; iter < 10000 * 0.1 * flint_test_multiplier(); iter++)
     {
         fmpz_mod_mpoly_ctx_t ctx;
         fmpz_mod_mpoly_q_t A, B, C, D;
@@ -25,8 +25,7 @@ TEST_FUNCTION_START(fmpz_mod_mpoly_q_add, state)
         fmpz_t m;
 
         fmpz_init(m);
-        fmpz_randtest_unsigned(m, state, 200);
-        fmpz_add_ui(m, m, 2);
+        fmpz_randtest_unsigned(m, state, n_randint(state, 2) ? 4 : n_randint(state, 100));
         fmpz_nextprime(m, m, 0);
         fmpz_mod_mpoly_ctx_init(ctx, 1 + n_randint(state, 4), ORD_LEX, m);
 
@@ -37,8 +36,8 @@ TEST_FUNCTION_START(fmpz_mod_mpoly_q_add, state)
         fmpz_mod_mpoly_init(t, ctx);
         fmpz_mod_mpoly_init(u, ctx);
 
-        fmpz_mod_mpoly_q_randtest(A, state, 5, 5, ctx);
-        fmpz_mod_mpoly_q_randtest(B, state, 5, 5, ctx);
+        fmpz_mod_mpoly_q_randtest(A, state, 4, 4, ctx);
+        fmpz_mod_mpoly_q_randtest(B, state, 4, 4, ctx);
 
         fmpz_mod_mpoly_q_add(C, A, B, ctx);
 

--- a/src/fmpz_mod_mpoly_q/test/t-add_fmpq.c
+++ b/src/fmpz_mod_mpoly_q/test/t-add_fmpq.c
@@ -27,8 +27,7 @@ TEST_FUNCTION_START(fmpz_mod_mpoly_q_add_fmpq, state)
         fmpz_t m;
 
         fmpz_init(m);
-        fmpz_randtest_unsigned(m, state, 200);
-        fmpz_add_ui(m, m, 2);
+        fmpz_randtest_unsigned(m, state, n_randint(state, 2) ? 4 : n_randint(state, 100));
         fmpz_nextprime(m, m, 0);
         fmpz_mod_mpoly_ctx_init(ctx, 1 + n_randint(state, 4), ORD_LEX, m);
 

--- a/src/fmpz_mod_mpoly_q/test/t-add_fmpz.c
+++ b/src/fmpz_mod_mpoly_q/test/t-add_fmpz.c
@@ -25,8 +25,7 @@ TEST_FUNCTION_START(fmpz_mod_mpoly_q_add_fmpz, state)
         fmpz_t m;
 
         fmpz_init(m);
-        fmpz_randtest_unsigned(m, state, 200);
-        fmpz_add_ui(m, m, 2);
+        fmpz_randtest_unsigned(m, state, n_randint(state, 2) ? 4 : n_randint(state, 100));
         fmpz_nextprime(m, m, 0);
         fmpz_mod_mpoly_ctx_init(ctx, 1 + n_randint(state, 4), ORD_LEX, m);
 

--- a/src/fmpz_mod_mpoly_q/test/t-div.c
+++ b/src/fmpz_mod_mpoly_q/test/t-div.c
@@ -25,8 +25,7 @@ TEST_FUNCTION_START(fmpz_mod_mpoly_q_div, state)
         fmpz_t m;
 
         fmpz_init(m);
-        fmpz_randtest_unsigned(m, state, 200);
-        fmpz_add_ui(m, m, 2);
+        fmpz_randtest_unsigned(m, state, n_randint(state, 2) ? 4 : n_randint(state, 100));
         fmpz_nextprime(m, m, 0);
         fmpz_mod_mpoly_ctx_init(ctx, 1 + n_randint(state, 4), ORD_LEX, m);
 
@@ -35,16 +34,16 @@ TEST_FUNCTION_START(fmpz_mod_mpoly_q_div, state)
         fmpz_mod_mpoly_q_init(C, ctx);
         fmpz_mod_mpoly_q_init(D, ctx);
 
-        fmpz_mod_mpoly_q_randtest(A, state, 10,  5, ctx);
+        fmpz_mod_mpoly_q_randtest(A, state, 5,  5, ctx);
         do {
-            fmpz_mod_mpoly_q_randtest(B, state, 10, 5, ctx);
+            fmpz_mod_mpoly_q_randtest(B, state, 5, 5, ctx);
         } while (fmpz_mod_mpoly_q_is_zero(B, ctx));
 
         fmpz_mod_mpoly_q_div(C, A, B, ctx);
 
         fmpz_mod_mpoly_mul(fmpz_mod_mpoly_q_numref(D), fmpz_mod_mpoly_q_numref(A), fmpz_mod_mpoly_q_denref(B), ctx);
         fmpz_mod_mpoly_mul(fmpz_mod_mpoly_q_denref(D), fmpz_mod_mpoly_q_denref(A), fmpz_mod_mpoly_q_numref(B), ctx);
-        
+
         fmpz_mod_mpoly_q_canonicalise(D, ctx);
 
         if (!fmpz_mod_mpoly_q_equal(C, D, ctx))

--- a/src/fmpz_mod_mpoly_q/test/t-div_fmpq.c
+++ b/src/fmpz_mod_mpoly_q/test/t-div_fmpq.c
@@ -25,9 +25,11 @@ TEST_FUNCTION_START(fmpz_mod_mpoly_q_div_fmpq, state)
         fmpz_t m;
 
         fmpz_init(m);
-        fmpz_randtest_unsigned(m, state, 200);
-        fmpz_add_ui(m, m, 2);
+        fmpz_randtest_unsigned(m, state, n_randint(state, 2) ? 4 : n_randint(state, 100));
         fmpz_nextprime(m, m, 0);
+
+        fmpz_set_ui(m, 17);
+
         fmpz_mod_mpoly_ctx_init(ctx, 1 + n_randint(state, 4), ORD_LEX, m);
 
         fmpz_mod_mpoly_q_init(A, ctx);

--- a/src/fmpz_mod_mpoly_q/test/t-div_fmpz.c
+++ b/src/fmpz_mod_mpoly_q/test/t-div_fmpz.c
@@ -25,8 +25,7 @@ TEST_FUNCTION_START(fmpz_mod_mpoly_q_div_fmpz, state)
         fmpz_t m;
 
         fmpz_init(m);
-        fmpz_randtest_unsigned(m, state, 200);
-        fmpz_add_ui(m, m, 2);
+        fmpz_randtest_unsigned(m, state, n_randint(state, 2) ? 4 : n_randint(state, 100));
         fmpz_nextprime(m, m, 0);
         fmpz_mod_mpoly_ctx_init(ctx, 1 + n_randint(state, 4), ORD_LEX, m);
 

--- a/src/fmpz_mod_mpoly_q/test/t-inv.c
+++ b/src/fmpz_mod_mpoly_q/test/t-inv.c
@@ -25,8 +25,7 @@ TEST_FUNCTION_START(fmpz_mod_mpoly_q_inv, state)
         fmpz_t m;
 
         fmpz_init(m);
-        fmpz_randtest_unsigned(m, state, 200);
-        fmpz_add_ui(m, m, 2);
+        fmpz_randtest_unsigned(m, state, n_randint(state, 2) ? 4 : n_randint(state, 100));
         fmpz_nextprime(m, m, 0);
         fmpz_mod_mpoly_ctx_init(ctx, 1 + n_randint(state, 4), ORD_LEX, m);
 

--- a/src/fmpz_mod_mpoly_q/test/t-mul.c
+++ b/src/fmpz_mod_mpoly_q/test/t-mul.c
@@ -25,8 +25,7 @@ TEST_FUNCTION_START(fmpz_mod_mpoly_q_mul, state)
         fmpz_t m;
 
         fmpz_init(m);
-        fmpz_randtest_unsigned(m, state, 200);
-        fmpz_add_ui(m, m, 2);
+        fmpz_randtest_unsigned(m, state, n_randint(state, 2) ? 4 : n_randint(state, 100));
         fmpz_nextprime(m, m, 0);
         fmpz_mod_mpoly_ctx_init(ctx, 1 + n_randint(state, 4), ORD_LEX, m);
 
@@ -35,8 +34,8 @@ TEST_FUNCTION_START(fmpz_mod_mpoly_q_mul, state)
         fmpz_mod_mpoly_q_init(C, ctx);
         fmpz_mod_mpoly_q_init(D, ctx);
 
-        fmpz_mod_mpoly_q_randtest(A, state, 10, 5, ctx);
-        fmpz_mod_mpoly_q_randtest(B, state, 10, 5, ctx);
+        fmpz_mod_mpoly_q_randtest(A, state, 5, 5, ctx);
+        fmpz_mod_mpoly_q_randtest(B, state, 5, 5, ctx);
 
         fmpz_mod_mpoly_q_mul(C, A, B, ctx);
 

--- a/src/fmpz_mod_mpoly_q/test/t-mul_fmpq.c
+++ b/src/fmpz_mod_mpoly_q/test/t-mul_fmpq.c
@@ -26,8 +26,7 @@ TEST_FUNCTION_START(fmpz_mod_mpoly_q_mul_fmpq, state)
         fmpz_t m;
 
         fmpz_init(m);
-        fmpz_randtest_unsigned(m, state, 200);
-        fmpz_add_ui(m, m, 2);
+        fmpz_randtest_unsigned(m, state, n_randint(state, 2) ? 4 : n_randint(state, 100));
         fmpz_nextprime(m, m, 0);
         fmpz_mod_mpoly_ctx_init(ctx, 1 + n_randint(state, 4), ORD_LEX, m);
 

--- a/src/fmpz_mod_mpoly_q/test/t-mul_fmpz.c
+++ b/src/fmpz_mod_mpoly_q/test/t-mul_fmpz.c
@@ -26,8 +26,7 @@ TEST_FUNCTION_START(fmpz_mod_mpoly_q_mul_fmpz, state)
         fmpz_t m;
 
         fmpz_init(m);
-        fmpz_randtest_unsigned(m, state, 200);
-        fmpz_add_ui(m, m, 2);
+        fmpz_randtest_unsigned(m, state, n_randint(state, 2) ? 4 : n_randint(state, 100));
         fmpz_nextprime(m, m, 0);
         fmpz_mod_mpoly_ctx_init(ctx, 1 + n_randint(state, 4), ORD_LEX, m);
 

--- a/src/fmpz_mod_mpoly_q/test/t-randtest.c
+++ b/src/fmpz_mod_mpoly_q/test/t-randtest.c
@@ -25,8 +25,7 @@ TEST_FUNCTION_START(fmpz_mod_mpoly_q_randtest, state)
         fmpz_t m;
 
         fmpz_init(m);
-        fmpz_randtest_unsigned(m, state, 200);
-        fmpz_add_ui(m, m, 2);
+        fmpz_randtest_unsigned(m, state, n_randint(state, 2) ? 4 : n_randint(state, 100));
         fmpz_nextprime(m, m, 0);
         fmpz_mod_mpoly_ctx_init(ctx, 1 + n_randint(state, 4), ORD_LEX, m);
 

--- a/src/fmpz_mod_mpoly_q/test/t-sub.c
+++ b/src/fmpz_mod_mpoly_q/test/t-sub.c
@@ -17,7 +17,7 @@ TEST_FUNCTION_START(fmpz_mod_mpoly_q_sub, state)
 {
     slong iter;
 
-    for (iter = 0; iter < 100000 * 0.1 * flint_test_multiplier(); iter++)
+    for (iter = 0; iter < 10000 * 0.1 * flint_test_multiplier(); iter++)
     {
         fmpz_mod_mpoly_ctx_t ctx;
         fmpz_mod_mpoly_q_t A, B, C, D;
@@ -26,8 +26,7 @@ TEST_FUNCTION_START(fmpz_mod_mpoly_q_sub, state)
         fmpz_t m;
 
         fmpz_init(m);
-        fmpz_randtest_unsigned(m, state, 200);
-        fmpz_add_ui(m, m, 2);
+        fmpz_randtest_unsigned(m, state, n_randint(state, 2) ? 4 : n_randint(state, 100));
         fmpz_nextprime(m, m, 0);
         fmpz_mod_mpoly_ctx_init(ctx, 1 + n_randint(state, 4), ORD_LEX, m);
 
@@ -38,8 +37,8 @@ TEST_FUNCTION_START(fmpz_mod_mpoly_q_sub, state)
         fmpz_mod_mpoly_init(t, ctx);
         fmpz_mod_mpoly_init(u, ctx);
 
-        fmpz_mod_mpoly_q_randtest(A, state, 10, 5, ctx);
-        fmpz_mod_mpoly_q_randtest(B, state, 10, 5, ctx);
+        fmpz_mod_mpoly_q_randtest(A, state, 4, 4, ctx);
+        fmpz_mod_mpoly_q_randtest(B, state, 4, 4, ctx);
 
         fmpz_mod_mpoly_q_sub(C, A, B, ctx);
 

--- a/src/fmpz_mod_mpoly_q/test/t-sub_fmpq.c
+++ b/src/fmpz_mod_mpoly_q/test/t-sub_fmpq.c
@@ -26,8 +26,7 @@ TEST_FUNCTION_START(fmpz_mod_mpoly_q_sub_fmpq, state)
         fmpz_t m;
 
         fmpz_init(m);
-        fmpz_randtest_unsigned(m, state, 200);
-        fmpz_add_ui(m, m, 2);
+        fmpz_randtest_unsigned(m, state, n_randint(state, 2) ? 4 : n_randint(state, 100));
         fmpz_nextprime(m, m, 0);
         fmpz_mod_mpoly_ctx_init(ctx, 1 + n_randint(state, 4), ORD_LEX, m);
 

--- a/src/fmpz_mod_mpoly_q/test/t-sub_fmpz.c
+++ b/src/fmpz_mod_mpoly_q/test/t-sub_fmpz.c
@@ -26,8 +26,7 @@ TEST_FUNCTION_START(fmpz_mod_mpoly_q_sub_fmpz, state)
         fmpz_t m;
 
         fmpz_init(m);
-        fmpz_randtest_unsigned(m, state, 200);
-        fmpz_add_ui(m, m, 2);
+        fmpz_randtest_unsigned(m, state, n_randint(state, 2) ? 4 : n_randint(state, 100));
         fmpz_nextprime(m, m, 0);
         fmpz_mod_mpoly_ctx_init(ctx, 1 + n_randint(state, 4), ORD_LEX, m);
 

--- a/src/gr.h
+++ b/src/gr.h
@@ -1436,7 +1436,7 @@ void gr_ctx_init_fmpz_mpoly_q(gr_ctx_t ctx, slong nvars, const ordering_t ord);
 #endif
 
 #ifdef FMPZ_MOD_MPOLY_Q_H
-void gr_ctx_init_fmpz_mod_mpoly_q(gr_ctx_t ctx, slong nvars, const ordering_t ord, const fmpz *mod);
+void gr_ctx_init_fmpz_mod_mpoly_q(gr_ctx_t ctx, slong nvars, const ordering_t ord, const fmpz_t mod);
 #endif
 
 /* Generic fractions */

--- a/src/gr/fmpz_mod_mpoly_q.c
+++ b/src/gr/fmpz_mod_mpoly_q.c
@@ -29,7 +29,7 @@ _gr_fmpz_mod_mpoly_ctx_t;
 
 int _gr_fmpz_mod_mpoly_q_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Fraction field of multivariate polynomials over finite field ring (fmpz_mod) mod:");
+    gr_stream_write(out, "Fraction field of multivariate polynomials over finite field (fmpz_mod) mod ");
     gr_stream_write_fmpz(out, MPOLYNOMIAL_MCTX(ctx)->ffinfo->n);
     gr_stream_write(out, " in ");
     gr_stream_write_si(out, MPOLYNOMIAL_MCTX(ctx)->minfo->nvars);
@@ -233,8 +233,7 @@ _gr_fmpz_mod_mpoly_q_set_fmpz(fmpz_mod_mpoly_q_t res, const fmpz_t v, gr_ctx_t c
 int
 _gr_fmpz_mod_mpoly_q_set_fmpq(fmpz_mod_mpoly_q_t res, const fmpq_t v, gr_ctx_t ctx)
 {
-    fmpz_mod_mpoly_q_set_fmpq(res, v, MPOLYNOMIAL_MCTX(ctx));
-    return GR_SUCCESS;
+    return fmpz_mod_mpoly_q_set_fmpq(res, v, MPOLYNOMIAL_MCTX(ctx)) ? GR_SUCCESS : GR_DOMAIN;
 }
 
 int
@@ -270,8 +269,7 @@ _gr_fmpz_mod_mpoly_q_add_fmpz(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t p
 int
 _gr_fmpz_mod_mpoly_q_add_fmpq(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t poly1, const fmpq_t c, gr_ctx_t ctx)
 {
-    fmpz_mod_mpoly_q_add_fmpq(res, poly1, c, MPOLYNOMIAL_MCTX(ctx));
-    return GR_SUCCESS;
+    return fmpz_mod_mpoly_q_add_fmpq(res, poly1, c, MPOLYNOMIAL_MCTX(ctx)) ? GR_SUCCESS : GR_DOMAIN;
 }
 
 int
@@ -298,8 +296,7 @@ _gr_fmpz_mod_mpoly_q_sub_fmpz(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t p
 int
 _gr_fmpz_mod_mpoly_q_sub_fmpq(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t poly1, const fmpq_t c, gr_ctx_t ctx)
 {
-    fmpz_mod_mpoly_q_sub_fmpq(res, poly1, c, MPOLYNOMIAL_MCTX(ctx));
-    return GR_SUCCESS;
+    return fmpz_mod_mpoly_q_sub_fmpq(res, poly1, c, MPOLYNOMIAL_MCTX(ctx)) ? GR_SUCCESS : GR_DOMAIN;
 }
 
 int
@@ -326,8 +323,7 @@ _gr_fmpz_mod_mpoly_q_mul_fmpz(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t p
 int
 _gr_fmpz_mod_mpoly_q_mul_fmpq(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t poly1, const fmpq_t c, gr_ctx_t ctx)
 {
-    fmpz_mod_mpoly_q_mul_fmpq(res, poly1, c, MPOLYNOMIAL_MCTX(ctx));
-    return GR_SUCCESS;
+    return fmpz_mod_mpoly_q_mul_fmpq(res, poly1, c, MPOLYNOMIAL_MCTX(ctx)) ? GR_SUCCESS : GR_DOMAIN;
 }
 
 int
@@ -343,31 +339,19 @@ _gr_fmpz_mod_mpoly_q_div(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t poly1,
 int
 _gr_fmpz_mod_mpoly_q_div_si(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t poly1, slong c, gr_ctx_t ctx)
 {
-    if (c == 0)
-        return GR_DOMAIN;
-
-    fmpz_mod_mpoly_q_div_si(res, poly1, c, MPOLYNOMIAL_MCTX(ctx));
-    return GR_SUCCESS;
+    return fmpz_mod_mpoly_q_div_si(res, poly1, c, MPOLYNOMIAL_MCTX(ctx)) ? GR_SUCCESS : GR_DOMAIN;
 }
 
 int
 _gr_fmpz_mod_mpoly_q_div_fmpz(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t poly1, const fmpz_t c, gr_ctx_t ctx)
 {
-    if (fmpz_is_zero(c))
-        return GR_DOMAIN;
-
-    fmpz_mod_mpoly_q_div_fmpz(res, poly1, c, MPOLYNOMIAL_MCTX(ctx));
-    return GR_SUCCESS;
+    return fmpz_mod_mpoly_q_div_fmpz(res, poly1, c, MPOLYNOMIAL_MCTX(ctx)) ? GR_SUCCESS : GR_DOMAIN;
 }
 
 int
 _gr_fmpz_mod_mpoly_q_div_fmpq(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_t poly1, const fmpq_t c, gr_ctx_t ctx)
 {
-    if (fmpq_is_zero(c))
-        return GR_DOMAIN;
-
-    fmpz_mod_mpoly_q_div_fmpq(res, poly1, c, MPOLYNOMIAL_MCTX(ctx));
-    return GR_SUCCESS;
+    return fmpz_mod_mpoly_q_div_fmpq(res, poly1, c, MPOLYNOMIAL_MCTX(ctx)) ? GR_SUCCESS : GR_DOMAIN;
 }
 
 truth_t
@@ -518,7 +502,7 @@ gr_method_tab_input _gr_fmpz_mod_mpoly_q_methods_input[] =
 
 
 void
-gr_ctx_init_fmpz_mod_mpoly_q(gr_ctx_t ctx, slong nvars, const ordering_t ord, const fmpz *mod)
+gr_ctx_init_fmpz_mod_mpoly_q(gr_ctx_t ctx, slong nvars, const ordering_t ord, const fmpz_t mod)
 {
     ctx->which_ring = GR_CTX_FMPZ_MOD_MPOLY_Q;
     ctx->sizeof_elem = sizeof(fmpz_mod_mpoly_q_struct);

--- a/src/gr/test/t-fmpz_mod_mpoly_q.c
+++ b/src/gr/test/t-fmpz_mod_mpoly_q.c
@@ -25,8 +25,7 @@ TEST_FUNCTION_START(gr_fmpz_mod_mpoly_q, state)
         fmpz_t m;
 
         fmpz_init(m);
-        fmpz_randtest_unsigned(m, state, 200);
-        fmpz_add_ui(m, m, 1000000);
+        fmpz_randtest_unsigned(m, state, n_randint(state, 2) ? 4 : 100);
         fmpz_nextprime(m, m, 0);
 
         gr_ctx_init_fmpz_mod_mpoly_q(ZZxy, n_randint(state, 3), mpoly_ordering_randtest(state), m);

--- a/src/nmod_mpoly/gcd.c
+++ b/src/nmod_mpoly/gcd.c
@@ -530,6 +530,7 @@ try_again:
         goto cleanup;
     }
 
+    fq_zech_ctx_clear(medctx);
     fq_zech_ctx_init_ui(medctx, smctx->mod.n, d, "#");
 
     for (j = 0; j < nvars; j++)


### PR DESCRIPTION
Follow up #2327 by @andrii302

* Add arithmetic functions that take an ``fmpz_mod`` as input and simplify handling scalars

* Simplify arithmetic operations and remove some redundant calculations

* Add error handling to functions that divide by an integer

* Improve test code by testing small moduli

* Minor changes to the documentation

* Fix a memory leak in nmod_mpoly_gcd uncovered while valgrinding this module

* Remove meaningless function fmpz_mod_mpoly_q_is_fmpq