### PR TITLE
Orthogonal matrices

### DIFF
--- a/doc/source/flint.rst
+++ b/doc/source/flint.rst
@@ -264,6 +264,8 @@ Input/Output
     :type:`nmod_poly_t`, :type:`fmpz_poly_t`, :type:`fmpq_poly_t`,
     :type:`arb_poly_t` and :type:`acb_poly_t`.
 
+    Triple-valued booleans of type :type:`truth_t` can also be printed.
+
     Finally, we support printing generic elements of type :type:`gr_ptr`
     as well as :type:`gr_poly_t` and :type:`gr_mat_t`. For
     each of these types, the object to be printed must be followed
@@ -285,6 +287,7 @@ Input/Output
     fmpz_mod_ctx_t bfmpz_mod_ctx;
     mpz_t bmpz;
     mpq_t bmpq;
+    truth_t btruth;
     gr_ctx_t bgr_ctx;
     gr_ptr bgr;
 
@@ -303,7 +306,8 @@ Input/Output
         "fmpz_mod_ctx: %{fmpz_mod_ctx}\n"
         "mpz: %{mpz}\n"
         "mpq: %{mpq}\n"
-        "gr: %{gr}\n",
+        "truth: %{truth}\n"
+        "gr: %{gr}\n"
         "gr: %{gr_ctx}\n",
         bulong,
         bslong,
@@ -317,8 +321,9 @@ Input/Output
         bfmpz_mod_ctx,
         bmpz,
         bmpq,
-        gr, bgr_ctx,
-        gr_ctx);
+        btruth,
+        bgr, bgr_ctx,
+        bgr_ctx);
 
 .. code-block:: c
 

--- a/doc/source/gr_mat.rst
+++ b/doc/source/gr_mat.rst
@@ -972,6 +972,22 @@ Random matrices
     operations. More precisely, at most *opcount* conjugations by random
     elementary row/column operations will be performed.
 
+Orthogonal matrices
+-------------------------------------------------------------------------------
+
+.. function:: truth_t gr_mat_is_orthogonal(const gr_mat_t A, gr_ctx_t ctx)
+
+    Returns whether *A* is an orthogonal matrix, i.e. a square matrix
+    satisfying `A A^T = A^T A = I`. It is assumed (not checked) that the
+    scalar ring is commutative.
+
+.. function:: int gr_mat_randtest_orthogonal(gr_mat_t A, flint_rand_t state, gr_ctx_t ctx)
+
+    Generates a random orthogonal matrix. Uses Cayley's construction
+    with a permutation matrix is a fallback. It is assumed (not checked) that
+    the scalar ring is commutative.
+    Fails with ``GR_DOMAIN`` if *A* is not square.
+
 Special matrices
 -------------------------------------------------------------------------------
 

--- a/src/generic_files/io.c
+++ b/src/generic_files/io.c
@@ -698,6 +698,14 @@ print_flint_type:
         res += __mpq_fprint(fs, va_arg(vlist, mpq_srcptr));
         ip += STRING_LENGTH("mpq}");
     }
