### PR TITLE
Improved Buchberger algorithm; add groebner example program

### DIFF
--- a/dev/check_examples.sh
+++ b/dev/check_examples.sh
@@ -149,6 +149,23 @@ then
 elif test "$1" = "functions_benchmark";
 then
     echo "functions_benchmark....SKIPPED"
+elif test "$1" = "groebner";
+then
+    echo -n "groebner...."
+    res=$($2/groebner cyclic4/drl)
+    if test "$?" != "0";
+    then
+        echo "FAIL"
+        exit 1
+    fi
+    echo "$res" | perl -0ne 'if (/gb:OK red:OK.*\|G\| =  10/) { $found=1; last } END { exit !$found }'
+    if test "$?" != "0";
+    then
+        echo "FAIL"
+        exit 2
+    fi
+    echo "PASS"
+    exit 0
 elif test "$1" = "hilbert_matrix";
 then
     echo -n "hilbert_matrix...."

--- a/doc/source/fmpz_mod_mpoly.rst
+++ b/doc/source/fmpz_mod_mpoly.rst
@@ -723,8 +723,8 @@ We use monic polynomials as normalised generators.
 
 .. function:: void fmpz_mod_mpoly_buchberger_naive(fmpz_mod_mpoly_vec_t G, const fmpz_mod_mpoly_vec_t F, const fmpz_mod_mpoly_ctx_t ctx)
 
-    Sets *G* to a Gröbner basis for *F*, computed using
-    a naive implementation of Buchberger's algorithm.
+    Sets *G* to a Gröbner basis for *F*, computed using a version of
+    Buchberger's algorithm. The algorithm essentially follows [BW1993]_.
 
 .. function:: int fmpz_mod_mpoly_buchberger_naive_with_limits(fmpz_mod_mpoly_vec_t G, const fmpz_mod_mpoly_vec_t F, slong ideal_len_limit, slong poly_len_limit, const fmpz_mod_mpoly_ctx_t ctx)
 

--- a/doc/source/fmpz_mpoly.rst
+++ b/doc/source/fmpz_mpoly.rst
@@ -999,8 +999,8 @@ in place of monic rational polynomials.
 
 .. function:: void fmpz_mpoly_buchberger_naive(fmpz_mpoly_vec_t G, const fmpz_mpoly_vec_t F, const fmpz_mpoly_ctx_t ctx)
 
-    Sets *G* to a Gröbner basis for *F*, computed using
-    a naive implementation of Buchberger's algorithm.
+    Sets *G* to a Gröbner basis for *F*, computed using a version of
+    Buchberger's algorithm. The algorithm essentially follows [BW1993]_.
 
 .. function:: int fmpz_mpoly_buchberger_naive_with_limits(fmpz_mpoly_vec_t G, const fmpz_mpoly_vec_t F, slong ideal_len_limit, slong poly_len_limit, slong poly_bits_limit, const fmpz_mpoly_ctx_t ctx)
 

--- a/doc/source/references.rst
+++ b/doc/source/references.rst
@@ -69,6 +69,8 @@ References
 
 .. [BuhlerCrandallSompolski1992] \Buhler, J.P. and Crandall, R.E. and Sompolski, R.W. : Irregular primes to one million : Math. Comp. 59:2000 (1992) 717--722
 
+.. [BW1993] \T. Becker and V. Weispfenning, *Gröbner Bases: A Computational Approach to Commutative Algebra*, Graduate Texts in Mathematics 141, Springer-Verlag (1993). https://doi.org/10.1007/978-1-4612-0913-3
+
 .. [CFG2017] \F. Cléry, C. Faber, and G. van der Geer. "Covariants of binary sextics and vector-valued Siegel modular forms of genus two", Math. Ann. 369 (2017), 1649--1669. https://doi.org/10.1007/s00208-016-1510-2
 
 .. [CFG2019] \F. Cléry, C. Faber, and G. van der Geer. "Covariants of binary sextics and modular forms of degree 2 with character", Math. Comp. 88 (2019), 2423--2441. https://doi.org/10.1090/mcom/3412

