### PR TITLE
Implement Kinoshita-Li power series composition

### DIFF
--- a/doc/source/fmpq_poly.rst
+++ b/doc/source/fmpq_poly.rst
@@ -1516,8 +1516,6 @@ Power series composition
     of the inputs and the output.
 
     This implementation uses Brent-Kung algorithm 2.1 [BrentKung1978]_.
-    The default ``fmpz_poly`` composition algorithm is automatically
-    used when the composition can be performed over the integers.
 
 .. function:: void fmpq_poly_compose_series_brent_kung(fmpq_poly_t res, const fmpq_poly_t poly1, const fmpq_poly_t poly2, slong n)
 
@@ -1526,8 +1524,25 @@ Power series composition
     to be zero.
 
     This implementation uses Brent-Kung algorithm 2.1 [BrentKung1978]_.
-    The default ``fmpz_poly`` composition algorithm is automatically
-    used when the composition can be performed over the integers.
+
+.. function:: void _fmpq_poly_compose_series_kinoshita_li(fmpz * res, fmpz_t den, const fmpz * poly1, const fmpz_t den1, slong len1, const fmpz * poly2, const fmpz_t den2, slong len2, slong n)
+
+    Sets ``(res, den, n)`` to the composition of
+    ``(poly1, den1, len1)`` and ``(poly2, den2, len2)`` modulo `x^n`,
+    where the constant term of ``poly2`` is required to be zero.
+
+    Assumes that ``len1, len2, n > 0``, that ``len1, len2 <= n``,
+    and that ``res`` has space for ``n`` coefficients.
+
+    This implementation uses the Kinoshita-Li algorithm [KL2024]_.
+
+.. function:: void fmpq_poly_compose_series_kinoshita_li(fmpq_poly_t res, const fmpq_poly_t poly1, const fmpq_poly_t poly2, slong n)
+
+    Sets ``res`` to the composition of ``poly1`` and ``poly2``
+    modulo `x^n`, where the constant term of ``poly2`` is required
+    to be zero.
+
+    This implementation uses the Kinoshita-Li algorithm [KL2024]_.
 
 .. function:: void _fmpq_poly_compose_series(fmpz * res, fmpz_t den, const fmpz * poly1, const fmpz_t den1, slong len1, const fmpz * poly2, const fmpz_t den2, slong len2, slong n)
 
@@ -1540,10 +1555,10 @@ Power series composition
     space for ``n`` coefficients. Does not support aliasing between any
     of the inputs and the output.
 
-    This implementation automatically switches between the Horner scheme
-    and Brent-Kung algorithm 2.1 depending on the size of the inputs.
-    The default ``fmpz_poly`` composition algorithm is automatically
-    used when the composition can be performed over the integers.
+    This implementation automatically switches between the Horner scheme,
+    Brent-Kung algorithm 2.1 and the Kinoshita-Li algorithm depending on the
+    size of the inputs. The default ``fmpz_poly`` composition algorithm is
+    automaticallyused when the composition can be performed over the integers.
 
 .. function:: void fmpq_poly_compose_series(fmpq_poly_t res, const fmpq_poly_t poly1, const fmpq_poly_t poly2, slong n)
 
@@ -1641,7 +1656,8 @@ Power series reversion
     the linear term is required to be nonzero. Assumes that `n > 0`.
     Does not support aliasing between any of the inputs and the output.
 
-    This implementation defaults to using Newton iteration.
+    This implementation chooses between fast Lagrange inversion and
+    Newton iteration depending on the inputs.
     The default ``fmpz_poly`` reversion algorithm is automatically
     used when the reversion can be performed over the integers.
 
@@ -1651,7 +1667,8 @@ Power series reversion
     The constant term of ``poly2`` is required to be zero and
     the linear term is required to be nonzero.
 
-    This implementation defaults to using Newton iteration.
+    This implementation chooses between fast Lagrange inversion and
+    Newton iteration depending on the inputs.
     The default ``fmpz_poly`` reversion algorithm is automatically
     used when the reversion can be performed over the integers.
 

--- a/doc/source/gr_poly.rst
+++ b/doc/source/gr_poly.rst
@@ -798,13 +798,16 @@ Power series composition and reversion
               int gr_poly_compose_series_brent_kung(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, slong n, gr_ctx_t ctx)
               int _gr_poly_compose_series_divconquer(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, slong n, gr_ctx_t ctx)
               int gr_poly_compose_series_divconquer(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, slong n, gr_ctx_t ctx)
+              int _gr_poly_compose_series_kinoshita_li(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, slong n, gr_ctx_t ctx)
+              int gr_poly_compose_series_kinoshita_li(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, slong n, gr_ctx_t ctx)
               int _gr_poly_compose_series(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, slong n, gr_ctx_t ctx)
               int gr_poly_compose_series(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, slong n, gr_ctx_t ctx)
 
     Sets *res* to the power series composition `h(x) = f(g(x))` truncated
     to order `O(x^n)` where `f` is given by *poly1* and `g` is given by *poly2*,
     respectively using Horner's rule, the Brent-Kung baby step-giant step
-    algorithm [BrentKung1978]_, divide-and-conquer, and an automatic choice between the algorithms.
+    algorithm [BrentKung1978]_, divide-and-conquer, the quasilinear-complexity
+    Kinoshita-Li algorithm [KL2024]_, and an automatic choice between the algorithms.
 
     The default algorithm also handles short input and
     special-form input `g = ax^n` efficiently.

--- a/doc/source/references.rst
+++ b/doc/source/references.rst
@@ -217,6 +217,8 @@ References
 
 .. [Kar1998] \E. A. Karatsuba, "Fast evaluation of the Hurwitz zeta function and Dirichlet L-series", Problems of Information Transmission 34:4 (1998), 342-353, http://www.mathnet.ru/php/archive.phtml?wshow=paper&jrnid=ppi&paperid=425&option_lang=eng
 
+.. [KL2024] \Y. Kinoshita and B. Li, "Power series composition in near-linear time", 2024, https://arxiv.org/abs/2404.05177
+
 .. [Knu1997] \Knuth, D. E. The Art of Computer Programming, volume 2: Seminumerical algorithms, 1997
 
 .. [Kob2010] \A. Kobel, "Certified Complex Numerical Root Finding", Seminar on Computational Geometry and Geometric Computing (2010), http://www.mpi-inf.mpg.de/departments/d1/teaching/ss10/Seminar_CGGC/Slides/02_Kobel_NRS.pdf

