### PR TITLE
Fast certification of singular matrices over Z and Q

### DIFF
--- a/doc/source/fmpz_mat.rst
+++ b/doc/source/fmpz_mat.rst
@@ -1158,18 +1158,44 @@ Row reduction
     and returns the rank of ``A``. Aliasing of ``A`` and ``B``
     is allowed.
 
-    The algorithm works by computing the reduced row echelon form of ``A``
-    modulo a prime `p` using ``nmod_mat_rref``. The pivot columns and rows
+    The algorithm works by computing an echelon form of ``A``
+    modulo a prime `p`. The pivot columns and rows
     of this matrix will then define a non-singular submatrix of ``A``,
     nonsingular solving and matrix multiplication can then be used to determine
     the reduced row echelon form of the whole of ``A``. This procedure is
-    described in [Stein2007]_.
+    described in [Stein2007]_. The certification
+    step itself is implemented by :func:`fmpz_mat_compressed_rref_given_mod_p_structure`.
 
 .. function:: int fmpz_mat_is_in_rref_with_rank(const fmpz_mat_t A, const fmpz_t den, slong rank)
 
     Checks that the matrix `A/den` is in reduced row echelon form of rank
     ``rank``, returns 1 if so and 0 otherwise.
 
+.. function:: int fmpz_mat_rref_upper_certify_lu_mod_p(fmpz_mat_t E, fmpz_t den, const fmpz_mat_t A, slong rank, const slong * P, const slong * pivs)
+
+    Given the echelon structure for the `m \times n` matrix *A* computed
+    modulo some prime `p`, attempt to compute a certified RREF of *A* over
+    `\mathbb{Z}`.
+
+    The user supplies the following data from an LU factorization as computed by
+    :func:`nmod_mat_lu_with_pivots` (or an equivalent procedure):
+    the mod-`p` *rank*, row permutations *P*, and an array *pivs*
+    containing the the *rank* pivot column positions followed by the `n - rank`
+    non-pivot column positions.
+    The output matrix *E* is *rank* by *n*, must be zero-initialized by the caller,
+    and must not be aliased with *A*.
+
+    Returns 1 if the rank is certified: *E* will then hold the top *rank* rows
+    of the RREF of *A* with common denominator *den*.
+
+    Returns 0 if the prime was unlucky (the mod-`p` rank is below the true rank,
+    or the remaining rows are not in the row span); the contents of *E* and *den*
+    are then unspecified and the caller should try another prime.
+
+.. function:: int fmpz_mat_rank_certify_lu_mod_p(const fmpz_mat_t A, slong rank, const slong * P, const slong * pivs)
+
+    As :func:`fmpz_mat_rref_upper_certify_lu_mod_p`, certifying the
+    rank without storing the echelon form.
 
 Strong echelon form and Howell form
 --------------------------------------------------------------------------------
@@ -1211,30 +1237,6 @@ Nullspace
     the pivot entries in `B` will generally differ from unity.
     `B` must be allocated with sufficient space to represent the result
     (at most `n \times n` where `n` is the number of columns of `A`).
-
-
-
-Echelon form
---------------------------------------------------------------------------------
-
-
-.. function:: slong fmpz_mat_rref_fraction_free(slong * perm, fmpz_mat_t B, fmpz_t den, const fmpz_mat_t A)
-
-    Computes an integer matrix ``B`` and an integer ``den`` such that
-    ``B / den`` is the unique row reduced echelon form (RREF) of ``A``
-    and returns the rank, i.e. the number of nonzero rows in ``B``.
-
-    Aliasing of ``B`` and ``A`` is allowed, with an in-place
-    computation being more efficient. The size of ``B`` must be
-    the same as that of ``A``.
-
-    The permutation order will be written to ``perm`` unless this
-    argument is ``NULL``. That is, row ``i`` of the output matrix will
-    correspond to row ``perm[i]`` of the input matrix.
-
-    The denominator will always be a divisor of the determinant of (some
-    submatrix of) `A`, but is not guaranteed to be minimal or canonical in
-    any other sense.
 
 
 Hermite normal form

