### PR TITLE
Speed up `fmpz_mat_charpoly`

### DIFF
--- a/doc/source/fmpz_mat.rst
+++ b/doc/source/fmpz_mat.rst
@@ -839,6 +839,30 @@ Transforms
 Characteristic polynomial
 --------------------------------------------------------------------------------
 
+.. function:: void fmpz_mat_charpoly_bound(fmpz_t bound, const fmpz_mat_t A)
+
+    Compute a bound for the absolute value of the coefficients `c_k` of the
+    characteristic polynomial of `A` which is required to be an `n \times n`
+    (square) matrix. We use the fact that
+
+    .. math ::
+
+        c_{n-k} = (-1)^k \sum_{\substack{S \subseteq \{1,\ldots,n\} \\ |S|=k}} \det(A_S)
+
+    where `A_S` is the `k \times k` principal submatrix of `A` with rows
+    and columns indexed by `S`. Counting the number of terms and applying
+    Hadamard's bound to the determinants gives
+
+    .. math ::
+
+        |c_{n-k}| \le \binom{n}{k} \max_{\substack{S \subseteq \{1,\ldots,n\} \\ |S|=k}}
+           \prod_{i \in S} \|r_i\|_2
+           = \binom{n}{k} \prod_{i=1}^{k} \|r_i\|_2
+
+    where `r_1, \ldots, r_n` are the rows of `A` indexed in order of decreasing
+    Euclidean norm. We compute the maximum of these bounds for all `k`.
+    The same computation is done both rowwise and columnwise and the minimum
+    of these bounds is returned.
 
 .. function:: void _fmpz_mat_charpoly_berkowitz(fmpz * cp, const fmpz_mat_t mat)
 

--- a/doc/source/fmpz_mat.rst
+++ b/doc/source/fmpz_mat.rst
@@ -879,7 +879,7 @@ Characteristic polynomial
     several primes and combines them using CRT, using the bound
     returned by :func:`fmpz_mat_charpoly_bound` to guarantee that sufficiently
     many primes are chosen. This algorithm supports multithreading.
-    The default algorithm handles for various special cases and otherwise
+    The default algorithm handles various special cases and otherwise
     delegates to the *berkowitz* or *modular* algorithms depending on the
     size of the input.
 

--- a/doc/source/fmpz_mat.rst
+++ b/doc/source/fmpz_mat.rst
@@ -865,37 +865,23 @@ Characteristic polynomial
     of these bounds is returned.
 
 .. function:: void _fmpz_mat_charpoly_berkowitz(fmpz * cp, const fmpz_mat_t mat)
+              void fmpz_mat_charpoly_berkowitz(fmpz_poly_t cp, const fmpz_mat_t mat)
+              void _fmpz_mat_charpoly_modular(fmpz * cp, const fmpz_mat_t mat)
+              void fmpz_mat_charpoly_modular(fmpz_poly_t cp, const fmpz_mat_t mat)
+              void _fmpz_mat_charpoly(fmpz * cp, const fmpz_mat_t mat)
+              void fmpz_mat_charpoly(fmpz_poly_t cp, const fmpz_mat_t mat)
 
-    Sets ``(cp, n+1)`` to the characteristic polynomial of
-    an `n \times n` square matrix.
+    Compute the characteristic polynomial of an `n \times n` square matrix.
+    The underscore methods write `n + 1` coefficients.
 
-.. function:: void fmpz_mat_charpoly_berkowitz(fmpz_poly_t cp, const fmpz_mat_t mat)
-
-    Computes the characteristic polynomial of length `n + 1` of
-    an `n \times n` square matrix. Uses an `O(n^4)` algorithm based on the
-    method of Berkowitz.
-
-.. function:: void _fmpz_mat_charpoly_modular(fmpz * cp, const fmpz_mat_t mat)
-
-    Sets ``(cp, n+1)`` to the characteristic polynomial of
-    an `n \times n` square matrix.
-
-.. function:: void fmpz_mat_charpoly_modular(fmpz_poly_t cp, const fmpz_mat_t mat)
-
-    Computes the characteristic polynomial of length `n + 1` of
-    an `n \times n` square matrix. Uses a modular method based on an `O(n^3)`
-    method over `\mathbb{Z}/n\mathbb{Z}`.
-
-.. function:: void _fmpz_mat_charpoly(fmpz * cp, const fmpz_mat_t mat)
-
-    Sets ``(cp, n+1)`` to the characteristic polynomial of
-    an `n \times n` square matrix.
-
-.. function:: void fmpz_mat_charpoly(fmpz_poly_t cp, const fmpz_mat_t mat)
-
-    Computes the characteristic polynomial of length `n + 1` of
-    an `n \times n` square matrix.
-
+    The *berkowitz* algorithm is a wrapper of :func:`gr_mat_charpoly_berkowitz`.
+    The *modular* algorithm computes the characteristic polynomial modulo
+    several primes and combines them using CRT, using the bound
+    returned by :func:`fmpz_mat_charpoly_bound` to guarantee that sufficiently
+    many primes are chosen. This algorithm supports multithreading.
+    The default algorithm handles for various special cases and otherwise
+    delegates to the *berkowitz* or *modular* algorithms depending on the
+    size of the input.
 
 Minimal polynomial
 --------------------------------------------------------------------------------

--- a/doc/source/fmpz_vec.rst
+++ b/doc/source/fmpz_vec.rst
@@ -382,6 +382,12 @@ Reduction mod `p`
     Reduces all entries in ``(vec, len)`` modulo `p > 0`, choosing
     the unique representative in `(-p/2, p/2]`.
 
+.. function:: void _fmpz_vec_multi_CRT_ui(fmpz * res, nn_srcptr * residues, slong len, nn_srcptr primes, slong num_primes, int sign)
+
+    Sets ``(res, len)`` to the CRT lift of the ``num_primes``
+    vectors in ``residues`` modulo the respective moduli in ``primes``.
+    Equivalent to reconstructing each entry using :func:`fmpz_multi_CRT_ui`.
+
 
 Gaussian content
 --------------------------------------------------------------------------------

--- a/src/fmpz_mat.h
+++ b/src/fmpz_mat.h
@@ -295,22 +295,8 @@ void fmpz_mat_charpoly_berkowitz(fmpz_poly_t cp, const fmpz_mat_t mat);
 void _fmpz_mat_charpoly_modular(fmpz * rop, const fmpz_mat_t op);
 void fmpz_mat_charpoly_modular(fmpz_poly_t cp, const fmpz_mat_t mat);
 
