### PR TITLE
Optimize output modular reductions in fft_small nmod_poly_mul

### DIFF
--- a/src/fft_small/nmod_poly_mul.c
+++ b/src/fft_small/nmod_poly_mul.c
@@ -247,6 +247,8 @@ static void CAT(_crt, NP)( \
  \
     ulong Xs[BLK_SZ*NP]; \
  \
+    (void) min_an_bn; \
+ \
     for (ulong i = n_round_down(zi_start, BLK_SZ); i < zi_stop; i += BLK_SZ) \
     { \
         _convert_block(Xs, Rffts, d, dstride, np, i/BLK_SZ); \
@@ -395,19 +397,37 @@ static void _crt_2(
             high_reduced = 1;
     }
 
+#if defined(__SIZEOF_INT128__)
+
     /* The two-limb CRT is slightly faster using __uint128_t than using
        the generic macros. */
     __uint128_t crt_M = ((__uint128_t) crt_data_prod_primes(Rcrts + np - 1)[0]) |
                         (((__uint128_t) crt_data_prod_primes(Rcrts + np - 1)[1]) << 64);
     ulong c0 = _crt_data_co_prime(Rcrts + np - 1, 0, 2)[0];
     ulong c1 = _crt_data_co_prime(Rcrts + np - 1, 1, 2)[0];
-    __uint128_t r;
 
 #define DO_CRT \
-    r = ((__uint128_t) c0) * ((__uint128_t) (Xs[0*BLK_SZ + j])) + \
+    ulong r[2]; \
+    __uint128_t rr; \
+    rr = ((__uint128_t) c0) * ((__uint128_t) (Xs[0*BLK_SZ + j])) + \
          ((__uint128_t) c1) * ((__uint128_t) (Xs[1*BLK_SZ + j])); \
-    if (r >= crt_M) \
-        r -= crt_M; \
+    if (rr >= crt_M) \
+        rr -= crt_M; \
+    r[0] = rr; \
+    r[1] = rr >> 64;
+
+#else
+
+#define DO_CRT \
+    ulong r[2]; \
+    ulong t[2]; \
+    ulong l = 0; \
+    CAT3(_big_mul, 2, 1)(r, t, _crt_data_co_prime(Rcrts + np - 1, l, n), Xs[l*BLK_SZ + j]); \
+    for (l++; l < np; l++) \
+        CAT3(_big_addmul, 2, 1)(r, t, _crt_data_co_prime(Rcrts + np - 1, l, n), Xs[l*BLK_SZ + j]); \
+    CAT(_reduce_big_sum, 2)(r, t, crt_data_prod_primes(Rcrts + np - 1)); \
+
+#endif
 
     for (ulong i = n_round_down(zi_start, BLK_SZ); i < zi_stop; i += BLK_SZ)
     {
@@ -421,8 +441,8 @@ static void _crt_2(
             for (ulong j = jstart; j < jstop; j += 1)
             {
                 DO_CRT
-                FLINT_ASSERT((ulong)(r >> 64) < mod.n);
-                NMOD_RED2_NONFULLWORD(z[i+j-zl], (ulong)(r >> 64), (ulong) r, mod);
+                FLINT_ASSERT(r[1] < mod.n);
+                NMOD_RED2_NONFULLWORD(z[i+j-zl], r[1], r[0], mod);
             }
         }
         else
@@ -430,7 +450,7 @@ static void _crt_2(
             for (ulong j = jstart; j < jstop; j += 1)
             {
                 DO_CRT
-                NMOD2_RED2(z[i+j-zl], (ulong)(r >> 64), (ulong) r, mod);
+                NMOD2_RED2(z[i+j-zl], r[1], r[0], mod);
             }
         }
     }

--- a/src/fft_small/nmod_poly_mul.c
+++ b/src/fft_small/nmod_poly_mul.c
@@ -219,11 +219,12 @@ FLINT_ASSERT(i+j < atrunc);
 }
 
 
+
 #define DEFINE_IT(NP, N, M) \
 static void CAT(_crt, NP)( \
     ulong* z, ulong zl, ulong zi_start, ulong zi_stop, \
     sd_fft_ctx_struct* Rffts, double* d, ulong dstride, \
-    crt_data_struct* Rcrts, \
+    crt_data_struct* Rcrts, ulong min_an_bn,\
     nmod_t mod) \
 { \
     ulong np = NP; \
@@ -281,15 +282,28 @@ static void CAT(_crt, NP)( \
     } \
 }
 
-DEFINE_IT(2, 2, 1)
-DEFINE_IT(3, 3, 2)
+// DEFINE_IT(1, 1, 1) -- special-cased below
+// DEFINE_IT(2, 2, 1) -- special-cased below
+// DEFINE_IT(3, 3, 2) -- special-cased below
 DEFINE_IT(4, 4, 3)
 #undef DEFINE_IT
+
+
+FLINT_FORCE_INLINE
+void mullo_2x1(ulong * r1, ulong * r0, ulong a1, ulong a0, ulong b0)
+{
+    ulong t0, t1;
+    umul_ppmm(t1, t0, a0, b0);
+    t1 += a1 * b0;
+    *r0 = t0;
+    *r1 = t1;
+}
 
 static void _crt_1(
     ulong* z, ulong zl, ulong zi_start, ulong zi_stop,
     sd_fft_ctx_struct* Rffts, double* d, ulong dstride,
     crt_data_struct* FLINT_UNUSED(Rcrts),
+    ulong FLINT_UNUSED(min_an_bn),
     nmod_t mod)
 {
     ulong i, j, jstart, jstop;
@@ -335,6 +349,284 @@ static void _crt_1(
         }
     }
 }
