### PR TITLE
Fixes and generic `_other` test code

### DIFF
--- a/doc/source/gr.rst
+++ b/doc/source/gr.rst
@@ -298,6 +298,13 @@ Context operations
     Get the name of the generator of index *i*.
     The returned buffer must be freed with :func:`flint_free`.
 
+.. function:: gr_ptr gr_ctx_base(gr_ctx_t ctx)
+
+    Assuming that ``ctx`` is an extension of a base structure ``base_ctx``,
+    returns the pointer to ``base_ctx``.
+    Otherwise, returns ``NULL``.
+
+
 Element operations
 --------------------------------------------------------------------------------
 

--- a/doc/source/gr_ore_poly.rst
+++ b/doc/source/gr_ore_poly.rst
@@ -258,7 +258,7 @@ Action
               int gr_ore_poly_delta(gr_ptr res, gr_srcptr a, gr_ore_poly_ctx_t ctx)
               int gr_ore_poly_sigma_delta(gr_ptr sigma, gr_ptr delta, gr_srcptr a, gr_ore_poly_ctx_t ctx)
 
-    Compute *σ(a)*,  *δ(a)*, or both, where *a* is an element of the base ring.
+    Compute `\sigma(a)`, `\delta(a)`, or both, where *a* is an element of the base ring.
     In the *sigma_delta* variant, the output variables *sigma* or *delta* can be
     ``NULL``.
 
@@ -309,15 +309,15 @@ Arithmetic
               int gr_ore_poly_lmul_gen(gr_ore_poly_t res, const gr_ore_poly_t poly, gr_ore_poly_ctx_t ctx)
 
     Sets *res* to the result of the left multiplication:
-    *D · poly = σ(poly) · D + δ(poly)*.
-    The underscore method assumes *len ≠ 0*.
+    `D \cdot poly = \sigma(poly) \cdot D + \sigma(poly)`.
+    The underscore method assumes *len != 0*.
 
 .. function:: int _gr_ore_poly_mul(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ore_poly_ctx_t ctx)
               int gr_ore_poly_mul(gr_ore_poly_t res, const gr_ore_poly_t poly1, const gr_ore_poly_t poly2, gr_ore_poly_ctx_t ctx)
 
     Sets *res* to *poly1* multiplied by *poly2*
     which must be two Ore polynomials in the Ore algebra *ctx*.
-    The underscore method assumes *res ≠ poly1*, *res ≠ poly2* (no aliasing) and *len1* ≠ 0, *len2* ≠ 0.
+    The underscore method assumes *res != poly1*, *res != poly2* (no aliasing) and *len1* != 0, *len2* != 0.
 
 .. raw:: latex
 

--- a/src/gr.h
+++ b/src/gr.h
@@ -138,6 +138,8 @@ typedef enum
     GR_METHOD_CTX_NGENS,
     GR_METHOD_CTX_GEN_NAME,
 
+    GR_METHOD_CTX_BASE,
+
     GR_METHOD_INIT,
     GR_METHOD_CLEAR,
     GR_METHOD_SWAP,
@@ -762,6 +764,7 @@ typedef void ((*gr_method_init_clear_op)(gr_ptr, gr_ctx_ptr));
 typedef void ((*gr_method_swap_op)(gr_ptr, gr_ptr, gr_ctx_ptr));
 typedef int ((*gr_method_ctx)(gr_ctx_ptr));
 typedef void ((*gr_method_ctx_void_op)(gr_ctx_ptr));
+typedef gr_ctx_ptr ((*gr_method_ctx_base)(gr_ctx_ptr));
 typedef truth_t ((*gr_method_ctx_predicate)(gr_ctx_ptr));
 typedef slong ((*gr_method_ctx_size)(gr_ctx_ptr));
 typedef int ((*gr_method_ctx_gen_name)(char **, slong, gr_ctx_ptr));
@@ -872,6 +875,7 @@ typedef int ((*gr_method_set_fexpr_op)(gr_ptr, fexpr_vec_t, gr_vec_t, const fexp
 #define GR_CTX_SET_TRUTH(ctx, NAME) (((gr_method_ctx_set_truth *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_CTX_SET_STR(ctx, NAME) (((gr_method_ctx_set_str *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_CTX_SET_STRS(ctx, NAME) (((gr_method_ctx_set_strs *) ctx->methods)[GR_METHOD_ ## NAME])
+#define GR_CTX_BASE(ctx, NAME) (((gr_method_ctx_base *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_STREAM_IN(ctx, NAME) (((gr_method_stream_in *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_STREAM_IN_SI(ctx, NAME) (((gr_method_stream_in_si *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_RANDTEST(ctx, NAME) (((gr_method_randtest *) ctx->methods)[GR_METHOD_ ## NAME])
@@ -1006,6 +1010,9 @@ GR_INLINE slong _gr_ctx_get_real_prec(gr_ctx_t ctx)
     GR_IGNORE(gr_ctx_get_real_prec(&res, ctx));
     return res;
 }
+
+GR_INLINE gr_ptr gr_ctx_base(gr_ctx_t ctx) { return GR_CTX_BASE(ctx, CTX_BASE)(ctx); }
+
 
 GR_INLINE void gr_init(gr_ptr res, gr_ctx_t ctx) { GR_INIT_CLEAR_OP(ctx, INIT)(res, ctx); }
 GR_INLINE void gr_clear(gr_ptr res, gr_ctx_t ctx) { GR_INIT_CLEAR_OP(ctx, CLEAR)(res, ctx); }

--- a/src/gr/complex.c
+++ b/src/gr/complex.c
@@ -75,6 +75,8 @@ _gr_complex_ctx_gen_name(char ** name, slong i, gr_ctx_t ctx)
     return GR_SUCCESS;
 }
 
