### PR TITLE
Improve radix_invmod_bn and add more profile programs

### DIFF
--- a/src/radix/profile/p-add.c
+++ b/src/radix/profile/p-add.c
@@ -1,0 +1,74 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <math.h>
+#include "profiler.h"
+#include "radix.h"
+
+int main()
+{
+    radix_t radix;
+    slong digits, nd, n1, n2;
+    nn_ptr a, b, c;
+    double tmpn, tradix, FLINT_SET_BUT_UNUSED(tt);
+
+    flint_rand_t state;
+    flint_rand_init(state);
+
+    flint_printf("   decimal      mpn  decimal        time        time    relative\n");
+    flint_printf("    digits    limbs    limbs       mpn_add   radix_add  time\n\n");
+
+    for (nd = 1; nd <= 100000000; nd = FLINT_MAX(nd + 1, nd * 1.5))
+    {
+        radix_init(radix, 10, 0);
+
+        digits = nd * 19;
+
+        /* Number of full-word limbs */
+        n1 = (slong) (digits * (log(10) / (FLINT_BITS * log(2))) + 1.0);
+        /* Number of radix 10^e limbs */
+        n2 = (digits + radix->exp - 1) / radix->exp;
+
+        a = flint_malloc(n2 * sizeof(ulong));
+        b = flint_malloc(n2 * sizeof(ulong));
+        c = flint_malloc(2 * n2 * sizeof(ulong));
+
+        flint_mpn_urandomb(a, state, n1 * FLINT_BITS);
+        flint_mpn_urandomb(b, state, n1 * FLINT_BITS);
+
+        mpn_add(c, a, n1, b, n1);
+        TIMEIT_START;
+        mpn_add(c, a, n1, b, n1);
+        TIMEIT_STOP_VALUES(tt, tmpn);
+
+        radix_rand_limbs(a, state, n2, radix);
+        radix_rand_limbs(b, state, n2, radix);
+
+        radix_add(c, a, n2, b, n2, radix);
+        TIMEIT_START;
+        radix_add(c, a, n2, b, n2, radix);
+        TIMEIT_STOP_VALUES(tt, tradix);
+
+        flint_printf("%10wd %8wd %8wd    %8g    %8g    %.3fx\n",
+            digits, n1, n2, tmpn, tradix, tradix / tmpn);
+
+        flint_free(a);
+        flint_free(b);
+        flint_free(c);
+
+        radix_clear(radix);
+    }
+
+    flint_rand_clear(state);
+    flint_cleanup_master();
+    return 0;
+}
+

