### PR TITLE
Use nmod_poly_minimal_irreducible for qadic context creation with small p

### DIFF
--- a/src/qadic/ctx_init.c
+++ b/src/qadic/ctx_init.c
@@ -92,17 +92,28 @@ void qadic_ctx_init_conway(qadic_ctx_t ctx, const fmpz_t p, slong d,
 void qadic_ctx_init(qadic_ctx_t ctx, const fmpz_t p, slong d,
         slong min, slong max, const char * var, enum padic_print_mode mode)
 {
-    flint_rand_t state;
-    fmpz_mod_poly_t poly;
-    fmpz_mod_ctx_t ctxp;
-    nmod_poly_t poly_small_p;
-
     if (*p >= 2 && *p <= 109987)
         if (_qadic_ctx_init_conway_ui(ctx, *p, d, min, max, var, mode))
             return;
 
-    if (COEFF_IS_MPZ(*p))
+    if (fmpz_size(p) == 1)
     {
+        const ulong small_p = fmpz_get_ui(p);
+        nmod_poly_t poly_small_p;
+
+        nmod_poly_init(poly_small_p, small_p);
+        nmod_poly_minimal_irreducible(poly_small_p, d);
+
+        qadic_ctx_init_modulus_nmod(ctx, small_p, poly_small_p, min, max, var, mode);
+
+        nmod_poly_clear(poly_small_p);
+    }
+    else
+    {
+        flint_rand_t state;
+        fmpz_mod_poly_t poly;
+        fmpz_mod_ctx_t ctxp;
+
         flint_rand_init(state);
 
         fmpz_mod_ctx_init(ctxp, p);
@@ -116,15 +127,6 @@ void qadic_ctx_init(qadic_ctx_t ctx, const fmpz_t p, slong d,
 
         fmpz_mod_poly_clear(poly, ctxp);
         fmpz_mod_ctx_clear(ctxp);
-    }
-    else
-    {
-        nmod_poly_init(poly_small_p, *p);
-        nmod_poly_minimal_irreducible(poly_small_p, d);
-
-        qadic_ctx_init_modulus_nmod(ctx, *p, poly_small_p, min, max, var, mode);
-
-        nmod_poly_clear(poly_small_p);
     }
 }
 

--- a/src/qadic/profile/p-init.c
+++ b/src/qadic/profile/p-init.c
@@ -16,7 +16,6 @@
       does not "pessimize" in this case (nmod_poly routines should be used)
  */
 
-#include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
 


### PR DESCRIPTION
When no Conway polynomial is available and the characteristic fits in a ulong, use nmod_poly_minimal_irreducible instead of the fmpz_mod_poly_randtest_sparse_irreducible. The former is a deterministic search with heavy pruning, improving creation time significantly.

The net result is, locally, from
```
julia> @time qadic_field(2,1024;precision=1)
  3.849074 seconds (481.74 k allocations: 3.087 GiB, 0.99% gc time, 0.06% compilation time)
(Unramified extension of 2-adic numbers of degree 1024, (2^0 + O(2^1))*a)

julia> @time qadic_field(2,2048;precision=1)
 53.298277 seconds (4.44 M allocations: 37.756 GiB, 2.27% gc time, 0.01% compilation time)
(Unramified extension of 2-adic numbers of degree 2048, (2^0 + O(2^1))*a)
```

to creating qadic contexts for [2, 3, 5, 7, 11]^[123, 628, 1024, 2048, 2755, 2867] in 15.9 seconds