### PR TITLE
Remove backslashes after i.e. and e.g.

### DIFF
--- a/doc/source/fmpz_mod_poly.rst
+++ b/doc/source/fmpz_mod_poly.rst
@@ -1783,7 +1783,7 @@ depends on~`r` and an upper bound on the degree of~`f`.
 
     where necessarily `N = \lfloor\deg(F) / \deg(R)\rfloor`.
 
-    Assumes that `R` is non-constant, i.e. `\deg(R) \geq 1`,
+    Assumes that `R` is non-constant, i.e., `\deg(R) \geq 1`,
     and that the leading coefficient is a unit.
 
 

--- a/doc/source/fmpz_mod_poly.rst
+++ b/doc/source/fmpz_mod_poly.rst
@@ -1783,7 +1783,7 @@ depends on~`r` and an upper bound on the degree of~`f`.
 
     where necessarily `N = \lfloor\deg(F) / \deg(R)\rfloor`.
 
-    Assumes that `R` is non-constant, i.e.\ `\deg(R) \geq 1`,
+    Assumes that `R` is non-constant, i.e. `\deg(R) \geq 1`,
     and that the leading coefficient is a unit.
 
 

--- a/doc/source/gr.rst
+++ b/doc/source/gr.rst
@@ -805,7 +805,7 @@ Factorization
 
     where `f_k` will be irreducible or prime (depending on `R`).
 
-    The prefactor `c` stores a unit, sign, or coefficient, e.g. the
+    The prefactor `c` stores a unit, sign, or coefficient, e.g., the
     sign `-1`, `0` or `+1` in `\mathbb{Z}`, or a sign multiplied
     by the coefficient content in `\mathbb{Z}[x]`.
     Note that this function outputs `c` as an element of the

--- a/doc/source/gr.rst
+++ b/doc/source/gr.rst
@@ -805,7 +805,7 @@ Factorization
 
     where `f_k` will be irreducible or prime (depending on `R`).
 
-    The prefactor `c` stores a unit, sign, or coefficient, e.g.\ the
+    The prefactor `c` stores a unit, sign, or coefficient, e.g. the
     sign `-1`, `0` or `+1` in `\mathbb{Z}`, or a sign multiplied
     by the coefficient content in `\mathbb{Z}[x]`.
     Note that this function outputs `c` as an element of the

--- a/doc/source/gr_implementing.rst
+++ b/doc/source/gr_implementing.rst
@@ -107,7 +107,7 @@ Placeholder and trivial methods
 
     This function does nothing and returns ``GR_DOMAIN``. It can be used
     for an operation that never makes sense in the present domain,
-    e.g.\ for the constant `\pi` in the rational numbers.
+    e.g. for the constant `\pi` in the rational numbers.
 
 .. function:: truth_t gr_generic_ctx_predicate(gr_ctx_t ctx)
 

--- a/doc/source/gr_implementing.rst
+++ b/doc/source/gr_implementing.rst
@@ -107,7 +107,7 @@ Placeholder and trivial methods
 
     This function does nothing and returns ``GR_DOMAIN``. It can be used
     for an operation that never makes sense in the present domain,
-    e.g. for the constant `\pi` in the rational numbers.
+    e.g., for the constant `\pi` in the rational numbers.
 
 .. function:: truth_t gr_generic_ctx_predicate(gr_ctx_t ctx)
 

--- a/doc/source/nmod_poly.rst
+++ b/doc/source/nmod_poly.rst
@@ -23,7 +23,7 @@ In reality one never deals directly with the ``struct`` and simply
 deals with objects of type :type:`nmod_poly_t`. For simplicity we will
 think of an :type:`nmod_poly_t` as a ``struct``, though in practice to
 access fields of this ``struct``, one needs to dereference first,
-e.g. to access the ``length`` field of an :type:`nmod_poly_t` called
+e.g., to access the ``length`` field of an :type:`nmod_poly_t` called
 ``poly1`` one writes ``poly1->length``.
 
 An :type:`nmod_poly_t` is said to be *normalised* if either ``length``

--- a/doc/source/nmod_poly.rst
+++ b/doc/source/nmod_poly.rst
@@ -23,7 +23,7 @@ In reality one never deals directly with the ``struct`` and simply
 deals with objects of type :type:`nmod_poly_t`. For simplicity we will
 think of an :type:`nmod_poly_t` as a ``struct``, though in practice to
 access fields of this ``struct``, one needs to dereference first,
-e.g.\ to access the ``length`` field of an :type:`nmod_poly_t` called
+e.g. to access the ``length`` field of an :type:`nmod_poly_t` called
 ``poly1`` one writes ``poly1->length``.
 
 An :type:`nmod_poly_t` is said to be *normalised* if either ``length``


### PR DESCRIPTION
the backslash is needed in TeX, but not in reStructuredText.

See for example https://github.com/sphinx-doc/sphinx/blob/master/doc/usage/restructuredtext/basics.rst?plain=1#L378

a backslash-escaped space renders to nothing, see https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#character-level-inline-markup . For example https://flintlib.org/doc/gr.html#c.gr_factor . 