### PR TITLE
Fix of argument order: count_success, domain, unable in TEST_GR_FUNCTION

### DIFF
--- a/src/gr_generic/test/t-fmpz_mpoly_evaluate.c
+++ b/src/gr_generic/test/t-fmpz_mpoly_evaluate.c
@@ -93,5 +93,5 @@ TEST_FUNCTION_START(gr_generic_fmpz_mpoly_evaluate, state)
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_generic/test/t-fmpz_poly_evaluate.c
+++ b/src/gr_generic/test/t-fmpz_poly_evaluate.c
@@ -115,5 +115,5 @@ TEST_FUNCTION_START(gr_generic_fmpz_poly_evaluate, state)
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_generic/test/t-poly_factor.c
+++ b/src/gr_generic/test/t-poly_factor.c
@@ -79,6 +79,6 @@ cleanup:
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }
 

--- a/src/gr_mat/test/t-charpoly.c
+++ b/src/gr_mat/test/t-charpoly.c
@@ -15,7 +15,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-TEST_GR_FUNCTION_START(gr_mat_charpoly, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_charpoly, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -71,5 +71,5 @@ TEST_GR_FUNCTION_START(gr_mat_charpoly, state, count_success, count_unable, coun
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-charpoly_faddeev.c
+++ b/src/gr_mat/test/t-charpoly_faddeev.c
@@ -15,7 +15,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-TEST_GR_FUNCTION_START(gr_mat_charpoly_faddeev, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_charpoly_faddeev, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -76,5 +76,5 @@ TEST_GR_FUNCTION_START(gr_mat_charpoly_faddeev, state, count_success, count_unab
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-charpoly_faddeev_bsgs.c
+++ b/src/gr_mat/test/t-charpoly_faddeev_bsgs.c
@@ -15,7 +15,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-TEST_GR_FUNCTION_START(gr_mat_charpoly_faddeev_bsgs, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_charpoly_faddeev_bsgs, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -76,5 +76,5 @@ TEST_GR_FUNCTION_START(gr_mat_charpoly_faddeev_bsgs, state, count_success, count
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-charpoly_gauss.c
+++ b/src/gr_mat/test/t-charpoly_gauss.c
@@ -15,7 +15,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-TEST_GR_FUNCTION_START(gr_mat_charpoly_gauss, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_charpoly_gauss, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -71,5 +71,5 @@ TEST_GR_FUNCTION_START(gr_mat_charpoly_gauss, state, count_success, count_unable
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-charpoly_householder.c
+++ b/src/gr_mat/test/t-charpoly_householder.c
@@ -15,7 +15,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-TEST_GR_FUNCTION_START(gr_mat_charpoly_householder, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_charpoly_householder, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -71,5 +71,5 @@ TEST_GR_FUNCTION_START(gr_mat_charpoly_householder, state, count_success, count_
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-det_berkowitz.c
+++ b/src/gr_mat/test/t-det_berkowitz.c
@@ -15,7 +15,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-TEST_GR_FUNCTION_START(gr_mat_det_berkowitz, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_det_berkowitz, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -85,5 +85,5 @@ TEST_GR_FUNCTION_START(gr_mat_det_berkowitz, state, count_success, count_unable,
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-det_cofactor.c
+++ b/src/gr_mat/test/t-det_cofactor.c
@@ -15,7 +15,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-TEST_GR_FUNCTION_START(gr_mat_det_cofactor, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_det_cofactor, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -85,5 +85,5 @@ TEST_GR_FUNCTION_START(gr_mat_det_cofactor, state, count_success, count_unable, 
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-det_fflu.c
+++ b/src/gr_mat/test/t-det_fflu.c
@@ -15,7 +15,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-TEST_GR_FUNCTION_START(gr_mat_det_fflu, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_det_fflu, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -85,5 +85,5 @@ TEST_GR_FUNCTION_START(gr_mat_det_fflu, state, count_success, count_unable, coun
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-det_lu.c
+++ b/src/gr_mat/test/t-det_lu.c
@@ -15,7 +15,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-TEST_GR_FUNCTION_START(gr_mat_det_lu, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_det_lu, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -107,5 +107,5 @@ TEST_GR_FUNCTION_START(gr_mat_det_lu, state, count_success, count_unable, count_
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-gr_poly_solve_lode_newton.c
+++ b/src/gr_mat/test/t-gr_poly_solve_lode_newton.c
@@ -15,7 +15,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-TEST_GR_FUNCTION_START(gr_mat_gr_poly_solve_lode_newton, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_gr_poly_solve_lode_newton, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -139,5 +139,5 @@ TEST_GR_FUNCTION_START(gr_mat_gr_poly_solve_lode_newton, state, count_success, c
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-hadamard.c
+++ b/src/gr_mat/test/t-hadamard.c
@@ -12,7 +12,7 @@
 #include "test_helpers.h"
 #include "gr_mat.h"
 
-TEST_GR_FUNCTION_START(gr_mat_hadamard, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_hadamard, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -71,5 +71,5 @@ TEST_GR_FUNCTION_START(gr_mat_hadamard, state, count_success, count_unable, coun
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-hessenberg.c
+++ b/src/gr_mat/test/t-hessenberg.c
@@ -15,7 +15,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-TEST_GR_FUNCTION_START(gr_mat_hessenberg, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_hessenberg, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -76,5 +76,5 @@ TEST_GR_FUNCTION_START(gr_mat_hessenberg, state, count_success, count_unable, co
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-hessenberg_gauss.c
+++ b/src/gr_mat/test/t-hessenberg_gauss.c
@@ -15,7 +15,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-TEST_GR_FUNCTION_START(gr_mat_hessenberg_gauss, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_hessenberg_gauss, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -77,5 +77,5 @@ TEST_GR_FUNCTION_START(gr_mat_hessenberg_gauss, state, count_success, count_unab
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-hessenberg_householder.c
+++ b/src/gr_mat/test/t-hessenberg_householder.c
@@ -15,7 +15,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-TEST_GR_FUNCTION_START(gr_mat_hessenberg_householder, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_hessenberg_householder, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -77,5 +77,5 @@ TEST_GR_FUNCTION_START(gr_mat_hessenberg_householder, state, count_success, coun
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-inv.c
+++ b/src/gr_mat/test/t-inv.c
@@ -15,7 +15,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-TEST_GR_FUNCTION_START(gr_mat_inv, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_inv, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -92,5 +92,5 @@ TEST_GR_FUNCTION_START(gr_mat_inv, state, count_success, count_unable, count_dom
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-minpoly_field.c
+++ b/src/gr_mat/test/t-minpoly_field.c
@@ -18,7 +18,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-TEST_GR_FUNCTION_START(gr_mat_minpoly_field, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_minpoly_field, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -168,5 +168,5 @@ TEST_GR_FUNCTION_START(gr_mat_minpoly_field, state, count_success, count_unable,
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-nullspace.c
+++ b/src/gr_mat/test/t-nullspace.c
@@ -12,7 +12,7 @@
 #include "test_helpers.h"
 #include "gr_mat.h"
 
-TEST_GR_FUNCTION_START(gr_mat_nullspace, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_nullspace, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -94,5 +94,5 @@ TEST_GR_FUNCTION_START(gr_mat_nullspace, state, count_success, count_unable, cou
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-rank.c
+++ b/src/gr_mat/test/t-rank.c
@@ -12,7 +12,7 @@
 #include "test_helpers.h"
 #include "gr_mat.h"
 
-TEST_GR_FUNCTION_START(gr_mat_rank, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_rank, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -66,5 +66,5 @@ TEST_GR_FUNCTION_START(gr_mat_rank, state, count_success, count_unable, count_do
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-rank_fflu.c
+++ b/src/gr_mat/test/t-rank_fflu.c
@@ -12,7 +12,7 @@
 #include "test_helpers.h"
 #include "gr_mat.h"
 
-TEST_GR_FUNCTION_START(gr_mat_rank_fflu, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_rank_fflu, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -69,5 +69,5 @@ TEST_GR_FUNCTION_START(gr_mat_rank_fflu, state, count_success, count_unable, cou
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-rank_lu.c
+++ b/src/gr_mat/test/t-rank_lu.c
@@ -12,7 +12,7 @@
 #include "test_helpers.h"
 #include "gr_mat.h"
 
-TEST_GR_FUNCTION_START(gr_mat_rank_lu, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_rank_lu, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -66,5 +66,5 @@ TEST_GR_FUNCTION_START(gr_mat_rank_lu, state, count_success, count_unable, count
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-rref_den_fflu.c
+++ b/src/gr_mat/test/t-rref_den_fflu.c
@@ -44,7 +44,7 @@ gr_mat_randrowops(gr_mat_t mat, flint_rand_t state, slong count, gr_ctx_t ctx)
 }
 #endif
 
-TEST_GR_FUNCTION_START(gr_mat_rref_den_fflu, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_rref_den_fflu, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -108,5 +108,5 @@ TEST_GR_FUNCTION_START(gr_mat_rref_den_fflu, state, count_success, count_unable,
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-rref_fflu.c
+++ b/src/gr_mat/test/t-rref_fflu.c
@@ -44,7 +44,7 @@ gr_mat_randrowops(gr_mat_t mat, flint_rand_t state, slong count, gr_ctx_t ctx)
 }
 #endif
 
-TEST_GR_FUNCTION_START(gr_mat_rref_fflu, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_rref_fflu, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -104,5 +104,5 @@ TEST_GR_FUNCTION_START(gr_mat_rref_fflu, state, count_success, count_unable, cou
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-rref_lu.c
+++ b/src/gr_mat/test/t-rref_lu.c
@@ -44,7 +44,7 @@ gr_mat_randrowops(gr_mat_t mat, flint_rand_t state, slong count, gr_ctx_t ctx)
 }
 #endif
 
-TEST_GR_FUNCTION_START(gr_mat_rref_lu, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_rref_lu, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -104,5 +104,5 @@ TEST_GR_FUNCTION_START(gr_mat_rref_lu, state, count_success, count_unable, count
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-solve.c
+++ b/src/gr_mat/test/t-solve.c
@@ -15,7 +15,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-TEST_GR_FUNCTION_START(gr_mat_solve, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_solve, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -94,5 +94,5 @@ TEST_GR_FUNCTION_START(gr_mat_solve, state, count_success, count_unable, count_d
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-solve_den.c
+++ b/src/gr_mat/test/t-solve_den.c
@@ -15,7 +15,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-TEST_GR_FUNCTION_START(gr_mat_solve_den, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_solve_den, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -100,5 +100,5 @@ TEST_GR_FUNCTION_START(gr_mat_solve_den, state, count_success, count_unable, cou
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-solve_den_fflu.c
+++ b/src/gr_mat/test/t-solve_den_fflu.c
@@ -15,7 +15,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-TEST_GR_FUNCTION_START(gr_mat_solve_den_fflu, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_solve_den_fflu, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -100,5 +100,5 @@ TEST_GR_FUNCTION_START(gr_mat_solve_den_fflu, state, count_success, count_unable
         gr_ctx_clear(ctx);
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-solve_fflu.c
+++ b/src/gr_mat/test/t-solve_fflu.c
@@ -15,7 +15,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-TEST_GR_FUNCTION_START(gr_mat_solve_fflu, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_solve_fflu, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -95,5 +95,5 @@ TEST_GR_FUNCTION_START(gr_mat_solve_fflu, state, count_success, count_unable, co
 
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-solve_lu.c
+++ b/src/gr_mat/test/t-solve_lu.c
@@ -15,7 +15,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-TEST_GR_FUNCTION_START(gr_mat_solve_lu, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_solve_lu, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -95,5 +95,5 @@ TEST_GR_FUNCTION_START(gr_mat_solve_lu, state, count_success, count_unable, coun
 
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-solve_tril.c
+++ b/src/gr_mat/test/t-solve_tril.c
@@ -15,7 +15,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-TEST_GR_FUNCTION_START(gr_mat_solve_tril, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_solve_tril, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -104,5 +104,5 @@ TEST_GR_FUNCTION_START(gr_mat_solve_tril, state, count_success, count_unable, co
 
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }

--- a/src/gr_mat/test/t-solve_triu.c
+++ b/src/gr_mat/test/t-solve_triu.c
@@ -15,7 +15,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-TEST_GR_FUNCTION_START(gr_mat_solve_triu, state, count_success, count_unable, count_domain)
+TEST_GR_FUNCTION_START(gr_mat_solve_triu, state, count_success, count_domain, count_unable)
 {
     slong iter;
 
@@ -104,5 +104,5 @@ TEST_GR_FUNCTION_START(gr_mat_solve_triu, state, count_success, count_unable, co
 
     }
 
-    TEST_GR_FUNCTION_END(state, count_success, count_unable, count_domain);
+    TEST_GR_FUNCTION_END(state, count_success, count_domain, count_unable);
 }


### PR DESCRIPTION
Together with @rburing, we realized that the `TEST_GR_FUNCTION_START` and `TEST_GR_FUNCTION_END` macros require the order of arguments `count_success, count_domain, count_unable` and not `count_success, count_unable, count_domain`, the latter being used in several test functions of FLINT. 

This Pull Request fixes all occurrences of the order of these arguments.