+static gr_ptr _gr_complex_ctx_base(gr_ctx_t ctx) { return REAL_CTX(ctx); }
+
 static void
 _gr_complex_init(gr_ptr x, gr_complex_ctx_t ctx)
 {
@@ -639,6 +641,7 @@ gr_method_tab_input _gr_complex_methods_input[] =
     {GR_METHOD_CTX_IS_EXACT,    (gr_funcptr) _gr_complex_ctx_is_exact},
     {GR_METHOD_CTX_NGENS,       (gr_funcptr) gr_generic_ctx_ngens_1},
     {GR_METHOD_CTX_GEN_NAME,    (gr_funcptr) _gr_complex_ctx_gen_name},
+    {GR_METHOD_CTX_BASE,                (gr_funcptr) _gr_complex_ctx_base},
     {GR_METHOD_INIT,            (gr_funcptr) _gr_complex_init},
     {GR_METHOD_CLEAR,           (gr_funcptr) _gr_complex_clear},
     {GR_METHOD_SWAP,            (gr_funcptr) _gr_complex_swap},

--- a/src/gr/fraction.c
+++ b/src/gr/fraction.c
@@ -82,6 +82,7 @@ static truth_t _gr_fraction_ctx_is_finite(gr_ctx_t ctx) { return gr_ctx_is_finit
 static truth_t _gr_fraction_ctx_is_finite_characteristic(gr_ctx_t ctx) { return gr_ctx_is_finite_characteristic(GR_FRACTION_DOMAIN_CTX(ctx)); }
 static truth_t _gr_fraction_ctx_is_exact(gr_ctx_t ctx) { return gr_ctx_is_exact(GR_FRACTION_DOMAIN_CTX(ctx)); }
 
+static gr_ptr _gr_fraction_ctx_base(gr_ctx_t ctx) { return GR_FRACTION_DOMAIN_CTX(ctx); }
 
 static void
 _gr_fraction_init(gr_ptr x, gr_fraction_ctx_t ctx)
@@ -1146,6 +1147,7 @@ gr_method_tab_input _gr_fraction_methods_input[] =
     {GR_METHOD_CTX_IS_FINITE_CHARACTERISTIC,    (gr_funcptr) _gr_fraction_ctx_is_finite_characteristic},
 
     {GR_METHOD_CTX_IS_EXACT,    (gr_funcptr) _gr_fraction_ctx_is_exact},
+    {GR_METHOD_CTX_BASE,    (gr_funcptr) _gr_fraction_ctx_base},
 
     {GR_METHOD_INIT,            (gr_funcptr) _gr_fraction_init},
     {GR_METHOD_CLEAR,           (gr_funcptr) _gr_fraction_clear},

--- a/src/gr/matrix.c
+++ b/src/gr/matrix.c
@@ -167,6 +167,9 @@ matrix_ctx_is_threadsafe(gr_ctx_t ctx)
     return gr_ctx_is_threadsafe(MATRIX_CTX(ctx)->base_ring);
 }
 
+static gr_ptr matrix_ctx_base(gr_ctx_t ctx) { return MATRIX_CTX(ctx)->base_ring; }
+
+
 static void
 matrix_clear(gr_mat_t res, gr_ctx_t ctx)
 {
@@ -600,6 +603,7 @@ gr_method_tab_input _gr_mat_methods_input[] =
     {GR_METHOD_CTX_IS_REAL_VECTOR_SPACE, (gr_funcptr) matrix_ctx_is_real_vector_space},
     {GR_METHOD_CTX_IS_COMPLEX_VECTOR_SPACE, (gr_funcptr) matrix_ctx_is_complex_vector_space},
     {GR_METHOD_CTX_IS_APPROX_COMMUTATIVE_RING, (gr_funcptr) matrix_ctx_is_approx_commutative_ring},
+    {GR_METHOD_CTX_BASE,    (gr_funcptr) matrix_ctx_base},
     {GR_METHOD_INIT,        (gr_funcptr) matrix_init},
     {GR_METHOD_CLEAR,       (gr_funcptr) matrix_clear},
     {GR_METHOD_SWAP,        (gr_funcptr) matrix_swap},

--- a/src/gr/polynomial.c
+++ b/src/gr/polynomial.c
@@ -62,12 +62,18 @@ _gr_gr_poly_ctx_gen_name(char ** name, slong i, gr_ctx_t ctx)
 
     char * var = POLYNOMIAL_CTX(ctx)->var;
     size_t len = strlen(var);
+
     * name = flint_malloc(len + 1);
     if (* name == NULL)
         return GR_UNABLE;
     strncpy(* name, var, len + 1);
 
     return GR_SUCCESS;
+}
+
+static gr_ptr _gr_gr_poly_ctx_base(gr_ctx_t ctx)
+{
+    return POLYNOMIAL_ELEM_CTX(ctx);
 }
 
 static void
@@ -782,6 +788,7 @@ gr_method_tab_input _gr_poly_methods_input[] =
     {GR_METHOD_CTX_SET_GEN_NAMES,       (gr_funcptr) _gr_gr_poly_ctx_set_gen_names},
     {GR_METHOD_CTX_NGENS,               (gr_funcptr) gr_generic_ctx_ngens_1},
     {GR_METHOD_CTX_GEN_NAME,            (gr_funcptr) _gr_gr_poly_ctx_gen_name},
+    {GR_METHOD_CTX_BASE,                (gr_funcptr) _gr_gr_poly_ctx_base},
 
     {GR_METHOD_INIT,        (gr_funcptr) polynomial_init},
     {GR_METHOD_CLEAR,       (gr_funcptr) polynomial_clear},

--- a/src/gr/test_ring.c
+++ b/src/gr/test_ring.c
@@ -1334,7 +1334,6 @@ gr_test_binary_op_other_variants(gr_ctx_t R,
                 flint_printf("y = %{gr}\n", y, R);
                 if (gr_op == gr_divexact)
                     flint_printf("x2 = %{gr}\n", x2, R2);
-                flint_printf("y2 = %{gr}\n", y2, R2);
                 flint_printf("x op y = %{gr}\n", xy, R);
                 flint_printf("x2 op y = %{gr}\n", xy2, R);
                 status = GR_TEST_FAIL;

--- a/src/gr/test_ring.c
+++ b/src/gr/test_ring.c
@@ -873,9 +873,20 @@ gr_test_set_other(gr_ctx_t R, flint_rand_t state, int test_flags)
 {
     int status = GR_SUCCESS;
     gr_ptr x, y, z, xy, x2, y2, z2, t2;
-    gr_ctx_t R2;
+    gr_ctx_t R2ctx;
+    gr_ctx_struct * R2;
 
-    gr_ctx_init_random(R2, state);
+    if (n_randint(state, 4) == 0)
+    {
+        R2 = R;
+        while (n_randint(state, 2) && gr_ctx_base(R2) != NULL)
+            R2 = gr_ctx_base(R2);
+    }
+    else
+    {
+        gr_ctx_init_random(R2ctx, state);
+        R2 = R2ctx;
+    }
 
     GR_TMP_INIT4(x, y, z, xy, R);
     GR_TMP_INIT4(x2, y2, z2, t2, R2);
@@ -921,7 +932,8 @@ gr_test_set_other(gr_ctx_t R, flint_rand_t state, int test_flags)
     GR_TMP_CLEAR4(x, y, z, xy, R);
     GR_TMP_CLEAR4(x2, y2, z2, t2, R2);
 
-    gr_ctx_clear(R2);
+    if (R2 == R2ctx)
+        gr_ctx_clear(R2ctx);
 
     return status;
 }
@@ -1201,13 +1213,25 @@ gr_test_binary_op_other_variants(gr_ctx_t R,
     int fused,
     flint_rand_t state, int test_flags)
 {
-    gr_ctx_t R2;
-    gr_ctx_init_random(R2, state);
+    gr_ctx_struct * R2;
+    gr_ctx_t R2ctx;
     int status = GR_SUCCESS;
     int status2;
     int alias = n_randint(state, 2);
 
     gr_ptr x, y, x2, y2, xy, xy2;
+
+    if (n_randint(state, 4) == 0)
+    {
+        R2 = R;
+        while (n_randint(state, 2) && gr_ctx_base(R2) != NULL)
+            R2 = gr_ctx_base(R2);
+    }
+    else
+    {
+        gr_ctx_init_random(R2ctx, state);
+        R2 = R2ctx;
+    }
 
     GR_TMP_INIT4(x, y, xy, xy2, R);
     GR_TMP_INIT2(x2, y2, R2);
@@ -1241,21 +1265,22 @@ gr_test_binary_op_other_variants(gr_ctx_t R,
             status2 = gr_op_other(xy2, x, y2, R2, R);
         }
 
-        if ((status == GR_SUCCESS && status2 == GR_DOMAIN) ||
+        if ((status == GR_SUCCESS && status2 == GR_DOMAIN
+                && (gr_op != gr_divexact || gr_ctx_is_integral_domain(R) == T_TRUE)) ||
             (status == GR_SUCCESS && status2 == GR_SUCCESS &&
             gr_equal(xy, xy2, R) == T_FALSE))
         {
-            status = GR_TEST_FAIL;
             flint_printf("binary_op_other_variants\n");
             gr_ctx_println(R);
             gr_ctx_println(R2);
-            flint_printf("status2 = %d, alias = %d\n", status2, alias);
+            flint_printf("status = %d, status2 = %d, alias = %d\n", status, status2, alias);
             flint_printf("%s (right)\n", opname);
             flint_printf("x = %{gr}\n", x, R);
             flint_printf("y = %{gr}\n", y, R);
             flint_printf("y2 = %{gr}\n", y2, R2);
             flint_printf("x op y = %{gr}\n", xy, R);
             flint_printf("x op y2 = %{gr}\n", xy2, R);
+            status = GR_TEST_FAIL;
             goto cleanup;
         }
 
@@ -1295,15 +1320,15 @@ gr_test_binary_op_other_variants(gr_ctx_t R,
                 status2 = gr_other_op(xy2, x2, R2, y, R);
             }
 
-            if ((status == GR_SUCCESS && status2 == GR_DOMAIN) ||
+            if ((status == GR_SUCCESS && status2 == GR_DOMAIN
+                    && (gr_op != gr_divexact || gr_ctx_is_integral_domain(R) == T_TRUE)) ||
                 (status == GR_SUCCESS && status2 == GR_SUCCESS &&
                 gr_equal(xy, xy2, R) == T_FALSE))
             {
-                status = GR_TEST_FAIL;
                 flint_printf("binary_op_other_variants (left)\n");
                 gr_ctx_println(R);
                 gr_ctx_println(R2);
-                flint_printf("status2 = %d, alias = %d\n", status2, alias);
+                flint_printf("status = %d, status2 = %d, alias = %d\n", status, status2, alias);
                 flint_printf("%s (left)\n", opname);
                 flint_printf("x = %{gr}\n", x, R);
                 flint_printf("y = %{gr}\n", y, R);
@@ -1312,6 +1337,7 @@ gr_test_binary_op_other_variants(gr_ctx_t R,
                 flint_printf("y2 = %{gr}\n", y2, R2);
                 flint_printf("x op y = %{gr}\n", xy, R);
                 flint_printf("x2 op y = %{gr}\n", xy2, R);
+                status = GR_TEST_FAIL;
                 goto cleanup;
             }
         }
@@ -1321,7 +1347,8 @@ cleanup:
     GR_TMP_CLEAR4(x, y, xy, xy2, R);
     GR_TMP_CLEAR2(x2, y2, R2);
 
-    gr_ctx_clear(R2);
+    if (R2 == R2ctx)
+        gr_ctx_clear(R2ctx);
 
     return status;
 }

--- a/src/gr/test_ring.c
+++ b/src/gr/test_ring.c
@@ -1193,6 +1193,141 @@ gr_test_binary_op_type_variants(gr_ctx_t R,
 }
 
 static int
+gr_test_binary_op_other_variants(gr_ctx_t R,
+    const char * opname,
+    int (*gr_op)(gr_ptr, gr_srcptr, gr_srcptr, gr_ctx_t),
+    int (*gr_op_other)(gr_ptr, gr_srcptr, gr_srcptr, gr_ctx_t, gr_ctx_t),
+    int (*gr_other_op)(gr_ptr, gr_srcptr, gr_ctx_t, gr_srcptr, gr_ctx_t),
+    int fused,
+    flint_rand_t state, int test_flags)
+{
+    gr_ctx_t R2;
+    gr_ctx_init_random(R2, state);
+    int status = GR_SUCCESS;
+    int status2;
+    int alias = n_randint(state, 2);
+
+    gr_ptr x, y, x2, y2, xy, xy2;
+
+    GR_TMP_INIT4(x, y, xy, xy2, R);
+    GR_TMP_INIT2(x2, y2, R2);
+
+    GR_MUST_SUCCEED(gr_randtest_small(y2, state, R2));
+    GR_MUST_SUCCEED(gr_randtest_small(x, state, R));
+    GR_MUST_SUCCEED(gr_randtest_small(y, state, R));
+
+    /* Todo: how to test the other variants when set_other fails? */
+    if (gr_set_other(y, y2, R2, R) == GR_SUCCESS)
+    {
+        if (gr_op == gr_divexact)
+            status |= gr_mul(x, x, y, R);
+
+        GR_MUST_SUCCEED(gr_randtest_small(xy, state, R));
+        if (fused)
+            GR_MUST_SUCCEED(gr_set(xy2, xy, R));
+        else
+            GR_MUST_SUCCEED(gr_randtest_small(xy2, state, R));
+
+        if (alias)
+        {
+            GR_MUST_SUCCEED(gr_set(xy, x, R));
+            GR_MUST_SUCCEED(gr_set(xy2, x, R));
+            status = gr_op(xy, xy, y, R);
+            status2 = gr_op_other(xy2, xy2, y2, R2, R);
+        }
+        else
+        {
+            status = gr_op(xy, x, y, R);
+            status2 = gr_op_other(xy2, x, y2, R2, R);
+        }
+
+        if ((status == GR_SUCCESS && status2 == GR_DOMAIN) ||
+            (status == GR_SUCCESS && status2 == GR_SUCCESS &&
+            gr_equal(xy, xy2, R) == T_FALSE))
+        {
+            status = GR_TEST_FAIL;
+            flint_printf("binary_op_other_variants\n");
+            gr_ctx_println(R);
+            gr_ctx_println(R2);
+            flint_printf("status2 = %d, alias = %d\n", status2, alias);
+            flint_printf("%s (right)\n", opname);
+            flint_printf("x = %{gr}\n", x, R);
+            flint_printf("y = %{gr}\n", y, R);
+            flint_printf("y2 = %{gr}\n", y2, R2);
+            flint_printf("x op y = %{gr}\n", xy, R);
+            flint_printf("x op y2 = %{gr}\n", xy2, R);
+            goto cleanup;
+        }
+
+        if (gr_other_op != NULL)
+        {
+            status = GR_SUCCESS;
+
+            if (gr_op == gr_divexact)
+            {
+                status |= gr_set_other(x2, x, R, R2);
+            }
+            else
+            {
+                GR_MUST_SUCCEED(gr_randtest_small(x2, state, R2));
+                status |= gr_set_other(x, x2, R2, R);
+            }
+
+            if (status != GR_SUCCESS)
+                goto cleanup;
+
+            GR_MUST_SUCCEED(gr_randtest_small(xy, state, R));
+            if (fused)
+                GR_MUST_SUCCEED(gr_set(xy2, xy, R));
+            else
+                GR_MUST_SUCCEED(gr_randtest_small(xy2, state, R));
+
+            if (alias)
+            {
+                GR_MUST_SUCCEED(gr_set(xy, y, R));
+                GR_MUST_SUCCEED(gr_set(xy2, y, R));
+                status = gr_op(xy, x, y, R);
+                status2 = gr_other_op(xy2, x2, R2, xy2, R);
+            }
+            else
+            {
+                status = gr_op(xy, x, y, R);
+                status2 = gr_other_op(xy2, x2, R2, y, R);
+            }
+
+            if ((status == GR_SUCCESS && status2 == GR_DOMAIN) ||
+                (status == GR_SUCCESS && status2 == GR_SUCCESS &&
+                gr_equal(xy, xy2, R) == T_FALSE))
+            {
+                status = GR_TEST_FAIL;
+                flint_printf("binary_op_other_variants (left)\n");
+                gr_ctx_println(R);
+                gr_ctx_println(R2);
+                flint_printf("status2 = %d, alias = %d\n", status2, alias);
+                flint_printf("%s (left)\n", opname);
+                flint_printf("x = %{gr}\n", x, R);
+                flint_printf("y = %{gr}\n", y, R);
+                if (gr_op == gr_divexact)
+                    flint_printf("x2 = %{gr}\n", x2, R2);
+                flint_printf("y2 = %{gr}\n", y2, R2);
+                flint_printf("x op y = %{gr}\n", xy, R);
+                flint_printf("x2 op y = %{gr}\n", xy2, R);
+                goto cleanup;
+            }
+        }
+    }
+
+cleanup:
+    GR_TMP_CLEAR4(x, y, xy, xy2, R);
+    GR_TMP_CLEAR2(x2, y2, R2);
+
+    gr_ctx_clear(R2);
+
+    return status;
+}
+
+
+static int
 gr_test_binary_op_associative(gr_ctx_t R, int (*gr_op)(gr_ptr, gr_srcptr, gr_srcptr, gr_ctx_t), flint_rand_t state, int test_flags)
 {
     int status;
@@ -1709,6 +1844,14 @@ gr_test_add_type_variants(gr_ctx_t R, flint_rand_t state, int test_flags)
 }
 
 static int
+gr_test_add_other_variants(gr_ctx_t R, flint_rand_t state, int test_flags)
+{
+    return gr_test_binary_op_other_variants(R, "add",
+        gr_add, gr_add_other, gr_other_add,
+            0, state, test_flags);
+}
+
+static int
 gr_test_sub_equal_neg_add(gr_ctx_t R, flint_rand_t state, int test_flags)
 {
     int status;
@@ -1766,6 +1909,14 @@ gr_test_sub_type_variants(gr_ctx_t R, flint_rand_t state, int test_flags)
 }
 
 static int
+gr_test_sub_other_variants(gr_ctx_t R, flint_rand_t state, int test_flags)
+{
+    return gr_test_binary_op_other_variants(R, "sub",
+        gr_sub, gr_sub_other, gr_other_sub,
+            0, state, test_flags);
+}
+
+static int
 gr_test_mul_associative(gr_ctx_t R, flint_rand_t state, int test_flags)
 {
     return gr_test_binary_op_associative(R, gr_mul, state, test_flags);
@@ -1802,6 +1953,14 @@ gr_test_mul_type_variants(gr_ctx_t R, flint_rand_t state, int test_flags)
     return gr_test_binary_op_type_variants(R, "mul",
         gr_mul, gr_mul_ui, gr_mul_si, gr_mul_fmpz, gr_mul_fmpq,
             0, 0, state, test_flags);
+}
+
+static int
+gr_test_mul_other_variants(gr_ctx_t R, flint_rand_t state, int test_flags)
+{
+    return gr_test_binary_op_other_variants(R, "mul",
+        gr_mul, gr_mul_other, gr_other_mul,
+            0, state, test_flags);
 }
 
 static int
@@ -1919,6 +2078,22 @@ gr_test_submul_type_variants(gr_ctx_t R, flint_rand_t state, int test_flags)
 }
 
 static int
+gr_test_addmul_other_variants(gr_ctx_t R, flint_rand_t state, int test_flags)
+{
+    return gr_test_binary_op_other_variants(R, "addmul",
+        gr_addmul, gr_addmul_other, NULL,
+            1, state, test_flags);
+}
+
+static int
+gr_test_submul_other_variants(gr_ctx_t R, flint_rand_t state, int test_flags)
+{
+    return gr_test_binary_op_other_variants(R, "submul",
+        gr_submul, gr_submul_other, NULL,
+            1, state, test_flags);
+}
+
+static int
 gr_test_div_aliasing(gr_ctx_t R, flint_rand_t state, int test_flags)
 {
     return gr_test_binary_op_aliasing(R, gr_div, state, test_flags);
@@ -1930,6 +2105,14 @@ gr_test_div_type_variants(gr_ctx_t R, flint_rand_t state, int test_flags)
     return gr_test_binary_op_type_variants(R, "div",
         gr_div, gr_div_ui, gr_div_si, gr_div_fmpz, gr_div_fmpq,
             0, 0, state, test_flags);
+}
+
+static int
+gr_test_div_other_variants(gr_ctx_t R, flint_rand_t state, int test_flags)
+{
+    return gr_test_binary_op_other_variants(R, "div",
+        gr_div, gr_div_other, gr_other_div,
+            0, state, test_flags);
 }
 
 static int
@@ -2297,6 +2480,14 @@ gr_test_divexact_type_variants(gr_ctx_t R, flint_rand_t state, int test_flags)
     fmpz_clear(zy);
 
     return status;
+}
+
+static int
+gr_test_divexact_other_variants(gr_ctx_t R, flint_rand_t state, int test_flags)
+{
+    return gr_test_binary_op_other_variants(R, "divexact",
+        gr_divexact, gr_divexact_other, gr_other_divexact,
+            0, state, test_flags);
 }
 
 static int
@@ -2872,6 +3063,14 @@ gr_test_pow_type_variants(gr_ctx_t R, flint_rand_t state, int test_flags)
     return gr_test_binary_op_type_variants(R, "pow",
         gr_pow, gr_pow_ui, gr_pow_si, gr_pow_fmpz, gr_pow_fmpq,
             0, 1, state, test_flags);
+}
+
+static int
+gr_test_pow_other_variants(gr_ctx_t R, flint_rand_t state, int test_flags)
+{
+    return gr_test_binary_op_other_variants(R, "pow",
+        gr_pow, gr_pow_other, gr_other_pow,
+            0, state, test_flags);
 }
 
 static int
@@ -4732,6 +4931,15 @@ gr_test_ring(gr_ctx_t R, slong iters, int test_flags)
     gr_test_iter(R, state, "pow: aliasing", gr_test_pow_aliasing, iters, test_flags & (~GR_TEST_ALWAYS_ABLE));
     gr_test_iter(R, state, "pow: exponent addition", gr_test_pow_exponent_addition, iters, test_flags & (~GR_TEST_ALWAYS_ABLE));
     gr_test_iter(R, state, "pow: ui/si/fmpz/fmpq", gr_test_pow_type_variants, iters, test_flags & (~GR_TEST_ALWAYS_ABLE));
+
+    gr_test_iter(R, state, "add: other", gr_test_add_other_variants, iters, test_flags);
+    gr_test_iter(R, state, "sub: other", gr_test_sub_other_variants, iters, test_flags);
+    gr_test_iter(R, state, "mul: other", gr_test_mul_other_variants, iters, test_flags);
+    gr_test_iter(R, state, "addmul: other", gr_test_addmul_other_variants, iters, test_flags);
+    gr_test_iter(R, state, "submul: other", gr_test_submul_other_variants, iters, test_flags);
+    gr_test_iter(R, state, "div: other", gr_test_div_other_variants, iters, test_flags);
+    gr_test_iter(R, state, "divexact: other", gr_test_divexact_other_variants, iters, test_flags);
+    gr_test_iter(R, state, "pow: other", gr_test_pow_other_variants, iters, test_flags);
 
     if (gr_ctx_is_ordered_ring(R) == T_TRUE)
         gr_test_iter(R, state, "ordered_ring_cmp", gr_test_ordered_ring_cmp, iters, test_flags);

--- a/src/gr/vector.c
+++ b/src/gr/vector.c
@@ -133,6 +133,9 @@ vector_ctx_is_threadsafe(gr_ctx_t ctx)
     return gr_ctx_is_threadsafe(ENTRY_CTX(ctx));
 }
 