--- a/src/fmpq_mat/solve_multi_mod.c
+++ b/src/fmpq_mat/solve_multi_mod.c
@@ -1,6 +1,6 @@
 /*
     Copyright (C) 2019 William Hart
-    Copyright (C) 2019 Fredrik Johansson
+    Copyright (C) 2019, 2026 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -11,6 +11,8 @@
 */
 
 #include "ulong_extras.h"
+#include "perm.h"
+#include "nmod_vec.h"
 #include "nmod_mat.h"
 #include "fmpz.h"
 #include "fmpz_vec.h"
@@ -23,11 +25,20 @@ static ulong fmpz_mat_find_good_prime_and_solve(nmod_mat_t Xmod,
         const fmpz_mat_t A, const fmpz_mat_t B, const fmpz_t det_bound)
 {
     ulong p;
-    fmpz_t tested;
+    slong i, n, rank, * pivs, * P;
+    fmpz_t tested, den;
+    nmod_mat_t PB;
+
+    n = A->r;   /* A is square (checked by the caller) */
+
+    pivs = (slong *) flint_malloc(n * sizeof(slong));
+    P = _perm_init(n);
+
+    fmpz_init(tested);
+    fmpz_init(den);
+    fmpz_one(tested);
 
     p = UWORD(1) << NMOD_MAT_OPTIMAL_MODULUS_BITS;
-    fmpz_init(tested);
-    fmpz_one(tested);
 
     while (1)
     {
@@ -37,17 +48,48 @@ static ulong fmpz_mat_find_good_prime_and_solve(nmod_mat_t Xmod,
         nmod_mat_set_mod(Bmod, p);
         fmpz_mat_get_nmod_mat(Amod, A);
         fmpz_mat_get_nmod_mat(Bmod, B);
-        if (nmod_mat_solve(Xmod, Amod, Bmod))
-            break;
+
+        rank = nmod_mat_lu_with_pivots(P, pivs, Amod);
+
+        if (rank == n)
+        {
+            /* full rank mod p: solve A X = B with the LU we just computed */
+            /* todo: could avoid copies if permutation is the identity */
+            nmod_mat_init(PB, B->r, B->c, p);
+
+            for (i = 0; i < n; i++)
+                _nmod_vec_set(nmod_mat_entry_ptr(PB, i, 0),
+                              nmod_mat_entry_ptr(Bmod, P[i], 0), Bmod->c);
+
+            nmod_mat_solve_tril(Xmod, Amod, PB, 1);
+            nmod_mat_solve_triu(Xmod, Amod, Xmod, 0);
+
+            nmod_mat_clear(PB);
+            break;   /* success: return p, with the solution mod p in Xmod */
+        }
+
+        /* enough primes to certify rank deficiency */
         fmpz_mul_ui(tested, tested, p);
         if (fmpz_cmp(tested, det_bound) > 0)
         {
             p = 0;
             break;
         }
-    }
+
+        /* rank-deficient mod p: try to certify that A is rank-deficient over
+           Z (hence singular), as in fmpz_mat_rref_mul */
+        if (fmpz_mat_rank_certify_lu_mod_p(A, rank, P, pivs))
+        {
+            p = 0;
+            break;
+        }
+     }
 
     fmpz_clear(tested);
+    fmpz_clear(den);
+    flint_free(pivs);
+    _perm_clear(P);
+
     return p;
 }
 
@@ -199,6 +241,7 @@ fmpq_mat_solve_fmpz_mat_multi_mod(fmpq_mat_t X,
     nmod_mat_init(Xmod, B->r, B->c, 1);
 
     p = fmpz_mat_find_good_prime_and_solve(Xmod, Amod, Bmod, A, B, D);
+
     if (p != 0)
         _fmpq_mat_solve_multi_mod(X, A, B, Xmod, Amod, Bmod, p, N, D);
 

--- a/src/fmpz_mat.h
+++ b/src/fmpz_mat.h
@@ -253,6 +253,10 @@ slong fmpz_mat_rref(fmpz_mat_t B, fmpz_t den, const fmpz_mat_t A);
 slong fmpz_mat_rref_fflu(fmpz_mat_t B, fmpz_t den, const fmpz_mat_t A);
 slong fmpz_mat_rref_mul(fmpz_mat_t B, fmpz_t den, const fmpz_mat_t A);
 
+int fmpz_mat_rref_upper_certify_lu_mod_p(fmpz_mat_t E, fmpz_t den, const fmpz_mat_t A, slong rank, const slong * P, const slong * pivs);
+
+int fmpz_mat_rank_certify_lu_mod_p(const fmpz_mat_t A, slong rank, const slong * P, const slong * pivs);
+
 int fmpz_mat_is_in_rref_with_rank(const fmpz_mat_t A, const fmpz_t den, slong rank);
 
 /* Modular Howell and strong echelon form ***********************************/

--- a/src/fmpz_mat/det_modular_given_divisor.c
+++ b/src/fmpz_mat/det_modular_given_divisor.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Fredrik Johansson
+    Copyright (C) 2011, 2026 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -10,6 +10,8 @@
 */
 
 #include "ulong_extras.h"
+#include "perm.h"
+#include "nmod.h"
 #include "nmod_mat.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
@@ -31,7 +33,6 @@ next_good_prime(const fmpz_t d, ulong p)
 
     return p;
 }
