### PR TITLE
Small rref improvements, add nmod_mat_lu_with_pivots

### DIFF
--- a/doc/source/nmod_mat.rst
+++ b/doc/source/nmod_mat.rst
@@ -590,7 +590,6 @@ Nonsingular square solving
     elements of `x` to undefined values.
 
 
-
 LU decomposition
 --------------------------------------------------------------------------------
 
@@ -622,7 +621,11 @@ LU decomposition
     The *recursive* version uses block recursive decomposition.
     The default function chooses an algorithm automatically.
 
+.. function:: slong nmod_mat_lu_with_pivots(slong * P, slong * pivots_nonpivots, nmod_mat_t A)
 
+    Like :func:`nmod_mat_lu` with ``rank_check`` 0, but additionally
+    writes to ``pivots_nonpivots`` the indices of the pivot columns in order,
+    followed by the indices of the nonpivot columns in order.
 
 Reduced row echelon form
 --------------------------------------------------------------------------------

--- a/src/fmpz_mat/rref_mul.c
+++ b/src/fmpz_mat/rref_mul.c
@@ -40,7 +40,7 @@ fmpz_mat_rref_mul(fmpz_mat_t R, fmpz_t den, const fmpz_mat_t A)
         nmod_mat_init(Amod, m, n, p);
         fmpz_mat_get_nmod_mat(Amod, A);
 
-        rank = _nmod_mat_rref(Amod, pivs, P);
+        rank = nmod_mat_lu_with_pivots(P, pivs, Amod);
 
         nmod_mat_clear(Amod);
 

--- a/src/gr_mat/rref_lu.c
+++ b/src/gr_mat/rref_lu.c
@@ -52,16 +52,6 @@ gr_mat_rref_lu(slong * res_rank, gr_mat_t R, const gr_mat_t A, gr_ctx_t ctx)
         for (j = 0; j < FLINT_MIN(i, rank); j++)
             status |= gr_zero(GR_MAT_ENTRY(R, i, j, sz), ctx);
 
-    /* We now reorder U to proper upper triangular form U | V
-       with U full-rank triangular, set V = U^(-1) V, and then
-       put the column back in the original order.
-
-       An improvement for some matrices would be to compress V by
-       discarding columns containing nothing but zeros. */
-
-    gr_mat_init(U, rank, rank, ctx);
-    gr_mat_init(V, rank, n - rank, ctx);
-
     pivots = flint_malloc(sizeof(slong) * rank);
     nonpivots = flint_malloc(sizeof(slong) * (n - rank));
 
@@ -100,20 +90,41 @@ gr_mat_rref_lu(slong * res_rank, gr_mat_t R, const gr_mat_t A, gr_ctx_t ctx)
         j++;
     }
 
-    for (i = 0; i < rank; i++)
-        for (j = 0; j <= i; j++)
-            status |= gr_set(GR_MAT_ENTRY(U, j, i, sz), GR_MAT_ENTRY(R, j, pivots[i], sz), ctx);
+    if (rank != n)
+    {
+        /* We now reorder U to proper upper triangular form U | V
+           with U full-rank triangular, set V = U^(-1) V, and then
+           put the column back in the original order.
 
-    for (i = 0; i < n - rank; i++)
+           An improvement for some matrices would be to compress V by
+           discarding columns containing nothing but zeros. */
+
+        gr_mat_init(U, rank, rank, ctx);
+        gr_mat_init(V, rank, n - rank, ctx);
+
         for (j = 0; j < rank; j++)
-            status |= gr_set(GR_MAT_ENTRY(V, j, i, sz), GR_MAT_ENTRY(R, j, nonpivots[i], sz), ctx);
+            for (i = j; i < rank; i++)
+                status |= gr_set(GR_MAT_ENTRY(U, j, i, sz), GR_MAT_ENTRY(R, j, pivots[i], sz), ctx);
 
-    status |= gr_mat_nonsingular_solve_triu(V, U, V, 0, ctx);
+        for (j = 0; j < rank; j++)
+            for (i = 0; i < n - rank; i++)
+                status |= gr_set(GR_MAT_ENTRY(V, j, i, sz), GR_MAT_ENTRY(R, j, nonpivots[i], sz), ctx);
+
+        status |= gr_mat_nonsingular_solve_triu(V, U, V, 0, ctx);
+
+        /* Write back the actual content */
+        for (j = 0; j < rank; j++)
+            for (i = 0; i < n - rank; i++)
+                status |= gr_set(GR_MAT_ENTRY(R, j, nonpivots[i], sz), GR_MAT_ENTRY(V, j, i, sz), ctx);
+
+        gr_mat_clear(U, ctx);
+        gr_mat_clear(V, ctx);
+    }
 
     /* Clear pivot columns */
