### PR TITLE
Fix 32bit segfault in `flint_sprintf`

### DIFF
--- a/src/generic_files/io_vprintf_impl.h
+++ b/src/generic_files/io_vprintf_impl.h
@@ -369,7 +369,9 @@ continue_while:
         if (IS_FLINT_PRINTF_ULONGFMT(ipcur))
         {
             size_t cpsz;
+            int is_signed;
 
+            is_signed = (ipcur[1] == 'd' || ipcur[1] == 'i');
             ipcur += 2; /* To include 'w' and following format specifier */
             cpsz = ipcur - ip;
 
@@ -386,7 +388,10 @@ continue_while:
             opcur[-2] = 'l';
 #endif
             /* Pop entry from vlist (still present in vlist_cpy) */
-            va_arg(vlist, ulong);
+            if (is_signed)
+                va_arg(vlist, slong);
+            else
+                va_arg(vlist, ulong);
         }
         else if (IS_PRINTF_INTFMT(ipcur)
                 || IS_PRINTF_CHARFMT(ipcur)


### PR DESCRIPTION
Hopefully resolves https://github.com/flintlib/flint/issues/2646#issuecomment-4325687408. I don't have access to a 32bit arm system where the issue reproduces, so @fredrik-johansson @d-torrance could one of you please give this a try?

Bug analysis by Codex, implementation by hand.