### PR TITLE
Fix return values for `gr_write` methods

### DIFF
--- a/doc/source/history.rst
+++ b/doc/source/history.rst
@@ -22,6 +22,15 @@ Bug fixes
   ``"x1"``) on 32-bit glibc, which broke ``mpoly_test_irreducible`` and the
   ``compose_mpoly`` tests on i386/armhf
   [EC, `#2648 <https://github.com/flintlib/flint/pull/2648>`_].
+* Fix return values for ``gr_write`` and ``gr_ctx_write methods``.
+  Some ``gr_ctx_write`` implementations were incorrectly declared ``void``
+  instead of ``int``, causing test failures on ppc64el. In addition,
+  several methods ignored the return value from inner writes and would always
+  return ``GR_SUCCESS`` even in the case of failure.
+  The ``gr_stream_write`` family of functions have been marked
+  ``WARN_UNUSED_RESULT`` to catch similar bugs more easily.
+  [FJ, `#2652 <https://github.com/flintlib/flint/pull/2652>`_].
+
 
 2026-04-24 -- FLINT 3.5.0
 -------------------------------------------------------------------------------

--- a/src/gr.h
+++ b/src/gr.h
@@ -85,11 +85,11 @@ void gr_stream_init_file(gr_stream_t out, FILE * fp);
 #endif
 
 void gr_stream_init_str(gr_stream_t out);
-int gr_stream_write(gr_stream_t out, const char * s);
-int gr_stream_write_si(gr_stream_t out, slong x);
-int gr_stream_write_ui(gr_stream_t out, ulong x);
-int gr_stream_write_free(gr_stream_t out, char * s);
-int gr_stream_write_fmpz(gr_stream_t out, const fmpz_t x);
+WARN_UNUSED_RESULT int gr_stream_write(gr_stream_t out, const char * s);
+WARN_UNUSED_RESULT int gr_stream_write_si(gr_stream_t out, slong x);
+WARN_UNUSED_RESULT int gr_stream_write_ui(gr_stream_t out, ulong x);
+WARN_UNUSED_RESULT int gr_stream_write_free(gr_stream_t out, char * s);
+WARN_UNUSED_RESULT int gr_stream_write_fmpz(gr_stream_t out, const fmpz_t x);
 
 #define GR_MUST_SUCCEED(expr) do { if ((expr) != GR_SUCCESS) { flint_throw(FLINT_ERROR, "GR_MUST_SUCCEED failure: %s", __FILE__); } } while (0)
 #define GR_IGNORE(expr) do { int ___unused = (expr); (void) ___unused; } while (0)

--- a/src/gr/acb.c
+++ b/src/gr/acb.c
@@ -61,10 +61,11 @@ static int _gr_acb_ctx_get_real_prec(slong * res, gr_ctx_t ctx)
 static int
 _gr_acb_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Complex numbers (acb, prec = ");
-    gr_stream_write_si(out, ACB_CTX_PREC(ctx));
-    gr_stream_write(out, ")");
-    return GR_SUCCESS;
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Complex numbers (acb, prec = ");
+    status |= gr_stream_write_si(out, ACB_CTX_PREC(ctx));
+    status |= gr_stream_write(out, ")");
+    return status;
 }
 
 static void
@@ -105,6 +106,8 @@ _gr_acb_randtest(acb_t res, flint_rand_t state, const gr_ctx_t ctx)
 static int
 __gr_acb_write(gr_stream_t out, const acb_t x, slong digits, int flags, const gr_ctx_t ctx)
 {
+    int status = GR_SUCCESS;
+
     if (arb_is_zero(acb_imagref(x)))
     {
         /* used by polynomial printing */
@@ -112,32 +115,29 @@ __gr_acb_write(gr_stream_t out, const acb_t x, slong digits, int flags, const gr
         {
             if (arf_is_zero(arb_midref(acb_realref(x))))
             {
-                gr_stream_write(out, "0");
-                return GR_SUCCESS;
+                return gr_stream_write(out, "0");
             }
             else if (arf_is_one(arb_midref(acb_realref(x))))
             {
-                gr_stream_write(out, "1");
-                return GR_SUCCESS;
+                return gr_stream_write(out, "1");
             }
             else if (arf_equal_si(arb_midref(acb_realref(x)), -1))
             {
-                gr_stream_write(out, "-1");
-                return GR_SUCCESS;
+                return gr_stream_write(out, "-1");
             }
         }
 
-        gr_stream_write_free(out, arb_get_str(acb_realref(x), digits, flags));
+        status |= gr_stream_write_free(out, arb_get_str(acb_realref(x), digits, flags));
     }
     else if (arb_is_zero(acb_realref(x)))
     {
-        gr_stream_write_free(out, arb_get_str(acb_imagref(x), digits, flags));
-        gr_stream_write(out, "*I");
+        status |= gr_stream_write_free(out, arb_get_str(acb_imagref(x), digits, flags));
+        status |= gr_stream_write(out, "*I");
     }
     else
     {
-        gr_stream_write(out, "(");
-        gr_stream_write_free(out, arb_get_str(acb_realref(x), digits, flags));
+        status |= gr_stream_write(out, "(");
+        status |= gr_stream_write_free(out, arb_get_str(acb_realref(x), digits, flags));
 
         if ((arb_is_exact(acb_imagref(x)) || (flags & ARB_STR_NO_RADIUS))
                 && arf_sgn(arb_midref(acb_imagref(x))) < 0)
@@ -145,20 +145,20 @@ __gr_acb_write(gr_stream_t out, const acb_t x, slong digits, int flags, const gr
             arb_t t;
             arb_init(t);
             arb_neg(t, acb_imagref(x));
-            gr_stream_write(out, " - ");
-            gr_stream_write_free(out, arb_get_str(t, digits, flags));
+            status |= gr_stream_write(out, " - ");
+            status |= gr_stream_write_free(out, arb_get_str(t, digits, flags));
             arb_clear(t);
         }
         else
         {
-            gr_stream_write(out, " + ");
-            gr_stream_write_free(out, arb_get_str(acb_imagref(x), digits, flags));
+            status |= gr_stream_write(out, " + ");
+            status |= gr_stream_write_free(out, arb_get_str(acb_imagref(x), digits, flags));
         }
 
-        gr_stream_write(out, "*I)");
+        status |= gr_stream_write(out, "*I)");
     }
 
-    return GR_SUCCESS;
+    return status;
 }
 static int
 _gr_acb_write(gr_stream_t out, const acb_t x, const gr_ctx_t ctx)

--- a/src/gr/acf.c
+++ b/src/gr/acf.c
@@ -49,10 +49,11 @@ static int _gr_acf_ctx_get_real_prec(slong * res, gr_ctx_t ctx)
 static int
 _gr_acf_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Complex floating-point numbers (acf, prec = ");
-    gr_stream_write_si(out, ACF_CTX_PREC(ctx));
-    gr_stream_write(out, ")");
-    return GR_SUCCESS;
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Complex floating-point numbers (acf, prec = ");
+    status |= gr_stream_write_si(out, ACF_CTX_PREC(ctx));
+    status |= gr_stream_write(out, ")");
+    return status;
 }
 
 static void
@@ -96,38 +97,39 @@ static int
 _gr_acf_write(gr_stream_t out, const acf_t x, const gr_ctx_t ctx)
 {
     slong digits = ACF_CTX_PREC(ctx) * 0.30102999566398 + 1;
+    int status = GR_SUCCESS;
 
     if (arf_is_zero(acf_imagref(x)))
     {
-        gr_stream_write_free(out, arf_get_str(acf_realref(x), digits));
+        status |= gr_stream_write_free(out, arf_get_str(acf_realref(x), digits));
     }
     else if (arf_is_zero(acf_realref(x)))
     {
-        gr_stream_write_free(out, arf_get_str(acf_imagref(x), digits));
-        gr_stream_write(out, "*I");
+        status |= gr_stream_write_free(out, arf_get_str(acf_imagref(x), digits));
+        status |= gr_stream_write(out, "*I");
     }
     else
     {
-        gr_stream_write(out, "(");
-        gr_stream_write_free(out, arf_get_str(acf_realref(x), digits));
+        status |= gr_stream_write(out, "(");
+        status |= gr_stream_write_free(out, arf_get_str(acf_realref(x), digits));
 
         if (arf_sgn(acf_imagref(x)) < 0)
         {
             arf_t t;
             arf_init_neg_shallow(t, acf_imagref(x));
-            gr_stream_write(out, " - ");
-            gr_stream_write_free(out, arf_get_str(t, digits));
+            status |= gr_stream_write(out, " - ");
+            status |= gr_stream_write_free(out, arf_get_str(t, digits));
         }
         else
         {
-            gr_stream_write(out, " + ");
-            gr_stream_write_free(out, arf_get_str(acf_imagref(x), digits));
+            status |= gr_stream_write(out, " + ");
+            status |= gr_stream_write_free(out, arf_get_str(acf_imagref(x), digits));
         }
 
-        gr_stream_write(out, "*I)");
+        status |= gr_stream_write(out, "*I)");
     }
 
-    return GR_SUCCESS;
+    return status;
 }
 
 static int

--- a/src/gr/arb.c
+++ b/src/gr/arb.c
@@ -102,10 +102,11 @@ static int _gr_arb_ctx_get_real_prec(slong * res, gr_ctx_t ctx)
 static int
 _gr_arb_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Real numbers (arb, prec = ");
-    gr_stream_write_si(out, ARB_CTX_PREC(ctx));
-    gr_stream_write(out, ")");
-    return GR_SUCCESS;
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Real numbers (arb, prec = ");
+    status |= gr_stream_write_si(out, ARB_CTX_PREC(ctx));
+    status |= gr_stream_write(out, ")");
+    return status;
 }
 
 static void
@@ -151,32 +152,21 @@ _gr_arb_write(gr_stream_t out, const arb_t x, const gr_ctx_t ctx)
     if (arb_is_exact(x))
     {
         if (arf_is_zero(arb_midref(x)))
-        {
-            gr_stream_write(out, "0");
-            return GR_SUCCESS;
-        }
+            return gr_stream_write(out, "0");
         else if (arf_is_one(arb_midref(x)))
-        {
-            gr_stream_write(out, "1");
-            return GR_SUCCESS;
-        }
+            return gr_stream_write(out, "1");
         else if (arf_equal_si(arb_midref(x), -1))
-        {
-            gr_stream_write(out, "-1");
-            return GR_SUCCESS;
-        }
+            return gr_stream_write(out, "-1");
     }
 
-    gr_stream_write_free(out, arb_get_str(x, ARB_CTX_PREC(ctx) * 0.30102999566398 + 1, 0));
-    return GR_SUCCESS;
+    return gr_stream_write_free(out, arb_get_str(x, ARB_CTX_PREC(ctx) * 0.30102999566398 + 1, 0));
 }
 
 static int
 _gr_arb_write_n(gr_stream_t out, gr_srcptr x, slong n, gr_ctx_t ctx)
 {
     n = FLINT_MAX(n, 1);
-    gr_stream_write_free(out, arb_get_str(x, n, ARB_STR_NO_RADIUS));
-    return GR_SUCCESS;
+    return gr_stream_write_free(out, arb_get_str(x, n, ARB_STR_NO_RADIUS));
 }
 
 static int

--- a/src/gr/arf.c
+++ b/src/gr/arf.c
@@ -49,10 +49,11 @@ static int _gr_arf_ctx_get_real_prec(slong * res, gr_ctx_t ctx)
 static int
 _gr_arf_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Floating-point numbers (arf, prec = ");
-    gr_stream_write_si(out, ARF_CTX_PREC(ctx));
-    gr_stream_write(out, ")");
-    return GR_SUCCESS;
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Floating-point numbers (arf, prec = ");
+    status |= gr_stream_write_si(out, ARF_CTX_PREC(ctx));
+    status |= gr_stream_write(out, ")");
+    return status;
 }
 
 static void
@@ -94,8 +95,7 @@ _gr_arf_randtest(arf_t res, flint_rand_t state, const gr_ctx_t ctx)
 static int
 _gr_arf_write(gr_stream_t out, const arf_t x, const gr_ctx_t ctx)
 {
-    gr_stream_write_free(out, arf_get_str(x, ARF_CTX_PREC(ctx) * 0.30102999566398 + 1));
-    return GR_SUCCESS;
+    return gr_stream_write_free(out, arf_get_str(x, ARF_CTX_PREC(ctx) * 0.30102999566398 + 1));
 }
 
 static int

--- a/src/gr/ca.c
+++ b/src/gr/ca.c
@@ -28,16 +28,16 @@ static int
 _gr_ca_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
     if (ctx->which_ring == GR_CTX_RR_CA)
-        gr_stream_write(out, "Real numbers (ca)");
+        return gr_stream_write(out, "Real numbers (ca)");
     else if (ctx->which_ring == GR_CTX_CC_CA)
-        gr_stream_write(out, "Complex numbers (ca)");
+        return gr_stream_write(out, "Complex numbers (ca)");
     else if (ctx->which_ring == GR_CTX_REAL_ALGEBRAIC_CA)
-        gr_stream_write(out, "Real algebraic numbers (ca)");
+        return gr_stream_write(out, "Real algebraic numbers (ca)");
     else if (ctx->which_ring == GR_CTX_COMPLEX_ALGEBRAIC_CA)
-        gr_stream_write(out, "Complex algebraic numbers (ca)");
+        return gr_stream_write(out, "Complex algebraic numbers (ca)");
     else if (ctx->which_ring == GR_CTX_COMPLEX_EXTENDED_CA)
-        gr_stream_write(out, "Complex numbers + extended values (ca)");
-    return GR_SUCCESS;
+        return gr_stream_write(out, "Complex numbers + extended values (ca)");
+    return GR_UNABLE;
 }
 
 void
@@ -123,8 +123,7 @@ _gr_ca_randtest(ca_t res, flint_rand_t state, gr_ctx_t ctx)
 static int
 _gr_ca_write(gr_stream_t out, const ca_t x, gr_ctx_t ctx)
 {
-    gr_stream_write_free(out, ca_get_str(x, GR_CA_CTX(ctx)));
-    return GR_SUCCESS;
+    return gr_stream_write_free(out, ca_get_str(x, GR_CA_CTX(ctx)));
 }
 
 static int

--- a/src/gr/complex.c
+++ b/src/gr/complex.c
@@ -38,9 +38,10 @@ typedef gr_complex_ctx_struct gr_complex_ctx_t[1];
 static int
 _gr_complex_ctx_write(gr_stream_t out, gr_complex_ctx_t ctx)
 {
-    gr_stream_write(out, "Complex algebra over ");
-    gr_ctx_write(out, REAL_CTX(ctx));
-    return GR_SUCCESS;
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Complex algebra over ");
+    status |= gr_ctx_write(out, REAL_CTX(ctx));
+    return status;
 }
 
 static void

--- a/src/gr/dirichlet.c
+++ b/src/gr/dirichlet.c
@@ -17,10 +17,11 @@
 
 static int _gr_dirichlet_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Dirichlet group modulo ");
-    gr_stream_write_ui(out, DIRICHLET_CTX(ctx)->q);
-    gr_stream_write(out, " (dirichlet_char)");
-    return GR_SUCCESS;
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Dirichlet group modulo ");
+    status |= gr_stream_write_ui(out, DIRICHLET_CTX(ctx)->q);
+    status |= gr_stream_write(out, " (dirichlet_char)");
+    return status;
 }
 
 static void
@@ -55,34 +56,35 @@ _gr_dirichlet_swap(dirichlet_char_t x, dirichlet_char_t y, gr_ctx_t ctx)
     *y = t;
 }
 
-static void
+static int
 _dirichlet_char_print(gr_stream_t out, const dirichlet_group_t G, const dirichlet_char_t x)
 {
-    gr_stream_write(out, "chi_");
-    gr_stream_write_ui(out, G->q);
-    gr_stream_write(out, "(");
-    gr_stream_write_ui(out, G->q == 1 ? 1 : x->n);
-    gr_stream_write(out, ", .)");
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "chi_");
+    status |= gr_stream_write_ui(out, G->q);
+    status |= gr_stream_write(out, "(");
+    status |= gr_stream_write_ui(out, G->q == 1 ? 1 : x->n);
+    status |= gr_stream_write(out, ", .)");
 /*
     slong k;
-    gr_stream_write(out, "Character ");
-    gr_stream_write_ui(out, G->q == 1 ? 1 : x->n);
-    gr_stream_write(out, " [");
+    status |= gr_stream_write(out, "Character ");
+    status |= gr_stream_write_ui(out, G->q == 1 ? 1 : x->n);
+    status |= gr_stream_write(out, " [");
     for (k = 0; k < G->num; k++)
     {
-        gr_stream_write_ui(out, x->log[k]);
+        status |= gr_stream_write_ui(out, x->log[k]);
         if (k + 1 < G->num)
-            gr_stream_write(out, ", ");
+            status |= gr_stream_write(out, ", ");
     }
-    gr_stream_write(out, "]");
+    status |= gr_stream_write(out, "]");
 */
+    return status;
 }
 
 static int
 _gr_dirichlet_write(gr_stream_t out, dirichlet_char_t x, gr_ctx_t ctx)
 {
-    _dirichlet_char_print(out, DIRICHLET_CTX(ctx), x);
-    return GR_SUCCESS;
+    return _dirichlet_char_print(out, DIRICHLET_CTX(ctx), x);
 }
 
 static int