--- a/src/radix/profile/p-invmod.c
+++ b/src/radix/profile/p-invmod.c
@@ -1,0 +1,172 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdint.h>
+#include "fmpz.h"
+#include "gr.h"
+#include "profiler.h"
+#include "gmp.h"
+#include "radix.h"
+#include "fmpz_mod.h"
+#include "padic.h"
+#include "nmod.h"
+
+int main()
+{
+    flint_rand_t state;
+    ulong p;
+    slong n, exp;
+    int have_mpn_mod;
+
+    flint_rand_init(state);
+    radix_t radix;
+
+    p = 7;
+    radix_init(radix, p, 0);
+    exp = radix->exp;
+
+    flint_printf("radix = %wu^%wd\n", p, radix->exp);
+
+    for (n = 1; n <= 10000000; n *= 2)
+    {
+        fmpz_mod_ctx_t mod_ctx;
+        gr_ctx_t gr_ctx;
+        radix_integer_t x, y, z;
+        gr_ptr gx = NULL, gy = NULL, gz = NULL;
+        fmpz_t fx, fy, fz, fp, pn;
+        padic_ctx_t pctx;
+        padic_t px, py, pz;
+
+        fmpz_init_set_ui(fp, p);
+        fmpz_init(pn);
+        fmpz_ui_pow_ui(pn, p, exp * n);
+
+        fmpz_mod_ctx_init(mod_ctx, pn);
+        padic_ctx_init(pctx, fp, exp * n, exp * n, PADIC_SERIES);
+        have_mpn_mod = (gr_ctx_init_mpn_mod(gr_ctx, pn) == GR_SUCCESS);
+
+        fmpz_init(fx);
+        fmpz_init(fy);
+        fmpz_init(fz);
+
+        radix_integer_init(x, radix);
+        radix_integer_init(y, radix);
+        radix_integer_init(z, radix);
+
+        padic_init2(px, exp * n);
+        padic_init2(py, exp * n);
+        padic_init2(pz, exp * n);
+
+        do
+        {
+            fmpz_randm(fx, state, pn);
+        } while (fmpz_divisible_ui(fx, p));
+        do
+        {
+            fmpz_randm(fy, state, pn);
+        } while (fmpz_divisible_ui(fy, p));
+
+        padic_set_fmpz(px, fx, pctx);
+        padic_set_fmpz(py, fy, pctx);
+
+        if (have_mpn_mod)
+        {
+            gx = gr_heap_init(gr_ctx);
+            gy = gr_heap_init(gr_ctx);
+            gz = gr_heap_init(gr_ctx);
+
+            GR_MUST_SUCCEED(gr_set_fmpz(gx, fx, gr_ctx));
+            GR_MUST_SUCCEED(gr_set_fmpz(gy, fy, gr_ctx));
+        }
+
+        do
+        {
+            radix_integer_rand_limbs(x, state, n, radix);
+        } while (x->d[0] % p == 0);
+        do
+        {
+            radix_integer_rand_limbs(y, state, n, radix);
+        } while (y->d[0] % p == 0);
+
+        double t1, t2, t3, t4, FLINT_SET_BUT_UNUSED(__);
+
+        TIMEIT_START;
+        padic_inv(pz, px, pctx);
+        TIMEIT_STOP_VALUES(__, t1);
+
+        TIMEIT_START;
+        fmpz_mod_inv(fz, fx, mod_ctx);
+        TIMEIT_STOP_VALUES(__, t2);
+
+        if (have_mpn_mod)
+        {
+            TIMEIT_START;
+            GR_IGNORE(gr_inv(gz, gx, gr_ctx));
+            TIMEIT_STOP_VALUES(__, t3);
+        }
+        else
+            t3 = 0.0;
+
+        TIMEIT_START;
+        radix_integer_invmod_limbs(z, x, n, radix);
+        TIMEIT_STOP_VALUES(__, t4);
+
+        char st1[20];
+        char st2[20];
+        char st3[20];
+        char st4[20];
+
+        sprintf(st1, "%.2e", t1);
+        sprintf(st2, "%.2e", t2);
+        if (t3 == 0.0)
+            sprintf(st3, "-");
+        else
+            sprintf(st3, "%.2e", t3);
+        sprintf(st4, "%.2e", t4);
+
+        if (n == 1)
+            flint_printf("       n      padic   fmpz_mod    mpn_mod   radix_integer    speedup/padic  speedup/fmpz_mod\n");
+
+        flint_printf("%8wd   %8s   %8s   %8s   %8s         %.2fx          %.2fx\n", n, st1, st2, st3, st4, t1 / t4, t2 / t4);
+
+        padic_clear(px);
+        padic_clear(py);
+        padic_clear(pz);
+
+        radix_integer_clear(x, radix);
+        radix_integer_clear(y, radix);
+        radix_integer_clear(z, radix);
+
+        fmpz_clear(fx);
+        fmpz_clear(fy);
+        fmpz_clear(fz);
+
+        if (have_mpn_mod)
+        {
+            gr_heap_clear(gx, gr_ctx);
+            gr_heap_clear(gy, gr_ctx);
+            gr_heap_clear(gz, gr_ctx);
+            gr_ctx_clear(gr_ctx);
+        }
+
+        fmpz_mod_ctx_clear(mod_ctx);
+        padic_ctx_clear(pctx);
+
+        fmpz_clear(pn);
+        fmpz_clear(fp);
+    }
+
+    radix_clear(radix);
+    flint_rand_clear(state);
+    flint_cleanup_master();
+    return 0;
+}
+

