### PR TITLE
Consistently throw `FLINT_DIVZERO` when trying to divide by zero

### DIFF
--- a/src/arb_fmpz_poly/deflate.c
+++ b/src/arb_fmpz_poly/deflate.c
@@ -20,7 +20,7 @@ arb_fmpz_poly_deflate(fmpz_poly_t result, const fmpz_poly_t input, ulong deflati
 
     if (deflation == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_deflate). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_deflate). Division by zero.\n");
     }
 
     if (input->length <= 1 || deflation == 1)

--- a/src/fmpq/div.c
+++ b/src/fmpq/div.c
@@ -48,7 +48,7 @@ void fmpq_div(fmpq_t res, const fmpq_t op1, const fmpq_t op2)
 {
     if (fmpq_is_zero(op2))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpq_div). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpq_div). Division by zero.\n");
     }
 
     _fmpq_div(fmpq_numref(res), fmpq_denref(res),
@@ -62,7 +62,7 @@ void fmpq_div_fmpz(fmpq_t res, const fmpq_t op, const fmpz_t x)
 
     if (fmpz_is_zero(x))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpq_div_fmpz). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpq_div_fmpz). Division by zero.\n");
     }
 
     if (!COEFF_IS_MPZ(*fmpq_numref(op)) && !COEFF_IS_MPZ(*fmpq_denref(op)) && !COEFF_IS_MPZ(*x))

--- a/src/fmpq/pow_fmpz.c
+++ b/src/fmpq/pow_fmpz.c
@@ -20,7 +20,7 @@ int fmpq_pow_fmpz(fmpq_t a, const fmpq_t b, const fmpz_t e)
         e_sgn = fmpz_sgn(e);
 
         if (e_sgn < 0)
-            flint_throw(FLINT_ERROR, "Division by zero in fmpq_pow_fmpz");
+            flint_throw(FLINT_DIVZERO, "Division by zero in fmpq_pow_fmpz");
 
         fmpz_set_si(fmpq_numref(a), e_sgn == 0 ? 1 : 0);
         fmpz_one(fmpq_denref(a));

--- a/src/fmpq/pow_si.c
+++ b/src/fmpq/pow_si.c
@@ -50,7 +50,7 @@ void fmpq_pow_si(fmpq_t rop, const fmpq_t op, slong e)
 {
     if (e < 0 && fmpz_is_zero(fmpq_numref(op)))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpq_pow_si). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpq_pow_si). Division by zero.\n");
     }
 
     _fmpq_pow_si(fmpq_numref(rop), fmpq_denref(rop),

--- a/src/fmpq_poly/div.c
+++ b/src/fmpq_poly/div.c
@@ -74,7 +74,7 @@ void fmpq_poly_div(fmpq_poly_t Q,
 
     if (fmpq_poly_is_zero(poly2))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpq_poly_div). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpq_poly_div). Division by zero.\n");
     }
 
     if (poly1->length < poly2->length)

--- a/src/fmpq_poly/div_series.c
+++ b/src/fmpq_poly/div_series.c
@@ -42,7 +42,7 @@ void fmpq_poly_div_series(fmpq_poly_t Q, const fmpq_poly_t A,
 
     if (B->length == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpq_poly_div_series). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpq_poly_div_series). Division by zero.\n");
     }
 
     if (Q == A || Q == B)

--- a/src/fmpq_poly/divrem.c
+++ b/src/fmpq_poly/divrem.c
@@ -90,7 +90,7 @@ void fmpq_poly_divrem(fmpq_poly_t Q, fmpq_poly_t R,
 
     if (fmpq_poly_is_zero(poly2))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpq_poly_divrem). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpq_poly_divrem). Division by zero.\n");
     }
     if (Q == R)
     {

--- a/src/fmpq_poly/inv_series_newton.c
+++ b/src/fmpq_poly/inv_series_newton.c
@@ -143,7 +143,7 @@ fmpq_poly_inv_series_newton(fmpq_poly_t Qinv, const fmpq_poly_t Q, slong n)
 
     if (Qlen == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpq_poly_inv_series_newton). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpq_poly_inv_series_newton). Division by zero.\n");
     }
 
     if (Qinv != Q)

--- a/src/fmpq_poly/powers_precompute.c
+++ b/src/fmpq_poly/powers_precompute.c
@@ -58,7 +58,7 @@ void fmpq_poly_powers_precompute(fmpq_poly_powers_precomp_t pinv,
 {
     if (poly->length == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_powers_precompute). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_powers_precompute). Division by zero.\n");
     }
 
     pinv->powers = _fmpq_poly_powers_precompute(fmpq_poly_numref(poly),

--- a/src/fmpq_poly/rem.c
+++ b/src/fmpq_poly/rem.c
@@ -78,7 +78,7 @@ void fmpq_poly_rem(fmpq_poly_t R,
 
     if (fmpq_poly_is_zero(poly2))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpq_poly_rem). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpq_poly_rem). Division by zero.\n");
     }
 
     if (poly1->length < poly2->length)

--- a/src/fmpq_poly/remove.c
+++ b/src/fmpq_poly/remove.c
@@ -25,7 +25,7 @@ slong fmpq_poly_remove(fmpq_poly_t q, const fmpq_poly_t poly1,
 
     if (len2 == 0)
     {
-        flint_throw(FLINT_ERROR, "(fmpq_poly_remove): Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "(fmpq_poly_remove): Division by zero.\n");
     }
 
     if (len2 == 1)

--- a/src/fmpq_poly/scalar.c
+++ b/src/fmpq_poly/scalar.c
@@ -87,7 +87,7 @@ void fmpq_poly_scalar_div_fmpq(fmpq_poly_t rop, const fmpq_poly_t op, const fmpq
 {
     if (fmpq_is_zero(c))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpq_poly_scalar_div_fmpq). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpq_poly_scalar_div_fmpq). Division by zero.\n");
     }
 
     if (fmpq_poly_is_zero(op))
@@ -141,7 +141,7 @@ void fmpq_poly_scalar_div_fmpz(fmpq_poly_t rop, const fmpq_poly_t op, const fmpz
 {
     if (*c == WORD(0))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpq_poly_scalar_div_fmpz). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpq_poly_scalar_div_fmpz). Division by zero.\n");
     }
 
     if (fmpq_poly_is_zero(op))
@@ -206,7 +206,7 @@ void fmpq_poly_scalar_div_si(fmpq_poly_t rop, const fmpq_poly_t op, slong c)
 {
     if (c == WORD(0))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpq_poly_scalar_div_si). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpq_poly_scalar_div_si). Division by zero.\n");
     }
 
     if (fmpq_poly_is_zero(op))
@@ -254,7 +254,7 @@ void fmpq_poly_scalar_div_ui(fmpq_poly_t rop, const fmpq_poly_t op, ulong c)
 {
     if (c == UWORD(0))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpq_poly_scalar_div_ui). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpq_poly_scalar_div_ui). Division by zero.\n");
     }
 
     if (fmpq_poly_is_zero(op))

--- a/src/fmpz/cdiv.c
+++ b/src/fmpz/cdiv.c
@@ -39,7 +39,7 @@ fmpz_cdiv_q(fmpz_t f, const fmpz_t g, const fmpz_t h)
 
     if (fmpz_is_zero(h))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_cdiv_q). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_cdiv_q). Division by zero.\n");
     }
 
     if (!COEFF_IS_MPZ(c1))  /* g is small */
@@ -105,7 +105,7 @@ void fmpz_cdiv_qr(fmpz_t f, fmpz_t s, const fmpz_t g, const fmpz_t h)
 
     if (fmpz_is_zero(h))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_cdiv_q). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_cdiv_q). Division by zero.\n");
     }
 
     if (!COEFF_IS_MPZ(c1))      /* g is small */
