### PR TITLE
fix(qsieve): initialize qs_inf->low and qs_inf->high in qsieve_init

### DIFF
--- a/src/qsieve/compute_poly_data.c
+++ b/src/qsieve/compute_poly_data.c
@@ -545,12 +545,6 @@ int qsieve_next_A(qs_t qs_inf)
 
                 break;
             }
-
-            /* When h == 1 only the last element of curr_subset increases, so
-               prod is non-decreasing.  Once prod * smallest final prime exceeds
-               upper_bound, exit rather than scanning all remaining subsets. */
-
-
         }
     }
 

--- a/src/qsieve/init.c
+++ b/src/qsieve/init.c
@@ -62,4 +62,6 @@ void qsieve_init(qs_t qs_inf, const fmpz_t n)
     qs_inf->sqrts       = NULL;
 
     qs_inf->s = 0;
+    qs_inf->low = 0;
+    qs_inf->high = 0;
 }


### PR DESCRIPTION
Follow-up fixes from a review of the recently-merged #2689 (quadratic-sieve polynomial-selection hang, #2250). Two small items.

### 1. Initialize `qs_inf->low`/`qs_inf->high` in `qsieve_init` (bug)

#2689 added a "retry-detection" check `if (low != qs_inf->low || high != qs_inf->high) break;` at three sites in `qsieve_init_A`. On every `qsieve_factor` call the first `qsieve_init_A` evaluates that condition before the function writes those fields. `qsieve_init` initialises the `qs_t` struct field by field but not `low`/`high`, and `qs_t qs_inf` is an uninitialised stack variable in `qsieve_factor`, so the reads are of uninitialised stack memory.

The functional impact is almost always nil (the stack garbage would have to match both freshly-computed `low` AND `high`), but valgrind on the merge commit `7f17ee5f9a` flags it on every qsieve test run. Excerpt from `FLINT_TEST_MULTIPLIER=0.1 make valgrind MOD=qsieve`:

```
==149225== Conditional jump or move depends on uninitialised value(s)
==149225==    at 0x4CF9826: qsieve_init_A (compute_poly_data.c:156)
==149225==    by 0x4CFC6D4: qsieve_factor (factor.c:270)
==149225==    by 0x4C5F54A: fmpz_factor_no_trial (factor_no_trial.c:100)
==149225==    by 0x4CFC482: qsieve_factor (factor.c:176)
==149225==    by 0x10AB2F: test_qsieve_factor (t-factor.c:118)
==149225==  Uninitialised value was created by a stack allocation
==149225==    at 0x4CFC3D3: qsieve_factor (factor.c:55)
...
==149225== ERROR SUMMARY: 5 errors from 4 contexts (suppressed: 0 from 0)
```

After this branch:

```
==149928== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

The existing late writes in `qsieve_init_A` continue to maintain the retry-detection semantics; the zero initialisation in `qsieve_init` just guarantees the first read is defined.

### 2. Remove dead comment in `qsieve_next_A` (cleanup)

Commit 7d3ed8a284 (in #2689) added an upper-bound early-exit in `qsieve_next_A`. Commit c93a585375 (also in #2689) removed the four-line code body but kept its explanatory comment, leaving a comment that describes an early-exit no longer in the code. `qsieve_next_A` still terminates through the `h > s - 2` guard added in #2689, so this is not a hang; the comment is just misleading. Drop it.

If the early-exit was meant to be reinstated (properly guarded for the `h == 1` monotonicity precondition the comment itself notes), that's a follow-up for a separate PR with maintainer review of the correctness condition.