### PR TITLE
fft_small/mpn_mul: Speed up CRT reconstruction by avoid  split accumulator

### DIFF
--- a/src/crt_helpers.h
+++ b/src/crt_helpers.h
@@ -425,10 +425,46 @@ DEFINE_IT(4, 3)
 DEFINE_IT(4, 4)
 DEFINE_IT(5, 4)
 DEFINE_IT(6, 5)
-DEFINE_IT(7, 6)
 #undef DEFINE_IT
 
+/* The (7, 6) functions differ from the other variants, that they do not use t[],
+   instead they accumulate everything into r[] to save registers. */
+FLINT_FORCE_INLINE void CAT3(_big_mul, 7, 6)(ulong r[], ulong FLINT_UNUSED(t[]), ulong C[], ulong y)
+{
+    ulong hi, lo;
+    ulong k;
 
+    _mul(&r[1], &r[0], C[0], y);
+    r[2] = 0;
+
+    for (k = 1; k < 5; k++)
+    {
+        umul_ppmm(hi, lo, C[k], y);
+        add_sssaaaaaa(r[k + 2], r[k + 1], r[k],
+                      0,        r[k + 1], r[k],
+                      0,        hi,       lo);
+    }
+
+    umul_ppmm(hi, lo, C[5], y);
+    add_ssaaaa(r[6], r[5], r[6], r[5], hi, lo);
+}
+
+FLINT_FORCE_INLINE void CAT3(_big_addmul, 7, 6)(ulong r[], ulong FLINT_UNUSED(t[]), ulong C[], ulong y)
+{
+    ulong hi, lo;
+    ulong k, carry;
+
+    carry = 0;
+    for (k = 0; k < 6; k++)
+    {
+        umul_ppmm(hi, lo, C[k], y);
+        add_sssaaaaaa(carry, r[k + 1], r[k],
+                      0,     r[k + 1], r[k],
+                      0,     hi + carry, lo);
+    }
+
+    FLINT_ASSERT(carry == 0);
+}
 
 #define DEFINE_IT(n, n_minus_1) \
 FLINT_FORCE_INLINE void CAT(_reduce_big_sum, n)(ulong r[], ulong t[], const ulong* limit) \
@@ -455,8 +491,24 @@ DEFINE_IT(3, 2)
 DEFINE_IT(4, 3)
 DEFINE_IT(5, 4)
 DEFINE_IT(6, 5)
-DEFINE_IT(7, 6)
 #undef DEFINE_IT
+
+FLINT_FORCE_INLINE void CAT(_reduce_big_sum, 7)(ulong r[], ulong FLINT_UNUSED(t[]), const ulong* limit)
+{
+check:
+    for (ulong k = 7; k > 1; k--)
+    {
+        if (FLINT_LIKELY(r[k - 1] > limit[k - 1]))
+            goto sub;
+        if (r[k - 1] < limit[k - 1])
+            return;
+    }
+    if (r[0] < limit[0])
+        return;
+sub:
+    multi_sub_7(r, limit);
+    goto check;
+}
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Currently, in order to reduce dependency chain length, functions in `crt_helpers.h` use two parallel arrays `r` and `t` to represent a multi-limb values.

Unfortunately, this means a N-limb value needs 2N registers. In the largest case, this leads to massive slowdown, likely because of register spilling to memory.

This PR address that by changing the code of the largest case to use just N registers.

Speedup can be verified by running `./build/fft_small/profile/p-mul` before and after the change, the `.40` and `.50` rows are ~ 2x faster, and is essentially tied with https://github.com/flintlib/flint/pull/2692 . (Probably because of added instruction level parallelism.)

Since the change here is obviously much simpler than https://github.com/flintlib/flint/pull/2692 , this is to be preferred.

Points for discussion: is it worth switching everything to use this one-accumulator version? It _might_ lead to slower performance because of the need to propagate carry.

Benchmark result

<details><summary>`crt-register-reduce` (this PR)</summary>

