### PR TITLE
Add `--enable-lto` configure option

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -74,6 +74,8 @@ WANT_DEPS:=@WANT_DEPS@
 WANT_ASSEMBLY:=@WANT_ASSEMBLY@
 ASM_PATH:=$(ABS_SRC_DIR)/mpn_extras/@ASM_PATH@
 
+WANT_LTO:=@WANT_LTO@
+
 GMP_LIB_PATH:=@GMP_LIB_PATH@
 MPFR_LIB_PATH:=@MPFR_LIB_PATH@
 BLAS_LIB_PATH:=@BLAS_LIB_PATH@
@@ -431,9 +433,15 @@ endef
 $(foreach dir, $(DIRS), $(eval $(call xxx_merged_lobj_rule,$(dir))))
 MERGED_LOBJS:=$(foreach dir, $(DIRS),$(BUILD_DIR)/$(dir)_merged.lo)
 
-$(FLINT_DIR)/$(FLINT_LIB_FULL): $(MERGED_LOBJS)
+ifeq ($(WANT_LTO),1)
+	LIB_DEPS = $(LOBJS)
+else
+	LIB_DEPS = $(MERGED_LOBJS)
+endif
+
+$(FLINT_DIR)/$(FLINT_LIB_FULL): $(LIB_DEPS)
 	@echo "Building $(FLINT_LIB_FULL)"
-	$(CMD) $(CC) $(CFLAGS) -shared $(EXTRA_SHARED_FLAGS) $(MERGED_LOBJS) -o $(FLINT_LIB_FULL) $(LDFLAGS) $(LIBS)
+	$(CMD) $(CC) $(CFLAGS) -shared $(EXTRA_SHARED_FLAGS) $(LIB_DEPS) -o $(FLINT_LIB_FULL) $(LDFLAGS) $(LIBS)
 	@$(RM_F) $(FLINT_LIB)
 	@$(RM_F) $(FLINT_LIB_MAJOR)
 	@$(LN_S) $(FLINT_LIB_FULL) $(FLINT_LIB)
@@ -452,9 +460,15 @@ endef
 $(foreach dir, $(DIRS), $(eval $(call xxx_merged_obj_rule,$(dir))))
 MERGED_OBJS:=$(foreach dir, $(DIRS),$(BUILD_DIR)/$(dir)_merged.o)
 
-$(FLINT_DIR)/$(FLINT_LIB_STATIC): $(MERGED_OBJS)
+ifeq ($(WANT_LTO),1)
+	LIB_DEPS = $(OBJS)
+else
+	LIB_DEPS = $(MERGED_OBJS)
+endif
+
+$(FLINT_DIR)/$(FLINT_LIB_STATIC): $(LIB_DEPS)
 	@echo "Building $(FLINT_LIB_STATIC)"
-	@$(AR) rcs $(FLINT_DIR)/$(FLINT_LIB_STATIC) $(MERGED_OBJS)
+	@$(AR) rcs $(FLINT_DIR)/$(FLINT_LIB_STATIC) $(LIB_DEPS)
 endif
 
 ################################################################################

--- a/configure.ac
+++ b/configure.ac
@@ -340,6 +340,17 @@ yes|no)
 esac],
 enable_fast_build="no")
 
+AC_ARG_ENABLE(lto,
+[AS_HELP_STRING([--enable-lto],[Enable link-time optimization [default=no]])],
+[case $enableval in
+yes|no)
+  ;;
+*)
+  AC_MSG_ERROR([Bad value $enableval for --enable-lto. Need yes or no.])
+  ;;
+esac],
+enable_lto="no")
+
 ################################################################################
 # packages
 ################################################################################
@@ -1274,6 +1285,13 @@ then
     [AC_MSG_ERROR([$CC does not support the flag -mavx512f needed for AVX512 instructions])])
 fi
 
+if test "$enable_lto" = "yes";
+then
+    AX_CHECK_COMPILE_FLAG([-flto],
+    [save_CFLAGS="-flto $save_CFLAGS"],
+    [AC_MSG_ERROR([$CC does not support the flag -flto needed for link-time optimization])])
+fi
+
 if test "$cflags_set" = "no";
 then
     for flag in $gcc_cflags $gcc_warnings;
@@ -1425,6 +1443,13 @@ then
 else
     AC_SUBST(WANT_ASSEMBLY,0)
     AC_SUBST(ASM_PATH,)
+fi
+
+if test "$enable_lto" = "yes";
+then
+    AC_SUBST(WANT_LTO,1)
+else
+    AC_SUBST(WANT_LTO,0)
 fi
 
 ################################################################################


### PR DESCRIPTION
Added link-time optimization support with the new `--enable-lto` configure option.
I set it to disabled by default since the liking time becomes quite long.
Tested on `arm64` (Apple M3) and `x86_64` (Intel, running Linux).