### PR TITLE
Do not discard const qualifiers from pointers

### DIFF
--- a/src/arb/set_str.c
+++ b/src/arb/set_str.c
@@ -16,7 +16,7 @@
 static int
 arb_set_float_str(arb_t res, const char * inp, slong prec)
 {
-    char * emarker;
+    const char * emarker;
     char * buf;
     int error;
     slong i;

--- a/src/arf/io.c
+++ b/src/arf/io.c
@@ -86,7 +86,7 @@ int
 arf_load_str(arf_t x, const char* data)
 {
     fmpz_t mantissa, exponent;
-    char * e_str;
+    const char * e_str;
     char * m_str;
     int err = 0;
 

--- a/src/qqbar/set_fexpr.c
+++ b/src/qqbar/set_fexpr.c
@@ -223,7 +223,7 @@ _fexpr_parse_acb(acb_t res, const fexpr_t expr)
 static int
 fmpq_set_decimal(fmpq_t res, const char * inp, slong max_bits)
 {
-    char * emarker;
+    const char * emarker;
     char * buf;
     int success;
     slong i;


### PR DESCRIPTION
GCC issues several warnings of this form:
```
/builddir/build/BUILD/flint-3.4.0-build/flint-3.4.0/src/arf/io.c: In function ‘arf_load_str’:
/builddir/build/BUILD/flint-3.4.0-build/flint-3.4.0/src/arf/io.c:96:11: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   96 |     e_str = strchr(data, ' ');
      |           ^
```

This PR fixes all of them by adding `const` qualifiers as needed.