-    for (i = 0; i < rank; i++)
+    for (j = 0; j < rank; j++)
     {
-        for (j = 0; j <= i; j++)
+        for (i = j; i < rank; i++)
         {
             if (i == j)
                 status |= gr_one(GR_MAT_ENTRY(R, j, pivots[i], sz), ctx);
@@ -122,14 +133,7 @@ gr_mat_rref_lu(slong * res_rank, gr_mat_t R, const gr_mat_t A, gr_ctx_t ctx)
         }
     }
 
-    /* Write back the actual content */
-    for (i = 0; i < n - rank; i++)
-        for (j = 0; j < rank; j++)
-            status |= gr_set(GR_MAT_ENTRY(R, j, nonpivots[i], sz), GR_MAT_ENTRY(V, j, i, sz), ctx);
-
 cleanup1:
-    gr_mat_clear(U, ctx);
-    gr_mat_clear(V, ctx);
 
     flint_free(pivots);
     flint_free(nonpivots);

--- a/src/nmod_mat.h
+++ b/src/nmod_mat.h
@@ -319,6 +319,8 @@ slong nmod_mat_lu_classical(slong * P, nmod_mat_t A, int rank_check);
 slong nmod_mat_lu_classical_delayed(slong * P, nmod_mat_t A, int rank_check);
 slong nmod_mat_lu_recursive(slong * P, nmod_mat_t A, int rank_check);
 
+slong nmod_mat_lu_with_pivots(slong * P, slong * pivots_nonpivots, nmod_mat_t A);
+
 /* Nonsingular solving */
 
 int nmod_mat_solve(nmod_mat_t X, const nmod_mat_t A, const nmod_mat_t B);

--- a/src/nmod_mat/lu_with_pivots.c
+++ b/src/nmod_mat/lu_with_pivots.c
@@ -1,0 +1,58 @@
+/*
+    Copyright (C) 2011, 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "nmod.h"
+#include "nmod_vec.h"
+#include "nmod_mat.h"
+
+slong
+nmod_mat_lu_with_pivots(slong * P, slong * pivots_nonpivots, nmod_mat_t A)
+{
+    slong i, j, k, n, rank;
+    slong * pivots;
+    slong * nonpivots;
+
+    n = A->c;
+
+    rank = nmod_mat_lu(P, A, 0);
+
+    if (rank == 0)
+    {
+        for (i = 0; i < n; i++)
+            pivots_nonpivots[i] = i;
+        return rank;
+    }
+
+    pivots = pivots_nonpivots;
+    nonpivots = pivots_nonpivots + rank;
+
+    for (i = j = k = 0; i < rank; i++)
+    {
+        while (nmod_mat_entry(A, i, j) == UWORD(0))
+        {
+            nonpivots[k] = j;
+            k++;
+            j++;
+        }
+        pivots[i] = j;
+        j++;
+    }
+
+    while (k < n - rank)
+    {
+        nonpivots[k] = j;
+        k++;
+        j++;
+    }
+
+    return rank;
+}
+

--- a/src/nmod_mat/rref.c
+++ b/src/nmod_mat/rref.c
@@ -16,7 +16,7 @@
 slong
 _nmod_mat_rref(nmod_mat_t A, slong * pivots_nonpivots, slong * P)
 {
-    slong i, j, k, n, rank;
+    slong i, j, n, rank;
     slong * pivots;
     slong * nonpivots;
 
@@ -24,81 +24,62 @@ _nmod_mat_rref(nmod_mat_t A, slong * pivots_nonpivots, slong * P)
 
     n = A->c;
 
-    rank = nmod_mat_lu(P, A, 0);
+    rank = nmod_mat_lu_with_pivots(P, pivots_nonpivots, A);
 
     if (rank == 0)
-    {
-        for (i = 0; i < n; i++)
-            pivots_nonpivots[i] = i;
         return rank;
-    }
-
-    /* Clear L */
-    for (i = 0; i < A->r; i++)
-        for (j = 0; j < FLINT_MIN(i, rank); j++)
-            nmod_mat_entry(A, i, j) = UWORD(0);
-
-    /* We now reorder U to proper upper triangular form U | V
-       with U full-rank triangular, set V = U^(-1) V, and then
-       put the column back in the original order.
-
-       An improvement for some matrices would be to compress V by
-       discarding columns containing nothing but zeros. */
-
-    nmod_mat_init(U, rank, rank, A->mod.n);
-    nmod_mat_init(V, rank, n - rank, A->mod.n);
 
     pivots = pivots_nonpivots;
     nonpivots = pivots_nonpivots + rank;
 
