### PR TITLE
Clean profile files

### DIFF
--- a/doc/source/nmod_vec.rst
+++ b/doc/source/nmod_vec.rst
@@ -28,7 +28,8 @@ Random functions
 
 .. function:: void _nmod_vec_rand(nn_ptr vec, flint_rand_t state, slong len, nmod_t mod)
 
-    Sets ``vec`` to a vector of the given length with entries picked uniformly at random in `[0, mod.n)`.
+    Sets ``vec`` to a vector of the given length with entries picked uniformly
+    at random in ``[0, mod.n)``.
 
 
 Basic manipulation and comparison

--- a/src/nmod_vec/profile/p-dot.c
+++ b/src/nmod_vec/profile/p-dot.c
@@ -19,21 +19,6 @@
 #include "nmod_poly.h"
 #include "gr_poly.h"
 
-// utility (nmod vec uniform random)
-static inline
-void _nmod_vec_rand(nn_ptr vec, flint_rand_t state, slong len, nmod_t mod)
-{
-    for (slong i = 0; i < len; i++)
-        vec[i] = n_randint(state, mod.n);
-}
-
-// uniform (nmod mat uniform random)
-static inline
-void nmod_mat_rand(nmod_mat_t mat, flint_rand_t state)
-{
-    _nmod_vec_rand(mat->entries, state, mat->r * mat->c, mat->mod);
-}
-
 /*------------------------------------*/
 /* direct: dot / dot_rev / dot expr   */
 /*------------------------------------*/


### PR DESCRIPTION
After some recent changes, there was a redundant function definition. This fixes this so that `make profile` compiles again; and also fixes a minor documentation formatting issue.