### PR TITLE
Improve fmpz_mat_det_bound

### DIFF
--- a/doc/source/fmpz_mat.rst
+++ b/doc/source/fmpz_mat.rst
@@ -787,16 +787,20 @@ Determinant
 
 .. function:: void fmpz_mat_det_bound(fmpz_t bound, const fmpz_mat_t A)
 
-    Sets ``bound`` to a nonnegative integer `B` such that
-    `|\det(A)| \le B`. Assumes `A` to be a square matrix.
-    The bound is computed from the Hadamard inequality
-    `|\det(A)| \le \prod \|a_i\|_2` where the product is taken
-    over the rows `a_i` of `A`.
+    Assuming that `A` is a square matrix, sets ``bound`` to a nonnegative
+    integer `B` such that `|\det(A)| \le B`. The bound is computed from the
+    Hadamard inequality `|\det(A)| \le \prod \|a_i\|_2` where the product is
+    taken over the rows `a_i` of `A`. The same bound is also computed
+    columnwise and the minimum of the two bounds is returned.
 
-.. function:: void fmpz_mat_det_bound_nonzero(fmpz_t bound, const fmpz_mat_t A)
+.. function:: void fmpz_mat_det_bound_submatrix(fmpz_t bound, const fmpz_mat_t A)
 
-    As per ``fmpz_mat_det_bound()`` but excludes zero columns. For use with
-    non-square matrices.
+    Given an arbitrary matrix `A`, returns a bound for the
+    determinant of any square submatrix of `A` obtained by removing any
+    number of rows and/or columns. This uses the same algorithm as
+    :func:`fmpz_mat_det_bound`, but excludes row and column norms which are zero.
+    The bound may be suboptimal if the number of rows is significantly larger
+    or smaller than the number of columns.
 
 .. function:: void fmpz_mat_det_divisor(fmpz_t d, const fmpz_mat_t A)
 

--- a/src/fmpq_mat/can_solve_multi_mod.c
+++ b/src/fmpq_mat/can_solve_multi_mod.c
@@ -247,7 +247,7 @@ fmpq_mat_can_solve_fmpz_mat_multi_mod(fmpq_mat_t X,
 
     fmpz_init(D);
 
-    fmpz_mat_det_bound_nonzero(D, A);
+    fmpz_mat_det_bound_submatrix(D, A);
 
     res = _fmpq_mat_can_solve_multi_mod(X, A, B, D);
 

--- a/src/fmpz_mat.h
+++ b/src/fmpz_mat.h
@@ -275,7 +275,7 @@ void fmpz_mat_det_modular_given_divisor(fmpz_t det, const fmpz_mat_t A, const fm
 void fmpz_mat_det(fmpz_t det, const fmpz_mat_t A);
 
 void fmpz_mat_det_bound(fmpz_t bound, const fmpz_mat_t A);
-void fmpz_mat_det_bound_nonzero(fmpz_t bound, const fmpz_mat_t A);
+void fmpz_mat_det_bound_submatrix(fmpz_t bound, const fmpz_mat_t A);
 
 void fmpz_mat_det_divisor(fmpz_t d, const fmpz_mat_t A);
 

--- a/src/fmpz_mat/charpoly_bound.c
+++ b/src/fmpz_mat/charpoly_bound.c
@@ -43,9 +43,8 @@ void fmpz_mat_charpoly_bound(fmpz_t bound, const fmpz_mat_t A)
         for (j = 0; j < n; j++)
         {
             mag_set_fmpz(t, fmpz_mat_entry(A, i, j));
-            mag_fast_mul(t, t, t);
-            mag_add(rnorms + i, rnorms + i, t);
-            mag_add(cnorms + j, cnorms + j, t);
+            mag_fast_addmul(rnorms + i, t, t);
+            mag_fast_addmul(cnorms + j, t, t);
         }
     }
 

--- a/src/fmpz_mat/det_bound.c
+++ b/src/fmpz_mat/det_bound.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Fredrik Johansson
+    Copyright (C) 2011, 2026 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -11,38 +11,66 @@
 
 #include "fmpz.h"
 #include "fmpz_mat.h"
+#include "mag.h"
 
 static void
-fmpz_mat_det_bound_inner(fmpz_t bound, const fmpz_mat_t A, int zero_cols)
+fmpz_mat_det_bound_inner(fmpz_t bound, const fmpz_mat_t A, int include_zero_norms)
 {
-    fmpz_t p, s, t;
+    slong r = fmpz_mat_nrows(A);
+    slong c = fmpz_mat_ncols(A);
     slong i, j;
+    mag_t t, rbound, cbound;
+    mag_struct *rnorms, *cnorms;
 
-    fmpz_init(p);
-    fmpz_init(s);
-    fmpz_init(t);
-    fmpz_one(p);
-
-    for (i = 0; i < A->r; i++)
+    if (r == 0 || c == 0)
     {
-        fmpz_zero(s);
-
-        for (j = 0; j < A->c; j++)
-            fmpz_addmul(s, fmpz_mat_entry(A, i, j), fmpz_mat_entry(A, i, j));
-
-        fmpz_sqrtrem(s, t, s);
-        if (!fmpz_is_zero(t))
-            fmpz_add_ui(s, s, UWORD(1));
-
-        if (zero_cols || !fmpz_is_zero(s))
-            fmpz_mul(p, p, s);
+        fmpz_one(bound);
+        return;
     }
 
-    fmpz_set(bound, p);
-    fmpz_clear(p);
-    fmpz_clear(s);
-    fmpz_clear(t);
+    rnorms = _mag_vec_init(r + c);
+    cnorms = rnorms + r;
+
+    mag_init(t);
+    mag_init(rbound);
+    mag_init(cbound);
+
+    for (i = 0; i < r; i++)
+    {
+        for (j = 0; j < c; j++)
+        {
+            mag_set_fmpz(t, fmpz_mat_entry(A, i, j));
+            mag_fast_addmul(rnorms + i, t, t);
+            mag_fast_addmul(cnorms + j, t, t);
+        }
+    }
+
+    mag_one(rbound);
+    mag_one(cbound);
+
+    for (i = 0; i < r; i++)
+    {
+        if (include_zero_norms || !mag_is_zero(rnorms + i))
+            mag_mul(rbound, rbound, rnorms + i);
+    }
+
+    for (i = 0; i < c; i++)
+    {
+        if (include_zero_norms || !mag_is_zero(cnorms + i))
+            mag_mul(cbound, cbound, cnorms + i);
+    }
+
+    mag_min(t, rbound, cbound);
+    mag_sqrt(t, t);
+    mag_get_fmpz(bound, t);
+
+    _mag_vec_clear(rnorms, r + c);
+
+    mag_clear(t);
+    mag_clear(rbound);
+    mag_clear(cbound);
 }
+
 
 void
 fmpz_mat_det_bound(fmpz_t bound, const fmpz_mat_t A)
@@ -51,7 +79,8 @@ fmpz_mat_det_bound(fmpz_t bound, const fmpz_mat_t A)
 }
 
 void