-FMPZ_MAT_INLINE
-void _fmpz_mat_charpoly(fmpz * cp, const fmpz_mat_t mat)
-{
-   _fmpz_mat_charpoly_modular(cp, mat);
-}
-
-FMPZ_MAT_INLINE
-void fmpz_mat_charpoly(fmpz_poly_t cp, const fmpz_mat_t mat)
-{
-   if (mat->r != mat->c)
-   {
-       flint_throw(FLINT_ERROR, "Exception (nmod_mat_charpoly).  Non-square matrix.\n");
-   }
-
-   fmpz_mat_charpoly_modular(cp, mat);
-}
+void _fmpz_mat_charpoly(fmpz * cp, const fmpz_mat_t mat);
+void fmpz_mat_charpoly(fmpz_poly_t cp, const fmpz_mat_t mat);
 
 /* Characteristic polynomial ************************************************/
 

--- a/src/fmpz_mat.h
+++ b/src/fmpz_mat.h
@@ -287,6 +287,8 @@ void fmpz_mat_similarity(fmpz_mat_t A, slong r, fmpz_t d);
 
 /* Characteristic polynomial ************************************************/
 
+void fmpz_mat_charpoly_bound(fmpz_t bound, const fmpz_mat_t A);
+
 void _fmpz_mat_charpoly_berkowitz(fmpz * rop, const fmpz_mat_t op);
 void fmpz_mat_charpoly_berkowitz(fmpz_poly_t cp, const fmpz_mat_t mat);
 

--- a/src/fmpz_mat/charpoly.c
+++ b/src/fmpz_mat/charpoly.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2012, 2013 Sebastian Pancratz
+    Copyrigth (C) 2026 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -9,23 +10,13 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include <math.h>
 #include "ulong_extras.h"
-#include "nmod_mat.h"
-#include "nmod_poly.h"
+#include "gr.h"
+#include "gr_mat.h"
 #include "fmpz.h"
 #include "fmpz_vec.h"
 #include "fmpz_mat.h"
 #include "fmpz_poly.h"
-#include "gr.h"
-#include "gr_mat.h"
-
-/*
-    Assumes that \code{mat} is an $n \times n$ matrix and sets \code{(cp,n+1)}
-    to its characteristic polynomial.
-
-    Employs a division-free algorithm using $O(n^4)$ ring operations.
- */
 
 void _fmpz_mat_charpoly_berkowitz(fmpz *cp, const fmpz_mat_t mat)
 {
@@ -38,28 +29,17 @@ void fmpz_mat_charpoly_berkowitz(fmpz_poly_t cp, const fmpz_mat_t mat)
 {
      fmpz_poly_fit_length(cp, mat->r + 1);
     _fmpz_poly_set_length(cp, mat->r + 1);
-
     _fmpz_mat_charpoly_berkowitz(cp->coeffs, mat);
 }
 
-#define CHARPOLY_M_LOG2E  1.44269504088896340736  /* log2(e) */
-
-static inline long double _log2(const long double x)
-{
-    return log(x) * CHARPOLY_M_LOG2E;
-}
+#define MAT(ii, jj) fmpz_mat_entry(x, ii, jj)
 
 static void _fmpz_mat_charpoly_small_2x2(fmpz *rop, const fmpz_mat_t x)
 {
-#define MAT(ii, jj) fmpz_mat_entry(x, ii, jj)
-
-    fmpz_one   (rop + 2);
     fmpz_add   (rop + 1, MAT(0, 0), MAT(1, 1));
     fmpz_neg   (rop + 1, rop + 1);
     fmpz_mul   (rop + 0, MAT(0, 0), MAT(1, 1));
     fmpz_submul(rop + 0, MAT(0, 1), MAT(1, 0));
-
-#undef MAT
 }
 
 static void _fmpz_mat_charpoly_small_3x3(fmpz *rop, const fmpz_mat_t x)
@@ -67,8 +47,6 @@ static void _fmpz_mat_charpoly_small_3x3(fmpz *rop, const fmpz_mat_t x)
     fmpz a[2];
     fmpz_init(a + 0);
     fmpz_init(a + 1);
-
-#define MAT(ii, jj) fmpz_mat_entry(x, ii, jj)
 
     fmpz_mul(   a + 0,   MAT(1, 0), MAT(2, 1));
     fmpz_submul(a + 0,   MAT(1, 1), MAT(2, 0));
@@ -91,119 +69,62 @@ static void _fmpz_mat_charpoly_small_3x3(fmpz *rop, const fmpz_mat_t x)
     fmpz_submul(rop + 1, a + 1,    MAT(0, 0));
     fmpz_add(   rop + 1, rop + 1,  a + 0);
     fmpz_sub(   rop + 2, a + 1,    MAT(0, 0));
-    fmpz_one(   rop + 3);
-
-#undef MAT
 
     fmpz_clear(a + 0);
     fmpz_clear(a + 1);
 }
 
-static void _fmpz_mat_charpoly_small(fmpz * rop, const fmpz_mat_t op)
+#undef MAT
+
+static int
+want_berkowitz(slong n, const fmpz_mat_t op)
 {
-    if (op->r == 0)
-    {
-        fmpz_one(rop + 0);
-    }
-    else if (op->r == 1)
-    {
-        fmpz_one(rop + 1);
-        fmpz_neg(rop + 0, op->entries);
-    }
-    else if (op->r == 2)
-    {
-        _fmpz_mat_charpoly_small_2x2(rop, op);
-    }
-    else  /* op->r == 3 */
-    {
-        _fmpz_mat_charpoly_small_3x3(rop, op);
-    }
+    if (n <= 8)
+        return 1;
+
+    slong bits = fmpz_mat_max_bits(op);
+    bits = FLINT_ABS(bits);
+
+    return n < (slong) FLINT_BIT_COUNT(bits);
 }
 
