### PR TITLE
Fix fmpz_read

### DIFF
--- a/src/fmpz/io.c
+++ b/src/fmpz/io.c
@@ -43,7 +43,7 @@ fmpz_fread(FILE * file, fmpz_t f)
     return (r > 0) ? 1 : 0;
 }
 
-int fmpz_read(fmpz_t f) { return fmpz_fread(stdout, f); }
+int fmpz_read(fmpz_t f) { return fmpz_fread(stdin, f); }
 
 /* file I/O ********************************************************************/
 


### PR DESCRIPTION
Fixes #2570: `fmpz_read` was completely broken (tried to read from stdout instead of stdin).

This fixes the qfb profile programs. Before:

```
$ build/qfb/profile/p-factor_qfb
Enter number to be factored: Read failed
Aborted (core dumped)
```

After:

```
$ build/qfb/profile/p-factor_qfb
Enter number to be factored: 1000000000000000000000033
iters = 10, multipliers = 10
iters = 20, multipliers = 11
Factor: 1726503814391
```