### PR TITLE
Fix unused variable warnings by using n_mulhi

### DIFF
--- a/src/acb_hypgeom/dilog_zero_taylor.c
+++ b/src/acb_hypgeom/dilog_zero_taylor.c
@@ -155,8 +155,7 @@ acb_hypgeom_dilog_taylor_sum(acb_t res, const acb_t z, slong n, slong prec)
 
             while (qk > 1)
             {
-                ulong hi, lo;
-                umul_ppmm(hi, lo, q, qk * qk);
+                ulong hi = n_mulhi(q, qk * qk);
                 if (hi != 0)
                     break;
                 q *= qk * qk;

--- a/src/arb/exp_arf_rs_generic.c
+++ b/src/arb/exp_arf_rs_generic.c
@@ -40,7 +40,7 @@ arb_exp_taylor_sum_rs_generic(arb_t res, const arb_t x, slong N, slong prec)
     {
         arb_ptr tpow;
         slong j, k, m, M, tp, xmag;
-        ulong c, d, chi, clo;
+        ulong c, d, chi;
 
         xmag = arf_abs_bound_lt_2exp_si(arb_midref(x));
 
@@ -74,7 +74,7 @@ arb_exp_taylor_sum_rs_generic(arb_t res, const arb_t x, slong N, slong prec)
 
             if (k != 0)
             {
-                umul_ppmm(chi, clo, c, d);
+                chi = n_mulhi(c, d);
 
                 if (chi != 0)
                 {

--- a/src/arb/sin_cos_arf_generic.c
+++ b/src/arb/sin_cos_arf_generic.c
@@ -56,7 +56,7 @@ arb_sin_cos_taylor_sum_rs(arb_t s, const arb_t x, slong N, int cosine, slong pre
     {
         arb_ptr tpow;
         slong j, k, m, M, tp, xmag;
-        ulong c, d, chi, clo;
+        ulong c, d, chi;
 
         xmag = arf_abs_bound_lt_2exp_si(arb_midref(x));
 
@@ -96,7 +96,7 @@ arb_sin_cos_taylor_sum_rs(arb_t s, const arb_t x, slong N, int cosine, slong pre
 
             if (k != 0)
             {
-                umul_ppmm(chi, clo, c, d);
+                chi = n_mulhi(c, d);
 
                 if (chi != 0)
                 {

--- a/src/arb_hypgeom/gamma_lower_sum_rs.c
+++ b/src/arb_hypgeom/gamma_lower_sum_rs.c
@@ -38,7 +38,7 @@ _arb_hypgeom_gamma_lower_sum_rs_1(arb_t res, ulong p, ulong q, const arb_t z, sl
 {
     slong m, j, k, jlen, jbot, wp;
     double dz, logdz;
-    ulong c, chi, clo;
+    ulong c, chi;
     arb_t s;
     arb_ptr zpow;
     nn_ptr cs;
@@ -83,7 +83,7 @@ _arb_hypgeom_gamma_lower_sum_rs_1(arb_t res, ulong p, ulong q, const arb_t z, sl
         if (k != 0)
         {
             /* Check if new coefficient will overflow limb */
-            umul_ppmm(chi, clo, c, p + (k - 1) * q);
+            chi = n_mulhi(c, p + (k - 1) * q);
 
             if (chi != 0)
             {

--- a/src/fmpz_mod/mul.c
+++ b/src/fmpz_mod/mul.c
@@ -71,7 +71,7 @@ void _fmpz_mod_mul2(fmpz_t a, const fmpz_t b, const fmpz_t c,
     ulong a1, a0, b1, b0, c1, c0;
     ulong x3, x2, x1, x0;
     ulong q2, q1, q0;
-    ulong z4, z3, z2, z1, z0;
+    ulong z4, z3, z2, z1;
     ulong t4, t3, t2, t1;
     ulong s3, s2, s1;
     ulong u4, u3, u2, u1;
@@ -93,7 +93,7 @@ void _fmpz_mod_mul2(fmpz_t a, const fmpz_t b, const fmpz_t c,
     add_sssaaaaaa(x3, x2, x1, x3, x2, x1, t3, t2, t1);
 
     /* z[5:0] = x[3:1] * ninv[2:0], z[5] should end up zero */
-    umul_ppmm(z1, z0, x1, ctx->ninv_limbs[0]);
+    z1 = n_mulhi(x1, ctx->ninv_limbs[0]);
     umul_ppmm(z3, z2, x2, ctx->ninv_limbs[1]);
     z4 = x3 * ctx->ninv_limbs[2];
     umul_ppmm(t3, t2, x3, ctx->ninv_limbs[0]);

--- a/src/mpn_extras.h
+++ b/src/mpn_extras.h
@@ -23,6 +23,7 @@
 
 #include <gmp.h>
 #include "longlong.h"
+#include "ulong_extras.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -347,15 +348,15 @@ char * flint_mpn_get_str(char * res, int base, mp_srcptr x, mp_size_t xn, int ne
 /* Like NN_DOTREV_S3_1X1 but summing only over the high parts of the products. */
 #define NN_DOTREV_S3_1X1_HIGH(s2, s1, u, v, n) \
     do { \
-        mp_limb_t __dt0, __dt1, __ds0, __ds1, __ds2; \
+        mp_limb_t __dt1, __ds1, __ds2; \
         slong __i; \
         FLINT_ASSERT((n) >= 2); \
-        umul_ppmm(__ds1, __ds0, (u)[0], (v)[(n) - 1]); \
-        umul_ppmm(__dt1, __dt0, (u)[1], (v)[(n) - 2]); \
+        __ds1 = n_mulhi((u)[0], (v)[(n) - 1]); \
+        __dt1 = n_mulhi((u)[1], (v)[(n) - 2]); \
         add_ssaaaa(__ds2, __ds1, 0, __ds1, 0, __dt1); \
         for (__i = 2; __i < (n); __i++) \
         { \
-            umul_ppmm(__dt1, __dt0, (u)[__i], (v)[(n) - 1 - __i]); \
+            __dt1 = n_mulhi((u)[__i], (v)[(n) - 1 - __i]); \
             add_ssaaaa(__ds2, __ds1, __ds2, __ds1, 0, __dt1); \
         } \
         (s1) = __ds1; (s2) = __ds2; \
@@ -389,9 +390,9 @@ char * flint_mpn_get_str(char * res, int base, mp_srcptr x, mp_size_t xn, int ne
 
 #define flint_mpn_divrem21_preinv(q, a_hi, a_lo, dinv) \
    do { \
-      mp_limb_t __q2, __q3, __q4; \
+      mp_limb_t __q2, __q3; \
       umul_ppmm((q), __q2, (a_hi), (dinv)); \
-      umul_ppmm(__q3, __q4, (a_lo), (dinv)); \
+      __q3 = n_mulhi((a_lo), (dinv)); \
       add_ssaaaa((q), __q2, (q), __q2, 0, __q3); \
       add_ssaaaa((q), __q2, (q), __q2, (a_hi), (a_lo)); \
    } while (0)

--- a/src/mpn_extras/mulhigh.c
+++ b/src/mpn_extras/mulhigh.c
@@ -161,15 +161,15 @@ _flint_mpn_mulhigh_n_mulders_recursive(mp_ptr rp, mp_srcptr np, mp_srcptr mp, mp
     /* Corrections for precise high product (not needed for the
        original Mulders). */
     {
-        mp_limb_t hi, lo;
+        mp_limb_t hi;
 
         /* Note: if we relax the condition on k, we will need
            a branch for k == l here to avoid double counting. */
         FLINT_ASSERT(k != l);
 
-        umul_ppmm(hi, lo, np[k - 1], mp[l - 1]);
+        hi = n_mulhi(np[k - 1], mp[l - 1]);
         MPN_INCR_U(rp + n - 1, n + 1, hi);
-        umul_ppmm(hi, lo, np[l - 1], mp[k - 1]);
+        hi = n_mulhi(np[l - 1], mp[k - 1]);
         MPN_INCR_U(rp + n - 1, n + 1, hi);
     }
 }

--- a/src/mpn_extras/mulhigh_basecase.c
+++ b/src/mpn_extras/mulhigh_basecase.c
@@ -25,11 +25,11 @@ mp_limb_t flint_mpn_mulhigh_9(mp_ptr, mp_srcptr, mp_srcptr);
 
 static mp_limb_t flint_mpn_mulhigh_10(nn_ptr r, nn_srcptr x, nn_srcptr y)
 {
-    mp_limb_t w0, w1, lo, w2, cy;
+    mp_limb_t w0, w1, w2, cy;
 
     w0 = flint_mpn_mulhigh_9(r, x + 1, y);
     r[9] = mpn_addmul_1(r, x + 1, 9, y[9]);
-    umul_ppmm(w1, lo, x[0], y[8]);
+    w1 = n_mulhi(x[0], y[8]);
     umul_ppmm(cy, w2, x[0], y[9]);
     add_ssaaaa(cy, w0, cy, w0, 0, w1);
     add_ssaaaa(cy, w0, cy, w0, 0, w2);
@@ -40,14 +40,14 @@ static mp_limb_t flint_mpn_mulhigh_10(nn_ptr r, nn_srcptr x, nn_srcptr y)
 
 static mp_limb_t flint_mpn_mulhigh_11(nn_ptr r, nn_srcptr x, nn_srcptr y)
 {
-    mp_limb_t w0, w1, lo, w2, cy;
+    mp_limb_t w0, w1, w2, cy;
 
 #if 0
     w0 = flint_mpn_mulhigh_10(r, x + 1, y);
 #else
     w0 = flint_mpn_mulhigh_9(r, x + 2, y);
     r[9] = mpn_addmul_1(r, x + 2, 9, y[9]);
-    umul_ppmm(w1, lo, x[1], y[8]);
+    w1 = n_mulhi(x[1], y[8]);
     umul_ppmm(cy, w2, x[1], y[9]);
     add_ssaaaa(cy, w0, cy, w0, 0, w1);
     add_ssaaaa(cy, w0, cy, w0, 0, w2);
@@ -55,7 +55,7 @@ static mp_limb_t flint_mpn_mulhigh_11(nn_ptr r, nn_srcptr x, nn_srcptr y)
 #endif
 
     r[10] = mpn_addmul_1(r, x + 1, 10, y[10]);
-    umul_ppmm(w1, lo, x[0], y[9]);
+    w1 = n_mulhi(x[0], y[9]);
     umul_ppmm(cy, w2, x[0], y[10]);
     add_ssaaaa(cy, w0, cy, w0, 0, w1);
     add_ssaaaa(cy, w0, cy, w0, 0, w2);
@@ -68,21 +68,21 @@ static mp_limb_t flint_mpn_mulhigh_11(nn_ptr r, nn_srcptr x, nn_srcptr y)
 
 static mp_limb_t flint_mpn_mulhigh_12(nn_ptr r, nn_srcptr x, nn_srcptr y)
 {
-    mp_limb_t w0, w1, lo, w2, cy;
+    mp_limb_t w0, w1, w2, cy;
 
 #if 0
     w0 = flint_mpn_mulhigh_11(r, x + 1, y);
 #else
     w0 = flint_mpn_mulhigh_9(r, x + 3, y);
     r[9] = mpn_addmul_1(r, x + 3, 9, y[9]);
-    umul_ppmm(w1, lo, x[2], y[8]);
+    w1 = n_mulhi(x[2], y[8]);
     umul_ppmm(cy, w2, x[2], y[9]);
     add_ssaaaa(cy, w0, cy, w0, 0, w1);
     add_ssaaaa(cy, w0, cy, w0, 0, w2);
     MPN_INCR_U(r, 10, cy);
 
     r[10] = mpn_addmul_1(r, x + 2, 10, y[10]);
-    umul_ppmm(w1, lo, x[1], y[9]);
+    w1 = n_mulhi(x[1], y[9]);
     umul_ppmm(cy, w2, x[1], y[10]);
     add_ssaaaa(cy, w0, cy, w0, 0, w1);
     add_ssaaaa(cy, w0, cy, w0, 0, w2);
@@ -90,7 +90,7 @@ static mp_limb_t flint_mpn_mulhigh_12(nn_ptr r, nn_srcptr x, nn_srcptr y)
 #endif
 
     r[11] = mpn_addmul_1(r, x + 1, 11, y[11]);
-    umul_ppmm(w1, lo, x[0], y[10]);
+    w1 = n_mulhi(x[0], y[10]);
     umul_ppmm(cy, w2, x[0], y[11]);
     add_ssaaaa(cy, w0, cy, w0, 0, w1);
     add_ssaaaa(cy, w0, cy, w0, 0, w2);
@@ -101,11 +101,11 @@ static mp_limb_t flint_mpn_mulhigh_12(nn_ptr r, nn_srcptr x, nn_srcptr y)
 
 static mp_limb_t flint_mpn_mulhigh_13(nn_ptr r, nn_srcptr x, nn_srcptr y)
 {
-    mp_limb_t w0, w1, lo, w2, cy;
+    mp_limb_t w0, w1, w2, cy;
 
     w0 = flint_mpn_mulhigh_12(r, x + 1, y);
     r[12] = mpn_addmul_1(r, x + 1, 12, y[12]);
-    umul_ppmm(w1, lo, x[0], y[11]);
+    w1 = n_mulhi(x[0], y[11]);
     umul_ppmm(cy, w2, x[0], y[12]);
     add_ssaaaa(cy, w0, cy, w0, 0, w1);
     add_ssaaaa(cy, w0, cy, w0, 0, w2);

--- a/src/mpn_extras/mulhigh_recursive.c
+++ b/src/mpn_extras/mulhigh_recursive.c
@@ -25,7 +25,7 @@ _flint_mpn_mulhigh_n_recursive(mp_ptr r, mp_srcptr x, mp_srcptr y, mp_size_t n)
 
         mp_size_t m1 = n - FLINT_MPN_MULHIGH_BEST_TAB_N;
         mp_size_t m2 = FLINT_MPN_MULHIGH_BEST_TAB_N;
-        mp_limb_t cy, lo, w0, w1, w2;
+        mp_limb_t cy, w0, w1, w2;
 
         FLINT_ASSERT(FLINT_MPN_MULHIGH_BEST_TAB_N <= FLINT_MPN_MULHIGH_FUNC_TAB_WIDTH);
 
@@ -37,7 +37,7 @@ _flint_mpn_mulhigh_n_recursive(mp_ptr r, mp_srcptr x, mp_srcptr y, mp_size_t n)
         cy = mpn_add_n(r, r, t, m1);
         MPN_INCR_U(r + m1, m2, cy);
 
-        umul_ppmm(w2, lo, x[m1 - 1], y[m2 - 1]);
+        w2 = n_mulhi(x[m1 - 1], y[m2 - 1]);
         add_ssaaaa(cy, w0, 0, w0, 0, w1);
         add_ssaaaa(cy, w0, cy, w0, 0, w2);
         MPN_INCR_U(r, n, cy);
@@ -47,7 +47,7 @@ _flint_mpn_mulhigh_n_recursive(mp_ptr r, mp_srcptr x, mp_srcptr y, mp_size_t n)
     else
     {
         mp_ptr t;
-        mp_limb_t cy, lo, w0, w1, w2;
+        mp_limb_t cy, w0, w1, w2;
         mp_size_t m1 = n / 2;
         mp_size_t m2 = n - m1;
         TMP_INIT;
@@ -75,7 +75,7 @@ _flint_mpn_mulhigh_n_recursive(mp_ptr r, mp_srcptr x, mp_srcptr y, mp_size_t n)
             MPN_INCR_U(r + m1, m2, cy);
         }
 
-        umul_ppmm(w2, lo, x[m1 - 1], y[m2 - 1]);
+        w2 = n_mulhi(x[m1 - 1], y[m2 - 1]);
         add_ssaaaa(cy, w0, 0, w0, 0, w1);
         add_ssaaaa(cy, w0, cy, w0, 0, w2);
         MPN_INCR_U(r, n, cy);

--- a/src/mpn_extras/sqrhigh.c
+++ b/src/mpn_extras/sqrhigh.c
@@ -134,13 +134,13 @@ _flint_mpn_sqrhigh_mulders_recursive(mp_ptr rp, mp_srcptr np, mp_size_t n)
     /* Corrections for precise high product (not needed for the
        original Mulders). */
     {
-        mp_limb_t hi, lo;
+        mp_limb_t hi;
 
         /* Note: if we relax the condition on k, we will need
            a branch for k == l here to avoid double counting. */
         FLINT_ASSERT(k != l);
 
-        umul_ppmm(hi, lo, np[k - 1], np[l - 1]);
+        hi = n_mulhi(np[k - 1], np[l - 1]);
         MPN_INCR_U(rp + n - 1, n + 1, hi);
         MPN_INCR_U(rp + n - 1, n + 1, hi);
     }

--- a/src/nmod.h
+++ b/src/nmod.h
@@ -364,9 +364,7 @@ ulong n_redc(ulong x, ulong n, ulong nred)
 FLINT_FORCE_INLINE
 ulong n_ll_redc(ull_t x, ulong n, ulong nred)
 {
-    ulong lo, hi;
-
-    lo = n_mulhi(ull_lo(x) * (-nred), n);
+    ulong lo = n_mulhi(ull_lo(x) * (-nred), n), hi;
     hi = ull_hi(x);
 
     if (hi < lo)

--- a/src/nmod_poly/evaluate_nmod.c
+++ b/src/nmod_poly/evaluate_nmod.c
@@ -71,7 +71,7 @@ ulong
 _nmod_poly_evaluate_nmod_precomp_lazy(nn_srcptr poly, slong len, ulong c, ulong c_precomp, ulong modn)
 {
     slong m;
-    ulong val, p_hi, p_lo;
+    ulong val, p_hi;
 
     if (len == 0)
         return 0;
@@ -88,7 +88,7 @@ _nmod_poly_evaluate_nmod_precomp_lazy(nn_srcptr poly, slong len, ulong c, ulong 
     {
         // computes either val = (c*val mod n) or val = (c*val mod n) + n
         // see documentation of ulong_extras / n_mulmod_shoup for details
-        umul_ppmm(p_hi, p_lo, c_precomp, val);
+        p_hi = n_mulhi(c_precomp, val);
         val = c * val - p_hi * modn;
         // lazy addition, yields val in [0..k+2n-1), where max(poly) < k
         // --> if k == n (poly is reduced mod n), constraint: 3n-1 <= 2**FLINT_BITS

--- a/src/nmod_vec.h
+++ b/src/nmod_vec.h
@@ -237,8 +237,7 @@ FLINT_FORCE_INLINE dot_params_t _nmod_vec_dot_params(ulong len, nmod_t mod)
     if (mod.n <= UWORD(1) << (FLINT_BITS / 2)) // implies <= 2 limbs
     {
         const ulong t0 = (mod.n - 1) * (mod.n - 1);
-        ulong u1, u0;
-        umul_ppmm(u1, u0, t0, len);
+        ulong u1 = n_mulhi(t0, len);
         if (u1 == 0)  // 1 limb
         {
             dot_params_t params = {_DOT1, UWORD(0)};
@@ -268,10 +267,10 @@ FLINT_FORCE_INLINE dot_params_t _nmod_vec_dot_params(ulong len, nmod_t mod)
     // from here on, mod.n > 2**(FLINT_BITS / 2)
     // --> unreduced dot cannot fit in 1 limb
 
-    ulong t2, t1, t0, u1, u0;
+    ulong t2, t1, t0, u1;
     umul_ppmm(t1, t0, mod.n - 1, mod.n - 1);
     umul_ppmm(t2, t1, t1, len);
-    umul_ppmm(u1, u0, t0, len);
+    u1 = n_mulhi(t0, len);
     add_ssaaaa(t2, t1, t2, t1, UWORD(0), u1);
 
     if (t2 == 0) // 2 limbs

--- a/src/ulong_extras.h
+++ b/src/ulong_extras.h
@@ -434,9 +434,8 @@ ulong n_mulmod_precomp_shoup(ulong a, ulong n)
 ULONG_EXTRAS_INLINE
 ulong n_mulmod_shoup(ulong a, ulong b, ulong a_precomp, ulong n)
 {
-    ulong res, p_hi, p_lo;
+    ulong res, p_hi = n_mulhi(a_precomp, b);
 
-    umul_ppmm(p_hi, p_lo, a_precomp, b);
     res = a * b - p_hi * n;
 
     if (res >= n)

--- a/src/ulong_extras/cbrt.c
+++ b/src/ulong_extras/cbrt.c
@@ -249,7 +249,7 @@ n_cbrt_estimate(double a)
     } uni;
 
     uni alias;
-    ulong n, hi, lo;
+    ulong n;
 
 #ifdef FLINT64
     const ulong mul_factor = UWORD(6148914691236517205);
@@ -262,8 +262,7 @@ n_cbrt_estimate(double a)
     alias.double_val = a;
     n = alias.uword_val;
     n -= s;
-    umul_ppmm(hi, lo, n, mul_factor);
-    n = hi;
+    n = n_mulhi(n, mul_factor);
     n += s;
     alias.uword_val = n;
     return alias.double_val;


### PR DESCRIPTION
Fix https://github.com/flintlib/flint/issues/2655

The transformations are clearly safe, and the warnings are gone on my machine.