### PR TITLE
More general squarefree factorization

### DIFF
--- a/doc/source/gr_domains.rst
+++ b/doc/source/gr_domains.rst
@@ -128,6 +128,7 @@ Basic rings and fields
 .. function:: void gr_ctx_init_random(gr_ctx_t ctx, flint_rand_t state)
               void gr_ctx_init_random_commutative_ring(gr_ctx_t ctx, flint_rand_t state)
               void gr_ctx_init_random_field(gr_ctx_t ctx, flint_rand_t state)
+              void gr_ctx_init_random_finite_field(gr_ctx_t ctx, flint_rand_t state)
 
     Initializes *ctx* to a random ring. This will currently
     only generate base rings and composite rings over certain

--- a/doc/source/gr_poly.rst
+++ b/doc/source/gr_poly.rst
@@ -358,6 +358,7 @@ Scalar division
 --------------------------------------------------------------------------------
 
 .. function:: int gr_poly_div_scalar(gr_poly_t res, const gr_poly_t poly, gr_srcptr c, gr_ctx_t ctx)
+              int gr_poly_divexact_scalar(gr_poly_t res, const gr_poly_t poly, gr_srcptr c, gr_ctx_t ctx)
 
 Division with remainder
 --------------------------------------------------------------------------------
@@ -1024,21 +1025,38 @@ of the two polynomials is zero.
 Squarefree factorization
 -------------------------------------------------------------------------------
 
-TODO: currently only fields of characteristic 0 are supported.
-
 .. function:: int gr_poly_factor_squarefree(gr_ptr c, gr_vec_t fac, gr_vec_t exp, const gr_poly_t poly, gr_ctx_t ctx)
 
-    Computes a squarefree factorization of *poly*.
+    Computes a squarefree factorization
+
+    .. math ::
+
+        f = c \prod_i {g_i}^{e_i}
+
+    of the polynomial *f* given by *poly*.
+    On success, *fac* is set to a vector of pairwise coprime squarefree
+    factors `g_i` with respective multiplicities `e_i` in *exp*.
+    The order of the factors is arbitrary.
+    The user must initialize *fac* to a vector of polynomials of the same
+    type as *poly* (and *not* to the scalar type *ctx*).
+    The exponent vector *exp* must be initialized to the *fmpz* type.
 
     The constant *c* is set to an element of the scalar ring.
-    The factors in *fac* are set to polynomials; the user must thus
-    initialize it to a vector of polynomials of the same type as
-    *poly* (and *not* to the parent *ctx*).
-    The exponent vector *exp* must be initialized to the *fmpz* type.
+    If *ctx* is known to be a field, all factors will be monic and the
+    leading coefficient of *f* is stored in *c*.
+    Otherwise, the factors are normalized to be content-free and to have
+    a canonical associate as the leading coefficient; *c* will be set
+    to a unit multiple of the content of *f*.
+    Note that *c* itself is not factored over the base ring.
+
+    This function requiires that *ctx* is a unique factorization domain
+    and returns ``GR_UNABLE`` if this cannot be verified.
 
 .. function:: int gr_poly_squarefree_part(gr_poly_t res, const gr_poly_t poly, gr_ctx_t ctx)
 
     Sets *res* to the squarefreepart of *poly*.
+
+    TODO: currently only fields of characteristic 0 are supported.
 
 Shift equivalence
 -------------------------------------------------------------------------------

--- a/doc/source/gr_poly.rst
+++ b/doc/source/gr_poly.rst
@@ -1031,9 +1031,8 @@ Squarefree factorization
 
     .. math ::
 
-        f = c \prod_i {g_i}^{e_i}
+        poly = c \prod_i {g_i}^{e_i}.
 
-    of the polynomial *f* given by *poly*.
     On success, *fac* is set to a vector of pairwise coprime squarefree
     factors `g_i` with respective multiplicities `e_i` in *exp*.
     The order of the factors is arbitrary.
@@ -1043,20 +1042,19 @@ Squarefree factorization
 
     The constant *c* is set to an element of the scalar ring.
     If *ctx* is known to be a field, all factors will be monic and the
-    leading coefficient of *f* is stored in *c*.
+    leading coefficient of *poly* is stored in *c*.
     Otherwise, the factors are normalized to be content-free and to have
     a canonical associate as the leading coefficient; *c* will be set
-    to a unit multiple of the content of *f*.
+    to a unit multiple of the content of *poly*.
     Note that *c* itself is not factored over the base ring.
 
-    This function requiires that *ctx* is a unique factorization domain
+    This function requires that *ctx* is a unique factorization domain
     and returns ``GR_UNABLE`` if this cannot be verified.
 
 .. function:: int gr_poly_squarefree_part(gr_poly_t res, const gr_poly_t poly, gr_ctx_t ctx)
 
-    Sets *res* to the squarefreepart of *poly*.
-
-    TODO: currently only fields of characteristic 0 are supported.
+    Sets *res* to the squarefree part of *poly*. In terms of the squarefree
+    factorization, this corresponds to the canonical associate of `\prod_i g_i`.
 
 Shift equivalence
 -------------------------------------------------------------------------------

--- a/src/gr.h
+++ b/src/gr.h
@@ -1398,6 +1398,7 @@ void gr_ctx_uninitialized(gr_ctx_t ctx);
 void gr_ctx_init_random(gr_ctx_t ctx, flint_rand_t state);
 void gr_ctx_init_random_commutative_ring(gr_ctx_t ctx, flint_rand_t state);
 void gr_ctx_init_random_field(gr_ctx_t ctx, flint_rand_t state);
+void gr_ctx_init_random_finite_field(gr_ctx_t ctx, flint_rand_t state);
 void gr_ctx_init_random_poly(gr_ctx_t ctx, flint_rand_t state);
 void gr_ctx_init_random_mpoly(gr_ctx_t ctx, flint_rand_t state);
 void gr_ctx_init_random_series(gr_ctx_t ctx, flint_rand_t state);

--- a/src/gr/fmpz_mod.c
+++ b/src/gr/fmpz_mod.c
@@ -483,6 +483,14 @@ _gr_fmpz_mod_is_square(const fmpz_t x, const gr_ctx_t ctx)
     }
 }
 
+static int
+_gr_fmpz_mod_ctx_fq_prime(fmpz_t res, gr_ctx_t ctx)
+{
+    fmpz_set(res, FMPZ_MOD_CTX(ctx)->n);
+    return GR_SUCCESS;
+}
+
+
 /* todo: len 1 */
 static int
 _gr_fmpz_mod_vec_dot(fmpz_t res, const fmpz_t initial, int subtract, const fmpz * vec1, const fmpz * vec2, slong len, gr_ctx_t ctx)
@@ -847,7 +855,8 @@ gr_method_tab_input _fmpz_mod_methods_input[] =
     {GR_METHOD_POW_FMPZ,        (gr_funcptr) _gr_fmpz_mod_pow_fmpz},
     {GR_METHOD_SQRT,            (gr_funcptr) _gr_fmpz_mod_sqrt},
     {GR_METHOD_IS_SQUARE,       (gr_funcptr) _gr_fmpz_mod_is_square},
-
+    {GR_METHOD_FQ_PTH_ROOT,     (gr_funcptr) _gr_fmpz_mod_set},
+    {GR_METHOD_CTX_FQ_PRIME,    (gr_funcptr) _gr_fmpz_mod_ctx_fq_prime},
 /*
     {GR_METHOD_VEC_INIT,        (gr_funcptr) _gr_mpn_mod_vec_zero},
     {GR_METHOD_VEC_CLEAR,       (gr_funcptr) _gr_mpn_mod_vec_clear},

--- a/src/gr/fmpz_mod.c
+++ b/src/gr/fmpz_mod.c
@@ -354,6 +354,7 @@ _gr_fmpz_mod_inv(fmpz_t res, const fmpz_t x, const gr_ctx_t ctx)
 
         fmpz_t d;
         fmpz_init(d);
+
         fmpz_gcdinv(d, res, x, FMPZ_MOD_CTX(ctx)->n);
 
         if (fmpz_is_one(d))
@@ -451,7 +452,11 @@ _gr_fmpz_mod_sqrt(fmpz_t res, const fmpz_t x, const gr_ctx_t ctx)
     }
     else if (FMPZ_MOD_IS_PRIME(ctx) == T_TRUE)
     {
-        return fmpz_sqrtmod(res, x, FMPZ_MOD_CTX(ctx)->n) ? GR_SUCCESS : GR_DOMAIN;
+        int status = fmpz_sqrtmod(res, x, FMPZ_MOD_CTX(ctx)->n) ? GR_SUCCESS : GR_DOMAIN;
+        /* fmpz_sqrtmod may have set res to an unreduced value on failure */
+        if (status != GR_SUCCESS)
+            fmpz_zero(res);
+        return status;
     }
     else
     {

--- a/src/gr/init_random.c
+++ b/src/gr/init_random.c
@@ -123,15 +123,44 @@ gr_ctx_init_random_ring_integers_mod(gr_ctx_t ctx, flint_rand_t state)
     }
 }
 
