### PR TITLE
GR maintenance

### DIFF
--- a/doc/source/gr.rst
+++ b/doc/source/gr.rst
@@ -100,6 +100,16 @@ when the user knows the type.
 Users may wish to define their own union types when only some
 particular types will appear in an application.
 
+.. function:: void gr_ctx_uninitialized(gr_ctx_t ctx)
+
+    Create an uninitialized context. This context object does not support
+    any operations, but it can be printed with :func:`gr_ctx_print`
+    and cleared with :func:`gr_ctx_clear`. A context constructor that can fail
+    (see for example :func:`gr_ctx_init_mpn_mod`) should call this method
+    so that the context object is safe to clear even if initialization
+    failed, i.e. ensuring that ``ctx`` contains a valid function pointer
+    for :func:`gr_ctx_clear`.
+
 Error handling
 ...............................................................................
 

--- a/src/gr.h
+++ b/src/gr.h
@@ -733,6 +733,7 @@ typedef enum
     GR_CTX_PSL2Z, GR_CTX_DIRICHLET_GROUP, GR_CTX_PERM,
     GR_CTX_FEXPR,
     GR_CTX_DEBUG,
+    GR_CTX_UNINITIALIZED,
     GR_CTX_UNKNOWN_DOMAIN,
     GR_CTX_WHICH_STRUCTURE_TAB_SIZE
 }
@@ -1376,6 +1377,8 @@ truth_t gr_generic_ctx_predicate_true(gr_ctx_t ctx);
 truth_t gr_generic_ctx_predicate_false(gr_ctx_t ctx);
 
 /* Some base rings */
+
+void gr_ctx_uninitialized(gr_ctx_t ctx);
 
 void gr_ctx_init_random(gr_ctx_t ctx, flint_rand_t state);
 

