### PR TITLE
Port naive LLL reduction checks to gr_mat; speed up fmpz_mat versions

### DIFF
--- a/doc/source/gr_mat.rst
+++ b/doc/source/gr_mat.rst
@@ -1034,6 +1034,36 @@ Helper functions for reduction
     By default the *generic* version is called; specific rings
     can overload this (typically to implement delayed canonicalisation).
 
+LLL
+-------------------------------------------------------------------------------
+
+Let `A = (a_0, \ldots, a_{n-1})` be a set of linearly independent vectors over `\mathbb{R}`
+with Gram-Schmidt orthogonalization `(b_0, \ldots, b_{n-1})`
+and Gram-Schmidt coefficients `\mu_{i,j} = \langle a_i, b_i \rangle / \| b_j \|^2`.
+The basis `A` is said to be LLL-reduced with parameter (`\delta`, `\eta`)
+where `0.25 < \delta \le 1` and `0.5 \le \eta < \sqrt{\delta}` if they satisfy
+the size reduction condition
+
+.. math ::
+
+    |\mu_{i,j}| \le \eta, \quad 0 \le j < i < n
+
+and the Lovász condition
+
+.. math ::
+
+    (\delta - \mu_{i,i-1}^2) \| b_{i-1} \|_2^2 \le \| b_i \|_2^2, \quad 1 \le i \le n - 1.
+
+.. function:: truth_t gr_mat_is_row_lll_reduced_naive(const gr_mat_t A, gr_srcptr delta, gr_srcptr eta, gr_ctx_t ctx)
+              truth_t gr_mat_is_row_lll_reduced_with_removal_naive(const gr_mat_t A, gr_srcptr delta, gr_srcptr eta, gr_srcptr gs_B, slong newd, gr_ctx_t ctx)
+
+    Check if the rows of *A* are LLL-reduced by naively performing the
+    Gram-Schmidt orthogonalization and checking the conditions one row
+    at a time.
+
+    In interval arithmetic, these functions terminate eagerly: ``T_UNKNOWN``
+    is returned if the tests are inconclusive for one row, even if there is a
+    possibility that a later row could prove that the result should be ``T_FALSE``.
 
 Test functions
 -------------------------------------------------------------------------------

--- a/src/fmpz_mat/is_reduced.c
+++ b/src/fmpz_mat/is_reduced.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2014 Abhinav Baid
+    Copyright (C) 2025 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -9,104 +10,55 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include <gmp.h>
+#include "gr.h"
+#include "gr_mat.h"
 #include "fmpz_mat.h"