--- a/examples/groebner.c
+++ b/examples/groebner.c
@@ -1,0 +1,811 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+/*
+    Groebner basis example program.
+
+    Computes Groebner bases over Z (using fmpz_mpoly_buchberger_naive) or
+    over Z/pZ (using fmpz_mod_mpoly_buchberger_naive) and reports timing,
+    basis size, and correctness.
+
+    Usage:
+    groebner                   run all examples over Z then Z/pZ
+        groebner <name>             run one built-in example by name (over Z)
+        groebner <name> --prime p   run one built-in example over Z/pZ
+        groebner -vars v,w -input "f,g"         custom system over Z
+        groebner -vars v,w -input "f,g" -prime p   custom over Z/pZ
+
+    Options:
+        -order lex|deglex|degrevlex   monomial ordering (default: degrevlex)
+        -prime p                      work over Z/pZ for prime p
+        -print                        print the computed bases
+        -ideal-limit n                cap on number of basis elements
+        -poly-limit  n                cap on polynomial length
+        -bits-limit  n                cap on coefficient bit size (Z only)
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <flint/flint.h>
+#include <flint/fmpz.h>
+#include <flint/fmpz_mpoly.h>
+#include <flint/fmpz_mod_mpoly.h>
+#include <flint/profiler.h>
+
+/* Default prime used when running all built-in examples over Z/pZ. */
+#define DEFAULT_PRIME 10007
+
+typedef struct
+{
+    const char * name;
+    const char * ordering;
+    const char ** vars;
+    int nvars;
+    const char ** polys;
+    int npolys;
+    const char * description;
+    int skip;  /* if 1, omit from "run all" (too slow); still runs when named explicitly */
+}
+testcase_t;
+
+static const char * cyclic4_vars[]  = {"a","b","c","d"};
+static const char * cyclic4_polys[] = {
+    "a + b + c + d",
+    "a*b + b*c + c*d + d*a",
+    "a*b*c + b*c*d + c*d*a + d*a*b",
+    "a*b*c*d - 1"
+};
+
+static const char * katsura4_vars[]  = {"u0","u1","u2","u3","u4"};
+static const char * katsura4_polys[] = {
+    "u0 + 2*u1 + 2*u2 + 2*u3 + 2*u4 - 1",
+    "u0^2 + 2*u1^2 + 2*u2^2 + 2*u3^2 + 2*u4^2 - u0",
+    "2*u0*u1 + 2*u1*u2 + 2*u2*u3 + 2*u3*u4 - u1",
+    "u1^2 + 2*u0*u2 + 2*u1*u3 + 2*u2*u4 - u2",
+    "2*u1*u2 + 2*u0*u3 + 2*u1*u4 - u3"
+};
+
+static const char * eco5_vars[]  = {"x1","x2","x3","x4","x5"};
+static const char * eco5_polys[] = {
+    "x1 + x2 + x3 + x4 + x5 - 1",
+    "x1*x2 + x2*x3 + x3*x4 + x4*x5 - x5",
+    "x1*x2*x3 + x2*x3*x4 + x3*x4*x5 - x4*x5",
+    "x1*x2*x3*x4 + x2*x3*x4*x5 - x3*x4*x5",
+    "x1*x2*x3*x4*x5 - x1"
+};
+
+static const char * noon3_vars[]  = {"x1","x2","x3"};
+static const char * noon3_polys[] = {
+    "10*x1*x2^2 + 10*x1*x3^2 - 11*x1 + 10",
+    "10*x2*x1^2 + 10*x2*x3^2 - 11*x2 + 10",
+    "10*x3*x1^2 + 10*x3*x2^2 - 11*x3 + 10"
+};
+
+static const char * reimer4_vars[]  = {"x0","x1","x2","x3"};
+static const char * reimer4_polys[] = {
+    "2*x0^2 - 2*x1^2 + 2*x2^2 - 2*x3^2 - 1",
+    "8*x0^3 - 8*x1^3 + 8*x2^3 - 8*x3^3 - 1",
+    "32*x0^5 - 32*x1^5 + 32*x2^5 - 32*x3^5 - 1",
+    "128*x0^7 - 128*x1^7 + 128*x2^7 - 128*x3^7 - 1"
+};
+
+static const char * caprasse_vars[]  = {"w","x","y","z"};
+static const char * caprasse_polys[] = {
+    "-w*y^2 + 4*x*y*z + 2*w*y + x - 1",
+    "w^2*y - 4*x*y^2 + 4*x^2*z + 2*w*x + 4*y",
+    "4*z^3 + 4*y*z^2 - 4*x^2 + 10*z + 10*y - 4",
+    "2*y*z + w - 2*x"
+};
+
+/* Regression test: a lex system whose input is almost a Groebner basis,
+   for which total-degree-first pair selection is significantly faster
+   than normal lex selection. */
+static const char * symm5_vars[]  = {"x1","x2","x3","x4","x5"};
+static const char * symm5_polys[] = {
+    "257257*x1+257257*x2+257257*x3+257257*x4+257257*x5",
+    "257257*x1*x2+257257*x1*x3+257257*x1*x4+257257*x1*x5"
+        "+257257*x2*x3+257257*x2*x4+257257*x2*x5"
+        "+257257*x3*x4+257257*x3*x5+257257*x4*x5+9856",
+    "257257*x1*x2*x3+257257*x1*x2*x4+257257*x1*x2*x5"
+        "+257257*x1*x3*x4+257257*x1*x3*x5+257257*x1*x4*x5"
+        "+257257*x2*x3*x4+257257*x2*x3*x5+257257*x2*x4*x5"
+        "+257257*x3*x4*x5+958737472",
+    "257257*x1*x2*x3*x4+257257*x1*x2*x3*x5+257257*x1*x2*x4*x5"
+        "+257257*x1*x3*x4*x5+257257*x2*x3*x4*x5-8224",
+    "257257*x1*x2*x3*x4*x5-1266496",
+    "257257*x1^5-9856*x1^3+958737472*x1^2+8224*x1-1266496",
+    "257257*x2^5-9856*x2^3+958737472*x2^2+8224*x2-1266496",
+    "257257*x3^5-9856*x3^3+958737472*x3^2+8224*x3-1266496",
+    "257257*x4^5-9856*x4^3+958737472*x4^2+8224*x4-1266496",
+    "257257*x5^5-9856*x5^3+958737472*x5^2+8224*x5-1266496"
+};
+
+static const testcase_t builtin_cases[] =
+{
+    { "cyclic4/drl",  "degrevlex", cyclic4_vars,  4, cyclic4_polys,  4,
+      "Cyclic-4 (degrevlex)", 0 },
+    { "cyclic4/lex",  "lex",       cyclic4_vars,  4, cyclic4_polys,  4,
+      "Cyclic-4 (lex)", 0 },
+    { "katsura4/drl", "degrevlex", katsura4_vars, 5, katsura4_polys, 5,
+      "Katsura-4 (degrevlex)", 0 },
+    { "katsura4/lex", "lex",       katsura4_vars, 5, katsura4_polys, 5,
+      "Katsura-4 (lex)", 1 },
+    { "eco5/drl",     "degrevlex", eco5_vars,     5, eco5_polys,     5,
+      "Eco-5 (degrevlex)", 0 },
+    { "noon3/drl",    "degrevlex", noon3_vars,    3, noon3_polys,    3,
+      "Noon-3 (degrevlex)", 0 },
+    { "reimer4/drl",  "degrevlex", reimer4_vars,  4, reimer4_polys,  4,
+      "Reimer-4 (degrevlex)", 0 },
+    { "caprasse/drl", "degrevlex", caprasse_vars, 4, caprasse_polys, 4,
+      "Caprasse (degrevlex)", 0 },
+    { "symm5/lex",    "lex",       symm5_vars,    5, symm5_polys,   10,
+      "Symmetric-5/lex (near-GB regression test)", 0 }
+};
+
+#define NUM_BUILTIN ((slong)(sizeof(builtin_cases) / sizeof(builtin_cases[0])))
+
+static ordering_t
+parse_ordering(const char * s)
+{
+    if (!strcmp(s, "lex"))       return ORD_LEX;
+    if (!strcmp(s, "deglex"))    return ORD_DEGLEX;
+    if (!strcmp(s, "degrevlex")) return ORD_DEGREVLEX;
+
+    flint_printf("unknown ordering \"%s\"; use lex, deglex, or degrevlex\n", s);
+    flint_abort();
+    return ORD_LEX;
+}
+
+static const char *
+ordering_name(ordering_t ord)
+{
+    if (ord == ORD_LEX)    return "lex";
+    if (ord == ORD_DEGLEX) return "deglex";
+    return "degrevlex";
+}
+
+static void
+print_gb_stats_z(const fmpz_mpoly_vec_t G, const fmpz_mpoly_ctx_t ctx)
+{
+    slong i, max_terms, max_bits, terms, bits;
+
+    max_terms = 0;
+    max_bits  = 0;
+
+    for (i = 0; i < G->length; i++)
+    {
+        terms = fmpz_mpoly_length(fmpz_mpoly_vec_entry(G, i), ctx);
+        bits  = FLINT_ABS(fmpz_mpoly_max_bits(fmpz_mpoly_vec_entry(G, i)));
+
+        if (terms > max_terms) max_terms = terms;
+        if (bits  > max_bits)  max_bits  = bits;
+    }
+
+    flint_printf("|G| =%4wd  (max terms =%4wd, max bits =%4wd)",
+                 G->length, max_terms, max_bits);
+}
+
+static void
+print_gb_stats_mod(const fmpz_mod_mpoly_vec_t G,
+                   const fmpz_mod_mpoly_ctx_t ctx)
+{
+    slong i, max_terms, terms;
+
+    max_terms = 0;
+
+    for (i = 0; i < G->length; i++)
+    {
+        terms = fmpz_mod_mpoly_length(fmpz_mod_mpoly_vec_entry(G, i), ctx);
+        if (terms > max_terms) max_terms = terms;
+    }
+
+    flint_printf("|G| =%4wd  (max terms =%4wd)", G->length, max_terms);
+}
+
+static int
+parse_poly_list_z(fmpz_mpoly_vec_t F, char * buf,
+                  const char ** varnames, const fmpz_mpoly_ctx_t ctx)
+{
+    fmpz_mpoly_t tmp;
+    char * p;
+    char * tok;
+    int depth;
+
+    fmpz_mpoly_init(tmp, ctx);
+    p = buf;
+
+    while (*p != '\0')
+    {
+        depth = 0;
+        tok = p;
+
+        while (*p != '\0')
+        {
+            if      (*p == '(') depth++;
+            else if (*p == ')') depth--;
+            else if (*p == ',' && depth == 0) break;
+            p++;
+        }
+
+        if (*p == ',') { *p = '\0'; p++; }
+
+        if (fmpz_mpoly_set_str_pretty(tmp, tok, varnames, ctx) != 0)
+        {
+            flint_printf("failed to parse polynomial: \"%s\"\n", tok);
+            fmpz_mpoly_clear(tmp, ctx);
+            return -1;
+        }
+
+        fmpz_mpoly_vec_append(F, tmp, ctx);
+    }
+
+    fmpz_mpoly_clear(tmp, ctx);
+    return 0;
+}
+
+static int
+parse_poly_list_mod(fmpz_mod_mpoly_vec_t F, char * buf,
+                    const char ** varnames, const fmpz_mod_mpoly_ctx_t ctx)
+{
+    fmpz_mod_mpoly_t tmp;
+    char * p;
+    char * tok;
+    int depth;
+
+    fmpz_mod_mpoly_init(tmp, ctx);
+    p = buf;
+
+    while (*p != '\0')
+    {
+        depth = 0;
+        tok = p;
+
+        while (*p != '\0')
+        {
+            if      (*p == '(') depth++;
+            else if (*p == ')') depth--;
+            else if (*p == ',' && depth == 0) break;
+            p++;
+        }
+
+        if (*p == ',') { *p = '\0'; p++; }
+
+        if (fmpz_mod_mpoly_set_str_pretty(tmp, tok, varnames, ctx) != 0)
+        {
+            flint_printf("failed to parse polynomial: \"%s\"\n", tok);
+            fmpz_mod_mpoly_clear(tmp, ctx);
+            return -1;
+        }
+
+        fmpz_mod_mpoly_vec_append(F, tmp, ctx);
+    }
+
+    fmpz_mod_mpoly_clear(tmp, ctx);
+    return 0;
+}
+
+static const char **
+parse_varnames(char * buf, int * nvars_out)
+{
+    const char ** names;
+    char * p;
+    int n, i;
+
+    n = 1;
+    for (p = buf; *p != '\0'; p++)
+        if (*p == ',') n++;
+
+    names    = flint_malloc(n * sizeof(char *));
+    names[0] = buf;
+    i        = 1;
+
+    for (p = buf; *p != '\0'; p++)
+    {
+        if (*p == ',') { *p = '\0'; names[i++] = p + 1; }
+    }
+
+    *nvars_out = n;
+    return names;
+}
+
+static void
+run_one_z(const char * label, ordering_t ord,
+          const fmpz_mpoly_vec_t F, const char ** varnames,
+          const fmpz_mpoly_ctx_t ctx,
+          int do_print,
+          slong ideal_limit, slong poly_limit, slong bits_limit)
+{
+    fmpz_mpoly_vec_t G, R;
+    double gb_cpu, gb_wall, red_cpu, red_wall;
+    int ok_gb, ok_autored;
+    slong i;
+    (void)gb_cpu;
+    (void)red_cpu;
+
+    fmpz_mpoly_vec_init(G, 0, ctx);
+    fmpz_mpoly_vec_init(R, 0, ctx);
+
+    flint_printf("%-22s  %-10s  ", label, ordering_name(ord));
+
+    TIMEIT_START
+    fmpz_mpoly_buchberger_naive_with_limits(G, F,
+        ideal_limit, poly_limit, bits_limit, ctx);
+    TIMEIT_STOP_VALUES(gb_cpu, gb_wall);
+    flint_printf("%8.6f s   ", gb_wall);
+    fflush(stdout);
+
+    TIMEIT_START
+    fmpz_mpoly_vec_autoreduction_groebner(R, G, ctx);
+    TIMEIT_STOP_VALUES(red_cpu, red_wall);
+    flint_printf("  %8.6f s     ", red_wall);
+    fflush(stdout);
+
+    ok_gb      = fmpz_mpoly_vec_is_groebner(G, F, ctx);
+    ok_autored = fmpz_mpoly_vec_is_autoreduced(R, ctx)
+                 && fmpz_mpoly_vec_is_groebner(R, F, ctx);
+
+    flint_printf("gb:%s red:%s   ",
+                 ok_gb      ? "OK" : "FAIL",
+                 ok_autored ? "OK" : "FAIL");
+
+    print_gb_stats_z(G, ctx);
+    flint_printf("\n");
+
+    if (do_print)
+    {
+        flint_printf("\nGroebner basis (%wd elements):\n", G->length);
+        for (i = 0; i < G->length; i++)
+        {
+            flint_printf("  G[%wd] = ", i);
+            fmpz_mpoly_print_pretty(fmpz_mpoly_vec_entry(G, i), varnames, ctx);
+            flint_printf("\n");
+        }
+
+        flint_printf("\nReduced Groebner basis (%wd elements):\n", R->length);
+        for (i = 0; i < R->length; i++)
+        {
+            flint_printf("  R[%wd] = ", i);
+            fmpz_mpoly_print_pretty(fmpz_mpoly_vec_entry(R, i), varnames, ctx);
+            flint_printf("\n");
+        }
+
+        flint_printf("\n");
+    }
+
+    fmpz_mpoly_vec_clear(G, ctx);
+    fmpz_mpoly_vec_clear(R, ctx);
+}
+
+static void
+run_testcase_z(const testcase_t * tc, ordering_t ord,
+               int do_print,
+               slong ideal_limit, slong poly_limit, slong bits_limit)
+{
+    fmpz_mpoly_ctx_t ctx;
+    fmpz_mpoly_vec_t F;
+    fmpz_mpoly_t tmp;
+    slong i;
+
+    fmpz_mpoly_ctx_init(ctx, tc->nvars, ord);
+    fmpz_mpoly_vec_init(F, 0, ctx);
+    fmpz_mpoly_init(tmp, ctx);
+
+    for (i = 0; i < tc->npolys; i++)
+    {
+        if (fmpz_mpoly_set_str_pretty(tmp, tc->polys[i], tc->vars, ctx) != 0)
+        {
+            flint_printf("failed to parse \"%s\"\n", tc->polys[i]);
+            goto cleanup;
+        }
+        fmpz_mpoly_vec_append(F, tmp, ctx);
+    }
+
+    run_one_z(tc->name, ord, F, tc->vars, ctx,
+              do_print, ideal_limit, poly_limit, bits_limit);
+
+cleanup:
+    fmpz_mpoly_clear(tmp, ctx);
+    fmpz_mpoly_vec_clear(F, ctx);
+    fmpz_mpoly_ctx_clear(ctx);
+}
+
+static void
+run_one_mod(const char * label, ordering_t ord,
+            const fmpz_mod_mpoly_vec_t F, const char ** varnames,
+            const fmpz_mod_mpoly_ctx_t ctx,
+            int do_print,
+            slong ideal_limit, slong poly_limit)
+{
+    fmpz_mod_mpoly_vec_t G, R;
+    double gb_cpu, gb_wall, red_cpu, red_wall;
+    int ok_gb, ok_autored;
+    slong i;
+    (void)gb_cpu;
+    (void)red_cpu;
+
+    fmpz_mod_mpoly_vec_init(G, 0, ctx);
+    fmpz_mod_mpoly_vec_init(R, 0, ctx);
+
+    flint_printf("%-22s  %-10s  ", label, ordering_name(ord));
+
+    TIMEIT_START
+    fmpz_mod_mpoly_buchberger_naive_with_limits(G, F,
+        ideal_limit, poly_limit, ctx);
+    TIMEIT_STOP_VALUES(gb_cpu, gb_wall);
+    flint_printf("%8.6f s   ", gb_wall);
+    fflush(stdout);
+
+    TIMEIT_START
+    fmpz_mod_mpoly_vec_autoreduction_groebner(R, G, ctx);
+    TIMEIT_STOP_VALUES(red_cpu, red_wall);
+    flint_printf("  %8.6f s     ", red_wall);
+    fflush(stdout);
+
+    ok_gb      = fmpz_mod_mpoly_vec_is_groebner(G, F, ctx);
+    ok_autored = fmpz_mod_mpoly_vec_is_autoreduced(R, ctx)
+                 && fmpz_mod_mpoly_vec_is_groebner(R, F, ctx);
+
+    flint_printf("gb:%s red:%s   ",
+                 ok_gb      ? "OK" : "FAIL",
+                 ok_autored ? "OK" : "FAIL");
+
+    print_gb_stats_mod(G, ctx);
+    flint_printf("\n");
+
+    if (do_print)
+    {
+        flint_printf("\nGroebner basis (%wd elements):\n", G->length);
+        for (i = 0; i < G->length; i++)
+        {
+            flint_printf("  G[%wd] = ", i);
+            fmpz_mod_mpoly_print_pretty(
+                fmpz_mod_mpoly_vec_entry(G, i), varnames, ctx);
+            flint_printf("\n");
+        }
+
+        flint_printf("\nReduced Groebner basis (%wd elements):\n", R->length);
+        for (i = 0; i < R->length; i++)
+        {
+            flint_printf("  R[%wd] = ", i);
+            fmpz_mod_mpoly_print_pretty(
+                fmpz_mod_mpoly_vec_entry(R, i), varnames, ctx);
+            flint_printf("\n");
+        }
+
+        flint_printf("\n");
+    }
+
+    fmpz_mod_mpoly_vec_clear(G, ctx);
+    fmpz_mod_mpoly_vec_clear(R, ctx);
+}
+
+static void
+run_testcase_mod(const testcase_t * tc, ordering_t ord,
+                 const fmpz_t prime,
+                 int do_print,
+                 slong ideal_limit, slong poly_limit)
+{
+    fmpz_mod_mpoly_ctx_t ctx;
+    fmpz_mod_mpoly_vec_t F;
+    fmpz_mod_mpoly_t tmp;
+    slong i;
+
+    fmpz_mod_mpoly_ctx_init(ctx, tc->nvars, ord, prime);
+    fmpz_mod_mpoly_vec_init(F, 0, ctx);
+    fmpz_mod_mpoly_init(tmp, ctx);
+
+    for (i = 0; i < tc->npolys; i++)
+    {
+        if (fmpz_mod_mpoly_set_str_pretty(
+                tmp, tc->polys[i], tc->vars, ctx) != 0)
+        {
+            flint_printf("failed to parse \"%s\"\n", tc->polys[i]);
+            goto cleanup;
+        }
+        fmpz_mod_mpoly_vec_append(F, tmp, ctx);
+    }
+
+    run_one_mod(tc->name, ord, F, tc->vars, ctx,
+                do_print, ideal_limit, poly_limit);
+
+cleanup:
+    fmpz_mod_mpoly_clear(tmp, ctx);
+    fmpz_mod_mpoly_vec_clear(F, ctx);
+    fmpz_mod_mpoly_ctx_clear(ctx);
+}
+
+static void
+print_table_header(void)
+{
+    flint_printf("%-22s  %-10s  %-13s  %-12s  %-13s  %s\n",
+                 "system", "ordering",
+                 "buchberger", "autoreduction",
+                 "checks", "size");
+    flint_printf("%-22s  %-10s  %-13s  %-12s  %-13s  %s\n",
+                 "------", "--------",
+                 "----------", "-------------",
+                 "------", "----");
+}
+
+static void
+usage(void)
+{
+    slong i;
+
+    flint_printf(
+"usage:\n"
+"  groebner                    run all built-in examples over Z and Z/pZ\n"
+"  groebner <name>                       run one built-in example over Z\n"
+"  groebner <name> -prime p              run one built-in example over Z/pZ\n"
+"  groebner -vars v1,v2 -input \"f,g\"   run a custom system over Z\n"
+"  groebner -vars v1,v2 -input \"f,g\" -prime p    custom system over Z/pZ\n"
+"\n"
+"options:\n"
+"  -order lex|deglex|degrevlex   monomial ordering (default: degrevlex)\n"
+"  -prime p                      work over Z/pZ for prime p\n"
+"  -print                        print the Groebner basis elements\n"
+"  -ideal-limit n                cap on number of basis elements\n"
+"  -poly-limit  n                cap on polynomial length\n"
+"  -bits-limit  n                cap on coefficient bit size (Z only)\n"
+"\n"
+"built-in examples (examples marked [skip] are omitted from 'run all'):\n"
+    );
+
+    for (i = 0; i < NUM_BUILTIN; i++)
+        flint_printf("  %-22s  %s%s\n",
+                     builtin_cases[i].name,
+                     builtin_cases[i].description,
+                     builtin_cases[i].skip ? "  [skip]" : "");
+
+    flint_printf(
+"\n"
+"output columns:\n"
+"  gb    wall time for buchberger_naive\n"
+"  red   wall time for vec_autoreduction_groebner\n"
+"  gb:OK / red:OK  self-check via is_groebner / is_autoreduced\n"
+"  |G|   number of elements in the (unreduced) Groebner basis\n"
+"  max terms / max bits  largest polynomial and coefficient height in G\n"
+    );
+}
+
+int
+main(int argc, char * argv[])
+{
+    const char * single_name     = NULL;
+    const char * custom_vars_str = NULL;
+    const char * custom_input    = NULL;
+    const char * ordering_str    = NULL;
+    const char * prime_str       = NULL;
+    int do_print   = 0;
+    slong ideal_limit = WORD_MAX;
+    slong poly_limit  = WORD_MAX;
+    slong bits_limit  = WORD_MAX;
+    int start_arg = 1;
+    int i;
+
+    if (argc >= 2 && argv[1][0] != '-')
+    {
+        single_name = argv[1];
+        start_arg   = 2;
+    }
+
+    for (i = start_arg; i < argc; i++)
+    {
+        if (!strcmp(argv[i], "-vars") && i + 1 < argc)
+        {
+            custom_vars_str = argv[++i];
+        }
+        else if (!strcmp(argv[i], "-input") && i + 1 < argc)
+        {
+            custom_input = argv[++i];
+        }
+        else if (!strcmp(argv[i], "-order") && i + 1 < argc)
+        {
+            ordering_str = argv[++i];
+        }
+        else if (!strcmp(argv[i], "-prime") && i + 1 < argc)
+        {
+            prime_str = argv[++i];
+        }
+        else if (!strcmp(argv[i], "-print"))
+        {
+            do_print = 1;
+        }
+        else if (!strcmp(argv[i], "-ideal-limit") && i + 1 < argc)
+        {
+            ideal_limit = atol(argv[++i]);
+        }
+        else if (!strcmp(argv[i], "-poly-limit") && i + 1 < argc)
+        {
+            poly_limit = atol(argv[++i]);
+        }
+        else if (!strcmp(argv[i], "-bits-limit") && i + 1 < argc)
+        {
+            bits_limit = atol(argv[++i]);
+        }
+        else if (!strcmp(argv[i], "-help") || !strcmp(argv[i], "-h"))
+        {
+            usage();
+            return 0;
+        }
+        else
+        {
+            flint_printf("unknown option \"%s\"\n", argv[i]);
+            flint_printf("run with -help for usage information\n");
+            return 1;
+        }
+    }
+
+    if (custom_input != NULL)
+    {
+        /* Custom system from command line. */
+        ordering_t ord;
+        const char ** varnames;
+        char * vars_copy;
+        char * input_copy;
+        int nvars;
+
+        if (custom_vars_str == NULL)
+        {
+            flint_printf("--input requires --vars\n");
+            return 1;
+        }
+
+        ord = ordering_str ? parse_ordering(ordering_str) : ORD_DEGREVLEX;
+
+        vars_copy  = flint_malloc(strlen(custom_vars_str) + 1);
+        input_copy = flint_malloc(strlen(custom_input) + 1);
+        strcpy(vars_copy, custom_vars_str);
+        strcpy(input_copy, custom_input);
+
+        varnames = parse_varnames(vars_copy, &nvars);
+
+        if (prime_str != NULL)
+        {
+            fmpz_t prime;
+            fmpz_mod_mpoly_ctx_t ctx;
+            fmpz_mod_mpoly_vec_t F;
+
+            fmpz_init(prime);
+            fmpz_set_str(prime, prime_str, 10);
+            fmpz_mod_mpoly_ctx_init(ctx, nvars, ord, prime);
+            fmpz_mod_mpoly_vec_init(F, 0, ctx);
+
+            if (parse_poly_list_mod(F, input_copy, varnames, ctx) == 0)
+                run_one_mod("custom", ord, F, varnames, ctx,
+                            do_print, ideal_limit, poly_limit);
+
+            fmpz_mod_mpoly_vec_clear(F, ctx);
+            fmpz_mod_mpoly_ctx_clear(ctx);
+            fmpz_clear(prime);
+        }
+        else
+        {
+            fmpz_mpoly_ctx_t ctx;
+            fmpz_mpoly_vec_t F;
+
+            fmpz_mpoly_ctx_init(ctx, nvars, ord);
+            fmpz_mpoly_vec_init(F, 0, ctx);
+
+            if (parse_poly_list_z(F, input_copy, varnames, ctx) == 0)
+                run_one_z("custom", ord, F, varnames, ctx,
+                          do_print, ideal_limit, poly_limit, bits_limit);
+
+            fmpz_mpoly_vec_clear(F, ctx);
+            fmpz_mpoly_ctx_clear(ctx);
+        }
+
+        flint_free(varnames);
+        flint_free(vars_copy);
+        flint_free(input_copy);
+    }
+    else if (single_name != NULL)
+    {
+        /* Run one built-in case by name. */
+        int found = 0;
+        slong j;
+
+        for (j = 0; j < NUM_BUILTIN; j++)
+        {
+            if (!strcmp(builtin_cases[j].name, single_name))
+            {
+                ordering_t ord = ordering_str
+                    ? parse_ordering(ordering_str)
+                    : parse_ordering(builtin_cases[j].ordering);
+
+                if (prime_str != NULL)
+                {
+                    fmpz_t prime;
+                    fmpz_init(prime);
+                    fmpz_set_str(prime, prime_str, 10);
+                    run_testcase_mod(&builtin_cases[j], ord, prime,
+                                     do_print, ideal_limit, poly_limit);
+                    fmpz_clear(prime);
+                }
+                else
+                {
+                    run_testcase_z(&builtin_cases[j], ord,
+                                   do_print, ideal_limit, poly_limit,
+                                   bits_limit);
+                }
+
+                found = 1;
+                break;
+            }
+        }
+
+        if (!found)
+        {
+            flint_printf("unknown example \"%s\"\n", single_name);
+            flint_printf("run with --help to list built-in examples\n");
+            return 1;
+        }
+    }
+    else
+    {
+        /* Run all built-in examples: first over Z, then over Z/pZ. */
+        fmpz_t prime;
+        slong j;
+
+        fmpz_init(prime);
+        fmpz_set_ui(prime, DEFAULT_PRIME);
+
+        flint_printf("=== Over Z ===\n\n");
+        print_table_header();
+
+        for (j = 0; j < NUM_BUILTIN; j++)
+        {
+            ordering_t ord = ordering_str
+                ? parse_ordering(ordering_str)
+                : parse_ordering(builtin_cases[j].ordering);
+
+            if (builtin_cases[j].skip)
+            {
+                flint_printf("%-22s  %-10s  "
+                             "(skipped -- name explicitly to run)\n",
+                             builtin_cases[j].name,
+                             builtin_cases[j].ordering);
+                continue;
+            }
+
+            run_testcase_z(&builtin_cases[j], ord,
+                           do_print, ideal_limit, poly_limit, bits_limit);
+        }
+
+        flint_printf("\n=== Over Z mod %d ===\n\n", DEFAULT_PRIME);
+        print_table_header();
+
+        for (j = 0; j < NUM_BUILTIN; j++)
+        {
+            ordering_t ord = ordering_str
+                ? parse_ordering(ordering_str)
+                : parse_ordering(builtin_cases[j].ordering);
+
+            if (builtin_cases[j].skip && 0)
+            {
+                flint_printf("%-22s  %-10s  "
+                             "(skipped -- name explicitly to run)\n",
+                             builtin_cases[j].name,
+                             builtin_cases[j].ordering);
+                continue;
+            }
+
+            run_testcase_mod(&builtin_cases[j], ord, prime,
+                             do_print, ideal_limit, poly_limit);
+        }
+
+        fmpz_clear(prime);
+    }
+
+    flint_cleanup_master();
+    return 0;
+}

