### PR TITLE
Fix static linkage of d_randtest

### DIFF
--- a/src/mag/test/t-d_log_lower_bound.c
+++ b/src/mag/test/t-d_log_lower_bound.c
@@ -23,7 +23,7 @@
 #define EXP_MINUS_32 2.3283064365386962891e-10
 #define EXP_MINUS_64 5.42101086242752217e-20
 
-double
+static double
 d_randtest2(flint_rand_t state)
 {
     ulong m1, m2;

--- a/src/mag/test/t-d_log_upper_bound.c
+++ b/src/mag/test/t-d_log_upper_bound.c
@@ -23,7 +23,7 @@
 #define EXP_MINUS_32 2.3283064365386962891e-10
 #define EXP_MINUS_64 5.42101086242752217e-20
 
-double
+static double
 d_randtest2(flint_rand_t state)
 {
     ulong m1, m2;

--- a/src/mag/test/t-set_d.c
+++ b/src/mag/test/t-set_d.c
@@ -23,7 +23,7 @@
 #define EXP_MINUS_32 2.3283064365386962891e-10
 #define EXP_MINUS_64 5.42101086242752217e-20
 
-double
+static double
 d_randtest2(flint_rand_t state)
 {
     ulong m1, m2;

--- a/src/mag/test/t-set_d_2exp_fmpz.c
+++ b/src/mag/test/t-set_d_2exp_fmpz.c
@@ -23,7 +23,7 @@
 #define EXP_MINUS_32 2.3283064365386962891e-10
 #define EXP_MINUS_64 5.42101086242752217e-20
 
-double
+static double
 d_randtest2(flint_rand_t state)
 {
     ulong m1, m2;


### PR DESCRIPTION
Fixes #2058.  Makes #2411 obsolete.