### PR TITLE
Speed up `nmod_addmul` and fullword `_nmod_vec_scalar_mul_nmod`, `_nmod_vec_scalar_addmul_nmod`

### DIFF
--- a/doc/source/nmod_vec.rst
+++ b/doc/source/nmod_vec.rst
@@ -128,6 +128,13 @@ Arithmetic operations
     `2^{\mathtt{FLINT\_BITS} - 1}`, and `c` should be less than ``mod.n``.
     There is no constraint on elements of ``vec``.
 
+.. function:: void _nmod_vec_scalar_mul_nmod_redc(nn_ptr res, nn_srcptr vec, slong len, ulong c, nmod_t mod)
+
+    Sets ``(res, len)`` to ``(vec, len)`` multiplied by `c` using
+    Montgomery multiplication. Requires that ``mod.n`` is odd.
+    The element `c` and all elements of ``vec`` are assumed to be less
+    than ``mod.n``.
+
 .. function:: void _nmod_vec_scalar_addmul_nmod(nn_ptr res, nn_srcptr vec, slong len, ulong c, nmod_t mod)
 
     Adds ``(vec, len)`` times `c` to the vector ``(res, len)``. The element

--- a/src/gr/nmod.c
+++ b/src/gr/nmod.c
@@ -362,19 +362,14 @@ _gr_nmod_mul_fmpz(ulong * res, const ulong * x, const fmpz_t y, const gr_ctx_t c
 static int
 _gr_nmod_addmul(ulong * res, const ulong * x, const ulong * y, const gr_ctx_t ctx)
 {
-    ulong r = res[0];
-    NMOD_ADDMUL(r, x[0], y[0], NMOD_CTX(ctx));
-    res[0] = r;
+    res[0] = nmod_addmul(res[0], x[0], y[0], NMOD_CTX(ctx));
     return GR_SUCCESS;
 }
 
 static int
 _gr_nmod_submul(ulong * res, const ulong * x, const ulong * y, const gr_ctx_t ctx)
 {
-    ulong r = res[0];
-    ulong t = nmod_neg(y[0], NMOD_CTX(ctx));
-    NMOD_ADDMUL(r, x[0], t, NMOD_CTX(ctx));
-    res[0] = r;
+    res[0] = nmod_addmul(res[0], x[0], nmod_neg(y[0], NMOD_CTX(ctx)), NMOD_CTX(ctx));
     return GR_SUCCESS;
 }
 
@@ -656,48 +651,17 @@ _gr_nmod_vec_mul(ulong * res, const ulong * vec1, const ulong * vec2, slong len,
     return GR_SUCCESS;
 }
 
-static inline void _nmod_vec_scalar_mul_nmod_fullword_inline(nn_ptr res, nn_srcptr vec,
-                               slong len, ulong c, nmod_t mod)
-{
-    slong i;
-
-    for (i = 0; i < len; i++)
-        NMOD_MUL_FULLWORD(res[i], vec[i], c, mod);
-}
-
-static inline void _nmod_vec_scalar_mul_nmod_generic_inline(nn_ptr res, nn_srcptr vec,
-                               slong len, ulong c, nmod_t mod)
-{
-    slong i;
-
-    for (i = 0; i < len; i++)
-        NMOD_MUL_PRENORM(res[i], vec[i], c << mod.norm, mod);
-}
-
-static inline void _nmod_vec_scalar_mul_nmod_inline(nn_ptr res, nn_srcptr vec,
-                               slong len, ulong c, nmod_t mod)
-{
-    if (NMOD_BITS(mod) == FLINT_BITS)
-        _nmod_vec_scalar_mul_nmod_fullword_inline(res, vec, len, c, mod);
-    else if (len > 10)
-        _nmod_vec_scalar_mul_nmod_shoup(res, vec, len, c, mod);
-    else
-        _nmod_vec_scalar_mul_nmod_generic_inline(res, vec, len, c, mod);
-}
-
 static int
 _gr_nmod_vec_mul_scalar(ulong * res, const ulong * vec1, slong len, const ulong * c, gr_ctx_t ctx)
 {
-    nmod_t mod = NMOD_CTX(ctx);
-    _nmod_vec_scalar_mul_nmod_inline(res, vec1, len, c[0], mod);
+    _nmod_vec_scalar_mul_nmod(res, vec1, len, c[0], NMOD_CTX(ctx));
     return GR_SUCCESS;
 }
 
 static int
 _gr_nmod_scalar_mul_vec(ulong * res, ulong * c, const ulong * vec1, slong len, gr_ctx_t ctx)
 {
-    nmod_t mod = NMOD_CTX(ctx);
-    _nmod_vec_scalar_mul_nmod_inline(res, vec1, len, c[0], mod);
+    _nmod_vec_scalar_mul_nmod(res, vec1, len, c[0], NMOD_CTX(ctx));
     return GR_SUCCESS;
 }
 
@@ -705,7 +669,7 @@ static int
 _gr_nmod_vec_mul_scalar_si(ulong * res, const ulong * vec1, slong len, slong c, gr_ctx_t ctx)
 {
     nmod_t mod = NMOD_CTX(ctx);
-    _nmod_vec_scalar_mul_nmod_inline(res, vec1, len, nmod_set_si(c, mod), NMOD_CTX(ctx));
+    _nmod_vec_scalar_mul_nmod(res, vec1, len, nmod_set_si(c, mod), NMOD_CTX(ctx));
     return GR_SUCCESS;
 }
 
@@ -713,7 +677,7 @@ static int
 _gr_nmod_vec_mul_scalar_ui(ulong * res, const ulong * vec1, slong len, ulong c, gr_ctx_t ctx)
 {
     nmod_t mod = NMOD_CTX(ctx);
-    _nmod_vec_scalar_mul_nmod_inline(res, vec1, len, nmod_set_ui(c, mod), NMOD_CTX(ctx));
+    _nmod_vec_scalar_mul_nmod(res, vec1, len, nmod_set_ui(c, mod), NMOD_CTX(ctx));
     return GR_SUCCESS;
 }
 

--- a/src/nmod.h
+++ b/src/nmod.h
@@ -221,12 +221,16 @@ ulong _nmod_mul_fullword(ulong a, ulong b, nmod_t mod)
 }
 
 NMOD_INLINE
