### PR TITLE
Faster _fmpz_vec_scalar_divexact_ui

### DIFF
--- a/src/fmpz_mpoly/test/t-scalar_divexact_fmpz.c
+++ b/src/fmpz_mpoly/test/t-scalar_divexact_fmpz.c
@@ -92,7 +92,7 @@ TEST_FUNCTION_START(fmpz_mpoly_scalar_divexact_fmpz, state)
           fmpz_mpoly_randtest_bits(f, state, len, coeff_bits, exp_bits, ctx);
           fmpz_mpoly_randtest_bits(h, state, len, coeff_bits, exp_bits, ctx);
 
-          fmpz_randtest_not_zero(c, state, n_randint(state, 200));
+          fmpz_randtest_not_zero(c, state, n_randint(state, 200) + 1);
 
           fmpz_mpoly_scalar_mul_fmpz(f, f, c, ctx);
 

--- a/src/fmpz_mpoly/test/t-scalar_divexact_fmpz.c
+++ b/src/fmpz_mpoly/test/t-scalar_divexact_fmpz.c
@@ -92,7 +92,7 @@ TEST_FUNCTION_START(fmpz_mpoly_scalar_divexact_fmpz, state)
           fmpz_mpoly_randtest_bits(f, state, len, coeff_bits, exp_bits, ctx);
           fmpz_mpoly_randtest_bits(h, state, len, coeff_bits, exp_bits, ctx);
 
-          fmpz_randtest(c, state, n_randint(state, 200));
+          fmpz_randtest_not_zero(c, state, n_randint(state, 200));
 
           fmpz_mpoly_scalar_mul_fmpz(f, f, c, ctx);
 

--- a/src/fmpz_vec/profile/p-divexact_ui.c
+++ b/src/fmpz_vec/profile/p-divexact_ui.c
@@ -1,0 +1,60 @@
+#include "ulong_extras.h"
+#include "fmpz.h"
+#include "fmpz_vec.h"
+#include "profiler.h"
+
+void
+_fmpz_vec_scalar_divexact_ui_naive(fmpz * vec1, const fmpz * vec2,
+                               slong len2, ulong c)
+{
+    slong i;
+    for (i = 0; i < len2; i++)
+        fmpz_divexact_ui(vec1 + i, vec2 + i, c);
+}
+
+int main()
+{
+    slong len, bits;
+
+    flint_rand_t state;
+    flint_rand_init(state);
+
+    fmpz *A, *Ac, *B;
+    ulong c;
+
+    double t1, t2, FLINT_SET_BUT_UNUSED(__);
+
+    flint_printf("   len    bits(A*c)  bits(c)      old       new    speedup\n");
+
+    for (len = 1; len <= 10; len++)
+    {
+        for (bits = 5; bits <= 10000; bits *= 2)
+        {
+            A = _fmpz_vec_init(len);
+            Ac = _fmpz_vec_init(len);
+            B = _fmpz_vec_init(len);
+
+            _fmpz_vec_randtest(A, state, len, bits);
+            c = n_randtest_not_zero(state);
+            _fmpz_vec_scalar_mul_ui(Ac, A, len, c);
+
+            TIMEIT_START
+            _fmpz_vec_scalar_divexact_ui_naive(B, Ac, len, c);
+            TIMEIT_STOP_VALUES(__, t1)
+            TIMEIT_START
+            _fmpz_vec_scalar_divexact_ui(B, Ac, len, c);
+            TIMEIT_STOP_VALUES(__, t2)
+
+            flint_printf("%6wd    %6wd   %6wd    %8g   %8g   %.3f\n",
+                    len, _fmpz_vec_max_bits(Ac, len), FLINT_BIT_COUNT(c),
+                    t1, t2, t1 / t2);
+
+            _fmpz_vec_clear(A, len);
+            _fmpz_vec_clear(Ac, len);
+            _fmpz_vec_clear(B, len);
+        }
+    }
+
+    flint_rand_clear(state);
+}
+

--- a/src/fmpz_vec/scalar.c
+++ b/src/fmpz_vec/scalar.c
@@ -127,46 +127,6 @@ _fmpz_vec_scalar_addmul_ui(fmpz * vec1, const fmpz * vec2, slong len2, ulong c)
 }
 
 void
