### PR TITLE
Clarify expectations of `flint_set_throw`'s argument

### DIFF
--- a/doc/source/flint.rst
+++ b/doc/source/flint.rst
@@ -502,7 +502,8 @@ Exceptions
 .. function:: void flint_set_throw(void (* func)(flint_err_t, const char *, va_list))
 
     Sets the :func:`flint_throw` function use ``func`` instead of a private
-    throw function.
+    throw function. ``func`` is expected to ``va_end`` the ``va_list``,
+    but it does not take ownership of the ``char *``.
 
 Sorting and searching
 -----------------------------------------------

--- a/doc/source/flint.rst
+++ b/doc/source/flint.rst
@@ -502,8 +502,8 @@ Exceptions
 .. function:: void flint_set_throw(void (* func)(flint_err_t, const char *, va_list))
 
     Sets the :func:`flint_throw` function use ``func`` instead of a private
-    throw function. ``func`` is expected to ``va_end`` the ``va_list``,
-    but it does not take ownership of the ``char *``.
+    throw function. ``func`` is expected to call ``va_end``, and to not alter
+    `const char *` in any way.
 
 Sorting and searching
 -----------------------------------------------


### PR DESCRIPTION
I am playing around to use `flint_set_throw` in Nemo (cf. https://github.com/Nemocas/Nemo.jl/pull/2115). Since the `flint_throw` function we want to introduce (to throw a proper julia error) does not completely abort FLINT (but just aborts the current call, thus yielding back to julia), I need to think about memory management.

Experimentally, I found out that when not `va_end`ing the `va_list`, objects may live in it until the next throw, thus leading to very weird interpolation of wrong objects.
In particular, since the situation is not symmetric here (the `va_list` is started by FLINT, but it needs to be ended by the callback), I think it would make sense to document this expectation.

Furthermore, since my callback is expected to clean up the `va_list`, I also tried cleaning up the `char * msg` argument, but that led to crashes. Thus, I propose to also add a sentence about that.

ping @albinahlback 