### PR TITLE
fix gr_poly_shift_equivalent in char > 0

### DIFF
--- a/src/gr_poly/shift_equivalent.c
+++ b/src/gr_poly/shift_equivalent.c
@@ -26,7 +26,10 @@ gr_poly_shift_equivalent(fmpz_t shift, const gr_poly_t p, const gr_poly_t q,
     int status = GR_SUCCESS;
 
     status |= gr_poly_leading_taylor_shift(elt, p, q, ctx);
+    /* todo: what we actually want here is to lift _shift to ZZ */
     status |= gr_get_fmpz(_shift, elt, ctx);
+    if (status == GR_DOMAIN && gr_ctx_is_finite_characteristic(ctx) != T_FALSE)
+	status = GR_UNABLE;
 
     /* when status == GR_SUCCESS, deg(p) is well-defined */
     if (status == GR_SUCCESS && p->length > 2)

--- a/src/gr_poly/test/t-shift_equivalent.c
+++ b/src/gr_poly/test/t-shift_equivalent.c
@@ -15,7 +15,7 @@
 
 TEST_FUNCTION_START(gr_poly_shift_equivalent, state)
 {
-    for (slong i = 0; i < 1000 * flint_test_multiplier(); i++)
+    for (slong i = 0; i < 20000 * flint_test_multiplier(); i++)
     {
         gr_ctx_t ctx;
         gr_poly_t f, g;


### PR DESCRIPTION
Quick fix for #2345. For a proper fix we would need a way of lifing
elements of nmod rings to integers.
