### PR TITLE
Add arb/acb_poly_scalar_mul_si

### DIFF
--- a/doc/source/acb.rst
+++ b/doc/source/acb.rst
@@ -1229,6 +1229,8 @@ Vector functions
 
 .. function:: void _acb_vec_scalar_mul(acb_ptr res, acb_srcptr vec, slong len, const acb_t c, slong prec)
 
+.. function:: void _acb_vec_scalar_mul_si(acb_ptr res, acb_srcptr vec, slong len, slong c, slong prec)
+
 .. function:: void _acb_vec_scalar_mul_ui(acb_ptr res, acb_srcptr vec, slong len, ulong c, slong prec)
 
 .. function:: void _acb_vec_scalar_mul_2exp_si(acb_ptr res, acb_srcptr vec, slong len, slong c)

--- a/doc/source/acb_poly.rst
+++ b/doc/source/acb_poly.rst
@@ -282,6 +282,8 @@ Arithmetic
 
 .. function:: void acb_poly_scalar_mul(acb_poly_t C, const acb_poly_t A, const acb_t c, slong prec)
 
+.. function:: void acb_poly_scalar_mul_si(acb_poly_t C, const acb_poly_t A, slong c, slong prec)
+
     Sets *C* to *A* multiplied by *c*.
 
 .. function:: void acb_poly_scalar_div(acb_poly_t C, const acb_poly_t A, const acb_t c, slong prec)

--- a/doc/source/arb.rst
+++ b/doc/source/arb.rst
@@ -1975,9 +1975,13 @@ Vector functions
 
 .. function:: void _arb_vec_scalar_mul(arb_ptr res, arb_srcptr vec, slong len, const arb_t c, slong prec)
 
+.. function:: void _arb_vec_scalar_mul_arf(arb_ptr res, arb_srcptr vec, slong len, const arf_t c, slong prec)
+
 .. function:: void _arb_vec_scalar_div(arb_ptr res, arb_srcptr vec, slong len, const arb_t c, slong prec)
 
 .. function:: void _arb_vec_scalar_mul_fmpz(arb_ptr res, arb_srcptr vec, slong len, const fmpz_t c, slong prec)
+
+.. function:: void _arb_vec_scalar_mul_si(arb_ptr res, arb_srcptr vec, slong len, slong c, slong prec)
 
 .. function:: void _arb_vec_scalar_mul_2exp_si(arb_ptr res, arb_srcptr src, slong len, slong c)
 

--- a/doc/source/arb_poly.rst
+++ b/doc/source/arb_poly.rst
@@ -263,6 +263,8 @@ Arithmetic
 
 .. function:: void arb_poly_scalar_mul(arb_poly_t C, const arb_poly_t A, const arb_t c, slong prec)
 
+.. function:: void arb_poly_scalar_mul_si(arb_poly_t C, const arb_poly_t A, slong c, slong prec)
+
     Sets *C* to *A* multiplied by *c*.
 
 .. function:: void arb_poly_scalar_div(arb_poly_t C, const arb_poly_t A, const arb_t c, slong prec)

--- a/src/acb.h
+++ b/src/acb.h
@@ -839,6 +839,7 @@ void _acb_vec_sub(acb_ptr res, acb_srcptr vec1, acb_srcptr vec2, slong len, slon
 void _acb_vec_scalar_submul(acb_ptr res, acb_srcptr vec, slong len, const acb_t c, slong prec);
 void _acb_vec_scalar_addmul(acb_ptr res, acb_srcptr vec, slong len, const acb_t c, slong prec);
 void _acb_vec_scalar_mul(acb_ptr res, acb_srcptr vec, slong len, const acb_t c, slong prec);
+void _acb_vec_scalar_mul_si(acb_ptr res, acb_srcptr vec, slong len, slong c, slong prec);
 void _acb_vec_scalar_mul_ui(acb_ptr res, acb_srcptr vec, slong len, ulong c, slong prec);
 void _acb_vec_scalar_mul_2exp_si(acb_ptr res, acb_srcptr vec, slong len, slong c);
 void _acb_vec_scalar_mul_onei(acb_ptr res, acb_srcptr vec, slong len);

--- a/src/acb/vec.c
+++ b/src/acb/vec.c
@@ -141,6 +141,7 @@ void func_name(S rp, T ap, slong len, U b, slong prec) \
         OP(rp + ix, ap + ix, b, prec); \
 }
 
