### PR TITLE
Reduce multiplication depth in _gr_poly_compose_axnc

### DIFF
--- a/src/gr_generic/generic.c
+++ b/src/gr_generic/generic.c
@@ -2632,7 +2632,7 @@ gr_generic_vec_set_powers(gr_ptr res, gr_srcptr x, slong len, gr_ctx_t ctx)
             if (i % 2 == 0)
                 status |= sqr(GR_ENTRY(res, i, sz), GR_ENTRY(res, i / 2, sz), ctx);
             else
-                status |= mul(GR_ENTRY(res, i, sz), GR_ENTRY(res, i - 1, sz), x, ctx);
+                status |= mul(GR_ENTRY(res, i, sz), GR_ENTRY(res, (i + 1) / 2, sz), GR_ENTRY(res, i / 2, sz), ctx);
         }
     }
     else

--- a/src/gr_poly/compose.c
+++ b/src/gr_poly/compose.c
@@ -13,6 +13,7 @@
 
 #include "gr_vec.h"
 #include "gr_poly.h"
+#include "longlong.h"
 
 /* compose by poly2 = a*x^n + c, no aliasing; n >= 1 */
 static int
@@ -39,19 +40,48 @@ _gr_poly_compose_axnc(gr_ptr res, gr_srcptr poly1, slong len1,
         }
         else
         {
-            gr_ptr t;
-            GR_TMP_INIT(t, ctx);
-
-            status |= gr_set(t, a, ctx);
-
-            for (i = 1; i < len1; i++)
+            int maxbit = FLINT_CLOG2(len1);
+            gr_ptr pw, t;
+            /* Prefer squaring for powers? cf. _gr_vec_set_powers */
+            if (gr_ctx_is_finite(ctx) == T_TRUE || gr_ctx_has_real_prec(ctx) == T_TRUE)
             {
-                status |= gr_mul(GR_ENTRY(res, i, sz), GR_ENTRY(res, i, sz), t, ctx);
-                if (i + 1 < len1)
-                    status |= gr_mul(t, t, a, ctx);
-            }
+                GR_TMP_INIT_VEC(pw, maxbit, ctx);
+                GR_TMP_INIT_VEC(t, maxbit, ctx);
 
-            GR_TMP_CLEAR(t, ctx);
+                status |= gr_set(GR_ENTRY(pw, 0, sz), a, ctx);
+                status |= gr_mul(GR_ENTRY(res, 1, sz), GR_ENTRY(res, 1, sz), a, ctx);
+                for (i = 2; i < len1; i++)
+                {
+                    int j = flint_ctz(i);
+                    if (i == ((slong)1 << j))
+                    {
+                        status |= gr_sqr(GR_ENTRY(pw, j, sz), GR_ENTRY(pw, j-1, sz), ctx);
+                        status |= gr_set(GR_ENTRY(t, j, sz), GR_ENTRY(pw, j, sz), ctx);
+                    }
+                    else
+                        status |= gr_mul(GR_ENTRY(t, j, sz), GR_ENTRY(t, flint_ctz(i - ((slong)1 << j)), sz),
+                                GR_ENTRY(pw, j, sz), ctx);
+                    status |= gr_mul(GR_ENTRY(res, i, sz), GR_ENTRY(res, i, sz), GR_ENTRY(t, j, sz), ctx);
+                }
+
+                GR_TMP_CLEAR_VEC(pw, maxbit, ctx);
+                GR_TMP_CLEAR_VEC(t, maxbit, ctx);
+            }
+            else
+            {
+                GR_TMP_INIT(t, ctx);
+
+                status |= gr_set(t, a, ctx);
+
+                for (i = 1; i < len1; i++)
+                {
+                    status |= gr_mul(GR_ENTRY(res, i, sz), GR_ENTRY(res, i, sz), t, ctx);
+                    if (i + 1 < len1)
+                        status |= gr_mul(t, t, a, ctx);
+                }
+
+                GR_TMP_CLEAR(t, ctx);
+            }
         }
     }
 

--- a/src/gr_poly/compose_series_brent_kung.c
+++ b/src/gr_poly/compose_series_brent_kung.c
@@ -46,7 +46,7 @@ _gr_poly_compose_series_brent_kung(gr_ptr res, gr_srcptr poly1, slong len1,
         status |= _gr_vec_set(Brow(i), GR_ENTRY(poly1, i * m, sz), m, ctx);
     status |= _gr_vec_set(Brow(i), GR_ENTRY(poly1, i * m, sz), len1 % m, ctx);
 
-    /* Set rows of A to powers of poly2 */
+    /* Set rows of A to powers of poly2 (cf. _gr_vec_set_powers) */
     status |= gr_one(Arow(0), ctx);
     status |= _gr_vec_set(Arow(1), poly2, len2, ctx);
 


### PR DESCRIPTION
In this code, we want to compute $a, a^2, a^3,…, a^{\texttt{len1}}$.
Previously, it computes $a^i = a^{i-1}⋅ a$. Now, we use $a^i = a^{2^j} ⋅ a^{i-2^j}$, where $j$ is `flint_ctz(i)`.
Both ways, `len1` multiplications are performed. However, the latter makes the tree depth only $O(\log \texttt{len1})$.

The advantage is that if we have an `arb_poly`, then the accumulated error would be approximately linear in the computation tree depth. This change reduces the final error.

The disadvantage of this method includes
* if somehow multiply an arbitrary entry by $a$ is faster than multiplying two arbitrary entries, then we get a slowdown. (Half of all multiplications still multiply by $a$, however).
* over something like ℤ, where multiplying an integer with $x$ bits with an integer with $y$ bits have complexity roughly $O((x+y) \log\min(x, y))$, this would make the $\log$ factor larger.

What do you think?

Attached benchmark below. The code is rather ugly, but I'm pretty sure it measures the right thing.
[c.c](https://github.com/user-attachments/files/23435934/c.c)