--- a/src/fmpz_mod_mpoly/buchberger_naive.c
+++ b/src/fmpz_mod_mpoly/buchberger_naive.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020 Fredrik Johansson
+    Copyright (C) 2020, 2026 Fredrik Johansson
     Copyright (C) 2025 Andrii Yanovets
 
     This file is part of FLINT.
@@ -10,10 +10,18 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "fmpz_vec.h"
 #include "fmpz_mod_mpoly.h"
 
-/* Index pairs (for Buchberger algorithm) */
+/* Implements a version of GROEBNERNEW2 (Becker and Weispfenning, p. 232).
+   Parts of the implementation were inspired by SymPy's groebner().
+   The current version of the code has been substantially rewritten using
+   Claude to incorporate optimizations from BW that were omitted or
+   done incorrectly in the original hand-written version.
+
+   Note: the fmpz_mpoly and fmpz_mod_mpoly implementations are essentially
+   identical. Any future improvements should be applied to both. */
+
+/* Helper functions for index pairs. */
 
 typedef struct
 {
@@ -67,102 +75,136 @@ pairs_append(pairs_t vec, slong i, slong j)
     vec->length++;
 }
 
+/* Two selection strategies are available.
+
+   BUCHBERGER_DEGREE_SELECTION 1 (default): Degree strategy.
+   Select the pair whose lcm(LM(f), LM(g)) has the smallest total degree,
+   for ALL monomial orderings. For a lex ordering, equal-degree pairs are
+   broken by lex comparison. For degree orderings (degrevlex, deglex),
+   equal-degree pairs are broken by position in the pairs vector.
+
+   Motivation: pure lex comparison (BW's strategy, below) causes
+   pathological blowup on certain lex systems that we encounter in
+   practice in the Calcium test suite.
+
+   BUCHBERGER_DEGREE_SELECTION 0: BW Normal strategy.
+   Select the pair whose lcm(LM(f), LM(g)) is smallest in the monomial order
+   being used, for all orderings. For lex this is a pure lexicographic
+   comparison. For degree orderings it coincides with minimum total degree
+   (same as the degree strategy), so the two variants differ only for lex.
+*/
+#define BUCHBERGER_DEGREE_SELECTION 1
+
 static pair_t
