### PR TITLE
Optimize `nmod_mat_lu_classical_delayed`

### DIFF
--- a/src/nmod_mat/lu.c
+++ b/src/nmod_mat/lu.c
@@ -13,47 +13,42 @@
 #include "nmod_vec.h"
 #include "nmod_mat.h"
 
+#if FLINT_USES_BLAS || (FLINT_BITS == 32) || !defined(__AVX2__)
+
+/* Tuned for Zen 3 with BLAS */
+static const slong lu_cutoff_tab[64] = { 64, 64, 244, 280, 296, 320, 332,
+    792, 800, 800, 800, 400, 400, 400, 400, 404, 404, 400, 408, 416, 400,
+    412, 424, 408, 484, 1352, 1032, 260, 68, 56, 56, 56, 148, 160, 148, 156,
+    156, 156, 120, 168, 160, 124, 156, 124, 156, 148, 112, 156, 148, 136,
+    156, 160, 116, 136, 168, 148, 156, 160, 120, 128, 68, 64, 104, 104 };
+
+#else
+
+/* Tuned for Zen 3 without BLAS */
+static const slong lu_cutoff_tab[64] = { 64, 64, 212, 260, 280, 316, 344,
+    792, 872, 904, 856, 1016, 1136, 1456, 1440, 1464, 1376, 1392, 1448, 1448,
+    1360, 1392, 1400, 1392, 1448, 1416, 1032, 260, 68, 56, 56, 60, 168, 164,
+    152, 152, 156, 148, 148, 148, 152, 164, 160, 148, 164, 148, 164, 160, 160,
+    148, 156, 156, 148, 164, 148, 164, 148, 148, 148, 128, 68, 64, 96, 96 };
+
+#endif
+
 slong
 nmod_mat_lu(slong * P, nmod_mat_t A, int rank_check)
 {
-    slong nrows, ncols, n, cutoff;
-    int bits;
-    nrows = A->r;
-    ncols = A->c;
-
+    slong nrows = A->r, ncols = A->c, n;
     n = FLINT_MIN(nrows, ncols);
 
-    if (n <= 3)
+    if (n <= 3 || (NMOD_BITS(A->mod) > 28 && n <= 7))
     {
         return nmod_mat_lu_classical(P, A, rank_check);
     }
     else
     {
-        if (n >= 20)
-        {
-            bits = NMOD_BITS(A->mod);
-
-            if (bits >= FLINT_BITS - 1)
-                cutoff = 80;
-            else if (bits >= FLINT_BITS / 2 - 2)
-                cutoff = 60;
-            else if (bits >= FLINT_BITS / 4 - 1)
-                cutoff = 180;
-            else
-                cutoff = 60;
-
-            if (n >= cutoff)
-                return nmod_mat_lu_recursive(P, A, rank_check);
-        }
-
-        const dot_params_t params = _nmod_vec_dot_params(n, A->mod);
-
-        // TODO thresholds to re-examine after dot product changes
-        if (params.method <= _DOT1                        // <= 0,1 limb
-                || (params.method <= _DOT2 && n >= 12)    // <= 2 limbs (n >= 12 if exactly 2)
-                || (params.method > _DOT2 && n >= 20))    // == 3 limbs && n >= 20
+        if (n < lu_cutoff_tab[NMOD_BITS(A->mod) - 1])
             return nmod_mat_lu_classical_delayed(P, A, rank_check);
         else
-            return nmod_mat_lu_classical(P, A, rank_check);
+            return nmod_mat_lu_recursive(P, A, rank_check);
     }
 }
+

--- a/src/nmod_mat/lu_classical_delayed.c
+++ b/src/nmod_mat/lu_classical_delayed.c
@@ -13,14 +13,6 @@
 #include "nmod_vec.h"
 #include "nmod_mat.h"
 
