### PR TITLE
Miscellaneous `nmod` optimizations and helper functions

### DIFF
--- a/doc/source/ulong_extras.rst
+++ b/doc/source/ulong_extras.rst
@@ -139,6 +139,11 @@ Basic arithmetic
 --------------------------------------------------------------------------------
 
 
+.. function:: ulong n_mulhi(ulong a, ulong b)
+
+    Returns the high word of the product of ``a`` and ``b``, i.e.
+    returns `\lfloor ab / 2^{\mathtt{FLINT\_BITS}} \rfloor`.
+
 .. function:: ulong n_pow(ulong n, ulong exp)
 
     Returns ``n^exp``. No checking is done for overflow. The exponent
@@ -410,6 +415,31 @@ Basic arithmetic with precomputed inverses
 
     The algorithm used is that of Granlund and Möller [GraMol2010]_.
 
+.. function:: ulong n_barrett_precomp(ulong n)
+
+    Given `n \ge 2`, return a precomputed inverse for Barrett division.
+
+.. function:: ulong n_mod_barrett_sloppy(ulong x, ulong n, ulong npre)
+              ulong n_mod_barrett(ulong x, ulong n, ulong npre)
+
+    Returns `x \bmod n` given the precomputed inverse ``npre`` returned
+    by :func:`n_barrett_precomp`. The ``sloppy`` function returns a
+    noncanonical residue in the interval `[0, 2n)`; the other version
+    returns the canonical residue in `[0, n)`. There are no restrictions
+    on `x`.
+
+    Note: these functions support `n = 1` if one sets ``npre`` to ``UWORD_MAX``.
+
+.. function:: ulong n_lemire_precomp(ulong n)
+
+    Given `n \ge 1`, returns a precomputed inverse for Lemire, Kaser & Kurz
+    remainder.
+
+.. function:: ulong n_mod_lemire(ulong x, ulong n, ulong npre)
+
+    Returns `x \bmod n` given the precomputed inverse ``npre`` returned
+    by :func:`n_lemire_precomp`. This function is only guaranteed to be
+    correct if `n, x < 2^{\mathtt{FLINT\_BITS} / 2}`.
 
 
 Greatest common divisor

--- a/doc/source/ulong_extras.rst
+++ b/doc/source/ulong_extras.rst
@@ -419,11 +419,11 @@ Basic arithmetic with precomputed inverses
 
     Given `n \ge 2`, return a precomputed inverse for Barrett division.
 
-.. function:: ulong n_mod_barrett_sloppy(ulong x, ulong n, ulong npre)
+.. function:: ulong n_mod_barrett_lazy(ulong x, ulong n, ulong npre)
               ulong n_mod_barrett(ulong x, ulong n, ulong npre)
 
     Returns `x \bmod n` given the precomputed inverse ``npre`` returned
-    by :func:`n_barrett_precomp`. The ``sloppy`` function returns a
+    by :func:`n_barrett_precomp`. The ``lazy`` function returns a
     noncanonical residue in the interval `[0, 2n)`; the other version
     returns the canonical residue in `[0, n)`. There are no restrictions
     on `x`.