+
+static void _crt_2(
+    ulong* z, ulong zl, ulong zi_start, ulong zi_stop,
+    sd_fft_ctx_struct* Rffts, double* d, ulong dstride,
+    crt_data_struct* Rcrts, ulong min_an_bn,
+    nmod_t mod)
+{
+    ulong np = 2;
+    ulong n = 2;
+    ulong m = 1;
+
+    FLINT_ASSERT(n == Rcrts[np-1].coeff_len);
+
+    if (n == m + 1)
+    {
+        for (ulong l = 0; l < np; l++) {
+            FLINT_ASSERT(crt_data_co_prime(Rcrts + np - 1, l)[m] == 0);
+        }
+    }
+    else
+    {
+        FLINT_ASSERT(n == m);
+    }
+
+    ulong Xs[BLK_SZ*2];
+
+    /* If the output fits in 100 bits then certainly the modulus
+       should have <= 63 bits. */
+    FLINT_ASSERT(mod.n < (UWORD(1) << (FLINT_BITS - 1)));
+
+    /* The output coefficients are bounded by min(an,bn) * (n-1)^2. If
+       the high words are smaller than n (i.e. already reduced mod n), we
+       can use NMOD_RED2 (or NMOD_RED2_NONFULLWORD), otherwise NMOD2_RED2.
+       We could do something faster than NMOD2_RED2, but in practice the bound
+       is rarely exceeded (we need products longer than 10^10 or so), so just
+       keep it simple and fall back on NMOD2_RED2 when that occurs. */
+    int high_reduced = 0;
+
+    {
+        ulong hi, lo;
+        umul_ppmm(hi, lo, mod.n - 1, mod.n - 1);
+        mullo_2x1(&hi, &lo, hi, lo, min_an_bn);
+        if (hi < mod.n)
+            high_reduced = 1;
+    }
+
+    /* The two-limb CRT is slightly faster using __uint128_t than using
+       the generic macros. */
+    __uint128_t crt_M = ((__uint128_t) crt_data_prod_primes(Rcrts + np - 1)[0]) |
+                        (((__uint128_t) crt_data_prod_primes(Rcrts + np - 1)[1]) << 64);
+    ulong c0 = _crt_data_co_prime(Rcrts + np - 1, 0, 2)[0];
+    ulong c1 = _crt_data_co_prime(Rcrts + np - 1, 1, 2)[0];
+    __uint128_t r;
+
+#define DO_CRT \
+    r = ((__uint128_t) c0) * ((__uint128_t) (Xs[0*BLK_SZ + j])) + \
+         ((__uint128_t) c1) * ((__uint128_t) (Xs[1*BLK_SZ + j])); \
+    if (r >= crt_M) \
+        r -= crt_M; \
+
+    for (ulong i = n_round_down(zi_start, BLK_SZ); i < zi_stop; i += BLK_SZ)
+    {
+        _convert_block(Xs, Rffts, d, dstride, np, i/BLK_SZ);
+
+        ulong jstart = (i < zi_start) ? zi_start - i : 0;
+        ulong jstop = FLINT_MIN(BLK_SZ, zi_stop - i);
+
+        if (high_reduced)
+        {
+            for (ulong j = jstart; j < jstop; j += 1)
+            {
+                DO_CRT
+                FLINT_ASSERT((ulong)(r >> 64) < mod.n);
+                NMOD_RED2_NONFULLWORD(z[i+j-zl], (ulong)(r >> 64), (ulong) r, mod);
+            }
+        }
+        else
+        {
+            for (ulong j = jstart; j < jstop; j += 1)
+            {
+                DO_CRT
+                NMOD2_RED2(z[i+j-zl], (ulong)(r >> 64), (ulong) r, mod);
+            }
+        }
+    }
+#undef DO_CRT
+}
+
+/* Ad hoc modular reduction to do better than NMOD2_RED2 and NMOD_RED3.
+   This should eventually be moved out and used elsewhere. */
+
+/* Precompute floor(2^(2*FLINT_BITS) / n) for Shoup-style modular reduction.
+   This could be optimized (not necessary here, but relevant for other
+   applications). */
+static void
+n_ll_rem_l_precomp(ulong * qhi, ulong * qlo, ulong n)
+{
+    ulong q[4];
+    ulong a[4];
+    a[0] = 0;
+    a[1] = 0;
+    a[2] = 1;
+    mpn_divrem_1(q, 0, a, 3, n);
+    *qlo = q[0];
+    *qhi = q[1];
+}
+
+/* 2 -> 1 limb mod, n < 2^(FLINT_BITS-1), using linear combination + Shoup */
+FLINT_FORCE_INLINE ulong
+n_ll_rem_l_nonfullword(ulong xhi, ulong xlo, ulong n, ulong qhi, ulong qlo)
+{
+    ulong c2, c1, c0;
+    FLINT_MPN_MUL_3P2X2(c2, c1, c0, qhi, qlo, xhi, xlo);
+    (void) c1;
+    (void) c0;
+    xlo -= c2 * n;
+    if (xlo >= n)
+        xlo -= n;
+    return xlo;
+}
+
+/* 3 -> 1 limb mod, n < 2^(FLINT_BITS-1), using linear combination + Shoup */
+FLINT_FORCE_INLINE ulong
+n_lll_rem_l_nonfullword(ulong y2, ulong y1, ulong y0, ulong n, ulong qhi, ulong qlo, ulong alpha2, ulong alpha1)
+{
+    ulong c2, c1, c0, t1, t0;
+    ulong xhi, xlo;
+
+    umul_ppmm(t1, t0, y2, alpha2);
+    umul_ppmm(c1, c0, y1, alpha1);
+    add_ssaaaa(xhi, xlo, t1, t0, c1, c0);
+    add_ssaaaa(xhi, xlo, xhi, xlo, 0, y0);
+
+    FLINT_MPN_MUL_3P2X2(c2, c1, c0, qhi, qlo, xhi, xlo);
+    (void) c1;
+    (void) c0;
+    xlo -= c2 * n;
+    if (xlo >= n)
+        xlo -= n;
+
+    return xlo;
+}
+
+/* 3 -> 1 limb mod, n >= 2^(FLINT_BITS-1), using linear combination + Granlund-Möller */
+FLINT_FORCE_INLINE ulong
+n_lll_rem_l_fullword(ulong y2, ulong y1, ulong y0, nmod_t mod, ulong alpha2, ulong alpha1)
+{
+    ulong c1, c0, t1, t0;
+    ulong xhi, xlo;
+    ulong hi, lo;
+
+    umul_ppmm(t1, t0, y2, alpha2);
+    umul_ppmm(c1, c0, y1, alpha1);
+    add_ssaaaa(xhi, xlo, t1, t0, c1, c0);
+    add_ssaaaa(xhi, xlo, xhi, xlo, 0, y0);
+
+    umul_ppmm(hi, lo, xhi, alpha1);
+    add_ssaaaa(hi, lo, hi, lo, 0, xlo);
+    NMOD_RED2_FULLWORD(xlo, hi, lo, mod);
+
+    return xlo;
+}
+
+static void _crt_3(
+    ulong* z, ulong zl, ulong zi_start, ulong zi_stop,
+    sd_fft_ctx_struct* Rffts, double* d, ulong dstride,
+    crt_data_struct* Rcrts, ulong min_an_bn,
+    nmod_t mod)
+{
+    ulong np = 3;
+    ulong n = 3;
+
+#if FLINT_WANT_ASSERT
+    ulong m = 2;
+    FLINT_ASSERT(n == Rcrts[np-1].coeff_len);
+    for (ulong l = 0; l < np; l++)
+        FLINT_ASSERT(crt_data_co_prime(Rcrts + np - 1, l)[m] == 0);
+#endif
+
+    ulong Xs[BLK_SZ*3];
+
+    ulong qhi = 0, qlo = 0;
+    ulong alpha1 = 0, alpha2 = 0;
+    ulong hi, lo, u2, u1, u0;
+
+    /* Coefficients before modular reduction can have 2 or 3 limbs. */
+    int two_limbs = 0;
+    /* High word of 2-limb input is reduced */
+    int high_reduced = 0;
+    /* Modulus has MSB set. */
+    int mod_fullword = (mod.norm == 0);
+
+    /* Bound coefficients before modular reduction. */
+    umul_ppmm(hi, lo, mod.n - 1, mod.n - 1);
+    FLINT_MPN_MUL_2X1(u2, u1, u0, hi, lo, min_an_bn);
+    two_limbs = (u2 == 0);
+
+    /* Branch 1 and 2 of mod code */
+    if (two_limbs && !mod_fullword)
+    {
+        high_reduced = (u1 < mod.n);
+
+        /* Extra precomputation for branch 2 */
+        if (!high_reduced)
+            n_ll_rem_l_precomp(&qhi, &qlo, mod.n);
+    }
+    else
+    {
+        /* Extra precomputation for branch 3 and 4 of mod code */
+        alpha1 = nmod_set_ui(UWORD(1) << (FLINT_BITS / 2), mod);
+        alpha1 = nmod_mul(alpha1, alpha1, mod);
+        alpha2 = nmod_mul(alpha1, alpha1, mod);
+
+        /* Extra precomputation for branch 3 */
+        if (!mod_fullword)
+            n_ll_rem_l_precomp(&qhi, &qlo, mod.n);
+    }
+
+#define DO_CRT \
+    ulong r[3]; \
+    ulong t[3]; \
+    ulong l = 0; \
+    CAT3(_big_mul, 3, 2)(r, t, _crt_data_co_prime(Rcrts + np - 1, l, n), Xs[l*BLK_SZ + j]); \
+    for (l++; l < np; l++) \
+        CAT3(_big_addmul, 3, 2)(r, t, _crt_data_co_prime(Rcrts + np - 1, l, n), Xs[l*BLK_SZ + j]); \
+    CAT(_reduce_big_sum, 3)(r, t, crt_data_prod_primes(Rcrts + np - 1));
+
+    for (ulong i = n_round_down(zi_start, BLK_SZ); i < zi_stop; i += BLK_SZ)
+    {
+        _convert_block(Xs, Rffts, d, dstride, np, i/BLK_SZ);
+
+        ulong jstart = (i < zi_start) ? zi_start - i : 0;
+        ulong jstop = FLINT_MIN(BLK_SZ, zi_stop - i);
+
+        if (two_limbs && !mod_fullword)
+        {
+            if (high_reduced)
+            {
+                for (ulong j = jstart; j < jstop; j += 1)
+                {
+                    DO_CRT
+                    FLINT_ASSERT(r[2] == 0);
+                    NMOD_RED2_NONFULLWORD(z[i+j-zl], r[1], r[0], mod);
+                }
+            }
+            else
+            {
+                for (ulong j = jstart; j < jstop; j += 1)
+                {
+                    DO_CRT
+                    FLINT_ASSERT(r[2] == 0);
+                    z[i+j-zl] = n_ll_rem_l_nonfullword(r[1], r[0], mod.n, qhi, qlo);
+                }
+            }
+        }
+        else
+        {
+            if (!mod_fullword)
+            {
+                for (ulong j = jstart; j < jstop; j += 1)
+                {
+                    DO_CRT
+                    z[i+j-zl] = n_lll_rem_l_nonfullword(r[2], r[1], r[0], mod.n, qhi, qlo, alpha2, alpha1);
+                }
+            }
+            else
+            {
+                for (ulong j = jstart; j < jstop; j += 1)
+                {
+                    DO_CRT
+                    z[i+j-zl] = n_lll_rem_l_fullword(r[2], r[1], r[0], mod, alpha2, alpha1);
+                }
+            }
+        }
+    }
+#undef DO_CRT
+}
+
 
 typedef struct {
     ulong np;
@@ -435,10 +727,11 @@ typedef struct {
     sd_fft_ctx_struct* ffts;
     crt_data_struct* crts;
     nmod_t mod;
+    ulong min_an_bn;  /* for precise output bounds */
     void (*f)(
         ulong* z, ulong zl, ulong zi_start, ulong zi_stop,
         sd_fft_ctx_struct* Rffts, double* d, ulong dstride,
-        crt_data_struct* Rcrts,
+        crt_data_struct* Rcrts, ulong min_an_bn,
         nmod_t mod);
 } s2worker_struct;
 
@@ -447,7 +740,7 @@ static void s2worker_func(void* varg)
     s2worker_struct* X = (s2worker_struct*) varg;
 
     X->f(X->z, X->zl, X->start_zi, X->stop_zi, X->ffts + X->offset, X->buf,
-         X->stride, X->crts + X->offset, X->mod);
+         X->stride, X->crts + X->offset, X->min_an_bn, X->mod);
 }
 
 void _nmod_poly_mul_mid_mpn_ctx(
@@ -608,6 +901,7 @@ got_np_and_offset:
         X->ffts = R->ffts;
         X->crts = R->crts;
         X->mod = mod;
+        X->min_an_bn = FLINT_MIN(an, bn);
         X->f = np == 1 ? _crt_1 : np == 2 ? _crt_2 : np == 3 ? _crt_3 : _crt_4;
     }
 