-static ulong
-nmod_set_uiuiui(ulong s2, ulong s1, ulong s0, nmod_t mod)
-{
-    NMOD_RED(s2, s2, mod);
-    NMOD_RED3(s0, s2, s1, s0, mod);
-    return s0;
-}
-
 static slong
 nmod_mat_lu_classical_delayed_1(slong * P, nmod_mat_t A, int rank_check)
 {
@@ -28,11 +20,21 @@ nmod_mat_lu_classical_delayed_1(slong * P, nmod_mat_t A, int rank_check)
     nmod_t mod;
     slong i, j, nrows, ncols, rank, row, col, pivot_row;
     slong stride = A->stride;
+    int unreduced_fits_halflimb;
+    int reduced_fits_quarterlimb;
 
     nrows = A->r;
     ncols = A->c;
     aa = A->entries;
     mod = A->mod;
+
+    ulong unreduced_bound = (mod.n - 1) * (mod.n - 1) * FLINT_MIN(nrows, ncols);
+
+    unreduced_fits_halflimb = unreduced_bound < UWORD(1) << (FLINT_BITS / 2);
+    reduced_fits_quarterlimb = NMOD_BITS(mod) <= FLINT_BITS / 4;
+
+    ulong npre = n_barrett_precomp(mod.n);
+    ulong npre2 = n_lemire_precomp(mod.n);
 
 #define a(ii, jj) (aa[(ii) * stride + (jj)])
 
@@ -46,8 +48,18 @@ nmod_mat_lu_classical_delayed_1(slong * P, nmod_mat_t A, int rank_check)
         /* reduce current column */
         /* can be skipped on the first iteration */
         if (col != 0)
-            for (j = row; j < nrows; j++)
-                NMOD_RED(a(j, col), a(j, col), mod);
+        {
+            if (unreduced_fits_halflimb)
+            {
+                for (j = row; j < nrows; j++)
+                    a(j, col) = n_mod_lemire(a(j, col), mod.n, npre2);
+            }
+            else
+            {
+                for (j = row; j < nrows; j++)
+                    a(j, col) = n_mod_barrett(a(j, col), mod.n, npre);
+            }
+        }
 
         pivot_row = -1;
         for (i = row; i < nrows; i++)
@@ -75,33 +87,36 @@ nmod_mat_lu_classical_delayed_1(slong * P, nmod_mat_t A, int rank_check)
 
         /* reduce current pivot row */
         if (col != 0)
-            for (j = col + 1; j < ncols; j++)
-                NMOD_RED(a(row, j), a(row, j), mod);
+        {
+            if (unreduced_fits_halflimb)
+            {
+                for (j = col + 1; j < ncols; j++)
+                    a(row, j) = n_mod_lemire(a(row, j), mod.n, npre2);
+            }
+            else
+            {
+                for (j = col + 1; j < ncols; j++)
+                    a(row, j) = n_mod_barrett(a(row, j), mod.n, npre);
+            }
+        }
 
         rank++;
 
         /* eliminate remaining submatrix */
         d = nmod_inv(a(row, col), mod);
+
         for (i = row + 1; i < nrows; i++)
         {
-            e = nmod_mul(a(i, col), d, mod);
-            f = nmod_neg(e, mod);
+            if (d == 1)
+                e = a(i, col);
+            else if (reduced_fits_quarterlimb)
+                e = n_mod_lemire(d * a(i, col), mod.n, npre2);
+            else
+                e = n_mod_barrett(d * a(i, col), mod.n, npre);
 
-            for (j = col + 1; j + 4 < ncols; j += 4)
-            {
-                ulong x0, x1, x2, x3;
-                x0 = a(row, j + 0);
-                x1 = a(row, j + 1);
-                x2 = a(row, j + 2);
-                x3 = a(row, j + 3);
-                a(i, j + 0) += x0 * f;
-                a(i, j + 1) += x1 * f;
-                a(i, j + 2) += x2 * f;
-                a(i, j + 3) += x3 * f;
-            }
+            f = mod.n - e;
 
-            for ( ; j < ncols; j++)
-                a(i, j) += a(row, j) * f;
+            _nmod_vec_nored_scalar_addmul_halflimb(&a(i, col + 1), &a(row, col + 1), ncols - col - 1, f);
 
             a(i, col) = 0;
             a(i, rank - 1) = e;
@@ -113,6 +128,48 @@ nmod_mat_lu_classical_delayed_1(slong * P, nmod_mat_t A, int rank_check)
 #undef a
 
     return rank;
+}
+
+FLINT_FORCE_INLINE
+void mullo_2x1(ulong * r1, ulong * r0, ulong a1, ulong a0, ulong b0)
+{
+    ulong t0, t1;
+    umul_ppmm(t1, t0, a0, b0);
+    t1 += a1 * b0;
+    *r0 = t0;
+    *r1 = t1;
+}
+
+#include "mpn_extras.h"
+
+/* Precompute floor(2^(2*FLINT_BITS) / n) for Barrett-style modular reduction.
+   This could be optimized. */
+static void
+n_ll_rem_l_precomp(ulong * qhi, ulong * qlo, ulong n)
+{
+    ulong q[4];
+    ulong a[4];
+    a[0] = 0;
+    a[1] = 0;
+    a[2] = 1;
+    mpn_divrem_1(q, 0, a, 3, n);
+    *qlo = q[0];
+    *qhi = q[1];
+}
+
+/* 2 -> 1 limb mod, n < 2^(FLINT_BITS-1), using linear combination + Barrett */
+FLINT_FORCE_INLINE ulong
+n_ll_rem_l_nonfullword(ulong xhi, ulong xlo, ulong n, ulong qhi, ulong qlo)
+{
+    ulong c2, c1, c0;
+
+    FLINT_MPN_MUL_3P2X2(c2, c1, c0, qhi, qlo, xhi, xlo);
+    (void) c1;
+    (void) c0;
+    xlo -= c2 * n;
+    if (xlo >= n)
+        xlo -= n;
+    return xlo;
 }
 
 static slong
@@ -129,6 +186,12 @@ nmod_mat_lu_classical_delayed_2(slong * P, nmod_mat_t A, int rank_check)
     ncols = A->c;
     aa = A->entries;
     mod = A->mod;
+
+    /* For simplicity, we only deal with nonfullword moduli. This branch
+       is normally only reachable with min(nrows,ncols) <= 3, where
+       non-delayed Gaussian elimination is fine anyway. */
+    if (mod.norm == 0)
+        return nmod_mat_lu_classical(P, A, rank_check);
 
 #define a(ii, jj) (aa[(ii) * stride + (jj)])
 
@@ -152,13 +215,40 @@ nmod_mat_lu_classical_delayed_2(slong * P, nmod_mat_t A, int rank_check)
         }
     }
 
