### PR TITLE
Add a debug context for generics

### DIFF
--- a/doc/source/gr_domains.rst
+++ b/doc/source/gr_domains.rst
@@ -55,6 +55,31 @@ Domain properties
 
     Sets or retrieves the floating-point precision in bits.
 
+Debugging
+-------------------------------------------------------------------------------
+
+.. function:: void gr_ctx_init_debug(gr_ctx_t ctx, gr_ctx_t elem_ctx, int flags, double unable_probability)
+
+    Initialize *ctx* to a wrapper around *elem_ctx* for debugging.
+    This will execute supported methods (currently only a handful
+    of methods are supported, e.g. ``gr_add``) as if one is computing
+    directly over *elem_ctx*, but with added debugging features.
+
+    If *unable_probability* is positive, some methods will randomly return
+    ``GR_UNABLE`` and predicates will randomly return ``T_UNKNOWN``.
+
+    The following flags are supported:
+
+    * ``GR_DEBUG_WRAP`` - wrap elements in a box with a pointer. This allows
+      performing extra checks such as whether a variable is being cleared
+      twice or whether the wrong context object is passed as input. It can
+      also help catch some bugs that are not revealed when entries are
+      stored shallowly.
+
+    * ``GR_DEBUG_VERBOSE`` - print debugging information for each operation.
+
+    * ``GR_DEBUG_TIMING`` - print elapsed time for each operation.
+
 
 Groups
 -------------------------------------------------------------------------------

--- a/src/gr.h
+++ b/src/gr.h
@@ -725,6 +725,7 @@ typedef enum
     GR_CTX_GR_VEC,
     GR_CTX_PSL2Z, GR_CTX_DIRICHLET_GROUP, GR_CTX_PERM,
     GR_CTX_FEXPR,
+    GR_CTX_DEBUG,
     GR_CTX_UNKNOWN_DOMAIN,
     GR_CTX_WHICH_STRUCTURE_TAB_SIZE
 }
@@ -1515,6 +1516,13 @@ void gr_ctx_init_fexpr(gr_ctx_t ctx);
 int gr_ctx_cmp_coercion(gr_ctx_t ctx1, gr_ctx_t ctx2);
 
 /* Testing */
+
+#define GR_DEBUG_WRAP                     1
+#define GR_DEBUG_VERBOSE                  2
+#define GR_DEBUG_CHECK_ALWAYS_ABLE        4
+#define GR_DEBUG_TIMING                   8
+
+void gr_ctx_init_debug(gr_ctx_t ctx, gr_ctx_t elem_ctx, int flags, double unable_probability);
 
 #define GR_TEST_VERBOSE 8
 #define GR_TEST_ALWAYS_ABLE 16

