### PR TITLE
nmod_poly_sqrt: throw error for non-prime modulus

### DIFF
--- a/src/nmod_poly/invsqrt_series.c
+++ b/src/nmod_poly/invsqrt_series.c
@@ -11,7 +11,6 @@
 */
 
 #include "flint.h"
-#include "ulong_extras.h"
 #include "nmod_poly.h"
 #include "gr_poly.h"
 
@@ -20,13 +19,10 @@ _nmod_poly_invsqrt_series(nn_ptr g, nn_srcptr h, slong hlen, slong n, nmod_t mod
 {
     gr_ctx_t ctx;
 
-    /* Algorithm requires prime modulus */
-    if (!n_is_prime(mod.n))
-        flint_throw(FLINT_ERROR, "Exception (nmod_poly_invsqrt_series). "
-            "Modulus must be prime.\n");
-
     _gr_ctx_init_nmod(ctx, &mod);
-    GR_MUST_SUCCEED(_gr_poly_rsqrt_series(g, h, hlen, n, ctx));
+    if (_gr_poly_rsqrt_series(g, h, hlen, n, ctx) != GR_SUCCESS)
+        flint_throw(FLINT_ERROR, "Exception (_nmod_poly_invsqrt_series). "
+            "Modulus is not prime, or square root does not exist.\n");
 }
 
 void

--- a/src/nmod_poly/sqrt_series.c
+++ b/src/nmod_poly/sqrt_series.c
@@ -11,7 +11,6 @@
 */
 
 #include "flint.h"
-#include "ulong_extras.h"
 #include "nmod_poly.h"
 #include "gr_poly.h"
 
@@ -20,13 +19,10 @@ _nmod_poly_sqrt_series(nn_ptr g, nn_srcptr h, slong hlen, slong n, nmod_t mod)
 {
     gr_ctx_t ctx;
 
-    /* Algorithm requires prime modulus */
-    if (!n_is_prime(mod.n))
-        flint_throw(FLINT_ERROR, "Exception (nmod_poly_sqrt_series). "
-            "Modulus must be prime.\n");
-
     _gr_ctx_init_nmod(ctx, &mod);
-    GR_MUST_SUCCEED(_gr_poly_sqrt_series(g, h, hlen, n, ctx));
+    if (_gr_poly_sqrt_series(g, h, hlen, n, ctx) != GR_SUCCESS)
+        flint_throw(FLINT_ERROR, "Exception (_nmod_poly_sqrt_series). "
+            "Modulus is not prime, or square root does not exist.\n");
 }
 
 void


### PR DESCRIPTION
The ``nmod_poly_sqrt``, ``nmod_poly_sqrt_series``, and ``nmod_poly_invsqrt_series`` functions only work correctly for prime moduli because:

1. ``n_sqrtmod`` uses Tonelli-Shanks algorithm (requires prime)
2. ``gr_sqrt`` returns GR_UNABLE for non-fields
3. Division by 2 (``gr_mul_2exp_si``) fails for even moduli
4. Newton iteration requires invertible elements

Previously, using these functions with composite moduli like 16 would cause a crash with an uninformative ``GR_MUST_SUCCEED`` failure message.

Now they throw a clear error: 'Modulus must be prime.'

Fixes #2508