### PR TITLE
Add V Makefile variable for verbose builds

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -125,6 +125,16 @@ NJOBS:=8
 endif
 endif
 
+V ?= 0 # verbosity (0 = quiet, 1 = verbose)
+
+ifeq ($(V),1)
+  MSG = @:
+  CMD =
+else
+  MSG = @echo
+  CMD = @
+endif
+
 ################################################################################
 ################################################################################
 # files and directories
@@ -423,7 +433,7 @@ MERGED_LOBJS:=$(foreach dir, $(DIRS),$(BUILD_DIR)/$(dir)_merged.lo)
 
 $(FLINT_DIR)/$(FLINT_LIB_FULL): $(MERGED_LOBJS)
 	@echo "Building $(FLINT_LIB_FULL)"
-	@$(CC) $(CFLAGS) -shared $(EXTRA_SHARED_FLAGS) $(MERGED_LOBJS) -o $(FLINT_LIB_FULL) $(LDFLAGS) $(LIBS)
+	$(CMD) $(CC) $(CFLAGS) -shared $(EXTRA_SHARED_FLAGS) $(MERGED_LOBJS) -o $(FLINT_LIB_FULL) $(LDFLAGS) $(LIBS)
 	@$(RM_F) $(FLINT_LIB)
 	@$(RM_F) $(FLINT_LIB_MAJOR)
 	@$(LN_S) $(FLINT_LIB_FULL) $(FLINT_LIB)
@@ -591,20 +601,20 @@ endif
 ifneq ($(STATIC), 0)
 define xxx_OBJS_rule
 $(BUILD_DIR)/$(1)/%.o: $(ABS_SRC_DIR)/$(1)/%.c | $(BUILD_DIR)/$(1)
-	@echo "  CC  $$(<:$(ABS_SRC_DIR)/%=%)"
-	@$(CC) $(CFLAGS) $($(1)_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) -c $$< -o $$@ $$(DEPFLAGS)
+	$(MSG) "  CC  $$(<:$(ABS_SRC_DIR)/%=%)"
+	$(CMD) $(CC) $(CFLAGS) $($(1)_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) -c $$< -o $$@ $$(DEPFLAGS)
 endef
 
 ifeq ($(IS_OUT_OF_TREE),1)
 $(BUILD_DIR)/fmpz/fmpz.o: $(SRC_DIR)/fmpz/fmpz.c | $(BUILD_DIR)/fmpz
-	@echo "  CC  $(<:$(SRC_DIR)/%=%)"
-	@$(CC) $(CFLAGS) $(fmpz_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) -c $< -o $@ $(DEPFLAGS)
+	$(MSG) "  CC  $(<:$(SRC_DIR)/%=%)"
+	$(CMD) $(CC) $(CFLAGS) $(fmpz_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) -c $< -o $@ $(DEPFLAGS)
 endif
 
 ifeq ($(WANT_ASSEMBLY),1)
 %.o: %.s
-	@echo "  CC  $(<:$(BUILD_DIR)/%.s=%.asm)"
-	@$(CC) $(ASMFLAGS) -c $< -o $@
+	$(MSG) "  CC  $(<:$(BUILD_DIR)/%.s=%.asm)"
+	$(CMD) $(CC) $(ASMFLAGS) -c $< -o $@
 endif
 
 $(foreach dir, $(DIRS), $(eval $(call xxx_OBJS_rule,$(dir))))
@@ -617,20 +627,20 @@ endif
 ifneq ($(SHARED), 0)
 define xxx_LOBJS_rule
 $(BUILD_DIR)/$(1)/%.lo: $(ABS_SRC_DIR)/$(1)/%.c | $(BUILD_DIR)/$(1)
-	@echo "  CC  $$(<:$(ABS_SRC_DIR)/%=%)"
-	@$(CC) $(PIC_FLAG) $(CFLAGS) $($(1)_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) -c $$< -o $$@ $$(DEPFLAGS)
+	$(MSG) "  CC  $$(<:$(ABS_SRC_DIR)/%=%)"
+	$(CMD) $(CC) $(PIC_FLAG) $(CFLAGS) $($(1)_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) -c $$< -o $$@ $$(DEPFLAGS)
 endef
 
 ifeq ($(IS_OUT_OF_TREE),1)
 $(BUILD_DIR)/fmpz/fmpz.lo: $(SRC_DIR)/fmpz/fmpz.c | $(BUILD_DIR)/fmpz
