### PR TITLE
Use SQUFOF in ``fmpz_factor``

### DIFF
--- a/src/ulong_extras.h
+++ b/src/ulong_extras.h
@@ -448,6 +448,7 @@ ulong n_factor_power235(ulong *exp, ulong n);
 ulong n_factor_one_line(ulong n, ulong iters);
 ulong n_factor_lehman(ulong n);
 
+ulong n_ll_factor_SQUFOF(ulong nhi, ulong nlo, ulong iters);
 ulong n_factor_SQUFOF(ulong n, ulong iters);
 
 ulong n_factor_pp1(ulong n, ulong B1, ulong c);


### PR DESCRIPTION
The SQUFOF implementation in ``ulong_extras`` was only being used to factor single-word integers via ``n_factor`` although it works perfectly well for double-word integers too. Quick benchmarking shows that it consistently outperforms the quadratic sieve up to about 80 bits, with more than a 5x speedup around 65-70 bits.

Timings to factor 1000 random ``bits``-length integers using ``fmpz_factor`` before and after wrapping SQUFOF there:

```
bits         old        new         speedup
 64         0.073      0.0727       1.004
 65         0.247      0.0778       3.175
 66          0.41         0.1       4.100
 67         0.523       0.128       4.086
 68         0.763       0.154       4.955
 69         0.907       0.187       4.850
 70         1.004       0.207       4.850
 71         1.277        0.26       4.912
 72         1.416       0.319       4.439
 73         1.753       0.359       4.883
 74          1.69       0.381       4.436
 75         2.227       0.567       3.928
 76         2.575       0.588       4.379
 77         2.546       0.746       3.413
 78         2.891       0.931       3.105
 79         3.123       1.036       3.014
 80          3.14       1.305       2.406
 81         3.461       1.464       2.364
 82         3.764       2.011       1.872
 83          4.22       2.334       1.808
 84         4.265       2.624       1.625
 85         4.759       2.869       1.659
 86         4.816       3.043       1.583
 87         5.281       3.491       1.513
 88         4.989       3.544       1.408
 89         5.687       4.278       1.329
 90         5.892        4.47       1.318
 91         5.717       4.421       1.293
 92         5.925       4.752       1.247
 93         5.552        4.59       1.210
 94         5.888       5.004       1.177
 95          6.09       5.131       1.187
 96         6.392       5.587       1.144
 97         6.244       5.604       1.114
 98         6.511       6.054       1.075
 99         6.063       5.556       1.091
100         6.685        6.11       1.094
101         6.663       6.089       1.094
102         7.015       6.559       1.070
103         6.818       6.423       1.061
104         6.986       6.731       1.038
105         7.356       7.006       1.050
106         6.851       6.469       1.059
107         7.379       7.112       1.037
108         7.519       7.405       1.015
109         7.394        7.14       1.036
110         7.154       7.111       1.006
111         8.441       8.198       1.030
112         7.696       7.306       1.053
113         7.969       7.817       1.019
114          8.01       7.754       1.033
115         8.205       8.083       1.015
116          8.05       7.899       1.019
117         8.733       8.611       1.014
118         8.375       8.291       1.010
119         8.576       8.472       1.012
120         9.223       9.139       1.009
```
