### PR TITLE
Bump FLINT_MAJOR_SO

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -101,9 +101,10 @@ AC_LANG(C)
 # 3.2.0    => 20.0.0
 # 3.2.1    => 20.0.1
 # 3.3.0    => 21.0.0
+# 3.4.0    => 22.0.0
 
 # NOTE: This must be after AC_INIT
-FLINT_MAJOR_SO=21
+FLINT_MAJOR_SO=22
 FLINT_MINOR_SO=0
 FLINT_PATCH_SO=0
 


### PR DESCRIPTION
3.3 was 21, so 3.4-dev (and soon 3.4.0) should be 22.