-	@echo "  CC  $(<:$(SRC_DIR)/%=%)"
-	@$(CC) $(PIC_FLAG) $(CFLAGS) $(fmpz_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) -c $< -o $@ $(DEPFLAGS)
+	$(MSG) "  CC  $(<:$(SRC_DIR)/%=%)"
+	$(CMD) $(CC) $(PIC_FLAG) $(CFLAGS) $(fmpz_CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) -c $< -o $@ $(DEPFLAGS)
 endif
 
 ifeq ($(WANT_ASSEMBLY),1)
 %.lo: %_pic.s
-	@echo "  CC  $(<:$(BUILD_DIR)/%.s=%.asm)"
-	@$(CC) $(ASMFLAGS) $(ASM_PIC_FLAG) -c $< -o $@
+	$(MSG) "  CC  $(<:$(BUILD_DIR)/%.s=%.asm)"
+	$(CMD) $(CC) $(ASMFLAGS) $(ASM_PIC_FLAG) -c $< -o $@
 endif
 
 $(foreach dir, $(DIRS), $(eval $(call xxx_LOBJS_rule,$(dir))))
@@ -642,25 +652,25 @@ endif
 
 ifeq ($(SHARED), 0)
 $(BUILD_DIR)/profile/%$(EXEEXT): $(ABS_SRC_DIR)/profile/%.c $(FLINT_DIR)/$(FLINT_LIB_STATIC) | $(BUILD_DIR)/profile
-	@echo "  CC  $(<:$(ABS_SRC_DIR)/%=%)"
-	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) $(DEPFLAGS)
+	$(MSG) "  CC  $(<:$(ABS_SRC_DIR)/%=%)"
+	$(CMD) $(CC) $(TESTCFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) $(DEPFLAGS)
 else
 $(BUILD_DIR)/profile/%$(EXEEXT): $(ABS_SRC_DIR)/profile/%.c | $(FLINT_DIR)/$(FLINT_LIB_FULL) $(BUILD_DIR)/profile
-	@echo "  CC  $(<:$(ABS_SRC_DIR)/%=%)"
-	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) $(DEPFLAGS)
+	$(MSG) "  CC  $(<:$(ABS_SRC_DIR)/%=%)"
+	$(CMD) $(CC) $(TESTCFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) $(DEPFLAGS)
 endif
 
 ifeq ($(SHARED), 0)
 define xxx_PROFS_rule
 $(BUILD_DIR)/$(1)/profile/%$(EXEEXT): $(ABS_SRC_DIR)/$(1)/profile/%.c $(FLINT_DIR)/$(FLINT_LIB_STATIC) | $(BUILD_DIR)/$(1)/profile
-	@echo "  CC  $$(<:$(ABS_SRC_DIR)/%=%)"
-	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $$< -o $$@ $(EXE_LDFLAGS) $(LIBS2) $$(DEPFLAGS)
+	$(MSG) "  CC  $$(<:$(ABS_SRC_DIR)/%=%)"
+	$(CMD) $(CC) $(TESTCFLAGS) $(CPPFLAGS2) $$< -o $$@ $(EXE_LDFLAGS) $(LIBS2) $$(DEPFLAGS)
 endef
 else
 define xxx_PROFS_rule
 $(BUILD_DIR)/$(1)/profile/%$(EXEEXT): $(ABS_SRC_DIR)/$(1)/profile/%.c | $(FLINT_DIR)/$(FLINT_LIB_FULL) $(BUILD_DIR)/$(1)/profile
-	@echo "  CC  $$(<:$(ABS_SRC_DIR)/%=%)"
-	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $$< -o $$@ $(EXE_LDFLAGS) $(LIBS2) $$(DEPFLAGS)
+	$(MSG) "  CC  $$(<:$(ABS_SRC_DIR)/%=%)"
+	$(CMD) $(CC) $(TESTCFLAGS) $(CPPFLAGS2) $$< -o $$@ $(EXE_LDFLAGS) $(LIBS2) $$(DEPFLAGS)
 endef
 endif
 