```
 --- fft_small 1 thread  --- 
20.00:  2.883  2.827  2.924
20.10:  2.729  2.667  2.799
20.20:  2.599  2.526  2.705
20.30:  2.517  2.424  2.627
20.40:  2.599  2.524  2.691
20.50:  2.512  2.480  2.591
20.60:  2.736  2.686  2.773
20.70:  2.709  2.665  2.753
20.80:  2.664  2.604  2.738
20.90:  2.809  2.771  2.835
precomp: avg 0.207837, max 1.982478
21.00:  2.777  2.751  2.846
21.10:  2.728  2.679  2.766
21.20:  2.695  2.590  3.055
21.30:  2.640  2.570  2.828
21.40:  2.650  2.563  2.896
21.50:  2.563  2.532  2.622
21.60:  2.711  2.648  2.769
21.70:  2.701  2.648  2.778
21.80:  2.665  2.606  2.720
21.90:  2.753  2.673  2.824
precomp: avg 0.141137, max 2.508518
22.00:  2.688  2.646  2.752
22.10:  2.681  2.623  2.775
22.20:  2.618  2.518  2.680
22.30:  2.604  2.494  2.734
22.40:  2.628  2.537  2.761
22.50:  2.659  2.513  2.867
22.60:  2.730  2.664  2.827
22.70:  2.713  2.618  2.952
22.80:  2.710  2.659  2.750
22.90:  2.678  2.668  2.683
precomp: avg 0.072375, max 1.270793
23.00:  2.671  2.623  2.727
23.10:  2.638  2.579  2.749
23.20:  2.564  2.532  2.617
23.30:  2.630  2.518  2.670
23.40:  2.603  2.546  2.725
23.50:  2.722  2.655  2.879
23.60:  2.597  2.544  2.762
23.70:  2.577  2.505  2.735
23.80:  2.571  2.502  2.620
23.90:  2.743  2.696  2.815
precomp: avg 0.078434, max 1.254857
24.00:  2.718  2.630  2.769
24.10:  2.722  2.614  2.831
24.20:  2.636  2.547  2.723
24.30:  2.614  2.570  2.672
24.40:  2.695  2.618  2.782
24.50:  2.639  2.570  2.691
24.60:  2.674  2.608  2.727
24.70:  2.746  2.664  2.808
24.80:  2.682  2.642  2.716
24.90:  2.690  2.591  2.853
precomp: avg 0.062011, max 1.107677
25.00:  2.764  2.657  2.897
25.10:  2.663  2.636  2.690
25.20:  2.621  2.573  2.681
25.30:  2.665  2.618  2.785
25.40:  2.715  2.650  2.799
25.50:  2.680  2.631  2.816
25.60:  2.711  2.650  2.758
25.70:  2.765  2.696  2.930
25.80:  2.659  2.613  2.733
25.90:  2.740  2.638  2.825
precomp: avg 0.062647, max 1.382998
```

</details>

<details><summary>`mpn-mul-crt-asm` (the other PR with massive amount of inline assembly)</summary>

```
 --- fft_small 1 thread  --- 
20.00:  2.933  2.809  3.149
20.10:  2.817  2.762  2.888
20.20:  2.717  2.619  2.828
20.30:  2.561  2.502  2.618
20.40:  2.633  2.590  2.682
20.50:  2.581  2.543  2.637
20.60:  2.811  2.696  2.904
20.70:  2.816  2.677  2.956
20.80:  2.758  2.653  2.975
20.90:  2.861  2.756  2.938
precomp: avg 0.220455, max 2.087928
21.00:  2.782  2.732  2.835
21.10:  2.894  2.779  3.029
21.20:  2.758  2.610  2.938
21.30:  2.650  2.591  2.767
21.40:  2.746  2.659  2.826
21.50:  2.620  2.526  2.729
21.60:  2.835  2.734  2.942
21.70:  2.790  2.686  2.874
21.80:  2.739  2.623  2.839
21.90:  2.818  2.753  2.908
precomp: avg 0.118175, max 1.716897
22.00:  2.812  2.719  2.895
22.10:  2.684  2.629  2.788
22.20:  2.645  2.573  2.778
22.30:  2.658  2.536  2.775
22.40:  2.614  2.476  2.748
22.50:  2.540  2.450  2.622
22.60:  2.622  2.610  2.631
22.70:  2.611  2.593  2.661
22.80:  2.711  2.650  2.785
22.90:  2.719  2.658  2.770
precomp: avg 0.067073, max 1.119393
23.00:  2.741  2.668  2.894
23.10:  2.675  2.612  2.720
23.20:  2.627  2.572  2.718
23.30:  2.695  2.610  2.745
23.40:  2.666  2.558  2.820
23.50:  2.687  2.606  2.790
23.60:  2.639  2.583  2.754
23.70:  2.657  2.537  2.721
23.80:  2.681  2.599  2.771
23.90:  2.802  2.760  2.919
precomp: avg 0.066612, max 1.159107
24.00:  2.745  2.662  2.804
24.10:  2.785  2.696  2.894
24.20:  2.575  2.468  2.663
24.30:  2.638  2.559  2.716
24.40:  2.699  2.545  2.940
24.50:  2.588  2.532  2.664
24.60:  2.743  2.686  2.900
24.70:  2.746  2.638  2.838
24.80:  2.638  2.550  2.698
24.90:  2.639  2.603  2.706
precomp: avg 0.124808, max 1.258381
25.00:  2.662  2.631  2.730
25.10:  2.651  2.601  2.777
25.20:  2.566  2.517  2.646
25.30:  2.533  2.503  2.579
25.40:  2.594  2.544  2.637
25.50:  2.592  2.547  2.610
25.60:  2.663  2.637  2.718
25.70:  2.662  2.620  2.705
25.80:  2.684  2.619  2.922
25.90:  2.679  2.650  2.741
precomp: avg 0.060714, max 0.983494
```

