### PR TITLE
Add gr_big_o

### DIFF
--- a/doc/source/gr.rst
+++ b/doc/source/gr.rst
@@ -928,6 +928,13 @@ Ordering methods
 Enclosure and interval methods
 ........................................................................
 
+.. function:: int gr_big_o(gr_ptr res, gr_srcptr x, gr_ctx_t ctx)
+
+    In a structure (typically a discrete valuation ring) with
+    big-O enclosures, return a big-O error term of the same magnitude as the
+    given element. For example, in a ring of formal power series `R[[t]]`,
+    `O(2t^3 + t^4)` returns `O(t^3)`.
+
 .. function:: int gr_set_interval_mid_rad(gr_ptr res, gr_srcptr m, gr_srcptr r, gr_ctx_t ctx)
 
     In ball representations of the real numbers, sets *res* to

--- a/src/gr.h
+++ b/src/gr.h
@@ -598,6 +598,8 @@ typedef enum
     GR_METHOD_GENS,
     GR_METHOD_GENS_RECURSIVE,
 
+    GR_METHOD_BIG_O,
+
     /* Finite field methods */
     GR_METHOD_CTX_FQ_PRIME,
     GR_METHOD_CTX_FQ_DEGREE,
@@ -1209,6 +1211,8 @@ GR_INLINE WARN_UNUSED_RESULT int gr_max(gr_ptr res, gr_srcptr x, gr_srcptr y, gr
 GR_INLINE WARN_UNUSED_RESULT int gr_gen(gr_ptr res, gr_ctx_t ctx) { return GR_CONSTANT_OP(ctx, GEN)(res, ctx); }
 GR_INLINE WARN_UNUSED_RESULT int gr_gens(gr_vec_t res, gr_ctx_t ctx) { return GR_VEC_CTX_OP(ctx, GENS)(res, ctx); }
 GR_INLINE WARN_UNUSED_RESULT int gr_gens_recursive(gr_vec_t res, gr_ctx_t ctx) { return GR_VEC_CTX_OP(ctx, GENS_RECURSIVE)(res, ctx); }
+
+GR_INLINE WARN_UNUSED_RESULT int gr_big_o(gr_ptr res, gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_OP(ctx, BIG_O)(res, x, ctx); }
 
 GR_INLINE WARN_UNUSED_RESULT int gr_ctx_fq_prime(fmpz_t res, gr_ctx_t ctx) { return GR_CONSTANT_OP_GET_FMPZ(ctx, CTX_FQ_PRIME)(res, ctx); }
 GR_INLINE WARN_UNUSED_RESULT int gr_ctx_fq_degree(slong * res, gr_ctx_t ctx) { return GR_CONSTANT_OP_GET_SI(ctx, CTX_FQ_DEGREE)(res, ctx); }

--- a/src/gr_generic/set_str_expr.c
+++ b/src/gr_generic/set_str_expr.c
@@ -86,6 +86,7 @@ static const function1 functions1[] = {
     { "tanpi", 5, GR_METHOD_TAN_PI },
     { "gamma", 5, GR_METHOD_GAMMA },
     { "zeta", 4, GR_METHOD_ZETA },
+    { "O", 1, GR_METHOD_BIG_O },
 };
 
 #define NUM_FUNCTIONS1 (sizeof(functions1) / sizeof(function1))

--- a/src/gr_series.h
+++ b/src/gr_series.h
@@ -103,6 +103,7 @@ WARN_UNUSED_RESULT int gr_series_set(gr_series_t res, const gr_series_t x, gr_ct
 WARN_UNUSED_RESULT int gr_series_gen(gr_series_t res, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_series_gens_recursive(gr_vec_t vec, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_series_neg(gr_series_t res, const gr_series_t x, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_series_big_o(gr_series_t res, const gr_series_t x, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_series_set_gr_poly(gr_series_t res, const gr_poly_t x, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_series_set_scalar(gr_series_t res, gr_srcptr x, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_series_set_si(gr_series_t res, slong c, gr_ctx_t ctx);

--- a/src/gr_series/series.c
+++ b/src/gr_series/series.c
@@ -184,6 +184,42 @@ gr_series_one(gr_series_t res, gr_ctx_t ctx)
     }
 }
 
+int
+gr_series_big_o(gr_series_t res, const gr_series_t x, gr_ctx_t ctx)
+{
+    slong xlen, val;
+    int status = GR_SUCCESS;
+    truth_t is_zero;
+
+    xlen = GR_SERIES_POLY(x)->length;
+
+    if (xlen == 0)
+    {
+        val = GR_SERIES_ERROR(x);
+    }
+    else
+    {
+        val = 0;
+        while (val < xlen)
+        {
+            is_zero = gr_series_coeff_is_zero(x, val, ctx);
+            if (is_zero == T_UNKNOWN)
+                break;   /* Alternative: return GR_UNABLE */
+            if (is_zero == T_FALSE)
+                break;
+            val++;
+        }
+
+        /* Defensive */
+        val = FLINT_MIN(val, GR_SERIES_ERROR(x));
+    }
+
+    status |= gr_poly_zero(GR_SERIES_POLY(res), GR_SERIES_ELEM_CTX(ctx));
+    GR_SERIES_ERROR(res) = val;
+
+    return status;
+}
+
 /* todo: truncate without set */
 int
 gr_series_set(gr_series_t res, const gr_series_t x, gr_ctx_t ctx)
@@ -2122,6 +2158,7 @@ gr_method_tab_input _gr_series_methods_input[] =
     {GR_METHOD_GEN,         (gr_funcptr) gr_series_gen},
     {GR_METHOD_GENS,        (gr_funcptr) gr_generic_gens_single},
     {GR_METHOD_GENS_RECURSIVE,  (gr_funcptr) gr_series_gens_recursive},
+    {GR_METHOD_BIG_O,       (gr_funcptr) gr_series_big_o},
     {GR_METHOD_SET,         (gr_funcptr) gr_series_set},
     {GR_METHOD_SET_UI,      (gr_funcptr) gr_series_set_ui},
     {GR_METHOD_SET_SI,      (gr_funcptr) gr_series_set_si},

--- a/src/python/flint_ctypes.py
+++ b/src/python/flint_ctypes.py
@@ -1071,6 +1071,32 @@ class gr_ctx:
         else:
             return ctx._op_vec_ctx(libgr.gr_gens, "gens")
 
+    def O(ctx, x):
+        """
+        Return a big-O error term with the magnitude of the given
+        element.
+
+            >>> ZZser
+            Power series over Integer ring (fmpz) with precision O(x^6)
+            >>> x = ZZser.gen()
+            >>> ZZser.O(x**4)
+            0 + O(x^4)
+            >>> ZZser.O(3)
+            0 + O(x^0)
+            >>> ZZser.O(0)
+            0
+            >>> ZZser.O(5*x**3 + 7*x**4)
+            0 + O(x^3)
+            >>> ZZser.O(x**100)
+            0 + O(x^6)
+            >>> 3*x + 5*x**4 + ZZser.O(x**3)
+            3*x + O(x^3)
+            >>> QQser("1/3 + x/5 - O(x^2)")
+            (1/3) + (1/5)*x + O(x^2)
+
+        """
+        return ctx._unary_op(x, libgr.gr_big_o, "O($x)")
+
     def zero(ctx):
         """
         The zero element of this domain.


### PR DESCRIPTION
This is mostly a hack intended to allow parsing strings with big-O terms e.g. for power series (making string conversion for such elements roundtrippable):

    >>> QQser("1/3 + x/5 - O(x^2)")
    (1/3) + (1/5)*x + O(x^2)

Note that the implemented definition is useless in a multivariate setting, e.g.:

    >>> PowerSeriesRing(QQser, 6, "y")("(x + O(x^5)) + O(y^5)")
    0 + O(y^0)

I don't think this is possible to support in a mathematically consistent way as you can't distinguish between x^0 and y^0 once evaluated. The only reasonable solution I can think of would be to hack the expression parser to identify the generator syntactically.