@@ -668,25 +678,25 @@ $(foreach dir, $(DIRS), $(eval $(call xxx_PROFS_rule,$(dir))))
 
 ifeq ($(SHARED), 0)
 $(BUILD_DIR)/test/%$(EXEEXT): $(ABS_SRC_DIR)/test/%.c $(FLINT_DIR)/$(FLINT_LIB_STATIC) | $(BUILD_DIR)/test
-	@echo "  CC  $(<:$(ABS_SRC_DIR)/%=%)"
-	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) $(DEPFLAGS)
+	$(MSG) "  CC  $(<:$(ABS_SRC_DIR)/%=%)"
+	$(CMD) $(CC) $(TESTCFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) $(DEPFLAGS)
 else
 $(BUILD_DIR)/test/%$(EXEEXT): $(ABS_SRC_DIR)/test/%.c | $(FLINT_DIR)/$(FLINT_LIB_FULL) $(BUILD_DIR)/test
-	@echo "  CC  $(<:$(ABS_SRC_DIR)/%=%)"
-	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) $(DEPFLAGS)
+	$(MSG) "  CC  $(<:$(ABS_SRC_DIR)/%=%)"
+	$(CMD) $(CC) $(TESTCFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) $(DEPFLAGS)
 endif
 
 ifeq ($(SHARED), 0)
 define xxx_TESTS_rule
 $(BUILD_DIR)/$(1)/test/%$(EXEEXT): $(ABS_SRC_DIR)/$(1)/test/%.c $(FLINT_DIR)/libflint.a | $(BUILD_DIR)/$(1)/test
-	@echo "  CC  $$(<:$(ABS_SRC_DIR)/%=%)"
-	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $$< -o $$@ $(EXE_LDFLAGS) $(LIBS2) $$(DEPFLAGS)
+	$(MSG) "  CC  $$(<:$(ABS_SRC_DIR)/%=%)"
+	$(CMD) $(CC) $(TESTCFLAGS) $(CPPFLAGS2) $$< -o $$@ $(EXE_LDFLAGS) $(LIBS2) $$(DEPFLAGS)
 endef
 else
 define xxx_TESTS_rule
 $(BUILD_DIR)/$(1)/test/%$(EXEEXT): $(ABS_SRC_DIR)/$(1)/test/%.c | $(FLINT_DIR)/$(FLINT_LIB_FULL) $(BUILD_DIR)/$(1)/test
-	@echo "  CC  $$(<:$(ABS_SRC_DIR)/%=%)"
-	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $$< -o $$@ $(EXE_LDFLAGS) $(LIBS2) $$(DEPFLAGS)
+	$(MSG) "  CC  $$(<:$(ABS_SRC_DIR)/%=%)"
+	$(CMD) $(CC) $(TESTCFLAGS) $(CPPFLAGS2) $$< -o $$@ $(EXE_LDFLAGS) $(LIBS2) $$(DEPFLAGS)
 endef
 endif
 
@@ -695,36 +705,36 @@ $(foreach dir, $(DIRS), $(eval $(call xxx_TESTS_rule,$(dir))))
 ifneq ($(WANT_NTL), 0)
 ifeq ($(SHARED), 0)
 $(BUILD_DIR)/interfaces/test/t-NTL-interface$(EXEEXT): $(ABS_SRC_DIR)/interfaces/test/t-NTL-interface.cpp $(FLINT_DIR)/$(FLINT_LIB_STATIC) | $(BUILD_DIR)/interfaces/test
-	@echo "  CXX $(<:$(ABS_SRC_DIR)/%=%)"
-	@$(CXX) $(CXXFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) $(DEPFLAGS)
+	$(MSG) "  CXX $(<:$(ABS_SRC_DIR)/%=%)"
+	$(CMD) $(CXX) $(CXXFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) $(DEPFLAGS)
 else
 $(BUILD_DIR)/interfaces/test/t-NTL-interface$(EXEEXT): $(ABS_SRC_DIR)/interfaces/test/t-NTL-interface.cpp | $(FLINT_DIR)/$(FLINT_LIB_FULL) $(BUILD_DIR)/interfaces/test
