### PR TITLE
fmpz_lll_mpf: use simple dot product instead of slow cancellation-checking dot product

### DIFF
--- a/src/fmpz_lll/check_babai_heuristic.c
+++ b/src/fmpz_lll/check_babai_heuristic.c
@@ -56,15 +56,17 @@ fmpz_lll_check_babai_heuristic(int kappa, fmpz_mat_t B, fmpz_mat_t U,
 
             for (j = aa; j < kappa; j++)
             {
-                if (mpf_cmp_d(mpf_mat_entry(A->appSP2, kappa, j), DBL_MIN)
-                    == 0)
+                if (mpf_cmp_d(mpf_mat_entry(A->appSP2, kappa, j), DBL_MIN) == 0)
                 {
-                    if (!
-                        (_mpf_vec_dot2
-                         (mpf_mat_entry(A->appSP2, kappa, j),
-                          appB->rows[kappa], appB->rows[j], n, prec)))
+#if 1
+/* Use slow dot product and check for cancellation */
+                    if (!(_mpf_vec_dot2(mpf_mat_entry(A->appSP2, kappa, j), appB->rows[kappa], appB->rows[j], n, prec)))
+#else
+/* Use fast dot product (always returns 1, pretending that there is no cancellation) */
+                    if (!(_mpf_vec_dot1(mpf_mat_entry(A->appSP2, kappa, j), appB->rows[kappa], appB->rows[j], n, prec)))
+#endif
                     {
-/* In this case a heuristic told us that some cancellation probably happened so we just compute the scalar product at full precision */
+                        /* In this case a heuristic told us that some cancellation probably happened so we just compute the scalar product at full precision */
                         _fmpz_vec_dot(ztmp, fmpz_mat_row(B, kappa), fmpz_mat_row(B, j), n);
                         fmpz_get_mpf(mpf_mat_entry(A->appSP2, kappa, j), ztmp);
                     }

--- a/src/fmpz_lll/check_babai_heuristic.c
+++ b/src/fmpz_lll/check_babai_heuristic.c
@@ -58,7 +58,7 @@ fmpz_lll_check_babai_heuristic(int kappa, fmpz_mat_t B, fmpz_mat_t U,
             {
                 if (mpf_cmp_d(mpf_mat_entry(A->appSP2, kappa, j), DBL_MIN) == 0)
                 {
-#if 1
+#if 0
 /* Use slow dot product and check for cancellation */
                     if (!(_mpf_vec_dot2(mpf_mat_entry(A->appSP2, kappa, j), appB->rows[kappa], appB->rows[j], n, prec)))
 #else

--- a/src/fmpz_lll/mpf-impl.c
+++ b/src/fmpz_lll/mpf-impl.c
@@ -76,6 +76,25 @@ void _mpf_vec_norm2(mpf_t res, const mpf * vec, slong len, flint_bitcnt_t prec)
 }
 
 int
+_mpf_vec_dot1(mpf_t res, const mpf * vec1, const mpf * vec2, slong len2, flint_bitcnt_t prec)
+{
+    slong i;
+    mpf_t tmp;
+    mpf_init2(tmp, prec);
+
+    flint_mpf_set_ui(res, 0);
+    for (i = 0; i < len2; i++)
+    {
+        mpf_mul(tmp, vec1 + i, vec2 + i);
+        mpf_add(res, res, tmp);
+    }
+
+    mpf_clear(tmp);
+
+    return 1;
+}
+
+int
 _mpf_vec_dot2(mpf_t res, const mpf * vec1, const mpf * vec2, slong len2, flint_bitcnt_t prec)
 {
     slong i;

--- a/src/mpf-impl.h
+++ b/src/mpf-impl.h
@@ -39,6 +39,7 @@ typedef mpf_mat_struct mpf_mat_t[1];
 mpf * _mpf_vec_init(slong len, flint_bitcnt_t prec);
 void _mpf_vec_clear(mpf * vec, slong len);
 void _mpf_vec_set_fmpz_vec(mpf * appv, const fmpz * vec, slong len);
+int _mpf_vec_dot1(mpf_t res, const mpf * vec1, const mpf * vec2, slong len2, flint_bitcnt_t prec);
 int _mpf_vec_dot2(mpf_t res, const mpf * vec1, const mpf * vec2, slong len2, flint_bitcnt_t prec);
 void _mpf_vec_norm2(mpf_t res, const mpf * vec, slong len, flint_bitcnt_t prec);
 void _mpf_vec_norm(mpf_t res, const mpf * vec, slong len);


### PR DESCRIPTION
In ``fmpz_lll_check_babai_heuristic``, there is an ``mpf`` dot product computation which attempts to guess if there is too much cancellation and then falls back to an exact ``fmpz`` dot product. Looking at all calls to LLL that occur in our test suite, it seems that this fallback is very rarely useful, while the cancellation check costs more than the actual dot product. We could optimize the cancellation check, but let's try to simplify things and just skip it.

It turns out that this gives a nearly 2x speedup in the polynomial factoring examples which are currently commented out in ``build/fmpz_poly_factor/profile/p-factor_hard`` due to being excessively slow.

Old:

```
H2 has 6 factors: 443192 ms
S9 has 1 factors: 364048 ms
```

New:

```
H2 has 6 factors: 235941 ms
S9 has 1 factors: 201570 ms
```