+static gr_ptr vector_ctx_base(gr_ctx_t ctx) { return ENTRY_CTX(ctx); }
+
+
 static void
 vector_gr_vec_clear(gr_vec_t res, gr_ctx_t ctx)
 {
@@ -738,6 +741,7 @@ gr_method_tab_input _gr_vec_methods_input[] =
     {GR_METHOD_CTX_IS_COMPLEX_VECTOR_SPACE, (gr_funcptr) vector_ctx_is_complex_vector_space},
     {GR_METHOD_CTX_IS_APPROX_COMMUTATIVE_RING, (gr_funcptr) vector_ctx_is_approx_commutative_ring},
     {GR_METHOD_CTX_IS_THREADSAFE,    (gr_funcptr) vector_ctx_is_threadsafe},
+    {GR_METHOD_CTX_BASE,    (gr_funcptr) vector_ctx_base},
 
     {GR_METHOD_CTX_WRITE,   (gr_funcptr) vector_gr_vec_ctx_write},
     {GR_METHOD_INIT,        (gr_funcptr) vector_gr_vec_init},

--- a/src/gr_generic.h
+++ b/src/gr_generic.h
@@ -89,6 +89,8 @@ void gr_generic_ctx_clear(gr_ctx_t ctx);
 slong gr_generic_ctx_ngens_0(slong * ngens, gr_ctx_t ctx);
 slong gr_generic_ctx_ngens_1(slong * ngens, gr_ctx_t ctx);
 
+gr_ptr gr_generic_ctx_base(gr_ctx_t ctx);
+
 void gr_generic_set_shallow(gr_ptr res, gr_srcptr x, const gr_ctx_t ctx);
 
 WARN_UNUSED_RESULT int gr_generic_write_n(gr_stream_t out, gr_srcptr x, slong n, gr_ctx_t ctx);

--- a/src/gr_generic/generic.c
+++ b/src/gr_generic/generic.c
@@ -110,6 +110,11 @@ gr_generic_ctx_ngens_1(slong * ngens, gr_ctx_t ctx)
     return GR_SUCCESS;
 }
 
