### PR TITLE
gr_mat_permanent: only use threading if ctx is threadsafe

### DIFF
--- a/src/gr_mat/permanent.c
+++ b/src/gr_mat/permanent.c
@@ -417,7 +417,7 @@ gr_mat_permanent_generic(gr_ptr res, const gr_mat_t A, gr_ctx_t ctx)
             int status;
 
             /* todo: cutoff could be lower if we have expensive entries */
-            if (n >= 11 && flint_get_num_available_threads() > 1)
+            if (n >= 11 && flint_get_num_available_threads() > 1 && gr_ctx_is_threadsafe(ctx) == T_TRUE)
                 status = gr_mat_permanent_glynn_threaded(res, A, ctx);
             else
                 status = gr_mat_permanent_glynn(res, A, ctx);


### PR DESCRIPTION
Without fix this crashes:

```
from flint_ctypes import *
C = CC_ca; N = 12; set_num_threads(8)
A = Mat(C)([[C.exp(2 * C.pi() * i * j * C.i() / N) for i in range(N)] for j in range(N)])
A.permanent()
```
