### PR TITLE
Add volatile to rdtsc assembly

### DIFF
--- a/src/profiler.h
+++ b/src/profiler.h
@@ -52,7 +52,7 @@ int gettimeofday(struct timeval * p, void * tz);
 void fprint_memory_usage(FILE *);
 #endif
 void print_memory_usage(void);
-#endif /* FLINT_HAVE_getrusage */
+#endif
 
 /* timeit ********************************************************************/
 
@@ -87,7 +87,6 @@ static inline void timeit_start_us(timeit_t t)
     gettimeofday(&tv, 0);
     t->wall = - tv.tv_sec * 1000000 - tv.tv_usec;
 }
-
 
 static inline void timeit_stop_us(timeit_t t)
 {
@@ -143,7 +142,7 @@ static inline void timeit_print(timeit_t timer, ulong reps)
     { \
       timeit_t __timer; \
       timeit_start(__timer); \
-      do { \
+      do {
 
 #define TIMEIT_ONCE_STOP \
       } while (0); \
@@ -160,8 +159,8 @@ static inline double get_cycle_counter(void)
     return __rdtsc();
 #elif defined(__x86_64__)
     unsigned int hi, lo;
-    __asm__ ("rdtsc; movl %%edx,%0; movl %%eax,%1"
-          : "=r" (hi), "=r" (lo) : : "%edx", "%eax");
+    __asm__ volatile ("rdtsc; movl %%edx,%0; movl %%eax,%1"
+            : "=r" (hi), "=r" (lo) : : "%edx", "%eax");
     return hi * (double) (WORD(1) << 32) + lo;
 #elif defined(__aarch64__)
     ulong val;


### PR DESCRIPTION
Fixes issues with profiling on Clang

Solves #2496 