### PR TITLE
Fix corner case in evaluation at geometric progression

### DIFF
--- a/doc/source/nmod_poly.rst
+++ b/doc/source/nmod_poly.rst
@@ -742,7 +742,7 @@ Multiplication
     product of ``poly1`` and ``poly2``.
 
 .. function:: void _nmod_poly_mulmid(nn_ptr res, nn_srcptr poly1, slong len1, nn_srcptr poly2, slong len2, slong nlo, slong nhi, nmod_t mod)
-              void nmod_poly_mulmid(nn_ptr res, nn_srcptr poly1, slong len1, nn_srcptr poly2, slong len2, slong nlo, slong nhi, nmod_t mod)
+              void nmod_poly_mulmid(nmod_poly_t res, const nmod_poly_t poly1, const nmod_poly_t poly2, slong nlo, slong nhi)
               void _nmod_poly_mulmid_classical(nn_ptr res, nn_srcptr poly1, slong len1, nn_srcptr poly2, slong len2, slong nlo, slong nhi, nmod_t mod)
               void nmod_poly_mulmid_classical(nn_ptr res, nn_srcptr poly1, slong len1, nn_srcptr poly2, slong len2, slong nlo, slong nhi, nmod_t mod)
               void _nmod_poly_mulmid_KS(nn_ptr res, nn_srcptr poly1, slong len1, nn_srcptr poly2, slong len2, slong nlo, slong nhi, nmod_t mod)

--- a/src/nmod_poly/evaluate_geometric_nmod_vec.c
+++ b/src/nmod_poly/evaluate_geometric_nmod_vec.c
@@ -24,20 +24,20 @@ void _nmod_poly_evaluate_geometric_nmod_vec_fast_precomp(nn_ptr vs, nn_srcptr po
     FLINT_ASSERT(G->function & 1);
     FLINT_ASSERT(len <= G->len);
 
-    if (plen == 0)
-    {
-        _nmod_vec_zero(vs, len);
-        return;
-    }
-
     /* val = valuation of poly */
-    slong val;
-    for (val = 0; val < plen; val++)
+    slong val = 0;
+    for ( ; val < plen; val++)
     {
         if (poly[val] != 0)
         {
             break;
         }
+    }
+
+    if (val == plen) /* covers the case plen == 0 */
+    {
+        _nmod_vec_zero(vs, len);
+        return;
     }
 
     /** Formula, based on Bluestein's trick:


### PR DESCRIPTION
- fix a corner case: for the input polynomial zero, given by a coefficient vector of positive length (filled with 0s), some code led to calling `_nmod_poly_mulmid` with `nlo == -1`, which is not allowed
- fix typo in documentation of `nmod_poly_mulmid`