-fmpz_mod_mpoly_select_pop_pair(pairs_t pairs, const fmpz_mod_mpoly_vec_t G, const fmpz_mod_mpoly_ctx_t ctx)
+fmpz_mod_mpoly_select_pop_pair(pairs_t pairs, const fmpz_mod_mpoly_vec_t G,
+                           const fmpz_mod_mpoly_ctx_t ctx)
 {
     slong len, choice, nvars;
     pair_t result;
-
+ 
     nvars = ctx->minfo->nvars;
     len = pairs->length;
     choice = 0;
-
+ 
     if (len > 1)
     {
         slong i, j, a, b;
         ulong * exp;
-        ulong * tmp;
         ulong * lcm;
         ulong * best_lcm;
         ulong l, total;
         int best;
-
+ 
         exp = flint_malloc(sizeof(ulong) * G->length * nvars);
         lcm = flint_malloc(sizeof(ulong) * (nvars + 1));
-        tmp = flint_malloc(sizeof(ulong) * (nvars + 1));
         best_lcm = flint_malloc(sizeof(ulong) * (nvars + 1));
-
+ 
         for (i = 0; i <= nvars; i++)
             best_lcm[i] = UWORD_MAX;
-
+ 
         for (i = 0; i < G->length; i++)
             fmpz_mod_mpoly_get_term_exp_ui(exp + i * nvars, G->p + i, 0, ctx);
-
+ 
         for (i = 0; i < len; i++)
         {
             a = pairs->pairs[i].a;
             b = pairs->pairs[i].b;
             total = 0;
             best = 1;
+ 
+            /* Compute the full lcm vector and total degree unconditionally.
+             * Both strategies need lcm[] fully populated before comparing
+             * so that best_lcm[] is always written with complete data. */
+            for (j = 0; j < nvars; j++)
+            {
+                l = FLINT_MAX(exp[a * nvars + j], exp[b * nvars + j]);
+                lcm[j] = l;
+                total += l;
+            }
+ 
+#if BUCHBERGER_DEGREE_SELECTION
+            /* Degree strategy  */
+            if (total > best_lcm[nvars])
+            {
+                best = 0;
+            }
+            else if (total == best_lcm[nvars] && ctx->minfo->ord == ORD_LEX)
+            {
+                for (j = 0; j < nvars; j++)
+                {
+                    if (lcm[j] > best_lcm[j]) { best = 0; break; }
+                    if (lcm[j] < best_lcm[j]) break;
+                }
+            }
+            else if (total == best_lcm[nvars])
+            {
+                best = 0;
+            }
 
+#else
+            /* BW Normal strategy */
             if (ctx->minfo->ord == ORD_LEX)
             {
                 for (j = 0; j < nvars; j++)
                 {
-                    l = FLINT_MAX(exp[a * nvars + j], exp[b * nvars + j]);
-
-                    if (l > best_lcm[j])
-                    {
-                        best = 0;
-                        break;
-                    }
-
-                    lcm[j] = l;
-                    total += l;  /* total degree */
+                    if (lcm[j] > best_lcm[j]) { best = 0; break; }
+                    if (lcm[j] < best_lcm[j]) break;
                 }
             }
-            else  /* todo: correct order */
+            else
             {
-                for (j = 0; j < nvars; j++)
-                {
-                    l = FLINT_MAX(exp[a * nvars + j], exp[b * nvars + j]);
-                    total += l;  /* total degree */
-
-                    if (total >= best_lcm[j])
-                    {
-                        best = 0;
-                        break;
-                    }
-
-                    lcm[j] = l;
-                }
+                if (total > best_lcm[nvars])
+                    best = 0;
+                else if (total == best_lcm[nvars])
+                    best = 0;
             }
-
+#endif
             if (best)
             {
                 for (j = 0; j < nvars; j++)
                     best_lcm[j] = lcm[j];
-
+ 
                 best_lcm[nvars] = total;
                 choice = i;
             }
         }
-
+ 
         flint_free(exp);
-        flint_free(tmp);
         flint_free(lcm);
         flint_free(best_lcm);
     }
-
+ 
     result = pairs->pairs[choice];
     pairs->pairs[choice] = pairs->pairs[pairs->length - 1];
     pairs->length--;
-
+ 
     return result;
 }
 
+/* Evaluation limits to allow aborting a basis that spirals out of control. */
 static int
