### PR TITLE
Optimize `nmod_poly_divrem_basecase`

### DIFF
--- a/doc/source/nmod_vec.rst
+++ b/doc/source/nmod_vec.rst
@@ -141,6 +141,39 @@ Arithmetic operations
     `c` and all elements of ``vec`` are assumed to be less than ``mod.n``.
 
 
+Arithmetic operations without reduction
+--------------------------------------------------------------------------------
+
+The following functions set `r_i \gets r_i + v_i \cdot c`,
+`0 \le i < len`, with `r` given by ``res`` and `v` given by ``vec``,
+without performing modular reduction,
+with specific limitations on the inputs.
+
+.. function:: void _nmod_vec_nored_scalar_addmul_halflimb(nn_ptr res, nn_srcptr vec, slong len, ulong c)
+
+    Assumes that `v_i` and `c` are half-limb values and that
+    `r_i + v_i \cdot c` does not overflow a limb.
+
+.. function:: void _nmod_vec_nored_ll_scalar_addmul_halflimb(nn_ptr res, nn_srcptr vec, slong len, ulong c)
+
+    The array ``res`` contains ``2 len`` limbs, representing double-limb
+    integers contiguously.
+    Assumes that `v_i` and `c` are half-limb values and that
+    `r_i + v_i \cdot c` does not overflow two limbs.
+
+.. function:: void _nmod_vec_nored_ll_scalar_addmul(nn_ptr res, nn_srcptr vec, slong len, ulong c)
+
+    The array ``res`` contains ``2 len`` limbs, representing double-limb
+    integers contiguously.
+    Assumes that `r_i + v_i \cdot c` does not overflow two limbs.
+
+.. function:: void _nmod_vec_nored_lll_scalar_addmul(nn_ptr res, nn_srcptr vec, slong len, ulong c)
+
+    The array ``res`` contains ``3 len`` limbs, representing triple-limb
+    integers contiguously.
+    Assumes that `r_i + v_i \cdot c` does not overflow three limbs.
+
+
 Dot products
 --------------------------------------------------------------------------------
 

