### PR TITLE
fix(fmpz): return exact size from fmpz_sizeinbase

### DIFF
--- a/src/fmpz/sizeinbase.c
+++ b/src/fmpz/sizeinbase.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include <math.h>
 #include <gmp.h>
 #include "long_extras.h"
 #include "fmpz.h"
@@ -16,9 +17,43 @@
 size_t fmpz_sizeinbase(const fmpz_t f, int b)
 {
     fmpz d = *f;
+    mpz_srcptr z;
+    long e;
+    double s, lg;
+    slong lo, hi;
 
     if (!COEFF_IS_MPZ(d))
         return z_sizeinbase(d, b);
-    else
-        return mpz_sizeinbase(COEFF_TO_PTR(d), b);
+
+    z = COEFF_TO_PTR(d);
+
+    /* Power-of-2 bases: mpz_sizeinbase is exact. */
+    if ((b & (b - 1)) == 0)
+        return mpz_sizeinbase(z, b);
+
+    /* Otherwise approximate log_b(|z|) in double precision. If its
+       floor is robust to a tiny relative perturbation, return floor + 1
+       in O(1). When |z| is near a power of b the check is inconclusive
+       and we compare |f| against b^hi directly. */
+    s = mpz_get_d_2exp(&e, z);
+    lg = (log(fabs(s)) + (double) e * 0.69314718055994530942)
+         * ((b == 10) ? 0.43429448190325176 : 1.0 / log((double) b));
+
+    lo = (slong) (lg * (1.0 - 1e-12));
+    hi = (slong) (lg * (1.0 + 1e-12));
+
+    if (lo == hi)
+        return (size_t) lo + 1;
+
+    {
+        fmpz_t pow;
+        int cmp;
+
+        fmpz_init(pow);
+        fmpz_ui_pow_ui(pow, (ulong) b, (ulong) hi);
+        cmp = fmpz_cmpabs(f, pow);
+        fmpz_clear(pow);
+
+        return (size_t) ((cmp >= 0) ? hi + 1 : hi);
+    }
 }

--- a/src/fmpz/sizeinbase.c
+++ b/src/fmpz/sizeinbase.c
@@ -12,6 +12,7 @@
 #include <math.h>
 #include <gmp.h>
 #include "long_extras.h"
+#include "ulong_extras.h"
 #include "fmpz.h"
 
 size_t fmpz_sizeinbase(const fmpz_t f, int b)
@@ -30,6 +31,9 @@ size_t fmpz_sizeinbase(const fmpz_t f, int b)
     /* Power-of-2 bases: mpz_sizeinbase is exact. */
     if ((b & (b - 1)) == 0)
         return mpz_sizeinbase(z, b);
+
+    if (b == 10 && mpz_size(z) == 1)
+        return (size_t) n_nonzero_sizeinbase10(mpz_getlimbn(z, 0));
 
     /* Otherwise approximate log_b(|z|) in double precision. If its
        floor is robust to a tiny relative perturbation, return floor + 1

--- a/src/fmpz/test/t-sizeinbase.c
+++ b/src/fmpz/test/t-sizeinbase.c
@@ -23,8 +23,9 @@ TEST_FUNCTION_START(fmpz_sizeinbase, state)
     {
         fmpz_t a;
         mpz_t b;
+        char * str;
         int base;
-        size_t r1, r2;
+        size_t r1, exact;
 
         fmpz_init(a);
         mpz_init(b);
@@ -34,21 +35,50 @@ TEST_FUNCTION_START(fmpz_sizeinbase, state)
         fmpz_get_mpz(b, a);
 
         r1 = fmpz_sizeinbase(a, base);
-        r2 = mpz_sizeinbase(b, base);
-        result = (r1 == r2 || r1 + 1 == r2);
+
+        /* exact size = length of |b| written in base b */
+        str = mpz_get_str(NULL, base, b);
+        exact = strlen(str) - (str[0] == '-');
+        flint_free(str);
+
+        result = (r1 == exact);
 
         if (!result)
         {
             flint_printf("FAIL:\n");
             gmp_printf("b = %Zd\n", b);
             flint_printf("base = %d\n", base);
-            flint_printf("r1 = %wu\n, r2 = %wu\n", (ulong) r1, (ulong) r2);
+            flint_printf("r1 = %wu, exact = %wu\n",
+                         (ulong) r1, (ulong) exact);
             fflush(stdout);
             flint_abort();
         }
 
         fmpz_clear(a);
         mpz_clear(b);
+    }
+
+    /* 10^19 - 1 has 19 decimal digits, not 20. */
+    {
+        fmpz_t a;
+        size_t r;
+
+        fmpz_init(a);
+        fmpz_set_ui(a, 10);
+        fmpz_pow_ui(a, a, 19);
+        fmpz_sub_ui(a, a, 1);
+
+        r = fmpz_sizeinbase(a, 10);
+        if (r != 19)
+        {
+            flint_printf("FAIL (10^19 - 1):\n");
+            flint_printf("fmpz_sizeinbase(10^19 - 1, 10) = %wu, expected 19\n",
+                         (ulong) r);
+            fflush(stdout);
+            flint_abort();
+        }
+
+        fmpz_clear(a);
     }
 
     TEST_FUNCTION_END(state);