-#include "fmpq.h"
-#include "fmpq_vec.h"
-#include "fmpq_mat.h"
 
 int
 fmpz_mat_is_reduced(const fmpz_mat_t A, double delta, double eta)
 {
-    int res;
-    slong i, j, k, d = A->r, n = A->c;
-    fmpq_mat_t Aq, Bq, mu;
-    mpq_t deltax, etax;
-    fmpq_t deltaq, etaq, tmp;
+    truth_t is_reduced = T_UNKNOWN;
+    slong prec;
+    gr_ctx_t ctx;
+    gr_ptr Rdelta, Reta;
+    gr_mat_t RA;
+    slong exact_cutoff;
 
-    if (d == 0 || d == 1)
-        return 1;
+    /* To do: for very small matrices, consider doing a division-free version
+       of the naive algorithm over Z instead of working over Q. */
+    /* To do: this is not at all tuned. */
+    exact_cutoff = fmpz_mat_max_bits(A);
+    exact_cutoff = FLINT_ABS(exact_cutoff);
+    exact_cutoff = (64 + exact_cutoff) * FLINT_MAX(A->r, A->c);
 
-    fmpq_mat_init(Aq, d, n);
-    fmpq_mat_init(Bq, d, n);
-    fmpq_mat_init(mu, d, d);
-
-    mpq_init(deltax);
-    mpq_init(etax);
-
-    fmpq_init(deltaq);
-    fmpq_init(etaq);
-    fmpq_init(tmp);
-
-    fmpq_mat_set_fmpz_mat(Aq, A);
-
-    mpq_set_d(deltax, delta);
-    mpq_set_d(etax, eta);
-    fmpq_set_mpq(deltaq, deltax);
-    fmpq_set_mpq(etaq, etax);
-    mpq_clears(deltax, etax, NULL);
-
-    for (j = 0; j < n; j++)
+    for (prec = 64; ; prec *= 2)
     {
-        fmpq_set(fmpq_mat_entry(Bq, 0, j), fmpq_mat_entry(Aq, 0, j));
-    }
-    /* diagonal of mu stores the squared GS norms */
-    _fmpq_vec_dot(fmpq_mat_entry(mu, 0, 0), fmpq_mat_entry(Bq, 0, 0), fmpq_mat_entry(Bq, 0, 0), n);
+        /* flint_printf("fmpz_mat_is_reduced : prec %wd / %wd\n", prec, exact_cutoff); */
+        if (prec >= exact_cutoff)
+            gr_ctx_init_fmpq(ctx);
+        else
+            gr_ctx_init_real_arb(ctx, prec);
 
-    for (i = 1; i < d; i++)
-    {
-        for (j = 0; j < n; j++)
-        {
-            fmpq_set(fmpq_mat_entry(Bq, i, j), fmpq_mat_entry(Aq, i, j));
-        }
+        gr_mat_init(RA, A->r, A->c, ctx);
+        Rdelta = gr_heap_init(ctx);
+        Reta = gr_heap_init(ctx);
 
-        for (j = 0; j < i; j++)
-        {
-            _fmpq_vec_dot(tmp, fmpq_mat_entry(Aq, i, 0), fmpq_mat_entry(Bq, j, 0), n);
+        GR_MUST_SUCCEED(gr_mat_set_fmpz_mat(RA, A, ctx));
+        GR_MUST_SUCCEED(gr_set_d(Rdelta, delta, ctx));
+        GR_MUST_SUCCEED(gr_set_d(Reta, eta, ctx));
 
-            /* avoid division by zero (???) */
-            if (fmpq_is_zero(fmpq_mat_entry(mu, j, j)))
-            {
-                res = 0;
-                goto cleanup;
-            }
+        is_reduced = gr_mat_is_row_lll_reduced_naive(RA, Rdelta, Reta, ctx);
 
-            fmpq_div(fmpq_mat_entry(mu, i, j), tmp, fmpq_mat_entry(mu, j, j));
+        gr_mat_clear(RA, ctx);
+        gr_heap_clear(Rdelta, ctx);
+        gr_heap_clear(Reta, ctx);
 
-            for (k = 0; k < n; k++)
-            {
-                fmpq_submul(fmpq_mat_entry(Bq, i, k),
-                            fmpq_mat_entry(mu, i, j), fmpq_mat_entry(Bq, j,
-                                                                     k));
-            }
-            fmpq_abs(tmp, fmpq_mat_entry(mu, i, j));
-            if (fmpq_cmp(tmp, etaq) > 0)    /* check size reduction */
-            {
-                res = 0;
-                goto cleanup;
-            }
-        }
-        fmpq_set(tmp, deltaq);
-        fmpq_submul(tmp, fmpq_mat_entry(mu, i, i - 1),
-                         fmpq_mat_entry(mu, i, i - 1));
-        fmpq_mul(tmp, tmp, fmpq_mat_entry(mu, i - 1, i - 1));
-        _fmpq_vec_dot(fmpq_mat_entry(mu, i, i), fmpq_mat_entry(Bq, i, 0), fmpq_mat_entry(Bq, i, 0), n);
-        if (fmpq_cmp(tmp, fmpq_mat_entry(mu, i, i)) > 0)    /* check Lovasz condition */
-        {
-            res = 0;
-            goto cleanup;
-        }
+        gr_ctx_clear(ctx);
+
+        if (is_reduced != T_UNKNOWN)
+            break;
     }
 
-    res = 1;
-
-cleanup:
-
-    fmpq_mat_clear(Aq);
-    fmpq_mat_clear(Bq);
-    fmpq_mat_clear(mu);
-    fmpq_clear(deltaq);
-    fmpq_clear(etaq);
-    fmpq_clear(tmp);
-    return res;
+    return (is_reduced == T_TRUE);
 }
+

--- a/src/fmpz_mat/is_reduced_with_removal.c
+++ b/src/fmpz_mat/is_reduced_with_removal.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2014 Abhinav Baid
+    Copyright (C) 2025 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -9,125 +10,59 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include <gmp.h>
+#include "gr.h"
+#include "gr_mat.h"
 #include "fmpz_mat.h"
