### PR TITLE
Factor optimizations in `fmpz_mat_mul_multi_mod` out to helper functions

### DIFF
--- a/doc/source/fmpz_mat.rst
+++ b/doc/source/fmpz_mat.rst
@@ -433,11 +433,11 @@ Modular reduction and reconstruction
     with entries satisfying `-mn/2 <= c < mn/2` (if sign = 1)
     or `0 <= c < mn` (if sign = 0).
 
-.. function:: void fmpz_mat_multi_mod_ui_precomp(nmod_mat_t * residues, slong nres, const fmpz_mat_t mat, const fmpz_comb_t comb, fmpz_comb_temp_t temp)
+.. function:: void fmpz_mat_multi_mod_ui_precomp(nmod_mat_t * residues, slong nres, const fmpz_mat_t mat, const fmpz_comb_t comb)
 
     Sets each of the ``nres`` matrices in ``residues`` to ``mat`` reduced modulo
-    the modulus of the respective matrix, given precomputed ``comb`` and
-    ``comb_temp`` structures.
+    the modulus of the respective matrix, given a precomputed ``comb``
+    structure.
 
     Note: ``fmpz.h`` must be included **before** ``fmpz_mat.h`` in order for
     this function to be declared.
@@ -451,10 +451,10 @@ Modular reduction and reconstruction
     For reducing or reconstructing multiple integer matrices over the same
     set of moduli, it is faster to use ``fmpz_mat_multi_mod_precomp``.
 
-.. function:: void fmpz_mat_multi_CRT_ui_precomp(fmpz_mat_t mat, nmod_mat_t * const residues, slong nres, const fmpz_comb_t comb, fmpz_comb_temp_t temp, int sign)
+.. function:: void fmpz_mat_multi_CRT_ui_precomp(fmpz_mat_t mat, nmod_mat_t * const residues, slong nres, const fmpz_comb_t comb, int sign)
 
     Reconstructs ``mat`` from its images modulo the ``nres`` matrices in
-    ``residues``, given precomputed ``comb`` and ``comb_temp`` structures.
+    ``residues``, given a precomputed ``comb`` structure.
 
     Note: ``fmpz.h`` must be included **before** ``fmpz_mat.h`` in order for
     this function to be declared.

--- a/src/fmpz_mat.h
+++ b/src/fmpz_mat.h
@@ -386,9 +386,19 @@ void fmpz_mat_get_nmod_mat(nmod_mat_t Amod, const fmpz_mat_t A);
 
 void fmpz_mat_CRT_ui(fmpz_mat_t res, const fmpz_mat_t mat1, const fmpz_t m1, const nmod_mat_t mat2, int sign);
 
+/* fmpz_comb has poor basecase code; only use it when it's worth it.
+   Fixme: improve fmpz_comb so that this isn't necessary. */
+#define FMPZ_MAT_MOD_PRIMES_COMB_CUTOFF 200
+#define FMPZ_MAT_CRT_PRIMES_COMB_CUTOFF 8
+
+/* Minimum (entries * primes) that warrant spawning a worker for multimodular
+   reduction/CRT. */
+#define FMPZ_MAT_CRT_MIN_WORK_PER_THREAD 1024
+
 #ifdef FMPZ_H
-void fmpz_mat_multi_mod_ui_precomp(nmod_mat_t * residues, slong nres, const fmpz_mat_t mat, const fmpz_comb_t comb, fmpz_comb_temp_t temp);
-void fmpz_mat_multi_CRT_ui_precomp(fmpz_mat_t mat, nmod_mat_t * const residues, slong nres, const fmpz_comb_t comb, fmpz_comb_temp_t temp, int sign);
+void fmpz_mat_multi_mod_ui_precomp(nmod_mat_t * residues, slong nres, const fmpz_mat_t mat, const fmpz_comb_t comb);
+void fmpz_mat_multi_mod_2_ui_precomp(nmod_mat_t * residues_A, nmod_mat_t * residues_B, slong nres, const fmpz_mat_t A, const fmpz_mat_t B, const fmpz_comb_t comb);
+void fmpz_mat_multi_CRT_ui_precomp(fmpz_mat_t mat, nmod_mat_t * const residues, slong nres, const fmpz_comb_t comb, int sign);
 #endif
 
 void fmpz_mat_multi_mod_ui(nmod_mat_t * residues, slong nres, const fmpz_mat_t mat);

--- a/src/fmpz_mat/mul_multi_mod.c
+++ b/src/fmpz_mat/mul_multi_mod.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2010, 2018 Fredrik Johansson
+    Copyright (C) 2010, 2018, 2026 Fredrik Johansson
     Copyright (C) 2021 Daniel Schultz
 
     This file is part of FLINT.
@@ -10,301 +10,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include <gmp.h>
-#include "thread_pool.h"
-#include "thread_support.h"
-#include "nmod.h"
+#include "nmod_vec.h"
 #include "nmod_mat.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