-ulong nmod_addmul(ulong a, ulong b, ulong c, nmod_t mod)
+ulong nmod_addmul(ulong s, ulong a, ulong b, nmod_t mod)
 {
+    ulong hi, lo;
+    FLINT_ASSERT(s < mod.n);
     FLINT_ASSERT(a < mod.n);
     FLINT_ASSERT(b < mod.n);
-    FLINT_ASSERT(c < mod.n);
-    return nmod_add(a, nmod_mul(b, c, mod), mod);
+    umul_ppmm(hi, lo, a, b);
+    add_ssaaaa(hi, lo, hi, lo, 0, s);
+    NMOD_RED2(lo, hi, lo, mod);
+    return lo;
 }
 
 #define NMOD_ADDMUL(r, a, b, mod) \

--- a/src/nmod_vec.h
+++ b/src/nmod_vec.h
@@ -118,6 +118,7 @@ void _nmod_vec_sub(nn_ptr res, nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t
 void _nmod_vec_neg(nn_ptr res, nn_srcptr vec, slong len, nmod_t mod);
 
 void _nmod_vec_scalar_mul_nmod(nn_ptr res, nn_srcptr vec, slong len, ulong c, nmod_t mod);
+void _nmod_vec_scalar_mul_nmod_redc(nn_ptr res, nn_srcptr vec, slong len, ulong c, nmod_t mod);
 void _nmod_vec_scalar_mul_nmod_generic(nn_ptr res, nn_srcptr vec, slong len, ulong c, nmod_t mod);
 void _nmod_vec_scalar_mul_nmod_shoup(nn_ptr res, nn_srcptr vec, slong len, ulong c, nmod_t mod);
 


### PR DESCRIPTION
`nmod_addmul` is replaced with simpler and faster code which simplifies and speeds up the generic fallback in `_nmod_vec_scalar_addmul_nmod`. The old code for 64-bit moduli in `_nmod_vec_scalar_addmul_nmod` was particularly bad; the new code is more than 3x faster.

Also, ``nmod_redc_mul`` is used to speed up the 64-bit case in `_nmod_vec_scalar_mul_nmod` where Shoup can't be used. Asymptotically this is about 20% faster than the old code, with the only restriction is that ``n`` needs to be odd to benefit.

Timings on Zen 3:

```
           vec_mul               vec_scalar_addmul            speedup
bits len   old       new         old        new             mul     addmul
63   1     4.66e-09  4.69e-09    4.21e-09   4.23e-09        0.994   0.995
63   2     6.02e-09  6.02e-09    6.14e-09   6.92e-09        1.000   0.887
63   3     6.77e-09  6.79e-09    7.37e-09   7.89e-09        0.997   0.934
63   4     8.52e-09  8.52e-09    1e-08      9.85e-09        1.000   1.015
63   5     1.04e-08  1.03e-08    1.16e-08   1.12e-08        1.010   1.036
63   6     1.18e-08  1.17e-08    1.27e-08   1.26e-08        1.009   1.008
63   7     1.25e-08  1.26e-08    1.48e-08   1.42e-08        0.992   1.042
63   8     1.46e-08  1.44e-08    1.71e-08   1.59e-08        1.014   1.075
63  10     1.22e-08  1.21e-08    1.53e-08   1.59e-08        1.008   0.962
63  12     1.28e-08  1.28e-08    1.77e-08   1.76e-08        1.000   1.006
63  15     1.58e-08  1.58e-08    2.14e-08   2.14e-08        1.000   1.000
63  18     1.7e-08   1.69e-08    2.53e-08   2.52e-08        1.006   1.004
63  22     1.98e-08  1.99e-08    2.95e-08   2.98e-08        0.995   0.990
63  27     2.38e-08  2.34e-08    3.74e-08   3.73e-08        1.017   1.003
63  33     2.81e-08  2.77e-08    4.51e-08   4.5e-08         1.014   1.002
63  41     3.26e-08  3.25e-08    5.52e-08   5.59e-08        1.003   0.987
63  51     4.01e-08  4.01e-08    6.94e-08   6.88e-08        1.000   1.009
63  63     4.84e-08  4.83e-08    8.41e-08   8.41e-08        1.002   1.000
63  78     5.86e-08  5.86e-08    1.03e-07   1.02e-07        1.000   1.010
63  97     7.24e-08  7.24e-08    1.28e-07   1.28e-07        1.000   1.000
63 121     8.99e-08  9e-08       1.61e-07   1.6e-07         0.999   1.006

64   1     3.9e-09   3.78e-09    4.01e-09   4.14e-09        1.032   0.969
64   2     5.01e-09  5.29e-09    6.01e-09   5.44e-09        0.947   1.105
64   3     5.8e-09   6.43e-09    8.85e-09   6.57e-09        0.902   1.347
64   4     7.18e-09  7.17e-09    1.21e-08   7.8e-09         1.001   1.551
64   5     8.7e-09   8.76e-09    1.47e-08   9.2e-09         0.993   1.598
64   6     1.03e-08  1.02e-08    2.26e-08   1.05e-08        1.010   2.152
64   7     1.11e-08  1.17e-08    2e-08      1.18e-08        0.949   1.695
64   8     1.41e-08  1.39e-08    3.46e-08   1.32e-08        1.014   2.621
64  10     1.6e-08   1.6e-08     3.19e-08   1.6e-08         1.000   1.994
64  12     1.85e-08  1.88e-08    4.1e-08    1.87e-08        0.984   2.193
64  15     2.22e-08  2.19e-08    7.66e-08   2.31e-08        1.014   3.316
64  18     2.7e-08   2.44e-08    8.16e-08   2.72e-08        1.107   3.000
64  22     3.22e-08  2.9e-08     9.9e-08    3.3e-08         1.110   3.000
64  27     3.89e-08  3.64e-08    1.45e-07   4.07e-08        1.069   3.563
64  33     4.71e-08  4.34e-08    1.68e-07   4.83e-08        1.085   3.478
64  41     5.9e-08   5.25e-08    2.21e-07   5.94e-08        1.124   3.721
64  51     7.29e-08  6.26e-08    2.82e-07   7.3e-08         1.165   3.863
64  63     8.93e-08  7.72e-08    3.34e-07   9.48e-08        1.157   3.523
64  78     1.11e-07  9.12e-08    4.3e-07    1.16e-07        1.217   3.707
64  97     1.37e-07  1.14e-07    5.47e-07   1.43e-07        1.202   3.825
64 121     1.72e-07  1.41e-07    6.96e-07   1.77e-07        1.220   3.932
```