--- a/src/radix/profile/p-mulmod.c
+++ b/src/radix/profile/p-mulmod.c
@@ -1,0 +1,172 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdint.h>
+#include "fmpz.h"
+#include "gr.h"
+#include "profiler.h"
+#include "gmp.h"
+#include "radix.h"
+#include "fmpz_mod.h"
+#include "padic.h"
+#include "nmod.h"
+
+int main()
+{
+    flint_rand_t state;
+    ulong p;
+    slong n, exp;
+    int have_mpn_mod;
+
+    flint_rand_init(state);
+    radix_t radix;
+
+    p = 7;
+    radix_init(radix, p, 0);
+    exp = radix->exp;
+
+    flint_printf("radix = %wu^%wd\n", p, radix->exp);
+
+    for (n = 1; n <= 10000000; n *= 2)
+    {
+        fmpz_mod_ctx_t mod_ctx;
+        gr_ctx_t gr_ctx;
+        radix_integer_t x, y, z;
+        gr_ptr gx = NULL, gy = NULL, gz = NULL;
+        fmpz_t fx, fy, fz, fp, pn;
+        padic_ctx_t pctx;
+        padic_t px, py, pz;
+
+        fmpz_init_set_ui(fp, p);
+        fmpz_init(pn);
+        fmpz_ui_pow_ui(pn, p, exp * n);
+
+        fmpz_mod_ctx_init(mod_ctx, pn);
+        padic_ctx_init(pctx, fp, exp * n, exp * n, PADIC_SERIES);
+        have_mpn_mod = (gr_ctx_init_mpn_mod(gr_ctx, pn) == GR_SUCCESS);
+
+        fmpz_init(fx);
+        fmpz_init(fy);
+        fmpz_init(fz);
+
+        radix_integer_init(x, radix);
+        radix_integer_init(y, radix);
+        radix_integer_init(z, radix);
+
+        padic_init2(px, exp * n);
+        padic_init2(py, exp * n);
+        padic_init2(pz, exp * n);
+
+        do
+        {
+            fmpz_randm(fx, state, pn);
+        } while (fmpz_divisible_ui(fx, p));
+        do
+        {
+            fmpz_randm(fy, state, pn);
+        } while (fmpz_divisible_ui(fy, p));
+
+        padic_set_fmpz(px, fx, pctx);
+        padic_set_fmpz(py, fy, pctx);
+
+        if (have_mpn_mod)
+        {
+            gx = gr_heap_init(gr_ctx);
+            gy = gr_heap_init(gr_ctx);
+            gz = gr_heap_init(gr_ctx);
+
+            GR_MUST_SUCCEED(gr_set_fmpz(gx, fx, gr_ctx));
+            GR_MUST_SUCCEED(gr_set_fmpz(gy, fy, gr_ctx));
+        }
+
+        do
+        {
+            radix_integer_rand_limbs(x, state, n, radix);
+        } while (x->d[0] % p == 0);
+        do
+        {
+            radix_integer_rand_limbs(y, state, n, radix);
+        } while (y->d[0] % p == 0);
+
+        double t1, t2, t3, t4, FLINT_SET_BUT_UNUSED(__);
+
+        TIMEIT_START;
+        padic_mul(pz, px, py, pctx);
+        TIMEIT_STOP_VALUES(__, t1);
+
+        TIMEIT_START;
+        fmpz_mod_mul(fz, fx, fy, mod_ctx);
+        TIMEIT_STOP_VALUES(__, t2);
+
+        if (have_mpn_mod)
+        {
+            TIMEIT_START;
+            GR_IGNORE(gr_mul(gz, gx, gy, gr_ctx));
+            TIMEIT_STOP_VALUES(__, t3);
+        }
+        else
+            t3 = 0.0;
+
+        TIMEIT_START;
+        radix_integer_mullow_limbs(z, x, y, n, radix);
+        TIMEIT_STOP_VALUES(__, t4);
+
+        char st1[20];
+        char st2[20];
+        char st3[20];
+        char st4[20];
+
+        sprintf(st1, "%.2e", t1);
+        sprintf(st2, "%.2e", t2);
+        if (t3 == 0.0)
+            sprintf(st3, "-");
+        else
+            sprintf(st3, "%.2e", t3);
+        sprintf(st4, "%.2e", t4);
+
+        if (n == 1)
+            flint_printf("       n      padic   fmpz_mod    mpn_mod   radix_integer    speedup/padic  speedup/fmpz_mod\n");
+
+        flint_printf("%8wd   %8s   %8s   %8s   %8s         %.2fx          %.2fx\n", n, st1, st2, st3, st4, t1 / t4, t2 / t4);
+
+        padic_clear(px);
+        padic_clear(py);
+        padic_clear(pz);
+
+        radix_integer_clear(x, radix);
+        radix_integer_clear(y, radix);
+        radix_integer_clear(z, radix);
+
+        fmpz_clear(fx);
+        fmpz_clear(fy);
+        fmpz_clear(fz);
+
+        if (have_mpn_mod)
+        {
+            gr_heap_clear(gx, gr_ctx);
+            gr_heap_clear(gy, gr_ctx);
+            gr_heap_clear(gz, gr_ctx);
+            gr_ctx_clear(gr_ctx);
+        }
+
+        fmpz_mod_ctx_clear(mod_ctx);
+        padic_ctx_clear(pctx);
+
+        fmpz_clear(pn);
+        fmpz_clear(fp);
+    }
+
+    radix_clear(radix);
+    flint_rand_clear(state);
+    flint_cleanup_master();
+    return 0;
+}
+