+    else if (IS_FLINT_TYPE(ip, "truth"))
+    {
+        truth_t t = va_arg(vlist, truth_t);
+        if (t == T_TRUE) res += fprintf(fs, "T_TRUE");
+        else if (t == T_FALSE) res += fprintf(fs, "T_FALSE");
+        else res += fprintf(fs, "T_UNKNOWN");
+        ip += STRING_LENGTH("truth}");
+    }
     else if (IS_FLINT_BASE_TYPE(ip, "gr"))
     {
         gr_stream_t out;

--- a/src/gr_mat.h
+++ b/src/gr_mat.h
@@ -379,6 +379,10 @@ WARN_UNUSED_RESULT int gr_mat_norm_1(gr_ptr res, const gr_mat_t mat, gr_ctx_t ct
 WARN_UNUSED_RESULT int gr_mat_norm_inf(gr_ptr res, const gr_mat_t mat, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mat_norm_frobenius(gr_ptr res, const gr_mat_t mat, gr_ctx_t ctx);
 
+/* Orthogonal matrices */
+truth_t gr_mat_is_orthogonal(const gr_mat_t A, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_mat_randtest_orthogonal(gr_mat_t A, flint_rand_t state, gr_ctx_t ctx);
+
 /* LLL */
 
 truth_t gr_mat_is_row_lll_reduced_naive(const gr_mat_t A, gr_srcptr delta, gr_srcptr eta, gr_ctx_t ctx);

--- a/src/gr_mat/is_orthogonal.c
+++ b/src/gr_mat/is_orthogonal.c
@@ -1,0 +1,108 @@
+/*
+    Copyright (C) 2025 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "gr_vec.h"
+#include "gr_mat.h"
+
+/* To do: over rings with coefficent explosion, instead of checking that
+   a dot product or matrix product is zero, compute two half-length
+   products and check that they are neg-equal. */
+
+/* Check that the square submatrix [a,b) x [a,b) in A*A^T is the identity matrix. */
+static truth_t
+gr_mat_is_orthogonal_recursive(const gr_mat_t A, gr_ptr tmp, slong a, slong b, gr_ctx_t ctx)
+{
+    slong i, j;
+    truth_t ok, res = T_TRUE;
+    slong n = A->r;
+    int status;
+    slong sz = ctx->sizeof_elem;
+
+    if (b - a <= 10)
+    {
+        for (i = a; i < b; i++)
+        {
+            for (j = a; j <= i; j++)
+            {
+                status = _gr_vec_dot(tmp, NULL, 0, GR_MAT_ENTRY(A, i, 0, sz),
+                                                 GR_MAT_ENTRY(A, j, 0, sz), n, ctx);
+
+                ok = (status == GR_SUCCESS) ?
+                    ((i == j) ? gr_is_one(tmp, ctx) : gr_is_zero(tmp, ctx)) : T_UNKNOWN;
+                res = truth_and(res, ok);
+                if (res == T_FALSE)
+                    return res;
+            }
+        }
+    }
+    else
+    {
+        slong m = a + (b - a) / 2;
+
+        res = truth_and(res, gr_mat_is_orthogonal_recursive(A, tmp, a, m, ctx));
+        if (res == T_FALSE)
+            return res;
+
+        res = truth_and(res, gr_mat_is_orthogonal_recursive(A, tmp, m, b, ctx));
+        if (res == T_FALSE)
+            return res;
+
+        /* Check that [m,b) x [a,m) in A*A^T is the zero matrix. */
+        gr_mat_t A1, A2, A2t, T;
+
+        gr_mat_window_init(A1, A, m, 0, b, n, ctx);
+        gr_mat_window_init(A2, A, a, 0, m, n, ctx);
+
+        /* There is no transposed gr_mat_mul yet, so do a shallow transpose */
+        slong r = A2->r;
+        slong c = A2->c;
+        A2t->r = c;
+        A2t->c = r;
+        A2t->stride = A2t->c;
+        A2t->entries = GR_TMP_ALLOC(sz * r * c);
+        for (i = 0; i < r; i++)
+            for (j = 0; j < c; j++)
+                gr_set_shallow(GR_MAT_ENTRY(A2t, j, i, sz), GR_MAT_ENTRY(A2, i, j, sz), ctx);
+
+        gr_mat_init(T, b - m, m - a, ctx);
+
+        if (gr_mat_mul(T, A1, A2t, ctx) == GR_SUCCESS)
+            res = gr_mat_is_zero(T, ctx);
+        else
+            res = T_UNKNOWN;
+
+        GR_TMP_FREE(A2t->entries, sz * r * c);
+        gr_mat_clear(T, ctx);
+    }
+
+    return res;
+}
+
+
+truth_t
+gr_mat_is_orthogonal(const gr_mat_t A, gr_ctx_t ctx)
+{
+    slong n = gr_mat_nrows(A, ctx);
+    truth_t res;
+    gr_ptr t;
+
+    if (n != gr_mat_ncols(A, ctx))
+        return T_FALSE;
+    if (n == 0)
+        return T_TRUE;
+
+    GR_TMP_INIT(t, ctx);
+    res = gr_mat_is_orthogonal_recursive(A, t, 0, n, ctx);
+    GR_TMP_CLEAR(t, ctx);
+
+    return res;
+}
+

--- a/src/gr_mat/randtest_orthogonal.c
+++ b/src/gr_mat/randtest_orthogonal.c
@@ -1,0 +1,76 @@
+/*
+    Copyright (C) 2025 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "perm.h"
+#include "gr.h"
+#include "gr_vec.h"
+#include "gr_mat.h"
+
+int
+gr_mat_randtest_orthogonal(gr_mat_t A, flint_rand_t state, gr_ctx_t ctx)
+{
+    slong n = A->r;
+    slong i, j, density;
+    int status = GR_SUCCESS;
+
+    if (n != A->c)
+        return GR_DOMAIN;
+
+    /* See https://arxiv.org/abs/math/0606320 */
+    /* If S is skew-symmetric, then (I + S)^(-1) (I - S) is orthogonal. */
+    gr_mat_t S, T;
+
+    gr_mat_init(S, n, n, ctx);
+    gr_mat_init(T, n, n, ctx);
+
+    /* Generate a random skew-symmetric matrix */
+    density = n_randint(state, 16);
+    for (i = 0; i < n; i++)
+    {
+        for (j = 0; j < i; j++)
+        {
+            if (n_randint(state, 16) < density)
+            {
+                status |= gr_randtest(gr_mat_entry_ptr(S, i, j, ctx), state, ctx);
+                status |= gr_neg(gr_mat_entry_ptr(S, j, i, ctx), gr_mat_entry_ptr(S, i, j, ctx), ctx);
+            }
+        }
+    }
+
+    status |= gr_mat_neg(T, S, ctx);
+    status |= gr_mat_add_ui(S, S, 1, ctx);
+    status |= gr_mat_add_ui(T, T, 1, ctx);
+    status |= gr_mat_nonsingular_solve(A, S, T, ctx);
+
+    gr_mat_clear(S, ctx);
+    gr_mat_clear(T, ctx);
+
+    /* Fall back to a random permutation matrix */
+    if (status != GR_SUCCESS)
+    {
+        slong * P;
+        status = gr_mat_zero(A, ctx);
+
+        P = _perm_init(n);
+        _perm_randtest(P, n, state);
+        for (i = 0; i < n; i++)
+            status |= gr_one(gr_mat_entry_ptr(A, i, P[i], ctx), ctx);
+        _perm_clear(P);
+    }
+
+    for (i = 0; i < n; i++)
+        if (n_randint(state, 2))
+            status |= _gr_vec_neg(gr_mat_entry_ptr(A, i, 0, ctx),
+                                  gr_mat_entry_ptr(A, i, 0, ctx), n, ctx);
+
+    return status;
+}
+

--- a/src/gr_mat/test/main.c
+++ b/src/gr_mat/test/main.c
@@ -34,6 +34,7 @@
 #include "t-hessenberg_householder.c"
 #include "t-inv.c"
 #include "t-invert_rows_cols.c"
+#include "t-is_orthogonal.c"
 #include "t-lu.c"
 #include "t-lu_classical.c"
 #include "t-lu_recursive.c"
@@ -95,6 +96,7 @@ test_struct tests[] =
     TEST_FUNCTION(gr_mat_hessenberg_householder),
     TEST_FUNCTION(gr_mat_inv),
     TEST_FUNCTION(gr_mat_invert_rows_cols),
+    TEST_FUNCTION(gr_mat_is_orthogonal),
     TEST_FUNCTION(gr_mat_lu),
     TEST_FUNCTION(gr_mat_lu_classical),
     TEST_FUNCTION(gr_mat_lu_recursive),

--- a/src/gr_mat/test/t-is_orthogonal.c
+++ b/src/gr_mat/test/t-is_orthogonal.c
@@ -1,0 +1,105 @@
+/*
+    Copyright (C) 2025 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "ulong_extras.h"
+#include "gr_mat.h"
+
+static truth_t
+gr_mat_is_orthogonal_naive(const gr_mat_t A, gr_ctx_t ctx)
+{
+    gr_mat_t T, U;
+    slong n = A->r;
+    truth_t res;
+
+    gr_mat_init(T, n, n, ctx);
+    gr_mat_init(U, n, n, ctx);
+
+    GR_MUST_SUCCEED(gr_mat_transpose(T, A, ctx));
+    GR_MUST_SUCCEED(gr_mat_mul(U, A, T, ctx));
+    res = gr_mat_is_one(U, ctx);
+
+    gr_mat_clear(T, ctx);
+    gr_mat_clear(U, ctx);
+
+    return res;
+}
+
+TEST_FUNCTION_START(gr_mat_is_orthogonal, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
+    {
+        slong n;
+        gr_ctx_t ctx;
+        gr_mat_t A;
+        truth_t r1, r2;
+
+        switch (n_randint(state, 4))
+        {
+            case 0:
+                gr_ctx_init_fmpz(ctx);
+                n = n_randint(state, 15);
+                break;
+            case 1:
+                gr_ctx_init_fmpq(ctx);
+                n = n_randint(state, 5);
+                break;
+            case 2:
+                gr_ctx_init_nmod(ctx, n_randtest_not_zero(state));
+                n = n_randint(state, 50);
+                break;
+            default:
+                gr_ctx_init_random(ctx, state);
+                n = n_randint(state, 4);
+                break;
+        }
+
+        gr_mat_init(A, n, n, ctx);
+        GR_MUST_SUCCEED(gr_mat_randtest_orthogonal(A, state, ctx));
+
+        r1 = gr_mat_is_orthogonal(A, ctx);
+
+        if (r1 == T_FALSE)
+        {
+            flint_printf("FAIL\n");
+            gr_ctx_println(ctx);
+            flint_printf("A = "), gr_mat_print(A, ctx); flint_printf("\n");
+            flint_printf("r1 = %{truth}\n", r1);
+            flint_abort();
+        }
+
+        if (n != 0)
+        {
+            GR_IGNORE(gr_randtest(gr_mat_entry_ptr(A,
+                n_randint(state, n), n_randint(state, n), ctx), state, ctx));
+
+            r1 = gr_mat_is_orthogonal(A, ctx);
+            r2 = gr_mat_is_orthogonal_naive(A, ctx);
+
+            if ((r1 == T_FALSE && r2 == T_TRUE) || (r1 == T_TRUE && r2 == T_FALSE))
+            {
+                flint_printf("FAIL\n");
+                gr_ctx_println(ctx);
+                flint_printf("A = "), gr_mat_print(A, ctx); flint_printf("\n");
+                flint_printf("r1 = %{truth}\n", r1);
+                flint_printf("r2 = %{truth}\n", r2);
+                flint_abort();
+            }
+        }
+
+        gr_mat_clear(A, ctx);
+        gr_ctx_clear(ctx);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/test/t-io.c
+++ b/src/test/t-io.c
@@ -453,6 +453,8 @@ do                      \
 #define MY_GR_MAT_CLEAR(xgr_mat, xgr_ctx) gr_mat_clear(xgr_mat, xgr_ctx)
 #define MY_GR_CTX_CLEAR(xgr_ctx) gr_ctx_clear(xgr_ctx)
 
+#define TRUTH_STRING "T_TRUE T_FALSE T_UNKNOWN"
+
 #define GR_VEC_LEN WORD(3)
 #define GR_STRING "5"
 #define GR_VEC_STRING "[1, 2, I]"
@@ -746,6 +748,7 @@ TEST_FUNCTION_START(flint_fprintf, state)
                 "fmpq_poly (2): " FMPQ_POLY2_STRING "\n"
                 "arb_poly: " ARB_POLY_STRING "\n"
                 "acb_poly: " ACB_POLY_STRING "\n"
+                "truth: " TRUTH_STRING "\n"
                 "gr: " GR_STRING "\n"
                 "gr_vec: " GR_VEC_STRING "\n"
                 "gr_poly: " GR_POLY_STRING "\n"
@@ -872,6 +875,7 @@ TEST_FUNCTION_START(flint_fprintf, state)
                 "fmpq_poly (2): %{fmpq_poly}\n"
                 "arb_poly: %{arb_poly}\n"
                 "acb_poly: %{acb_poly}\n"
+                "truth: %{truth} %{truth} %{truth}\n"
                 "gr: %{gr}\n"
                 "gr_vec: %{gr*}\n"
                 "gr_poly: %{gr_poly}\n"
@@ -943,6 +947,7 @@ TEST_FUNCTION_START(flint_fprintf, state)
                 xfmpq_poly2,
                 xarb_poly,
                 xacb_poly,
+                T_TRUE, T_FALSE, T_UNKNOWN,
                 xgr, xgr_ctx,
                 xgr_vec, GR_VEC_LEN, xgr_ctx,
                 xgr_poly, xgr_ctx,


### PR DESCRIPTION
* Add ``gr_mat_is_orthogonal``
* Add ``gr_mat_randtest_orthogonal``
* (Also support ``truth_t`` in ``flint_printf`` which is useful for debugging ``gr`` predicates)

I implemented ``is_orthogonal`` recursively using matrix multiplications for large off-diagonal blocks and iterated dot products around the diagonal. This should run in about half the time of naively expanding ``A A^T`` with a single ``gr_mat_mul`` (because we take advantage of symmetry), and allows early termination for random non-orthogonal matrices where we can expect needing O(1) dot products to certify non-orthogonality.