-fmpz_mat_det_bound_nonzero(fmpz_t bound, const fmpz_mat_t A)
+fmpz_mat_det_bound_submatrix(fmpz_t bound, const fmpz_mat_t A)
 {
     fmpz_mat_det_bound_inner(bound, A, 0);
 }
+

--- a/src/fmpz_mat/test/t-det_bound.c
+++ b/src/fmpz_mat/test/t-det_bound.c
@@ -50,5 +50,121 @@ TEST_FUNCTION_START(fmpz_mat_det_bound, state)
         fmpz_mat_clear(A);
     }
 
+    /* Test fmpz_mat_det_bound_nonzero on random rectangular matrices.
+       For each test matrix, extract a few random square submatrices,
+       compute their determinants, and verify all are bounded by the
+       nonzero bound. Also verify the bound is always positive.       */
+    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
+    {
+        fmpz_mat_t B, sub;
+        fmpz_t det, bound;
+        slong r, c, k, s, t, trial;
+        slong *row_idx, *col_idx;
+
+        r = n_randint(state, 8) + 1;
+        c = n_randint(state, 8) + 1;
+
+        fmpz_mat_init(B, r, c);
+        fmpz_init(det);
+        fmpz_init(bound);
+
+        /* Occasionally insert zero rows/columns to exercise the
+           nonzero-exclusion logic specifically                    */
+        if (n_randint(state, 3) == 0)
+            fmpz_mat_randtest(B, state, 1 + n_randint(state, 100));
+        else
+            fmpz_mat_randtest(B, state, 1 + n_randint(state, 100));
+
+        if (n_randint(state, 4) == 0)
+        {
+            /* Zero out a random row */
+            slong zr = n_randint(state, r);
+            for (t = 0; t < c; t++)
+                fmpz_zero(fmpz_mat_entry(B, zr, t));
+        }
+
+        if (n_randint(state, 4) == 0)
+        {
+            /* Zero out a random column */
+            slong zc = n_randint(state, c);
+            for (s = 0; s < r; s++)
+                fmpz_zero(fmpz_mat_entry(B, s, zc));
+        }
+
+        fmpz_mat_det_bound_submatrix(bound, B);
+
+        /* Bound must always be positive */
+        if (fmpz_sgn(bound) <= 0)
+        {
+            flint_printf("FAIL (det_bound_submatrix):\n");
+            flint_printf("bound is not positive!\n");
+            fmpz_mat_print_pretty(B), flint_printf("\n");
+            flint_printf("bound: "), fmpz_print(bound), flint_printf("\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        /* Extract and test a few random square submatrices of size
+           k x k where k <= min(r, c)                               */
+        k = FLINT_MIN(r, c);
+        k = n_randint(state, k) + 1;
+
+        row_idx = (slong *) flint_malloc(r * sizeof(slong));
+        col_idx = (slong *) flint_malloc(c * sizeof(slong));
+
+        for (trial = 0; trial < 3; trial++)
+        {
+            slong ri, ci;
+
+            /* Choose k distinct rows at random via partial Fisher-Yates */
+            for (s = 0; s < r; s++) row_idx[s] = s;
+            for (s = 0; s < k; s++)
+            {
+                slong swap = s + n_randint(state, r - s);
+                slong tmp = row_idx[s]; row_idx[s] = row_idx[swap]; row_idx[swap] = tmp;
+            }
+
+            /* Choose k distinct columns at random */
+            for (s = 0; s < c; s++) col_idx[s] = s;
+            for (s = 0; s < k; s++)
+            {
+                slong swap = s + n_randint(state, c - s);
+                slong tmp = col_idx[s]; col_idx[s] = col_idx[swap]; col_idx[swap] = tmp;
+            }
+
+            fmpz_mat_init(sub, k, k);
+
+            for (ri = 0; ri < k; ri++)
+                for (ci = 0; ci < k; ci++)
+                    fmpz_set(fmpz_mat_entry(sub, ri, ci),
+                             fmpz_mat_entry(B, row_idx[ri], col_idx[ci]));
+
+            fmpz_mat_det(det, sub);
+            fmpz_abs(det, det);
+
+            if (fmpz_cmp(det, bound) > 0)
+            {
+                flint_printf("FAIL (det_bound_submatrix):\n");
+                flint_printf("bound too small for submatrix determinant!\n");
+                flint_printf("A (%wd x %wd):\n", r, c);
+                fmpz_mat_print_pretty(B), flint_printf("\n");
+                flint_printf("submatrix size: %wd\n", k);
+                flint_printf("|det(sub)|: "), fmpz_print(det), flint_printf("\n");
+                flint_printf("bound: "), fmpz_print(bound), flint_printf("\n");
+                fflush(stdout);
+                flint_abort();
+            }
+
+            fmpz_mat_clear(sub);
+        }
+
+        flint_free(row_idx);
+        flint_free(col_idx);
+
+        fmpz_clear(det);
+        fmpz_clear(bound);
+        fmpz_mat_clear(B);
+    }
+
     TEST_FUNCTION_END(state);
 }


### PR DESCRIPTION
A couple of related changes:

* Change `fmpz_mat_det_bound` to compute both rowwise and columnwise Hadamard bounds and take the minimum of these. This can lead to significantly better bounds for structured matrices. For example, if $A$ is a companion matrix of a random polynomial with 200-bit entries, then applying `fmpz_mat_det` to $A^T$ was previously 230x slower than applying it to $A$; they now run essentially in the same time.

* Also, `fmpz_mat_det_bound` is reimplemented using `mag` arithmetic instead of `fmpz` arithmetic so that we don't need to perform $n^2$ 10000-bit multiplications if we have 10000-bit multiplications. The performance impact for the modular determinant algorithm should be pretty minimal since actually computing the determinant generally takes much longer, but this might be relevant for other applications of determinant bounds.

* Rename `fmpz_mat_det_bound_nonzero` to `fmpz_mat_det_bound_submatrix` and update its documentation to better reflect its purpose (i.e. bounding the determinant of any submatrix of the given matrix obtained by removing rows or columns), and use the same optimization of looking at both rowwise and columnwise bounds. Also add test code for this function, which was missing. One could tighten the bound a bit for rectangular matrices by sorting entries (as done in the charpoly code), but I'm not sure if it's worth the trouble.

* Small optimization to `fmpz_mat_charpoly_bound`.