### PR TITLE
Fix compilation under emscripten

### DIFF
--- a/src/profiler.h
+++ b/src/profiler.h
@@ -27,7 +27,7 @@
 #if defined(_MSC_VER) || defined(__x86_64__) || defined(__aarch64__)
 # define FLINT_HAVE_get_cycle_counter  1
 #endif
-#if (defined(__unix__) && !defined(__CYGWIN__)) || defined(__APPLE__)
+#if (defined(__unix__) && !defined(__CYGWIN__) && !defined(__EMSCRIPTEN__)) || defined(__APPLE__)
 # define FLINT_HAVE_getrusage   1
 #endif
 


### PR DESCRIPTION
This change is necessary, or we get the compilation error below when compiling under emscripten. Emscripen happens to be unix, but without rusage. Annoying, but it's extremely useful for compiling to the web, and gives access to people to use flint who otherwise would not have a chance of getting access, e.g. who use tablets or smartphones. Please consider. This fixes the compile.

Thanks,

Mate 


```
/home/soos/development/flint-3.4.0/src/generic_files/profiler.c:117:20: warning: result of comparison of constant 1099511627776 with expression of type 'ulong' (aka 'unsigned long') is always true [-Wtautological-constant-out-of-range-compare]
  117 |     else if (bytes < TB) { num = bytes / (doubl  CC  generic_files/test_helpers.c
e) GB; str[5] = 'G'; }
      |              ~~~~~ ^ ~~
/home/soos/development/flint-3.4.0/src/generic_files/profiler.c:118:20: warning: result of comparison of constant 1125899906842624 with expression of type 'ulong' (aka 'unsigned long') is always true [-Wtautological-constant-out-of-range-compare]
  118 |     else if (bytes < PB) { num = bytes / (double) TB; str[5] = 'T'; }
      |              ~~~~~ ^ ~~
  CC  thread_pool/clear.c
/home/soos/development/flint-3.4.0/src/generic_files/profiler.c:160:19: error: variable has incomplete type 'struct rusage'
  160 |     struct rusage usage;
      |                   ^
/home/soos/development/flint-3.4.0/src/generic_files/profiler.c:160:12: note: forward declaration of 'struct rusage'
  160 |     struct rusage usage;
      |            ^
  CC  thread_pool/distribute_work.c
/home/soos/development/flint-3.4.0/src/generic_files/profiler.c:161:5: error: call to undeclared function 'getrusage'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  161 |     getrusage(RUSAGE_SELF, &usage);
      |     ^
  CC  thread_pool/find_work.c
  CC  thread_pool/get_size.c
/home/soos/development/flint-3.4.0/src/generic_files/profiler.c:161:15: error: use of undeclared identifier 'RUSAGE_SELF'
  161 |     getrusage(RUSAGE_SELF, &usage);
      |               ^
/home/soos/development/flint-3.4.0/src/generic_files/profiler.c:173:23: error: variable has incomplete type 'struct kinfo_proc'
  173 |     struct kinfo_proc kp;
      |                       ^
/home/soos/development/flint-3.4.0/src/generic_files/profiler.c:173:12: note: forward declaration of 'struct kinfo_proc'
  173 |     struct kinfo_proc kp;
      |            ^
/home/soos/development/flint-3.4.0/src/generic_files/profiler.c:174:18: error: invalid application of 'sizeof' to an incomplete type 'struct kinfo_proc'
  174 |     size_t len = sizeof(struct kinfo_proc);
      |                  ^     ~~~~~~~~~~~~~~~~~~~
/home/soos/development/flint-3.4.0/src/generic_files/profiler.c:173:12: note: forward declaration of 'struct kinfo_proc'
  173 |     struct kinfo_proc kp;
      |            ^
  CC  thread_pool/give_back.c
/home/soos/development/flint-3.4.0/src/generic_files/profiler.c:175:19: error: use of undeclared identifier 'CTL_KERN'
  175 |     int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()};
      |                   ^
/home/soos/development/flint-3.4.0/src/generic_files/profiler.c:175:29: error: use of undeclared identifier 'KERN_PROC'
  175 |     int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()};
      |                             ^
/home/soos/development/flint-3.4.0/src/generic_files/profiler.c:175:40: error: use of undeclared identifier 'KERN_PROC_PID'
  175 |     int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()};
      |                                        ^
/home/soos/development/flint-3.4.0/src/generic_files/profiler.c:175:55: error: call to undeclared function 'getpid'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  175 |     int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()};
      |                                                       ^
/home/soos/development/flint-3.4.0/src/generic_files/profiler.c:177:9: error: call to undeclared function 'sysctl'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  177 |     if (sysctl(mib, 4, &kp, &len, NULL, 0) == -1)
      |         ^
  CC  thread_pool/init.c
2 warnings and 10 errors generated.
make: *** [Makefile:629: build/generic_files/profiler.o] Error 1
make: *** Waiting for unfinished jobs....
emmake: error: 'make -j12' failed (returned 2)
```