-    for (i = j = k = 0; i < rank; i++)
-    {
-        while (nmod_mat_entry(A, i, j) == UWORD(0))
-        {
-            nonpivots[k] = j;
-            k++;
-            j++;
-        }
-        pivots[i] = j;
-        j++;
-    }
-    while (k < n - rank)
-    {
-        nonpivots[k] = j;
-        k++;
-        j++;
-    }
+    /* Clear L. */
+    for (i = 0; i < A->r; i++)
+        for (j = 0; j < FLINT_MIN(i, rank); j++)
+            nmod_mat_entry(A, i, j) = UWORD(0);
 
-    for (i = 0; i < rank; i++)
+    if (rank != n)
     {
-        for (j = 0; j <= i; j++)
-            nmod_mat_entry(U, j, i) = nmod_mat_entry(A, j, pivots[i]);
-    }
+        /* We now reorder U to proper upper triangular form U | V
+           with U full-rank triangular, set V = U^(-1) V, and then
+           put the column back in the original order.
+ 
+           An improvement for some matrices would be to compress V by
+           discarding columns containing nothing but zeros. */
 
-    for (i = 0; i < n - rank; i++)
-    {
+        nmod_mat_init(U, rank, rank, A->mod.n);
+        nmod_mat_init(V, rank, n - rank, A->mod.n);
+
         for (j = 0; j < rank; j++)
-            nmod_mat_entry(V, j, i) = nmod_mat_entry(A, j, nonpivots[i]);
-    }
+        {
+            for (i = j; i < rank; i++)
+                nmod_mat_entry(U, j, i) = nmod_mat_entry(A, j, pivots[i]);
+        }
 
-    nmod_mat_solve_triu(V, U, V, 0);
+        for (j = 0; j < rank; j++)
+        {
+            for (i = 0; i < n - rank; i++)
+                nmod_mat_entry(V, j, i) = nmod_mat_entry(A, j, nonpivots[i]);
+        }
+
+        nmod_mat_solve_triu(V, U, V, 0);
+
+        /* Write back the actual content */
+        for (j = 0; j < rank; j++)
+        {
+            for (i = 0; i < n - rank; i++)
+                nmod_mat_entry(A, j, nonpivots[i]) = nmod_mat_entry(V, j, i);
+        }
+
+        nmod_mat_clear(U);
+        nmod_mat_clear(V);
+    }
 
     /* Clear pivot columns */
-    for (i = 0; i < rank; i++)
+    for (j = 0; j < rank; j++)
     {
-        for (j = 0; j <= i; j++)
+        for (i = j; i < rank; i++)
             nmod_mat_entry(A, j, pivots[i]) = (i == j);
     }
-
-    /* Write back the actual content */
-    for (i = 0; i < n - rank; i++)
-    {
-        for (j = 0; j < rank; j++)
-            nmod_mat_entry(A, j, nonpivots[i]) = nmod_mat_entry(V, j, i);
-    }
-
-    nmod_mat_clear(U);
-    nmod_mat_clear(V);
 
     return rank;
 }
@@ -148,3 +129,4 @@ nmod_mat_rref(nmod_mat_t A)
 
     return rank;
 }
+


### PR DESCRIPTION
* Two small optimizations to `nmod_mat_rref`: early return when rank equals number of columns, and use cache-friendly loop order for postprocessing. The same changes are applied to `gr_mat_rref_lu` for consistency.

* Factor out public function `nmod_mat_lu_with_pivots`.

* Small optimization to `fmpz_mat_rref_mul`: we don't actually need the rref mod `p`, just the pivots, so call the aforementioned `nmod_mat_lu_with_pivots` instead of `nmod_mat_rref`.

Timings for `nmod_mat_rref`, 60-bit modulus, input is n x n with entries randrank(rank) + randops(2*n^2):