-static void
-gr_ctx_init_random_ring_finite_field(gr_ctx_t ctx, flint_rand_t state)
+void
+gr_ctx_init_random_finite_field(gr_ctx_t ctx, flint_rand_t state)
 {
     fmpz_t t;
     fmpz_init(t);
 
-    switch (n_randint(state, 3))
+    switch (n_randint(state, 9))
     {
-        case 0:
+        case 0: gr_ctx_init_nmod8(ctx, 2); break;
+        case 1: gr_ctx_init_nmod8(ctx, 3); break;
+        case 2: gr_ctx_init_nmod8(ctx, 5); break;
+
+        case 3:
+            {
+                ulong p = n_randtest_prime(state, 0);
+                gr_ctx_init_nmod(ctx, p);
+                GR_MUST_SUCCEED(gr_ctx_set_is_field(ctx, T_TRUE));
+            }
+            break;
+
+        case 4:
+            {
+                flint_bitcnt_t bits = 2 + n_randint(state, 70);
+                fmpz_randprime(t, state, bits, 0);
+                gr_ctx_init_fmpz_mod(ctx, t);
+                GR_MUST_SUCCEED(gr_ctx_set_is_field(ctx, T_TRUE));
+            }
+            break;
+
+        case 5:
+            /* gr_ctx_init_mpn_mod_randtest is cheap and
+               generates primes with high probability */
+            do {
+                gr_ctx_init_mpn_mod_randtest(ctx, state);
+            } while (gr_ctx_is_field(ctx) != T_TRUE);
+            break;
+
+        case 6:
             {
                 /* Split state-mutating calls so consumption order is architecture-independent. */
                 ulong p = n_randtest_prime(state, 0);
@@ -140,7 +169,7 @@ gr_ctx_init_random_ring_finite_field(gr_ctx_t ctx, flint_rand_t state)
             }
             break;
 
-        case 1:
+        case 7:
             {
                 ulong p = n_randprime(state, 4, 0);
                 slong d = 1 + n_randint(state, 3);
@@ -148,9 +177,9 @@ gr_ctx_init_random_ring_finite_field(gr_ctx_t ctx, flint_rand_t state)
             }
             break;
 
-        case 2:
+        default:
             {
-                flint_bitcnt_t bits = 2 + n_randint(state, 100);
+                flint_bitcnt_t bits = 2 + n_randint(state, 70);
                 slong d;
                 fmpz_randprime(t, state, bits, 0);
                 d = 1 + n_randint(state, 4);
@@ -288,7 +317,7 @@ void gr_ctx_init_random(gr_ctx_t ctx, flint_rand_t state)
             gr_ctx_init_random_ring_integers_mod(ctx, state);
             break;
         case 6:
-            gr_ctx_init_random_ring_finite_field(ctx, state);
+            gr_ctx_init_random_finite_field(ctx, state);
             break;
         case 7:
             gr_ctx_init_random_ring_number_field(ctx, state);

--- a/src/gr/init_random.c
+++ b/src/gr/init_random.c
@@ -155,9 +155,14 @@ gr_ctx_init_random_finite_field(gr_ctx_t ctx, flint_rand_t state)
         case 5:
             /* gr_ctx_init_mpn_mod_randtest is cheap and
                generates primes with high probability */
-            do {
+            while (1)
+            {
                 gr_ctx_init_mpn_mod_randtest(ctx, state);
-            } while (gr_ctx_is_field(ctx) != T_TRUE);
+                if (gr_ctx_is_field(ctx) == T_TRUE)
+                    break;
+                else
+                    gr_ctx_clear(ctx);
+            } 
             break;
 
         case 6:

--- a/src/gr/nmod.c
+++ b/src/gr/nmod.c
@@ -559,6 +559,12 @@ _gr_nmod_pow_fmpz(ulong * res, const ulong * x, const fmpz_t y, gr_ctx_t ctx)
     }
 }
 
+static int
+_gr_nmod_ctx_fq_prime(fmpz_t res, gr_ctx_t ctx)
+{
+    fmpz_set_ui(res, NMOD_CTX(ctx).n);
+    return GR_SUCCESS;
+}
 
 static void
 _gr_nmod_vec_init(ulong * res, slong len, gr_ctx_t ctx)
@@ -1464,6 +1470,8 @@ gr_method_tab_input __gr_nmod_methods_input[] =
     {GR_METHOD_POW_FMPZ,        (gr_funcptr) _gr_nmod_pow_fmpz},
     {GR_METHOD_IS_SQUARE,       (gr_funcptr) _gr_nmod_is_square},
     {GR_METHOD_SQRT,            (gr_funcptr) _gr_nmod_sqrt},
+    {GR_METHOD_FQ_PTH_ROOT,     (gr_funcptr) _gr_nmod_set},
+    {GR_METHOD_CTX_FQ_PRIME,    (gr_funcptr) _gr_nmod_ctx_fq_prime},
     {GR_METHOD_VEC_INIT,        (gr_funcptr) _gr_nmod_vec_init},
     {GR_METHOD_VEC_CLEAR,       (gr_funcptr) _gr_nmod_vec_clear},
     {GR_METHOD_VEC_SET,         (gr_funcptr) _gr_nmod_vec_set},

--- a/src/gr/nmod32.c
+++ b/src/gr/nmod32.c
@@ -332,6 +332,13 @@ nmod32_div_nonunique(nmod32_t res, const nmod32_t x, const nmod32_t y, const gr_
     return status;
 }
 
+static int
+nmod32_ctx_fq_prime(fmpz_t res, gr_ctx_t ctx)
+{
+    fmpz_set_ui(res, NMOD32_CTX(ctx).n);
+    return GR_SUCCESS;
+}
+
 static void
 _nmod32_vec_init(uint32_t * res, slong len, gr_ctx_t ctx)
 {
@@ -741,6 +748,8 @@ gr_method_tab_input _nmod32_methods_input[] =
     {GR_METHOD_DIVIDES,         (gr_funcptr) nmod32_divides},
     {GR_METHOD_IS_INVERTIBLE,   (gr_funcptr) nmod32_is_invertible},
     {GR_METHOD_INV,             (gr_funcptr) nmod32_inv},
+    {GR_METHOD_FQ_PTH_ROOT,     (gr_funcptr) nmod32_set},
+    {GR_METHOD_CTX_FQ_PRIME,    (gr_funcptr) nmod32_ctx_fq_prime},
     {GR_METHOD_VEC_INIT,        (gr_funcptr) _nmod32_vec_init},
     {GR_METHOD_VEC_CLEAR,       (gr_funcptr) _nmod32_vec_clear},
     {GR_METHOD_VEC_SET,         (gr_funcptr) _nmod32_vec_zero},

--- a/src/gr/nmod8.c
+++ b/src/gr/nmod8.c
@@ -332,6 +332,13 @@ nmod8_div_nonunique(nmod8_t res, const nmod8_t x, const nmod8_t y, const gr_ctx_
     return status;
 }
 
+static int
+nmod8_ctx_fq_prime(fmpz_t res, gr_ctx_t ctx)
+{
+    fmpz_set_ui(res, NMOD8_CTX(ctx).n);
+    return GR_SUCCESS;
+}
+
 static void
 _nmod8_vec_init(uint8_t * res, slong len, gr_ctx_t ctx)
 {
@@ -877,6 +884,8 @@ gr_method_tab_input _nmod8_methods_input[] =
     {GR_METHOD_DIVIDES,         (gr_funcptr) nmod8_divides},
     {GR_METHOD_IS_INVERTIBLE,   (gr_funcptr) nmod8_is_invertible},
     {GR_METHOD_INV,             (gr_funcptr) nmod8_inv},
+    {GR_METHOD_FQ_PTH_ROOT,     (gr_funcptr) nmod8_set},
+    {GR_METHOD_CTX_FQ_PRIME,    (gr_funcptr) nmod8_ctx_fq_prime},
     {GR_METHOD_VEC_INIT,        (gr_funcptr) _nmod8_vec_init},
     {GR_METHOD_VEC_CLEAR,       (gr_funcptr) _nmod8_vec_clear},
     {GR_METHOD_VEC_SET,         (gr_funcptr) _nmod8_vec_set},

--- a/src/gr_mat/test/t-adjugate.c
+++ b/src/gr_mat/test/t-adjugate.c
@@ -33,7 +33,7 @@ TEST_GR_FUNCTION_START(gr_mat_adjugate, state, count_success, count_domain, coun
         while (ctx->methods == _ca_methods)
         {
             gr_ctx_clear(ctx);
-            gr_ctx_init_random(ctx, state);
+            gr_ctx_init_random_commutative_ring(ctx, state);
         }
 
         n = n_randint(state, 5);
@@ -52,6 +52,7 @@ TEST_GR_FUNCTION_START(gr_mat_adjugate, state, count_success, count_domain, coun
         if (status == GR_SUCCESS && (gr_mat_equal(B, C, ctx) == T_FALSE || gr_equal(d, e, ctx) == T_FALSE))
         {
             flint_printf("FAIL\n");
+            gr_ctx_println(ctx);
             flint_printf("A = "), gr_mat_print(A, ctx); flint_printf("\n");
             flint_printf("B = "), gr_mat_print(B, ctx); flint_printf("\n");
             flint_printf("C = "), gr_mat_print(C, ctx); flint_printf("\n");

--- a/src/gr_mat/test/t-charpoly.c
+++ b/src/gr_mat/test/t-charpoly.c
@@ -33,7 +33,7 @@ TEST_GR_FUNCTION_START(gr_mat_charpoly, state, count_success, count_domain, coun
         while (ctx->methods == _ca_methods)
         {
             gr_ctx_clear(ctx);
-            gr_ctx_init_random(ctx, state);
+            gr_ctx_init_random_commutative_ring(ctx, state);
         }
 
         n = n_randint(state, 8);

--- a/src/gr_mat/test/t-charpoly_danilevsky.c
+++ b/src/gr_mat/test/t-charpoly_danilevsky.c
@@ -33,7 +33,7 @@ TEST_GR_FUNCTION_START(gr_mat_charpoly_danilevsky, state, count_success, count_d
         while (ctx->methods == _ca_methods)
         {
             gr_ctx_clear(ctx);
-            gr_ctx_init_random(ctx, state);
+            gr_ctx_init_random_commutative_ring(ctx, state);
         }
 
         n = n_randint(state, 8);

--- a/src/gr_mat/test/t-charpoly_faddeev.c
+++ b/src/gr_mat/test/t-charpoly_faddeev.c
@@ -33,7 +33,7 @@ TEST_GR_FUNCTION_START(gr_mat_charpoly_faddeev, state, count_success, count_doma
         while (ctx->methods == _ca_methods)
         {
             gr_ctx_clear(ctx);
-            gr_ctx_init_random(ctx, state);
+            gr_ctx_init_random_commutative_ring(ctx, state);
         }
 
         n = n_randint(state, 8);

--- a/src/gr_mat/test/t-charpoly_faddeev_bsgs.c
+++ b/src/gr_mat/test/t-charpoly_faddeev_bsgs.c
@@ -33,7 +33,7 @@ TEST_GR_FUNCTION_START(gr_mat_charpoly_faddeev_bsgs, state, count_success, count
         while (ctx->methods == _ca_methods)
         {
             gr_ctx_clear(ctx);
-            gr_ctx_init_random(ctx, state);
+            gr_ctx_init_random_commutative_ring(ctx, state);
         }
 
         n = n_randint(state, 8);

--- a/src/gr_mat/test/t-charpoly_gauss.c
+++ b/src/gr_mat/test/t-charpoly_gauss.c
@@ -33,7 +33,7 @@ TEST_GR_FUNCTION_START(gr_mat_charpoly_gauss, state, count_success, count_domain
         while (ctx->methods == _ca_methods)
         {
             gr_ctx_clear(ctx);
-            gr_ctx_init_random(ctx, state);
+            gr_ctx_init_random_commutative_ring(ctx, state);
         }
 
         n = n_randint(state, 8);

--- a/src/gr_mat/test/t-charpoly_householder.c
+++ b/src/gr_mat/test/t-charpoly_householder.c
@@ -33,7 +33,7 @@ TEST_GR_FUNCTION_START(gr_mat_charpoly_householder, state, count_success, count_
         while (ctx->methods == _ca_methods)
         {
             gr_ctx_clear(ctx);
-            gr_ctx_init_random(ctx, state);
+            gr_ctx_init_random_commutative_ring(ctx, state);
         }
 
         n = n_randint(state, 8);

--- a/src/gr_mat/test/t-companion.c
+++ b/src/gr_mat/test/t-companion.c
@@ -26,14 +26,7 @@ TEST_FUNCTION_START(gr_mat_companion, state)
         gr_ptr den;
         slong n;
 
-        while (1)
-        {
-            gr_ctx_init_random(ctx, state);
-            if (gr_ctx_is_field(ctx) == T_TRUE)
-                break;
-            else
-                gr_ctx_clear(ctx);
-        }
+        gr_ctx_init_random_field(ctx, state);
 
         gr_poly_init(f, ctx);
         gr_poly_init(g, ctx);

--- a/src/gr_mat/test/t-det_berkowitz.c
+++ b/src/gr_mat/test/t-det_berkowitz.c
@@ -32,7 +32,7 @@ TEST_GR_FUNCTION_START(gr_mat_det_berkowitz, state, count_success, count_domain,
         while (ctx->methods == _ca_methods)
         {
             gr_ctx_clear(ctx);
-            gr_ctx_init_random(ctx, state);
+            gr_ctx_init_random_commutative_ring(ctx, state);
         }
 
         n = n_randint(state, 7);

--- a/src/gr_mat/test/t-det_cofactor.c
+++ b/src/gr_mat/test/t-det_cofactor.c
@@ -32,7 +32,7 @@ TEST_GR_FUNCTION_START(gr_mat_det_cofactor, state, count_success, count_domain, 
         while (ctx->methods == _ca_methods)
         {
             gr_ctx_clear(ctx);
-            gr_ctx_init_random(ctx, state);
+            gr_ctx_init_random_commutative_ring(ctx, state);
         }
 
         n = n_randint(state, 7);

--- a/src/gr_mat/test/t-det_fflu.c
+++ b/src/gr_mat/test/t-det_fflu.c
@@ -32,7 +32,7 @@ TEST_GR_FUNCTION_START(gr_mat_det_fflu, state, count_success, count_domain, coun
         while (ctx->methods == _ca_methods)
         {
             gr_ctx_clear(ctx);
-            gr_ctx_init_random(ctx, state);
+            gr_ctx_init_random_commutative_ring(ctx, state);
         }
 
         n = n_randint(state, 7);

--- a/src/gr_mat/test/t-det_lu.c
+++ b/src/gr_mat/test/t-det_lu.c
@@ -32,7 +32,7 @@ TEST_GR_FUNCTION_START(gr_mat_det_lu, state, count_success, count_domain, count_
         while (ctx->methods == _ca_methods)
         {
             gr_ctx_clear(ctx);
-            gr_ctx_init_random(ctx, state);
+            gr_ctx_init_random_commutative_ring(ctx, state);
         }
 
         n = n_randint(state, 7);

--- a/src/gr_mat/test/t-diagonalization.c
+++ b/src/gr_mat/test/t-diagonalization.c
@@ -29,7 +29,7 @@ TEST_FUNCTION_START(gr_mat_diagonalization, state)
         int status = GR_SUCCESS;
         int haveL, haveR;
 
-        gr_ctx_init_random(ctx, state);
+        gr_ctx_init_random_commutative_ring(ctx, state);
         n = n_randint(state, 5);
         haveL = n_randint(state, 2);
         haveR = n_randint(state, 2);

--- a/src/gr_mat/test/t-exp.c
+++ b/src/gr_mat/test/t-exp.c
@@ -27,13 +27,7 @@ TEST_GR_FUNCTION_START(gr_mat_exp, state, count_success, count_domain, count_una
         int status = GR_SUCCESS;
         int which;
 
-        while (1)
-        {
-            gr_ctx_init_random(ctx, state);
-            if (gr_ctx_is_field(ctx) == T_TRUE)
-                break;
-            gr_ctx_clear(ctx);
-        }
+        gr_ctx_init_random_field(ctx, state);
 
         if (ctx->methods == _ca_methods)
             n = n_randint(state, 3);

--- a/src/gr_mat/test/t-hessenberg.c
+++ b/src/gr_mat/test/t-hessenberg.c
@@ -32,7 +32,7 @@ TEST_GR_FUNCTION_START(gr_mat_hessenberg, state, count_success, count_domain, co
         while (ctx->methods == _ca_methods)
         {
             gr_ctx_clear(ctx);
-            gr_ctx_init_random(ctx, state);
+            gr_ctx_init_random_commutative_ring(ctx, state);
         }
 
         n = n_randint(state, 7);

--- a/src/gr_mat/test/t-hessenberg_gauss.c
+++ b/src/gr_mat/test/t-hessenberg_gauss.c
@@ -33,7 +33,7 @@ TEST_GR_FUNCTION_START(gr_mat_hessenberg_gauss, state, count_success, count_doma
         while (ctx->methods == _ca_methods)
         {
             gr_ctx_clear(ctx);
-            gr_ctx_init_random(ctx, state);
+            gr_ctx_init_random_commutative_ring(ctx, state);
         }
 
         n = n_randint(state, 8);

--- a/src/gr_mat/test/t-hessenberg_householder.c
+++ b/src/gr_mat/test/t-hessenberg_householder.c
@@ -33,7 +33,7 @@ TEST_GR_FUNCTION_START(gr_mat_hessenberg_householder, state, count_success, coun
         while (ctx->methods == _ca_methods)
         {
             gr_ctx_clear(ctx);
-            gr_ctx_init_random(ctx, state);
+            gr_ctx_init_random_commutative_ring(ctx, state);
         }
 
         n = n_randint(state, 8);

--- a/src/gr_mat/test/t-inv.c
+++ b/src/gr_mat/test/t-inv.c
@@ -32,7 +32,7 @@ TEST_GR_FUNCTION_START(gr_mat_inv, state, count_success, count_domain, count_una
         while (ctx->methods == _ca_methods)
         {
             gr_ctx_clear(ctx);
-            gr_ctx_init_random(ctx, state);
+            gr_ctx_init_random_commutative_ring(ctx, state);
         }
 
         n = n_randint(state, 6);

--- a/src/gr_mat/test/t-lq.c
+++ b/src/gr_mat/test/t-lq.c
@@ -29,7 +29,7 @@ TEST_GR_FUNCTION_START(gr_mat_lq, state, count_success, count_domain, count_unab
         int method = n_randint(state, 3);
         gr_method_mat_binary_unary_op func;
 
-        gr_ctx_init_random(ctx, state);
+        gr_ctx_init_random_commutative_ring(ctx, state);
 
         if (ctx->methods == _ca_methods)
             n = n_randint(state, 3);

--- a/src/gr_mat/test/t-nullspace.c
+++ b/src/gr_mat/test/t-nullspace.c
@@ -25,7 +25,7 @@ TEST_GR_FUNCTION_START(gr_mat_nullspace, state, count_success, count_domain, cou
         int status = GR_SUCCESS;
         int status2 = GR_SUCCESS;
 
-        gr_ctx_init_random(ctx, state);
+        gr_ctx_init_random_commutative_ring(ctx, state);
 
         r = n_randint(state, 6);
         c = n_randint(state, 6);

--- a/src/gr_mat/test/t-rref_den_fflu.c
+++ b/src/gr_mat/test/t-rref_den_fflu.c
@@ -57,7 +57,7 @@ TEST_GR_FUNCTION_START(gr_mat_rref_den_fflu, state, count_success, count_domain,
         slong rank1, rank2, r, c;
         int status = GR_SUCCESS;
 
-        gr_ctx_init_random(ctx, state);
+        gr_ctx_init_random_commutative_ring(ctx, state);
 
         r = n_randint(state, 6);
         c = n_randint(state, 6);

--- a/src/gr_mat/test/t-rref_fflu.c
+++ b/src/gr_mat/test/t-rref_fflu.c
@@ -56,7 +56,7 @@ TEST_GR_FUNCTION_START(gr_mat_rref_fflu, state, count_success, count_domain, cou
         slong rank1, rank2, r, c;
         int status = GR_SUCCESS;
 
-        gr_ctx_init_random(ctx, state);
+        gr_ctx_init_random_commutative_ring(ctx, state);
 
         r = n_randint(state, 6);
         c = n_randint(state, 6);

--- a/src/gr_mat/test/t-rref_lu.c
+++ b/src/gr_mat/test/t-rref_lu.c
@@ -56,7 +56,7 @@ TEST_GR_FUNCTION_START(gr_mat_rref_lu, state, count_success, count_domain, count
         slong rank1, rank2, r, c;
         int status = GR_SUCCESS;
 
-        gr_ctx_init_random(ctx, state);
+        gr_ctx_init_random_commutative_ring(ctx, state);
 
         r = n_randint(state, 6);
         c = n_randint(state, 6);

--- a/src/gr_mat/test/t-solve.c
+++ b/src/gr_mat/test/t-solve.c
@@ -34,7 +34,7 @@ TEST_GR_FUNCTION_START(gr_mat_solve, state, count_success, count_domain, count_u
         while (ctx->methods == _ca_methods)
         {
             gr_ctx_clear(ctx);
-            gr_ctx_init_random(ctx, state);
+            gr_ctx_init_random_commutative_ring(ctx, state);
         }
 
         gr_mat_init(A, n, n, ctx);

--- a/src/gr_mat/test/t-solve_den.c
+++ b/src/gr_mat/test/t-solve_den.c
@@ -35,7 +35,7 @@ TEST_GR_FUNCTION_START(gr_mat_solve_den, state, count_success, count_domain, cou
         while (ctx->methods == _ca_methods)
         {
             gr_ctx_clear(ctx);
-            gr_ctx_init_random(ctx, state);
+            gr_ctx_init_random_commutative_ring(ctx, state);
         }
 
         gr_mat_init(A, n, n, ctx);

--- a/src/gr_mat/test/t-solve_den_fflu.c
+++ b/src/gr_mat/test/t-solve_den_fflu.c
@@ -35,7 +35,7 @@ TEST_GR_FUNCTION_START(gr_mat_solve_den_fflu, state, count_success, count_domain
         while (ctx->methods == _ca_methods)
         {
             gr_ctx_clear(ctx);
-            gr_ctx_init_random(ctx, state);
+            gr_ctx_init_random_commutative_ring(ctx, state);
         }
 
         gr_mat_init(A, n, n, ctx);

--- a/src/gr_mat/test/t-solve_fflu.c
+++ b/src/gr_mat/test/t-solve_fflu.c
@@ -34,7 +34,7 @@ TEST_GR_FUNCTION_START(gr_mat_solve_fflu, state, count_success, count_domain, co
         while (ctx->methods == _ca_methods)
         {
             gr_ctx_clear(ctx);
-            gr_ctx_init_random(ctx, state);
+            gr_ctx_init_random_commutative_ring(ctx, state);
         }
 
         gr_mat_init(A, n, n, ctx);

--- a/src/gr_mat/test/t-solve_lu.c
+++ b/src/gr_mat/test/t-solve_lu.c
@@ -34,7 +34,7 @@ TEST_GR_FUNCTION_START(gr_mat_solve_lu, state, count_success, count_domain, coun
         while (ctx->methods == _ca_methods)
         {
             gr_ctx_clear(ctx);
-            gr_ctx_init_random(ctx, state);
+            gr_ctx_init_random_commutative_ring(ctx, state);
         }
 
         gr_mat_init(A, n, n, ctx);

--- a/src/gr_mat/test/t-solve_tril.c
+++ b/src/gr_mat/test/t-solve_tril.c
@@ -37,7 +37,7 @@ TEST_GR_FUNCTION_START(gr_mat_solve_tril, state, count_success, count_domain, co
         while (ctx->methods == _ca_methods)
         {
             gr_ctx_clear(ctx);
-            gr_ctx_init_random(ctx, state);
+            gr_ctx_init_random_commutative_ring(ctx, state);
         }
 
         sz = ctx->sizeof_elem;

--- a/src/gr_mat/test/t-solve_triu.c
+++ b/src/gr_mat/test/t-solve_triu.c
@@ -37,7 +37,7 @@ TEST_GR_FUNCTION_START(gr_mat_solve_triu, state, count_success, count_domain, co
         while (ctx->methods == _ca_methods)
         {
             gr_ctx_clear(ctx);
-            gr_ctx_init_random(ctx, state);
+            gr_ctx_init_random_commutative_ring(ctx, state);
         }
 
         sz = ctx->sizeof_elem;

--- a/src/gr_poly.h
+++ b/src/gr_poly.h
@@ -231,6 +231,7 @@ WARN_UNUSED_RESULT int gr_poly_shift_right(gr_poly_t res, const gr_poly_t poly, 
 /* division */
 
 WARN_UNUSED_RESULT int gr_poly_div_scalar(gr_poly_t res, const gr_poly_t poly, gr_srcptr c, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_poly_divexact_scalar(gr_poly_t res, const gr_poly_t poly, gr_srcptr c, gr_ctx_t ctx);
 
 WARN_UNUSED_RESULT int gr_poly_inv(gr_poly_t res, const gr_poly_t poly, gr_ctx_t ctx);
 

--- a/src/gr_poly/div_scalar.c
+++ b/src/gr_poly/div_scalar.c
@@ -31,3 +31,24 @@ gr_poly_div_scalar(gr_poly_t res, const gr_poly_t poly, gr_srcptr c, gr_ctx_t ct
     _gr_poly_normalise(res, ctx);
     return status;
 }
+
+int
+gr_poly_divexact_scalar(gr_poly_t res, const gr_poly_t poly, gr_srcptr c, gr_ctx_t ctx)
+{
+    int status;
+    slong len = poly->length;
+
+    if (len == 0 && gr_is_zero(c, ctx) == T_FALSE)
+        return gr_poly_zero(res, ctx);
+
+    if (res != poly)
+    {
+        gr_poly_fit_length(res, len, ctx);
+        _gr_poly_set_length(res, len, ctx);
+    }
+
+    status = _gr_vec_divexact_scalar(res->coeffs, poly->coeffs, len, c, ctx);
+    _gr_poly_normalise(res, ctx);
+    return status;
+}
+

--- a/src/gr_poly/factor_squarefree.c
+++ b/src/gr_poly/factor_squarefree.c
@@ -1,5 +1,11 @@
 /*
-    Copyright (C) 2020 Fredrik Johansson
+    Copyright (C) 2007 David Howden
+    Copyright (C) 2007, 2008, 2009, 2010 William Hart
+    Copyright (C) 2008 Richard Howell-Peak
+    Copyright (C) 2011, 2020, 2025, 2026 Fredrik Johansson
+    Copyright (C) 2012 Lina Kulakova
+    Copyright (C) 2013 Mike Hansen
+    Copyright (C) 2024 Albin Ahlbäck
 
     This file is part of FLINT.
 
@@ -13,52 +19,204 @@
 #include "gr_vec.h"
 #include "gr_poly.h"
 
-int
-gr_poly_factor_squarefree(gr_ptr c, gr_vec_t fac, gr_vec_t exp, const gr_poly_t F, gr_ctx_t ctx)
+/* Extract the p-th root of a polynomial over a finite field of characteristic p.
+   Precondition: f' = 0. */
+static int
+_gr_poly_pth_root(gr_poly_t h, const gr_poly_t f, ulong p, gr_ctx_t ctx)
 {
-    gr_poly_t f, d, t1;
-    gr_poly_t v, w, s;
+    slong deg, i;
+    int status = GR_SUCCESS;
+    gr_ptr x;
+
+    if (f->length == 0)
+        return gr_poly_zero(h, ctx);
+
+    deg = f->length - 1;
+    GR_TMP_INIT(x, ctx);
+
+    gr_poly_fit_length(h, deg / p + 1, ctx);
+
+    for (i = 0; i <= (slong)(deg / p); i++)
+    {
+        status |= gr_poly_get_coeff_scalar(x, f, (slong)(i * p), ctx);
+        status |= gr_fq_pth_root(x, x, ctx);
+        status |= gr_poly_set_coeff_scalar(h, i, x, ctx);
+    }
+
+    _gr_poly_set_length(h, deg / p + 1, ctx);
+    _gr_poly_normalise(h, ctx);
+    GR_TMP_CLEAR(x, ctx);
+
+    return status;
+}
+
+/* Helper before degree-dependent branches */
+#define CHECK_PROPER(pol) \
+    if (status != GR_SUCCESS || ((pol)->length > 0 && \
+        gr_is_zero(gr_poly_coeff_srcptr((pol), \
+        (pol)->length - 1, ctx), ctx) != T_FALSE)) \
+    { \
+        status |= GR_UNABLE; \
+        goto cleanup; \
+    }
+
+static int
+gr_poly_factor_squarefree_finite_field(gr_ptr c, gr_vec_t fac, gr_vec_t exp,
+    const gr_poly_t f, gr_ctx_t poly_ctx, gr_ctx_t fmpz_ctx, gr_ctx_t ctx)
+{
+    gr_poly_t d, t1, v, w, s;
+    fmpz_t e, p;
     slong i;
     int status = GR_SUCCESS;
+
+    fmpz_init(e);
+    fmpz_init(p);
+    gr_poly_init(d, ctx);
+    gr_poly_init(t1, ctx);
+    gr_poly_init(v, ctx);
+    gr_poly_init(w, ctx);
+    gr_poly_init(s, ctx);
+
+    status |= gr_poly_get_coeff_scalar(c, f, f->length - 1, ctx);
+    status |= gr_poly_derivative(t1, f, ctx);
+    CHECK_PROPER(t1)
+
+    /* Case 1: f' = 0 means f = h(x^p); extract h and recurse. */
+    if (t1->length == 0)
+    {
+        gr_vec_t sub_fac, sub_exp;
+        gr_ptr sub_c;
+        ulong p_ui;
+        slong j;
+
+        status |= gr_ctx_fq_prime(p, ctx);
+        if (status != GR_SUCCESS)
+            goto cleanup;
+        p_ui = fmpz_get_ui(p);
+
+        gr_vec_init(sub_fac, 0, poly_ctx);
+        gr_vec_init(sub_exp, 0, fmpz_ctx);
+        sub_c = gr_heap_init(ctx);
+
+        status |= _gr_poly_pth_root(t1, f, p_ui, ctx);
+        status |= gr_poly_factor_squarefree_finite_field(sub_c, sub_fac, sub_exp, t1, poly_ctx, fmpz_ctx, ctx);
+
+        for (j = 0; j < sub_fac->length; j++)
+        {
+            status |= gr_vec_append(fac,
+                gr_vec_entry_ptr(sub_fac, j, poly_ctx), poly_ctx);
+            fmpz_mul_ui(e,
+                (fmpz *) gr_vec_entry_ptr(sub_exp, j, fmpz_ctx), p_ui);
+            status |= gr_vec_append(exp, e, fmpz_ctx);
+        }
+
+        gr_vec_clear(sub_fac, poly_ctx);
+        gr_vec_clear(sub_exp, fmpz_ctx);
+        gr_heap_clear(sub_c, ctx);
+
+        goto cleanup;
+    }
+
+    /* Case 2: f' != 0.  Yun's (g_1, g) loop; track the inseparable residual. */
+    status |= gr_poly_gcd(d, f, t1, ctx);
+    CHECK_PROPER(d)
+
+    if (d->length == 1)
+    {
+        /* f is already squarefree */
+        status |= gr_vec_append(fac, f, poly_ctx);
+        fmpz_one(e);
+        status |= gr_vec_append(exp, e, fmpz_ctx);
+    }
+    else
+    {
+        /* g_1 = f/d,  g = d  (refined at each step) */
+        status |= gr_poly_divexact(v, f, d, ctx);
+        CHECK_PROPER(v)
+
+        i = 1;
+        while (v->length > 1)
+        {
+            status |= gr_poly_gcd(s, v, d, ctx);
+            status |= gr_poly_divexact(w, v, s, ctx);
+            CHECK_PROPER(w)
+
+            if (w->length > 1)
+            {
+                status |= gr_poly_make_monic(w, w, ctx);
+                status |= gr_vec_append(fac, w, poly_ctx);
+                fmpz_set_ui(e, i);
+                status |= gr_vec_append(exp, e, fmpz_ctx);
+            }
+
+            status |= gr_poly_divexact(d, d, s, ctx);
+            status |= gr_poly_set(v, s, ctx);
+            i++;
+        }
+
+        CHECK_PROPER(d)
+
+        /* d holds the inseparable part; recurse on d^(1/p). */
+        if (d->length > 1)
+        {
+            gr_vec_t sub_fac, sub_exp;
+            gr_ptr sub_c;
+            ulong p_ui;
+            slong j;
+
+            status |= gr_ctx_fq_prime(p, ctx);
+            if (status != GR_SUCCESS)
+                goto cleanup;
+            p_ui = fmpz_get_ui(p);
+
+            gr_vec_init(sub_fac, 0, poly_ctx);
+            gr_vec_init(sub_exp, 0, fmpz_ctx);
+            sub_c = gr_heap_init(ctx);
+
+            status |= gr_poly_make_monic(d, d, ctx);
+            status |= _gr_poly_pth_root(t1, d, p_ui, ctx);
+            status |= gr_poly_factor_squarefree_finite_field(sub_c, sub_fac, sub_exp, t1, poly_ctx, fmpz_ctx, ctx);
+
+            for (j = 0; j < sub_fac->length; j++)
+            {
+                status |= gr_vec_append(fac,
+                    gr_vec_entry_ptr(sub_fac, j, poly_ctx), poly_ctx);
+                fmpz_mul_ui(e,
+                    (fmpz *) gr_vec_entry_ptr(sub_exp, j, fmpz_ctx), p_ui);
+                status |= gr_vec_append(exp, e, fmpz_ctx);
+            }
+
+            gr_vec_clear(sub_fac, poly_ctx);
+            gr_vec_clear(sub_exp, fmpz_ctx);
+            gr_heap_clear(sub_c, ctx);
+        }
+    }
+
+    for (i = 0; i < fac->length; i++)
+        status |= gr_poly_make_monic(gr_vec_entry_ptr(fac, i, poly_ctx),
+            gr_vec_entry_srcptr(fac, i, poly_ctx), ctx);
+
+cleanup:
+    gr_poly_clear(d, ctx);
+    gr_poly_clear(t1, ctx);
+    gr_poly_clear(v, ctx);
+    gr_poly_clear(w, ctx);
+    gr_poly_clear(s, ctx);
+    fmpz_clear(e);
+    fmpz_clear(p);
+
+    return status;
+}
+
+static int
+gr_poly_factor_squarefree_ufd_char_0(gr_ptr c, gr_vec_t fac, gr_vec_t exp,
+    const gr_poly_t F, gr_ctx_t poly_ctx, gr_ctx_t fmpz_ctx, truth_t is_field, gr_ctx_t ctx)
+{
+    gr_poly_t f, d, t1, v, w, s;
+    gr_ptr lc, lc_pow;
     fmpz_t e;
-    gr_ctx_t poly_ctx, fmpz_ctx;
-
-    /* todo */
-    if (gr_ctx_is_finite_characteristic(ctx) != T_FALSE)
-        return GR_UNABLE;
-
-    /* for vector of polynomials */
-    gr_ctx_init_gr_poly(poly_ctx, ctx);
-    /* for vector of exponents */
-    gr_ctx_init_fmpz(fmpz_ctx);
-
-    if (F->length == 0)
-    {
-        status |= gr_zero(c, ctx);
-        gr_vec_set_length(fac, 0, poly_ctx);
-        gr_vec_set_length(exp, 0, fmpz_ctx);
-        gr_ctx_clear(poly_ctx);
-        gr_ctx_clear(fmpz_ctx);
-        return GR_SUCCESS;
-    }
-
-    status |= gr_poly_get_coeff_scalar(c, F, F->length - 1, ctx);
-
-    if (gr_is_zero(c, ctx) != T_FALSE)
-    {
-        gr_ctx_clear(poly_ctx);
-        gr_ctx_clear(fmpz_ctx);
-        return GR_UNABLE;
-    }
-
-    if (F->length == 1)
-    {
-        gr_vec_set_length(fac, 0, poly_ctx);
-        gr_vec_set_length(exp, 0, fmpz_ctx);
-        gr_ctx_clear(poly_ctx);
-        gr_ctx_clear(fmpz_ctx);
-        return GR_SUCCESS;
-    }
+    slong i, k;
+    int status = GR_SUCCESS;
 
     fmpz_init(e);
     gr_poly_init(f, ctx);
@@ -67,19 +225,26 @@ gr_poly_factor_squarefree(gr_ptr c, gr_vec_t fac, gr_vec_t exp, const gr_poly_t 
     gr_poly_init(v, ctx);
     gr_poly_init(w, ctx);
     gr_poly_init(s, ctx);
+    lc = gr_heap_init(ctx);
+    lc_pow = gr_heap_init(ctx);
 
-    status |= gr_poly_make_monic(f, F, ctx);
-    status |= gr_poly_derivative(t1, f, ctx);
-    status |= gr_poly_gcd(d, f, t1, ctx);
-
-    if (status != GR_SUCCESS)
+    if (is_field == T_TRUE)
     {
-        status = GR_UNABLE;
-        goto cleanup;
+        status |= gr_poly_get_coeff_scalar(c, F, F->length - 1, ctx);
+        status |= gr_poly_make_monic(f, F, ctx);
+    }
+    else
+    {
+        /* todo: public vec_content, poly_contents methods */
+        status |= gr_poly_get_coeff_scalar(c, F, 0, ctx);
+        for (k = 1; k < F->length; k++)
+            status |= gr_gcd(c, c, gr_poly_coeff_srcptr(F, k, ctx), ctx);
+        status |= gr_poly_divexact_scalar(f, F, c, ctx);
     }
 
-    gr_vec_set_length(fac, 0, ctx);
-    gr_vec_set_length(exp, 0, ctx);
+    status |= gr_poly_derivative(t1, f, ctx);
+    status |= gr_poly_gcd(d, f, t1, ctx);
+    CHECK_PROPER(d)
 
     if (d->length == 1)
     {
@@ -89,55 +254,73 @@ gr_poly_factor_squarefree(gr_ptr c, gr_vec_t fac, gr_vec_t exp, const gr_poly_t 
     }
     else
     {
-        /* todo: should be divexact over field */
-        status |= gr_poly_divrem(v, s, f, d, ctx);
-        status |= gr_poly_divrem(w, s, t1, d, ctx);
+        status |= gr_poly_divexact(v, f, d, ctx);
+        status |= gr_poly_divexact(w, t1, d, ctx);
 
-        if (status != GR_SUCCESS)
-            goto cleanup;
-
-        /* invariant: v is monic, so we don't need to check if it is proper */
         for (i = 1; ; i++)
         {
             status |= gr_poly_derivative(t1, v, ctx);
             status |= gr_poly_sub(s, w, t1, ctx);
-
-            /* check if polynomial is proper */
-            if (s->length != 0 && gr_is_zero(gr_poly_coeff_ptr(s, s->length - 1, ctx), ctx) != T_FALSE)
-            {
-                status = GR_UNABLE;
-                goto cleanup;
-            }
+            CHECK_PROPER(s)
 
             if (s->length == 0)
             {
+                CHECK_PROPER(v)
+
                 if (v->length > 1)
                 {
                     status |= gr_vec_append(fac, v, poly_ctx);
-                    fmpz_set_ui(e, i); /* append_ui? */
+                    fmpz_set_ui(e, i);
                     status |= gr_vec_append(exp, e, fmpz_ctx);
                 }
+
                 break;
             }
 
             status |= gr_poly_gcd(d, v, s, ctx);
+            status |= gr_poly_divexact(v, v, d, ctx);
+            status |= gr_poly_divexact(w, s, d, ctx);
 
-            if (status != GR_SUCCESS)
-                goto cleanup;
-
-            /* should be divexact over field */
-            status |= gr_poly_divrem(v, t1, v, d, ctx);
-            status |= gr_poly_divrem(w, t1, s, d, ctx);
-
-            if (status != GR_SUCCESS)
-                goto cleanup;
+            CHECK_PROPER(d)
 
             if (d->length > 1)
             {
                 status |= gr_vec_append(fac, d, poly_ctx);
-                fmpz_set_ui(e, i); /* append_ui? */
+                fmpz_set_ui(e, i);
                 status |= gr_vec_append(exp, e, fmpz_ctx);
             }
+        }
+    }
+
+    /* Normalize leading coefficients of all factors and adjust unit. */
+    if (status == GR_SUCCESS)
+    {
+        if (is_field == T_TRUE)
+        {
+            for (i = 0; i < fac->length; i++)
+                status |= gr_poly_make_monic(gr_vec_entry_ptr(fac, i, poly_ctx),
+                    gr_vec_entry_srcptr(fac, i, poly_ctx), ctx);
+        }
+        else
+        {
+            fmpz *expc = exp->entries;
+            slong j;
+
+            status |= gr_one(lc, ctx);
+
+            for (j = 0; j < fac->length; j++)
+            {
+                gr_poly_struct *fac_j = (gr_poly_struct *) gr_vec_entry_ptr(fac, j, poly_ctx);
+
+                status |= gr_poly_canonical_associate(fac_j, NULL, fac_j, ctx);
+                CHECK_PROPER(fac_j)
+                gr_srcptr lc_j = gr_poly_coeff_srcptr(fac_j, fac_j->length - 1, ctx);
+                status |= gr_pow_ui(lc_pow, lc_j, (ulong) expc[j], ctx);
+                status |= gr_mul(lc, lc, lc_pow, ctx);
+            }
+
+            status |= gr_divexact(lc, gr_poly_coeff_srcptr(f, f->length - 1, ctx), lc, ctx);
+            status |= gr_mul(c, c, lc, ctx);
         }
     }
 
@@ -148,10 +331,66 @@ cleanup:
     gr_poly_clear(v, ctx);
     gr_poly_clear(w, ctx);
     gr_poly_clear(s, ctx);
+    gr_heap_clear(lc, ctx);
+    gr_heap_clear(lc_pow, ctx);
     fmpz_clear(e);
 
+    return status;
+}
+
+
+int
+gr_poly_factor_squarefree(gr_ptr c, gr_vec_t fac, gr_vec_t exp,
+    const gr_poly_t F, gr_ctx_t ctx)
+{
+    gr_ctx_t poly_ctx, fmpz_ctx;
+    int status = GR_SUCCESS;
+    truth_t is_field, is_fin_char;
+
+    gr_ctx_init_gr_poly(poly_ctx, ctx);
+    gr_ctx_init_fmpz(fmpz_ctx);
+
+    gr_vec_set_length(fac, 0, poly_ctx);
+    gr_vec_set_length(exp, 0, fmpz_ctx);
+
+    if (F->length == 0)
+    {
+        status |= gr_zero(c, ctx);
+        goto done;
+    }
+
+    if (gr_is_zero(gr_poly_coeff_srcptr(F, F->length - 1, ctx), ctx) != T_FALSE)
+    {
+        status = GR_UNABLE;
+        goto done;
+    }
+
+    if (F->length == 1)
+    {
+        status |= gr_set(c, F->coeffs, ctx);
+        goto done;
+    }
+
+    is_field = gr_ctx_is_field(ctx);
+    is_fin_char = gr_ctx_is_finite_characteristic(ctx);
+
+    if (is_field == T_TRUE && is_fin_char == T_TRUE)
+    {
+        status |= gr_poly_factor_squarefree_finite_field(c, fac, exp, F, poly_ctx, fmpz_ctx, ctx);
+    }
+    else if (gr_ctx_is_unique_factorization_domain(ctx) == T_TRUE && is_fin_char == T_FALSE)
+    {
+        status |= gr_poly_factor_squarefree_ufd_char_0(c, fac, exp, F, poly_ctx, fmpz_ctx, is_field, ctx);
+    }
+    else
+    {
+        status = GR_UNABLE;
+    }
+
+done:
     gr_ctx_clear(poly_ctx);
     gr_ctx_clear(fmpz_ctx);
 
     return status;
 }
+

--- a/src/gr_poly/squarefree_part.c
+++ b/src/gr_poly/squarefree_part.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2023 Fredrik Johansson
+    Copyright (C) 2023, 2026 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -17,8 +17,7 @@ gr_poly_squarefree_part(gr_poly_t res, const gr_poly_t poly, gr_ctx_t ctx)
     gr_poly_t t;
     int status = GR_SUCCESS;
 
-    /* todo */
-    if (gr_ctx_is_field(ctx) != T_TRUE || gr_ctx_is_finite_characteristic(ctx) != T_FALSE)
+    if (gr_ctx_is_field(ctx) != T_TRUE && gr_ctx_is_unique_factorization_domain(ctx) != T_TRUE)
         return GR_UNABLE;
 
     if (poly->length <= 1)

--- a/src/gr_poly/squarefree_part.c
+++ b/src/gr_poly/squarefree_part.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2023, 2026 Fredrik Johansson
+    Copyright (C) 2023, 2025, 2026 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
+#include "gr_vec.h"
 #include "gr_poly.h"
 
 int
@@ -16,43 +18,56 @@ gr_poly_squarefree_part(gr_poly_t res, const gr_poly_t poly, gr_ctx_t ctx)
 {
     gr_poly_t t;
     int status = GR_SUCCESS;
-
-    if (gr_ctx_is_field(ctx) != T_TRUE && gr_ctx_is_unique_factorization_domain(ctx) != T_TRUE)
-        return GR_UNABLE;
+    truth_t is_fin_char;
 
     if (poly->length <= 1)
         return gr_poly_one(res, ctx);
 
-    if (poly->length == 2)
+    is_fin_char = gr_ctx_is_finite_characteristic(ctx);
+
+    if (is_fin_char == T_UNKNOWN)
+        return GR_UNABLE;
+
+    if (is_fin_char == T_TRUE)
     {
-        status |= gr_poly_make_monic(res, poly, ctx);
-        if (status != GR_SUCCESS)
-            return GR_UNABLE;
+        /* The finite characteristic case is more complicated, so just call
+           the factorization algorithm and multiply the distinct factors
+           together. */
+        gr_ptr c;
+        gr_vec_t fac, exp;
+        gr_ctx_t poly_ctx, fmpz_ctx;
+        slong i;
+
+        gr_ctx_init_gr_poly(poly_ctx, ctx);
+        gr_ctx_init_fmpz(fmpz_ctx);
+        gr_vec_init(fac, 0, poly_ctx);
+        gr_vec_init(exp, 0, fmpz_ctx);
+        c = gr_heap_init(ctx);
+
+        status |= gr_poly_factor_squarefree(c, fac, exp, poly, ctx);
+
+        if (status == GR_SUCCESS)
+        {
+            status |= _gr_vec_product(res, fac->entries, fac->length, poly_ctx);
+            status |= gr_poly_canonical_associate(res, NULL, res, ctx);
+        }
+
+        gr_heap_clear(c, ctx);
+        gr_vec_clear(fac, poly_ctx);
+        gr_vec_clear(exp, fmpz_ctx);
+        gr_ctx_clear(poly_ctx);
+        gr_ctx_clear(fmpz_ctx);
+
+        return status;
     }
 
+    /* Characteristic 0: canonical_associate(poly / gcd(poly, poly')). */
     gr_poly_init(t, ctx);
     status |= gr_poly_derivative(t, poly, ctx);
     status |= gr_poly_gcd(t, poly, t, ctx);
-
-    if (status == GR_SUCCESS)
-    {
-        if (t->length == 1)  /* gcd = 1 */
-        {
-            status |= gr_poly_make_monic(res, poly, ctx);
-        }
-        else
-        {
-            /* should be divexact */
-            status |= gr_poly_divrem(res, t, poly, t, ctx);
-            if (status == GR_SUCCESS)
-                status |= gr_poly_make_monic(res, res, ctx);
-        }
-    }
-
+    status |= gr_poly_divexact(res, poly, t, ctx);
+    status |= gr_poly_canonical_associate(res, NULL, res, ctx);
     gr_poly_clear(t, ctx);
-
-    if (status != GR_SUCCESS)
-        status = GR_UNABLE;
 
     return status;
 }

--- a/src/gr_poly/test/t-factor_squarefree.c
+++ b/src/gr_poly/test/t-factor_squarefree.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2023 Fredrik Johansson
+    Copyright (C) 2023, 2025, 2026 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -20,157 +20,185 @@ TEST_FUNCTION_START(gr_poly_factor_squarefree, state)
 {
     slong iter;
 
-    for (iter = 0; iter < 1000; iter++)
+    for (iter = 0; iter < 100 * flint_test_multiplier(); iter++)
     {
         gr_ctx_t ctx;
-        gr_poly_t A, B, C, P, Q, G1, G2, G3;
+        gr_poly_t A, B, P, Q, G1, G2, G3;
         gr_ptr c;
-        gr_vec_t F;
+        gr_vec_t fac, exp;
         gr_ctx_t poly_ctx, fmpz_ctx;
-        ulong ea, eb, ec, maxexp;
-        fmpz * expc;
-        gr_vec_t exp;
-        slong i, j;
+        ulong e, emax, maxexp;
+        fmpz *expc;
+        slong i, j, exp_bound, factor_len_bound, factor_bound;
         int status = GR_SUCCESS;
-        int attempts = 0;
+        int must_succeed;
+        slong ngens;
 
-        gr_ctx_init_random(ctx, state);
-
-        while (gr_ctx_is_field(ctx) != T_TRUE || ctx->methods == _ca_methods)
+        if (n_randint(state, 2))
         {
-            gr_ctx_clear(ctx);
-            gr_ctx_init_random(ctx, state);
+            gr_ctx_init_random_finite_field(ctx, state);
         }
+        else
+        {
+            gr_ctx_init_random_commutative_ring(ctx, state);
+
+            while (gr_ctx_is_integral_domain(ctx) != T_TRUE || ctx->methods == _ca_methods)
+            {
+                gr_ctx_clear(ctx);
+                gr_ctx_init_random(ctx, state);
+            }
+        }
+
+        must_succeed = (ctx->which_ring == GR_CTX_FMPQ  ||
+                        ctx->which_ring == GR_CTX_FMPZ  ||
+                        ctx->which_ring == GR_CTX_FMPZI ||
+                        ctx->which_ring == GR_CTX_FMPZ_POLY ||
+                        (ctx->which_ring == GR_CTX_NMOD && gr_ctx_is_field(ctx) == T_TRUE) ||
+                        (ctx->which_ring == GR_CTX_NMOD8 && gr_ctx_is_field(ctx) == T_TRUE) ||
+                        (ctx->which_ring == GR_CTX_MPN_MOD && gr_ctx_is_field(ctx) == T_TRUE) ||
+                        (ctx->which_ring == GR_CTX_FMPZ_MOD && gr_ctx_is_field(ctx) == T_TRUE) ||
+                        ctx->which_ring == GR_CTX_FQ_NMOD ||
+                        ctx->which_ring == GR_CTX_FQ_ZECH);
 
         gr_ctx_init_gr_poly(poly_ctx, ctx);
         gr_ctx_init_fmpz(fmpz_ctx);
 
         gr_poly_init(A, ctx);
         gr_poly_init(B, ctx);
-        gr_poly_init(C, ctx);
         gr_poly_init(G1, ctx);
         gr_poly_init(G2, ctx);
         gr_poly_init(G3, ctx);
         gr_poly_init(P, ctx);
         gr_poly_init(Q, ctx);
 
-        gr_vec_init(F, 0, poly_ctx);
+        gr_vec_init(fac, 0, poly_ctx);
         gr_vec_init(exp, 0, fmpz_ctx);
 
         c = gr_heap_init(ctx);
 
-        attempts = 0;
-
-        do
+        if (gr_ctx_is_finite(ctx) == T_TRUE)
         {
-            attempts++;
+            factor_bound = 5;
+            factor_len_bound = 5;
+            exp_bound = 5;
+        }
+        else
+        {
+            factor_bound = 3;
+            factor_len_bound = 3;
+            exp_bound = 3;
 
-            if (ctx->methods == _ca_methods)
+            /* Keep tests fast with multivariates */
+            if (gr_ctx_ngens(&ngens, ctx) == GR_SUCCESS)
             {
-                ea = 1 + n_randint(state, 2);
-                eb = 1 + n_randint(state, 2);
-                ec = 1 + n_randint(state, 2);
-
-                status |= gr_poly_randtest(A, state, 2, ctx);
-                status |= gr_poly_randtest(B, state, 2, ctx);
-                status |= gr_poly_randtest(C, state, 2, ctx);
-            }
-            else
-            {
-                ea = 1 + n_randint(state, 2);
-                eb = 1 + n_randint(state, 2);
-                ec = 1 + n_randint(state, 4);
-
-                status |= gr_poly_randtest(A, state, 3, ctx);
-                status |= gr_poly_randtest(B, state, 3, ctx);
-                status |= gr_poly_randtest(C, state, 3, ctx);
-            }
-
-            if (ctx->which_ring != GR_CTX_FMPQ && attempts > 4)
-            {
-                status = GR_UNABLE;
-                break;
+                if (ngens > 1)
+                {
+                    factor_bound = 2;
+                    factor_len_bound = 2;
+                    exp_bound = 2;
+                }
             }
         }
-        while (A->length < 2 || B->length < 2 || C->length < 2 ||
-               gr_poly_gcd(G1, A, B, ctx) != GR_SUCCESS || (gr_poly_is_one(G1, ctx) != T_TRUE) ||
-               gr_poly_gcd(G2, A, C, ctx) != GR_SUCCESS || (gr_poly_is_one(G2, ctx) != T_TRUE) ||
-               gr_poly_gcd(G3, B, C, ctx) != GR_SUCCESS || (gr_poly_is_one(G3, ctx) != T_TRUE));
 
         status |= gr_poly_one(P, ctx);
-        for (i = 0; i < ea; i++)
-            status |= gr_poly_mul(P, P, A, ctx);
-        for (i = 0; i < eb; i++)
-            status |= gr_poly_mul(P, P, B, ctx);
-        for (i = 0; i < ec; i++)
-            status |= gr_poly_mul(P, P, C, ctx);
+        emax = 0;
 
-        status |= gr_poly_factor_squarefree(c, F, exp, P, ctx);
-
-        if (ctx->which_ring == GR_CTX_FMPQ && status != GR_SUCCESS)
+        for (i = 0; i < factor_bound; i++)
         {
-            flint_printf("FAIL (unexpected failure)\n\n");
+            do {
+                status |= gr_poly_randtest(A, state, factor_len_bound, ctx);
+            } while (A->length < 2);
+
+            e = 1 + n_randint(state, exp_bound);
+
+            if (gr_poly_gcd(G1, P, A, ctx) == GR_SUCCESS && gr_poly_is_scalar(G1, ctx) == T_TRUE)
+            {
+                status |= gr_poly_pow_ui(B, A, e, ctx);
+                status |= gr_poly_mul(P, P, B, ctx);
+                emax = FLINT_MAX(emax, e);
+            }
+        }
+
+        if (status != GR_SUCCESS && !must_succeed)
+            goto cleanup;
+
+        status = gr_poly_factor_squarefree(c, fac, exp, P, ctx);
+
+        if (must_succeed && status != GR_SUCCESS)
+        {
+            flint_printf("FAIL (unexpected GR_UNABLE)\n\n");
+            gr_ctx_println(ctx);
             flint_printf("P = "); gr_poly_print(P, ctx); flint_printf("\n");
             flint_abort();
         }
 
         if (status == GR_SUCCESS)
         {
+            int status1 = GR_SUCCESS;
+
+            for (i = 0; i < fac->length; i++)
+            {
+                status1 |= gr_poly_derivative(Q, gr_vec_entry_ptr(fac, i, poly_ctx), ctx);
+                status1 |= gr_poly_gcd(Q, Q, gr_vec_entry_ptr(fac, i, poly_ctx), ctx);
+
+                if (status1 == GR_SUCCESS && gr_poly_is_scalar(Q, ctx) == T_FALSE)
+                {
+                    flint_printf("FAIL (factor not squarefree)\n\n");
+                    gr_ctx_println(ctx);
+                    flint_printf("emax = %wd\n\n", emax);
+                    flint_printf("fac = %{gr*}\n\n", fac->entries, fac->length, poly_ctx);
+                    flint_printf("exp = %{gr*}\n\n", exp->entries, exp->length, fmpz_ctx);
+                    flint_printf("c = %{gr}\n\n", c, ctx);
+                    flint_printf("P = "); gr_poly_print(P, ctx); flint_printf("\n");
+                    flint_printf("Q = "); gr_poly_print(Q, ctx); flint_printf("\n");
+                    flint_abort();
+                }
+            }
+        }
+
+        if (status == GR_SUCCESS)
+        {
             expc = exp->entries;
 
-/*
-            printf("LENGTHS %ld %ld\n", F->length, exp->length);
-            gr_vec_print(F, poly_ctx); printf("\n\n");
-            gr_vec_print(exp, fmpz_ctx); printf("\n\n");
-*/
-
             status |= gr_poly_one(Q, ctx);
-            for (i = 0; i < F->length; i++)
+            for (i = 0; i < fac->length; i++)
                 for (j = 0; j < expc[i]; j++)
-                    status |= gr_poly_mul(Q, Q, gr_vec_entry_ptr(F, i, poly_ctx), ctx);
-
+                    status |= gr_poly_mul(Q, Q,
+                        gr_vec_entry_ptr(fac, i, poly_ctx), ctx);
             status |= gr_poly_mul_scalar(Q, Q, c, ctx);
 
             maxexp = 0;
-            for (i = 0; i < F->length; i++)
+            for (i = 0; i < fac->length; i++)
                 maxexp = FLINT_MAX(maxexp, expc[i]);
 
-            if (status == GR_SUCCESS && (gr_poly_equal(P, Q, ctx) == T_FALSE || maxexp < FLINT_MAX(FLINT_MAX(ea, eb), ec)))
+            if (status == GR_SUCCESS &&
+                (gr_poly_equal(P, Q, ctx) == T_FALSE ||
+                 maxexp < emax))
             {
                 flint_printf("FAIL (product)\n\n");
-                flint_printf("A = "); gr_poly_print(A, ctx); flint_printf("\n");
-                flint_printf("ea = %wu\n\n", ea);
-                flint_printf("B = "); gr_poly_print(B, ctx); flint_printf("\n");
-                flint_printf("eb = %wu\n\n", eb);
-                flint_printf("C = "); gr_poly_print(C, ctx); flint_printf("\n");
-                flint_printf("ec = %wu\n\n", ec);
+                gr_ctx_println(ctx);
+                flint_printf("emax = %wd\n\n", emax);
+                flint_printf("fac = %{gr*}\n\n", fac->entries, fac->length, poly_ctx);
+                flint_printf("exp = %{gr*}\n\n", exp->entries, exp->length, fmpz_ctx);
+                flint_printf("c = %{gr}\n\n", c, ctx);
                 flint_printf("P = "); gr_poly_print(P, ctx); flint_printf("\n");
                 flint_printf("Q = "); gr_poly_print(Q, ctx); flint_printf("\n");
-
-                for (i = 0; i < F->length; i++)
-                {
-                    flint_printf("Multiplicity %wu: ", exp[i]);
-                    gr_poly_print(gr_vec_entry_ptr(F, i, poly_ctx), ctx);
-                }
-
                 flint_abort();
             }
         }
 
         gr_poly_clear(A, ctx);
         gr_poly_clear(B, ctx);
-        gr_poly_clear(C, ctx);
         gr_poly_clear(G1, ctx);
         gr_poly_clear(G2, ctx);
         gr_poly_clear(G3, ctx);
         gr_poly_clear(P, ctx);
         gr_poly_clear(Q, ctx);
 
-        gr_vec_clear(F, poly_ctx);
+cleanup:
+        gr_vec_clear(fac, poly_ctx);
         gr_vec_clear(exp, fmpz_ctx);
-
         gr_heap_clear(c, ctx);
-
         gr_ctx_clear(poly_ctx);
         gr_ctx_clear(fmpz_ctx);
         gr_ctx_clear(ctx);

--- a/src/gr_poly/test/t-shiftless_decomposition.c
+++ b/src/gr_poly/test/t-shiftless_decomposition.c
@@ -36,8 +36,14 @@ TEST_FUNCTION_START(gr_poly_shiftless_decomposition, state)
         if (n_randint(state, 2))
             gr_ctx_init_fmpz(ctx);
         else
+        {
             gr_ctx_init_random(ctx, state);
-        int calcium = ctx->methods == _ca_methods;
+            while (ctx->methods == _ca_methods)
+            {
+                gr_ctx_clear(ctx);
+                gr_ctx_init_random(ctx, state);
+            }
+        }
 
         gr_ptr a = gr_heap_init(ctx);
         gr_poly_init(f, ctx);
@@ -46,13 +52,13 @@ TEST_FUNCTION_START(gr_poly_shiftless_decomposition, state)
         int status = GR_SUCCESS;
 
         status |= gr_poly_one(f, ctx);
-        slong li = 1 + n_randint(state, calcium ? 2 : 5);
+        slong li = 1 + n_randint(state, 5);
 
         for (slong i = 0; i < li && status == GR_SUCCESS; i++)
         {
             for (slong j = 0; j < 10 && gr_poly_is_zero(u, ctx) == T_TRUE; j++)
-                gr_poly_randtest(u, state, 2 + (calcium ? 0 : n_randint(state, 3)), ctx);
-            slong lj = 1 + n_randint(state, calcium ? 5 : 2);
+                gr_poly_randtest(u, state, 2 + n_randint(state, 3), ctx);
+            slong lj = 1 + n_randint(state, 5);
             for (slong j = 0; j < lj && status == GR_SUCCESS; j++)
             {
                 if (n_randint(state, 2))

--- a/src/gr_poly/test/t-squarefree_part.c
+++ b/src/gr_poly/test/t-squarefree_part.c
@@ -29,13 +29,12 @@ TEST_FUNCTION_START(gr_poly_squarefree_part, state)
         slong i;
         int status = GR_SUCCESS;
 
-        gr_ctx_init_random(ctx, state);
+        gr_ctx_init_random_commutative_ring(ctx, state);
 
-        while (gr_ctx_is_integral_domain(ctx) != T_TRUE ||
-            gr_ctx_is_finite_characteristic(ctx) != T_FALSE || ctx->methods == _ca_methods)
+        while (ctx->methods == _ca_methods)
         {
             gr_ctx_clear(ctx);
-            gr_ctx_init_random(ctx, state);
+            gr_ctx_init_random_commutative_ring(ctx, state);
         }
 
         gr_ctx_init_gr_poly(poly_ctx, ctx);
@@ -50,7 +49,7 @@ TEST_FUNCTION_START(gr_poly_squarefree_part, state)
 
         c = gr_heap_init(ctx);
 
-        status |= gr_poly_randtest(A, state, 6, ctx);
+        status |= gr_poly_randtest(A, state, 8, ctx);
 
         status |= gr_poly_factor_squarefree(c, F, exp, A, ctx);
 

--- a/src/gr_poly/test/t-squarefree_part.c
+++ b/src/gr_poly/test/t-squarefree_part.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2023 Fredrik Johansson
+    Copyright (C) 2023, 2025 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -20,7 +20,7 @@ TEST_FUNCTION_START(gr_poly_squarefree_part, state)
 {
     slong iter;
 
-    for (iter = 0; iter < 1000; iter++)
+    for (iter = 0; iter < 100 * flint_test_multiplier(); iter++)
     {
         gr_ctx_t ctx, poly_ctx, fmpz_ctx;
         gr_poly_t A, B, C;
@@ -31,7 +31,8 @@ TEST_FUNCTION_START(gr_poly_squarefree_part, state)
 
         gr_ctx_init_random(ctx, state);
 
-        while (gr_ctx_is_field(ctx) != T_TRUE)
+        while (gr_ctx_is_integral_domain(ctx) != T_TRUE ||
+            gr_ctx_is_finite_characteristic(ctx) != T_FALSE || ctx->methods == _ca_methods)
         {
             gr_ctx_clear(ctx);
             gr_ctx_init_random(ctx, state);
@@ -49,10 +50,7 @@ TEST_FUNCTION_START(gr_poly_squarefree_part, state)
 
         c = gr_heap_init(ctx);
 
-        if (ctx->methods == _ca_methods)
-            status |= gr_poly_randtest(A, state, 3, ctx);
-        else
-            status |= gr_poly_randtest(A, state, 10, ctx);
+        status |= gr_poly_randtest(A, state, 6, ctx);
 
         status |= gr_poly_factor_squarefree(c, F, exp, A, ctx);
 
@@ -65,14 +63,15 @@ TEST_FUNCTION_START(gr_poly_squarefree_part, state)
                 status |= gr_poly_one(C, ctx);
                 for (i = 0; i < F->length; i++)
                     status |= gr_poly_mul(C, C, gr_vec_entry_ptr(F, i, poly_ctx), ctx);
+                status |= gr_poly_canonical_associate(C, NULL, C, ctx);
 
                 if (status == GR_SUCCESS && gr_poly_equal(B, C, ctx) == T_FALSE)
                 {
                     flint_printf("FAIL (product)\n\n");
+                    gr_ctx_println(ctx);
                     flint_printf("A = "); gr_poly_print(A, ctx); flint_printf("\n");
                     flint_printf("B = "); gr_poly_print(B, ctx); flint_printf("\n");
                     flint_printf("C = "); gr_poly_print(C, ctx); flint_printf("\n");
-
                     flint_abort();
                 }
             }

--- a/src/mpn_mod/ctx.c
+++ b/src/mpn_mod/ctx.c
@@ -13,6 +13,13 @@
 #include "mpn_mod.h"
 #include "gr.h"
 
+static int
+_mpn_mod_ctx_fq_prime(fmpz_t res, gr_ctx_t ctx)
+{
+    fmpz_set_ui_array(res, MPN_MOD_CTX_MODULUS(ctx), MPN_MOD_CTX_NLIMBS(ctx));
+    return GR_SUCCESS;
+}
+
 int _mpn_mod_methods_initialized = 0;
 
 gr_static_method_table _mpn_mod_methods;
@@ -99,6 +106,9 @@ gr_method_tab_input _mpn_mod_methods_input[] =
     {GR_METHOD_SQRT,            (gr_funcptr) mpn_mod_sqrt},
     {GR_METHOD_IS_SQUARE,       (gr_funcptr) mpn_mod_is_square},
 */
+
+    {GR_METHOD_FQ_PTH_ROOT,     (gr_funcptr) mpn_mod_set},
+    {GR_METHOD_CTX_FQ_PRIME,    (gr_funcptr) _mpn_mod_ctx_fq_prime},
 
     {GR_METHOD_VEC_INIT,        (gr_funcptr) _mpn_mod_vec_zero},
     {GR_METHOD_VEC_CLEAR,       (gr_funcptr) _mpn_mod_vec_clear},


### PR DESCRIPTION
The functions `gr_poly_factor_squarefree` and `gr_poly_squarefree_part` previously only worked over fields of characteristic zero. We extend them to work over non-field UFDs in characteristic zero and finite fields (though currently not extension rings of finite fields). The finite field case is a port of the ``fq_poly_factor_templates`` algorithm with some adaptations for the GR case, and the characteristic zero UFD case is essentially as before except that we need a bit more work to handle the units of leading coefficients when we can't just make things monic (or set leading coefficients to positive, as in the `fmpz_poly` code). Both done with some AI assistance, though the AI seemed stupider than usual and made a lot of mistakes to clean up.

Minor fixes/changes part of the PR:

* Add `gr_poly_divexact_scalar`
* Make `gr_ctx_init_random_finite_field` public and add more cases
* Fix slow or failing tests revealed by RNG change in `gr_ctx_init_random`
* Add `gr_fq_prime` and `gr_fq_pth_root` for some more Z/pZ types allowing the squarefree factorization code for finite fields to pass with them
* `gr_sqrt` over `fmpz_mod` could produce an invalid element on failure, causing an assertion failure