### PR TITLE
Port some van Hoeij improvements from FLINT 1.6

### DIFF
--- a/dev/bench.py
+++ b/dev/bench.py
@@ -134,9 +134,9 @@ def fmpz_bench():
 def fmpz_poly_bench():
     s = run("build/fmpz_poly_factor/profile/p-factor_hard")
     for line in s.splitlines():
-        if " ms" in line:
+        if "factors" in line:
             poly = line.split()[0]
-            time = float(line.split()[-2]) * 0.001
+            time = float(line.split()[-2])
             add_result(["fmpz_poly", "factor", poly], time)
 
 def fmpz_mpoly_bench():

--- a/src/fmpz_mat/next_col_van_hoeij.c
+++ b/src/fmpz_mat/next_col_van_hoeij.c
@@ -10,6 +10,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include <math.h>
 #include <gmp.h>
 #include "longlong.h"
 #include "fmpz.h"
@@ -32,6 +33,17 @@ static void _fmpz_mat_resize_van_hoeij(fmpz_mat_t M, slong r, slong c)
     fmpz_mat_clear(T);
 }
 
+/*
+    Goal here is to take a matrix M, get U, multiply U by col look at max bits
+    of U*col and P subtract exp and decide if it's worth calling LLL.
+    If is not return 0. U_exp is the assumed power of the scalar multiple of U
+    (so 2^U_exp is the scalar weight of U).
+    This should match the virtual precision.
+    If it is then return weight of last column (check that it should not
+    be zero... ??) and  augment M with the new column and new row
+    This new column should be truncated to the correct amount before
+    re-multiplying by U first make sure there are enough bits to even bother.
+*/
 int fmpz_mat_next_col_van_hoeij(fmpz_mat_t M, fmpz_t P,
                                         fmpz_mat_t col, slong exp, slong U_exp)
 {
@@ -40,10 +52,11 @@ int fmpz_mat_next_col_van_hoeij(fmpz_mat_t M, fmpz_t P,
    slong s = M->r;
    fmpz_mat_t U, x, y;
    fmpz_t P_trunc;
+   slong mbts_full;
 
    k = fmpz_bits(P) - bit_r - bit_r/2;
 
-   /* check if LLL justified */
+   /* primary check: is LLL potentially justified at this precision? */
    if (k < exp + (slong) FLINT_BIT_COUNT(r + 1))
       return 0;
 
@@ -53,6 +66,37 @@ int fmpz_mat_next_col_van_hoeij(fmpz_mat_t M, fmpz_t P,
 
    /* find U, the combinatorial part of M */
    fmpz_mat_window_init(U, M, 0, 0, s, r);
+
+   /*
+      Secondary check (from FLINT 1.6, _F_mpz_mat_next_col):
+      compute y_full = U * col / 2^U_exp mod P at full CLD precision (no
+      k-based truncation).  If the sup-norm of y_full is too small relative
+      to the CLD bound (exp), the column carries insufficient information to
+      improve the lattice even though the primary ISD check passed.  This
+      filters out columns whose actual data is negligibly small -- typically
+      because the CLD coefficient is genuinely close to a multiple of P at
+      this precision -- and avoids a full LLL call that would remove zero rows.
+
+      Threshold 0.973*bit_r matches FLINT 1.6.
+   */
+   fmpz_mat_t y_full;
+   fmpz_mat_init(y_full, s, 1);
+   fmpz_mat_mul(y_full, U, col);
+   fmpz_mat_scalar_tdiv_q_2exp(y_full, y_full, U_exp);
+   fmpz_mat_scalar_smod(y_full, y_full, P);
+   mbts_full = FLINT_ABS(fmpz_mat_max_bits(y_full));
+
+   if (mbts_full < (slong)(0.973*(double)bit_r - 0.1) + exp)
+   {
+      fmpz_mat_clear(x);
+      fmpz_mat_clear(y);
+      fmpz_mat_clear(y_full);
+      fmpz_clear(P_trunc);
+      fmpz_mat_window_clear(U);
+      return 0;
+   }
+
+   fmpz_mat_clear(y_full);
 
    /* find scale factor 2^k */
    k -= U_exp; /* we want this many bits beyond the radix point */

--- a/src/fmpz_poly_factor/factor_van_hoeij.c
+++ b/src/fmpz_poly_factor/factor_van_hoeij.c
@@ -19,6 +19,21 @@
 #include "fmpz_poly_factor.h"
 #include "fmpz_lll.h"
 
+/* Some tuning parameters */
+
+/* Use ULLL or standard LLL? */
+#define VAN_HOEIJ_USE_ULLL 1
+
+/* FLINT 1.6 parameters */
+#define LLL_DELTA 0.75
+#define LLL_ETA 0.81
+
+#define ULLL_BIG_CUTOFF 100
+#define ULLL_BIG_SIZE_PARAM 150
+#define ULLL_SMALL_SIZE_PARAM 350
+
+#define VAN_HOEIJ_VERBOSE 0
+
 static slong _heuristic_van_hoeij_starting_precision(const fmpz_poly_t f,
                                                             slong r, ulong p)
 {
@@ -125,7 +140,8 @@ void fmpz_poly_factor_van_hoeij(fmpz_poly_factor_t final_fac,
 
    /* compute leading coefficient */
    N = f->length - 1;
-   sqN = (ulong) sqrt(N);
+   sqN = sqrt(N);
+
    fmpz_init(lc);
    fmpz_set(lc, f->coeffs + N);
 
@@ -138,7 +154,12 @@ void fmpz_poly_factor_van_hoeij(fmpz_poly_factor_t final_fac,
 
    fmpz_init(bound_sum);
    fmpz_mat_init(col, r, 1);
-   fmpz_lll_context_init_default(fl);
+
+   fmpz_lll_context_init(fl, LLL_DELTA, LLL_ETA, Z_BASIS, APPROX);
+
+#if VAN_HOEIJ_VERBOSE
+   flint_printf("factor_van_hoeij: len = %wd, bits = %wd, r = %wd\n", f->length, fmpz_poly_max_bits(f), r);
+#endif
 
    while (!fmpz_poly_factor_van_hoeij_check_if_solved(M, final_fac, lifted_fac, f, P, exp, lc))
    {
@@ -174,8 +195,16 @@ void fmpz_poly_factor_van_hoeij(fmpz_poly_factor_t final_fac,
 
             if (do_lll)
             {
-                /* flint_printf("LLL %wd %wd  %wd\n", M->r, M->c, fmpz_mat_max_bits(M)); */
-               num_rows = fmpz_lll_wrapper_with_removal_knapsack(M, NULL, B, fl);
+#if VAN_HOEIJ_VERBOSE
+                flint_printf("LLL %wd %wd  %wd\n", M->r, M->c, fmpz_mat_max_bits(M));
+#endif
+
+#if VAN_HOEIJ_USE_ULLL
+                   slong new_size_ulll = (M->r > ULLL_BIG_CUTOFF) ? ULLL_BIG_SIZE_PARAM : ULLL_SMALL_SIZE_PARAM;
+                   num_rows = fmpz_lll_with_removal_ulll(M, NULL, new_size_ulll, B, fl);
+#else
+                    num_rows = fmpz_lll_wrapper_with_removal_knapsack(M, NULL, B, fl);
+#endif
 
                fmpz_mat_van_hoeij_resize_matrix(M, num_rows);
 
@@ -221,3 +250,4 @@ cleanup:
    flint_free(w);
    flint_free(link);
 }
+

--- a/src/fmpz_poly_factor/profile/p-factor_hard.c
+++ b/src/fmpz_poly_factor/profile/p-factor_hard.c
@@ -25,8 +25,6 @@ void factor_poly(const char * file_str, const char * name, slong wanted_factors)
     FILE * file;
     fmpz_poly_t f;
     fmpz_poly_factor_t fac;
-    struct timeval start, stop;
-    ulong ms;
 
     fmpz_poly_init(f);
 
@@ -42,10 +40,10 @@ void factor_poly(const char * file_str, const char * name, slong wanted_factors)
     {
         fmpz_poly_t g;
         fmpz_poly_init(g);
-        file = fopen(MY_DIR"P7_flint", "rw");
+        file = fopen(MY_DIR"P7_flint", "r");
         fmpz_poly_fread(file, g);
         fclose(file);
-        file = fopen((!strcmp(name, "P7*M12_5") ? MY_DIR"M12_5_flint" : MY_DIR"M12_6_flint"), "rw");
+        file = fopen((!strcmp(name, "P7*M12_5") ? MY_DIR"M12_5_flint" : MY_DIR"M12_6_flint"), "r");
         fmpz_poly_fread(file, f);
         fclose(file);
         fmpz_poly_mul(f, f, g);
@@ -53,19 +51,21 @@ void factor_poly(const char * file_str, const char * name, slong wanted_factors)
     }
     else
     {
-        file = fopen(file_str, "rw");
+        file = fopen(file_str, "r");
         fmpz_poly_fread(file, f);
         fclose(file);
     }
 
     fmpz_poly_factor_init(fac);
 
-    gettimeofday(&start, NULL);
-    fmpz_poly_factor(fac, f);
-    gettimeofday(&stop, NULL);
-    ms = (stop.tv_sec - start.tv_sec)*1000 + (stop.tv_usec - start.tv_usec) / 1000;
+    double tcpu, twall;
 
-    flint_printf("%s has %wd factors: %ld ms\n", name, fac->num, ms);
+    TIMEIT_START;
+    fmpz_poly_factor(fac, f);
+    TIMEIT_STOP_VALUES(tcpu, twall);
+    (void) tcpu;
+
+    flint_printf("%9s has %3wd factors: %10.3f s\n", name, fac->num, twall);
 
     if (fac->num != wanted_factors)
     {
@@ -103,11 +103,11 @@ int main(int argc, char *argv[])
     /* Not run by default because they are too slow currently */
     if (argc > 1 && !strcmp(argv[1], "-hard"))
     {
-        factor_poly(MY_DIR"P7_M12_5_flint", "P7*M12_5", 2);     /*  51 seconds */
-        factor_poly(MY_DIR"P7_M12_6_flint", "P7*M12_6", 3);     /*  96 seconds */
-        factor_poly(MY_DIR"H2_flint", "H2", 6);     /*  71 seconds */
-        factor_poly(MY_DIR"S9_flint", "S9", 1);     /*  57 seconds */
-        factor_poly(MY_DIR"S10_flint", "S10", 1);   /* 6300 seconds */
+        factor_poly(MY_DIR"S9_flint", "S9", 1);     /*  28 seconds */
+        factor_poly(MY_DIR"H2_flint", "H2", 6);     /*  18 seconds */
+        factor_poly(MY_DIR"P7_M12_5_flint", "P7*M12_5", 2);     /*  31 seconds */
+        factor_poly(MY_DIR"P7_M12_6_flint", "P7*M12_6", 3);     /*  53 seconds */
+        factor_poly(MY_DIR"S10_flint", "S10", 1);   /* 1170 seconds */
     }
 
     return 0;


### PR DESCRIPTION
Port three simple optimizations to `fmpz_poly_factor_van_hoeij` (#932) from the FLINT 1.6 version:

* Call ULLL instead of plain LLL
* Add the "secondary check" to `fmpz_mat_next_col_van_hoeij`
* Use looser LLL parameters

Together these very significantly speed up large `fmpz_poly` factorisations: S9 is 2.5x faster, and S10 is 5x faster, completing in 20 minutes instead of nearly 2 hours.

The first two changes seem to be consistently better or at worst preserve the same speed as before for all inputs. The third (LLL parameters) is better for some input and worse for others, but does seem to be consistently better for harder factorisations, so I've enabled it by default. Some tuning parameters have been defined as macros for easier future experimentation.

Timings on `build/fmpz_poly_factor/profile/p-factor_hard -hard`:

```
                                  old          new     speedup
       P1 has  36 factors:      0.005 s      0.005 s    1.00x
       P2 has  12 factors:      0.011 s      0.011 s    1.00x
       P3 has  16 factors:      0.021 s      0.022 s    0.95x
       P4 has   2 factors:      0.155 s      0.138 s    1.12x
       P5 has   1 factors:      0.008 s      0.007 s    1.14x
       P6 has   6 factors:      0.011 s      0.010 s    1.10x
       P7 has   1 factors:      0.231 s      0.155 s    1.49x
       P8 has   1 factors:      0.114 s      0.095 s    1.20x
    M12_5 has   1 factors:      0.315 s      0.431 s    0.73x
    M12_6 has   2 factors:      5.079 s      3.834 s    1.32x
       T1 has   2 factors:      0.085 s      0.088 s    0.97x
       T2 has   2 factors:      0.092 s      0.094 s    0.98x
       T3 has   4 factors:      1.793 s      1.679 s    1.07x
       H1 has  28 factors:      0.949 s      1.042 s    0.91x
       S7 has   1 factors:      0.101 s      0.050 s    2.02x
       S8 has   1 factors:      1.190 s      0.961 s    1.24x
       C1 has  32 factors:      0.278 s      0.140 s    1.99x
       S9 has   1 factors:     67.968 s     27.712 s    2.45x
       H2 has   6 factors:     79.242 s     17.517 s    4.52x
 P7*M12_5 has   2 factors:     56.141 s     30.962 s    1.81x
 P7*M12_6 has   3 factors:    112.179 s     53.072 s    2.11x
      S10 has   1 factors:   6292.000 s   1169.115 s    5.38x
```

Another data point: `build/examples/huge_expr -ca` improves from 2.1 seconds to 1.7 seconds.