--- a/src/gr/nmod.c
+++ b/src/gr/nmod.c
@@ -964,9 +964,11 @@ static int
 _gr_nmod_poly_divrem(nn_ptr Q, nn_ptr R, nn_srcptr A, slong lenA,
                                   nn_srcptr B, slong lenB, gr_ctx_t ctx)
 {
-    if (lenA <= 20 || lenB <= 8 || lenA - lenB <= 6 ||
-            (NMOD_BITS(NMOD_CTX(ctx)) <= 61 && lenA <= 40) ||
-            (NMOD_BITS(NMOD_CTX(ctx)) <= 29 && lenA <= 70))
+#if FLINT_BITS == 64 && defined(__AVX2__)
+    if (lenA - lenB < 80 || lenB < ((NMOD_BITS(NMOD_CTX(ctx)) <= 27) ? 400 : 80))
+#else
+    if (lenA - lenB < 80 || lenB < ((NMOD_BITS(NMOD_CTX(ctx)) <= 27) ? 200 : 80))
+#endif
     {
         ulong invB;
         int status;

--- a/src/nmod_poly/divrem.c
+++ b/src/nmod_poly/divrem.c
@@ -21,9 +21,11 @@ _nmod_poly_divrem(nn_ptr Q, nn_ptr R, nn_srcptr A, slong lenA,
 {
     ulong invB;
 
-    if (lenA <= 20 || lenB <= 8 || lenA - lenB <= 6 ||
-            (NMOD_BITS(mod) <= 61 && lenA <= 40) ||
-            (NMOD_BITS(mod) <= 29 && lenA <= 70))
+#if FLINT_BITS == 64 && defined(__AVX2__)
+    if (lenA - lenB < 80 || lenB < ((NMOD_BITS(mod) <= 27) ? 400 : 80))
+#else
+    if (lenA - lenB < 80 || lenB < ((NMOD_BITS(mod) <= 27) ? 200 : 80))
+#endif
     {
         invB = (B[lenB - 1] == 1) ? 1 : n_invmod(B[lenB - 1], mod.n);
 

--- a/src/nmod_poly/divrem_basecase.c
+++ b/src/nmod_poly/divrem_basecase.c
@@ -226,104 +226,187 @@ void _nmod_poly_divrem_q1_preinv1(nn_ptr Q, nn_ptr R,
 }
 
 static void
-_nmod_poly_divrem_basecase_preinv1_1(nn_ptr Q, nn_ptr R, nn_ptr W,
-                             nn_srcptr A, slong lenA, nn_srcptr B, slong lenB,
-                             ulong invL,
-                             nmod_t mod)
-{
-    slong iR;
-    nn_ptr ptrQ = Q - lenB + 1;
-    nn_ptr R1 = W;
-
-    flint_mpn_copyi(R1, A, lenA);
-
-    for (iR = lenA - 1; iR >= lenB - 1; iR--)
-    {
-        if (R1[iR] == 0)
-        {
-            ptrQ[iR] = WORD(0);
-        }
-        else
-        {
-            ptrQ[iR] = n_mulmod2_preinv(R1[iR], invL, mod.n, mod.ninv);
-
-            if (lenB > 1)
-            {
-                const ulong c = n_negmod(ptrQ[iR], mod.n);
-                mpn_addmul_1(R1 + iR - lenB + 1, B, lenB - 1, c);
-            }
-        }
-    }
-
-    if (lenB > 1)
-        _nmod_vec_reduce(R, R1, lenB - 1, mod);
-}
-
-static void
-_nmod_poly_divrem_basecase_preinv1_2(nn_ptr Q, nn_ptr R, nn_ptr W,
+_nmod_poly_divrem_basecase_preinv1_1(nn_ptr Q, nn_ptr R,
                              nn_srcptr A, slong lenA, nn_srcptr B, slong lenB,
                              ulong invL,
                              nmod_t mod)
 {
     slong iR, i;
-    nn_ptr B2 = W, R2 = W + 2*(lenB - 1), ptrQ = Q - lenB + 1;
+    nn_ptr R1, ptrQ = Q - lenB + 1;
+    ulong r, c;
+    int unreduced_fits_halflimb;
+    int reduced_fits_quarterlimb;
 
-    for (i = 0; i < lenB - 1; i++)
+    FLINT_ASSERT(NMOD_BITS(mod) <= FLINT_BITS / 2);
+
+    ulong unreduced_bound = (mod.n - 1) * (mod.n - 1) * (lenA - lenB + 1);
+
+    unreduced_fits_halflimb = unreduced_bound < UWORD(1) << (FLINT_BITS / 2);
+    reduced_fits_quarterlimb = NMOD_BITS(mod) <= FLINT_BITS / 4;
+
+    ulong npre = n_barrett_precomp(mod.n);
+    ulong npre2 = n_lemire_precomp(mod.n);
+
+    TMP_INIT;
+    TMP_START;
+    R1 = TMP_ALLOC(lenA * sizeof(ulong));
+
+    flint_mpn_copyi(R1, A, lenA);
+
+    for (iR = lenA - 1; iR >= lenB - 1; iR--)
     {
-        B2[2 * i] = B[i];
-        B2[2 * i + 1] = 0;
+        if (unreduced_fits_halflimb)
+            r = n_mod_lemire(R1[iR], mod.n, npre2);
+        else
+            r = n_mod_barrett(R1[iR], mod.n, npre);
+
+        if (r == 0)
+        {
+            ptrQ[iR] = 0;
+        }
+        else
+        {
+            if (invL == 1)
+                ptrQ[iR] = r;
+            else if (reduced_fits_quarterlimb)
+                ptrQ[iR] = n_mod_lemire(invL * r, mod.n, npre2);
+            else
+                ptrQ[iR] = n_mod_barrett(invL * r, mod.n, npre);
+
+            if (lenB > 1)
+            {
+                c = mod.n - ptrQ[iR];
+                _nmod_vec_nored_scalar_addmul_halflimb(R1 + iR - lenB + 1, B, lenB - 1, c);
+            }
+        }
     }
+
+    if (lenB > 1)
+    {
+        if (unreduced_fits_halflimb)
+        {
+            for (i = 0; i < lenB - 1; i++)
+                R[i] = n_mod_lemire(R1[i], mod.n, npre2);
+        }
+        else
+        {
+            for (i = 0; i < lenB - 1; i++)
+                R[i] = n_mod_barrett(R1[i], mod.n, npre);
+        }
+    }
+
+    TMP_END;
+}
+
+/* Note: we can do better than n_ll_mod_preinv when the high limb
+   of the double-limb sum is not reduced, but this benefits only a narrow
+   set of parameters, so it is not currently implemented. */
+static void
+_nmod_poly_divrem_basecase_preinv1_2(nn_ptr Q, nn_ptr R,
+                             nn_srcptr A, slong lenA, nn_srcptr B, slong lenB,
+                             ulong invL,
+                             nmod_t mod)
+{
+    slong iR, i;
+    nn_ptr R2, ptrQ = Q - lenB + 1;
+    ulong r, c;
+    int halflimb;
+
+    TMP_INIT;
+    TMP_START;
+    R2 = TMP_ALLOC(2 * lenA * sizeof(ulong));
+
     for (i = 0; i < lenA; i++)
     {
         R2[2 * i] = A[i];
         R2[2 * i + 1] = 0;
     }
 
-    for (iR = lenA - 1; iR >= lenB - 1; )
+    halflimb = (mod.n <= (UWORD(1) << (FLINT_BITS / 2)));
+
+    for (iR = lenA - 1; iR >= lenB - 1; iR--)
     {
-        ulong r =
-            n_ll_mod_preinv(R2[2 * iR + 1], R2[2 * iR], mod.n, mod.ninv);
+        r = n_ll_mod_preinv(R2[2 * iR + 1], R2[2 * iR], mod.n, mod.ninv);
 
-        while ((iR + 1 >= lenB) && (r == WORD(0)))
+        if (r == 0)
         {
-            ptrQ[iR--] = WORD(0);
-            if (iR + 1 >= lenB)
-                r = n_ll_mod_preinv(R2[2 * iR + 1], R2[2 * iR], mod.n,
-                                    mod.ninv);
+            ptrQ[iR] = 0;
         }
-
-        if (iR + 1 >= lenB)
+        else
         {
-            ptrQ[iR] = n_mulmod2_preinv(r, invL, mod.n, mod.ninv);
+            if (invL == 1)
+                ptrQ[iR] = r;
+            else
+                ptrQ[iR] = nmod_mul(r, invL, mod);
 
             if (lenB > 1)
             {
-                const ulong c = n_negmod(ptrQ[iR], mod.n);
-                mpn_addmul_1(R2 + 2 * (iR - lenB + 1), B2, 2 * lenB - 2, c);
+                c = mod.n - ptrQ[iR];
+
+                if (halflimb)
+                    _nmod_vec_nored_ll_scalar_addmul_halflimb(R2 + 2 * (iR - lenB + 1), B, lenB - 1, c);
+                else
+                    _nmod_vec_nored_ll_scalar_addmul(R2 + 2 * (iR - lenB + 1), B, lenB - 1, c);
             }
-            iR--;
         }
     }
 
     for (iR = 0; iR < lenB - 1; iR++)
         R[iR] = n_ll_mod_preinv(R2[2*iR+1], R2[2*iR], mod.n, mod.ninv);
+
+    TMP_END;
+}
+
+FLINT_FORCE_INLINE ulong
+n_lll_rem_l_fullword_limited(ulong y2, ulong y1, ulong y0, nmod_t mod, ulong alpha2, ulong alpha1)
+{
+    ulong c1, c0, t1, t0;
+    ulong xhi, xlo;
+
+    FLINT_ASSERT(mod.n >= (UWORD(1) << (FLINT_BITS - 1)));
+    FLINT_ASSERT(mod.n < (UWORD(1) << (FLINT_BITS - 1)) + (UWORD(1) << (FLINT_BITS / 2 - 2)));
+
+    umul_ppmm(t1, t0, y2, alpha2);
+    umul_ppmm(c1, c0, y1, alpha1);
+    add_ssaaaa(xhi, xlo, t1, t0, c1, c0);
+    add_ssaaaa(xhi, xlo, xhi, xlo, 0, y0);
+
+    NMOD_RED2_FULLWORD(xlo, xhi, xlo, mod);
+
+    return xlo;
+}
+
+FLINT_FORCE_INLINE ulong
+n_lll_rem_l(ulong y2, ulong y1, ulong y0, nmod_t mod, ulong alpha2, ulong alpha1)
+{
+    ulong c1, c0, t1, t0;
+    ulong xhi, xlo;
+
+    umul_ppmm(t1, t0, y2, alpha2);
+    umul_ppmm(c1, c0, y1, alpha1);
+    add_ssaaaa(xhi, xlo, t1, t0, c1, c0);
+    add_ssaaaa(xhi, xlo, xhi, xlo, 0, y0);
+
+    if (xhi >= mod.n) xhi -= mod.n;
+    NMOD_RED2(xlo, xhi, xlo, mod);
+
+    return xlo;
 }
 
 static void
-_nmod_poly_divrem_basecase_preinv1_3(nn_ptr Q, nn_ptr R, nn_ptr W,
+_nmod_poly_divrem_basecase_preinv1_3(nn_ptr Q, nn_ptr R,
                                      nn_srcptr A, slong lenA, nn_srcptr B, slong lenB,
                                      ulong invL,
                                      nmod_t mod)
 {
     slong iR, i;
-    nn_ptr B3 = W, R3 = W + 3*(lenB - 1), ptrQ = Q - lenB + 1;
+    nn_ptr R3, ptrQ = Q - lenB + 1;
+    ulong r, c;
 
-    for (i = 0; i < lenB - 1; i++)
-    {
-        B3[3 * i] = B[i];
-        B3[3 * i + 1] = 0;
-        B3[3 * i + 2] = 0;
-    }
+    TMP_INIT;
+    TMP_START;
+    R3 = TMP_ALLOC(3 * lenA * sizeof(ulong));
+
     for (i = 0; i < lenA; i++)
     {
         R3[3 * i] = A[i];
@@ -331,50 +414,67 @@ _nmod_poly_divrem_basecase_preinv1_3(nn_ptr Q, nn_ptr R, nn_ptr W,
         R3[3 * i + 2] = 0;
     }
 
-    for (iR = lenA - 1; iR >= lenB - 1; )
-    {
-        ulong r =
-            n_lll_mod_preinv(R3[3 * iR + 2], R3[3 * iR + 1],
-                             R3[3 * iR], mod.n, mod.ninv);
+    /* Special case for moduli close to 2^63, which are often used
+       in multimodular algorithms. */
+    int fullword_limited = (mod.norm == 0) &&
+            mod.n < (UWORD(1) << (FLINT_BITS - 1)) + (UWORD(1) << (FLINT_BITS / 2 - 2));
 
-        while ((iR + 1 >= lenB) && (r == WORD(0)))
+    ulong alpha1, alpha2;
+
+    if (fullword_limited)
+    {
+        alpha1 = -mod.n;               /* 2^FLINT_BITS */
+        alpha2 = 4 * alpha1 * alpha1;  /* 2^(2 FLINT_BITS) */
+    }
+    else
+    {
+        alpha1 = nmod_set_ui(UWORD(1) << (FLINT_BITS - 1), mod);
+        alpha1 = nmod_add(alpha1, alpha1, mod);    /* 2^FLINT_BITS */
+        alpha2 = nmod_mul(alpha1, alpha1, mod);    /* 2^(2 FLINT_BITS) */
+    }
+
+    for (iR = lenA - 1; iR >= lenB - 1; iR--)
+    {
+        if (fullword_limited)
         {
-            ptrQ[iR--] = WORD(0);
-            if (iR + 1 >= lenB)
-                r = n_lll_mod_preinv(R3[3 * iR + 2], R3[3 * iR + 1],
-                                     R3[3 * iR], mod.n, mod.ninv);
+            r = n_lll_rem_l_fullword_limited(R3[3 * iR + 2], R3[3 * iR + 1],
+                                 R3[3 * iR], mod, alpha2, alpha1);
+        }
+        else
+        {
+            r = n_lll_rem_l(R3[3 * iR + 2], R3[3 * iR + 1],
+                                 R3[3 * iR], mod, alpha2, alpha1);
         }
 
-        if (iR + 1 >= lenB)
+        if (r == 0)
         {
-            ptrQ[iR] = n_mulmod2_preinv(r, invL, mod.n, mod.ninv);
+            ptrQ[iR] = 0;
+        }
+        else
+        {
+            if (invL == 1)
+                ptrQ[iR] = r;
+            else
+                ptrQ[iR] = nmod_mul(r, invL, mod);
 
             if (lenB > 1)
             {
-                const ulong c = n_negmod(ptrQ[iR], mod.n);
-                mpn_addmul_1(R3 + 3 * (iR - lenB + 1), B3, 3 * lenB - 3, c);
+                c = mod.n - ptrQ[iR];
+                _nmod_vec_nored_lll_scalar_addmul(R3 + 3 * (iR - lenB + 1), B, lenB - 1, c);
             }
-            iR--;
         }
     }
 
-    for (iR = 0; iR < lenB - 1; iR++)
-        R[iR] = n_lll_mod_preinv(R3[3 * iR + 2], R3[3 * iR + 1],
-                                 R3[3 * iR], mod.n, mod.ninv);
-}
-
-static
-slong NMOD_DIVREM_BC_ITCH(slong lenA, slong lenB, nmod_t mod)
-{
-    const flint_bitcnt_t bits =
-        2 * (FLINT_BITS - mod.norm) + FLINT_BIT_COUNT(lenA - lenB + 1);
-
-    if (bits <= FLINT_BITS)
-        return lenA;
-    else if (bits <= 2 * FLINT_BITS)
-        return 2*(lenA + lenB - 1);
+    if (fullword_limited)
+        for (iR = 0; iR < lenB - 1; iR++)
+            R[iR] = n_lll_rem_l_fullword_limited(R3[3 * iR + 2], R3[3 * iR + 1],
+                                     R3[3 * iR], mod, alpha2, alpha1);
     else
-        return 3*(lenA + lenB - 1);
+        for (iR = 0; iR < lenB - 1; iR++)
+            R[iR] = n_lll_rem_l(R3[3 * iR + 2], R3[3 * iR + 1],
+                                     R3[3 * iR], mod, alpha2, alpha1);
+
+    TMP_END;
 }
 
 void
@@ -397,21 +497,15 @@ _nmod_poly_divrem_basecase_preinv1(nn_ptr Q, nn_ptr R,
     }
     else
     {
-        nn_ptr W;
-        TMP_INIT;
-        slong bits = 2 * (FLINT_BITS - mod.norm) + FLINT_BIT_COUNT(lenA - lenB + 1);
 
-        TMP_START;
-        W = TMP_ALLOC(NMOD_DIVREM_BC_ITCH(lenA, lenB, mod)*sizeof(ulong));
+        slong bits = 2 * NMOD_BITS(mod) + FLINT_BIT_COUNT(lenA - lenB + 1);
 
         if (bits <= FLINT_BITS)
-            _nmod_poly_divrem_basecase_preinv1_1(Q, R, W, A, lenA, B, lenB, invB, mod);
+            _nmod_poly_divrem_basecase_preinv1_1(Q, R, A, lenA, B, lenB, invB, mod);
         else if (bits <= 2 * FLINT_BITS)
-            _nmod_poly_divrem_basecase_preinv1_2(Q, R, W, A, lenA, B, lenB, invB, mod);
+            _nmod_poly_divrem_basecase_preinv1_2(Q, R, A, lenA, B, lenB, invB, mod);
         else
-            _nmod_poly_divrem_basecase_preinv1_3(Q, R, W, A, lenA, B, lenB, invB, mod);
-
-        TMP_END;
+            _nmod_poly_divrem_basecase_preinv1_3(Q, R, A, lenA, B, lenB, invB, mod);
     }
 }
 
@@ -441,7 +535,7 @@ void nmod_poly_divrem_basecase(nmod_poly_t Q, nmod_poly_t R,
             return;
         } else
         {
-            flint_throw(FLINT_DIVZERO, "Exception (nmod_poly_divrem). Division by zero.");
+            flint_throw(FLINT_DIVZERO, "Exception (nmod_poly_divrem_basecase). Division by zero.");
         }
     }
 
@@ -474,7 +568,7 @@ void nmod_poly_divrem_basecase(nmod_poly_t Q, nmod_poly_t R,
         r = R->coeffs;
     }
 
-    _nmod_poly_divrem(q, r, A->coeffs, lenA, B->coeffs, lenB, A->mod);
+    _nmod_poly_divrem_basecase(q, r, A->coeffs, lenA, B->coeffs, lenB, A->mod);
 
     if (Q == A || Q == B)
     {

--- a/src/nmod_vec.h
+++ b/src/nmod_vec.h
@@ -126,6 +126,31 @@ void _nmod_vec_scalar_addmul_nmod(nn_ptr res, nn_srcptr vec, slong len, ulong c,
 void _nmod_vec_scalar_addmul_nmod_generic(nn_ptr res, nn_srcptr vec, slong len, ulong c, nmod_t mod);
 void _nmod_vec_scalar_addmul_nmod_shoup(nn_ptr res, nn_srcptr vec, slong len, ulong c, nmod_t mod);
 
+#if FLINT_BITS == 64 && defined(__AVX2__)
+void _nmod_vec_nored_scalar_addmul_halflimb_avx2(nn_ptr res, nn_srcptr vec, slong len, ulong c);
+#endif
+
+NMOD_VEC_INLINE void
+_nmod_vec_nored_scalar_addmul_halflimb(nn_ptr res, nn_srcptr vec, slong len, ulong c)
+{
+#if FLINT_BITS == 64 && defined(__AVX2__)
+    if (len >= 16)
+    {
+        _nmod_vec_nored_scalar_addmul_halflimb_avx2(res, vec, len, c);
+        return;
+    }
+#endif
+
+    slong i;
+    for (i = 0; i < len; i++)
+        res[i] += vec[i] * c;
+}
+
+void _nmod_vec_nored_scalar_addmul_halflimb(nn_ptr res, nn_srcptr vec, slong len, ulong c);
+void _nmod_vec_nored_ll_scalar_addmul_halflimb(nn_ptr res, nn_srcptr vec, slong len, ulong c);
+void _nmod_vec_nored_ll_scalar_addmul(nn_ptr res, nn_srcptr vec, slong len, ulong c);
+void _nmod_vec_nored_lll_scalar_addmul(nn_ptr res, nn_srcptr vec, slong len, ulong c);
+
 /* invert each coefficient */
 void _nmod_vec_invert(nn_ptr res, nn_srcptr vec, ulong len, nmod_t mod);
 void _nmod_vec_invert_naive(nn_ptr res, nn_srcptr vec, ulong len, nmod_t mod);

--- a/src/nmod_vec/nored_scalar.c
+++ b/src/nmod_vec/nored_scalar.c
@@ -1,0 +1,179 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "flint-mparam.h"
+#include "nmod_vec.h"
+
+
+#if FLINT_BITS == 64 && defined(__AVX2__)
+
+#include "machine_vectors.h"
+
+void
+_nmod_vec_nored_scalar_addmul_halflimb_avx2(nn_ptr res, nn_srcptr vec, slong len, ulong c)
+{
+    vec4n vc = _mm256_set1_epi32((unsigned int) c);
+    slong i = 0;
+
+    /* vec4n_mul does a 32x32 -> 64 bit mul */
+
+    for ( ; i + 3 < len; i += 4)
+    {
+        vec4n va = vec4n_load_unaligned(res + i);
+        vec4n vb = vec4n_load_unaligned(vec + i);
+        vec4n_store_unaligned(res + i, vec4n_add(va, vec4n_mul(vb, vc)));
+    }
+
+    for ( ; i < len; i++)
+        res[i] += vec[i] * c;
+}
+
+#endif
+
+
+
+#define ADD2(r, hi, lo) add_ssaaaa(*((r)+1), *((r)), *((r)+1), *(r), hi, lo);
+#define ADD3(r, hi, lo) add_sssaaaaaa(*((r)+2), *((r)+1), *(r), *((r)+2), *((r)+1), *(r), 0, hi, lo);
+
+
+static void
+_nmod_vec_nored_ll_scalar_addmul_halflimb_unroll4(nn_ptr res, nn_srcptr vec, slong len, ulong c)
+{
+    slong i;
+
+    for (i = 0; i + 3 < len; i += 4)
+    {
+        ADD2(res + 2 * (i + 0), 0, vec[i + 0] * c);
+        ADD2(res + 2 * (i + 1), 0, vec[i + 1] * c);
+        ADD2(res + 2 * (i + 2), 0, vec[i + 2] * c);
+        ADD2(res + 2 * (i + 3), 0, vec[i + 3] * c);
+    }
+
+    for ( ; i < len; i++)
+        ADD2(res + 2 * i, 0, vec[i] * c);
+}
+
+void
+_nmod_vec_nored_ll_scalar_addmul_halflimb(nn_ptr res, nn_srcptr vec, slong len, ulong c)
+{
+    slong i;
+
+    if (len >= 12)
+    {
+        _nmod_vec_nored_ll_scalar_addmul_halflimb_unroll4(res, vec, len, c);
+        return;
+    }
+
+    for (i = 0; i < len; i++)
+        ADD2(res + 2 * i, 0, vec[i] * c);
+}
+
+static void
+_nmod_vec_nored_ll_scalar_addmul_1(nn_ptr res, nn_srcptr vec, slong len, ulong c)
+{
+    slong i;
+
+    for (i = 0; i < len; i++)
+    {
+        ulong hi, lo;
+        umul_ppmm(hi, lo, vec[i], c);
+        ADD2(res + 2 * i, hi, lo);
+    }
+}
+
+
+static void
+_nmod_vec_nored_ll_scalar_addmul_unroll4(nn_ptr res, nn_srcptr vec, slong len, ulong c)
+{
+    slong i;
+
+    for (i = 0; i + 3 < len; i += 4)
+    {
+        ulong l0, l1, l2, l3, h0, h1, h2, h3;
+
+        umul_ppmm(h0, l0, vec[i + 0], c);
+        ADD2(res + 2 * (i + 0), h0, l0);
+        umul_ppmm(h1, l1, vec[i + 1], c);
+        ADD2(res + 2 * (i + 1), h1, l1);
+        umul_ppmm(h2, l2, vec[i + 2], c);
+        ADD2(res + 2 * (i + 2), h2, l2);
+        umul_ppmm(h3, l3, vec[i + 3], c);
+        ADD2(res + 2 * (i + 3), h3, l3);
+    }
+
+    for ( ; i < len; i++)
+    {
+        ulong hi, lo;
+        umul_ppmm(hi, lo, vec[i], c);
+        ADD2(res + 2 * i, hi, lo);
+    }
+}
+
+void
+_nmod_vec_nored_ll_scalar_addmul(nn_ptr res, nn_srcptr vec, slong len, ulong c)
+{
+    if (len < 24)
+        _nmod_vec_nored_ll_scalar_addmul_1(res, vec, len, c);
+    else
+        _nmod_vec_nored_ll_scalar_addmul_unroll4(res, vec, len, c);
+}
+
+
+static void
+_nmod_vec_nored_lll_scalar_addmul_unroll4(nn_ptr res, nn_srcptr vec, slong len, ulong c)
+{
+    slong i;
+
+    for (i = 0; i + 3 < len; i += 4)
+    {
+        ulong l0, l1, l2, l3, h0, h1, h2, h3;
+
+        umul_ppmm(h0, l0, vec[i + 0], c);
+        umul_ppmm(h1, l1, vec[i + 1], c);
+        umul_ppmm(h2, l2, vec[i + 2], c);
+        umul_ppmm(h3, l3, vec[i + 3], c);
+
+        ADD3(res + 3 * (i + 0), h0, l0);
+        ADD3(res + 3 * (i + 1), h1, l1);
+        ADD3(res + 3 * (i + 2), h2, l2);
+        ADD3(res + 3 * (i + 3), h3, l3);
+    }
+
+    for ( ; i < len; i++)
+    {
+        ulong hi, lo;
+        umul_ppmm(hi, lo, vec[i], c);
+        ADD3(res + 3 * i, hi, lo);
+    }
+}
+
+static void
+_nmod_vec_nored_lll_scalar_addmul_1(nn_ptr res, nn_srcptr vec, slong len, ulong c)
+{
+    slong i;
+
+    for (i = 0; i < len; i++)
+    {
+        ulong hi, lo;
+        umul_ppmm(hi, lo, vec[i], c);
+        ADD3(res + 3 * i, hi, lo);
+    }
+}
+
+void
+_nmod_vec_nored_lll_scalar_addmul(nn_ptr res, nn_srcptr vec, slong len, ulong c)
+{
+    if (len < 24)
+        _nmod_vec_nored_lll_scalar_addmul_1(res, vec, len, c);
+    else
+        _nmod_vec_nored_lll_scalar_addmul_unroll4(res, vec, len, c);
+}
+

--- a/src/nmod_vec/test/main.c
+++ b/src/nmod_vec/test/main.c
@@ -19,6 +19,7 @@
 #include "t-invert.c"
 #include "t-nmod.c"
 #include "t-nmod_pow_fmpz.c"
+#include "t-nored_scalar_addmul.c"
 #include "t-reduce.c"
 #include "t-scalar_addmul_nmod.c"
 #include "t-scalar_mul_nmod.c"
@@ -36,6 +37,7 @@ test_struct tests[] =
     TEST_FUNCTION(nmod_vec_invert),
     TEST_FUNCTION(nmod_vec_nmod),
     TEST_FUNCTION(nmod_vec_nmod_pow_fmpz),
+    TEST_FUNCTION(nmod_vec_nored_scalar_addmul),
     TEST_FUNCTION(nmod_vec_reduce),
     TEST_FUNCTION(nmod_vec_scalar_addmul_nmod),
     TEST_FUNCTION(nmod_vec_scalar_mul_nmod),

--- a/src/nmod_vec/test/t-nored_scalar_addmul.c
+++ b/src/nmod_vec/test/t-nored_scalar_addmul.c
@@ -1,0 +1,172 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "nmod_vec.h"
+#include "test_helpers.h"
+
+static ulong
+n_randtest_upto_bits(flint_rand_t state, ulong bits)
+{
+    ulong x = n_randtest(state);
+    if (bits != FLINT_BITS)
+        x &= ((UWORD(1) << bits) - 1);
+    return x;
+}
+
+TEST_FUNCTION_START(nmod_vec_nored_scalar_addmul, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 1000000 * flint_test_multiplier(); iter++)
+    {
+        nn_ptr Ain, A, B, Aref;
+        nmod_t mod;
+        ulong c;
+        ulong n = n_randtest_not_zero(state);
+        slong len = n_randint(state, 30);
+        slong i;
+
+        nmod_init(&mod, n);
+
+        Ain = flint_malloc(sizeof(ulong) * 3 * len);
+        A = flint_malloc(sizeof(ulong) * 3 * len);
+        B = flint_malloc(sizeof(ulong) * len);
+        Aref = flint_malloc(sizeof(ulong) * 3 * len);
+
+        /* halflimb */
+
+        for (i = 0; i < len; i++)
+        {
+            Ain[i] = A[i] = n_randtest_upto_bits(state, FLINT_BITS - 1);
+            B[i] = n_randtest_upto_bits(state, FLINT_BITS / 2);
+        }
+
+        c = n_randtest_upto_bits(state, FLINT_BITS / 2);
+
+        _nmod_vec_nored_scalar_addmul_halflimb(A, B, len, c);
+
+        for (i = 0; i < len; i++)
+            Aref[i] = Ain[i] + B[i] * c;
+
+        if (!_nmod_vec_equal(A, Aref, len))
+        {
+            flint_printf("FAIL: _nmod_vec_nored_scalar_addmul_halflimb\n");
+            flint_printf("Ain = %{ulong*}\n", Ain, len);
+            flint_printf("A = %{ulong*}\n", A, len);
+            flint_printf("B = %{ulong*}\n", B, len);
+            flint_printf("c = %wu\n", c);
+            flint_printf("Aref = %{ulong*}\n", Aref, len);
+            flint_abort();
+        }
+
+        /* ll_halflimb */
+
+        for (i = 0; i < len; i++)
+        {
+            Ain[2 * i + 1] = A[2 * i + 1] = n_randtest_upto_bits(state, FLINT_BITS - 1);
+            Ain[2 * i] = A[2 * i] = n_randtest(state);
+            B[i] = n_randtest_upto_bits(state, FLINT_BITS / 2);
+        }
+
+        c = n_randtest_upto_bits(state, FLINT_BITS / 2 - 1);
+
+        _nmod_vec_nored_ll_scalar_addmul_halflimb(A, B, len, c);
+
+        for (i = 0; i < len; i++)
+        {
+            ulong hi, lo;
+            umul_ppmm(hi, lo, B[i], c);
+            add_ssaaaa(Aref[2 * i + 1], Aref[2 * i], Ain[2 * i + 1], Ain[2 * i], hi, lo);
+        }
+
+        if (!_nmod_vec_equal(A, Aref, 2 * len))
+        {
+            flint_printf("FAIL: _nmod_vec_nored_ll_scalar_addmul_halflimb\n");
+            flint_printf("Ain = %{ulong*}\n", Ain, 2 * len);
+            flint_printf("A = %{ulong*}\n", A, 2 * len);
+            flint_printf("B = %{ulong*}\n", B, len);
+            flint_printf("c = %wu\n", c);
+            flint_printf("Aref = %{ulong*}\n", Aref, 2 * len);
+            flint_abort();
+        }
+
+        /* ll */
+
+        for (i = 0; i < len; i++)
+        {
+            Ain[2 * i + 1] = A[2 * i + 1] = n_randtest_upto_bits(state, FLINT_BITS - 1);
+            Ain[2 * i] = A[2 * i] = n_randtest(state);
+            B[i] = n_randtest(state);
+        }
+
+        c = n_randtest_upto_bits(state, FLINT_BITS - 1);
+
+        _nmod_vec_nored_ll_scalar_addmul(A, B, len, c);
+
+        for (i = 0; i < len; i++)
+        {
+            ulong hi, lo;
+            umul_ppmm(hi, lo, B[i], c);
+            add_ssaaaa(Aref[2 * i + 1], Aref[2 * i], Ain[2 * i + 1], Ain[2 * i], hi, lo);
+        }
+
+        if (!_nmod_vec_equal(A, Aref, 2 * len))
+        {
+            flint_printf("FAIL: _nmod_vec_nored_ll_scalar_addmul\n");
+            flint_printf("Ain = %{ulong*}\n", Ain, 2 * len);
+            flint_printf("A = %{ulong*}\n", A, 2 * len);
+            flint_printf("B = %{ulong*}\n", B, len);
+            flint_printf("c = %wu\n", c);
+            flint_printf("Aref = %{ulong*}\n", Aref, 2 * len);
+            flint_abort();
+        }
+
+        /* lll */
+
+        for (i = 0; i < len; i++)
+        {
+            Ain[3 * i + 2] = A[3 * i + 2] = n_randtest_upto_bits(state, FLINT_BITS - 1);
+            Ain[3 * i + 1] = A[3 * i + 1] = n_randtest(state);
+            Ain[3 * i] = A[3 * i] = n_randtest(state);
+            B[i] = n_randtest(state);
+        }
+
+        c = n_randtest(state);
+
+        _nmod_vec_nored_lll_scalar_addmul(A, B, len, c);
+
+        for (i = 0; i < len; i++)
+        {
+            ulong hi, lo;
+            umul_ppmm(hi, lo, B[i], c);
+            add_sssaaaaaa(Aref[3 * i + 2], Aref[3 * i + 1], Aref[3 * i],
+                          Ain[3 * i + 2], Ain[3 * i + 1], Ain[3 * i], 0, hi, lo);
+        }
+
+        if (!_nmod_vec_equal(A, Aref, 3 * len))
+        {
+            flint_printf("FAIL: _nmod_vec_nored_lll_scalar_addmul\n");
+            flint_printf("Ain = %{ulong*}\n", Ain, 3 * len);
+            flint_printf("A = %{ulong*}\n", A, 3 * len);
+            flint_printf("B = %{ulong*}\n", B, len);
+            flint_printf("c = %wu\n", c);
+            flint_printf("Aref = %{ulong*}\n", Aref, 3 * len);
+            flint_abort();
+        }
+
+        flint_free(Ain);
+        flint_free(A);
+        flint_free(B);
+        flint_free(Aref);
+    }
+
+    TEST_FUNCTION_END(state);
+}


### PR DESCRIPTION
Basecase polynomial division with remainder (`nmod_poly_divrem_basecase`) is optimized in several ways:

* Don't use `mpn_addmul_1` for the unreduced vector addmuls; we don't need carry propagation, so do it with plain loops and benefit from instruction level parallelism (verified to be significantly faster on Zen 3; I presume that this will be the case for other modern architectures)
* Use AVX2 when the unreduced sums fit in 64 bits
* Skip a multiplication when the divisor is monic
* Replace a `negmod` with a plain subtraction
* Specialize modular reduction for different cases
* Simplify some of the logic
* Optimize temporary allocations

The basecase->Newton thresholds in `_nmod_poly_divrem` have also been increased, but I have not touched tuning values in higher algorithms that may benefit indirectly. Note that this speeds up `nmod_poly_rem` but does not affect `nmod_poly_div` since division without remainder uses a different algorithm.

Speedup on Zen 3 for `nmod_poly_divrem` to perform a 2 len by len division with moduli of different bit size, monic divisor:

```
  len \ bits   2    16    27    28    32    48    56    63    64    64(close to UWORD_MAX)

       2    1.73  1.92  1.80  1.81  1.63  1.62  1.62  1.64  1.64  1.52
       3    2.24  1.93  1.91  1.92  1.59  1.57  1.57  1.42  1.69  1.54
       4    1.83  1.75  1.75  1.74  1.59  1.57  1.58  1.49  1.71  1.59
       6    1.99  1.73  1.73  1.71  1.58  1.55  1.52  1.53  1.71  1.62
       8    2.40  1.82  1.84  1.80  1.58  1.54  1.53  1.63  1.83  1.70
      12    2.79  1.88  1.86  1.85  1.73  1.56  1.57  1.64  1.98  1.91
      16    3.07  2.10  2.15  2.10  1.65  1.56  1.56  1.62  1.77  1.66
      24    3.25  2.29  2.32  2.31  1.69  1.49  1.48  1.48  1.56  1.50
      32    3.79  2.47  2.48  2.44  1.54  1.25  1.28  1.27  1.34  1.31
      48    3.75  3.30  3.08  2.97  1.39  1.15  1.16  1.13  1.20  1.13
      64    3.54  3.28  3.00  3.04  1.29  1.06  1.08  1.06  1.11  1.09
      96    2.67  3.18  4.20  1.00  1.00  1.00  1.00  1.00  1.00  1.00
     128    2.30  2.48  4.09  1.00  1.00  1.00  1.00  1.01  1.02  1.00
     192    1.63  2.16  3.19  0.99  1.00  1.01  1.00  1.00  1.00  1.01
     256    1.53  1.93  2.48  1.00  1.00  1.00  1.00  1.01  1.00  1.00
     384    1.10  1.18  2.26  1.01  1.00  1.00  1.00  1.00  1.00  1.00
     512    1.01  1.00  0.99  1.00  1.00  1.00  0.99  1.00  1.00  1.00
```

Non-monic divisor:

```
               2    16    27    28    32    48    56    63    64    64(close to UWORD_MAX)
       2    1.30  1.39  1.29  1.23  1.22  1.15  1.18  1.13  1.20  1.20
       3    1.75  1.46  1.32  1.21  1.17  1.20  1.14  1.12  1.22  1.18
       4    1.56  1.43  1.30  1.26  1.20  1.16  1.14  1.14  1.26  1.19
       6    1.71  1.49  1.40  1.37  1.22  1.15  1.17  1.20  1.28  1.23
       8    1.80  1.48  1.33  1.33  1.21  1.15  1.14  1.26  1.38  1.29
      12    2.58  1.64  1.43  1.36  1.26  1.16  1.16  1.46  1.73  1.70
      16    2.30  1.82  1.61  1.53  1.25  1.20  1.20  1.51  1.60  1.54
      24    3.08  2.13  1.82  1.79  1.54  1.37  1.36  1.39  1.47  1.40
      32    3.06  2.21  2.13  2.12  1.44  1.19  1.22  1.22  1.31  1.27
      48    3.89  3.51  3.09  3.07  1.36  1.15  1.14  1.12  1.17  1.15
      64    4.59  3.49  3.06  3.03  1.27  1.08  1.08  1.06  1.09  1.04
      96    2.54  3.52  4.22  1.00  1.00  1.00  1.00  1.00  1.00  0.99
     128    2.38  2.71  4.18  1.00  1.00  1.01  1.00  1.01  1.00  1.00
     192    1.90  2.28  2.96  1.02  1.00  0.99  1.00  1.00  1.00  1.00
     256    1.51  2.01  2.42  1.00  1.00  1.00  1.00  1.00  1.01  1.00
     384    1.14  1.21  2.35  1.00  1.00  1.00  1.00  1.00  1.00  1.01
     512    1.01  1.00  1.00  1.00  1.00  1.00  1.00  1.00  1.00  1.00
```

The added helper functions `_nmod_vec_nored_scalar_addmul...` can be useful elsewhere, notably in basecase LU factorization which I'll do in a separate PR.

Possible further improvements which I did not implement:

* The AVX2 code goes up to ~27 bits; specifically, it handles the case where unreduced sums are guaranteed to fit in 64 bits. It shouldn't be too difficult to handle all 32-bit moduli: doing 128-bit additions with carry-handling sounds terrible, but you could rearrange the data to accumulate the high and low 32 bits of the products into two independent 64-bit sums.

* Neon version of the AVX2 code.

* For really small moduli I guess you could get another 2x speedup by repacking to work on vectors of 32-bit integers instead of vectors of 64-bit integers holding 32-bit values.

* At each iteration, we reduce `R[iR]`, check if it is zero, and then multiply by the leading inverse. It would sometimes be better to multiply by the unreduced value of `R[iR]`, and *then* check for zero, thus skipping a modular reduction.

* Vectorized modular reduction (not specific to polynomial division).