### PR TITLE
Add asymptotically fast interpolation for gr_poly

### DIFF
--- a/doc/source/gr_poly.rst
+++ b/doc/source/gr_poly.rst
@@ -621,7 +621,7 @@ Multipoint evaluation and interpolation
 
     Set *poly* to the polynomial `(x-x_0) (x-x_1) \cdots (x-x_{n-1})`.
 
-.. function:: int _gr_poly_evaluate_vec_fast_precomp(gr_ptr vs, gr_srcptr poly, slong plen, gr_ptr * tree, slong len, gr_ctx_t ctx)
+.. function:: int _gr_poly_evaluate_vec_fast_precomp(gr_ptr vs, gr_srcptr poly, slong plen, const gr_ptr * tree, slong len, gr_ctx_t ctx)
 
 .. function:: int _gr_poly_evaluate_vec_fast(gr_ptr ys, gr_srcptr poly, slong plen, gr_srcptr xs, slong n, gr_ctx_t ctx)
               int gr_poly_evaluate_vec_fast(gr_vec_t ys, const gr_poly_t poly, const gr_vec_t xs, gr_ctx_t ctx)
@@ -655,6 +655,18 @@ Multipoint evaluation and interpolation
     The *exact* versions presume that the evaluation points are distinct
     and that *f* has coefficients in *R*; they may silently output some
     arbitary polynomial otherwise.
+
+.. function:: int _gr_poly_interpolation_weights(gr_ptr w, const gr_ptr * tree, slong len, gr_ctx_t ctx)
+              int _gr_poly_interpolate_fast_precomp(gr_ptr poly, gr_srcptr ys, const gr_ptr * tree, gr_srcptr weights, slong len, gr_ctx_t ctx)
+              int _gr_poly_interpolate_fast(gr_ptr res, gr_srcptr xs, gr_srcptr ys, slong len, gr_ctx_t ctx)
+              int gr_poly_interpolate_fast(gr_poly_t poly, const gr_vec_t xs, const gr_vec_t ys, gr_ctx_t ctx)
+
+    Fast polynomial interpolation using a subproduct tree. The *precomp*
+    version requires a precomputed subproduct tree generated using
+    :func:`_gr_poly_tree_build` and precomputed interpolation weights
+    generated using :func:`_gr_poly_interpolation_weights`.
+
+    This currently requires a field.
 
 
 Composition

