### PR TITLE
Add `gr_derivative_gen`, with implementations for polynomial rings

### DIFF
--- a/doc/source/gr.rst
+++ b/doc/source/gr.rst
@@ -739,6 +739,14 @@ Powering
     should override these methods with faster versions or
     to support more general notions of exponentiation when possible.
 
+Derivative
+........................................................................
+
+.. function:: int gr_derivative_gen(gr_ptr res, gr_srcptr x, slong var, gr_ctx_t ctx)
+
+    Sets *res* to the derivative of *x* with respect to the variable of index *var*.
+    The variables here are the generators of *ctx*.
+
 Square roots
 ........................................................................
 

--- a/src/gr.h
+++ b/src/gr.h
@@ -265,6 +265,8 @@ typedef enum
     GR_METHOD_POW_OTHER,
     GR_METHOD_OTHER_POW,
 
+    GR_METHOD_DERIVATIVE_GEN,
+
     GR_METHOD_IS_SQUARE,
     GR_METHOD_SQRT,
     GR_METHOD_RSQRT,
@@ -1129,6 +1131,8 @@ GR_INLINE WARN_UNUSED_RESULT int gr_pow_fmpz(gr_ptr res, gr_srcptr x, const fmpz
 GR_INLINE WARN_UNUSED_RESULT int gr_pow_fmpq(gr_ptr res, gr_srcptr x, const fmpq_t y, gr_ctx_t ctx) { return GR_BINARY_OP_FMPQ(ctx, POW_FMPQ)(res, x, y, ctx); }
 GR_INLINE WARN_UNUSED_RESULT int gr_pow_other(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx) { return GR_BINARY_OP_OTHER(ctx, POW_OTHER)(res, x, y, y_ctx, ctx); }
 GR_INLINE WARN_UNUSED_RESULT int gr_other_pow(gr_ptr res, gr_srcptr x, gr_ctx_t x_ctx, gr_srcptr y, gr_ctx_t ctx) { return GR_OTHER_BINARY_OP(ctx, OTHER_POW)(res, x, x_ctx, y, ctx); }
+
+GR_INLINE WARN_UNUSED_RESULT int gr_derivative_gen(gr_ptr res, gr_srcptr x, slong var, gr_ctx_t ctx) { return GR_BINARY_OP_SI(ctx, DERIVATIVE_GEN)(res, x, var, ctx); }
 
 GR_INLINE WARN_UNUSED_RESULT int gr_sqrt(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, SQRT)(res, x, ctx); }
 GR_INLINE WARN_UNUSED_RESULT int gr_rsqrt(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, RSQRT)(res, x, ctx); }

--- a/src/gr/fmpq_poly.c
+++ b/src/gr/fmpq_poly.c
@@ -640,6 +640,17 @@ _gr_fmpq_poly_pow_fmpz(fmpq_poly_t res, const fmpq_poly_t x, const fmpz_t exp, g
 }
 
 int
