### PR TITLE
Introduce fmpz_vec_t and gr_poly_vec_t types

### DIFF
--- a/doc/source/fmpz_vec.rst
+++ b/doc/source/fmpz_vec.rst
@@ -16,6 +16,54 @@ Memory management
     Clears the entries of ``(vec, len)`` and frees the space allocated
     for ``vec``.
 
+Resizable vectors
+-------------------------------------------------------------------------------
+ 
+.. type:: fmpz_vec_struct
+          fmpz_vec_t
+ 
+    A resizable vector of :type:`fmpz` elements. It is safe to cast an
+    :type:`fmpz_vec_t` to a :type:`gr_vec_t` with :type:`fmpz` elements
+    and vice versa.
+
+.. function:: void fmpz_vec_init(fmpz_vec_t vec, slong len)
+ 
+    Initializes *vec* to a vector of length *len* with all entries set
+    to zero. The length must be nonnegative.
+ 
+.. function:: void fmpz_vec_clear(fmpz_vec_t vec)
+ 
+    Clears the vector *vec*, freeing all allocated memory.
+ 
+.. function:: fmpz * fmpz_vec_entry_ptr(fmpz_vec_t vec, slong i)
+              const fmpz * fmpz_vec_entry_srcptr(const fmpz_vec_t vec, slong i)
+ 
+    Returns a pointer to the *i*-th element in the vector, indexed from zero.
+    The index must be in bounds.
+ 
+.. function:: slong fmpz_vec_length(const fmpz_vec_t vec)
+ 
+    Returns the length of the vector.
+ 
+.. function:: void fmpz_vec_fit_length(fmpz_vec_t vec, slong len)
+ 
+    Allocates space for at least *len* elements. This does not change
+    the length of the vector.
+ 
+.. function:: void fmpz_vec_set_length(fmpz_vec_t vec, slong len)
+ 
+    Resizes the vector to length *len*, which must be nonnegative.
+    The vector will be extended with zeros if necessary.
+ 
+.. function:: void fmpz_vec_set(fmpz_vec_t res, const fmpz_vec_t src)
+ 
+    Sets *res* to a copy of *src*.
+ 
+.. function:: void fmpz_vec_append(fmpz_vec_t vec, const fmpz_t f)
+              void fmpz_vec_append_ui(fmpz_vec_t vec, ulong f) 
+
+    Appends the integer *f* to the end of the vector.
+
 
 Randomisation
 --------------------------------------------------------------------------------

--- a/doc/source/gr.rst
+++ b/doc/source/gr.rst
@@ -815,7 +815,7 @@ Factorization
     `u x` with respect to multiplication by units, also writing the normalizing
     unit *u* as a second output. If `x = 0`, sets *res* to 0 and *u* to 1.
 
-.. function:: int gr_factor(gr_ptr c, gr_vec_t factors, gr_vec_t exponents, gr_srcptr x, int flags, gr_ctx_t ctx)
+.. function:: int gr_factor(gr_ptr c, gr_vec_t factors, fmpz_vec_t exponents, gr_srcptr x, int flags, gr_ctx_t ctx)
 
     Given `x \in R`, computes a factorization
 

--- a/doc/source/gr_generic.rst
+++ b/doc/source/gr_generic.rst
@@ -306,7 +306,7 @@ To do: move to ``gr_vec``
 Generic polynomial methods
 -----------------------------------------------------------------------------------------
 
-.. function:: int gr_generic_poly_factor_roots( gr_ptr c, gr_vec_t fac, gr_vec_t mult, gr_srcptr elt, int flags, gr_ctx_t ctx)
+.. function:: int gr_generic_poly_factor_roots( gr_ptr c, gr_vec_t fac, fmpz_vec_t mult, gr_srcptr elt, int flags, gr_ctx_t ctx)
 
     Calls :func:`gr_poly_roots` to factor a polynomial that splits into linear factors.
 

--- a/doc/source/gr_mat.rst
+++ b/doc/source/gr_mat.rst
@@ -852,8 +852,8 @@ Similarity transformations
 Eigenvalues
 -------------------------------------------------------------------------------
 
