### PR TITLE
Speed up nmod_poly_is_irreducible, high-degree finite field construction and arithmetic

### DIFF
--- a/src/nmod_poly/divrem_newton_n_preinv.c
+++ b/src/nmod_poly/divrem_newton_n_preinv.c
@@ -25,7 +25,7 @@
 int
 _nmod_poly_divrem_try_sparse(nn_ptr Q, nn_ptr R, nn_srcptr A,
                                         slong lenA, nn_srcptr B, slong lenB,
-                                       nn_srcptr Binv, slong lenBinv, nmod_t mod)
+                                       nn_srcptr Binv, slong FLINT_UNUSED(lenBinv), nmod_t mod)
 {
     slong nz, i, j, k;
     slong exps[MAX_NZ];

--- a/src/nmod_poly_factor/is_irreducible.c
+++ b/src/nmod_poly_factor/is_irreducible.c
@@ -163,7 +163,7 @@ int nmod_poly_is_irreducible_ddf(const nmod_poly_t poly)
 int
 nmod_poly_is_irreducible(const nmod_poly_t f)
 {
-    if (nmod_poly_length(f) <= 1)
+    if (nmod_poly_length(f) <= 2)
         return 1;
 
     if (nmod_poly_is_reducible_trial_div(f))


### PR DESCRIPTION
The main goal here is to speed up finite field arithmetic and construction for extension fields of high degree. There are two new tricks:

* Incorporate trial division in ``nmod_poly_is_irreducible`` to reject many candidates quickly when the prime is small (this speeds up ``nmod_poly_randtest_sparse_irreducible`` and hence ``fq_nmod_ctx_init_ui`` when one is not in the Conway table).

* Speed up nmod_poly preinv remainder and modular multiplication by doing schoolbook division when the modulus polynomial is extremely sparse. For now, we do this as a hack by detecting sparse polynomials on the fly in ``_nmod_poly_divrem_newton_n_preinv``. The proper way to do it would be to introduce some kind of ``nmod_poly_mod_precomp_t`` object that can store different representations (including FFT:ed dense polynomials), but this quick and dirty hack at least gives most of the possible speedup asymptotically.

Motivated by https://github.com/oscar-system/Oscar.jl/issues/5358, sample timings for constructing ``GF(5^(5^n))`` (speedup coming from this PR together with #2415):

```
deg    flint-3.3    new          speedup
5      4.05e-07     3.93e-07     1.03x
25     8.53e-07     8.47e-07     1.01x
125    0.0452       0.0146       3.09x
625    0.935        0.201        4.65x
3125   309.567      83.8         3.69x
```