@@ -194,7 +194,7 @@ fmpz_cdiv_q_si(fmpz_t f, const fmpz_t g, slong h)
 
     if (h == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_cdiv_q_si). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_cdiv_q_si). Division by zero.\n");
     }
 
     if (!COEFF_IS_MPZ(c1))      /* g is small */
@@ -232,7 +232,7 @@ fmpz_cdiv_q_ui(fmpz_t f, const fmpz_t g, ulong h)
 
     if (h == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception: division by zero in fmpz_cdiv_q_ui\n");
+        flint_throw(FLINT_DIVZERO, "Exception: division by zero in fmpz_cdiv_q_ui\n");
     }
 
     if (!COEFF_IS_MPZ(c1))      /* g is small */

--- a/src/fmpz/divexact.c
+++ b/src/fmpz/divexact.c
@@ -21,7 +21,7 @@ fmpz_divexact(fmpz_t f, const fmpz_t g, const fmpz_t h)
 
     if (fmpz_is_zero(h))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_divexact). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_divexact). Division by zero.\n");
     }
 
     if (!COEFF_IS_MPZ(c1))  /* g is small, h must be also or division isn't exact */
@@ -70,7 +70,7 @@ void fmpz_divexact_si(fmpz_t f, const fmpz_t g, slong h)
 
     if (h == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_divexact_si). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_divexact_si). Division by zero.\n");
     }
 
     if (!COEFF_IS_MPZ(c1))  /* g is small */
@@ -101,7 +101,7 @@ void fmpz_divexact_ui(fmpz_t f, const fmpz_t g, ulong h)
 
     if (h == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_divexact_ui). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_divexact_ui). Division by zero.\n");
     }
 
     if (!COEFF_IS_MPZ(c1))  /* g is small */

--- a/src/fmpz/fdiv.c
+++ b/src/fmpz/fdiv.c
@@ -40,7 +40,7 @@ fmpz_fdiv_q(fmpz_t f, const fmpz_t g, const fmpz_t h)
 
     if (fmpz_is_zero(h))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_fdiv_q). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_fdiv_q). Division by zero.\n");
     }
 
     if (!COEFF_IS_MPZ(c1))      /* g is small */
@@ -107,7 +107,7 @@ fmpz_fdiv_qr(fmpz_t f, fmpz_t s, const fmpz_t g, const fmpz_t h)
 
     if (fmpz_is_zero(h))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_fdiv_q). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_fdiv_q). Division by zero.\n");
     }
 
     if (!COEFF_IS_MPZ(c1))      /* g is small */
@@ -306,7 +306,7 @@ fmpz_fdiv_qr_preinvn(fmpz_t f, fmpz_t s, const fmpz_t g,
 
     if (fmpz_is_zero(h))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_fdiv_q). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_fdiv_q). Division by zero.\n");
     }
 
     if (!COEFF_IS_MPZ(c1))      /* g is small */
@@ -371,7 +371,7 @@ fmpz_fdiv_q_si(fmpz_t f, const fmpz_t g, slong h)
 
     if (h == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpq_fdiv_q_si). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpq_fdiv_q_si). Division by zero.\n");
     }
 
     if (!COEFF_IS_MPZ(c1))      /* g is small */
@@ -409,7 +409,7 @@ fmpz_fdiv_q_ui(fmpz_t f, const fmpz_t g, ulong h)
 
     if (h == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_fdiv_q_ui). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_fdiv_q_ui). Division by zero.\n");
     }
 
     if (!COEFF_IS_MPZ(c1))      /* g is small */
@@ -480,7 +480,7 @@ fmpz_fdiv_r(fmpz_t f, const fmpz_t g, const fmpz_t h)
 
     if (fmpz_is_zero(h))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_fdiv_r). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_fdiv_r). Division by zero.\n");
     }
 
     if (!COEFF_IS_MPZ(c1))      /* g is small */

--- a/src/fmpz/invmod.c
+++ b/src/fmpz/invmod.c
@@ -38,7 +38,7 @@ fmpz_invmod(fmpz_t f, const fmpz_t g, const fmpz_t h)
 
     if (fmpz_is_zero(h))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_invmod). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_invmod). Division by zero.\n");
     }
 
     if (!COEFF_IS_MPZ(c1))      /* g is small */

--- a/src/fmpz/ndiv_qr.c
+++ b/src/fmpz/ndiv_qr.c
@@ -62,7 +62,7 @@ fmpz_ndiv_qr(fmpz_t q, fmpz_t r, const fmpz_t a, const fmpz_t b)
 
     if (fmpz_is_zero(b))
     {
-        flint_throw(FLINT_ERROR, "Exception: division by zero in fmpz_ndiv_qr\n");
+        flint_throw(FLINT_DIVZERO, "Exception: division by zero in fmpz_ndiv_qr\n");
     }
 
     if (!COEFF_IS_MPZ(A) && !COEFF_IS_MPZ(B))

--- a/src/fmpz/preinvn.c
+++ b/src/fmpz/preinvn.c
@@ -20,7 +20,7 @@ void fmpz_preinvn_init(fmpz_preinvn_t inv, const fmpz_t f)
 
    if (c == 0)
    {
-      flint_throw(FLINT_ERROR, "Exception (fmpz_preinvn_init). Division by zero.\n");
+      flint_throw(FLINT_DIVZERO, "Exception (fmpz_preinvn_init). Division by zero.\n");
    } else if (!COEFF_IS_MPZ(c)) /* c is small */
    {
       ulong cc;

--- a/src/fmpz/tdiv.c
+++ b/src/fmpz/tdiv.c
@@ -44,7 +44,7 @@ fmpz_tdiv_q(fmpz_t f, const fmpz_t g, const fmpz_t h)
 
     if (fmpz_is_zero(h))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_tdiv_q). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_tdiv_q). Division by zero.\n");
     }
 
     if (!COEFF_IS_MPZ(c1))      /* g is small */
@@ -98,7 +98,7 @@ fmpz_tdiv_qr(fmpz_t f, fmpz_t s, const fmpz_t g, const fmpz_t h)
 
     if (fmpz_is_zero(h))
     {
-        flint_throw(FLINT_ERROR, "Exception: division by zero in fmpz_tdiv_qr\n");
+        flint_throw(FLINT_DIVZERO, "Exception: division by zero in fmpz_tdiv_qr\n");
     }
 
     if (!COEFF_IS_MPZ(c1))      /* g is small */
@@ -169,7 +169,7 @@ fmpz_tdiv_q_si(fmpz_t f, const fmpz_t g, slong h)
 
     if (h == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_tdiv_q_si). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_tdiv_q_si). Division by zero.\n");
     }
 
     if (!COEFF_IS_MPZ(c1))      /* g is small */
@@ -201,7 +201,7 @@ fmpz_tdiv_q_ui(fmpz_t f, const fmpz_t g, ulong h)
 
     if (h == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_tdiv_q_ui). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_tdiv_q_ui). Division by zero.\n");
     }
 
     if (!COEFF_IS_MPZ(c1))      /* g is small */

--- a/src/fmpz_mod_poly/div.c
+++ b/src/fmpz_mod_poly/div.c
@@ -45,7 +45,7 @@ void fmpz_mod_poly_div(fmpz_mod_poly_t Q, const fmpz_mod_poly_t A, const fmpz_mo
         }
         else
         {
-            flint_throw(FLINT_ERROR, "Exception (fmpz_mod_poly_div_basecase). Division by zero.\n");
+            flint_throw(FLINT_DIVZERO, "Exception (fmpz_mod_poly_div_basecase). Division by zero.\n");
         }
     }
 