--- a/src/gr/debug.c
+++ b/src/gr/debug.c
@@ -1,0 +1,532 @@
+#include <stdio.h>
+#include "gr.h"
+#include "profiler.h"
+
+typedef struct
+{
+    gr_ptr elem;
+    gr_ctx_struct * elem_ctx;
+    int cleared;
+}
+gr_debug_wrap_struct;
+
+typedef struct
+{
+    gr_ctx_struct * cctx;
+    int flags;
+    float unable_probability;
+    flint_rand_struct * rand_state;
+}
+_gr_debug_ctx_t;
+
+#define GR_DEBUG_CTX(ctx) (((_gr_debug_ctx_t *)(ctx)))
+#define GR_DEBUG_ELEM_CTX(ctx) (GR_DEBUG_CTX(ctx)->cctx)
+#define GR_DEBUG_CTX_FLAGS(ctx) (GR_DEBUG_CTX(ctx)->flags)
+#define GR_DEBUG_CTX_RAND_STATE(ctx) (GR_DEBUG_CTX(ctx)->rand_state)
+#define GR_DEBUG_CTX_UNABLE_PROBABILITY(ctx) (GR_DEBUG_CTX(ctx)->unable_probability)
+
+#define GR_DEBUG_ELEM(xx) ((GR_DEBUG_CTX_FLAGS(ctx) & GR_DEBUG_WRAP) ? (((gr_debug_wrap_struct *) (xx))->elem) : (xx))
+
+#define CHECK_TRUTH(t) \
+    if ((GR_DEBUG_CTX_FLAGS(ctx) & GR_DEBUG_CHECK_ALWAYS_ABLE) && ((t) == T_UNKNOWN)) \
+        flint_throw(FLINT_ERROR, "unexpected T_UNKNOWN");
+
+#define CHECK_STATUS \
+    if ((GR_DEBUG_CTX_FLAGS(ctx) & GR_DEBUG_CHECK_ALWAYS_ABLE) && (status & GR_UNABLE)) \
+        flint_throw(FLINT_ERROR, "unexpected GR_UNABLE");
+
+#define CHECK_WRAPPER(x) \
+    if ((GR_DEBUG_CTX_FLAGS(ctx) & GR_DEBUG_WRAP) && (((const gr_debug_wrap_struct *) x)->elem_ctx != GR_DEBUG_ELEM_CTX(ctx))) \
+    { \
+        flint_printf("\n%{gr_ctx} at %p\n", ctx, ctx); \
+        flint_printf("%{gr_ctx} at %p\n", GR_DEBUG_ELEM_CTX(ctx), GR_DEBUG_ELEM_CTX(ctx)); \
+        flint_printf("%{gr_ctx} at %p\n", ((const gr_debug_wrap_struct *) x)->elem_ctx, ((const gr_debug_wrap_struct *) x)->elem_ctx); \
+        flint_throw(FLINT_ERROR, "ctx of wrapped element does not match ctx of debug context"); \
+    }
+
+#define DEBUG_PRINT_MSG(msg) \
+    if (GR_DEBUG_CTX_FLAGS(ctx) & GR_DEBUG_VERBOSE) \
+        flint_printf("%s\n", msg);
+
+#define DEBUG_PRINT_ELEM(name, x) \
+    if (GR_DEBUG_CTX_FLAGS(ctx) & GR_DEBUG_VERBOSE) \
+    { \
+        flint_printf("%s = %{gr}\n", name, GR_DEBUG_ELEM(x), GR_DEBUG_ELEM_CTX(ctx)); \
+    }
+
+#define DEBUG_PRINT_STATUS \
+    if (GR_DEBUG_CTX_FLAGS(ctx) & GR_DEBUG_VERBOSE) \
+    { \
+        if (status == (GR_DOMAIN | GR_UNABLE)) flint_printf("status = GR_DOMAIN | GR_UNABLE\n"); \
+        else if (status == GR_DOMAIN) flint_printf("status = GR_DOMAIN\n"); \
+        else if (status == GR_UNABLE) flint_printf("status = GR_UNABLE\n"); \
+        else if (status == GR_SUCCESS) flint_printf("status = GR_SUCCESS\n"); \
+        else flint_printf("status = ???"); \
+    }
+
+#define DEBUG_PRINT_TRUTH(name, t) \
+    if (GR_DEBUG_CTX_FLAGS(ctx) & GR_DEBUG_VERBOSE) \
+    { \
+        flint_printf("%s = %{truth}\n", name, t); \
+    }
+
+#define RANDOMLY_UNABLE \
+    if (GR_DEBUG_CTX_UNABLE_PROBABILITY(ctx) != 0.0) \
+    { \
+        if (n_randlimb(GR_DEBUG_CTX_RAND_STATE(ctx)) < GR_DEBUG_CTX_UNABLE_PROBABILITY(ctx) * (double) UWORD_MAX) \
+        { \
+            DEBUG_PRINT_MSG("randomly returning GR_UNABLE"); \
+            return GR_UNABLE; \
+        } \
+    }
+
+#define RANDOMLY_UNKNOWN \
+    if (GR_DEBUG_CTX_UNABLE_PROBABILITY(ctx) != 0.0) \
+    { \
+        if (n_randlimb(GR_DEBUG_CTX_RAND_STATE(ctx)) < GR_DEBUG_CTX_UNABLE_PROBABILITY(ctx) * (double) UWORD_MAX) \
+        { \
+            DEBUG_PRINT_MSG("randomly returning T_UNKNOWN"); \
+            return T_UNKNOWN; \
+        } \
+    }
+
+
+
+
+static void
+_gr_debug_ctx_clear(gr_ctx_t ctx)
+{
+    flint_rand_clear(GR_DEBUG_CTX_RAND_STATE(ctx));
+    flint_free(GR_DEBUG_CTX_RAND_STATE(ctx));
+}
+
+static int
+_gr_debug_ctx_write(gr_stream_t out, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Debugging context (flags = ");
+    status |= gr_stream_write_si(out, GR_DEBUG_CTX_FLAGS(ctx));
+    status |= gr_stream_write(out, ", unable_probability = ");
+    char tmp[1024];
+    sprintf(tmp, "%.3f", GR_DEBUG_CTX_UNABLE_PROBABILITY(ctx));
+    status |= gr_stream_write(out, tmp);
+    status |= gr_stream_write(out, ") for ");
+    status |= gr_ctx_write(out, GR_DEBUG_ELEM_CTX(ctx));
+    return status;
+}
+
+static truth_t
+_gr_debug_ctx_is_threadsafe(gr_ctx_t ctx)
+{
+    /* currently threadsafe because we access the random state */
+    if (GR_DEBUG_CTX_UNABLE_PROBABILITY(ctx) != 0.0)
+        return T_FALSE;
+
+    return gr_ctx_is_threadsafe(GR_DEBUG_ELEM_CTX(ctx));
+}
+
+static void
+_gr_debug_init(gr_ptr x, gr_ctx_t ctx)
+{
+    gr_ctx_struct * cctx = GR_DEBUG_ELEM_CTX(ctx);
+
+    if (GR_DEBUG_CTX_FLAGS(ctx) & GR_DEBUG_VERBOSE)
+        flint_printf("gr_init: %p, %{gr_ctx}\n", x, cctx);
+
+    if (GR_DEBUG_CTX_FLAGS(ctx) & GR_DEBUG_WRAP)
+    {
+        gr_debug_wrap_struct * xx = x;
+
+        xx->elem = flint_malloc(cctx->sizeof_elem);
+        gr_init(xx->elem, cctx);
+        xx->elem_ctx = cctx;
+        xx->cleared = 0;
+    }
+    else
+    {
+        gr_init(x, GR_DEBUG_ELEM_CTX(ctx));
+    }
+}
+
+static void
+_gr_debug_clear(gr_ptr x, gr_ctx_t ctx)
+{
+    gr_ctx_struct * cctx = GR_DEBUG_ELEM_CTX(ctx);
+
+    if (GR_DEBUG_CTX_FLAGS(ctx) & GR_DEBUG_VERBOSE)
+        flint_printf("gr_clear: %p, %{gr_ctx}\n", x, cctx);
+
+    CHECK_WRAPPER(x)
+
+    if (GR_DEBUG_CTX_FLAGS(ctx) & GR_DEBUG_WRAP)
+    {
+        gr_debug_wrap_struct * xx = x;
+
+        if (xx->cleared)
+            flint_throw(FLINT_ERROR, "gr_clear: element cleared twice");
+
+        gr_clear(xx->elem, cctx);
+        flint_free(xx->elem);
+        xx->cleared = 1;
+    }
+    else
+    {
+        gr_clear(x, cctx);
+    }
+}
+
+static void
+_gr_debug_swap(gr_ptr x, gr_ptr y, gr_ctx_t ctx)
+{
+    gr_ctx_struct * cctx = GR_DEBUG_ELEM_CTX(ctx);
+
+    CHECK_WRAPPER(x)
+    CHECK_WRAPPER(y)
+
+    if (GR_DEBUG_CTX_FLAGS(ctx) & GR_DEBUG_WRAP)
+    {
+        gr_debug_wrap_struct * xx = x;
+        gr_debug_wrap_struct * yy = y;
+        FLINT_SWAP(gr_debug_wrap_struct, *xx, *yy);
+    }
+    else
+    {
+        gr_swap(x, y, cctx);
+    }
+}
+
+static void
+_gr_debug_set_shallow(gr_ptr res, gr_srcptr x, gr_ctx_t ctx)
+{
+    gr_ctx_struct * cctx = GR_DEBUG_ELEM_CTX(ctx);
+
+    CHECK_WRAPPER(x)
+
+    if (GR_DEBUG_CTX_FLAGS(ctx) & GR_DEBUG_WRAP)
+    {
+        gr_debug_wrap_struct * rres = res;
+        const gr_debug_wrap_struct * xx = x;
+        *rres = *xx;
+    }
+    else
+    {
+        gr_set_shallow(res, x, cctx);
+    }
+
+    CHECK_WRAPPER(res)
+}
+
+static int
+_gr_debug_randtest(gr_ptr res, flint_rand_t state, gr_ctx_t ctx)
+{
+    int status;
+    CHECK_WRAPPER(res)
+    status = gr_randtest(GR_DEBUG_ELEM(res), state, GR_DEBUG_ELEM_CTX(ctx));
+    return status;
+}
+
+static int
+_gr_debug_randtest_small(gr_ptr res, flint_rand_t state, gr_ctx_t ctx)
+{
+    int status;
+    CHECK_WRAPPER(res)
+    status = gr_randtest_small(GR_DEBUG_ELEM(res), state, GR_DEBUG_ELEM_CTX(ctx));
+    return status;
+}
+
+static int
+_gr_debug_write(gr_stream_t out, gr_srcptr x, gr_ctx_t ctx)
+{
+    int status;
+    CHECK_WRAPPER(x)
+    status = gr_write(out, GR_DEBUG_ELEM(x), GR_DEBUG_ELEM_CTX(ctx));
+    return status;
+}
+
+#define DEBUG_UNARY_PREDICATE_WITHOUT_UNABLE(name) \
+    truth_t res; \
+    DEBUG_PRINT_MSG(""); \
+    DEBUG_PRINT_MSG(#name "(x)"); \
+    DEBUG_PRINT_ELEM("x", x); \
+    CHECK_WRAPPER(x) \
+    res = name(GR_DEBUG_ELEM(x), GR_DEBUG_ELEM_CTX(ctx)); \
+    DEBUG_PRINT_TRUTH("res", res) \
+    CHECK_TRUTH(res) \
+    DEBUG_PRINT_MSG(""); \
+    return res;
+
+#define DEBUG_UNARY_PREDICATE(name) \
+    truth_t res; \
+    DEBUG_PRINT_MSG(""); \
+    DEBUG_PRINT_MSG(#name "(x)"); \
+    DEBUG_PRINT_ELEM("x", x); \
+    CHECK_WRAPPER(x) \
+    RANDOMLY_UNKNOWN \
+    res = name(GR_DEBUG_ELEM(x), GR_DEBUG_ELEM_CTX(ctx)); \
+    DEBUG_PRINT_TRUTH("res", res) \
+    CHECK_TRUTH(res) \
+    DEBUG_PRINT_MSG(""); \
+    return res;
+
+#define DEBUG_BINARY_PREDICATE(name) \
+    truth_t res; \
+    DEBUG_PRINT_MSG(""); \
+    DEBUG_PRINT_MSG(#name "(x, y)"); \
+    DEBUG_PRINT_ELEM("x", x); \
+    DEBUG_PRINT_ELEM("y", y); \
+    CHECK_WRAPPER(x) \
+    CHECK_WRAPPER(y) \
+    RANDOMLY_UNKNOWN \
+    res = name(GR_DEBUG_ELEM(x), GR_DEBUG_ELEM(y), GR_DEBUG_ELEM_CTX(ctx)); \
+    DEBUG_PRINT_TRUTH("res", res) \
+    CHECK_TRUTH(res) \
+    DEBUG_PRINT_MSG(""); \
+    return res;
+
+#define DEBUG_UNARY_OP_WITHOUT_UNABLE(name) \
+    int status; \
+    DEBUG_PRINT_MSG(""); \
+    DEBUG_PRINT_MSG(#name "(res, x)"); \
+    if (res == x) DEBUG_PRINT_MSG("res is aliased with x"); \
+    DEBUG_PRINT_ELEM("x   (before)", x); \
+    if (res != x) DEBUG_PRINT_ELEM("res (before)", res); \
+    CHECK_WRAPPER(res) \
+    CHECK_WRAPPER(x) \
+    if (GR_DEBUG_CTX_FLAGS(ctx) & GR_DEBUG_TIMING) \
+    { \
+        TIMEIT_ONCE_START \
+        status = name(GR_DEBUG_ELEM(res), GR_DEBUG_ELEM(x), GR_DEBUG_ELEM_CTX(ctx)); \
+        TIMEIT_ONCE_STOP \
+    } \
+    else \
+    { \
+        status = name(GR_DEBUG_ELEM(res), GR_DEBUG_ELEM(x), GR_DEBUG_ELEM_CTX(ctx)); \
+    } \
+    DEBUG_PRINT_ELEM("x   (after) ", x); \
+    DEBUG_PRINT_ELEM("res (after) ", res); \
+    DEBUG_PRINT_STATUS \
+    DEBUG_PRINT_MSG(""); \
+    return status;
+
+#define DEBUG_UNARY_OP(name) \
+    int status; \
+    DEBUG_PRINT_MSG(""); \
+    DEBUG_PRINT_MSG(#name "(res, x)"); \
+    DEBUG_PRINT_ELEM("x   (before)", x); \
+    if (res == x) DEBUG_PRINT_MSG("res is aliased with x"); \
+    if (res != x) DEBUG_PRINT_ELEM("res (before)", res); \
+    CHECK_WRAPPER(res) \
+    CHECK_WRAPPER(x) \
+    RANDOMLY_UNABLE \
+    if (GR_DEBUG_CTX_FLAGS(ctx) & GR_DEBUG_TIMING) \
+    { \
+        TIMEIT_ONCE_START \
+        status = name(GR_DEBUG_ELEM(res), GR_DEBUG_ELEM(x), GR_DEBUG_ELEM_CTX(ctx)); \
+        TIMEIT_ONCE_STOP \
+    } \
+    else \
+    { \
+        status = name(GR_DEBUG_ELEM(res), GR_DEBUG_ELEM(x), GR_DEBUG_ELEM_CTX(ctx)); \
+    } \
+    DEBUG_PRINT_ELEM("res (after) ", res); \
+    DEBUG_PRINT_STATUS \
+    DEBUG_PRINT_MSG(""); \
+    return status;
+
+#define DEBUG_BINARY_OP(name) \
+    int status; \
+    DEBUG_PRINT_MSG(""); \
+    DEBUG_PRINT_MSG(#name "(res, x, y)"); \
+    if (x == y)   DEBUG_PRINT_MSG("y is aliased with x"); \
+    if (x != y) DEBUG_PRINT_ELEM("y   (before)", y); \
+    if (res == x) DEBUG_PRINT_MSG("res is aliased with x"); \
+    if (res == y) DEBUG_PRINT_MSG("res is aliased with y"); \
+    if (res != x && res != y) DEBUG_PRINT_ELEM("res (before)", res); \
+    DEBUG_PRINT_ELEM("x   (before)", x); \
+    CHECK_WRAPPER(res) \
+    CHECK_WRAPPER(x) \
+    CHECK_WRAPPER(y) \
+    RANDOMLY_UNABLE \
+    if (GR_DEBUG_CTX_FLAGS(ctx) & GR_DEBUG_TIMING) \
+    { \
+        TIMEIT_ONCE_START \
+        status = name(GR_DEBUG_ELEM(res), GR_DEBUG_ELEM(x), GR_DEBUG_ELEM(y), GR_DEBUG_ELEM_CTX(ctx)); \
+        TIMEIT_ONCE_STOP \
+    } \
+    else \
+    { \
+        status = name(GR_DEBUG_ELEM(res), GR_DEBUG_ELEM(x), GR_DEBUG_ELEM(y), GR_DEBUG_ELEM_CTX(ctx)); \
+    } \
+    DEBUG_PRINT_ELEM("res (after) ", res); \
+    DEBUG_PRINT_STATUS \
+    DEBUG_PRINT_MSG(""); \
+    return status;
+
+static int
+_gr_debug_zero(gr_ptr res, gr_ctx_t ctx)
+{
+    int status;
+    CHECK_WRAPPER(res)
+    /* RANDOMLY_UNABLE */
+    status = gr_zero(GR_DEBUG_ELEM(res), GR_DEBUG_ELEM_CTX(ctx));
+    return status;
+}
+
+static int
+_gr_debug_one(gr_ptr res, gr_ctx_t ctx)
+{
+    int status;
+    CHECK_WRAPPER(res)
+    /* RANDOMLY_UNABLE */
+    status = gr_one(GR_DEBUG_ELEM(res), GR_DEBUG_ELEM_CTX(ctx));
+    return status;
+}
+
+static truth_t
+_gr_debug_is_zero(gr_srcptr x, gr_ctx_t ctx)
+{
+    DEBUG_UNARY_PREDICATE_WITHOUT_UNABLE(gr_is_zero)
+}
+
+static truth_t
+_gr_debug_is_one(gr_srcptr x, gr_ctx_t ctx)
+{
+    DEBUG_UNARY_PREDICATE(gr_is_one)
+}
+
+static truth_t
+_gr_debug_equal(gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    DEBUG_BINARY_PREDICATE(gr_equal)
+}
+
+static int
+_gr_debug_set(gr_ptr res, gr_srcptr x, gr_ctx_t ctx)
+{
+    DEBUG_UNARY_OP_WITHOUT_UNABLE(gr_set)
+}
+
+static int
+_gr_debug_neg(gr_ptr res, gr_srcptr x, gr_ctx_t ctx)
+{
+    DEBUG_UNARY_OP_WITHOUT_UNABLE(gr_neg)
+}
+
+static int
+_gr_debug_add(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    DEBUG_BINARY_OP(gr_add)
+}
+
+static int
+_gr_debug_sub(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    DEBUG_BINARY_OP(gr_sub)
+}
+
+static int
+_gr_debug_mul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    DEBUG_BINARY_OP(gr_mul)
+}
+
+static int
+_gr_debug_div(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    DEBUG_BINARY_OP(gr_div)
+}
+
+static int
+_gr_debug_pow(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    DEBUG_BINARY_OP(gr_pow)
+}
+
+
+static truth_t
+_gr_debug_is_invertible(gr_srcptr x, gr_ctx_t ctx)
+{
+    DEBUG_UNARY_PREDICATE(gr_is_invertible)
+}
+
+static int
+_gr_debug_inv(gr_ptr res, gr_srcptr x, gr_ctx_t ctx)
+{
+    DEBUG_UNARY_OP(gr_inv)
+}
+
+static int
+_gr_debug_sqrt(gr_ptr res, gr_srcptr x, gr_ctx_t ctx)
+{
+    DEBUG_UNARY_OP(gr_sqrt)
+}
+
+static int
+_gr_debug_rsqrt(gr_ptr res, gr_srcptr x, gr_ctx_t ctx)
+{
+    DEBUG_UNARY_OP(gr_rsqrt)
+}
+
+int _gr_debug_methods_initialized = 0;
+
+gr_static_method_table _gr_debug_methods;
+
+gr_method_tab_input _gr_debug_methods_input[] =
+{
+    {GR_METHOD_CTX_CLEAR,       (gr_funcptr) _gr_debug_ctx_clear},
+    {GR_METHOD_CTX_WRITE,       (gr_funcptr) _gr_debug_ctx_write},
+    {GR_METHOD_CTX_IS_RING,     (gr_funcptr) gr_generic_ctx_predicate_true},
+    {GR_METHOD_CTX_IS_COMMUTATIVE_RING, (gr_funcptr) gr_generic_ctx_predicate_true},
+    {GR_METHOD_CTX_IS_EXACT,     (gr_funcptr) gr_generic_ctx_predicate_true},
+    {GR_METHOD_CTX_IS_THREADSAFE,  (gr_funcptr) _gr_debug_ctx_is_threadsafe},
+    {GR_METHOD_INIT,            (gr_funcptr) _gr_debug_init},
+    {GR_METHOD_CLEAR,           (gr_funcptr) _gr_debug_clear},
+    {GR_METHOD_SWAP,            (gr_funcptr) _gr_debug_swap},
+    {GR_METHOD_SET_SHALLOW,     (gr_funcptr) _gr_debug_set_shallow},
+    {GR_METHOD_RANDTEST,        (gr_funcptr) _gr_debug_randtest},
+    {GR_METHOD_RANDTEST_SMALL,  (gr_funcptr) _gr_debug_randtest_small},
+    {GR_METHOD_WRITE,           (gr_funcptr) _gr_debug_write},
+    {GR_METHOD_ZERO,            (gr_funcptr) _gr_debug_zero},
+    {GR_METHOD_ONE,             (gr_funcptr) _gr_debug_one},
+    {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_debug_is_zero},
+    {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_debug_is_one},
+    {GR_METHOD_EQUAL,           (gr_funcptr) _gr_debug_equal},
+    {GR_METHOD_SET,             (gr_funcptr) _gr_debug_set},
+    {GR_METHOD_NEG,             (gr_funcptr) _gr_debug_neg},
+    {GR_METHOD_ADD,             (gr_funcptr) _gr_debug_add},
+    {GR_METHOD_SUB,             (gr_funcptr) _gr_debug_sub},
+    {GR_METHOD_MUL,             (gr_funcptr) _gr_debug_mul},
+    {GR_METHOD_DIV,             (gr_funcptr) _gr_debug_div},
+    {GR_METHOD_IS_INVERTIBLE,   (gr_funcptr) _gr_debug_is_invertible},
+    {GR_METHOD_INV,             (gr_funcptr) _gr_debug_inv},
+    {GR_METHOD_SQRT,            (gr_funcptr) _gr_debug_sqrt},
+    {GR_METHOD_RSQRT,           (gr_funcptr) _gr_debug_rsqrt},
+    {GR_METHOD_POW,             (gr_funcptr) _gr_debug_pow},
+    {0,                         (gr_funcptr) NULL},
+};
+
+void
+gr_ctx_init_debug(gr_ctx_t ctx, gr_ctx_t elem_ctx, int flags, double unable_probability)
+{
+    ctx->which_ring = GR_CTX_DEBUG;
+
+    GR_DEBUG_ELEM_CTX(ctx) = elem_ctx;
+    GR_DEBUG_CTX_FLAGS(ctx) = flags;
+    GR_DEBUG_CTX_RAND_STATE(ctx) = flint_malloc(sizeof(flint_rand_struct));
+    flint_rand_init(GR_DEBUG_CTX_RAND_STATE(ctx));
+
+    if (GR_DEBUG_CTX_FLAGS(ctx) & GR_DEBUG_WRAP)
+        ctx->sizeof_elem = sizeof(gr_debug_wrap_struct);
+    else
+        ctx->sizeof_elem = GR_DEBUG_ELEM_CTX(ctx)->sizeof_elem;
+
+    GR_DEBUG_CTX_UNABLE_PROBABILITY(ctx) = unable_probability;
+
+    ctx->methods = _gr_debug_methods;
+    if (!_gr_debug_methods_initialized)
+    {
+        gr_method_tab_init(_gr_debug_methods, _gr_debug_methods_input);
+        _gr_debug_methods_initialized = 1;
+    }
+}
+

--- a/src/gr/init_random.c
+++ b/src/gr/init_random.c
@@ -48,7 +48,7 @@ gr_ctx_init_random_ring_composite(gr_ctx_t ctx, flint_rand_t state)
 {
     gr_ctx_struct * base_ring = _gr_random_base_ring(state);
 
-    switch (n_randint(state, 5))
+    switch (n_randint(state, 6))
     {
         case 0:
             gr_ctx_init_gr_poly(ctx, base_ring);
@@ -64,6 +64,15 @@ gr_ctx_init_random_ring_composite(gr_ctx_t ctx, flint_rand_t state)
             break;
         case 4:
             gr_ctx_init_vector_space_gr_vec(ctx, base_ring, n_randint(state, 4));
+            break;
+        case 5:
+            {
+                int flags = 0;
+                flags |= n_randint(state, 2) ? GR_DEBUG_WRAP : 0;
+                /* flags |= GR_DEBUG_VERBOSE; */
+                double unable_probability = n_randint(state, 2) ? 0 : 0.1;
+                gr_ctx_init_debug(ctx, base_ring, flags, unable_probability);
+            }
             break;
 /*
     this will break tests that currently assume commutativity

--- a/src/gr/test/main.c
+++ b/src/gr/test/main.c
@@ -22,6 +22,7 @@
 #include "t-arb.c"
 #include "t-arf.c"
 #include "t-ca.c"
+#include "t-debug.c"
 #include "t-dirichlet.c"
 #include "t-fmpq.c"
 #include "t-fmpq_poly.c"
@@ -72,6 +73,7 @@ test_struct tests[] =
     TEST_FUNCTION(gr_arb),
     TEST_FUNCTION(gr_arf),
     TEST_FUNCTION(gr_ca),
+    TEST_FUNCTION(gr_debug),
     TEST_FUNCTION(gr_dirichlet),
     TEST_FUNCTION(gr_fmpq),
     TEST_FUNCTION(gr_fmpq_poly),

--- a/src/gr/test/t-debug.c
+++ b/src/gr/test/t-debug.c
@@ -1,0 +1,36 @@
+/*
+    Copyright (C) 2025 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "gr.h"
+
+TEST_FUNCTION_START(gr_debug, state)
+{
+    gr_ctx_t R, Rdebug;
+
+    gr_ctx_init_fmpz(R);
+
+    gr_ctx_init_debug(Rdebug, R, 0, 0.0);
+    gr_test_ring(Rdebug, 1000, 0);
+    gr_ctx_clear(Rdebug);
+
+    gr_ctx_init_debug(Rdebug, R, 0, 0.2);
+    gr_test_ring(Rdebug, 1000, 0);
+    gr_ctx_clear(Rdebug);
+
+    gr_ctx_init_debug(Rdebug, R, GR_DEBUG_WRAP, 0.2);
+    gr_test_ring(Rdebug, 1000, 0);
+    gr_ctx_clear(Rdebug);
+
+    gr_ctx_clear(R);
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/gr/test_ring.c
+++ b/src/gr/test_ring.c
@@ -167,7 +167,6 @@ gr_test_set_si(gr_ctx_t R, flint_rand_t state, int test_flags)
     while (z_add_checked(&c, a, b));
 
     GR_TMP_INIT4(xa, xb, xc, xa_xb, R);
-
     GR_MUST_SUCCEED(gr_randtest(xa, state, R));
 
     status = GR_SUCCESS;
@@ -1931,7 +1930,6 @@ gr_test_is_invertible(gr_ctx_t R, flint_rand_t state, int test_flags)
     gr_ptr x, x_inv;
 
     GR_TMP_INIT2(x, x_inv, R);
-
     GR_MUST_SUCCEED(gr_randtest(x, state, R));
 
     status = GR_SUCCESS;
@@ -1955,7 +1953,7 @@ gr_test_is_invertible(gr_ctx_t R, flint_rand_t state, int test_flags)
         flint_printf("is_invertible\n");
         flint_printf("x = \n"); gr_println(x, R);
         flint_printf("x ^ -1 = \n"); gr_println(x_inv, R);
-        flint_printf("status = %d, invertible = %d\n", status, invertible);
+        flint_printf("status = %d, invertible = %{truth}\n", status, invertible);
         flint_printf("\n");
     }
 
@@ -2696,7 +2694,7 @@ gr_test_pow_fmpz_exponent_addition(gr_ctx_t R, flint_rand_t state, int test_flag
     {
         if (gr_set_si(x, -1 + (slong) n_randint(state, 3), R) != GR_SUCCESS)
             /* allow using for groups */
-            GR_MUST_SUCCEED(gr_one(x, R));
+            GR_IGNORE(gr_one(x, R));
         fmpz_randtest(a, state, 100);
         fmpz_randtest(b, state, 100);
     }
@@ -3373,7 +3371,7 @@ gr_test_canonical_associate(gr_ctx_t R, flint_rand_t state, int test_flags)
 
             if (i == 5)
             {
-                GR_MUST_SUCCEED(n_randint(state, 2) ? gr_one(v, R) : gr_neg_one(v, R));
+                GR_IGNORE(n_randint(state, 2) ? gr_one(v, R) : gr_neg_one(v, R));
                 break;
             }
         }

--- a/src/gr_generic/generic.c
+++ b/src/gr_generic/generic.c
@@ -196,6 +196,9 @@ int gr_generic_randtest_small(gr_ptr x, flint_rand_t state, gr_ctx_t ctx)
     if (status != GR_SUCCESS)
         status = gr_set_si(x, -3 + (slong) n_randint(state, 7), ctx);
 
+    if (status != GR_SUCCESS)
+        return gr_zero(x, ctx);
+
     return status;
 }
 

--- a/src/gr_mat/test/t-is_orthogonal.c
+++ b/src/gr_mat/test/t-is_orthogonal.c
@@ -19,20 +19,24 @@ gr_mat_is_orthogonal_naive(const gr_mat_t A, gr_ctx_t ctx)
     gr_mat_t T, U;
     slong n = A->r;
     truth_t res, res2;
+    int status = GR_SUCCESS;
 
     gr_mat_init(T, n, n, ctx);
     gr_mat_init(U, n, n, ctx);
 
-    GR_MUST_SUCCEED(gr_mat_transpose(T, A, ctx));
-    GR_MUST_SUCCEED(gr_mat_mul(U, A, T, ctx));
+    status |= gr_mat_transpose(T, A, ctx);
+    status |= gr_mat_mul(U, A, T, ctx);
     res = gr_mat_is_one(U, ctx);
 
-    GR_MUST_SUCCEED(gr_mat_mul(U, T, A, ctx));
+    status |= gr_mat_mul(U, T, A, ctx);
     res2 = gr_mat_is_one(U, ctx);
     res = truth_and(res, res2);
 
     gr_mat_clear(T, ctx);
     gr_mat_clear(U, ctx);
+
+    if (status != GR_SUCCESS)
+        res = T_UNKNOWN;
 
     return res;
 }
@@ -44,18 +48,20 @@ gr_mat_is_orthogonal2_naive(const gr_mat_t A, int cols, int unit, gr_ctx_t ctx)
     slong r = A->r;
     slong c = A->c;
     truth_t res;
+    int status = GR_SUCCESS;
+
     gr_mat_init(AT, c, r, ctx);
-    GR_MUST_SUCCEED(gr_mat_transpose(AT, A, ctx));
+    status |= gr_mat_transpose(AT, A, ctx);
 
     if (cols)
     {
         gr_mat_init(P, c, c, ctx);
-        GR_MUST_SUCCEED(gr_mat_mul(P, AT, A, ctx));
+        status |= gr_mat_mul(P, AT, A, ctx);
     }
     else
     {
         gr_mat_init(P, r, r, ctx);
-        GR_MUST_SUCCEED(gr_mat_mul(P, A, AT, ctx));
+        status |= gr_mat_mul(P, A, AT, ctx);
     }
 
     if (unit)
@@ -65,6 +71,10 @@ gr_mat_is_orthogonal2_naive(const gr_mat_t A, int cols, int unit, gr_ctx_t ctx)
 
     gr_mat_clear(AT, ctx);
     gr_mat_clear(P, ctx);
+
+    if (status != GR_SUCCESS)
+        res = T_UNKNOWN;
+
     return res;
 }
 

--- a/src/gr_mat/test_lu.c
+++ b/src/gr_mat/test_lu.c
@@ -101,14 +101,16 @@ static void check(slong * P, gr_mat_t LU, const gr_mat_t A, slong rank, gr_ctx_t
     gr_mat_clear(U, ctx);
 }
 
-static void
+static int
 _gr_mat_randrank(gr_mat_t mat, flint_rand_t state, slong rank, slong bits, gr_ctx_t ctx)
 {
+    int status;
     fmpz_mat_t A;
     fmpz_mat_init(A, mat->r, mat->c);
     fmpz_mat_randrank(A, state, rank, bits);
-    GR_MUST_SUCCEED(gr_mat_set_fmpz_mat(mat, A, ctx));
+    status = gr_mat_set_fmpz_mat(mat, A, ctx);
     fmpz_mat_clear(A);
+    return status;
 }
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
@@ -173,14 +175,15 @@ void gr_mat_test_lu(gr_method_mat_lu_op lu_impl, flint_rand_t state, slong iters
         else
         {
             r = n_randint(state, FLINT_MIN(m, n) + 1);
-            _gr_mat_randrank(A, state, r, 5, ctx);
+            status = _gr_mat_randrank(A, state, r, 5, ctx);
+
             if (n_randint(state, 2))
             {
                 d = n_randint(state, 2*m*n + 1);
-                GR_MUST_SUCCEED(gr_mat_randops(A, state, d, ctx));
+                status |= gr_mat_randops(A, state, d, ctx);
             }
 
-            if (gr_ctx_is_finite_characteristic(ctx) == T_FALSE)
+            if (status == GR_SUCCESS && gr_ctx_is_finite_characteristic(ctx) == T_FALSE)
                 rank_lower_bound = rank_upper_bound = r;
             else
             {

--- a/src/gr_mpoly/randtest_bits.c
+++ b/src/gr_mpoly/randtest_bits.c
@@ -41,7 +41,7 @@ int gr_mpoly_randtest_bits(gr_mpoly_t A, flint_rand_t state,
     }
 
     gr_mpoly_sort_terms(A, ctx);
-    status |= gr_mpoly_combine_like_terms(A, ctx);
+    GR_IGNORE(gr_mpoly_combine_like_terms(A, ctx));
 
     for (j = 0; j < nvars; j++)
         fmpz_clear(exp + j);

--- a/src/gr_poly/test/t-compose_series.c
+++ b/src/gr_poly/test/t-compose_series.c
@@ -43,7 +43,7 @@ test_compose_series(flint_rand_t state, int which)
     GR_MUST_SUCCEED(gr_poly_randtest(A, state, 1 + n_randint(state, 20), ctx));
     GR_MUST_SUCCEED(gr_poly_randtest(B, state, 1 + n_randint(state, 20), ctx));
     GR_MUST_SUCCEED(gr_poly_randtest(C, state, 1 + n_randint(state, 20), ctx));
-    GR_MUST_SUCCEED(gr_poly_set_coeff_si(B, 0, 0, ctx));
+    status |= gr_poly_set_coeff_si(B, 0, 0, ctx);
 
     switch (which)
     {

--- a/src/gr_poly/test/t-pow_ui.c
+++ b/src/gr_poly/test/t-pow_ui.c
@@ -55,7 +55,7 @@ test(flint_rand_t state, int which)
         status |= gr_poly_pow_ui_binexp(Anm, A, n + m, ctx);
     }
 
-    if (gr_poly_equal(AnAm, Anm, ctx) == T_FALSE)
+    if (status == GR_SUCCESS && gr_poly_equal(AnAm, Anm, ctx) == T_FALSE)
     {
         flint_printf("FAIL\n\n");
         gr_ctx_println(ctx);

--- a/src/gr_poly/test/t-revert_series.c
+++ b/src/gr_poly/test/t-revert_series.c
@@ -43,10 +43,10 @@ test_revert_series(flint_rand_t state, int which)
     GR_MUST_SUCCEED(gr_poly_randtest(C, state, 1 + n_randint(state, 20), ctx));
 
     if (n_randint(state, 10) != 0)
-        GR_MUST_SUCCEED(gr_poly_set_coeff_si(A, 0, 0, ctx));
+        status |= gr_poly_set_coeff_si(A, 0, 0, ctx);
 
     if (n_randint(state, 2))
-        GR_MUST_SUCCEED(gr_poly_set_coeff_si(A, 1, 1, ctx));
+        status |= gr_poly_set_coeff_si(A, 1, 1, ctx);
 
 
     switch (which)

--- a/src/gr_vec/test/t-sum.c
+++ b/src/gr_vec/test/t-sum.c
@@ -50,6 +50,7 @@ test_sum(flint_rand_t state, int which)
     if (status == GR_SUCCESS && gr_equal(x1, x2, ctx) == T_FALSE)
     {
         flint_printf("FAIL\n");
+        gr_ctx_println(ctx);
         printf("which = %d\n", which);
         printf("vec = "); _gr_vec_print(vec, len, ctx); printf("\n");
         printf("x1 = "); gr_println(x1, ctx); printf("\n");


### PR DESCRIPTION
Add a context for debugging generic rings and algorithms, as discussed briefly with @mezzarobba.

Currently supports the following features, but more can be added:
* A minimal set of operations (enough to run generic ring tests)
* Wrapping elements in boxes (and doing some validity checks enabled by this)
* Randomly returning ``GR_UNABLE`` / ``GR_UNKNOWN``, to debug error handling and triple-valued logic in algorithms
* Verbose printing
* Timing the execution of each operation

Debug contexts (without verbose printing) can be generated randomly in ``gr_ctx_init_random``. This PR also fixes a couple of minor issues manifest with this change.

Verbose output currently looks like this:

```
#include "gr.h"
#include "gr_mat.h"

int main()
{
    gr_ctx_t R;
    gr_ctx_t R2;

    gr_ctx_init_fmpz(R);
    gr_ctx_init_debug(R2, R, GR_DEBUG_WRAP | GR_DEBUG_VERBOSE | GR_DEBUG_TIMING, 0.0);

    gr_mat_t A;
    gr_ptr x;

    flint_rand_t state;
    flint_rand_init(state);

    x = gr_heap_init(R2);
    gr_mat_init(A, 2, 2, R2);
    gr_mat_randrank(A, state, 2, R2);
    gr_mat_det(x, A, R2);

    flint_printf("\n");
    gr_mat_print(A, R2); flint_printf("\n");
    gr_println(x, R2);
}
```

```
gr_init: 0x55e8e46242c0, Integer ring (fmpz)
gr_init: 0x55e8e4624710, Integer ring (fmpz)
gr_init: 0x55e8e4624728, Integer ring (fmpz)
gr_init: 0x55e8e4624740, Integer ring (fmpz)
gr_init: 0x55e8e4624758, Integer ring (fmpz)
gr_init: 0x7ffec3c7bd80, Integer ring (fmpz)
gr_init: 0x7ffec3c7bd98, Integer ring (fmpz)

gr_is_zero(x)
x = 16
res = T_FALSE


gr_is_zero(x)
x = 0
res = T_TRUE


gr_is_zero(x)
x = -302213008159583600885760
res = T_FALSE


gr_set(res, x)
x   (before) = 16
res (before) = 0
cpu/wall(s): 0 0
x   (after)  = 16
res (after)  = 16
status = GR_SUCCESS


gr_set(res, x)
x   (before) = -302213008159583600885760
res (before) = 0
cpu/wall(s): 0 0
x   (after)  = -302213008159583600885760
res (after)  = -302213008159583600885760
status = GR_SUCCESS

gr_clear: 0x7ffec3c7bd80, Integer ring (fmpz)
gr_clear: 0x7ffec3c7bd98, Integer ring (fmpz)
gr_init: 0x7ffec3c7bda0, Integer ring (fmpz)

gr_mul(res, x, y)
y   (before) = -302213008159583600885760
res (before) = 0
x   (before) = 16
cpu/wall(s): 0 0
res (after)  = -4835408130553337614172160
status = GR_SUCCESS


gr_mul(res, x, y)
y   (before) = 0
res (before) = 0
x   (before) = 0
cpu/wall(s): 0 0
res (after)  = 0
status = GR_SUCCESS


gr_sub(res, x, y)
y   (before) = 0
res is aliased with y
x   (before) = -4835408130553337614172160
cpu/wall(s): 0 0
res (after)  = -4835408130553337614172160
status = GR_SUCCESS

gr_clear: 0x7ffec3c7bda0, Integer ring (fmpz)

[[16, 0],
[0, -302213008159583600885760]]
-4835408130553337614172160
```

