### PR TITLE
Use faster code for remainder by p in `qsieve_evaluate_candidate`

### DIFF
--- a/src/qsieve.h
+++ b/src/qsieve.h
@@ -36,6 +36,7 @@ extern "C" {
 typedef struct
 {
    ulong pinv;     /* precomputed inverse */
+   ulong pinv2;    /* alternative precomputed inverse */
    int p;              /* prime */
    char size;
 } prime_t;

--- a/src/qsieve/collect_relations.c
+++ b/src/qsieve/collect_relations.c
@@ -199,6 +199,16 @@ void qsieve_do_sieving2(qs_t qs_inf, unsigned char * sieve, qs_poly_t poly)
     }
 }
 
+
+/* Lemire-Kaser-Kurz remainder for half-limb primes */
+#include "nmod.h"
+
+FLINT_FORCE_INLINE
+ulong n_mod_halflimb_preinv(ulong x, ulong d, ulong dinv)
+{
+    return n_mulhi(dinv * x, d);
+}
+
 /*
     check position i in sieve array for smoothness
 */
@@ -279,8 +289,9 @@ slong qsieve_evaluate_candidate(qs_t qs_inf, ulong i, unsigned char * sieve, qs_
    for (j = 3; j < qs_inf->small_primes; j++) /* pull out small primes */
    {
       prime = factor_base[j].p;
-      pinv = factor_base[j].pinv;
-      modp = n_mod2_preinv(i, prime, pinv);
+      pinv = factor_base[j].pinv2;
+      FLINT_ASSERT(prime < UWORD(1) << (FLINT_BITS / 2));
+      modp = n_mod_halflimb_preinv(i, prime, pinv);
 
       if (modp == soln1[j] || modp == soln2[j])
       {
@@ -310,39 +321,76 @@ slong qsieve_evaluate_candidate(qs_t qs_inf, ulong i, unsigned char * sieve, qs_
           we stop once we have reached the same number of bits as indicated in
           the sieve entry
       */
-      for (j = qs_inf->small_primes; j < num_primes && extra_bits < sieve[i]; j++)
-      {
-         prime = factor_base[j].p;
-         pinv = factor_base[j].pinv;
-         modp = n_mod2_preinv(i, prime, pinv);
 
-         if (soln2[j] != 0) /* not a prime dividing A */
+      /* can use fast remainder */
+      if (factor_base[num_primes - 1].p < UWORD(1) << (FLINT_BITS / 2))
+      {
+         for (j = qs_inf->small_primes; j < num_primes && extra_bits < sieve[i]; j++)
          {
-            if (modp == soln1[j] || modp == soln2[j])
+            prime = factor_base[j].p;
+            pinv = factor_base[j].pinv2;
+            modp = n_mod_halflimb_preinv(i, prime, pinv);
+
+            if (soln2[j] != 0) /* not a prime dividing A */
+            {
+               if (modp == soln1[j] || modp == soln2[j])
+               {
+                  fmpz_set_ui(p, prime);
+                  exp = fmpz_remove(res, res, p);
+                  extra_bits += qs_inf->factor_base[j].size;
+                  factor[num_factors].ind = j;
+                  factor[num_factors++].exp = exp;
+#if QS_DEBUG & 128
+                     flint_printf("%ld^%ld ", prime, exp);
+#endif
+               }
+            } else /* prime dividing A */
             {
                fmpz_set_ui(p, prime);
                exp = fmpz_remove(res, res, p);
-               extra_bits += qs_inf->factor_base[j].size;
                factor[num_factors].ind = j;
-               factor[num_factors++].exp = exp;
+               factor[num_factors++].exp = exp + 1; /* really factoring A*f(i) */
 #if QS_DEBUG & 128
+               if (exp)
                   flint_printf("%ld^%ld ", prime, exp);
 #endif
-
             }
-         } else /* prime dividing A */
-         {
-            fmpz_set_ui(p, prime);
-            exp = fmpz_remove(res, res, p);
-            factor[num_factors].ind = j;
-            factor[num_factors++].exp = exp + 1; /* really factoring A*f(i) */
-#if QS_DEBUG & 128
-            if (exp)
-               flint_printf("%ld^%ld ", prime, exp);
-#endif
-
          }
-      }
+    }
+    else
+    {
+         for (j = qs_inf->small_primes; j < num_primes && extra_bits < sieve[i]; j++)
+         {
+            prime = factor_base[j].p;
+            pinv = factor_base[j].pinv;
+            modp = n_mod2_preinv(i, prime, pinv);
+
+            if (soln2[j] != 0) /* not a prime dividing A */
+            {
+               if (modp == soln1[j] || modp == soln2[j])
+               {
+                  fmpz_set_ui(p, prime);
+                  exp = fmpz_remove(res, res, p);
+                  extra_bits += qs_inf->factor_base[j].size;
+                  factor[num_factors].ind = j;
+                  factor[num_factors++].exp = exp;
+#if QS_DEBUG & 128
+                     flint_printf("%ld^%ld ", prime, exp);
+#endif
+               }
+            } else /* prime dividing A */
+            {
+               fmpz_set_ui(p, prime);
+               exp = fmpz_remove(res, res, p);
+               factor[num_factors].ind = j;
+               factor[num_factors++].exp = exp + 1; /* really factoring A*f(i) */
+#if QS_DEBUG & 128
+               if (exp)
+                  flint_printf("%ld^%ld ", prime, exp);
+#endif
+            }
+         }
+    }
 
 #if QS_DEBUG & 128
       if (num_factors > 0)

--- a/src/qsieve/primes_init.c
+++ b/src/qsieve/primes_init.c
@@ -80,6 +80,7 @@ compute_factor_base(ulong * small_factor, qs_t qs_inf, slong num_primes)
         {
             factor_base[fb_prime].p = p;
             factor_base[fb_prime].pinv = pinv;
+            factor_base[fb_prime].pinv2 = UWORD_MAX / p + 1;
             factor_base[fb_prime].size = FLINT_BIT_COUNT(p);
             sqrts[fb_prime] = n_sqrtmod(nmod, p);
             fb_prime++;


### PR DESCRIPTION
The quadratic sieve spends a decent portion of its time in `qsieve_evaluate_candidate` which checks the remainder of the candidate `i` by all factor base primes. There is maybe a better way to implement this function, but a trivial improvement is to replace `n_mod2_preinv` with a Lemire-Kaser-Kurz remainder. This speeds up the quadratic sieve 5-20%.

Time (single-threaded) to factor nextprime(10^n)*nextprime(10^(n+1)) with `fmpz_factor`:

```
         n        old        new   speedup
        10      0.004    0.00402   0.995
        11    0.00131    0.00131   1.000
        12     0.0151     0.0129   1.171
        13     0.0104    0.00886   1.174
        14     0.0107     0.0094   1.138
        15      0.012     0.0105   1.143
        16     0.0192     0.0166   1.157
        17     0.0217     0.0194   1.119
        18     0.0341     0.0283   1.205
        19     0.0317      0.029   1.093
        20      0.046     0.0406   1.133
        21     0.0653     0.0586   1.114
        22     0.0966     0.0879   1.099
        23       0.18      0.161   1.118
        24      0.441      0.383   1.151
        25      0.434      0.402   1.080
        26      0.533      0.456   1.169
        27      0.911      0.795   1.146
        28      1.259      1.112   1.132
        29      2.067      1.927   1.073
        30      2.539      2.269   1.119
        31      7.293      6.666   1.094
        32      7.502      6.671   1.125
        33     14.411     12.894   1.118
        34      23.94     20.594   1.162
        35     41.296      36.51   1.131
```