-#include "fmpq.h"
-#include "fmpq_vec.h"
-#include "fmpq_mat.h"
 
 int
 fmpz_mat_is_reduced_with_removal(const fmpz_mat_t A, double delta, double eta,
                                  const fmpz_t gs_B, int newd)
 {
-    int res;
-    slong i, j, k, d = A->r, n = A->c;
-    fmpq_mat_t Aq, Bq, mu;
-    mpq_t deltax, etax;
-    fmpq_t deltaq, etaq, tmp, gs_Bq;
+    truth_t is_reduced = T_UNKNOWN;
+    slong prec;
+    gr_ctx_t ctx;
+    gr_ptr Rdelta, Reta, Rgs_B;
+    gr_mat_t RA;
+    slong exact_cutoff;
 
-    if (d == 0 || d == 1)
-        return 1;
+    /* To do: for very small matrices, consider doing a division-free version
+       of the naive algorithm over Z instead of working over Q. */
+    /* To do: this is not at all tuned. */
+    exact_cutoff = fmpz_mat_max_bits(A);
+    exact_cutoff = FLINT_ABS(exact_cutoff);
+    exact_cutoff = (64 + exact_cutoff) * FLINT_MAX(A->r, A->c);
 
-    fmpq_mat_init(Aq, d, n);
-    fmpq_mat_init(Bq, d, n);
-    fmpq_mat_init(mu, d, d);
-
-    mpq_init(deltax);
-    mpq_init(etax);
-
-    fmpq_init(deltaq);
-    fmpq_init(etaq);
-    fmpq_init(tmp);
-    fmpq_init(gs_Bq);
-
-    mpq_set_d(deltax, delta);
-    mpq_set_d(etax, eta);
-    fmpq_set_mpq(deltaq, deltax);
-    fmpq_set_mpq(etaq, etax);
-    mpq_clears(deltax, etax, NULL);
-
-    fmpq_mat_set_fmpz_mat(Aq, A);
-
-    fmpz_set(fmpq_numref(gs_Bq), gs_B);
-    fmpz_one(fmpq_denref(gs_Bq));
-
-    for (j = 0; j < n; j++)
+    for (prec = 64; ; prec *= 2)
     {
-        fmpq_set(fmpq_mat_entry(Bq, 0, j), fmpq_mat_entry(Aq, 0, j));
-    }
-    /* diagonal of mu stores the squared GS norms */
-    _fmpq_vec_dot(fmpq_mat_entry(mu, 0, 0), fmpq_mat_entry(Bq, 0, 0), fmpq_mat_entry(Bq, 0, 0), n);
-    if (newd == 0 && fmpq_cmp(fmpq_mat_entry(mu, 0, 0), gs_Bq) < 0)
-    {
-        res = 0;
-        goto cleanup;
-    }
+        /* flint_printf("fmpz_mat_is_reduced_with_removal : prec %wd / %wd\n", prec, exact_cutoff); */
+        if (prec >= exact_cutoff)
+            gr_ctx_init_fmpq(ctx);
+        else
+            gr_ctx_init_real_arb(ctx, prec);
 
-    for (i = 1; i < d; i++)
-    {
-        for (j = 0; j < n; j++)
-        {
-            fmpq_set(fmpq_mat_entry(Bq, i, j), fmpq_mat_entry(Aq, i, j));
-        }
+        gr_mat_init(RA, A->r, A->c, ctx);
+        Rdelta = gr_heap_init(ctx);
+        Reta = gr_heap_init(ctx);
+        Rgs_B = gr_heap_init(ctx);
 
-        for (j = 0; j < i; j++)
-        {
-            _fmpq_vec_dot(tmp, fmpq_mat_entry(Aq, i, 0), fmpq_mat_entry(Bq, j, 0), n);
+        GR_MUST_SUCCEED(gr_mat_set_fmpz_mat(RA, A, ctx));
+        GR_MUST_SUCCEED(gr_set_d(Rdelta, delta, ctx));
+        GR_MUST_SUCCEED(gr_set_d(Reta, eta, ctx));
+        GR_MUST_SUCCEED(gr_set_fmpz(Rgs_B, gs_B, ctx));
 
-            /* avoid division by zero */
-            if (fmpq_is_zero(fmpq_mat_entry(mu, j, j)))
-            {
-                res = 0;
-                goto cleanup;
-            }
+        is_reduced = gr_mat_is_row_lll_reduced_with_removal_naive(RA, Rdelta, Reta, Rgs_B, newd, ctx);
 
-            fmpq_div(fmpq_mat_entry(mu, i, j), tmp, fmpq_mat_entry(mu, j, j));
+        gr_mat_clear(RA, ctx);
+        gr_heap_clear(Rdelta, ctx);
+        gr_heap_clear(Reta, ctx);
+        gr_heap_clear(Rgs_B, ctx);
 
-            for (k = 0; k < n; k++)
-            {
-                fmpq_submul(fmpq_mat_entry(Bq, i, k),
-                            fmpq_mat_entry(mu, i, j), fmpq_mat_entry(Bq, j, k));
-            }
-            if (i < newd)
-            {
-                fmpq_abs(tmp, fmpq_mat_entry(mu, i, j));
-                if (fmpq_cmp(tmp, etaq) > 0)    /* check size reduction */
-                {
-                    res = 0;
-                    goto cleanup;
-                }
-            }
-        }
-        _fmpq_vec_dot(fmpq_mat_entry(mu, i, i), fmpq_mat_entry(Bq, i, 0), fmpq_mat_entry(Bq, i, 0), n);
-        if (i >= newd && fmpq_cmp(fmpq_mat_entry(mu, i, i), gs_Bq) < 0) /* check removals */
-        {
-            res = 0;
-            goto cleanup;
-        }
-        if (i < newd)
-        {
-            fmpq_set(tmp, deltaq);
-            fmpq_submul(tmp, fmpq_mat_entry(mu, i, i - 1),
-                             fmpq_mat_entry(mu, i, i - 1));
-            fmpq_mul(tmp, tmp, fmpq_mat_entry(mu, i - 1, i - 1));
-            if (fmpq_cmp(tmp, fmpq_mat_entry(mu, i, i)) > 0)    /* check Lovasz condition */
-            {
-                res = 0;
-                goto cleanup;
-            }
-        }
+        gr_ctx_clear(ctx);
+
+        if (is_reduced != T_UNKNOWN)
+            break;
     }
 
-    res = 1;
-
-cleanup:
-
-    fmpq_mat_clear(Aq);
-    fmpq_mat_clear(Bq);
-    fmpq_mat_clear(mu);
-    fmpq_clear(deltaq);
-    fmpq_clear(etaq);
-    fmpq_clear(tmp);
-    fmpq_clear(gs_Bq);
-    return res;
+    return (is_reduced == T_TRUE);
 }
