### PR TITLE
[qadic] add context initialization with a user-defined modulus.

### DIFF
--- a/doc/source/qadic.rst
+++ b/doc/source/qadic.rst
@@ -80,6 +80,30 @@ elements.
     arithmetic in `\mathbf{Q}_p / (p^N)` such as powers of `p` close 
     to `p^N`.
 
+.. function:: void qadic_ctx_init_modulus(qadic_ctx_t ctx, const fmpz_t p, const fmpz_mod_poly_t modulus, slong min, slong max, const char *var, enum padic_print_mode mode)
+              void qadic_ctx_init_modulus_nmod(qadic_ctx_t ctx, ulong p, const nmod_poly_t modulus, slong min, slong max, const char *var, enum padic_print_mode mode)
+
+    Initialises the context ``ctx`` with prime `p`, given defining polynomial ``modulus``, variable name ``var``
+    and printing mode ``mode``.
+
+    Stores powers of `p` with exponents between ``min`` (inclusive) and
+    ``max`` exclusive.  Assumes that ``min`` is at most ``max``.
+
+    Assumes that `p` is a prime.
+
+    Assumes that ``modulus`` is a monic irreducible polynomial over
+    `\mathbf{F}_{p}`.
+
+    Assumes that the string ``var`` is a null-terminated string
+    of length at least one.
+
+    Assumes that the printing mode is one of ``PADIC_TERSE``,
+    ``PADIC_SERIES``, or ``PADIC_VAL_UNIT``.
+
+    This function also carries out some relevant precomputation for
+    arithmetic in `\mathbf{Q}_p / (p^N)` such as powers of `p` close
+    to `p^N`.
+
 .. function:: void qadic_ctx_clear(qadic_ctx_t ctx)
 
     Clears all memory that has been allocated as part of the context.

--- a/src/qadic.h
+++ b/src/qadic.h
@@ -19,6 +19,8 @@
 #endif
 
 #include "fmpz_vec.h"
+#include "fmpz_mod_types.h"
+#include "nmod_types.h"
 #include "padic.h"
 #include "padic_poly.h"
 
