### PR TITLE
Fix duplicate symbols linker error

### DIFF
--- a/src/double_interval.h
+++ b/src/double_interval.h
@@ -13,7 +13,7 @@
 #define DOUBLE_INTERVAL_H
 
 #ifdef DOUBLE_INTERVAL_INLINES_C
-#define DOUBLE_INTERVAL_INLINE
+#define DOUBLE_INTERVAL_INLINE static
 #else
 #define DOUBLE_INTERVAL_INLINE static inline
 #endif


### PR DESCRIPTION
When I run `make check` I get linker errors without this patch

Closes #2058 