--- a/src/gr/fexpr.c
+++ b/src/gr/fexpr.c
@@ -16,8 +16,7 @@
 static int
 _gr_fexpr_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Symbolic expressions (fexpr)");
-    return GR_SUCCESS;
+    return gr_stream_write(out, "Symbolic expressions (fexpr)");
 }
 
 static void
@@ -58,8 +57,7 @@ _gr_fexpr_randtest(fexpr_t res, flint_rand_t state, const gr_ctx_t ctx)
 static int
 _gr_fexpr_write(gr_stream_t out, const fexpr_t x, const gr_ctx_t ctx)
 {
-    gr_stream_write_free(out, fexpr_get_str(x));
-    return GR_SUCCESS;
+    return gr_stream_write_free(out, fexpr_get_str(x));
 }
 
 static int

--- a/src/gr/fmpq.c
+++ b/src/gr/fmpq.c
@@ -28,8 +28,7 @@
 static int
 _gr_fmpq_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Rational field (fmpq)");
-    return GR_SUCCESS;
+    return gr_stream_write(out, "Rational field (fmpq)");
 }
 
 static void
@@ -78,15 +77,16 @@ _gr_fmpq_randtest(fmpq_t res, flint_rand_t state, const gr_ctx_t ctx)
 static int
 _gr_fmpq_write(gr_stream_t out, const fmpq_t x, const gr_ctx_t ctx)
 {
-    gr_stream_write_fmpz(out, fmpq_numref(x));
+    int status = GR_SUCCESS;
+    status |= gr_stream_write_fmpz(out, fmpq_numref(x));
 
     if (!fmpz_is_one(fmpq_denref(x)))
     {
-        gr_stream_write(out, "/");
-        gr_stream_write_fmpz(out, fmpq_denref(x));
+        status |= gr_stream_write(out, "/");
+        status |= gr_stream_write_fmpz(out, fmpq_denref(x));
     }
 
-    return GR_SUCCESS;
+    return status;
 }
 
 static int

--- a/src/gr/fmpq_mpoly.c
+++ b/src/gr/fmpq_mpoly.c
@@ -30,17 +30,18 @@ _gr_fmpq_mpoly_ctx_t;
 
 static int _gr_fmpq_mpoly_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Ring of multivariate polynomials over Rational field (fmpq)");
-    gr_stream_write(out, " in ");
-    gr_stream_write_si(out, MPOLYNOMIAL_MCTX(ctx)->zctx->minfo->nvars);
-    gr_stream_write(out, " variables");
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Ring of multivariate polynomials over Rational field (fmpq)");
+    status |= gr_stream_write(out, " in ");
+    status |= gr_stream_write_si(out, MPOLYNOMIAL_MCTX(ctx)->zctx->minfo->nvars);
+    status |= gr_stream_write(out, " variables");
     if (MPOLYNOMIAL_MCTX(ctx)->zctx->minfo->ord == ORD_LEX)
-        gr_stream_write(out, ", lex order");
+        status |= gr_stream_write(out, ", lex order");
     else if (MPOLYNOMIAL_MCTX(ctx)->zctx->minfo->ord == ORD_DEGLEX)
-        gr_stream_write(out, ", deglex order");
+        status |= gr_stream_write(out, ", deglex order");
     else if (MPOLYNOMIAL_MCTX(ctx)->zctx->minfo->ord == ORD_DEGREVLEX)
-        gr_stream_write(out, ", degrevlex order");
-    return GR_SUCCESS;
+        status |= gr_stream_write(out, ", degrevlex order");
+    return status;
 }
 
 static void