--- a/src/fmpq_poly.h
+++ b/src/fmpq_poly.h
@@ -683,6 +683,13 @@ void _fmpq_poly_compose_series_brent_kung(fmpz * res, fmpz_t den,
 void fmpq_poly_compose_series_brent_kung(fmpq_poly_t res,
                     const fmpq_poly_t poly1, const fmpq_poly_t poly2, slong n);
 
+void _fmpq_poly_compose_series_kinoshita_li(fmpz * res, fmpz_t den,
+        const fmpz * poly1, const fmpz_t den1, slong len1,
+        const fmpz * poly2, const fmpz_t den2, slong len2, slong n);
+
+void fmpq_poly_compose_series_kinoshita_li(fmpq_poly_t res,
+                    const fmpq_poly_t poly1, const fmpq_poly_t poly2, slong n);
+
 void _fmpq_poly_compose_series(fmpz * res, fmpz_t den,
         const fmpz * poly1, const fmpz_t den1, slong len1,
         const fmpz * poly2, const fmpz_t den2, slong len2, slong n);

--- a/src/fmpq_poly/compose_series.c
+++ b/src/fmpq_poly/compose_series.c
@@ -19,11 +19,22 @@ _fmpq_poly_compose_series(fmpz * res, fmpz_t den, const fmpz * poly1,
         const fmpz_t den1, slong len1, const fmpz * poly2,
         const fmpz_t den2, slong len2, slong n)
 {
+    if (fmpz_is_one(den2))
+    {
+        _fmpz_poly_compose_series(res, poly1, len1, poly2, len2, n);
+        fmpz_set(den, den1);
+        _fmpq_poly_canonicalise(res, den, n);
+        return;
+    }
+
     if (FLINT_MIN(len1, n) < 8)
         _fmpq_poly_compose_series_horner(res, den, poly1, den1, len1,
                 poly2, den2, len2, n);
-    else
+    else if (n < 250)
         _fmpq_poly_compose_series_brent_kung(res, den, poly1, den1, len1,
+                poly2, den2, len2, n);
+    else
+        _fmpq_poly_compose_series_kinoshita_li(res, den, poly1, den1, len1,
                 poly2, den2, len2, n);
 }
 

--- a/src/fmpq_poly/compose_series.c
+++ b/src/fmpq_poly/compose_series.c
@@ -19,7 +19,7 @@ _fmpq_poly_compose_series(fmpz * res, fmpz_t den, const fmpz * poly1,
         const fmpz_t den1, slong len1, const fmpz * poly2,
         const fmpz_t den2, slong len2, slong n)
 {
-    if (len1 <= 20)
+    if (FLINT_MIN(len1, n) < 8)
         _fmpq_poly_compose_series_horner(res, den, poly1, den1, len1,
                 poly2, den2, len2, n);
     else

--- a/src/fmpq_poly/compose_series_brent_kung.c
+++ b/src/fmpq_poly/compose_series_brent_kung.c
@@ -1,6 +1,6 @@
 /*
     Copyright (C) 2010 Sebastian Pancratz
-    Copyright (C) 2011 Fredrik Johansson
+    Copyright (C) 2011, 2026 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -14,40 +14,19 @@
 #include "fmpz.h"
 #include "fmpz_vec.h"
 #include "fmpz_poly.h"
-#include "fmpq.h"
-#include "fmpq_mat.h"
+#include "fmpz_mat.h"
 #include "fmpq_poly.h"
-
-static void
-_fmpq_mat_get_row(fmpz * rnum, fmpz_t den, fmpq_mat_t A, slong i)
-{
-    slong j;
-    fmpz_t t;
-    fmpz_init(t);
-    fmpz_one(den);
-
-    for (j = 0; j < fmpq_mat_ncols(A); j++)
-        fmpz_lcm(den, den, fmpq_mat_entry_den(A, i, j));
-
-    for (j = 0; j < fmpq_mat_ncols(A); j++)
-    {
-        fmpz_divexact(t, den, fmpq_mat_entry_den(A, i, j));
-        fmpz_mul(rnum + j, fmpq_mat_entry_num(A, i, j), t);
-    }
-
-    fmpz_clear(t);
-}
-
 
 void
 _fmpq_poly_compose_series_brent_kung(fmpz * res, fmpz_t den, const fmpz * poly1,
         const fmpz_t den1, slong len1, const fmpz * poly2,
         const fmpz_t den2, slong len2, slong n)
 {
-    fmpq_mat_t A, B, C;
-    fmpz_t tden, uden, hden;
-    fmpz *t, *u, *h, *swap;
-    slong i, j, m;
+    fmpz_mat_t A, B, C;
+    fmpz *A_den, *t, *h;
+    fmpz_t lcd, scale;
+    fmpz_t C_den, tden, hden;
+    slong i, m;
 
     if (fmpz_is_one(den2))
     {
@@ -67,85 +46,98 @@ _fmpq_poly_compose_series_brent_kung(fmpz * res, fmpz_t den, const fmpz * poly1,
 
     m = n_sqrt(n) + 1;
 
-    fmpq_mat_init(A, m, n);
-    fmpq_mat_init(B, m, m);
-    fmpq_mat_init(C, m, n);
+    fmpz_mat_init(A, m, n);
+    fmpz_mat_init(B, m, m);
+    fmpz_mat_init(C, m, n);
+    A_den = _fmpz_vec_init(m);
 
+    fmpz_init(lcd);
+    fmpz_init(scale);
+    fmpz_init(C_den);
     fmpz_init(tden);
-    fmpz_init(uden);
     fmpz_init(hden);
     h = _fmpz_vec_init(n);
     t = _fmpz_vec_init(n);
-    u = _fmpz_vec_init(n);
 
-    /* Set rows of B to the segments of poly1 */
+    /* Set rows of B to the segments of poly1 with common denominator den1. */
     for (i = 0; i < len1; i++)
-    {
-        fmpz_set(fmpq_mat_entry_num(B, i / m, i % m), poly1 + i);
-        fmpz_set(fmpq_mat_entry_den(B, i / m, i % m), den1);
-        fmpq_canonicalise(fmpq_mat_entry(B, i / m, i % m));
-    }
+        fmpz_set(fmpz_mat_entry(B, i / m, i % m), poly1 + i);
+    /* Remark: if the poly is non-canonical e.g. due to being a truncation
+       of a longer power series, it could be helpful to remove its content
+       here. We could also consider removing content of B row by row. */
 
-    /* Set rows of A to powers of poly2 */
-    fmpq_set_si(fmpq_mat_entry(A, 0, 0), WORD(1), WORD(1));
-
-    for (i = 0; i < len2; i++)
-    {
-        fmpz_set(fmpq_mat_entry_num(A, 1, i), poly2 + i);
-        fmpz_set(fmpq_mat_entry_den(A, 1, i), den2);
-        fmpq_canonicalise(fmpq_mat_entry(A, 1, i));
-    }
-
-    _fmpz_vec_set(h, poly2, len2);
-    fmpz_set(hden, den2);
+    /* Set rows of A to the numerators of powers of poly2 with corresponding
+       denominators in A_den[i]. */
+    fmpz_one(fmpz_mat_entry(A, 0, 0));
+    fmpz_one(A_den + 0);
+    _fmpz_vec_set(fmpz_mat_row(A, 1), poly2, len2);
+    fmpz_set(A_den + 1, den2);
+    /* Optional: may improve performance if poly2 is non-canonical e.g. due
+       to being a truncation of a longer power series. */
+    _fmpq_poly_canonicalise(fmpz_mat_row(A, 1), A_den + 1, n);
 
     for (i = 2; i < m; i++)
     {
-        _fmpq_poly_mullow(t, tden, h, hden, n, poly2, den2, len2, n);
-        _fmpq_poly_canonicalise(t, tden, n);
+        fmpz * Ai = fmpz_mat_row(A, i);
+        fmpz * Ai1 = fmpz_mat_row(A, i - 1);
+        fmpz * Ai_den = A_den + i;
+        fmpz * Ai1_den = A_den + i - 1;
 
-        for (j = 0; j < n; j++)
-        {
-            fmpz_set(fmpq_mat_entry_num(A, i, j), t + j);
-            fmpz_set(fmpq_mat_entry_den(A, i, j), tden);
-            fmpq_canonicalise(fmpq_mat_entry(A, i, j));
-        }
-        swap = t; t = h; h = swap;
-        fmpz_swap(hden, tden);
+        _fmpq_poly_mullow(Ai, Ai_den, Ai1, Ai1_den, n, poly2, den2, len2, n);
+        _fmpq_poly_canonicalise(Ai, Ai_den, n);
     }
 
     /* Compute h = poly2 ^ m */
-    _fmpq_poly_mullow(t, tden, h, hden, n, poly2, den2, len2, n);
-    _fmpq_poly_canonicalise(t, tden, n);
-    swap = t; t = h; h = swap;
-    fmpz_swap(hden, tden);
+    _fmpq_poly_mullow(h, hden, fmpz_mat_row(A, m - 1), A_den + m - 1, n, poly2, den2, len2, n);
+    _fmpq_poly_canonicalise(h, hden, n);
 
-    /* Matrix multiply */
-    fmpq_mat_mul(C, B, A);
-    fmpq_mat_clear(A);
-    fmpq_mat_clear(B);
+    /* Matrix multiply C = B * A over the integers.
+       B (m x m) has common denominator den1.
+       A (m x n) has row denominator A_den[i].
 
+       We could remove gcd of A columnwise before multiplying, but
+       this is slower for small to moderate n where we want to use Brent-Kung
+       and faster only for large n where we want to use Kinoshita-Li instead. */
+    fmpz_one(lcd);
+    for (i = 0; i < m; i++)
+        fmpz_lcm(lcd, lcd, A_den + i);
+
+    for (i = 0; i < m; i++)
+    {
+        fmpz_divexact(scale, lcd, A_den + i);
+        if (!fmpz_is_one(scale))
+            _fmpz_vec_scalar_mul_fmpz(fmpz_mat_row(A, i), fmpz_mat_row(A, i), n, scale);
+    }
+
+    fmpz_mat_mul(C, B, A);
+    fmpz_mat_clear(A);
+    _fmpz_vec_clear(A_den, m);
+    fmpz_mat_clear(B);
+
+    fmpz_mul(C_den, den1, lcd);
+
+    _fmpz_vec_set(res, fmpz_mat_row(C, m - 1), n);
+    fmpz_set(den, C_den);
+    _fmpq_poly_canonicalise(res, den, n);
     /* Evaluate block composition using the Horner scheme */
-    _fmpq_mat_get_row(res, den, C, m - 1);
-
     for (i = m - 2; i >= 0; i--)
     {
         _fmpq_poly_mullow(t, tden, res, den, n, h, hden, n, n);
-        /* we could canonicalise t here, but it does not seem to make
-           much of a difference */
-        _fmpq_mat_get_row(u, uden, C, i);
-        _fmpq_poly_add(res, den, t, tden, n, u, uden, n);
+        /* Remark: we could canonicalise t and/or fmpz_mat_row(C, i)
+           here; in practice this seems to be slower at least for moderate n. */
+        _fmpq_poly_add(res, den, t, tden, n, fmpz_mat_row(C, i), C_den, n);
     }
 
     _fmpq_poly_canonicalise(res, den, n);
 
-    fmpq_mat_clear(C);
+    fmpz_mat_clear(C);
 
     _fmpz_vec_clear(t, n);
-    _fmpz_vec_clear(u, n);
     _fmpz_vec_clear(h, n);
+    fmpz_clear(lcd);
+    fmpz_clear(scale);
+    fmpz_clear(C_den);
     fmpz_clear(tden);
-    fmpz_clear(uden);
     fmpz_clear(hden);
 }
 

--- a/src/fmpq_poly/compose_series_brent_kung.c
+++ b/src/fmpq_poly/compose_series_brent_kung.c
@@ -28,14 +28,6 @@ _fmpq_poly_compose_series_brent_kung(fmpz * res, fmpz_t den, const fmpz * poly1,
     fmpz_t C_den, tden, hden;
     slong i, m;
 
-    if (fmpz_is_one(den2))
-    {
-        _fmpz_poly_compose_series(res, poly1, len1, poly2, len2, n);
-        fmpz_set(den, den1);
-        _fmpq_poly_canonicalise(res, den, n);
-        return;
-    }
-
     if (n == 1)
     {
         fmpz_set(res, poly1);

--- a/src/fmpq_poly/compose_series_horner.c
+++ b/src/fmpq_poly/compose_series_horner.c
@@ -20,13 +20,7 @@ _fmpq_poly_compose_series_horner(fmpz * res, fmpz_t den, const fmpz * poly1,
         const fmpz_t den1, slong len1, const fmpz * poly2,
         const fmpz_t den2, slong len2, slong n)
 {
-    if (fmpz_is_one(den2))
-    {
-        _fmpz_poly_compose_series(res, poly1, len1, poly2, len2, n);
-        fmpz_set(den, den1);
-        _fmpq_poly_canonicalise(res, den, n);
-    }
-    else if (n == 1)
+    if (n == 1)
     {
         fmpz_set(res, poly1);
         fmpz_set(den, den1);

--- a/src/fmpq_poly/compose_series_kinoshita_li.c
+++ b/src/fmpq_poly/compose_series_kinoshita_li.c
@@ -1,0 +1,332 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz.h"
+#include "fmpz_vec.h"
+#include "fmpz_poly.h"
+#include "fmpq_poly.h"
+
+/*  Adapted from _gr_poly_compose_series_kinoshita_li (see comments in that
+    function for more details about the algorithm) with the only difference that
+    we track a common denominator for each polynomial.
+
+    This file was developed with the assistance of Claude Sonnet 4.6.*/
+
+void
+_fmpq_poly_compose_series_kinoshita_li(fmpz *res, fmpz_t rden,
+                                        const fmpz *poly1, const fmpz_t den1, slong len1,
+                                        const fmpz *poly2, const fmpz_t den2, slong len2,
+                                        slong n)
+{
+    slong k, L;
+
+    FLINT_ASSERT(len1 >= 1);
+    FLINT_ASSERT(len2 >= 1);
+    FLINT_ASSERT(n >= 1);
+
+    /* ---- Trivial cases ---- */
+    if (len1 == 1 || n == 1)
+    {
+        _fmpz_vec_set(res, poly1, 1);
+        _fmpz_vec_zero(res + 1, n - 1);
+        fmpz_set(rden, den1);
+        _fmpq_poly_canonicalise(res, rden, 1);
+        return;
+    }
+
+    /* ---- Level count L = ceil(log2(n)) ---- */
+    L = 0;
+    { slong tmp = n; while (tmp > 1) { tmp = (tmp + 1) / 2; L++; } }
+
+    /* ---- Level parameters ---- */
+    slong *xn_arr   = flint_malloc((L + 1) * sizeof(slong));
+    slong *ylo_arr  = flint_malloc((L + 1) * sizeof(slong));
+    slong *ydeg_arr = flint_malloc((L + 1) * sizeof(slong));
+    slong *qoff_arr = flint_malloc((L + 1) * sizeof(slong));
+
+    xn_arr[0]   = n;
+    ylo_arr[0]  = n - 1;
+    ydeg_arr[0] = 2;
+
+    slong qchain_total = 0;
+    for (k = 0; k < L; k++)
+    {
+        qoff_arr[k]      = qchain_total;
+        qchain_total    += xn_arr[k] * ydeg_arr[k];
+        xn_arr[k + 1]   = (xn_arr[k] + 1) / 2;
+        ylo_arr[k + 1]  = (ylo_arr[k] >= ydeg_arr[k] - 1)
+                              ? (ylo_arr[k] - (ydeg_arr[k] - 1)) : 0;
+        ydeg_arr[k + 1] = FLINT_MIN(2 * ydeg_arr[k] - 1, n);
+    }
+    qoff_arr[L]   = qchain_total;
+    qchain_total += xn_arr[L] * ydeg_arr[L];
+
+    /* ---- Qchain numerators and per-level denominators ---- */
+    fmpz *Qchain_num = _fmpz_vec_init(qchain_total);
+    fmpz *Qchain_den = _fmpz_vec_init(L + 1);   /* one denominator per level */
+
+    /* ---- Build P_num = f.reverse(n-1), P_den = den1 ---- */
+    fmpz *P_num = _fmpz_vec_init(n);
+    fmpz_t P_den;
+    fmpz_init_set(P_den, den1);
+    {
+        slong glen = FLINT_MIN(len1, n);
+        for (slong i = 0; i < glen; i++)
+            fmpz_set(P_num + (n - 1 - i), poly1 + i);
+    }
+
+    /* ---- Initialise Q_0 = 1 - y*g(x) ---- */
+    {
+        fmpz *Q0_num = Qchain_num + qoff_arr[0];
+        fmpz_set(Q0_num + 0, den2);
+        slong glen = FLINT_MIN(len2, n);
+        for (slong i = 0; i < glen; i++)
+            fmpz_neg(Q0_num + n + i, poly2 + i);
+        fmpz_set(Qchain_den + 0, den2);
+        _fmpq_poly_canonicalise(Q0_num, Qchain_den + 0, n * 2);
+    }
+
+    /* ================================================================
+       DOWNWARD PASS: Graeffe steps k = 0, ..., L-1.
+       y-major KS with stride s = 2*ydeg - 1.
+       x^i y^j maps to flat index i*s + j.
+       ================================================================ */
+    for (k = 0; k < L; k++)
+    {
+        slong xn   = xn_arr[k];
+        slong ydeg = ydeg_arr[k];
+        slong xnh  = xn_arr[k + 1];
+        slong ydA  = ydeg_arr[k + 1];
+
+        slong s       = 2 * ydeg - 1;
+        slong qks_len = (xn - 1) * s + ydeg;
+        slong rks_len = s * (2 * xnh - 1);
+
+        fmpz *Qk_num  = Qchain_num + qoff_arr[k];
+        fmpz *Qk1_num = Qchain_num + qoff_arr[k + 1];
+
+        fmpz *Qks_num     = _fmpz_vec_init(qks_len);
+        fmpz *Qneg_ks_num = _fmpz_vec_init(qks_len);
+        fmpz *Rks_num     = _fmpz_vec_init(rks_len);
+        fmpz_t Qks_den, Rks_den;
+        fmpz_init_set(Qks_den, Qchain_den + k);
+        fmpz_init(Rks_den);
+
+        /* Pack Q and Q(-x,y): x^i y^j -> index i*s + j.
+         * Qneg is the same but odd-x entries are negated. */
+        for (slong j = 0; j < ydeg; j++)
+            for (slong i = 0; i < xn; i++)
+            {
+                const fmpz *src = Qk_num + j * xn + i;
+                if (i & 1)
+                {
+                    fmpz_set(Qks_num     + i * s + j,  src);
+                    fmpz_neg(Qneg_ks_num + i * s + j,  src);
+                }
+                else
+                {
+                    fmpz_set(Qks_num     + i * s + j,  src);
+                    fmpz_set(Qneg_ks_num + i * s + j,  src);
+                }
+            }
+
+        /* Product denominator = Qks_den^2 */
+        fmpz_mul(Rks_den, Qks_den, Qks_den);
+
+        _fmpz_poly_mullow(Rks_num, Qks_num, qks_len, Qneg_ks_num, qks_len, rks_len);
+
+        _fmpz_vec_clear(Qks_num,     qks_len);
+        _fmpz_vec_clear(Qneg_ks_num, qks_len);
+
+        /* Unpack even-x columns -> Q_{k+1}: x^{2i} y^j at index 2*i*s + j.
+         * Copy only the xnh*ydA entries that are used, then canonicalise. */
+        for (slong j = 0; j < ydA; j++)
+            for (slong i = 0; i < xnh; i++)
+                fmpz_set(Qk1_num + j * xnh + i, Rks_num + 2 * i * s + j);
+
+        _fmpz_vec_clear(Rks_num, rks_len);
+
+        fmpz_set(Qchain_den + (k + 1), Rks_den);
+        _fmpq_poly_canonicalise(Qk1_num, Qchain_den + (k + 1), xnh * ydA);
+
+        fmpz_clear(Qks_den);
+        fmpz_clear(Rks_den);
+    }
+
+    /* ================================================================
+       BASE CASE: W = P / Q_L(0,y) mod y^n.
+       Q_L has x-stride 1, so Q_L_num[j] is the j-th y-coefficient.
+       ylo_arr[L] = 0 always, so the full length-n result is needed.
+       ================================================================ */
+    slong W_alloc = 1;
+    while (W_alloc < n) W_alloc *= 2;
+
+    fmpz *W_num = _fmpz_vec_init(W_alloc);
+    fmpz_t W_den;
+    fmpz_init(W_den);
+    slong yn_W = n;
+
+    {
+        slong jmax = FLINT_MIN(ydeg_arr[L], n);
+        _fmpq_poly_div_series(W_num, W_den,
+                              P_num, P_den, n,
+                              Qchain_num + qoff_arr[L], Qchain_den + L, jmax,
+                              n);
+    }
+
+    /* ================================================================
+       UPWARD PASS: k = L-1 down to 0.
+
+       At level k, W has x-stride xn_arr[k+1] and y-width yn_W.
+       We compute r = Q_k(-x,y) * W(x^2,y), then extract the y-slice
+       [yslice_lo, yn_r) into W in place.
+       ================================================================ */
+    for (k = L - 1; k >= 0; k--)
+    {
+        slong xn   = xn_arr[k];
+        slong xnh  = xn_arr[k + 1];
+        slong ydeg = ydeg_arr[k];
+        slong ylo  = ylo_arr[k];
+        slong ylor = ylo_arr[k + 1];
+        slong yn_r = n - ylor;
+
+        slong s           = ydeg + yn_W - 1;
+        slong qneg_ks_len = (xn - 1) * s + ydeg;
+        slong W_ks_len    = 2 * (xnh - 1) * s + yn_W;
+        slong yslice_lo   = ylo - ylor;
+
+        /*
+         * We only need product coefficients [yslice_lo, yslice_lo+R_rks_len).
+         * _fmpz_poly_mulmid(res, f, flen, g, glen, lo, hi) computes slice [lo, hi)
+         * of the full product into res[0..hi-lo-1], so res[k] = product coefficient lo+k.
+         */
+        slong R_rks_len = (xn - 1) * s + yn_r - yslice_lo;
+
+        fmpz *Qk_num      = Qchain_num + qoff_arr[k];
+        fmpz *Qneg_ks_num = _fmpz_vec_init(qneg_ks_len);
+        fmpz *W_ks_num    = _fmpz_vec_init(W_ks_len);
+        fmpz *R_rks_num   = _fmpz_vec_init(R_rks_len);
+        fmpz_t Qneg_den, W_ks_den, R_rks_den;
+        fmpz_init_set(Qneg_den, Qchain_den + k);
+        fmpz_init_set(W_ks_den, W_den);
+        fmpz_init(R_rks_den);
+
+        /* Pack Qneg_k: x^i y^j -> i*s + j, odd-x entries negated. */
+        for (slong j = 0; j < ydeg; j++)
+            for (slong i = 0; i < xn; i++)
+            {
+                const fmpz *src = Qk_num + j * xn + i;
+                if (i & 1)
+                    fmpz_neg(Qneg_ks_num + i * s + j, src);
+                else
+                    fmpz_set(Qneg_ks_num + i * s + j, src);
+            }
+
+        /* Pack W(x^2): x^{2i} y^j -> 2*i*s + j. */
+        for (slong j = 0; j < yn_W; j++)
+            for (slong i = 0; i < xnh; i++)
+                fmpz_set(W_ks_num + 2 * i * s + j, W_num + j * xnh + i);
+
+        fmpz_mul(R_rks_den, Qneg_den, W_ks_den);
+
+        _fmpz_poly_mulmid(R_rks_num, Qneg_ks_num, qneg_ks_len,
+                                     W_ks_num,    W_ks_len,
+                                     yslice_lo, yslice_lo + R_rks_len);
+
+        _fmpz_vec_clear(Qneg_ks_num, qneg_ks_len);
+        _fmpz_vec_clear(W_ks_num,    W_ks_len);
+
+        /*
+         * Unpack y-slice [yslice_lo, yn_r) into W in place.
+         * R_rks_num[k] holds product coefficient yslice_lo + k.
+         * The entry R[jsrc][i] is product coefficient i*s + jsrc,
+         * so it sits at R_rks_num[i*s + jsrc - yslice_lo].
+         */
+        slong new_yn_W = n - ylo;
+        {
+            slong jout = 0;
+            for (slong jsrc = yslice_lo; jsrc < yn_r; jsrc++, jout++)
+                for (slong i = 0; i < xn; i++)
+                    fmpz_set(W_num + jout * xn + i,
+                             R_rks_num + i * s + jsrc - yslice_lo);
+        }
+
+        _fmpz_vec_clear(R_rks_num, R_rks_len);
+
+        fmpz_set(W_den, R_rks_den);
+        _fmpq_poly_canonicalise(W_num, W_den, new_yn_W * xn);
+
+        fmpz_clear(Qneg_den);
+        fmpz_clear(W_ks_den);
+        fmpz_clear(R_rks_den);
+
+        yn_W = new_yn_W;
+    }
+
+    /* W_num[0..n) / W_den is the result f(g(x)) mod x^n. */
+    _fmpz_vec_set(res, W_num, n);
+    fmpz_set(rden, W_den);
+    /* Already canonical from the last upward step. */
+
+    _fmpz_vec_clear(W_num, W_alloc);
+    fmpz_clear(W_den);
+    _fmpz_vec_clear(P_num, n);
+    fmpz_clear(P_den);
+    _fmpz_vec_clear(Qchain_num, qchain_total);
+    _fmpz_vec_clear(Qchain_den, L + 1);
+
+    flint_free(xn_arr);
+    flint_free(ylo_arr);
+    flint_free(ydeg_arr);
+    flint_free(qoff_arr);
+}
+
+void
+fmpq_poly_compose_series_kinoshita_li(fmpq_poly_t res,
+                                       const fmpq_poly_t poly1,
+                                       const fmpq_poly_t poly2,
+                                       slong n)
+{
+    slong len1 = poly1->length;
+    slong len2 = poly2->length;
+    slong lenr;
+
+    if (len1 == 0 || n == 0)
+    {
+        fmpq_poly_zero(res);
+        return;
+    }
+
+    if (len2 != 0 && !fmpz_is_zero(poly2->coeffs))
+    {
+        flint_throw(FLINT_ERROR, "(fmpq_poly_compose_series_kinoshita_li): "
+                "Inner polynomial must have zero constant term.\n");
+    }
+
+    if (len2 == 0 || len1 == 1)
+    {
+        fmpq_poly_set(res, poly1);
+        fmpq_poly_truncate(res, 1);
+        return;
+    }
+
+    lenr = FLINT_MIN((len1 - 1) * (len2 - 1) + 1, n);
+    len1 = FLINT_MIN(len1, lenr);
+    len2 = FLINT_MIN(len2, lenr);
+
+    fmpq_poly_fit_length(res, lenr);
+    _fmpq_poly_compose_series_kinoshita_li(res->coeffs, res->den,
+                       poly1->coeffs, poly1->den, len1,
+                       poly2->coeffs, poly2->den, len2, lenr);
+    _fmpq_poly_set_length(res, lenr);
+    _fmpq_poly_normalise(res);
+}
+

--- a/src/fmpq_poly/compose_series_kinoshita_li.c
+++ b/src/fmpq_poly/compose_series_kinoshita_li.c
@@ -73,16 +73,6 @@ _fmpq_poly_compose_series_kinoshita_li(fmpz *res, fmpz_t rden,
     fmpz *Qchain_num = _fmpz_vec_init(qchain_total);
     fmpz *Qchain_den = _fmpz_vec_init(L + 1);   /* one denominator per level */
 
-    /* ---- Build P_num = f.reverse(n-1), P_den = den1 ---- */
-    fmpz *P_num = _fmpz_vec_init(n);
-    fmpz_t P_den;
-    fmpz_init_set(P_den, den1);
-    {
-        slong glen = FLINT_MIN(len1, n);
-        for (slong i = 0; i < glen; i++)
-            fmpz_set(P_num + (n - 1 - i), poly1 + i);
-    }
-
     /* ---- Initialise Q_0 = 1 - y*g(x) ---- */
     {
         fmpz *Q0_num = Qchain_num + qoff_arr[0];
@@ -175,11 +165,20 @@ _fmpq_poly_compose_series_kinoshita_li(fmpz *res, fmpz_t rden,
     slong yn_W = n;
 
     {
-        slong jmax = FLINT_MIN(ydeg_arr[L], n);
-        _fmpq_poly_div_series(W_num, W_den,
-                              P_num, P_den, n,
+        /* ---- Build P_num = f.reverse(n-1), P_den = den1 ---- */
+        slong glen = FLINT_MIN(n, len1);
+        fmpz *P_num = _fmpz_vec_init(glen);
+
+        _fmpz_poly_reverse(P_num, poly1, glen, glen);
+
+        slong jmax = FLINT_MIN(ydeg_arr[L], glen);
+        _fmpq_poly_div_series(W_num + n - glen, W_den,
+                              P_num, den1, glen,
                               Qchain_num + qoff_arr[L], Qchain_den + L, jmax,
-                              n);
+                              glen);
+        /* Low (n - glen) coefficients of W are a priori zero. */
+
+        _fmpz_vec_clear(P_num, glen);
     }
 
     /* ================================================================
@@ -278,8 +277,6 @@ _fmpq_poly_compose_series_kinoshita_li(fmpz *res, fmpz_t rden,
 
     _fmpz_vec_clear(W_num, W_alloc);
     fmpz_clear(W_den);
-    _fmpz_vec_clear(P_num, n);
-    fmpz_clear(P_den);
     _fmpz_vec_clear(Qchain_num, qchain_total);
     _fmpz_vec_clear(Qchain_den, L + 1);
 

--- a/src/fmpq_poly/revert_series.c
+++ b/src/fmpq_poly/revert_series.c
@@ -25,7 +25,10 @@ _fmpq_poly_revert_series(fmpz * Qinv, fmpz_t den,
         return;
     }
 
-    _fmpq_poly_revert_series_lagrange_fast(Qinv, den, Q, Qden, Qlen, n);
+    if (n < 20)
+        _fmpq_poly_revert_series_lagrange_fast(Qinv, den, Q, Qden, Qlen, n);
+    else
+        _fmpq_poly_revert_series_newton(Qinv, den, Q, Qden, Qlen, n);
 }
 
 void

--- a/src/fmpq_poly/revert_series_newton.c
+++ b/src/fmpq_poly/revert_series_newton.c
@@ -39,7 +39,7 @@
 #define FLINT_NEWTON_END }
 
 
-#define FLINT_REVERSE_NEWTON_CUTOFF 4
+#define FLINT_REVERSE_NEWTON_CUTOFF 8
 
 void
 _fmpq_poly_revert_series_newton(fmpz * Qinv, fmpz_t den,
@@ -75,15 +75,15 @@ _fmpq_poly_revert_series_newton(fmpz * Qinv, fmpz_t den,
         FLINT_NEWTON_INIT(FLINT_REVERSE_NEWTON_CUTOFF, n)
 
         FLINT_NEWTON_BASECASE(k)
-        _fmpq_poly_revert_series_lagrange(Qinv, den, Q, Qden, Qlen, k);
+        _fmpq_poly_revert_series_lagrange_fast(Qinv, den, Q, Qden, Qlen, k);
         _fmpz_vec_zero(Qinv + k, n - k);
         FLINT_NEWTON_END_BASECASE
 
         FLINT_NEWTON_LOOP(k0, k)
         _fmpq_poly_compose_series(T, Tden, Q, Qden, FLINT_MIN(Qlen, k), Qinv, den, k0, k);
-        _fmpq_poly_derivative(U, Uden, T, Tden, k); fmpz_zero(U + k - 1);
+        _fmpq_poly_derivative(U, Uden, T, Tden, k);
         fmpz_zero(T + 1);
-        _fmpq_poly_div_series(V, Vden, T, Tden, k, U, Uden, k, k);
+        _fmpq_poly_div_series(V, Vden, T, Tden, k, U, Uden, k - 1, k);
         _fmpq_poly_canonicalise(V, Vden, k);
         _fmpq_poly_derivative(T, Tden, Qinv, den, k);
         _fmpq_poly_mullow(U, Uden, V, Vden, k, T, Tden, k, k);

--- a/src/fmpq_poly/test/main.c
+++ b/src/fmpq_poly/test/main.c
@@ -36,6 +36,7 @@
 #include "t-compose_series_brent_kung.c"
 #include "t-compose_series.c"
 #include "t-compose_series_horner.c"
+#include "t-compose_series_kinoshita_li.c"
 #include "t-content.c"
 #include "t-cosh_series.c"
 #include "t-cos_series.c"
@@ -136,6 +137,7 @@ test_struct tests[] =
     TEST_FUNCTION(fmpq_poly_compose_series_brent_kung),
     TEST_FUNCTION(fmpq_poly_compose_series),
     TEST_FUNCTION(fmpq_poly_compose_series_horner),
+    TEST_FUNCTION(fmpq_poly_compose_series_kinoshita_li),
     TEST_FUNCTION(fmpq_poly_content),
     TEST_FUNCTION(fmpq_poly_cosh_series),
     TEST_FUNCTION(fmpq_poly_cos_series),

--- a/src/fmpq_poly/test/t-compose_series_kinoshita_li.c
+++ b/src/fmpq_poly/test/t-compose_series_kinoshita_li.c
@@ -1,0 +1,125 @@
+/*
+    Copyright (C) 2009 William Hart
+    Copyright (C) 2010 Sebastian Pancratz
+    Copyright (C) 2011 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "fmpq_poly.h"
+
+TEST_FUNCTION_START(fmpq_poly_compose_series_kinoshita_li, state)
+{
+    int i, result;
+
+    /* Check aliasing of the first argument */
+    for (i = 0; i < 10 * flint_test_multiplier(); i++)
+    {
+        fmpq_poly_t f, g, h;
+        slong n;
+
+        fmpq_poly_init(f);
+        fmpq_poly_init(g);
+        fmpq_poly_init(h);
+        fmpq_poly_randtest(g, state, n_randint(state, 40), 80);
+        fmpq_poly_randtest(h, state, n_randint(state, 20), 50);
+        fmpq_poly_set_coeff_ui(h, 0, 0);
+        n = n_randint(state, 20);
+
+        fmpq_poly_compose_series_kinoshita_li(f, g, h, n);
+        fmpq_poly_compose_series_kinoshita_li(g, g, h, n);
+
+        result = (fmpq_poly_equal(f, g));
+        if (!result)
+        {
+            flint_printf("FAIL (aliasing 1):\n");
+            fmpq_poly_print(f), flint_printf("\n\n");
+            fmpq_poly_print(g), flint_printf("\n\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        fmpq_poly_clear(f);
+        fmpq_poly_clear(g);
+        fmpq_poly_clear(h);
+    }
+
+    /* Check aliasing of the second argument */
+    for (i = 0; i < 10 * flint_test_multiplier(); i++)
+    {
+        fmpq_poly_t f, g, h;
+        slong n;
+
+        fmpq_poly_init(f);
+        fmpq_poly_init(g);
+        fmpq_poly_init(h);
+        fmpq_poly_randtest(g, state, n_randint(state, 40), 80);
+        fmpq_poly_randtest(h, state, n_randint(state, 20), 50);
+        fmpq_poly_set_coeff_ui(h, 0, 0);
+        n = n_randint(state, 20);
+
+        fmpq_poly_compose_series_kinoshita_li(f, g, h, n);
+        fmpq_poly_compose_series_kinoshita_li(h, g, h, n);
+
+        result = (fmpq_poly_equal(f, h));
+        if (!result)
+        {
+            flint_printf("FAIL (aliasing 2):\n");
+            fmpq_poly_print(f), flint_printf("\n\n");
+            fmpq_poly_print(h), flint_printf("\n\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        fmpq_poly_clear(f);
+        fmpq_poly_clear(g);
+        fmpq_poly_clear(h);
+    }
+
+    /* Compare with brent_kung */
+    for (i = 0; i < 20 * flint_test_multiplier(); i++)
+    {
+        fmpq_poly_t f, g, h, s, t;
+        slong n;
+
+        fmpq_poly_init(f);
+        fmpq_poly_init(g);
+        fmpq_poly_init(h);
+        fmpq_poly_init(s);
+        fmpq_poly_init(t);
+        fmpq_poly_randtest(g, state, n_randint(state, 40), 80);
+        fmpq_poly_randtest(h, state, n_randint(state, 20), 50);
+        fmpq_poly_set_coeff_ui(h, 0, 0);
+        n = n_randint(state, 40);
+
+        fmpq_poly_compose_series_brent_kung(s, g, h, n);
+        fmpq_poly_compose_series_kinoshita_li(f, g, h, n);
+
+        result = (fmpq_poly_equal(f, s));
+        if (!result)
+        {
+            flint_printf("FAIL (comparison):\n");
+            flint_printf("n = %wd\n", n);
+            flint_printf("g = "), fmpq_poly_print(g), flint_printf("\n\n");
+            flint_printf("h = "), fmpq_poly_print(h), flint_printf("\n\n");
+            flint_printf("f = "), fmpq_poly_print(f), flint_printf("\n\n");
+            flint_printf("s = "), fmpq_poly_print(s), flint_printf("\n\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        fmpq_poly_clear(f);
+        fmpq_poly_clear(g);
+        fmpq_poly_clear(h);
+        fmpq_poly_clear(s);
+        fmpq_poly_clear(t);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/fmpz_poly/compose_series.c
+++ b/src/fmpz_poly/compose_series.c
@@ -15,6 +15,8 @@
 #include "fmpz_vec.h"
 #include "fmpz_mat.h"
 #include "fmpz_poly.h"
+#include "gr.h"
+#include "gr_poly.h"
 
 void
 _fmpz_poly_compose_series(fmpz * res, const fmpz * poly1, slong len1,
@@ -22,8 +24,14 @@ _fmpz_poly_compose_series(fmpz * res, const fmpz * poly1, slong len1,
 {
     if (len1 <= 10)
         _fmpz_poly_compose_series_horner(res, poly1, len1, poly2, len2, n);
-    else
+    else if (n < 500)
         _fmpz_poly_compose_series_brent_kung(res, poly1, len1, poly2, len2, n);
+    else
+    {
+        gr_ctx_t ctx;
+        gr_ctx_init_fmpz(ctx);
+        GR_MUST_SUCCEED(_gr_poly_compose_series_kinoshita_li(res, poly1, len1, poly2, len2, n, ctx));
+    }
 }
 
 void

--- a/src/gr_poly.h
+++ b/src/gr_poly.h
@@ -388,6 +388,8 @@ WARN_UNUSED_RESULT int _gr_poly_compose_series_brent_kung(gr_ptr res, gr_srcptr 
 WARN_UNUSED_RESULT int gr_poly_compose_series_brent_kung(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, slong n, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int _gr_poly_compose_series_divconquer(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, slong n, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_compose_series_divconquer(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, slong n, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int _gr_poly_compose_series_kinoshita_li(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, slong n, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_poly_compose_series_kinoshita_li(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, slong n, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int _gr_poly_compose_series(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, slong n, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_compose_series(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, slong n, gr_ctx_t ctx);
 

--- a/src/gr_poly/compose_series.c
+++ b/src/gr_poly/compose_series.c
@@ -10,6 +10,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include <math.h>
 #include "gr_vec.h"
 #include "gr_poly.h"
 
@@ -82,13 +83,31 @@ _gr_poly_compose_series(gr_ptr res, gr_srcptr poly1, slong len1,
     {
         status |= _gr_poly_compose_series_horner(res, poly1, len1, poly2, len2, n, ctx);
     }
-    else if (len1 * len1 < n || (len1 - 1) * (len2 - 1) + 1 < 4 * n)  /* todo: tune these cutoffs */
+    else if (len1 * len1 < n || (len1 - 1) * (len2 - 1) + 1 < 4 * n)  /* todo: tune this */
     {
         status |= _gr_poly_compose_series_divconquer(res, poly1, len1, poly2, len2, n, ctx);
     }
     else
     {
-        status |= _gr_poly_compose_series_brent_kung(res, poly1, len1, poly2, len2, n, ctx);
+        /* Try to figure out a reasonable cutoff for Kinoshita-Li.
+           The following fallback is OK for fmpz and
+           nmod with 64-bit coefficients.
+           See also _gr_poly_revert_series. */
+        slong cutoff = 500;
+
+        /* Tuned for arb and acb. */
+        if (n >= 100 && gr_ctx_has_real_prec(ctx) == T_TRUE)
+        {
+            GR_MUST_SUCCEED(gr_ctx_get_real_prec(&cutoff, ctx));
+
+            cutoff = 15000 / sqrt(FLINT_MAX(64, cutoff));
+            cutoff = FLINT_MAX(cutoff, 100);
+        }
+
+        if (n < cutoff)
+            status |= _gr_poly_compose_series_brent_kung(res, poly1, len1, poly2, len2, n, ctx);
+        else
+            status |= _gr_poly_compose_series_kinoshita_li(res, poly1, len1, poly2, len2, n, ctx);
     }
 
     return status;

--- a/src/gr_poly/compose_series_kinoshita_li.c
+++ b/src/gr_poly/compose_series_kinoshita_li.c
@@ -133,6 +133,9 @@ _gr_poly_compose_series_kinoshita_li(gr_ptr res, gr_srcptr poly1, slong len1,
         return status;
     }
 
+    len1 = FLINT_MIN(len1, n);
+    len2 = FLINT_MIN(len2, n);
+
     /* ---- Compute level count L = ceil(log2(n)) ---- */
     L = 0;
     { slong tmp = n; while (tmp > 1) { tmp = (tmp + 1) / 2; L++; } }
@@ -174,17 +177,54 @@ _gr_poly_compose_series_kinoshita_li(gr_ptr res, gr_srcptr poly1, slong len1,
     qoff_arr[L]   = qchain_total;
     qchain_total += xn_arr[L] * ydeg_arr[L];
 
-    /* ---- Allocate Qchain ---- */
+    /* ---- Compute scratch_total: maximum KS working memory across all levels ---- */
+    /*
+     * Both passes use three temporary buffers laid out consecutively in a
+     * single pre-allocated scratch vector, avoiding GR_TMP_INIT_VEC and
+     * GR_TMP_CLEAR_VEC calls inside the loops.
+     *
+     * Downward level k: Qks (qks_len) | Qneg_ks (qks_len) | Rks (rks_len).
+     * Upward level k:   Qneg_ks (qneg_ks_len) | W_ks (W_ks_len) | R_rks (R_rks_len).
+     *
+     * scratch_total = max over all levels of the per-level total size.
+     */
+    slong scratch_total = 0;
+    {
+        slong yn_W_pre = n;
+        for (k = 0; k < L; k++)
+        {
+            slong xn   = xn_arr[k];
+            slong ydeg = ydeg_arr[k];
+            slong xnh  = xn_arr[k + 1];
+            slong s       = 2 * ydeg - 1;
+            slong qks_len = (xn - 1) * s + ydeg;
+            slong rks_len = s * (2 * xnh - 1);
+            scratch_total = FLINT_MAX(scratch_total, 2 * qks_len + rks_len);
+        }
+        for (k = L - 1; k >= 0; k--)
+        {
+            slong xn   = xn_arr[k];
+            slong xnh  = xn_arr[k + 1];
+            slong ydeg = ydeg_arr[k];
+            slong ylo  = ylo_arr[k];
+            slong ylor = ylo_arr[k + 1];
+            slong yn_r      = n - ylor;
+            slong yslice_lo = ylo - ylor;
+            slong s           = ydeg + yn_W_pre - 1;
+            slong qneg_ks_len = (xn - 1) * s + ydeg;
+            slong W_ks_len    = 2 * (xnh - 1) * s + yn_W_pre;
+            slong R_rks_len   = (xn - 1) * s + yn_r - yslice_lo;
+            scratch_total = FLINT_MAX(scratch_total, qneg_ks_len + W_ks_len + R_rks_len);
+            yn_W_pre = n - ylo;
+        }
+    }
+
+    /* ---- Allocate Qchain and scratch ---- */
     gr_ptr Qchain;
     GR_TMP_INIT_VEC(Qchain, qchain_total, ctx);
 
-    /* ---- Build P(y) = f.reverse(n-1) ---- */
-    gr_ptr P;
-    GR_TMP_INIT_VEC(P, n, ctx);
-    {
-        slong glen = FLINT_MIN(len1, n);
-        status |= _gr_poly_reverse(GR_ENTRY(P, n - glen, sz), poly1, glen, glen, ctx);
-    }
+    gr_ptr scratch;
+    GR_TMP_INIT_VEC(scratch, scratch_total, ctx);
 
     /* ---- Initialise Q_0 = 1 - y*g(x) ---- */
     {
@@ -214,10 +254,15 @@ _gr_poly_compose_series_kinoshita_li(gr_ptr res, gr_srcptr poly1, slong len1,
         gr_srcptr Qk  = GR_ENTRY(Qchain, qoff_arr[k],     sz);
         gr_ptr    Qk1 = GR_ENTRY(Qchain, qoff_arr[k + 1], sz);
 
-        gr_ptr Qks, Qneg_ks, Rks;
-        GR_TMP_INIT_VEC(Qks,     qks_len, ctx);
-        GR_TMP_INIT_VEC(Qneg_ks, qks_len, ctx);
-        GR_TMP_INIT_VEC(Rks,     rks_len, ctx);
+        gr_ptr Qks     = GR_ENTRY(scratch, 0,           sz);
+        gr_ptr Qneg_ks = GR_ENTRY(scratch, qks_len,     sz);
+        gr_ptr Rks     = GR_ENTRY(scratch, 2 * qks_len, sz);
+
+        /* Qks and Qneg_ks must be zeroed before packing: the KS encoding
+         * occupies only qks_len of the s*xn positions; gap slots between
+         * columns must be zero for the multiply to be correct. */
+        status |= _gr_vec_zero(Qks,     qks_len, ctx);
+        status |= _gr_vec_zero(Qneg_ks, qks_len, ctx);
 
         /* Pack Q and Q(-x,y): x^i y^j -> flat index i*s + j */
         for (slong j = 0; j < ydeg; j++)
@@ -231,10 +276,8 @@ _gr_poly_compose_series_kinoshita_li(gr_ptr res, gr_srcptr poly1, slong len1,
                     status |= gr_set(GR_ENTRY(Qneg_ks, i * s + j, sz), src, ctx);
             }
 
+        /* Rks is fully written by mullow; no zeroing needed. */
         status |= _gr_poly_mullow(Rks, Qks, qks_len, Qneg_ks, qks_len, rks_len, ctx);
-
-        GR_TMP_CLEAR_VEC(Qks,     qks_len, ctx);
-        GR_TMP_CLEAR_VEC(Qneg_ks, qks_len, ctx);
 
         /* Unpack even-x columns -> Q_{k+1}.
          * [x^{2i} y^j] lives at flat index 2*i*s + j in the y-major layout. */
@@ -242,8 +285,6 @@ _gr_poly_compose_series_kinoshita_li(gr_ptr res, gr_srcptr poly1, slong len1,
             for (slong i = 0; i < xnh; i++)
                 status |= gr_set(GR_ENTRY(Qk1, j * xnh + i, sz),
                                  GR_ENTRY(Rks, 2 * i * s + j, sz), ctx);
-
-        GR_TMP_CLEAR_VEC(Rks, rks_len, ctx);
     }
 
     /* ================================================================
@@ -268,9 +309,16 @@ _gr_poly_compose_series_kinoshita_li(gr_ptr res, gr_srcptr poly1, slong len1,
     slong yn_W = n;   /* ylo_arr[L] == 0 always */
 
     {
+        /* Build P(y) = f.reverse(n-1) into scratch, which is at least n elements. */
+        gr_ptr P = scratch;
+        slong glen = FLINT_MIN(len1, n);
+        status |= _gr_poly_reverse(P, poly1, glen, glen, ctx);
+
         gr_srcptr QL = GR_ENTRY(Qchain, qoff_arr[L], sz);
-        slong jmax = FLINT_MIN(ydeg_arr[L], n);
-        status |= _gr_poly_div_series(W, P, n, QL, jmax, n, ctx);
+        slong jmax = FLINT_MIN(ydeg_arr[L], glen);
+
+        status |= _gr_poly_div_series(GR_ENTRY(W, n - glen, sz), P, glen, QL, jmax, glen, ctx);
+        /* Low (n - glen) coefficients of W are a priori zero. */
     }
 
     /* ================================================================
@@ -313,10 +361,16 @@ _gr_poly_compose_series_kinoshita_li(gr_ptr res, gr_srcptr poly1, slong len1,
         slong R_rks_len   = (xn - 1) * s + yn_r - yslice_lo;
 
         gr_srcptr Qk = GR_ENTRY(Qchain, qoff_arr[k], sz);
-        gr_ptr Qneg_ks, W_ks, R_rks;
-        GR_TMP_INIT_VEC(Qneg_ks, qneg_ks_len, ctx);
-        GR_TMP_INIT_VEC(W_ks,    W_ks_len,    ctx);
-        GR_TMP_INIT_VEC(R_rks,   R_rks_len,   ctx);
+
+        gr_ptr Qneg_ks = GR_ENTRY(scratch, 0,                      sz);
+        gr_ptr W_ks    = GR_ENTRY(scratch, qneg_ks_len,            sz);
+        gr_ptr R_rks   = GR_ENTRY(scratch, qneg_ks_len + W_ks_len, sz);
+
+        /* Qneg_ks and W_ks must be zeroed before packing: KS gap slots
+         * between columns must be zero for the multiply to be correct.
+         * R_rks is fully written by mulmid; no zeroing needed. */
+        status |= _gr_vec_zero(Qneg_ks, qneg_ks_len, ctx);
+        status |= _gr_vec_zero(W_ks,    W_ks_len,    ctx);
 
         /* Pack Qneg_k: x^i y^j -> flat index i*s + j, with sign flip for odd i */
         for (slong j = 0; j < ydeg; j++)
@@ -340,9 +394,6 @@ _gr_poly_compose_series_kinoshita_li(gr_ptr res, gr_srcptr poly1, slong len1,
                                          W_ks,    W_ks_len,
                                          yslice_lo, yslice_lo + R_rks_len, ctx);
 
-        GR_TMP_CLEAR_VEC(Qneg_ks, qneg_ks_len, ctx);
-        GR_TMP_CLEAR_VEC(W_ks,    W_ks_len,    ctx);
-
         /* Unpack y-slice [yslice_lo, yn_r) -> W (in place).
          * R_rks[k] holds product coefficient yslice_lo+k.
          * R[jsrc][i] was at i*s+jsrc; it is now at i*s+jsrc-yslice_lo in R_rks. */
@@ -355,8 +406,6 @@ _gr_poly_compose_series_kinoshita_li(gr_ptr res, gr_srcptr poly1, slong len1,
                                      GR_ENTRY(R_rks, i * s + jsrc - yslice_lo, sz), ctx);
         }
 
-        GR_TMP_CLEAR_VEC(R_rks, R_rks_len, ctx);
-
         yn_W = new_yn_W;
     }
 
@@ -364,7 +413,7 @@ _gr_poly_compose_series_kinoshita_li(gr_ptr res, gr_srcptr poly1, slong len1,
     status |= _gr_vec_set(res, W, n, ctx);
 
     GR_TMP_CLEAR_VEC(W, W_alloc, ctx);
-    GR_TMP_CLEAR_VEC(P, n, ctx);
+    GR_TMP_CLEAR_VEC(scratch, scratch_total, ctx);
     GR_TMP_CLEAR_VEC(Qchain, qchain_total, ctx);
 
     flint_free(xn_arr);

--- a/src/gr_poly/compose_series_kinoshita_li.c
+++ b/src/gr_poly/compose_series_kinoshita_li.c
@@ -1,0 +1,415 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version. See <https://www.gnu.org/licenses/>.
+*/
+
+#include "gr_vec.h"
+#include "gr_poly.h"
+
+/* This file was developed with the assistance of Claude Sonnet 4.6. */
+
+/*
+    Power series composition f(g(x)) mod x^n via the quasilinear algorithm of
+
+        Yasunori Kinoshita and Baitian Li,
+        "Power Series Composition in Near-Linear Time",
+        arXiv:2404.05177 (2024).
+
+    Setup
+    -----
+    Given f (length len1) and g (with g(0) = 0), set:
+
+        P(y)   = f.reverse(n-1)   in R[y]      (P[i] = f[n-1-i])
+        Q(x,y) = 1 - y * g(x)    in R[x][y]
+
+    Then  f(g(x)) mod x^n  =  [y^{n-1}]( P(y)/Q(x,y) mod x^n ).
+
+    Algorithm overview
+    ------------------
+    The algorithm is a two-phase iterative computation.
+
+    At each level k = 0, 1, ..., L-1 (where L = ceil(log2(n))), the
+    "current Q" has x-degree < xn_k and actual y-degree ydeg_k-1.
+    The Graeffe step replaces Q by V where V(x^2,y) = Q(x,y)*Q(-x,y),
+    halving the x-degree and approximately doubling the y-degree.
+
+    DOWNWARD PASS (Graeffe chain):
+        Compute Q_0 = initial Q, Q_1 = Graeffe(Q_0), Q_2 = Graeffe(Q_1), ...
+        until Q_L has x-degree 1 (base case).  Store all Q_k in a single
+        pre-allocated flat array "Qchain".
+
+    BASE CASE:
+        Solve the univariate problem: W = P(y) / Q_L(0,y) mod y^n.
+        (ylo_arr[L] = 0 always, so the full length-n result is needed.)
+
+    UPWARD PASS (post-multiply chain):
+        For k = L-1 down to 0:
+            W <- [y-slice of Q_k(-x,y) * W(x^2,y)]
+        where the y-slice is chosen so that the final W is [y^{n-1}] of P/Q_0,
+        which equals f(g(x)) mod x^n.
+
+    Memory analysis
+    ---------------
+    The recursive formulation pins O(N) data per live stack frame, and with
+    O(log N) frames simultaneously live, uses O(N log N) memory total.
+
+    This iterative formulation separates storage from processing:
+
+      Qchain: holds Q_0, Q_1, ..., Q_L end-to-end.
+        - Q_k has x-stride xn_k and y-bound ydeg_k, size = xn_k * ydeg_k.
+        - Each entry exceeds n: xn_k * ydeg_k ≈ (n/2^k) * (2^{k+1}-1) > n.
+        - With L = ceil(log2(n)) entries, total Qchain size is O(n log n).
+          (Measured: ~11n for n=1000, ~18n for n=10000.)
+
+      Working memory (W buffers, KS temporaries): O(n) at every instant.
+        - W has x-degree < xn_k and y-width yn_W_k ≈ 2^k, so size ≈ n.
+        - KS temporaries scale with the current product length ≈ 4n.
+
+    Total memory is O(n log n), dominated by the Qchain.  The working
+    memory outside the Qchain is O(n) at every instant, but the Qchain
+    itself must be fully allocated upfront and cannot be reduced below
+    O(n log n) without recomputing Graeffe steps on the way back up.
+
+    Bivariate storage layout
+    ------------------------
+    Q and W are stored as flat arrays throughout the algorithm.  The coefficient
+    of x^i y^j in a bivariate with x-degree < xn and y-degree-bound ydeg sits at
+    index i + j*xn  (x-contiguous).  This storage format is independent of the
+    KS packing used during multiplication.
+
+    Kronecker substitution (KS)
+    --------------------------------------
+    To multiply two bivariates F (x-degree < a, y-degree < p) and
+    G (x-degree < b, y-degree < q), we use the substitution y -> t, x -> t^s
+    with stride s = p+q-1.  The coefficient of x^i y^j maps to flat index i*s + j.
+    The univariate product has length s*(a+b-1), and _gr_poly_mullow is called
+    with an output length trimmed to only the portion that is actually read back.
+
+    In benchmarks, y-major substitution consistently performed better than
+    the transposed (x-major) substitution.
+
+    For a bivariate with x-degree < a and y-degree < b packed with stride s,
+    the exact (tight) KS array length is (a-1)*s + b: the highest-occupied
+    flat index is (a-1)*s + (b-1), so the array length is (a-1)*s + b.
+
+    Downward pass: s = 2*ydeg - 1.  Both inputs have length (xn-1)*s + ydeg.
+      Output (rks_len): we unpack even-x columns 0,2,...,2*(xnh-1), each of
+      y-height s.  Highest read: 2*(xnh-1)*s + (ydA-1) < s*(2*xnh-1).  -> s*(2*xnh-1).
+
+    Upward pass: s = ydeg + yn_W - 1.  Qneg has length (xn-1)*s + ydeg.
+      W(x^2) packs x^{2i} y^j at 2*i*s+j; highest: 2*(xnh-1)*s+(yn_W-1)
+      -> W_ks_len = 2*(xnh-1)*s + yn_W.
+      Output (R_rks_len): we read R at i*s+jsrc for i<xn, jsrc<yn_W;
+      highest: (xn-1)*s + yn_W - 1 -> R_rks_len = (xn-1)*s + yn_W.
+      Note: R_rks_len <= W_ks_len + qneg_ks_len - 1, and both inputs are
+      shorter than the output (inputs <= R_rks_len because yn_W >= ydeg holds
+      at every upward level, provable by induction).
+*/
+
+int
+_gr_poly_compose_series_kinoshita_li(gr_ptr res, gr_srcptr poly1, slong len1,
+                           gr_srcptr poly2, slong len2, slong n,
+                           gr_ctx_t ctx)
+{
+    slong sz = ctx->sizeof_elem;
+    int status = GR_SUCCESS;
+    slong k, L;
+
+    FLINT_ASSERT(len1 >= 1);
+    FLINT_ASSERT(len2 >= 1);
+    FLINT_ASSERT(n >= 1);
+
+    /* ---- Trivial cases ---- */
+    if (len1 == 1 || n == 1)
+    {
+        status |= gr_set(res, poly1, ctx);
+        status |= _gr_vec_zero(GR_ENTRY(res, 1, sz), n - 1, ctx);
+        return status;
+    }
+
+    /* ---- Compute level count L = ceil(log2(n)) ---- */
+    L = 0;
+    { slong tmp = n; while (tmp > 1) { tmp = (tmp + 1) / 2; L++; } }
+
+    /* ---- Precompute level parameters ---- */
+    /*
+        For level k:
+            xn[k]      = x-degree bound of Q at this level
+            ylo[k]     = lower y-index of the slice we want
+            ydeg[k]    = y-degree bound (= ydegQ_actual) of Q at this level
+            qoff[k]    = offset into Qchain where Q_k is stored
+
+        xn[0] = n, ylo[0] = n-1, ydeg[0] = 2 (Q = 1 - y*g has y-degree 1).
+        xn[k+1] = ceil(xn[k]/2).
+        ylo[k+1] = max(0, ylo[k] - (ydeg[k] - 1)).
+        ydeg[k+1] = min(2*ydeg[k] - 1, n).  (y-degree of Graeffe output)
+
+        Level L is the base case (xn[L] = 1).
+    */
+    slong *xn_arr   = flint_malloc((L + 1) * sizeof(slong));
+    slong *ylo_arr  = flint_malloc((L + 1) * sizeof(slong));
+    slong *ydeg_arr = flint_malloc((L + 1) * sizeof(slong));
+    slong *qoff_arr = flint_malloc((L + 1) * sizeof(slong));
+
+    xn_arr[0]   = n;
+    ylo_arr[0]  = n - 1;
+    ydeg_arr[0] = 2;
+
+    slong qchain_total = 0;
+    for (k = 0; k < L; k++)
+    {
+        qoff_arr[k]      = qchain_total;
+        qchain_total    += xn_arr[k] * ydeg_arr[k];
+        xn_arr[k + 1]   = (xn_arr[k] + 1) / 2;
+        ylo_arr[k + 1]  = (ylo_arr[k] >= ydeg_arr[k] - 1)
+                              ? (ylo_arr[k] - (ydeg_arr[k] - 1)) : 0;
+        ydeg_arr[k + 1] = FLINT_MIN(2 * ydeg_arr[k] - 1, n);
+    }
+    qoff_arr[L]   = qchain_total;
+    qchain_total += xn_arr[L] * ydeg_arr[L];
+
+    /* ---- Allocate Qchain ---- */
+    gr_ptr Qchain;
+    GR_TMP_INIT_VEC(Qchain, qchain_total, ctx);
+
+    /* ---- Build P(y) = f.reverse(n-1) ---- */
+    gr_ptr P;
+    GR_TMP_INIT_VEC(P, n, ctx);
+    {
+        slong glen = FLINT_MIN(len1, n);
+        status |= _gr_poly_reverse(GR_ENTRY(P, n - glen, sz), poly1, glen, glen, ctx);
+    }
+
+    /* ---- Initialise Q_0 = 1 - y*g(x) ---- */
+    {
+        gr_ptr Q0 = GR_ENTRY(Qchain, qoff_arr[0], sz);
+        status |= gr_one(GR_ENTRY(Q0, 0, sz), ctx);
+        slong glen = FLINT_MIN(len2, n);
+        status |= _gr_vec_neg(GR_ENTRY(Q0, n, sz), poly2, glen, ctx);
+    }
+
+    /* ================================================================
+       DOWNWARD PASS: compute Q_1, Q_2, ..., Q_L via Graeffe steps.
+
+       y-major KS with stride s = 2*ydeg - 1.
+       x^i y^j -> flat index i*s + j.
+       ================================================================ */
+    for (k = 0; k < L; k++)
+    {
+        slong xn   = xn_arr[k];
+        slong ydeg = ydeg_arr[k];
+        slong xnh  = xn_arr[k + 1];
+        slong ydA  = ydeg_arr[k + 1];
+
+        slong s       = 2 * ydeg - 1;
+        slong qks_len = (xn - 1) * s + ydeg;   /* tight: highest pos (xn-1)*s+(ydeg-1) */
+        slong rks_len = s * (2 * xnh - 1);      /* even-x cols 0..2*(xnh-1), each of height s */
+
+        gr_srcptr Qk  = GR_ENTRY(Qchain, qoff_arr[k],     sz);
+        gr_ptr    Qk1 = GR_ENTRY(Qchain, qoff_arr[k + 1], sz);
+
+        gr_ptr Qks, Qneg_ks, Rks;
+        GR_TMP_INIT_VEC(Qks,     qks_len, ctx);
+        GR_TMP_INIT_VEC(Qneg_ks, qks_len, ctx);
+        GR_TMP_INIT_VEC(Rks,     rks_len, ctx);
+
+        /* Pack Q and Q(-x,y): x^i y^j -> flat index i*s + j */
+        for (slong j = 0; j < ydeg; j++)
+            for (slong i = 0; i < xn; i++)
+            {
+                gr_srcptr src = GR_ENTRY(Qk, j * xn + i, sz);
+                status |= gr_set(GR_ENTRY(Qks,     i * s + j, sz), src, ctx);
+                if (i & 1)
+                    status |= gr_neg(GR_ENTRY(Qneg_ks, i * s + j, sz), src, ctx);
+                else
+                    status |= gr_set(GR_ENTRY(Qneg_ks, i * s + j, sz), src, ctx);
+            }
+
+        status |= _gr_poly_mullow(Rks, Qks, qks_len, Qneg_ks, qks_len, rks_len, ctx);
+
+        GR_TMP_CLEAR_VEC(Qks,     qks_len, ctx);
+        GR_TMP_CLEAR_VEC(Qneg_ks, qks_len, ctx);
+
+        /* Unpack even-x columns -> Q_{k+1}.
+         * [x^{2i} y^j] lives at flat index 2*i*s + j in the y-major layout. */
+        for (slong j = 0; j < ydA; j++)
+            for (slong i = 0; i < xnh; i++)
+                status |= gr_set(GR_ENTRY(Qk1, j * xnh + i, sz),
+                                 GR_ENTRY(Rks, 2 * i * s + j, sz), ctx);
+
+        GR_TMP_CLEAR_VEC(Rks, rks_len, ctx);
+    }
+
+    /* ================================================================
+       BASE CASE: solve P(y) / Q_L(0,y) mod y^n.
+       Q_L has x-stride = xn_arr[L] = 1, so Q_L[j*1+0] = Q_L[j].
+       ylo_arr[L] = 0 always, so the full length-n result fills W.
+       ================================================================ */
+
+    /*
+     * W is used in-place across all upward steps: at each level the old
+     * contents are fully consumed (packed into W_ks) before the new
+     * contents are written (unpacked from R_rks), so no temporary is needed.
+     * The required capacity is the maximum of xn_k * yn_W_k over all levels,
+     * which never exceeds the next power of two >= n.
+     */
+    slong W_alloc = 1;
+    while (W_alloc < n) W_alloc *= 2;
+
+    gr_ptr W;
+    GR_TMP_INIT_VEC(W, W_alloc, ctx);
+
+    slong yn_W = n;   /* ylo_arr[L] == 0 always */
+
+    {
+        gr_srcptr QL = GR_ENTRY(Qchain, qoff_arr[L], sz);
+        slong jmax = FLINT_MIN(ydeg_arr[L], n);
+        status |= _gr_poly_div_series(W, P, n, QL, jmax, n, ctx);
+    }
+
+    /* ================================================================
+       UPWARD PASS: for k = L-1 down to 0, compute the post-multiply.
+
+       At level k, W has:
+           x-stride = xn_arr[k+1]
+           y-width  = yn_W  (= n at the start, shrinking toward 1)
+
+       Compute r = Q_k(-x,y) * W(x^2,y) using y-major KS with
+       stride s = ydeg + yn_W - 1, then extract the y-slice
+       [ylo_arr[k]-ylo_arr[k+1], n-ylo_arr[k+1]) of r into W (in place).
+
+       In-place safety: W is fully read into W_ks before R_rks is unpacked
+       back into W, so there is no read-after-write conflict.
+       ================================================================ */
+    for (k = L - 1; k >= 0; k--)
+    {
+        slong xn   = xn_arr[k];
+        slong xnh  = xn_arr[k + 1];
+        slong ydeg = ydeg_arr[k];
+        slong ylo  = ylo_arr[k];
+        slong ylor = ylo_arr[k + 1];
+
+        slong yn_r = n - ylor;   /* loop bound for jsrc; equals yn_W */
+
+        slong s           = ydeg + yn_W - 1;
+        slong qneg_ks_len = (xn - 1) * s + ydeg;       /* tight: highest pos (xn-1)*s+(ydeg-1) */
+        slong W_ks_len    = 2 * (xnh - 1) * s + yn_W;  /* tight: highest pos 2*(xnh-1)*s+(yn_W-1) */
+
+        /*
+         * We only need product coefficients at positions i*s+jsrc for
+         * jsrc in [yslice_lo, yn_r) and i in [0, xn).  The lowest such
+         * position is yslice_lo (i=0, jsrc=yslice_lo) and the highest is
+         * (xn-1)*s + yn_r - 1.  Using _gr_poly_mulmid with nlo=yslice_lo
+         * avoids computing the yslice_lo coefficients at the low end that
+         * are never read.  R_rks_len = (xn-1)*s + yn_r - yslice_lo.
+         */
+        slong yslice_lo   = ylo - ylor;
+        slong R_rks_len   = (xn - 1) * s + yn_r - yslice_lo;
+
+        gr_srcptr Qk = GR_ENTRY(Qchain, qoff_arr[k], sz);
+        gr_ptr Qneg_ks, W_ks, R_rks;
+        GR_TMP_INIT_VEC(Qneg_ks, qneg_ks_len, ctx);
+        GR_TMP_INIT_VEC(W_ks,    W_ks_len,    ctx);
+        GR_TMP_INIT_VEC(R_rks,   R_rks_len,   ctx);
+
+        /* Pack Qneg_k: x^i y^j -> flat index i*s + j, with sign flip for odd i */
+        for (slong j = 0; j < ydeg; j++)
+            for (slong i = 0; i < xn; i++)
+            {
+                gr_srcptr src = GR_ENTRY(Qk, j * xn + i, sz);
+                gr_ptr    dst = GR_ENTRY(Qneg_ks, i * s + j, sz);
+                if (i & 1)
+                    status |= gr_neg(dst, src, ctx);
+                else
+                    status |= gr_set(dst, src, ctx);
+            }
+
+        /* Pack W(x^2): x^{2i} y^j -> flat index 2*i*s + j  (optimization 3) */
+        for (slong j = 0; j < yn_W; j++)
+            for (slong i = 0; i < xnh; i++)
+                status |= gr_set(GR_ENTRY(W_ks, 2 * i * s + j,   sz),
+                                 GR_ENTRY(W,    j * xnh + i,      sz), ctx);
+
+        status |= _gr_poly_mulmid(R_rks, Qneg_ks, qneg_ks_len,
+                                         W_ks,    W_ks_len,
+                                         yslice_lo, yslice_lo + R_rks_len, ctx);
+
+        GR_TMP_CLEAR_VEC(Qneg_ks, qneg_ks_len, ctx);
+        GR_TMP_CLEAR_VEC(W_ks,    W_ks_len,    ctx);
+
+        /* Unpack y-slice [yslice_lo, yn_r) -> W (in place).
+         * R_rks[k] holds product coefficient yslice_lo+k.
+         * R[jsrc][i] was at i*s+jsrc; it is now at i*s+jsrc-yslice_lo in R_rks. */
+        slong new_yn_W = n - ylo;
+        {
+            slong jout = 0;
+            for (slong jsrc = yslice_lo; jsrc < yn_r; jsrc++, jout++)
+                for (slong i = 0; i < xn; i++)
+                    status |= gr_set(GR_ENTRY(W, jout * xn + i, sz),
+                                     GR_ENTRY(R_rks, i * s + jsrc - yslice_lo, sz), ctx);
+        }
+
+        GR_TMP_CLEAR_VEC(R_rks, R_rks_len, ctx);
+
+        yn_W = new_yn_W;
+    }
+
+    /* W[0..n) holds the result f(g(x)) mod x^n. */
+    status |= _gr_vec_set(res, W, n, ctx);
+
+    GR_TMP_CLEAR_VEC(W, W_alloc, ctx);
+    GR_TMP_CLEAR_VEC(P, n, ctx);
+    GR_TMP_CLEAR_VEC(Qchain, qchain_total, ctx);
+
+    flint_free(xn_arr);
+    flint_free(ylo_arr);
+    flint_free(ydeg_arr);
+    flint_free(qoff_arr);
+
+    return status;
+}
+
+int
+gr_poly_compose_series_kinoshita_li(gr_poly_t res,
+                    const gr_poly_t poly1,
+                    const gr_poly_t poly2,
+                    slong n,
+                    gr_ctx_t ctx)
+{
+    slong len1 = poly1->length;
+    slong len2 = poly2->length;
+    slong lenr;
+    int status;
+
+    if (len2 != 0)
+    {
+        truth_t is_zero = gr_is_zero(poly2->coeffs, ctx);
+        if (is_zero == T_FALSE)   return GR_DOMAIN;
+        if (is_zero == T_UNKNOWN) return GR_UNABLE;
+    }
+
+    if (len1 == 0 || n == 0)
+        return gr_poly_zero(res, ctx);
+
+    if (len2 == 0 || len1 == 1)
+        return gr_poly_set_scalar(res, poly1->coeffs, ctx);
+
+    lenr = FLINT_MIN((len1 - 1) * (len2 - 1) + 1, n);
+    len1 = FLINT_MIN(len1, lenr);
+    len2 = FLINT_MIN(len2, lenr);
+
+    gr_poly_fit_length(res, lenr, ctx);
+    status = _gr_poly_compose_series_kinoshita_li(res->coeffs, poly1->coeffs, len1,
+                                        poly2->coeffs, len2, lenr, ctx);
+    _gr_poly_set_length(res, lenr, ctx);
+    _gr_poly_normalise(res, ctx);
+
+    return status;
+}
+

--- a/src/gr_poly/revert_series.c
+++ b/src/gr_poly/revert_series.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include <math.h>
 #include "gr_vec.h"
 #include "gr_poly.h"
 #include "ulong_extras.h"
@@ -188,6 +189,26 @@ int
 _gr_poly_revert_series(gr_ptr res, gr_srcptr f, slong flen, slong n, gr_ctx_t ctx)
 {
     int status;
+
+    /* Estimate composition cutoff for Kinoshita-Li; see _gr_poly_compose_series. */
+    if (n >= 100)
+    {
+        slong cutoff = 500;
+
+        if (n >= 100 && gr_ctx_has_real_prec(ctx) == T_TRUE)
+        {
+            GR_MUST_SUCCEED(gr_ctx_get_real_prec(&cutoff, ctx));
+            cutoff = 15000 / sqrt(FLINT_MAX(64, cutoff));
+            cutoff = FLINT_MAX(cutoff, 100);
+        }
+
+        /* Guess that the optimal cutoff for reversion is quite a bit higher
+           than that for composition. */
+        cutoff *= 5;
+
+        if (n >= cutoff)
+            return _gr_poly_revert_series_newton(res, f, flen, n, ctx);
+    }
 
     status = _gr_poly_revert_series_lagrange_fast(res, f, flen, n, ctx);
 

--- a/src/gr_poly/test/t-compose_series.c
+++ b/src/gr_poly/test/t-compose_series.c
@@ -37,12 +37,14 @@ test_compose_series(flint_rand_t state, int which)
 
     if (ctx->methods == _ca_methods)
         n = n_randint(state, 5);
+    else if (gr_ctx_is_finite(ctx) == T_TRUE)
+        n = n_randint(state, 100);
     else
         n = n_randint(state, 20);
 
-    GR_MUST_SUCCEED(gr_poly_randtest(A, state, 1 + n_randint(state, 20), ctx));
-    GR_MUST_SUCCEED(gr_poly_randtest(B, state, 1 + n_randint(state, 20), ctx));
-    GR_MUST_SUCCEED(gr_poly_randtest(C, state, 1 + n_randint(state, 20), ctx));
+    GR_MUST_SUCCEED(gr_poly_randtest(A, state, 1 + n_randint(state, n + 5), ctx));
+    GR_MUST_SUCCEED(gr_poly_randtest(B, state, 1 + n_randint(state, n + 5), ctx));
+    GR_MUST_SUCCEED(gr_poly_randtest(C, state, 1 + n_randint(state, n + 5), ctx));
     status |= gr_poly_set_coeff_si(B, 0, 0, ctx);
 
     switch (which)
@@ -95,6 +97,19 @@ test_compose_series(flint_rand_t state, int which)
             status |= gr_poly_compose_series(C, A, C, n, ctx);
             break;
 
+        case 12:
+            status |= gr_poly_compose_series_kinoshita_li(C, A, B, n, ctx);
+            break;
+        case 13:
+            status |= gr_poly_set(C, A, ctx);
+            status |= gr_poly_compose_series_kinoshita_li(C, C, B, n, ctx);
+            break;
+        case 14:
+            status |= gr_poly_set(C, B, ctx);
+            status |= gr_poly_compose_series_kinoshita_li(C, A, C, n, ctx);
+            break;
+
+
         default:
             flint_abort();
     }
@@ -146,9 +161,10 @@ TEST_FUNCTION_START(gr_poly_compose_series, state)
 {
     slong iter;
 
-    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
+    for (iter = 0; iter < 100 * flint_test_multiplier(); iter++)
     {
-        test_compose_series(state, n_randint(state, 12));
+        for (slong i = 0; i < 15; i++)
+            test_compose_series(state, i);
     }
 
     TEST_FUNCTION_END(state);


### PR DESCRIPTION
Adds `_gr_poly_compose_series_kinoshita_li` / `gr_poly_compose_series_kinoshita_li` for power series composition in $O(M(n) \log n)$ over generic rings using the Kinoshita-Li algorithm (by @EntropyIncreaser). See discussion in #1911.

The threshold where this starts to beat the Brent-Kung baby-step giant-step algorithm seems to be between 100 and 1000, obviously depending on the ring and input; see below for benchmarks. Note that this algorithm might be preferable to Brent-Kung even in cases where it is not faster, as it uses less memory asymptotically ($O(n \log n)$ vs $O(n^{1.5})$ coefficients).

I have not yet switched over any other series composition and reversion functions (e.g. `fmpz_poly_compose_series`) to use this algorithm.

This code was written using Claude Sonnet. Methodology: I first asked Claude to read the paper and the comments in #1911 and implement the algorithm following FLINT coding conventions, using `gr_poly_compose_series_brent_kung` as a guideline for the API. I explicitly instructed it to represent the bivariate polynomials in flat format and to implement KS multiplication. The first draft looked OK structurally but failed the tests. When I asked Claude to debug, it asked me for a copy of @vneiger's Sage implementation. With this as a blueprint, Claude was able to fix the bugs. After that, I reviewed the code and prompted Claude to make a series improvements:

* Convert from recursive to iterative form
* Avoid unnecessary temporary vectors and copying
* Fix an unsafe pointer swap of temporary vectors
* Avoid excessive zero-padding and tighten allocations
* Switch the Kronecker substitution format for bivariate multiplication from Claude's initial choice of x-major to y-major. I did extensive benchmarking to verify that y-major consistently performs better, and sometimes dramatically better with `arb` whose univariate polynomial multiplication is designed for typical univariate input and poorly tuned for coefficients in the scrambled KS order
* (Not kept in the final version): use Harvey's multipoint KS instead of standard KS; on every example I tested, this performed worse, but this may have been due to not being implemented optimally and may be worth retrying in the future
* Fix errors in comments

## nmod example

Timings in seconds to compute $f(g(x)) \bmod x^n$ with random $f$ and $g$, `nmod` coefficients mod $p = 2^{63} + 29$. Speedup ratios are relative to Brent-Kung.

```
        n     Brent-Kung Kinoshita-Li (speedup)
       100      7.79e-05    0.000162  (0.481)
       200      0.000285    0.000347  (0.821)
       400      0.000869    0.000839  (1.036)
       800       0.00254     0.00193  (1.316)
      1600       0.00763     0.00434  (1.758)
      3200        0.0238     0.00974  (2.444)
      6400        0.0776      0.0218  (3.560)
     12800         0.257      0.0487  (5.277)
     25600         0.882       0.115  (7.670)
     51200         3.036       0.266  (11.414)
    102400         10.82       0.646  (16.749)
    204800         37.76       1.556  (24.267)
    409600       140.573       3.736  (37.627)
    819200       497.694      10.274  (48.442)
```

Excellent speedup with evident quasilinear asymptotics!

## fmpz example

Example timings with `fmpz` coefficients, $f = g = \sum_{k \ge 0} F_k x^k$ (Fibonacci generating function):

```
        n     Brent-Kung Kinoshita-Li (speedup)
       100      0.000298    0.000443  (0.673)
       200       0.00243     0.00284  (0.856)
       400        0.0153      0.0144  (1.062)
       800         0.108      0.0683  (1.581)
      1600         0.682       0.339  (2.012)
      3200         4.651       1.716  (2.710)
      6400        33.263       8.462  (3.931)
     12800        266.59      43.331  (6.152)
```

## fmpq example

Example with `fmpq` coefficients, $f = g = \log(1+x)$:

```
        n     Brent-Kung Kinoshita-Li (speedup)
       100       0.00516      0.0053  (0.974)
       200        0.0333      0.0268  (1.243)
       400         0.235       0.169  (1.391)
       800         1.821       1.046  (1.741)
      1600        15.511       6.986  (2.220)
      3200       153.219      48.735  (3.144)
```

Note that the implementation has not been optimized specifically for fraction fields; one can presumably gain something by handling denominators less generically.

## arb example

Example with `arb` coefficients, prec = 128, $f = g = \log(1+x)$:

```
        n     Brent-Kung Kinoshita-Li (speedup)      [x^(n-1)]  (Brent-Kung)      [x^(n-1)]  (Kinoshita-Li)
       100      0.000866     0.00178  (0.487)           [5e+17 +/- 9.13e-20]           [5e+17 +/- 8.90e-20] 
       200       0.00392     0.00606  (0.647)               [2e+37 +/- 7.35]               [2e+37 +/- 6.40] 
       400        0.0144       0.017  (0.847)           [8e+76 +/- 4.50e+40]           [8e+76 +/- 4.14e+40] 
       800        0.0597      0.0603  (0.990)         [2e+156 +/- 2.22e+120]         [2e+156 +/- 1.91e+120] 
      1600         0.218       0.174  (1.253)         [2e+315 +/- 4.61e+279]         [2e+315 +/- 4.32e+279] 
      3200         0.946       0.545  (1.736)         [5e+633 +/- 2.55e+598]         [5e+633 +/- 2.26e+598] 
      6400         4.441       2.008  (2.212)       [8e+1270 +/- 6.44e+1235]       [8e+1270 +/- 6.22e+1235] 
     12800        23.467       8.449  (2.777)       [3e+2545 +/- 5.20e+2510]       [3e+2545 +/- 4.75e+2510] 
     25600       130.642      37.419  (3.491)       [8e+5094 +/- 2.77e+5060]       [8e+5094 +/- 2.74e+5060] 
```

Same polynomials with prec = 3333:

```
        n     Brent-Kung Kinoshita-Li (speedup)      [x^(n-1)]  (Brent-Kung)      [x^(n-1)]  (Kinoshita-Li)
       100        0.0175       0.023  (0.761)          [5e+17 +/- 1.53e-984]          [5e+17 +/- 1.61e-984] 
       200        0.0621      0.0575  (1.080)          [2e+37 +/- 1.23e-964]          [2e+37 +/- 1.17e-964] 
       400         0.225       0.154  (1.461)          [8e+76 +/- 8.11e-925]          [8e+76 +/- 7.63e-925] 
       800         0.827        0.39  (2.121)         [2e+156 +/- 3.75e-845]         [2e+156 +/- 3.55e-845] 
      1600         2.538       1.008  (2.518)         [2e+315 +/- 8.40e-686]         [2e+315 +/- 8.05e-686] 
      3200         8.114       2.715  (2.989)         [5e+633 +/- 4.32e-367]         [5e+633 +/- 4.20e-367] 
      6400         27.16       8.036  (3.380)        [8e+1270 +/- 1.18e+271]        [8e+1270 +/- 1.15e+271] 
     12800       100.991      24.848  (4.064)       [3e+2545 +/- 8.82e+1545]       [3e+2545 +/- 8.76e+1545] 
```

Same polynomials with prec = 333333:

```
        n     Brent-Kung Kinoshita-Li (speedup)      [x^(n-1)]  (Brent-Kung)      [x^(n-1)]  (Kinoshita-Li)
       100         3.965       3.735  (1.062)       [5e+17 +/- 1.93e-100324]       [5e+17 +/- 2.04e-100324] 
       200        15.886       9.082  (1.749)       [2e+37 +/- 1.56e-100304]       [2e+37 +/- 1.48e-100304] 
       400        62.491      22.944  (2.724)       [8e+76 +/- 1.02e-100264]       [8e+76 +/- 9.63e-100265] 
       800       244.042      63.805  (3.825)      [2e+156 +/- 4.74e-100185]      [2e+156 +/- 4.48e-100185] 
```

Numerical stability with `arb` coefficients seems to be quite similar to that of Brent-Kung. I was worried in advance that Kinoshita-Li might be numerically unstable, but it turns out to be very well behaved! The only catch is that it isn't consistently faster than Brent-Kung at low precision (where numerically stable polynomial multiplication is not necessarily quasilinear), but it clearly wins when the precision grows.

## qqbar example

Example in a ring where we currently only use schoolbook multiplication: $f = g = \sum_{k \ge 1} (\sqrt{2}+k) x^k$ with `qqbar` coefficients.

```
        n     Brent-Kung Kinoshita-Li (speedup)
        25          0.13       0.138  (0.942)
        50          1.05       0.852  (1.232)
       100         7.355       4.968  (1.480)
       200        54.726      29.232  (1.872)
       400       393.888     179.693  (2.192)
```

## Multivariate example

Example with `gr_poly(nmod)` coefficients, $f = g = \sum_k (k+t) x^k \in ((\mathbb{Z}/17 \mathbb{Z})[t])[x]$.

```
        n     Brent-Kung Kinoshita-Li (speedup)
        25      7.29e-05    0.000201  (0.363)
        50      0.000329    0.000852  (0.386)
       100       0.00151      0.0038  (0.397)
       200       0.00757      0.0183  (0.414)
       400        0.0419       0.134  (0.313)
       800         0.305       0.699  (0.436)
      1600         2.068       3.821  (0.541)
      3200         13.34      17.828  (0.748)
      6400        81.608      89.788  (0.909)
```

Here Kinoshita-Li seems to underperform. We might want some heuristic to detect such rings before using it by default in `gr_poly_compose_series`.
