### PR TITLE
Fix flipped functions for length 1 input in gr_poly_sin_cos_series_basecase

### DIFF
--- a/src/gr_poly/sin_cos_series_basecase.c
+++ b/src/gr_poly/sin_cos_series_basecase.c
@@ -30,7 +30,7 @@ _gr_poly_sin_cos_series_basecase(gr_ptr s, gr_ptr c, gr_srcptr h, slong hlen,
         {
             if (s == NULL)
             {
-                if (times_pi == 0)
+                if (times_pi)
                     status |= gr_cos_pi(c, h, ctx);
                 else
                     status |= gr_cos(c, h, ctx);
@@ -38,7 +38,7 @@ _gr_poly_sin_cos_series_basecase(gr_ptr s, gr_ptr c, gr_srcptr h, slong hlen,
             }
             else
             {
-                if (times_pi == 0)
+                if (times_pi)
                     status |= gr_sin_pi(s, h, ctx);
                 else
                     status |= gr_sin(s, h, ctx);

--- a/src/python/flint_ctypes.py
+++ b/src/python/flint_ctypes.py
@@ -9437,6 +9437,13 @@ def test_gr_series():
 
     assert raises(lambda: x / 0, FlintDomainError)
 
+    # regression test
+    assert CCser(1).cos_pi() == -1
+    assert str(CCser(1).cos()) == "[0.540302305868140 +/- 4.59e-16]"
+    assert CCser(1).sin_pi() == 0
+    assert str(CCser(1).sin()) == "[0.841470984807897 +/- 6.08e-16]"
+
+
 def test_integers_mod():
     R = IntegersMod_mpn_mod(10**20 + 1)
     c = ZZ(2) ** 4321


### PR DESCRIPTION
Trivial bugfix: for input of length 1, the recently added `gr_poly_cos_series`/`gr_poly_cos_pi_series` had their values switched and likewise for `gr_poly_sin_series`/`gr_poly_sin_pi_series`.