### PR TITLE
Make bivariate version of gcd_zippel reachable

### DIFF
--- a/src/fq_nmod_mpoly/gcd.c
+++ b/src/fq_nmod_mpoly/gcd.c
@@ -1638,7 +1638,25 @@ skip_monomial_cofactors:
             goto successful;
     }
 
-    if (I->mvars < 3)
+    if (algo == MPOLY_GCD_USE_HENSEL)
+    {
+        mpoly_gcd_info_measure_hensel(I, A->length, B->length, ctx->minfo);
+        success = _try_hensel(G, Abar, Bbar, A, B, I, ctx);
+        goto cleanup;
+    }
+    else if (algo == MPOLY_GCD_USE_BROWN)
+    {
+        mpoly_gcd_info_measure_brown(I, A->length, B->length, ctx->minfo);
+        success = _try_brown(G, Abar, Bbar, A, B, I, ctx);
+        goto cleanup;
+    }
+    else if (algo == MPOLY_GCD_USE_ZIPPEL)
+    {
+        mpoly_gcd_info_measure_zippel(I, A->length, B->length, ctx->minfo);
+        success = _try_zippel(G, Abar, Bbar, A, B, I, ctx);
+        goto cleanup;
+    }
+    else if (I->mvars < 3)
     {
         mpoly_gcd_info_measure_brown(I, A->length, B->length, ctx->minfo);
         mpoly_gcd_info_measure_hensel(I, A->length, B->length, ctx->minfo);
@@ -1667,24 +1685,6 @@ skip_monomial_cofactors:
             }
         }
 
-        goto cleanup;
-    }
-    else if (algo == MPOLY_GCD_USE_HENSEL)
-    {
-        mpoly_gcd_info_measure_hensel(I, A->length, B->length, ctx->minfo);
-        success = _try_hensel(G, Abar, Bbar, A, B, I, ctx);
-        goto cleanup;
-    }
-    else if (algo == MPOLY_GCD_USE_BROWN)
-    {
-        mpoly_gcd_info_measure_brown(I, A->length, B->length, ctx->minfo);
-        success = _try_brown(G, Abar, Bbar, A, B, I, ctx);
-        goto cleanup;
-    }
-    else if (algo == MPOLY_GCD_USE_ZIPPEL)
-    {
-        mpoly_gcd_info_measure_zippel(I, A->length, B->length, ctx->minfo);
-        success = _try_zippel(G, Abar, Bbar, A, B, I, ctx);
         goto cleanup;
     }
     else if (algo == MPOLY_GCD_USE_ZIPPEL2)

--- a/src/nmod_mpoly/gcd.c
+++ b/src/nmod_mpoly/gcd.c
@@ -1915,7 +1915,25 @@ skip_monomial_cofactors:
             goto successful;
     }
 
-    if (I->mvars < 3)
+    if (algo == MPOLY_GCD_USE_HENSEL)
+    {
+        mpoly_gcd_info_measure_hensel(I, A->length, B->length, ctx->minfo);
+        success = _try_hensel(G, Abar, Bbar, A, B, I, ctx);
+        goto cleanup;
+    }
+    else if (algo == MPOLY_GCD_USE_BROWN)
+    {
+        mpoly_gcd_info_measure_brown(I, A->length, B->length, ctx->minfo);
+        success = _try_brown(G, Abar, Bbar, A, B, I, ctx);
+        goto cleanup;
+    }
+    else if (algo == MPOLY_GCD_USE_ZIPPEL)
+    {
+        mpoly_gcd_info_measure_zippel(I, A->length, B->length, ctx->minfo);
+        success = _try_zippel(G, Abar, Bbar, A, B, I, ctx);
+        goto cleanup;
+    }
+    else if (I->mvars < 3)
     {
         mpoly_gcd_info_measure_brown(I, A->length, B->length, ctx->minfo);
         mpoly_gcd_info_measure_hensel(I, A->length, B->length, ctx->minfo);
@@ -1948,24 +1966,6 @@ skip_monomial_cofactors:
             }
         }
 
-        goto cleanup;
-    }
-    else if (algo == MPOLY_GCD_USE_HENSEL)
-    {
-        mpoly_gcd_info_measure_hensel(I, A->length, B->length, ctx->minfo);
-        success = _try_hensel(G, Abar, Bbar, A, B, I, ctx);
-        goto cleanup;
-    }
-    else if (algo == MPOLY_GCD_USE_BROWN)
-    {
-        mpoly_gcd_info_measure_brown(I, A->length, B->length, ctx->minfo);
-        success = _try_brown(G, Abar, Bbar, A, B, I, ctx);
-        goto cleanup;
-    }
-    else if (algo == MPOLY_GCD_USE_ZIPPEL)
-    {
-        mpoly_gcd_info_measure_zippel(I, A->length, B->length, ctx->minfo);
-        success = _try_zippel(G, Abar, Bbar, A, B, I, ctx);
         goto cleanup;
     }
     else if (algo == MPOLY_GCD_USE_ZIPPEL2)


### PR DESCRIPTION
``nmod_mpoly_gcd_zippel`` has a special case for bivariates. However, this is never actually reached, because a different special case for bivariates is chosen first when going through ``gcd_algo``. We move this branch down so that the bivariate code in ``nmod_mpoly_gcd_zippel`` becomes testable. This should just change the behavior when one calls ``nmod_mpoly_gcd_zippel`` directly; it should not affect the main ``nmod_mpoly_gcd`` function.

Ditto for ``fq_nmod_mpoly_gcd_zippel``.