-void _fmpz_mat_charpoly_modular(fmpz * rop, const fmpz_mat_t op)
+void _fmpz_mat_charpoly(fmpz * rop, const fmpz_mat_t op)
 {
     const slong n = op->r;
 
-    if (n < 4)
+    if (n <= 3)
     {
-        _fmpz_mat_charpoly_small(rop, op);
+        fmpz_one(rop + n);
+
+        if (n == 1)
+            fmpz_neg(rop, op->entries);
+        else if (n == 2)
+            _fmpz_mat_charpoly_small_2x2(rop, op);
+        else if (n == 3)
+            _fmpz_mat_charpoly_small_3x3(rop, op);
+        return;
     }
+
+    if (fmpz_mat_is_zero(op))
+    {
+        _fmpz_vec_zero(rop, n);
+        fmpz_one(rop + n);
+        return;
+    }
+
+    if (want_berkowitz(n, op))
+        _fmpz_mat_charpoly_berkowitz(rop, op);
     else
-    {
-        /*
-            If $A$ is an $n \times n$ matrix with $n \geq 4$ and
-            coefficients bounded in absolute value by $B > 1$ then
-            the coefficients of the characteristic polynomial have
-            less than $\ceil{n/2 (\log_2(n) + \log_2(B^2) + 1.6669)}$
-            bits.
-            See Lemma 4.1 in Dumas, Pernet, and Wan, "Efficient computation
-            of the characteristic polynomial", 2008.
-         */
-        slong bound;
-
-        slong pbits  = FLINT_BITS - 1;
-        ulong p = (UWORD(1) << pbits);
-
-        fmpz_t m;
-
-        /* Determine the bound in bits */
-        {
-            slong i, j;
-            fmpz *ptr;
-            double t;
-
-            ptr = fmpz_mat_entry(op, 0, 0);
-            for (i = 0; i < n; i++)
-                for (j = 0; j < n; j++)
-                    if (fmpz_cmpabs(ptr, fmpz_mat_entry(op, i, j)) < 0)
-                        ptr = fmpz_mat_entry(op, i, j);
-
-            if (fmpz_bits(ptr) == 0)  /* Zero matrix */
-            {
-                for (i = 0; i < n; i++)
-                   fmpz_zero(rop + i);
-                fmpz_set_ui(rop + n, 1);
-                return;
-            }
-
-            t = (fmpz_bits(ptr) <= FLINT_D_BITS) ?
-                _log2(FLINT_ABS(fmpz_get_d(ptr))) : fmpz_bits(ptr);
-
-            bound = ceil( (n / 2.0) * (_log2(n) + 2.0 * t + 1.6669) );
-        }
-
-        fmpz_init_set_ui(m, 1);
-        _fmpz_vec_zero(rop, n + 1);
-
-        for ( ; (slong) fmpz_bits(m) < bound; )
-        {
-            nmod_mat_t mat;
-            nmod_poly_t poly;
-
-            p = n_nextprime(p, 0);
-
-            nmod_mat_init(mat, n, n, p);
-            nmod_poly_init(poly, p);
-
-            fmpz_mat_get_nmod_mat(mat, op);
-            nmod_mat_charpoly(poly, mat);
-
-            _fmpz_poly_CRT_ui(rop, rop, n + 1, m, poly->coeffs, n + 1, poly->mod.n, poly->mod.ninv, 1);
-
-            fmpz_mul_ui(m, m, p);
-
-            nmod_mat_clear(mat);
-            nmod_poly_clear(poly);
-        }
-
-        fmpz_clear(m);
-    }
+        _fmpz_mat_charpoly_modular(rop, op);
 }
 
-void fmpz_mat_charpoly_modular(fmpz_poly_t cp, const fmpz_mat_t mat)
+void fmpz_mat_charpoly(fmpz_poly_t cp, const fmpz_mat_t mat)
 {
+    if (mat->r != mat->c)
+        flint_throw(FLINT_ERROR, "Exception (fmpz_mat_charpoly).  Non-square matrix.\n");
+
      fmpz_poly_fit_length(cp, mat->r + 1);
     _fmpz_poly_set_length(cp, mat->r + 1);
-
-    _fmpz_mat_charpoly_modular(cp->coeffs, mat);
+    _fmpz_mat_charpoly(cp->coeffs, mat);
 }
+

--- a/src/fmpz_mat/charpoly.c
+++ b/src/fmpz_mat/charpoly.c
@@ -1,6 +1,6 @@
 /*
     Copyright (C) 2012, 2013 Sebastian Pancratz
-    Copyrigth (C) 2026 Fredrik Johansson
+    Copyright (C) 2026 Fredrik Johansson
 
     This file is part of FLINT.
 

--- a/src/fmpz_mat/charpoly_bound.c
+++ b/src/fmpz_mat/charpoly_bound.c
@@ -1,0 +1,104 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdlib.h>
+#include "fmpz.h"
+#include "fmpz_mat.h"
+#include "mag.h"
+
+void fmpz_mat_charpoly_bound(fmpz_t bound, const fmpz_mat_t A)
+{
+    slong n = fmpz_mat_nrows(A);
+    slong i, j;
+    mag_t t, rprod, cprod, rbound, cbound;
+    mag_struct *rnorms, *cnorms, *binoms;
+
+    if (n == 0)
+    {
+        fmpz_one(bound);
+        return;
+    }
+
+    rnorms = _mag_vec_init(n);
+    cnorms = _mag_vec_init(n);
+    binoms = _mag_vec_init(n / 2 + 2);
+
+    mag_init(t);
+    mag_init(rprod);
+    mag_init(cprod);
+    mag_init(rbound);
+    mag_init(cbound);
+
+    /* Squared row and column norms */
+    for (i = 0; i < n; i++)
+    {
+        for (j = 0; j < n; j++)
+        {
+            mag_set_fmpz(t, fmpz_mat_entry(A, i, j));
+            mag_fast_mul(t, t, t);
+            mag_add(rnorms + i, rnorms + i, t);
+            mag_add(cnorms + j, cnorms + j, t);
+        }
+    }
+
+    for (i = 0; i < n; i++)
+    {
+        mag_sqrt(rnorms + i, rnorms + i);
+        mag_sqrt(cnorms + i, cnorms + i);
+    }
+
+    /* Sort norms ascending; we will read in reverse */
+    qsort(rnorms, n, sizeof(mag_struct),
+        (int (*)(const void *, const void *)) mag_cmp);
+    qsort(cnorms, n, sizeof(mag_struct),
+        (int (*)(const void *, const void *)) mag_cmp);
+
+    mag_one(binoms + 0);
+    mag_set_ui(binoms + 1, n);
+    for (i = 2; i <= n / 2; i++)
+    {
+        mag_mul_ui(binoms + i, binoms + i - 1, n - i + 1);
+        mag_div_ui(binoms + i, binoms + i, i);
+    }
+
+    mag_one(rprod);
+    mag_one(cprod);
+    mag_one(rbound);
+    mag_one(cbound);
+
+    for (j = 0; j < n; j++)
+    {
+        slong k = j + 1;
+        slong binom_idx = (k <= n / 2) ? k : n - k;
+
+        mag_mul(rprod, rprod, rnorms + (n - 1 - j));
+        mag_mul(cprod, cprod, cnorms + (n - 1 - j));
+
+        mag_mul(t, binoms + binom_idx, rprod);
+        mag_max(rbound, rbound, t);
+        mag_mul(t, binoms + binom_idx, cprod);
+        mag_max(cbound, cbound, t);
+    }
+
+    mag_min(t, rbound, cbound);
+    mag_get_fmpz(bound, t);
+
+    _mag_vec_clear(rnorms, n);
+    _mag_vec_clear(cnorms, n);
+    _mag_vec_clear(binoms, n / 2 + 2);
+
+    mag_clear(t);
+    mag_clear(rprod);
+    mag_clear(cprod);
+    mag_clear(rbound);
+    mag_clear(cbound);
+}
+