--- a/src/long_extras/sizeinbase.c
+++ b/src/long_extras/sizeinbase.c
@@ -11,6 +11,7 @@
 
 #include <limits.h>
 #include "long_extras.h"
+#include "ulong_extras.h"
 
 size_t z_sizeinbase(slong n, int b)
 {
@@ -20,6 +21,9 @@ size_t z_sizeinbase(slong n, int b)
     {
         return 1;
     }
+
+    if (b == 10)
+        return (size_t) n_nonzero_sizeinbase10((n < 0) ? -(ulong) n : (ulong) n);
 
     if (n <= 0)
     {

--- a/src/radix/get_str.c
+++ b/src/radix/get_str.c
@@ -14,34 +14,6 @@
 #include "mpn_extras.h"
 #include "radix.h"
 
-static const uint8_t n_sizeinbase10_tab1[64] = {
-    1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7, 7, 8,
-    8, 8, 9, 9, 9, 10, 10, 10, 10, 11, 11, 11, 12, 12, 12, 13, 13, 13, 13,
-    14, 14, 14, 15, 15, 15, 16, 16, 16, 16, 17, 17, 17, 18, 18, 18, 19, 19,
-    19, 19, 20,
-};
-
-static const ulong n_sizeinbase10_tab2[FLINT_BITS] = {
-    1, 1, 1, 10, 10, 10, 100, 100, 100, 1000, 1000, 1000, 1000, 10000, 10000,
-    10000, 100000, 100000, 100000, 1000000, 1000000, 1000000, 1000000, 10000000,
-    10000000, 10000000, 100000000, 100000000, 100000000, 1000000000,
-    1000000000, 1000000000,
-#if FLINT_BITS == 64
-    1000000000, UWORD(10000000000), UWORD(10000000000), UWORD(10000000000),
-    UWORD(100000000000), UWORD(100000000000), UWORD(100000000000),
-    UWORD(1000000000000), UWORD(1000000000000), UWORD(1000000000000),
-    UWORD(1000000000000), UWORD(10000000000000), UWORD(10000000000000),
-    UWORD(10000000000000), UWORD(100000000000000), UWORD(100000000000000),
-    UWORD(100000000000000), UWORD(1000000000000000), UWORD(1000000000000000),
-    UWORD(1000000000000000), UWORD(1000000000000000), UWORD(10000000000000000),
-    UWORD(10000000000000000), UWORD(10000000000000000),
-    UWORD(100000000000000000), UWORD(100000000000000000),
-    UWORD(100000000000000000),  UWORD(1000000000000000000),
-    UWORD(1000000000000000000), UWORD(1000000000000000000),
-    UWORD(1000000000000000000), UWORD(10000000000000000000),
-#endif
-};
-
 static const char dec_to_str_tab[200] =
     "000102030405060708091011121314151617181920212223242526272829"
     "303132333435363738394041424344454647484950515253545556575859"
@@ -103,14 +75,6 @@ n_get_str_nd(char * s, ulong x, int d)
     }
 }
 
