### PR TITLE
Make MAINTAINER_MODE regeneration logic consistent with bootstrap.sh

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -988,9 +988,9 @@ endif
 
 ifneq ($(MAINTAINER_MODE),no)  # disable this for releases?
 ifneq ($(shell command -v autoconf 2> /dev/null),)
-$(ABS_FLINT_DIR)/configure: $(ABS_FLINT_DIR)/configure.ac
-	@echo "Running autoconf"
-	@cd $(ABS_FLINT_DIR) && autoconf && cd - >/dev/null
+$(ABS_FLINT_DIR)/configure: $(ABS_FLINT_DIR)/configure.ac $(ABS_FLINT_DIR)/bootstrap.sh
+	@echo "Running bootstrap.sh!"
+	@cd $(ABS_FLINT_DIR) && ./bootstrap.sh && cd - >/dev/null
 else
 $(ABS_FLINT_DIR)/configure: $(ABS_FLINT_DIR)/configure.ac
 	$(warning autoconf not available, proceeding with stale configure)


### PR DESCRIPTION
The documented way to generate `./configure` is running `./bootstrap`
(which in turn runs `autoreconf -i`).

However, when Makefile detects that `./configure` is stale relative
to `configure.ac`, it regenerates it using this snippet:
https://github.com/flintlib/flint/blob/2498f7f588ebcbfbf0617307f23a117968525495/Makefile.in#L989-L998

This uses plain `autoconf`, which is incorrect.
`autoconf` relies on presence of `aclocal.m4`, which is created
by `aclocal` as part of `autoreconf -i` chain.
If this file is not present, `autoconf` fails with cryptic error
messages (see below).

Granted, this scenario is uncommon. Typically if you have a Makefile,
you've already run bootstrap.sh and ./configure, so aclocal.m4
exists. However, it can happen in exotic situations, such as
modifying configure.ac when building from a release tarball.

To reproduce:
```
curl -L https://github.com/flintlib/flint/releases/download/v3.4.0/flint-3.4.0.tar.gz | tar -xzf -
cd flint-3.4.0/
touch configure.ac
./configure
make
```

`make` fails with a confusing error message:
```
Running autoconf
configure.ac:163: error: possibly undefined macro: AC_MSG_ERROR
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
configure.ac:933: error: possibly undefined macro: AC_SUBST
configure.ac:987: error: possibly undefined macro: AC_DEFINE
make: *** [Makefile:993: /home/username/flint-3.4.0/configure] Error 1
```

-----

This change fixes this inconsistency: now bootstrap.sh will be used for
regenerating too.