--- a/src/fmpz_mat/charpoly_modular.c
+++ b/src/fmpz_mat/charpoly_modular.c
@@ -1,6 +1,6 @@
 /*
     Copyright (C) 2012, 2013 Sebastian Pancratz
-    Copyrigth (C) 2026 Fredrik Johansson
+    Copyright (C) 2026 Fredrik Johansson
 
     This file is part of FLINT.
 

--- a/src/fmpz_mat/charpoly_modular.c
+++ b/src/fmpz_mat/charpoly_modular.c
@@ -1,0 +1,135 @@
+/*
+    Copyright (C) 2012, 2013 Sebastian Pancratz
+    Copyrigth (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "ulong_extras.h"
+#include "nmod_mat.h"
+#include "nmod_poly.h"
+#include "fmpz.h"
+#include "fmpz_vec.h"
+#include "fmpz_mat.h"
+#include "fmpz_poly.h"
+#include "thread_pool.h"
+#include "thread_support.h"
+
+typedef struct
+{
+    const fmpz_mat_struct * op;
+    const nmod_mat_struct * op_mod;
+    nn_ptr primes;
+    nn_ptr coeffs;
+} _charpoly_mod_arg_t;
+
+static void _charpoly_mod_worker(slong i, void * arg_ptr)
+{
+    _charpoly_mod_arg_t *arg = (_charpoly_mod_arg_t *) arg_ptr;
+
+    slong n = (arg->op)->r;
+
+    nmod_poly_t poly;
+    poly->coeffs = arg->coeffs + i * (n + 1);
+    poly->length = poly->alloc = n + 1;
+
+    if (arg->op_mod == NULL)
+    {
+        nmod_mat_t mat;
+        nmod_mat_init(mat, n, n, arg->primes[i]);
+        fmpz_mat_get_nmod_mat(mat, arg->op);
+        nmod_mat_charpoly(poly, mat);
+        nmod_mat_clear(mat);
+    }
+    else
+    {
+        nmod_mat_charpoly(poly, arg->op_mod + i);
+    }
+}
+
+void _fmpz_mat_charpoly_modular(fmpz * rop, const fmpz_mat_t op)
+{
+    const slong n = op->r;
+
+    if (n == 0)
+    {
+        fmpz_one(rop);
+        return;
+    }
+
+    slong bound;
+    slong pbits = FLINT_BITS - 1;
+    ulong p = (UWORD(1) << pbits);
+
+    fmpz_t b;
+    fmpz_init(b);
+    fmpz_mat_charpoly_bound(b, op);
+    bound = fmpz_bits(b);
+    fmpz_clear(b);
+
+    /* Account for signs */
+    bound++;
+
+    slong num_primes = (bound + pbits - 1) / pbits;
+    ulong *primes = flint_malloc(num_primes * sizeof(ulong));
+    for (slong i = 0; i < num_primes; i++)
+    {
+        p = n_nextprime(p, 0);
+        primes[i] = p;
+    }
+
+    nn_ptr coeff_buf = flint_malloc(num_primes * (n + 1) * sizeof(ulong));
+
+    _charpoly_mod_arg_t args;
+    args.op = op;
+    args.op_mod = NULL;
+    args.primes = primes;
+    args.coeffs = coeff_buf;
+
+    /* Want asymptotically fast multimodular reduction */
+    if (num_primes > FMPZ_MAT_MOD_PRIMES_COMB_CUTOFF)
+    {
+        nmod_mat_struct * Amod;
+
+        Amod = flint_malloc(sizeof(nmod_mat_struct) * num_primes);
+        for (slong i = 0; i < num_primes; i++)
+            nmod_mat_init(Amod + i, n, n, primes[i]);
+
+        fmpz_mat_multi_mod_ui((nmod_mat_t *) Amod, num_primes, op);
+        args.op_mod = Amod;
+
+        flint_parallel_do(_charpoly_mod_worker, &args, num_primes, 0, FLINT_PARALLEL_UNIFORM);
+
+        for (slong i = 0; i < num_primes; i++)
+            nmod_mat_clear(Amod + i);
+        flint_free(Amod);
+    }
+    else
+    {
+        /* Just do the mod p reductions inline with the mod p charpolys */
+        flint_parallel_do(_charpoly_mod_worker, &args, num_primes, 0, FLINT_PARALLEL_UNIFORM);
+    }
+
+    nn_srcptr *residues = flint_malloc(num_primes * sizeof(nn_srcptr));
+    for (slong i = 0; i < num_primes; i++)
+        residues[i] = coeff_buf + i * (n + 1);
+
+    _fmpz_vec_multi_CRT_ui(rop, residues, n + 1, primes, num_primes, 1);
+
+    flint_free(residues);
+    flint_free(coeff_buf);
+    flint_free(primes);
+}
+
+void fmpz_mat_charpoly_modular(fmpz_poly_t cp, const fmpz_mat_t mat)
+{
+     fmpz_poly_fit_length(cp, mat->r + 1);
+    _fmpz_poly_set_length(cp, mat->r + 1);
+    _fmpz_mat_charpoly_modular(cp->coeffs, mat);
+}
+

--- a/src/fmpz_mat/test/main.c
+++ b/src/fmpz_mat/test/main.c
@@ -27,6 +27,7 @@
 #include "t-can_solve_fflu.c"
 #include "t-can_solve_multi_mod_den.c"
 #include "t-charpoly_berkowitz.c"
+#include "t-charpoly_bound.c"
 #include "t-charpoly.c"
 #include "t-chol_d.c"
 #include "t-col_partition.c"
@@ -131,6 +132,7 @@ test_struct tests[] =
     TEST_FUNCTION(fmpz_mat_can_solve_fflu),
     TEST_FUNCTION(fmpz_mat_can_solve_multi_mod_den),
     TEST_FUNCTION(fmpz_mat_charpoly_berkowitz),
+    TEST_FUNCTION(fmpz_mat_charpoly_bound),
     TEST_FUNCTION(fmpz_mat_charpoly),
     TEST_FUNCTION(fmpz_mat_chol_d),
     TEST_FUNCTION(fmpz_mat_col_partition),

--- a/src/fmpz_mat/test/main.c
+++ b/src/fmpz_mat/test/main.c
@@ -28,6 +28,7 @@
 #include "t-can_solve_multi_mod_den.c"
 #include "t-charpoly_berkowitz.c"
 #include "t-charpoly_bound.c"
+#include "t-charpoly_modular.c"
 #include "t-charpoly.c"
 #include "t-chol_d.c"
 #include "t-col_partition.c"
@@ -133,6 +134,7 @@ test_struct tests[] =
     TEST_FUNCTION(fmpz_mat_can_solve_multi_mod_den),
     TEST_FUNCTION(fmpz_mat_charpoly_berkowitz),
     TEST_FUNCTION(fmpz_mat_charpoly_bound),
