### PR TITLE
Optimize fmpz_mul_tdiv_q_2exp

### DIFF
--- a/doc/source/fmpz.rst
+++ b/doc/source/fmpz.rst
@@ -937,9 +937,6 @@ Basic arithmetic
     As per :func:`fmpz_fdiv_qr`, but takes a precomputed inverse ``hinv``
     of `h` constructed using :func:`fmpz_preinvn`.
 
-    This function will be faster than :func:`fmpz_fdiv_qr_preinvn` when the
-    number of limbs of `h` is at least ``PREINVN_CUTOFF``.
-
 .. function:: void fmpz_pow_ui(fmpz_t f, const fmpz_t g, ulong x)
               void fmpz_ui_pow_ui(fmpz_t f, ulong g, ulong x)
 

--- a/src/fmpz/mul_tdiv_q_2exp.c
+++ b/src/fmpz/mul_tdiv_q_2exp.c
@@ -17,7 +17,6 @@ void
 fmpz_mul_tdiv_q_2exp(fmpz_t f, const fmpz_t g, const fmpz_t h, ulong exp)
 {
     fmpz c1, c2;
-    mpz_ptr mf;
 
     c1 = *g;
 
@@ -35,13 +34,6 @@ fmpz_mul_tdiv_q_2exp(fmpz_t f, const fmpz_t g, const fmpz_t h, ulong exp)
         return;
     }
 
-    mf = _fmpz_promote(f); /* h is saved, g is already large */
-
-    if (!COEFF_IS_MPZ(c2))      /* g is large, h is small */
-        flint_mpz_mul_si(mf, COEFF_TO_PTR(c1), c2);
-    else                        /* c1 and c2 are large */
-        mpz_mul(mf, COEFF_TO_PTR(c1), COEFF_TO_PTR(c2));
-
-    mpz_tdiv_q_2exp(mf, mf, exp);
-    _fmpz_demote_val(f);  /* division may make value small */
+    fmpz_mul(f, g, h);
+    fmpz_tdiv_q_2exp(f, f, exp);
 }


### PR DESCRIPTION
... by using fmpz_mul instead of mpz_mul. A lot of optimizations went into fmpz_mul, surely this cannot be slower than mpz_mul.

Of course there are more optimizations possible in certain ranges e.g.
- if the required number of bits in the output is much less than the number of bits in either input, it would be worth trying to multiply just the top [number of output bits + 64] bits of both coefficients, and see if this already uniquely determines the result. With high probability, it will. If it doesn't, retry with the full multiplication later
- if both inputs are small, consider using `flint_mpn_mul_or_mulhigh_n` or equivalent

but that can be left for later.

Also remove a stray remark in `fmpz_fdiv_qr_preinvn`, surely the function cannot be faster than itself.