+gr_ptr gr_generic_ctx_base(gr_ctx_t ctx)
+{
+    return NULL;
+}
+
 void
 gr_generic_set_shallow(gr_ptr res, gr_srcptr x, const gr_ctx_t ctx)
 {
@@ -2719,6 +2724,7 @@ const gr_method_tab_input _gr_generic_methods[] =
     {GR_METHOD_CTX_IS_CANONICAL,        (gr_funcptr) gr_generic_ctx_predicate},
 
     {GR_METHOD_CTX_NGENS,               (gr_funcptr) gr_generic_ctx_ngens_0},
+    {GR_METHOD_CTX_BASE,                (gr_funcptr) gr_generic_ctx_base},
 
     {GR_METHOD_INIT,                    (gr_funcptr) gr_generic_init},
     {GR_METHOD_CLEAR,                   (gr_funcptr) gr_generic_clear},

--- a/src/gr_mpoly/ctx.c
+++ b/src/gr_mpoly/ctx.c
@@ -156,6 +156,9 @@ gr_mpoly_ctx_is_threadsafe(gr_mpoly_ctx_t ctx)
     return gr_ctx_is_threadsafe(GR_MPOLY_CCTX(ctx));
 }
 
+static gr_ptr _gr_mpoly_ctx_base(gr_ctx_t ctx) { return GR_MPOLY_CCTX(ctx); }
+
+
 int
 gr_mpoly_gens(gr_vec_t res, gr_mpoly_ctx_t ctx)
 {
@@ -331,6 +334,7 @@ gr_method_tab_input _gr_mpoly_methods_input[] =
     {GR_METHOD_CTX_SET_GEN_NAMES,       (gr_funcptr) gr_mpoly_ctx_set_gen_names},
     {GR_METHOD_CTX_NGENS,               (gr_funcptr) _gr_mpoly_ctx_ngens},
     {GR_METHOD_CTX_GEN_NAME,            (gr_funcptr) _gr_mpoly_ctx_gen_name},
+    {GR_METHOD_CTX_BASE,    (gr_funcptr) _gr_mpoly_ctx_base},
     {GR_METHOD_INIT,        (gr_funcptr) gr_mpoly_init},
     {GR_METHOD_CLEAR,       (gr_funcptr) gr_mpoly_clear},
     {GR_METHOD_SWAP,        (gr_funcptr) gr_mpoly_swap},

--- a/src/gr_ore_poly/ctx.c
+++ b/src/gr_ore_poly/ctx.c
@@ -105,6 +105,12 @@ _gr_ore_poly_ctx_gen_name(char ** name, slong i, gr_ctx_t ctx)
     return GR_SUCCESS;
 }
 