+    int halflimb;
+    int high_reduced = 0;
+
+    halflimb = (mod.n <= (UWORD(1) << (FLINT_BITS / 2)));
+
+    if (!halflimb)
+    {
+        ulong hi, lo;
+        umul_ppmm(hi, lo, mod.n - 1, mod.n - 1);
+        mullo_2x1(&hi, &lo, hi, lo, FLINT_MIN(nrows, ncols));
+        if (hi < mod.n)
+            high_reduced = 1;
+    }
+
+    ulong qlo = 0, qhi = 0;
+
+    if (!high_reduced)
+        n_ll_rem_l_precomp(&qhi, &qlo, mod.n);
+
     while (row < nrows && col < ncols)
     {
         /* reduce current column */
         /* can be skipped on the first iteration */
         if (col != 0)
-            for (j = row; j < nrows; j++)
-                NMOD2_RED2(a(j, col), UNREDUCED_HI(j, col), UNREDUCED_LO(j, col), mod);
+        {
+            if (high_reduced)
+                for (j = row; j < nrows; j++)
+                    NMOD_RED2(a(j, col), UNREDUCED_HI(j, col), UNREDUCED_LO(j, col), mod);
+            else
+            {
+                for (j = row; j < nrows; j++)
+                    a(j, col) = n_ll_rem_l_nonfullword(UNREDUCED_HI(j, col), UNREDUCED_LO(j, col), mod.n, qhi, qlo);
+            }
+        }
 
         pivot_row = -1;
         for (i = row; i < nrows; i++)
@@ -188,87 +278,60 @@ nmod_mat_lu_classical_delayed_2(slong * P, nmod_mat_t A, int rank_check)
             nmod_mat_swap_rows(A, P, row, pivot_row);
 
             /* swap rows in unreduced submatrix, and reduce new pivot row */
-            for (j = col + 1; j < ncols; j++)
+            if (high_reduced)
             {
-                ulong hi, lo;
-                lo = UNREDUCED_LO(row, j);
-                hi = UNREDUCED_HI(row, j);
-                NMOD2_RED2(a(row, j), UNREDUCED_HI(pivot_row, j), UNREDUCED_LO(pivot_row, j), mod);
-                UNREDUCED_LO(pivot_row, j) = lo;
-                UNREDUCED_HI(pivot_row, j) = hi;
+                for (j = col + 1; j < ncols; j++)
+                {
+                    ulong hi, lo;
+                    lo = UNREDUCED_LO(row, j);
+                    hi = UNREDUCED_HI(row, j);
+                    NMOD_RED2(a(row, j), UNREDUCED_HI(pivot_row, j), UNREDUCED_LO(pivot_row, j), mod);
+                    UNREDUCED_LO(pivot_row, j) = lo;
+                    UNREDUCED_HI(pivot_row, j) = hi;
+                }
+            }
+            else
+            {
+                for (j = col + 1; j < ncols; j++)
+                {
+                    ulong hi, lo;
+                    lo = UNREDUCED_LO(row, j);
+                    hi = UNREDUCED_HI(row, j);
+                    a(row, j) = n_ll_rem_l_nonfullword(UNREDUCED_HI(pivot_row, j), UNREDUCED_LO(pivot_row, j), mod.n, qhi, qlo);
+                    UNREDUCED_LO(pivot_row, j) = lo;
+                    UNREDUCED_HI(pivot_row, j) = hi;
+                }
             }
         }
         else if (row != 0)
         {
             /* reduce current pivot row */
-            for (j = col + 1; j < ncols; j++)
-                NMOD2_RED2(a(row, j), UNREDUCED_HI(row, j), UNREDUCED_LO(row, j), mod);
+            if (high_reduced)
+            {
+                for (j = col + 1; j < ncols; j++)
+                    NMOD_RED2(a(row, j), UNREDUCED_HI(row, j), UNREDUCED_LO(row, j), mod);
+            }
+            else
+            {
+                for (j = col + 1; j < ncols; j++)
+                    a(row, j) = n_ll_rem_l_nonfullword(UNREDUCED_HI(row, j), UNREDUCED_LO(row, j), mod.n, qhi, qlo);
+            }
         }
 
         rank++;
 
         /* eliminate remaining submatrix */
         d = nmod_inv(a(row, col), mod);