-_fmpz_vec_scalar_divexact_fmpz(fmpz * vec1, const fmpz * vec2,
-                               slong len2, const fmpz_t x)
-{
-    fmpz c = *x;
-
-    if (!COEFF_IS_MPZ(c))
-    {
-        if (c == 1)
-            _fmpz_vec_set(vec1, vec2, len2);
-        else if (c == -1)
-            _fmpz_vec_neg(vec1, vec2, len2);
-        else
-            _fmpz_vec_scalar_divexact_si(vec1, vec2, len2, c);
-    }
-    else
-    {
-        slong i;
-        for (i = 0; i < len2; i++)
-            fmpz_divexact(vec1 + i, vec2 + i, x);
-    }
-}
-
-void
-_fmpz_vec_scalar_divexact_si(fmpz * vec1, const fmpz * vec2, slong len2, slong c)
-{
-    slong i;
-    for (i = 0; i < len2; i++)
-        fmpz_divexact_si(vec1 + i, vec2 + i, c);
-}
-
-void
-_fmpz_vec_scalar_divexact_ui(fmpz * vec1, const fmpz * vec2,
-                             slong len2, ulong c)
-{
-    slong i;
-    for (i = 0; i < len2; i++)
-        fmpz_divexact_ui(vec1 + i, vec2 + i, c);
-}
-
-void
 _fmpz_vec_scalar_fdiv_q_2exp(fmpz * vec1, const fmpz * vec2, slong len2,
                              ulong exp)
 {
@@ -209,6 +169,8 @@ _fmpz_vec_scalar_fdiv_r_2exp(fmpz * vec1, const fmpz * vec2, slong len2,
         fmpz_fdiv_r_2exp(vec1 + i, vec2 + i, exp);
 }
 
+/* todo: preinvert p when appropriate; or better, make sure we don't
+   call this function in places where we have an fmpz_mod */
 void _fmpz_vec_scalar_mod_fmpz(fmpz *res, const fmpz *vec, slong len, const fmpz_t p)
 {
     slong i;
@@ -267,6 +229,7 @@ _fmpz_vec_scalar_mul_ui(fmpz * vec1, const fmpz * vec2, slong len2, ulong c)
         fmpz_mul_ui(vec1 + i, vec2 + i, c);
 }
 
+/* todo: preinvert p when appropriate */
 void _fmpz_vec_scalar_smod_fmpz(fmpz *res, const fmpz *vec, slong len, const fmpz_t p)
 {
     slong i;

--- a/src/fmpz_vec/scalar_divexact.c
+++ b/src/fmpz_vec/scalar_divexact.c
@@ -1,0 +1,404 @@
+/*
+    Copyright 2000-2003, 2005, 2013 Free Software Foundation, Inc.
+    Copyright 1991-2018, 2021, 2022 Free Software Foundation, Inc.
+    Copyright (C) 2025 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+/* This file includes code adapted from GMP (gmp-impl.h, mpn/generic/dive_1.c). */
+
+#include <gmp.h>
+#include "longlong.h"
+#include "fmpz.h"
+#include "fmpz_vec.h"
+
+/* Helper functions that could go in longlong.h, ulong_extras.h
+   and mpn_extras.h as soon as they find a use elsewhere. */
+
+/* The table is slightly faster but requires GMP internals. */
+#define USE BINVERT_TABLE 0
+
+/* Tuned for Zen 3; with assembly code we would not need GMP. */
+#define DIVEXACT_1_ODD_GMP_CUTOFF 35
+#define DIVEXACT_1_EVEN_GMP_CUTOFF 25
+
+#if USE_BINVERT_TABLE
+extern const unsigned char  __gmp_binvert_limb_table[128];
+#endif
+
+/* Invert n mod 2^FLINT_BITS */
+static ulong n_binvert(ulong n)
+{
+    ulong r;
+
+    FLINT_ASSERT(n % 2);
+
+#if USE_BINVERT_TABLE
+    r = __gmp_binvert_limb_table[(n / 2) & 0x7F];
+#else
+    r = (((n + 2) & 4) << 1) ^ n;   /* 4 bits */
+    r = 2 * r - r * r * n;          /* 8 bits */
+#endif
+
+    r = 2 * r - r * r * n;          /* 16 bits */
+    r = 2 * r - r * r * n;          /* 32 bits */
+#if FLINT_BITS == 64
+    r = 2 * r - r * r * n;          /* 64 bits */
+#endif
+
+    return r;
+}
+
+FLINT_FORCE_INLINE
+ulong n_mulhi(ulong a, ulong b)
+{
+    ulong h, l;
+    umul_ppmm(h, l, a, b);
+    return h;
+}
+
+FLINT_FORCE_INLINE
+ulong n_subc(ulong * c, ulong a, ulong b)
+{
+    ulong d = a - b;
+    *c = d > a;     /* the compiler should recognize this idiom */
+    return d;
+}
+
+static
+void nn_divexact_2_1_odd(nn_ptr res, nn_srcptr x, ulong d, ulong dinv)
+{
+    ulong s, l, c;
+
+    s = x[0];
+    l = s * dinv;
+    res[0] = l;
+    c = n_mulhi(l, d);
+    s = x[1];
+    l = s - c;
+    l = l * dinv;
+    res[1] = l;
+}
+
+static
+void nn_divexact_2_1_even(nn_ptr res, nn_srcptr x, ulong d, ulong dinv, unsigned int norm)
+{
+    ulong s, l, c;
+    ulong ls, s_next;
+    ulong h;
+
+    d >>= norm;
+    c = 0;
+    s = x[0];
+    s_next = x[1];
+    ls = (s >> norm) | (s_next << (FLINT_BITS - norm));
+    s = s_next;
+    l = n_subc(&c, ls, c);
+    l = l * dinv;
+	res[0] = l;
+    h = n_mulhi(l, d);
+    c += h;
+    ls = s >> norm;
+    l = ls - c;
+    l = l * dinv;
+    res[1] = l;
+}
+
+static
+void nn_divexact_1_odd(nn_ptr res, nn_srcptr x, slong xn, ulong d, ulong dinv)
+{
+    ulong s, l, c;
+    slong i;
+
+    if (xn >= DIVEXACT_1_ODD_GMP_CUTOFF)
+    {
+        mpn_divexact_1(res, x, xn, d);
+        return;
+    }
+
+    s = x[0];
+    l = s * dinv;
+    res[0] = l;
+    c = 0;
+
+    for (i = 1; i < xn; i++)
+    {
+        c += n_mulhi(l, d);
+        s = x[i];
+        l = n_subc(&c, s, c);
+        l = l * dinv;
+        res[i] = l;
+    }
+}
+
+static
+void nn_divexact_1_even(nn_ptr res, nn_srcptr x, slong xn, ulong d, ulong dinv, unsigned int norm)
+{
+    ulong s, l, c, h;
+    slong i;
+    ulong ls, s_next;
+
+    if (xn >= DIVEXACT_1_EVEN_GMP_CUTOFF)
+    {
+        mpn_divexact_1(res, x, xn, d);
+        return;
+    }
+
+    d >>= norm;
+    c = 0;
+    s = x[0];
+
+    for (i = 1; i < xn; i++)
+    {
+        s_next = x[i];
+        ls = (s >> norm) | (s_next << (FLINT_BITS - norm));
+        s = s_next;
+        l = n_subc(&c, ls, c);
+        l = l * dinv;
+        res[i - 1] = l;
+        h = n_mulhi(l, d);
+        c += h;
+    }
+
+    ls = s >> norm;
+    l = ls - c;
+    l = l * dinv;
+    res[xn - 1] = l;
+}
+
+#define FLINT_MPZ_GET_MPN(zd, zn, zsgnbit, z) \
+    do { \
+        (zsgnbit) = (z)->_mp_size < 0; \
+        (zn) = FLINT_ABS((z)->_mp_size); \
+        (zd) = (z)->_mp_d; \
+    } \
+    while (0)
+
+static void
+_fmpz_vec_divexact_ui(fmpz * res, const fmpz * x, slong len, ulong c, int negc)
+{
+    ulong cinv;
+    slong i;
+    unsigned int norm;
+    mpz_ptr z;
+    slong xn;
+    int negative;
+    nn_srcptr xd;
+    ulong cinv_signed;
+
+    FLINT_ASSERT(c != 0);
+
+    if (c == 1)
+    {
+        if (negc)
+            _fmpz_vec_neg(res, x, len);
+        else
+            _fmpz_vec_set(res, x, len);
+        return;
+    }
+
+    if (c & 1)
+    {
+        cinv = n_binvert(c);
+        cinv_signed = negc ? -cinv : cinv;
+
+        for (i = 0; i < len; i++)
+        {
+            slong v = x[i];
+
+            if (!COEFF_IS_MPZ(v))
+            {
+                _fmpz_demote(res + i);
+                res[i] = v * cinv_signed;
+            }
+            else
+            {
+                z = COEFF_TO_PTR(v);
+                FLINT_MPZ_GET_MPN(xd, xn, negative, z);
+                negative ^= negc;
+
+                if (xn == 1)
+                {
+                    /* cannot overflow if c >= 2 */
+                    fmpz_set_si(res + i, negative ? -xd[0] * cinv : xd[0] * cinv);
+                }
+                else if (xn == 2)
+                {
+                    ulong t[2];
+                    nn_divexact_2_1_odd(t, xd, c, cinv);
+
+                    if (negative)
+                        fmpz_neg_uiui(res + i, t[1], t[0]);
+                    else
+                        fmpz_set_uiui(res + i, t[1], t[0]);
+                }
+                else
+                {
+                    mpz_ptr rp = _fmpz_promote(res + i);
+                    nn_ptr zd = FLINT_MPZ_REALLOC(rp, xn);
+
+                    nn_divexact_1_odd(zd, xd, xn, c, cinv);
+
+                    xn -= (zd[xn - 1] == 0);
+                    FLINT_ASSERT(zd[xn - 1] != 0);
+                    rp->_mp_size = negative ? -xn : xn;
+                }
+
+            }
+        }
+    }
+    else
+    {
+        norm = flint_ctz(c);
+
+        /* Special case for powers of 2 */
+        if ((c & (c - 1)) == 0)
+        {
+            if (negc)
+            {
+                for (i = 0; i < len; i++)
+                {
+                    slong v = x[i];
+
+                    if (!COEFF_IS_MPZ(v))
+                    {
+                        _fmpz_demote(res + i);
+                        res[i] = (-v) >> norm;
+                    }
+                    else
+                    {
+                        fmpz_tdiv_q_2exp(res + i, x + i, norm);
+                        fmpz_neg(res + i, res + i);
+                    }
+                }
+            }
+            else
+            {
+                for (i = 0; i < len; i++)
+                {
+                    slong v = x[i];
+
+                    if (!COEFF_IS_MPZ(v))
+                    {
+                        _fmpz_demote(res + i);
+                        res[i] = v >> norm;
+                    }
+                    else
+                        fmpz_tdiv_q_2exp(res + i, x + i, norm);
+                }
+            }
+
+            return;
+        }
+
+        cinv = n_binvert(c >> norm);
+        cinv_signed = negc ? -cinv : cinv;
+
+        for (i = 0; i < len; i++)
+        {
+            slong v = x[i];
+
+            if (!COEFF_IS_MPZ(v))
+            {
+                _fmpz_demote(res + i);
+                res[i] = ((slong) (v * cinv_signed)) >> norm;
+            }
+            else
+            {
+                z = COEFF_TO_PTR(v);
+                FLINT_MPZ_GET_MPN(xd, xn, negative, z);
+                negative ^= negc;
+
+                if (xn == 1)
+                {
+                    if (negative)
+                        fmpz_neg_ui(res + i, (xd[0] * cinv) >> norm);
+                    else
+                        fmpz_set_ui(res + i, (xd[0] * cinv) >> norm);
+                }
+                else if (xn == 2)
+                {
+                    ulong t[2];
+                    nn_divexact_2_1_even(t, xd, c, cinv, norm);
+
+                    if (negative)
+                        fmpz_neg_uiui(res + i, t[1], t[0]);
+                    else
+                        fmpz_set_uiui(res + i, t[1], t[0]);
+                }
+                else
+                {
+                    mpz_ptr rp = _fmpz_promote(res + i);
+                    nn_ptr zd = FLINT_MPZ_REALLOC(rp, xn);
+
+                    nn_divexact_1_even(zd, xd, xn, c, cinv, norm);
+                    xn -= (zd[xn - 1] == 0);
+                    FLINT_ASSERT(zd[xn - 1] != 0);
+                    rp->_mp_size = negative ? -xn : xn;
+
+                    _fmpz_demote_val(res + i);
+                }
+            }
+        }
+    }
+}
+
+void
+_fmpz_vec_scalar_divexact_si(fmpz * vec1, const fmpz * vec2, slong len2, slong c)
+{
+/*
+    slong i;
+    for (i = 0; i < len2; i++)
+        fmpz_divexact_si(vec1 + i, vec2 + i, c);
+    return ;
+*/
+
+    if (c > 0)
+        _fmpz_vec_divexact_ui(vec1, vec2, len2, c, 0);
+    else
+        _fmpz_vec_divexact_ui(vec1, vec2, len2, -(ulong) c, 1);
+}
+
+void
+_fmpz_vec_scalar_divexact_ui(fmpz * vec1, const fmpz * vec2,
+                             slong len2, ulong c)
+{
+/*
+    slong i;
+    for (i = 0; i < len2; i++)
+        fmpz_divexact_ui(vec1 + i, vec2 + i, c);
+    return ;
+*/
+
+    _fmpz_vec_divexact_ui(vec1, vec2, len2, c, 0);
+}
+
+void
+_fmpz_vec_scalar_divexact_fmpz(fmpz * vec1, const fmpz * vec2,
+                               slong len2, const fmpz_t x)
+{
+    fmpz c = *x;
+
+    if (!COEFF_IS_MPZ(c))
+    {
+        if (c == 1)
+            _fmpz_vec_set(vec1, vec2, len2);
+        else if (c == -1)
+            _fmpz_vec_neg(vec1, vec2, len2);
+        else
+            _fmpz_vec_scalar_divexact_si(vec1, vec2, len2, c);
+    }
+    else
+    {
+        slong i;
+        for (i = 0; i < len2; i++)
+            fmpz_divexact(vec1 + i, vec2 + i, x);
+    }
+}
+

--- a/src/fmpz_vec/scalar_divexact.c
+++ b/src/fmpz_vec/scalar_divexact.c
@@ -249,7 +249,6 @@ _fmpz_vec_divexact_ui(fmpz * res, const fmpz * x, slong len, ulong c, int negc)
                     FLINT_ASSERT(zd[xn - 1] != 0);
                     rp->_mp_size = negative ? -xn : xn;
                 }
-
             }
         }
     }