+SCALAR_OP(_acb_vec_scalar_mul_si,   acb_ptr, acb_srcptr, slong,        acb_mul_si)
 SCALAR_OP(_acb_vec_scalar_mul_ui,   acb_ptr, acb_srcptr, ulong,        acb_mul_ui)
 SCALAR_OP(_acb_vec_scalar_mul_fmpz, acb_ptr, acb_srcptr, const fmpz_t, acb_mul_fmpz)
 SCALAR_OP(_acb_vec_scalar_mul_arb,  acb_ptr, acb_srcptr, const arb_t,  acb_mul_arb)

--- a/src/acb_poly.h
+++ b/src/acb_poly.h
@@ -286,6 +286,15 @@ acb_poly_scalar_mul(acb_poly_t res, const acb_poly_t poly, const acb_t c, slong 
 }
 
 ACB_POLY_INLINE void
+acb_poly_scalar_mul_si(acb_poly_t res, const acb_poly_t poly, slong c, slong prec)
+{
+    acb_poly_fit_length(res, poly->length);
+    _acb_vec_scalar_mul_si(res->coeffs, poly->coeffs, poly->length, c, prec);
+    _acb_poly_set_length(res, poly->length);
+    _acb_poly_normalise(res);
+}
+
+ACB_POLY_INLINE void
 acb_poly_scalar_div(acb_poly_t res, const acb_poly_t poly, const acb_t c, slong prec)
 {
     acb_poly_fit_length(res, poly->length);

--- a/src/acb_poly/test/main.c
+++ b/src/acb_poly/test/main.c
@@ -76,6 +76,7 @@
 #include "t-rising_ui_series.c"
 #include "t-root_bound_fujiwara.c"
 #include "t-rsqrt_series.c"
+#include "t-scalar_mul_si.c"
 #include "t-set_trunc_round.c"
 #include "t-shift_left_right.c"
 #include "t-sin_cos_pi_series.c"
@@ -163,6 +164,7 @@ test_struct tests[] =
     TEST_FUNCTION(acb_poly_rising_ui_series),
     TEST_FUNCTION(acb_poly_root_bound_fujiwara),
     TEST_FUNCTION(acb_poly_rsqrt_series),
+    TEST_FUNCTION(acb_poly_scalar_mul_si),
     TEST_FUNCTION(acb_poly_set_trunc_round),
     TEST_FUNCTION(acb_poly_shift_left_right),
     TEST_FUNCTION(acb_poly_sin_cos_pi_series),

--- a/src/acb_poly/test/t-scalar_mul_si.c
+++ b/src/acb_poly/test/t-scalar_mul_si.c
@@ -1,0 +1,60 @@
+/*
+    Copyright (C) 2026 Joel Dahne
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "acb_poly.h"
+
+TEST_FUNCTION_START(acb_poly_scalar_mul_si, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 10000 * 0.1 * flint_test_multiplier(); iter++)
+    {
+        acb_poly_t a, b, c;
+        acb_t s;
+        slong v;
+        slong prec;
+
+        acb_poly_init(a);
+        acb_poly_init(b);
+        acb_poly_init(c);
+        acb_init(s);
+
+        prec = 2 + n_randint(state, 200);
+        acb_poly_randtest(a, state, 1 + n_randint(state, 10), prec, 10);
+        v = (slong) n_randtest(state);
+
+        acb_set_si(s, v);
+        acb_poly_scalar_mul(b, a, s, prec);
+        acb_poly_scalar_mul_si(c, a, v, prec);
+
+        if (!acb_poly_overlaps(b, c))
+        {
+            flint_printf("FAIL\n\n");
+            flint_abort();
+        }
+
+        acb_poly_scalar_mul_si(a, a, v, prec);
+
+        if (!acb_poly_overlaps(a, c))
+        {
+            flint_printf("FAIL (aliasing)\n\n");
+            flint_abort();
+        }
+
+        acb_poly_clear(a);
+        acb_poly_clear(b);
+        acb_poly_clear(c);
+        acb_clear(s);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/arb.h
+++ b/src/arb.h
@@ -663,7 +663,9 @@ void _arb_vec_sub(arb_ptr C, arb_srcptr A, arb_srcptr B, slong n, slong prec);
 void _arb_vec_add(arb_ptr C, arb_srcptr A, arb_srcptr B, slong n, slong prec);
 
 void _arb_vec_scalar_mul(arb_ptr res, arb_srcptr vec, slong len, const arb_t c, slong prec);
+void _arb_vec_scalar_mul_arf(arb_ptr res, arb_srcptr vec, slong len, const arf_t c, slong prec);
 void _arb_vec_scalar_mul_fmpz(arb_ptr res, arb_srcptr vec, slong len, const fmpz_t c, slong prec);
+void _arb_vec_scalar_mul_si(arb_ptr res, arb_srcptr vec, slong len, slong c, slong prec);
 void _arb_vec_scalar_mul_2exp_si(arb_ptr res, arb_srcptr src, slong len, slong c);
 void _arb_vec_scalar_div(arb_ptr res, arb_srcptr vec, slong len, const arb_t c, slong prec);
 void _arb_vec_scalar_addmul(arb_ptr res, arb_srcptr vec, slong len, const arb_t c, slong prec);

--- a/src/arb/vec.c
+++ b/src/arb/vec.c
@@ -17,17 +17,6 @@ arb_ptr _arb_vec_entry_ptr(arb_ptr vec, slong i)
     return vec + i;
 }
 
-void _arb_vec_scalar_mul_fmpz(arb_ptr res, arb_srcptr vec, slong len, const fmpz_t c, slong prec)
-{
-    slong i;
-    arf_t t;
-    arf_init(t);
-    arf_set_fmpz(t, c);
-    for (i = 0; i < len; i++)
-        arb_mul_arf(res + i, vec + i, t, prec);
-    arf_clear(t);
-}
-
 void _arb_vec_scalar_mul_2exp_si(arb_ptr res, arb_srcptr src, slong len, slong c)
 {
     slong i;
@@ -149,8 +138,27 @@ void func_name(S rp, T ap, slong len, U b, slong prec) \
 }
 
 SCALAR_OP(_arb_vec_scalar_mul,      arb_ptr, arb_srcptr, const arb_t,  arb_mul)
+SCALAR_OP(_arb_vec_scalar_mul_arf,  arb_ptr, arb_srcptr, const arf_t,  arb_mul_arf)
 SCALAR_OP(_arb_vec_scalar_div,      arb_ptr, arb_srcptr, const arb_t,  arb_div)
 SCALAR_OP(_arb_vec_scalar_addmul,   arb_ptr, arb_srcptr, const arb_t, arb_addmul)
+
+void
+_arb_vec_scalar_mul_fmpz(arb_ptr res, arb_srcptr vec, slong len, const fmpz_t c, slong prec)
+{
+    arf_t t;
+    arf_init(t);
+    arf_set_fmpz(t, c);
+    _arb_vec_scalar_mul_arf(res, vec, len, t, prec);
+    arf_clear(t);
+}
+
+void
+_arb_vec_scalar_mul_si(arb_ptr res, arb_srcptr vec, slong len, slong c, slong prec)
+{
+    arf_t t;
+    arf_init_set_si(t, c); /* no need to free */
+    _arb_vec_scalar_mul_arf(res, vec, len, t, prec);
+}
 
 #define COMPARISON_OP(func_name, S, T, OP) \
 int func_name(S ap, T bp, slong len)\