```
     n      rank         old          new    speedup
     8       2       6.24e-07     6.28e-07   0.994
     8       4       9.65e-07     9.76e-07   0.989
     8       7       1.19e-06     1.22e-06   0.975
     8       8       1.15e-06     7.61e-07   1.511
    16       4       2.33e-06     2.33e-06   1.000
    16       8       3.38e-06     3.38e-06   1.000
    16      15       3.65e-06     3.68e-06   0.992
    16      16       3.44e-06     2.65e-06   1.298
    32       8       1.06e-05     1.06e-05   1.000
    32      16       1.56e-05     1.56e-05   1.000
    32      31       1.48e-05     1.48e-05   1.000
    32      32       1.42e-05     1.24e-05   1.145
    64      16       5.91e-05      5.9e-05   1.002
    64      32       8.85e-05     8.85e-05   1.000
    64      63       8.08e-05     8.07e-05   1.001
    64      64       8.03e-05     7.45e-05   1.078
   128      32       0.000402     0.000401   1.002
   128      64       0.000597     0.000592   1.008
   128     127       0.000548     0.000536   1.022
   128     128       0.000548     0.000519   1.056
   256      64        0.00271      0.00267   1.015
   256     128        0.00413      0.00404   1.022
   256     255        0.00386      0.00372   1.038
   256     256        0.00385      0.00366   1.052
   512     128         0.0192       0.0188   1.021
   512     256         0.0297        0.029   1.024
   512     511         0.0277       0.0267   1.037
   512     512         0.0277       0.0263   1.053
  1024     256          0.132         0.13   1.015
  1024     512          0.203          0.2   1.015
  1024    1023          0.191        0.187   1.021
  1024    1024          0.191        0.185   1.032
```

Timings for `fmpz_mat_rref_mul`, n x n input, entries randrank(rank,bits=1) + randops(10*n):

```
     n      rank         old          new    speedup
     8       2       1.71e-06     1.44e-06   1.188
     8       4       2.48e-06     2.13e-06   1.164
     8       7       2.75e-06     2.45e-06   1.122
     8       8       8.34e-07     6.33e-07   1.318
    16       4       6.65e-06     5.95e-06   1.118
    16       8       9.03e-06     7.81e-06   1.156
    16      15       1.14e-05     1.05e-05   1.086
    16      16       2.72e-06     2.18e-06   1.248
    32       8       3.02e-05     2.72e-05   1.110
    32      16       6.43e-05     5.98e-05   1.075
    32      31        9.3e-05     9.13e-05   1.019
    32      32       1.06e-05     9.32e-06   1.137
    64      16       0.000214     0.000202   1.059
    64      32       0.000339     0.000317   1.069
    64      63       0.000473     0.000464   1.019
    64      64       4.57e-05     3.93e-05   1.163
   128      32        0.00152      0.00145   1.048
   128      64        0.00202      0.00187   1.080
   128     127        0.00276      0.00272   1.015
   128     128        0.00026     0.000217   1.198
   256      64         0.0103      0.01004   1.026
   256     128         0.0164       0.0156   1.051
   256     255         0.0185       0.0182   1.016
   256     256        0.00171      0.00149   1.148
   512     128          0.122        0.121   1.008
   512     256          0.306        0.295   1.037
   512     511          0.128        0.128   1.000
   512     512         0.0142       0.0114   1.246
  1024     256          1.522        1.522   1.000
  1024     512          2.841        2.893   0.982
  1024    1023          0.871         0.86   1.013
  1024    1024         0.0908       0.0842   1.078
```

Ditto, but matrix is n x 2n:

```
     n      rank         old          new    speedup
     8       2       3.23e-06     2.86e-06   1.129
     8       4       4.59e-06     3.96e-06   1.159
     8       7       5.94e-06        5e-06   1.188
     8       8       6.35e-06     5.27e-06   1.205
    16       4       1.39e-05     1.28e-05   1.086
    16       8       1.97e-05     1.72e-05   1.145
    16      15       3.03e-05     2.61e-05   1.161
    16      16       4.52e-05     4.08e-05   1.108
    32       8       7.44e-05     6.92e-05   1.075
    32      16       0.000131      0.00012   1.092
    32      31       0.000176     0.000158   1.114
    32      32       0.000174     0.000155   1.123
    64      16       0.000589     0.000563   1.046
    64      32       0.000816     0.000758   1.077
    64      63        0.00103     0.000948   1.086
    64      64        0.00111     0.000993   1.118
   128      32         0.0036      0.00346   1.040
   128      64        0.00438      0.00404   1.084
   128     127        0.00591      0.00529   1.117
   128     128        0.00611      0.00541   1.129
   256      64         0.0194       0.0185   1.049
   256     128         0.0248       0.0226   1.097
   256     255          0.035       0.0308   1.136
   256     256         0.0352       0.0308   1.143
   512     128          0.137        0.132   1.038
   512     256          0.161        0.148   1.088
   512     511          0.216        0.191   1.131
   512     512          0.222        0.195   1.138
  1024     256          0.973        0.936   1.040
  1024     512          1.102        1.013   1.088
  1024    1023          1.494        1.312   1.139
  1024    1024          1.481        1.287   1.151
```