-within_limits(const fmpz_mod_mpoly_t poly, slong poly_len_limit, const fmpz_mod_mpoly_ctx_t ctx)
+within_limits(const fmpz_mod_mpoly_t poly, slong poly_len_limit,
+              const fmpz_mod_mpoly_ctx_t ctx)
 {
     if (fmpz_mod_mpoly_length(poly, ctx) > poly_len_limit)
         return 0;
@@ -170,37 +212,248 @@ within_limits(const fmpz_mod_mpoly_t poly, slong poly_len_limit, const fmpz_mod_
     return 1;
 }
 
+/* Helper functions for exponent vectors, packed to 1 ulong per exponent.
+   TODO: better packing for small exponents? If we ensure that all
+   polynomials pack to the same number of bits (resizing if necessary
+   during the algorithm), we could maybe work directly with the
+   exponent vectors stored in the polynomials? */
+
 static int
-fmpz_mod_mpoly_disjoint_lt(const fmpz_mod_mpoly_t f, const fmpz_mod_mpoly_t g, const fmpz_mod_mpoly_ctx_t ctx)
+monomial_divides(const ulong * a, const ulong * b, slong nvars)
 {
-    int result;
-    slong i, nvars;
-    ulong * exp1, * exp2;
+    slong i;
 
-    nvars = ctx->minfo->nvars;
-    exp1 = flint_malloc(2 * nvars * sizeof(ulong));
-    exp2 = exp1 + nvars;
+    for (i = 0; i < nvars; i++)
+        if (a[i] > b[i])
+            return 0;
 
-    fmpz_mod_mpoly_get_term_exp_ui(exp1, f, 0, ctx);
-    fmpz_mod_mpoly_get_term_exp_ui(exp2, g, 0, ctx);
+    return 1;
+}
 
-    result = 1;
-    for (i = 0; i < nvars && result; i++)
-        if (exp1[i] && exp2[i])
-            result = 0;
+static int
+monomial_disjoint(const ulong * a, const ulong * b, slong nvars)
+{
+    slong i;
 
-    flint_free(exp1);
+    for (i = 0; i < nvars; i++)
+        if (a[i] && b[i])
+            return 0;
 
-    return result;
+    return 1;
+}
+
+static void
+monomial_lcm(ulong * out, const ulong * a, const ulong * b, slong nvars)
+{
+    slong i;
+
+    for (i = 0; i < nvars; i++)
+        out[i] = FLINT_MAX(a[i], b[i]);
+}
+
+static int
+monomial_equal(const ulong * a, const ulong * b, slong nvars)
+{
+    slong i;
+
+    for (i = 0; i < nvars; i++)
+        if (a[i] != b[i])
+            return 0;
+
+    return 1;
+}
+
+/* Basis-element filtering. When a new polynomial h at index ih is added to
+   the basis, any existing basis element g whose leading monomial is
+   divisible by LM(h) is redundant: every future S-polynomial involving g as
+   a basis candidate is already subsumed by pairs involving h. Removing such
+   g from G_active shrinks the candidate set for future calls to update_pairs.
+
+   Note: pairs already in the pair set that mention a removed index are left
+   in place. Their S-polynomials are not guaranteed to reduce to zero
+   immediately (they may still yield new generators), and update_pairs's own
+   pair-filtering step already handles the subset of redundant old pairs.
+   The polynomial store G is also left untouched; removed indices remain valid
+   for spoly and reduction computations. */
+static void
+filter_redundant(slong * G_active, slong * G_active_len,
+                 slong ih, const ulong * exp, slong nvars)
+{
+    const ulong * mh;
+    slong i, new_active_len;
+
+    mh = exp + ih * nvars;
+
+    new_active_len = 0;
+    for (i = 0; i < *G_active_len; i++)
+    {
+        slong ig = G_active[i];
+
+        if (!monomial_divides(mh, exp + ig * nvars, nvars))
+            G_active[new_active_len++] = ig;
+    }
+    *G_active_len = new_active_len;
+}
+
+/* Gebauer-Moller pair-set update (Becker & Weispfenning, p. 230).
+
+   Given the current pair set B and a new polynomial at index ih (with leading
+   monomial exp[ih * nvars ...]), update B as follows:
+
+   1. Compute the set E of new pairs (ih, ig) to add, using the chain
+      criterion to discard candidates dominated by a pair with smaller lcm,
+      and the product criterion to discard pairs with disjoint leading
+      monomials (the C -> D -> E reduction in BW's description).
+
+   2. Remove from B any existing pair (ig1, ig2) made redundant by ih:
+      those where LM(ih) | lcm(LM(ig1), LM(ig2)), subject to two
+      correctness guards that prevent over-aggressive removal.
+
+   3. Append E to B.
+*/
+static void
+update_pairs(const slong * G_active, slong G_active_len,
+             pairs_t B, slong ih, const ulong * exp, slong nvars)
+{
+    const ulong * mh;
+    ulong * lcm_hg;
+    ulong * lcm_tmp;
+    slong * D_ig;
+    slong * E_ig;
+    slong D_alloc, D_len, E_len;
+    slong i, k;
+    int dominated;
+
+    mh = exp + ih * nvars;
+    lcm_hg  = flint_malloc(nvars * sizeof(ulong));
+    lcm_tmp = flint_malloc(nvars * sizeof(ulong));
+
+    /* Step 1 (C -> D): decide which candidate pairs (ih, ig) to accept.
+
+       Process G_active left-to-right.  At step i, the "C" set of BW's
+       algorithm is G_active[i + 1 ..] (not yet visited) and "D" is the
+       pairs already accepted.  Accept (ih, ig) unless some p already in D
+       or still in C satisfies lcm(LM(h), LM(p)) | lcm(LM(h), LM(g)) --
+       the pair (h, p) then dominates (h, g) by the chain criterion.
+       Coprime pairs (product criterion) are also accepted here; Step 2
+       removes them again. */
+    D_alloc = G_active_len + 1;
+    D_len   = 0;
+    D_ig    = flint_malloc(D_alloc * sizeof(slong));
+
+    for (i = 0; i < G_active_len; i++)
+    {
+        slong ig = G_active[i];
+        const ulong * mg = exp + ig * nvars;
+
+        if (!monomial_disjoint(mh, mg, nvars))
+        {
+            monomial_lcm(lcm_hg, mh, mg, nvars);
+            dominated = 0;
+
+            for (k = 0; k < D_len && !dominated; k++)
+            {
+                monomial_lcm(lcm_tmp, mh, exp + D_ig[k] * nvars, nvars);
+                if (monomial_divides(lcm_tmp, lcm_hg, nvars))
+                    dominated = 1;
+            }
+
+            for (k = i + 1; k < G_active_len && !dominated; k++)
+            {
+                monomial_lcm(lcm_tmp, mh, exp + G_active[k] * nvars, nvars);
+                if (monomial_divides(lcm_tmp, lcm_hg, nvars))
+                    dominated = 1;
+            }
+
+            if (dominated)
+                continue;
+        }
+
+        if (D_len == D_alloc)
+        {
+            D_alloc *= 2;
+            D_ig = flint_realloc(D_ig, D_alloc * sizeof(slong));
+        }
+
+        D_ig[D_len++] = ig;
+    }
+
+    /* Step 2 (D -> E): apply the product criterion to D. */
+    E_ig  = flint_malloc((D_len + 1) * sizeof(slong));
+    E_len = 0;
+
+    for (i = 0; i < D_len; i++)
+    {
+        slong ig = D_ig[i];
+
+        if (!monomial_disjoint(mh, exp + ig * nvars, nvars))
+            E_ig[E_len++] = ig;
+    }
+
+    flint_free(D_ig);
+
+    /* Step 3: remove stale pairs from B (Gebauer-Moller criterion).
+
+       Discard (ig1, ig2) if all three conditions hold:
+         (a) LM(h) | lcm(LM(ig1), LM(ig2))
+         (b) lcm(LM(ig1), LM(h)) != lcm(LM(ig1), LM(ig2))
+         (c) lcm(LM(ig2), LM(h)) != lcm(LM(ig1), LM(ig2))
+      
+       The equality guards (b) and (c) prevent incorrectly removing a pair
+       for which one element's lcm with h already equals the pair's lcm. */
+    {
+        slong new_len = 0;
+
+        for (k = 0; k < B->length; k++)
+        {
+            slong ig1 = B->pairs[k].a;
+            slong ig2 = B->pairs[k].b;
+            const ulong * mg1 = exp + ig1 * nvars;
+            const ulong * mg2 = exp + ig2 * nvars;
+
+            monomial_lcm(lcm_hg, mg1, mg2, nvars);
+
+            if (!monomial_divides(mh, lcm_hg, nvars))
+                goto keep;
+
+            monomial_lcm(lcm_tmp, mg1, mh, nvars);
+            if (monomial_equal(lcm_tmp, lcm_hg, nvars))
+                goto keep;
+
+            monomial_lcm(lcm_tmp, mg2, mh, nvars);
+            if (monomial_equal(lcm_tmp, lcm_hg, nvars))
+                goto keep;
+
+            continue;   /* discard */
+
+        keep:
+
+            B->pairs[new_len++] = B->pairs[k];
+        }
+
+        B->length = new_len;
+    }
+
+    /* Step 4: append the surviving new pairs E to B. */
+    for (i = 0; i < E_len; i++)
+        pairs_append(B, ih, E_ig[i]);
+
+    flint_free(E_ig);
+    flint_free(lcm_hg);
+    flint_free(lcm_tmp);
 }
 
 int
-fmpz_mod_mpoly_buchberger_naive_with_limits(fmpz_mod_mpoly_vec_t G, const fmpz_mod_mpoly_vec_t F,
-    slong ideal_len_limit, slong poly_len_limit, const fmpz_mod_mpoly_ctx_t ctx)
+fmpz_mod_mpoly_buchberger_naive_with_limits(fmpz_mod_mpoly_vec_t G,
+    const fmpz_mod_mpoly_vec_t F,
+    slong ideal_len_limit, slong poly_len_limit,
+    const fmpz_mod_mpoly_ctx_t ctx)
 {
     pairs_t B;
     fmpz_mod_mpoly_t h;
-    slong i, j, index_h;
+    slong * G_active;
+    ulong * exp;
+    slong i, ih, G_active_len, G_active_alloc, exp_alloc, nvars;
     pair_t pair;
     int success;
 
@@ -216,49 +469,115 @@ fmpz_mod_mpoly_buchberger_naive_with_limits(fmpz_mod_mpoly_vec_t G, const fmpz_m
         if (!within_limits(fmpz_mod_mpoly_vec_entry(G, i), poly_len_limit, ctx))
             return 0;
 
+    nvars = ctx->minfo->nvars;
+
+    /* Cache leading monomial exponent vectors for fast comparisons. */
+    exp_alloc = G->length + 16;
+    exp = flint_malloc(exp_alloc * nvars * sizeof(ulong));
+
+    for (i = 0; i < G->length; i++)
+        fmpz_mod_mpoly_get_term_exp_ui(exp + i * nvars,
+                                       fmpz_mod_mpoly_vec_entry(G, i), 0, ctx);
+
+    /* G_active tracks which indices in G belong to the current basis,
+       allowing update_pairs to enumerate candidates without disturbing the
+       storage layout that spoly and reduction use. */
+    G_active_alloc = exp_alloc;
+    G_active = flint_malloc(G_active_alloc * sizeof(slong));
+    G_active_len = 0;
+
     pairs_init(B);
     fmpz_mod_mpoly_init(h, ctx);
 
-    for (i = 0; i < G->length; i++)
-        for (j = i + 1; j < G->length; j++)
-            if (!fmpz_mod_mpoly_disjoint_lt(fmpz_mod_mpoly_vec_entry(G, i), fmpz_mod_mpoly_vec_entry(G, j), ctx))
-                pairs_append(B, i, j);
+    /* Build the initial pair set by simulating GROEBNERNEW2's initialisation
+       loop: start with G_active = {0} and call update_pairs for
+       each subsequent initial polynomial in turn. The original code only
+       applied the product criterion here; update_pairs applies the full
+       Gebauer-Moller criteria, eliminating more redundant pairs up front. */
+    G_active[G_active_len++] = 0;
 
+    for (i = 1; i < G->length; i++)
+    {
+        update_pairs(G_active, G_active_len, B, i, exp, nvars);
+        filter_redundant(G_active, &G_active_len, i, exp, nvars);
+        G_active[G_active_len++] = i;
+    }
+
+    /* Main loop -- GROEBNERNEW2 */
     success = 1;
+
     while (B->length != 0)
     {
         pair = fmpz_mod_mpoly_select_pop_pair(B, G, ctx);
 
-        fmpz_mod_mpoly_spoly(h, fmpz_mod_mpoly_vec_entry(G, pair.a), fmpz_mod_mpoly_vec_entry(G, pair.b), ctx);
+        fmpz_mod_mpoly_spoly(h, fmpz_mod_mpoly_vec_entry(G, pair.a),
+                                fmpz_mod_mpoly_vec_entry(G, pair.b), ctx);
         fmpz_mod_mpoly_reduction_monic_part(h, h, G, ctx);
 
         if (!fmpz_mod_mpoly_is_zero(h, ctx))
         {
-            /* printf("h stats %ld, %ld, %ld\n", h->length, h->bits, G->length); */
-
-            if (G->length >= ideal_len_limit || !within_limits(h, poly_len_limit, ctx))
+            if (G->length >= ideal_len_limit ||
+                !within_limits(h, poly_len_limit, ctx))
             {
                 success = 0;
                 break;
             }
 
-            index_h = G->length;
+            ih = G->length;
             fmpz_mod_mpoly_vec_append(G, h, ctx);
 
-            for (i = 0; i < index_h; i++)
-                if (!fmpz_mod_mpoly_disjoint_lt(fmpz_mod_mpoly_vec_entry(G, i), fmpz_mod_mpoly_vec_entry(G, index_h), ctx))
-                    pairs_append(B, i, index_h);
+            if (ih >= exp_alloc)
+            {
+                exp_alloc = FLINT_MAX(exp_alloc * 2, ih + 1);
+                exp = flint_realloc(exp, exp_alloc * nvars * sizeof(ulong));
+            }
+
+            fmpz_mod_mpoly_get_term_exp_ui(exp + ih * nvars,
+                                           fmpz_mod_mpoly_vec_entry(G, ih), 0,
+                                           ctx);
+
+            if (G_active_len + 1 > G_active_alloc)
+            {
+                G_active_alloc = FLINT_MAX(G_active_alloc * 2,
+                                           G_active_len + 2);
+                G_active = flint_realloc(G_active,
+                                         G_active_alloc * sizeof(slong));
+            }
+
+            update_pairs(G_active, G_active_len, B, ih, exp, nvars);
+            filter_redundant(G_active, &G_active_len, ih, exp, nvars);
+            G_active[G_active_len++] = ih;
         }
+    }
+
+    /* Compact G to the active basis in-place. G has accumulated every
+       polynomial ever added, including those later made redundant by
+       basis-element filtering.
+
+       G_active is strictly increasing throughout the algorithm: indices are
+       appended in the order they are added to the store (always ih = old
+       G->length, strictly larger than everything already there), and
+       filter_redundant only removes elements while preserving the order of
+       survivors. Therefore G_active[i] >= i for all i. We exploit this to
+       compact G with a single forward pass. */
+    for (i = 0; i < G_active_len; i++)
+    {
+        FLINT_ASSERT(G_active[i] >= i);
+        fmpz_mod_mpoly_swap(fmpz_mod_mpoly_vec_entry(G, i),
+                        fmpz_mod_mpoly_vec_entry(G, G_active[i]), ctx);
     }
 
     fmpz_mod_mpoly_clear(h, ctx);
     pairs_clear(B);
+    flint_free(G_active);
+    flint_free(exp);
 
     return success;
 }
 
 void
-fmpz_mod_mpoly_buchberger_naive(fmpz_mod_mpoly_vec_t G, const fmpz_mod_mpoly_vec_t F, const fmpz_mod_mpoly_ctx_t ctx)
+fmpz_mod_mpoly_buchberger_naive(fmpz_mod_mpoly_vec_t G,
+    const fmpz_mod_mpoly_vec_t F, const fmpz_mod_mpoly_ctx_t ctx)
 {
     fmpz_mod_mpoly_buchberger_naive_with_limits(G, F, WORD_MAX, WORD_MAX, ctx);
 }

--- a/src/fmpz_mod_mpoly/vec_autoreduction_groebner.c
+++ b/src/fmpz_mod_mpoly/vec_autoreduction_groebner.c
@@ -43,6 +43,7 @@ fmpz_mod_mpoly_vec_autoreduction_groebner(fmpz_mod_mpoly_vec_t G, const fmpz_mod
         {
             fmpz_mod_mpoly_swap(fmpz_mod_mpoly_vec_entry(G, i), fmpz_mod_mpoly_vec_entry(G, G->length - 1), ctx);
             fmpz_mod_mpoly_vec_set_length(G, G->length - 1, ctx);
+            i--;
         }
         else
         {
@@ -52,6 +53,7 @@ fmpz_mod_mpoly_vec_autoreduction_groebner(fmpz_mod_mpoly_vec_t G, const fmpz_mod
                 {
                     fmpz_mod_mpoly_swap(fmpz_mod_mpoly_vec_entry(G, j), fmpz_mod_mpoly_vec_entry(G, G->length - 1), ctx);
                     fmpz_mod_mpoly_vec_set_length(G, G->length - 1, ctx);
+                    j--;
                 }
             }
         }
@@ -80,6 +82,7 @@ fmpz_mod_mpoly_vec_autoreduction_groebner(fmpz_mod_mpoly_vec_t G, const fmpz_mod
                 {
                     fmpz_mod_mpoly_swap(fmpz_mod_mpoly_vec_entry(G, i), fmpz_mod_mpoly_vec_entry(G, G->length - 1), ctx);
                     fmpz_mod_mpoly_vec_set_length(G, G->length - 1, ctx);
+                    i--;
                     break;
                 }
             }

--- a/src/fmpz_mpoly/buchberger_naive.c
+++ b/src/fmpz_mpoly/buchberger_naive.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020 Fredrik Johansson
+    Copyright (C) 2020, 2026 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -11,7 +11,16 @@
 
 #include "fmpz_mpoly.h"
 
-/* Index pairs (for Buchberger algorithm) */
+/* Implements a version of GROEBNERNEW2 (Becker and Weispfenning, p. 232).
+   Parts of the implementation were inspired by SymPy's groebner().
+   The current version of the code has been substantially rewritten using
+   Claude to incorporate optimizations from BW that were omitted or
+   done incorrectly in the original hand-written version.
+
+   Note: the fmpz_mpoly and fmpz_mod_mpoly implementations are essentially
+   identical. Any future improvements should be applied to both. */
+
+/* Helper functions for index pairs. */
 
 typedef struct
 {
@@ -65,119 +74,136 @@ pairs_append(pairs_t vec, slong i, slong j)
     vec->length++;
 }
 
+/* Two selection strategies are available.
 
-/*
-static void
-pairs_insert_unique(pairs_t vec, slong i, slong j)
-{
-    slong k;
+   BUCHBERGER_DEGREE_SELECTION 1 (default): Degree strategy.
+   Select the pair whose lcm(LM(f), LM(g)) has the smallest total degree,
+   for ALL monomial orderings. For a lex ordering, equal-degree pairs are
+   broken by lex comparison. For degree orderings (degrevlex, deglex),
+   equal-degree pairs are broken by position in the pairs vector.
 
-    for (k = 0; k < vec->length; k++)
-    {
-        if (vec->pairs[k].a == i && vec->pairs[k].b == j)
-            return;
-    }
+   Motivation: pure lex comparison (BW's strategy, below) causes
+   pathological blowup on certain lex systems that we encounter in
+   practice in the Calcium test suite.
 
-    pairs_append(vec, i, j);
-}
+   BUCHBERGER_DEGREE_SELECTION 0: BW Normal strategy.
+   Select the pair whose lcm(LM(f), LM(g)) is smallest in the monomial order
+   being used, for all orderings. For lex this is a pure lexicographic
+   comparison. For degree orderings it coincides with minimum total degree
+   (same as the degree strategy), so the two variants differ only for lex.
 */
+#define BUCHBERGER_DEGREE_SELECTION 1
 
 static pair_t
-fmpz_mpoly_select_pop_pair(pairs_t pairs, const fmpz_mpoly_vec_t G, const fmpz_mpoly_ctx_t ctx)
+fmpz_mpoly_select_pop_pair(pairs_t pairs, const fmpz_mpoly_vec_t G,
+                           const fmpz_mpoly_ctx_t ctx)
 {
     slong len, choice, nvars;
     pair_t result;
-
+ 
     nvars = ctx->minfo->nvars;
     len = pairs->length;
     choice = 0;
-
+ 
     if (len > 1)
     {
         slong i, j, a, b;
         ulong * exp;
-        ulong * tmp;
         ulong * lcm;
         ulong * best_lcm;
         ulong l, total;
         int best;
-
+ 
         exp = flint_malloc(sizeof(ulong) * G->length * nvars);
         lcm = flint_malloc(sizeof(ulong) * (nvars + 1));
-        tmp = flint_malloc(sizeof(ulong) * (nvars + 1));
         best_lcm = flint_malloc(sizeof(ulong) * (nvars + 1));
-
+ 
         for (i = 0; i <= nvars; i++)
             best_lcm[i] = UWORD_MAX;
-
+ 
         for (i = 0; i < G->length; i++)
             fmpz_mpoly_get_term_exp_ui(exp + i * nvars, G->p + i, 0, ctx);
-
+ 
         for (i = 0; i < len; i++)
         {
             a = pairs->pairs[i].a;
             b = pairs->pairs[i].b;
             total = 0;
             best = 1;
+ 
+            /* Compute the full lcm vector and total degree unconditionally.
+             * Both strategies need lcm[] fully populated before comparing
+             * so that best_lcm[] is always written with complete data. */
+            for (j = 0; j < nvars; j++)
+            {
+                l = FLINT_MAX(exp[a * nvars + j], exp[b * nvars + j]);
+                lcm[j] = l;
+                total += l;
+            }
+ 
+#if BUCHBERGER_DEGREE_SELECTION
+            /* Degree strategy  */
+            if (total > best_lcm[nvars])
+            {
+                best = 0;
+            }
+            else if (total == best_lcm[nvars] && ctx->minfo->ord == ORD_LEX)
+            {
+                for (j = 0; j < nvars; j++)
+                {
+                    if (lcm[j] > best_lcm[j]) { best = 0; break; }
+                    if (lcm[j] < best_lcm[j]) break;
+                }
+            }
+            else if (total == best_lcm[nvars])
+            {
+                best = 0;
+            }
 
+#else
+            /* BW Normal strategy */
             if (ctx->minfo->ord == ORD_LEX)
             {
                 for (j = 0; j < nvars; j++)
                 {
-                    l = FLINT_MAX(exp[a * nvars + j], exp[b * nvars + j]);
-
-                    if (l > best_lcm[j])
-                    {
-                        best = 0;
-                        break;
-                    }
-
-                    lcm[j] = l;
-                    total += l;  /* total degree */
+                    if (lcm[j] > best_lcm[j]) { best = 0; break; }
+                    if (lcm[j] < best_lcm[j]) break;
                 }
             }
-            else  /* todo: correct order */
+            else
             {
-                for (j = 0; j < nvars; j++)
-                {
-                    l = FLINT_MAX(exp[a * nvars + j], exp[b * nvars + j]);
-                    total += l;  /* total degree */
-
-                    if (total >= best_lcm[j])
-                    {
-                        best = 0;
-                        break;
-                    }
-
-                    lcm[j] = l;
-                }
+                if (total > best_lcm[nvars])
+                    best = 0;
+                else if (total == best_lcm[nvars])
+                    best = 0;
             }
-
+#endif
             if (best)
             {
                 for (j = 0; j < nvars; j++)
                     best_lcm[j] = lcm[j];
-
+ 
                 best_lcm[nvars] = total;
                 choice = i;
             }
         }
-
+ 
         flint_free(exp);
-        flint_free(tmp);
         flint_free(lcm);
         flint_free(best_lcm);
     }
-
+ 
     result = pairs->pairs[choice];
     pairs->pairs[choice] = pairs->pairs[pairs->length - 1];
     pairs->length--;
-
+ 
     return result;
 }
 
+/* Evaluation limits to allow aborting a basis that spirals out of control. */
 static int
-within_limits(const fmpz_mpoly_t poly, slong poly_len_limit, slong poly_bits_limit, const fmpz_mpoly_ctx_t ctx)
+within_limits(const fmpz_mpoly_t poly, slong poly_len_limit,
+              slong poly_bits_limit, const fmpz_mpoly_ctx_t ctx)
 {
     slong bits;
 
@@ -193,37 +219,248 @@ within_limits(const fmpz_mpoly_t poly, slong poly_len_limit, slong poly_bits_lim
     return 1;
 }
 
+/* Helper functions for exponent vectors, packed to 1 ulong per exponent.
+   TODO: better packing for small exponents? If we ensure that all
+   polynomials pack to the same number of bits (resizing if necessary
+   during the algorithm), we could maybe work directly with the
+   exponent vectors stored in the polynomials? */
+
 static int
-fmpz_mpoly_disjoint_lt(const fmpz_mpoly_t f, const fmpz_mpoly_t g, const fmpz_mpoly_ctx_t ctx)
+monomial_divides(const ulong * a, const ulong * b, slong nvars)
 {
-    int result;
-    slong i, nvars;
-    ulong * exp1, * exp2;
+    slong i;
 
-    nvars = ctx->minfo->nvars;
-    exp1 = flint_malloc(2 * nvars * sizeof(ulong));
-    exp2 = exp1 + nvars;
+    for (i = 0; i < nvars; i++)
+        if (a[i] > b[i])
+            return 0;
 
-    fmpz_mpoly_get_term_exp_ui(exp1, f, 0, ctx);
-    fmpz_mpoly_get_term_exp_ui(exp2, g, 0, ctx);
+    return 1;
+}
 
-    result = 1;
-    for (i = 0; i < nvars && result; i++)
-        if (exp1[i] && exp2[i])
-            result = 0;
+static int
+monomial_disjoint(const ulong * a, const ulong * b, slong nvars)
+{
+    slong i;
 
-    flint_free(exp1);
+    for (i = 0; i < nvars; i++)
+        if (a[i] && b[i])
+            return 0;
 
-    return result;
+    return 1;
+}
+
+static void
+monomial_lcm(ulong * out, const ulong * a, const ulong * b, slong nvars)
+{
+    slong i;
+
+    for (i = 0; i < nvars; i++)
+        out[i] = FLINT_MAX(a[i], b[i]);
+}
+
+static int
+monomial_equal(const ulong * a, const ulong * b, slong nvars)
+{
+    slong i;
+
+    for (i = 0; i < nvars; i++)
+        if (a[i] != b[i])
+            return 0;
+
+    return 1;
+}
+
+/* Basis-element filtering. When a new polynomial h at index ih is added to
+   the basis, any existing basis element g whose leading monomial is
+   divisible by LM(h) is redundant: every future S-polynomial involving g as
+   a basis candidate is already subsumed by pairs involving h. Removing such
+   g from G_active shrinks the candidate set for future calls to update_pairs.
+
+   Note: pairs already in the pair set that mention a removed index are left
+   in place. Their S-polynomials are not guaranteed to reduce to zero
+   immediately (they may still yield new generators), and update_pairs's own
+   pair-filtering step already handles the subset of redundant old pairs.
+   The polynomial store G is also left untouched; removed indices remain valid
+   for spoly and reduction computations. */
+static void
+filter_redundant(slong * G_active, slong * G_active_len,
+                 slong ih, const ulong * exp, slong nvars)
+{
+    const ulong * mh;
+    slong i, new_active_len;
+
+    mh = exp + ih * nvars;
+
+    new_active_len = 0;
+    for (i = 0; i < *G_active_len; i++)
+    {
+        slong ig = G_active[i];
+
+        if (!monomial_divides(mh, exp + ig * nvars, nvars))
+            G_active[new_active_len++] = ig;
+    }
+    *G_active_len = new_active_len;
+}
+
+/* Gebauer-Moller pair-set update (Becker & Weispfenning, p. 230).
+
+   Given the current pair set B and a new polynomial at index ih (with leading
+   monomial exp[ih * nvars ...]), update B as follows:
+
+   1. Compute the set E of new pairs (ih, ig) to add, using the chain
+      criterion to discard candidates dominated by a pair with smaller lcm,
+      and the product criterion to discard pairs with disjoint leading
+      monomials (the C -> D -> E reduction in BW's description).
+
+   2. Remove from B any existing pair (ig1, ig2) made redundant by ih:
+      those where LM(ih) | lcm(LM(ig1), LM(ig2)), subject to two
+      correctness guards that prevent over-aggressive removal.
+
+   3. Append E to B.
+*/
+static void
+update_pairs(const slong * G_active, slong G_active_len,
+             pairs_t B, slong ih, const ulong * exp, slong nvars)
+{
+    const ulong * mh;
+    ulong * lcm_hg;
+    ulong * lcm_tmp;
+    slong * D_ig;
+    slong * E_ig;
+    slong D_alloc, D_len, E_len;
+    slong i, k;
+    int dominated;
+
+    mh = exp + ih * nvars;
+    lcm_hg  = flint_malloc(nvars * sizeof(ulong));
+    lcm_tmp = flint_malloc(nvars * sizeof(ulong));
+
+    /* Step 1 (C -> D): decide which candidate pairs (ih, ig) to accept.
+
+       Process G_active left-to-right.  At step i, the "C" set of BW's
+       algorithm is G_active[i + 1 ..] (not yet visited) and "D" is the
+       pairs already accepted.  Accept (ih, ig) unless some p already in D
+       or still in C satisfies lcm(LM(h), LM(p)) | lcm(LM(h), LM(g)) --
+       the pair (h, p) then dominates (h, g) by the chain criterion.
+       Coprime pairs (product criterion) are also accepted here; Step 2
+       removes them again. */
+    D_alloc = G_active_len + 1;
+    D_len   = 0;
+    D_ig    = flint_malloc(D_alloc * sizeof(slong));
+
+    for (i = 0; i < G_active_len; i++)
+    {
+        slong ig = G_active[i];
+        const ulong * mg = exp + ig * nvars;
+
+        if (!monomial_disjoint(mh, mg, nvars))
+        {
+            monomial_lcm(lcm_hg, mh, mg, nvars);
+            dominated = 0;
+
+            for (k = 0; k < D_len && !dominated; k++)
+            {
+                monomial_lcm(lcm_tmp, mh, exp + D_ig[k] * nvars, nvars);
+                if (monomial_divides(lcm_tmp, lcm_hg, nvars))
+                    dominated = 1;
+            }
+
+            for (k = i + 1; k < G_active_len && !dominated; k++)
+            {
+                monomial_lcm(lcm_tmp, mh, exp + G_active[k] * nvars, nvars);
+                if (monomial_divides(lcm_tmp, lcm_hg, nvars))
+                    dominated = 1;
+            }
+
+            if (dominated)
+                continue;
+        }
+
+        if (D_len == D_alloc)
+        {
+            D_alloc *= 2;
+            D_ig = flint_realloc(D_ig, D_alloc * sizeof(slong));
+        }
+
+        D_ig[D_len++] = ig;
+    }
+
+    /* Step 2 (D -> E): apply the product criterion to D. */
+    E_ig  = flint_malloc((D_len + 1) * sizeof(slong));
+    E_len = 0;
+
+    for (i = 0; i < D_len; i++)
+    {
+        slong ig = D_ig[i];
+
+        if (!monomial_disjoint(mh, exp + ig * nvars, nvars))
+            E_ig[E_len++] = ig;
+    }
+
+    flint_free(D_ig);
+
+    /* Step 3: remove stale pairs from B (Gebauer-Moller criterion).
+
+       Discard (ig1, ig2) if all three conditions hold:
+         (a) LM(h) | lcm(LM(ig1), LM(ig2))
+         (b) lcm(LM(ig1), LM(h)) != lcm(LM(ig1), LM(ig2))
+         (c) lcm(LM(ig2), LM(h)) != lcm(LM(ig1), LM(ig2))
+      
+       The equality guards (b) and (c) prevent incorrectly removing a pair
+       for which one element's lcm with h already equals the pair's lcm. */
+    {
+        slong new_len = 0;
+
+        for (k = 0; k < B->length; k++)
+        {
+            slong ig1 = B->pairs[k].a;
+            slong ig2 = B->pairs[k].b;
+            const ulong * mg1 = exp + ig1 * nvars;
+            const ulong * mg2 = exp + ig2 * nvars;
+
+            monomial_lcm(lcm_hg, mg1, mg2, nvars);
+
+            if (!monomial_divides(mh, lcm_hg, nvars))
+                goto keep;
+
+            monomial_lcm(lcm_tmp, mg1, mh, nvars);
+            if (monomial_equal(lcm_tmp, lcm_hg, nvars))
+                goto keep;
+
+            monomial_lcm(lcm_tmp, mg2, mh, nvars);
+            if (monomial_equal(lcm_tmp, lcm_hg, nvars))
+                goto keep;
+
+            continue;   /* discard */
+
+        keep:
+
+            B->pairs[new_len++] = B->pairs[k];
+        }
+
+        B->length = new_len;
+    }
+
+    /* Step 4: append the surviving new pairs E to B. */
+    for (i = 0; i < E_len; i++)
+        pairs_append(B, ih, E_ig[i]);
+
+    flint_free(E_ig);
+    flint_free(lcm_hg);
+    flint_free(lcm_tmp);
 }
 
 int
-fmpz_mpoly_buchberger_naive_with_limits(fmpz_mpoly_vec_t G, const fmpz_mpoly_vec_t F,
-    slong ideal_len_limit, slong poly_len_limit, slong poly_bits_limit, const fmpz_mpoly_ctx_t ctx)
+fmpz_mpoly_buchberger_naive_with_limits(fmpz_mpoly_vec_t G,
+    const fmpz_mpoly_vec_t F,
+    slong ideal_len_limit, slong poly_len_limit, slong poly_bits_limit,
+    const fmpz_mpoly_ctx_t ctx)
 {
     pairs_t B;
     fmpz_mpoly_t h;
-    slong i, j, index_h;
+    slong * G_active;
+    ulong * exp;
+    slong i, ih, G_active_len, G_active_alloc, exp_alloc, nvars;
     pair_t pair;
     int success;
 
@@ -236,52 +473,120 @@ fmpz_mpoly_buchberger_naive_with_limits(fmpz_mpoly_vec_t G, const fmpz_mpoly_vec
         return 0;
 
     for (i = 0; i < G->length; i++)
-        if (!within_limits(fmpz_mpoly_vec_entry(G, i), poly_len_limit, poly_bits_limit, ctx))
+        if (!within_limits(fmpz_mpoly_vec_entry(G, i), poly_len_limit,
+                           poly_bits_limit, ctx))
             return 0;
+
+    nvars = ctx->minfo->nvars;
+
+    /* Cache leading monomial exponent vectors for fast comparisons. */
+    exp_alloc = G->length + 16;
+    exp = flint_malloc(exp_alloc * nvars * sizeof(ulong));
+
+    for (i = 0; i < G->length; i++)
+        fmpz_mpoly_get_term_exp_ui(exp + i * nvars,
+                                   fmpz_mpoly_vec_entry(G, i), 0, ctx);
+
+    /* G_active tracks which indices in G belong to the current basis,
+       allowing update_pairs to enumerate candidates without disturbing the
+       storage layout that spoly and reduction use. */
+    G_active_alloc = exp_alloc;
+    G_active = flint_malloc(G_active_alloc * sizeof(slong));
+    G_active_len = 0;
 
     pairs_init(B);
     fmpz_mpoly_init(h, ctx);
 
-    for (i = 0; i < G->length; i++)
-        for (j = i + 1; j < G->length; j++)
-            if (!fmpz_mpoly_disjoint_lt(fmpz_mpoly_vec_entry(G, i), fmpz_mpoly_vec_entry(G, j), ctx))
-                pairs_append(B, i, j);
+    /* Build the initial pair set by simulating GROEBNERNEW2's initialisation
+       loop: start with G_active = {0} and call update_pairs for
+       each subsequent initial polynomial in turn. The original code only
+       applied the product criterion here; update_pairs applies the full
+       Gebauer-Moller criteria, eliminating more redundant pairs up front. */
+    G_active[G_active_len++] = 0;
 
+    for (i = 1; i < G->length; i++)
+    {
+        update_pairs(G_active, G_active_len, B, i, exp, nvars);
+        filter_redundant(G_active, &G_active_len, i, exp, nvars);
+        G_active[G_active_len++] = i;
+    }
+
+    /* Main loop -- GROEBNERNEW2 */
     success = 1;
+
     while (B->length != 0)
     {
         pair = fmpz_mpoly_select_pop_pair(B, G, ctx);
 
-        fmpz_mpoly_spoly(h, fmpz_mpoly_vec_entry(G, pair.a), fmpz_mpoly_vec_entry(G, pair.b), ctx);
+        fmpz_mpoly_spoly(h, fmpz_mpoly_vec_entry(G, pair.a),
+                            fmpz_mpoly_vec_entry(G, pair.b), ctx);
         fmpz_mpoly_reduction_primitive_part(h, h, G, ctx);
 
         if (!fmpz_mpoly_is_zero(h, ctx))
         {
-            /* printf("h stats %ld, %ld, %ld\n", h->length, h->bits, G->length); */
-
-            if (G->length >= ideal_len_limit || !within_limits(h, poly_len_limit, poly_bits_limit, ctx))
+            if (G->length >= ideal_len_limit ||
+                !within_limits(h, poly_len_limit, poly_bits_limit, ctx))
             {
                 success = 0;
                 break;
             }
 
-            index_h = G->length;
+            ih = G->length;
             fmpz_mpoly_vec_append(G, h, ctx);
 
-            for (i = 0; i < index_h; i++)
-                if (!fmpz_mpoly_disjoint_lt(fmpz_mpoly_vec_entry(G, i), fmpz_mpoly_vec_entry(G, index_h), ctx))
-                    pairs_append(B, i, index_h);
+            if (ih >= exp_alloc)
+            {
+                exp_alloc = FLINT_MAX(exp_alloc * 2, ih + 1);
+                exp = flint_realloc(exp, exp_alloc * nvars * sizeof(ulong));
+            }
+
+            fmpz_mpoly_get_term_exp_ui(exp + ih * nvars,
+                                       fmpz_mpoly_vec_entry(G, ih), 0, ctx);
+
+            if (G_active_len + 1 > G_active_alloc)
+            {
+                G_active_alloc = FLINT_MAX(G_active_alloc * 2,
+                                           G_active_len + 2);
+                G_active = flint_realloc(G_active,
+                                         G_active_alloc * sizeof(slong));
+            }
+
+            update_pairs(G_active, G_active_len, B, ih, exp, nvars);
+            filter_redundant(G_active, &G_active_len, ih, exp, nvars);
+            G_active[G_active_len++] = ih;
         }
     }
 
+    /* Compact G to the active basis in-place. G has accumulated every
+       polynomial ever added, including those later made redundant by
+       basis-element filtering.
+
+       G_active is strictly increasing throughout the algorithm: indices are
+       appended in the order they are added to the store (always ih = old
+       G->length, strictly larger than everything already there), and
+       filter_redundant only removes elements while preserving the order of
+       survivors. Therefore G_active[i] >= i for all i. We exploit this to
+       compact G with a single forward pass. */
+    for (i = 0; i < G_active_len; i++)
+    {
+        FLINT_ASSERT(G_active[i] >= i);
+        fmpz_mpoly_swap(fmpz_mpoly_vec_entry(G, i),
+                        fmpz_mpoly_vec_entry(G, G_active[i]), ctx);
+    }
+
+    fmpz_mpoly_vec_set_length(G, G_active_len, ctx);
+
     fmpz_mpoly_clear(h, ctx);
     pairs_clear(B);
+    flint_free(G_active);
+    flint_free(exp);
 
     return success;
 }
 
 void
-fmpz_mpoly_buchberger_naive(fmpz_mpoly_vec_t G, const fmpz_mpoly_vec_t F, const fmpz_mpoly_ctx_t ctx)
+fmpz_mpoly_buchberger_naive(fmpz_mpoly_vec_t G, const fmpz_mpoly_vec_t F,
+                            const fmpz_mpoly_ctx_t ctx)
 {
     fmpz_mpoly_buchberger_naive_with_limits(G, F, WORD_MAX, WORD_MAX, WORD_MAX, ctx);
 }

--- a/src/fmpz_mpoly/vec_autoreduction.c
+++ b/src/fmpz_mpoly/vec_autoreduction.c
@@ -31,6 +31,7 @@ fmpz_mpoly_vec_autoreduction(fmpz_mpoly_vec_t G, const fmpz_mpoly_vec_t Gin, con
         {
             fmpz_mpoly_swap(fmpz_mpoly_vec_entry(G, i), fmpz_mpoly_vec_entry(G, G->length - 1), ctx);
             fmpz_mpoly_vec_set_length(G, G->length - 1, ctx);
+            i--;
         }
         else
         {
@@ -40,6 +41,7 @@ fmpz_mpoly_vec_autoreduction(fmpz_mpoly_vec_t G, const fmpz_mpoly_vec_t Gin, con
                 {
                     fmpz_mpoly_swap(fmpz_mpoly_vec_entry(G, j), fmpz_mpoly_vec_entry(G, G->length - 1), ctx);
                     fmpz_mpoly_vec_set_length(G, G->length - 1, ctx);
+                    j--;
                 }
             }
         }

--- a/src/fmpz_mpoly/vec_autoreduction_groebner.c
+++ b/src/fmpz_mpoly/vec_autoreduction_groebner.c
@@ -42,6 +42,7 @@ fmpz_mpoly_vec_autoreduction_groebner(fmpz_mpoly_vec_t G, const fmpz_mpoly_vec_t
         {
             fmpz_mpoly_swap(fmpz_mpoly_vec_entry(G, i), fmpz_mpoly_vec_entry(G, G->length - 1), ctx);
             fmpz_mpoly_vec_set_length(G, G->length - 1, ctx);
+            i--;
         }
         else
         {
@@ -51,6 +52,7 @@ fmpz_mpoly_vec_autoreduction_groebner(fmpz_mpoly_vec_t G, const fmpz_mpoly_vec_t
                 {
                     fmpz_mpoly_swap(fmpz_mpoly_vec_entry(G, j), fmpz_mpoly_vec_entry(G, G->length - 1), ctx);
                     fmpz_mpoly_vec_set_length(G, G->length - 1, ctx);
+                    j--;
                 }
             }
         }
@@ -79,6 +81,7 @@ fmpz_mpoly_vec_autoreduction_groebner(fmpz_mpoly_vec_t G, const fmpz_mpoly_vec_t
                 {
                     fmpz_mpoly_swap(fmpz_mpoly_vec_entry(G, i), fmpz_mpoly_vec_entry(G, G->length - 1), ctx);
                     fmpz_mpoly_vec_set_length(G, G->length - 1, ctx);
+                    i--;
                     break;
                 }
             }


### PR DESCRIPTION
Fixes #2505 (with caveats: many Groebner basis computations will speed up, but others will slow down).

The Groebner bases routines `fmpz_mpoly_buchberger_naive` and `fmpz_mod_mpoly_buchberger_naive` are based on GROEBNERNEW2 from Becker & Weispfenning (missing citation added), but did not implement all filtering tricks and did some steps incorrectly (suboptimally). This rewrite done with the help of Claude fixes the algorithm and adds the missing optimizations. Also adds `examples/groebner.c` which allows running some benchmark examples or computing a GB for a custom ideal.

Sample of speedups with this patch:

```
build/examples/hilbert_matrix_ca -vieta N

   N      old     new     speedup
   7     0.25     0.007    35.7x
   8     2.14     0.033    64.8x
   9    27.74     0.186   149.1x
  10   312.56     1.369   228.3x
```

Test cases from `examples/groebner` over Z:

```
                     old           new         speedup
cyclic4/drl       0.000145 s   0.000027 s       5.4x
cyclic4/lex       0.000143 s   0.000036 s       4.0x
katsura4/drl         >1min     0.000410 s        ?
katsura4/lex         >1min        >1min          ?
eco5/drl             >1min     0.004170 s        ?
noon3/drl         0.000514 s   0.000047 s      10.9x
reimer4/drl          >1min     0.028400 s        ?
caprasse/drl         >1min     0.000767 s        ?
symm5/lex         0.000830 s   0.000056 s      14.8x
```

Test cases from `examples/groebner` over Z mod 10007:

```
                     old           new         speedup
cyclic4/drl       0.000135 s   0.000030 s       4.5x
cyclic4/lex       0.000127 s   0.000037 s       3.4x
katsura4/drl      0.058100 s   0.000300 s     193.7x
katsura4/lex         >1min     0.006510 s        ?
eco5/drl             >1min     0.002250 s        ?
noon3/drl         0.000474 s   0.000055 s       8.6x
reimer4/drl          >1min     0.009040 s        ?
caprasse/drl      1.704000 s   0.000698 s    2441.3x
symm5/lex         0.000711 s   0.000055 s      12.9x
```

Some comments about the pair selection. This is a critical tuning factor in Buchberger's algorithm; choosing the "wrong" pair at any step can lead the ideal basis to blow up exponentially. Previously we used what is known as the "normal" strategy for all orders.

Unfortunately, it turned out that some lex input generated naturally from constant relations in the GR/Calcium test suite ran significantly slower after the rewrite. As far as I can tell this is not due to a new bug; the previous version just happened to get luckier with the pairs for some input that we run into in practice.

A workaround included in this PR (enabled by default with an `#if` block) is to choose pairs based on total degree even in lex mode. See for example the "symm5/lex" test case (which  came up in the unit test for ``gr_poly_roots``); this originally took 0.8 milliseconds, 5 seconds after the rewrite when still using the normal strategy, and 0.06 milliseconds when using the degree strategy.

The nature of the pair selection is that you can't always win: a fixed strategy that works best for some input will always be worse for some other input. A counterexample to the new strategy is the test case mod 4722366482869611659327 from #2445, i.e.

```
build/examples/groebner -vars x1,x2,x3 -prime 4722366482869611659327 -order lex -input "4491077222722822274764*x1^3*x2^2*x3^3+1142989093829542840957*x1*x2*x3+161135877041952360283*x2^2*x3^2+1963195568815792903903*x3^2,473518656873042772582*x1^3*x2^2*x3^2+538964973504606229287*x1^3*x3^3+2996428526938692536564*x1^2*x2^2*x3^2+1389613235437080610847*x1*x3"
```

which did not finish in Sage and Magma when using direct Buchberger. This took 14 seconds with the previous version of the code and 260 seconds with the new version, an unfortunate 20x slowdown. If one re-enables normal selection (by setting ``#define BUCHBERGER_DEGREE_SELECTION 0``) it takes just 0.6 seconds.

There might be ways to do better than either of these fixed strategies on average, though ultimately we ought to just implement FGLM.