--- a/src/fmpz_mod_poly/div_newton_n_preinv.c
+++ b/src/fmpz_mod_poly/div_newton_n_preinv.c
@@ -51,7 +51,7 @@ void fmpz_mod_poly_div_newton_n_preinv(fmpz_mod_poly_t Q,
         }
         else
         {
-            flint_throw(FLINT_ERROR, "Exception (fmpz_mod_poly_div_newton_n_preinv). Division by zero.\n");
+            flint_throw(FLINT_DIVZERO, "Exception (fmpz_mod_poly_div_newton_n_preinv). Division by zero.\n");
         }
     }
 

--- a/src/fmpz_mod_poly/div_series.c
+++ b/src/fmpz_mod_poly/div_series.c
@@ -96,7 +96,7 @@ void fmpz_mod_poly_div_series(fmpz_mod_poly_t Q, const fmpz_mod_poly_t A,
     slong Blen = FLINT_MIN(B->length, n);
 
     if (Blen == 0)
-        flint_throw(FLINT_ERROR, "Division by zero in %s\n", __func__);
+        flint_throw(FLINT_DIVZERO, "Division by zero in %s\n", __func__);
 
     if (Alen == 0)
     {

--- a/src/fmpz_mod_poly/divrem.c
+++ b/src/fmpz_mod_poly/divrem.c
@@ -55,7 +55,7 @@ fmpz_mod_poly_divrem(fmpz_mod_poly_t Q, fmpz_mod_poly_t R,
         }
         else
         {
-            flint_throw(FLINT_ERROR, "Exception (fmpz_mod_poly_divrem). Division by zero.\n");
+            flint_throw(FLINT_DIVZERO, "Exception (fmpz_mod_poly_divrem). Division by zero.\n");
         }
     }
 

--- a/src/fmpz_mod_poly/divrem_basecase.c
+++ b/src/fmpz_mod_poly/divrem_basecase.c
@@ -82,7 +82,7 @@ void fmpz_mod_poly_divrem_basecase(fmpz_mod_poly_t Q, fmpz_mod_poly_t R,
         }
         else
         {
-            flint_throw(FLINT_ERROR, "Exception (fmpz_mod_poly_divrem_basecase). Division by zero.\n");
+            flint_throw(FLINT_DIVZERO, "Exception (fmpz_mod_poly_divrem_basecase). Division by zero.\n");
         }
     }
 

--- a/src/fmpz_mod_poly/divrem_f.c
+++ b/src/fmpz_mod_poly/divrem_f.c
@@ -54,7 +54,7 @@ void fmpz_mod_poly_divrem_f(fmpz_t f, fmpz_mod_poly_t Q, fmpz_mod_poly_t R,
     if (lenB == 0)
     {
         fmpz_clear(invB); /* flint_throw */
-        flint_throw(FLINT_ERROR, "Exception (fmpz_mod_poly_divrem_f). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_mod_poly_divrem_f). Division by zero.\n");
     }
 
     if (lenA < lenB)

--- a/src/fmpz_mod_poly/divrem_newton_n_preinv.c
+++ b/src/fmpz_mod_poly/divrem_newton_n_preinv.c
@@ -52,7 +52,7 @@ void fmpz_mod_poly_divrem_newton_n_preinv(fmpz_mod_poly_t Q, fmpz_mod_poly_t R,
         }
         else
         {
-            flint_throw(FLINT_ERROR, "(fmpz_mod_poly_divrem_newton_n_preinv): Division by zero.\n");
+            flint_throw(FLINT_DIVZERO, "(fmpz_mod_poly_divrem_newton_n_preinv): Division by zero.\n");
         }
     }
 

--- a/src/fmpz_mod_poly/inv_series.c
+++ b/src/fmpz_mod_poly/inv_series.c
@@ -31,7 +31,7 @@ void fmpz_mod_poly_inv_series(fmpz_mod_poly_t g, const fmpz_mod_poly_t h, slong 
 
     if (n == 0 || h->length == 0 || fmpz_is_zero(h->coeffs + 0))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_mod_poly_inv). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_mod_poly_inv). Division by zero.\n");
     }
 
     if (hlen == 1)

--- a/src/fmpz_mod_poly/invsqrt_series.c
+++ b/src/fmpz_mod_poly/invsqrt_series.c
@@ -28,7 +28,7 @@ void fmpz_mod_poly_invsqrt_series(fmpz_mod_poly_t g, const fmpz_mod_poly_t h, sl
 
     if (n == 0 || h->length == 0 || fmpz_is_zero(h->coeffs + 0))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_mod_poly_invsqrt). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_mod_poly_invsqrt). Division by zero.\n");
     }
 
     if (!fmpz_is_one(h->coeffs + 0))

--- a/src/fmpz_mod_poly/scalar.c
+++ b/src/fmpz_mod_poly/scalar.c
@@ -77,7 +77,7 @@ void fmpz_mod_poly_scalar_div_fmpz(fmpz_mod_poly_t res,
         }
         else
         {
-            flint_throw(FLINT_ERROR, "Exception (fmpz_mod_poly_scalar_div_fmpz). Division by zero.\n");
+            flint_throw(FLINT_DIVZERO, "Exception (fmpz_mod_poly_scalar_div_fmpz). Division by zero.\n");
         }
     }
 

