### PR TITLE
nmod_poly/mullow_fft_small: Use n_mulhi

### DIFF
--- a/src/nmod_poly/mullow_fft_small.c
+++ b/src/nmod_poly/mullow_fft_small.c
@@ -166,14 +166,7 @@ FLINT_FORCE_INLINE
 uint32_t u32_mod_preinv(uint32_t x, uint32_t d, uint64_t dinv)
 {
     uint64_t l = dinv * x;
-
-#if !defined(__GNUC__)
-    uint64_t hi, lo;
-    umul_ppmm(hi, lo, l, d);
-    return hi;
-#else
-    return ((__uint128_t) l * d ) >> 64;
-#endif
+    return n_mulhi(l, d);
 }
 
 FLINT_FORCE_INLINE


### PR DESCRIPTION
Trivial change to shorten the code slightly.

Technically if `ulong` is 32-bit then the code is problematic, but the old code also have the exact same issue.