### PR TITLE
Add bounds checking to `gr_mat_swap_cols/rows`

### DIFF
--- a/doc/source/gr_mat.rst
+++ b/doc/source/gr_mat.rst
@@ -199,14 +199,18 @@ Basic row, column and entry operations
     Aliasing is allowed for square matrices.
 
 .. function:: int gr_mat_swap_rows(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx)
+.. function:: void _gr_mat_swap_rows(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx)
 
     Swaps rows ``r`` and ``s`` of ``mat``.  If ``perm`` is non-``NULL``, the
     permutation of the rows will also be applied to ``perm``.
+    The underscore method will not check bounds of ``r`` and ``s``.
 
 .. function:: int gr_mat_swap_cols(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx)
+.. function:: void _gr_mat_swap_cols(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx)
 
     Swaps columns ``r`` and ``s`` of ``mat``.  If ``perm`` is non-``NULL``, the
     permutation of the columns will also be applied to ``perm``.
+    The underscore method will not check bounds of ``r`` and ``s``.
 
 .. function:: int gr_mat_invert_rows(gr_mat_t mat, slong * perm, gr_ctx_t ctx)
 

--- a/src/gr_mat.h
+++ b/src/gr_mat.h
@@ -71,8 +71,10 @@ gr_mat_swap(gr_mat_t mat1, gr_mat_t mat2, gr_ctx_t FLINT_UNUSED(ctx))
     FLINT_SWAP(gr_mat_struct, *mat1, *mat2);
 }
 
+void _gr_mat_swap_rows(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mat_swap_rows(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mat_invert_rows(gr_mat_t mat, slong * perm, gr_ctx_t ctx);
+void _gr_mat_swap_cols(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mat_swap_cols(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mat_invert_cols(gr_mat_t mat, slong * perm, gr_ctx_t ctx);
 

--- a/src/gr_mat/fflu.c
+++ b/src/gr_mat/fflu.c
@@ -12,20 +12,6 @@
 #include "gr_vec.h"
 #include "gr_mat.h"
 
-static void
-_gr_mat_swap_rows(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx)
-{
-    if (r != s)
-    {
-        slong sz = ctx->sizeof_elem;
-
-        if (perm != NULL)
-            FLINT_SWAP(slong, perm[r], perm[s]);
-
-        _gr_vec_swap(GR_MAT_ENTRY(mat, r, 0, sz), GR_MAT_ENTRY(mat, s, 0, sz), mat->c, ctx);
-    }
-}
-
 int
 gr_mat_fflu(slong * res_rank, slong * P, gr_mat_t LU, gr_ptr den, const gr_mat_t A, int rank_check, gr_ctx_t ctx)
 {

--- a/src/gr_mat/lu_classical.c
+++ b/src/gr_mat/lu_classical.c
@@ -12,20 +12,6 @@
 #include "gr_vec.h"
 #include "gr_mat.h"
 
-static void
-_gr_mat_swap_rows(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx)
-{
-    if (r != s)
-    {
-        slong sz = ctx->sizeof_elem;
-
-        if (perm != NULL)
-            FLINT_SWAP(slong, perm[r], perm[s]);
-
-        _gr_vec_swap(GR_MAT_ENTRY(mat, r, 0, sz), GR_MAT_ENTRY(mat, s, 0, sz), mat->c, ctx);
-    }
-}
-
 int
 gr_mat_lu_classical(slong * res_rank, slong * P, gr_mat_t LU, const gr_mat_t A, int rank_check, gr_ctx_t ctx)
 {

--- a/src/gr_mat/swap_cols.c
+++ b/src/gr_mat/swap_cols.c
@@ -15,9 +15,13 @@
 int
 gr_mat_swap_cols(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx)
 {
-    /* todo: bounds checking */
+    if (r < 0 || r >= mat->c || s < 0 || s >= mat->c)
+        return GR_DOMAIN;
 
-    if (r != s && gr_mat_is_empty(mat, ctx) == T_FALSE)
+    if (r == s)
+        return GR_SUCCESS;
+
+    if (gr_mat_is_empty(mat, ctx) == T_FALSE)
     {
         slong t;
         slong sz = ctx->sizeof_elem;

--- a/src/gr_mat/swap_cols.c
+++ b/src/gr_mat/swap_cols.c
@@ -18,10 +18,15 @@ gr_mat_swap_cols(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx)
     if (r < 0 || r >= mat->c || s < 0 || s >= mat->c)
         return GR_DOMAIN;
 
-    if (r == s)
-        return GR_SUCCESS;
+    _gr_mat_swap_cols(mat, perm, r, s, ctx);
 
-    if (gr_mat_is_empty(mat, ctx) == T_FALSE)
+    return GR_SUCCESS;
+}
+
+void
+_gr_mat_swap_cols(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx)
+{
+    if (r != s && gr_mat_is_empty(mat, ctx) == T_FALSE)
     {
         slong t;
         slong sz = ctx->sizeof_elem;
@@ -32,6 +37,4 @@ gr_mat_swap_cols(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx)
         for (t = 0; t < mat->r; t++)
             gr_swap(GR_MAT_ENTRY(mat, t, r, sz), GR_MAT_ENTRY(mat, t, s, sz), ctx);
     }
-
-    return GR_SUCCESS;
 }

--- a/src/gr_mat/swap_rows.c
+++ b/src/gr_mat/swap_rows.c
@@ -14,9 +14,13 @@
 
 int gr_mat_swap_rows(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx)
 {
-    /* todo: bounds checking */
+    if (r < 0 || r >= mat->r || s < 0 || s >= mat->r)
+        return GR_DOMAIN;
 
-    if (r != s && gr_mat_is_empty(mat, ctx) == T_FALSE)
+    if (r == s)
+        return GR_SUCCESS;
+
+    if (gr_mat_is_empty(mat, ctx) == T_FALSE)
     {
         slong sz = ctx->sizeof_elem;
 

--- a/src/gr_mat/swap_rows.c
+++ b/src/gr_mat/swap_rows.c
@@ -12,15 +12,21 @@
 #include "gr_vec.h"
 #include "gr_mat.h"
 
-int gr_mat_swap_rows(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx)
+int
+gr_mat_swap_rows(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx)
 {
     if (r < 0 || r >= mat->r || s < 0 || s >= mat->r)
         return GR_DOMAIN;
 
-    if (r == s)
-        return GR_SUCCESS;
+    _gr_mat_swap_rows(mat, perm, r, s, ctx);
 
-    if (gr_mat_is_empty(mat, ctx) == T_FALSE)
+    return GR_SUCCESS;
+}
+
+void
+_gr_mat_swap_rows(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx)
+{
+    if (r != s && gr_mat_is_empty(mat, ctx) == T_FALSE)
     {
         slong sz = ctx->sizeof_elem;
 
@@ -29,6 +35,4 @@ int gr_mat_swap_rows(gr_mat_t mat, slong * perm, slong r, slong s, gr_ctx_t ctx)
 
         _gr_vec_swap(GR_MAT_ENTRY(mat, r, 0, sz), GR_MAT_ENTRY(mat, s, 0, sz), mat->c, ctx);
     }
-
-    return GR_SUCCESS;
 }


### PR DESCRIPTION
thus resolving the TODO comments in the code.

Note, however, that in specialized versions of this (like `fmpz_mat_swap_cols` in https://github.com/flintlib/flint/blob/213a4cff74d1bff9f0e07b63c57b6f3f8876e3a0/src/fmpz_mat/swap.c#L32), there is no bound checking whatsoever.