--- a/src/gr/dirichlet.c
+++ b/src/gr/dirichlet.c
@@ -233,7 +233,10 @@ int
 gr_ctx_init_dirichlet_group(gr_ctx_t ctx, ulong q)
 {
     if (q == 0)
+    {
+        gr_ctx_uninitialized(ctx);
         return GR_DOMAIN;
+    }
 
     ctx->which_ring = GR_CTX_DIRICHLET_GROUP;
     ctx->sizeof_elem = sizeof(dirichlet_char_struct);
@@ -244,6 +247,7 @@ gr_ctx_init_dirichlet_group(gr_ctx_t ctx, ulong q)
     if (!dirichlet_group_init(DIRICHLET_CTX(ctx), q))
     {
         flint_free(GR_CTX_DATA_AS_PTR(ctx));
+        gr_ctx_uninitialized(ctx);
         return GR_UNABLE;
     }
 

--- a/src/gr/fq_nmod.c
+++ b/src/gr/fq_nmod.c
@@ -815,7 +815,10 @@ gr_ctx_init_fq_nmod_modulus_fmpz_mod_poly(gr_ctx_t ctx, const fmpz_mod_poly_t mo
     int status;
 
     if (!fmpz_abs_fits_ui(mod_ctx->n))
+    {
+        gr_ctx_uninitialized(ctx);
         return GR_UNABLE;
+    }
 
     nmod_poly_init(nmodulus, fmpz_get_ui(mod_ctx->n));
     fmpz_mod_poly_get_nmod_poly(nmodulus, modulus);

--- a/src/gr/fq_zech.c
+++ b/src/gr/fq_zech.c
@@ -710,6 +710,7 @@ gr_ctx_init_fq_zech_modulus_nmod_poly(gr_ctx_t ctx, const nmod_poly_t modulus, c
         fq_nmod_ctx_clear(fq_nmod_ctx);
         flint_free(fq_zech_ctx);
         flint_free(fq_nmod_ctx);
+        gr_ctx_uninitialized(ctx);
         return GR_DOMAIN;
     }
 }
@@ -721,7 +722,10 @@ gr_ctx_init_fq_zech_modulus_fmpz_mod_poly(gr_ctx_t ctx, const fmpz_mod_poly_t mo
     int status;
 
     if (!fmpz_abs_fits_ui(mod_ctx->n))
+    {
+        gr_ctx_uninitialized(ctx);
         return GR_UNABLE;
+    }
 
     nmod_poly_init(nmodulus, fmpz_get_ui(mod_ctx->n));
     fmpz_mod_poly_get_nmod_poly(nmodulus, modulus);

--- a/src/gr/nmod.c
+++ b/src/gr/nmod.c
@@ -1447,7 +1447,10 @@ int
 gr_ctx_init_nmod(gr_ctx_t ctx, ulong n)
 {
     if (n == 0)
+    {
+        gr_ctx_uninitialized(ctx);
         return GR_DOMAIN;
+    }
 
     ctx->which_ring = GR_CTX_NMOD;
     ctx->sizeof_elem = sizeof(ulong);

--- a/src/gr/nmod32.c
+++ b/src/gr/nmod32.c
@@ -680,9 +680,16 @@ int
 gr_ctx_init_nmod32(gr_ctx_t ctx, ulong n)
 {
     if (n == 0)
+    {
+        gr_ctx_uninitialized(ctx);
         return GR_DOMAIN;
+    }
+
     if (n > UWORD(4294967295))
+    {
+        gr_ctx_uninitialized(ctx);
         return GR_UNABLE;
+    }
 
     ctx->which_ring = GR_CTX_NMOD32;
     ctx->sizeof_elem = sizeof(uint32_t);

--- a/src/gr/nmod8.c
+++ b/src/gr/nmod8.c
@@ -794,9 +794,16 @@ int
 gr_ctx_init_nmod8(gr_ctx_t ctx, ulong n)
 {
     if (n == 0)
+    {
+        gr_ctx_uninitialized(ctx);
         return GR_DOMAIN;
+    }
+
     if (n > 255)
+    {
+        gr_ctx_uninitialized(ctx);
         return GR_UNABLE;
+    }
 
     ctx->which_ring = GR_CTX_NMOD8;
     ctx->sizeof_elem = sizeof(uint8_t);

--- a/src/gr/uninitialized.c
+++ b/src/gr/uninitialized.c
@@ -1,0 +1,60 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "gr.h"
+
+
+static void
+_gr_uninitialized_ctx_clear(gr_ctx_t ctx)
+{
+    /* For debugging: flint_printf("CLEARING UNINTIIALIZED\n"); */
+}
+
+static int _gr_uninitialized_ctx_write(gr_stream_t out, gr_ctx_t ctx)
+{
+    return gr_stream_write(out, "Uninitialized context (init failed)");
+}
+
+static int
+_gr_uninitialized_init(gr_ptr res, gr_ctx_t ctx)
+{
+    flint_throw(FLINT_ERROR, "Cannot initialize element of uninitialized context");
+    return GR_UNABLE;
+}
+
+int _uninitialized_methods_initialized = 0;
+
+gr_static_method_table _uninitialized_methods;
+
+gr_method_tab_input _uninitialized_methods_input[] =
+{
+    {GR_METHOD_CTX_CLEAR,     (gr_funcptr) _gr_uninitialized_ctx_clear},
+    {GR_METHOD_CTX_WRITE,   (gr_funcptr) _gr_uninitialized_ctx_write},
+    {GR_METHOD_INIT,        (gr_funcptr) _gr_uninitialized_init},
+    {0,                     (gr_funcptr) NULL},
+};
+
+void
+gr_ctx_uninitialized(gr_ctx_t ctx)
+{
+    ctx->which_ring = GR_CTX_UNINITIALIZED;
+    ctx->sizeof_elem = 1;
+    ctx->size_limit = WORD_MAX;
+
+    ctx->methods = _uninitialized_methods;
+
+    if (!_uninitialized_methods_initialized)
+    {
+        gr_method_tab_init(_uninitialized_methods, _uninitialized_methods_input);
+        _uninitialized_methods_initialized = 1;
+    }
+}
+

--- a/src/mpn_mod/ctx.c
+++ b/src/mpn_mod/ctx.c
@@ -145,7 +145,10 @@ _gr_ctx_init_mpn_mod(gr_ctx_t ctx, nn_srcptr n, slong nlimbs)
 {
     flint_bitcnt_t norm;
     if (nlimbs < MPN_MOD_MIN_LIMBS || nlimbs > MPN_MOD_MAX_LIMBS || n[nlimbs - 1] == 0)
+    {
+        gr_ctx_uninitialized(ctx);
         return GR_UNABLE;
+    }
 
     ctx->which_ring = GR_CTX_MPN_MOD;
     ctx->sizeof_elem = nlimbs * sizeof(ulong);
@@ -182,10 +185,16 @@ int
 gr_ctx_init_mpn_mod(gr_ctx_t ctx, const fmpz_t n)
 {
     if (fmpz_sgn(n) <= 0)
+    {
+        gr_ctx_uninitialized(ctx);
         return GR_DOMAIN;
+    }
 
     if (!COEFF_IS_MPZ(*n))
+    {
+        gr_ctx_uninitialized(ctx);
         return GR_UNABLE;
+    }
 
     return _gr_ctx_init_mpn_mod(ctx, COEFF_TO_PTR(*n)->_mp_d, COEFF_TO_PTR(*n)->_mp_size);
 }

--- a/src/nfloat/complex.c
+++ b/src/nfloat/complex.c
@@ -2043,7 +2043,10 @@ nfloat_complex_ctx_init(gr_ctx_t ctx, slong prec, int flags)
     slong nlimbs;
 
     if (prec <= 0 || prec > NFLOAT_MAX_LIMBS * FLINT_BITS)
+    {
+        gr_ctx_uninitialized(ctx);
         return GR_UNABLE;
+    }
 
     nlimbs = (prec + FLINT_BITS - 1) / FLINT_BITS;
 

--- a/src/nfloat/ctx.c
+++ b/src/nfloat/ctx.c
@@ -193,7 +193,10 @@ nfloat_ctx_init(gr_ctx_t ctx, slong prec, int flags)
     slong nlimbs;
 
     if (prec <= 0 || prec > NFLOAT_MAX_LIMBS * FLINT_BITS)
+    {
+        gr_ctx_uninitialized(ctx);
         return GR_UNABLE;
+    }
 
     nlimbs = (prec + FLINT_BITS - 1) / FLINT_BITS;
 

--- a/src/python/flint_ctypes.py
+++ b/src/python/flint_ctypes.py
@@ -5120,9 +5120,20 @@ def get_nfloat_class(prec):
     return _nfloat_class
 
 class RealFloat_nfloat(gr_ctx):
+    """
+        >>> RealFloat_nfloat(128)
+        Floating-point numbers with prec = 128 (nfloat)
+        >>> RealFloat_nfloat(128).pi()
+        3.14159265358979323846264338327950288420
+        >>> RealFloat_nfloat(10000)
+        Traceback (most recent call last):
+          ...
+        FlintUnableError: precision out of range for nfloat
+    """
     def __init__(self, prec=128):
         gr_ctx.__init__(self)
-        libflint.nfloat_ctx_init(self._ref, prec, 0)
+        if libflint.nfloat_ctx_init(self._ref, prec, 0) != GR_SUCCESS:
+            raise FlintUnableError("precision out of range for nfloat")
         self._elem_type = get_nfloat_class(prec)
 
 @functools.cache
@@ -5147,9 +5158,20 @@ def get_nfloat_complex_class(prec):
     return _nfloat_complex_class
 
 class ComplexFloat_nfloat_complex(gr_ctx):
+    """
+        >>> ComplexFloat_nfloat_complex(128)
+        Complex floating-point numbers with prec = 128 (nfloat_complex)
+        >>> ComplexFloat_nfloat_complex(128).i()
+        1.00000000000000000000000000000000000000*I
+        >>> ComplexFloat_nfloat_complex(10000)
+        Traceback (most recent call last):
+          ...
+        FlintUnableError: precision out of range for nfloat_complex
+    """
     def __init__(self, prec=128):
         gr_ctx.__init__(self)
-        libflint.nfloat_complex_ctx_init(self._ref, prec, 0)
+        if libflint.nfloat_complex_ctx_init(self._ref, prec, 0) != GR_SUCCESS:
+            raise FlintUnableError("precision out of range for nfloat_complex")
         self._elem_type = get_nfloat_complex_class(prec)
 
 
@@ -5170,12 +5192,21 @@ class nmod(gr_elem):
 
 
 class IntegersMod_mpn_mod(gr_ctx):
+    """
+
+        >>> IntegersMod_mpn_mod(10**20 + 1)
+        Integers mod 100000000000000000001 (mpn)
+        >>> IntegersMod_mpn_mod(10**1000)
+        Traceback (most recent call last):
+          ...
+        FlintUnableError: n is not in range for the mpn_mod implementation
+
+    """
     def __init__(self, n, n_is_prime=None):
         n = self._as_fmpz(n)
-        # todo: error handling (must handle cleanup when ctx has not been initialized
-        assert n >= (1 << FLINT_BITS) and n < (1 << (8 * FLINT_BITS))
         gr_ctx.__init__(self)
-        libgr.gr_ctx_init_mpn_mod(self._ref, n._ref)
+        if libgr.gr_ctx_init_mpn_mod(self._ref, n._ref) != GR_SUCCESS:
+            raise FlintUnableError("n is not in range for the mpn_mod implementation")
         self._elem_type = mpn_mod
         if n_is_prime is not None:
             libgr.gr_ctx_set_is_field(self, T_TRUE if n_is_prime else T_FALSE)
@@ -5720,6 +5751,12 @@ class DirichletGroup_dirichlet_char(gr_ctx_ca):
         4
         >>> [G(i) for i in [1,3,7,9]]
         [chi_10(1, .), chi_10(3, .), chi_10(7, .), chi_10(9, .)]
+
+        >>> DirichletGroup(10**16+61)
+        Traceback (most recent call last):
+          ...
+        NotImplementedError: modulus with prime factor p > 10^16 is not currently supported
+
     """
 
     def __init__(self, q, **kwargs):
@@ -6888,6 +6925,10 @@ class Fraction_gr_fraction(gr_ctx):
     Fractions with GCD reduction:
 
         >>> Q = Fraction_gr_fraction(ZZi)
+        >>> Q(ZZi.i())
+        (I) / (1)
+        >>> Q(Fraction_gr_fraction(QQbar).i())
+        (I) / (1)
         >>> I, = Q.gens(recursive=True)
         >>> s = sum(1/(1+j*I) for j in range(10))
         >>> s


### PR DESCRIPTION
We add a special `gr_ctx_uninitialized` constructor and call this in GR context initializers that have the ability to fail, e.g. `mpn_mod` with a modulus that is out of range. This makes it a bit forgiving to write wrappers and cleanup blocks for generics, since it becomes safe to call `gr_ctx_clear` even if initialization failed. Indeed, thanks to this change context initialization should now fail gracefully in the ctypes wrapper instead of randomly segfaulting.

IIRC @mezzarobba  requested something like this.

Not sure if we should actually call `gr_ctx_uninitialized` in the failing constructors ourselves or leave this to the user? I made this automatic for now in all places I could think of, but I don't have a strong opinion either way.

Also, add ctypes wrapper for `gr_fraction` with some tests.