+_gr_fmpq_poly_derivative_gen(fmpq_poly_t res, const fmpq_poly_t x, slong var, const gr_ctx_t ctx)
+{
+    if (var == 0)
+    {
+        fmpq_poly_derivative(res, x);
+        return GR_SUCCESS;
+    }
+    return GR_DOMAIN;
+}
+
+int
 _gr_fmpq_poly_numerator(fmpq_poly_t res, const fmpq_poly_t x, const gr_ctx_t ctx)
 {
     fmpq_poly_set(res, x);
@@ -799,6 +810,7 @@ gr_method_tab_input _fmpq_poly_methods_input[] =
     {GR_METHOD_POW_UI,          (gr_funcptr) _gr_fmpq_poly_pow_ui},
     {GR_METHOD_POW_SI,          (gr_funcptr) _gr_fmpq_poly_pow_si},
     {GR_METHOD_POW_FMPZ,        (gr_funcptr) _gr_fmpq_poly_pow_fmpz},
+    {GR_METHOD_DERIVATIVE_GEN,  (gr_funcptr) _gr_fmpq_poly_derivative_gen},
     {GR_METHOD_NUMERATOR,       (gr_funcptr) _gr_fmpq_poly_numerator},
     {GR_METHOD_DENOMINATOR,     (gr_funcptr) _gr_fmpq_poly_denominator},
     {GR_METHOD_CANONICAL_ASSOCIATE,  (gr_funcptr) _gr_fmpq_poly_canonical_associate},

--- a/src/gr/fmpz_mpoly.c
+++ b/src/gr/fmpz_mpoly.c
@@ -492,6 +492,17 @@ _gr_fmpz_mpoly_pow_fmpz(fmpz_mpoly_t res, const fmpz_mpoly_t poly1, const fmpz_t
         return GR_UNABLE;
 }
 
+int
+_gr_fmpz_mpoly_derivative_gen(fmpz_mpoly_t res, const fmpz_mpoly_t poly, slong var, gr_ctx_t ctx)
+{
+    if (var >= 0 && var < MPOLYNOMIAL_MCTX(ctx)->minfo->nvars)
+    {
+        fmpz_mpoly_derivative(res, poly, var, MPOLYNOMIAL_MCTX(ctx));
+        return GR_SUCCESS;
+    }
+    return GR_DOMAIN;
+}
+
 truth_t
 _gr_fmpz_mpoly_is_square(const fmpz_mpoly_t poly, gr_ctx_t ctx)
 {
@@ -643,6 +654,7 @@ gr_method_tab_input _gr_fmpz_mpoly_methods_input[] =
     {GR_METHOD_IS_INVERTIBLE,   (gr_funcptr) _gr_fmpz_mpoly_is_invertible},
     {GR_METHOD_POW_UI,      (gr_funcptr) _gr_fmpz_mpoly_pow_ui},
     {GR_METHOD_POW_FMPZ,    (gr_funcptr) _gr_fmpz_mpoly_pow_fmpz},
+    {GR_METHOD_DERIVATIVE_GEN,  (gr_funcptr) _gr_fmpz_mpoly_derivative_gen},
     {GR_METHOD_SQRT,        (gr_funcptr) _gr_fmpz_mpoly_sqrt},
     {GR_METHOD_IS_SQUARE,   (gr_funcptr) _gr_fmpz_mpoly_is_square},
     {GR_METHOD_CANONICAL_ASSOCIATE,   (gr_funcptr) _gr_fmpz_mpoly_canonical_associate},

--- a/src/gr/fmpz_poly.c
+++ b/src/gr/fmpz_poly.c
@@ -707,6 +707,17 @@ _gr_fmpz_poly_pow_fmpz(fmpz_poly_t res, const fmpz_poly_t x, const fmpz_t exp, c
     }
 }
 
+int
+_gr_fmpz_poly_derivative_gen(fmpz_poly_t res, const fmpz_poly_t x, slong var, const gr_ctx_t ctx)
+{
+    if (var == 0)
+    {
+        fmpz_poly_derivative(res, x);
+        return GR_SUCCESS;
+    }
+    return GR_DOMAIN;
+}
+
 truth_t
 _gr_fmpz_poly_is_square(const fmpz_poly_t x, const gr_ctx_t ctx)
 {
@@ -904,6 +915,7 @@ gr_method_tab_input _fmpz_poly_methods_input[] =
     {GR_METHOD_POW_UI,          (gr_funcptr) _gr_fmpz_poly_pow_ui},
     {GR_METHOD_POW_SI,          (gr_funcptr) _gr_fmpz_poly_pow_si},
     {GR_METHOD_POW_FMPZ,        (gr_funcptr) _gr_fmpz_poly_pow_fmpz},
+    {GR_METHOD_DERIVATIVE_GEN,  (gr_funcptr) _gr_fmpz_poly_derivative_gen},
     {GR_METHOD_IS_SQUARE,       (gr_funcptr) _gr_fmpz_poly_is_square},
     {GR_METHOD_SQRT,            (gr_funcptr) _gr_fmpz_poly_sqrt},
     {GR_METHOD_RSQRT,           (gr_funcptr) _gr_fmpz_poly_rsqrt},

--- a/src/gr/polynomial.c
+++ b/src/gr/polynomial.c
@@ -670,6 +670,12 @@ polynomial_pow_si(gr_poly_t res, const gr_poly_t poly, slong exp, gr_ctx_t ctx)
 }
 
 int
+polynomial_derivative_gen(gr_poly_t res, const gr_poly_t poly, slong var, gr_ctx_t ctx)
+{
+    return (var == 0) ? gr_poly_derivative(res, poly, POLYNOMIAL_ELEM_CTX(ctx)) : GR_DOMAIN;
+}
+
+int
 polynomial_gcd(gr_poly_t res, const gr_poly_t x, const gr_poly_t y, const gr_ctx_t ctx)
 {
     return gr_poly_gcd(res, x, y, POLYNOMIAL_ELEM_CTX(ctx));
@@ -807,6 +813,8 @@ gr_method_tab_input _gr_poly_methods_input[] =
     {GR_METHOD_DIV,         (gr_funcptr) polynomial_div},
     {GR_METHOD_DIVEXACT,    (gr_funcptr) polynomial_divexact},
     {GR_METHOD_INV,         (gr_funcptr) polynomial_inv},
+
+    {GR_METHOD_DERIVATIVE_GEN,        (gr_funcptr) polynomial_derivative_gen},
 
     {GR_METHOD_EUCLIDEAN_DIV,         (gr_funcptr) polynomial_euclidean_div},
     {GR_METHOD_EUCLIDEAN_REM,         (gr_funcptr) polynomial_euclidean_rem},

--- a/src/gr_mpoly/ctx.c
+++ b/src/gr_mpoly/ctx.c
@@ -355,6 +355,7 @@ gr_method_tab_input _gr_mpoly_methods_input[] =
     {GR_METHOD_MUL_FMPQ,    (gr_funcptr) gr_mpoly_mul_fmpq},
     {GR_METHOD_INV,         (gr_funcptr) gr_mpoly_inv},
     {GR_METHOD_CANONICAL_ASSOCIATE,         (gr_funcptr) gr_mpoly_canonical_associate},
+    {GR_METHOD_DERIVATIVE_GEN,              (gr_funcptr) gr_mpoly_derivative},
     {0,                     (gr_funcptr) NULL},
 };
 


### PR DESCRIPTION
Comments welcome about the fallback behavior, and the need for another variant that takes a `gr_ptr` for the variable.

Derivatives are not yet implemented for `fmpz_mpoly_q`, `fmpz_mod_mpoly_q`, or symbolic expressions, so I did not cover them here. Also `fmpq_mpoly` does not have a GR context yet, so it is not covered either.

P.S. I struggled a bit where to put the respective lines in each file. Right now it's mostly after powering. I can change this if someone has a proposal where it should go instead.