### PR TITLE
Fix compilation for static

### DIFF
--- a/src/mpoly.h
+++ b/src/mpoly.h
@@ -28,6 +28,7 @@ extern "C" {
 /* choose m so that (m + 1)/(n - m) ~= la/lb, i.e. m = (n*la - lb)/(la + lb) */
 slong mpoly_divide_threads(slong n, double la, double lb);
 
+#ifndef __GMP_H__
 #ifdef _MSC_VER
 # define DECLSPEC_IMPORT __declspec(dllimport)
 #else
@@ -40,6 +41,7 @@ DECLSPEC_IMPORT ulong __gmpn_submul_1(nn_ptr, nn_srcptr, long int, ulong);
 DECLSPEC_IMPORT ulong __gmpn_rshift(nn_ptr, nn_srcptr, long int, unsigned int);
 DECLSPEC_IMPORT ulong __gmpn_mul_1(nn_ptr, nn_srcptr, long int, ulong);
 #undef DECLSPEC_IMPORT
+#endif
 
 /* context *******************************************************************/
 

--- a/src/ulong_extras.h
+++ b/src/ulong_extras.h
@@ -179,6 +179,7 @@ ulong n_flog(ulong n, ulong b);
 ulong n_clog(ulong n, ulong b);
 ulong n_clog_2exp(ulong n, ulong b);
 
+#ifndef __GMP_H__
 #ifdef _MSC_VER
 # define DECLSPEC_IMPORT __declspec(dllimport)
 #else
@@ -187,6 +188,7 @@ ulong n_clog_2exp(ulong n, ulong b);
 DECLSPEC_IMPORT ulong __gmpn_gcd_11(ulong, ulong);
 DECLSPEC_IMPORT ulong __gmpn_gcd_1(nn_srcptr, long int, ulong);
 #undef DECLSPEC_IMPORT
+#endif
 
 ULONG_EXTRAS_INLINE
 ulong n_gcd(ulong x, ulong y)


### PR DESCRIPTION
When I compiled flint on windows static (with vcpkg) flint redefine all the functions `__gmpn_*`
These functions come from gmp header, that also define `__GMP_H__`.
So I am guarding all this functions with this define. 

You can also take a look on my PR on vcpkg.
https://github.com/microsoft/vcpkg/pull/50349