+
         for (i = row + 1; i < nrows; i++)
         {
-            e = nmod_mul(a(i, col), d, mod);
-            f = nmod_neg(e, mod);
+            e = nmod_mul(d, a(i, col), mod);
+            f = mod.n - e;
 
-            if (mod.n <= UWORD(1) << (FLINT_BITS / 2))
-            {
-                for (j = col + 1; j + 4 < ncols; j += 4)
-                {
-                    ulong x0, x1, x2, x3;
-                    x0 = a(row, j + 0) * f;
-                    x1 = a(row, j + 1) * f;
-                    x2 = a(row, j + 2) * f;
-                    x3 = a(row, j + 3) * f;
-                    add_ssaaaa(UNREDUCED_HI(i, j + 0), UNREDUCED_LO(i, j + 0),
-                               UNREDUCED_HI(i, j + 0), UNREDUCED_LO(i, j + 0), 0, x0);
-                    add_ssaaaa(UNREDUCED_HI(i, j + 1), UNREDUCED_LO(i, j + 1),
-                               UNREDUCED_HI(i, j + 1), UNREDUCED_LO(i, j + 1), 0, x1);
-                    add_ssaaaa(UNREDUCED_HI(i, j + 2), UNREDUCED_LO(i, j + 2),
-                               UNREDUCED_HI(i, j + 2), UNREDUCED_LO(i, j + 2), 0, x2);
-                    add_ssaaaa(UNREDUCED_HI(i, j + 3), UNREDUCED_LO(i, j + 3),
-                               UNREDUCED_HI(i, j + 3), UNREDUCED_LO(i, j + 3), 0, x3);
-                }
-
-                for ( ; j < ncols; j++)
-                {
-                    ulong hi, lo;
-                    hi = 0;
-                    lo = a(row, j) * f;
-                    add_ssaaaa(UNREDUCED_HI(i, j), UNREDUCED_LO(i, j),
-                               UNREDUCED_HI(i, j), UNREDUCED_LO(i, j), hi, lo);
-                }
-            }
+            if (halflimb)
+                _nmod_vec_nored_ll_scalar_addmul_halflimb(&UNREDUCED_LO(i, col + 1), &a(row, col + 1), ncols - col - 1, f);
             else
-            {
-                for (j = col + 1; j + 4 < ncols; j += 4)
-                {
-                    ulong x0, x1, x2, x3, h0, h1, h2, h3;
-                    umul_ppmm(h0, x0, a(row, j + 0), f);
-                    umul_ppmm(h1, x1, a(row, j + 1), f);
-                    umul_ppmm(h2, x2, a(row, j + 2), f);
-                    umul_ppmm(h3, x3, a(row, j + 3), f);
-                    add_ssaaaa(UNREDUCED_HI(i, j + 0), UNREDUCED_LO(i, j + 0),
-                               UNREDUCED_HI(i, j + 0), UNREDUCED_LO(i, j + 0), h0, x0);
-                    add_ssaaaa(UNREDUCED_HI(i, j + 1), UNREDUCED_LO(i, j + 1),
-                               UNREDUCED_HI(i, j + 1), UNREDUCED_LO(i, j + 1), h1, x1);
-                    add_ssaaaa(UNREDUCED_HI(i, j + 2), UNREDUCED_LO(i, j + 2),
-                               UNREDUCED_HI(i, j + 2), UNREDUCED_LO(i, j + 2), h2, x2);
-                    add_ssaaaa(UNREDUCED_HI(i, j + 3), UNREDUCED_LO(i, j + 3),
-                               UNREDUCED_HI(i, j + 3), UNREDUCED_LO(i, j + 3), h3, x3);
-                }
-
-                for ( ; j < ncols; j++)
-                {
-                    ulong hi, lo;
-                    umul_ppmm(hi, lo, a(row, j), f);
-                    add_ssaaaa(UNREDUCED_HI(i, j), UNREDUCED_LO(i, j),
-                               UNREDUCED_HI(i, j), UNREDUCED_LO(i, j), hi, lo);
-                }
-            }
+                _nmod_vec_nored_ll_scalar_addmul(&UNREDUCED_LO(i, col + 1), &a(row, col + 1), ncols - col - 1, f);
 
             a(i, col) = 0;
             a(i, rank - 1) = e;
@@ -281,6 +344,42 @@ nmod_mat_lu_classical_delayed_2(slong * P, nmod_mat_t A, int rank_check)
 
     TMP_END;
     return rank;
+}
+
+FLINT_FORCE_INLINE ulong
+n_lll_rem_l_fullword_limited(ulong y2, ulong y1, ulong y0, nmod_t mod, ulong alpha2, ulong alpha1)
+{
+    ulong c1, c0, t1, t0;
+    ulong xhi, xlo;
+
+    FLINT_ASSERT(mod.n >= (UWORD(1) << (FLINT_BITS - 1)));
+    FLINT_ASSERT(mod.n < (UWORD(1) << (FLINT_BITS - 1)) + (UWORD(1) << (FLINT_BITS / 2 - 2)));
+
+    umul_ppmm(t1, t0, y2, alpha2);
+    umul_ppmm(c1, c0, y1, alpha1);
+    add_ssaaaa(xhi, xlo, t1, t0, c1, c0);
+    add_ssaaaa(xhi, xlo, xhi, xlo, 0, y0);
+
+    NMOD_RED2_FULLWORD(xlo, xhi, xlo, mod);
+
+    return xlo;
+}
+
+FLINT_FORCE_INLINE ulong
+n_lll_rem_l(ulong y2, ulong y1, ulong y0, nmod_t mod, ulong alpha2, ulong alpha1)
+{
+    ulong c1, c0, t1, t0;
+    ulong xhi, xlo;
+
+    umul_ppmm(t1, t0, y2, alpha2);
+    umul_ppmm(c1, c0, y1, alpha1);
+    add_ssaaaa(xhi, xlo, t1, t0, c1, c0);
+    add_ssaaaa(xhi, xlo, xhi, xlo, 0, y0);
+
+    if (xhi >= mod.n) xhi -= mod.n;
+    NMOD_RED2(xlo, xhi, xlo, mod);
+
+    return xlo;
 }
 
 static slong
