### PR TITLE
Try to improve test coverage for nmod_mpoly_gcd

### DIFF
--- a/src/nmod_mpoly/gcd.c
+++ b/src/nmod_mpoly/gcd.c
@@ -457,6 +457,10 @@ cleanup:
     return;
 }
 
+/* With this value, _set_estimates_medprime almost always succeeds.
+   Hack: allow changing this parameter to a small value from the test code
+   to verify what happens when it fails. */
+FLINT_DLL slong _nmod_mpoly_medprime_ignore_limit = WORD(9999);
 
 /* call to improve on the (valid) results of smprime */
 static void _set_estimates_medprime(
@@ -501,7 +505,7 @@ static void _set_estimates_medprime(
     fq_zech_poly_init(Geval, medctx);
 
     ignore_limit = (A->length + B->length)/4096;
-    ignore_limit = FLINT_MAX(WORD(9999), ignore_limit);
+    ignore_limit = FLINT_MAX(_nmod_mpoly_medprime_ignore_limit, ignore_limit);
     I->Gdeflate_deg_bounds_are_nice = 1;
     for (j = 0; j < nvars; j++)
     {

--- a/src/nmod_mpoly/test/t-gcd.c
+++ b/src/nmod_mpoly/test/t-gcd.c
@@ -15,6 +15,11 @@
 #include "mpoly.h"
 #include "nmod_mpoly.h"
 
+/* Hack: internal parameter of nmod_mpoly_gcd that we randomly change
+   to trigger unlikely code paths which are currently unreachable
+   from the test code. */
+FLINT_DLL extern slong _nmod_mpoly_medprime_ignore_limit;
+
 /* Defined in t-gcd.c, t-gcd_brown.c, t-gcd_cofactors.c, t-gcd_hensel.c,
  * t-gcd_zippel2.c and t-gcd_zippel.c */
 #define gcd_check gcd_check_gcd
@@ -32,6 +37,11 @@ void gcd_check(
     nmod_mpoly_init(ca, ctx);
     nmod_mpoly_init(cb, ctx);
     nmod_mpoly_init(cg, ctx);
+
+    if ((i + j) % 2)
+        _nmod_mpoly_medprime_ignore_limit = 8;
+    else
+        _nmod_mpoly_medprime_ignore_limit = 9999;
 
     if (!nmod_mpoly_gcd(g, a, b, ctx))
     {

--- a/src/nmod_mpoly/test/t-gcd_brown.c
+++ b/src/nmod_mpoly/test/t-gcd_brown.c
@@ -235,6 +235,58 @@ TEST_FUNCTION_START(nmod_mpoly_gcd_brown, state)
         nmod_mpoly_ctx_clear(ctx);
     }
 
+    for (i = 0; i < 1 * flint_test_multiplier(); i++)
+    {
+        nmod_mpoly_ctx_t ctx;
+        nmod_mpoly_t a, b, g, t;
+        slong len, len1, len2;
+        slong n, degbound;
+        ulong p;
+
+        p = n_randint(state, FLINT_BITS - 1) + 1;
+        p = n_randbits(state, p);
+        p = n_nextprime(p, 1);
+
+        flint_set_num_threads(2 + n_randint(state, max_threads - 1));
+
+        nmod_mpoly_ctx_init_rand(ctx, state, p < 3000 ? 3 : 4, p);
+
+        nmod_mpoly_init(g, ctx);
+        nmod_mpoly_init(a, ctx);
+        nmod_mpoly_init(b, ctx);
+        nmod_mpoly_init(t, ctx);
+
+        len = n_randint(state, 100) + 1;
+        len1 = n_randint(state, 200);
+        len2 = n_randint(state, 200);
+
+        n = FLINT_MAX(WORD(1), ctx->minfo->nvars);
+        degbound = 1 + 120/n/n;
+
+        for (j = 0; j < 3; j++)
+        {
+            nmod_mpoly_randtest_bound(t, state, len, degbound, ctx);
+            if (nmod_mpoly_is_zero(t, ctx))
+                nmod_mpoly_one(t, ctx);
+            nmod_mpoly_randtest_bound(a, state, len1, degbound, ctx);
+            nmod_mpoly_randtest_bound(b, state, len2, degbound, ctx);
+            nmod_mpoly_mul(a, a, t, ctx);
+            nmod_mpoly_mul(b, b, t, ctx);
+            nmod_mpoly_randtest_bits(g, state, len, FLINT_BITS, ctx);
+
+            gcd_check(g, a, b, t, ctx, i, j, "random dense 2");
+        }
+
+        flint_set_num_threads(1);
+
+        nmod_mpoly_clear(g, ctx);
+        nmod_mpoly_clear(a, ctx);
+        nmod_mpoly_clear(b, ctx);
+        nmod_mpoly_clear(t, ctx);
+        nmod_mpoly_ctx_clear(ctx);
+    }
+
+
     TEST_FUNCTION_END(state);
 }
 #undef gcd_check


### PR DESCRIPTION
I'm unable to come up with input requiring use of ``_set_estimates_lgprime``, so put in a hack to activate it from the test code. It would be better to refactor ``gcd_algo`` to make it easier to test the different code paths more directly, but I'm not up for doing that right now.

Also test ``gcd_brown`` with some larger input so that we hit the threaded branch.