### PR TITLE
Optimize arb/acb poly coefficient set

### DIFF
--- a/src/acb_poly/set_coeff_acb.c
+++ b/src/acb_poly/set_coeff_acb.c
@@ -14,10 +14,11 @@
 void
 acb_poly_set_coeff_acb(acb_poly_t poly, slong n, const acb_t x)
 {
-    acb_poly_fit_length(poly, n + 1);
-
     if (n + 1 > poly->length)
     {
+        if (acb_is_zero(x))
+            return;
+        acb_poly_fit_length(poly, n + 1);
         _acb_vec_zero(poly->coeffs + poly->length, n - poly->length);
         poly->length = n + 1;
     }

--- a/src/acb_poly/set_coeff_si.c
+++ b/src/acb_poly/set_coeff_si.c
@@ -14,10 +14,11 @@
 void
 acb_poly_set_coeff_si(acb_poly_t poly, slong n, slong x)
 {
-    acb_poly_fit_length(poly, n + 1);
-
     if (n + 1 > poly->length)
     {
+        if (x == 0)
+            return;
+        acb_poly_fit_length(poly, n + 1);
         _acb_vec_zero(poly->coeffs + poly->length, n - poly->length);
         poly->length = n + 1;
     }

--- a/src/arb_poly/set_coeff_arb.c
+++ b/src/arb_poly/set_coeff_arb.c
@@ -14,10 +14,11 @@
 void
 arb_poly_set_coeff_arb(arb_poly_t poly, slong n, const arb_t x)
 {
-    arb_poly_fit_length(poly, n + 1);
-
     if (n + 1 > poly->length)
     {
+        if (arb_is_zero(x))
+            return;
+        arb_poly_fit_length(poly, n + 1);
         _arb_vec_zero(poly->coeffs + poly->length, n - poly->length);
         poly->length = n + 1;
     }

--- a/src/arb_poly/set_coeff_si.c
+++ b/src/arb_poly/set_coeff_si.c
@@ -14,10 +14,11 @@
 void
 arb_poly_set_coeff_si(arb_poly_t poly, slong n, slong x)
 {
-    arb_poly_fit_length(poly, n + 1);
-
     if (n + 1 > poly->length)
     {
+        if (x == 0)
+            return;
+        arb_poly_fit_length(poly, n + 1);
         _arb_vec_zero(poly->coeffs + poly->length, n - poly->length);
         poly->length = n + 1;
     }


### PR DESCRIPTION
Fix #2418 

there's one more occurrence in calcium `ca_poly_set_coeff_ca`, but checking for zero might be expensive, so I'd leave it alone.

meanwhile e.g. `fmpz_poly_set_coeff_fmpz` already have such a check.