### PR TITLE
Add functions to iterate over permutations

### DIFF
--- a/doc/source/perm.rst
+++ b/doc/source/perm.rst
@@ -69,3 +69,24 @@ Randomisation
 
     This function uses the Knuth shuffle algorithm to generate a uniformly 
     random permutation without retries.
+
+
+Iteration
+--------------------------------------------------------------------------------
+
+.. function:: int _perm_next_lex(slong * res, slong n)
+
+    Sets ``res`` to the next permutation after the input ``res``, with
+    respect to the lexicographic ordering, if possible. Returns 1 on success,
+    i.e. if the input ``res`` was not the lexicographically last permutation,
+    and returns 0 otherwise (in that case ``res`` is not modified).
+
+.. function:: int _perm_next_heap(slong * res, slong n, slong * stack)
+
+    Sets ``res`` to the next permutation after the input ``res``, according to
+    an iterative version of B.R. Heap's algorithm, if possible. The
+    implementation uses a vector ``stack`` of size ``n`` to keep track of
+    iteration counters. The standard way to use this function is to call it
+    first with ``res`` set to the identity permutation and ``stack`` set to a
+    vector of zeros; each call will try to update ``res`` and ``stack`` in
+    place. Returns 1 on success, i.e. if ``res`` was updated, and 0 otherwise.

--- a/src/perm.h
+++ b/src/perm.h
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2011 Sebastian Pancratz
+    Copyright (C) 2026 Ricardo Buring
 
     This file is part of FLINT.
 
@@ -138,6 +139,39 @@ int _perm_randtest(slong * vec, slong n, flint_rand_t state);
 /* Parity ********************************************************************/
 
 int _perm_parity(const slong * vec, slong n);
+
+/* Iteration *****************************************************************/
+
+PERM_INLINE int _perm_next_lex(slong *perm, slong n)
+{
+    slong k = n-2;
+    while (k >= 0 && perm[k] >= perm[k+1])
+        k--;
+    if (k < 0)
+        return 0;
+    slong l = n-1;
+    while (l >= k && perm[k] >= perm[l])
+        l--;
+    FLINT_SWAP(slong, perm[k], perm[l]);
+    slong i = k+1, j = n-1;
+    while (i < j) {
+        FLINT_SWAP(slong, perm[i], perm[j]);
+        i++;
+        j--;
+    }
+    return 1;
+}
+
+PERM_INLINE int _perm_next_heap(slong *perm, slong n, slong *stack)
+{
+    slong sp = 1;
+    while (sp < n && stack[sp] >= sp)
+        stack[sp++] = 0;
+    if (sp == n) return 0;
+    FLINT_SWAP(slong, perm[sp % 2 ? stack[sp] : 0], perm[sp]);
+    stack[sp]++;
+    return 1;
+}
 
 #define _long_vec_print _Pragma("GCC error \"'_long_vec_print(vec, len)' is deprecated. Use 'flint_printf(\"%{slong*}\", vec, len)' instead.\"")
 #define _perm_print _Pragma("GCC error \"'_perm_print(vec, len)' is deprecated. Use 'flint_printf(\"%{slong*}\", vec, len)' instead.\"")

--- a/src/perm/test/main.c
+++ b/src/perm/test/main.c
@@ -14,6 +14,7 @@
 #include "t-compose.c"
 #include "t-inv.c"
 #include "t-parity.c"
+#include "t-next.c"
 
 /* Array of test functions ***************************************************/
 
@@ -21,7 +22,8 @@ test_struct tests[] =
 {
     TEST_FUNCTION(perm_compose),
     TEST_FUNCTION(perm_inv),
-    TEST_FUNCTION(perm_parity)
+    TEST_FUNCTION(perm_parity),
+    TEST_FUNCTION(perm_next)
 };
 
 /* main function *************************************************************/

--- a/src/perm/test/t-next.c
+++ b/src/perm/test/t-next.c
@@ -1,0 +1,82 @@
+/*
+    Copyright (C) 2026 Ricardo Buring
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "perm.h"
+#include "fmpz.h"
+
+TEST_FUNCTION_START(perm_next, state)
+{
+    /* check |S_n| = n! and |A_n| = n! / 2 */
+
+    slong n;
+    slong lex_count, lex_count_even;
+    slong heap_count, heap_count_even, *perm, *stack;
+    fmpz_t fact, half_fact;
+    fmpz_init(fact);
+    fmpz_init(half_fact);
+
+    for (n = 2; n < 11; n++)
+    {
+        fmpz_fac_ui(fact, (ulong) n);
+        fmpz_divexact_ui(half_fact, fact, (ulong) 2);
+
+        lex_count = lex_count_even = 0;
+        perm = _perm_init(n);
+        do {
+            //flint_printf("%{slong*}\n", perm, n);
+            ++lex_count;
+            if (!_perm_parity(perm, n)) ++lex_count_even;
+        } while (_perm_next_lex(perm, n));
+
+        heap_count = heap_count_even = 0;
+        _perm_one(perm, n);
+        stack = (slong*) flint_calloc(n, sizeof(slong));
+        do {
+            //flint_printf("%{slong*}\n", perm, n);
+            int odd = _perm_parity(perm, n);
+            if (odd != (heap_count % 2)) {
+                TEST_FUNCTION_FAIL("unexpected sign in Heap's algorithm\n"
+                        "parity = %d\n"
+                        "index = %wd\n",
+                        odd, heap_count);
+            }
+            ++heap_count;
+            if (!odd) ++heap_count_even;
+        } while (_perm_next_heap(perm, n, stack));
+
+        _perm_clear(perm);
+        flint_free(stack);
+
+        if (!fmpz_equal_si(fact, lex_count) ||
+            !fmpz_equal_si(half_fact, lex_count_even) ||
+            !fmpz_equal_si(fact, heap_count) ||
+            !fmpz_equal_si(half_fact, heap_count_even))
+        {
+            TEST_FUNCTION_FAIL(
+                    "n = %wd\n"
+                    "n! = %{fmpz}\n"
+                    "n!/2 = %{fmpz}\n",
+                    "lex_count = %wd\n"
+                    "lex_count_even = %wd\n"
+                    "heap_count = %wd\n"
+                    "heap_count_even = %wd\n",
+                    n, fact, half_fact,
+                    lex_count, lex_count_even,
+                    heap_count, heap_count_even);
+        }
+    }
+
+    fmpz_clear(fact);
+    fmpz_clear(half_fact);
+
+    TEST_FUNCTION_END(state);
+}


### PR DESCRIPTION
Sometimes I want e.g. to take a sum over permutations with signs.

It's not that hard to iterate over permutations, and I can write the code again each time, but maybe we can add it to FLINT?