### PR TITLE
Fix memory leaks

### DIFF
--- a/src/fmpq_poly/test/t-print_read.c
+++ b/src/fmpq_poly/test/t-print_read.c
@@ -102,6 +102,7 @@ TEST_FUNCTION_START(fmpq_poly_print_read, state)
             for (i = 0; i < n; ++i)
                 fmpq_poly_clear(a[i]);
             flint_free(a);
+            flint_cleanup_master();
             exit(0);
         }
         else  /* Parent process */
@@ -208,6 +209,7 @@ TEST_FUNCTION_START(fmpq_poly_print_read, state)
             }
 
             fclose(out);
+            flint_cleanup_master();
             exit(0);
         }
         else  /* Parent process */

--- a/src/fmpz/test/t-out_inp_raw.c
+++ b/src/fmpz/test/t-out_inp_raw.c
@@ -97,6 +97,7 @@ TEST_FUNCTION_START(fmpz_out_inp_raw, state)
             for (i = 0; i < n; ++i)
                 fmpz_clear(a + i);
             flint_free(a);
+            flint_cleanup_master();
             exit(0);
         }
         else  /* Parent process */

--- a/src/fmpz/test/t-print_read.c
+++ b/src/fmpz/test/t-print_read.c
@@ -99,6 +99,7 @@ TEST_FUNCTION_START(fmpz_print_read, state)
             for (i = 0; i < n; ++i)
                 fmpz_clear(a + i);
             flint_free(a);
+            flint_cleanup_master();
             exit(0);
         }
         else  /* Parent process */
@@ -205,6 +206,7 @@ TEST_FUNCTION_START(fmpz_print_read, state)
             }
 
             fclose(out);
+            flint_cleanup_master();
             exit(0);
         }
         else  /* Parent process */

--- a/src/fmpz_mat/test/t-print_read.c
+++ b/src/fmpz_mat/test/t-print_read.c
@@ -104,6 +104,7 @@ TEST_FUNCTION_START(fmpz_mat_print_read, state)
             for (i = 0; i < k; ++i)
                 fmpz_mat_clear(M[i]);
             flint_free(M);
+            flint_cleanup_master();
             exit(0);
         }
         else  /* Parent process */
@@ -208,6 +209,7 @@ TEST_FUNCTION_START(fmpz_mat_print_read, state)
             }
 
             fclose(out);
+            flint_cleanup_master();
             exit(0);
         }
         else  /* Parent process */

--- a/src/fmpz_mod_poly/test/t-print_read.c
+++ b/src/fmpz_mod_poly/test/t-print_read.c
@@ -108,6 +108,7 @@ TEST_FUNCTION_START(fmpz_mod_poly_print_read, state)
                 fmpz_mod_poly_clear(a[j], ctx);
             flint_free(a);
             fclose(out);
+            flint_cleanup_master();
             exit(0);
         }
         else  /* Parent process */
@@ -217,6 +218,7 @@ TEST_FUNCTION_START(fmpz_mod_poly_print_read, state)
             }
 
             fclose(out);
+            flint_cleanup_master();
             exit(0);
         }
         else  /* Parent process */

--- a/src/fmpz_poly/test/t-print_read.c
+++ b/src/fmpz_poly/test/t-print_read.c
@@ -103,6 +103,7 @@ TEST_FUNCTION_START(fmpz_poly_print_read, state)
             for (i = 0; i < n; ++i)
                 fmpz_poly_clear(a[i]);
             flint_free(a);
+            flint_cleanup_master();
             exit(0);
         }
         else  /* Parent process */
@@ -209,6 +210,7 @@ TEST_FUNCTION_START(fmpz_poly_print_read, state)
             }
 
             fclose(out);
+            flint_cleanup_master();
             exit(0);
         }
         else  /* Parent process */

--- a/src/fmpz_poly/test/t-print_read_pretty.c
+++ b/src/fmpz_poly/test/t-print_read_pretty.c
@@ -104,6 +104,7 @@ TEST_FUNCTION_START(fmpz_poly_print_read_pretty, state)
             for (i = 0; i < n; ++i)
                 fmpz_poly_clear(a[i]);
             flint_free(a);
+            flint_cleanup_master();
             exit(0);
         }
         else  /* Parent process */
@@ -214,6 +215,7 @@ TEST_FUNCTION_START(fmpz_poly_print_read_pretty, state)
             }
 
             fclose(out);
+            flint_cleanup_master();
             exit(0);
         }
         else  /* Parent process */

--- a/src/fmpz_poly/tree.c
+++ b/src/fmpz_poly/tree.c
@@ -40,7 +40,7 @@ void _fmpz_poly_tree_free(fmpz ** tree, slong len)
         slong i, height = FLINT_CLOG2(len);
 
         for (i = 0; i <= height; i++)
-            flint_free(tree[i]);
+            _fmpz_vec_clear(tree[i], len + (len >> i) + 1);
 
         flint_free(tree);
     }

--- a/src/gr/fmpz_poly.c
+++ b/src/gr/fmpz_poly.c
@@ -29,14 +29,12 @@
 
 static const char * default_var = "x";
 
-#if 0
 static void
 _gr_fmpz_poly_ctx_clear(gr_ctx_t ctx)
 {
     if (FMPZ_POLY_CTX_VAR(ctx) != default_var)
         flint_free(FMPZ_POLY_CTX_VAR(ctx));
 }
-#endif
 
 static int _gr_fmpz_poly_ctx_set_gen_name(gr_ctx_t ctx, const char * s)
 {
@@ -835,6 +833,7 @@ gr_static_method_table _fmpz_poly_methods;
 
 gr_method_tab_input _fmpz_poly_methods_input[] =
 {
+    {GR_METHOD_CTX_CLEAR,       (gr_funcptr) _gr_fmpz_poly_ctx_clear},
     {GR_METHOD_CTX_WRITE,       (gr_funcptr) _gr_fmpz_poly_ctx_write},
     {GR_METHOD_CTX_IS_RING,     (gr_funcptr) gr_generic_ctx_predicate_true},
     {GR_METHOD_CTX_IS_COMMUTATIVE_RING, (gr_funcptr) gr_generic_ctx_predicate_true},


### PR DESCRIPTION
Fix severe memory leak in `fmpq_poly_interpolate_fast`, minor memory leak in `gr_fmpz_poly`, and some missing cleanups in test functions.