--- a/src/radix/profile/p-sub.c
+++ b/src/radix/profile/p-sub.c
@@ -1,0 +1,74 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <math.h>
+#include "profiler.h"
+#include "radix.h"
+
+int main()
+{
+    radix_t radix;
+    slong digits, nd, n1, n2;
+    nn_ptr a, b, c;
+    double tmpn, tradix, FLINT_SET_BUT_UNUSED(tt);
+
+    flint_rand_t state;
+    flint_rand_init(state);
+
+    flint_printf("   decimal      mpn  decimal        time        time    relative\n");
+    flint_printf("    digits    limbs    limbs       mpn_add   radix_add  time\n\n");
+
+    for (nd = 1; nd <= 100000000; nd = FLINT_MAX(nd + 1, nd * 1.5))
+    {
+        radix_init(radix, 10, 0);
+
+        digits = nd * 19;
+
+        /* Number of full-word limbs */
+        n1 = (slong) (digits * (log(10) / (FLINT_BITS * log(2))) + 1.0);
+        /* Number of radix 10^e limbs */
+        n2 = (digits + radix->exp - 1) / radix->exp;
+
+        a = flint_malloc(n2 * sizeof(ulong));
+        b = flint_malloc(n2 * sizeof(ulong));
+        c = flint_malloc(2 * n2 * sizeof(ulong));
+
+        flint_mpn_urandomb(a, state, n1 * FLINT_BITS);
+        flint_mpn_urandomb(b, state, n1 * FLINT_BITS);
+
+        mpn_sub(c, a, n1, b, n1);
+        TIMEIT_START;
+        mpn_sub(c, a, n1, b, n1);
+        TIMEIT_STOP_VALUES(tt, tmpn);
+
+        radix_rand_limbs(a, state, n2, radix);
+        radix_rand_limbs(b, state, n2, radix);
+
+        radix_sub(c, a, n2, b, n2, radix);
+        TIMEIT_START;
+        radix_sub(c, a, n2, b, n2, radix);
+        TIMEIT_STOP_VALUES(tt, tradix);
+
+        flint_printf("%10wd %8wd %8wd    %8g    %8g    %.3fx\n",
+            digits, n1, n2, tmpn, tradix, tradix / tmpn);
+
+        flint_free(a);
+        flint_free(b);
+        flint_free(c);
+
+        radix_clear(radix);
+    }
+
+    flint_rand_clear(state);
+    flint_cleanup_master();
+    return 0;
+}
+

--- a/src/radix/test/t-invmod_bn.c
+++ b/src/radix/test/t-invmod_bn.c
@@ -24,8 +24,8 @@ TEST_FUNCTION_START(radix_invmod_bn, state)
 
         radix_init_randtest(radix, state);
 
-        an = 1 + n_randint(state, 10);
-        n = 1 + n_randint(state, 10);
+        an = 1 + n_randint(state, 50);
+        n = 1 + n_randint(state, 50);
 
         a = flint_malloc(an * sizeof(ulong));
         b = flint_malloc(n * sizeof(ulong));


### PR DESCRIPTION
Newton iteration for $r = 1/x$ mod $B^n$ is updated to use the evaluation formula $r (rx)$ with middle product instead of the naive $r x^2$. Timings for inverse mod $(7^{22})^N$ vs old timings from #2561:

```
       N       old       new  speedup
       1  3.09e-08  3.02e-08  1.02x
       2  5.19e-08   5.1e-08  1.02x
       4  1.12e-07  1.03e-07  1.09x
       8  2.36e-07  2.07e-07  1.14x
      16  5.75e-07  3.71e-07  1.55x
      32  1.56e-06  9.84e-07  1.59x
      64  4.26e-06  2.55e-06  1.67x
     128  1.28e-05  7.55e-06  1.70x
     256  2.84e-05  2.21e-05  1.29x
     512  5.97e-05  4.59e-05  1.30x
    1024  0.000125  9.65e-05  1.30x
    2048  0.000266  0.000201  1.32x
    4096  0.000561  0.000423  1.33x
    8192   0.00117  0.000901  1.30x
   16384   0.00246   0.00187  1.32x
   32768   0.00508   0.00392  1.30x
   65536    0.0104   0.00817  1.27x
  131072    0.0221    0.0172  1.28x
  262144    0.0469    0.0371  1.26x
  524288     0.102    0.0823  1.24x
 1048576     0.223     0.193  1.16x
 2097152      0.48     0.422  1.14x
 4194304      1.06     0.917  1.16x
 8388608      2.22      1.92  1.16x
```

This PR also adds profile programs for add, sub mulmod_bn, invmod_bn.