### PR TITLE
Add `gr_mpoly_derivative` and `gr_mpoly_integral`

### DIFF
--- a/doc/source/gr_mpoly.rst
+++ b/doc/source/gr_mpoly.rst
@@ -297,6 +297,17 @@ Arithmetic
 
 .. function:: int gr_mpoly_inv(gr_mpoly_t res, const gr_mpoly_t src, gr_mpoly_ctx_t ctx)
 
+Derivative and integral
+-------------------------------------------------------------------------------
+
+.. function:: int gr_mpoly_derivative(gr_mpoly_t A, const gr_mpoly_t B, slong var, gr_mpoly_ctx_t ctx)
+
+    Set *A* to the derivative of *B* with respect to the variable of index *var*.
+
+.. function:: int gr_mpoly_integral(gr_mpoly_t A, const gr_mpoly_t B, slong var, gr_mpoly_ctx_t ctx)
+
+    Set *A* to the integral of *B* with respect to the variable of index *var*.
+
 Other operations
 -------------------------------------------------------------------------------
 

--- a/src/gr_mpoly.h
+++ b/src/gr_mpoly.h
@@ -267,6 +267,12 @@ WARN_UNUSED_RESULT int gr_mpoly_mul_fmpq(gr_mpoly_t A, const gr_mpoly_t B, const
 WARN_UNUSED_RESULT int gr_mpoly_inv(gr_mpoly_t res, const gr_mpoly_t poly, gr_mpoly_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mpoly_canonical_associate(gr_mpoly_t res, gr_mpoly_t u, const gr_mpoly_t poly, gr_mpoly_ctx_t ctx);
 
+/* Derivative and integral */
+
+WARN_UNUSED_RESULT int gr_mpoly_derivative(gr_mpoly_t A, const gr_mpoly_t B, slong var, gr_mpoly_ctx_t ctx);
+
+WARN_UNUSED_RESULT int gr_mpoly_integral(gr_mpoly_t A, const gr_mpoly_t B, slong var, gr_mpoly_ctx_t ctx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/gr_mpoly/derivative.c
+++ b/src/gr_mpoly/derivative.c
@@ -1,0 +1,120 @@
+/*
+    Copyright (C) 2025 Ricardo Buring
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+/* Based on src/fmpz_mpoly/derivative.c */
+
+#include "fmpz.h"
+#include "mpoly.h"
+#include "gr_mpoly.h"
+
+int
+_gr_mpoly_derivative_sp(gr_ptr coeff1, ulong * exp1, slong * len1,
+                        gr_srcptr coeff2, const ulong * exp2, slong len2,
+                        flint_bitcnt_t bits, slong N, slong offset, slong shift,
+                        ulong * oneexp, gr_ctx_t cctx)
+{
+    int status = GR_SUCCESS;
+    slong i;
+    ulong mask = (-UWORD(1)) >> (FLINT_BITS - bits);
+
+    /* x^c -> c*x^(c-1) */
+    *len1 = 0;
+    for (i = 0; i < len2; i++)
+    {
+        ulong c = (exp2[N*i + offset] >> shift) & mask;
+        gr_ptr c1 = GR_ENTRY(coeff1, *len1, cctx->sizeof_elem);
+        status |= gr_mul_ui(c1, GR_ENTRY(coeff2, i, cctx->sizeof_elem), c, cctx);
+        if (gr_is_zero(c1, cctx) != T_TRUE)
+        {
+            mpoly_monomial_sub(exp1 + N*(*len1), exp2 + N*i, oneexp, N);
+            (*len1)++;
+        }
+    }
+
+    return status;
+}
+
+
+int
+_gr_mpoly_derivative_mp(gr_ptr coeff1, ulong * exp1, slong * len1,
+                        gr_srcptr coeff2, const ulong * exp2, slong len2,
+                        flint_bitcnt_t bits, slong N, slong offset,
+                        ulong * oneexp, gr_ctx_t cctx)
+{
+    int status = GR_SUCCESS;
+    slong i;
+    fmpz_t c;
+    fmpz_init(c);
+
+    /* x^c -> c*x^(c-1) */
+    *len1 = 0;
+    for (i = 0; i < len2; i++)
+    {
+        fmpz_set_ui_array(c, exp2 + N*i + offset, bits/FLINT_BITS);
+        gr_ptr c1 = GR_ENTRY(coeff1, *len1, cctx->sizeof_elem);
+        status |= gr_mul_fmpz(c1, GR_ENTRY(coeff2, i, cctx->sizeof_elem), c, cctx);
+        if (gr_is_zero(c1, cctx) != T_TRUE)
+        {
+            mpoly_monomial_sub_mp(exp1 + N*(*len1), exp2 + N*i, oneexp, N);
+            (*len1)++;
+        }
+    }
+
+    fmpz_clear(c);
+
+    return status;
+}
+
+
+int
+gr_mpoly_derivative(gr_mpoly_t A, const gr_mpoly_t B, slong var,
+                    gr_mpoly_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    mpoly_ctx_struct * mctx = GR_MPOLY_MCTX(ctx);
+    gr_ctx_struct * cctx = GR_MPOLY_CCTX(ctx);
+    slong N, offset, shift;
+    flint_bitcnt_t bits;
+    ulong * oneexp;
+    slong len1;
+    TMP_INIT;
+
+    TMP_START;
+    bits = B->bits;
+
+    if (A != B)
+        gr_mpoly_fit_length_reset_bits(A, B->length, bits, ctx);
+
+    N = mpoly_words_per_exp(bits, GR_MPOLY_MCTX(ctx));
+    oneexp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
+
+    if (bits <= FLINT_BITS)
+    {
+        mpoly_gen_monomial_offset_shift_sp(oneexp, &offset, &shift,
+                                           var, bits, mctx);
+        status |= _gr_mpoly_derivative_sp(A->coeffs, A->exps, &len1,
+                                          B->coeffs, B->exps, B->length,
+                                          bits, N, offset, shift, oneexp, cctx);
+    }
+    else
+    {
+        offset = mpoly_gen_monomial_offset_mp(oneexp, var, bits, mctx);
+        status |= _gr_mpoly_derivative_mp(A->coeffs, A->exps, &len1,
+                                          B->coeffs, B->exps, B->length,
+                                          bits, N, offset, oneexp, cctx);
+    }
+
+    _gr_mpoly_set_length(A, len1, ctx);
+
+    TMP_END;
+
+    return status;
+}

--- a/src/gr_mpoly/integral.c
+++ b/src/gr_mpoly/integral.c
@@ -1,0 +1,166 @@
+/*
+    Copyright (C) 2025 Ricardo Buring
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+/* Based on src/fmpz_mpoly/integral.c */
+
+#include "fmpz.h"
+#include "fmpz_vec.h"
+#include "mpoly.h"
+#include "gr_mpoly.h"
+
+int
+_gr_mpoly_integral(gr_ptr coeff1, ulong * exp1,
+                   gr_srcptr coeff2, const ulong * exp2, slong len2,
+                   slong var, slong bits, gr_mpoly_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    mpoly_ctx_struct * mctx = GR_MPOLY_MCTX(ctx);
+    gr_ctx_struct * cctx = GR_MPOLY_CCTX(ctx);
+    slong i, N;
+    slong offset;
+    slong shift;
+    ulong * oneexp;
+    TMP_INIT;
+
+    TMP_START;
+
+    N = mpoly_words_per_exp(bits, mctx);
+    oneexp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
+
+    if (bits <= FLINT_BITS)
+    {
+        ulong c, mask;
+
+        mask = (-UWORD(1)) >> (FLINT_BITS - bits);
+        mpoly_gen_monomial_offset_shift_sp(oneexp, &offset, &shift, var, bits, mctx);
+
+        /* x^c -> x^(c+1)/(c+1) */
+        for (i = 0; i < len2; i++)
+        {
+            c = (exp2[N*i + offset] >> shift) & mask;
+            c++;
+            gr_ptr c1 = GR_ENTRY(coeff1, i, cctx->sizeof_elem);
+            status |= gr_div_ui(c1, GR_ENTRY(coeff2, i, cctx->sizeof_elem), c, cctx);
+            mpoly_monomial_add(exp1 + N*i, exp2 + N*i, oneexp, N);
+        }
+    }
+    else
+    {
+        fmpz_t c;
+        fmpz_init(c);
+
+        offset = mpoly_gen_monomial_offset_mp(oneexp, var, bits, mctx);
+
+        /* x^c -> x^(c+1)/(c+1) */
+        for (i = 0; i < len2; i++)
+        {
+            fmpz_set_ui_array(c, exp2 + N*i + offset, bits/FLINT_BITS);
+            fmpz_add_ui(c, c, 1);
+            gr_ptr c1 = GR_ENTRY(coeff1, i, cctx->sizeof_elem);
+            status |= gr_div_fmpz(c1, GR_ENTRY(coeff2, i, cctx->sizeof_elem), c, cctx);
+            mpoly_monomial_add_mp(exp1 + N*i, exp2 + N*i, oneexp, N);
+        }
+
+        fmpz_clear(c);
+    }
+
+    TMP_END;
+
+    return status;
+}
+
+
+int
+gr_mpoly_integral(gr_mpoly_t poly1, const gr_mpoly_t poly2, slong var,
+                  gr_mpoly_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    mpoly_ctx_struct * mctx = GR_MPOLY_MCTX(ctx);
+    slong i;
+    flint_bitcnt_t exp_bits;
+    ulong * exp2 = poly2->exps;
+    fmpz * gen_fields, * max_fields;
+    int free2 = 0;
+    TMP_INIT;
+
+    TMP_START;
+
+    /* compute bits required to represent result */
+    gen_fields = (fmpz *) TMP_ALLOC(mctx->nfields*sizeof(fmpz));
+    max_fields = (fmpz *) TMP_ALLOC(mctx->nfields*sizeof(fmpz));
+    for (i = 0; i < mctx->nfields; i++)
+    {
+        fmpz_init(gen_fields + i);
+        fmpz_init(max_fields + i);
+    }
+    mpoly_gen_fields_fmpz(gen_fields, var, mctx);
+    mpoly_max_fields_fmpz(max_fields, poly2->exps, poly2->length,
+                          poly2->bits, mctx);
+    _fmpz_vec_add(max_fields, max_fields, gen_fields, mctx->nfields);
+
+    exp_bits = _fmpz_vec_max_bits(max_fields, mctx->nfields);
+    exp_bits = FLINT_MAX(MPOLY_MIN_BITS, exp_bits + 1);
+    exp_bits = FLINT_MAX(exp_bits, poly2->bits);
+    exp_bits = mpoly_fix_bits(exp_bits, mctx);
+
+    for (i = 0; i < mctx->nfields; i++)
+    {
+        fmpz_clear(gen_fields + i);
+        fmpz_clear(max_fields + i);
+    }
+
+
+    /* ensure input exponents are packed into same sized fields as output */
+    if (exp_bits > poly2->bits)
+    {
+        slong N = mpoly_words_per_exp(exp_bits, mctx);
+        free2 = 1;
+        exp2 = (ulong *) flint_malloc(N*poly2->length*sizeof(ulong));
+        mpoly_repack_monomials(exp2, exp_bits, poly2->exps, poly2->bits,
+                               poly2->length, mctx);
+    }
+
+    /* deal with aliasing and do integration */
+    if (poly1 == poly2)
+    {
+        gr_mpoly_t temp;
+
+        gr_mpoly_init2(temp, poly2->length, ctx);
+        gr_mpoly_fit_bits(temp, exp_bits, ctx);
+        temp->bits = exp_bits;
+
+        status |= _gr_mpoly_integral(temp->coeffs, temp->exps,
+                                     poly2->coeffs, exp2, poly2->length,
+                                     var, exp_bits, ctx);
+        _gr_mpoly_set_length(temp, poly2->length, ctx);
+
+        gr_mpoly_swap(temp, poly1, ctx);
+        gr_mpoly_clear(temp, ctx);
+    }
+    else
+    {
+        gr_mpoly_fit_length(poly1, poly2->length, ctx);
+        gr_mpoly_fit_bits(poly1, exp_bits, ctx);
+        poly1->bits = exp_bits;
+
+        status |= _gr_mpoly_integral(poly1->coeffs, poly1->exps,
+                                     poly2->coeffs, exp2, poly2->length,
+                                     var, exp_bits, ctx);
+        _gr_mpoly_set_length(poly1, poly2->length, ctx);
+    }
+
+    if (free2)
+        flint_free(exp2);
+
+    TMP_END;
+
+    return status;
+}

--- a/src/gr_mpoly/test/main.c
+++ b/src/gr_mpoly/test/main.c
@@ -14,6 +14,7 @@
 #include "t-add_sub.c"
 #include "t-gen.c"
 #include "t-get_set_coeff.c"
+#include "t-integral.c"
 #include "t-mul_johnson.c"
 #include "t-mul_monomial.c"
 #include "t-ring.c"
@@ -25,6 +26,7 @@ test_struct tests[] =
     TEST_FUNCTION(gr_mpoly_add_sub),
     TEST_FUNCTION(gr_mpoly_gen),
     TEST_FUNCTION(gr_mpoly_get_set_coeff),
+    TEST_FUNCTION(gr_mpoly_integral),
     TEST_FUNCTION(gr_mpoly_mul_johnson),
     TEST_FUNCTION(gr_mpoly_mul_monomial),
     TEST_FUNCTION(gr_mpoly_ring)

--- a/src/gr_mpoly/test/t-integral.c
+++ b/src/gr_mpoly/test/t-integral.c
@@ -1,0 +1,96 @@
+/*
+    Copyright (C) 2025 Ricardo Buring
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "ulong_extras.h"
+#include "gr_mpoly.h"
+
+TEST_FUNCTION_START(gr_mpoly_integral, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 10000; iter++)
+    {
+        int status;
+        gr_ctx_t cctx;
+        gr_mpoly_ctx_t ctx;
+        gr_mpoly_t F, G, Gprime;
+        slong len;
+        flint_bitcnt_t exp_bits;
+        slong var;
+
+        /* check derivative(integral(f)) == f */
+
+        gr_ctx_init_random(cctx, state);
+        gr_mpoly_ctx_init_rand(ctx, state, cctx, 10);
+        /* ensure we have a variable */
+        while (GR_MPOLY_NVARS(ctx) == 0)
+        {
+            gr_mpoly_ctx_clear(ctx);
+            gr_mpoly_ctx_init_rand(ctx, state, cctx, 10);
+        }
+
+        var = n_randint(state, GR_MPOLY_NVARS(ctx));
+
+        gr_mpoly_init(F, ctx);
+        gr_mpoly_init(G, ctx);
+        gr_mpoly_init(Gprime, ctx);
+
+        status = GR_SUCCESS;
+
+        len = n_randint(state, 100);
+        exp_bits = n_randint(state, 200) + 2;
+
+        status |= gr_mpoly_randtest_bits(F, state, len, exp_bits, ctx);
+
+        if (n_randint(state, 2))
+        {
+            status |= gr_mpoly_integral(G, F, var, ctx);
+        }
+        else
+        {
+            status |= gr_mpoly_set(G, F, ctx);
+            status |= gr_mpoly_integral(G, G, var, ctx);
+        }
+
+        if (n_randint(state, 2))
+        {
+            status |= gr_mpoly_derivative(Gprime, G, var, ctx);
+        }
+        else
+        {
+            status |= gr_mpoly_set(Gprime, G, ctx);
+            status |= gr_mpoly_derivative(Gprime, Gprime, var, ctx);
+        }
+
+        if (status == GR_SUCCESS && gr_mpoly_equal(F, Gprime, ctx) == T_FALSE)
+        {
+            flint_printf("FAIL\n\n");
+            flint_printf("var = %ld\n", var);
+            flint_printf("F = "); gr_mpoly_print_pretty(F, ctx); flint_printf("\n");
+            flint_printf("G = "); gr_mpoly_print_pretty(G, ctx); flint_printf("\n");
+            flint_printf("Gprime = "); gr_mpoly_print_pretty(Gprime, ctx); flint_printf("\n");
+            status |= gr_mpoly_sub(Gprime, Gprime, F, ctx);
+            flint_printf("Gprime - F = "); gr_mpoly_print_pretty(Gprime, ctx); flint_printf("\n");
+            flint_abort();
+        }
+
+        gr_mpoly_clear(F, ctx);
+        gr_mpoly_clear(G, ctx);
+        gr_mpoly_clear(Gprime, ctx);
+
+        gr_mpoly_ctx_clear(ctx);
+        gr_ctx_clear(cctx);
+    }
+
+    TEST_FUNCTION_END(state);
+}
+


### PR DESCRIPTION
This will be useful for implementing `gr_derivative` in a sensible way in the (near?) future. Also, it will be useful for implementing the total derivative on polynomials in jet variables, which I plan to contribute as an example for the `examples` folder.

I figured these (simplest, most performant) variants that take an index could use the "most basic" / "main" names (without suffixes), and we can use other names (with suffixes) for methods that take a `gr_ptr` for the variable.