-	@echo "  CXX $(<:$(ABS_SRC_DIR)/%=%)"
-	@$(CXX) $(CXXFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) $(DEPFLAGS)
+	$(MSG) "  CXX $(<:$(ABS_SRC_DIR)/%=%)"
+	$(CMD) $(CXX) $(CXXFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) $(DEPFLAGS)
 endif
 endif
 
 ifeq ($(SHARED), 0)
 $(BUILD_DIR)/tune/%$(EXEEXT): $(ABS_SRC_DIR)/tune/%.c $(FLINT_DIR)/$(FLINT_LIB_STATIC) | $(BUILD_DIR)/tune
-	@echo "  CC  $(<:$(ABS_SRC_DIR)/%=%)"
-	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) $(DEPFLAGS)
+	$(MSG) "  CC  $(<:$(ABS_SRC_DIR)/%=%)"
+	$(CMD) $(CC) $(TESTCFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) $(DEPFLAGS)
 else
 $(BUILD_DIR)/tune/%$(EXEEXT): $(ABS_SRC_DIR)/tune/%.c | $(FLINT_DIR)/$(FLINT_LIB_FULL) $(BUILD_DIR)/tune
-	@echo "  CC  $(<:$(ABS_SRC_DIR)/%=%)"
-	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) $(DEPFLAGS)
+	$(MSG) "  CC  $(<:$(ABS_SRC_DIR)/%=%)"
+	$(CMD) $(CC) $(TESTCFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) $(DEPFLAGS)
 endif
 
 ifeq ($(SHARED), 0)
 define xxx_TUNES_rule
 $(BUILD_DIR)/$(1)/tune/%$(EXEEXT): $(ABS_SRC_DIR)/$(1)/tune/%.c $(FLINT_DIR)/$(FLINT_LIB_STATIC) | $(BUILD_DIR)/$(1)/tune
-	@echo "  CC  $$(<:$(ABS_SRC_DIR)/%=%)"
-	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $$< -o $$@ $(EXE_LDFLAGS) $(LIBS2) $$(DEPFLAGS)
+	$(MSG) "  CC  $$(<:$(ABS_SRC_DIR)/%=%)"
+	$(CMD) $(CC) $(TESTCFLAGS) $(CPPFLAGS2) $$< -o $$@ $(EXE_LDFLAGS) $(LIBS2) $$(DEPFLAGS)
 endef
 else
 define xxx_TUNES_rule
 $(BUILD_DIR)/$(1)/tune/%$(EXEEXT): $(ABS_SRC_DIR)/$(1)/tune/%.c | $(FLINT_DIR)/$(FLINT_LIB_FULL) $(BUILD_DIR)/$(1)/tune
-	@echo "  CC  $$(<:$(ABS_SRC_DIR)/%=%)"
-	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $$< -o $$@ $(EXE_LDFLAGS) $(LIBS2) $$(DEPFLAGS)
+	$(MSG) "  CC  $$(<:$(ABS_SRC_DIR)/%=%)"
+	$(CMD) $(CC) $(TESTCFLAGS) $(CPPFLAGS2) $$< -o $$@ $(EXE_LDFLAGS) $(LIBS2) $$(DEPFLAGS)
 endef
 endif
 
@@ -732,12 +742,12 @@ $(foreach dir, $(DIRS), $(eval $(call xxx_TUNES_rule,$(dir))))
 
 ifeq ($(SHARED), 0)
 $(BUILD_DIR)/examples/%$(EXEEXT): $(ABS_FLINT_DIR)/examples/%.c $(FLINT_DIR)/$(FLINT_LIB_STATIC) | $(BUILD_DIR)/examples $(BUILD_DIR)/include
-	@echo "  CC  $(<:$(ABS_FLINT_DIR)/%=%)"
-	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) $(DEPFLAGS) -I$(BUILD_DIR)/include
+	$(MSG) "  CC  $(<:$(ABS_FLINT_DIR)/%=%)"
+	$(CMD) $(CC) $(TESTCFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) $(DEPFLAGS) -I$(BUILD_DIR)/include
 else
 $(BUILD_DIR)/examples/%$(EXEEXT): $(ABS_FLINT_DIR)/examples/%.c | $(FLINT_DIR)/$(FLINT_LIB_FULL) $(BUILD_DIR)/examples $(BUILD_DIR)/include