-
-typedef struct {
-    slong m;
-    slong k;
-    slong n;
-    slong Astartrow;
-    slong Astoprow;
-    slong Bstartrow;
-    slong Bstoprow;
-    slong Cstartrow;
-    slong Cstoprow;
-    fmpz * Aentries;
-    slong Astride;
-    fmpz * Bentries;
-    slong Bstride;
-    fmpz * Centries;
-    slong Cstride;
-    nmod_mat_t * mod_A;
-    nmod_mat_t * mod_B;
-    nmod_mat_t * mod_C;
-    const fmpz_comb_struct * comb;
-    slong num_primes;
-    nn_ptr primes;
-    int sign;
-} _worker_arg;
-
-
-static void _mod_worker(void * varg)
-{
-    _worker_arg * arg = (_worker_arg *) varg;
-    slong i, j, l;
-    slong k = arg->k;
-    slong n = arg->n;
-    slong Astartrow = arg->Astartrow;
-    slong Astoprow = arg->Astoprow;
-    slong Bstartrow = arg->Bstartrow;
-    slong Bstoprow = arg->Bstoprow;
-    fmpz * Aentries = arg->Aentries;
-    slong Astride = arg->Astride;
-    fmpz * Bentries = arg->Bentries;
-    slong Bstride = arg->Bstride;
-    nmod_mat_t * mod_A = arg->mod_A;
-    nmod_mat_t * mod_B = arg->mod_B;
-    slong num_primes = arg->num_primes;
-    const fmpz_comb_struct * comb = arg->comb;
-
-    if (comb != NULL)
-    {
-        ulong * residues;
-        fmpz_comb_temp_t comb_temp;
-
-        residues = FLINT_ARRAY_ALLOC(num_primes, ulong);
-        fmpz_comb_temp_init(comb_temp, comb);
-
-        for (i = Astartrow; i < Astoprow; i++)
-        {
-            for (j = 0; j < k; j++)
-            {
-                fmpz_multi_mod_ui(residues, Aentries + i * Astride + j, comb, comb_temp);
-                for (l = 0; l < num_primes; l++)
-                    nmod_mat_entry(mod_A[l], i, j) = residues[l];
-            }
-        }
-
-        if (mod_B != NULL)
-        {
-            for (i = Bstartrow; i < Bstoprow; i++)
-            {
-                for (j = 0; j < n; j++)
-                {
-                    fmpz_multi_mod_ui(residues, Bentries + i * Bstride + j, comb, comb_temp);
-                    for (l = 0; l < num_primes; l++)
-                        nmod_mat_entry(mod_B[l], i, j) = residues[l];
-                }
-            }
-        }
-
-        flint_free(residues);
-        fmpz_comb_temp_clear(comb_temp);
-    }
-    else
-    {
-        for (i = Astartrow; i < Astoprow; i++)
-        {
-            for (j = 0; j < k; j++)
-            {
-                for (l = 0; l < num_primes; l++)
-                    nmod_mat_entry(mod_A[l], i, j) = fmpz_get_nmod(Aentries + i * Astride + j,
-                                                                    mod_A[l]->mod);
-            }
-        }
-
-        if (mod_B != NULL)
-        {
-            for (i = Bstartrow; i < Bstoprow; i++)
-            {
-                for (j = 0; j < n; j++)
-                {
-                    for (l = 0; l < num_primes; l++)
-                        nmod_mat_entry(mod_B[l], i, j) = fmpz_get_nmod(Bentries + i * Bstride + j,
-                                                                        mod_A[l]->mod);
-                }
-            }
-        }
-    }
-}
-
-static void _crt_worker(void * varg)
-{
-    _worker_arg * arg = (_worker_arg *) varg;
-    slong i, j, l;
-    slong n = arg->n;
-    slong Cstartrow = arg->Cstartrow;
-    slong Cstoprow = arg->Cstoprow;
-    fmpz * Centries = arg->Centries;
-    slong Cstride = arg->Cstride;
-    nmod_mat_t * mod_C = arg->mod_C;
-    ulong * primes = arg->primes;
-    slong num_primes = arg->num_primes;
-    const fmpz_comb_struct * comb = arg->comb;
-    int sign = arg->sign;
-
-    FLINT_ASSERT(sign == 0 || sign == 1);
-
-    if (comb != NULL)
-    {
-        ulong * residues;
-        fmpz_comb_temp_t comb_temp;
-
-        residues = FLINT_ARRAY_ALLOC(num_primes, ulong);
-        fmpz_comb_temp_init(comb_temp, comb);
-
-        for (i = Cstartrow; i < Cstoprow; i++)
-        for (j = 0; j < n; j++)
-        {
-            for (l = 0; l < num_primes; l++)
-                residues[l] = nmod_mat_entry(mod_C[l], i, j);
-
-            fmpz_multi_CRT_ui(Centries + i * Cstride + j, residues, comb, comb_temp, sign);
-        }
-
-        flint_free(residues);
-        fmpz_comb_temp_clear(comb_temp);
-    }
-    else if (num_primes == 1)
-    {
-        ulong r, t, p = primes[0];
-
-        if (sign)
-        {
-            for (i = Cstartrow; i < Cstoprow; i++)
-            for (j = 0; j < n; j++)
-            {
-                r = nmod_mat_entry(mod_C[0], i, j);
-                t = p - r;
-                if (t < r)
-                    fmpz_neg_ui(Centries + i * Cstride + j, t);
-                else
-                    fmpz_set_ui(Centries + i * Cstride + j, r);
-            }
-        }
-        else
-        {
-            for (i = Cstartrow; i < Cstoprow; i++)
-            for (j = 0; j < n; j++)
-            {
-                r = nmod_mat_entry(mod_C[0], i, j);
-                fmpz_set_ui(Centries + i * Cstride + j, r);
-            }
-        }
-    }
-    else if (num_primes == 2)
-    {
-        ulong r0, r1, i0, i1, m0, m1, M[2], t[2], u[2];
-        m0 = primes[0];
-        m1 = primes[1];
-        i0 = n_invmod(m1 % m0, m0);
-        i1 = n_invmod(m0 % m1, m1);
-        umul_ppmm(M[1], M[0], m0, m1);
-
-        for (i = Cstartrow; i < Cstoprow; i++)
-        for (j = 0; j < n; j++)
-        {
-            r0 = nmod_mul(i0, nmod_mat_entry(mod_C[0], i, j), mod_C[0]->mod);
-            r1 = nmod_mul(i1, nmod_mat_entry(mod_C[1], i, j), mod_C[1]->mod);
-
-            /*
-                0 <= r0 <= m0 - 1
-                0 <= r1 <= m1 - 1
-                if m0*m1 < 2^(2*FLINT_BITS-1), then the sum
-                    t = r0*m1 + r1*m0 <= 2*m0*m1 - m0 - m1
-                does not overflow
-            */
-            FLINT_ASSERT(FLINT_BIT_COUNT(M[1]) < FLINT_BITS);
-            umul_ppmm(t[1], t[0], r0, m1);
-            umul_ppmm(u[1], u[0], r1, m0);
-            add_ssaaaa(t[1], t[0], t[1], t[0], u[1], u[0]);
-
-            /* t = t mod M */
-            if (t[1] > M[1] || (t[1] == M[1] && t[0] > M[0]))
-                sub_ddmmss(t[1], t[0], t[1], t[0], M[1], M[0]);
-
-            FLINT_ASSERT(t[1] < M[1] || (t[1] == M[1] && t[0] < M[0]));
-
-            if (sign)
-            {
-                sub_ddmmss(u[1], u[0], M[1], M[0], t[1], t[0]);
-                if (u[1] < t[1] || (u[1] == t[1] && u[0] < t[0]))
-                    fmpz_neg_uiui(Centries + i * Cstride + j, u[1], u[0]);
-                else
-                    fmpz_set_uiui(Centries + i * Cstride + j, t[1], t[0]);
-            }
-            else
-            {
-                fmpz_set_uiui(Centries + i * Cstride + j, t[1], t[0]);
-            }
-        }
-    }
-    else
-    {
-        nn_ptr M, Ns, T, U;
-        slong Msize, Nsize;
-        ulong cy, ri;
-
-        M = FLINT_ARRAY_ALLOC(num_primes + 1, ulong);
-
-        M[0] = primes[0];
-        Msize = 1;
-        for (i = 1; i < num_primes; i++)
-        {
-            FLINT_ASSERT(Msize > 0);
-            M[Msize] = cy = mpn_mul_1(M, M, Msize, primes[i]);
-            Msize += (cy != 0);
-        }
-
-        /* We add terms with Msize + 1 limbs, with one extra limb for the
-           carry accumulation. todo: reduce Nsize by 1 when the carries
-           do not require an extra limb. */
-        Nsize = Msize + 2;
-
-        Ns = FLINT_ARRAY_ALLOC(Nsize*num_primes, ulong);
-        T = FLINT_ARRAY_ALLOC(Nsize, ulong);
-        U = FLINT_ARRAY_ALLOC(Nsize, ulong);
-
-        for (i = 0; i < num_primes; i++)
-        {
-            Ns[i*Nsize + (Nsize - 1)] = 0;
-            Ns[i*Nsize + (Nsize - 2)] = 0;
-            mpn_divrem_1(Ns + i * Nsize, 0, M, Msize, primes[i]);
-            ri = mpn_mod_1(Ns + i * Nsize, Msize, primes[i]);
-            ri = n_invmod(ri, primes[i]);
-            FLINT_ASSERT(Msize > 0);
-            Ns[i*Nsize + Msize] = mpn_mul_1(Ns + i*Nsize, Ns + i*Nsize, Msize, ri);
-        }
-
-        for (i = Cstartrow; i < Cstoprow; i++)
-        for (j = 0; j < n; j++)
-        {
-            ri = nmod_mat_entry(mod_C[0], i, j);
-            FLINT_ASSERT(Nsize > 1);
-            T[Nsize - 1] = mpn_mul_1(T, Ns, Nsize - 1, ri);
-
-            for (l = 1; l < num_primes; l++)
-            {
-                ri = nmod_mat_entry(mod_C[l], i, j);
-                T[Nsize - 1] += mpn_addmul_1(T, Ns + l*Nsize, Nsize - 1, ri);
-            }
-
-            mpn_tdiv_qr(U, T, 0, T, Nsize, M, Msize);
-
-            if (sign && (mpn_sub_n(U, M, T, Msize), mpn_cmp(U, T, Msize) < 0))
-            {
-                fmpz_set_ui_array(Centries + i * Cstride + j, U, Msize);
-                fmpz_neg(Centries + i * Cstride + j, Centries + i * Cstride + j);
-            }
-            else
-            {
-                fmpz_set_ui_array(Centries + i * Cstride + j, T, Msize);
-            }
-        }
-
-        flint_free(M);
-        flint_free(Ns);
-        flint_free(T);
-        flint_free(U);
-    }
-}
-
 
 void _fmpz_mat_mul_multi_mod(
     fmpz_mat_t C,
@@ -313,27 +22,20 @@ void _fmpz_mat_mul_multi_mod(
     int sign,
     flint_bitcnt_t bits)
 {
-    slong i, start, stop;
+    slong i;
     slong m, k, n;
     flint_bitcnt_t primes_bits;
-    _worker_arg mainarg;
-    _worker_arg * args;
     fmpz_comb_t comb;
-    slong num_workers;
-    thread_pool_handle * handles;
-    slong limit;
-    ulong first_prime; /* not prime */
+    fmpz_comb_struct * comb_ptr;
+    ulong first_prime;
     int squaring = (A == B);
+    nmod_mat_t * mod_A, * mod_B, * mod_C;
+    nn_ptr primes;
+    slong num_primes;
 
-    mainarg.m = m = A->r;
-    mainarg.k = k = A->c;
-    mainarg.n = n = B->c;
-    mainarg.Aentries = A->entries;
-    mainarg.Astride = A->stride;
-    mainarg.Bentries = B->entries;
-    mainarg.Bstride = B->stride;
-    mainarg.Centries = C->entries;
-    mainarg.Cstride = C->stride;
+    m = A->r;
+    k = A->c;
+    n = B->c;
 
     if (m < 1 || n < 1 || k < 1)
     {
@@ -344,173 +46,79 @@ void _fmpz_mat_mul_multi_mod(
     FLINT_ASSERT(sign == 0 || sign == 1);
     bits += sign;
 
-    /* TUNING */
     primes_bits = NMOD_MAT_OPTIMAL_MODULUS_BITS;
 
     if (bits < primes_bits || bits <= FLINT_BITS - 1)
     {
-        mainarg.num_primes = 1;
+        num_primes = 1;
         first_prime = UWORD(1) << bits;
     }
     else
     {
-        /* Round up in the division */
-        mainarg.num_primes = 1 + (bits - (FLINT_BITS - 1) + primes_bits - 1)/primes_bits;
+        num_primes = 1 + (bits - (FLINT_BITS - 1) + primes_bits - 1) / primes_bits;
         first_prime = UWORD(1) << (FLINT_BITS - 1);
     }
 
-    /* Initialize */
-    mainarg.sign = sign;
-    mainarg.primes = FLINT_ARRAY_ALLOC(mainarg.num_primes, ulong);
-    mainarg.primes[0] = first_prime;
-    if (mainarg.num_primes > 1)
+    primes = FLINT_ARRAY_ALLOC(num_primes, ulong);
+    primes[0] = first_prime;
+    if (num_primes > 1)
     {
-        mainarg.primes[1] = n_nextprime(UWORD(1) << primes_bits, 0);
-        for (i = 2; i < mainarg.num_primes; i++)
-            mainarg.primes[i] = n_nextprime(mainarg.primes[i-1], 0);
+        primes[1] = n_nextprime(UWORD(1) << primes_bits, 0);
+        for (i = 2; i < num_primes; i++)
+            primes[i] = n_nextprime(primes[i - 1], 0);
     }
 
-    mainarg.mod_A = FLINT_ARRAY_ALLOC(mainarg.num_primes, nmod_mat_t);
+    mod_A = FLINT_ARRAY_ALLOC(num_primes, nmod_mat_t);
+    mod_B = squaring ? NULL : FLINT_ARRAY_ALLOC(num_primes, nmod_mat_t);
+    mod_C = FLINT_ARRAY_ALLOC(num_primes, nmod_mat_t);
 
-    if (squaring)
-        mainarg.mod_B = NULL;
-    else
-        mainarg.mod_B = FLINT_ARRAY_ALLOC(mainarg.num_primes, nmod_mat_t);
-
-    mainarg.mod_C = FLINT_ARRAY_ALLOC(mainarg.num_primes, nmod_mat_t);
-    for (i = 0; i < mainarg.num_primes; i++)
+    for (i = 0; i < num_primes; i++)
     {
-        nmod_mat_init(mainarg.mod_A[i], A->r, A->c, mainarg.primes[i]);
+        nmod_mat_init(mod_A[i], A->r, A->c, primes[i]);
         if (!squaring)
-            nmod_mat_init(mainarg.mod_B[i], B->r, B->c, mainarg.primes[i]);
-        nmod_mat_init(mainarg.mod_C[i], C->r, C->c, mainarg.primes[i]);
+            nmod_mat_init(mod_B[i], B->r, B->c, primes[i]);
+        nmod_mat_init(mod_C[i], C->r, C->c, primes[i]);
     }
 
-    /* TUNING */
-    if (mainarg.num_primes > 200)
+    if (num_primes > FMPZ_MAT_MOD_PRIMES_COMB_CUTOFF ||
+        num_primes > FMPZ_MAT_CRT_PRIMES_COMB_CUTOFF)
     {
-        /* use comb */
-        fmpz_comb_init(comb, mainarg.primes, mainarg.num_primes);
-        mainarg.comb = comb;
+        fmpz_comb_init(comb, primes, num_primes);
+        comb_ptr = comb;
     }
     else
     {
-        /* don't use comb */
-        mainarg.comb = NULL;
+        comb_ptr = NULL;
     }
 
-    /* limit on the number of threads */
-    limit = ((m + k + n)/128)*(1 + bits/1024);
-    limit = FLINT_MIN(limit, (m + k)/4);
+    fmpz_mat_multi_mod_2_ui_precomp(mod_A, squaring ? NULL : mod_B, num_primes,
+            A, squaring ? NULL : B, num_primes > FMPZ_MAT_MOD_PRIMES_COMB_CUTOFF ? comb_ptr : NULL);
 
-    /* mod */
-    if (limit < 2)
-    {
-mod_single:
-        mainarg.Astartrow = 0;
-        mainarg.Astoprow = m;
-        mainarg.Bstartrow = 0;
-        mainarg.Bstoprow = k;
-        _mod_worker(&mainarg);
-    }
-    else
-    {
-        num_workers = flint_request_threads(&handles, limit);
-        if (num_workers < 1)
-        {
-            flint_give_back_threads(handles, num_workers);
-            goto mod_single;
-        }
+    for (i = 0; i < num_primes; i++)
+        nmod_mat_mul(mod_C[i], mod_A[i], squaring ? mod_A[i] : mod_B[i]);
 
-        args = FLINT_ARRAY_ALLOC(num_workers, _worker_arg);
-        for (start = 0, i = 0; i < num_workers; start = stop, i++)
-        {
-            args[i] = mainarg;
-            stop = _thread_pool_find_work_2(m, k, k, n, i + 1, num_workers + 1);
-            _thread_pool_distribute_work_2(start, stop,
-                                     &args[i].Astartrow, &args[i].Astoprow, m,
-                                     &args[i].Bstartrow, &args[i].Bstoprow, k);
-        }
-
-        _thread_pool_distribute_work_2(start, m + k,
-                                     &mainarg.Astartrow, &mainarg.Astoprow, m,
-                                     &mainarg.Bstartrow, &mainarg.Bstoprow, k);
-
-        for (i = 0; i < num_workers; i++)
-            thread_pool_wake(global_thread_pool, handles[i], 0, _mod_worker, &args[i]);
-        _mod_worker(&mainarg);
-        for (i = 0; i < num_workers; i++)
-            thread_pool_wait(global_thread_pool, handles[i]);
-
-        flint_give_back_threads(handles, num_workers);
-        flint_free(args);
-    }
-
-    /* mul */
-    for (i = 0; i < mainarg.num_primes; i++)
-        nmod_mat_mul(mainarg.mod_C[i], mainarg.mod_A[i], squaring ? mainarg.mod_A[i] : mainarg.mod_B[i]);
-
-    /* limit on the number of threads */
-    limit = ((m + n)/64)*(1 + bits/1024);
-    limit = FLINT_MIN(limit, m/2);
-
-    /* crt */
-    if (limit < 2)
-    {
-crt_single:
-        mainarg.Cstartrow = 0;
-        mainarg.Cstoprow = m;
-        _crt_worker(&mainarg);
-    }
-    else
-    {
-        num_workers = flint_request_threads(&handles, limit);
-        if (num_workers < 1)
-        {
-            flint_give_back_threads(handles, num_workers);
-            goto crt_single;
-        }
-
-        args = FLINT_ARRAY_ALLOC(num_workers, _worker_arg);
-        for (start = 0, i = 0; i < num_workers; start = stop, i++)
-        {
-            args[i] = mainarg;
-            stop = (i + 1)*m/(num_workers + 1);
-            args[i].Cstartrow = start;
-            args[i].Cstoprow = stop;
-        }
-
-        mainarg.Cstartrow = start;
-        mainarg.Cstoprow = m;
-
-        for (i = 0; i < num_workers; i++)
-            thread_pool_wake(global_thread_pool, handles[i], 0, _crt_worker, &args[i]);
-        _crt_worker(&mainarg);
-        for (i = 0; i < num_workers; i++)
-            thread_pool_wait(global_thread_pool, handles[i]);
-
-        flint_give_back_threads(handles, num_workers);
-        flint_free(args);
-    }
+    fmpz_mat_multi_CRT_ui_precomp(C, mod_C, num_primes,
+            num_primes > FMPZ_MAT_CRT_PRIMES_COMB_CUTOFF ? comb_ptr : NULL, sign);
 
     /* Cleanup */
-    if (mainarg.comb != NULL)
+    if (comb_ptr != NULL)
         fmpz_comb_clear(comb);
 
-    for (i = 0; i < mainarg.num_primes; i++)
+    for (i = 0; i < num_primes; i++)
     {
-        nmod_mat_clear(mainarg.mod_A[i]);
+        nmod_mat_clear(mod_A[i]);
         if (!squaring)
-            nmod_mat_clear(mainarg.mod_B[i]);
-        nmod_mat_clear(mainarg.mod_C[i]);
+            nmod_mat_clear(mod_B[i]);
+        nmod_mat_clear(mod_C[i]);
     }
 
-    flint_free(mainarg.mod_A);
+    flint_free(mod_A);
     if (!squaring)
-        flint_free(mainarg.mod_B);
-    flint_free(mainarg.mod_C);
-    flint_free(mainarg.primes);
+        flint_free(mod_B);
+    flint_free(mod_C);
+    flint_free(primes);
 }
+
 
 void
 fmpz_mat_mul_multi_mod(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B)

--- a/src/fmpz_mat/multi_CRT_ui.c
+++ b/src/fmpz_mat/multi_CRT_ui.c
@@ -1,5 +1,6 @@
 /*
-    Copyright (C) 2011 Fredrik Johansson
+    Copyright (C) 2010, 2011, 2018, 2026 Fredrik Johansson
+    Copyright (C) 2021 Daniel Schultz
 
     This file is part of FLINT.
 
@@ -9,53 +10,274 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "thread_pool.h"
+#include "thread_support.h"
+#include "mpn_extras.h"
 #include "nmod_vec.h"
 #include "nmod_mat.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
 
-void
-fmpz_mat_multi_CRT_ui_precomp(fmpz_mat_t mat,
-    nmod_mat_t * const residues, slong nres,
-    const fmpz_comb_t comb, fmpz_comb_temp_t temp, int sign)
+typedef struct {
+    slong n;
+    slong Cstartrow;
+    slong Cstoprow;
+    fmpz * Centries;
+    slong Cstride;
+    nmod_mat_t * mod_C;
+    nn_ptr primes;
+    slong num_primes;
+    const fmpz_comb_struct * comb;
+    int sign;
+} _crt_worker_arg;
+
+static void _crt_worker(void * varg)
 {
-    slong i, j, k;
-    nn_ptr r;
+    _crt_worker_arg * arg = (_crt_worker_arg *) varg;
+    slong i, j, l;
+    slong n            = arg->n;
+    slong Cstartrow    = arg->Cstartrow;
+    slong Cstoprow     = arg->Cstoprow;
+    fmpz * Centries    = arg->Centries;
+    slong Cstride      = arg->Cstride;
+    nmod_mat_t * mod_C = arg->mod_C;
+    slong num_primes   = arg->num_primes;
+    const fmpz_comb_struct * comb = arg->comb;
+    int sign           = arg->sign;
 
-    r = _nmod_vec_init(nres);
+    FLINT_ASSERT(sign == 0 || sign == 1);
 
-    for (i = 0; i < fmpz_mat_nrows(mat); i++)
+    if (comb != NULL)
     {
-        for (j = 0; j < fmpz_mat_ncols(mat); j++)
+        ulong * residues;
+        fmpz_comb_temp_t comb_temp;
+
+        residues = FLINT_ARRAY_ALLOC(num_primes, ulong);
+        fmpz_comb_temp_init(comb_temp, comb);
+
+        for (i = Cstartrow; i < Cstoprow; i++)
+        for (j = 0; j < n; j++)
         {
-            for (k = 0; k < nres; k++)
-                r[k] = nmod_mat_entry(residues[k], i, j);
-            fmpz_multi_CRT_ui(fmpz_mat_entry(mat, i, j), r, comb, temp, sign);
+            for (l = 0; l < num_primes; l++)
+                residues[l] = nmod_mat_entry(mod_C[l], i, j);
+            fmpz_multi_CRT_ui(Centries + i * Cstride + j, residues, comb, comb_temp, sign);
+        }
+
+        flint_free(residues);
+        fmpz_comb_temp_clear(comb_temp);
+    }
+    else if (num_primes == 1)
+    {
+        ulong r, t, p = mod_C[0]->mod.n;
+
+        if (sign)
+        {
+            for (i = Cstartrow; i < Cstoprow; i++)
+            for (j = 0; j < n; j++)
+            {
+                r = nmod_mat_entry(mod_C[0], i, j);
+                t = p - r;
+                if (t < r)
+                    fmpz_neg_ui(Centries + i * Cstride + j, t);
+                else
+                    fmpz_set_ui(Centries + i * Cstride + j, r);
+            }
+        }
+        else
+        {
+            for (i = Cstartrow; i < Cstoprow; i++)
+            for (j = 0; j < n; j++)
+            {
+                r = nmod_mat_entry(mod_C[0], i, j);
+                fmpz_set_ui(Centries + i * Cstride + j, r);
+            }
         }
     }
+    else if (num_primes == 2)
+    {
+        ulong r0, r1, i0, i1, m0, m1, M[2], t[2], u[2];
+        m0 = mod_C[0]->mod.n;
+        m1 = mod_C[1]->mod.n;
+        umul_ppmm(M[1], M[0], m0, m1);
+        if (FLINT_BIT_COUNT(M[1]) >= FLINT_BITS)
+            goto generic;
 
-    _nmod_vec_clear(r);
+        i0 = n_invmod(m1 % m0, m0);
+        i1 = n_invmod(m0 % m1, m1);
+
+        for (i = Cstartrow; i < Cstoprow; i++)
+        for (j = 0; j < n; j++)
+        {
+            r0 = nmod_mul(i0, nmod_mat_entry(mod_C[0], i, j), mod_C[0]->mod);
+            r1 = nmod_mul(i1, nmod_mat_entry(mod_C[1], i, j), mod_C[1]->mod);
+
+            FLINT_ASSERT(FLINT_BIT_COUNT(M[1]) < FLINT_BITS);
+            umul_ppmm(t[1], t[0], r0, m1);
+            umul_ppmm(u[1], u[0], r1, m0);
+            add_ssaaaa(t[1], t[0], t[1], t[0], u[1], u[0]);
+
+            if (t[1] > M[1] || (t[1] == M[1] && t[0] > M[0]))
+                sub_ddmmss(t[1], t[0], t[1], t[0], M[1], M[0]);
+
+            FLINT_ASSERT(t[1] < M[1] || (t[1] == M[1] && t[0] < M[0]));
+
+            if (sign)
+            {
+                sub_ddmmss(u[1], u[0], M[1], M[0], t[1], t[0]);
+                if (u[1] < t[1] || (u[1] == t[1] && u[0] < t[0]))
+                    fmpz_neg_uiui(Centries + i * Cstride + j, u[1], u[0]);
+                else
+                    fmpz_set_uiui(Centries + i * Cstride + j, t[1], t[0]);
+            }
+            else
+            {
+                fmpz_set_uiui(Centries + i * Cstride + j, t[1], t[0]);
+            }
+        }
+    }
+    else
+    {
+        nn_ptr M, Ns, T, U, primes;
+        slong Msize, Nsize;
+        ulong cy, ri;
+
+generic:
+        primes = FLINT_ARRAY_ALLOC(num_primes, ulong);
+        M = FLINT_ARRAY_ALLOC(num_primes + 1, ulong);
+        M[0] = primes[0] = mod_C[0]->mod.n;
+        Msize = 1;
+        for (i = 1; i < num_primes; i++)
+        {
+            primes[i] = mod_C[i]->mod.n;
+            M[Msize] = cy = mpn_mul_1(M, M, Msize, primes[i]);
+            Msize += (cy != 0);
+        }
+
+        Nsize = Msize + 2;
+        Ns = FLINT_ARRAY_ALLOC(Nsize * num_primes, ulong);
+        T  = FLINT_ARRAY_ALLOC(Nsize, ulong);
+        U  = FLINT_ARRAY_ALLOC(Nsize, ulong);
+
+        for (i = 0; i < num_primes; i++)
+        {
+            Ns[i*Nsize + (Nsize - 1)] = 0;
+            Ns[i*Nsize + (Nsize - 2)] = 0;
+            mpn_divexact_1(Ns + i * Nsize, M, Msize, primes[i]);
+            ri = mpn_mod_1(Ns + i * Nsize, Msize, primes[i]);
+            ri = n_invmod(ri, primes[i]);
+            Ns[i*Nsize + Msize] = mpn_mul_1(Ns + i*Nsize, Ns + i*Nsize, Msize, ri);
+        }
+
+        for (i = Cstartrow; i < Cstoprow; i++)
+        for (j = 0; j < n; j++)
+        {
+            ri = nmod_mat_entry(mod_C[0], i, j);
+            T[Nsize - 1] = mpn_mul_1(T, Ns, Nsize - 1, ri);
+            for (l = 1; l < num_primes; l++)
+            {
+                ri = nmod_mat_entry(mod_C[l], i, j);
+                T[Nsize - 1] += mpn_addmul_1(T, Ns + l*Nsize, Nsize - 1, ri);
+            }
+            mpn_tdiv_qr(U, T, 0, T, Nsize, M, Msize);
+            if (sign && (mpn_sub_n(U, M, T, Msize), mpn_cmp(U, T, Msize) < 0))
+            {
+                fmpz_set_ui_array(Centries + i * Cstride + j, U, Msize);
+                fmpz_neg(Centries + i * Cstride + j, Centries + i * Cstride + j);
+            }
+            else
+            {
+                fmpz_set_ui_array(Centries + i * Cstride + j, T, Msize);
+            }
+        }
+
+        flint_free(primes);
+        flint_free(M);
+        flint_free(Ns);
+        flint_free(T);
+        flint_free(U);
+    }
 }
 
-void
-fmpz_mat_multi_CRT_ui(fmpz_mat_t mat, nmod_mat_t * const residues,
-    slong nres, int sign)
+void fmpz_mat_multi_CRT_ui_precomp(
+    fmpz_mat_t mat,
+    nmod_mat_t * const residues, slong nres,
+    const fmpz_comb_t comb,
+    int sign)
 {
-    fmpz_comb_t comb;
-    fmpz_comb_temp_t temp;
-    nn_ptr primes;
-    slong i;
+    slong i, start, stop;
+    slong m = fmpz_mat_nrows(mat);
+    slong n = fmpz_mat_ncols(mat);
+    slong num_workers, thread_limit;
+    thread_pool_handle * handles;
+    _crt_worker_arg mainarg, * args;
 
-    primes = _nmod_vec_init(nres);
-    for (i = 0; i < nres; i++)
-        primes[i] = residues[i]->mod.n;
+    mainarg.n          = n;
+    mainarg.Centries   = mat->entries;
+    mainarg.Cstride    = mat->stride;
+    mainarg.mod_C      = residues;
+    mainarg.num_primes = nres;
+    mainarg.comb       = comb;
+    mainarg.sign       = sign;
 
-    fmpz_comb_init(comb, primes, nres);
-    fmpz_comb_temp_init(temp, comb);
+    thread_limit = (m * n * nres) / FMPZ_MAT_CRT_MIN_WORK_PER_THREAD;
 
-    fmpz_mat_multi_CRT_ui_precomp(mat, residues, nres, comb, temp, sign);
+    if (thread_limit < 2)
+    {
+single:
+        mainarg.Cstartrow = 0;
+        mainarg.Cstoprow  = m;
+        _crt_worker(&mainarg);
+        return;
+    }
 
-    fmpz_comb_clear(comb);
-    fmpz_comb_temp_clear(temp);
-    _nmod_vec_clear(primes);
+    num_workers = flint_request_threads(&handles, thread_limit);
+    if (num_workers < 1)
+    {
+        flint_give_back_threads(handles, num_workers);
+        goto single;
+    }
+
+    args = FLINT_ARRAY_ALLOC(num_workers, _crt_worker_arg);
+    for (start = 0, i = 0; i < num_workers; start = stop, i++)
+    {
+        args[i]           = mainarg;
+        stop              = (i + 1) * m / (num_workers + 1);
+        args[i].Cstartrow = start;
+        args[i].Cstoprow  = stop;
+    }
+    mainarg.Cstartrow = start;
+    mainarg.Cstoprow  = m;
+
+    for (i = 0; i < num_workers; i++)
+        thread_pool_wake(global_thread_pool, handles[i], 0, _crt_worker, &args[i]);
+    _crt_worker(&mainarg);
+    for (i = 0; i < num_workers; i++)
+        thread_pool_wait(global_thread_pool, handles[i]);
+
+    flint_give_back_threads(handles, num_workers);
+    flint_free(args);
 }
+
+void fmpz_mat_multi_CRT_ui(fmpz_mat_t mat, nmod_mat_t * const residues, slong nres, int sign)
+{
+    if (nres > FMPZ_MAT_CRT_PRIMES_COMB_CUTOFF)
+    {
+        fmpz_comb_t comb;
+        slong i;
+        nn_ptr primes;
+        primes = _nmod_vec_init(nres);
+        for (i = 0; i < nres; i++)
+            primes[i] = residues[i]->mod.n;
+        fmpz_comb_init(comb, primes, nres);
+        _nmod_vec_clear(primes);
+
+        fmpz_mat_multi_CRT_ui_precomp(mat, residues, nres, comb, sign);
+
+        fmpz_comb_clear(comb);
+    }
+    else
+    {
+        fmpz_mat_multi_CRT_ui_precomp(mat, residues, nres, NULL, sign);
+    }
+}
+

--- a/src/fmpz_mat/multi_mod_ui.c
+++ b/src/fmpz_mat/multi_mod_ui.c
@@ -1,5 +1,6 @@
 /*
-    Copyright (C) 2011 Fredrik Johansson
+    Copyright (C) 2010, 2011, 2018, 2026 Fredrik Johansson
+    Copyright (C) 2021 Daniel Schultz
 
     This file is part of FLINT.
 
@@ -9,50 +10,204 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "thread_pool.h"
+#include "thread_support.h"
 #include "nmod_vec.h"
 #include "nmod_mat.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
+#include "mpn_extras.h"
 
-void
-fmpz_mat_multi_mod_ui_precomp(nmod_mat_t * residues, slong nres,
-    const fmpz_mat_t mat, const fmpz_comb_t comb, fmpz_comb_temp_t temp)
+typedef struct {
+    slong ncols_A;
+    slong ncols_B;
+    slong Astartrow;
+    slong Astoprow;
+    slong Bstartrow;
+    slong Bstoprow;
+    fmpz * Aentries;
+    slong Astride;
+    fmpz * Bentries;
+    slong Bstride;
+    nmod_mat_t * mod_A;
+    nmod_mat_t * mod_B;   /* NULL for single-matrix case */
+    const fmpz_comb_struct * comb;
+    slong num_primes;
+} _mod_worker_arg;
+
+static void _mod_worker(void * varg)
 {
-    slong i, j, k;
-    nn_ptr r;
+    _mod_worker_arg * arg = (_mod_worker_arg *) varg;
+    slong i, j, l;
+    slong ncols_A    = arg->ncols_A;
+    slong ncols_B    = arg->ncols_B;
+    slong Astartrow  = arg->Astartrow;
+    slong Astoprow   = arg->Astoprow;
+    slong Bstartrow  = arg->Bstartrow;
+    slong Bstoprow   = arg->Bstoprow;
+    fmpz * Aentries  = arg->Aentries;
+    slong Astride    = arg->Astride;
+    fmpz * Bentries  = arg->Bentries;
+    slong Bstride    = arg->Bstride;
+    nmod_mat_t * mod_A = arg->mod_A;
+    nmod_mat_t * mod_B = arg->mod_B;
+    slong num_primes   = arg->num_primes;
+    const fmpz_comb_struct * comb = arg->comb;
 
-    r = _nmod_vec_init(nres);
-
-    for (i = 0; i < fmpz_mat_nrows(mat); i++)
+    if (comb != NULL)
     {
-        for (j = 0; j < fmpz_mat_ncols(mat); j++)
-        {
-            fmpz_multi_mod_ui(r, fmpz_mat_entry(mat, i, j), comb, temp);
-            for (k = 0; k < nres; k++)
-                nmod_mat_entry(residues[k], i, j) = r[k];
-        }
+        ulong * residues;
+        fmpz_comb_temp_t comb_temp;
+
+        residues = FLINT_ARRAY_ALLOC(num_primes, ulong);
+        fmpz_comb_temp_init(comb_temp, comb);
+
+        for (i = Astartrow; i < Astoprow; i++)
+            for (j = 0; j < ncols_A; j++)
+            {
+                fmpz_multi_mod_ui(residues, Aentries + i * Astride + j, comb, comb_temp);
+                for (l = 0; l < num_primes; l++)
+                    nmod_mat_entry(mod_A[l], i, j) = residues[l];
+            }
+
+        if (mod_B != NULL)
+            for (i = Bstartrow; i < Bstoprow; i++)
+                for (j = 0; j < ncols_B; j++)
+                {
+                    fmpz_multi_mod_ui(residues, Bentries + i * Bstride + j, comb, comb_temp);
+                    for (l = 0; l < num_primes; l++)
+                        nmod_mat_entry(mod_B[l], i, j) = residues[l];
+                }
+
+        flint_free(residues);
+        fmpz_comb_temp_clear(comb_temp);
+    }
+    else
+    {
+        for (i = Astartrow; i < Astoprow; i++)
+            for (j = 0; j < ncols_A; j++)
+                for (l = 0; l < num_primes; l++)
+                    nmod_mat_entry(mod_A[l], i, j) = fmpz_get_nmod(
+                        Aentries + i * Astride + j, mod_A[l]->mod);
+
+        if (mod_B != NULL)
+            for (i = Bstartrow; i < Bstoprow; i++)
+                for (j = 0; j < ncols_B; j++)
+                    for (l = 0; l < num_primes; l++)
+                        nmod_mat_entry(mod_B[l], i, j) = fmpz_get_nmod(
+                            Bentries + i * Bstride + j, mod_B[l]->mod);
+    }
+}
+
+static void _fmpz_mat_multi_mod_ui_internal(
+    nmod_mat_t * residues,
+    nmod_mat_t * residues_B,   /* NULL for single-matrix case */
+    const fmpz_mat_t A,
+    const fmpz_mat_t B,        /* NULL for single-matrix case */
+    const fmpz_comb_t comb,
+    slong num_primes)
+{
+    slong i, start, stop;
+    slong m  = A->r;
+    slong k  = A->c;
+    slong kB = (B != NULL) ? B->c : 0;
+    slong num_workers, thread_limit;
+    thread_pool_handle * handles;
+    _mod_worker_arg mainarg, * args;
+
+    mainarg.ncols_A   = k;
+    mainarg.ncols_B   = kB;
+    mainarg.Aentries  = A->entries;
+    mainarg.Astride   = A->stride;
+    mainarg.Bentries  = (B != NULL) ? B->entries : NULL;
+    mainarg.Bstride   = (B != NULL) ? B->stride  : 0;
+    mainarg.mod_A     = residues;
+    mainarg.mod_B     = residues_B;
+    mainarg.comb      = comb;
+    mainarg.num_primes = num_primes;
+
+    thread_limit = (FLINT_MAX(m * k, k * kB) * num_primes) / FMPZ_MAT_CRT_MIN_WORK_PER_THREAD;
+
+    if (thread_limit < 2)
+    {
+single:
+        mainarg.Astartrow = 0;
+        mainarg.Astoprow  = m;
+        mainarg.Bstartrow = 0;
+        mainarg.Bstoprow  = (B != NULL) ? B->r : 0;
+        _mod_worker(&mainarg);
+        return;
     }
 
-    _nmod_vec_clear(r);
+    num_workers = flint_request_threads(&handles, thread_limit);
+    if (num_workers < 1)
+    {
+        flint_give_back_threads(handles, num_workers);
+        goto single;
+    }
+
+    args = FLINT_ARRAY_ALLOC(num_workers, _mod_worker_arg);
+    for (start = 0, i = 0; i < num_workers; start = stop, i++)
+    {
+        args[i] = mainarg;
+        stop = _thread_pool_find_work_2(m, k, (B != NULL) ? B->r : 0, kB,
+                                        i + 1, num_workers + 1);
+        _thread_pool_distribute_work_2(start, stop,
+                                       &args[i].Astartrow, &args[i].Astoprow, m,
+                                       &args[i].Bstartrow, &args[i].Bstoprow,
+                                       (B != NULL) ? B->r : 0);
+    }
+    _thread_pool_distribute_work_2(start, m + ((B != NULL) ? B->r : 0),
+                                   &mainarg.Astartrow, &mainarg.Astoprow, m,
+                                   &mainarg.Bstartrow, &mainarg.Bstoprow,
+                                   (B != NULL) ? B->r : 0);
+
+    for (i = 0; i < num_workers; i++)
+        thread_pool_wake(global_thread_pool, handles[i], 0, _mod_worker, &args[i]);
+    _mod_worker(&mainarg);
+    for (i = 0; i < num_workers; i++)
+        thread_pool_wait(global_thread_pool, handles[i]);
+
+    flint_give_back_threads(handles, num_workers);
+    flint_free(args);
 }
 
-void
-fmpz_mat_multi_mod_ui(nmod_mat_t * residues, slong nres, const fmpz_mat_t mat)
+void fmpz_mat_multi_mod_ui_precomp(
+    nmod_mat_t * residues, slong nres,
+    const fmpz_mat_t A,
+    const fmpz_comb_t comb)
 {
-    fmpz_comb_t comb;
-    fmpz_comb_temp_t temp;
-    nn_ptr primes;
-    slong i;
-
-    primes = _nmod_vec_init(nres);
-    for (i = 0; i < nres; i++)
-        primes[i] = residues[i]->mod.n;
-    fmpz_comb_init(comb, primes, nres);
-    fmpz_comb_temp_init(temp, comb);
-
-    fmpz_mat_multi_mod_ui_precomp(residues, nres, mat, comb, temp);
-
-    fmpz_comb_clear(comb);
-    fmpz_comb_temp_clear(temp);
-    _nmod_vec_clear(primes);
+    _fmpz_mat_multi_mod_ui_internal(residues, NULL, A, NULL, comb, nres);
 }
+
+void fmpz_mat_multi_mod_2_ui_precomp(
+    nmod_mat_t * residues_A, nmod_mat_t * residues_B, slong nres,
+    const fmpz_mat_t A, const fmpz_mat_t B,
+    const fmpz_comb_t comb)
+{
+    _fmpz_mat_multi_mod_ui_internal(residues_A, residues_B, A, B, comb, nres);
+}
+
+void fmpz_mat_multi_mod_ui(nmod_mat_t * residues, slong nres, const fmpz_mat_t A)
+{
+    if (nres > FMPZ_MAT_MOD_PRIMES_COMB_CUTOFF)
+    {
+        fmpz_comb_t comb;
+        slong i;
+        nn_ptr primes;
+        primes = _nmod_vec_init(nres);
+        for (i = 0; i < nres; i++)
+            primes[i] = residues[i]->mod.n;
+        fmpz_comb_init(comb, primes, nres);
+        _nmod_vec_clear(primes);
+
+        fmpz_mat_multi_mod_ui_precomp(residues, nres, A, comb);
+
+        fmpz_comb_clear(comb);
+    }
+    else
+    {
+        fmpz_mat_multi_mod_ui_precomp(residues, nres, A, NULL);
+    }
+}
+

--- a/src/fmpz_mat/test/t-multi_CRT_ui.c
+++ b/src/fmpz_mat/test/t-multi_CRT_ui.c
@@ -25,10 +25,19 @@ TEST_FUNCTION_START(fmpz_mat_multi_CRT_ui, state)
         slong bits, prime_bits, rows, cols, num_primes, j;
         fmpz_t mod;
         fmpz_mat_t A, B, C;
-        nmod_mat_t Amod[1000];
-        ulong primes[1000];
+        nmod_mat_t * Amod;
+        nn_ptr primes;
 
-        bits = n_randint(state, 500) + 1;
+        flint_set_num_threads(1 + n_randint(state, 4));
+
+        if (n_randint(state, 100) == 0)
+            bits = n_randint(state, 10000) + 1;
+        else
+            bits = n_randint(state, 500) + 1;
+
+        primes = flint_malloc(bits * sizeof(ulong));
+        Amod = flint_malloc(bits * sizeof(nmod_mat_struct));
+
         rows = n_randint(state, 10);
         cols = n_randint(state, 10);
         prime_bits = 1 + n_randint(state, FLINT_BITS - 1);
@@ -81,6 +90,9 @@ TEST_FUNCTION_START(fmpz_mat_multi_CRT_ui, state)
         fmpz_mat_clear(B);
         fmpz_mat_clear(C);
         fmpz_clear(mod);
+
+        flint_free(Amod);
+        flint_free(primes);
     }
 
     TEST_FUNCTION_END(state);

--- a/src/fmpz_mat/test/t-multi_CRT_ui_unsigned.c
+++ b/src/fmpz_mat/test/t-multi_CRT_ui_unsigned.c
@@ -25,10 +25,19 @@ TEST_FUNCTION_START(fmpz_mat_multi_CRT_ui_unsigned, state)
         slong bits, prime_bits, rows, cols, num_primes, j;
         fmpz_t mod;
         fmpz_mat_t A, B, C;
-        nmod_mat_t Amod[1000];
-        ulong primes[1000];
+        nmod_mat_t * Amod;
+        nn_ptr primes;
 
-        bits = n_randint(state, 500) + 1;
+        flint_set_num_threads(1 + n_randint(state, 4));
+
+        if (n_randint(state, 100) == 0)
+            bits = n_randint(state, 10000) + 1;
+        else
+            bits = n_randint(state, 500) + 1;
+
+        primes = flint_malloc(bits * sizeof(ulong));
+        Amod = flint_malloc(bits * sizeof(nmod_mat_struct));
+
         rows = n_randint(state, 10);
         cols = n_randint(state, 10);
         prime_bits = 1 + n_randint(state, FLINT_BITS - 1);
@@ -80,6 +89,9 @@ TEST_FUNCTION_START(fmpz_mat_multi_CRT_ui_unsigned, state)
         fmpz_mat_clear(B);
         fmpz_mat_clear(C);
         fmpz_clear(mod);
+
+        flint_free(Amod);
+        flint_free(primes);
     }
 
     TEST_FUNCTION_END(state);


### PR DESCRIPTION
Once upon a time, `fmpz_mat_mul_multi_mod` did an `fmpz_mat_multi_mod_ui`, then some multiplications, then an `fmpz_mat_multi_CRT_ui`.

At some point someone decided that `fmpz_mat_multi_mod_ui` and `fmpz_mat_multi_CRT_ui` weren't good enough and wrote some replacement code which all ended up inside `fmpz_mat_mul_multi_mod` itself.

We factor this improved code out to `fmpz_mat_multi_mod_ui` and `fmpz_mat_multi_CRT_ui` since these functions have other uses than matrix multiplication.

Also some minor tweaks: the calculation of thread limits is simplified, and the cutoffs for using ``fmpz_comb_t`` are chosen differently for the modular reduction and CRT phases. The asymmetric cutoffs give some small speedup (<10%) for certain parameters. (These cutoffs shouldn't actually be necessary at all -- the ``fmpz_comb`` ought to be optimized so that it's always fast, but that's another issue.)