-.. function:: int gr_mat_eigenvalues(gr_vec_t lambda, gr_vec_t mult, const gr_mat_t mat, int flags, gr_ctx_t ctx)
-              int gr_mat_eigenvalues_other(gr_vec_t lambda, gr_vec_t mult, const gr_mat_t mat, gr_ctx_t mat_ctx, int flags, gr_ctx_t ctx)
+.. function:: int gr_mat_eigenvalues(gr_vec_t lambda, fmpz_vec_t mult, const gr_mat_t mat, int flags, gr_ctx_t ctx)
+              int gr_mat_eigenvalues_other(gr_vec_t lambda, fmpz_vec_t mult, const gr_mat_t mat, gr_ctx_t mat_ctx, int flags, gr_ctx_t ctx)
 
     Finds all eigenvalues of the given matrix in the ring defined by *ctx*,
     storing the eigenvalues without duplication in *lambda* (a vector with
@@ -863,7 +863,7 @@ Eigenvalues
     The interface is essentially the same as that of
     :func:`gr_poly_roots`; see its documentation for details.
 
-.. function:: int gr_mat_diagonalization_precomp(gr_vec_t D, gr_mat_t L, gr_mat_t R, const gr_mat_t A, const gr_vec_t eigenvalues, const gr_vec_t mult, gr_ctx_t ctx)
+.. function:: int gr_mat_diagonalization_precomp(gr_vec_t D, gr_mat_t L, gr_mat_t R, const gr_mat_t A, const gr_vec_t eigenvalues, const fmpz_vec_t mult, gr_ctx_t ctx)
               int gr_mat_diagonalization_generic(gr_vec_t D, gr_mat_t L, gr_mat_t R, const gr_mat_t A, int flags, gr_ctx_t ctx)
               int gr_mat_diagonalization(gr_vec_t D, gr_mat_t L, gr_mat_t R, const gr_mat_t A, int flags, gr_ctx_t ctx)
 

--- a/doc/source/gr_poly.rst
+++ b/doc/source/gr_poly.rst
@@ -99,6 +99,58 @@ Memory management
 
 .. function:: void _gr_poly_set_length(gr_poly_t poly, slong len, gr_ctx_t ctx)
 
+
+Vectors of polynomials
+-------------------------------------------------------------------------------
+ 
+.. type:: gr_poly_vec_struct
+          gr_poly_vec_t
+ 
+    A resizable vector of :type:`gr_poly_t` elements. Unlike
+    :type:`gr_vec_t`, this type stores actual :type:`gr_poly_struct`
+    objects, so no polynomial-ring context object is needed: the *ctx* argument
+    refers directly to the coefficient ring of the polynomials. It is safe to
+    cast a :type:`gr_poly_vec_t` to a :type:`gr_vec_t` (with :type:`gr_poly_t`
+    elements of the correct type) and vice versa.
+
+.. function:: void gr_poly_vec_init(gr_poly_vec_t vec, slong len, gr_ctx_t ctx)
+ 
+    Initializes *vec* to a vector of length *len* with all entries
+    set to the zero polynomial over *ctx*. The length must be nonnegative.
+ 
+.. function:: void gr_poly_vec_clear(gr_poly_vec_t vec, gr_ctx_t ctx)
+ 
+    Clears the vector *vec*, freeing all allocated memory.
+ 
+.. function:: gr_poly_struct * gr_poly_vec_entry_ptr(gr_poly_vec_t vec, slong i, gr_ctx_t ctx)
+              const gr_poly_struct * gr_poly_vec_entry_srcptr(const gr_poly_vec_t vec, slong i, gr_ctx_t ctx)
+ 
+    Returns a pointer to the *i*-th polynomial in the vector, indexed from zero.
+    The index must be in bounds.
+ 
+.. function:: slong gr_poly_vec_length(const gr_poly_vec_t vec, gr_ctx_t ctx)
+ 
+    Returns the length of the vector.
+ 
+.. function:: void gr_poly_vec_fit_length(gr_poly_vec_t vec, slong len, gr_ctx_t ctx)
+ 
+    Allocates space for at least *len* elements. This does not change
+    the length of the vector.
+ 
+.. function:: void gr_poly_vec_set_length(gr_poly_vec_t vec, slong len, gr_ctx_t ctx)
+ 
+    Resizes the vector to length *len*, which must be nonnegative.
+    The vector will be extended with zero polynomials if necessary.
+ 
+.. function:: int gr_poly_vec_set(gr_poly_vec_t res, const gr_poly_vec_t src, gr_ctx_t ctx)
+ 
+    Sets *res* to a copy of *src*.
+ 
+.. function:: int gr_poly_vec_append(gr_poly_vec_t vec, const gr_poly_t f, gr_ctx_t ctx)
+ 
+    Appends the polynomial *f* to the end of the vector.
+
+
 Basic manipulation
 -------------------------------------------------------------------------------
 
@@ -1025,7 +1077,7 @@ of the two polynomials is zero.
 Squarefree factorization
 -------------------------------------------------------------------------------
 
-.. function:: int gr_poly_factor_squarefree(gr_ptr c, gr_vec_t fac, gr_vec_t exp, const gr_poly_t poly, gr_ctx_t ctx)
+.. function:: int gr_poly_factor_squarefree(gr_ptr c, gr_poly_vec_t fac, fmpz_vec_t exp, const gr_poly_t poly, gr_ctx_t ctx)
 
     Computes a squarefree factorization
 
@@ -1037,8 +1089,7 @@ Squarefree factorization
     factors `g_i` with respective multiplicities `e_i` in *exp*.
     The order of the factors is arbitrary.
     The user must initialize *fac* to a vector of polynomials of the same
-    type as *poly* (and *not* to the scalar type *ctx*).
-    The exponent vector *exp* must be initialized to the *fmpz* type.
+    type as *poly*.
 
     The constant *c* is set to an element of the scalar ring.
     If *ctx* is known to be a field, all factors will be monic and the
@@ -1089,15 +1140,14 @@ Shift equivalence
     The *resultant* version computes the integer roots of a bivariate resultant
     and is mainly intended for testing.
 
-.. function:: int gr_poly_dispersion_from_factors(fmpz_t disp, gr_vec_t disp_set, const gr_vec_t ffac, const gr_vec_t gfac, gr_ctx_t ctx)
+.. function:: int gr_poly_dispersion_from_factors(fmpz_t disp, gr_vec_t disp_set, const gr_poly_vec_t ffac, const gr_poly_vec_t gfac, gr_ctx_t ctx)
 
     Same as :func:`gr_poly_dispersion_factor` for nonzero *f* and *g* but takes
     as input their nonconstant irreducible factors (without multiplicities)
     instead of the polynomials themselves.
 
-.. function:: int gr_poly_shiftless_decomposition_factor(gr_ptr c, gr_vec_t slfac, gr_vec_t slshifts, gr_vec_t slmult, const gr_poly_t f, gr_ctx_t ctx)
-              int gr_poly_shiftless_decomposition(gr_ptr c, gr_vec_t slfac, gr_vec_t slshifts, gr_vec_t slmult, const gr_poly_t f, gr_ctx_t ctx)
-
+.. function:: int gr_poly_shiftless_decomposition_factor(gr_ptr c, gr_poly_vec_t slfac, gr_vec_t slshifts, gr_vec_t slmult, const gr_poly_t f, gr_ctx_t ctx)
+              int gr_poly_shiftless_decomposition(gr_ptr c, gr_poly_vec_t slfac, gr_vec_t slshifts, gr_vec_t slmult, const gr_poly_t f, gr_ctx_t ctx)
 
     Computes a decomposition of *f* of the form
 
@@ -1124,8 +1174,8 @@ Shift equivalence
     No algorithm avoiding a full irreducible factorization is currently
     implemented.
 
-.. function:: int _gr_poly_shiftless_decomposition_from_factors(gr_vec_t slfac, gr_vec_t slshifts, gr_vec_t slmult, const gr_vec_t fac, const gr_vec_t mult, gr_ctx_t ctx)
-              int gr_poly_shiftless_decomposition_from_factors(gr_vec_t slfac, gr_vec_t slshifts, gr_vec_t slmult, const gr_vec_t fac, const gr_vec_t mult, gr_ctx_t ctx)
+.. function:: int _gr_poly_shiftless_decomposition_from_factors(gr_poly_vec_t slfac, gr_vec_t slshifts, gr_vec_t slmult, const gr_poly_vec_t fac, const fmpz_vec_t mult, gr_ctx_t ctx)
+              int gr_poly_shiftless_decomposition_from_factors(gr_poly_vec_t slfac, gr_vec_t slshifts, gr_vec_t slmult, const gr_poly_vec_t fac, const fmpz_vec_t mult, gr_ctx_t ctx)
 
     Same as :func:`gr_poly_shiftless_decomposition_factor` but takes as input
     an irreducible factorization (*fac*, *mult*) of *f* (without the
@@ -1135,8 +1185,8 @@ Shift equivalence
 Roots
 -------------------------------------------------------------------------------
 
-.. function:: int gr_poly_roots(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, int flags, gr_ctx_t ctx)
-              int gr_poly_roots_other(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, gr_ctx_t poly_ctx, int flags, gr_ctx_t ctx)
+.. function:: int gr_poly_roots(gr_vec_t roots, fmpz_vec_t mult, const gr_poly_t poly, int flags, gr_ctx_t ctx)
+              int gr_poly_roots_other(gr_vec_t roots, fmpz_vec_t mult, const gr_poly_t poly, gr_ctx_t poly_ctx, int flags, gr_ctx_t ctx)
 
     Finds all roots of the given polynomial in the ring defined by *ctx*,
     storing the roots without duplication in *roots* (a vector with

--- a/src/fmpz_types.h
+++ b/src/fmpz_types.h
@@ -52,6 +52,16 @@ typedef fmpz_preinvn_struct fmpz_preinvn_t[1];
 
 typedef struct
 {
+    fmpz * entries;
+    slong alloc;
+    slong length;
+}
+fmpz_vec_struct;
+ 
+typedef fmpz_vec_struct fmpz_vec_t[1];
+
+typedef struct
+{
     fmpz * coeffs;
     slong alloc;
     slong length;

--- a/src/fmpz_vec.h
+++ b/src/fmpz_vec.h
@@ -64,6 +64,34 @@ FMPZ_VEC_INLINE fmpz * _fmpz_vec_init(slong len)
 
 void _fmpz_vec_clear(fmpz * vec, slong len);
 
+/* Resizable vector objects */
+
+void fmpz_vec_init(fmpz_vec_t vec, slong len);
+void fmpz_vec_clear(fmpz_vec_t vec);
+void fmpz_vec_set(fmpz_vec_t res, const fmpz_vec_t src);
+void fmpz_vec_fit_length(fmpz_vec_t vec, slong len);
+void fmpz_vec_set_length(fmpz_vec_t vec, slong len);
+void fmpz_vec_append(fmpz_vec_t vec, const fmpz_t f);
+void fmpz_vec_append_ui(fmpz_vec_t vec, ulong f);
+ 
+FMPZ_VEC_INLINE slong
+fmpz_vec_length(const fmpz_vec_t vec)
+{
+    return vec->length;
+}
+ 
+FMPZ_VEC_INLINE fmpz *
+fmpz_vec_entry_ptr(fmpz_vec_t vec, slong i)
+{
+    return vec->entries + i;
+}
+ 
+FMPZ_VEC_INLINE const fmpz *
+fmpz_vec_entry_srcptr(const fmpz_vec_t vec, slong i)
+{
+    return vec->entries + i;
+}
+
 /*  Randomisation  ***********************************************************/
 
 void _fmpz_vec_randtest(fmpz * f, flint_rand_t state, slong len, flint_bitcnt_t bits);

--- a/src/fmpz_vec/vec.c
+++ b/src/fmpz_vec/vec.c
@@ -1,0 +1,93 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz.h"
+#include "fmpz_vec.h"
+#include <string.h>
+
+void
+fmpz_vec_init(fmpz_vec_t vec, slong len)
+{
+    vec->length = vec->alloc = len;
+
+    if (len == 0)
+    {
+        vec->entries = NULL;
+    }
+    else
+    {
+        vec->entries = _fmpz_vec_init(len);
+    }
+}
+
+void
+fmpz_vec_clear(fmpz_vec_t vec)
+{
+    _fmpz_vec_clear(vec->entries, vec->alloc);
+}
+
+void
+fmpz_vec_fit_length(fmpz_vec_t vec, slong len)
+{
+    slong alloc = vec->alloc;
+
+    if (len > alloc)
+    {
+        if (len < 2 * alloc)
+            len = 2 * alloc;
+
+        vec->entries = flint_realloc(vec->entries, len * sizeof(fmpz));
+        memset(vec->entries + alloc, 0, (len - alloc) * sizeof(fmpz));
+        vec->alloc = len;
+    }
+}
+
+void
+fmpz_vec_set_length(fmpz_vec_t vec, slong len)
+{
+    if (vec->length > len)
+    {
+        _fmpz_vec_zero(vec->entries + len, vec->length - len);
+    }
+    else if (vec->length < len)
+    {
+        fmpz_vec_fit_length(vec, len);
+        _fmpz_vec_zero(vec->entries + vec->length, len - vec->length);
+    }
+
+    vec->length = len;
+}
+
+void
+fmpz_vec_set(fmpz_vec_t res, const fmpz_vec_t src)
+{
+    if (res == src)
+        return;
+
+    fmpz_vec_set_length(res, src->length);
+    _fmpz_vec_set(res->entries, src->entries, src->length);
+}
+
+void
+fmpz_vec_append(fmpz_vec_t vec, const fmpz_t f)
+{
+    fmpz_vec_fit_length(vec, vec->length + 1);
+    vec->length++;
+    fmpz_set(vec->entries + vec->length - 1, f);
+}
+
+void
+fmpz_vec_append_ui(fmpz_vec_t vec, ulong f)
+{
+    fmpz_vec_fit_length(vec, vec->length + 1);
+    vec->length++;
+    fmpz_set_ui(vec->entries + vec->length - 1, f);
+}

--- a/src/gr.h
+++ b/src/gr.h
@@ -18,6 +18,7 @@
 #define GR_INLINE static inline
 #endif
 
+#include "fmpz_types.h"
 #include "gr_types.h"
 
 #ifdef __cplusplus
@@ -848,7 +849,7 @@ typedef int ((*gr_method_vec_scalar_op_fmpz)(gr_ptr, gr_srcptr, slong, const fmp
 typedef int ((*gr_method_vec_scalar_op_fmpq)(gr_ptr, gr_srcptr, slong, const fmpq_t, gr_ctx_ptr));
 typedef truth_t ((*gr_method_vec_predicate)(gr_srcptr, slong, gr_ctx_ptr));
 typedef truth_t ((*gr_method_vec_vec_predicate)(gr_srcptr, gr_srcptr, slong, gr_ctx_ptr));
-typedef int ((*gr_method_factor_op)(gr_ptr, gr_vec_t, gr_vec_t, gr_srcptr, int, gr_ctx_ptr));
+typedef int ((*gr_method_factor_op)(gr_ptr, gr_vec_t, fmpz_vec_t, gr_srcptr, int, gr_ctx_ptr));
 typedef int ((*gr_method_poly_unary_trunc_op)(gr_ptr, gr_srcptr, slong, slong, gr_ctx_ptr));
 typedef int ((*gr_method_poly_binary_op)(gr_ptr, gr_srcptr, slong, gr_srcptr, slong, gr_ctx_ptr));
 typedef int ((*gr_method_poly_binary_binary_op)(gr_ptr, gr_ptr, gr_srcptr, slong, gr_srcptr, slong, gr_ctx_ptr));
@@ -1144,7 +1145,7 @@ GR_INLINE WARN_UNUSED_RESULT int gr_lcm(gr_ptr res, gr_srcptr x, gr_srcptr y, gr
 GR_INLINE WARN_UNUSED_RESULT int gr_numerator(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, NUMERATOR)(res, x, ctx); }
 GR_INLINE WARN_UNUSED_RESULT int gr_denominator(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, DENOMINATOR)(res, x, ctx); }
 
-GR_INLINE WARN_UNUSED_RESULT int gr_factor(gr_ptr c, gr_vec_t factors, gr_vec_t exponents, gr_srcptr x, int flags, gr_ctx_t ctx) { return GR_FACTOR_OP(ctx, FACTOR)(c, factors, exponents, x, flags, ctx); }
+GR_INLINE WARN_UNUSED_RESULT int gr_factor(gr_ptr c, gr_vec_t factors, fmpz_vec_t exponents, gr_srcptr x, int flags, gr_ctx_t ctx) { return GR_FACTOR_OP(ctx, FACTOR)(c, factors, exponents, x, flags, ctx); }
 
 GR_INLINE WARN_UNUSED_RESULT int gr_pow(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_OP(ctx, POW)(res, x, y, ctx); }
 GR_INLINE WARN_UNUSED_RESULT int gr_pow_ui(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx) { return GR_BINARY_OP_UI(ctx, POW_UI)(res, x, y, ctx); }

--- a/src/gr/acb.c
+++ b/src/gr/acb.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
 #include "fmpz_poly.h"
 #include "fmpz_poly_factor.h"
 #include "fmpzi.h"
@@ -2003,12 +2004,11 @@ roots_accurate(acb_ptr roots, slong len, slong prec)
 
 /* hidden feature: also works with arb ctx */
 int
-_gr_acb_poly_roots(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, int flags, gr_ctx_t ctx)
+_gr_acb_poly_roots(gr_vec_t roots, fmpz_vec_t mult, const gr_poly_t poly, int flags, gr_ctx_t ctx)
 {
     slong prec, initial_prec, target_prec, isolated, maxiter, maxprec, deg, i;
     acb_ptr croots;
     acb_poly_t tmp;
-    gr_ctx_t ZZ;
     int status = GR_UNABLE;
     int arb_roots;
 
@@ -2020,7 +2020,6 @@ _gr_acb_poly_roots(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, int flag
     if (acb_contains_zero(((acb_srcptr) poly->coeffs) + deg))
         return GR_UNABLE;
 
-    gr_ctx_init_fmpz(ZZ);
     croots = _acb_vec_init(deg);
     acb_poly_init(tmp);
     acb_poly_fit_length(tmp, deg + 1);
@@ -2079,41 +2078,39 @@ _gr_acb_poly_roots(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, int flag
         if (arb_roots)
         {
             gr_vec_set_length(roots, 0, ctx);
-            gr_vec_set_length(mult, 0, ZZ);
+            fmpz_vec_set_length(mult, 0);
 
             for (i = 0; i < deg; i++)
             {
                 if (arb_contains_zero(acb_imagref(croots + i)))
                 {
-                    fmpz one = 1;
                     arb_set_round(acb_realref(croots + i), acb_realref(croots + i), target_prec);
                     GR_MUST_SUCCEED(gr_vec_append(roots, acb_realref(croots + i), ctx));
-                    GR_MUST_SUCCEED(gr_vec_append(mult, &one, ZZ));
+                    fmpz_vec_append_ui(mult, 1);
                 }
             }
         }
         else
         {
             gr_vec_set_length(roots, deg, ctx);
-            gr_vec_set_length(mult, deg, ZZ);
+            fmpz_vec_set_length(mult, deg);
 
             for (i = 0; i < deg; i++)
             {
                 acb_set_round(((acb_ptr) roots->entries) + i, croots + i, target_prec);
-                fmpz_one(((fmpz *) mult->entries) + i);
+                fmpz_one(mult->entries + i);
             }
         }
     }
 
     acb_poly_clear(tmp);
     _acb_vec_clear(croots, deg);
-    gr_ctx_clear(ZZ);
 
     return status;
 }
 
 static int
-_gr_acb_poly_roots_other(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, gr_ctx_t other_ctx, int flags, gr_ctx_t ctx)
+_gr_acb_poly_roots_other(gr_vec_t roots, fmpz_vec_t mult, const gr_poly_t poly, gr_ctx_t other_ctx, int flags, gr_ctx_t ctx)
 {
     if (poly->length == 0)
         return GR_DOMAIN;
@@ -2123,17 +2120,14 @@ _gr_acb_poly_roots_other(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, gr
 
     if (other_ctx->which_ring == GR_CTX_FMPZ)
     {
-        gr_ctx_t ZZ;
         slong i, j, deg, deg2;
         acb_ptr croots;
         int status = GR_SUCCESS;
 
         deg = poly->length - 1;
 
-        gr_ctx_init_fmpz(ZZ);
-
         gr_vec_set_length(roots, 0, ctx);
-        gr_vec_set_length(mult, 0, ZZ);
+        fmpz_vec_set_length(mult, 0);
 
         if (deg != 0)
         {
@@ -2150,9 +2144,8 @@ _gr_acb_poly_roots_other(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, gr
 
                 for (j = 0; j < deg2; j++)
                 {
-                    fmpz m2 = fac->exp[i];
                     GR_MUST_SUCCEED(gr_vec_append(roots, croots + j, ctx));
-                    GR_MUST_SUCCEED(gr_vec_append(mult, &m2, ZZ));
+                    fmpz_vec_append_ui(mult, fac->exp[i]);
                 }
 
                 _acb_vec_clear(croots, deg2);
@@ -2160,8 +2153,6 @@ _gr_acb_poly_roots_other(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, gr
 
             fmpz_poly_factor_clear(fac);
         }
-
-        gr_ctx_clear(ZZ);
 
         return status;
     }

--- a/src/gr/acf.c
+++ b/src/gr/acf.c
@@ -10,6 +10,7 @@
 */
 
 #include "double_extras.h"
+#include "fmpz_vec.h"
 #include "fmpz_poly.h"
 #include "fmpz_poly_factor.h"
 #include "arb_fmpz_poly.h"
@@ -1068,24 +1069,21 @@ _gr_acf_poly_mullow(acf_ptr res,
 }
 
 static int
-_gr_acf_poly_roots_other(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, gr_ctx_t other_ctx, int flags, gr_ctx_t ctx)
+_gr_acf_poly_roots_other(gr_vec_t roots, fmpz_vec_t mult, const gr_poly_t poly, gr_ctx_t other_ctx, int flags, gr_ctx_t ctx)
 {
     if (poly->length == 0)
         return GR_DOMAIN;
 
     if (other_ctx->which_ring == GR_CTX_FMPZ)
     {
-        gr_ctx_t ZZ;
         slong i, j, deg, deg2;
         acb_ptr croots;
         int status = GR_SUCCESS;
 
         deg = poly->length - 1;
 
-        gr_ctx_init_fmpz(ZZ);
-
         gr_vec_set_length(roots, 0, ctx);
-        gr_vec_set_length(mult, 0, ZZ);
+        fmpz_vec_set_length(mult, 0);
 
         if (deg != 0)
         {
@@ -1103,11 +1101,10 @@ _gr_acf_poly_roots_other(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, gr
                 for (j = 0; j < deg2; j++)
                 {
                     acf_t t;
-                    fmpz m2 = fac->exp[i];
                     *acf_realref(t) = *arb_midref(acb_realref(croots + j));
                     *acf_imagref(t) = *arb_midref(acb_imagref(croots + j));
                     GR_MUST_SUCCEED(gr_vec_append(roots, t, ctx));
-                    GR_MUST_SUCCEED(gr_vec_append(mult, &m2, ZZ));
+                    fmpz_vec_append_ui(mult, fac->exp[i]);
                 }
 
                 _acb_vec_clear(croots, deg2);
@@ -1115,8 +1112,6 @@ _gr_acf_poly_roots_other(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, gr
 
             fmpz_poly_factor_clear(fac);
         }
-
-        gr_ctx_clear(ZZ);
 
         return status;
     }

--- a/src/gr/arb.c
+++ b/src/gr/arb.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
 #include "fmpz_poly.h"
 #include "fmpz_poly_factor.h"
 #include "fmpq.h"
@@ -1589,7 +1590,7 @@ _gr_arb_poly_mulmid(arb_ptr res,
 }
 
 static int
-_gr_arb_poly_roots(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, int flags, gr_ctx_t ctx)
+_gr_arb_poly_roots(gr_vec_t roots, fmpz_vec_t mult, const gr_poly_t poly, int flags, gr_ctx_t ctx)
 {
     int status;
     slong i;
@@ -1605,7 +1606,7 @@ _gr_arb_poly_roots(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, int flag
 }
 
 static int
-_gr_arb_poly_roots_other(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, gr_ctx_t other_ctx, int flags, gr_ctx_t ctx)
+_gr_arb_poly_roots_other(gr_vec_t roots, fmpz_vec_t mult, const gr_poly_t poly, gr_ctx_t other_ctx, int flags, gr_ctx_t ctx)
 {
     if (poly->length == 0)
         return GR_DOMAIN;
@@ -1617,17 +1618,14 @@ _gr_arb_poly_roots_other(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, gr
 
     if (other_ctx->which_ring == GR_CTX_FMPZ)
     {
-        gr_ctx_t ZZ;
         slong i, j, deg, deg2;
         acb_ptr croots;
         int status = GR_SUCCESS;
 
         deg = poly->length - 1;
 
-        gr_ctx_init_fmpz(ZZ);
-
         gr_vec_set_length(roots, 0, ctx);
-        gr_vec_set_length(mult, 0, ZZ);
+        fmpz_vec_set_length(mult, 0);
 
         if (deg != 0)
         {
@@ -1646,9 +1644,8 @@ _gr_arb_poly_roots_other(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, gr
                 {
                     if (acb_is_real(croots + j))
                     {
-                        fmpz m2 = fac->exp[i];
                         GR_MUST_SUCCEED(gr_vec_append(roots, acb_realref(croots + j), ctx));
-                        GR_MUST_SUCCEED(gr_vec_append(mult, &m2, ZZ));
+                        fmpz_vec_append_ui(mult, fac->exp[i]);
                     }
                 }
 
@@ -1657,8 +1654,6 @@ _gr_arb_poly_roots_other(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, gr
 
             fmpz_poly_factor_clear(fac);
         }
-
-        gr_ctx_clear(ZZ);
 
         return status;
     }

--- a/src/gr/arf.c
+++ b/src/gr/arf.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
 #include "fmpz_poly.h"
 #include "fmpz_poly_factor.h"
 #include "arb_poly.h"
@@ -1209,24 +1210,21 @@ _gr_arf_poly_mullow(arf_ptr res,
 
 /* todo: real-only roots in arb */
 static int
-_gr_arf_poly_roots_other(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, gr_ctx_t other_ctx, int flags, gr_ctx_t ctx)
+_gr_arf_poly_roots_other(gr_vec_t roots, fmpz_vec_t mult, const gr_poly_t poly, gr_ctx_t other_ctx, int flags, gr_ctx_t ctx)
 {
     if (poly->length == 0)
         return GR_DOMAIN;
 
     if (other_ctx->which_ring == GR_CTX_FMPZ)
     {
-        gr_ctx_t ZZ;
         slong i, j, deg, deg2;
         acb_ptr croots;
         int status = GR_SUCCESS;
 
         deg = poly->length - 1;
 
-        gr_ctx_init_fmpz(ZZ);
-
         gr_vec_set_length(roots, 0, ctx);
-        gr_vec_set_length(mult, 0, ZZ);
+        fmpz_vec_set_length(mult, 0);
 
         if (deg != 0)
         {
@@ -1245,9 +1243,8 @@ _gr_arf_poly_roots_other(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, gr
                 {
                     if (acb_is_real(croots + j))
                     {
-                        fmpz m2 = fac->exp[i];
                         GR_MUST_SUCCEED(gr_vec_append(roots, arb_midref(acb_realref(croots + j)), ctx));
-                        GR_MUST_SUCCEED(gr_vec_append(mult, &m2, ZZ));
+                        fmpz_vec_append_ui(mult, fac->exp[i]);
                     }
                 }
 
@@ -1256,8 +1253,6 @@ _gr_arf_poly_roots_other(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, gr
 
             fmpz_poly_factor_clear(fac);
         }
-
-        gr_ctx_clear(ZZ);
 
         return status;
     }

--- a/src/gr/ca.c
+++ b/src/gr/ca.c
@@ -1482,7 +1482,7 @@ _gr_ca_poly_mullow(ca_ptr res,
 }
 
 static int
-_gr_ca_poly_factor(gr_ptr c, gr_vec_t fac, gr_vec_t mult, gr_srcptr elt,
+_gr_ca_poly_factor(gr_ptr c, gr_vec_t fac, fmpz_vec_t mult, gr_srcptr elt,
                    int flags, gr_ctx_t ctx)
 {
     if (gr_ctx_is_algebraically_closed(ctx) == T_TRUE)
@@ -1491,23 +1491,18 @@ _gr_ca_poly_factor(gr_ptr c, gr_vec_t fac, gr_vec_t mult, gr_srcptr elt,
 }
 
 static int
-_gr_ca_poly_roots(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, int flags, gr_ctx_t ctx)
+_gr_ca_poly_roots(gr_vec_t roots, fmpz_vec_t mult, const gr_poly_t poly, int flags, gr_ctx_t ctx)
 {
     int status = GR_SUCCESS;
     ca_vec_t ca_roots;
     ulong * exp;
     slong deg;
-    gr_ctx_t ZZ;
     slong i;
-    fmpz_t exp_z;
 
     if (poly->length == 0)
         return GR_DOMAIN;
 
     deg = poly->length - 1;
-
-    gr_ctx_init_fmpz(ZZ);
-    fmpz_init(exp_z);
 
     ca_vec_init(ca_roots, 0, GR_CA_CTX(ctx));
     exp = flint_malloc(sizeof(ulong) * deg);
@@ -1515,7 +1510,7 @@ _gr_ca_poly_roots(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, int flags
     if (ca_poly_roots(ca_roots, exp, (const ca_poly_struct *) poly, GR_CA_CTX(ctx)))
     {
         gr_vec_set_length(roots, 0, ctx);
-        gr_vec_set_length(mult, 0, ZZ);
+        fmpz_vec_set_length(mult, 0);
 
         for (i = 0; i < ca_roots->length; i++)
         {
@@ -1533,62 +1528,19 @@ _gr_ca_poly_roots(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, int flags
                 }
             }
 
-            fmpz_set_ui(exp_z, exp[i]);
             status |= gr_vec_append(roots, ca_roots->entries + i, ctx);
-            status |= gr_vec_append(mult, exp_z, ZZ);
+            fmpz_vec_append_ui(mult, exp[i]);
         }
     }
     else
     {
         status = GR_UNABLE;
         gr_vec_set_length(roots, 0, ctx);
-        gr_vec_set_length(mult, 0, ZZ);
+        fmpz_vec_set_length(mult, 0);
     }
 
     ca_vec_clear(ca_roots, GR_CA_CTX(ctx));
     flint_free(exp);
-
-    gr_ctx_clear(ZZ);
-    fmpz_clear(exp_z);
-
-/*
-    if (status == GR_SUCCESS)
-    {
-        _acb_vec_sort_pretty(croots, deg);
-
-        if (arb_roots)
-        {
-
-            for (i = 0; i < deg; i++)
-            {
-                if (arb_contains_zero(acb_imagref(croots + i)))
-                {
-                    fmpz one = 1;
-                    arb_set_round(acb_realref(croots + i), acb_realref(croots + i), target_prec);
-                    GR_MUST_SUCCEED(gr_vec_append(roots, acb_realref(croots + i), ctx));
-                    GR_MUST_SUCCEED(gr_vec_append(mult, &one, ZZ));
-                }
-            }
-        }
-        else
-        {
-            gr_vec_set_length(roots, deg, ctx);
-            gr_vec_set_length(mult, deg, ZZ);
-
-            for (i = 0; i < deg; i++)
-            {
-                acb_set_round(((acb_ptr) roots->entries) + i, croots + i, target_prec);
-                fmpz_one(((fmpz *) mult->entries) + i);
-            }
-        }
-    }
-
-    acb_poly_clear(tmp);
-    _acb_vec_clear(croots, deg);
-    gr_ctx_clear(ZZ);
-
-    return status;
-*/
 
     return status;
 }

--- a/src/gr/fmpq.c
+++ b/src/gr/fmpq.c
@@ -952,7 +952,7 @@ _gr_fmpq_poly_mullow(fmpq * res,
 }
 
 static int
-_gr_fmpq_poly_roots(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, int flags, gr_ctx_t ctx)
+_gr_fmpq_poly_roots(gr_vec_t roots, fmpz_vec_t mult, const gr_poly_t poly, int flags, gr_ctx_t ctx)
 {
     gr_ctx_t ZZ;
     gr_poly_t f;
@@ -981,7 +981,7 @@ _gr_fmpq_poly_roots(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, int fla
 }
 
 static int
-_gr_fmpq_poly_roots_other(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, gr_ctx_t other_ctx, int flags, gr_ctx_t ctx)
+_gr_fmpq_poly_roots_other(gr_vec_t roots, fmpz_vec_t mult, const gr_poly_t poly, gr_ctx_t other_ctx, int flags, gr_ctx_t ctx)
 {
     if (poly->length == 0)
         return GR_DOMAIN;
@@ -991,18 +991,15 @@ _gr_fmpq_poly_roots_other(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, g
 
     if (other_ctx->which_ring == GR_CTX_FMPZ)
     {
-        gr_ctx_t ZZ;
         int status = GR_SUCCESS;
         slong deg;
 
         deg = poly->length - 1;
 
-        gr_ctx_init_fmpz(ZZ);
-
         if (deg == 0)
         {
             gr_vec_set_length(roots, 0, ctx);
-            gr_vec_set_length(mult, 0, ZZ);
+            fmpz_vec_set_length(mult, 0);
         }
         else /* todo: special cases */
         {
@@ -1021,7 +1018,7 @@ _gr_fmpq_poly_roots_other(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, g
                     num++;
 
             gr_vec_set_length(roots, num, ctx);
-            gr_vec_set_length(mult, num, ZZ);
+            fmpz_vec_set_length(mult, num);
 
             res_entries = roots->entries;
             mult_entries = mult->entries;
@@ -1043,8 +1040,6 @@ _gr_fmpq_poly_roots_other(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, g
 
             fmpz_poly_factor_clear(fac);
         }
-
-        gr_ctx_clear(ZZ);
 
         return status;
     }

--- a/src/gr/fmpz_poly.c
+++ b/src/gr/fmpz_poly.c
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "fmpz.h"
+#include "fmpz_vec.h"
 #include "fmpz_poly.h"
 #include "fmpz_mat.h"
 #include "fmpq.h"
@@ -780,10 +781,10 @@ _gr_fmpz_poly_canonical_associate(fmpz_poly_t ux, fmpz_poly_t u, const fmpz_poly
 
 
 int
-_gr_fmpz_poly_factor(fmpz_poly_t c, gr_vec_t factors, gr_vec_t exponents, gr_srcptr x, int flags, gr_ctx_t ctx)
+_gr_fmpz_poly_factor(fmpz_poly_t c, gr_vec_t factors, fmpz_vec_t exponents, gr_srcptr x, int flags, gr_ctx_t ctx)
 {
     fmpz_poly_factor_t fac;
-    gr_ctx_t Pol, ZZ;
+    gr_ctx_t Pol;
     slong i;
 
     fmpz_poly_factor_init(fac);
@@ -794,18 +795,16 @@ _gr_fmpz_poly_factor(fmpz_poly_t c, gr_vec_t factors, gr_vec_t exponents, gr_src
     /* Avoid using ctx so that this function can be used both with ctx = ZZ and
      * with ctx = ZZ[x] */
     gr_ctx_init_fmpz_poly(Pol);
-    gr_ctx_init_fmpz(ZZ);
 
     gr_vec_set_length(factors, fac->num, Pol);
-    gr_vec_set_length(exponents, fac->num, ZZ);
+    fmpz_vec_set_length(exponents, fac->num);
 
     for (i = 0; i < fac->num; i++)
     {
         fmpz_poly_swap((fmpz_poly_struct *) (factors->entries) + i, fac->p + i);
-        fmpz_set_ui((fmpz *) (exponents->entries) + i, fac->exp[i]);
+        fmpz_set_ui(exponents->entries + i, fac->exp[i]);
     }
 
-    gr_ctx_clear(ZZ);
     gr_ctx_clear(Pol);
 
     fmpz_poly_factor_clear(fac);

--- a/src/gr/impl.h
+++ b/src/gr/impl.h
@@ -12,12 +12,13 @@
 #ifndef GR_IMPL_H
 #define GR_IMPL_H
 
+#include "fmpz_types.h"
 #include "nmod_types.h"
 #include "fmpz_mod_types.h"
 #include "gr_types.h"
 #include "qqbar.h"
 
-int _gr_fmpz_poly_factor(fmpz_poly_t c, gr_vec_t factors, gr_vec_t exponents, gr_srcptr x, int flags, gr_ctx_t ctx);
+int _gr_fmpz_poly_factor(fmpz_poly_t c, gr_vec_t factors, fmpz_vec_t exponents, gr_srcptr x, int flags, gr_ctx_t ctx);
 
 void _gr_fmpz_mpoly_ctx_clear(gr_ctx_t ctx);
 int _gr_fmpz_mpoly_ctx_set_gen_names(gr_ctx_t ctx, const char ** s);
@@ -38,7 +39,7 @@ int _gr_arf_get_ui(ulong * res, const arf_t x, const gr_ctx_t ctx);
 
 int _gr_arb_cmpabs(int * res, const arb_t x, const arb_t y, const gr_ctx_t ctx);
 
-int _gr_acb_poly_roots(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, int flags, gr_ctx_t ctx);
+int _gr_acb_poly_roots(gr_vec_t roots, fmpz_vec_t mult, const gr_poly_t poly, int flags, gr_ctx_t ctx);
 
 int _gr_ca_get_arb_with_prec(arb_t res, gr_srcptr x, gr_ctx_t x_ctx, slong prec);
 int _gr_ca_get_acb_with_prec(acb_t res, gr_srcptr x, gr_ctx_t x_ctx, slong prec);

--- a/src/gr/nmod.c
+++ b/src/gr/nmod.c
@@ -1303,7 +1303,7 @@ _gr_nmod_poly_exp_series(ulong * res,
 }
 
 static int
-_gr_nmod_roots_gr_poly(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, int flags, gr_ctx_t ctx)
+_gr_nmod_roots_gr_poly(gr_vec_t roots, fmpz_vec_t mult, const gr_poly_t poly, int flags, gr_ctx_t ctx)
 {
     if (poly->length == 0)
         return GR_DOMAIN;

--- a/src/gr/polynomial.c
+++ b/src/gr/polynomial.c
@@ -696,7 +696,7 @@ polynomial_canonical_associate(gr_poly_t ux, gr_poly_t u, const gr_poly_t x, gr_
 
 
 static int
-polynomial_factor(gr_ptr c, gr_vec_t fac, gr_vec_t mult, const gr_poly_t pol, int flags, const gr_ctx_t ctx)
+polynomial_factor(gr_ptr c, gr_vec_t fac, fmpz_vec_t mult, const gr_poly_t pol, int flags, const gr_ctx_t ctx)
 {
     gr_ctx_struct * cctx = POLYNOMIAL_ELEM_CTX(ctx);
     return GR_FACTOR_OP(cctx, POLY_FACTOR)(c, fac, mult, pol, flags, cctx);

--- a/src/gr/qqbar.c
+++ b/src/gr/qqbar.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
 #include "fmpz_poly.h"
 #include "fmpz_poly_factor.h"
 #include "fmpq.h"
@@ -1166,7 +1167,7 @@ TRIG3(acsc_pi)
 
 
 static int
-_gr_qqbar_poly_factor(gr_ptr c, gr_vec_t fac, gr_vec_t mult, gr_srcptr elt,
+_gr_qqbar_poly_factor(gr_ptr c, gr_vec_t fac, fmpz_vec_t mult, gr_srcptr elt,
                       int flags, gr_ctx_t ctx)
 {
     if (gr_ctx_is_algebraically_closed(ctx) == T_TRUE)
@@ -1176,11 +1177,11 @@ _gr_qqbar_poly_factor(gr_ptr c, gr_vec_t fac, gr_vec_t mult, gr_srcptr elt,
 
 /* todo: quickly skip nonreal roots over the real algebraic numbers */
 static int
-_gr_qqbar_poly_roots(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, int flags, gr_ctx_t ctx)
+_gr_qqbar_poly_roots(gr_vec_t roots, fmpz_vec_t mult, const gr_poly_t poly, int flags, gr_ctx_t ctx)
 {
     int status;
-    gr_ctx_t ZZ, Rx;
-    gr_vec_t fac, exp;
+    gr_poly_vec_t fac;
+    fmpz_vec_t exp;
     gr_ptr c;
     slong i;
 
@@ -1189,15 +1190,12 @@ _gr_qqbar_poly_roots(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, int fl
 
     /* todo: fast numerical check to avoid an exact squarefree factorization */
 
-    gr_ctx_init_fmpz(ZZ);
-    gr_ctx_init_gr_poly(Rx, ctx);
-
     gr_vec_set_length(roots, 0, ctx);
-    gr_vec_set_length(mult, 0, ZZ);
+    fmpz_vec_set_length(mult, 0);
 
     c = gr_heap_init(ctx);
-    gr_vec_init(fac, 0, Rx);
-    gr_vec_init(exp, 0, ZZ);
+    gr_poly_vec_init(fac, 0, ctx);
+    fmpz_vec_init(exp, 0);
 
     status = gr_poly_factor_squarefree(c, fac, exp, poly, ctx);
 
@@ -1210,8 +1208,7 @@ _gr_qqbar_poly_roots(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, int fl
 
         for (i = 0; i < fac->length; i++)
         {
-            gr_poly_struct * fac_i = gr_vec_entry_ptr(fac, i, Rx);
-            fmpz * exp_i = gr_vec_entry_ptr(exp, i, ZZ);
+            gr_poly_struct * fac_i = gr_poly_vec_entry_ptr(fac, i, ctx);
 
             deg2 = fac_i->length - 1;
 
@@ -1230,7 +1227,7 @@ _gr_qqbar_poly_roots(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, int fl
                     continue;
 
                 GR_MUST_SUCCEED(gr_vec_append(roots, croots + j, ctx));
-                GR_MUST_SUCCEED(gr_vec_append(mult, exp_i, ZZ));
+                fmpz_vec_append(mult, exp->entries + i);
             }
 
             _qqbar_vec_clear(croots, deg2);
@@ -1239,36 +1236,30 @@ _gr_qqbar_poly_roots(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, int fl
 
     /* todo: qqbar_cmp_root_order, but must sort exponents as well */
 
-    gr_vec_clear(fac, Rx);
-    gr_vec_clear(exp, ZZ);
+    gr_poly_vec_clear(fac, ctx);
+    fmpz_vec_clear(exp);
     gr_heap_clear(c, ctx);
-
-    gr_ctx_clear(ZZ);
-    gr_ctx_clear(Rx);
 
     return status;
 }
 
 /* todo: quickly skip nonreal roots over the real algebraic numbers */
 static int
-_gr_qqbar_poly_roots_other(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, gr_ctx_t other_ctx, int flags, gr_ctx_t ctx)
+_gr_qqbar_poly_roots_other(gr_vec_t roots, fmpz_vec_t mult, const gr_poly_t poly, gr_ctx_t other_ctx, int flags, gr_ctx_t ctx)
 {
     if (poly->length == 0)
         return GR_DOMAIN;
 
     if (other_ctx->which_ring == GR_CTX_FMPZ)
     {
-        gr_ctx_t ZZ;
         slong i, j, deg, deg2;
         qqbar_struct * croots;
         int status = GR_SUCCESS;
 
         deg = poly->length - 1;
 
-        gr_ctx_init_fmpz(ZZ);
-
         gr_vec_set_length(roots, 0, ctx);
-        gr_vec_set_length(mult, 0, ZZ);
+        fmpz_vec_set_length(mult, 0);
 
         if (deg != 0)
         {
@@ -1285,13 +1276,11 @@ _gr_qqbar_poly_roots_other(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, 
 
                 for (j = 0; j < deg2; j++)
                 {
-                    fmpz m2 = fac->exp[i];
-
                     if (QQBAR_CTX(ctx)->real_only && !qqbar_is_real(croots + j))
                         continue;
 
                     GR_MUST_SUCCEED(gr_vec_append(roots, croots + j, ctx));
-                    GR_MUST_SUCCEED(gr_vec_append(mult, &m2, ZZ));
+                    fmpz_vec_append_ui(mult, fac->exp[i]);
                 }
 
                 _qqbar_vec_clear(croots, deg2);
@@ -1301,8 +1290,6 @@ _gr_qqbar_poly_roots_other(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, 
         }
 
         /* todo: qqbar_cmp_root_order, but must sort exponents as well */
-
-        gr_ctx_clear(ZZ);
 
         return status;
     }

--- a/src/gr/test_ring.c
+++ b/src/gr/test_ring.c
@@ -16,6 +16,7 @@
 
 #include "fexpr.h"
 #include "fmpq.h"
+#include "fmpz_vec.h"
 #include "gr.h"
 #include "gr_generic.h"
 #include "gr_vec.h"
@@ -3683,14 +3684,15 @@ gr_test_factor(gr_ctx_t R, flint_rand_t state, int test_flags)
     int status;
     gr_ptr x, c, t, u;
     gr_ctx_t ZZ;
-    gr_vec_t fac, exp;
+    gr_vec_t fac;
+    fmpz_vec_t exp;
     slong i;
 
     GR_TMP_INIT4(x, c, t, u, R);
     gr_ctx_init_fmpz(ZZ);
 
     gr_vec_init(fac, n_randint(state, 3), R);
-    gr_vec_init(exp, n_randint(state, 3), ZZ);
+    fmpz_vec_init(exp, n_randint(state, 3));
 
     status = GR_SUCCESS;
     status |= gr_randtest_small(x, state, R);
@@ -3715,7 +3717,7 @@ gr_test_factor(gr_ctx_t R, flint_rand_t state, int test_flags)
 
             for (i = 0; i < fac->length; i++)
             {
-                status |= gr_pow_fmpz(t, gr_vec_entry_srcptr(fac, i, R), gr_vec_entry_srcptr(exp, i, ZZ), R);
+                status |= gr_pow_fmpz(t, gr_vec_entry_srcptr(fac, i, R), fmpz_vec_entry_srcptr(exp, i), R);
                 status |= gr_mul(u, u, t, R);
             }
 
@@ -3732,7 +3734,7 @@ gr_test_factor(gr_ctx_t R, flint_rand_t state, int test_flags)
             flint_printf("x = "); gr_println(x, R);
             flint_printf("c = "); gr_println(c, R);
             flint_printf("fac = "); gr_vec_print(fac, R); flint_printf("\n");
-            flint_printf("exp = "); gr_vec_print(exp, ZZ); flint_printf("\n");
+            flint_printf("exp = "); gr_vec_print((gr_vec_struct *) exp, ZZ); flint_printf("\n");
             flint_printf("\n");
         }
     }
@@ -3760,7 +3762,7 @@ gr_test_factor(gr_ctx_t R, flint_rand_t state, int test_flags)
     gr_ctx_clear(ZZ);
 
     gr_vec_clear(fac, R);
-    gr_vec_clear(exp, ZZ);
+    fmpz_vec_clear(exp);
 
     return status;
 }

--- a/src/gr_generic.h
+++ b/src/gr_generic.h
@@ -18,6 +18,7 @@
 #define GR_GENERIC_INLINE static inline
 #endif
 
+#include "fmpz_types.h"
 #include "gr_types.h"
 
 #ifdef __cplusplus
@@ -205,7 +206,7 @@ WARN_UNUSED_RESULT int gr_generic_cmpabs(int * res, gr_srcptr x, gr_srcptr y, gr
 WARN_UNUSED_RESULT int gr_generic_cmp_other(int * res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_generic_cmpabs_other(int * res, gr_srcptr x, gr_srcptr y, gr_ctx_t y_ctx, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_generic_poly_factor_roots( gr_ptr c, gr_vec_t fac, gr_vec_t mult, gr_srcptr elt, int flags, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_generic_poly_factor_roots(gr_ptr c, gr_vec_t fac, fmpz_vec_t mult, gr_srcptr elt, int flags, gr_ctx_t ctx);
 
 WARN_UNUSED_RESULT int gr_generic_bernoulli_ui(gr_ptr res, ulong n, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_generic_bernoulli_fmpz(gr_ptr res, const fmpz_t n, gr_ctx_t ctx);

--- a/src/gr_generic/poly_factor.c
+++ b/src/gr_generic/poly_factor.c
@@ -16,7 +16,7 @@
 
 int
 gr_generic_poly_factor_roots(
-        gr_ptr c, gr_vec_t fac, gr_vec_t mult, gr_srcptr elt, int flags,
+        gr_ptr c, gr_vec_t fac, fmpz_vec_t mult, gr_srcptr elt, int flags,
         gr_ctx_t ctx)
 {
     gr_ctx_t pctx;

--- a/src/gr_generic/test/t-poly_factor.c
+++ b/src/gr_generic/test/t-poly_factor.c
@@ -51,7 +51,7 @@ TEST_FUNCTION_START(gr_generic_poly_factor, state)
             status |= gr_poly_mul(pol, pol, f, ctx);
         }
 
-        status |= gr_generic_poly_factor_roots(c, fac, mult, pol, 0, ctx);
+        status |= gr_generic_poly_factor_roots(c, fac, (fmpz_vec_struct *) mult, pol, 0, ctx);
 
         if (status != GR_SUCCESS)
             goto cleanup;
@@ -70,6 +70,10 @@ TEST_FUNCTION_START(gr_generic_poly_factor, state)
         }
 
 cleanup:
+
+        count_success += (status == GR_SUCCESS);
+        count_domain += ((status & GR_DOMAIN) != 0);
+        count_unable += ((status & GR_UNABLE) != 0);
 
         gr_heap_clear(c, pctx);
         gr_vec_clear(fac, pctx);

--- a/src/gr_mat.h
+++ b/src/gr_mat.h
@@ -368,10 +368,10 @@ int gr_mat_reduce_row(slong * column, gr_mat_t A, slong * P, slong * L, slong m,
 int gr_mat_apply_row_similarity(gr_mat_t A, slong r, gr_ptr d, gr_ctx_t ctx);
 int gr_mat_minpoly_field(gr_poly_t p, const gr_mat_t X, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_eigenvalues(gr_vec_t lambda, gr_vec_t mult, const gr_mat_t mat, int flags, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mat_eigenvalues_other(gr_vec_t lambda, gr_vec_t mult, const gr_mat_t mat, gr_ctx_t mat_ctx, int flags, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_mat_eigenvalues(gr_vec_t lambda, fmpz_vec_t mult, const gr_mat_t mat, int flags, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_mat_eigenvalues_other(gr_vec_t lambda, fmpz_vec_t mult, const gr_mat_t mat, gr_ctx_t mat_ctx, int flags, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int gr_mat_diagonalization_precomp(gr_vec_t D, gr_mat_t L, gr_mat_t R, const gr_mat_t A, const gr_vec_t eigenvalues, const gr_vec_t mult, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_mat_diagonalization_precomp(gr_vec_t D, gr_mat_t L, gr_mat_t R, const gr_mat_t A, const gr_vec_t eigenvalues, const fmpz_vec_t mult, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mat_diagonalization_generic(gr_vec_t D, gr_mat_t L, gr_mat_t R, const gr_mat_t A, int flags, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mat_diagonalization(gr_vec_t D, gr_mat_t L, gr_mat_t R, const gr_mat_t A, int flags, gr_ctx_t ctx);
 

--- a/src/gr_mat/diagonalization.c
+++ b/src/gr_mat/diagonalization.c
@@ -9,11 +9,12 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
 #include "gr_vec.h"
 #include "gr_mat.h"
 
 int
-gr_mat_diagonalization_precomp(gr_vec_t D, gr_mat_t L, gr_mat_t R, const gr_mat_t A, const gr_vec_t eigenvalues, const gr_vec_t mult, gr_ctx_t ctx)
+gr_mat_diagonalization_precomp(gr_vec_t D, gr_mat_t L, gr_mat_t R, const gr_mat_t A, const gr_vec_t eigenvalues, const fmpz_vec_t mult, gr_ctx_t ctx)
 {
     int status = GR_SUCCESS;
     gr_mat_t AIe, b;
@@ -100,15 +101,14 @@ int
 gr_mat_diagonalization_generic(gr_vec_t D, gr_mat_t L, gr_mat_t R, const gr_mat_t A, int flags, gr_ctx_t ctx)
 {
     int status;
-    gr_ctx_t ZZ;
-    gr_vec_t eigenvalues, mult;
+    gr_vec_t eigenvalues;
+    fmpz_vec_t mult;
 
     if (gr_mat_is_square(A, ctx) != T_TRUE)
         return GR_DOMAIN;
 
-    gr_ctx_init_fmpz(ZZ);
     gr_vec_init(eigenvalues, 0, ctx);
-    gr_vec_init(mult, 0, ZZ);
+    fmpz_vec_init(mult, 0);
 
     if (gr_mat_eigenvalues(eigenvalues, mult, A, flags, ctx) == GR_SUCCESS)
     {
@@ -120,8 +120,7 @@ gr_mat_diagonalization_generic(gr_vec_t D, gr_mat_t L, gr_mat_t R, const gr_mat_
     }
 
     gr_vec_clear(eigenvalues, ctx);
-    gr_vec_clear(mult, ZZ);
-    gr_ctx_clear(ZZ);
+    fmpz_vec_clear(mult);
 
     return status;
 }

--- a/src/gr_mat/eigenvalues.c
+++ b/src/gr_mat/eigenvalues.c
@@ -13,7 +13,7 @@
 #include "gr_poly.h"
 
 int
-gr_mat_eigenvalues(gr_vec_t lambda, gr_vec_t mult, const gr_mat_t mat, int flags, gr_ctx_t ctx)
+gr_mat_eigenvalues(gr_vec_t lambda, fmpz_vec_t mult, const gr_mat_t mat, int flags, gr_ctx_t ctx)
 {
     int status;
     gr_poly_t cp;
@@ -26,7 +26,7 @@ gr_mat_eigenvalues(gr_vec_t lambda, gr_vec_t mult, const gr_mat_t mat, int flags
 }
 
 int
-gr_mat_eigenvalues_other(gr_vec_t lambda, gr_vec_t mult, const gr_mat_t mat, gr_ctx_t mat_ctx, int flags, gr_ctx_t ctx)
+gr_mat_eigenvalues_other(gr_vec_t lambda, fmpz_vec_t mult, const gr_mat_t mat, gr_ctx_t mat_ctx, int flags, gr_ctx_t ctx)
 {
     int status;
     gr_poly_t cp;

--- a/src/gr_mat/jordan_blocks.c
+++ b/src/gr_mat/jordan_blocks.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
 #include "gr_vec.h"
 #include "gr_mat.h"
 
@@ -64,8 +65,7 @@ gr_mat_jordan_blocks(gr_vec_t lambda, slong * num_blocks, slong * block_lambda, 
     fmpz * exp;
     slong exp_i;
     int status = GR_SUCCESS;
-    gr_ctx_t ZZ;
-    gr_vec_t mult;
+    fmpz_vec_t mult;
 
     n = gr_mat_nrows(A, ctx);
 
@@ -78,8 +78,7 @@ gr_mat_jordan_blocks(gr_vec_t lambda, slong * num_blocks, slong * block_lambda, 
     ranks = flint_malloc(sizeof(slong) * (n + 1));
     diagram = flint_malloc(sizeof(slong) * n);
 
-    gr_ctx_init_fmpz(ZZ);
-    gr_vec_init(mult, 0, ZZ);
+    fmpz_vec_init(mult, 0);
 
     status |= gr_mat_eigenvalues(lambda, mult, A, 0, ctx);
 
@@ -157,8 +156,7 @@ gr_mat_jordan_blocks(gr_vec_t lambda, slong * num_blocks, slong * block_lambda, 
         }
     }
 
-    gr_vec_clear(mult, ZZ);
-    gr_ctx_clear(ZZ);
+    fmpz_vec_clear(mult);
 
     flint_free(ranks);
     flint_free(diagram);

--- a/src/gr_poly.h
+++ b/src/gr_poly.h
@@ -68,6 +68,35 @@ void gr_poly_fit_length(gr_poly_t poly, slong len, gr_ctx_t ctx);
 void _gr_poly_set_length(gr_poly_t poly, slong len, gr_ctx_t ctx);
 void _gr_poly_normalise(gr_poly_t poly, gr_ctx_t ctx);
 
+/* Vector of gr_poly objects (gr_poly_vec_t).
+   The ctx argument refers to the coefficient ring of the polynomials. */
+ 
+void gr_poly_vec_init(gr_poly_vec_t vec, slong len, gr_ctx_t ctx);
+void gr_poly_vec_clear(gr_poly_vec_t vec, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_poly_vec_set(gr_poly_vec_t res, const gr_poly_vec_t src, gr_ctx_t ctx);
+void gr_poly_vec_fit_length(gr_poly_vec_t vec, slong len, gr_ctx_t ctx);
+void gr_poly_vec_set_length(gr_poly_vec_t vec, slong len, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_poly_vec_append(gr_poly_vec_t vec, const gr_poly_t f, gr_ctx_t ctx);
+ 
+GR_POLY_INLINE slong
+gr_poly_vec_length(const gr_poly_vec_t vec, gr_ctx_t FLINT_UNUSED(ctx))
+{
+    return vec->length;
+}
+ 
+GR_POLY_INLINE gr_poly_struct *
+gr_poly_vec_entry_ptr(gr_poly_vec_t vec, slong i, gr_ctx_t FLINT_UNUSED(ctx))
+{
+    return vec->entries + i;
+}
+ 
+GR_POLY_INLINE const gr_poly_struct *
+gr_poly_vec_entry_srcptr(const gr_poly_vec_t vec, slong i, gr_ctx_t FLINT_UNUSED(ctx))
+{
+    return vec->entries + i;
+}
+
+
 WARN_UNUSED_RESULT int gr_poly_set(gr_poly_t res, const gr_poly_t src, gr_ctx_t ctx);
 
 WARN_UNUSED_RESULT int _gr_poly_reverse(gr_ptr res, gr_srcptr poly, slong len, slong n, gr_ctx_t ctx);
@@ -522,7 +551,7 @@ WARN_UNUSED_RESULT int gr_poly_interpolate(gr_poly_t poly, const gr_vec_t xs, co
 
 /* Squarefree factorization */
 
-WARN_UNUSED_RESULT int gr_poly_factor_squarefree(gr_ptr c, gr_vec_t fac, gr_vec_t exp, const gr_poly_t F, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_poly_factor_squarefree(gr_ptr c, gr_poly_vec_t fac, fmpz_vec_t exp, const gr_poly_t F, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_squarefree_part(gr_poly_t res, const gr_poly_t poly, gr_ctx_t ctx);
 
 /* Shift factorization */
@@ -532,27 +561,27 @@ WARN_UNUSED_RESULT int gr_poly_leading_taylor_shift(gr_ptr shift, const gr_poly_
 truth_t gr_poly_shift_equivalent(fmpz_t shift, const gr_poly_t p, const gr_poly_t q, gr_ctx_t ctx);
 
 WARN_UNUSED_RESULT int gr_poly_dispersion_resultant(fmpz_t disp, gr_vec_t disp_set, const gr_poly_t f, const gr_poly_t g, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_dispersion_from_factors(fmpz_t disp, gr_vec_t disp_set, const gr_vec_t ffac, const gr_vec_t gfac, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_poly_dispersion_from_factors(fmpz_t disp, gr_vec_t disp_set, const gr_poly_vec_t ffac, const gr_poly_vec_t gfac, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_dispersion_factor(fmpz_t disp, gr_vec_t disp_set, const gr_poly_t f, const gr_poly_t g, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_dispersion(fmpz_t disp, gr_vec_t disp_set, const gr_poly_t f, const gr_poly_t g, gr_ctx_t ctx);
 
-WARN_UNUSED_RESULT int _gr_poly_shiftless_decomposition_from_factors(gr_vec_t slfac, gr_vec_t slshifts, gr_vec_t slmult, const gr_vec_t fac, const gr_vec_t mult, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_shiftless_decomposition_from_factors(gr_vec_t slfac, gr_vec_t slshifts, gr_vec_t slmult, const gr_vec_t fac, const gr_vec_t mult, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_shiftless_decomposition_factor(gr_ptr c, gr_vec_t slfac, gr_vec_t slshifts, gr_vec_t slmult, const gr_poly_t pol, gr_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_poly_shiftless_decomposition(gr_ptr c, gr_vec_t slfac, gr_vec_t slshifts, gr_vec_t slmult, const gr_poly_t pol, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int _gr_poly_shiftless_decomposition_from_factors(gr_poly_vec_t slfac, gr_vec_t slshifts, gr_vec_t slmult, const gr_poly_vec_t fac, const fmpz_vec_t mult, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_poly_shiftless_decomposition_from_factors(gr_poly_vec_t slfac, gr_vec_t slshifts, gr_vec_t slmult, const gr_poly_vec_t fac, const fmpz_vec_t mult, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_poly_shiftless_decomposition_factor(gr_ptr c, gr_poly_vec_t slfac, gr_vec_t slshifts, gr_vec_t slmult, const gr_poly_t pol, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_poly_shiftless_decomposition(gr_ptr c, gr_poly_vec_t slfac, gr_vec_t slshifts, gr_vec_t slmult, const gr_poly_t pol, gr_ctx_t ctx);
 
 /* Roots */
 
 WARN_UNUSED_RESULT int _gr_poly_refine_roots_aberth(gr_ptr w, gr_srcptr f, gr_srcptr f_prime, slong deg, gr_srcptr z, int progressive, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int _gr_poly_refine_roots_wdk(gr_ptr w, gr_srcptr f, slong deg, gr_srcptr z, int progressive, gr_ctx_t ctx);
 
-typedef int ((*gr_poly_roots_op)(gr_vec_t, gr_vec_t, const gr_poly_t, int, gr_ctx_ptr));
+typedef int ((*gr_poly_roots_op)(gr_vec_t, fmpz_vec_t, const gr_poly_t, int, gr_ctx_ptr));
 #define GR_POLY_ROOTS_OP(ctx, NAME) (((gr_poly_roots_op *) ctx->methods)[GR_METHOD_ ## NAME])
-GR_POLY_INLINE WARN_UNUSED_RESULT int gr_poly_roots(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, int flags, gr_ctx_t ctx) { return GR_POLY_ROOTS_OP(ctx, POLY_ROOTS)(roots, mult, poly, flags, ctx); }
+GR_POLY_INLINE WARN_UNUSED_RESULT int gr_poly_roots(gr_vec_t roots, fmpz_vec_t mult, const gr_poly_t poly, int flags, gr_ctx_t ctx) { return GR_POLY_ROOTS_OP(ctx, POLY_ROOTS)(roots, mult, poly, flags, ctx); }
 
-typedef int ((*gr_poly_roots_op_other)(gr_vec_t, gr_vec_t, const gr_poly_t, gr_ctx_ptr, int, gr_ctx_ptr));
+typedef int ((*gr_poly_roots_op_other)(gr_vec_t, fmpz_vec_t, const gr_poly_t, gr_ctx_ptr, int, gr_ctx_ptr));
 #define GR_POLY_ROOTS_OP_OTHER(ctx, NAME) (((gr_poly_roots_op_other *) ctx->methods)[GR_METHOD_ ## NAME])
-GR_POLY_INLINE WARN_UNUSED_RESULT int gr_poly_roots_other(gr_vec_t roots, gr_vec_t mult, const gr_poly_t poly, gr_ctx_t poly_ctx, int flags, gr_ctx_t ctx) { return GR_POLY_ROOTS_OP_OTHER(ctx, POLY_ROOTS_OTHER)(roots, mult, poly, poly_ctx, flags, ctx); }
+GR_POLY_INLINE WARN_UNUSED_RESULT int gr_poly_roots_other(gr_vec_t roots, fmpz_vec_t mult, const gr_poly_t poly, gr_ctx_t poly_ctx, int flags, gr_ctx_t ctx) { return GR_POLY_ROOTS_OP_OTHER(ctx, POLY_ROOTS_OTHER)(roots, mult, poly, poly_ctx, flags, ctx); }
 
 WARN_UNUSED_RESULT int _gr_poly_asin_series(gr_ptr res, gr_srcptr f, slong flen, slong len, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_asin_series(gr_poly_t res, const gr_poly_t f, slong len, gr_ctx_t ctx);

--- a/src/gr_poly/dispersion.c
+++ b/src/gr_poly/dispersion.c
@@ -25,14 +25,15 @@ gr_poly_dispersion_resultant(fmpz_t disp, gr_vec_t disp_set,
 {
     gr_ctx_t Pol_a, ZZ;
     gr_poly_t a, fa, ga, res;
-    gr_vec_t roots, mult;
+    gr_vec_t roots;
+    fmpz_vec_t mult;
 
     truth_t is_zero = truth_and(gr_poly_is_zero(f, ctx),
 				gr_poly_is_zero(g, ctx));
     if (is_zero == T_TRUE)
-	return GR_DOMAIN;
+        return GR_DOMAIN;
     else if (is_zero == T_UNKNOWN)
-	return GR_UNABLE;
+        return GR_UNABLE;
 
     gr_ctx_init_gr_poly(Pol_a, ctx);
     gr_ctx_init_fmpz(ZZ);
@@ -43,7 +44,7 @@ gr_poly_dispersion_resultant(fmpz_t disp, gr_vec_t disp_set,
     gr_poly_init(res, ZZ);
 
     gr_vec_init(roots, 0, ZZ);
-    gr_vec_init(mult, 0, ZZ);
+    fmpz_vec_init(mult, 0);
 
     int status = GR_SUCCESS;
 
@@ -59,23 +60,24 @@ gr_poly_dispersion_resultant(fmpz_t disp, gr_vec_t disp_set,
     status |= gr_poly_roots_other(roots, mult, res, ctx, 0, ZZ);
 
     if (disp_set != NULL)
-	gr_vec_set_length(disp_set, 0, ZZ);
+        gr_vec_set_length(disp_set, 0, ZZ);
 
     for (slong i = 0; i < roots->length; i++)
     {
-	gr_srcptr rt = gr_vec_entry_srcptr(roots, i, ZZ);
-	if (fmpz_sgn(rt) >= 0) {
-	    if (disp_set != NULL)
-		status |= gr_vec_append(disp_set, rt, ZZ);
-	    if (disp != NULL && fmpz_cmp(rt, disp) >= 0)
-		fmpz_swap(disp, (fmpz *) rt);
-	}
+        gr_srcptr rt = gr_vec_entry_srcptr(roots, i, ZZ);
+        if (fmpz_sgn(rt) >= 0)
+        {
+            if (disp_set != NULL)
+                status |= gr_vec_append(disp_set, rt, ZZ);
+            if (disp != NULL && fmpz_cmp(rt, disp) >= 0)
+                fmpz_swap(disp, (fmpz *) rt);
+        }
     }
 
     if (disp_set != NULL)
-	_fmpz_vec_sort(disp_set->entries, disp_set->length);
+        _fmpz_vec_sort(disp_set->entries, disp_set->length);
 
-    gr_vec_clear(mult, ZZ);
+    fmpz_vec_clear(mult);
     gr_vec_clear(roots, ZZ);
 
     gr_poly_clear(res, ctx);
@@ -91,7 +93,7 @@ gr_poly_dispersion_resultant(fmpz_t disp, gr_vec_t disp_set,
 
 int
 gr_poly_dispersion_from_factors(fmpz_t disp, gr_vec_t disp_set,
-			   const gr_vec_t ffac, const gr_vec_t gfac,
+			   const gr_poly_vec_t ffac, const gr_poly_vec_t gfac,
 			   gr_ctx_t ctx)
 {
     gr_ctx_t ZZ, pctx;
@@ -100,20 +102,20 @@ gr_poly_dispersion_from_factors(fmpz_t disp, gr_vec_t disp_set,
     gr_poly_t pshift;
 
     if (gr_ctx_is_unique_factorization_domain(ctx) != T_TRUE)
-	return GR_UNABLE;
+        return GR_UNABLE;
 
     /* todo: generalize to positive characteristic? (cf. Gerhard et al.) */
     if (gr_ctx_is_finite_characteristic(ctx) != T_FALSE)
-	return GR_UNABLE;
+        return GR_UNABLE;
 
     gr_ctx_init_fmpz(ZZ);
 
     if (disp_set != NULL)
-	gr_vec_set_length(disp_set, 0, ZZ);
+        gr_vec_set_length(disp_set, 0, ZZ);
 
     /* We assume that f and g are nonzero, so no factors means constant */
     if (ffac->length == 0 || gfac->length == 0)
-	return GR_SUCCESS;
+        return GR_SUCCESS;
 
     gr_ctx_init_gr_poly(pctx, ctx);
     GR_TMP_INIT3(a, b, _alpha, ctx);
@@ -124,66 +126,67 @@ gr_poly_dispersion_from_factors(fmpz_t disp, gr_vec_t disp_set,
 
     if (ffac == gfac)
     {
-	if (disp_set != NULL)
-	    status |= gr_vec_append(disp_set, alpha, ZZ);
-	if (disp != NULL)
-	    fmpz_zero(disp);
+        if (disp_set != NULL)
+            status |= gr_vec_append(disp_set, alpha, ZZ);
+        if (disp != NULL)
+            fmpz_zero(disp);
     }
 
     for (slong i = 0; i < ffac->length; i++)
     {
-	const gr_poly_struct *p = gr_vec_entry_srcptr(ffac, i, pctx);
+        const gr_poly_struct *p = gr_poly_vec_entry_srcptr(ffac, i, ctx);
 
-	slong j0 = (ffac == gfac) ? i + 1 : 0;
-	for (slong j = j0; j < gfac->length; j++)
-	{
-	    const gr_poly_struct *q = gr_vec_entry_srcptr(gfac, j, pctx);
+        slong j0 = (ffac == gfac) ? i + 1 : 0;
 
-	    int status1 = GR_SUCCESS;
+        for (slong j = j0; j < gfac->length; j++)
+        {
+            const gr_poly_struct *q = gr_poly_vec_entry_srcptr(gfac, j, ctx);
 
-	    status1 |= gr_poly_leading_taylor_shift(_alpha, p, q, ctx);
-	    if (status1 == GR_DOMAIN)
-		continue;
-	    status1 |= gr_get_fmpz(alpha, _alpha, ctx);
-	    if (status1 == GR_DOMAIN)
-		continue;
-	    status |= status1;
+            int status1 = GR_SUCCESS;
 
-	    if (status != GR_SUCCESS)
-		goto cleanup;
+            status1 |= gr_poly_leading_taylor_shift(_alpha, p, q, ctx);
+            if (status1 == GR_DOMAIN)
+                continue;
+            status1 |= gr_get_fmpz(alpha, _alpha, ctx);
+            if (status1 == GR_DOMAIN)
+                continue;
+            status |= status1;
 
-	    if (ffac == gfac)
-		fmpz_abs(alpha, alpha);
-	    else if (fmpz_sgn(alpha) < 0)
-		continue;
+            if (status != GR_SUCCESS)
+                goto cleanup;
 
-	    if (disp_set != NULL
-		? gr_vec_contains(disp_set, alpha, ZZ) == T_TRUE
-		: disp != NULL && fmpz_cmp(alpha, disp) <= 0)
-		    continue;
+            if (ffac == gfac)
+                fmpz_abs(alpha, alpha);
+            else if (fmpz_sgn(alpha) < 0)
+                continue;
 
-	    if (p->length > 2)  /* GR_SUCCESS => degree well-defined */
-	    {
-		status |= gr_poly_taylor_shift(pshift, p, _alpha, ctx);
-		int eq = gr_poly_equal(pshift, q, ctx);
-		if (eq == T_FALSE)
-		    continue;
-		else if (eq == T_UNKNOWN)
-		    status = GR_UNABLE;
-	    }
+            if (disp_set != NULL
+                ? gr_vec_contains(disp_set, alpha, ZZ) == T_TRUE
+                : disp != NULL && fmpz_cmp(alpha, disp) <= 0)
+                continue;
 
-	    if (status != GR_SUCCESS)
-		goto cleanup;
+            if (p->length > 2)  /* GR_SUCCESS => degree well-defined */
+            {
+                status |= gr_poly_taylor_shift(pshift, p, _alpha, ctx);
+                int eq = gr_poly_equal(pshift, q, ctx);
+                if (eq == T_FALSE)
+                    continue;
+                else if (eq == T_UNKNOWN)
+                    status = GR_UNABLE;
+            }
 
-	    if (disp_set != NULL)
-		status |= gr_vec_append(disp_set, alpha, ZZ);
-	    if (disp != NULL && fmpz_cmp(alpha, disp) > 0)
-		fmpz_swap(disp, alpha);
-	}
+            if (status != GR_SUCCESS)
+                goto cleanup;
+
+            if (disp_set != NULL)
+                status |= gr_vec_append(disp_set, alpha, ZZ);
+            if (disp != NULL && fmpz_cmp(alpha, disp) > 0)
+                fmpz_swap(disp, alpha);
+        }
     }
 
     if (disp_set != NULL)
-	_fmpz_vec_sort(disp_set->entries, disp_set->length);
+        _fmpz_vec_sort(disp_set->entries, disp_set->length);
 
 cleanup:
 
@@ -203,17 +206,18 @@ gr_poly_dispersion_factor(fmpz_t disp, gr_vec_t disp_set,
 {
     gr_ctx_t pctx, ZZ;
     gr_poly_t fsqf, gsqf;
-    gr_vec_t ffac, gfac, ignored;
+    gr_poly_vec_t ffac, gfac;
+    fmpz_vec_t ignored;
     gr_ptr c;
 
     switch (truth_and(gr_poly_is_zero(f, ctx), gr_poly_is_zero(g, ctx)))
     {
-	case T_TRUE:
-	    return GR_DOMAIN;
-	case T_UNKNOWN:
-	    return GR_UNABLE;
-	case T_FALSE:
-	    ;
+        case T_TRUE:
+            return GR_DOMAIN;
+        case T_UNKNOWN:
+            return GR_UNABLE;
+        case T_FALSE:
+            ;
     }
 
     int status = GR_SUCCESS;
@@ -222,33 +226,34 @@ gr_poly_dispersion_factor(fmpz_t disp, gr_vec_t disp_set,
     gr_ctx_init_gr_poly(pctx, ctx);
     gr_poly_init(fsqf, ctx);
     gr_poly_init(gsqf, ctx);
-    gr_vec_init(ffac, 0, pctx);
-    gr_vec_init(gfac, 0, pctx);
-    gr_vec_init(ignored, 0, ZZ);
+    gr_poly_vec_init(ffac, 0, ctx);
+    gr_poly_vec_init(gfac, 0, ctx);
+    fmpz_vec_init(ignored, 0);
     GR_TMP_INIT(c, pctx);
 
     if (gr_poly_squarefree_part(fsqf, f, ctx) != GR_SUCCESS)
-	status |= gr_poly_set(fsqf, f, ctx);
-    status |= gr_factor(c, ffac, ignored, f, 0, pctx);
+        status |= gr_poly_set(fsqf, f, ctx);
+
+    status |= gr_factor(c, (gr_vec_struct *) ffac, ignored, f, 0, pctx);
 
     if (f == g)
     {
-	status |= gr_poly_dispersion_from_factors(disp, disp_set, ffac, ffac, ctx);
+        status |= gr_poly_dispersion_from_factors(disp, disp_set, ffac, ffac, ctx);
     }
     else
     {
-	if (gr_poly_squarefree_part(gsqf, g, ctx) != GR_SUCCESS)
-	    status |= gr_poly_set(gsqf, g, ctx);
-	status |= gr_factor(c, gfac, ignored, g, 0, pctx);
-	status |= gr_poly_dispersion_from_factors(disp, disp_set, ffac, gfac, ctx);
+        if (gr_poly_squarefree_part(gsqf, g, ctx) != GR_SUCCESS)
+            status |= gr_poly_set(gsqf, g, ctx);
+        status |= gr_factor(c, (gr_vec_struct *) gfac, ignored, g, 0, pctx);
+        status |= gr_poly_dispersion_from_factors(disp, disp_set, ffac, gfac, ctx);
     }
 
     GR_TMP_CLEAR(c, pctx);
-    gr_vec_clear(gfac, pctx);
-    gr_vec_clear(ffac, pctx);
+    gr_poly_vec_clear(gfac, ctx);
+    gr_poly_vec_clear(ffac, ctx);
     gr_poly_clear(fsqf, ctx);
     gr_poly_clear(gsqf, ctx);
-    gr_vec_clear(ignored, ZZ);
+    fmpz_vec_clear(ignored);
     gr_ctx_clear(pctx);
     gr_ctx_clear(ZZ);
 

--- a/src/gr_poly/factor_squarefree.c
+++ b/src/gr_poly/factor_squarefree.c
@@ -16,6 +16,7 @@
 */
 
 #include "fmpz.h"
+#include "fmpz_vec.h"
 #include "gr_vec.h"
 #include "gr_poly.h"
 
@@ -61,15 +62,18 @@ _gr_poly_pth_root(gr_poly_t h, const gr_poly_t f, ulong p, gr_ctx_t ctx)
     }
 
 static int
-gr_poly_factor_squarefree_finite_field(gr_ptr c, gr_vec_t fac, gr_vec_t exp,
-    const gr_poly_t f, gr_ctx_t poly_ctx, gr_ctx_t fmpz_ctx, gr_ctx_t ctx)
+gr_poly_factor_squarefree_finite_field(gr_ptr c, gr_poly_vec_t fac, fmpz_vec_t exp,
+    const gr_poly_t f, gr_ctx_t ctx)
 {
     gr_poly_t d, t1, v, w, s;
-    fmpz_t e, p;
-    slong i;
+    gr_poly_vec_t sub_fac;
+    fmpz_vec_t sub_exp;
+    gr_ptr sub_c;
+    ulong p_ui;
+    fmpz_t p;
+    slong i, j;
     int status = GR_SUCCESS;
 
-    fmpz_init(e);
     fmpz_init(p);
     gr_poly_init(d, ctx);
     gr_poly_init(t1, ctx);
@@ -84,34 +88,26 @@ gr_poly_factor_squarefree_finite_field(gr_ptr c, gr_vec_t fac, gr_vec_t exp,
     /* Case 1: f' = 0 means f = h(x^p); extract h and recurse. */
     if (t1->length == 0)
     {
-        gr_vec_t sub_fac, sub_exp;
-        gr_ptr sub_c;
-        ulong p_ui;
-        slong j;
-
         status |= gr_ctx_fq_prime(p, ctx);
         if (status != GR_SUCCESS)
             goto cleanup;
         p_ui = fmpz_get_ui(p);
 
-        gr_vec_init(sub_fac, 0, poly_ctx);
-        gr_vec_init(sub_exp, 0, fmpz_ctx);
+        gr_poly_vec_init(sub_fac, 0, ctx);
+        fmpz_vec_init(sub_exp, 0);
         sub_c = gr_heap_init(ctx);
 
         status |= _gr_poly_pth_root(t1, f, p_ui, ctx);
-        status |= gr_poly_factor_squarefree_finite_field(sub_c, sub_fac, sub_exp, t1, poly_ctx, fmpz_ctx, ctx);
+        status |= gr_poly_factor_squarefree_finite_field(sub_c, sub_fac, sub_exp, t1, ctx);
 
         for (j = 0; j < sub_fac->length; j++)
         {
-            status |= gr_vec_append(fac,
-                gr_vec_entry_ptr(sub_fac, j, poly_ctx), poly_ctx);
-            fmpz_mul_ui(e,
-                (fmpz *) gr_vec_entry_ptr(sub_exp, j, fmpz_ctx), p_ui);
-            status |= gr_vec_append(exp, e, fmpz_ctx);
+            status |= gr_poly_vec_append(fac, sub_fac->entries + j, ctx);
+            fmpz_vec_append_ui(exp, p_ui * (ulong) (sub_exp->entries[j]));
         }
 
-        gr_vec_clear(sub_fac, poly_ctx);
-        gr_vec_clear(sub_exp, fmpz_ctx);
+        gr_poly_vec_clear(sub_fac, ctx);
+        fmpz_vec_clear(sub_exp);
         gr_heap_clear(sub_c, ctx);
 
         goto cleanup;
@@ -124,9 +120,8 @@ gr_poly_factor_squarefree_finite_field(gr_ptr c, gr_vec_t fac, gr_vec_t exp,
     if (d->length == 1)
     {
         /* f is already squarefree */
-        status |= gr_vec_append(fac, f, poly_ctx);
-        fmpz_one(e);
-        status |= gr_vec_append(exp, e, fmpz_ctx);
+        status |= gr_poly_vec_append(fac, f, ctx);
+        fmpz_vec_append_ui(exp, 1);
     }
     else
     {
@@ -144,9 +139,8 @@ gr_poly_factor_squarefree_finite_field(gr_ptr c, gr_vec_t fac, gr_vec_t exp,
             if (w->length > 1)
             {
                 status |= gr_poly_make_monic(w, w, ctx);
-                status |= gr_vec_append(fac, w, poly_ctx);
-                fmpz_set_ui(e, i);
-                status |= gr_vec_append(exp, e, fmpz_ctx);
+                status |= gr_poly_vec_append(fac, w, ctx);
+                fmpz_vec_append_ui(exp, i);
             }
 
             status |= gr_poly_divexact(d, d, s, ctx);
@@ -159,42 +153,33 @@ gr_poly_factor_squarefree_finite_field(gr_ptr c, gr_vec_t fac, gr_vec_t exp,
         /* d holds the inseparable part; recurse on d^(1/p). */
         if (d->length > 1)
         {
-            gr_vec_t sub_fac, sub_exp;
-            gr_ptr sub_c;
-            ulong p_ui;
-            slong j;
-
             status |= gr_ctx_fq_prime(p, ctx);
             if (status != GR_SUCCESS)
                 goto cleanup;
             p_ui = fmpz_get_ui(p);
 
-            gr_vec_init(sub_fac, 0, poly_ctx);
-            gr_vec_init(sub_exp, 0, fmpz_ctx);
+            gr_poly_vec_init(sub_fac, 0, ctx);
+            fmpz_vec_init(sub_exp, 0);
             sub_c = gr_heap_init(ctx);
 
             status |= gr_poly_make_monic(d, d, ctx);
             status |= _gr_poly_pth_root(t1, d, p_ui, ctx);
-            status |= gr_poly_factor_squarefree_finite_field(sub_c, sub_fac, sub_exp, t1, poly_ctx, fmpz_ctx, ctx);
+            status |= gr_poly_factor_squarefree_finite_field(sub_c, sub_fac, sub_exp, t1, ctx);
 
             for (j = 0; j < sub_fac->length; j++)
             {
-                status |= gr_vec_append(fac,
-                    gr_vec_entry_ptr(sub_fac, j, poly_ctx), poly_ctx);
-                fmpz_mul_ui(e,
-                    (fmpz *) gr_vec_entry_ptr(sub_exp, j, fmpz_ctx), p_ui);
-                status |= gr_vec_append(exp, e, fmpz_ctx);
+                status |= gr_poly_vec_append(fac, sub_fac->entries + j, ctx);
+                fmpz_vec_append_ui(exp, p_ui * (ulong) (sub_exp->entries[j]));
             }
 
-            gr_vec_clear(sub_fac, poly_ctx);
-            gr_vec_clear(sub_exp, fmpz_ctx);
+            gr_poly_vec_clear(sub_fac, ctx);
+            fmpz_vec_clear(sub_exp);
             gr_heap_clear(sub_c, ctx);
         }
     }
 
     for (i = 0; i < fac->length; i++)
-        status |= gr_poly_make_monic(gr_vec_entry_ptr(fac, i, poly_ctx),
-            gr_vec_entry_srcptr(fac, i, poly_ctx), ctx);
+        status |= gr_poly_make_monic(fac->entries + i, fac->entries + i, ctx);
 
 cleanup:
     gr_poly_clear(d, ctx);
@@ -202,23 +187,20 @@ cleanup:
     gr_poly_clear(v, ctx);
     gr_poly_clear(w, ctx);
     gr_poly_clear(s, ctx);
-    fmpz_clear(e);
     fmpz_clear(p);
 
     return status;
 }
 
 static int
-gr_poly_factor_squarefree_ufd_char_0(gr_ptr c, gr_vec_t fac, gr_vec_t exp,
-    const gr_poly_t F, gr_ctx_t poly_ctx, gr_ctx_t fmpz_ctx, truth_t is_field, gr_ctx_t ctx)
+gr_poly_factor_squarefree_ufd_char_0(gr_ptr c, gr_poly_vec_t fac, fmpz_vec_t exp,
+    const gr_poly_t F, truth_t is_field, gr_ctx_t ctx)
 {
     gr_poly_t f, d, t1, v, w, s;
     gr_ptr lc, lc_pow;
-    fmpz_t e;
     slong i, k;
     int status = GR_SUCCESS;
 
-    fmpz_init(e);
     gr_poly_init(f, ctx);
     gr_poly_init(d, ctx);
     gr_poly_init(t1, ctx);
@@ -248,9 +230,8 @@ gr_poly_factor_squarefree_ufd_char_0(gr_ptr c, gr_vec_t fac, gr_vec_t exp,
 
     if (d->length == 1)
     {
-        status |= gr_vec_append(fac, f, poly_ctx);
-        fmpz_one(e);
-        status |= gr_vec_append(exp, e, fmpz_ctx);
+        status |= gr_poly_vec_append(fac, f, ctx);
+        fmpz_vec_append_ui(exp, 1);
     }
     else
     {
@@ -269,9 +250,8 @@ gr_poly_factor_squarefree_ufd_char_0(gr_ptr c, gr_vec_t fac, gr_vec_t exp,
 
                 if (v->length > 1)
                 {
-                    status |= gr_vec_append(fac, v, poly_ctx);
-                    fmpz_set_ui(e, i);
-                    status |= gr_vec_append(exp, e, fmpz_ctx);
+                    status |= gr_poly_vec_append(fac, v, ctx);
+                    fmpz_vec_append_ui(exp, i);
                 }
 
                 break;
@@ -285,9 +265,8 @@ gr_poly_factor_squarefree_ufd_char_0(gr_ptr c, gr_vec_t fac, gr_vec_t exp,
 
             if (d->length > 1)
             {
-                status |= gr_vec_append(fac, d, poly_ctx);
-                fmpz_set_ui(e, i);
-                status |= gr_vec_append(exp, e, fmpz_ctx);
+                status |= gr_poly_vec_append(fac, d, ctx);
+                fmpz_vec_append_ui(exp, i);
             }
         }
     }
@@ -298,24 +277,21 @@ gr_poly_factor_squarefree_ufd_char_0(gr_ptr c, gr_vec_t fac, gr_vec_t exp,
         if (is_field == T_TRUE)
         {
             for (i = 0; i < fac->length; i++)
-                status |= gr_poly_make_monic(gr_vec_entry_ptr(fac, i, poly_ctx),
-                    gr_vec_entry_srcptr(fac, i, poly_ctx), ctx);
+                status |= gr_poly_make_monic(fac->entries + i, fac->entries + i, ctx);
         }
         else
         {
-            fmpz *expc = exp->entries;
             slong j;
 
             status |= gr_one(lc, ctx);
 
             for (j = 0; j < fac->length; j++)
             {
-                gr_poly_struct *fac_j = (gr_poly_struct *) gr_vec_entry_ptr(fac, j, poly_ctx);
-
+                gr_poly_struct *fac_j = fac->entries + j;
                 status |= gr_poly_canonical_associate(fac_j, NULL, fac_j, ctx);
                 CHECK_PROPER(fac_j)
                 gr_srcptr lc_j = gr_poly_coeff_srcptr(fac_j, fac_j->length - 1, ctx);
-                status |= gr_pow_ui(lc_pow, lc_j, (ulong) expc[j], ctx);
+                status |= gr_pow_ui(lc_pow, lc_j, (ulong) (exp->entries[j]), ctx);
                 status |= gr_mul(lc, lc, lc_pow, ctx);
             }
 
@@ -333,64 +309,37 @@ cleanup:
     gr_poly_clear(s, ctx);
     gr_heap_clear(lc, ctx);
     gr_heap_clear(lc_pow, ctx);
-    fmpz_clear(e);
 
     return status;
 }
 
 
 int
-gr_poly_factor_squarefree(gr_ptr c, gr_vec_t fac, gr_vec_t exp,
+gr_poly_factor_squarefree(gr_ptr c, gr_poly_vec_t fac, fmpz_vec_t exp,
     const gr_poly_t F, gr_ctx_t ctx)
 {
-    gr_ctx_t poly_ctx, fmpz_ctx;
-    int status = GR_SUCCESS;
     truth_t is_field, is_fin_char;
 
-    gr_ctx_init_gr_poly(poly_ctx, ctx);
-    gr_ctx_init_fmpz(fmpz_ctx);
-
-    gr_vec_set_length(fac, 0, poly_ctx);
-    gr_vec_set_length(exp, 0, fmpz_ctx);
+    gr_poly_vec_set_length(fac, 0, ctx);
+    fmpz_vec_set_length(exp, 0);
 
     if (F->length == 0)
-    {
-        status |= gr_zero(c, ctx);
-        goto done;
-    }
+        return gr_zero(c, ctx);
 
     if (gr_is_zero(gr_poly_coeff_srcptr(F, F->length - 1, ctx), ctx) != T_FALSE)
-    {
-        status = GR_UNABLE;
-        goto done;
-    }
+        return GR_UNABLE;
 
     if (F->length == 1)
-    {
-        status |= gr_set(c, F->coeffs, ctx);
-        goto done;
-    }
+        return gr_set(c, F->coeffs, ctx);
 
     is_field = gr_ctx_is_field(ctx);
     is_fin_char = gr_ctx_is_finite_characteristic(ctx);
 
     if (is_field == T_TRUE && is_fin_char == T_TRUE)
-    {
-        status |= gr_poly_factor_squarefree_finite_field(c, fac, exp, F, poly_ctx, fmpz_ctx, ctx);
-    }
+        return gr_poly_factor_squarefree_finite_field(c, fac, exp, F, ctx);
     else if (gr_ctx_is_unique_factorization_domain(ctx) == T_TRUE && is_fin_char == T_FALSE)
-    {
-        status |= gr_poly_factor_squarefree_ufd_char_0(c, fac, exp, F, poly_ctx, fmpz_ctx, is_field, ctx);
-    }
+        return gr_poly_factor_squarefree_ufd_char_0(c, fac, exp, F, is_field, ctx);
     else
-    {
-        status = GR_UNABLE;
-    }
-
-done:
-    gr_ctx_clear(poly_ctx);
-    gr_ctx_clear(fmpz_ctx);
-
-    return status;
+        return GR_UNABLE;
 }
 

--- a/src/gr_poly/shiftless_decomposition.c
+++ b/src/gr_poly/shiftless_decomposition.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpz.h"
+#include "fmpz_vec.h"
 #include "gr.h"
 #include "gr_poly.h"
 #include "gr_vec.h"
@@ -29,8 +30,8 @@ cmp(const void * i, const void * j, void * data)
 
 int
 _gr_poly_shiftless_decomposition_from_factors(
-        gr_vec_t slfac, gr_vec_t slshifts, gr_vec_t slmult,
-        const gr_vec_t fac, const gr_vec_t mult,
+        gr_poly_vec_t slfac, gr_vec_t slshifts, gr_vec_t slmult,
+        const gr_poly_vec_t fac, const fmpz_vec_t mult,
         gr_ctx_t ctx)
 {
     gr_ctx_t pctx, ZZ, ZZvec;
@@ -53,13 +54,13 @@ _gr_poly_shiftless_decomposition_from_factors(
 
     for (slong i = 0; i < fac->length; i++)
     {
-        const gr_poly_struct * f = gr_vec_entry_srcptr(fac, i, pctx);
-        const fmpz * m = gr_vec_entry_srcptr(mult, i, ZZ);
+        const gr_poly_struct * f = gr_poly_vec_entry_srcptr(fac, i, ctx);
+        const fmpz * m = fmpz_vec_entry_srcptr(mult, i);
         slong j = 0;
 
         for (; j < slfac->length; j++)
         {
-            const gr_poly_struct * sl = gr_vec_entry_srcptr(slfac, j, pctx);
+            const gr_poly_struct * sl = gr_poly_vec_entry_srcptr(slfac, j, ctx);
 
             int equiv = gr_poly_shift_equivalent(shift, sl, f, ctx);
             if (equiv == T_TRUE)
@@ -73,7 +74,7 @@ _gr_poly_shiftless_decomposition_from_factors(
 
         if (j == slfac->length)
         {
-            status |= gr_vec_append(slfac, f, pctx);
+            status |= gr_poly_vec_append(slfac, f, ctx);
             gr_vec_fit_length(slshifts, ++slshifts->length, ZZvec);
             gr_vec_fit_length(slmult, ++slmult->length, ZZvec);
         }
@@ -87,7 +88,7 @@ _gr_poly_shiftless_decomposition_from_factors(
     for (slong j = 0; j < slfac->length; j++)
     {
 
-        gr_poly_struct * f = gr_vec_entry_ptr(slfac, j, pctx);
+        gr_poly_struct * f = gr_poly_vec_entry_ptr(slfac, j, ctx);
         gr_vec_struct * shifts = gr_vec_entry_ptr(slshifts, j, ZZvec);
         gr_vec_struct * shmult = gr_vec_entry_ptr(slmult, j, ZZvec);
 
@@ -122,34 +123,30 @@ cleanup:
 
 int
 gr_poly_shiftless_decomposition_from_factors(
-        gr_vec_t slfac, gr_vec_t slshifts, gr_vec_t slmult,
-        const gr_vec_t fac, const gr_vec_t mult,
+        gr_poly_vec_t slfac, gr_vec_t slshifts, gr_vec_t slmult,
+        const gr_poly_vec_t fac, const fmpz_vec_t mult,
         gr_ctx_t ctx)
 {
-    gr_ctx_t pctx;
-    gr_vec_t _slfac;
-
-    gr_ctx_init_gr_poly(pctx, ctx);
-    gr_vec_init(_slfac, 0, pctx);
+    gr_poly_vec_t _slfac;
+    gr_poly_vec_init(_slfac, 0, ctx);
 
     int status = _gr_poly_shiftless_decomposition_from_factors(
             _slfac, slshifts, slmult, fac, mult, ctx);
-    FLINT_SWAP(gr_vec_struct, *slfac, *_slfac);
+    FLINT_SWAP(gr_poly_vec_struct, *slfac, *_slfac);
 
-    gr_vec_clear(_slfac, pctx);
-    gr_ctx_clear(pctx);
+    gr_poly_vec_clear(_slfac, ctx);
 
     return status;
 }
 
 int
 gr_poly_shiftless_decomposition_factor(
-        gr_ptr c, gr_vec_t slfac, gr_vec_t slshifts, gr_vec_t slmult,
+        gr_ptr c, gr_poly_vec_t slfac, gr_vec_t slshifts, gr_vec_t slmult,
         const gr_poly_t pol,
         gr_ctx_t ctx)
 {
     gr_ctx_t pctx, ZZ;
-    gr_vec_t mult;
+    fmpz_vec_t mult;
     gr_poly_t polc;
 
     if (gr_poly_is_zero(pol, ctx) == T_TRUE)
@@ -159,11 +156,11 @@ gr_poly_shiftless_decomposition_factor(
     gr_ctx_init_gr_poly(pctx, ctx);
 
     gr_poly_init(polc, ctx);
-    gr_vec_init(mult, 0, ZZ);
+    fmpz_vec_init(mult, 0);
 
     int status = GR_SUCCESS;
 
-    status |= gr_factor(polc, slfac, mult, pol, 0, pctx);
+    status |= gr_factor(polc, (gr_vec_struct *) slfac, mult, pol, 0, pctx);
     if (status != GR_SUCCESS)
         goto cleanup;
 
@@ -175,7 +172,7 @@ gr_poly_shiftless_decomposition_factor(
 
 cleanup:
     gr_poly_clear(polc, ctx);
-    gr_vec_clear(mult, ZZ);
+    fmpz_vec_clear(mult);
 
     gr_ctx_clear(pctx);
     gr_ctx_clear(ZZ);
@@ -185,7 +182,7 @@ cleanup:
 
 int
 gr_poly_shiftless_decomposition(
-        gr_ptr c, gr_vec_t slfac, gr_vec_t slshifts, gr_vec_t slmult,
+        gr_ptr c, gr_poly_vec_t slfac, gr_vec_t slshifts, gr_vec_t slmult,
         const gr_poly_t pol,
         gr_ctx_t ctx)
 {

--- a/src/gr_poly/squarefree_part.c
+++ b/src/gr_poly/squarefree_part.c
@@ -9,7 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "fmpz.h"
+#include "fmpz_vec.h"
 #include "gr_vec.h"
 #include "gr_poly.h"
 
@@ -34,29 +34,27 @@ gr_poly_squarefree_part(gr_poly_t res, const gr_poly_t poly, gr_ctx_t ctx)
            the factorization algorithm and multiply the distinct factors
            together. */
         gr_ptr c;
-        gr_vec_t fac, exp;
-        gr_ctx_t poly_ctx, fmpz_ctx;
+        gr_poly_vec_t fac;
+        fmpz_vec_t exp;
         slong i;
 
-        gr_ctx_init_gr_poly(poly_ctx, ctx);
-        gr_ctx_init_fmpz(fmpz_ctx);
-        gr_vec_init(fac, 0, poly_ctx);
-        gr_vec_init(exp, 0, fmpz_ctx);
+        gr_poly_vec_init(fac, 0, ctx);
+        fmpz_vec_init(exp, 0);
         c = gr_heap_init(ctx);
 
         status |= gr_poly_factor_squarefree(c, fac, exp, poly, ctx);
 
         if (status == GR_SUCCESS)
         {
-            status |= _gr_vec_product(res, fac->entries, fac->length, poly_ctx);
+            status |= gr_poly_one(res, ctx);
+            for (i = 0; i < fac->length; i++)
+                status |= gr_poly_mul(res, res, fac->entries + i, ctx);
             status |= gr_poly_canonical_associate(res, NULL, res, ctx);
         }
 
         gr_heap_clear(c, ctx);
-        gr_vec_clear(fac, poly_ctx);
-        gr_vec_clear(exp, fmpz_ctx);
-        gr_ctx_clear(poly_ctx);
-        gr_ctx_clear(fmpz_ctx);
+        gr_poly_vec_clear(fac, ctx);
+        fmpz_vec_clear(exp);
 
         return status;
     }

--- a/src/gr_poly/test/t-factor_squarefree.c
+++ b/src/gr_poly/test/t-factor_squarefree.c
@@ -11,6 +11,7 @@
 
 #include "test_helpers.h"
 #include "ulong_extras.h"
+#include "fmpz_vec.h"
 #include "gr_vec.h"
 #include "gr_poly.h"
 
@@ -25,8 +26,8 @@ TEST_FUNCTION_START(gr_poly_factor_squarefree, state)
         gr_ctx_t ctx;
         gr_poly_t A, B, P, Q, G1, G2, G3;
         gr_ptr c;
-        gr_vec_t fac, exp;
-        gr_ctx_t poly_ctx, fmpz_ctx;
+        gr_poly_vec_t fac;
+        fmpz_vec_t exp;
         ulong e, emax, maxexp;
         fmpz *expc;
         slong i, j, exp_bound, factor_len_bound, factor_bound;
@@ -60,9 +61,6 @@ TEST_FUNCTION_START(gr_poly_factor_squarefree, state)
                         ctx->which_ring == GR_CTX_FQ_NMOD ||
                         ctx->which_ring == GR_CTX_FQ_ZECH);
 
-        gr_ctx_init_gr_poly(poly_ctx, ctx);
-        gr_ctx_init_fmpz(fmpz_ctx);
-
         gr_poly_init(A, ctx);
         gr_poly_init(B, ctx);
         gr_poly_init(G1, ctx);
@@ -71,8 +69,8 @@ TEST_FUNCTION_START(gr_poly_factor_squarefree, state)
         gr_poly_init(P, ctx);
         gr_poly_init(Q, ctx);
 
-        gr_vec_init(fac, 0, poly_ctx);
-        gr_vec_init(exp, 0, fmpz_ctx);
+        gr_poly_vec_init(fac, 0, ctx);
+        fmpz_vec_init(exp, 0);
 
         c = gr_heap_init(ctx);
 
@@ -138,16 +136,16 @@ TEST_FUNCTION_START(gr_poly_factor_squarefree, state)
 
             for (i = 0; i < fac->length; i++)
             {
-                status1 |= gr_poly_derivative(Q, gr_vec_entry_ptr(fac, i, poly_ctx), ctx);
-                status1 |= gr_poly_gcd(Q, Q, gr_vec_entry_ptr(fac, i, poly_ctx), ctx);
+                status1 |= gr_poly_derivative(Q, fac->entries + i, ctx);
+                status1 |= gr_poly_gcd(Q, Q, fac->entries + i, ctx);
 
                 if (status1 == GR_SUCCESS && gr_poly_is_scalar(Q, ctx) == T_FALSE)
                 {
                     flint_printf("FAIL (factor not squarefree)\n\n");
                     gr_ctx_println(ctx);
                     flint_printf("emax = %wd\n\n", emax);
-                    flint_printf("fac = %{gr*}\n\n", fac->entries, fac->length, poly_ctx);
-                    flint_printf("exp = %{gr*}\n\n", exp->entries, exp->length, fmpz_ctx);
+                    flint_printf("fac = %{gr_poly*}\n\n", fac->entries, fac->length, ctx);
+                    flint_printf("exp = %{fmpz*}\n\n", exp->entries, exp->length);
                     flint_printf("c = %{gr}\n\n", c, ctx);
                     flint_printf("P = "); gr_poly_print(P, ctx); flint_printf("\n");
                     flint_printf("Q = "); gr_poly_print(Q, ctx); flint_printf("\n");
@@ -163,8 +161,7 @@ TEST_FUNCTION_START(gr_poly_factor_squarefree, state)
             status |= gr_poly_one(Q, ctx);
             for (i = 0; i < fac->length; i++)
                 for (j = 0; j < expc[i]; j++)
-                    status |= gr_poly_mul(Q, Q,
-                        gr_vec_entry_ptr(fac, i, poly_ctx), ctx);
+                    status |= gr_poly_mul(Q, Q, fac->entries + i, ctx);
             status |= gr_poly_mul_scalar(Q, Q, c, ctx);
 
             maxexp = 0;
@@ -178,8 +175,8 @@ TEST_FUNCTION_START(gr_poly_factor_squarefree, state)
                 flint_printf("FAIL (product)\n\n");
                 gr_ctx_println(ctx);
                 flint_printf("emax = %wd\n\n", emax);
-                flint_printf("fac = %{gr*}\n\n", fac->entries, fac->length, poly_ctx);
-                flint_printf("exp = %{gr*}\n\n", exp->entries, exp->length, fmpz_ctx);
+                flint_printf("fac = %{gr_poly*}\n\n", fac->entries, fac->length, ctx);
+                flint_printf("exp = %{fmpz*}\n\n", exp->entries, exp->length);
                 flint_printf("c = %{gr}\n\n", c, ctx);
                 flint_printf("P = "); gr_poly_print(P, ctx); flint_printf("\n");
                 flint_printf("Q = "); gr_poly_print(Q, ctx); flint_printf("\n");
@@ -196,11 +193,9 @@ TEST_FUNCTION_START(gr_poly_factor_squarefree, state)
         gr_poly_clear(Q, ctx);
 
 cleanup:
-        gr_vec_clear(fac, poly_ctx);
-        gr_vec_clear(exp, fmpz_ctx);
+        gr_poly_vec_clear(fac, ctx);
+        fmpz_vec_clear(exp);
         gr_heap_clear(c, ctx);
-        gr_ctx_clear(poly_ctx);
-        gr_ctx_clear(fmpz_ctx);
         gr_ctx_clear(ctx);
     }
 

--- a/src/gr_poly/test/t-roots.c
+++ b/src/gr_poly/test/t-roots.c
@@ -12,6 +12,7 @@
 #include "test_helpers.h"
 #include "ulong_extras.h"
 #include "fmpz.h"
+#include "fmpz_vec.h"
 #include "gr_vec.h"
 #include "gr_poly.h"
 
@@ -22,18 +23,18 @@ TEST_FUNCTION_START(gr_poly_roots, state)
     for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
     {
         int status;
-        gr_ctx_t ctx, ZZ;
+        gr_ctx_t ctx;
         gr_poly_t f, g, h, q, r;
-        gr_vec_t roots, mult;
+        gr_vec_t roots;
+        fmpz_vec_t mult;
         slong i, j, expected_mult;
         int init_from_roots;
 
         gr_ctx_init_random(ctx, state);
-        gr_ctx_init_fmpz(ZZ);
 
         gr_poly_init(f, ctx);
         gr_vec_init(roots, 0, ctx);
-        gr_vec_init(mult, 0, ZZ);
+        fmpz_vec_init(mult, 0);
 
         status = GR_SUCCESS;
 
@@ -99,7 +100,7 @@ TEST_FUNCTION_START(gr_poly_roots, state)
                     status |= gr_poly_neg(h, h, ctx);
                     status |= gr_poly_set_coeff_si(h, 1, 1, ctx);
 
-                    for (j = 0; j < fmpz_get_si(gr_vec_entry_ptr(mult, i, ZZ)); j++)
+                    for (j = 0; j < fmpz_get_si(mult->entries + i); j++)
                         status |= gr_poly_mul(g, g, h, ctx);
                 }
 
@@ -150,10 +151,9 @@ TEST_FUNCTION_START(gr_poly_roots, state)
 
         gr_poly_clear(f, ctx);
         gr_vec_clear(roots, ctx);
-        gr_vec_clear(mult, ZZ);
+        fmpz_vec_clear(mult);
 
         gr_ctx_clear(ctx);
-        gr_ctx_clear(ZZ);
     }
 
     TEST_FUNCTION_END(state);

--- a/src/gr_poly/test/t-roots_other.c
+++ b/src/gr_poly/test/t-roots_other.c
@@ -12,6 +12,7 @@
 #include "test_helpers.h"
 #include "ulong_extras.h"
 #include "fmpz.h"
+#include "fmpz_vec.h"
 #include "gr_vec.h"
 #include "gr_poly.h"
 
@@ -22,9 +23,10 @@ TEST_FUNCTION_START(gr_poly_roots_other, state)
     for (iter = 0; iter < 10000; iter++)
     {
         int status;
-        gr_ctx_t ctx, ctx_other, ZZ;
+        gr_ctx_t ctx, ctx_other;
         gr_poly_t f, f_other, g, h, q, r;
-        gr_vec_t roots, mult;
+        gr_vec_t roots;
+        fmpz_vec_t mult;
         slong i, j;
 
         gr_ctx_init_random(ctx, state);
@@ -34,13 +36,11 @@ TEST_FUNCTION_START(gr_poly_roots_other, state)
         else
             gr_ctx_init_random(ctx_other, state);
 
-        gr_ctx_init_fmpz(ZZ);
-
         gr_poly_init(f, ctx);
         gr_poly_init(f_other, ctx_other);
 
         gr_vec_init(roots, 0, ctx);
-        gr_vec_init(mult, 0, ZZ);
+        fmpz_vec_init(mult, 0);
 
         status = GR_SUCCESS;
 
@@ -67,7 +67,7 @@ TEST_FUNCTION_START(gr_poly_roots_other, state)
                     status |= gr_poly_neg(h, h, ctx);
                     status |= gr_poly_set_coeff_si(h, 1, 1, ctx);
 
-                    for (j = 0; j < fmpz_get_si(gr_vec_entry_ptr(mult, i, ZZ)); j++)
+                    for (j = 0; j < fmpz_get_si(mult->entries + i); j++)
                         status |= gr_poly_mul(g, g, h, ctx);
                 }
 
@@ -91,11 +91,10 @@ TEST_FUNCTION_START(gr_poly_roots_other, state)
         gr_poly_clear(f, ctx);
         gr_poly_clear(f_other, ctx_other);
         gr_vec_clear(roots, ctx);
-        gr_vec_clear(mult, ZZ);
+        fmpz_vec_clear(mult);
 
         gr_ctx_clear(ctx);
         gr_ctx_clear(ctx_other);
-        gr_ctx_clear(ZZ);
     }
 
     TEST_FUNCTION_END(state);

--- a/src/gr_poly/test/t-shiftless_decomposition.c
+++ b/src/gr_poly/test/t-shiftless_decomposition.c
@@ -84,7 +84,7 @@ TEST_FUNCTION_START(gr_poly_shiftless_decomposition, state)
         gr_vec_init(slshifts, n_randint(state, 4), ZZvec);
         gr_vec_init(slmult, n_randint(state, 4), ZZvec);
 
-        status |= gr_poly_shiftless_decomposition(c, slfac, slshifts, slmult, f, ctx);
+        status |= gr_poly_shiftless_decomposition(c, (gr_poly_vec_struct *) slfac, slshifts, slmult, f, ctx);
 
         if (status == GR_SUCCESS)
         {

--- a/src/gr_poly/test/t-squarefree_part.c
+++ b/src/gr_poly/test/t-squarefree_part.c
@@ -11,6 +11,7 @@
 
 #include "test_helpers.h"
 #include "ulong_extras.h"
+#include "fmpz_vec.h"
 #include "gr_vec.h"
 #include "gr_poly.h"
 
@@ -22,10 +23,11 @@ TEST_FUNCTION_START(gr_poly_squarefree_part, state)
 
     for (iter = 0; iter < 100 * flint_test_multiplier(); iter++)
     {
-        gr_ctx_t ctx, poly_ctx, fmpz_ctx;
+        gr_ctx_t ctx;
         gr_poly_t A, B, C;
         gr_ptr c;
-        gr_vec_t F, exp;
+        gr_poly_vec_t F;
+        fmpz_vec_t exp;
         slong i;
         int status = GR_SUCCESS;
 
@@ -37,15 +39,12 @@ TEST_FUNCTION_START(gr_poly_squarefree_part, state)
             gr_ctx_init_random_commutative_ring(ctx, state);
         }
 
-        gr_ctx_init_gr_poly(poly_ctx, ctx);
-        gr_ctx_init_fmpz(fmpz_ctx);
-
         gr_poly_init(A, ctx);
         gr_poly_init(B, ctx);
         gr_poly_init(C, ctx);
 
-        gr_vec_init(F, 0, poly_ctx);
-        gr_vec_init(exp, 0, fmpz_ctx);
+        gr_poly_vec_init(F, 0, ctx);
+        fmpz_vec_init(exp, 0);
 
         c = gr_heap_init(ctx);
 
@@ -61,7 +60,7 @@ TEST_FUNCTION_START(gr_poly_squarefree_part, state)
             {
                 status |= gr_poly_one(C, ctx);
                 for (i = 0; i < F->length; i++)
-                    status |= gr_poly_mul(C, C, gr_vec_entry_ptr(F, i, poly_ctx), ctx);
+                    status |= gr_poly_mul(C, C, F->entries + i, ctx);
                 status |= gr_poly_canonical_associate(C, NULL, C, ctx);
 
                 if (status == GR_SUCCESS && gr_poly_equal(B, C, ctx) == T_FALSE)
@@ -80,13 +79,10 @@ TEST_FUNCTION_START(gr_poly_squarefree_part, state)
         gr_poly_clear(B, ctx);
         gr_poly_clear(C, ctx);
 
-        gr_vec_clear(F, poly_ctx);
-        gr_vec_clear(exp, fmpz_ctx);
-
+        gr_poly_vec_clear(F, ctx);
+        fmpz_vec_clear(exp);
         gr_heap_clear(c, ctx);
 
-        gr_ctx_clear(poly_ctx);
-        gr_ctx_clear(fmpz_ctx);
         gr_ctx_clear(ctx);
     }
 

--- a/src/gr_poly/vec.c
+++ b/src/gr_poly/vec.c
@@ -1,0 +1,100 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "gr_poly.h"
+
+void
+gr_poly_vec_init(gr_poly_vec_t vec, slong len, gr_ctx_t ctx)
+{
+    slong i;
+
+    vec->length = vec->alloc = len;
+
+    if (len == 0)
+    {
+        vec->entries = NULL;
+    }
+    else
+    {
+        vec->entries = flint_malloc(len * sizeof(gr_poly_struct));
+        for (i = 0; i < len; i++)
+            gr_poly_init(vec->entries + i, ctx);
+    }
+}
+
+void
+gr_poly_vec_clear(gr_poly_vec_t vec, gr_ctx_t ctx)
+{
+    slong i;
+    for (i = 0; i < vec->alloc; i++)
+        gr_poly_clear(vec->entries + i, ctx);
+    flint_free(vec->entries);
+}
+
+int
+gr_poly_vec_set(gr_poly_vec_t res, const gr_poly_vec_t src, gr_ctx_t ctx)
+{
+    slong i;
+    int status = GR_SUCCESS;
+
+    if (res == src)
+        return GR_SUCCESS;
+
+    gr_poly_vec_set_length(res, src->length, ctx);
+    for (i = 0; i < src->length; i++)
+        status |= gr_poly_set(res->entries + i, src->entries + i, ctx);
+    return status;
+}
+
+void
+gr_poly_vec_fit_length(gr_poly_vec_t vec, slong len, gr_ctx_t ctx)
+{
+    slong i, alloc = vec->alloc;
+
+    if (len > alloc)
+    {
+        if (len < 2 * alloc)
+            len = 2 * alloc;
+
+        vec->entries = flint_realloc(vec->entries, len * sizeof(gr_poly_struct));
+        for (i = alloc; i < len; i++)
+            gr_poly_init(vec->entries + i, ctx);
+        vec->alloc = len;
+    }
+}
+
+void
+gr_poly_vec_set_length(gr_poly_vec_t vec, slong len, gr_ctx_t ctx)
+{
+    slong i;
+
+    if (vec->length > len)
+    {
+        for (i = len; i < vec->length; i++)
+            GR_IGNORE(gr_poly_zero(vec->entries + i, ctx));
+    }
+    else if (vec->length < len)
+    {
+        gr_poly_vec_fit_length(vec, len, ctx);
+        for (i = vec->length; i < len; i++)
+            GR_IGNORE(gr_poly_zero(vec->entries + i, ctx));
+    }
+
+    vec->length = len;
+}
+
+int
+gr_poly_vec_append(gr_poly_vec_t vec, const gr_poly_t f, gr_ctx_t ctx)
+{
+    gr_poly_vec_fit_length(vec, vec->length + 1, ctx);
+    vec->length++;
+    return gr_poly_set(vec->entries + vec->length - 1, f, ctx);
+}

--- a/src/gr_types.h
+++ b/src/gr_types.h
@@ -101,6 +101,16 @@ gr_poly_struct;
 
 typedef gr_poly_struct gr_poly_t[1];
 
+typedef struct
+{
+    gr_poly_struct * entries;
+    slong alloc;
+    slong length;
+}
+gr_poly_vec_struct;
+ 
+typedef gr_poly_vec_struct gr_poly_vec_t[1];
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Add memory-managed types

* ``fmpz_vec_t``
* ``gr_poly_vec_t``

with a minimal interface, and replace uses of ``gr_vec_t`` with these where appropriate in the generics code. For example,

```
int gr_poly_factor_squarefree(gr_ptr c, gr_vec_t fac, gr_vec_t exp,
    const gr_poly_t f, gr_ctx_t ctx)
```

becomes

```
int gr_poly_factor_squarefree(gr_ptr c, gr_poly_vec_t fac, fmpz_vec_t exp,
    const gr_poly_t f, gr_ctx_t ctx)
```

Pros:

* Function signatures are more descriptive
* Compiler can do more type checking
* Easier to access elements; one can do `vec->entries + i` directly and get a pointer of the correct type without having to go through wrapper functions or macros
* The user doesn't have to create GR context objects for `fmpz` and `gr_poly` rings to work with the respective vectors; the context `ctx` for the coefficient base ring suffices for `gr_poly_vec_t`, and `fmpz_vec_t` doesn't require a context object at all

Note that the new types are explicitly ABI-compatible with `gr_vec_t` so the necessary changes for downstream code should be minimal. The lazy solution to avoid compiler warnings/errors is to just insert a cast instead of actually replacing the types, though switching the code to the new types of course is cleaner.