--- a/src/arb_poly.h
+++ b/src/arb_poly.h
@@ -231,6 +231,15 @@ arb_poly_scalar_mul(arb_poly_t res, const arb_poly_t poly, const arb_t c, slong 
 }
 
 ARB_POLY_INLINE void
+arb_poly_scalar_mul_si(arb_poly_t res, const arb_poly_t poly, slong c, slong prec)
+{
+    arb_poly_fit_length(res, poly->length);
+    _arb_vec_scalar_mul_si(res->coeffs, poly->coeffs, poly->length, c, prec);
+    _arb_poly_set_length(res, poly->length);
+    _arb_poly_normalise(res);
+}
+
+ARB_POLY_INLINE void
 arb_poly_scalar_div(arb_poly_t res, const arb_poly_t poly, const arb_t c, slong prec)
 {
     arb_poly_fit_length(res, poly->length);

--- a/src/arb_poly/test/main.c
+++ b/src/arb_poly/test/main.c
@@ -73,6 +73,7 @@
 #include "t-rising_ui_series.c"
 #include "t-root_bound_fujiwara.c"
 #include "t-rsqrt_series.c"
+#include "t-scalar_mul_si.c"
 #include "t-set_trunc_round.c"
 #include "t-shift_left_right.c"
 #include "t-sin_cos_pi_series.c"
@@ -156,6 +157,7 @@ test_struct tests[] =
     TEST_FUNCTION(arb_poly_rising_ui_series),
     TEST_FUNCTION(arb_poly_root_bound_fujiwara),
     TEST_FUNCTION(arb_poly_rsqrt_series),
+    TEST_FUNCTION(arb_poly_scalar_mul_si),
     TEST_FUNCTION(arb_poly_set_trunc_round),
     TEST_FUNCTION(arb_poly_shift_left_right),
     TEST_FUNCTION(arb_poly_sin_cos_pi_series),

--- a/src/arb_poly/test/t-scalar_mul_si.c
+++ b/src/arb_poly/test/t-scalar_mul_si.c
@@ -1,0 +1,60 @@
+/*
+    Copyright (C) 2026 Joel Dahne
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "arb_poly.h"
+
+TEST_FUNCTION_START(arb_poly_scalar_mul_si, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 10000 * 0.1 * flint_test_multiplier(); iter++)
+    {
+        arb_poly_t a, b, c;
+        arb_t s;
+        slong v;
+        slong prec;
+
+        arb_poly_init(a);
+        arb_poly_init(b);
+        arb_poly_init(c);
+        arb_init(s);
+
+        prec = 2 + n_randint(state, 200);
+        arb_poly_randtest(a, state, 1 + n_randint(state, 10), prec, 10);
+        v = (slong) n_randtest(state);
+
+        arb_set_si(s, v);
+        arb_poly_scalar_mul(b, a, s, prec);
+        arb_poly_scalar_mul_si(c, a, v, prec);
+
+        if (!arb_poly_overlaps(b, c))
+        {
+            flint_printf("FAIL\n\n");
+            flint_abort();
+        }
+
+        arb_poly_scalar_mul_si(a, a, v, prec);
+
+        if (!arb_poly_overlaps(a, c))
+        {
+            flint_printf("FAIL (aliasing)\n\n");
+            flint_abort();
+        }
+
+        arb_poly_clear(a);
+        arb_poly_clear(b);
+        arb_poly_clear(c);
+        arb_clear(s);
+    }
+
+    TEST_FUNCTION_END(state);
+}


### PR DESCRIPTION
This adds the functions:

- `_arb_vec_scalar_mul_si`
- `_acb_vec_scalar_mul_si`
- `arb_poly_scalar_mul_si`
- `acb_poly_scalar_mul_si`

The code was written by Claude, but I checked that everything seems to okay. Not counting tests, this only adds 30 lines of code, most of it following earlier templates. Three comments:

1. The main reason I want this implementation is that I (using Arblib.jl) often write mutable code that should work for both scalar values and series expansions. Currently I need to distinguish between the two types whenever I multiply with an integer. With this change, that would not be needed.
2. The tests check that `arb_poly_scalar_mul_si` agrees with `arb_poly_scalar_mul`. Note that there are currently no tests for `arb_poly_scalar_mul`. It seems like Claude made a good job of following the structure of other tests (it's my first time interacting with this new test structure).
3. The implementation is done as
    ``` C
    SCALAR_OP(_arb_vec_scalar_mul_si,   arb_ptr, arb_srcptr, slong,        arb_mul_si)
    ```
    The function `arb_mul_si` converts the integer to an `arf` and then calls `arb_mul_arf`. In theory this might mean that the integer is converted to an `arf` multiple times, once for each element in the vector. In practice the compiler might be smart enough to optimize this? Though I'm not sure it is smart enough to do this over the `arb_mul_arf` call? Note that for example the function `arb_mat_scalar_mul_si` has a similar implementation.