+static gr_ctx_ptr
+_gr_ore_poly_ctx_base(gr_ctx_t ctx)
+{
+    return GR_ORE_POLY_ELEM_CTX(ctx);
+}
+
 void
 gr_ore_poly_ctx_clear(gr_ore_poly_ctx_t ctx)
 {
@@ -235,6 +241,7 @@ gr_method_tab_input _gr_ore_poly_methods_input[] =
     {GR_METHOD_CTX_SET_GEN_NAMES,       (gr_funcptr) _gr_ore_poly_ctx_set_gen_names},
     {GR_METHOD_CTX_NGENS,               (gr_funcptr) gr_generic_ctx_ngens_1},
     {GR_METHOD_CTX_GEN_NAME,            (gr_funcptr) _gr_ore_poly_ctx_gen_name},
+    {GR_METHOD_CTX_BASE,            (gr_funcptr) _gr_ore_poly_ctx_base},
 
     {GR_METHOD_INIT,        (gr_funcptr) gr_ore_poly_init},
     {GR_METHOD_CLEAR,       (gr_funcptr) gr_ore_poly_clear},

--- a/src/gr_ore_poly/ctx.c
+++ b/src/gr_ore_poly/ctx.c
@@ -258,9 +258,9 @@ gr_method_tab_input _gr_ore_poly_methods_input[] =
     {GR_METHOD_GENS,           (gr_funcptr) gr_generic_gens_single},
     {GR_METHOD_GENS_RECURSIVE, (gr_funcptr) gr_ore_poly_gens_recursive},
 
-/*
     {GR_METHOD_IS_ZERO,     (gr_funcptr) gr_ore_poly_is_zero},
     {GR_METHOD_IS_ONE,      (gr_funcptr) gr_ore_poly_is_one},
+/*
     {GR_METHOD_IS_NEG_ONE,  (gr_funcptr) gr_ore_poly_is_neg_one},
 */
     {GR_METHOD_EQUAL,       (gr_funcptr) gr_ore_poly_equal},

--- a/src/gr_ore_poly/ring.c
+++ b/src/gr_ore_poly/ring.c
@@ -340,8 +340,7 @@ int
 gr_ore_poly_other_mul(gr_ore_poly_t res, gr_srcptr x, gr_ctx_t x_ctx, const gr_ore_poly_t poly, gr_ore_poly_ctx_t ctx)
 {
     if (x_ctx == ctx) {
-        /* TODO: Multiplication of Ore polynomials. */
-        return GR_UNABLE;
+        return gr_ore_poly_mul(res, x, poly, ctx);
     } else if (x_ctx == GR_ORE_POLY_ELEM_CTX(ctx)) {
         return gr_poly_scalar_mul((gr_poly_struct *) res, x, (const gr_poly_struct *) poly, GR_ORE_POLY_ELEM_CTX(ctx));
     } else if (GR_ORE_POLY_CTX(ctx)->base_ring->which_ring == GR_CTX_GR_POLY && \

--- a/src/gr_ore_poly/ring.c
+++ b/src/gr_ore_poly/ring.c
@@ -257,7 +257,7 @@ gr_ore_poly_add_other(gr_ore_poly_t res, const gr_ore_poly_t poly, gr_srcptr x, 
         tmp->coeffs = (gr_ptr) x;
         tmp->length = 1;
         tmp->alloc = 1;
-        return gr_poly_add_scalar((gr_poly_struct *) poly, (gr_poly_struct *) poly, tmp, GR_ORE_POLY_ELEM_CTX(ctx));
+        return gr_poly_add_scalar((gr_poly_struct *) res, (gr_poly_struct *) poly, tmp, GR_ORE_POLY_ELEM_CTX(ctx));
     } else if (x_ctx->which_ring == GR_CTX_FMPZ) {
         return gr_poly_add_fmpz((gr_poly_struct *) res, (const gr_poly_struct *) poly, x, GR_ORE_POLY_ELEM_CTX(ctx));
     } else if (x_ctx->which_ring == GR_CTX_FMPQ) {
@@ -303,7 +303,7 @@ gr_ore_poly_sub_other(gr_ore_poly_t res, const gr_ore_poly_t poly, gr_srcptr x, 
         tmp->coeffs = (gr_ptr) x;
         tmp->length = 1;
         tmp->alloc = 1;
-        return gr_poly_sub_scalar((gr_poly_struct *) poly, (gr_poly_struct *) poly, tmp, GR_ORE_POLY_ELEM_CTX(ctx));
+        return gr_poly_sub_scalar((gr_poly_struct *) res, (gr_poly_struct *) poly, tmp, GR_ORE_POLY_ELEM_CTX(ctx));
     } else if (x_ctx->which_ring == GR_CTX_FMPZ) {
         return gr_poly_sub_fmpz((gr_poly_struct *) res, (const gr_poly_struct *) poly, x, GR_ORE_POLY_ELEM_CTX(ctx));
     } else if (x_ctx->which_ring == GR_CTX_FMPQ) {
@@ -349,7 +349,7 @@ gr_ore_poly_other_mul(gr_ore_poly_t res, gr_srcptr x, gr_ctx_t x_ctx, const gr_o
         tmp->coeffs = (gr_ptr) x;
         tmp->length = 1;
         tmp->alloc = 1;
-        return gr_poly_scalar_mul((gr_poly_struct *) poly, tmp, (const gr_poly_struct *) poly, GR_ORE_POLY_ELEM_CTX(ctx));
+        return gr_poly_scalar_mul((gr_poly_struct *) res, tmp, (const gr_poly_struct *) poly, GR_ORE_POLY_ELEM_CTX(ctx));
     } else if (x_ctx->which_ring == GR_CTX_FMPZ) {
         return gr_poly_mul_fmpz((gr_poly_struct *) res, (const gr_poly_struct *) poly, x, GR_ORE_POLY_ELEM_CTX(ctx));
     } else if (x_ctx->which_ring == GR_CTX_FMPQ) {

--- a/src/gr_series/series.c
+++ b/src/gr_series/series.c
@@ -1950,6 +1950,9 @@ _gr_series_ctx_gen_name(char ** name, slong i, gr_ctx_t ctx)
     return GR_SUCCESS;
 }
 
+static gr_ptr _gr_series_ctx_base(gr_ctx_t ctx) { return GR_SERIES_ELEM_CTX(ctx); }
+
+
 int
 gr_series_gens_recursive(gr_vec_t vec, gr_ctx_t ctx)
 {
@@ -2054,6 +2057,7 @@ gr_method_tab_input _gr_series_methods_input[] =
     {GR_METHOD_CTX_IS_RATIONAL_VECTOR_SPACE, (gr_funcptr) gr_series_ctx_is_rational_vector_space},
     {GR_METHOD_CTX_IS_REAL_VECTOR_SPACE, (gr_funcptr) gr_series_ctx_is_real_vector_space},
     {GR_METHOD_CTX_IS_COMPLEX_VECTOR_SPACE, (gr_funcptr) gr_series_ctx_is_complex_vector_space},
+    {GR_METHOD_CTX_BASE,    (gr_funcptr) _gr_series_ctx_base},
     {GR_METHOD_INIT,        (gr_funcptr) gr_series_init},
     {GR_METHOD_CLEAR,       (gr_funcptr) gr_series_clear},
     {GR_METHOD_SWAP,        (gr_funcptr) gr_series_swap},

--- a/src/gr_series/series_mod.c
+++ b/src/gr_series/series_mod.c
@@ -147,6 +147,9 @@ gr_series_mod_gens_recursive(gr_vec_t vec, gr_ctx_t ctx)
     return status;
 }
 
+static gr_ptr _gr_series_mod_ctx_base(gr_ctx_t ctx) { return GR_SERIES_MOD_ELEM_CTX(ctx); }
+
+
 void gr_series_mod_init(gr_poly_t res, gr_ctx_t ctx)
 {
     gr_poly_init(res, GR_SERIES_MOD_ELEM_CTX(ctx));
@@ -344,7 +347,7 @@ gr_series_mod_set_other(gr_poly_t res, gr_srcptr x, gr_ctx_t x_ctx, gr_ctx_t ctx
 {
     if (x_ctx == ctx)
     {
-        return gr_poly_set(res, x, ctx);
+        return gr_series_mod_set(res, x, ctx);
     }
     else if (x_ctx == GR_SERIES_MOD_ELEM_CTX(ctx))
     {
@@ -412,6 +415,7 @@ gr_method_tab_input _gr_series_mod_methods_input[] =
     {GR_METHOD_CTX_IS_RATIONAL_VECTOR_SPACE, (gr_funcptr) gr_series_mod_ctx_is_rational_vector_space},
     {GR_METHOD_CTX_IS_REAL_VECTOR_SPACE, (gr_funcptr) gr_series_mod_ctx_is_real_vector_space},
     {GR_METHOD_CTX_IS_COMPLEX_VECTOR_SPACE, (gr_funcptr) gr_series_mod_ctx_is_complex_vector_space},
+    {GR_METHOD_CTX_BASE,    (gr_funcptr) _gr_series_mod_ctx_base},
     {GR_METHOD_INIT,        (gr_funcptr) gr_series_mod_init},
     {GR_METHOD_CLEAR,       (gr_funcptr) gr_series_mod_clear},
     {GR_METHOD_SWAP,        (gr_funcptr) gr_series_mod_swap},


### PR DESCRIPTION
* Add some generic test code for ``gr_op_other`` / ``gr_other_op`` methods and improve coverage for `gr_set_other`
* Fix a couple of bugs in ``gr_op_other`` / ``gr_other_op`` methods
* Add the helper function ``gr_ctx_base`` to retrieve the pointer to the base ring of an extension ring (used in the above test code)
* Fix documentation PDF build
