### PR TITLE
fix(gr): arg-eval-order divergence in randtest helpers (closes #2646)

### DIFF
--- a/doc/source/history.rst
+++ b/doc/source/history.rst
@@ -7,6 +7,19 @@ FLINT version history
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 
+FLINT 3.6.0 (in development)
+-------------------------------------------------------------------------------
+
+Bug fixes
+
+* Fix architecture-dependent test behaviour caused by undefined argument
+  evaluation order in several ``gr_ctx_init_random_*`` and ``_gr_*_randtest``
+  functions, which produced different RNG sequences on 32-bit ARM, i386, and
+  x86_64. Also gate the ``log(a*b) = log(a) + log(b)`` check in
+  ``gr_poly_log_series`` on commutativity of the coefficient ring
+  [EC, `#2649 <https://github.com/flintlib/flint/pull/2649>`_].
+
+
 2026-04-24 -- FLINT 3.5.0
 -------------------------------------------------------------------------------
 

--- a/src/gr/fmpq_mpoly.c
+++ b/src/gr/fmpq_mpoly.c
@@ -140,21 +140,30 @@ _gr_fmpq_mpoly_set_shallow(fmpq_mpoly_t res, const fmpq_mpoly_t poly, gr_ctx_t c
 static int
 _gr_fmpq_mpoly_randtest(fmpq_mpoly_t res, flint_rand_t state, gr_ctx_t ctx)
 {
-    slong bits;
+    slong bits, length;
+    flint_bitcnt_t exp_bits;
 
     if (n_randint(state, 10) != 0)
         bits = 10;
     else
         bits = 100;
 
-    fmpq_mpoly_randtest_bits(res, state, n_randint(state, 5), bits, 1 + n_randint(state, 3), MPOLYNOMIAL_MCTX(ctx));
+    /* Split state-mutating calls so consumption order is architecture-independent. */
+    length = n_randint(state, 5);
+    exp_bits = 1 + n_randint(state, 3);
+    fmpq_mpoly_randtest_bits(res, state, length, bits, exp_bits, MPOLYNOMIAL_MCTX(ctx));
     return GR_SUCCESS;
 }
 
 static int
 _gr_fmpq_mpoly_randtest_small(fmpq_mpoly_t res, flint_rand_t state, gr_ctx_t ctx)
 {
-    fmpq_mpoly_randtest_bits(res, state, n_randint(state, 3), 3, 1 + n_randint(state, 3), MPOLYNOMIAL_MCTX(ctx));
+    slong length;
+    flint_bitcnt_t exp_bits;
+
+    length = n_randint(state, 3);
+    exp_bits = 1 + n_randint(state, 3);
+    fmpq_mpoly_randtest_bits(res, state, length, 3, exp_bits, MPOLYNOMIAL_MCTX(ctx));
     return GR_SUCCESS;
 }
 

--- a/src/gr/fmpz_mod_mpoly_q.c
+++ b/src/gr/fmpz_mod_mpoly_q.c
@@ -139,14 +139,25 @@ _gr_fmpz_mod_mpoly_q_set_shallow(fmpz_mod_mpoly_q_t res, const fmpz_mod_mpoly_q_
 static int
 _gr_fmpz_mod_mpoly_q_randtest(fmpz_mod_mpoly_q_t res, flint_rand_t state, gr_ctx_t ctx)
 {
-    fmpz_mod_mpoly_q_randtest(res, state, n_randint(state, 5), 1 + n_randint(state, 3), MPOLYNOMIAL_MCTX(ctx));
+    slong length;
+    flint_bitcnt_t exp_bits;
+
+    /* Split state-mutating calls so consumption order is architecture-independent. */
+    length = n_randint(state, 5);
+    exp_bits = 1 + n_randint(state, 3);
+    fmpz_mod_mpoly_q_randtest(res, state, length, exp_bits, MPOLYNOMIAL_MCTX(ctx));
     return GR_SUCCESS;
 }
 
 static int
 _gr_fmpz_mod_mpoly_q_randtest_small(fmpz_mod_mpoly_q_t res, flint_rand_t state, gr_ctx_t ctx)
 {
-    fmpz_mod_mpoly_q_randtest(res, state, n_randint(state, 3), 1 + n_randint(state, 3), MPOLYNOMIAL_MCTX(ctx));
+    slong length;
+    flint_bitcnt_t exp_bits;
+
+    length = n_randint(state, 3);
+    exp_bits = 1 + n_randint(state, 3);
+    fmpz_mod_mpoly_q_randtest(res, state, length, exp_bits, MPOLYNOMIAL_MCTX(ctx));
     return GR_SUCCESS;
 }
 

--- a/src/gr/fmpz_mpoly.c
+++ b/src/gr/fmpz_mpoly.c
@@ -140,21 +140,32 @@ _gr_fmpz_mpoly_set_shallow(fmpz_mpoly_t res, const fmpz_mpoly_t poly, gr_ctx_t c
 static int
 _gr_fmpz_mpoly_randtest(fmpz_mpoly_t res, flint_rand_t state, gr_ctx_t ctx)
 {
-    slong bits;
+    slong bits, length;
+    flint_bitcnt_t exp_bits;
 
     if (n_randint(state, 10) != 0)
         bits = 10;
     else
         bits = 100;
 
-    fmpz_mpoly_randtest_bits(res, state, n_randint(state, 5), bits, 1 + n_randint(state, 3), MPOLYNOMIAL_MCTX(ctx));
+    /* The two n_randint calls have side effects on `state`; split them so
+       the consumption order is the same on every architecture (C does not
+       specify the order in which function arguments are evaluated). */
+    length = n_randint(state, 5);
+    exp_bits = 1 + n_randint(state, 3);
+    fmpz_mpoly_randtest_bits(res, state, length, bits, exp_bits, MPOLYNOMIAL_MCTX(ctx));
     return GR_SUCCESS;
 }
 
 static int
 _gr_fmpz_mpoly_randtest_small(fmpz_mpoly_t res, flint_rand_t state, gr_ctx_t ctx)
 {
-    fmpz_mpoly_randtest_bits(res, state, n_randint(state, 3), 3, 1 + n_randint(state, 3), MPOLYNOMIAL_MCTX(ctx));
+    slong length;
+    flint_bitcnt_t exp_bits;
+
+    length = n_randint(state, 3);
+    exp_bits = 1 + n_randint(state, 3);
+    fmpz_mpoly_randtest_bits(res, state, length, 3, exp_bits, MPOLYNOMIAL_MCTX(ctx));
     return GR_SUCCESS;
 }
 

--- a/src/gr/fmpz_mpoly_q.c
+++ b/src/gr/fmpz_mpoly_q.c
@@ -74,21 +74,30 @@ _gr_fmpz_mpoly_q_set_shallow(fmpz_mpoly_q_t res, const fmpz_mpoly_q_t poly, gr_c
 static int
 _gr_fmpz_mpoly_q_randtest(fmpz_mpoly_q_t res, flint_rand_t state, gr_ctx_t ctx)
 {
-    slong bits;
+    slong bits, length;
+    flint_bitcnt_t exp_bits;
 
     if (n_randint(state, 10) != 0)
         bits = 10;
     else
         bits = 100;
 
-    fmpz_mpoly_q_randtest(res, state, n_randint(state, 5), bits, 1 + n_randint(state, 3), MPOLYNOMIAL_MCTX(ctx));
+    /* Split state-mutating calls so consumption order is architecture-independent. */
+    length = n_randint(state, 5);
+    exp_bits = 1 + n_randint(state, 3);
+    fmpz_mpoly_q_randtest(res, state, length, bits, exp_bits, MPOLYNOMIAL_MCTX(ctx));
     return GR_SUCCESS;
 }
 
 static int
 _gr_fmpz_mpoly_q_randtest_small(fmpz_mpoly_q_t res, flint_rand_t state, gr_ctx_t ctx)
 {
-    fmpz_mpoly_q_randtest(res, state, n_randint(state, 3), 3, 1 + n_randint(state, 3), MPOLYNOMIAL_MCTX(ctx));
+    slong length;
+    flint_bitcnt_t exp_bits;
+
+    length = n_randint(state, 3);
+    exp_bits = 1 + n_randint(state, 3);
+    fmpz_mpoly_q_randtest(res, state, length, 3, exp_bits, MPOLYNOMIAL_MCTX(ctx));
     return GR_SUCCESS;
 }
 

--- a/src/gr/init_random.c
+++ b/src/gr/init_random.c
@@ -54,7 +54,12 @@ gr_ctx_init_random_ring_composite(gr_ctx_t ctx, flint_rand_t state)
             gr_ctx_init_gr_poly(ctx, base_ring);
             break;
         case 1:
-            gr_ctx_init_gr_mpoly(ctx, base_ring, n_randint(state, 3), mpoly_ordering_randtest(state));
+            {
+                /* Split state-mutating calls so consumption order is architecture-independent. */
+                slong nvars = n_randint(state, 3);
+                ordering_t ord = mpoly_ordering_randtest(state);
+                gr_ctx_init_gr_mpoly(ctx, base_ring, nvars, ord);
+            }
             break;
         case 2:
             gr_series_ctx_init(ctx, base_ring, n_randint(state, 6));
@@ -127,16 +132,30 @@ gr_ctx_init_random_ring_finite_field(gr_ctx_t ctx, flint_rand_t state)
     switch (n_randint(state, 3))
     {
         case 0:
-            gr_ctx_init_fq_nmod(ctx, n_randtest_prime(state, 0), 1 + n_randint(state, 4), NULL);
+            {
+                /* Split state-mutating calls so consumption order is architecture-independent. */
+                ulong p = n_randtest_prime(state, 0);
+                slong d = 1 + n_randint(state, 4);
+                gr_ctx_init_fq_nmod(ctx, p, d, NULL);
+            }
             break;
 
         case 1:
-            gr_ctx_init_fq_zech(ctx, n_randprime(state, 4, 0), 1 + n_randint(state, 3), NULL);
+            {
+                ulong p = n_randprime(state, 4, 0);
+                slong d = 1 + n_randint(state, 3);
+                gr_ctx_init_fq_zech(ctx, p, d, NULL);
+            }
             break;
 
         case 2:
-            fmpz_randprime(t, state, 2 + n_randint(state, 100), 0);
-            gr_ctx_init_fq(ctx, t, 1 + n_randint(state, 4), NULL);
+            {
+                flint_bitcnt_t bits = 2 + n_randint(state, 100);
+                slong d;
+                fmpz_randprime(t, state, bits, 0);
+                d = 1 + n_randint(state, 4);
+                gr_ctx_init_fq(ctx, t, d, NULL);
+            }
             break;
     }
 
@@ -154,7 +173,16 @@ gr_ctx_init_random_ring_number_field(gr_ctx_t ctx, flint_rand_t state)
 
     do
     {
-        fmpz_poly_randtest_irreducible(g, state, 2 + n_randint(state, 5), 1 + n_randint(state, 10));
+        slong len;
+        flint_bitcnt_t bits;
+
+        /* The two n_randint calls below have side effects on `state`; we
+           split them into separate statements so the order of consumption
+           is the same on every architecture (C does not specify the order
+           in which function arguments are evaluated). */
+        len = 2 + n_randint(state, 5);
+        bits = 1 + n_randint(state, 10);
+        fmpz_poly_randtest_irreducible(g, state, len, bits);
     } while (g->length < 2);
 
     fmpq_poly_set_fmpz_poly(f, g);
@@ -217,10 +245,19 @@ gr_ctx_init_random_ring_builtin_poly(gr_ctx_t ctx, flint_rand_t state)
             gr_ctx_init_fmpq_poly(ctx);
             break;
         case 2:
-            gr_ctx_init_fmpz_mpoly(ctx, n_randint(state, 3), mpoly_ordering_randtest(state));
+            {
+                /* Split state-mutating calls so consumption order is architecture-independent. */
+                slong nvars = n_randint(state, 3);
+                ordering_t ord = mpoly_ordering_randtest(state);
+                gr_ctx_init_fmpz_mpoly(ctx, nvars, ord);
+            }
             break;
         case 3:
-            gr_ctx_init_fmpz_mpoly_q(ctx, n_randint(state, 2), mpoly_ordering_randtest(state));
+            {
+                slong nvars = n_randint(state, 2);
+                ordering_t ord = mpoly_ordering_randtest(state);
+                gr_ctx_init_fmpz_mpoly_q(ctx, nvars, ord);
+            }
             break;
     }
 }
@@ -323,10 +360,19 @@ gr_ctx_init_random_mpoly(gr_ctx_t ctx, flint_rand_t state)
     switch (n_randint(state, 2))
     {
         case 0:
-            gr_ctx_init_gr_mpoly(ctx, _gr_random_base_ring(state), n_randint(state, 3), ordering);
+            {
+                /* Split state-mutating calls so consumption order is architecture-independent. */
+                gr_ctx_struct * base = _gr_random_base_ring(state);
+                slong nvars = n_randint(state, 3);
+                gr_ctx_init_gr_mpoly(ctx, base, nvars, ordering);
+            }
             break;
         case 1:
-            gr_ctx_init_fmpz_mpoly(ctx, n_randint(state, 3), mpoly_ordering_randtest(state));
+            {
+                slong nvars = n_randint(state, 3);
+                ordering_t ord = mpoly_ordering_randtest(state);
+                gr_ctx_init_fmpz_mpoly(ctx, nvars, ord);
+            }
             break;
     }
 }

--- a/src/gr/matrix.c
+++ b/src/gr/matrix.c
@@ -198,7 +198,12 @@ static int
 matrix_randtest(gr_mat_t res, flint_rand_t state, gr_ctx_t ctx)
 {
     if (MATRIX_CTX(ctx)->all_sizes)
-        _gr_mat_resize(res, n_randint(state, 7), n_randint(state, 7), MATRIX_CTX(ctx)->base_ring);
+    {
+        /* Split state-mutating calls so consumption order is architecture-independent. */
+        slong r = n_randint(state, 7);
+        slong c = n_randint(state, 7);
+        _gr_mat_resize(res, r, c, MATRIX_CTX(ctx)->base_ring);
+    }
 
     return gr_mat_randtest(res, state, MATRIX_CTX(ctx)->base_ring);
 }

--- a/src/gr_poly/test/t-log_series.c
+++ b/src/gr_poly/test/t-log_series.c
@@ -58,7 +58,14 @@ test_log_series(flint_rand_t state)
         status |= gr_poly_set_coeff_si(fab, 0, 0, ctx);
         status |= gr_poly_set_coeff_si(fafb, 0, 0, ctx);
 
-        if (status == GR_SUCCESS && gr_poly_equal(fab, fafb, ctx) == T_FALSE)
+        /* The identity log(a*b) = log(a) + log(b) only holds when a and b
+           commute as polynomials, i.e. when the coefficient ring is
+           commutative.  Skip the check for non-commutative rings (e.g.
+           matrix rings) where the BCH commutator terms make the two sides
+           differ in general. */
+        if (status == GR_SUCCESS
+                && gr_ctx_is_commutative_ring(ctx) == T_TRUE
+                && gr_poly_equal(fab, fafb, ctx) == T_FALSE)
         {
             flint_printf("FAIL\n\n");
             gr_ctx_println(ctx);


### PR DESCRIPTION
This PR is the follow-up to #2648 reported by @d-torrance. After the `flint_sprintf` fix landed, the `gr_poly_log_series` test was still failing on Debian armhf (and reproduces under qemu-arm-static and on i386 native).

Two distinct bugs, both pre-existing:

1. **C undefined behaviour, the divergence cause:** several `gr_ctx_init_random_*` and `_gr_*_randtest` functions placed two or more state-mutating `n_randint(state, ...)` (or similar) calls in a single function-call argument list, e.g.

    ```c
    fmpz_poly_randtest_irreducible(g, state,
                                   2 + n_randint(state, 5),
                                   1 + n_randint(state, 10));
    ```

    C does not specify the order in which function arguments are evaluated, and gcc's choice differs by ABI: i386 (cdecl) evaluates right-to-left, ARM PCS and x86_64 SysV typically left-to-right. Same RNG seed therefore produced different sequences on different architectures, and the existing tests "passed" only because the per-arch sequence happened to dodge bad cases.

    Fix is mechanical: split each affected call into named local variables so the side-effect order is fixed to program text order. Touched files: `src/gr/init_random.c`, `src/gr/fmpz_mpoly.c`, `src/gr/fmpq_mpoly.c`, `src/gr/fmpz_mpoly_q.c`, `src/gr/fmpz_mod_mpoly_q.c`, `src/gr/matrix.c`.

2. **Test bug, the actual failure exposed once the RNG is deterministic:** `gr_poly_log_series` asserts `log(a*b) == log(a) + log(b)`. This identity holds in formal power series only when the coefficient ring is commutative. For non-commutative rings (matrix rings) the difference begins with a Baker-Campbell-Hausdorff commutator at some truncation order. amd64 dodged this by RNG luck of `gr_ctx_init_random` not landing on a matrix ring within 1000 iterations; once the random sequence is made arch-independent (item 1 above), both 32-bit and 64-bit hit a non-commutative case.

    Fix: gate the equality check on `gr_ctx_is_commutative_ring(ctx) == T_TRUE` in `src/gr_poly/test/t-log_series.c`.

## Additional context

Verification:

- Iter-by-iter RNG state matches between i386 native (`-m32`) and armhf under qemu-arm-static through 1000 iterations of `test_log_series` (was diverging at iter 55 before).
- Full `make check` passes on amd64 and i386 (`-m32`).
- Full `gr_poly`, `gr_mat`, `gr_mpoly`, `mpoly`, `fmpz_mpoly`, `nmod_mpoly`, and top-level `test` modules pass on armhf under qemu-arm-static.
- The original three #2646 tests + `gr_poly_log_series` all pass on all three architectures.

This builds on top of #2648 (the `flint_sprintf` fix). Either order of merging is fine; this PR has no textual conflict with `main` even if #2648 lands first.

## Checklist before merging

- [x] The commits makes sense by themselves (no "oops" commits etc.)

- [x] Git messages are nicely formatted (title written in imperative, at most
  50 characters, optionally with a more detailed explanatory text below).
  The first two title lines are 51 and 65 chars; the third is well under. Happy to rebase to tighten if desired.

- [x] If I added additional code, I have written tests for it as well as made
  sure that I have close to 100% code coverage.
  (No new code paths added; this is a deflaking fix. The existing `gr_poly_log_series` test now passes with the deterministic RNG.)

- [x] I have added a corresponding entry in `doc/source/history.rst` for my
  changes.