-
 
 void
 fmpz_mat_det_modular_given_divisor(fmpz_t det, const fmpz_mat_t A,
@@ -75,6 +76,13 @@ fmpz_mat_det_modular_given_divisor(fmpz_t det, const fmpz_mat_t A,
     p = UWORD(1) << NMOD_MAT_OPTIMAL_MODULUS_BITS;
 #endif
 
+    slong * P;
+    slong * pivs;
+    slong rank;
+
+    P = flint_malloc(n * sizeof(slong));
+    pivs = flint_malloc(n * sizeof(slong));
+
     /* Compute x = det(A) / d */
     while (fmpz_cmp(prod, bound) <= 0)
     {
@@ -83,7 +91,22 @@ fmpz_mat_det_modular_given_divisor(fmpz_t det, const fmpz_mat_t A,
         fmpz_mat_get_nmod_mat(Amod, A);
 
         /* Compute x = det(A) / d mod p */
-        xmod = _nmod_mat_det(Amod);
+        rank = nmod_mat_lu_with_pivots(P, pivs, Amod);
+
+        /* Attempt to certify zero determinant. May want to skip this
+           check if proved == 0. */
+        if (rank != n && fmpz_mat_rank_certify_lu_mod_p(A, rank, P, pivs))
+        {
+            fmpz_zero(x);
+            break;
+        }
+
+        xmod = 1;
+        for (slong i = 0; i < n; i++)
+            xmod = nmod_mul(xmod, nmod_mat_entry(Amod, i, i), Amod->mod);
+        if (_perm_parity(P, n) != 0)
+            xmod = nmod_neg(xmod, Amod->mod);
+
         xmod = n_mulmod2_preinv(xmod,
             n_invmod(fmpz_fdiv_ui(d, p), p), Amod->mod.n, Amod->mod.ninv);
 
@@ -103,6 +126,9 @@ fmpz_mat_det_modular_given_divisor(fmpz_t det, const fmpz_mat_t A,
         fmpz_mul_ui(prod, prod, p);
         fmpz_set(x, xnew);
     }
+
+    flint_free(P);
+    flint_free(pivs);
 
     /* det(A) = x * d */
     fmpz_mul(det, x, d);

--- a/src/fmpz_mat/rref_mul.c
+++ b/src/fmpz_mat/rref_mul.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2010-2012 Fredrik Johansson
+    Copyright (C) 2010-2012, 2026 Fredrik Johansson
     Copyright (C) 2014 Alex J. Best
 
     This file is part of FLINT.
@@ -10,19 +10,121 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "ulong_extras.h"
 #include "perm.h"
+#include "ulong_extras.h"
 #include "nmod_mat.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
+
+int
+fmpz_mat_rref_upper_certify_lu_mod_p(fmpz_mat_t E, fmpz_t den, const fmpz_mat_t A,
+                          slong rank, const slong * P, const slong * pivs)
+{
+    slong i, j, m, n;
+    fmpz_mat_t B, C, D, E2, F, FD;
+
+    m = fmpz_mat_nrows(A);
+    n = fmpz_mat_ncols(A);
+
+    fmpz_mat_init(B, rank, rank);
+    fmpz_mat_init(C, rank, n - rank);
+
+    /* B = pivot rows x pivot columns, C = pivot rows x non-pivot columns */
+    for (i = 0; i < rank; i++)
+    {
+        for (j = 0; j < rank; j++)
+            fmpz_set(fmpz_mat_entry(B, i, j),
+                    fmpz_mat_entry(A, P[i], pivs[j]));
+        for (j = 0; j < n - rank; j++)
+            fmpz_set(fmpz_mat_entry(C, i, j),
+                    fmpz_mat_entry(A, P[i], pivs[rank + j]));
+    }
+
+    /* solve B*E2 = den*C (B is invertible mod p, hence over Z) */
+    fmpz_mat_init(E2, rank, n - rank);
+    if (!fmpz_mat_solve(E2, den, B, C))
+    {
+        flint_throw(FLINT_ERROR, "(fmpz_mat_rref_upper_certify_lu_mod_p): "
+                "Singular input matrix for solve.\n");
+    }
+
+    fmpz_mat_clear(B);
+    fmpz_mat_clear(C);
+
+    /* assemble the scaled rref rows into E: den on the pivot "diagonal", E2 in
+       the non-pivot columns; the remaining pivot-column entries stay zero */
+    for (i = 0; i < rank; i++)
+    {
+        fmpz_set(fmpz_mat_entry(E, i, pivs[i]), den);
+        for (j = 0; j < n - rank; j++)
+            fmpz_set(fmpz_mat_entry(E, i, pivs[rank + j]),
+                    fmpz_mat_entry(E2, i, j));
+    }
+    fmpz_mat_clear(E2);
+
+    if (!fmpz_mat_is_in_rref_with_rank(E, den, rank))
+        return 0;
+
+    /* D = nullspace basis for E (n x (n - rank)) */
+    fmpz_mat_init(D, n, n - rank);
+    for (j = 0; j < n - rank; j++)
+    {
+        fmpz_set(fmpz_mat_entry(D, pivs[rank + j], j), den);
+        for (i = 0; i < rank; i++)
+            fmpz_neg(fmpz_mat_entry(D, pivs[i], j),
+                    fmpz_mat_entry(E, i, pivs[rank + j]));
+    }
+
+    /* F = the non-pivot rows of A. The rank is certified iff F*D == 0, i.e.
+       every remaining row lies in the span of the pivot rows. */
+    fmpz_mat_init(F, m - rank, n);
+    for (i = 0; i < m - rank; i++)
+        for (j = 0; j < n; j++)
+            fmpz_set(fmpz_mat_entry(F, i, j),
+                    fmpz_mat_entry(A, P[rank + i], j));
+
+    fmpz_mat_init(FD, m - rank, n - rank);
+    fmpz_mat_mul(FD, F, D);
+    fmpz_mat_clear(F);
+    fmpz_mat_clear(D);
+
+    if (!fmpz_mat_is_zero(FD))
+    {
+        fmpz_mat_clear(FD);
+        return 0;
+    }
+
+    fmpz_mat_clear(FD);
+    return 1;
+}
+
+int
+fmpz_mat_rank_certify_lu_mod_p(const fmpz_mat_t A,
+    slong rank, const slong * P, const slong * pivs)
+{
+    int result;
+
+    fmpz_mat_t E;
+    fmpz_t den;
+
+    fmpz_init(den);
+    fmpz_mat_init(E, rank, A->c);
+
+    result = fmpz_mat_rref_upper_certify_lu_mod_p(E, den, A, rank, P, pivs);
+
+    fmpz_clear(den);
+    fmpz_mat_clear(E);
+
+    return result;
+}
 
 slong
 fmpz_mat_rref_mul(fmpz_mat_t R, fmpz_t den, const fmpz_mat_t A)
 {
     nmod_mat_t Amod;
+    fmpz_mat_t E;
     ulong p;
     slong i, j, m, n, rank, * pivs, * P;
-    fmpz_mat_t B, C, D, E, E2, F, FD;
 
     m = fmpz_mat_nrows(A);
     n = fmpz_mat_ncols(A);
@@ -41,107 +143,38 @@ fmpz_mat_rref_mul(fmpz_mat_t R, fmpz_t den, const fmpz_mat_t A)
         fmpz_mat_get_nmod_mat(Amod, A);
 
         rank = nmod_mat_lu_with_pivots(P, pivs, Amod);
-
         nmod_mat_clear(Amod);
 
-        /* stop early if the rank is the number of columns */
+        /* stop early if the rank is the number of columns: the rref is the
+           identity (with zero rows below) and the denominator is 1 */
         if (rank == n)
         {
             fmpz_mat_one(R);
             fmpz_one(den);
-
-            flint_free(pivs);
-            _perm_clear(P);
-
-            return rank;
-        }
-
-        fmpz_mat_init(B, rank, rank);
-        fmpz_mat_init(C, rank, n - rank);
-
-        /* set B to be the pivot columns and rows and C to be the non-pivot
-           columns in the pivot rows */
-        for (i = 0; i < rank; i++)
-        {
-            for (j = 0; j < rank; j++)
-                fmpz_set(fmpz_mat_entry(B, i, j),
-                        fmpz_mat_entry(A, P[i], pivs[j]));
-            for (j = 0; j < n - rank; j++)
-                fmpz_set(fmpz_mat_entry(C, i, j),
-                        fmpz_mat_entry(A, P[i], pivs[rank + j]));
-        }
-
-        /* solve B*E2 = den*C */
-        fmpz_mat_init(E2, rank, n - rank);
-        if (!fmpz_mat_solve(E2, den, B, C))
-        {
-            flint_throw(FLINT_ERROR, "(fmpz_mat_rref_mul): "
-                    "Singular input matrix for solve.\n");
-        }
-
-        fmpz_mat_clear(B);
-        fmpz_mat_clear(C);
-        fmpz_mat_init(E, rank, n);
-
-        /* move columns of E2 and identity matrix into E so that it should be
-           in rref */
-        for (i = 0; i < rank; i++)
-        {
-            fmpz_set(fmpz_mat_entry(E, i, pivs[i]), den);
-            for (j = 0; j < n - rank; j++)
-                fmpz_set(fmpz_mat_entry(E, i, pivs[rank + j]),
-                        fmpz_mat_entry(E2, i, j));
-        }
-        fmpz_mat_clear(E2);
-
-        if (!fmpz_mat_is_in_rref_with_rank(E, den, rank))
-        {
-            fmpz_mat_clear(E);
-            continue;
-        }
-
-        /* set D to be the nullspace basis matrix for E */
-        fmpz_mat_init(D, n, n - rank);
-
-        for (j = 0; j < n - rank; j++)
-        {
-            fmpz_set(fmpz_mat_entry(D, pivs[rank + j], j), den);
-            for (i = 0; i < rank; i++)
-                fmpz_neg(fmpz_mat_entry(D, pivs[i], j),
-                        fmpz_mat_entry(E, i, pivs[rank + j]));
-        }
-
-        fmpz_mat_init(F, m - rank, n);
-
-        for (i = 0; i < m - rank; i++)
-            for (j = 0; j < n; j++)
-                fmpz_set(fmpz_mat_entry(F, i, j),
-                        fmpz_mat_entry(A, P[rank + i], j));
-
-        fmpz_mat_init(FD, m - rank, n - rank);
-        fmpz_mat_mul(FD, F, D);
-        fmpz_mat_clear(F);
-        fmpz_mat_clear(D);
-
-        /* if FD = 0 we have computed the rref right so stop, otherwise try a
-           different p in the next iteration */
-        if (fmpz_mat_is_zero(FD))
             break;
+        }
 
-        fmpz_mat_clear(E);
-        fmpz_mat_clear(FD);
+        /* otherwise compute and certify the rref for this prime */
+        fmpz_mat_init(E, rank, n);
+        if (fmpz_mat_rref_upper_certify_lu_mod_p(E, den, A, rank, P, pivs))
+        {
+            /* E is valid */
+            /* write the entries of E into R and zeroes at the bottom */
+            for (i = 0; i < rank; i++)
+                for (j = 0; j < n; j++)
+                    fmpz_set(fmpz_mat_entry(R, i, j), fmpz_mat_entry(E, i, j));
+            for (i = rank; i < m; i++)
+                for (j = 0; j < n; j++)
+                    fmpz_zero(fmpz_mat_entry(R, i, j));
+            fmpz_mat_clear(E);
+            break;
+        }
+        else
+        {
+            fmpz_mat_clear(E);          /* unlucky prime: discard and try again */
+        }
     }
 
-    /* write the entries of E into R and zeroes at the bottom */
-    for (i = 0; i < rank; i++)
-        for (j = 0; j < n; j++)
-            fmpz_set(fmpz_mat_entry(R, i, j), fmpz_mat_entry(E, i, j));
-    for (i = rank; i < m; i++)
-        for (j = 0; j < n; j++)
-            fmpz_zero(fmpz_mat_entry(R, i, j));
-
-    fmpz_mat_clear(E);
-    fmpz_mat_clear(FD);
     flint_free(pivs);
     _perm_clear(P);
 

--- a/src/fmpz_mat/solve_dixon.c
+++ b/src/fmpz_mat/solve_dixon.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Fredrik Johansson
+    Copyright (C) 2011, 2026 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -10,6 +10,7 @@
 */
 
 #include "ulong_extras.h"
+#include "perm.h"
 #include "nmod_mat.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
@@ -18,29 +19,74 @@ ulong
 fmpz_mat_find_good_prime_and_invert(nmod_mat_t Ainv,
                                 const fmpz_mat_t A, const fmpz_t det_bound)
 {
+    nmod_mat_t LU, PB;
+    fmpz_t den, tested;
     ulong p;
-    fmpz_t tested;
+    slong i, n, rank, * pivs, * P;
 
-    p = UWORD(1) << NMOD_MAT_OPTIMAL_MODULUS_BITS;
+    n = fmpz_mat_nrows(A);   /* A is square: nrows == ncols */
+
+    pivs = (slong *) flint_malloc(n * sizeof(slong));
+    P = _perm_init(n);
+
+    fmpz_init(den);
     fmpz_init(tested);
     fmpz_one(tested);
+
+    /* workspace for A mod p / its LU; the modulus is reset each iteration */
+    nmod_mat_init(LU, n, n, UWORD(2));
+
+    p = UWORD(1) << NMOD_MAT_OPTIMAL_MODULUS_BITS;
 
     while (1)
     {
         p = n_nextprime(p, 0);
-        nmod_mat_set_mod(Ainv, p);
-        fmpz_mat_get_nmod_mat(Ainv, A);
-        if (nmod_mat_inv(Ainv, Ainv))
-            break;
+
+        nmod_mat_set_mod(LU, p);
+        fmpz_mat_get_nmod_mat(LU, A);
+
+        rank = nmod_mat_lu_with_pivots(P, pivs, LU);
+
+        if (rank == n)
+        {
+            /* full rank mod p: A is invertible mod p. Reuse the LU we just
+               computed to solve A * Ainv = I. */
+            nmod_mat_set_mod(Ainv, p);
+
+            nmod_mat_init(PB, n, n, p);
+            for (i = 0; i < n; i++)
+                nmod_mat_entry(PB, i, P[i]) = UWORD(1);
+
+            nmod_mat_solve_tril(Ainv, LU, PB, 1);
+            nmod_mat_solve_triu(Ainv, LU, Ainv, 0);
+
+            nmod_mat_clear(PB);
+            break;   /* success: return p */
+        }
+
+        /* enough primes to certify rank deficiency */
         fmpz_mul_ui(tested, tested, p);
         if (fmpz_cmp(tested, det_bound) > 0)
         {
             p = 0;
             break;
         }
+
+        /* rank-deficient mod p: try to certify that A is rank-deficient over
+           Z (hence singular), as in fmpz_mat_rref_mul */
+        if (fmpz_mat_rank_certify_lu_mod_p(A, rank, P, pivs))
+        {
+            p = 0;
+            break;
+        }
     }
 
+    nmod_mat_clear(LU);
+    fmpz_clear(den);
     fmpz_clear(tested);
+    flint_free(pivs);
+    _perm_clear(P);
+
     return p;
 }
 

--- a/src/nmod_mat/lu_with_pivots.c
+++ b/src/nmod_mat/lu_with_pivots.c
@@ -24,7 +24,7 @@ nmod_mat_lu_with_pivots(slong * P, slong * pivots_nonpivots, nmod_mat_t A)
 
     rank = nmod_mat_lu(P, A, 0);
 
-    if (rank == 0)
+    if (rank == 0 || rank == n)
     {
         for (i = 0; i < n; i++)
             pivots_nonpivots[i] = i;


### PR DESCRIPTION
When given a singular system, multimodular and Dixon solvers for `fmpz_mat` and `fmpq_mat` would previously try to invert mod $p$ up to a product of primes exceeding the Hadamard bound to certify non-invertibility over the integers/rationals.

A better solution: when we detect that the matrix is singular mod $p$,
immediately certify that it is singular over the integers/rationals using the same technique as `fmpz_mat_rref_mul`. The certification functionality is factored out into two new public helper functions: `fmpz_mat_rref_upper_certify_lu_mod_p` and `fmpz_mat_rank_certify_lu_mod_p`.

This significantly speeds up `fmpz_mat_inv`, `fmpz_mat_solve` and similar functions when the matrix is singular, and also significantly speeds up `fmpz_mat_det` when the determinant is zero. For all these functions, performance for nonsingular matrices is unchanged.

This does not touch the ``can_solve`` variants.

Timings for determinants and inversion:

Low rank input; entries $A_{i,j} = in+j$:

```
     n          fmpz_mat_det                  fmpz_mat_inv

               old       new   speedup        old       new   speedup
    10     9.85e-07  9.89e-07   0.996     1.05e-06  1.06e-06   0.991
    20     3.94e-06  3.93e-06   1.003     2.45e-05  1.59e-05   1.541
    30     4.44e-05  2.78e-05   1.597     6.45e-05  3.44e-05   1.875
    40     0.000108  5.23e-05   2.065     0.000159  6.36e-05   2.500
    50     0.000191  8.47e-05   2.255     0.000318  0.000136   2.338
   100      0.00258  0.000472   5.466      0.00352  0.000764   4.607
   200       0.0227   0.00322   7.050        0.021   0.00377   5.570
   400        0.238    0.0208  11.442        0.179    0.0229   7.817
   800        2.073      0.16  12.956          1.8     0.156  11.538
  1600       19.742     0.934  21.137       18.023     1.024  17.601
```

Nearly full rank with small entries: `randrank(n-1, bits=1) + randops(10*n)`:

```
     n          fmpz_mat_det                  fmpz_mat_inv

               old       new   speedup        old       new   speedup
    10     1.58e-06   1.6e-06   0.988     1.64e-06  1.64e-06   1.000
    20     1.13e-05  1.11e-05   1.018     1.94e-05  4.27e-05   0.454
    30     6.18e-05  8.73e-05   0.708     7.53e-05  9.38e-05   0.803
    40     0.000143  0.000162   0.883     0.000143  0.000172   0.831
    50     0.000291   0.00027   1.078     0.000366  0.000327   1.119
   100      0.00402    0.0017   2.365      0.00456   0.00188   2.426
   200       0.0475    0.0107   4.439       0.0468    0.0109   4.294
   400        0.627    0.0686   9.140        0.609      0.07   8.700
   800        8.288     0.463  17.901        8.187     0.471  17.382
  1600      114.763     3.176  36.134      123.227     3.447  35.749
```

Nearly full rank with huge entries: `randrank(n-1, bits=1000) + randops(10*n)`:

```
     n          fmpz_mat_det                  fmpz_mat_inv

               old       new   speedup        old       new   speedup
    10     0.000424  0.000423    1.002     0.000422  0.000422    1.000
    20       0.0102      0.01    1.020       0.0058  0.000277   20.939
    30       0.0192  0.000622   30.868       0.0203   0.00063   32.222
    40       0.0465   0.00119   39.076       0.0494   0.00122   40.492
    50       0.0856   0.00189   45.291       0.0929   0.00199   46.683
   100        1.054   0.01016  103.740        1.146    0.0104  110.192
   200       11.221    0.0484  231.839       12.487    0.0538  232.100
   400       208.43     0.478  436.046      230.303     0.368  625.823
```

For the small bit size, nearly full rank input, there are some slowdowns. This might be avoidable by running the certification conditionally depending on the rank and bit size. However, the slowdown is mild enough that I don't think we need to worry too much about it, and it might in any case go away with future improvements to the solving code.