--- a/src/gr_poly.h
+++ b/src/gr_poly.h
@@ -444,7 +444,7 @@ WARN_UNUSED_RESULT int _gr_poly_tree_build(gr_ptr * tree, gr_srcptr roots, slong
 WARN_UNUSED_RESULT int _gr_poly_product_roots(gr_ptr poly, gr_srcptr xs, slong n, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_product_roots(gr_poly_t poly, const gr_vec_t xs, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_evaluate_vec_fast_precomp(gr_ptr vs, gr_srcptr poly, slong plen, gr_ptr * tree, slong len, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int _gr_poly_evaluate_vec_fast_precomp(gr_ptr vs, gr_srcptr poly, slong plen, const gr_ptr * tree, slong len, gr_ctx_t ctx);
 
 WARN_UNUSED_RESULT int _gr_poly_evaluate_vec_fast(gr_ptr ys, gr_srcptr poly, slong plen, gr_srcptr xs, slong n, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_evaluate_vec_fast(gr_vec_t ys, const gr_poly_t poly, const gr_vec_t xs, gr_ctx_t ctx);
@@ -456,6 +456,11 @@ WARN_UNUSED_RESULT int _gr_poly_interpolate_exact_newton(gr_ptr res, gr_srcptr x
 WARN_UNUSED_RESULT int gr_poly_interpolate_exact_newton(gr_poly_t poly, const gr_vec_t xs, const gr_vec_t ys, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int _gr_poly_interpolate_newton(gr_ptr res, gr_srcptr xs, gr_srcptr ys, slong len, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_interpolate_newton(gr_poly_t poly, const gr_vec_t xs, const gr_vec_t ys, gr_ctx_t ctx);
+
+WARN_UNUSED_RESULT int _gr_poly_interpolation_weights(gr_ptr w, const gr_ptr * tree, slong len, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int _gr_poly_interpolate_fast_precomp(gr_ptr poly, gr_srcptr ys, const gr_ptr * tree, gr_srcptr weights, slong len, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int _gr_poly_interpolate_fast(gr_ptr res, gr_srcptr xs, gr_srcptr ys, slong len, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_poly_interpolate_fast(gr_poly_t poly, const gr_vec_t xs, const gr_vec_t ys, gr_ctx_t ctx);
 
 WARN_UNUSED_RESULT int _gr_poly_interpolate_exact(gr_ptr res, gr_srcptr xs, gr_srcptr ys, slong len, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_interpolate_exact(gr_poly_t poly, const gr_vec_t xs, const gr_vec_t ys, gr_ctx_t ctx);

--- a/src/gr_poly/evaluate_vec_fast.c
+++ b/src/gr_poly/evaluate_vec_fast.c
@@ -162,7 +162,7 @@ _gr_poly_rem_2(gr_ptr q, gr_ptr r, gr_srcptr a, slong al,
 
 int
 _gr_poly_evaluate_vec_fast_precomp(gr_ptr vs, gr_srcptr poly,
-    slong plen, gr_ptr * tree, slong len, gr_ctx_t ctx)
+    slong plen, const gr_ptr * tree, slong len, gr_ctx_t ctx)
 {
     slong height, i, j, pow, left;
     slong tree_height;

--- a/src/gr_poly/interpolate_fast.c
+++ b/src/gr_poly/interpolate_fast.c
@@ -1,0 +1,138 @@
+/*
+    Copyright (C) 2012 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "longlong.h"
+#include "gr_vec.h"
+#include "gr_poly.h"
+
+/* todo */
+#define _gr_poly_mul_monic _gr_poly_mul
+
+int
+_gr_poly_interpolation_weights(gr_ptr w,
+    const gr_ptr * tree, slong len, gr_ctx_t ctx)
+{
+    gr_ptr tmp;
+    slong i, n, height;
+    int status = GR_SUCCESS;
+    slong sz = ctx->sizeof_elem;
+
+    if (len == 0)
+        return status;
+
+    if (len == 1)
+        return gr_one(w, ctx);
+
+    GR_TMP_INIT_VEC(tmp, len + 1, ctx);
+    height = FLINT_CLOG2(len);
+    n = WORD(1) << (height - 1);
+
+    status |= _gr_poly_mul_monic(tmp, tree[height-1], n + 1,
+                        GR_ENTRY(tree[height-1], (n + 1), sz), (len - n + 1), ctx);
+
+    status |= _gr_poly_derivative(tmp, tmp, len + 1, ctx);
+    status |= _gr_poly_evaluate_vec_fast_precomp(w, tmp, len, tree, len, ctx);
+
+    for (i = 0; i < len; i++)
+        status |= gr_inv(GR_ENTRY(w, i, sz), GR_ENTRY(w, i, sz), ctx);
+
+    GR_TMP_CLEAR_VEC(tmp, len + 1, ctx);
+
+    return status;
+}
+
+int
+_gr_poly_interpolate_fast_precomp(gr_ptr poly,
+    gr_srcptr ys, const gr_ptr * tree, gr_srcptr weights,
+    slong len, gr_ctx_t ctx)
+{
+    gr_ptr t, u, pa, pb;
+    slong i, pow, left;
+    int status = GR_SUCCESS;
+    slong sz = ctx->sizeof_elem;
+
+    if (len == 0)
+        return status;
+
+    GR_TMP_INIT_VEC(t, 2 * len, ctx);
+    u = GR_ENTRY(t, len, sz);
+
+    status |= _gr_vec_mul(poly, weights, ys, len, ctx);
+
+    for (i = 0; i < FLINT_CLOG2(len); i++)
+    {
+        pow = (WORD(1) << i);
+        pa = tree[i];
+        pb = poly;
+        left = len;
+
+        while (left >= 2 * pow)
+        {
+            status |= _gr_poly_mul(t, pa, pow + 1, GR_ENTRY(pb, pow, sz), pow, ctx);
+            status |= _gr_poly_mul(u, GR_ENTRY(pa, pow + 1, sz), pow + 1, pb, pow, ctx);
+            status |= _gr_vec_add(pb, t, u, 2 * pow, ctx);
+
+            left -= 2 * pow;
+            pa = GR_ENTRY(pa, 2 * pow + 2, sz);
+            pb = GR_ENTRY(pb, 2 * pow, sz);
+        }
+
+        if (left > pow)
+        {
+            status |= _gr_poly_mul(t, pa, pow + 1, GR_ENTRY(pb, pow, sz), left - pow, ctx);
+            status |= _gr_poly_mul(u, pb, pow, GR_ENTRY(pa, pow + 1, sz), left - pow + 1, ctx);
+            status |= _gr_vec_add(pb, t, u, left, ctx);
+        }
+    }
+
+    GR_TMP_CLEAR_VEC(t, 2 * len, ctx);
+
+    return status;
+}
+
+int
+_gr_poly_interpolate_fast(gr_ptr poly,
+    gr_srcptr xs, gr_srcptr ys, slong len, gr_ctx_t ctx)
+{
+    gr_ptr * tree;
+    gr_ptr w;
+    int status = GR_SUCCESS;
+
+    tree = _gr_poly_tree_alloc(len, ctx);
+
+    GR_TMP_INIT_VEC(w, len, ctx);
+
+    status |= _gr_poly_tree_build(tree, xs, len, ctx);
+    status |= _gr_poly_interpolation_weights(w, tree, len, ctx);
+    status |= _gr_poly_interpolate_fast_precomp(poly, ys, tree, w, len, ctx);
+
+    GR_TMP_CLEAR_VEC(w, len, ctx);
+    _gr_poly_tree_free(tree, len, ctx);
+
+    return status;
+}
+
+int
+gr_poly_interpolate_fast(gr_poly_t poly, const gr_vec_t xs, const gr_vec_t ys, gr_ctx_t ctx)
+{
+    int status;
+    slong n = xs->length;
+
+    if (n != ys->length)
+        return GR_DOMAIN;
+
+    gr_poly_fit_length(poly, n, ctx);
+    status = _gr_poly_interpolate_fast(poly->coeffs, xs->entries, ys->entries, n, ctx);
+    _gr_poly_set_length(poly, n, ctx);
+    _gr_poly_normalise(poly, ctx);
+    return status;
+}
+

--- a/src/gr_poly/test/main.c
+++ b/src/gr_poly/test/main.c
@@ -48,6 +48,7 @@
 #include "t-hgcd.c"
 #include "t-integral.c"
 #include "t-interpolate.c"
+#include "t-interpolate_fast.c"
 #include "t-interpolate_newton.c"
 #include "t-inv_series.c"
 #include "t-leading_taylor_shift.c"
@@ -128,6 +129,7 @@ test_struct tests[] =
     TEST_FUNCTION(gr_poly_hgcd),
     TEST_FUNCTION(gr_poly_integral),
     TEST_FUNCTION(gr_poly_interpolate),
+    TEST_FUNCTION(gr_poly_interpolate_fast),
     TEST_FUNCTION(gr_poly_interpolate_newton),
     TEST_FUNCTION(gr_poly_inv_series),
     TEST_FUNCTION(gr_poly_leading_taylor_shift),

--- a/src/gr_poly/test/t-interpolate_fast.c
+++ b/src/gr_poly/test/t-interpolate_fast.c
@@ -1,0 +1,110 @@
+/*
+    Copyright (C) 2025 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "ulong_extras.h"
+#include "gr_vec.h"
+#include "gr_poly.h"
+
+FLINT_DLL extern gr_static_method_table _ca_methods;
+
+TEST_FUNCTION_START(gr_poly_interpolate_fast, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 10 * flint_test_multiplier(); iter++)
+    {
+        int status = GR_SUCCESS;
+        gr_ctx_t ctx;
+        gr_vec_t X, Y, Z;
+        gr_poly_t F, G, H;
+        slong N, n;
+
+        gr_ctx_init_random(ctx, state);
+        while (gr_ctx_is_integral_domain(ctx) != T_TRUE || ctx->methods == _ca_methods)
+        {
+            gr_ctx_clear(ctx);
+            gr_ctx_init_random(ctx, state);
+        }
+
+        gr_poly_init(F, ctx);
+        gr_poly_init(G, ctx);
+        gr_poly_init(H, ctx);
+
+        if (gr_ctx_is_finite(ctx) == T_TRUE)
+            N = 20;
+        else
+            N = 6;
+
+        status |= gr_poly_randtest(F, state, n_randint(state, N), ctx);
+        status |= gr_poly_randtest(G, state, n_randint(state, N), ctx);
+        status |= gr_poly_randtest(H, state, n_randint(state, N), ctx);
+
+        n = F->length + n_randint(state, 3);
+
+        gr_vec_init(X, n, ctx);
+        gr_vec_init(Y, n, ctx);
+        gr_vec_init(Z, n, ctx);
+
+        /* Test recovering random polynomial */
+        status |= _gr_vec_randtest(X->entries, state, n, ctx);
+        status |= gr_poly_evaluate_vec_iter(Y, F, X, ctx);
+
+        status |= gr_poly_interpolate_fast(G, X, Y, ctx);
+
+        if (status == GR_SUCCESS)
+        {
+            if (gr_poly_equal(F, G, ctx) == T_FALSE)
+            {
+                flint_printf("FAIL\n\n");
+                gr_ctx_println(ctx);
+                flint_printf("X = "); gr_vec_print(X, ctx); flint_printf("\n");
+                flint_printf("F = "); gr_poly_print(F, ctx); flint_printf("\n");
+                flint_printf("Y = "); gr_vec_print(Y, ctx); flint_printf("\n");
+                flint_printf("G = "); gr_poly_print(G, ctx); flint_printf("\n");
+                flint_abort();
+            }
+        }
+
+        /* Test interpolation from random points */
+        status |= _gr_vec_randtest(X->entries, state, n, ctx);
+        status |= _gr_vec_randtest(Y->entries, state, n, ctx);
+
+        status |= gr_poly_interpolate_fast(G, X, Y, ctx);
+
+        if (status == GR_SUCCESS)
+        {
+            status |= gr_poly_evaluate_vec_iter(Z, G, X, ctx);
+
+            if (status == GR_SUCCESS && _gr_vec_equal(Z->entries, Y->entries, Y->length, ctx) == T_FALSE)
+            {
+                flint_printf("FAIL\n\n");
+                gr_ctx_println(ctx);
+                flint_printf("X = "); gr_vec_print(X, ctx); flint_printf("\n");
+                flint_printf("Y = "); gr_vec_print(Y, ctx); flint_printf("\n");
+                flint_printf("G = "); gr_poly_print(F, ctx); flint_printf("\n");
+                flint_printf("Z = "); gr_vec_print(Z, ctx); flint_printf("\n");
+                flint_abort();
+            }
+        }
+
+        gr_poly_clear(F, ctx);
+        gr_poly_clear(G, ctx);
+        gr_poly_clear(H, ctx);
+        gr_vec_clear(X, ctx);
+        gr_vec_clear(Y, ctx);
+        gr_vec_clear(Z, ctx);
+
+        gr_ctx_clear(ctx);
+    }
+
+    TEST_FUNCTION_END(state);
+}


### PR DESCRIPTION
Add ``gr_poly_interpolate_fast`` plus the ``precomp`` underscore version.

Currently not used in ``gr_poly_interpolate`` because this algorithm will not be appropriate for all rings.