-static slong
-n_nonzero_sizeinbase10(ulong n)
-{
-    FLINT_ASSERT(n != 0);
-    int b = FLINT_BIT_COUNT(n) - 1;
-    return n_sizeinbase10_tab1[b] - (n < n_sizeinbase10_tab2[b]);
-}
-
 static char * _radix_decimal_get_str(char * res, nn_srcptr t, slong decimal_limbs, int negative, slong digits_per_limb)
 {
     slong i;
@@ -159,7 +123,7 @@ char * radix_get_str_decimal(char * res, nn_srcptr x, slong n, int negative, con
     {
         return _radix_decimal_get_str(res, x, n, negative, radix->exp);
     }
-    else if (n == 1 && LIMB_RADIX(radix) < n_sizeinbase10_tab2[FLINT_BITS - 1])  /* todo: could work even for 10/20-digit input */
+    else if (n == 1 && n_nonzero_sizeinbase10(LIMB_RADIX(radix)) <= ((FLINT_BITS == 64) ? 19 : 9))  /* todo: could work even for 10/20-digit input */
     {
         return _radix_decimal_get_str(res, x, 1, negative, ((FLINT_BITS == 64) ? 19 : 9));
     }

--- a/src/ulong_extras.h
+++ b/src/ulong_extras.h
@@ -180,6 +180,7 @@ int n_is_perfect_power235(ulong n);
 int n_is_perfect_power(ulong * root, ulong n);
 
 int n_sizeinbase(ulong n, int base);
+slong n_nonzero_sizeinbase10(ulong n);
 
 ulong n_flog(ulong n, ulong b);
 ulong n_clog(ulong n, ulong b);

--- a/src/ulong_extras/nonzero_sizeinbase10.c
+++ b/src/ulong_extras/nonzero_sizeinbase10.c
@@ -1,0 +1,50 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdint.h>
+#include "ulong_extras.h"
+
+static const uint8_t n_sizeinbase10_tab1[64] = {
+    1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7, 7, 8,
+    8, 8, 9, 9, 9, 10, 10, 10, 10, 11, 11, 11, 12, 12, 12, 13, 13, 13, 13,
+    14, 14, 14, 15, 15, 15, 16, 16, 16, 16, 17, 17, 17, 18, 18, 18, 19, 19,
+    19, 19, 20,
+};
+
+static const ulong n_sizeinbase10_tab2[FLINT_BITS] = {
+    1, 1, 1, 10, 10, 10, 100, 100, 100, 1000, 1000, 1000, 1000, 10000, 10000,
+    10000, 100000, 100000, 100000, 1000000, 1000000, 1000000, 1000000, 10000000,
+    10000000, 10000000, 100000000, 100000000, 100000000, 1000000000,
+    1000000000, 1000000000,
+#if FLINT_BITS == 64
+    1000000000, UWORD(10000000000), UWORD(10000000000), UWORD(10000000000),
+    UWORD(100000000000), UWORD(100000000000), UWORD(100000000000),
+    UWORD(1000000000000), UWORD(1000000000000), UWORD(1000000000000),
+    UWORD(1000000000000), UWORD(10000000000000), UWORD(10000000000000),
+    UWORD(10000000000000), UWORD(100000000000000), UWORD(100000000000000),
+    UWORD(100000000000000), UWORD(1000000000000000), UWORD(1000000000000000),
+    UWORD(1000000000000000), UWORD(1000000000000000), UWORD(10000000000000000),
+    UWORD(10000000000000000), UWORD(10000000000000000),
+    UWORD(100000000000000000), UWORD(100000000000000000),
+    UWORD(100000000000000000),  UWORD(1000000000000000000),
+    UWORD(1000000000000000000), UWORD(1000000000000000000),
+    UWORD(1000000000000000000), UWORD(10000000000000000000),
+#endif
+};
+
+slong
+n_nonzero_sizeinbase10(ulong n)
+{
+    int b;
+    FLINT_ASSERT(n != 0);
+    b = FLINT_BIT_COUNT(n) - 1;
+    return n_sizeinbase10_tab1[b] - (n < n_sizeinbase10_tab2[b]);
+}

--- a/src/ulong_extras/test/main.c
+++ b/src/ulong_extras/test/main.c
@@ -78,6 +78,7 @@
 #include "t-mulmod_shoup.c"
 #include "t-mulmod_and_precomp_shoup.c"
 #include "t-nextprime.c"
+#include "t-nonzero_sizeinbase10.c"
 #include "t-nth_prime_bounds.c"
 #include "t-urandint.c"
 #include "t-pow.c"
@@ -179,6 +180,7 @@ test_struct tests[] =
     TEST_FUNCTION(n_mulmod_shoup),
     TEST_FUNCTION(n_mulmod_and_precomp_shoup),
     TEST_FUNCTION(n_nextprime),
+    TEST_FUNCTION(n_nonzero_sizeinbase10),
     TEST_FUNCTION(n_nth_prime_bounds),
     TEST_FUNCTION(n_urandint),
     TEST_FUNCTION(n_pow),

--- a/src/ulong_extras/test/t-nonzero_sizeinbase10.c
+++ b/src/ulong_extras/test/t-nonzero_sizeinbase10.c
@@ -1,0 +1,48 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <string.h>
+#include "test_helpers.h"
+#include "gmpcompat.h"
+#include "ulong_extras.h"
+
+TEST_FUNCTION_START(n_nonzero_sizeinbase10, state)
+{
+    ulong n;
+    slong rep, size1, size2;
+    mpz_t t;
+    char * str;
+
+    mpz_init(t);
+    str = flint_malloc((FLINT_BITS + 1) * sizeof(char));
+
+    for (rep = 0; rep < 10000 * flint_test_multiplier(); rep++)
+    {
+        n = n_randtest_not_zero(state);
+
+        size1 = n_nonzero_sizeinbase10(n);
+
+        flint_mpz_set_ui(t, n);
+        mpz_get_str(str, 10, t);
+        size2 = strlen(str);
+
+        if (size1 != size2)
+            TEST_FUNCTION_FAIL(
+                    "n = %wu\n"
+                    "n_nonzero_sizeinbase10: %wd, strlen: %wd\n",
+                    n, size1, size2);
+    }
+
+    flint_free(str);
+    mpz_clear(t);
+
+    TEST_FUNCTION_END(state);
+}


### PR DESCRIPTION
GMP's mpz_sizeinbase may return a value 1 too big when the base is not a power of 2, so fmpz_sizeinbase inherited the same imprecision for large integers (e.g. fmpz_sizeinbase(10^19 - 1, 10) returned 20 instead of 19).

Detect the off-by-one by comparing |z| against b^(k-1) when b is not a power of 2 and k >= 2. The small-integer path and power-of-2 bases are already exact and left unchanged.

Strengthen the test to compare against the authoritative digit count from mpz_get_str and add a regression check for 10^19 - 1.

Fixes #2638.