+

--- a/src/gr_mat.h
+++ b/src/gr_mat.h
@@ -377,6 +377,11 @@ WARN_UNUSED_RESULT int gr_mat_norm_1(gr_ptr res, const gr_mat_t mat, gr_ctx_t ct
 WARN_UNUSED_RESULT int gr_mat_norm_inf(gr_ptr res, const gr_mat_t mat, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mat_norm_frobenius(gr_ptr res, const gr_mat_t mat, gr_ctx_t ctx);
 
+/* LLL */
+
+truth_t gr_mat_is_row_lll_reduced_naive(const gr_mat_t A, gr_srcptr delta, gr_srcptr eta, gr_ctx_t ctx);
+truth_t gr_mat_is_row_lll_reduced_with_removal_naive(const gr_mat_t A, gr_srcptr delta, gr_srcptr eta, gr_srcptr gs_B, slong newd, gr_ctx_t ctx);
+
 /* Test functions */
 
 void gr_mat_test_mul(gr_method_mat_binary_op mul_impl, flint_rand_t state, slong iters, slong maxn, gr_ctx_t ctx);

--- a/src/gr_mat/is_lll_reduced.c
+++ b/src/gr_mat/is_lll_reduced.c
@@ -1,0 +1,107 @@
+/*
+    Copyright (C) 2014 Abhinav Baid
+    Copyright (C) 2025 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "gr.h"
+#include "gr_vec.h"
+#include "gr_mat.h"
+
+truth_t
+gr_mat_is_row_lll_reduced_with_removal_naive(const gr_mat_t A, gr_srcptr delta, gr_srcptr eta, gr_srcptr gs_B, slong newd, gr_ctx_t ctx)
+{
+    truth_t res = T_TRUE;
+    int status = GR_SUCCESS;
+    slong i, j, d = A->r, n = A->c;
+    gr_mat_t B, mu;
+    gr_ptr tmp;
+    slong sz = ctx->sizeof_elem;
+    int with_removal = (gs_B != NULL);
+
+    if (d == 0 || d == 1)
+        return GR_SUCCESS;
+
+    gr_mat_init(B, d, n, ctx);
+    gr_mat_init(mu, d, d, ctx);
+    GR_TMP_INIT(tmp, ctx);
+
+    status |= _gr_vec_set(GR_MAT_ENTRY(B, 0, 0, sz), GR_MAT_ENTRY(A, 0, 0, sz), n, ctx);
+    /* diagonal of mu stores the squared GS norms */
+    status |= _gr_vec_dot(GR_MAT_ENTRY(mu, 0, 0, sz), NULL, 0,
+        GR_MAT_ENTRY(B, 0, 0, sz), GR_MAT_ENTRY(B, 0, 0, sz), n, ctx);
+
+    if (with_removal && newd == 0)
+    {
+        res = gr_ge(GR_MAT_ENTRY(mu, 0, 0, sz), gs_B, ctx);
+        if (res != GR_SUCCESS)
+            goto cleanup;
+    }
+
+    for (i = 1; i < d; i++)
+    {
+        status |= _gr_vec_set(GR_MAT_ENTRY(B, i, 0, sz), GR_MAT_ENTRY(A, i, 0, sz), n, ctx);
+
+        for (j = 0; j < i; j++)
+        {
+            status |= _gr_vec_dot(tmp, NULL, 0, GR_MAT_ENTRY(A, i, 0, sz), GR_MAT_ENTRY(B, j, 0, sz), n, ctx);
+            status |= gr_div(GR_MAT_ENTRY(mu, i, j, sz), tmp, GR_MAT_ENTRY(mu, j, j, sz), ctx);
+            if (status != GR_SUCCESS)
+                goto cleanup;
+
+            status |= _gr_vec_submul_scalar(GR_MAT_ENTRY(B, i, 0, sz), GR_MAT_ENTRY(B, j, 0, sz), n, GR_MAT_ENTRY(mu, i, j, sz), ctx);
+
+            if (!with_removal || i < newd)
+            {
+                /* Check size reduction. */
+                status |= gr_abs(tmp, GR_MAT_ENTRY(mu, i, j, sz), ctx);
+                res = gr_le(tmp, eta, ctx);
+                if (res != T_TRUE)
+                    goto cleanup;
+            }
+        }
+
+        status |= _gr_vec_dot(GR_MAT_ENTRY(mu, i, i, sz), NULL, 0, GR_MAT_ENTRY(B, i, 0, sz), GR_MAT_ENTRY(B, i, 0, sz), n, ctx);
+        if (with_removal && i >= newd)
+        {
+            res = gr_ge(GR_MAT_ENTRY(mu, i, i, sz), gs_B, ctx);
+            if (res != T_TRUE)
+                goto cleanup;
+        }
+
+        /* Check Lovasz condition. */
+        if (!with_removal || i < newd)
+        {
+            status |= gr_sqr(tmp, GR_MAT_ENTRY(mu, i, i - 1, sz), ctx);
+            status |= gr_sub(tmp, delta, tmp, ctx);
+            status |= gr_mul(tmp, tmp, GR_MAT_ENTRY(mu, i - 1, i - 1, sz), ctx);
+            res = gr_le(tmp, GR_MAT_ENTRY(mu, i, i, sz), ctx);
+            if (res != T_TRUE)
+                goto cleanup;
+        }
+    }
+
+cleanup:
+
+    if (status != GR_SUCCESS)
+        res = T_UNKNOWN;
+
+    gr_mat_clear(B, ctx);
+    gr_mat_clear(mu, ctx);
+    GR_TMP_CLEAR(tmp, ctx);
+
+    return res;
+}
+
+truth_t
+gr_mat_is_row_lll_reduced_naive(const gr_mat_t A, gr_srcptr delta, gr_srcptr eta, gr_ctx_t ctx)
+{
+    return gr_mat_is_row_lll_reduced_with_removal_naive(A, delta, eta, NULL, 0, ctx);
+}
+


### PR DESCRIPTION
The LLL code ends up calling ``fmpz_mat_is_reduced`` or ``fmpz_mat_is_reduced_with_removal`` as a fallback if the floating-point verifications fail. These functions implement the naive algorithm using rational arithmetic, so they can be extremely slow if the dimension is large. The LLL ought to be improved so that these fallbacks can be avoided (almost) entirely, but a slight improvement is to make them less horribly slow.

We thus port the naive algorithm to generics and make ``fmpz_mat_is_reduced`` / ``fmpz_mat_is_reduced_with_removal`` run some rounds with ``arb`` arithmetic before ultimately falling back on ``fmpq``.

Improvements on the ``fmpz_poly_factor`` benchmark:

Old:
```
H1 has 28 factors: 1669 ms
S7 has 1 factors: 139 ms
C1 has 32 factors: 580 ms
H2 has 6 factors: 230955 ms
S9 has 1 factors: 197224 ms
```

New:
```
H1 has 28 factors: 1585 ms
S7 has 1 factors: 110 ms
C1 has 32 factors: 520 ms
H2 has 6 factors: 218477 ms
S9 has 1 factors: 193651 ms
```