@@ -322,15 +421,46 @@ nmod_mat_lu_classical_delayed_3(slong * P, nmod_mat_t A, int rank_check)
         }
     }
 
+    /* Special case for moduli close to 2^63. */
+    int fullword_limited = (mod.norm == 0) &&
+            mod.n < (UWORD(1) << (FLINT_BITS - 1)) + (UWORD(1) << (FLINT_BITS / 2 - 2));
+
+    ulong alpha1, alpha2;
+
+    if (fullword_limited)
+    {
+        alpha1 = -mod.n;               /* 2^FLINT_BITS */
+        alpha2 = 4 * alpha1 * alpha1;  /* 2^(2 FLINT_BITS) */
+    }
+    else
+    {
+        alpha1 = nmod_set_ui(UWORD(1) << (FLINT_BITS - 1), mod);
+        alpha1 = nmod_add(alpha1, alpha1, mod);    /* 2^FLINT_BITS */
+        alpha2 = nmod_mul(alpha1, alpha1, mod);    /* 2^(2 FLINT_BITS) */
+    }
+
+
     while (row < nrows && col < ncols)
     {
         /* reduce current column */
         /* can be skipped on the first iteration */
         if (col != 0)
-            for (j = row; j < nrows; j++)
-                a(j, col) = nmod_set_uiuiui(UNREDUCED3_L2(j, col),
-                    UNREDUCED3_L1(j, col),
-                    UNREDUCED3_L0(j, col), mod);
+        {
+            if (fullword_limited)
+            {
+                for (j = row; j < nrows; j++)
+                    a(j, col) = n_lll_rem_l_fullword_limited(UNREDUCED3_L2(j, col),
+                        UNREDUCED3_L1(j, col),
+                        UNREDUCED3_L0(j, col), mod, alpha2, alpha1);
+            }
+            else
+            {
+                for (j = row; j < nrows; j++)
+                    a(j, col) = n_lll_rem_l(UNREDUCED3_L2(j, col),
+                        UNREDUCED3_L1(j, col),
+                        UNREDUCED3_L0(j, col), mod, alpha2, alpha1);
+            }
+        }
 
         pivot_row = -1;
         for (i = row; i < nrows; i++)
@@ -360,48 +490,73 @@ nmod_mat_lu_classical_delayed_3(slong * P, nmod_mat_t A, int rank_check)
             nmod_mat_swap_rows(A, P, row, pivot_row);
 
             /* swap rows in unreduced submatrix, and reduce new pivot row */
-            for (j = col + 1; j < ncols; j++)
+            if (fullword_limited)
             {
-                ulong t2, t1, t0;
-                t0 = UNREDUCED3_L0(row, j);
-                t1 = UNREDUCED3_L1(row, j);
-                t2 = UNREDUCED3_L2(row, j);
+                for (j = col + 1; j < ncols; j++)
+                {
+                    ulong t2, t1, t0;
+                    t0 = UNREDUCED3_L0(row, j);
+                    t1 = UNREDUCED3_L1(row, j);
+                    t2 = UNREDUCED3_L2(row, j);
 
-                a(row, j) = nmod_set_uiuiui(UNREDUCED3_L2(pivot_row, j),
-                            UNREDUCED3_L1(pivot_row, j),
-                            UNREDUCED3_L0(pivot_row, j), mod);
+                    a(row, j) = n_lll_rem_l_fullword_limited(UNREDUCED3_L2(pivot_row, j),
+                                UNREDUCED3_L1(pivot_row, j),
+                                UNREDUCED3_L0(pivot_row, j), mod, alpha2, alpha1);
 
-                UNREDUCED3_L0(pivot_row, j) = t0;
-                UNREDUCED3_L1(pivot_row, j) = t1;
-                UNREDUCED3_L2(pivot_row, j) = t2;
+                    UNREDUCED3_L0(pivot_row, j) = t0;
+                    UNREDUCED3_L1(pivot_row, j) = t1;
+                    UNREDUCED3_L2(pivot_row, j) = t2;
+                }
+            }
+            else
+            {
+                for (j = col + 1; j < ncols; j++)
+                {
+                    ulong t2, t1, t0;
+                    t0 = UNREDUCED3_L0(row, j);
+                    t1 = UNREDUCED3_L1(row, j);
+                    t2 = UNREDUCED3_L2(row, j);
+
+                    a(row, j) = n_lll_rem_l(UNREDUCED3_L2(pivot_row, j),
+                                UNREDUCED3_L1(pivot_row, j),
+                                UNREDUCED3_L0(pivot_row, j), mod, alpha2, alpha1);
+
+                    UNREDUCED3_L0(pivot_row, j) = t0;
+                    UNREDUCED3_L1(pivot_row, j) = t1;
+                    UNREDUCED3_L2(pivot_row, j) = t2;
+                }
             }
         }
         else if (row != 0)
         {
             /* reduce current pivot row */
-            for (j = col + 1; j < ncols; j++)
-                a(row, j) = nmod_set_uiuiui(UNREDUCED3_L2(row, j),
-                            UNREDUCED3_L1(row, j),
-                            UNREDUCED3_L0(row, j), mod);
+            if (fullword_limited)
+            {
+                for (j = col + 1; j < ncols; j++)
+                    a(row, j) = n_lll_rem_l_fullword_limited(UNREDUCED3_L2(row, j),
+                                UNREDUCED3_L1(row, j),
+                                UNREDUCED3_L0(row, j), mod, alpha2, alpha1);
+            }
+            else
+            {
+                for (j = col + 1; j < ncols; j++)
+                    a(row, j) = n_lll_rem_l(UNREDUCED3_L2(row, j),
+                                UNREDUCED3_L1(row, j),
+                                UNREDUCED3_L0(row, j), mod, alpha2, alpha1);
+            }
         }
 
         rank++;
 
         /* eliminate remaining submatrix */
         d = nmod_inv(a(row, col), mod);