--- a/src/fmpz_mpoly_q/div.c
+++ b/src/fmpz_mpoly_q/div.c
@@ -20,7 +20,7 @@ _fmpz_mpoly_q_div(fmpz_mpoly_t res_num, fmpz_mpoly_t res_den,
 {
     if (fmpz_mpoly_is_zero(y_num, ctx))
     {
-        flint_throw(FLINT_ERROR, "_fmpz_mpoly_q_div: division by zero\n");
+        flint_throw(FLINT_DIVZERO, "_fmpz_mpoly_q_div: division by zero\n");
     }
 
     if (fmpz_mpoly_is_zero(x_num, ctx) || fmpz_mpoly_is_zero(y_num, ctx))
@@ -67,7 +67,7 @@ fmpz_mpoly_q_div_fmpq(fmpz_mpoly_q_t res, const fmpz_mpoly_q_t x, const fmpq_t y
 {
     if (fmpq_is_zero(y))
     {
-        flint_throw(FLINT_ERROR, "fmpz_mpoly_q_div_fmpq: division by zero\n");
+        flint_throw(FLINT_DIVZERO, "fmpz_mpoly_q_div_fmpq: division by zero\n");
     }
     else
     {
@@ -102,7 +102,7 @@ fmpz_mpoly_q_div_fmpz(fmpz_mpoly_q_t res, const fmpz_mpoly_q_t x, const fmpz_t y
 {
     if (fmpz_is_zero(y))
     {
-        flint_throw(FLINT_ERROR, "fmpz_mpoly_q_div_fmpz: division by zero\n");
+        flint_throw(FLINT_DIVZERO, "fmpz_mpoly_q_div_fmpz: division by zero\n");
     }
     else
     {

--- a/src/fmpz_mpoly_q/inv.c
+++ b/src/fmpz_mpoly_q/inv.c
@@ -16,7 +16,7 @@ fmpz_mpoly_q_inv(fmpz_mpoly_q_t res, const fmpz_mpoly_q_t x, const fmpz_mpoly_ct
 {
     if (fmpz_mpoly_is_zero(fmpz_mpoly_q_numref(x), ctx))
     {
-        flint_throw(FLINT_ERROR, "fmpz_mpoly_q_inv: division by zero\n");
+        flint_throw(FLINT_DIVZERO, "fmpz_mpoly_q_inv: division by zero\n");
     }
 
     if (res != x)

--- a/src/fmpz_poly/deflate.c
+++ b/src/fmpz_poly/deflate.c
@@ -19,7 +19,7 @@ fmpz_poly_deflate(fmpz_poly_t result, const fmpz_poly_t input, ulong deflation)
 
     if (deflation == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_deflate). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_deflate). Division by zero.\n");
     }
 
     if (input->length <= 1 || deflation == 1)

--- a/src/fmpz_poly/div.c
+++ b/src/fmpz_poly/div.c
@@ -26,7 +26,7 @@ fmpz_poly_div(fmpz_poly_t Q, const fmpz_poly_t A, const fmpz_poly_t B)
 
     if (B->length == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_div). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_div). Division by zero.\n");
     }
 
     if (A->length < B->length)

--- a/src/fmpz_poly/div_basecase.c
+++ b/src/fmpz_poly/div_basecase.c
@@ -106,7 +106,7 @@ fmpz_poly_div_basecase(fmpz_poly_t Q,
 
     if (B->length == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_div_basecase). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_div_basecase). Division by zero.\n");
     }
     if (A->length < B->length)
     {

--- a/src/fmpz_poly/div_divconquer.c
+++ b/src/fmpz_poly/div_divconquer.c
@@ -118,7 +118,7 @@ fmpz_poly_div_divconquer(fmpz_poly_t Q,
 
     if (lenB == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_div_divconquer). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_div_divconquer). Division by zero.\n");
     }
 
     if (lenA < lenB)

--- a/src/fmpz_poly/div_series.c
+++ b/src/fmpz_poly/div_series.c
@@ -44,7 +44,7 @@ void fmpz_poly_div_series(fmpz_poly_t Q, const fmpz_poly_t A,
 
     if (Blen == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_div_series). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_div_series). Division by zero.\n");
     }
 
     if (Alen == 0)

--- a/src/fmpz_poly/div_series_basecase.c
+++ b/src/fmpz_poly/div_series_basecase.c
@@ -241,7 +241,7 @@ void fmpz_poly_div_series_basecase(fmpz_poly_t Q, const fmpz_poly_t A,
 
     if (Blen == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_div_series_basecase). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_div_series_basecase). Division by zero.\n");
     }
 
     if (Alen == 0)

--- a/src/fmpz_poly/div_series_divconquer.c
+++ b/src/fmpz_poly/div_series_divconquer.c
@@ -46,7 +46,7 @@ void fmpz_poly_div_series_divconquer(fmpz_poly_t Q, const fmpz_poly_t A,
 
     if (Blen == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_div_series_divconquer). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_div_series_divconquer). Division by zero.\n");
     }
 
     if (Alen == 0)

--- a/src/fmpz_poly/divexact.c
+++ b/src/fmpz_poly/divexact.c
@@ -78,7 +78,7 @@ fmpz_poly_divexact(fmpz_poly_t Q, const fmpz_poly_t A, const fmpz_poly_t B)
 
     if (lenB == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_divexact). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_divexact). Division by zero.\n");
     }
 
     if (lenA < lenB)

--- a/src/fmpz_poly/divides.c
+++ b/src/fmpz_poly/divides.c
@@ -68,7 +68,7 @@ int fmpz_poly_divides(fmpz_poly_t q, const fmpz_poly_t a, const fmpz_poly_t b)
 {
     if (fmpz_poly_is_zero(b))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_divides). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_divides). Division by zero.\n");
     }
     if (fmpz_poly_is_zero(a))
     {

--- a/src/fmpz_poly/divrem.c
+++ b/src/fmpz_poly/divrem.c
@@ -34,7 +34,7 @@ void fmpz_poly_divrem(fmpz_poly_t Q, fmpz_poly_t R,
 
     if (lenB == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_divrem). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_divrem). Division by zero.\n");
     }
 
     if (lenA < lenB)

--- a/src/fmpz_poly/divrem_basecase.c
+++ b/src/fmpz_poly/divrem_basecase.c
@@ -72,7 +72,7 @@ fmpz_poly_divrem_basecase(fmpz_poly_t Q, fmpz_poly_t R,
 
     if (B->length == 0)
     {
-        flint_throw(FLINT_ERROR, "(fmpz_poly_divrem_basecase). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "(fmpz_poly_divrem_basecase). Division by zero.\n");
     }
     if (Q == R)
     {

--- a/src/fmpz_poly/divrem_divconquer.c
+++ b/src/fmpz_poly/divrem_divconquer.c
@@ -140,7 +140,7 @@ fmpz_poly_divrem_divconquer(fmpz_poly_t Q, fmpz_poly_t R,
 
     if (lenB == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_divrem_divconquer). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_divrem_divconquer). Division by zero.\n");
     }
 
     if (lenA < lenB)

--- a/src/fmpz_poly/inv_series.c
+++ b/src/fmpz_poly/inv_series.c
@@ -33,7 +33,7 @@ fmpz_poly_inv_series(fmpz_poly_t Qinv, const fmpz_poly_t Q, slong n)
 
     if (Qlen == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_inv_series). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_inv_series). Division by zero.\n");
     }
 
     if (Qinv != Q)
@@ -239,7 +239,7 @@ fmpz_poly_inv_series_basecase(fmpz_poly_t Qinv, const fmpz_poly_t Q, slong n)
 
     if (Qlen == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_inv_series_basecase). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_inv_series_basecase). Division by zero.\n");
     }
 
     if (Qinv != Q)
@@ -318,7 +318,7 @@ fmpz_poly_inv_series_newton(fmpz_poly_t Qinv, const fmpz_poly_t Q, slong n)
 
     if (Qlen == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_inv_series_newton). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_inv_series_newton). Division by zero.\n");
     }
 
     if (Qinv != Q)

--- a/src/fmpz_poly/powers_precompute.c
+++ b/src/fmpz_poly/powers_precompute.c
@@ -52,7 +52,7 @@ void fmpz_poly_powers_precompute(fmpz_poly_powers_precomp_t pinv,
 {
     if (poly->length == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_powers_precompute). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_powers_precompute). Division by zero.\n");
     }
 
     pinv->powers = _fmpz_poly_powers_precompute(poly->coeffs, poly->length);

--- a/src/fmpz_poly/preinvert.c
+++ b/src/fmpz_poly/preinvert.c
@@ -77,7 +77,7 @@ fmpz_poly_preinvert(fmpz_poly_t B_inv, const fmpz_poly_t B)
 
     if (n == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_preinvert). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_preinvert). Division by zero.\n");
     }
 
     if (B == B_inv)

