### PR TITLE
Fix bug / corner case in interpolate_geometric

### DIFF
--- a/src/nmod_poly/interpolate_geometric_nmod_vec.c
+++ b/src/nmod_poly/interpolate_geometric_nmod_vec.c
@@ -53,7 +53,7 @@ void _nmod_poly_interpolate_geometric_nmod_vec_fast_precomp(nn_ptr poly,
     }
 
     slong f_len, h_len;
-    nn_ptr f = _nmod_vec_init(len);
+    nn_ptr f = _nmod_vec_init(len - val);
     nn_ptr h = _nmod_vec_init(len);
 
     /* actual length of f */
@@ -69,8 +69,8 @@ void _nmod_poly_interpolate_geometric_nmod_vec_fast_precomp(nn_ptr poly,
 
     /* h = (x**val * f) * G->int_f  mod x**len                     */
     /*   == x**val (f * G->int_f  mod x**(len-val))                */
-    /* note: len - val is <= G->int_f->length, since G->intf_1 has */
-    /* length G->len >= len (all its coefficients are nonzero)      */
+    /* note: len - val is <= G->int_f->length, since G->int_f has  */
+    /* length G->len >= len (all its coefficients are nonzero)     */
     _nmod_poly_mullow(h+val, G->int_f->coeffs, len - val, f, f_len, len - val, mod);
 
     /* for Newton interpolation, here we should compute h[i] = h[i]/q_i */
@@ -117,7 +117,7 @@ void _nmod_poly_interpolate_geometric_nmod_vec_fast_precomp(nn_ptr poly,
         f[i] = nmod_mul(h[h_len-1-i], G->int_s2[h_len-1-i], mod);
 
     /* transposed short product */
-    _nmod_poly_mullow(h+len-h_len, f, h_len-val, G->int_f->coeffs, h_len, h_len, mod);
+    _nmod_poly_mullow(h+len-h_len, G->int_f->coeffs, h_len, f, h_len-val, h_len, mod);
 
     /* final scaling */
     _nmod_vec_zero(poly+h_len, len-h_len);

--- a/src/nmod_poly/test/t-interpolate_geometric_nmod_vec_fast.c
+++ b/src/nmod_poly/test/t-interpolate_geometric_nmod_vec_fast.c
@@ -10,6 +10,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "flint.h"
 #include "test_helpers.h"
 #include "nmod_vec.h"
 #include "nmod_poly.h"
@@ -81,6 +82,29 @@ TEST_FUNCTION_START(nmod_poly_interpolate_geometric_nmod_vec_fast, state)
 
             nmod_poly_clear(P);
             nmod_poly_clear(Q);
+        }
+
+        /* use only `len` points, interpolate then evaluate */
+        {
+            nmod_poly_init(P, mod);
+            nn_ptr val = FLINT_ARRAY_ALLOC(len, ulong);
+            _nmod_vec_randtest(y, state, len, P->mod);
+
+            nmod_poly_interpolate_geometric_nmod_vec_fast(P, r, y, len);
+            nmod_poly_evaluate_geometric_nmod_vec_fast(val, P, r, len);
+            result = _nmod_vec_equal(val, y, len);
+            if (!result)
+            {
+                flint_printf("FAIL (`len` points):\n");
+                flint_printf("mod=%wu, len=%wd, npoints=%wd\n\n", mod, len, npoints);
+                flint_printf("val = %{slong*}...\n", val, len);
+                flint_printf("y = %{slong*}...\n", y, len);
+                fflush(stdout);
+                flint_abort();
+            }
+
+            flint_free(val);
+            nmod_poly_clear(P);
         }
 
         /* use variant with given precomputation */


### PR DESCRIPTION
The main computation in `nmod_poly_interpolate_geometric` was calling `_nmod_poly_mullow` with input arguments that do not meet its requirements that the first polynomial should have length greater than or equal to the second. This was not detected through tests because this only causes an issue in rare cases (apparently, only for input vectors that have `len-1` zeroes and then `1` nonzero entry).

Simply permuting both polynomials in input to `_nmod_poly_mullow` fixes the bug. The test for this interpolation function is augmented with a piece that tests this situation, and other unusual situations built with `_nmod_vec_randtest`.