+
         for (i = row + 1; i < nrows; i++)
         {
             e = nmod_mul(a(i, col), d, mod);
-            f = nmod_neg(e, mod);
+            f = mod.n - e;
 
-            for (j = col + 1; j < ncols; j++)
-            {
-                ulong hi, lo;
-                umul_ppmm(hi, lo, a(row, j), f);
-                add_sssaaaaaa(UNREDUCED3_L2(i, j), UNREDUCED3_L1(i, j), UNREDUCED3_L0(i, j),
-                              UNREDUCED3_L2(i, j), UNREDUCED3_L1(i, j), UNREDUCED3_L0(i, j),
-                              0, hi, lo);
-            }
+            _nmod_vec_nored_lll_scalar_addmul(&UNREDUCED3_L0(i, col + 1), &a(row, col + 1), ncols - col - 1, f);
 
             a(i, col) = 0;
             a(i, rank - 1) = e;

--- a/src/nmod_mat/solve_tril.c
+++ b/src/nmod_mat/solve_tril.c
@@ -47,7 +47,7 @@ nmod_mat_solve_tril_classical(nmod_mat_t X, const nmod_mat_t L, const nmod_mat_t
             s = _nmod_vec_dot(nmod_mat_entry_ptr(L, j, 0), tmp, j, mod, params);
             s = nmod_sub(nmod_mat_entry(B, j, i), s, mod);
             if (!unit)
-                s = n_mulmod2_preinv(s, inv[j], mod.n, mod.ninv);
+                s = nmod_mul(s, inv[j], mod);
             tmp[j] = s;
         }
 

--- a/src/nmod_mat/solve_triu.c
+++ b/src/nmod_mat/solve_triu.c
@@ -48,7 +48,7 @@ nmod_mat_solve_triu_classical(nmod_mat_t X, const nmod_mat_t U, const nmod_mat_t
                               tmp + j + 1, n - j - 1, mod, params);
             s = nmod_sub(nmod_mat_entry(B, j, i), s, mod);
             if (!unit)
-                s = n_mulmod2_preinv(s, inv[j], mod.n, mod.ninv);
+                s = nmod_mul(s, inv[j], mod);
             tmp[j] = s;
         }
 

