### PR TITLE
gr_ore_poly doc: fix of function signatures - div, rem

### DIFF
--- a/doc/source/gr_ore_poly.rst
+++ b/doc/source/gr_ore_poly.rst
@@ -324,11 +324,11 @@ Arithmetic
 
     Sets *(Q, R)* to the unique pair such that `U = QV + R` and `ord(R) < ord(V)`.
 
-.. function:: int _gr_ore_poly_div(gr_ptr Q, gr_srcptr U, slong lenU, gr_srcptr V, slong lenV, gr_ore_poly_ctx_t ctx)
+.. function:: int gr_ore_poly_div(gr_ore_poly_t Q, const gr_ore_poly_t U, gr_ore_poly_t V, gr_ore_poly_ctx_t ctx)
 
     Version of the divrem function which outputs only the quotient.
 
-.. function:: int _gr_ore_poly_rem(gr_ptr R, gr_srcptr U, slong lenU, gr_srcptr V, slong lenV, gr_ore_poly_ctx_t ctx)
+.. function:: int gr_ore_poly_rem(gr_ore_poly_t R, const gr_ore_poly_t U, gr_ore_poly_t V, gr_ore_poly_ctx_t ctx)
 
     Version of the divrem function which outputs only the remainder.
 

--- a/src/gr_ore_poly/divrem.c
+++ b/src/gr_ore_poly/divrem.c
@@ -37,7 +37,7 @@ int _gr_ore_poly_divrem(gr_ptr Q, gr_ptr R, gr_srcptr U, slong lenU, gr_srcptr V
     GR_TMP_INIT(c, cctx);
 
     gr_ptr A, B;
-    GR_TMP_INIT_VEC(A, lenQ, cctx); 
+    GR_TMP_INIT_VEC(A, lenQ, cctx);
     GR_TMP_INIT_VEC(B, lenU, cctx);
 
     gr_ptr sigma_pows;
@@ -65,7 +65,7 @@ int _gr_ore_poly_divrem(gr_ptr Q, gr_ptr R, gr_srcptr U, slong lenU, gr_srcptr V
         // R -= B
         slong lenB = lenA + lenV - 1;
         status |= _gr_vec_sub(R, R, B, lenB, cctx);
-        
+
         // Q += c * x^k, so Q[k] += c
         status |= gr_add(GR_ENTRY(Q, k, el_size), GR_ENTRY(Q, k, el_size), c, cctx);
 
@@ -75,7 +75,7 @@ int _gr_ore_poly_divrem(gr_ptr Q, gr_ptr R, gr_srcptr U, slong lenU, gr_srcptr V
     GR_TMP_CLEAR_VEC(sigma_pows, lenQ, cctx);
     GR_TMP_CLEAR(c, cctx);
 
-    GR_TMP_CLEAR_VEC(A, lenQ, cctx); 
+    GR_TMP_CLEAR_VEC(A, lenQ, cctx);
     GR_TMP_CLEAR_VEC(B, lenU, cctx);
 
     return status;


### PR DESCRIPTION
We found a mistake in the doc I wrote for gr_ore_poly (right after the Division with remainder PR had been merged, sorry for the unfortunate timing :D), specifically:

`int _gr_ore_poly_div(gr_ptr Q, gr_srcptr U, slong lenU, gr_srcptr V, slong lenV, gr_ore_poly_ctx_t ctx)` -> corrected to:
`int gr_ore_poly_div(gr_ore_poly_t Q, const gr_ore_poly_t U, gr_ore_poly_t V, gr_ore_poly_ctx_t ctx)` 

`int _gr_ore_poly_rem(gr_ptr R, gr_srcptr U, slong lenU, gr_srcptr V, slong lenV, gr_ore_poly_ctx_t ctx)` -> corrected to:
`int gr_ore_poly_rem(gr_ore_poly_t R, const gr_ore_poly_t U, gr_ore_poly_t V, gr_ore_poly_ctx_t ctx)` 

Apart from this fix, this PR only removes the few missed trailing whitespaces in `divrem.c`.