@@ -61,6 +63,14 @@ int _qadic_ctx_init_conway_ui(qadic_ctx_t ctx, ulong p, slong d,
 
 void qadic_ctx_init_conway(qadic_ctx_t ctx,
                            const fmpz_t p, slong d, slong min, slong max,
+                           const char *var, enum padic_print_mode mode);
+
+void qadic_ctx_init_modulus(qadic_ctx_t ctx, const fmpz_t p, const fmpz_mod_poly_t modulus,
+                           slong min, slong max,
+                           const char *var, enum padic_print_mode mode);
+
+void qadic_ctx_init_modulus_nmod(qadic_ctx_t ctx, ulong p, const nmod_poly_t modulus,
+                           slong min, slong max,
                            const char *var, enum padic_print_mode mode);
 
 void qadic_ctx_init(qadic_ctx_t ctx,

--- a/src/qadic/test/main.c
+++ b/src/qadic/test/main.c
@@ -16,6 +16,7 @@
 #include "t-exp.c"
 #include "t-exp_rectangular.c"
 #include "t-frobenius.c"
+#include "t-init.c"
 #include "t-inv.c"
 #include "t-log_balanced.c"
 #include "t-log.c"
@@ -41,6 +42,7 @@ test_struct tests[] =
     TEST_FUNCTION(qadic_exp_rectangular),
     TEST_FUNCTION(qadic_frobenius),
     TEST_FUNCTION(qadic_inv),
+    TEST_FUNCTION(qadic_init),
     TEST_FUNCTION(qadic_log_balanced),
     TEST_FUNCTION(qadic_log),
     TEST_FUNCTION(qadic_log_rectangular),

--- a/src/qadic/test/t-init.c
+++ b/src/qadic/test/t-init.c
@@ -1,0 +1,139 @@
+/*
+    Copyright (C) 2026 Alexey Orlov
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "ulong_extras.h"
+#include "long_extras.h"
+#include "qadic.h"
+#include "nmod_poly.h"
+#include "fmpz_mod.h"
+#include "fmpz_mod_poly.h"
+
+/*
+originally it was possible to create qadic context only with conway polynomial
+  or, using qadic_ctx_init, with a random irreducible polynomial if it fails
+
+we have two cubic irreducible polynomials over F_2
+x^3 + x + 1 (conway polynomial)
+x^3 + x^2 + 1
+we create 4 qadic contexts:
+  1. with conway polynomial, using _qadic_ctx_init_conway_ui
+  2. using qadic_ctx_init, which will also use conway polynomial
+  3. with nmod_poly_t modulus f = x^3 + x^2 + 1
+  4. with fmpz_mod_poly_t modulus f = x^3 + x^2 + 1
+for all 4 we compute g^3 + g^2 + 1 and g^3 + g + 1 for a generator g (lift of a generator of the residue field)
+*/
+
+static inline void compute_f(qadic_t out, qadic_ctx_t ctx)
+{
+    qadic_t z, z0, z2, z3, tmp;
+
+    qadic_init(z); qadic_init(z0); qadic_init(z2); qadic_init(z3); qadic_init(tmp);
+
+    qadic_gen(z, ctx); qadic_set_ui(z0, 1, ctx); qadic_mul(z2, z, z, ctx); qadic_mul(z3, z2, z, ctx);
+    qadic_add(tmp, z0, z2, ctx);
+    qadic_add(out, tmp, z3, ctx);
+
+    qadic_clear(z); qadic_clear(z0); qadic_clear(z2); qadic_clear(z3); qadic_clear(tmp);
+}
+
+static inline void compute_f_conway(qadic_t out, qadic_ctx_t ctx)
+{
+    qadic_t z, z0, z2, z3, tmp;
+
+    qadic_init(z); qadic_init(z0); qadic_init(z2); qadic_init(z3); qadic_init(tmp);
+
+    qadic_gen(z, ctx); qadic_set_ui(z0, 1, ctx); qadic_mul(z2, z, z, ctx); qadic_mul(z3, z2, z, ctx);
+    qadic_add(tmp, z0, z, ctx);
+    qadic_add(out, tmp, z3, ctx);
+
+    qadic_clear(z); qadic_clear(z0); qadic_clear(z2); qadic_clear(z3); qadic_clear(tmp);
+}
+
+static inline void error_exit(const char* prefix, qadic_t val, qadic_ctx_t ctx)
+{
+    flint_printf("FAIL\n\n");
+    flint_printf("%s", prefix), qadic_print_pretty(val, ctx), flint_printf("\n");
+    fflush(stdout);
+    flint_abort();
+}
+
+TEST_FUNCTION_START(qadic_init, state)
+{
+    fmpz_mod_ctx_t GF;
+    nmod_poly_t f_nmod; fmpz_mod_poly_t f;
+    qadic_ctx_t ctx_conway; qadic_ctx_t ctx; qadic_ctx_t ctx_f_nmod; qadic_ctx_t ctx_f;
+    qadic_t fg_val;
+    fmpz_t p;
+
+    fmpz_init(p); fmpz_set_ui(p, 2);
+
+    nmod_poly_init(f_nmod, 2);
+    nmod_poly_set_coeff_ui(f_nmod, 0, 1);
+    nmod_poly_set_coeff_ui(f_nmod, 2, 1);
+    nmod_poly_set_coeff_ui(f_nmod, 3, 1);
+
+    fmpz_mod_ctx_init_ui(GF, 2);
+    fmpz_mod_poly_init(f, GF);
+    fmpz_mod_poly_set_nmod_poly(f, f_nmod);
+
+    _qadic_ctx_init_conway_ui(ctx_conway, 2, 3, 0, 1, "x", PADIC_SERIES);
+    qadic_ctx_init(ctx, p, 3, 0, 1, "x", PADIC_SERIES);
+    qadic_ctx_init_modulus_nmod(ctx_f_nmod, 2, f_nmod, 0, 1, "x", PADIC_SERIES);
+    qadic_ctx_init_modulus(ctx_f, p, f, 0, 1, "x", PADIC_SERIES);
+
+    qadic_init(fg_val);
+
+    compute_f(fg_val, ctx_conway);
+    if (qadic_is_zero(fg_val))
+        error_exit("conway: g^3 + g^2 + 1 = ", fg_val, ctx_conway);
+
+    compute_f_conway(fg_val, ctx_conway);
+    if (!qadic_is_zero(fg_val))
+        error_exit("conway: g^3 + g + 1 = ", fg_val, ctx_conway);
+
+    compute_f(fg_val, ctx);
+    if (qadic_is_zero(fg_val))
+        error_exit("default: g^3 + g^2 + 1 = ", fg_val, ctx);
+
+    compute_f_conway(fg_val, ctx);
+    if (!qadic_is_zero(fg_val))
+        error_exit("default: g^3 + g + 1 = ", fg_val, ctx);
+
+    compute_f(fg_val, ctx_f);
+    if (!qadic_is_zero(fg_val))
+        error_exit("f_fmpz: g^3 + g^2 + 1 = ", fg_val, ctx_f);
+
+    compute_f_conway(fg_val, ctx_f);
+    if (qadic_is_zero(fg_val))
+        error_exit("f_fmpz: g^3 + g + 1 = ", fg_val, ctx_f);
+
+    compute_f(fg_val, ctx_f_nmod);
+    if (!qadic_is_zero(fg_val))
+        error_exit("f_nmod: g^3 + g^2 + 1 = ", fg_val, ctx_f_nmod);
+
+    compute_f_conway(fg_val, ctx_f_nmod);
+    if (qadic_is_zero(fg_val))
+        error_exit("f_nmod: g^3 + g + 1 = ", fg_val, ctx_f_nmod);
+
+    qadic_clear(fg_val);
+    qadic_ctx_clear(ctx_conway);
+    qadic_ctx_clear(ctx);
+    qadic_ctx_clear(ctx_f_nmod);
+    qadic_ctx_clear(ctx_f);
+    nmod_poly_clear(f_nmod);
+    fmpz_mod_poly_clear(f, GF);
+    fmpz_mod_ctx_clear(GF);
+    fmpz_clear(p);
+
+    TEST_FUNCTION_END(state);
+}
+


### PR DESCRIPTION
Added qadic_ctx_init_modulus and qadic_ctx_init_modulus_nmod to initialize a context with a given modulus.

This is useful when using q-adics with a fixed residue field F_q (e.g. counting points on elliptic curves over finite fields using the canonical lift). In this case, we must ensure that elements of F_q can be "lifted" to Q_q, which is straightforward when the modulus can be specified. Previously, if a Conway polynomial was unavailable (due to large characteristic or large degree), FLINT would use different random polynomials for F_q and Q_q, making them incompatible.