@@ -669,7 +963,7 @@ static void _nmod_poly_mul_mod_xpnm1(
     FLINT_ASSERT(bn > 0);
     FLINT_ASSERT(ztrunc <= N);
 
-    /* first see if mod.n is on of R->ffts[i].mod.n */
+    /* first see if mod.n is one of R->ffts[i].mod.n */
 
     if (modbits == 50)
     {
@@ -766,6 +1060,7 @@ got_np_and_offset:
         X->ffts = R->ffts;
         X->crts = R->crts;
         X->mod = mod;
+        X->min_an_bn = FLINT_MIN(an, bn);
         X->f = np == 1 ? _crt_1 : np == 2 ? _crt_2 : np == 3 ? _crt_3 : _crt_4;
     }
 
@@ -1000,6 +1295,7 @@ int _nmod_poly_mul_mid_precomp(
         X->ffts = R->ffts;
         X->crts = R->crts;
         X->mod = mod;
+        X->min_an_bn = FLINT_MIN(an, bn);
         X->f = np == 1 ? _crt_1 : np == 2 ? _crt_2 : np == 3 ? _crt_3 : _crt_4;
     }
 
@@ -1085,6 +1381,8 @@ static void _nmod_poly_mul_mod_xpnm1_precomp(
         X->ffts = R->ffts;
         X->crts = R->crts;
         X->mod = mod;
+        X->min_an_bn = an;  /* Todo: we might want to store bn and min by this here,
+                               in case this is much smaller than an. */
         X->f = np == 1 ? _crt_1 : np == 2 ? _crt_2 : np == 3 ? _crt_3 : _crt_4;
     }
 


### PR DESCRIPTION
Optimize the final output reductions mod $n$ in the `fft_small` based `nmod_poly` multiplication when there are 2 or 3 CRT primes (i.e. coefficients in the product over $\mathbb{Z}$ have between 50 and 150 bits). Followup to #2634 which did the single prime case. The 4 CRT prime case could be done too, but this only affects multiplications so large that one gets only about a 2% speedup, which I'm not going to bother with here.

In essence, we replace use of the slow macros `NMOD2_RED2` and `NMOD_RED3` with the faster algorithms discussed in #2597. I'm doing this ad hoc in `fft_small` for now to test things before rolling this out to other `nmod` modules. The main complication is that one needs different precomputations with some case distinctions.

In the 2 CRT prime case, we get 3% additional speedup using `__uint128_t` for the CRT step instead of the generic macros. (Ideally we'd do the CRT and modular reduction directly in the SIMD representation, but that looks very tricky to implement.)

Speedup ratios for `nmod_poly_mul`:

```
                            bits in modulus
     length     16      24      32      40      48      56      64
        64   0.992   1.001   1.000   1.000   0.995   1.000   0.993  
       128   1.000   1.004   0.997   1.186   1.002   0.998   1.044  
       256   1.004   1.002   1.177   1.185   1.116   1.119   1.055  
       512   1.000   1.179   1.187   1.179   1.121   1.112   1.048  
      1024   0.991   1.173   1.161   1.161   1.112   1.112   1.045  
      2048   1.004   1.164   1.162   1.160   1.106   1.107   1.043  
      4096   1.000   1.153   1.153   1.153   1.108   1.094   1.044  
      8192   1.009   1.143   1.138   1.139   1.092   1.065   1.024  
     16384   1.000   1.137   1.135   1.131   1.071   1.058   1.026  
     32768   1.000   1.128   1.139   1.128   1.074   1.057   1.020  
     65536   1.010   1.127   1.122   1.122   1.061   1.052   1.021  
    131072   1.000   1.119   1.120   1.119   1.057   1.048   1.025  
    262144   1.111   1.111   1.120   1.110   1.048   1.026   1.026  
    524288   1.101   1.097   1.097   1.096   1.038   1.024   1.019  
   1048576   1.087   1.089   1.089   1.043   1.036   1.020   1.018  
   2097152   1.094   1.094   1.085   1.041   1.036   1.020   1.015  
   4194304   1.083   1.079   1.083   1.036   1.029   1.012   1.005  
   8388608   1.080   1.061   1.086   1.036   1.040   1.020   1.008  
  16777216   1.073   1.077   1.071   1.043   1.030   1.004   1.012  
  33554432   1.072   1.066   1.066   1.038   1.025   1.012   1.004  
```

Speedup when squaring (slightly higher, as relatively more time is spent on output reconstruction):

```
                            bits in modulus
     length     16      24      32      40      48      56      64
        64   0.998   0.999   1.000   1.000   1.006   1.000   1.000  
       128   1.000   1.000   1.000   0.997   1.000   1.000   1.000  
       256   0.994   1.000   1.256   1.258   1.161   1.158   1.062  
       512   0.994   1.000   1.244   1.242   1.146   1.150   1.063  
      1024   1.001   1.242   1.232   1.226   1.143   1.145   1.057  
      2048   1.000   1.227   1.222   1.224   1.137   1.140   1.056  
      4096   1.000   1.220   1.198   1.209   1.161   1.104   1.045  
      8192   0.997   1.209   1.198   1.198   1.130   1.083   1.034  
     16384   1.000   1.199   1.194   1.194   1.096   1.075   1.032  
     32768   1.000   1.191   1.187   1.186   1.098   1.068   1.039  
     65536   1.002   1.190   1.184   1.184   1.084   1.072   1.028  
    131072   1.000   1.182   1.173   1.169   1.081   1.071   1.029  
    262144   1.165   1.168   1.164   1.158   1.067   1.029   1.035  
    524288   1.152   1.145   1.139   1.144   1.054   1.033   1.023  
   1048576   1.137   1.130   1.134   1.062   1.053   1.029   1.026  
   2097152   1.125   1.123   1.120   1.058   1.051   1.028   1.014  
   4194304   1.110   1.103   1.109   1.051   1.051   1.013   1.002  
   8388608   1.116   1.112   1.113   1.053   1.044   1.018   1.004  
  16777216   1.109   1.101   1.104   1.049   1.044   1.017   1.002  
  33554432   1.100   1.098   1.100   1.046   1.041   1.016   1.001  
```

In summary,

* Up to a 19% speedup for small (e.g. 30 bit) moduli (26% when squaring), diminishing with longer products.
* Up to a 12% speedup for near-wordsize moduli (16% when squaring).
* Up to a 6% speedup for 64-bit moduli.