--- a/src/fft_small/nmod_poly_mul.c
+++ b/src/fft_small/nmod_poly_mul.c
@@ -497,7 +497,7 @@ n_lll_rem_l_nonfullword(ulong y2, ulong y1, ulong y0, ulong n, ulong qhi, ulong 
     ulong c2, c1, c0, t1, t0;
     ulong xhi, xlo;
 
-    FLINT_ASSERT(mod.n < (UWORD(1) << (FLINT_BITS - 1)));
+    FLINT_ASSERT(n < (UWORD(1) << (FLINT_BITS - 1)));
 
     umul_ppmm(t1, t0, y2, alpha2);
     umul_ppmm(c1, c0, y1, alpha1);

--- a/src/fft_small/nmod_poly_mul.c
+++ b/src/fft_small/nmod_poly_mul.c
@@ -460,7 +460,7 @@ static void _crt_2(
 /* Ad hoc modular reduction to do better than NMOD2_RED2 and NMOD_RED3.
    This should eventually be moved out and used elsewhere. */
 
-/* Precompute floor(2^(2*FLINT_BITS) / n) for Shoup-style modular reduction.
+/* Precompute floor(2^(2*FLINT_BITS) / n) for Barrett-style modular reduction.
    This could be optimized (not necessary here, but relevant for other
    applications). */
 static void
@@ -476,7 +476,7 @@ n_ll_rem_l_precomp(ulong * qhi, ulong * qlo, ulong n)
     *qhi = q[1];
 }
 
-/* 2 -> 1 limb mod, n < 2^(FLINT_BITS-1), using linear combination + Shoup */
+/* 2 -> 1 limb mod, n < 2^(FLINT_BITS-1), using linear combination + Barrett */
 FLINT_FORCE_INLINE ulong
 n_ll_rem_l_nonfullword(ulong xhi, ulong xlo, ulong n, ulong qhi, ulong qlo)
 {
@@ -490,12 +490,14 @@ n_ll_rem_l_nonfullword(ulong xhi, ulong xlo, ulong n, ulong qhi, ulong qlo)
     return xlo;
 }
 
-/* 3 -> 1 limb mod, n < 2^(FLINT_BITS-1), using linear combination + Shoup */
+/* 3 -> 1 limb mod, n < 2^(FLINT_BITS-1), using linear combination + Barrett */
 FLINT_FORCE_INLINE ulong
 n_lll_rem_l_nonfullword(ulong y2, ulong y1, ulong y0, ulong n, ulong qhi, ulong qlo, ulong alpha2, ulong alpha1)
 {
     ulong c2, c1, c0, t1, t0;
     ulong xhi, xlo;
+
+    FLINT_ASSERT(mod.n < (UWORD(1) << (FLINT_BITS - 1)));
 
     umul_ppmm(t1, t0, y2, alpha2);
     umul_ppmm(c1, c0, y1, alpha1);
@@ -518,16 +520,37 @@ n_lll_rem_l_fullword(ulong y2, ulong y1, ulong y0, nmod_t mod, ulong alpha2, ulo
 {
     ulong c1, c0, t1, t0;
     ulong xhi, xlo;
-    ulong hi, lo;
+
+    FLINT_ASSERT(mod.n >= (UWORD(1) << (FLINT_BITS - 1)));
 
     umul_ppmm(t1, t0, y2, alpha2);
     umul_ppmm(c1, c0, y1, alpha1);
     add_ssaaaa(xhi, xlo, t1, t0, c1, c0);
     add_ssaaaa(xhi, xlo, xhi, xlo, 0, y0);
 
-    umul_ppmm(hi, lo, xhi, alpha1);
-    add_ssaaaa(hi, lo, hi, lo, 0, xlo);
-    NMOD_RED2_FULLWORD(xlo, hi, lo, mod);
+    if (xhi >= mod.n) xhi -= mod.n;
+    NMOD_RED2_FULLWORD(xlo, xhi, xlo, mod);
+
+    return xlo;
+}
+
+/* For moduli just larger than 2^63, the conditional subtraction can be shown
+   to be redundant. */
+FLINT_FORCE_INLINE ulong
+n_lll_rem_l_fullword_limited(ulong y2, ulong y1, ulong y0, nmod_t mod, ulong alpha2, ulong alpha1)
+{
+    ulong c1, c0, t1, t0;
+    ulong xhi, xlo;
+
+    FLINT_ASSERT(mod.n >= (UWORD(1) << (FLINT_BITS - 1)));
+    FLINT_ASSERT(mod.n < (UWORD(1) << (FLINT_BITS - 1)) + (UWORD(1) << (FLINT_BITS / 2 - 2)));
+
+    umul_ppmm(t1, t0, y2, alpha2);
+    umul_ppmm(c1, c0, y1, alpha1);
+    add_ssaaaa(xhi, xlo, t1, t0, c1, c0);
+    add_ssaaaa(xhi, xlo, xhi, xlo, 0, y0);
+
+    NMOD_RED2_FULLWORD(xlo, xhi, xlo, mod);
 
     return xlo;
 }
@@ -566,6 +589,10 @@ static void _crt_3(
     FLINT_MPN_MUL_2X1(u2, u1, u0, hi, lo, min_an_bn);
     two_limbs = (u2 == 0);
 
+    /* For moduli close to 2^63, we can avoid the high word reduction
+       before NMOD_RED2. */
+    int fullword_limited = 0;
+
     /* Branch 1 and 2 of mod code */
     if (two_limbs && !mod_fullword)
     {
@@ -585,6 +612,9 @@ static void _crt_3(
         /* Extra precomputation for branch 3 */
         if (!mod_fullword)
             n_ll_rem_l_precomp(&qhi, &qlo, mod.n);
+
+        if (mod_fullword && (mod.n < ((UWORD(1) << 63) + (UWORD(1) << 30))))
+            fullword_limited = 1;
     }
 
 #define DO_CRT \
@@ -632,6 +662,14 @@ static void _crt_3(
                 {
                     DO_CRT
                     z[i+j-zl] = n_lll_rem_l_nonfullword(r[2], r[1], r[0], mod.n, qhi, qlo, alpha2, alpha1);
+                }
+            }
+            else if (fullword_limited)
+            {
+                for (ulong j = jstart; j < jstop; j += 1)
+                {
+                    DO_CRT
+                    z[i+j-zl] = n_lll_rem_l_fullword_limited(r[2], r[1], r[0], mod, alpha2, alpha1);
                 }
             }
             else

--- a/src/fmpz_vec/scalar_divexact.c
+++ b/src/fmpz_vec/scalar_divexact.c
@@ -27,14 +27,6 @@
 #define DIVEXACT_1_EVEN_GMP_CUTOFF 25
 
 FLINT_FORCE_INLINE
-ulong n_mulhi(ulong a, ulong b)
-{
-    ulong h, l;
-    umul_ppmm(h, l, a, b);
-    return h;
-}
-
-FLINT_FORCE_INLINE
 ulong n_subc(ulong * c, ulong a, ulong b)
 {
     ulong d = a - b;

--- a/src/fq_nmod/ctx_init_modulus.c
+++ b/src/fq_nmod/ctx_init_modulus.c
@@ -49,12 +49,14 @@ fq_nmod_ctx_init_modulus(fq_nmod_ctx_t ctx, const nmod_poly_t modulus, const cha
     {
         if (modulus->coeffs[i] != 0)
         {
-            ctx->a[j] = n_mulmod2_preinv(inv, modulus->coeffs[i],
-                                         ctx->mod.n, ctx->mod.ninv);
+            ctx->a[j] = modulus->coeffs[i];
             ctx->j[j] = i;
             j++;
         }
     }
+
+    if (inv != 1)
+        _nmod_vec_scalar_mul_nmod(ctx->a, ctx->a, ctx->len, inv, ctx->mod);
 
     if (ctx->len < 6)
         ctx->sparse_modulus = 1;

--- a/src/fq_nmod/reduce.c
+++ b/src/fq_nmod/reduce.c
@@ -14,47 +14,98 @@
 #include "nmod_poly.h"
 #include "fq_nmod.h"
 
+/* Todo: merge code with _nmod_poly_divrem_try_sparse */
+
 void _fq_nmod_sparse_reduce(ulong *R, slong lenR, const fq_nmod_ctx_t ctx)
 {
     slong i, k;
+    ulong c, cbound;
     const slong d = ctx->j[ctx->len - 1];
+    nmod_t mod = ctx->mod;
+
+    cbound = 0;
+    for (i = 0; i < ctx->len - 1; i++)
+        cbound |= ctx->a[i];
 
     NMOD_VEC_NORM(R, lenR);
 
-    for (i = lenR - 1; i >= d; i--)
+    if (ctx->mod.n == 2)
     {
-        for (k = ctx->len - 2; k >= 0; k--)
+        for (i = lenR - 1; i >= d; i--)
         {
-            /* TODO clean this mess up */
-            R[ctx->j[k] + i - d] = n_submod(R[ctx->j[k] + i - d],
-                                            n_mulmod2_preinv(R[i], ctx->a[k], ctx->mod.n, ctx->mod.ninv),
-                                            ctx->mod.n);
+            c = R[i];
+
+            for (k = ctx->len - 2; k >= 0; k--)
+            {
+                R[ctx->j[k] + i - d] ^= c;
+            }
+            R[i] = 0;
         }
-        R[i] = UWORD(0);
+    }
+    else if (cbound == 1)
+    {
+        for (i = lenR - 1; i >= d; i--)
+        {
+            c = R[i];
+
+            for (k = ctx->len - 2; k >= 0; k--)
+            {
+                R[ctx->j[k] + i - d] = nmod_sub(R[ctx->j[k] + i - d], c, mod);
+            }
+            R[i] = 0;
+        }
+    }
+    else if (lenR > d + 2 && NMOD_BITS(mod) < FLINT_BITS / 2)
+    {
+        ulong ninv = n_barrett_precomp(mod.n);
+
+        for (i = lenR - 1; i >= d; i--)
+        {
+            for (k = ctx->len - 2; k >= 0; k--)
+            {
+                R[ctx->j[k] + i - d] = n_mod_barrett(R[ctx->j[k] + i - d]
+                    + R[i] * (mod.n - ctx->a[k]), mod.n, ninv);
+            }
+            R[i] = 0;
+        }
+    }
+    else
+    {
+        for (i = lenR - 1; i >= d; i--)
+        {
+            for (k = ctx->len - 2; k >= 0; k--)
+            {
+                R[ctx->j[k] + i - d] = nmod_addmul(R[ctx->j[k] + i - d], R[i], mod.n - ctx->a[k], ctx->mod);
+            }
+            R[i] = 0;
+        }
     }
 }
 
 void _fq_nmod_dense_reduce(ulong* R, slong lenR, const fq_nmod_ctx_t ctx)
 {
     ulong  *q, *r;
+    slong lenq, lenr;
 
     if (lenR < ctx->modulus->length)
-    {
-        _nmod_vec_reduce(R, R, lenR, ctx->mod);
         return;
-    }
 
-    q = _nmod_vec_init(lenR - ctx->modulus->length + 1);
-    r = _nmod_vec_init(ctx->modulus->length - 1);
+    TMP_INIT;
+    TMP_START;
+
+    lenq = (lenR - ctx->modulus->length + 1);
+    lenr = ctx->modulus->length - 1;
+    q = TMP_ALLOC((lenq + lenr) * sizeof(ulong));
+    r = q + lenq;
 
     _nmod_poly_divrem_newton_n_preinv(q, r, R, lenR,
                                       ctx->modulus->coeffs, ctx->modulus->length,
                                       ctx->inv->coeffs, ctx->inv->length,
                                       ctx->mod);
 
-    _nmod_vec_set(R, r, ctx->modulus->length - 1);
-    _nmod_vec_clear(q);
-    _nmod_vec_clear(r);
+    _nmod_vec_set(R, r, lenr);
+
+    TMP_END;
 
 }
 
@@ -73,3 +124,4 @@ void fq_nmod_reduce(fq_nmod_t rop, const fq_nmod_ctx_t ctx)
     rop->length = FLINT_MIN(rop->length, ctx->modulus->length - 1);
     _nmod_poly_normalise(rop);
 }
+

--- a/src/nmod.h
+++ b/src/nmod.h
@@ -318,18 +318,6 @@ NMOD_INLINE ull_t ull(ulong hi, ulong lo) { ull_t t; t.lo = lo; t.hi = hi; retur
 
 #endif
 
-FLINT_FORCE_INLINE ulong n_mulhi(ulong a, ulong b)
-{
-    return ull_hi(ull_u_mul_u(a, b));
-}
-
-FLINT_FORCE_INLINE void n_mul2(ulong * hi, ulong * lo, ulong a, ulong b)
-{
-    ull_t t = ull_u_mul_u(a, b);
-    *hi = ull_hi(t);
-    *lo = ull_lo(t);
-}
-
 /* Assumes a already reduced mod n. */
 FLINT_FORCE_INLINE ulong
 n_to_redc_preinv(ulong a, ulong n, ulong ninv, ulong norm)

--- a/src/nmod_poly/divrem_basecase.c
+++ b/src/nmod_poly/divrem_basecase.c
@@ -178,7 +178,7 @@ void _nmod_poly_divrem_q1_preinv1(nn_ptr Q, nn_ptr R,
 
         R[0] = n_mod_barrett(A[0] + q0 * B[0], n, ninv);
 
-        /* In the second branch, the sloppy mod maps
+        /* In the second branch, the lazy mod maps
                [0, ..., (n-1) + (n-1)^2] -> [0, 2n-1]
            and the _mod2 maps
                 [0, 2n-1 + (n-1)^2] -> [0,n-1]. */
@@ -188,7 +188,7 @@ void _nmod_poly_divrem_q1_preinv1(nn_ptr Q, nn_ptr R,
                 R[i] = n_mod_barrett(A[i] + q1*B[i - 1] + q0*B[i], n, ninv);
         else
             for (i = 1; i < lenB - 1; i++)
-                R[i] = n_mod_barrett(n_mod_barrett_sloppy(A[i] + q1*B[i - 1], n, ninv) + q0*B[i], n, ninv);
+                R[i] = n_mod_barrett(n_mod_barrett_lazy(A[i] + q1*B[i - 1], n, ninv) + q0*B[i], n, ninv);
     }
     else if (NMOD_BITS(mod) != FLINT_BITS)
     {

--- a/src/nmod_poly/divrem_basecase.c
+++ b/src/nmod_poly/divrem_basecase.c
@@ -141,7 +141,7 @@ void _nmod_poly_divrem_q1_preinv1(nn_ptr Q, nn_ptr R,
         ulong ninv = n_lemire_precomp(n);
 
         q1 = n_mod_lemire(A[lenA-1] * invL, n, ninv);
-        t  = n_mod_lemire(q1, B[lenB-2] * n, ninv);
+        t  = n_mod_lemire(q1 * B[lenB-2], n, ninv);
         t  = nmod_sub(t, A[lenA-2], mod);
         q0 = n_mod_lemire(t * invL, n, ninv);
         Q[0] = nmod_neg(q0, mod);

--- a/src/nmod_poly/divrem_basecase.c
+++ b/src/nmod_poly/divrem_basecase.c
@@ -36,54 +36,6 @@
 
 #endif
 
-/* Lemire, Kaser & Kurz */
-static ulong _mod1_preinvert(ulong n)
-{
-    return UWORD_MAX / n + 1;
-}
-
-/* Shoup */
-static ulong _mod2_preinvert(ulong n)
-{
-    return n_mulmod_precomp_shoup(1, n);
-}
-
-static ulong _mod1(ulong x, ulong n, ulong ninv)
-{
-    ulong l = ninv * x;
-
-#if FLINT_BITS != 64 || !defined(__GNUC__)
-    ulong hi, lo;
-    umul_ppmm(hi, lo, l, n);
-    return hi;
-#else
-    return ((__uint128_t) l * n ) >> 64;
-#endif
-}
-
-static ulong _mulmod1(ulong a, ulong b, ulong n, ulong ninv)
-{
-    return _mod1(a * b, n, ninv);
-}
-
-static ulong _mod2_fast(ulong x, ulong n, ulong ninv)
-{
-    return x - n_mulhi(ninv, x) * n;
-}
-
-static ulong _mod2(ulong x, ulong n, ulong ninv)
-{
-    ulong y = _mod2_fast(x, n, ninv);
-    if (y >= n)
-        y -= n;
-    return y;
-}
-
-static ulong _mulmod2(ulong a, ulong b, ulong n, ulong ninv)
-{
-    return _mod2(a * b, n, ninv);
-}
-
 void _nmod_poly_divrem_q0_preinv1(nn_ptr Q, nn_ptr R,
                           nn_srcptr A, nn_srcptr B, slong lenA, ulong invL, nmod_t mod)
 {
@@ -186,57 +138,57 @@ void _nmod_poly_divrem_q1_preinv1(nn_ptr Q, nn_ptr R,
     if (NMOD_ADDMUL_FITS_HALFWORD(mod))
     {
         ulong n = mod.n;
-        ulong ninv = _mod1_preinvert(n);
+        ulong ninv = n_lemire_precomp(n);
 
-        q1 = _mulmod1(A[lenA-1], invL, n, ninv);
-        t  = _mulmod1(q1, B[lenB-2], n, ninv);
+        q1 = n_mod_lemire(A[lenA-1] * invL, n, ninv);
+        t  = n_mod_lemire(q1, B[lenB-2] * n, ninv);
         t  = nmod_sub(t, A[lenA-2], mod);
-        q0 = _mulmod1(t, invL, n, ninv);
+        q0 = n_mod_lemire(t * invL, n, ninv);
         Q[0] = nmod_neg(q0, mod);
         Q[1] = q1;
         q1 = nmod_neg(q1, mod);
         /* R = A + (q1*x + q0)*B */
 
-        R[0] = _mod1(A[0] + q0 * B[0], n, ninv);
+        R[0] = n_mod_lemire(A[0] + q0 * B[0], n, ninv);
 
         if (NMOD_ADDMUL_ADDMUL_FITS_HALFWORD(mod))
         {
             for (i = 1; i < lenB - 1; i++)
-                R[i] = _mod1(A[i] + q1*B[i - 1] + q0*B[i], n, ninv);
+                R[i] = n_mod_lemire(A[i] + q1*B[i - 1] + q0*B[i], n, ninv);
         }
         else
         {
             for (i = 1; i < lenB - 1; i++)
-                R[i] = _mod1(_mod1(A[i] + q1*B[i - 1], n, ninv) + q0*B[i], n, ninv);
+                R[i] = n_mod_lemire(n_mod_lemire(A[i] + q1*B[i - 1], n, ninv) + q0*B[i], n, ninv);
         }
     }
     else if (NMOD_ADDMUL_FITS_WORD(mod))
     {
         ulong n = mod.n;
-        ulong ninv = _mod2_preinvert(n);
+        ulong ninv = n_barrett_precomp(n);
 
-        q1 = _mulmod2(A[lenA-1], invL, n, ninv);
-        t  = _mulmod2(q1, B[lenB-2], n, ninv);
+        q1 = n_mod_barrett(A[lenA-1] * invL, n, ninv);
+        t  = n_mod_barrett(q1 * B[lenB-2], n, ninv);
         t  = nmod_sub(t, A[lenA-2], mod);
-        q0 = _mulmod2(t, invL, n, ninv);
+        q0 = n_mod_barrett(t * invL, n, ninv);
         Q[0] = nmod_neg(q0, mod);
         Q[1] = q1;
         q1 = nmod_neg(q1, mod);
         /* R = A + (q1*x + q0)*B */
 
-        R[0] = _mod2(A[0] + q0 * B[0], n, ninv);
+        R[0] = n_mod_barrett(A[0] + q0 * B[0], n, ninv);
 
-        /* In the second branch, the _mod2_fast maps
+        /* In the second branch, the sloppy mod maps
                [0, ..., (n-1) + (n-1)^2] -> [0, 2n-1]
            and the _mod2 maps
                 [0, 2n-1 + (n-1)^2] -> [0,n-1]. */
 
         if (NMOD_ADDMUL_ADDMUL_FITS_WORD(mod))
             for (i = 1; i < lenB - 1; i++)
-                R[i] = _mod2(A[i] + q1*B[i - 1] + q0*B[i], n, ninv);
+                R[i] = n_mod_barrett(A[i] + q1*B[i - 1] + q0*B[i], n, ninv);
         else
             for (i = 1; i < lenB - 1; i++)
-                R[i] = _mod2(_mod2_fast(A[i] + q1*B[i - 1], n, ninv) + q0*B[i], n, ninv);
+                R[i] = n_mod_barrett(n_mod_barrett_sloppy(A[i] + q1*B[i - 1], n, ninv) + q0*B[i], n, ninv);
     }
     else if (NMOD_BITS(mod) != FLINT_BITS)
     {

--- a/src/nmod_poly/divrem_newton_n_preinv.c
+++ b/src/nmod_poly/divrem_newton_n_preinv.c
@@ -32,6 +32,7 @@ _nmod_poly_divrem_try_sparse(nn_ptr Q, nn_ptr R, nn_srcptr A,
     ulong coeffs[MAX_NZ];
     slong n = lenB - 1;
     ulong c, leadB;
+    ulong negcbound;
     nn_ptr r;
 
     nz = 1;
@@ -40,7 +41,7 @@ _nmod_poly_divrem_try_sparse(nn_ptr Q, nn_ptr R, nn_srcptr A,
         if (B[i] != 0)
         {
             exps[nz - 1] = i;
-            coeffs[nz - 1] = B[i];
+            coeffs[nz - 1] = mod.n - B[i];
             nz++;
             if (nz > MAX_NZ)
                 return 0;
@@ -52,6 +53,12 @@ _nmod_poly_divrem_try_sparse(nn_ptr Q, nn_ptr R, nn_srcptr A,
     if (leadB != 1)
         _nmod_vec_scalar_mul_nmod(coeffs, coeffs, nz - 1, Binv[0], mod);
 
+    /* Detect the common case of all coefficients 1 */
+    /* TODO: could optimize for combinations of 1, -1, other... */
+    negcbound = 0;
+    for (i = 0; i < nz - 1; i++)
+        negcbound |= (mod.n - coeffs[i]);
+
     TMP_INIT;
     TMP_START;
 
@@ -59,15 +66,58 @@ _nmod_poly_divrem_try_sparse(nn_ptr Q, nn_ptr R, nn_srcptr A,
     r = TMP_ALLOC((lenA) * sizeof(ulong));
     _nmod_vec_set(r, A, lenA);
 
-    for (i = lenA - 1; i >= n; i--)
+    if (mod.n == 2)
     {
-        Q[i - n] = c = r[i];
-
-        /* Todo: incorporate delayed reduction, specialize for coeffs +/- 1, ... */
-        for (k = nz - 2; k >= 0; k--)
+        for (i = lenA - 1; i >= n; i--)
         {
-            j = exps[k];
-            r[j + i - n] = nmod_sub(r[j + i - n], nmod_mul(c, coeffs[k], mod), mod);
+            Q[i - n] = c = r[i];
+
+            for (k = nz - 2; k >= 0; k--)
+            {
+                j = exps[k];
+                r[j + i - n] ^= c;
+            }
+        }
+    }
+    else if (negcbound == 1)
+    {
+        for (i = lenA - 1; i >= n; i--)
+        {
+            Q[i - n] = c = r[i];
+
+            for (k = nz - 2; k >= 0; k--)
+            {
+                j = exps[k];
+                r[j + i - n] = nmod_sub(r[j + i - n], c, mod);
+            }
+        }
+    }
+    else if (NMOD_BITS(mod) < FLINT_BITS / 2)
+    {
+        ulong ninv = n_barrett_precomp(mod.n);
+
+        for (i = lenA - 1; i >= n; i--)
+        {
+            Q[i - n] = c = r[i];
+
+            for (k = nz - 2; k >= 0; k--)
+            {
+                j = exps[k];
+                r[j + i - n] = n_mod_barrett(r[j + i - n] + c * coeffs[k], mod.n, ninv);
+            }
+        }
+    }
+    else
+    {
+        for (i = lenA - 1; i >= n; i--)
+        {
+            Q[i - n] = c = r[i];
+
+            for (k = nz - 2; k >= 0; k--)
+            {
+                j = exps[k];
+                r[j + i - n] = nmod_addmul(r[j + i - n], c, coeffs[k], mod);
+            }
         }
     }
 

--- a/src/qsieve/collect_relations.c
+++ b/src/qsieve/collect_relations.c
@@ -199,16 +199,6 @@ void qsieve_do_sieving2(qs_t qs_inf, unsigned char * sieve, qs_poly_t poly)
     }
 }
 
-
-/* Lemire-Kaser-Kurz remainder for half-limb primes */
-#include "nmod.h"
-
-FLINT_FORCE_INLINE
-ulong n_mod_halflimb_preinv(ulong x, ulong d, ulong dinv)
-{
-    return n_mulhi(dinv * x, d);
-}
-
 /*
     check position i in sieve array for smoothness
 */
@@ -291,7 +281,7 @@ slong qsieve_evaluate_candidate(qs_t qs_inf, ulong i, unsigned char * sieve, qs_
       prime = factor_base[j].p;
       pinv = factor_base[j].pinv2;
       FLINT_ASSERT(prime < UWORD(1) << (FLINT_BITS / 2));
-      modp = n_mod_halflimb_preinv(i, prime, pinv);
+      modp = n_mod_lemire(i, prime, pinv);
 
       if (modp == soln1[j] || modp == soln2[j])
       {
@@ -329,7 +319,7 @@ slong qsieve_evaluate_candidate(qs_t qs_inf, ulong i, unsigned char * sieve, qs_
          {
             prime = factor_base[j].p;
             pinv = factor_base[j].pinv2;
-            modp = n_mod_halflimb_preinv(i, prime, pinv);
+            modp = n_mod_lemire(i, prime, pinv);
 
             if (soln2[j] != 0) /* not a prime dividing A */
             {

--- a/src/qsieve/primes_init.c
+++ b/src/qsieve/primes_init.c
@@ -80,7 +80,7 @@ compute_factor_base(ulong * small_factor, qs_t qs_inf, slong num_primes)
         {
             factor_base[fb_prime].p = p;
             factor_base[fb_prime].pinv = pinv;
-            factor_base[fb_prime].pinv2 = UWORD_MAX / p + 1;
+            factor_base[fb_prime].pinv2 = n_lemire_precomp(p);
             factor_base[fb_prime].size = FLINT_BIT_COUNT(p);
             sqrts[fb_prime] = n_sqrtmod(nmod, p);
             fb_prime++;

--- a/src/radix.h
+++ b/src/radix.h
@@ -484,7 +484,7 @@ n_div_precomp_bounded(ulong x, const n_div_precomp_t pre)
 }
 
 RADIX_INLINE ulong
-n_rem_precomp_m0(ulong x, ulong d, const n_div_precomp_t pre)
+n_rem_precomp_m0(ulong x, ulong FLINT_UNUSED(d), const n_div_precomp_t pre)
 {
     return x & ((UWORD(1) << (FLINT_MAX(pre->e, 1) - 1)) - 1);
 }

--- a/src/radix.h
+++ b/src/radix.h
@@ -442,11 +442,81 @@ n_div_precomp_c0(ulong x, const n_div_precomp_t pre)
     return n_mulhi(x, pre->m) >> pre->e;
 }
 
+RADIX_INLINE ulong n_incsat(ulong x)
+{
+    ulong t = x + 1;
+    return (t > x) ? t : x;
+}
+
 /* Assumes x != UWORD_MAX */
 RADIX_INLINE ulong
-n_div_precomp_c1_unsafe(ulong x, const n_div_precomp_t pre)
+n_div_precomp_c1_bounded(ulong x, const n_div_precomp_t pre)
 {
     return n_mulhi(x + 1, pre->m) >> pre->e;
+}
+
+RADIX_INLINE ulong
+n_div_precomp_c1(ulong x, const n_div_precomp_t pre)
+{
+    return n_mulhi(n_incsat(x), pre->m) >> pre->e;
+}
+
+RADIX_INLINE ulong
+n_div_precomp(ulong x, const n_div_precomp_t pre)
+{
+    if (pre->m == 0)
+        return x >> pre->e;
+    else if (pre->c == 0)
+        return n_mulhi(x, pre->m) >> pre->e;
+    else
+        return n_mulhi(n_incsat(x), pre->m) >> pre->e;
+}
+
+RADIX_INLINE ulong
+n_div_precomp_bounded(ulong x, const n_div_precomp_t pre)
+{
+    if (pre->m == 0)
+        return x >> pre->e;
+    else if (pre->c == 0)
+        return n_mulhi(x, pre->m) >> pre->e;
+    else
+        return n_mulhi(x + 1, pre->m) >> pre->e;
+}
+
+RADIX_INLINE ulong
+n_rem_precomp_m0(ulong x, ulong d, const n_div_precomp_t pre)
+{
+    return x & ((UWORD(1) << (FLINT_MAX(pre->e, 1) - 1)) - 1);
+}
+
+RADIX_INLINE ulong
+n_rem_precomp_c0(ulong x, ulong d, const n_div_precomp_t pre)
+{
+    return x - d * n_div_precomp_c0(x, pre);
+}
+
+RADIX_INLINE ulong
+n_rem_precomp_c1(ulong x, ulong d, const n_div_precomp_t pre)
+{
+    return x - d * n_div_precomp_c1(x, pre);
+}
+
+RADIX_INLINE ulong
+n_rem_precomp_bounded(ulong x, ulong d, const n_div_precomp_t pre)
+{
+    return x - d * n_div_precomp_bounded(x, pre);
+}
+
+RADIX_INLINE ulong
+n_rem_precomp_c1_bounded(ulong x, ulong d, const n_div_precomp_t pre)
+{
+    return x - d * n_div_precomp_c1_bounded(x, pre);
+}
+
+RADIX_INLINE ulong
+n_rem_precomp(ulong x, ulong d, const n_div_precomp_t pre)
+{
+    return x - d * n_div_precomp(x, pre);
 }
 
 RADIX_INLINE ulong
@@ -466,30 +536,33 @@ n_divrem_precomp_c0(ulong * r, ulong x, ulong d, const n_div_precomp_t pre)
 }
 
 RADIX_INLINE ulong
-n_divrem_precomp_c1_unsafe(ulong * r, ulong x, ulong d, const n_div_precomp_t pre)
+n_divrem_precomp_c1(ulong * r, ulong x, ulong d, const n_div_precomp_t pre)
 {
-    ulong q = n_div_precomp_c1_unsafe(x, pre);
+    ulong q = n_div_precomp_c1(x, pre);
     *r = x - d * q;
     return q;
 }
 
 RADIX_INLINE ulong
-n_div_precomp_unsafe(ulong x, const n_div_precomp_t pre)
+n_divrem_precomp_c1_bounded(ulong * r, ulong x, ulong d, const n_div_precomp_t pre)
 {
-    if (pre->m == 0)
-        return x >> pre->e;
-    else
-        return n_mulhi(x + pre->c, pre->m) >> pre->e;
+    ulong q = n_div_precomp_c1_bounded(x, pre);
+    *r = x - d * q;
+    return q;
 }
 
 RADIX_INLINE ulong
-n_divrem_precomp_unsafe(ulong * r, ulong x, ulong d, const n_div_precomp_t pre)
+n_divrem_precomp(ulong * r, ulong x, ulong d, const n_div_precomp_t pre)
 {
-    ulong q;
-    if (pre->m == 0)
-        q = x >> pre->e;
-    else
-        q = n_mulhi(x + pre->c, pre->m) >> pre->e;
+    ulong q = n_div_precomp(x, pre);
+    *r = x - d * q;
+    return q;
+}
+
+RADIX_INLINE ulong
+n_divrem_precomp_bounded(ulong * r, ulong x, ulong d, const n_div_precomp_t pre)
+{
+    ulong q = n_div_precomp_bounded(x, pre);
     *r = x - d * q;
     return q;
 }

--- a/src/radix.h
+++ b/src/radix.h
@@ -486,7 +486,7 @@ n_div_precomp_bounded(ulong x, const n_div_precomp_t pre)
 RADIX_INLINE ulong
 n_rem_precomp_m0(ulong x, ulong FLINT_UNUSED(d), const n_div_precomp_t pre)
 {
-    return x & ((UWORD(1) << (FLINT_MAX(pre->e, 1) - 1)) - 1);
+    return x & ((UWORD(1) << pre->e) - 1);
 }
 
 RADIX_INLINE ulong

--- a/src/radix/integer.c
+++ b/src/radix/integer.c
@@ -496,8 +496,8 @@ radix_integer_get_digit(const radix_integer_t x, slong index, const radix_t radi
     }
     else
     {
-        d = n_div_precomp_unsafe(d, radix->bpow_div + id);
-        n_divrem_precomp_unsafe(&d, d, radix->bpow[1], radix->bpow_div + 1);
+        d = n_div_precomp_bounded(d, radix->bpow_div + id);
+        n_divrem_precomp_bounded(&d, d, radix->bpow[1], radix->bpow_div + 1);
         return d;
     }
 }
@@ -520,8 +520,8 @@ radix_integer_set_digit(radix_integer_t res, const radix_integer_t x, slong inde
     }
     else
     {
-        hi = n_divrem_precomp_unsafe(&lo, d, radix->bpow[id], radix->bpow_div + id);
-        hi = n_div_precomp_unsafe(hi, radix->bpow_div + 1);
+        hi = n_divrem_precomp_bounded(&lo, d, radix->bpow[id], radix->bpow_div + id);
+        hi = n_div_precomp_bounded(hi, radix->bpow_div + 1);
         d = hi * (radix->bpow[id] * radix->bpow[1]) + c * radix->bpow[id] + lo;
     }
 

--- a/src/radix/shift.c
+++ b/src/radix/shift.c
@@ -54,7 +54,7 @@ radix_lshift_digits(nn_ptr res, nn_srcptr a, slong n, unsigned int e, const radi
     {
         for (i = 0; i < n; i++)
         {
-            hi = n_divrem_precomp_c1_unsafe(&lo, a[i], be2, pre);
+            hi = n_divrem_precomp_c1_bounded(&lo, a[i], be2, pre);
             res[i] = cy + lo * be;
             cy = hi;
         }
@@ -101,7 +101,7 @@ radix_rshift_digits(nn_ptr res, nn_srcptr a, slong n, unsigned int e, const radi
     {
         for (i = n - 1; i >= 0; i--)
         {
-            hi = n_divrem_precomp_c1_unsafe(&lo, a[i], be, pre);
+            hi = n_divrem_precomp_c1_bounded(&lo, a[i], be, pre);
             res[i] = hi + cy * be2;
             cy = lo;
         }

--- a/src/radix/test/main.c
+++ b/src/radix/test/main.c
@@ -25,6 +25,7 @@
 #include "t-mulmid_classical.c"
 #include "t-mulmid_fft_small.c"
 #include "t-mulmid_KS.c"
+#include "t-n_divrem.c"
 #include "t-neg.c"
 #include "t-rshift.c"
 #include "t-rsqrt_1_approx.c"
@@ -49,6 +50,7 @@ test_struct tests[] =
     TEST_FUNCTION(radix_mulmid_classical),
     TEST_FUNCTION(radix_mulmid_fft_small),
     TEST_FUNCTION(radix_mulmid_KS),
+    TEST_FUNCTION(radix_n_divrem),
     TEST_FUNCTION(radix_neg),
     TEST_FUNCTION(radix_rshift),
     TEST_FUNCTION(radix_rsqrt_1_approx),

--- a/src/radix/test/t-n_divrem.c
+++ b/src/radix/test/t-n_divrem.c
@@ -1,0 +1,72 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "radix.h"
+
+TEST_FUNCTION_START(radix_n_divrem, state)
+{
+    slong iter, i;
+
+    for (iter = 0; iter < 10000 * flint_test_multiplier(); iter++)
+    {
+        ulong d, x, q, r, q1, q2, q3, r1, r2, r3;
+        n_div_precomp_t pre;
+
+        d = n_randtest_not_zero(state);
+
+        n_div_precomp_init(pre, d);
+
+        for (i = 0; i < 10; i++)
+        {
+            x = n_randtest(state);
+
+            q = x / d;
+            r = x % d;
+
+            q1 = n_divrem_precomp(&r1, x, d, pre);
+            q2 = n_div_precomp(x, pre);
+            r2 = n_rem_precomp(x, d, pre);
+
+            if (pre->m == 0)
+            {
+                q3 = n_div_precomp_m0(x, pre);
+                r3 = n_rem_precomp_m0(x, d, pre);
+            }
+            else if (pre->c == 0)
+            {
+                q3 = n_div_precomp_c0(x, pre);
+                r3 = n_rem_precomp_c0(x, d, pre);
+            }
+            else if (x < UWORD_MAX && n_randint(state, 2))
+            {
+                q3 = n_div_precomp_c1_bounded(x, pre);
+                r3 = n_rem_precomp_c1_bounded(x, d, pre);
+            }
+            else
+            {
+                q3 = n_div_precomp_c1(x, pre);
+                r3 = n_rem_precomp_c1(x, d, pre);
+            }
+
+            if (q != q1 || q != q2 || q != q3 || r != r1 || r != r2 || r != r3)
+            {
+                flint_printf("FAIL: d = %wu, x = %wu\n", d, x);
+                flint_printf("q = %wu, q1 = %wu, q2 = %wu, q3 = %wu\n", q, q1, q2, q3);
+                flint_printf("r = %wu, r1 = %wu, r2 = %wu, r3 = %wu\n", r, r1, r2, r3);
+                flint_abort();
+            }
+        }
+
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/ulong_extras.h
+++ b/src/ulong_extras.h
@@ -377,6 +377,42 @@ ulong n_invmod(ulong x, ulong y)
 
 ulong n_binvert(ulong a);
 
+ULONG_EXTRAS_INLINE
+ulong n_barrett_precomp(ulong n)
+{
+    ulong q, r;
+    FLINT_ASSERT(n >= 2);
+    udiv_qrnnd(q, r, UWORD(1), UWORD(0), n);
+    return q;
+}
+
+ULONG_EXTRAS_INLINE
+ulong n_mod_barrett_sloppy(ulong x, ulong n, ulong npre)
+{
+    return x - n_mulhi(x, npre) * n;
+}
+
+ULONG_EXTRAS_INLINE
+ulong n_mod_barrett(ulong x, ulong n, ulong npre)
+{
+    ulong y = n_mod_barrett_sloppy(x, n, npre);
+    if (y >= n)
+        y -= n;
+    return y;
+}
+
+ULONG_EXTRAS_INLINE
+ulong n_lemire_precomp(ulong n)
+{
+    return UWORD_MAX / n + 1;
+}
+
+ULONG_EXTRAS_INLINE
+ulong n_mod_lemire(ulong x, ulong n, ulong npre)
+{
+    return n_mulhi(n, x * npre);
+}
+
 /* Double-limb arithmetic. */
 
 void n_ll_small_preinv(nn_ptr minv, nn_srcptr m);

--- a/src/ulong_extras.h
+++ b/src/ulong_extras.h
@@ -41,6 +41,18 @@ ulong n_randtest(flint_rand_t state);
 ulong n_randtest_not_zero(flint_rand_t state);
 ulong n_randtest_prime(flint_rand_t state, int proved);
 
+ULONG_EXTRAS_INLINE ulong n_mulhi(ulong a, ulong b)
+{
+/* Experimental: see if the compiler generates better code than inline assembly */
+#if FLINT_BITS == 64 && defined(__GNUC__)
+    return ((__uint128_t) a * (__uint128_t) b) >> 64;
+#else
+    ulong hi, lo;
+    umul_ppmm(hi, lo, a, b);
+    return hi;
+#endif
+}
+
 #if FLINT64
 ULONG_EXTRAS_INLINE ulong _n_randlimb(flint_rand_t state)
 {
@@ -62,15 +74,9 @@ ULONG_EXTRAS_INLINE ulong _n_randlimb(flint_rand_t state)
 ULONG_EXTRAS_INLINE ulong _n_randint(flint_rand_t state, ulong limit)
 {
     if ((limit & (limit - 1)) == 0)
-    {
         return _n_randlimb(state) & (limit - 1);
-    }
     else
-    {
-        ulong hi, lo;
-        umul_ppmm(hi, lo, _n_randlimb(state), limit);
-        return hi;
-    }
+        return n_mulhi(_n_randlimb(state), limit);
 }
 
 /* Basic arithmetic **********************************************************/
@@ -370,6 +376,8 @@ ulong n_invmod(ulong x, ulong y)
 }
 
 ulong n_binvert(ulong a);
+
+/* Double-limb arithmetic. */
 
 void n_ll_small_preinv(nn_ptr minv, nn_srcptr m);
 void n_ll_small_powmod_triple(nn_ptr res1, nn_ptr res2, nn_ptr res3, ulong b1,

--- a/src/ulong_extras.h
+++ b/src/ulong_extras.h
@@ -387,7 +387,7 @@ ulong n_barrett_precomp(ulong n)
 }
 
 ULONG_EXTRAS_INLINE
-ulong n_mod_barrett_sloppy(ulong x, ulong n, ulong npre)
+ulong n_mod_barrett_lazy(ulong x, ulong n, ulong npre)
 {
     return x - n_mulhi(x, npre) * n;
 }
@@ -395,7 +395,7 @@ ulong n_mod_barrett_sloppy(ulong x, ulong n, ulong npre)
 ULONG_EXTRAS_INLINE
 ulong n_mod_barrett(ulong x, ulong n, ulong npre)
 {
-    ulong y = n_mod_barrett_sloppy(x, n, npre);
+    ulong y = n_mod_barrett_lazy(x, n, npre);
     if (y >= n)
         y -= n;
     return y;

--- a/src/ulong_extras/is_prime.c
+++ b/src/ulong_extras/is_prime.c
@@ -87,20 +87,6 @@ static int u32_is_base2_pseudoprime(uint32_t x)
 #include "radix.h"
 
 static ulong
-n_rem_precomp_c0(ulong x, ulong d, const n_div_precomp_t pre)
-{
-    ulong q = n_div_precomp_c0(x, pre);
-    return x - d * q;
-}
-
-static ulong
-n_rem_precomp_c1_unsafe(ulong x, ulong d, const n_div_precomp_t pre)
-{
-    ulong q = n_div_precomp_c1_unsafe(x, pre);
-    return x - d * q;
-}
-
-static ulong
 n_2_powmod_c0(uint32_t exp, ulong n, const n_div_precomp_t pre)
 {
     ulong x;
@@ -144,16 +130,16 @@ n_2_powmod_c1(uint32_t exp, ulong n, const n_div_precomp_t pre)
     int k, ebits;
 
     if (exp < FLINT_BITS)
-        return n_rem_precomp_c1_unsafe(UWORD(1) << exp, n, pre);
+        return n_rem_precomp_c1_bounded(UWORD(1) << exp, n, pre);
 
     ebits = FLINT_BITS - flint_clz(exp);
-    x = n_rem_precomp_c1_unsafe(UWORD(1) << (exp >> (ebits - 6)), n, pre);
+    x = n_rem_precomp_c1_bounded(UWORD(1) << (exp >> (ebits - 6)), n, pre);
 
     if (n < UWORD(1) << (FLINT_BITS / 2 - 1))
     {
         for (k = ebits - 7; k >= 0; k--)
         {
-            x = n_rem_precomp_c1_unsafe(x * x, n, pre);
+            x = n_rem_precomp_c1_bounded(x * x, n, pre);
             x <<= ((exp >> k) & 1);
         }
 
@@ -164,7 +150,7 @@ n_2_powmod_c1(uint32_t exp, ulong n, const n_div_precomp_t pre)
     {
         for (k = ebits - 7; k >= 0; k--)
         {
-            x = n_rem_precomp_c1_unsafe(x * x, n, pre);
+            x = n_rem_precomp_c1_bounded(x * x, n, pre);
             x <<= ((exp >> k) & 1);
             if (x >= n)
                 x -= n;
@@ -209,7 +195,7 @@ static int u32_is_base2_probabprime(uint32_t n)
         t <<= 1;
         while ((t != n - 1) && (y != n - 1))
         {
-            y = n_rem_precomp_c1_unsafe(y * y, n, pre);
+            y = n_rem_precomp_c1_bounded(y * y, n, pre);
             t <<= 1;
         }
     }

--- a/src/ulong_extras/test/main.c
+++ b/src/ulong_extras/test/main.c
@@ -67,6 +67,8 @@
 #include "t-ll_small_powmod.c"
 #include "t-mod2_precomp.c"
 #include "t-mod2_preinv.c"
+#include "t-mod_barrett.c"
+#include "t-mod_lemire.c"
 #include "t-mod_precomp.c"
 #include "t-moebius_mu.c"
 #include "t-mulmod2.c"
@@ -166,6 +168,8 @@ test_struct tests[] =
     TEST_FUNCTION(n_ll_small_powmod),
     TEST_FUNCTION(n_mod2_precomp),
     TEST_FUNCTION(n_mod2_preinv),
+    TEST_FUNCTION(n_mod_barrett),
+    TEST_FUNCTION(n_mod_lemire),
     TEST_FUNCTION(n_mod_precomp),
     TEST_FUNCTION(n_moebius_mu),
     TEST_FUNCTION(n_mulmod2),

--- a/src/ulong_extras/test/t-mod_barrett.c
+++ b/src/ulong_extras/test/t-mod_barrett.c
@@ -26,7 +26,7 @@ TEST_FUNCTION_START(n_mod_barrett, state)
         x = n_randtest(state);
 
         r1 = n_mod_barrett(x, n, npre);
-        r2 = n_mod_barrett_sloppy(x, n, npre);
+        r2 = n_mod_barrett_lazy(x, n, npre);
         r3 = x % n;
 
         result = (r1 == r3) && (r2 == r3 || (r3 <= UWORD_MAX - n && r2 == r3 + n));

--- a/src/ulong_extras/test/t-mod_barrett.c
+++ b/src/ulong_extras/test/t-mod_barrett.c
@@ -1,0 +1,41 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "ulong_extras.h"
+
+TEST_FUNCTION_START(n_mod_barrett, state)
+{
+    int i, result;
+
+    for (i = 0; i < 100000 * flint_test_multiplier(); i++)
+    {
+        ulong n, x, npre, r1, r2, r3;
+
+        n = n_randtest_not_zero(state);
+        npre = (n == 1) ? UWORD_MAX : n_barrett_precomp(n);
+
+        x = n_randtest(state);
+
+        r1 = n_mod_barrett(x, n, npre);
+        r2 = n_mod_barrett_sloppy(x, n, npre);
+        r3 = x % n;
+
+        result = (r1 == r3) && (r2 == r3 || (r3 <= UWORD_MAX - n && r2 == r3 + n));
+        if (!result)
+            TEST_FUNCTION_FAIL(
+                    "n = %wu, npre = %wu, x = %wu\n"
+                    "r1 = %wu, r2 = %wu, r3 = %wu\n",
+                    n, npre, x, r1, r2);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/ulong_extras/test/t-mod_lemire.c
+++ b/src/ulong_extras/test/t-mod_lemire.c
@@ -1,0 +1,45 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "ulong_extras.h"
+
+TEST_FUNCTION_START(n_mod_lemire, state)
+{
+    int i, result;
+
+    for (i = 0; i < 100000 * flint_test_multiplier(); i++)
+    {
+        ulong n, x, npre, r1, r2;
+
+        do {
+            n = n_randtest_not_zero(state);
+        } while (n >= (UWORD(1) << (FLINT_BITS / 2)));
+
+        npre = n_lemire_precomp(n);
+
+        do {
+            x = n_randtest_not_zero(state);
+        } while (x >= (UWORD(1) << (FLINT_BITS / 2)));
+
+        r1 = n_mod_lemire(x, n, npre);
+        r2 = x % n;
+
+        result = (r1 == r2);
+        if (!result)
+            TEST_FUNCTION_FAIL(
+                    "n = %wu, npre = %wu, x = %wu\n"
+                    "r1 = %wu, r2 = %wu\n",
+                    n, npre, x, r1, r2);
+    }
+
+    TEST_FUNCTION_END(state);
+}


### PR DESCRIPTION
* Add `n_mulhi` and `n_mod_barrett`, `n_mod_barrett_sloppy`, `n_mod_lemire` (plus their respective precomputation methods as public functions), replacing some previous private reimplementations of these functions
* Extend the internal `n_divrem` functions in the `radix` module (not yet made public in this PR, as I'm not yet sure about the interface)
* Micro-optimize modular reduction for fullword moduli in `fft_small` (up to 2.5% speedup for polynomial multiplication)
* Optimize arithmetic in sparse `nmod_poly` division (affecting polmod operations and `fq_nmod` arithmetic)
  * `make check MOD=fq_nmod_poly` (with 10x test multiplier): 5.995 s -> 7.371 s (23% speedup)
  * `build/examples/minimal_irreducibles 5 3125 3125`: 3.972 s  -> 3.256 s (22% speedup)