@@ -341,8 +340,6 @@ _fmpz_vec_divexact_ui(fmpz * res, const fmpz * x, slong len, ulong c, int negc)
                     xn -= (zd[xn - 1] == 0);
                     FLINT_ASSERT(zd[xn - 1] != 0);
                     rp->_mp_size = negative ? -xn : xn;
-
-                    _fmpz_demote_val(res + i);
                 }
             }
         }

--- a/src/gr/fmpz.c
+++ b/src/gr/fmpz.c
@@ -879,6 +879,27 @@ _gr_fmpz_vec_sub(fmpz * res, const fmpz * vec1, const fmpz * vec2, slong len, gr
 }
 
 int
+_gr_fmpz_vec_divexact_scalar_fmpz(fmpz * res, const fmpz * vec1, slong len, const fmpz_t c, gr_ctx_t ctx)
+{
+    _fmpz_vec_scalar_divexact_fmpz(res, vec1, len, c);
+    return GR_SUCCESS;
+}
+
+int
+_gr_fmpz_vec_divexact_scalar_ui(fmpz * res, const fmpz * vec1, slong len, ulong c, gr_ctx_t ctx)
+{
+    _fmpz_vec_scalar_divexact_ui(res, vec1, len, c);
+    return GR_SUCCESS;
+}
+
+int
+_gr_fmpz_vec_divexact_scalar_si(fmpz * res, const fmpz * vec1, slong len, slong c, gr_ctx_t ctx)
+{
+    _fmpz_vec_scalar_divexact_si(res, vec1, len, c);
+    return GR_SUCCESS;
+}
+
+int
 _gr_fmpz_vec_sum(fmpz_t res, const fmpz * vec, slong len, gr_ctx_t ctx)
 {
     if (len <= 2)
@@ -1207,6 +1228,10 @@ gr_method_tab_input _fmpz_methods_input[] =
     {GR_METHOD_VEC_EQUAL,       (gr_funcptr) _gr_fmpz_vec_equal},
     {GR_METHOD_VEC_ADD,         (gr_funcptr) _gr_fmpz_vec_add},
     {GR_METHOD_VEC_SUB,         (gr_funcptr) _gr_fmpz_vec_sub},
+    {GR_METHOD_VEC_DIVEXACT_SCALAR,        (gr_funcptr) _gr_fmpz_vec_divexact_scalar_fmpz},
+    {GR_METHOD_VEC_DIVEXACT_SCALAR_FMPZ,   (gr_funcptr) _gr_fmpz_vec_divexact_scalar_fmpz},
+    {GR_METHOD_VEC_DIVEXACT_SCALAR_UI,     (gr_funcptr) _gr_fmpz_vec_divexact_scalar_ui},
+    {GR_METHOD_VEC_DIVEXACT_SCALAR_SI,     (gr_funcptr) _gr_fmpz_vec_divexact_scalar_si},
     {GR_METHOD_VEC_SUM,         (gr_funcptr) _gr_fmpz_vec_sum},
     {GR_METHOD_VEC_DOT,         (gr_funcptr) _gr_fmpz_vec_dot},
     {GR_METHOD_VEC_DOT_REV,     (gr_funcptr) _gr_fmpz_vec_dot_rev},

--- a/src/gr/fmpz.c
+++ b/src/gr/fmpz.c
@@ -881,6 +881,8 @@ _gr_fmpz_vec_sub(fmpz * res, const fmpz * vec1, const fmpz * vec2, slong len, gr
 int
 _gr_fmpz_vec_divexact_scalar_fmpz(fmpz * res, const fmpz * vec1, slong len, const fmpz_t c, gr_ctx_t ctx)
 {
+    if (fmpz_is_zero(c))
+        return GR_DOMAIN;
     _fmpz_vec_scalar_divexact_fmpz(res, vec1, len, c);
     return GR_SUCCESS;
 }
@@ -888,6 +890,8 @@ _gr_fmpz_vec_divexact_scalar_fmpz(fmpz * res, const fmpz * vec1, slong len, cons
 int
 _gr_fmpz_vec_divexact_scalar_ui(fmpz * res, const fmpz * vec1, slong len, ulong c, gr_ctx_t ctx)
 {
+    if (c == 0)
+        return GR_DOMAIN;
     _fmpz_vec_scalar_divexact_ui(res, vec1, len, c);
     return GR_SUCCESS;
 }
@@ -895,6 +899,8 @@ _gr_fmpz_vec_divexact_scalar_ui(fmpz * res, const fmpz * vec1, slong len, ulong 
 int
 _gr_fmpz_vec_divexact_scalar_si(fmpz * res, const fmpz * vec1, slong len, slong c, gr_ctx_t ctx)
 {
+    if (c == 0)
+        return GR_DOMAIN;
     _fmpz_vec_scalar_divexact_si(res, vec1, len, c);
     return GR_SUCCESS;
 }

--- a/src/gr/test_ring.c
+++ b/src/gr/test_ring.c
@@ -3458,8 +3458,104 @@ int gr_test_vec_add(gr_ctx_t R, flint_rand_t state, int test_flags) { return gr_
 int gr_test_vec_sub(gr_ctx_t R, flint_rand_t state, int test_flags) { return gr_test_vec_binary_op(R, "vec_sub", gr_sub, _gr_vec_sub, state, test_flags); }
 int gr_test_vec_mul(gr_ctx_t R, flint_rand_t state, int test_flags) { return gr_test_vec_binary_op(R, "vec_mul", gr_mul, _gr_vec_mul, state, test_flags); }
 int gr_test_vec_div(gr_ctx_t R, flint_rand_t state, int test_flags) { return gr_test_vec_binary_op(R, "vec_div", gr_div, _gr_vec_div, state, test_flags); }
-int gr_test_vec_divexact(gr_ctx_t R, flint_rand_t state, int test_flags) { return gr_test_vec_binary_op(R, "vec_divexact", gr_divexact, _gr_vec_divexact, state, test_flags); }
 int gr_test_vec_pow(gr_ctx_t R, flint_rand_t state, int test_flags) { return gr_test_vec_binary_op(R, "vec_pow", gr_pow, _gr_vec_pow, state, test_flags); }
+
+int gr_test_vec_divexact(gr_ctx_t R, flint_rand_t state, int test_flags)
+{
+    int status, aliasing, ref_aliasing;
+    slong i, len;
+    gr_ptr x, y, xy1, xy2;
+
+    len = n_randint(state, 5);
+
+    GR_TMP_INIT_VEC(x, len, R);
+    GR_TMP_INIT_VEC(y, len, R);
+    GR_TMP_INIT_VEC(xy1, len, R);
+    GR_TMP_INIT_VEC(xy2, len, R);
+
+    GR_MUST_SUCCEED(_gr_vec_randtest(x, state, len, R));
+    GR_MUST_SUCCEED(_gr_vec_randtest(y, state, len, R));
+    GR_MUST_SUCCEED(_gr_vec_randtest(xy1, state, len, R));
+    GR_MUST_SUCCEED(_gr_vec_randtest(xy2, state, len, R));
+
+    status = GR_SUCCESS;
+    for (i = 0; i < len && status == GR_SUCCESS; i++)
+    {
+        status |= gr_mul(GR_ENTRY(x, i, R->sizeof_elem),
+                    GR_ENTRY(x, i, R->sizeof_elem),
+                    GR_ENTRY(y, i, R->sizeof_elem), R);
+
+        /* Check that we can perform division */
+        status |= gr_div(xy1, GR_ENTRY(x, i, R->sizeof_elem),
+                                GR_ENTRY(y, i, R->sizeof_elem), R);
+    }
+
+    if (status == GR_SUCCESS)
+    {
+        aliasing = n_randint(state, 4);
+        ref_aliasing = 0;
+
+        switch (aliasing)
+        {
+            case 0:
+                status |= _gr_vec_set(xy1, x, len, R);
+                status |= _gr_vec_divexact(xy1, xy1, y, len, R);
+                break;
+            case 1:
+                status |= _gr_vec_set(xy1, y, len, R);
+                status |= _gr_vec_divexact(xy1, x, xy1, len, R);
+                break;
+            case 2:
+                status |= _gr_vec_set(y, x, len, R);
+                status |= _gr_vec_divexact(xy1, x, x, len, R);
+                break;
+            case 3:
+                status |= _gr_vec_set(y, x, len, R);
+                status |= _gr_vec_set(xy1, x, len, R);
+                status |= _gr_vec_divexact(xy1, xy1, xy1, len, R);
+                break;
+            default:
+                status |= _gr_vec_divexact(xy1, x, y, len, R);
+        }
+
+        for (i = 0; i < len; i++)
+            if (ref_aliasing)
+                status |= gr_divexact(GR_ENTRY(xy2, i, R->sizeof_elem),
+                                 GR_ENTRY(x, i, R->sizeof_elem),
+                                 GR_ENTRY(x, i, R->sizeof_elem), R);
+            else
+                status |= gr_divexact(GR_ENTRY(xy2, i, R->sizeof_elem),
+                                 GR_ENTRY(x, i, R->sizeof_elem),
+                                 GR_ENTRY(y, i, R->sizeof_elem), R);
+
+        if (status == GR_SUCCESS && _gr_vec_equal(xy1, xy2, len, R) == T_FALSE)
+        {
+            status = GR_TEST_FAIL;
+        }
+
+        if ((test_flags & GR_TEST_ALWAYS_ABLE) && (status & GR_UNABLE))
+            status = GR_TEST_FAIL;
+
+        if ((test_flags & GR_TEST_VERBOSE) || status == GR_TEST_FAIL)
+        {
+            flint_printf("divexact\n");
+            gr_ctx_println(R);
+            flint_printf("aliasing: %d\n", aliasing);
+            _gr_vec_print(x, len, R); flint_printf("\n");
+            _gr_vec_print(y, len, R); flint_printf("\n");
+            _gr_vec_print(xy1, len, R); flint_printf("\n");
+            _gr_vec_print(xy2, len, R); flint_printf("\n");
+        }
+    }
+
+    GR_TMP_CLEAR_VEC(x, len, R);
+    GR_TMP_CLEAR_VEC(y, len, R);
+    GR_TMP_CLEAR_VEC(xy1, len, R);
+    GR_TMP_CLEAR_VEC(xy2, len, R);
+
+    return status;
+}
+
 
 int
 gr_test_vec_binary_op_scalar(gr_ctx_t R, const char * opname, int (*gr_op)(gr_ptr, gr_srcptr, gr_srcptr, gr_ctx_t),


### PR DESCRIPTION
Speed up ``_fmpz_vec_scalar_divexact_si``, ``_fmpz_vec_scalar_divexact_ui`` and small-divisor ``_fmpz_vec_scalar_divexact_fmpz`` by precomputing an inverse mod ``2^FLINT_BITS``. Also special case powers of two.

This probably will not make a measurable difference on any macrobenchmarks, because the standard use case is to divide out a GCD which was more expensive to compute in the first place. However, I thought I'd put this code in as a template for doing divexact with precomputed inverses; other functions like ``fmpz_mat_fflu`` and ``_fmpz_poly_interpolate_exact_newton`` could use the same trick in the future.

Multi-limb preinverted divexact should also be done some day but it's a lot more work.

Profile code output:

```
$ build/fmpz_vec/profile/p-divexact_ui 
   len    bits(A*c)  bits(c)      old       new    speedup
     1         2        2    2.77e-09   3.67e-09   0.755
     1         0       46    2.81e-09   3.46e-09   0.812
     1        66       51    2.61e-08   2.66e-08   0.981
     1         0       33    2.83e-09   3.47e-09   0.816
     1        79       44    2.34e-08   2.41e-08   0.971
     1       112       36       1e-08   1.06e-08   0.943
     1         0       44    2.83e-09   3.48e-09   0.813
     1      -518       34    1.88e-08   1.88e-08   1.000
     1       375       43    1.36e-08   1.36e-08   1.000
     1       929       17    2.64e-08   2.66e-08   0.992
     1      -114       54    2.37e-08   2.43e-08   0.975
     2         0       45    5.71e-09   7.27e-09   0.785
     2       -64       55    2.51e-08   7.06e-09   3.555
     2       -46       30     5.7e-09   7.24e-09   0.787
     2       -59       22    5.85e-09   6.64e-09   0.881
     2        45       17    5.99e-09   7.32e-09   0.818
     2      -170       63    2.06e-08   1.67e-08   1.234
     2         0       31    5.78e-09    6.6e-09   0.876
     2       564       18    2.08e-08    2.1e-08   0.990
     2       817       22    4.74e-08   4.54e-08   1.044
     2     -2270       43    1.21e-07   1.24e-07   0.976
     2     -4587       17    2.38e-07   2.42e-07   0.983
     3        58       54    8.15e-09   8.68e-09   0.939
     3       -58       56    8.18e-09   7.46e-09   1.097
     3       -28       13    8.15e-09   8.66e-09   0.941
     3       -39        7    8.12e-09   7.44e-09   1.091
     3      -131       55    5.78e-08   1.64e-08   3.524
     3      -133       21    2.25e-08   1.47e-08   1.531
     3      -262       23    3.42e-08   2.85e-08   1.200
     3      -497       34    4.78e-08   3.71e-08   1.288
     3     -1095       41    7.62e-08   6.96e-08   1.095
     3      2392       52    1.63e-07   1.62e-07   1.006
     3     -2164       30    6.37e-08   6.78e-08   0.940
     4       -31       27    1.08e-08   9.72e-09   1.111
     4       -27       20    1.07e-08   8.64e-09   1.238
     4       -64       64    6.98e-08   1.03e-08   6.777
     4       -91       53    9.38e-08    1.4e-08   6.700
     4       -81        4    2.51e-08   2.36e-08   1.064
     4      -165       64    3.24e-08    2.3e-08   1.409
     4      -365       56    5.74e-08   3.15e-08   1.822
     4      -488       47    4.56e-08   3.53e-08   1.292
     4     -1248       60    1.04e-07   7.02e-08   1.481
     4     -2282       30    2.04e-07   1.98e-07   1.030
     4      -234        7    1.86e-08   1.41e-08   1.319
     5        54       54    1.35e-08   9.52e-09   1.418
     5        32       24    1.36e-08   1.14e-08   1.193
     5        53       53    1.35e-08   1.14e-08   1.184
     5         0       29    1.35e-08   1.14e-08   1.184
     5      -135       64    8.81e-08   2.24e-08   3.933
     5         0       60    1.39e-08   9.54e-09   1.457
     5      -167       13    2.06e-08   1.38e-08   1.493
     5      -685       51    8.26e-08   6.32e-08   1.307
     5     -1235       27    9.26e-08   7.55e-08   1.226
     5     -2277        5    1.95e-07   1.89e-07   1.032
     5     -4833       22     3.6e-07   3.58e-07   1.006
     6        -6        2    1.61e-08   7.21e-09   2.233
     6       -32       22    1.61e-08   1.27e-08   1.268
     6       -82       62    9.71e-08   1.52e-08   6.388
     6        46       30    1.61e-08   1.07e-08   1.505
     6        75       14    3.64e-08   1.17e-08   3.111
     6      -189       37    4.66e-08   2.98e-08   1.564
     6       342       37    2.59e-08   2.12e-08   1.222
     6         0       41    1.61e-08   1.07e-08   1.505
     6     -1172        8    1.57e-07   1.36e-07   1.154
     6      2384       12    1.36e-07   1.37e-07   0.993
     6     -5083       53    6.66e-07   6.66e-07   1.000
     7       -33       28    1.87e-08   1.41e-08   1.326
     7         0       20    1.87e-08    1.4e-08   1.336
     7       -80       62    1.22e-07   1.75e-08   6.971
     7        69       56     3.9e-08   1.19e-08   3.277
     7      -105       32    5.39e-08   1.97e-08   2.736
     7         0       37    1.87e-08   1.18e-08   1.585
     7      -287       20     2.7e-08   1.86e-08   1.452
     7      -458       43     7.3e-08   5.17e-08   1.412
     7      -957       46    1.06e-07   8.26e-08   1.283
     7     -2357       58    2.86e-07   2.77e-07   1.032
     7     -4344       40    4.56e-07   4.45e-07   1.025
     8         0        9    2.14e-08   1.28e-08   1.672
     8        -4        4    2.14e-08   1.28e-08   1.672
     8       -78       59    1.24e-07    1.7e-08   7.294
     8       -74       37    8.35e-08   1.78e-08   4.691
     8      -116       36    1.13e-07    2.8e-08   4.036
     8      -191       63    3.68e-08   2.44e-08   1.508
     8      -271       36    3.85e-08   2.92e-08   1.318
     8      -398       23    9.22e-08    4.9e-08   1.882
     8     -1115        8    1.61e-07   1.25e-07   1.288
     8     -1371       46     1.1e-07   9.68e-08   1.136
     8     -4883       46     3.9e-07   3.69e-07   1.057
     9         0        4    2.41e-08   1.59e-08   1.516
     9       -42       33    2.41e-08    1.6e-08   1.506
     9       -45       29     2.4e-08   1.59e-08   1.509
     9        53       39     2.4e-08   1.35e-08   1.778
     9      -129       53    1.13e-07   3.16e-08   3.576
     9      -159        1    7.18e-08   5.42e-08   1.325
     9      -326       60     6.1e-08   4.38e-08   1.393
     9         0       62     2.4e-08   1.35e-08   1.778
     9     -1212       62    2.03e-07   1.62e-07   1.253
     9         0       28     2.4e-08   1.59e-08   1.509
     9     -3064       16    1.88e-07   1.75e-07   1.074
    10       -21       18    2.67e-08   1.44e-08   1.854
    10       -10        2    2.67e-08   1.43e-08   1.867
    10       -22        2    2.66e-08   1.44e-08   1.847
    10       -40       23    2.68e-08   1.43e-08   1.874
    10      -102       22    1.14e-07   2.03e-08   5.616
    10       178       64    3.45e-08   2.33e-08   1.481
    10      -299       36    6.36e-08   2.92e-08   2.178
    10       467       49    3.68e-08   2.59e-08   1.421
    10      -855       43    4.86e-08   3.99e-08   1.218
    10     -2122       63    1.22e-07   1.14e-07   1.070
    10     -4740       15    7.86e-07   1.45e-07   5.421
```