-	@echo "  CC  $(<:$(ABS_FLINT_DIR)/%=%)"
-	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) $(DEPFLAGS) -I$(BUILD_DIR)/include
+	$(MSG) "  CC  $(<:$(ABS_FLINT_DIR)/%=%)"
+	$(CMD) $(CC) $(TESTCFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) $(DEPFLAGS) -I$(BUILD_DIR)/include
 endif
 
 ################################################################################


### PR DESCRIPTION
`make V=0` (the default) prints "CC filename.c", as is the case currently.

`make V=1` prints the full gcc command with build flags, which is useful for parsing build logs to see if particular flags are being used. For example, Debian does this to check if hardening flags are used when building packages using the program blhc.

So for example:

```
$ make
/usr/bin/mkdir -p build/generic_files
  CC  generic_files/clz_tab.c
  CC  generic_files/exception.c
  CC  generic_files/fscanf.c
  CC  generic_files/gettimeofday.c
  CC  generic_files/inlines.c
  CC  generic_files/io.c
```

```
$ make V=1
/usr/bin/mkdir -p build/generic_files
gcc -fPIC -DPIC -march=skylake -Wno-stringop-overflow -Wno-stringop-overread -Wall -Werror=implicit-function-declaration -std=c11 -pedantic -O3 -g   -I/home/dtorrance/src/flint/flint/src -Isrc  -DBUILDING_FLINT -DFLINT_NOSTDIO -DFLINT_NOSTDARG -c /home/dtorrance/src/flint/flint/src/generic_files/clz_tab.c -o build/generic_files/clz_tab.lo -MMD -MP -MF build/generic_files/clz_tab.lo.d
gcc -fPIC -DPIC -march=skylake -Wno-stringop-overflow -Wno-stringop-overread -Wall -Werror=implicit-function-declaration -std=c11 -pedantic -O3 -g   -I/home/dtorrance/src/flint/flint/src -Isrc  -DBUILDING_FLINT -DFLINT_NOSTDIO -DFLINT_NOSTDARG -c /home/dtorrance/src/flint/flint/src/generic_files/exception.c -o build/generic_files/exception.lo -MMD -MP -MF build/generic_files/exception.lo.d
gcc -fPIC -DPIC -march=skylake -Wno-stringop-overflow -Wno-stringop-overread -Wall -Werror=implicit-function-declaration -std=c11 -pedantic -O3 -g   -I/home/dtorrance/src/flint/flint/src -Isrc  -DBUILDING_FLINT -DFLINT_NOSTDIO -DFLINT_NOSTDARG -c /home/dtorrance/src/flint/flint/src/generic_files/fscanf.c -o build/generic_files/fscanf.lo -MMD -MP -MF build/generic_files/fscanf.lo.d
gcc -fPIC -DPIC -march=skylake -Wno-stringop-overflow -Wno-stringop-overread -Wall -Werror=implicit-function-declaration -std=c11 -pedantic -O3 -g   -I/home/dtorrance/src/flint/flint/src -Isrc  -DBUILDING_FLINT -DFLINT_NOSTDIO -DFLINT_NOSTDARG -c /home/dtorrance/src/flint/flint/src/generic_files/gettimeofday.c -o build/generic_files/gettimeofday.lo -MMD -MP -MF build/generic_files/gettimeofday.lo.d
gcc -fPIC -DPIC -march=skylake -Wno-stringop-overflow -Wno-stringop-overread -Wall -Werror=implicit-function-declaration -std=c11 -pedantic -O3 -g   -I/home/dtorrance/src/flint/flint/src -Isrc  -DBUILDING_FLINT -DFLINT_NOSTDIO -DFLINT_NOSTDARG -c /home/dtorrance/src/flint/flint/src/generic_files/inlines.c -o build/generic_files/inlines.lo -MMD -MP -MF build/generic_files/inlines.lo.d
gcc -fPIC -DPIC -march=skylake -Wno-stringop-overflow -Wno-stringop-overread -Wall -Werror=implicit-function-declaration -std=c11 -pedantic -O3 -g   -I/home/dtorrance/src/flint/flint/src -Isrc  -DBUILDING_FLINT -DFLINT_NOSTDIO -DFLINT_NOSTDARG -c /home/dtorrance/src/flint/flint/src/generic_files/io.c -o build/generic_files/io.lo -MMD -MP -MF build/generic_files/io.lo.d
```