### PR TITLE
Fix some issues when building with ARM64 MSVC

### DIFF
--- a/src/longlong_msc_arm64.h
+++ b/src/longlong_msc_arm64.h
@@ -14,7 +14,9 @@
 
 #include <stdlib.h>
 #include <intrin.h>
+#if !defined(_MSC_VER) || defined(USE_SOFT_INTRINSICS)
 #include <immintrin.h>
+#endif
 
 /* Trailing and leading zeros */
 # define flint_clz _CountLeadingZeros64

--- a/src/machine_vectors.h
+++ b/src/machine_vectors.h
@@ -985,7 +985,13 @@ FLINT_FORCE_INLINE vec1d vec1d_reduce_pm1n_to_pmhn(vec1d a, vec1d n) {
 /* vec2d -- NEON/ARM64 *********************************************/
 
 FLINT_FORCE_INLINE double vec2d_get_index(vec2d a, int i) {
+#ifdef _MSC_VER
+    double as[2];
+    vst1q_f64(as, a);
+    return as[i];
+#else
     return a[i];
+#endif
 }
 
 FLINT_FORCE_INLINE vec2d vec2d_set_d2(double a0, double a1)
@@ -1101,11 +1107,11 @@ FLINT_FORCE_INLINE vec2d vec2d_fnmadd(vec2d a, vec2d b, vec2d c) {
 
 /* these two might be slow due to the extra negation */
 FLINT_FORCE_INLINE vec2d vec2d_fmsub(vec2d a, vec2d b, vec2d c) {
-    return -vfmsq_f64(c, a, b);
+    return vnegq_f64(vfmsq_f64(c, a, b));
 }
 
 FLINT_FORCE_INLINE vec2d vec2d_fnmsub(vec2d a, vec2d b, vec2d c) {
-    return -vfmaq_f64(c, a, b);
+    return vnegq_f64(vfmaq_f64(c, a, b));
 }
 
 FLINT_FORCE_INLINE vec2d vec2d_div(vec2d a, vec2d b)
@@ -1431,7 +1437,14 @@ EXTEND_VEC_DEF4(vec4d, vec8d, _nmulmod)
 
 
 FLINT_FORCE_INLINE int vec2d_same(vec2d a, vec2d b) {
+#ifdef _MSC_VER
+    double as[2], bs[2];
+    vst1q_f64(as, a);
+    vst1q_f64(bs, b);
+    return as[0] == bs[0] && as[1] == bs[1];
+#else
     return a[0] == b[0] && a[1] == b[1];
+#endif
 }
 
 


### PR DESCRIPTION
This PR fixes two issues previously addressed in #2609, albeit in a slightly different way. It likely does not cover all issues raised in #2608, but I'm now able to build FLINT on my ARM64 machine, and test it with a heavily-modified version of msolve (https://github.com/wegank/msolve/commit/e1ddc5d1ab9295842f178c9d84fda3f72196ceff) that allows building with MSVC.

<img width="1440" height="900" alt="Capture d’écran 2026-05-28 à 11 49 25" src="https://github.com/user-attachments/assets/9ab3aa97-8dac-406a-82fa-19a9c124ea05" />
