### PR TITLE
Optimize single-prime output conversion in fft_small nmod_poly multiplication

### DIFF
--- a/src/fft_small.h
+++ b/src/fft_small.h
@@ -372,6 +372,7 @@ typedef struct {
 typedef mpn_ctx_struct mpn_ctx_t[1];
 
 void _convert_block(ulong* Xs, sd_fft_ctx_struct* Rffts, double* d, ulong dstride, ulong np, ulong Iv);
+void _convert_block_1_mod(ulong* Xs, sd_fft_ctx_struct* Rffts, double* d, ulong dstride, ulong I, double p2, double p2inv);
 ulong flint_mpn_nbits(const ulong* a, ulong an);
 int flint_mpn_cmp_ui_2exp(const ulong* a, ulong an, ulong b, ulong e);
 unsigned char flint_mpn_add_inplace_c(ulong* z, ulong zn, ulong* a, ulong an, unsigned char cf);

--- a/src/fft_small/mpn_helpers.c
+++ b/src/fft_small/mpn_helpers.c
@@ -48,6 +48,51 @@ void _convert_block(
     }
 }
 
+/* Same as _convert_block, but only do the first prime, and additionally
+   reduce the results mod {p2, p2inv}. */
+void _convert_block_1_mod(
+    ulong* Xs,
+    sd_fft_ctx_struct* Rffts, double* d, ulong dstride,
+    ulong I,
+    double p2, double p2inv)
+{
+    ulong l = 0;
+    vec4d p = vec4d_set_d(Rffts[l].p);
+    vec4d pinv = vec4d_set_d(Rffts[l].pinv);
+    vec4d vp2 = vec4d_set_d(p2);
+    vec4d vp2inv = vec4d_set_d(p2inv);
+    double* x = sd_fft_ctx_blk_index(d + l*dstride, I);
+    ulong j = 0; do {
+        vec4d x0, x1, x2, x3;
+        vec4n y0, y1, y2, y3;
+        x0 = vec4d_load(x + j + 0*VEC_SZ);
+        x1 = vec4d_load(x + j + 1*VEC_SZ);
+        x2 = vec4d_load(x + j + 2*VEC_SZ);
+        x3 = vec4d_load(x + j + 3*VEC_SZ);
+        /* We first reduce by {p, pinv} and then by {vp2, vp2inv} as the
+           entries before reduction can be negative. An improvement would
+           be to just adjust negative entries in the first reduction,
+           if that could be done more quickly. */
+        x0 = vec4d_reduce_to_0n(x0, p, pinv);
+        x1 = vec4d_reduce_to_0n(x1, p, pinv);
+        x2 = vec4d_reduce_to_0n(x2, p, pinv);
+        x3 = vec4d_reduce_to_0n(x3, p, pinv);
+        x0 = vec4d_reduce_to_0n(x0, vp2, vp2inv);
+        x1 = vec4d_reduce_to_0n(x1, vp2, vp2inv);
+        x2 = vec4d_reduce_to_0n(x2, vp2, vp2inv);
+        x3 = vec4d_reduce_to_0n(x3, vp2, vp2inv);
+        y0 = vec4d_convert_limited_vec4n(x0);
+        y1 = vec4d_convert_limited_vec4n(x1);
+        y2 = vec4d_convert_limited_vec4n(x2);
+        y3 = vec4d_convert_limited_vec4n(x3);
+        vec4n_store_unaligned(Xs + l*BLK_SZ + j + 0*VEC_SZ, y0);
+        vec4n_store_unaligned(Xs + l*BLK_SZ + j + 1*VEC_SZ, y1);
+        vec4n_store_unaligned(Xs + l*BLK_SZ + j + 2*VEC_SZ, y2);
+        vec4n_store_unaligned(Xs + l*BLK_SZ + j + 3*VEC_SZ, y3);
+    } while (j += 4*VEC_SZ, j < BLK_SZ);
+    FLINT_ASSERT(j == BLK_SZ);
+}
+
 ulong flint_mpn_nbits(const ulong* a, ulong an)
 {
     while (an > 0 && a[an-1] == 0)

--- a/src/fft_small/nmod_poly_mul.c
+++ b/src/fft_small/nmod_poly_mul.c
@@ -294,34 +294,44 @@ static void _crt_1(
 {
     ulong i, j, jstart, jstop;
     ulong Xs[BLK_SZ*1];
+    int have_fft_prime;
+    double n = 0.0, ninv = 0.0;
 
-    if (mod.n == Rffts[0].mod.n)
+    /* Reconstructing from a single prime; the modulus is either an FFT
+       prime itself or small enough to be a valid FFT prime. */
+    FLINT_ASSERT(mod.n <= (UWORD(1) << 50));
+
+    /* Todo: generalize _convert_block to allow using the fast path
+       for all FFT primes. */
+    have_fft_prime = (mod.n == Rffts[0].mod.n);
+    if (!have_fft_prime)
     {
-        for (i = n_round_down(zi_start, BLK_SZ); i < zi_stop; i += BLK_SZ)
-        {
-            _convert_block(Xs, Rffts, d, dstride, 1, i/BLK_SZ);
-
-            jstart = (i < zi_start) ? zi_start - i : 0; \
-            jstop = FLINT_MIN(BLK_SZ, zi_stop - i);
-            for (j = jstart; j < jstop; j += 1)
-            {
-                z[i+j-zl] = Xs[j];
-            }
-        }
+        n = mod.n;
+        ninv = 1.0 / n;
     }
-    else
-    {
-        for (i = n_round_down(zi_start, BLK_SZ); i < zi_stop; i += BLK_SZ)
-        {
-            _convert_block(Xs, Rffts, d, dstride, 1, i/BLK_SZ);
 
-            jstart = (i < zi_start) ? zi_start - i : 0; \
-            jstop = FLINT_MIN(BLK_SZ, zi_stop - i);
+    for (i = n_round_down(zi_start, BLK_SZ); i < zi_stop; i += BLK_SZ)
+    {
+        jstart = (i < zi_start) ? zi_start - i : 0; \
+        jstop = FLINT_MIN(BLK_SZ, zi_stop - i);
+
+        /* Can write block directly to output */
+        if (jstart == 0 && jstop == BLK_SZ)
+        {
+            if (have_fft_prime)
+                _convert_block(z + i - zl, Rffts, d, dstride, 1, i/BLK_SZ);
+            else
+                _convert_block_1_mod(z + i - zl, Rffts, d, dstride, i/BLK_SZ, n, ninv);
+        }
+        else /* Write to temporary buffer, then copy truncated part of block */
+        {
+            if (have_fft_prime)
+                _convert_block(Xs, Rffts, d, dstride, 1, i/BLK_SZ);
+            else
+                _convert_block_1_mod(Xs, Rffts, d, dstride, i/BLK_SZ, n, ninv);
 
             for (j = jstart; j < jstop; j += 1)
-            {
-                NMOD_RED(z[i+j-zl], Xs[j], mod);
-            }
+                z[i+j-zl] = Xs[j];
         }
     }
 }


### PR DESCRIPTION
The `fft_small` based `nmod_poly` multiplication did something suboptimal for the output conversion when the modulus $n$ is small enough to use a single FFT prime $p$: it would first normalize each block of 256 `double` coefficients to $[0,p)$ and write it to a temporary `ulong` buffer, then copy the buffer to the output array while reducing it mod $n$ with `NMOD_RED`.

Improvement: do the reduction mod $n$ on SIMD `double` vectors inline with the reduction to $[0,p)$ (we can use the SIMD modular arithmetic because $n$ is guaranteed to be FFT prime-sized or smaller here), and skip the temporary buffer when we can write a whole block directly to the output.

This speeds up polynomial multiplication up to 25%. Timing example for `nmod_poly_mul` with modulus 43:

```
     length        old         new    speedup
        64     5.5e-07    5.49e-07    1.0018
       128    1.17e-06    1.16e-06    1.0086
       256    2.33e-06    2.32e-06    1.0043
       512    6.09e-06     6.1e-06    0.9984
      1024    1.28e-05    1.03e-05    1.2427
      2048    2.62e-05    2.14e-05    1.2243
      4096    5.53e-05    4.58e-05    1.2074
      8192    0.000119    9.95e-05    1.1960
     16384    0.000248    0.000209    1.1866
     32768    0.000509    0.000434    1.1728
     65536     0.00107    0.000911    1.1745
    131072     0.00225     0.00193    1.1658
    262144      0.0049     0.00434    1.1290
    524288      0.0115      0.0107    1.0748
   1048576      0.0265      0.0251    1.0558
   2097152      0.0564      0.0537    1.0503
   4194304       0.123       0.118    1.0424
   8388608       0.247       0.236    1.0466
  16777216       0.519       0.501    1.0359
  33554432       1.085       1.039    1.0443
  67108864       2.438        2.37    1.0287
 134217728       5.409       5.148    1.0507
 268435456      12.076      11.741    1.0285
```