--- a/src/nmod_mat/test/t-lu_classical_delayed.c
+++ b/src/nmod_mat/test/t-lu_classical_delayed.c
@@ -95,7 +95,10 @@ TEST_FUNCTION_START(nmod_mat_lu_classical_delayed, state)
         m = n_randint(state, 20);
         n = n_randint(state, 20);
 
-        mod = n_randtest_prime(state, 0);
+        if (n_randint(state, 10) == 0)
+            mod = n_nextprime(UWORD(1) << (FLINT_BITS - 1), 0);
+        else
+            mod = n_randtest_prime(state, 0);
 
         for (r = 0; r <= FLINT_MIN(m, n); r++)
         {


### PR DESCRIPTION
Applies the same optimizations as #2637 to classical Gaussian elimination for `nmod_mat`, and adjusts the algorithm selection in `nmod_mat_lu`. This mainly speeds up linear algebra up to dimension about 100, though for some small moduli there is a decent speedup up to dimension about 1000.

Nearly-optimal cutoffs between classical and recursive LU have been brute-forced for each bit size with and without ``--with-blas``. Very large threshold values (some over 1400) indicate that matrix multiplication is poorly optimized.

Speedup for `nmod_mat_lu`, without BLAS:

```
dim \ bits    2      8     20     27     28     32     40     56     60     62     63     64     64(near UWORD_MAX)
       4    1.324  1.263  1.211  1.164  1.200  1.000  1.017  1.009  1.018  1.012  1.074  1.004  1.008
       6    1.349  1.393  1.357  1.251  1.218  1.009  1.003  1.002  1.000  0.981  1.006  0.992  1.004
       8    1.370  1.353  1.341  1.283  1.264  1.208  1.243  1.202  1.198  1.156  1.155  1.074  1.077
      12    1.472  1.445  1.324  1.313  1.269  1.264  1.281  1.262  1.258  1.191  1.224  1.174  1.174
      16    1.503  1.491  1.354  1.331  1.343  1.180  1.248  1.237  1.229  1.215  1.232  1.266  1.245
      24    1.392  1.408  1.285  1.264  1.277  1.214  1.285  1.268  1.264  1.251  1.256  1.273  1.259
      32    1.418  1.394  1.283  1.263  1.269  1.208  1.224  1.198  1.193  1.248  1.208  1.239  1.229
      48    1.496  1.484  1.376  1.379  1.379  1.157  1.200  1.187  1.182  1.182  1.168  1.185  1.173
      64    1.182  1.933  1.472  1.462  1.452  1.123  1.203  1.203  1.202  1.123  1.134  1.156  1.141
      96    1.246  1.626  1.533  1.527  1.527  1.094  1.098  1.102  1.107  1.097  1.070  1.082  1.071
     128    1.128  1.646  1.530  1.541  1.534  1.073  1.093  1.092  1.092  1.055  1.054  1.065  1.055
     192    1.125  1.424  1.905  1.908  1.911  1.055  1.040  1.033  1.033  1.045  1.028  1.034  1.056
     256    0.991  1.366  1.843  1.792  1.827  1.039  1.034  1.031  1.043  1.035  1.024  1.024  1.024
     384    1.039  1.085  1.758  1.718  1.183  1.018  1.019  1.019  1.019  1.018  1.016  1.014  1.014
     512    0.985  1.076  1.648  1.626  1.169  1.000  0.992  0.992  1.008  0.996  1.007  1.003  1.003
     768    1.031  0.985  1.637  1.645  1.067  1.014  0.999  1.001  1.001  0.988  1.009  1.020  1.040
    1024    1.003  0.957  1.697  1.664  1.140  0.995  1.023  1.023  1.029  1.026  1.035  1.018  1.022
    1536    1.086  1.000  1.221  1.212  1.057  1.012  1.022  1.016  1.013  1.010  1.025  1.007  1.015
    2048    1.060  1.009  1.072  1.077  1.057  0.973  1.009  1.005  1.021  1.006  1.006  1.007  1.008
```


Speedup for `nmod_mat_lu`, with BLAS:

```
dim \ bits    2      8     20     27     28     32     40     56     60     62     63     64     64(near UWORD_MAX)
       4    1.150  1.089  1.167  1.149  1.153  1.012  1.023  1.000  1.018  1.004  1.012  1.000  1.008
       6    1.313  1.225  1.215  1.212  1.181  1.003  0.997  1.002  1.002  0.998  1.004  1.002  1.004
       8    1.304  1.276  1.253  1.214  1.256  1.212  1.191  1.181  1.177  1.154  1.155  1.076  1.078
      12    1.466  1.421  1.319  1.290  1.268  1.262  1.267  1.223  1.227  1.199  1.206  1.172  1.167
      16    1.432  1.405  1.334  1.277  1.290  1.223  1.242  1.248  1.235  1.219  1.191  1.264  1.242
      24    1.397  1.364  1.282  1.254  1.261  1.204  1.260  1.250  1.261  1.239  1.256  1.274  1.257
      32    1.415  1.404  1.304  1.286  1.289  1.178  1.209  1.212  1.209  1.217  1.207  1.237  1.227
      48    1.495  1.498  1.386  1.379  1.385  1.164  1.179  1.179  1.175  1.199  1.173  1.191  1.181
      64    1.185  1.894  1.477  1.467  1.472  1.112  1.164  1.164  1.170  1.105  1.148  1.156  1.143
      96    1.245  1.623  1.519  1.521  1.559  1.094  1.076  1.144  1.115  1.090  1.050  1.109  1.105
     128    1.124  1.667  1.519  1.515  1.515  1.084  1.084  1.077  1.083  1.053  1.048  1.056  1.054
     192    1.121  1.419  1.905  1.926  1.891  1.055  1.026  1.033  1.040  1.052  0.984  1.020  1.015
     256    0.972  1.373  1.800  1.810  1.837  1.045  1.026  1.031  1.031  1.024  1.031  1.026  1.022
     384    1.043  1.103  1.767  1.685  1.183  1.029  1.009  1.000  1.009  1.027  0.984  0.993  0.986
     512    0.985  1.127  1.235  1.698  1.176  1.008  0.988  0.992  0.992  1.004  1.003  1.003  1.006
     768    1.012  0.989  1.256  1.643  1.067  1.017  1.000  0.947  0.996  1.011  0.977  1.020  1.010
    1024    0.986  0.983  1.127  1.591  1.091  0.992  1.000  1.006  0.978  1.005  1.005  1.005  1.009
    1536    1.069  0.970  1.200  1.210  1.090  1.055  1.031  1.022  1.032  1.039  1.020  1.018  1.012
    2048    1.073  1.026  1.149  1.036  1.081  1.028  0.997  0.997  0.998  1.011  1.007  1.007  1.009
```