+    TEST_FUNCTION(fmpz_mat_charpoly_modular),
     TEST_FUNCTION(fmpz_mat_charpoly),
     TEST_FUNCTION(fmpz_mat_chol_d),
     TEST_FUNCTION(fmpz_mat_col_partition),

--- a/src/fmpz_mat/test/t-charpoly_bound.c
+++ b/src/fmpz_mat/test/t-charpoly_bound.c
@@ -1,0 +1,88 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "fmpz.h"
+#include "fmpz_poly.h"
+#include "fmpz_mat.h"
+#include "fmpz_extras.h"
+
+TEST_FUNCTION_START(fmpz_mat_charpoly_bound, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
+    {
+        fmpz_t c, bound, height;
+        fmpz_mat_t A;
+        slong i, n, cbits, psteps, pbits;
+
+        n = n_randint(state, 10);
+
+        fmpz_init(c);
+        fmpz_init(bound);
+        fmpz_init(height);
+        fmpz_mat_init(A, n, n);
+
+        cbits = 1 + n_randint(state, 30);
+
+        if (n_randint(state, 2) == 0)
+        {
+            fmpz_poly_t f;
+            fmpz_poly_init(f);
+            fmpz_mat_randtest(A, state, cbits);
+            fmpz_mat_charpoly_berkowitz(f, A);
+            fmpz_poly_height(height, f);
+            fmpz_poly_clear(f);
+        }
+        else
+        {
+            /* Similiarity transform of random companion matrix */
+            psteps = n_randint(state, 10);
+            pbits = 1 + n_randint(state, 10);
+
+            for (i = 0; i < n - 1; i++)
+                fmpz_one(fmpz_mat_entry(A, i, i + 1));
+            fmpz_one(height);
+            for (i = 0; i < n; i++)
+            {
+                fmpz_randtest(fmpz_mat_entry(A, n - 1, i), state, cbits);
+                fmpz_abs(c, fmpz_mat_entry(A, n - 1, i));
+                fmpz_max(height, height, c);
+            }
+
+            for (i = 0; i < psteps; i++)
+            {
+               fmpz_randtest(c, state, pbits);
+               fmpz_mat_similarity(A, n_randint(state, n), c);
+            }
+        }
+
+        fmpz_mat_charpoly_bound(bound, A);
+
+        if (fmpz_cmp(height, bound) > 0)
+        {
+            flint_printf("FAIL\n");
+            flint_printf("A = \n"), fmpz_mat_print(A), flint_printf("\n");
+            flint_printf("height = %{fmpz}\n", height);
+            flint_printf("bound = %{fmpz}\n", bound);
+            fflush(stdout);
+            flint_abort();
+        }
+
+        fmpz_clear(c);
+        fmpz_clear(bound);
+        fmpz_clear(height);
+        fmpz_mat_clear(A);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/fmpz_mat/test/t-charpoly_modular.c
+++ b/src/fmpz_mat/test/t-charpoly_modular.c
@@ -12,30 +12,29 @@
 
 #include "test_helpers.h"
 #include "fmpz.h"
-#include "fmpz_poly.h"
 #include "fmpz_mat.h"
+#include "fmpz_poly.h"
 
-TEST_FUNCTION_START(fmpz_mat_charpoly, state)
+TEST_FUNCTION_START(fmpz_mat_charpoly_modular, state)
 {
-    slong m, n, rep, i;
+    slong rep, i;
 
     for (rep = 0; rep < 1000 * flint_test_multiplier(); rep++)
     {
         fmpz_mat_t A, B, C, D;
         fmpz_poly_t f, g;
+        slong n;
 
-        m = n_randint(state, 10);
-        n = m;
+        n = n_randint(state, 8);
 
-        fmpz_mat_init(A, m, n);
-        fmpz_mat_init(B, m, n);
-        fmpz_mat_init(C, m, m);
+        flint_set_num_threads(1 + n_randint(state, 3));
+
+        fmpz_mat_init(A, n, n);
+        fmpz_mat_init(B, n, n);
+        fmpz_mat_init(C, n, n);
         fmpz_mat_init(D, n, n);
         fmpz_poly_init(f);
         fmpz_poly_init(g);
-
-        fmpz_poly_randtest(f, state, 10, 100);
-        fmpz_poly_randtest(g, state, 10, 100);
 
         fmpz_mat_randtest(A, state, 10);
         fmpz_mat_randtest(B, state, 10);
@@ -43,8 +42,8 @@ TEST_FUNCTION_START(fmpz_mat_charpoly, state)
         fmpz_mat_mul(C, A, B);
         fmpz_mat_mul(D, B, A);
 
-        fmpz_mat_charpoly(f, C);
-        fmpz_mat_charpoly(g, D);
+        fmpz_mat_charpoly_modular(f, C);
+        fmpz_mat_charpoly_modular(g, D);
 
         if (!fmpz_poly_equal(f, g))
         {
@@ -70,30 +69,38 @@ TEST_FUNCTION_START(fmpz_mat_charpoly, state)
         fmpz_t c;
         fmpz_mat_t A, B;
         fmpz_poly_t f, g;
+        slong n, bits;
 
-        m = n_randint(state, 10);
-        n = m;
+        if (n_randint(state, 10) == 0)
+        {
+            n = n_randint(state, 4);
+            bits = n_randint(state, 5000);
+        }
+        else
+        {
+            n = n_randint(state, 8);
+            bits = n_randint(state, 10);
+        }
+
+        flint_set_num_threads(1 + n_randint(state, 3));
 
         fmpz_init(c);
-        fmpz_mat_init(A, m, n);
-        fmpz_mat_init(B, m, n);
+        fmpz_mat_init(A, n, n);
+        fmpz_mat_init(B, n, n);
         fmpz_poly_init(f);
         fmpz_poly_init(g);
 
-        fmpz_poly_randtest(f, state, 10, 100);
-        fmpz_poly_randtest(g, state, 10, 100);
-
-        fmpz_mat_randtest(A, state, 10);
+        fmpz_mat_randtest(A, state, bits);
         fmpz_mat_set(B, A);
 
         for (i = 0; i < 10; i++)
         {
            fmpz_randtest(c, state, 5);
-           fmpz_mat_similarity(B, n_randint(state, m), c);
+           fmpz_mat_similarity(B, n_randint(state, n), c);
         }
 
-        fmpz_mat_charpoly(f, A);
-        fmpz_mat_charpoly(g, B);
+        fmpz_mat_charpoly_modular(f, A);
+        fmpz_mat_charpoly_modular(g, B);
 
         if (!fmpz_poly_equal(f, g))
         {

--- a/src/fmpz_vec.h
+++ b/src/fmpz_vec.h
@@ -182,6 +182,8 @@ void _fmpz_ui_vec_prod(fmpz_t res, nn_srcptr vec, slong len);
 void _fmpz_vec_scalar_mod_fmpz(fmpz *res, const fmpz *vec, slong len, const fmpz_t p);
 void _fmpz_vec_scalar_smod_fmpz(fmpz *res, const fmpz *vec, slong len, const fmpz_t p);
 
+void _fmpz_vec_multi_CRT_ui(fmpz * res, nn_srcptr * residues, slong len, nn_srcptr primes, slong num_primes, int sign);
+
 /*  Gaussian content  ********************************************************/
 
 void _fmpz_vec_content(fmpz_t res, const fmpz * vec, slong len);

--- a/src/fmpz_vec/multi_CRT_ui.c
+++ b/src/fmpz_vec/multi_CRT_ui.c
@@ -1,0 +1,136 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "thread_pool.h"
+#include "thread_support.h"
+#include "fmpz.h"
+#include "fmpz_vec.h"
+/* For FMPZ_MAT_CRT_MIN_WORK_PER_THREAD */
+#include "fmpz_mat.h"
+
+/* To do: implement optimizations currently used in the fmpz_mat version */
+
+typedef struct
+{
+    fmpz *res;
+    nn_srcptr *residues;
+    slong num_primes;
+    fmpz_comb_t *comb;
+    slong a;
+    slong b;
+    int sign;
+} _multi_CRT_chunk_t;
+
+static void _multi_CRT_worker(void *_work)
+{
+    _multi_CRT_chunk_t *work = (_multi_CRT_chunk_t *) _work;
+    fmpz_comb_temp_t temp;
+    slong i, k;
+
+    ulong * col = flint_malloc(work->num_primes * sizeof(ulong));
+
+    fmpz_comb_temp_init(temp, *work->comb);
+
+    for (k = work->a; k < work->b; k++)
+    {
+        for (i = 0; i < work->num_primes; i++)
+            col[i] = work->residues[i][k];
+
+        fmpz_multi_CRT_ui(work->res + k, col, *work->comb, temp, work->sign);
+    }
+
+    fmpz_comb_temp_clear(temp);
+    flint_free(col);
+}
+
+void _fmpz_vec_multi_CRT_ui(fmpz * res, nn_srcptr * residues, slong len,
+                             nn_srcptr primes, slong num_primes, int sign)
+{
+    slong thread_limit;
+
+    if (num_primes == 0)
+    {
+        _fmpz_vec_zero(res, len);
+        return;
+    }
+
+    if (num_primes == 1)
+    {
+        slong i;
+
+        if (sign)
+            for (i = 0; i < len; i++)
+                fmpz_set_ui_smod(res + i, residues[0][i], primes[0]);
+        else
+            for (i = 0; i < len; i++)
+                fmpz_set_ui(res + i, residues[0][i]);
+        return;
+    }
+
+    thread_limit = (len * num_primes) / FMPZ_MAT_CRT_MIN_WORK_PER_THREAD;
+
+    if (thread_limit > 1)
+        thread_limit = FLINT_MIN(thread_limit, flint_get_num_threads());
+
+    fmpz_comb_t comb;
+    fmpz_comb_init(comb, primes, num_primes);
+
+    if (thread_limit <= 1)
+    {
+        _multi_CRT_chunk_t work;
+        work.res        = res;
+        work.residues   = residues;
+        work.num_primes = num_primes;
+        work.comb       = &comb;
+        work.a          = 0;
+        work.b          = len;
+        work.sign       = sign;
+        _multi_CRT_worker(&work);
+    }
+    else
+    {
+        thread_pool_handle *handles;
+        slong num_workers = flint_request_threads(&handles, thread_limit);
+        slong num_threads = num_workers + 1;
+        slong chunk_size = (len + num_threads - 1) / num_threads;
+        slong i;
+
+        TMP_INIT;
+        TMP_START;
+
+        _multi_CRT_chunk_t *work = TMP_ALLOC(num_threads * sizeof(_multi_CRT_chunk_t));
+
+        for (i = 0; i < num_threads; i++)
+        {
+            work[i].res        = res;
+            work[i].residues   = residues;
+            work[i].num_primes = num_primes;
+            work[i].comb       = &comb;
+            work[i].a          = i * chunk_size;
+            work[i].b          = FLINT_MIN((i + 1) * chunk_size, len);
+            work[i].sign       = sign;
+        }
+
+        for (i = 0; i < num_workers; i++)
+            thread_pool_wake(global_thread_pool, handles[i], 0, _multi_CRT_worker, &work[i]);
+
+        _multi_CRT_worker(&work[num_workers]);
+
+        for (i = 0; i < num_workers; i++)
+            thread_pool_wait(global_thread_pool, handles[i]);
+
+        flint_give_back_threads(handles, num_workers);
+        TMP_END;
+    }
+
+    fmpz_comb_clear(comb);
+}
+

--- a/src/fmpz_vec/test/main.c
+++ b/src/fmpz_vec/test/main.c
@@ -27,6 +27,7 @@
 #include "t-lcm.c"
 #include "t-max_bits.c"
 #include "t-max_limbs.c"
+#include "t-multi_CRT_ui.c"
 #include "t-neg.c"
 #include "t-prod.c"
 #include "t-prod_ui.c"
@@ -73,6 +74,7 @@ test_struct tests[] =
     TEST_FUNCTION(fmpz_vec_lcm),
     TEST_FUNCTION(fmpz_vec_max_bits),
     TEST_FUNCTION(fmpz_vec_max_limbs),
+    TEST_FUNCTION(fmpz_vec_multi_CRT_ui),
     TEST_FUNCTION(fmpz_vec_neg),
     TEST_FUNCTION(fmpz_vec_prod),
     TEST_FUNCTION(fmpz_ui_vec_prod),

--- a/src/fmpz_vec/test/t-multi_CRT_ui.c
+++ b/src/fmpz_vec/test/t-multi_CRT_ui.c
@@ -84,7 +84,7 @@ TEST_FUNCTION_START(fmpz_vec_multi_CRT_ui, state)
             flint_printf("FAIL\n");
             flint_printf("primes = %{ulong*}\n\n", primes, num_primes);
             flint_printf("A = %{fmpz*}\n\n", A, len);
-            flint_printf("A = %{fmpz*}\n\n", B, len);
+            flint_printf("B = %{fmpz*}\n\n", B, len);
             flint_abort();
         }
 

--- a/src/fmpz_vec/test/t-multi_CRT_ui.c
+++ b/src/fmpz_vec/test/t-multi_CRT_ui.c
@@ -1,0 +1,100 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "fmpz.h"
+#include "nmod_vec.h"
+#include "fmpz_vec.h"
+
+TEST_FUNCTION_START(fmpz_vec_multi_CRT_ui, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 100 * flint_test_multiplier(); iter++)
+    {
+        slong i, j, len, pbits, num_primes;
+        ulong p;
+        fmpz_t M;
+        fmpz * A, * B;
+        int sign;
+        nn_ptr primes, Amod;
+        nn_srcptr * Amod_ptr;
+
+        flint_set_num_threads(1 + n_randint(state, 4));
+
+        if (n_randint(state, 2) == 0)
+        {
+            len = n_randint(state, 200);
+            num_primes = n_randint(state, 40);
+            pbits = 1;
+        }
+        else
+        {
+            len = n_randint(state, 10);
+            num_primes = n_randint(state, 4);
+            pbits = n_randint(state, FLINT_BITS);
+        }
+
+        sign = n_randint(state, 2);
+
+        A = _fmpz_vec_init(len);
+        B = _fmpz_vec_init(len);
+        primes = _nmod_vec_init(num_primes);
+        Amod = _nmod_vec_init(num_primes * len);
+        Amod_ptr = flint_malloc(sizeof(nn_ptr) * num_primes);
+
+        for (i = 0; i < num_primes; i++)
+            Amod_ptr[i] = Amod + i * len;
+
+        fmpz_init(M);
+        fmpz_one(M);
+
+        p = n_nextprime(UWORD(1) << pbits, 0);
+
+        for (i = 0; i < num_primes; i++)
+        {
+            primes[i] = p;
+            fmpz_mul_ui(M, M, p);
+            p = n_nextprime(p, 0);
+        }
+
+        for (i = 0; i < len; i++)
+        {
+            if (sign && !fmpz_is_one(M))
+                fmpz_randtest_mod_signed(A + i, state, M);
+            else
+                fmpz_randtest_mod(A + i, state, M);
+
+            for (j = 0; j < num_primes; j++)
+                Amod[j * len + i] = fmpz_fdiv_ui(A + i, primes[j]);
+        }
+
+        _fmpz_vec_multi_CRT_ui(B, Amod_ptr, len, primes, num_primes, sign);
+
+        if (!_fmpz_vec_equal(A, B, len))
+        {
+            flint_printf("FAIL\n");
+            flint_printf("primes = %{ulong*}\n\n", primes, num_primes);
+            flint_printf("A = %{fmpz*}\n\n", A, len);
+            flint_printf("A = %{fmpz*}\n\n", B, len);
+            flint_abort();
+        }
+
+        _fmpz_vec_clear(A, len);
+        _fmpz_vec_clear(B, len);
+        _nmod_vec_clear(primes);
+        _nmod_vec_clear(Amod);
+        flint_free(Amod_ptr);
+        fmpz_clear(M);
+    }
+
+    TEST_FUNCTION_END(state);
+}


### PR DESCRIPTION
Summary:

* We add `fmpz_mat_charpoly_bound` and use this in `fmpz_mat_charpoly_modular`. Instead of the old crude bound based on the height of the matrix, we compute Hadamard bounds for the determinants in the trace sum formula for the charpoly. This still costs only $O(n^2)$, gives a slightly better bound for uniform matrices, and gives dramatically better bounds for sparse and non-uniform matrices.

* We select appropriately between Berkowitz and the modular algorithm for small matrices in `fmpz_mat_charpoly` (previously the modular algorithm was always used for $n \ge 4$), speeding up small matrices and matrices with huge entries.

* The modular algorithm is reimplemented using asymptotically fast modular reduction and CRT, so the complexity scales quasi-linearly with the bit size of the output and not quasi-quadratically.

* We make the modular algorithm multithreaded.

* Add helper function `_fmpz_vec_multi_CRT_ui`.

Part of the code was written with the help of Claude.

Not done: detecting special cases (other than the zero matrix). One could easily detect triangular and Hessenberg matrices and handle these specially. I think nilpotent and single-eigenvalue (charpoly $(x-c)^n$) matrices could also be detected and certified faster than the general algorithm (with negligible overhead for generic input). Other cases where the characteristic polynomial is very sparse and has much smaller coefficients than the generic bound might also be doable with early termination based on direct verification, though this gets a bit more complicated (especially to ensure that this is actually only done when it is faster and that the generic case doesn't slow down).

Timings for uniform random matrices with randbits(bits) entries, both single-threaded and multithreaded. Note that "old" includes the preexisting 30% speedup of the modular algorithm from #2684.

```
                              1 thread                        8 threads
     n      bits  |       old        new   speedup |       old        new   speedup |

     4        16  |  1.52e-06   4.58e-07    3.319  |   1.47e-06   4.54e-07    3.238 |
     4        64  |  3.82e-06   1.39e-06    2.748  |   3.89e-06   1.38e-06    2.819 |
     4       256  |  1.61e-05   1.94e-06    8.299  |   1.61e-05   1.94e-06    8.299 |
     4      1024  |  0.000125   1.22e-05   10.246  |   0.000122   1.22e-05   10.000 |
     4      4096  |   0.00126   0.000119   10.588  |    0.00126   0.000119   10.588 |
     4     16384  |     0.014   0.000998   14.028  |      0.014      0.001   14.000 |
     4     65536  |      0.19    0.00482   39.419  |      0.188    0.00372   50.538 |
     4    262144  |     2.905     0.0189  153.704  |      2.889     0.0065  444.462 |

     8        16  |  8.59e-06    6.7e-06    1.282  |   8.56e-06   6.64e-06    1.289 |
     8        64  |  2.74e-05   1.48e-05    1.851  |   2.74e-05   1.47e-05    1.864 |
     8       256  |  0.000118   3.93e-05    3.003  |   0.000118   3.95e-05    2.987 |
     8      1024  |   0.00097   0.000382    2.539  |   0.000957   0.000382    2.505 |
     8      4096  |   0.00815    0.00395    2.063  |     0.0081    0.00394    2.056 |
     8     16384  |    0.0947     0.0323    2.932  |     0.0947     0.0331    2.861 |
     8     65536  |     1.363      0.126   10.817  |      1.362      0.067   20.328 |
     8    262144  |     21.55      0.519   41.522  |     21.571      0.156  138.276 |

    16        16  |  5.42e-05   5.67e-05    0.956  |    5.4e-05   3.34e-05    1.617 |
    16        64  |  0.000196   0.000182    1.077  |   0.000195    5.8e-05    3.362 |
    16       256  |   0.00119    0.00106    1.123  |    0.00117    0.00025    4.680 |
    16      1024  |   0.00737    0.00654    1.127  |    0.00736    0.00207    3.556 |
    16      4096  |    0.0606     0.0484    1.252  |     0.0606     0.0153    3.961 |
    16     16384  |     0.679      0.335    2.027  |      0.676       0.11    6.145 |
    16     65536  |    10.755      3.622    2.969  |     10.759      1.465    7.344 |

    32        16  |  0.000614   0.000608    1.010  |   0.000609   0.000269    2.264 |
    32        64  |   0.00233    0.00219    1.064  |    0.00234    0.00045    5.200 |
    32       256  |    0.0122    0.00981    1.244  |     0.0106     0.0023    4.609 |
    32      1024  |    0.0639     0.0524    1.219  |     0.0638     0.0123    5.187 |
    32      4096  |     0.508      0.368    1.380  |      0.505      0.093    5.430 |
    32     16384  |     5.873      2.452    2.395  |      5.837      0.515   11.334 |
    32     65536  |    87.079     17.669    4.928  |     87.046      3.587   24.267 |

    64        16  |    0.0116    0.00726    1.598  |    0.00804     0.0023    3.496 |
    64        64  |    0.0294     0.0284    1.035  |     0.0296     0.0056    5.286 |
    64       256  |     0.148      0.109    1.358  |      0.127      0.023    5.522 |
    64      1024  |      0.69      0.547    1.261  |      0.688      0.108    6.370 |
    64      4096  |      4.75      3.324    1.429  |      4.692      0.575    8.160 |
    64     16384  |    54.059     20.722    2.609  |     54.868      3.627   15.128 |

   128        16  |     0.176      0.125    1.408  |      0.134      0.022    6.091 |
   128        64  |     0.472       0.46    1.026  |      0.469      0.088    5.330 |
   128       256  |     1.894      1.708    1.109  |      1.852      0.279    6.638 |
   128      1024  |     8.795      7.571    1.162  |      8.717      1.231    7.081 |
   128      4096  |    63.556      39.46    1.611  |     63.049      6.479    9.731 |

   256        16  |     2.437       2.23    1.093  |      2.407       0.41    5.871 |
   256        64  |     8.202      7.697    1.066  |      8.145      1.232    6.611 |
   256       256  |    31.272     29.737    1.052  |     31.442      4.745    6.626 |
```

Example timings for sparse matrices: the input is the companion matrix of a polynomial with randbits(bits) entries, plus an extra 1 in position (0, 0) of the matrix.


```
                              1 thread                        8 threads
     n      bits  |       old        new   speedup |       old        new   speedup |

     4        16  |  1.44e-06   3.87e-07    3.721  |   1.39e-06   3.81e-07    3.648 |
     4        64  |  3.62e-06    7.5e-07    4.827  |   3.64e-06   7.55e-07    4.821 |
     4       256  |  1.45e-05   9.01e-07   16.093  |   1.51e-05   9.01e-07   16.759 |
     4      1024  |  9.22e-05   3.18e-06   28.994  |    9.2e-05   3.18e-06   28.931 |
     4      4096  |  0.000965   2.69e-05   35.874  |   0.000962   2.68e-05   35.896 |
     4     16384  |   0.00908    0.00021   43.238  |     0.0089   0.000207   42.995 |
     4     65536  |      0.11   0.000999  110.110  |       0.11    0.00089  123.596 |
     4    262144  |      1.47    0.00452  325.221  |      1.463    0.00155  943.871 |

     8        16  |  8.25e-06      3e-06    2.750  |   8.19e-06   2.97e-06    2.758 |
     8        64  |   2.7e-05   4.16e-06    6.490  |   2.59e-05   4.09e-06    6.333 |
     8       256  |  0.000106   5.45e-06   19.450  |   0.000103   5.42e-06   19.004 |
     8      1024  |  0.000663   2.67e-05   24.831  |   0.000668   2.64e-05   25.303 |
     8      4096  |   0.00517   0.000226   22.876  |    0.00518   0.000227   22.819 |
     8     16384  |    0.0486    0.00178   27.303  |     0.0494    0.00183   26.995 |
     8     65536  |     0.621    0.00715   86.853  |      0.595     0.0044  135.227 |
     8    262144  |    10.553     0.0308  342.630  |     10.216     0.0101 1011.485 |

    16        16  |  4.15e-05   1.06e-05    3.915  |   4.15e-05   1.04e-05    3.990 |
    16        64  |  0.000151   2.06e-05    7.330  |   0.000151    2.2e-05    6.864 |
    16       256  |  0.000874   4.34e-05   20.138  |    0.00087   2.42e-05   35.950 |
    16      1024  |   0.00487   0.000148   32.905  |    0.00491    5.1e-05   96.275 |
    16      4096  |    0.0305    0.00089   34.270  |     0.0304   0.000491   61.914 |
    16     16384  |     0.334    0.00575   58.087  |      0.325     0.0034   95.588 |
    16     65536  |     4.558     0.0524   86.985  |       4.57     0.0262  174.427 |
    16    262144  |     66.04       0.23  287.130  |     65.717      0.074  888.068 |

    32        16  |  0.000373   4.27e-05    8.735  |   0.000368   4.23e-05    8.700 |
    32        64  |   0.00154   7.89e-05   19.518  |    0.00153   5.84e-05   26.199 |
    32       256  |   0.00667   0.000178   37.472  |     0.0066    7.2e-05   91.667 |
    32      1024  |    0.0324   0.000702   46.154  |     0.0322    0.00033   97.576 |
    32      4096  |     0.258    0.00305   84.590  |      0.224     0.0006  373.333 |
    32     16384  |     2.675     0.0157  170.382  |      2.664     0.0065  409.846 |
    32     65536  |     29.96     0.0733  408.731  |     30.033      0.036  834.250 |

    64        16  |   0.00413   0.000383   10.783  |     0.0041   0.000242   16.942 |
    64        64  |    0.0141    0.00057   24.737  |     0.0137   0.000262   52.290 |
    64       256  |    0.0575    0.00117   49.145  |      0.057    0.00044  129.545 |
    64      1024  |     0.286    0.00353   81.020  |      0.274    0.00166  165.060 |
    64      4096  |     1.798     0.0133  135.188  |      1.773     0.0027  656.667 |
    64     16384  |    18.694     0.0603  310.017  |     18.775     0.0259  724.903 |

   128        16  |     0.067    0.00478   14.017  |     0.0669      0.002   33.450 |
   128        64  |     0.227    0.00638   35.580  |      0.225    0.00207  108.696 |
   128       256  |     0.882     0.0111   79.459  |      0.868     0.0023  377.391 |
   128      1024  |     3.797     0.0302  125.728  |      3.781     0.0066  572.879 |
   128      4096  |    20.906      0.113  185.009  |     21.659      0.019 1139.947 |

   256        16  |     1.378     0.0809   17.033  |      1.372      0.024   57.167 |
   256        64  |     4.733      0.101   46.861  |      4.732      0.024  197.167 |
   256       256  |    17.785      0.146  121.815  |     17.316      0.081  213.778 |
```