--- a/src/fmpz_poly/pseudo_div.c
+++ b/src/fmpz_poly/pseudo_div.c
@@ -29,7 +29,7 @@ void fmpz_poly_pseudo_div(fmpz_poly_t Q, ulong * d, const fmpz_poly_t A,
 
     if (B->length == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_pseudo_div). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_pseudo_div). Division by zero.\n");
     }
     if (A->length < B->length)
     {

--- a/src/fmpz_poly/pseudo_divrem_basecase.c
+++ b/src/fmpz_poly/pseudo_divrem_basecase.c
@@ -67,7 +67,7 @@ fmpz_poly_pseudo_divrem_basecase(fmpz_poly_t Q, fmpz_poly_t R,
 
     if (B->length == 0)
     {
-        flint_throw(FLINT_ERROR, "(fmpz_poly_pseudo_divrem_basecase): Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "(fmpz_poly_pseudo_divrem_basecase): Division by zero.\n");
     }
     if (Q == R)
     {

--- a/src/fmpz_poly/pseudo_divrem_cohen.c
+++ b/src/fmpz_poly/pseudo_divrem_cohen.c
@@ -79,7 +79,7 @@ fmpz_poly_pseudo_divrem_cohen(fmpz_poly_t Q, fmpz_poly_t R,
 
     if (B->length == 0)
     {
-        flint_throw(FLINT_ERROR, "(fmpz_poly_pseudo_divrem_cohen): Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "(fmpz_poly_pseudo_divrem_cohen): Division by zero.\n");
     }
     if (Q == R)
     {

--- a/src/fmpz_poly/pseudo_divrem_divconquer.c
+++ b/src/fmpz_poly/pseudo_divrem_divconquer.c
@@ -289,7 +289,7 @@ fmpz_poly_pseudo_divrem_divconquer(fmpz_poly_t Q, fmpz_poly_t R,
 
     if (B->length == 0)
     {
-        flint_throw(FLINT_ERROR, "(fmpz_poly_pseudo_divrem_divconquer): Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "(fmpz_poly_pseudo_divrem_divconquer): Division by zero.\n");
     }
     if (Q == R)
     {

--- a/src/fmpz_poly/pseudo_rem.c
+++ b/src/fmpz_poly/pseudo_rem.c
@@ -29,7 +29,7 @@ void fmpz_poly_pseudo_rem(fmpz_poly_t R, ulong * d, const fmpz_poly_t A,
 
     if (B->length == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_pseudo_rem). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_pseudo_rem). Division by zero.\n");
     }
     if (A->length < B->length)
     {

--- a/src/fmpz_poly/pseudo_rem_cohen.c
+++ b/src/fmpz_poly/pseudo_rem_cohen.c
@@ -57,7 +57,7 @@ fmpz_poly_pseudo_rem_cohen(fmpz_poly_t R, const fmpz_poly_t A, const fmpz_poly_t
 
     if (B->length == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_pseudo_rem_cohen). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_pseudo_rem_cohen). Division by zero.\n");
     }
     if (A->length < B->length)
     {

--- a/src/fmpz_poly/rem.c
+++ b/src/fmpz_poly/rem.c
@@ -36,7 +36,7 @@ void fmpz_poly_rem(fmpz_poly_t R, const fmpz_poly_t A, const fmpz_poly_t B)
 
     if (lenB == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_rem). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_rem). Division by zero.\n");
     }
 
     if (lenA < lenB)

--- a/src/fmpz_poly/rem_basecase.c
+++ b/src/fmpz_poly/rem_basecase.c
@@ -47,7 +47,7 @@ fmpz_poly_rem_basecase(fmpz_poly_t R,
 
     if (B->length == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_rem_basecase). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_rem_basecase). Division by zero.\n");
     }
     if (A->length < B->length)
     {

--- a/src/fmpz_poly/remove.c
+++ b/src/fmpz_poly/remove.c
@@ -23,7 +23,7 @@ fmpz_poly_remove(fmpz_poly_t res, const fmpz_poly_t poly1,
 
     if (poly2->length == 0)
     {
-        flint_throw(FLINT_ERROR, "(fmpz_poly_remove): Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "(fmpz_poly_remove): Division by zero.\n");
     }
 
     if (poly2->length == 1 && fmpz_is_pm1(poly2->coeffs + 0))

--- a/src/fmpz_poly/scalar.c
+++ b/src/fmpz_poly/scalar.c
@@ -84,7 +84,7 @@ fmpz_poly_scalar_divexact_fmpz(fmpz_poly_t poly1, const fmpz_poly_t poly2,
 {
     if (fmpz_is_zero(x))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_scalar_divexact_fmpz). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_scalar_divexact_fmpz). Division by zero.\n");
     }
 
     if (poly2->length == 0)
@@ -104,7 +104,7 @@ fmpz_poly_scalar_divexact_si(fmpz_poly_t poly1, const fmpz_poly_t poly2,
 {
     if (x == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_scalar_divexact_si). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_scalar_divexact_si). Division by zero.\n");
     }
 
     if (poly2->length == 0)
@@ -124,7 +124,7 @@ fmpz_poly_scalar_divexact_ui(fmpz_poly_t poly1, const fmpz_poly_t poly2,
 {
     if (x == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_scalar_divexact_ui). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_scalar_divexact_ui). Division by zero.\n");
     }
 
     if (poly2->length == 0)
@@ -160,7 +160,7 @@ fmpz_poly_scalar_fdiv_fmpz(fmpz_poly_t poly1, const fmpz_poly_t poly2,
 {
     if (fmpz_is_zero(x))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_scalar_fdiv_fmpz). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_scalar_fdiv_fmpz). Division by zero.\n");
     }
 
     if (poly2->length == 0)
@@ -180,7 +180,7 @@ fmpz_poly_scalar_fdiv_si(fmpz_poly_t poly1, const fmpz_poly_t poly2,
 {
     if (x == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_scalar_fdiv_si). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_scalar_fdiv_si). Division by zero.\n");
     }
 
     if (poly2->length == 0)
@@ -200,7 +200,7 @@ fmpz_poly_scalar_fdiv_ui(fmpz_poly_t poly1, const fmpz_poly_t poly2,
 {
     if (x == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_scalar_fdiv_ui). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_scalar_fdiv_ui). Division by zero.\n");
     }
 
     if (poly2->length == 0)
@@ -380,7 +380,7 @@ fmpz_poly_scalar_tdiv_fmpz(fmpz_poly_t poly1, const fmpz_poly_t poly2,
 {
     if (fmpz_is_zero(x))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_scalar_tdiv_fmpz). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_scalar_tdiv_fmpz). Division by zero.\n");
     }
 
     if (poly2->length == 0)
@@ -400,7 +400,7 @@ fmpz_poly_scalar_tdiv_si(fmpz_poly_t poly1, const fmpz_poly_t poly2,
 {
     if (x == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_scalar_tdiv_si). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_scalar_tdiv_si). Division by zero.\n");
     }
 
     if (poly2->length == 0)
@@ -420,7 +420,7 @@ fmpz_poly_scalar_tdiv_ui(fmpz_poly_t poly1, const fmpz_poly_t poly2,
 {
     if (x == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_scalar_tdiv_ui). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_scalar_tdiv_ui). Division by zero.\n");
     }
 
     if (poly2->length == 0)

--- a/src/fmpz_poly_q/div.c
+++ b/src/fmpz_poly_q/div.c
@@ -18,7 +18,7 @@ void fmpz_poly_q_div(fmpz_poly_q_t rop,
 {
     if (fmpz_poly_q_is_zero(op2))
     {
-        flint_throw(FLINT_ERROR, "Exception (fmpz_poly_q_div). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_q_div). Division by zero.\n");
     }
     if (fmpz_poly_q_is_zero(op1))
     {

--- a/src/fmpz_poly_q/scalar.c
+++ b/src/fmpz_poly_q/scalar.c
@@ -19,7 +19,7 @@ fmpz_poly_q_scalar_div_fmpq(fmpz_poly_q_t rop, const fmpz_poly_q_t op, const fmp
     fmpz_t num, den;
 
     if (fmpz_sgn(fmpq_numref(x)) == 0)
-        flint_throw(FLINT_ERROR, "Division by zero in %s\n", __func__);
+        flint_throw(FLINT_DIVZERO, "Division by zero in %s\n", __func__);
 
     fmpz_init(num);
     fmpz_init(den);
@@ -40,7 +40,7 @@ fmpz_poly_q_scalar_div_fmpz(fmpz_poly_q_t rop, const fmpz_poly_q_t op, const fmp
     fmpz_t y;
 
     if (fmpz_sgn(x) == 0)
-        flint_throw(FLINT_ERROR, "Division by zero in %s\n", __func__);
+        flint_throw(FLINT_DIVZERO, "Division by zero in %s\n", __func__);
 
     fmpz_init(y);
     fmpz_set(y, x);
@@ -60,7 +60,7 @@ void fmpz_poly_q_scalar_div_si(fmpz_poly_q_t rop, const fmpz_poly_q_t op, slong 
     {
         if (x == 0)
         {
-            flint_throw(FLINT_ERROR, "Exception (fmpz_poly_q_scalar_div_si). Division by zero.\n");
+            flint_throw(FLINT_DIVZERO, "Exception (fmpz_poly_q_scalar_div_si). Division by zero.\n");
         }
         if (x == 1)
             fmpz_poly_q_set(rop, op);

--- a/src/fmpzi/divexact.c
+++ b/src/fmpzi/divexact.c
@@ -74,7 +74,7 @@ fmpzi_divexact(fmpzi_t q, const fmpzi_t x, const fmpzi_t y)
 
     if (ybits == 0)
     {
-        flint_throw(FLINT_ERROR, "fmpzi_divexact: division by zero\n");
+        flint_throw(FLINT_DIVZERO, "fmpzi_divexact: division by zero\n");
     }
 
     if (xbits == 0)

--- a/src/fmpzi/divrem.c
+++ b/src/fmpzi/divrem.c
@@ -25,7 +25,7 @@ fmpzi_divrem(fmpzi_t q, fmpzi_t r, const fmpzi_t x, const fmpzi_t y)
 
     if (ybits == 0)
     {
-        flint_throw(FLINT_ERROR, "fmpzi_divrem: division by zero\n");
+        flint_throw(FLINT_DIVZERO, "fmpzi_divrem: division by zero\n");
     }
 
     if (xbits == 0)

--- a/src/fmpzi/divrem_approx.c
+++ b/src/fmpzi/divrem_approx.c
@@ -23,7 +23,7 @@ fmpzi_divrem_approx(fmpzi_t q, fmpzi_t r, const fmpzi_t x, const fmpzi_t y)
 
     if (ybits == 0)
     {
-        flint_throw(FLINT_ERROR, "fmpzi_divrem_approx: division by zero\n");
+        flint_throw(FLINT_DIVZERO, "fmpzi_divrem_approx: division by zero\n");
     }
 
     if (xbits == 0)

--- a/src/fq_poly_templates/deflate.c
+++ b/src/fq_poly_templates/deflate.c
@@ -24,7 +24,7 @@ TEMPLATE(T, poly_deflate) (TEMPLATE(T, poly_t) result,
 
     if (deflation == 0)
     {
-        flint_throw(FLINT_ERROR, "(%s): Division by zero\n", __func__);
+        flint_throw(FLINT_DIVZERO, "(%s): Division by zero\n", __func__);
     }
 
     if (input->length <= 1 || deflation == 1)

--- a/src/fq_poly_templates/div_newton_n_preinv.c
+++ b/src/fq_poly_templates/div_newton_n_preinv.c
@@ -53,7 +53,7 @@ TEMPLATE(T, poly_div_newton_n_preinv) (TEMPLATE(T, poly_t) Q,
 
     if (lenB == 0)
     {
-        flint_throw(FLINT_ERROR, "(%s): Division by zero\n", __func__);
+        flint_throw(FLINT_DIVZERO, "(%s): Division by zero\n", __func__);
     }
 
     if (lenA < lenB)

--- a/src/fq_poly_templates/div_series.c
+++ b/src/fq_poly_templates/div_series.c
@@ -105,7 +105,7 @@ void TEMPLATE(T, poly_div_series)(TEMPLATE(T, poly_t) Q, const TEMPLATE(T, poly_
 
     if (Blen == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fq_poly_div_series). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fq_poly_div_series). Division by zero.\n");
     }
 
     if (Alen == 0)

--- a/src/fq_poly_templates/divides.c
+++ b/src/fq_poly_templates/divides.c
@@ -43,7 +43,7 @@ TEMPLATE(T, poly_divides) (TEMPLATE(T, poly_t) Q,
 {
     if (TEMPLATE(T, poly_is_zero) (B, ctx))
     {
-        flint_throw(FLINT_ERROR, "(%s): Division by zero\n", __func__);
+        flint_throw(FLINT_DIVZERO, "(%s): Division by zero\n", __func__);
     }
 
     if (TEMPLATE(T, poly_is_zero) (A, ctx))

--- a/src/fq_poly_templates/divrem_newton_n_preinv.c
+++ b/src/fq_poly_templates/divrem_newton_n_preinv.c
@@ -53,7 +53,7 @@ TEMPLATE(T, poly_divrem_newton_n_preinv) (TEMPLATE(T, poly_t) Q,
 
     if (lenB == 0)
     {
-        flint_throw(FLINT_ERROR, "(%s): Division by zero\n", __func__);
+        flint_throw(FLINT_DIVZERO, "(%s): Division by zero\n", __func__);
     }
 
     if (lenA < lenB)

--- a/src/fq_poly_templates/invsqrt_series.c
+++ b/src/fq_poly_templates/invsqrt_series.c
@@ -92,7 +92,7 @@ void TEMPLATE(T, poly_invsqrt_series)(TEMPLATE(T, poly_t) g,
 
     if (n == 0 || h->length == 0 || TEMPLATE(T, is_zero)(h->coeffs + 0, ctx))
     {
-        flint_throw(FLINT_ERROR, "Exception (fq_poly_invsqrt). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fq_poly_invsqrt). Division by zero.\n");
     }
 
     if (!TEMPLATE(T, is_one)(h->coeffs + 0, ctx))

--- a/src/fq_poly_templates/mulmod.c
+++ b/src/fq_poly_templates/mulmod.c
@@ -62,7 +62,7 @@ TEMPLATE(T, poly_mulmod) (TEMPLATE(T, poly_t) res,
 
     if (lenf == 0)
     {
-        flint_throw(FLINT_ERROR, "(%s): Division by zero\n", __func__);
+        flint_throw(FLINT_DIVZERO, "(%s): Division by zero\n", __func__);
     }
 
     if (lenf == 1 || len1 == 0 || len2 == 0)

--- a/src/fq_poly_templates/mulmod_preinv.c
+++ b/src/fq_poly_templates/mulmod_preinv.c
@@ -73,7 +73,7 @@ TEMPLATE(T, poly_mulmod_preinv) (TEMPLATE(T, poly_t) res,
 
     if (lenf == 0)
     {
-        flint_throw(FLINT_ERROR, "(%s): Division by zero\n", __func__);
+        flint_throw(FLINT_DIVZERO, "(%s): Division by zero\n", __func__);
     }
 
     if (lenf == 1 || len1 == 0 || len2 == 0)

--- a/src/fq_poly_templates/scalar_div_fq.c
+++ b/src/fq_poly_templates/scalar_div_fq.c
@@ -35,7 +35,7 @@ TEMPLATE(T, TEMPLATE(poly_scalar_div, T)) (TEMPLATE(T, poly_t) rop,
 {
     if (TEMPLATE(T, is_zero) (x, ctx))
     {
-       flint_throw(FLINT_ERROR, "Exception (fq_poly_scalar_div) Division by zero");
+       flint_throw(FLINT_DIVZERO, "Exception (fq_poly_scalar_div) Division by zero");
     }
     if (TEMPLATE(T, poly_is_zero) (op, ctx))
     {

--- a/src/fq_poly_templates/sqrt_series.c
+++ b/src/fq_poly_templates/sqrt_series.c
@@ -37,7 +37,7 @@ TEMPLATE(T, poly_sqrt_series)(TEMPLATE(T, poly_t) g, const TEMPLATE(T, poly_t) h
 
     if (n == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (fq_poly_sqrt_series). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (fq_poly_sqrt_series). Division by zero.\n");
     }
 
     if (h->length == 0 || !TEMPLATE(T, is_one)(h->coeffs + 0, ctx))

--- a/src/n_poly/n_poly_mod.c
+++ b/src/n_poly/n_poly_mod.c
@@ -305,7 +305,7 @@ void n_poly_mod_div(n_poly_t Q, const n_poly_t A, const n_poly_t B, nmod_t ctx)
         }
         else
         {
-            flint_throw(FLINT_ERROR, "Exception (n_poly_mod_div). Division by zero.\n");
+            flint_throw(FLINT_DIVZERO, "Exception (n_poly_mod_div). Division by zero.\n");
         }
     }
 
@@ -356,7 +356,7 @@ void n_poly_mod_divexact(n_poly_t Q, const n_poly_t A, const n_poly_t B, nmod_t 
         }
         else
         {
-            flint_throw(FLINT_ERROR, "Exception (n_poly_mod_divexact). Division by zero.\n");
+            flint_throw(FLINT_DIVZERO, "Exception (n_poly_mod_divexact). Division by zero.\n");
         }
     }
 
@@ -398,7 +398,7 @@ void n_poly_mod_rem(n_poly_t R, const n_poly_t A, const n_poly_t B, nmod_t ctx)
 
     if (lenB == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (nmod_poly_rem). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (nmod_poly_rem). Division by zero.\n");
     }
     if (lenA < lenB)
     {
@@ -447,7 +447,7 @@ void n_poly_mod_divrem(n_poly_t Q, n_poly_t R,
         }
         else
         {
-            flint_throw(FLINT_ERROR, "Exception (n_poly_mod_divrem). Division by zero.");
+            flint_throw(FLINT_DIVZERO, "Exception (n_poly_mod_divrem). Division by zero.");
         }
     }
 
@@ -789,7 +789,7 @@ void n_poly_mod_inv_series(n_poly_t Qinv, const n_poly_t Q, slong n, nmod_t ctx)
 
     if (Qlen == 0)
     {
-        flint_throw(FLINT_ERROR, "n_poly_mod_inv_series_newton: Division by zero.");
+        flint_throw(FLINT_DIVZERO, "n_poly_mod_inv_series_newton: Division by zero.");
     }
 
     if (Qinv != Q)
@@ -819,7 +819,7 @@ void n_poly_mod_div_series(n_poly_t Q, const n_poly_t A, const n_poly_t B,
 
     if (order < 1 || Blen == 0 || B->coeffs[0] == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (n_poly_div_series). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (n_poly_div_series). Division by zero.\n");
     }
 
     if (Alen == 0)

--- a/src/nmod_poly/compose_mod.c
+++ b/src/nmod_poly/compose_mod.c
@@ -37,7 +37,7 @@ nmod_poly_compose_mod(nmod_poly_t res,
 
     if (len3 == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (nmod_poly_compose_mod). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (nmod_poly_compose_mod). Division by zero.\n");
     }
 
     if (len1 == 0 || len3 == 1)

--- a/src/nmod_poly/compose_mod_brent_kung.c
+++ b/src/nmod_poly/compose_mod_brent_kung.c
@@ -97,7 +97,7 @@ nmod_poly_compose_mod_brent_kung(nmod_poly_t res,
 
     if (len3 == 0)
     {
-        flint_throw(FLINT_ERROR, "(nmod_poly_compose_mod_brent_kung): Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "(nmod_poly_compose_mod_brent_kung): Division by zero.\n");
     }
 
     if (len1 >= len3)

--- a/src/nmod_poly/compose_mod_brent_kung_precomp_preinv.c
+++ b/src/nmod_poly/compose_mod_brent_kung_precomp_preinv.c
@@ -74,7 +74,7 @@ nmod_poly_precompute_matrix(nmod_mat_t A, const nmod_poly_t poly1,
 
     if (len2 == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (nmod_poly_precompute_matrix). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (nmod_poly_precompute_matrix). Division by zero.\n");
     }
 
     if (A->r != m || A->c != len)
@@ -179,7 +179,7 @@ nmod_poly_compose_mod_brent_kung_precomp_preinv(nmod_poly_t res,
 
     if (len3 == 0)
     {
-        flint_throw(FLINT_ERROR, "(nmod_poly_compose_mod_brent_kung_precomp_preinv): Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "(nmod_poly_compose_mod_brent_kung_precomp_preinv): Division by zero.\n");
     }
 
     if (len1 >= len3)

--- a/src/nmod_poly/compose_mod_brent_kung_preinv.c
+++ b/src/nmod_poly/compose_mod_brent_kung_preinv.c
@@ -108,7 +108,7 @@ nmod_poly_compose_mod_brent_kung_preinv(nmod_poly_t res,
 
     if (len3 == 0)
     {
-        flint_throw(FLINT_ERROR, "(nmod_poly_compose_mod_brent_kung_preinv): Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "(nmod_poly_compose_mod_brent_kung_preinv): Division by zero.\n");
     }
 
     if (len1 >= len3)

--- a/src/nmod_poly/compose_mod_horner.c
+++ b/src/nmod_poly/compose_mod_horner.c
@@ -69,7 +69,7 @@ nmod_poly_compose_mod_horner(nmod_poly_t res,
 
     if (len3 == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (nmod_poly_compose_mod_horner). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (nmod_poly_compose_mod_horner). Division by zero.\n");
     }
 
     if (len1 == 0 || len3 == 1)

--- a/src/nmod_poly/deflate.c
+++ b/src/nmod_poly/deflate.c
@@ -19,7 +19,7 @@ nmod_poly_deflate(nmod_poly_t result, const nmod_poly_t input, slong deflation)
 
     if (deflation == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (nmod_poly_deflate). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (nmod_poly_deflate). Division by zero.\n");
     }
 
     if (input->length <= 1 || deflation == 1)

--- a/src/nmod_poly/div.c
+++ b/src/nmod_poly/div.c
@@ -57,7 +57,7 @@ nmod_poly_div(nmod_poly_t Q,
             return;
         } else
         {
-            flint_throw(FLINT_ERROR, "Exception (nmod_poly_divrem). Division by zero.\n");
+            flint_throw(FLINT_DIVZERO, "Exception (nmod_poly_divrem). Division by zero.\n");
         }
     }
 

--- a/src/nmod_poly/div_newton_n_preinv.c
+++ b/src/nmod_poly/div_newton_n_preinv.c
@@ -47,7 +47,7 @@ void nmod_poly_div_newton_n_preinv(nmod_poly_t Q, const nmod_poly_t A,
             return;
         } else
         {
-            flint_throw(FLINT_ERROR, "Exception (nmod_poly_div_newton_n_preinv). Division by zero.\n");
+            flint_throw(FLINT_DIVZERO, "Exception (nmod_poly_div_newton_n_preinv). Division by zero.\n");
         }
     }
 

--- a/src/nmod_poly/div_series.c
+++ b/src/nmod_poly/div_series.c
@@ -78,7 +78,7 @@ nmod_poly_div_series_basecase(nmod_poly_t Q, const nmod_poly_t A,
 
     if (n == 0 || Blen == 0 || B->coeffs[0] == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (nmod_poly_div_series_basecase). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (nmod_poly_div_series_basecase). Division by zero.\n");
     }
 
     Alen = A->length;
@@ -135,7 +135,7 @@ nmod_poly_div_series(nmod_poly_t Q, const nmod_poly_t A,
 
     if (n == 0 || Blen == 0 || B->coeffs[0] == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (nmod_poly_div_series). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (nmod_poly_div_series). Division by zero.\n");
     }
 
     Alen = A->length;

--- a/src/nmod_poly/divexact.c
+++ b/src/nmod_poly/divexact.c
@@ -54,7 +54,7 @@ nmod_poly_divexact(nmod_poly_t Q,
         }
         else
         {
-            flint_throw(FLINT_ERROR, "Exception (nmod_poly_divexact). Division by zero.\n");
+            flint_throw(FLINT_DIVZERO, "Exception (nmod_poly_divexact). Division by zero.\n");
         }
     }
 

--- a/src/nmod_poly/divrem.c
+++ b/src/nmod_poly/divrem.c
@@ -61,7 +61,7 @@ void nmod_poly_divrem(nmod_poly_t Q, nmod_poly_t R,
             return;
         } else
         {
-            flint_throw(FLINT_ERROR, "Exception (nmod_poly_divrem). Division by zero.");
+            flint_throw(FLINT_DIVZERO, "Exception (nmod_poly_divrem). Division by zero.");
         }
     }
 

--- a/src/nmod_poly/divrem_basecase.c
+++ b/src/nmod_poly/divrem_basecase.c
@@ -320,7 +320,7 @@ void nmod_poly_divrem_basecase(nmod_poly_t Q, nmod_poly_t R,
             return;
         } else
         {
-            flint_throw(FLINT_ERROR, "Exception (nmod_poly_divrem). Division by zero.");
+            flint_throw(FLINT_DIVZERO, "Exception (nmod_poly_divrem). Division by zero.");
         }
     }
 

--- a/src/nmod_poly/divrem_newton_n_preinv.c
+++ b/src/nmod_poly/divrem_newton_n_preinv.c
@@ -55,7 +55,7 @@ void nmod_poly_divrem_newton_n_preinv(nmod_poly_t Q, nmod_poly_t R,
             return;
         } else
         {
-            flint_throw(FLINT_ERROR, "Exception (nmod_poly_divrem_newton_n_preinv). Division by zero.\n");
+            flint_throw(FLINT_DIVZERO, "Exception (nmod_poly_divrem_newton_n_preinv). Division by zero.\n");
         }
     }
 

--- a/src/nmod_poly/inv_series.c
+++ b/src/nmod_poly/inv_series.c
@@ -84,7 +84,7 @@ nmod_poly_inv_series(nmod_poly_t Qinv, const nmod_poly_t Q, slong n)
 
     if (Qlen == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (nmod_poly_inv_series). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (nmod_poly_inv_series). Division by zero.\n");
     }
 
     if (Qinv != Q)
@@ -114,7 +114,7 @@ nmod_poly_inv_series_basecase(nmod_poly_t Qinv, const nmod_poly_t Q, slong n)
 
     if (Qlen == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (nmod_poly_inv_series_basecase). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (nmod_poly_inv_series_basecase). Division by zero.\n");
     }
 
     if (Qinv != Q)

--- a/src/nmod_poly/invsqrt_series.c
+++ b/src/nmod_poly/invsqrt_series.c
@@ -29,7 +29,7 @@ nmod_poly_invsqrt_series(nmod_poly_t res, const nmod_poly_t h, slong len)
 
     if (h->length == 0 || h->coeffs[0] == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (nmod_poly_invsqrt_series). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (nmod_poly_invsqrt_series). Division by zero.\n");
     }
 
     if (len == 0)

--- a/src/nmod_poly/make_monic.c
+++ b/src/nmod_poly/make_monic.c
@@ -27,7 +27,7 @@ void nmod_poly_make_monic(nmod_poly_t res, const nmod_poly_t poly)
 {
     if (poly->length == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (nmod_poly_make_monic). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (nmod_poly_make_monic). Division by zero.\n");
     }
 
     nmod_poly_fit_length(res, poly->length);

--- a/src/nmod_poly/rem.c
+++ b/src/nmod_poly/rem.c
@@ -103,7 +103,7 @@ void nmod_poly_rem(nmod_poly_t R, const nmod_poly_t A, const nmod_poly_t B)
 
     if (lenB == 0)
     {
-        flint_throw(FLINT_ERROR, "Exception (nmod_poly_rem). Division by zero.\n");
+        flint_throw(FLINT_DIVZERO, "Exception (nmod_poly_rem). Division by zero.\n");
     }
     if (lenA < lenB)
     {

--- a/src/qqbar/affine_transform.c
+++ b/src/qqbar/affine_transform.c
@@ -63,7 +63,7 @@ qqbar_scalar_op(qqbar_t res, const qqbar_t x, const fmpz_t a, const fmpz_t b, co
 
     if (fmpz_is_zero(c))
     {
-        flint_throw(FLINT_ERROR, "qqbar_scalar_op: division by zero\n");
+        flint_throw(FLINT_DIVZERO, "qqbar_scalar_op: division by zero\n");
     }
 
     /* Special case: set to rational */

--- a/src/qqbar/composed_op.c
+++ b/src/qqbar/composed_op.c
@@ -138,7 +138,7 @@ qqbar_fmpz_poly_composed_op(fmpz_poly_t res, const fmpz_poly_t A, const fmpz_pol
     {
         if (fmpz_is_zero(P2->coeffs))
         {
-            flint_throw(FLINT_ERROR, "composed_op: division by zero\n");
+            flint_throw(FLINT_DIVZERO, "composed_op: division by zero\n");
         }
 
         fmpq_poly_reverse(P2, P2, d2 + 1);

--- a/src/qqbar/div.c
+++ b/src/qqbar/div.c
@@ -18,7 +18,7 @@ qqbar_div(qqbar_t res, const qqbar_t x, const qqbar_t y)
 {
     if (qqbar_is_zero(y))
     {
-        flint_throw(FLINT_ERROR, "qqbar_div: division by zero\n");
+        flint_throw(FLINT_DIVZERO, "qqbar_div: division by zero\n");
     }
     else if (qqbar_is_zero(x))
     {

--- a/src/qqbar/inv.c
+++ b/src/qqbar/inv.c
@@ -20,7 +20,7 @@ qqbar_inv(qqbar_t res, const qqbar_t x)
 
     if (qqbar_is_zero(x))
     {
-        flint_throw(FLINT_ERROR, "qqbar_inv: division by zero\n");
+        flint_throw(FLINT_DIVZERO, "qqbar_inv: division by zero\n");
     }
 
     if (qqbar_is_one(x) || qqbar_is_neg_one(x))

--- a/src/qqbar/pow.c
+++ b/src/qqbar/pow.c
@@ -212,7 +212,7 @@ qqbar_pow_fmpq(qqbar_t res, const qqbar_t x, const fmpq_t y)
     {
         if (fmpq_sgn(y) <= 0)
         {
-            flint_throw(FLINT_ERROR, "qqbar_pow_fmpq: division by zero\n");
+            flint_throw(FLINT_DIVZERO, "qqbar_pow_fmpq: division by zero\n");
         }
 
         qqbar_zero(res);


### PR DESCRIPTION
While working on https://github.com/Nemocas/Nemo.jl/pull/2128, I noticed that FLINT has quite a few different error types. However, in most cases, a general `FLINT_ERROR` is thrown. This PR is a first step towards using the other error types as it makes use of the `FLINT_DIVZERO` error type in all cases that throw a "divide by zero" error.