### PR TITLE
Workaround for gcc 15 C23 strict-aliasing bug

### DIFF
--- a/src/fmpz_mpoly_factor/bpoly_factor.c
+++ b/src/fmpz_mpoly_factor/bpoly_factor.c
@@ -725,7 +725,7 @@ static void _recombine_naive(
                 fmpz_tpoly_fit_length(F, F->length + 1);
                 fmpz_bpoly_swap(F->coeffs + F->length, trymez);
                 F->length++;
-                fmpz_bpoly_swap(B, Q);
+                fmpz_bpoly_swap(Q, B);
                 FLINT_ASSERT(B->length > 0);
                 fmpz_mod_poly_set_fmpz_poly(leadB, B->coeffs + B->length - 1, I->ctxpk);
 


### PR DESCRIPTION
Fix https://github.com/flintlib/flint/issues/2340. See discussion there (an alternative is to build with `-std=c17` or less)

While there's no guarantee similar thing may break in the future, the change is extremely simple, so why not.