@@ -176,8 +177,7 @@ _gr_fmpq_mpoly_length(const fmpq_mpoly_t x, gr_ctx_t ctx)
 static int
 _gr_fmpq_mpoly_write(gr_stream_t out, fmpq_mpoly_t poly, gr_ctx_t ctx)
 {
-    gr_stream_write_free(out, fmpq_mpoly_get_str_pretty(poly, (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
-    return GR_SUCCESS;
+    return gr_stream_write_free(out, fmpq_mpoly_get_str_pretty(poly, (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
 }
 
 static truth_t

--- a/src/gr/fmpq_poly.c
+++ b/src/gr/fmpq_poly.c
@@ -56,8 +56,7 @@ static int _gr_fmpq_poly_ctx_set_gen_names(gr_ctx_t ctx, const char ** s)
 static int
 _gr_fmpq_poly_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Polynomials over rationals (fmpq_poly)");
-    return GR_SUCCESS;
+    return gr_stream_write(out, "Polynomials over rationals (fmpq_poly)");
 }
 
 static void
@@ -102,8 +101,7 @@ _gr_fmpq_poly_randtest(fmpq_poly_t res, flint_rand_t state, const gr_ctx_t ctx)
 static int
 _gr_fmpq_poly_write(gr_stream_t out, const fmpq_poly_t x, const gr_ctx_t ctx)
 {
-    gr_stream_write_free(out, fmpq_poly_get_str_pretty(x, FMPQ_POLY_CTX_VAR(ctx)));
-    return GR_SUCCESS;
+    return gr_stream_write_free(out, fmpq_poly_get_str_pretty(x, FMPQ_POLY_CTX_VAR(ctx)));
 }
 
 static int

--- a/src/gr/fmpz.c
+++ b/src/gr/fmpz.c
@@ -29,8 +29,7 @@
 static int
 _gr_fmpz_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Integer ring (fmpz)");
-    return GR_SUCCESS;
+    return gr_stream_write(out, "Integer ring (fmpz)");
 }
 
 static void
@@ -79,8 +78,7 @@ _gr_fmpz_randtest(fmpz_t res, flint_rand_t state, const gr_ctx_t ctx)
 static int
 _gr_fmpz_write(gr_stream_t out, const fmpz_t x, const gr_ctx_t ctx)
 {
-    gr_stream_write_fmpz(out, x);
-    return GR_SUCCESS;
+    return gr_stream_write_fmpz(out, x);
 }
 
 static int

--- a/src/gr/fmpz_mod.c
+++ b/src/gr/fmpz_mod.c
@@ -37,10 +37,11 @@ _gr_fmpz_mod_ctx_struct;
 static int
 _gr_fmpz_mod_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Integers mod ");
-    gr_stream_write_fmpz(out, FMPZ_MOD_CTX(ctx)->n);
-    gr_stream_write(out, " (fmpz)");
-    return GR_SUCCESS;
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Integers mod ");
+    status |= gr_stream_write_fmpz(out, FMPZ_MOD_CTX(ctx)->n);
+    status |= gr_stream_write(out, " (fmpz)");
+    return status;
 }
 
 static void
@@ -106,8 +107,7 @@ _gr_fmpz_mod_randtest(fmpz_t res, flint_rand_t state, const gr_ctx_t ctx)
 static int
 _gr_fmpz_mod_write(gr_stream_t out, const fmpz_t x, const gr_ctx_t ctx)
 {
-    gr_stream_write_fmpz(out, x);
-    return GR_SUCCESS;
+    return gr_stream_write_fmpz(out, x);
 }
 
 static int

--- a/src/gr/fmpz_mod_mpoly_q.c
+++ b/src/gr/fmpz_mod_mpoly_q.c
@@ -29,18 +29,19 @@ _gr_fmpz_mod_mpoly_ctx_t;
 
 static int _gr_fmpz_mod_mpoly_q_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Fraction field of multivariate polynomials over finite field (fmpz_mod) mod ");
-    gr_stream_write_fmpz(out, MPOLYNOMIAL_MCTX(ctx)->ffinfo->n);
-    gr_stream_write(out, " in ");
-    gr_stream_write_si(out, MPOLYNOMIAL_MCTX(ctx)->minfo->nvars);
-    gr_stream_write(out, " variables");
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Fraction field of multivariate polynomials over finite field (fmpz_mod) mod ");
+    status |= gr_stream_write_fmpz(out, MPOLYNOMIAL_MCTX(ctx)->ffinfo->n);
+    status |= gr_stream_write(out, " in ");
+    status |= gr_stream_write_si(out, MPOLYNOMIAL_MCTX(ctx)->minfo->nvars);
+    status |= gr_stream_write(out, " variables");
     if (MPOLYNOMIAL_MCTX(ctx)->minfo->ord == ORD_LEX)
-        gr_stream_write(out, ", lex order");
+        status |= gr_stream_write(out, ", lex order");
     else if (MPOLYNOMIAL_MCTX(ctx)->minfo->ord == ORD_DEGLEX)
-        gr_stream_write(out, ", deglex order");
+        status |= gr_stream_write(out, ", deglex order");
     else if (MPOLYNOMIAL_MCTX(ctx)->minfo->ord == ORD_DEGREVLEX)
-        gr_stream_write(out, ", degrevlex order");
-    return GR_SUCCESS;
+        status |= gr_stream_write(out, ", degrevlex order");
+    return status;
 }
 
 static void _gr_fmpz_mod_mpoly_q_ctx_clear(gr_ctx_t ctx)
@@ -170,27 +171,33 @@ _gr_fmpz_mod_mpoly_q_length(const fmpz_mod_mpoly_q_t x, gr_ctx_t ctx)
 static int
 _gr_fmpz_mod_mpoly_q_write(gr_stream_t out, fmpz_mod_mpoly_q_t f, gr_ctx_t ctx)
 {
+    int status = GR_SUCCESS;
     if (fmpz_mod_mpoly_is_one(fmpz_mod_mpoly_q_denref(f), MPOLYNOMIAL_MCTX(ctx)))
     {
-        gr_stream_write_free(out, fmpz_mod_mpoly_get_str_pretty(fmpz_mod_mpoly_q_numref(f), (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
+        status |= gr_stream_write_free(out,
+            fmpz_mod_mpoly_get_str_pretty(fmpz_mod_mpoly_q_numref(f), (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
     }
     else if (fmpz_mod_mpoly_is_fmpz(fmpz_mod_mpoly_q_denref(f), MPOLYNOMIAL_MCTX(ctx)))
     {
-        gr_stream_write(out, "(");
-        gr_stream_write_free(out, fmpz_mod_mpoly_get_str_pretty(fmpz_mod_mpoly_q_numref(f), (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
-        gr_stream_write(out, ")/");
-        gr_stream_write_free(out, fmpz_mod_mpoly_get_str_pretty(fmpz_mod_mpoly_q_denref(f), (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
+        status |= gr_stream_write(out, "(");
+        status |= gr_stream_write_free(out,
+            fmpz_mod_mpoly_get_str_pretty(fmpz_mod_mpoly_q_numref(f), (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
+        status |= gr_stream_write(out, ")/");
+        status |= gr_stream_write_free(out,
+            fmpz_mod_mpoly_get_str_pretty(fmpz_mod_mpoly_q_denref(f), (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
     }
     else
     {
-        gr_stream_write(out, "(");
-        gr_stream_write_free(out, fmpz_mod_mpoly_get_str_pretty(fmpz_mod_mpoly_q_numref(f), (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
-        gr_stream_write(out, ")/(");
-        gr_stream_write_free(out, fmpz_mod_mpoly_get_str_pretty(fmpz_mod_mpoly_q_denref(f), (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
-        gr_stream_write(out, ")");
+        status |= gr_stream_write(out, "(");
+        status |= gr_stream_write_free(out,
+            fmpz_mod_mpoly_get_str_pretty(fmpz_mod_mpoly_q_numref(f), (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
+        status |= gr_stream_write(out, ")/(");
+        status |= gr_stream_write_free(out,
+            fmpz_mod_mpoly_get_str_pretty(fmpz_mod_mpoly_q_denref(f), (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
+        status |= gr_stream_write(out, ")");
     }
 
-    return GR_SUCCESS;
+    return status;
 }
 
 static truth_t

--- a/src/gr/fmpz_mpoly.c
+++ b/src/gr/fmpz_mpoly.c
@@ -30,17 +30,18 @@ _gr_fmpz_mpoly_ctx_t;
 
 static int _gr_fmpz_mpoly_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Ring of multivariate polynomials over Integer ring (fmpz)");
-    gr_stream_write(out, " in ");
-    gr_stream_write_si(out, MPOLYNOMIAL_MCTX(ctx)->minfo->nvars);
-    gr_stream_write(out, " variables");
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Ring of multivariate polynomials over Integer ring (fmpz)");
+    status |= gr_stream_write(out, " in ");
+    status |= gr_stream_write_si(out, MPOLYNOMIAL_MCTX(ctx)->minfo->nvars);
+    status |= gr_stream_write(out, " variables");
     if (MPOLYNOMIAL_MCTX(ctx)->minfo->ord == ORD_LEX)
-        gr_stream_write(out, ", lex order");
+        status |= gr_stream_write(out, ", lex order");
     else if (MPOLYNOMIAL_MCTX(ctx)->minfo->ord == ORD_DEGLEX)
-        gr_stream_write(out, ", deglex order");
+        status |= gr_stream_write(out, ", deglex order");
     else if (MPOLYNOMIAL_MCTX(ctx)->minfo->ord == ORD_DEGREVLEX)
-        gr_stream_write(out, ", degrevlex order");
-    return GR_SUCCESS;
+        status |= gr_stream_write(out, ", degrevlex order");
+    return status;
 }
 
 void
@@ -178,8 +179,7 @@ _gr_fmpz_mpoly_length(const fmpz_mpoly_t x, gr_ctx_t ctx)
 static int
 _gr_fmpz_mpoly_write(gr_stream_t out, fmpz_mpoly_t poly, gr_ctx_t ctx)
 {
-    gr_stream_write_free(out, fmpz_mpoly_get_str_pretty(poly, (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
-    return GR_SUCCESS;
+    return gr_stream_write_free(out, fmpz_mpoly_get_str_pretty(poly, (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
 }
 
 static truth_t

--- a/src/gr/fmpz_mpoly_q.c
+++ b/src/gr/fmpz_mpoly_q.c
@@ -28,17 +28,18 @@ _gr_fmpz_mpoly_ctx_t;
 
 static int _gr_fmpz_mpoly_q_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Fraction field of multivariate polynomials over Integer ring (fmpz)");
-    gr_stream_write(out, " in ");
-    gr_stream_write_si(out, MPOLYNOMIAL_MCTX(ctx)->minfo->nvars);
-    gr_stream_write(out, " variables");
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Fraction field of multivariate polynomials over Integer ring (fmpz)");
+    status |= gr_stream_write(out, " in ");
+    status |= gr_stream_write_si(out, MPOLYNOMIAL_MCTX(ctx)->minfo->nvars);
+    status |= gr_stream_write(out, " variables");
     if (MPOLYNOMIAL_MCTX(ctx)->minfo->ord == ORD_LEX)
-        gr_stream_write(out, ", lex order");
+        status |= gr_stream_write(out, ", lex order");
     else if (MPOLYNOMIAL_MCTX(ctx)->minfo->ord == ORD_DEGLEX)
-        gr_stream_write(out, ", deglex order");
+        status |= gr_stream_write(out, ", deglex order");
     else if (MPOLYNOMIAL_MCTX(ctx)->minfo->ord == ORD_DEGREVLEX)
-        gr_stream_write(out, ", degrevlex order");
-    return GR_SUCCESS;
+        status |= gr_stream_write(out, ", degrevlex order");
+    return status;
 }
 
 /* Some methods are identical to their fmpz_mpoly counterparts */
@@ -110,27 +111,33 @@ _gr_fmpz_mpoly_q_length(const fmpz_mpoly_q_t x, gr_ctx_t ctx)
 static int
 _gr_fmpz_mpoly_q_write(gr_stream_t out, fmpz_mpoly_q_t f, gr_ctx_t ctx)
 {
+    int status = GR_SUCCESS;
     if (fmpz_mpoly_is_one(fmpz_mpoly_q_denref(f), MPOLYNOMIAL_MCTX(ctx)))
     {
-        gr_stream_write_free(out, fmpz_mpoly_get_str_pretty(fmpz_mpoly_q_numref(f), (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
+        status |= gr_stream_write_free(out,
+            fmpz_mpoly_get_str_pretty(fmpz_mpoly_q_numref(f), (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
     }
     else if (fmpz_mpoly_is_fmpz(fmpz_mpoly_q_denref(f), MPOLYNOMIAL_MCTX(ctx)))
     {
-        gr_stream_write(out, "(");
-        gr_stream_write_free(out, fmpz_mpoly_get_str_pretty(fmpz_mpoly_q_numref(f), (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
-        gr_stream_write(out, ")/");
-        gr_stream_write_free(out, fmpz_mpoly_get_str_pretty(fmpz_mpoly_q_denref(f), (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
+        status |= gr_stream_write(out, "(");
+        status |= gr_stream_write_free(out,
+            fmpz_mpoly_get_str_pretty(fmpz_mpoly_q_numref(f), (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
+        status |= gr_stream_write(out, ")/");
+        status |= gr_stream_write_free(out,
+            fmpz_mpoly_get_str_pretty(fmpz_mpoly_q_denref(f), (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
     }
     else
     {
-        gr_stream_write(out, "(");
-        gr_stream_write_free(out, fmpz_mpoly_get_str_pretty(fmpz_mpoly_q_numref(f), (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
-        gr_stream_write(out, ")/(");
-        gr_stream_write_free(out, fmpz_mpoly_get_str_pretty(fmpz_mpoly_q_denref(f), (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
-        gr_stream_write(out, ")");
+        status |= gr_stream_write(out, "(");
+        status |= gr_stream_write_free(out,
+            fmpz_mpoly_get_str_pretty(fmpz_mpoly_q_numref(f), (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
+        status |= gr_stream_write(out, ")/(");
+        status |= gr_stream_write_free(out,
+            fmpz_mpoly_get_str_pretty(fmpz_mpoly_q_denref(f), (const char **) MPOLYNOMIAL_CTX(ctx)->vars, MPOLYNOMIAL_MCTX(ctx)));
+        status |= gr_stream_write(out, ")");
     }
 
-    return GR_SUCCESS;
+    return status;
 }
 
 static truth_t

--- a/src/gr/fmpz_poly.c
+++ b/src/gr/fmpz_poly.c
@@ -59,8 +59,7 @@ static int _gr_fmpz_poly_ctx_set_gen_names(gr_ctx_t ctx, const char ** s)
 static int
 _gr_fmpz_poly_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Polynomials over integers (fmpz_poly)");
-    return GR_SUCCESS;
+    return gr_stream_write(out, "Polynomials over integers (fmpz_poly)");
 }
 
 static void
@@ -110,8 +109,7 @@ _gr_fmpz_poly_write(gr_stream_t out, const fmpz_poly_t x, const gr_ctx_t ctx)
     if (var == NULL)
         var = "x";
 
-    gr_stream_write_free(out, fmpz_poly_get_str_pretty(x, var));
-    return GR_SUCCESS;
+    return gr_stream_write_free(out, fmpz_poly_get_str_pretty(x, var));
 }
 
 static int

--- a/src/gr/fmpzi.c
+++ b/src/gr/fmpzi.c
@@ -23,8 +23,7 @@
 static int
 _gr_fmpzi_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Gaussian integer ring (fmpzi)");
-    return GR_SUCCESS;
+    return gr_stream_write(out, "Gaussian integer ring (fmpzi)");
 }
 
 static int
@@ -88,41 +87,42 @@ _gr_fmpzi_randtest(fmpzi_t res, flint_rand_t state, const gr_ctx_t ctx)
 static int
 _gr_fmpzi_write(gr_stream_t out, const fmpzi_t x, const gr_ctx_t ctx)
 {
+    int status = GR_SUCCESS;
     if (fmpz_is_zero(fmpzi_imagref(x)))
     {
-        gr_stream_write_fmpz(out, fmpzi_realref(x));
+        status |= gr_stream_write_fmpz(out, fmpzi_realref(x));
     }
     else if (fmpz_is_zero(fmpzi_realref(x)))
     {
         if (fmpz_is_one(fmpzi_imagref(x)))
-            gr_stream_write(out, "I");
+            status |= gr_stream_write(out, "I");
         else if (fmpz_equal_si(fmpzi_imagref(x), -1))
-            gr_stream_write(out, "-I");
+            status |= gr_stream_write(out, "-I");
         else
         {
-            gr_stream_write_fmpz(out, fmpzi_imagref(x));
-            gr_stream_write(out, "*I");
+            status |= gr_stream_write_fmpz(out, fmpzi_imagref(x));
+            status |= gr_stream_write(out, "*I");
         }
     }
     else
     {
-        gr_stream_write(out, "(");
-        gr_stream_write_fmpz(out, fmpzi_realref(x));
+        status |= gr_stream_write(out, "(");
+        status |= gr_stream_write_fmpz(out, fmpzi_realref(x));
 
         if (fmpz_is_one(fmpzi_imagref(x)))
-            gr_stream_write(out, "+I)");
+            status |= gr_stream_write(out, "+I)");
         else if (fmpz_equal_si(fmpzi_imagref(x), -1))
-            gr_stream_write(out, "-I)");
+            status |= gr_stream_write(out, "-I)");
         else
         {
             if (fmpz_sgn(fmpzi_imagref(x)) > 0)
-                gr_stream_write(out, "+");
-            gr_stream_write_fmpz(out, fmpzi_imagref(x));
-            gr_stream_write(out, "*I)");
+                status |= gr_stream_write(out, "+");
+            status |= gr_stream_write_fmpz(out, fmpzi_imagref(x));
+            status |= gr_stream_write(out, "*I)");
         }
     }
 
-    return GR_SUCCESS;
+    return status;
 }
 
 static int

--- a/src/gr/fq.c
+++ b/src/gr/fq.c
@@ -40,8 +40,7 @@ _gr_fq_ctx_clear(gr_ctx_t ctx)
 static int
 _gr_fq_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Finite field (fq)");
-    return GR_SUCCESS;
+    return gr_stream_write(out, "Finite field (fq)");
 }
 
 static int _gr_fq_ctx_set_gen_name(gr_ctx_t ctx, const char * s)
@@ -112,8 +111,7 @@ _gr_fq_randtest(fq_t res, flint_rand_t state, const gr_ctx_t ctx)
 static int
 _gr_fq_write(gr_stream_t out, const fq_t x, const gr_ctx_t ctx)
 {
-    gr_stream_write_free(out, fq_get_str_pretty(x, FQ_CTX(ctx)));
-    return GR_SUCCESS;
+    return gr_stream_write_free(out, fq_get_str_pretty(x, FQ_CTX(ctx)));
 }
 
 static int

--- a/src/gr/fq_nmod.c
+++ b/src/gr/fq_nmod.c
@@ -41,8 +41,7 @@ _gr_fq_nmod_ctx_clear(gr_ctx_t ctx)
 static int
 _gr_fq_nmod_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Finite field (fq_nmod)");
-    return GR_SUCCESS;
+    return gr_stream_write(out, "Finite field (fq_nmod)");
 }
 
 static int _gr_fq_nmod_ctx_set_gen_name(gr_ctx_t ctx, const char * s)
@@ -113,8 +112,7 @@ _gr_fq_nmod_randtest(fq_nmod_t res, flint_rand_t state, const gr_ctx_t ctx)
 static int
 _gr_fq_nmod_write(gr_stream_t out, const fq_nmod_t x, const gr_ctx_t ctx)
 {
-    gr_stream_write_free(out, fq_nmod_get_str_pretty(x, FQ_CTX(ctx)));
-    return GR_SUCCESS;
+    return gr_stream_write_free(out, fq_nmod_get_str_pretty(x, FQ_CTX(ctx)));
 }
 
 static int

--- a/src/gr/fq_zech.c
+++ b/src/gr/fq_zech.c
@@ -42,8 +42,7 @@ _gr_fq_zech_ctx_clear(gr_ctx_t ctx)
 static int
 _gr_fq_zech_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Finite field (fq_zech)");
-    return GR_SUCCESS;
+    return gr_stream_write(out, "Finite field (fq_zech)");
 }
 
 static int _gr_fq_zech_ctx_set_gen_name(gr_ctx_t ctx, const char * s)
@@ -114,8 +113,7 @@ _gr_fq_zech_randtest(fq_zech_t res, flint_rand_t state, const gr_ctx_t ctx)
 static int
 _gr_fq_zech_write(gr_stream_t out, const fq_zech_t x, const gr_ctx_t ctx)
 {
-    gr_stream_write_free(out, fq_zech_get_str_pretty(x, FQ_CTX(ctx)));
-    return GR_SUCCESS;
+    return gr_stream_write_free(out, fq_zech_get_str_pretty(x, FQ_CTX(ctx)));
 }
 
 static int

--- a/src/gr/fraction.c
+++ b/src/gr/fraction.c
@@ -42,9 +42,10 @@ typedef gr_fraction_ctx_struct gr_fraction_ctx_t[1];
 static int
 _gr_fraction_ctx_write(gr_stream_t out, gr_fraction_ctx_t ctx)
 {
-    gr_stream_write(out, "Fraction field over ");
-    gr_ctx_write(out, GR_FRACTION_DOMAIN_CTX(ctx));
-    return GR_SUCCESS;
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Fraction field over ");
+    status |= gr_ctx_write(out, GR_FRACTION_DOMAIN_CTX(ctx));
+    return status;
 }
 
 static void

--- a/src/gr/matrix.c
+++ b/src/gr/matrix.c
@@ -56,28 +56,29 @@ static int
 matrix_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
     gr_ctx_ptr elem_ctx = MATRIX_CTX(ctx)->base_ring;
+    int status = GR_SUCCESS;
 
     if (MATRIX_CTX(ctx)->all_sizes)
     {
-        gr_stream_write(out, "Matrices (any shape) over ");
+        status |= gr_stream_write(out, "Matrices (any shape) over ");
     }
     else
     {
         if (gr_ctx_is_ring(ctx) == T_TRUE)
-            gr_stream_write(out, "Ring of ");
+            status |= gr_stream_write(out, "Ring of ");
         else
-            gr_stream_write(out, "Space of ");
+            status |= gr_stream_write(out, "Space of ");
 
-        gr_stream_write_si(out, MATRIX_CTX(ctx)->nrows);
-        gr_stream_write(out, " x ");
-        gr_stream_write_si(out, MATRIX_CTX(ctx)->ncols);
-        gr_stream_write(out, " ");
+        status |= gr_stream_write_si(out, MATRIX_CTX(ctx)->nrows);
+        status |= gr_stream_write(out, " x ");
+        status |= gr_stream_write_si(out, MATRIX_CTX(ctx)->ncols);
+        status |= gr_stream_write(out, " ");
 
-        gr_stream_write(out, "matrices over ");
+        status |= gr_stream_write(out, "matrices over ");
     }
 
-    gr_ctx_write(out, elem_ctx);
-    return GR_SUCCESS;
+    status |= gr_ctx_write(out, elem_ctx);
+    return status;
 }
 
 static truth_t matrix_ctx_is_ring(gr_ctx_t ctx)

--- a/src/gr/mpf.c
+++ b/src/gr/mpf.c
@@ -27,10 +27,11 @@ _mpf_ctx_struct;
 static int
 _gr_mpf_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Floating-point numbers with prec = ");
-    gr_stream_write_si(out, GR_MPF_CTX_PREC(ctx));
-    gr_stream_write(out, " (mpf)");
-    return GR_SUCCESS;
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Floating-point numbers with prec = ");
+    status |= gr_stream_write_si(out, GR_MPF_CTX_PREC(ctx));
+    status |= gr_stream_write(out, " (mpf)");
+    return status;
 }
 
 static void

--- a/src/gr/nf.c
+++ b/src/gr/nf.c
@@ -37,9 +37,10 @@ static const char * default_var = "a";
 static int
 _gr_nf_ctx_write(gr_stream_t out, const gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Number field ");
-    gr_stream_write_free(out, fmpq_poly_get_str_pretty(NF_CTX(ctx)->pol, NF_VAR(ctx)));
-    return GR_SUCCESS;
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Number field ");
+    status |= gr_stream_write_free(out, fmpq_poly_get_str_pretty(NF_CTX(ctx)->pol, NF_VAR(ctx)));
+    return status;
 }
 
 static int _gr_nf_ctx_set_gen_name(gr_ctx_t ctx, const char * s)
@@ -130,8 +131,7 @@ _gr_nf_randtest(nf_elem_t res, flint_rand_t state, const gr_ctx_t ctx)
 static int
 _gr_nf_write(gr_stream_t out, const nf_elem_t x, const gr_ctx_t ctx)
 {
-    gr_stream_write_free(out, nf_elem_get_str_pretty(x, NF_VAR(ctx), NF_CTX(ctx)));
-    return GR_SUCCESS;
+    return gr_stream_write_free(out, nf_elem_get_str_pretty(x, NF_VAR(ctx), NF_CTX(ctx)));
 }
 
 static int

--- a/src/gr/nmod.c
+++ b/src/gr/nmod.c
@@ -21,12 +21,14 @@
 #include "gr_poly.h"
 #include "gr_generic.h"
 
-static void
+static int
 _gr_nmod_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Integers mod ");
-    gr_stream_write_ui(out, NMOD_CTX(ctx).n);
-    gr_stream_write(out, " (_gr_nmod)");
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Integers mod ");
+    status |= gr_stream_write_ui(out, NMOD_CTX(ctx).n);
+    status |= gr_stream_write(out, " (_gr_nmod)");
+    return status;
 }
 
 static truth_t
@@ -81,8 +83,7 @@ _gr_nmod_randtest(ulong * res, flint_rand_t state, const gr_ctx_t ctx)
 static int
 _gr_nmod_write(gr_stream_t out, const ulong * x, const gr_ctx_t ctx)
 {
-    gr_stream_write_ui(out, x[0]);
-    return GR_SUCCESS;
+    return gr_stream_write_ui(out, x[0]);
 }
 
 static int

--- a/src/gr/nmod32.c
+++ b/src/gr/nmod32.c
@@ -24,12 +24,14 @@
 
 typedef uint32_t nmod32_t[1];
 
-static void
+static int
 nmod32_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Integers mod ");
-    gr_stream_write_ui(out, NMOD32_CTX(ctx).n);
-    gr_stream_write(out, " (nmod32)");
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Integers mod ");
+    status |= gr_stream_write_ui(out, NMOD32_CTX(ctx).n);
+    status |= gr_stream_write(out, " (nmod32)");
+    return status;
 }
 
 /* we don't want to call n_is_prime because this predicate should
@@ -76,8 +78,7 @@ nmod32_randtest(nmod32_t res, flint_rand_t state, const gr_ctx_t ctx)
 static int
 nmod32_write(gr_stream_t out, const nmod32_t x, const gr_ctx_t ctx)
 {
-    gr_stream_write_ui(out, x[0]);
-    return GR_SUCCESS;
+    return gr_stream_write_ui(out, x[0]);
 }
 
 static int

--- a/src/gr/nmod8.c
+++ b/src/gr/nmod8.c
@@ -24,12 +24,14 @@
 
 typedef uint8_t nmod8_t[1];
 
-static void
+static int
 nmod8_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Integers mod ");
-    gr_stream_write_ui(out, NMOD8_CTX(ctx).n);
-    gr_stream_write(out, " (nmod8)");
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Integers mod ");
+    status |= gr_stream_write_ui(out, NMOD8_CTX(ctx).n);
+    status |= gr_stream_write(out, " (nmod8)");
+    return status;
 }
 
 /* todo: n_is_prime is fast, but this should still be cached
@@ -76,8 +78,7 @@ nmod8_randtest(nmod8_t res, flint_rand_t state, const gr_ctx_t ctx)
 static int
 nmod8_write(gr_stream_t out, const nmod8_t x, const gr_ctx_t ctx)
 {
-    gr_stream_write_ui(out, x[0]);
-    return GR_SUCCESS;
+    return gr_stream_write_ui(out, x[0]);
 }
 
 static int

--- a/src/gr/perm.c
+++ b/src/gr/perm.c
@@ -27,10 +27,11 @@ typedef perm_struct perm_t[1];
 
 static int _gr_perm_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Symmetric group S_");
-    gr_stream_write_ui(out, PERM_N(ctx));
-    gr_stream_write(out, " (perm)");
-    return GR_SUCCESS;
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Symmetric group S_");
+    status |= gr_stream_write_ui(out, PERM_N(ctx));
+    status |= gr_stream_write(out, " (perm)");
+    return status;
 }
 
 static int
@@ -59,19 +60,20 @@ static int
 _gr_perm_write(gr_stream_t out, perm_t x, gr_ctx_t ctx)
 {
     slong i;
+    int status = GR_SUCCESS;
 
-    gr_stream_write(out, "[");
+    status |= gr_stream_write(out, "[");
 
     for (i = 0; i < PERM_N(ctx); i++)
     {
-        gr_stream_write_si(out, x->entries[i]);
+        status |= gr_stream_write_si(out, x->entries[i]);
         if (i + 1 < PERM_N(ctx))
-            gr_stream_write(out, ", ");
+            status |= gr_stream_write(out, ", ");
     }
 
-    gr_stream_write(out, "]");
+    status |= gr_stream_write(out, "]");
 
-    return GR_SUCCESS;
+    return status;
 }
 
 static int

--- a/src/gr/polynomial.c
+++ b/src/gr/polynomial.c
@@ -31,9 +31,10 @@ polynomial_init(gr_poly_t res, gr_ctx_t ctx)
 
 static int polynomial_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Ring of polynomials over ");
-    gr_ctx_write(out, POLYNOMIAL_ELEM_CTX(ctx));
-    return GR_SUCCESS;
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Ring of polynomials over ");
+    status |= gr_ctx_write(out, POLYNOMIAL_ELEM_CTX(ctx));
+    return status;
 }
 
 static int _gr_gr_poly_ctx_set_gen_name(gr_ctx_t ctx, const char * s)
@@ -161,13 +162,6 @@ polynomial_set_shallow(gr_poly_t res, const gr_poly_t x, const gr_ctx_t ctx)
 static int
 polynomial_write(gr_stream_t out, gr_poly_t poly, gr_ctx_t ctx)
 {
-    /* todo */
-    if (poly->length == 0)
-    {
-        gr_stream_write(out, "0");
-        return GR_SUCCESS;
-    }
-
     return gr_poly_write(out, poly, POLYNOMIAL_CTX(ctx)->var, POLYNOMIAL_ELEM_CTX(ctx));
 }
 

--- a/src/gr/psl2z.c
+++ b/src/gr/psl2z.c
@@ -15,8 +15,7 @@
 
 static int _gr_psl2z_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Modular group (psl2z)");
-    return GR_SUCCESS;
+    return gr_stream_write(out, "Modular group (psl2z)");
 }
 
 static int
@@ -42,16 +41,17 @@ _gr_psl2z_swap(psl2z_t x, psl2z_t y, gr_ctx_t ctx)
 static int
 _gr_psl2z_write(gr_stream_t out, psl2z_t x, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "[[");
-    gr_stream_write_fmpz(out, &x->a);
-    gr_stream_write(out, ", ");
-    gr_stream_write_fmpz(out, &x->b);
-    gr_stream_write(out, "], [");
-    gr_stream_write_fmpz(out, &x->c);
-    gr_stream_write(out, ", ");
-    gr_stream_write_fmpz(out, &x->d);
-    gr_stream_write(out, "]]");
-    return GR_SUCCESS;
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "[[");
+    status |= gr_stream_write_fmpz(out, &x->a);
+    status |= gr_stream_write(out, ", ");
+    status |= gr_stream_write_fmpz(out, &x->b);
+    status |= gr_stream_write(out, "], [");
+    status |= gr_stream_write_fmpz(out, &x->c);
+    status |= gr_stream_write(out, ", ");
+    status |= gr_stream_write_fmpz(out, &x->d);
+    status |= gr_stream_write(out, "]]");
+    return status;
 }
 
 static int

--- a/src/gr/qqbar.c
+++ b/src/gr/qqbar.c
@@ -45,24 +45,26 @@ _gr_ctx_qqbar_set_limits(gr_ctx_t ctx, slong deg_limit, slong bits_limit)
 static int
 _gr_qqbar_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
+    int status = GR_SUCCESS;
+
     if (QQBAR_CTX(ctx)->real_only)
-        gr_stream_write(out, "Real algebraic numbers (qqbar)");
+        status |= gr_stream_write(out, "Real algebraic numbers (qqbar)");
     else
-        gr_stream_write(out, "Complex algebraic numbers (qqbar)");
+        status |= gr_stream_write(out, "Complex algebraic numbers (qqbar)");
 
     if (QQBAR_CTX(ctx)->deg_limit != WORD_MAX)
     {
-        gr_stream_write(out, ", deg_limit = ");
-        gr_stream_write_si(out, QQBAR_CTX(ctx)->deg_limit);
+        status |= gr_stream_write(out, ", deg_limit = ");
+        status |= gr_stream_write_si(out, QQBAR_CTX(ctx)->deg_limit);
     }
 
     if (QQBAR_CTX(ctx)->bits_limit != WORD_MAX)
     {
-        gr_stream_write(out, ", bits_limit = ");
-        gr_stream_write_si(out, QQBAR_CTX(ctx)->bits_limit);
+        status |= gr_stream_write(out, ", bits_limit = ");
+        status |= gr_stream_write_si(out, QQBAR_CTX(ctx)->bits_limit);
     }
 
-    return GR_SUCCESS;
+    return status;
 }
 
 static void
@@ -132,17 +134,18 @@ static int
 _gr_qqbar_write(gr_stream_t out, const qqbar_t x, const gr_ctx_t ctx)
 {
     char *re_s, *im_s;
+    int status = GR_SUCCESS;
 
     if (qqbar_is_rational(x))
     {
         fmpq_t t;
         fmpq_init(t);
         qqbar_get_fmpq(t, x);
-        gr_stream_write_fmpz(out, fmpq_numref(t));
+        status |= gr_stream_write_fmpz(out, fmpq_numref(t));
         if (!fmpz_is_one(fmpq_denref(t)))
         {
-            gr_stream_write(out, "/");
-            gr_stream_write_fmpz(out, fmpq_denref(t));
+            status |= gr_stream_write(out, "/");
+            status |= gr_stream_write_fmpz(out, fmpq_denref(t));
         }
         fmpq_clear(t);
     }
@@ -150,11 +153,11 @@ _gr_qqbar_write(gr_stream_t out, const qqbar_t x, const gr_ctx_t ctx)
     {
         qqbar_get_decimal_root_nearest(&re_s, &im_s, x, 6);
 
-        gr_stream_write(out, "Root a = ");
+        status |= gr_stream_write(out, "Root a = ");
 
         if (re_s != NULL)
         {
-            gr_stream_write_free(out, re_s);
+            status |= gr_stream_write_free(out, re_s);
         }
 
         if (im_s != NULL)
@@ -163,28 +166,28 @@ _gr_qqbar_write(gr_stream_t out, const qqbar_t x, const gr_ctx_t ctx)
             {
                 if (im_s[0] == '-')
                 {
-                    gr_stream_write(out, " - ");
-                    gr_stream_write(out, im_s + 1);
+                    status |= gr_stream_write(out, " - ");
+                    status |= gr_stream_write(out, im_s + 1);
                     flint_free(im_s);
                 }
                 else
                 {
-                    gr_stream_write(out, " + ");
-                    gr_stream_write_free(out, im_s);
+                    status |= gr_stream_write(out, " + ");
+                    status |= gr_stream_write_free(out, im_s);
                 }
             }
             else
             {
-                gr_stream_write_free(out, im_s);
+                status |= gr_stream_write_free(out, im_s);
             }
 
-            gr_stream_write(out, "*I");
+            status |= gr_stream_write(out, "*I");
         }
-        gr_stream_write(out, " of ");
-        gr_stream_write_free(out, fmpz_poly_get_str_pretty(QQBAR_POLY(x), "a"));
+        status |= gr_stream_write(out, " of ");
+        status |= gr_stream_write_free(out, fmpz_poly_get_str_pretty(QQBAR_POLY(x), "a"));
     }
 
-    return GR_SUCCESS;
+    return status;
 }
 
 static int

--- a/src/gr/vector.c
+++ b/src/gr/vector.c
@@ -46,20 +46,21 @@ vector_gr_vec_init(gr_vec_t res, gr_ctx_t ctx)
 static int vector_gr_vec_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
     gr_ctx_ptr elem_ctx = ENTRY_CTX(ctx);
+    int status = GR_SUCCESS;
 
     if (VECTOR_CTX(ctx)->all_sizes)
     {
-        gr_stream_write(out, "Vectors (any length) over ");
+        status |= gr_stream_write(out, "Vectors (any length) over ");
     }
     else
     {
-        gr_stream_write(out, "Space of length ");
-        gr_stream_write_si(out, VECTOR_CTX(ctx)->n);
-        gr_stream_write(out, " vectors over ");
+        status |= gr_stream_write(out, "Space of length ");
+        status |= gr_stream_write_si(out, VECTOR_CTX(ctx)->n);
+        status |= gr_stream_write(out, " vectors over ");
     }
 
-    gr_ctx_write(out, elem_ctx);
-    return GR_SUCCESS;
+    status |= gr_ctx_write(out, elem_ctx);
+    return status;
 }
 
 static truth_t vector_ctx_is_ring(gr_ctx_t ctx)

--- a/src/gr_mat/write.c
+++ b/src/gr_mat/write.c
@@ -16,7 +16,7 @@
 int
 _gr_mat_write(gr_stream_t out, const gr_mat_t mat, int linebreaks, gr_ctx_t ctx)
 {
-    int status;
+    int status = GR_SUCCESS;
     slong r, c;
     slong i, j;
     slong sz;
@@ -25,26 +25,25 @@ _gr_mat_write(gr_stream_t out, const gr_mat_t mat, int linebreaks, gr_ctx_t ctx)
     r = gr_mat_nrows(mat, ctx);
     c = gr_mat_ncols(mat, ctx);
 
-    status = GR_SUCCESS;
-    gr_stream_write(out, "[");
+    status |= gr_stream_write(out, "[");
 
     for (i = 0; i < r; i++)
     {
-        gr_stream_write(out, "[");
+        status |= gr_stream_write(out, "[");
 
         for (j = 0; j < c; j++)
         {
             status |= gr_write(out, GR_MAT_ENTRY(mat, i, j, sz), ctx);
             if (j < c - 1)
-                gr_stream_write(out, ", ");
+                status |= gr_stream_write(out, ", ");
         }
 
         if (i < r - 1)
-            gr_stream_write(out, linebreaks ? "],\n" : "], ");
+            status |= gr_stream_write(out, linebreaks ? "],\n" : "], ");
         else
-            gr_stream_write(out, "]");
+            status |= gr_stream_write(out, "]");
     }
-    gr_stream_write(out, "]");
+    status |= gr_stream_write(out, "]");
     return status;
 }
 

--- a/src/gr_mpoly/ctx.c
+++ b/src/gr_mpoly/ctx.c
@@ -17,18 +17,19 @@
 
 int gr_mpoly_ctx_write(gr_stream_t out, gr_mpoly_ctx_t ctx)
 {
-    gr_stream_write(out, "Ring of multivariate polynomials over ");
-    gr_ctx_write(out, GR_MPOLY_CCTX(ctx));
-    gr_stream_write(out, " in ");
-    gr_stream_write_si(out, GR_MPOLY_NVARS(ctx));
-    gr_stream_write(out, " variables");
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Ring of multivariate polynomials over ");
+    status |= gr_ctx_write(out, GR_MPOLY_CCTX(ctx));
+    status |= gr_stream_write(out, " in ");
+    status |= gr_stream_write_si(out, GR_MPOLY_NVARS(ctx));
+    status |= gr_stream_write(out, " variables");
     if (GR_MPOLY_MCTX(ctx)->ord == ORD_LEX)
-        gr_stream_write(out, ", lex order");
+        status |= gr_stream_write(out, ", lex order");
     else if (GR_MPOLY_MCTX(ctx)->ord == ORD_DEGLEX)
-        gr_stream_write(out, ", deglex order");
+        status |= gr_stream_write(out, ", deglex order");
     else if (GR_MPOLY_MCTX(ctx)->ord == ORD_DEGREVLEX)
-        gr_stream_write(out, ", degrevlex order");
-    return GR_SUCCESS;
+        status |= gr_stream_write(out, ", degrevlex order");
+    return status;
 }
 
 void

--- a/src/gr_mpoly/write.c
+++ b/src/gr_mpoly/write.c
@@ -42,7 +42,6 @@ want_parens(const char * s)
     return 0;
 }
 
-/* todo: error handling */
 int gr_mpoly_write_pretty(gr_stream_t out, const gr_mpoly_t A, gr_mpoly_ctx_t ctx)
 {
     mpoly_ctx_struct * mctx = GR_MPOLY_MCTX(ctx);
@@ -54,13 +53,11 @@ int gr_mpoly_write_pretty(gr_stream_t out, const gr_mpoly_t A, gr_mpoly_ctx_t ct
     fmpz * exponents;
     char * s;
     char ** x = GR_MPOLY_VARS(ctx);
+    int status = GR_SUCCESS;
     TMP_INIT;
 
     if (len == 0)
-    {
-        gr_stream_write(out, "0");
-        return GR_SUCCESS;
-    }
+        return gr_stream_write(out, "0");
 
     N = mpoly_words_per_exp(bits, mctx);
 
@@ -96,13 +93,13 @@ int gr_mpoly_write_pretty(gr_stream_t out, const gr_mpoly_t A, gr_mpoly_ctx_t ct
     {
         int removed_coeff = 0;
 
-        gr_get_str(&s, GR_ENTRY(A->coeffs, i, cctx->sizeof_elem), cctx);
+        status |= gr_get_str(&s, GR_ENTRY(A->coeffs, i, cctx->sizeof_elem), cctx);
 
         if (!strcmp(s, "1"))
         {
             flint_free(s);
             if (i > 0)
-                gr_stream_write(out, " + ");
+                status |= gr_stream_write(out, " + ");
             removed_coeff = 1;
         }
         else if (!strcmp(s, "-1"))
@@ -110,9 +107,9 @@ int gr_mpoly_write_pretty(gr_stream_t out, const gr_mpoly_t A, gr_mpoly_ctx_t ct
             flint_free(s);
 
             if (i > 0)
-                gr_stream_write(out, " - ");
+                status |= gr_stream_write(out, " - ");
             else
-                gr_stream_write(out, "-");
+                status |= gr_stream_write(out, "-");
 
             removed_coeff = -1;
         }
@@ -121,26 +118,26 @@ int gr_mpoly_write_pretty(gr_stream_t out, const gr_mpoly_t A, gr_mpoly_ctx_t ct
             if (want_parens(s))
             {
                 if (i > 0)
-                    gr_stream_write(out, " + ");
+                    status |= gr_stream_write(out, " + ");
 
-                gr_stream_write(out, "(");
-                gr_stream_write_free(out, s);
-                gr_stream_write(out, ")");
+                status |= gr_stream_write(out, "(");
+                status |= gr_stream_write_free(out, s);
+                status |= gr_stream_write(out, ")");
             }
             else
             {
                 if (i > 0 && s[0] == '-')
                 {
-                    gr_stream_write(out, " - ");
-                    gr_stream_write(out, s + 1);
+                    status |= gr_stream_write(out, " - ");
+                    status |= gr_stream_write(out, s + 1);
                     flint_free(s);
                 }
                 else
                 {
                     if (i > 0)
-                        gr_stream_write(out, " + ");
+                        status |= gr_stream_write(out, " + ");
 
-                    gr_stream_write_free(out, s);
+                    status |= gr_stream_write_free(out, s);
                 }
             }
         }
@@ -150,7 +147,7 @@ int gr_mpoly_write_pretty(gr_stream_t out, const gr_mpoly_t A, gr_mpoly_ctx_t ct
         if (_fmpz_vec_is_zero(exponents, mctx->nvars))
         {
             if (removed_coeff != 0)
-                gr_stream_write(out, "1");
+                status |= gr_stream_write(out, "1");
         }
         else
         {
@@ -163,17 +160,17 @@ int gr_mpoly_write_pretty(gr_stream_t out, const gr_mpoly_t A, gr_mpoly_ctx_t ct
                 if (cmp > 0)
                 {
                     if (have_printed_var || !removed_coeff)
-                        gr_stream_write(out, "*");
-                    gr_stream_write(out, x[j]);
-                    gr_stream_write(out, "^");
-                    gr_stream_write_fmpz(out, exponents + j);
+                        status |= gr_stream_write(out, "*");
+                    status |= gr_stream_write(out, x[j]);
+                    status |= gr_stream_write(out, "^");
+                    status |= gr_stream_write_fmpz(out, exponents + j);
                     have_printed_var = 1;
                 }
                 else if (cmp == 0)
                 {
                     if (have_printed_var || !removed_coeff)
-                        gr_stream_write(out, "*");
-                    gr_stream_write(out, x[j]);
+                        status |= gr_stream_write(out, "*");
+                    status |= gr_stream_write(out, x[j]);
                     have_printed_var = 1;
                 }
             }
@@ -185,7 +182,7 @@ int gr_mpoly_write_pretty(gr_stream_t out, const gr_mpoly_t A, gr_mpoly_ctx_t ct
 
     TMP_END;
 
-    return GR_SUCCESS;
+    return status;
 }
 
 int gr_mpoly_print_pretty(const gr_mpoly_t A, gr_mpoly_ctx_t ctx)

--- a/src/gr_ore_poly/ctx.c
+++ b/src/gr_ore_poly/ctx.c
@@ -27,48 +27,49 @@ static const char * default_var = "D";
 
 int gr_ore_poly_ctx_write(gr_stream_t out, gr_ore_poly_ctx_t ctx)
 {
+    int status = GR_SUCCESS;
     switch (GR_ORE_POLY_CTX(ctx)->which_algebra)
     {
         case ORE_ALGEBRA_CUSTOM:
-            gr_stream_write(out, "Custom Ore polynomials");
+            status |= gr_stream_write(out, "Custom Ore polynomials");
             break;
         case ORE_ALGEBRA_COMMUTATIVE:
-            gr_stream_write(out, "Commutative Ore polynomials");
+            status |= gr_stream_write(out, "Commutative Ore polynomials");
             break;
         case ORE_ALGEBRA_DERIVATIVE:
-            gr_stream_write(out, "Differential operators");
+            status |= gr_stream_write(out, "Differential operators");
             break;
         case ORE_ALGEBRA_EULER_DERIVATIVE:
-            gr_stream_write(out, "Differential operators (Euler derivative)");
+            status |= gr_stream_write(out, "Differential operators (Euler derivative)");
             break;
         case ORE_ALGEBRA_FORWARD_SHIFT:
-            gr_stream_write(out, "Difference operators (forward shift)");
+            status |= gr_stream_write(out, "Difference operators (forward shift)");
             break;
         case ORE_ALGEBRA_FORWARD_DIFFERENCE:
-            gr_stream_write(out, "Difference operators (forward differences)");
+            status |= gr_stream_write(out, "Difference operators (forward differences)");
             break;
         case ORE_ALGEBRA_BACKWARD_SHIFT:
-            gr_stream_write(out, "Difference operators (backward shift)");
+            status |= gr_stream_write(out, "Difference operators (backward shift)");
             break;
         case ORE_ALGEBRA_BACKWARD_DIFFERENCE:
-            gr_stream_write(out, "Difference operators (backward differences)");
+            status |= gr_stream_write(out, "Difference operators (backward differences)");
             break;
         case ORE_ALGEBRA_Q_SHIFT:
-            gr_stream_write(out, "q-difference operators (q-shift)");
+            status |= gr_stream_write(out, "q-difference operators (q-shift)");
             break;
         case ORE_ALGEBRA_MAHLER:
-            gr_stream_write(out, "Mahler operators");
+            status |= gr_stream_write(out, "Mahler operators");
             break;
         case ORE_ALGEBRA_FROBENIUS:
-            gr_stream_write(out, "Ore-Frobenius polynomials");
+            status |= gr_stream_write(out, "Ore-Frobenius polynomials");
             break;
         default:
-            gr_stream_write(out, "Ore polynomials");
+            status |= gr_stream_write(out, "Ore polynomials");
             break;
     }
-    gr_stream_write(out, " over ");
-    gr_ctx_write(out, GR_ORE_POLY_ELEM_CTX(ctx));
-    return GR_SUCCESS;
+    status |= gr_stream_write(out, " over ");
+    status |= gr_ctx_write(out, GR_ORE_POLY_ELEM_CTX(ctx));
+    return status;
 }
 
 int _gr_ore_poly_ctx_set_gen_name(gr_ctx_t ctx, const char * s)
@@ -172,13 +173,6 @@ gr_ore_poly_ctx_is_threadsafe(gr_ore_poly_ctx_t ctx)
 static int
 ore_poly_write(gr_stream_t out, gr_ore_poly_t poly, gr_ctx_t ctx)
 {
-    /* todo */
-    if (poly->length == 0)
-    {
-        gr_stream_write(out, "0");
-        return GR_SUCCESS;
-    }
-
     return gr_ore_poly_write(out, poly, ctx);
 }
 

--- a/src/gr_poly/write.c
+++ b/src/gr_poly/write.c
@@ -68,8 +68,7 @@ _gr_poly_write(gr_stream_t out, gr_srcptr poly, slong n, const char * x, gr_ctx_
 
     if (n == 0)
     {
-        gr_stream_write(out, "0");
-        return status;
+        return gr_stream_write(out, "0");
     }
 
     for (i = 0; i < n; i++)
@@ -77,21 +76,21 @@ _gr_poly_write(gr_stream_t out, gr_srcptr poly, slong n, const char * x, gr_ctx_
         if (gr_is_zero(GR_ENTRY(poly, i, sz), ctx) == T_TRUE)
             continue;
 
-        gr_get_str(&s, GR_ENTRY(poly, i, sz), ctx);
+        status |= gr_get_str(&s, GR_ENTRY(poly, i, sz), ctx);
 
         if (i >= 1 && !strcmp(s, "1"))
         {
             flint_free(s);
 
             if (printed_previously)
-                gr_stream_write(out, " + ");
+                status |= gr_stream_write(out, " + ");
 
-            gr_stream_write(out, x);
+            status |= gr_stream_write(out, x);
 
             if (i >= 2)
             {
-                gr_stream_write(out, "^");
-                gr_stream_write_si(out, i);
+                status |= gr_stream_write(out, "^");
+                status |= gr_stream_write_si(out, i);
             }
         }
         else if (i >= 1 && !strcmp(s, "-1"))
@@ -99,16 +98,16 @@ _gr_poly_write(gr_stream_t out, gr_srcptr poly, slong n, const char * x, gr_ctx_
             flint_free(s);
 
             if (printed_previously)
-                gr_stream_write(out, " - ");
+                status |= gr_stream_write(out, " - ");
             else
-                gr_stream_write(out, "-");
+                status |= gr_stream_write(out, "-");
 
-            gr_stream_write(out, x);
+            status |= gr_stream_write(out, x);
 
             if (i >= 2)
             {
-                gr_stream_write(out, "^");
-                gr_stream_write_si(out, i);
+                status |= gr_stream_write(out, "^");
+                status |= gr_stream_write_si(out, i);
             }
         }
 
@@ -117,62 +116,62 @@ _gr_poly_write(gr_stream_t out, gr_srcptr poly, slong n, const char * x, gr_ctx_
             if (want_parens(s))
             {
                 if (printed_previously)
-                    gr_stream_write(out, " + ");
+                    status |= gr_stream_write(out, " + ");
 
-                gr_stream_write(out, "(");
-                gr_stream_write_free(out, s);
-                gr_stream_write(out, ")");
+                status |= gr_stream_write(out, "(");
+                status |= gr_stream_write_free(out, s);
+                status |= gr_stream_write(out, ")");
             }
             else
             {
                 if (printed_previously && s[0] == '-')
                 {
-                    gr_stream_write(out, " - ");
-                    gr_stream_write(out, s + 1);
+                    status |= gr_stream_write(out, " - ");
+                    status |= gr_stream_write(out, s + 1);
                     flint_free(s);
                 }
                 else
                 {
                     if (printed_previously)
-                        gr_stream_write(out, " + ");
+                        status |= gr_stream_write(out, " + ");
 
-                    gr_stream_write_free(out, s);
+                    status |= gr_stream_write_free(out, s);
                 }
             }
 
             if (i == 1)
             {
-                gr_stream_write(out, "*");
-                gr_stream_write(out, x);
+                status |= gr_stream_write(out, "*");
+                status |= gr_stream_write(out, x);
             }
             else if (i >= 2)
             {
-                gr_stream_write(out, "*");
-                gr_stream_write(out, x);
-                gr_stream_write(out, "^");
-                gr_stream_write_si(out, i);
+                status |= gr_stream_write(out, "*");
+                status |= gr_stream_write(out, x);
+                status |= gr_stream_write(out, "^");
+                status |= gr_stream_write_si(out, i);
             }
         }
 
         printed_previously = 1;
 
 /*
-        gr_stream_write(out, "(");
+        status |= gr_stream_write(out, "(");
         status |= gr_write(out, GR_ENTRY(poly, i, sz), ctx);
-        gr_stream_write(out, ")");
+        status |= gr_stream_write(out, ")");
 
         if (i == 1)
         {
-            gr_stream_write(out, "*x");
+            status |= gr_stream_write(out, "*x");
         }
         else if (i >= 2)
         {
-            gr_stream_write(out, "*x^");
-            gr_stream_write_si(out, i);
+            status |= gr_stream_write(out, "*x^");
+            status |= gr_stream_write_si(out, i);
         }
 
         if (i < n - 1)
-            gr_stream_write(out, " + ");
+            status |= gr_stream_write(out, " + ");
 */
     }
     return status;

--- a/src/gr_series/series.c
+++ b/src/gr_series/series.c
@@ -153,19 +153,20 @@ int
 gr_series_write(gr_stream_t out, const gr_series_t x, gr_ctx_t ctx)
 {
     const char * var = GR_SERIES_CTX(ctx)->var;
+    int status = GR_SUCCESS;
 
-    gr_poly_write(out, GR_SERIES_POLY(x), var, GR_SERIES_ELEM_CTX(ctx));
+    status |= gr_poly_write(out, GR_SERIES_POLY(x), var, GR_SERIES_ELEM_CTX(ctx));
 
     if (GR_SERIES_ERROR(x) != GR_SERIES_ERR_EXACT)
     {
-        gr_stream_write(out, " + O(");
-        gr_stream_write(out, var);
-        gr_stream_write(out, "^");
-        gr_stream_write_si(out, GR_SERIES_ERROR(x));
-        gr_stream_write(out, ")");
+        status |= gr_stream_write(out, " + O(");
+        status |= gr_stream_write(out, var);
+        status |= gr_stream_write(out, "^");
+        status |= gr_stream_write_si(out, GR_SERIES_ERROR(x));
+        status |= gr_stream_write(out, ")");
     }
 
-    return GR_SUCCESS;
+    return status;
 }
 
 int
@@ -1869,15 +1870,16 @@ void gr_series_ctx_clear(gr_ctx_t ctx)
 
 int gr_series_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Power series over ");
-    gr_ctx_write(out, GR_SERIES_ELEM_CTX(ctx));
-    gr_stream_write(out, " with precision ");
-    gr_stream_write(out, "O(");
-    gr_stream_write(out, GR_SERIES_CTX(ctx)->var);
-    gr_stream_write(out, "^");
-    gr_stream_write_si(out, GR_SERIES_PREC(ctx));
-    gr_stream_write(out, ")");
-    return GR_SUCCESS;
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Power series over ");
+    status |= gr_ctx_write(out, GR_SERIES_ELEM_CTX(ctx));
+    status |= gr_stream_write(out, " with precision ");
+    status |= gr_stream_write(out, "O(");
+    status |= gr_stream_write(out, GR_SERIES_CTX(ctx)->var);
+    status |= gr_stream_write(out, "^");
+    status |= gr_stream_write_si(out, GR_SERIES_PREC(ctx));
+    status |= gr_stream_write(out, ")");
+    return status;
 }
 
 truth_t

--- a/src/gr_series/series_mod.c
+++ b/src/gr_series/series_mod.c
@@ -27,13 +27,14 @@ void gr_series_mod_ctx_clear(gr_ctx_t ctx)
 
 int gr_series_mod_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Power series over ");
-    gr_ctx_write(out, GR_SERIES_MOD_ELEM_CTX(ctx));
-    gr_stream_write(out, " mod ");
-    gr_stream_write(out, GR_SERIES_MOD_CTX(ctx)->var);
-    gr_stream_write(out, "^");
-    gr_stream_write_si(out, GR_SERIES_MOD_N(ctx));
-    return GR_SUCCESS;
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Power series over ");
+    status |= gr_ctx_write(out, GR_SERIES_MOD_ELEM_CTX(ctx));
+    status |= gr_stream_write(out, " mod ");
+    status |= gr_stream_write(out, GR_SERIES_MOD_CTX(ctx)->var);
+    status |= gr_stream_write(out, "^");
+    status |= gr_stream_write_si(out, GR_SERIES_MOD_N(ctx));
+    return status;
 }
 
 truth_t
@@ -174,11 +175,11 @@ int gr_series_mod_write(gr_stream_t out, const gr_poly_t x, gr_ctx_t ctx)
 {
     int status = GR_SUCCESS;
     status |= gr_poly_write(out, x, GR_SERIES_MOD_CTX(ctx)->var, GR_SERIES_MOD_ELEM_CTX(ctx));
-    gr_stream_write(out, " (mod ");
-    gr_stream_write(out, GR_SERIES_MOD_CTX(ctx)->var);
-    gr_stream_write(out, "^");
-    gr_stream_write_si(out, GR_SERIES_MOD_N(ctx));
-    gr_stream_write(out, ")");
+    status |= gr_stream_write(out, " (mod ");
+    status |= gr_stream_write(out, GR_SERIES_MOD_CTX(ctx)->var);
+    status |= gr_stream_write(out, "^");
+    status |= gr_stream_write_si(out, GR_SERIES_MOD_N(ctx));
+    status |= gr_stream_write(out, ")");
     return status;
 }
 

--- a/src/gr_vec/write.c
+++ b/src/gr_vec/write.c
@@ -18,14 +18,14 @@ _gr_vec_write(gr_stream_t out, gr_srcptr vec, slong len, gr_ctx_t ctx)
     int status = GR_SUCCESS;
     slong i, sz = ctx->sizeof_elem;
 
-    gr_stream_write(out, "[");
+    status |= gr_stream_write(out, "[");
     for (i = 0; i < len; i++)
     {
         status |= gr_write(out, GR_ENTRY(vec, i, sz), ctx);
         if (i < len - 1)
-            gr_stream_write(out, ", ");
+            status |= gr_stream_write(out, ", ");
     }
-    gr_stream_write(out, "]");
+    status |= gr_stream_write(out, "]");
     return status;
 }
 

--- a/src/mpn_mod/ring.c
+++ b/src/mpn_mod/ring.c
@@ -24,10 +24,11 @@
 int
 mpn_mod_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Integers mod ");
-    gr_stream_write_free(out, flint_mpn_get_str(NULL, 10, MPN_MOD_CTX_MODULUS(ctx), MPN_MOD_CTX_NLIMBS(ctx), 0));
-    gr_stream_write(out, " (mpn)");
-    return GR_SUCCESS;
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Integers mod ");
+    status |= gr_stream_write_free(out, flint_mpn_get_str(NULL, 10, MPN_MOD_CTX_MODULUS(ctx), MPN_MOD_CTX_NLIMBS(ctx), 0));
+    status |= gr_stream_write(out, " (mpn)");
+    return status;
 }
 
 void
@@ -217,8 +218,7 @@ mpn_mod_randtest(nn_ptr res, flint_rand_t state, gr_ctx_t ctx)
 int
 mpn_mod_write(gr_stream_t out, nn_srcptr x, gr_ctx_t ctx)
 {
-    gr_stream_write_free(out, flint_mpn_get_str(NULL, 10, x, MPN_MOD_CTX_NLIMBS(ctx), 0));
-    return GR_SUCCESS;
+    return gr_stream_write_free(out, flint_mpn_get_str(NULL, 10, x, MPN_MOD_CTX_NLIMBS(ctx), 0));
 }
 
 int

--- a/src/nfloat/ctx.c
+++ b/src/nfloat/ctx.c
@@ -220,18 +220,19 @@ nfloat_ctx_init(gr_ctx_t ctx, slong prec, int flags)
 int
 nfloat_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
+    int status = GR_SUCCESS;
     if (ctx->which_ring == GR_CTX_NFLOAT_COMPLEX)
     {
-        gr_stream_write(out, "Complex floating-point numbers with prec = ");
-        gr_stream_write_si(out, NFLOAT_CTX_PREC(ctx));
-        gr_stream_write(out, " (nfloat_complex)");
-        return GR_SUCCESS;
+        status |= gr_stream_write(out, "Complex floating-point numbers with prec = ");
+        status |= gr_stream_write_si(out, NFLOAT_CTX_PREC(ctx));
+        status |= gr_stream_write(out, " (nfloat_complex)");
     }
     else
     {
-        gr_stream_write(out, "Floating-point numbers with prec = ");
-        gr_stream_write_si(out, NFLOAT_CTX_PREC(ctx));
-        gr_stream_write(out, " (nfloat)");
-        return GR_SUCCESS;
+        status |= gr_stream_write(out, "Floating-point numbers with prec = ");
+        status |= gr_stream_write_si(out, NFLOAT_CTX_PREC(ctx));
+        status |= gr_stream_write(out, " (nfloat)");
     }
+    return status;
 }
+

--- a/src/nmod/gr_redc.c
+++ b/src/nmod/gr_redc.c
@@ -20,15 +20,17 @@
 #include "gr_poly.h"
 #include "gr_generic.h"
 
-static void
+static int
 _gr_nmod_redc_ctx_write(gr_stream_t out, gr_ctx_t ctx)
 {
-    gr_stream_write(out, "Integers mod ");
-    gr_stream_write_ui(out, GR_NMOD_REDC_N(ctx));
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Integers mod ");
+    status |= gr_stream_write_ui(out, GR_NMOD_REDC_N(ctx));
     if (GR_NMOD_REDC_IS_FAST(ctx))
-        gr_stream_write(out, " (nmod_redc_fast)");
+        status |= gr_stream_write(out, " (nmod_redc_fast)");
     else
-        gr_stream_write(out, " (nmod_redc)");
+        status |= gr_stream_write(out, " (nmod_redc)");
+    return status;
 }
 
 static truth_t
@@ -83,8 +85,7 @@ _gr_nmod_redc_randtest(ulong * res, flint_rand_t state, gr_ctx_t ctx)
 static int
 _gr_nmod_redc_write(gr_stream_t out, const ulong * x, gr_ctx_t ctx)
 {
-    gr_stream_write_ui(out, nmod_redc_get_nmod(x[0], GR_NMOD_REDC_CTX(ctx)));
-    return GR_SUCCESS;
+    return gr_stream_write_ui(out, nmod_redc_get_nmod(x[0], GR_NMOD_REDC_CTX(ctx)));
 }
 
 static int


### PR DESCRIPTION
Fix return values for `gr_write` and `gr_ctx_write` methods.

* Some `gr_ctx_write` implementations were incorrectly declared `void` instead of ``int``. This caused tests to fail on some platforms, e.g. #2651.
* Many `gr_write` and `gr_ctx_write` implementations always returned `GR_SUCCESS` regardless of the status of the inner writes. This has been fixed, and the helper functions `gr_stream_write` etc. have been marked `WARN_UNUSED_RESULT`.