### PR TITLE
Accelerate single point evaluation for `nmod_poly`

### DIFF
--- a/src/nmod_poly/evaluate_nmod.c
+++ b/src/nmod_poly/evaluate_nmod.c
@@ -1,6 +1,6 @@
 /*
     Copyright (C) 2010 William Hart
-    Copyright (C) 2024 Vincent Neiger
+    Copyright (C) 2025 Vincent Neiger
 
     This file is part of FLINT.
 
@@ -15,8 +15,463 @@
 #include "nmod_poly.h"
 #include "nmod.h"
 
-ulong
-_nmod_poly_evaluate_nmod(nn_srcptr poly, slong len, ulong c, nmod_t mod)
+/*--------------------------------------*/
+/* special value: 1 (one) and -1 (mone) */
+/*--------------------------------------*/
+
+/* general */
+static ulong _nmod_poly_evaluate_one(nn_srcptr poly, slong len, ulong modn)
+{
+    if (len == 0)
+        return 0;
+
+    if (len <= 3)
+    {
+        ulong val = poly[0];
+        for (slong m = 1; m < len; m++)
+            val = n_addmod(val, poly[m], modn);
+        return val;
+    }
+
+    ulong val0, val1, val2, val3;
+
+    val0 = poly[0];
+    val1 = poly[1];
+    val2 = poly[2];
+    val3 = poly[3];
+
+    slong m = 4;
+
+    for ( ; m+3 < len; m += 4)
+    {
+        val0 = n_addmod(val0, poly[m+0], modn);
+        val1 = n_addmod(val1, poly[m+1], modn);
+        val2 = n_addmod(val2, poly[m+2], modn);
+        val3 = n_addmod(val3, poly[m+3], modn);
+    }
+
+    /* gather results */
+    val2 = n_addmod(val2, val3, modn);
+    val0 = n_addmod(val0, val1, modn);
+    val0 = n_addmod(val0, val2, modn);
+
+    /* last few terms */
+    for ( ; m < len; m++)
+        val0 = n_addmod(val0, poly[m], modn);
+
+    return val0;
+}
+
+/* requires nbits(modn) <= FLINT_BITS - 1 */
+static ulong _nmod_poly_evaluate_one1(nn_srcptr poly, slong len, ulong modn)
+{
+    if (len == 0)
+        return 0;
+
+    if (len <= 3)
+    {
+        ulong val = poly[0];
+        for (slong m = 1; m < len; m++)
+            val = n_addmod(val, poly[m], modn);
+        return val;
+    }
+
+    ulong val0, val1, val2, val3;
+
+    val0 = poly[0];
+    val1 = poly[1];
+    val2 = poly[2];
+    val3 = poly[3];
+
+    slong m = 4;
+
+    for ( ; m+3 < len; m += 4)
+    {
+        val0 = val0 + poly[m+0];
+        val1 = val1 + poly[m+1];
+        val2 = val2 + poly[m+2];
+        val3 = val3 + poly[m+3];
+        if (val0 >= modn)
+            val0 -= modn;
+        if (val1 >= modn)
+            val1 -= modn;
+        if (val2 >= modn)
+            val2 -= modn;
+        if (val3 >= modn)
+            val3 -= modn;
+    }
+
+    /* handle 2 more terms if they exist */
+    if (m+1 < len)
+    {
+        val0 = val0 + poly[m+0];
+        val1 = val1 + poly[m+1];
+        if (val0 >= modn)
+            val0 -= modn;
+        if (val1 >= modn)
+            val1 -= modn;
+        m += 2;
+    }
+
+    /* remains 0 or 1 term */
+    if (m < len)
+    {
+        val0 = val0 + poly[m+0];
+        if (val0 >= modn)
+            val0 -= modn;
+    }
+
+    /* gather results */
+    val2 = n_addmod(val2, val3, modn);
+    val0 = n_addmod(val0, val1, modn);
+    val0 = n_addmod(val0, val2, modn);
+
+    return val0;
+}
+
+/* requires nbits(modn) <= FLINT_BITS - 2 */
+static ulong _nmod_poly_evaluate_one2(nn_srcptr poly, slong len, ulong modn)
+{
+    if (len == 0)
+        return 0;
+
+    if (len <= 7)
+    {
+        ulong val = poly[0];
+        for (slong m = 1; m < len; m++)
+            val = n_addmod(val, poly[m], modn);
+        return val;
+    }
+
+    ulong val0, val1, val2, val3;
+
+    /* initial values, in [0, 2*modn) */
+    val0 = poly[0] + poly[4];
+    val1 = poly[1] + poly[5];
+    val2 = poly[2] + poly[6];
+    val3 = poly[3] + poly[7];
+
+    slong m = 8;
+    for ( ; m+7 < len; m += 8)
+    {
+        /* add new values */
+        val0 += poly[m+0] + poly[m+4];
+        val1 += poly[m+1] + poly[m+5];
+        val2 += poly[m+2] + poly[m+6];
+        val3 += poly[m+3] + poly[m+7];
+
+        /* reduce to [0, 2*modn) */
+        if (val0 >= 2*modn)
+            val0 -= 2*modn;
+        if (val1 >= 2*modn)
+            val1 -= 2*modn;
+        if (val2 >= 2*modn)
+            val2 -= 2*modn;
+        if (val3 >= 2*modn)
+            val3 -= 2*modn;
+    }
+
+    /* handle 4 more terms if they exist */
+    if (m+3 < len)
+    {
+        val0 += poly[m+0];
+        val1 += poly[m+1];
+        val2 += poly[m+2];
+        val3 += poly[m+3];
+        m += 4;
+    }
+
+    /* handle 2 more terms if they exist */
+    if (m+1 < len)
+    {
+        val0 += poly[m+0];
+        val1 += poly[m+1];
+        m += 2;
+    }
+
+    /* remains 0 or 1 term */
+    if (m < len)
+        val2 += poly[m+0];
+
+    /* reduce to [0, 2*modn) */
+    if (val0 >= 2*modn)
+        val0 -= 2*modn;
+    if (val1 >= 2*modn)
+        val1 -= 2*modn;
+    if (val2 >= 2*modn)
+        val2 -= 2*modn;
+    if (val3 >= 2*modn)
+        val3 -= 2*modn;
+
+    /* gather results */
+    val0 = val0 + val1;
+    if (val0 >= 2*modn)
+        val0 -= 2*modn;
+    val2 = val2 + val3;
+    if (val2 >= 2*modn)
+        val2 -= 2*modn;
+    val0 = val0 + val2;
+    if (val0 >= 2*modn)
+        val0 -= 2*modn;
+    if (val0 >= modn)
+        val0 -= modn;
+
+    return val0;
+}
+
+/* general */
+static ulong _nmod_poly_evaluate_mone(nn_srcptr poly, slong len, ulong modn)
+{
+    if (len == 0)
+        return 0;
+
+    if (len == 1)
+        return poly[0];
+
+    if (len == 2)
+        return n_submod(poly[0], poly[1], modn);
+
+    if (len == 3)
+        return n_addmod(n_submod(poly[0], poly[1], modn),
+                        poly[2], modn);
+
+    ulong val0, val1, val2, val3;
+
+    val0 = poly[0];
+    val1 = poly[1];
+    val2 = poly[2];
+    val3 = poly[3];
+
+    slong m = 4;
+
+    for ( ; m+3 < len; m += 4)
+    {
+        val0 = n_addmod(val0, poly[m+0], modn);
+        val1 = n_addmod(val1, poly[m+1], modn);
+        val2 = n_addmod(val2, poly[m+2], modn);
+        val3 = n_addmod(val3, poly[m+3], modn);
+    }
+
+    /* handle 2 more terms if they exist */
+    if (m+1 < len)
+    {
+        val0 = n_addmod(val0, poly[m+0], modn);
+        val1 = n_addmod(val1, poly[m+1], modn);
+        m += 2;
+    }
+
+    /* remains 0 or 1 term */
+    if (m < len)
+        val0 = n_addmod(val0, poly[m+0], modn);
+
+    /* gather results */
+    val2 = n_submod(val2, val3, modn);
+    val0 = n_submod(val0, val1, modn);
+    val0 = n_addmod(val0, val2, modn);
+
+    return val0;
+}
+
+/* requires nbits(modn) <= FLINT_BITS - 1 */
+static ulong _nmod_poly_evaluate_mone1(nn_srcptr poly, slong len, ulong modn)
+{
+    if (len == 0)
+        return 0;
+
+    if (len == 1)
+        return poly[0];
+
+    if (len == 2)
+        return n_submod(poly[0], poly[1], modn);
+
+    if (len == 3)
+        return n_addmod(n_submod(poly[0], poly[1], modn),
+                        poly[2], modn);
+
+    ulong val0, val1, val2, val3;
+
+    val0 = poly[0];
+    val1 = poly[1];
+    val2 = poly[2];
+    val3 = poly[3];
+
+    slong m = 4;
+
+    for ( ; m+3 < len; m += 4)
+    {
+        val0 = val0 + poly[m+0];
+        val1 = val1 + poly[m+1];
+        val2 = val2 + poly[m+2];
+        val3 = val3 + poly[m+3];
+        if (val0 >= modn)
+            val0 -= modn;
+        if (val1 >= modn)
+            val1 -= modn;
+        if (val2 >= modn)
+            val2 -= modn;
+        if (val3 >= modn)
+            val3 -= modn;
+    }
+
+    /* handle 2 more terms if they exist */
+    if (m+1 < len)
+    {
+        val0 = val0 + poly[m+0];
+        val1 = val1 + poly[m+1];
+        if (val0 >= modn)
+            val0 -= modn;
+        if (val1 >= modn)
+            val1 -= modn;
+        m += 2;
+    }
+
+    /* remains 0 or 1 term */
+    if (m < len)
+    {
+        val0 = val0 + poly[m+0];
+        if (val0 >= modn)
+            val0 -= modn;
+    }
+
+    /* gather results */
+    val2 = n_submod(val2, val3, modn);
+    val0 = n_submod(val0, val1, modn);
+    val0 = n_addmod(val0, val2, modn);
+
+    return val0;
+}
+
+/* requires nbits(modn) <= FLINT_BITS - 2 */
+static ulong _nmod_poly_evaluate_mone2(nn_srcptr poly, slong len, ulong modn)
+{
+    if (len == 0)
+        return 0;
+
+    if (len == 1)
+        return poly[0];
+
+    if (len == 2)
+        return n_submod(poly[0], poly[1], modn);
+
+    if (len == 3)
+        return n_addmod(n_submod(poly[0], poly[1], modn),
+                        poly[2], modn);
+
+    if (len <= 7)
+    {
+        ulong val0, val1;
+
+        val0 = poly[0] + poly[2];
+        val1 = poly[1] + poly[3];
+
+        /* handle 2 more terms if they exist */
+        slong m = 4;
+        if (m+1 < len)
+        {
+            val0 += poly[m+0];
+            val1 += poly[m+1];
+            m += 2;
+        }
+
+        if (m < len)
+            val0 += poly[m];
+
+        /* remains 0 or 1 term */
+
+        if (val0 >= 2*modn)
+            val0 -= 2*modn;
+        if (val1 >= 2*modn)
+            val1 -= 2*modn;
+        val0 = val0 + 2*modn - val1;
+        if (val0 >= 2*modn)
+            val0 -= 2*modn;
+        if (val0 >= modn)
+            val0 -= modn;
+
+        return val0;
+    }
+
+    ulong val0, val1, val2, val3;
+
+    /* initial values, in [0, 2*modn) */
+    val0 = poly[0] + poly[4];
+    val1 = poly[1] + poly[5];
+    val2 = poly[2] + poly[6];
+    val3 = poly[3] + poly[7];
+
+    slong m = 8;
+    for ( ; m+7 < len; m += 8)
+    {
+        /* add new values */
+        val0 += poly[m+0] + poly[m+4];
+        val1 += poly[m+1] + poly[m+5];
+        val2 += poly[m+2] + poly[m+6];
+        val3 += poly[m+3] + poly[m+7];
+
+        /* reduce to [0, 2*modn) */
+        if (val0 >= 2*modn)
+            val0 -= 2*modn;
+        if (val1 >= 2*modn)
+            val1 -= 2*modn;
+        if (val2 >= 2*modn)
+            val2 -= 2*modn;
+        if (val3 >= 2*modn)
+            val3 -= 2*modn;
+    }
+
+    /* handle 4 more terms if they exist */
+    if (m+3 < len)
+    {
+        val0 += poly[m+0];
+        val1 += poly[m+1];
+        val2 += poly[m+2];
+        val3 += poly[m+3];
+        m += 4;
+    }
+
+    /* handle 2 more terms if they exist */
+    if (m+1 < len)
+    {
+        val0 += poly[m+0];
+        val1 += poly[m+1];
+        m += 2;
+    }
+
+    /* remains 0 or 1 term */
+    if (m < len)
+        val2 += poly[m+0];
+
+    /* reduce to [0, 2*modn) */
+    if (val0 >= 2*modn)
+        val0 -= 2*modn;
+    if (val1 >= 2*modn)
+        val1 -= 2*modn;
+    if (val2 >= 2*modn)
+        val2 -= 2*modn;
+    if (val3 >= 2*modn)
+        val3 -= 2*modn;
+
+    /* gather results */
+    val0 = val0 + val2;
+    if (val0 >= 2*modn)
+        val0 -= 2*modn;
+    val1 = val1 + val3;
+    if (val1 >= 2*modn)
+        val1 -= 2*modn;
+    val0 = val0 + 2*modn - val1;
+    if (val0 >= 2*modn)
+        val0 -= 2*modn;
+    if (val0 >= modn)
+        val0 -= modn;
+
+    return val0;
+}
+
+/*-----------*/
+/* general c */
+/*-----------*/
+
+ulong _nmod_poly_evaluate_nmod(nn_srcptr poly, slong len, ulong c, nmod_t mod)
 {
     if (len == 0)
         return 0;
@@ -29,7 +484,7 @@ _nmod_poly_evaluate_nmod(nn_srcptr poly, slong len, ulong c, nmod_t mod)
         slong m = len - 1;
         ulong val = poly[m];
         m -= 1;
-        for (; m >= 0; m--)
+        for ( ; m >= 0; m--)
         {
             val = nmod_mul(val, c, mod);
             val = n_addmod(val, poly[m], mod.n);
@@ -50,7 +505,7 @@ _nmod_poly_evaluate_nmod(nn_srcptr poly, slong len, ulong c, nmod_t mod)
     val3 = poly[m-0];
     m -= 4;
 
-    for (; m-3 >= 0; m-=4)
+    for ( ; m-3 >= 0; m -= 4)
     {
         val0 = nmod_mul(val0, c4, mod);
         val0 = n_addmod(val0, poly[m-3], mod.n);
@@ -68,7 +523,7 @@ _nmod_poly_evaluate_nmod(nn_srcptr poly, slong len, ulong c, nmod_t mod)
     val0 = n_addmod(val0, nmod_mul(val1, c, mod), mod.n);
 
     /* last few terms */
-    for (; m >= 0; m--)
+    for ( ; m >= 0; m--)
     {
         val0 = nmod_mul(val0, c, mod);
         val0 = n_addmod(val0, poly[m], mod.n);
@@ -77,8 +532,7 @@ _nmod_poly_evaluate_nmod(nn_srcptr poly, slong len, ulong c, nmod_t mod)
     return val0;
 }
 
-ulong
-_nmod_poly_evaluate_nmod_precomp(nn_srcptr poly, slong len, ulong c, ulong c_precomp, ulong modn)
+ulong _nmod_poly_evaluate_nmod_precomp(nn_srcptr poly, slong len, ulong c, ulong c_precomp, ulong modn)
 {
     if (len == 0)
         return 0;
@@ -91,7 +545,7 @@ _nmod_poly_evaluate_nmod_precomp(nn_srcptr poly, slong len, ulong c, ulong c_pre
         slong m = len - 1;
         ulong val = poly[m];
         m -= 1;
-        for (; m >= 0; m--)
+        for ( ; m >= 0; m--)
         {
             val = n_mulmod_shoup(c, val, c_precomp, modn);
             val = n_addmod(val, poly[m], modn);
@@ -116,7 +570,7 @@ _nmod_poly_evaluate_nmod_precomp(nn_srcptr poly, slong len, ulong c, ulong c_pre
     val3 = poly[m-0];
     m -= 4;
 
-    for (; m-3 >= 0; m-=4)
+    for ( ; m-3 >= 0; m -= 4)
     {
         val0 = n_mulmod_shoup(c4, val0, c4_precomp, modn);
         val0 = n_addmod(val0, poly[m-3], modn);
@@ -137,7 +591,7 @@ _nmod_poly_evaluate_nmod_precomp(nn_srcptr poly, slong len, ulong c, ulong c_pre
     val0 = n_addmod(val0, val1, modn);
 
     /* last few terms */
-    for (; m >= 0; m--)
+    for ( ; m >= 0; m--)
     {
         val0 = n_mulmod_shoup(c, val0, c_precomp, modn);
         val0 = n_addmod(val0, poly[m], modn);
@@ -146,8 +600,7 @@ _nmod_poly_evaluate_nmod_precomp(nn_srcptr poly, slong len, ulong c, ulong c_pre
     return val0;
 }
 
-ulong
-_nmod_poly_evaluate_nmod_precomp_lazy(nn_srcptr poly, slong len, ulong c, ulong c_precomp, ulong modn)
+ulong _nmod_poly_evaluate_nmod_precomp_lazy(nn_srcptr poly, slong len, ulong c, ulong c_precomp, ulong modn)
 {
     if (len == 0)
         return 0;
@@ -161,7 +614,7 @@ _nmod_poly_evaluate_nmod_precomp_lazy(nn_srcptr poly, slong len, ulong c, ulong 
         slong m = len - 1;
         ulong val = poly[m];
         m -= 1;
-        for (; m >= 0; m--)
+        for ( ; m >= 0; m--)
         {
             umul_ppmm(p_hi, p_lo, c_precomp, val);
             val = poly[m] + c * val - p_hi * modn;
@@ -187,7 +640,7 @@ _nmod_poly_evaluate_nmod_precomp_lazy(nn_srcptr poly, slong len, ulong c, ulong 
     val3 = poly[m-0];
     m -= 4;
 
-    for (; m-3 >= 0; m-=4)
+    for ( ; m-3 >= 0; m -= 4)
     {
         umul_ppmm(p_hi, p_lo, c4_precomp, val0);
         val0 = poly[m-3] + c4 * val0 - p_hi * modn;
@@ -222,7 +675,7 @@ _nmod_poly_evaluate_nmod_precomp_lazy(nn_srcptr poly, slong len, ulong c, ulong 
     val0 = val0 + c * val1 - p_hi * modn;
 
     /* last few terms */
-    for (; m >= 0; m--)
+    for ( ; m >= 0; m--)
     {
         umul_ppmm(p_hi, p_lo, c_precomp, val0);
         val0 = poly[m] + c * val0 - p_hi * modn;
@@ -231,14 +684,37 @@ _nmod_poly_evaluate_nmod_precomp_lazy(nn_srcptr poly, slong len, ulong c, ulong 
     return val0;
 }
 
-ulong
-nmod_poly_evaluate_nmod(const nmod_poly_t poly, ulong c)
+/*----------------*/
+/* main interface */
+/*----------------*/
+
+ulong nmod_poly_evaluate_nmod(const nmod_poly_t poly, ulong c)
 {
     if (poly->length == 0)
         return 0;
 
     if (poly->length == 1 || c == 0)
         return poly->coeffs[0];
+
+    if (c == 1)
+    {
+        if (poly->mod.norm >= 2)
+            return _nmod_poly_evaluate_one2(poly->coeffs, poly->length, poly->mod.n);
+        else if (poly->mod.norm == 1)
+            return _nmod_poly_evaluate_one1(poly->coeffs, poly->length, poly->mod.n);
+        else
+            return _nmod_poly_evaluate_one(poly->coeffs, poly->length, poly->mod.n);
+    }
+
+    if (c == poly->mod.n - 1)
+    {
+        if (poly->mod.norm >= 2)
+            return _nmod_poly_evaluate_mone2(poly->coeffs, poly->length, poly->mod.n);
+        else if (poly->mod.norm == 1)
+            return _nmod_poly_evaluate_mone1(poly->coeffs, poly->length, poly->mod.n);
+        else
+            return _nmod_poly_evaluate_mone(poly->coeffs, poly->length, poly->mod.n);
+    }
 
     // if degree below the n_mulmod_shoup threshold
     // or modulus forbids n_mulmod_shoup usage, use nmod_mul


### PR DESCRIPTION
Here are some enhancements of evaluation at an `nmod` point for `nmod_poly`. I don't have specific uses for this, this was done as a "warmup" for writing more efficient implementations of reduction modulo polynomials `x^n - c` for `n >= 1` (draft started at https://github.com/flintlib/flint/pull/2470 , itself useful for the in-progress FFT https://github.com/flintlib/flint/pull/2107). But since this seems to accelerate the existing code in all cases, this might as well be merged in(?).

1. Acceleration of existing cases (mainly through unrolling loops):

- polynomials of small length (up to about 10) are unaffected
- speed-up becomes substantial for length 32 (factor 2)
- speed-up between 2.5 and 3 for large lengths

See first table below: for each modulus bitsize, the first column measures the old version, the second column measures the new one. (And some time ago, we only had the very first column, for all moduli...)

2. Adding specific functions for evaluation at `+1` and `-1`.

- the main evaluation function detects these cases and chooses the relevant function depending on the bitsize of the modulus
- independently of the modulus bitsize, the speed-up is consistently about 4, versus the best general (not specific to 1 or -1) variant we have at hand for that bitsize (see second table below).


```
Intel(R) Core(TM) Ultra 7 165H
length |    64 bits    |    63 bits    |   <= 62 bits
1      | 6.71    8.57  | 13.15   13.18 | 13.15   13.17
2      | 4.52    4.68  | 3.42    4.04  | 3.37    3.58
3      | 4.04    4.18  | 2.98    3.63  | 2.47    2.61
4      | 4.91    4.84  | 3.01    3.25  | 2.33    2.34
6      | 5.93    5.90  | 3.39    3.49  | 2.17    2.19
8      | 6.61    6.65  | 3.73    3.84  | 2.10    2.12
10     | 7.08    7.15  | 4.05    4.12  | 2.04    2.10
12     | 8.02    6.14  | 4.32    4.21  | 2.09    2.16
16     | 9.22    5.71  | 4.71    3.88  | 2.28    3.07
20     | 9.95    5.46  | 5.34    3.57  | 2.45    2.88
32     | 11.06   5.09  | 6.34    3.29  | 2.81    2.47
45     | 11.59   4.91  | 6.77    3.13  | 3.46    2.30
64     | 12.02   4.75  | 7.14    2.96  | 3.95    2.15
128    | 12.46   4.59  | 7.59    2.85  | 4.51    2.02
256    | 12.78   4.52  | 7.80    2.73  | 4.87    1.92
1024   | 12.90   4.41  | 7.92    2.64  | 5.09    1.87
8192   | 12.93   4.41  | 8.06    2.65  | 5.16    1.86
65536  | 12.99   4.39  | 7.98    2.63  | 5.19    1.86
200000 | 13.03   4.42  | 7.97    2.65  | 5.20    1.86
1000000| 13.04   4.48  | 8.01    2.69  | 5.22    1.92
```

```
AMD Ryzen 7 PRO 7840U
nbits = 62
length   generic precomp lazy    one     mone
1        8.07    7.51    7.69    6.11    6.23
2        6.34    4.39    4.18    4.72    5.06
3        6.38    4.36    3.40    3.15    3.61
4        6.75    4.41    3.25    2.55    2.95
6        7.76    5.28    3.92    2.23    1.90
8        8.86    5.44    3.71    1.71    1.88
10       9.96    5.74    3.70    1.45    1.53
12       7.87    5.39    3.55    1.20    1.32
16       7.02    5.03    4.13    1.27    1.32
20       6.76    4.78    3.73    1.05    1.08
32       6.37    4.47    3.24    0.88    0.92
45       6.00    4.14    2.79    0.73    0.75
64       5.66    3.93    2.58    0.75    0.74
128      5.46    3.72    2.31    0.64    0.66
256      5.34    3.62    2.21    0.60    0.59
1024     5.21    3.55    2.08    0.56    0.55
8192     5.21    3.54    2.06    0.57    0.56
65536    5.32    3.55    2.15    0.58    0.55
200000   5.44    3.55    2.08    0.57    0.55
1000000  5.24    3.56    2.07    0.58    0.55

nbits = 63
length   generic precomp one     mone
1        8.18    7.94    6.36    6.38
2        6.38    4.46    5.09    4.78
3        6.36    4.29    3.63    3.64
4        6.61    4.56    3.00    3.53
6        8.13    5.42    2.17    2.25
8        9.00    5.49    2.01    2.03
10       9.73    5.53    1.77    1.79
12       8.04    5.38    1.62    1.62
16       7.13    5.28    1.44    1.43
20       6.82    4.73    1.29    1.30
32       6.20    4.35    1.10    1.11
45       6.04    4.17    1.02    1.07
64       5.67    3.95    1.02    1.00
128      5.62    3.70    0.91    0.93
256      5.33    3.75    0.88    0.88
1024     5.26    3.55    0.86    0.86
8192     5.23    3.66    0.88    0.87
65536    5.25    3.52    0.86    0.85
200000   5.29    3.55    0.85    0.85
1000000  5.27    3.55    0.90    0.87

nbits = 64
length   generic one     mone
1        8.38    6.40    6.33
2        6.45    5.42    5.15
3        6.37    3.40    3.67
4        6.59    2.67    3.08
6        7.89    2.54    2.35
8        8.96    2.18    2.26
10       9.76    2.11    2.03
12       7.91    1.85    1.92
16       7.18    1.70    1.74
20       6.83    1.63    1.65
32       6.19    1.46    1.48
45       6.07    1.42    1.40
64       5.88    1.35    1.35
128      5.50    1.27    1.28
256      5.35    1.24    1.24
1024     5.26    1.21    1.21
8192     5.39    1.24    1.25
65536    5.23    1.22    1.23
200000   5.25    1.22    1.22
1000000  5.26    1.25    1.24
```