</details>

<details><summary>baseline</summary>

```
 --- fft_small 1 thread  --- 
20.00:  2.807  2.705  3.108
20.10:  2.726  2.674  2.783
20.20:  2.584  2.514  2.647
20.30:  2.528  2.476  2.583
20.40:  6.412  6.275  6.567
20.50:  6.522  6.269  6.951
20.60:  2.780  2.747  2.815
20.70:  2.761  2.696  2.858
20.80:  2.745  2.615  2.962
20.90:  2.799  2.768  2.864
precomp: avg 0.234419, max 1.939602
21.00:  2.808  2.718  2.920
21.10:  2.813  2.667  2.962
21.20:  2.643  2.563  2.691
21.30:  2.677  2.581  2.776
21.40:  6.441  6.224  6.679
21.50:  6.440  6.219  6.596
21.60:  2.794  2.716  2.840
21.70:  2.774  2.750  2.807
21.80:  2.732  2.666  2.797
21.90:  2.798  2.725  2.879
precomp: avg 0.129088, max 1.642563
22.00:  2.764  2.743  2.798
22.10:  2.688  2.658  2.724
22.20:  2.643  2.597  2.713
22.30:  2.598  2.566  2.629
22.40:  6.130  5.934  6.329
22.50:  6.074  5.877  6.279
22.60:  2.700  2.603  2.815
22.70:  2.657  2.637  2.702
22.80:  2.701  2.665  2.754
22.90:  2.676  2.638  2.723
precomp: avg 0.095950, max 1.388836
23.00:  2.731  2.645  2.869
23.10:  2.679  2.576  2.761
23.20:  2.559  2.513  2.682
23.30:  2.652  2.579  2.709
23.40:  6.081  5.960  6.236
23.50:  6.056  5.957  6.255
23.60:  2.631  2.570  2.699
23.70:  2.607  2.525  2.833
23.80:  2.544  2.499  2.569
23.90:  2.690  2.641  2.708
precomp: avg 0.062193, max 1.320420
24.00:  2.692  2.615  2.763
24.10:  2.667  2.607  2.727
24.20:  2.509  2.475  2.560
24.30:  2.528  2.484  2.656
24.40:  5.762  5.708  5.799
24.50:  5.789  5.673  5.952
24.60:  2.626  2.526  2.732
24.70:  2.670  2.549  2.796
24.80:  2.651  2.578  2.719
24.90:  2.648  2.585  2.741
precomp: avg 0.030542, max 1.112313
25.00:  2.686  2.616  2.759
25.10:  2.651  2.602  2.681
25.20:  2.547  2.511  2.598
25.30:  2.540  2.495  2.603
25.40:  5.684  5.633  5.743
25.50:  5.665  5.578  5.737
25.60:  2.751  2.685  2.949
25.70:  2.692  2.636  2.821
25.80:  2.649  2.594  2.733
25.90:  2.678  2.632  2.717
precomp: avg 0.060969, max 1.070591
```

</details>

Benchmark instruction

```
make -j50
make ./build/fft_small/profile/p-mul
./build/fft_small/profile/p-mul
```