### PR TITLE
Fix profiler.c for OpenBSD

### DIFF
--- a/doc/source/history.rst
+++ b/doc/source/history.rst
@@ -10,6 +10,12 @@ FLINT version history
 FLINT 3.6.0 (in development)
 -------------------------------------------------------------------------------
 
+Contributors
+
+* Albin Ahlbäck (AA)
+* Edgar Costa (EC)
+* Fredrik Johansson (FJ)
+
 Bug fixes
 
 * Fix architecture-dependent test behaviour caused by undefined argument
@@ -30,6 +36,8 @@ Bug fixes
   The ``gr_stream_write`` family of functions have been marked
   ``WARN_UNUSED_RESULT`` to catch similar bugs more easily.
   [FJ, `#2652 <https://github.com/flintlib/flint/pull/2652>`_].
+* Fix virtual memory usage fetchers for OpenBSD [AA reported by Oliver Krüger,
+  `#2653 <https://github.com/flintlib/flint/pull/2653>`_].
 
 
 2026-04-24 -- FLINT 3.5.0

--- a/src/generic_files/profiler.c
+++ b/src/generic_files/profiler.c
@@ -190,8 +190,8 @@ void fprint_memory_usage(FILE * fs)
     virt = kp.p_vm_msize * getpagesize();
     rss = kp.p_vm_rssize * getpagesize();
 #  elif defined(__OpenBSD__)
-    virt = kp.p_vmspace.vm_map.size;
-    rss = kp.p_vmspace.vm_rssize * getpagesize();
+    virt = kp.p_vm_map_size;
+    rss = kp.p_vm_rssize * getpagesize();
 #  endif
 # endif /* non-Linux OS */
 


### PR DESCRIPTION
Doesn't compile on OpenBSD.  Thanks to Oliver Krüger for raising this issue!

Edit: Also added an entry in `history.rst` and added list of contributors for 3.6.0.