### PR TITLE
Real root isolation for `fmpz_poly` from e-antic

### DIFF
--- a/doc/source/fmpz_poly.rst
+++ b/doc/source/fmpz_poly.rst
@@ -3315,7 +3315,7 @@ Roots
 
     Isolate the real roots of ``pol``. The array
     ``exact_roots`` will be set to the exact dyadic roots found
-    by the algorithm and ``n_exact_roots`` updated accordingly.
+    by the algorithm and ``n_exact`` updated accordingly.
     The arrays ``c_array`` and ``k_array`` are set to be
     interval data that enclose the remaining roots and
     ``n_interval`` is updated accordingly. The data

--- a/doc/source/fmpz_poly.rst
+++ b/doc/source/fmpz_poly.rst
@@ -3252,6 +3252,19 @@ Roots
 
     where the coefficients of the polynomial are `a_0, \ldots, a_n`.
 
+.. function:: slong _fmpz_poly_positive_root_upper_bound_2exp_local_max(const fmpz * pol, slong len)
+              slong _fmpz_poly_positive_root_upper_bound_2exp(const fmpz * pol, slong len)
+              slong fmpz_poly_positive_root_upper_bound_2exp(const fmpz_poly_t pol)
+
+    Return the bitsize `e` of an upper bound `2^e` for the largest
+    positive real root of ``pol``.
+
+.. function:: slong _fmpz_poly_descartes_bound_0_1(const fmpz * p, slong len, slong bound)
+
+    Return an upper bound on the number of real roots in the interval `(0, 1)`
+    (excluding the endpoints) of the polynomial ``(p, len)`` using Descartes' rule
+    of sign. If the result is larger than ``bound`` then ``WORD_MAX`` is returned.
+
 .. function:: void _fmpz_poly_num_real_roots_sturm(slong * n_neg, slong * n_pos, const fmpz * pol, slong len)
 
     Sets ``n_neg`` and ``n_pos`` to the number of negative and
@@ -3264,25 +3277,50 @@ Roots
     and with non-zero constant coefficient.
 
 .. function:: slong fmpz_poly_num_real_roots_sturm(const fmpz_poly_t pol)
+              slong _fmpz_poly_num_real_roots_vca(const fmpz * pol, slong len)
+              slong fmpz_poly_num_real_roots_vca(const fmpz_poly_t pol)
+              slong _fmpz_poly_num_real_roots(const fmpz * pol, slong len)
+              slong fmpz_poly_num_real_roots(const fmpz_poly_t pol)
 
-    Returns the number of real roots of the squarefree polynomial ``pol``
-    using Sturm sequence.
-
+    Returns the number of real roots of the polynomial ``pol``.
     The polynomial is assumed to be squarefree.
 
-.. function:: slong _fmpz_poly_num_real_roots(const fmpz * pol, slong len)
+.. function:: slong fmpz_poly_num_real_roots_0_1_sturm(const fmpz_poly_t pol)
+              slong fmpz_poly_num_real_roots_0_1_vca(const fmpz_poly_t pol)
+              slong fmpz_poly_num_real_roots_0_1(const fmpz_poly_t pol)
 
-    Returns the number of real roots of the squarefree polynomial
-    ``(pol, len)``.
-
+    Returns the number of real roots of the polynomial ``pol`` on the
+    interval `(0, 1)` (excluding the endpoints).
     The polynomial is assumed to be squarefree.
 
-.. function:: slong fmpz_poly_num_real_roots(const fmpz_poly_t pol)
+.. function:: int _fmpz_poly_has_real_root(const fmpz * p, slong len)
+              int fmpz_poly_has_real_root(const fmpz_poly_t pol)
 
-    Returns the number of real roots of the squarefree polynomial ``pol``.
-
+    Returns whether the polynomial has a real root.
     The polynomial is assumed to be squarefree.
 
+.. function:: void _fmpz_poly_isolate_real_roots_0_1_vca(fmpq * exact_roots, slong * n_exact_roots, fmpz * c_array, slong * k_array, slong * n_intervals, const fmpz * pol, slong len)
+
+    Isolate the real roots of ``(pol, len)`` in the interval `(0, 1)`
+    (excluding the endpoints). The array ``exact_roots`` will be set to
+    the exact dyadic roots found by the algorithm and
+    ``n_exact_roots`` updated accordingly. The arrays
+    ``c_array`` and ``k_array`` are set to be interval data
+    that enclose the remaining roots and ``n_interval`` is
+    updated accordingly. The data ``c = c_array + i`` and
+    ``k = k_array[i]`` represents the open interval
+    `(c 2^k, (c + 1) 2^k)`.
+
+.. function:: void fmpz_poly_isolate_real_roots(fmpq * exact_roots, slong * n_exact, fmpz * c_array, slong * k_array, slong * n_interval, const fmpz_poly_t pol)
+
+    Isolate the real roots of ``pol``. The array
+    ``exact_roots`` will be set to the exact dyadic roots found
+    by the algorithm and ``n_exact_roots`` updated accordingly.
+    The arrays ``c_array`` and ``k_array`` are set to be
+    interval data that enclose the remaining roots and
+    ``n_interval`` is updated accordingly. The data
+    ``c = c_array + i`` and ``k = k_array[i]`` represents the
+    open interval `(c 2^k, (c + 1) 2^k)`.
 
 Minimal polynomials
 --------------------------------------------------------------------------------

--- a/src/fmpz_poly.h
+++ b/src/fmpz_poly.h
@@ -1201,16 +1201,34 @@ void fmpz_poly_hensel_lift_once(fmpz_poly_factor_t lifted_fac,
 /* Roots */
 
 void _fmpz_poly_bound_roots(fmpz_t bound, const fmpz * poly, slong len);
-
 void fmpz_poly_bound_roots(fmpz_t bound, const fmpz_poly_t poly);
 
 void _fmpz_poly_num_real_roots_sturm(slong * n_neg, slong * n_pos, const fmpz * pol, slong len);
-
 slong fmpz_poly_num_real_roots_sturm(const fmpz_poly_t poly);
-
+slong _fmpz_poly_num_real_roots_vca(const fmpz * pol, slong len);
+slong fmpz_poly_num_real_roots_vca(const fmpz_poly_t pol);
 slong _fmpz_poly_num_real_roots(const fmpz * pol, slong len);
-
 slong fmpz_poly_num_real_roots(const fmpz_poly_t poly);
+
+slong fmpz_poly_num_real_roots_upper_bound(const fmpz_poly_t pol);
+slong _fmpz_poly_descartes_bound_0_1(const fmpz * p, slong len, slong bound);
+
+int _fmpz_poly_has_real_root(const fmpz * p, slong len);
+int fmpz_poly_has_real_root(const fmpz_poly_t pol);
+
+slong fmpz_poly_num_real_roots_0_1_sturm(const fmpz_poly_t pol);
+slong fmpz_poly_num_real_roots_0_1_vca(const fmpz_poly_t pol);
+slong fmpz_poly_num_real_roots_0_1(const fmpz_poly_t pol);
+
+slong _fmpz_poly_positive_root_upper_bound_2exp_local_max(const fmpz * pol, slong len);
+slong _fmpz_poly_positive_root_upper_bound_2exp(const fmpz * pol, slong len);
+slong fmpz_poly_positive_root_upper_bound_2exp(const fmpz_poly_t pol);
+
+void _fmpz_poly_isolate_real_roots_0_1_vca(fmpq * exact_roots, slong * n_exact,
+        fmpz * c_array, slong * k_array, slong * n_intervals,
+        const fmpz * pol, slong len);
+void fmpz_poly_isolate_real_roots(fmpq * exact_roots, slong * n_exact,
+    fmpz * c_array, slong * k_array, slong * n_interval, const fmpz_poly_t pol);
 
 /* CLD bounds */
 

--- a/src/fmpz_poly/descartes_bound.c
+++ b/src/fmpz_poly/descartes_bound.c
@@ -1,0 +1,59 @@
+/*
+    Copyright (C) 2015, Elias Tsigaridas
+    Copyright (C) 2016, Vincent Delecroix
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz.h"
+#include "fmpz_vec.h"
+#include "fmpz_poly.h"
+
+slong fmpz_poly_num_real_roots_upper_bound(const fmpz_poly_t pol)
+{
+    slong i, i0, k, ret, len;
+    fmpz * pol2;
+
+    if (fmpz_poly_is_zero(pol))
+        flint_throw(FLINT_ERROR, "(fmpz_poly_positive_roots_upper_bound): zero polynomial\n");
+
+    i0 = 0;
+    while (fmpz_is_zero(pol->coeffs + i0))
+        i0++;
+    len = pol->length - i0;
+    pol2 = _fmpz_vec_init(len);
+
+    /* zero roots */
+    ret = i0;
+
+    /* positive roots */
+    _fmpz_vec_set(pol2, pol->coeffs + i0, len);
+
+    k = _fmpz_poly_positive_root_upper_bound_2exp(pol2, len);
+    if (k != WORD_MIN)
+    {
+        _fmpz_poly_scale_2exp(pol2, len, k);
+        ret += _fmpz_poly_descartes_bound_0_1(pol2, len, len);
+    }
+
+    /* negative roots */
+    _fmpz_vec_set(pol2, pol->coeffs + i0, len);
+    for (i = 1; i < len; i += 2)
+        fmpz_neg(pol2 + i, pol2 + i);
+
+    k = _fmpz_poly_positive_root_upper_bound_2exp(pol2, len);
+    if (k != WORD_MIN)
+    {
+        _fmpz_poly_scale_2exp(pol2, len, k);
+        ret += _fmpz_poly_descartes_bound_0_1(pol2, len, len);
+    }
+
+    _fmpz_vec_clear(pol2, len);
+    return ret;
+}
+

--- a/src/fmpz_poly/descartes_bound_0_1.c
+++ b/src/fmpz_poly/descartes_bound_0_1.c
@@ -1,0 +1,102 @@
+/*
+    Copyright (C) 2015, Elias Tsigaridas
+    Copyright (C) 2016, Vincent Delecroix
+
+    The implementation was inspired from the SLV library version 0.5 by Elias
+    Tsigaridas (namely the function Descartes_test in the file vca_solver_1.c
+    lines 67-125)
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz.h"
+#include "fmpz_vec.h"
+#include "fmpz_poly.h"
+
+slong _fmpz_poly_descartes_bound_0_1(const fmpz * p, slong len, slong bound)
+{
+    slong V = 0;
+    slong i,j;
+    int s, t;
+    slong deg = len - 1;
+    fmpz * q;
+
+    j = deg;
+    t = fmpz_sgn(p + deg);
+
+    while ((j >= 0) && ((fmpz_sgn(p + j) == t) || fmpz_sgn(p + j) == 0))
+        j--;
+
+    if (j < 0)
+        /* all coefficients are non-negative */
+        return 0;
+
+    q = _fmpz_vec_init(len);
+    fmpz_set(q, p);
+    for (j = 0; j <= deg - 1; j++)
+    {
+        fmpz_set(q + j + 1, p + j + 1);
+        fmpz_add(q + j + 1, q + j + 1, q + j);
+    }
+
+
+    s = fmpz_sgn(q + deg);  /* = sign(p(1)) */
+
+    for (i = 1; i <= deg - 1; i++)
+    {
+        j = deg - i;
+        t = s;
+
+        while ((j >= 0) && (t == 0))
+        {
+            t = fmpz_sgn(q + j);
+            j--;
+        }
+
+        while ((j >= 0) && ((fmpz_sgn(q + j) == t) || (fmpz_sgn(q + j) == 0)))
+            j--;
+
+        if (j < 0)
+        {
+            /* all coefficients of q are non-negative */
+            _fmpz_vec_clear(q, len);
+            return V;
+        }
+
+        for (j = 0; j <= deg - i - 1; j++)
+            fmpz_add(q + j + 1, q + j + 1, q + j);
+
+        if (s == 0)
+            s = fmpz_sgn(q + deg - i);
+        else if (s == -fmpz_sgn(q + deg - i))
+        {
+            if (V == bound)
+            {
+                _fmpz_vec_clear(q, len);
+                return WORD_MAX;
+            }
+            V++;
+            s = -s;
+        }
+    }
+
+    if (s == -fmpz_sgn(q))
+    {
+        if (V == bound)
+        {
+            _fmpz_vec_clear(q, len);
+            return WORD_MAX;
+        }
+        V++;
+    }
+
+    _fmpz_vec_clear(q, len);
+    return V;
+}
+
+

--- a/src/fmpz_poly/descartes_bound_0_1.c
+++ b/src/fmpz_poly/descartes_bound_0_1.c
@@ -39,11 +39,7 @@ slong _fmpz_poly_descartes_bound_0_1(const fmpz * p, slong len, slong bound)
     q = _fmpz_vec_init(len);
     fmpz_set(q, p);
     for (j = 0; j <= deg - 1; j++)
-    {
-        fmpz_set(q + j + 1, p + j + 1);
-        fmpz_add(q + j + 1, q + j + 1, q + j);
-    }
-
+        fmpz_add(q + j + 1, q + j, p + j + 1);
 
     s = fmpz_sgn(q + deg);  /* = sign(p(1)) */
 

--- a/src/fmpz_poly/has_real_root.c
+++ b/src/fmpz_poly/has_real_root.c
@@ -1,0 +1,71 @@
+/*
+   Copyright (C) 2016 Vincent Delecroix
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz.h"
+#include "fmpz_vec.h"
+#include "fmpz_poly.h"
+
+int _fmpz_poly_has_real_root(const fmpz * p, slong len)
+{
+    slong n, i;
+    int s, t;
+
+    /* O(1) conditions:                          */
+    /*    - constant polynomial                  */
+    /*    - odd degree                           */
+    /*    - p(0) = 0                             */
+    /*    - sign(p(0)) * sign(p(+infinity)) = -1 */
+    if (len == 1)
+        return 0;
+    if (len % 2 == 0)
+        return 1;
+    if (fmpz_is_zero(p) || (fmpz_sgn(p) * fmpz_sgn(p + len - 1) < 0))
+       return 1;
+
+    /* O(len) conditions: Descartes rule of sign */
+    n = 0;
+    s = fmpz_sgn(p);
+    for (i = 1; i < len; i++)
+    {
+        if (fmpz_is_zero(p + i)) continue;
+        t = fmpz_sgn(p + i);
+        if (t != s)
+        {
+            n += 1;
+            s = t;
+        }
+    }
+    if (n % 2 == 1) return 1;
+
+    n = 0;
+    s = fmpz_sgn(p);
+    for (i = 1; i < len; i++)
+    {
+        if (fmpz_is_zero(p + i)) continue;
+        t = fmpz_sgn(p + i);
+        if (i % 2) t = -t;
+        if (t != s)
+        {
+            n += 1;
+            s = t;
+        }
+    }
+    if (n % 2 == 1) return 1;
+
+    /* try to isolate one root */
+    return _fmpz_poly_num_real_roots(p, len) != 0;
+}
+
+int fmpz_poly_has_real_root(const fmpz_poly_t pol)
+{
+    return _fmpz_poly_has_real_root(pol->coeffs, pol->length);
+}
+

--- a/src/fmpz_poly/isolate_real_roots.c
+++ b/src/fmpz_poly/isolate_real_roots.c
@@ -1,0 +1,217 @@
+/*
+    Copyright (C) 2016 Vincent Delecroix
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz.h"
+#include "fmpq.h"
+#include "fmpz_vec.h"
+#include "fmpz_poly.h"
+
+/* isolate the real roots of pol contained in [0,1] */
+/* using VCA (Vincent-Collins-Akritas) method       */
+/* the output are arrays of fmpz c and integers k so that the roots belong to */
+/* [c*2^k, (c+1)*2^k[ */
+/* if exact_roots is NULL only n_exact is updated */
+/* similarly if c_array/k_array is NULL only n_intervals is updated (useful to */
+/* count the roots) */
+void _fmpz_poly_isolate_real_roots_0_1_vca(fmpq * exact_roots, slong * n_exact,
+        fmpz * c_array, slong * k_array, slong * n_intervals,
+        const fmpz * pol, slong len)
+{
+    fmpz_t c;
+    slong k;
+    fmpz * p;
+    fmpz * p0;
+    slong i;
+    fmpz_t one;
+    slong len0 = len;
+
+    fmpz_init(one);
+    fmpz_one(one);
+    p0 = p = _fmpz_vec_init(len);
+    _fmpz_vec_set(p, pol, len);
+
+    fmpz_init(c);
+    fmpz_zero(c);
+    k = 0;
+
+    while (1)
+    {
+        /* check for exact zero */
+        while (fmpz_is_zero(p) && len)
+        {
+            if (exact_roots != NULL)
+            {
+                fmpz_set(fmpq_numref(exact_roots + *n_exact), c);
+                fmpz_one(fmpq_denref(exact_roots + *n_exact));
+
+                FLINT_ASSERT(k >= 0);
+                fmpq_div_2exp(exact_roots + *n_exact, exact_roots + *n_exact, (ulong)k);
+            }
+            (*n_exact)++;
+            p++;
+            len--;
+        }
+
+        /* use Descartes bound */
+        {
+            const slong bound = _fmpz_poly_descartes_bound_0_1(p, len, 2);
+            switch(bound)
+            {
+                case 2:
+                case WORD_MAX:
+                    /* unknown: go down */
+                    k += 1;
+                    fmpz_mul_2exp(c, c, 1);
+                    _fmpz_poly_scale_2exp(p, len, -1);
+                    continue;
+                case 1:
+                    /* got a root! */
+                    if ((c_array != NULL) && (k_array != NULL))
+                    {
+                        fmpz_set(c_array + *n_intervals, c);
+                        k_array[*n_intervals] = -k;
+                    }
+                    (*n_intervals)++;
+                    break;
+                case 0:
+                    break;
+                default:
+                    flint_throw(FLINT_ERROR, "ERROR: expected 0,1,WORD_MAX as output from descartes_bound but got %wd\n", bound);
+            }
+
+            /* no root: go up */
+            fmpz_add_ui(c, c, 1);
+            i = (slong)fmpz_val2(c);
+            if (k == i)
+            {
+                fmpz_clear(c);
+                fmpz_clear(one);
+                _fmpz_vec_clear(p0, len0);
+                return;
+            }
+
+            /* go to the next node */
+            _fmpz_poly_taylor_shift(p, one, len);
+            if (i)
+            {
+                _fmpz_poly_scale_2exp(p, len, i);
+                fmpz_fdiv_q_2exp(c, c, (ulong)i);
+
+                FLINT_ASSERT(k >= i);
+                k -= i;
+            }
+        }
+    }
+}
+
+void fmpz_poly_isolate_real_roots(fmpq * exact_roots, slong * n_exact, fmpz * c_array, slong * k_array, slong * n_interval, const fmpz_poly_t pol)
+{
+    slong i, k, n_neg, tmp, len, n_zeros, n_neg_exact;
+    fmpz * p;
+
+    n_neg = n_zeros = n_neg_exact = *n_exact = *n_interval = 0;
+    len = pol->length;
+
+    if (fmpz_poly_is_zero(pol))
+        flint_throw(FLINT_ERROR, "ERROR (fmpz_poly_isolate_real_roots): zero polynomial\n");
+
+    /* compute the number zero roots */
+    /* (they will be inserted after the negative ones) */
+    for (n_zeros = 0; (n_zeros < len) && fmpz_is_zero(pol->coeffs + n_zeros); n_zeros++);
+    len -= n_zeros;
+    p = _fmpz_vec_init(len);
+    _fmpz_vec_set(p, pol->coeffs + n_zeros, len);
+
+    /* negative roots (use P(-x)) */
+    for (i = 1; i < len; i += 2) fmpz_neg(p + i, p + i);
+    k = _fmpz_poly_positive_root_upper_bound_2exp(p, len);
+
+    if (k != WORD_MIN)
+    {
+        _fmpz_poly_scale_2exp(p, len, k);
+        _fmpz_poly_isolate_real_roots_0_1_vca(exact_roots, n_exact, c_array, k_array, n_interval, p, len);
+        n_neg = *n_interval;
+        n_neg_exact = *n_exact;
+        if ((c_array != NULL) && (k_array != NULL))
+        {
+            for (i = 0; i < *n_interval; i++)
+            {
+                fmpz_add_ui(c_array + i, c_array + i, 1);
+                fmpz_neg(c_array + i, c_array + i);
+                k_array[i] += k;
+            }
+            for (i = 0; i < *n_interval / 2; i++)
+            {
+                fmpz_swap(c_array + i, c_array + *n_interval - i - 1);
+                tmp = k_array[i];
+                k_array[i] = k_array[*n_interval - i - 1];
+                k_array[*n_interval - i - 1] = tmp;
+            }
+        }
+
+        if (exact_roots != NULL)
+        {
+            for (i = 0; i < n_neg_exact; i++)
+            {
+                fmpq_neg(exact_roots + i, exact_roots + i);
+                if (k > 0)
+                    fmpq_mul_2exp(exact_roots + i, exact_roots + i, (ulong)k);
+                else if (k < 0)
+                    fmpq_div_2exp(exact_roots + i, exact_roots + i, (ulong)-k);
+            }
+            for (i = 0; i < n_neg_exact/2; i++)
+            {
+                fmpq_swap(exact_roots + i, exact_roots + *n_exact - i - 1);
+            }
+        }
+    }
+    else
+        n_neg = 0;
+
+    /* insert zero roots */
+    if (exact_roots != NULL)
+    {
+        for (i = *n_exact; i < *n_exact+n_zeros; i++) fmpq_zero(exact_roots + i);
+    }
+    *n_exact += n_zeros;
+
+
+    /* positive roots */
+    _fmpz_vec_set(p, pol->coeffs + n_zeros, len);
+    k = _fmpz_poly_positive_root_upper_bound_2exp(p, len);
+    if (k != WORD_MIN)
+    {
+        _fmpz_poly_scale_2exp(p, len, k);
+        _fmpz_poly_isolate_real_roots_0_1_vca(exact_roots, n_exact, c_array, k_array, n_interval, p, len);
+
+        if ((c_array != NULL) && (k_array != NULL))
+        {
+            for (i = n_neg; i < *n_interval; i++)
+                k_array[i] += k;
+        }
+
+        if (exact_roots != NULL)
+        {
+            for (i = n_neg_exact + n_zeros; i < *n_exact; i++)
+            {
+                if (k > 0)
+                    fmpq_mul_2exp(exact_roots + i, exact_roots + i, (ulong)k);
+                else if (k < 0)
+                    fmpq_div_2exp(exact_roots + i, exact_roots + i, (ulong)-k);
+            }
+        }
+    }
+
+
+    _fmpz_vec_clear(p, len);
+}
+
+

--- a/src/fmpz_poly/num_real_roots_0_1.c
+++ b/src/fmpz_poly/num_real_roots_0_1.c
@@ -1,0 +1,18 @@
+/*
+   Copyright (C) 2016 Vincent Delecroix
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz.h"
+#include "fmpz_poly.h"
+
+slong fmpz_poly_num_real_roots_0_1(const fmpz_poly_t pol)
+{
+    return fmpz_poly_num_real_roots_0_1_vca(pol);
+}

--- a/src/fmpz_poly/num_real_roots_0_1_sturm.c
+++ b/src/fmpz_poly/num_real_roots_0_1_sturm.c
@@ -69,11 +69,15 @@ slong fmpz_poly_num_real_roots_0_1_sturm(const fmpz_poly_t pol)
 
         fmpz_poly_swap(p0, p1);
         fmpz_poly_pseudo_rem(p1, &d, p1, p0);
-        if ((d%2 == 0) || (fmpz_sgn(p0->coeffs + p0->length - 1) == 1))
-            fmpz_poly_neg(p1, p1);
-        fmpz_poly_content(c, p1);
-        if (!fmpz_is_one(c))
-            _fmpz_vec_scalar_divexact_fmpz(p1->coeffs, p1->coeffs, p1->length, c);
+
+        if (!fmpz_poly_is_zero(p1))
+        {
+            if ((d%2 == 0) || (fmpz_sgn(p0->coeffs + p0->length - 1) == 1))
+                fmpz_poly_neg(p1, p1);
+            fmpz_poly_content(c, p1);
+            if (!fmpz_is_one(c))
+                _fmpz_vec_scalar_divexact_fmpz(p1->coeffs, p1->coeffs, p1->length, c);
+        }
     }
 
     fmpz_poly_clear(p0);

--- a/src/fmpz_poly/num_real_roots_0_1_sturm.c
+++ b/src/fmpz_poly/num_real_roots_0_1_sturm.c
@@ -1,0 +1,88 @@
+/*
+    Copyright (C) 2016 Vincent Delecroix
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz.h"
+#include "fmpz_vec.h"
+#include "fmpz_poly.h"
+
+static void fmpz_poly_evaluate_at_one(fmpz_t res, const fmpz * p, slong len)
+{
+    _fmpz_vec_sum(res, p, len);
+}
+
+slong fmpz_poly_num_real_roots_0_1_sturm(const fmpz_poly_t pol)
+{
+    fmpz_poly_t p0, p1;
+    ulong d;
+    fmpz_t c;
+    int s, s0a, s0b, t;
+    int zero_at_0, zero_at_1;
+
+    if (fmpz_poly_is_zero(pol))
+        flint_throw(FLINT_ERROR, "(fmpz_poly_num_real_roots_sturm): zero polynomial\n");
+
+    fmpz_init(c);
+    fmpz_poly_init(p0);
+    fmpz_poly_init(p1);
+
+    fmpz_poly_set(p0, pol);
+    fmpz_poly_derivative(p1, p0);
+
+    s0a = fmpz_sgn(pol->coeffs);
+    fmpz_poly_evaluate_at_one(c, pol->coeffs, pol->length);
+    s0b = fmpz_sgn(c);
+
+    zero_at_0 = (s0a == 0);
+    zero_at_1 = (s0b == 0);
+
+    /* Sturm's theorem counts roots in (0, 1], so count if there's one at 0 */
+    t = zero_at_0;
+
+    while (!fmpz_poly_is_zero(p1))
+    {
+        /* sign change at 0 */
+        s = fmpz_sgn(p1->coeffs);
+        if (s != 0)
+        {
+            if (s0a != 0 && s != s0a)
+                t++;
+            s0a = s;
+        }
+
+        /* sign change at 1 */
+        fmpz_poly_evaluate_at_one(c, p1->coeffs, p1->length);
+        s = fmpz_sgn(c);
+        if (s != 0)
+        {
+            if (s0b != 0 && s != s0b)
+                t--;
+            s0b = s;
+        }
+
+        fmpz_poly_swap(p0, p1);
+        fmpz_poly_pseudo_rem(p1, &d, p1, p0);
+        if ((d%2 == 0) || (fmpz_sgn(p0->coeffs + p0->length - 1) == 1))
+            fmpz_poly_neg(p1, p1);
+        fmpz_poly_content(c, p1);
+        if (!fmpz_is_one(c))
+            _fmpz_vec_scalar_divexact_fmpz(p1->coeffs, p1->coeffs, p1->length, c);
+    }
+
+    fmpz_poly_clear(p0);
+    fmpz_poly_clear(p1);
+    fmpz_clear(c);
+
+    /* We return the count on (0, 1) for consistency with VCA */
+    t -= zero_at_1;
+
+    return t;
+}
+

--- a/src/fmpz_poly/num_real_roots_0_1_vca.c
+++ b/src/fmpz_poly/num_real_roots_0_1_vca.c
@@ -1,0 +1,22 @@
+/*
+    Copyright (C) 2016 Vincent Delecroix
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz_poly.h"
+
+slong fmpz_poly_num_real_roots_0_1_vca(const fmpz_poly_t pol)
+{
+    slong n_exact = 0;
+    slong n_interval = 0;
+
+    _fmpz_poly_isolate_real_roots_0_1_vca(NULL, &n_exact, NULL, NULL, &n_interval, pol->coeffs, pol->length);
+
+    return n_exact + n_interval;
+}

--- a/src/fmpz_poly/num_real_roots_vca.c
+++ b/src/fmpz_poly/num_real_roots_vca.c
@@ -1,0 +1,32 @@
+/*
+   Copyright (C) 2016 Vincent Delecroix
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz_poly.h"
+
+slong _fmpz_poly_num_real_roots_vca(const fmpz * pol, slong len)
+{
+    fmpz_poly_t f;
+    f->coeffs = (fmpz *) pol;
+    f->length = f->alloc = len;
+    return fmpz_poly_num_real_roots_vca(f);
+}
+
+
+slong fmpz_poly_num_real_roots_vca(const fmpz_poly_t pol)
+{
+    slong n_exact = 0;
+    slong n_interval = 0;
+
+    fmpz_poly_isolate_real_roots(NULL, &n_exact, NULL, NULL, &n_interval, pol);
+
+    return n_exact + n_interval;
+}
+

--- a/src/fmpz_poly/positive_root_upper_bound_2exp.c
+++ b/src/fmpz_poly/positive_root_upper_bound_2exp.c
@@ -1,0 +1,99 @@
+/*
+    Copyright (C) 2015, Elias Tsigaridas
+    Copyright (C) 2016, Vincent Delecroix
+
+    This file is part of FLINT.
+
+    The implementation follows the function slv_poly_root_upper_bound_2exp in
+    the library SLV version 0.5 by Elias Tsigaridas (in the file poly_ops.c
+    lines 67-125).
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz.h"
+#include "fmpz_poly.h"
+
+slong _fmpz_poly_positive_root_upper_bound_2exp_local_max(const fmpz * pol, slong len)
+{
+    slong b, b0, bmin;
+    slong i, j, jmin = -1;
+    fmpz_t tmp;
+
+    fmpz_init(tmp);
+
+    FLINT_ASSERT(len >= 0);
+
+    slong * coeffs = flint_malloc((ulong)len * sizeof(slong));
+    for (i = 0; i < len; i++)
+        coeffs[i] = 1;
+
+    b0 = WORD_MIN;
+    int sgn = fmpz_sgn(pol + len - 1);
+
+    for (i = len - 2; i >= 0; i--)
+    {
+        if (fmpz_sgn(pol + i) == 0 || fmpz_sgn(pol + i) == sgn)
+            continue;
+
+        bmin = WORD_MAX;
+        for (j = i + 1; j < len; j++)
+        {
+            /* compare the current bound with the log (in base 2) of */
+            /* (- 2^coeffs[j] * p_i / p_j) ^ (1 / (j - i))           */
+            /* which equals                                          */
+            /* (coeffs[j] + log(|p_i|) + log(|p_j|)) / (j - i)       */
+            b = coeffs[j];
+
+            fmpz_abs(tmp, pol + i);
+            b += fmpz_clog_ui(tmp, 2);
+
+            fmpz_abs(tmp, pol + j);
+            b -= fmpz_flog_ui(tmp, 2);
+
+            b = (b + j - i - 1) / (j - i);
+
+            if (b < bmin)
+            {
+                jmin = j;
+                bmin = b;
+                if (bmin < b0)
+                    break;
+            }
+        }
+
+        b0 = FLINT_MAX(b0, bmin);
+
+        FLINT_ASSERT(jmin >= 0);
+        coeffs[jmin] ++;
+    }
+
+    fmpz_clear(tmp);
+    flint_free(coeffs);
+
+    return b0;
+}
+
+slong _fmpz_poly_positive_root_upper_bound_2exp(const fmpz * pol, slong len)
+{
+    return _fmpz_poly_positive_root_upper_bound_2exp_local_max(pol, len);
+}
+
+slong fmpz_poly_positive_root_upper_bound_2exp(const fmpz_poly_t pol)
+{
+    slong i0;
+
+    if (fmpz_poly_is_zero(pol))
+        return 0;
+
+    i0 = 0;
+    while (fmpz_is_zero(pol->coeffs + i0))
+        i0++;
+
+    return _fmpz_poly_positive_root_upper_bound_2exp_local_max(
+               pol->coeffs + i0,
+               fmpz_poly_length(pol) - i0);
+}

--- a/src/fmpz_poly/profile/p-real_roots.c
+++ b/src/fmpz_poly/profile/p-real_roots.c
@@ -1,0 +1,160 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz_vec.h"
+#include "fmpz_poly.h"
+#include "fmpq_vec.h"
+#include "fmpq_poly.h"
+#include "arith.h"
+#include "profiler.h"
+#include "acb.h"
+#include "arb_fmpz_poly.h"
+
+#define MAXN 256
+
+int main()
+{
+    slong n, c1, c2, c3, c4;
+
+    flint_rand_t state;
+    flint_rand_init(state);
+
+    fmpz_poly_t f;
+    fmpq_poly_t g;
+    fmpz_poly_init(f);
+    fmpq_poly_init(g);
+
+    acb_ptr R = _acb_vec_init(MAXN);
+    fmpq * ex = _fmpq_vec_init(MAXN);
+    fmpz * iv = _fmpz_vec_init(MAXN);
+    slong karr[MAXN] = { 0 };
+    slong n_ex = 0;
+    slong n_iv = 0;
+
+    flint_printf("   polynomial  n       count real roots             count (0, 1) roots             isolate all roots\n");
+    flint_printf("                       sturm     vca     ratio         sturm     vca   ratio      acb       vca      ratio\n");
+    flint_printf("----------------------------------------------------------------------------------------------------------\n");
+
+
+    for (n = 8; n <= MAXN; n *= 2)
+    {
+        int pol;
+        for (pol = 0; pol < 8; pol++)
+        {
+            char * s;
+            if (pol == 0)
+            {
+                fmpz_poly_fibonacci(f, n);
+                s = "fibonacci";
+            }
+            else if (pol == 1)
+            {
+                do {
+                    fmpz_poly_zero(f);
+                    slong k;
+                    for (k = 0; k <= n; k++)
+                        fmpz_poly_set_coeff_si(f, k, (k == n || k == 0) ? 1 : (slong) n_randint(state, 3) - 1);
+                } while (!fmpz_poly_is_squarefree(f));
+                s = "rand1b";
+            }
+            else if (pol == 2)
+            {
+                arith_bernoulli_polynomial(g, n);
+                fmpq_poly_get_numerator(f, g);
+                s = "bernoulli";
+            }
+            else if (pol == 3)
+            {
+                fmpz_poly_chebyshev_t(f, n);
+                s = "chebyshev_t";
+            }
+            else if (pol == 4)
+            {
+                fmpq_poly_legendre_p(g, n);
+                fmpq_poly_get_numerator(f, g);
+                s = "legendre_p";
+            }
+            else if (pol == 5)
+            {
+                fmpz_poly_hermite_h(f, n);
+                s = "hermite_h";
+            }
+            else if (pol == 6)
+            {
+                fmpq_poly_laguerre_l(g, n);
+                fmpq_poly_get_numerator(f, g);
+                s = "laguerre_l";
+            }
+            else if (pol == 7)
+            {
+                fmpz_poly_zero(f);
+                slong k;
+                for (k = 0; k <= n; k++)
+                {
+                    fmpz_poly_set_coeff_si(f, k, 1);
+                    fmpz_randbits(f->coeffs + k, state, 1000);
+                }
+                s = "rand1000b";
+            }
+
+            double t1, t2, t3, t4, t5, t6, FLINT_SET_BUT_UNUSED(tcpu);
+
+            TIMEIT_START;
+            c1 = fmpz_poly_num_real_roots_sturm(f);
+            TIMEIT_STOP_VALUES(tcpu, t1);
+
+            TIMEIT_START;
+            c2 = fmpz_poly_num_real_roots_vca(f);
+            TIMEIT_STOP_VALUES(tcpu, t2);
+
+            TIMEIT_START;
+            c3 = fmpz_poly_num_real_roots_0_1_sturm(f);
+            TIMEIT_STOP_VALUES(tcpu, t3);
+
+            TIMEIT_START;
+            c4 = fmpz_poly_num_real_roots_0_1_vca(f);
+            TIMEIT_STOP_VALUES(tcpu, t4);
+
+            TIMEIT_START;
+            arb_fmpz_poly_complex_roots(R, f, 0, 32);
+            TIMEIT_STOP_VALUES(tcpu, t5);
+
+            TIMEIT_START;
+            fmpz_poly_isolate_real_roots(ex, &n_ex, iv, karr, &n_iv, f);
+            TIMEIT_STOP_VALUES(tcpu, t6);
+
+            if (c1 != c2)
+                flint_abort();
+            if (c3 != c4)
+                flint_abort();
+
+            flint_printf("%12s %3wd   %9g %9g %7.2f   %9g %9g %7.2f   %9g %9g %7.2f\n",
+                s, n, t1, t2, FLINT_MIN(t1 / t2, 9999.0),
+                      t3, t4, FLINT_MIN(t3 / t4, 9999.0),
+                      t5, t6, FLINT_MIN(t5 / t6, 9999.0));
+        }
+
+        flint_printf("\n");
+    }
+
+    fmpz_poly_clear(f);
+    fmpq_poly_clear(g);
+
+    _acb_vec_clear(R, MAXN);
+    _fmpq_vec_clear(ex, MAXN);
+    _fmpz_vec_clear(iv, MAXN);
+
+    flint_rand_clear(state);
+
+    flint_cleanup_master();
+    return 0;
+}
+

--- a/src/fmpz_poly/test/main.c
+++ b/src/fmpz_poly/test/main.c
@@ -107,6 +107,7 @@
 #include "t-inv_series_newton.c"
 #include "t-is_cyclotomic.c"
 #include "t-is_squarefree.c"
+#include "t-isolate_real_roots.c"
 #include "t-lcm.c"
 #include "t-legendre_pt.c"
 #include "t-mul.c"
@@ -132,7 +133,11 @@
 #include "t-newton_to_monomial.c"
 #include "t-nth_derivative.c"
 #include "t-num_real_roots.c"
+#include "t-num_real_roots_0_1.c"
 #include "t-num_real_roots_sturm.c"
+#include "t-num_real_roots_upper_bound.c"
+#include "t-num_real_roots_vca.c"
+#include "t-positive_root_upper_bound_2exp.c"
 #include "t-pow_addchains.c"
 #include "t-pow_binexp.c"
 #include "t-pow_binomial.c"
@@ -292,6 +297,7 @@ test_struct tests[] =
     TEST_FUNCTION(fmpz_poly_inv_series_newton),
     TEST_FUNCTION(fmpz_poly_is_cyclotomic),
     TEST_FUNCTION(fmpz_poly_is_squarefree),
+    TEST_FUNCTION(fmpz_poly_isolate_real_roots),
     TEST_FUNCTION(fmpz_poly_lcm),
     TEST_FUNCTION(fmpz_poly_legendre_pt),
     TEST_FUNCTION(fmpz_poly_mul),
@@ -317,7 +323,11 @@ test_struct tests[] =
     TEST_FUNCTION(fmpz_poly_newton_to_monomial),
     TEST_FUNCTION(fmpz_poly_nth_derivative),
     TEST_FUNCTION(fmpz_poly_num_real_roots),
+    TEST_FUNCTION(fmpz_poly_num_real_roots_0_1),
     TEST_FUNCTION(fmpz_poly_num_real_roots_sturm),
+    TEST_FUNCTION(fmpz_poly_num_real_roots_upper_bound),
+    TEST_FUNCTION(fmpz_poly_num_real_roots_vca),
+    TEST_FUNCTION(fmpz_poly_positive_root_upper_bound_2exp),
     TEST_FUNCTION(fmpz_poly_pow_addchains),
     TEST_FUNCTION(fmpz_poly_pow_binexp),
     TEST_FUNCTION(fmpz_poly_pow_binomial),

--- a/src/fmpz_poly/test/t-has_real_root.c
+++ b/src/fmpz_poly/test/t-has_real_root.c
@@ -1,0 +1,70 @@
+/*
+    Copyright (C) 2016 Vincent Delecroix
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "fmpz_poly.h"
+
+TEST_FUNCTION_START(fmpz_poly_has_real_root, state)
+{
+    slong iter;
+
+    /* test on polynomial without roots */
+    for (iter = 0; iter < 100; iter++)
+    {
+        fmpz_poly_t p;
+
+        fmpz_poly_init(p);
+
+        do{
+            fmpz_poly_randtest_no_real_root(p, state, 50, 1 + n_randint(state, 100));
+        } while (!fmpz_poly_is_squarefree(p));
+
+        if(fmpz_poly_has_real_root(p))
+        {
+            printf("FAIL:\n");
+            printf("polynomial with no real root p = ");
+            fmpz_poly_print(p); printf("\n");
+            abort();
+        }
+
+        fmpz_poly_clear(p);
+    }
+
+    for (iter = 0; iter < 100; iter++)
+    {
+        fmpz_poly_t p;
+        int ans;
+        slong n,n2;
+
+        fmpz_poly_init(p);
+
+        do{
+            fmpz_poly_randtest_not_zero(p, state, 50, 1 + n_randint(state, 100));
+        } while(!fmpz_poly_is_squarefree(p));
+
+        n = fmpz_poly_num_real_roots_sturm(p);
+        n2 = fmpz_poly_num_real_roots_vca(p);
+        ans = fmpz_poly_has_real_root(p);
+        if ((n > 0) != ans)
+        {
+            printf("FAIL:\n");
+            printf("p = "); fmpz_poly_print(p); printf("\n");
+            flint_printf("n = %wd n2 = %wd\n", n, n2);
+            flint_printf("ans = %wd\n", ans);
+            abort();
+        }
+        fmpz_poly_clear(p);
+    }
+
+
+    TEST_FUNCTION_END(state);
+}
+

--- a/src/fmpz_poly/test/t-isolate_real_roots.c
+++ b/src/fmpz_poly/test/t-isolate_real_roots.c
@@ -1,0 +1,388 @@
+/*
+    Copyright (C) 2019 Vincent Delecroix
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "fmpz_poly.h"
+#include "fmpq_poly.h"
+#include "fmpq_vec.h"
+
+/* check that a (= approximation of polynomial root) is in between */
+/* c 2^k and (c+1) 2^k (c and k are produced by root isolation).   */
+static int check_isolation(fmpz * c, slong k, fmpq_t a)
+{
+    fmpq_t r1, r2;
+
+    fmpq_init(r1);
+    fmpq_init(r2);
+
+    fmpz_set(fmpq_numref(r1), c);
+    fmpz_one(fmpq_denref(r1));
+    fmpq_set(r2, r1);
+    fmpq_add_si(r2, r2, 1);
+    if (k > 0)
+    {
+        fmpq_mul_2exp(r1, r1, (ulong)k);
+        fmpq_mul_2exp(r2, r2, (ulong)k);
+    }
+    else if (k < 0)
+    {
+        fmpq_div_2exp(r1, r1, (ulong)-k);
+        fmpq_div_2exp(r2, r2, (ulong)-k);
+    }
+    if (fmpq_cmp(r1, a) >= 0 || fmpq_cmp(r2, a) <= 0)
+    {
+        fprintf(stderr, "a  = "); fmpq_fprint(stderr, a); fprintf(stderr, "\n");
+        fprintf(stderr, "r1 = "); fmpq_fprint(stderr, r1); fprintf(stderr, "\n");
+        fprintf(stderr, "r2 = "); fmpq_fprint(stderr, r2); fprintf(stderr, "\n");
+        return 1;
+    }
+
+    fmpq_clear(r1);
+    fmpq_clear(r2);
+
+    return 0;
+}
+
+static void _slong_vec_print(const slong * vec, slong len)
+{
+    slong i;
+    flint_printf("%wd", len);
+    for (i = 0; i < len; ++i)
+        flint_printf(" %wd", vec[i]);
+}
+
+
+static void check_intervals(
+      fmpq * vec, slong len,
+      fmpq * exact, slong n_exact,
+      fmpz * c_array, slong * k_array, slong n_interval)
+{
+    slong i,j,k;
+    fmpq_t x,y;
+
+    if (n_exact + n_interval != len)
+    {
+        flint_printf("ERROR:\n");
+        flint_printf("found n_exact = %wd and n_interval = %wd but n = %wd\n", n_exact, n_interval, len);
+        flint_printf("vec = "); _fmpq_vec_print(vec, len);
+        flint_printf("\n");
+        flint_abort();
+    }
+
+    fmpq_init(x);
+    fmpq_init(y);
+    i = j = k = 0;
+    while ((j < n_exact) || (k < n_interval))
+    {
+        if (k < n_interval)
+        {
+            fmpz_set(fmpq_numref(x), c_array + k);
+            fmpz_set(fmpq_numref(y), c_array + k);
+            fmpz_one(fmpq_denref(x));
+            fmpz_one(fmpq_denref(y));
+            fmpz_add_ui(fmpq_numref(y), fmpq_numref(y), 1);
+            if (k_array[k] > 0)
+            {
+                fmpq_mul_2exp(x, x, (ulong)k_array[k]);
+                fmpq_mul_2exp(y, y, (ulong)k_array[k]);
+            }
+            else if (k_array[k] < 0)
+            {
+                fmpq_div_2exp(x, x, (ulong)-k_array[k]);
+                fmpq_div_2exp(y, y, (ulong)-k_array[k]);
+            }
+        }
+
+
+        if ((j < n_exact) && (k < n_interval))
+        {
+            if ((fmpq_cmp(exact + j, x) > 0) && (fmpq_cmp(y, exact + j) > 0))
+            {
+                flint_printf("ERROR:\n");
+                flint_printf("the %wd-th exact root ", j);
+                fmpq_print(exact + j); flint_printf("\n");
+                flint_printf("belongs to the %wd-th interval ", k);
+                flint_printf("("); fmpq_print(x); flint_printf(","); fmpq_print(y); flint_printf(")");
+                flint_printf("\n");
+                flint_printf("vec   = "); _fmpq_vec_print(vec, len);
+                flint_printf("\nc     = "); _fmpz_vec_print(c_array, n_interval);
+                flint_printf("\nk     = "); _slong_vec_print(k_array, n_interval);
+                flint_printf("\nexact = "); _fmpq_vec_print(exact, n_exact);
+                flint_printf("\n");
+                flint_abort();
+            }
+        }
+
+        if ((j == n_exact) || ((k < n_interval) && (fmpq_cmp(exact + j, y) >= 0)))
+        {
+            /* check interval */
+            if ((fmpq_cmp(x, vec + i) > 0) ||
+                 fmpq_cmp(vec + i, y) > 0)
+            {
+                flint_printf("ERROR:\n");
+                flint_printf(" the %wd-th root is vec[%wd] = ", i, i);
+                fmpq_print(vec + i);
+                flint_printf(" but got %wd-th interval ", k);
+                flint_printf("("); fmpq_print(x); flint_printf(","); fmpq_print(y); flint_printf(")");
+                flint_printf("\n");
+                flint_printf("vec   = "); _fmpq_vec_print(vec, len);
+                flint_printf("\nc     = "); _fmpz_vec_print(c_array, n_interval);
+                flint_printf("\nk     = "); _slong_vec_print(k_array, n_interval);
+                flint_printf("\nexact = "); _fmpq_vec_print(exact, n_exact);
+                flint_printf("\n");
+                flint_abort();
+            }
+            k += 1;
+            i += 1;
+        }
+        else
+        {
+            /* check root */
+            if (!fmpq_equal(vec + i, exact + j))
+            {
+                flint_printf("ERROR:\n");
+                flint_printf("the %wd-th root is vec[%wd] = ", i, i);
+                fmpq_print(vec + i);
+                flint_printf(" but got %wd-th exact root ", j);
+                fmpq_print(exact + j);
+                flint_printf("\n");
+                flint_printf("vec   = "); _fmpq_vec_print(vec, len);
+                flint_printf("\nc     = "); _fmpz_vec_print(c_array, n_interval);
+                flint_printf("\nk     = "); _slong_vec_print(k_array, n_interval);
+                flint_printf("\nexact = "); _fmpq_vec_print(exact, n_exact);
+                flint_printf("\n");
+                flint_abort();
+            }
+            j += 1;
+            i += 1;
+        }
+    }
+
+    fmpq_clear(x);
+    fmpq_clear(y);
+}
+
+static void fmpz_poly_from_fmpq_roots(fmpz_poly_t p, const fmpq * vec, slong n)
+{
+    fmpz_poly_t q;
+    slong i;
+
+    fmpz_poly_init(q);
+    fmpz_poly_one(p);
+    for (i = 0; i < n; i++)
+    {
+        if (fmpq_is_zero(vec + i))
+        {
+            fmpz_poly_set_coeff_si(q, 0, 0);
+            fmpz_poly_set_coeff_si(q, 1, 1);
+        }
+        else
+        {
+            fmpz_poly_set_coeff_fmpz(q, 0, fmpq_numref(vec + i));
+            fmpz_neg(fmpq_poly_numref(q), fmpq_poly_numref(q));
+            fmpz_poly_set_coeff_fmpz(q, 1, fmpq_denref(vec + i));
+        }
+        fmpz_poly_mul(p, p, q);
+    }
+    fmpz_poly_clear(q);
+}
+
+TEST_FUNCTION_START(fmpz_poly_isolate_real_roots, state)
+{
+    {
+        fmpz_poly_t p;
+        fmpq * exact_roots;
+        fmpz * c_array;
+        slong * k_array;
+        slong n_exact, n_interval;
+        fmpq_t a;
+
+        fmpq_init(a);
+        fmpz_poly_init(p);
+        exact_roots = _fmpq_vec_init(5);
+        c_array = _fmpz_vec_init(5);
+        k_array = (slong *) flint_malloc(5 * sizeof(slong));
+
+        /* -1705*x^2 - 7650*x - 3297 */
+        /* roots: -4.0038 and -0.4829 */
+        fmpz_poly_set_coeff_si(p, 0, -3297);
+        fmpz_poly_set_coeff_si(p, 1, -7650);
+        fmpz_poly_set_coeff_si(p, 2, -1705);
+
+        fmpz_poly_isolate_real_roots(exact_roots, &n_exact,
+                c_array, k_array, &n_interval, p);
+
+        if (n_exact != 0 || n_interval != 2)
+        {
+            fprintf(stderr, "wrong number of isolated roots\n");
+            flint_abort();
+        }
+
+        fmpq_set_si(a, WORD(-1933157935), WORD(482826508)); /* approx of root 1 */
+        if (check_isolation(c_array, k_array[0], a))
+        {
+            fprintf(stderr, "Failed root1 of poly1\n");
+            flint_abort();
+        }
+
+        fmpq_set_si(a, WORD(-151354505), WORD(313384144)); /* approx of root 2 */
+        if (check_isolation(c_array + 1, k_array[1], a))
+        {
+            fprintf(stderr, "Failed root2 of poly1\n");
+            flint_abort();
+        }
+
+        /* x^2 - 7650*x - 13297 */
+        /* roots: -1.7377 and 7651.7377 */
+        fmpz_poly_set_coeff_si(p, 0, -13297);
+        fmpz_poly_set_coeff_si(p, 1, -7650);
+        fmpz_poly_set_coeff_si(p, 2, 1);
+
+        n_exact = n_interval = 0;
+        fmpz_poly_isolate_real_roots(exact_roots, &n_exact,
+                c_array, k_array, &n_interval, p);
+
+        if (n_exact != 0 || n_interval != 2)
+        {
+            fprintf(stderr, "wrong number of isolated roots\n");
+            flint_abort();
+        }
+
+        fmpq_set_si(a, WORD(-833585025), WORD(479685194));
+        if (check_isolation(c_array, k_array[0], a))
+        {
+            fprintf(stderr, "Failed root1 of poly2\n");
+            flint_abort();
+        }
+        fmpq_set_si(a, WORD(1283601967), WORD(167753));
+        if (check_isolation(c_array + 1, k_array[1], a))
+        {
+            fprintf(stderr, "Failed root2 of poly2\n");
+            flint_abort();
+        }
+
+        /* x^2 - 1505*x + 566255 */
+        /* roots: 751.381, 753.618 */
+        fmpz_poly_set_coeff_si(p, 0, 566255);
+        fmpz_poly_set_coeff_si(p, 1, -1505);
+        fmpz_poly_set_coeff_si(p, 2, 1);
+
+        n_exact = n_interval = 0;
+        fmpz_poly_isolate_real_roots(exact_roots, &n_exact,
+                c_array, k_array, &n_interval, p);
+
+        if (n_exact != 0 || n_interval != 2)
+        {
+            fprintf(stderr, "wrong number of isolated roots\n");
+            flint_abort();
+        }
+
+        fmpq_set_si(a, WORD(1011562248), WORD(1346269));
+        if (check_isolation(c_array, k_array[0], a))
+        {
+            fprintf(stderr, "Failed root1 of poly2\n");
+            flint_abort();
+        }
+        fmpq_set_si(a, WORD(148024147), WORD(196418));
+        if (check_isolation(c_array + 1, k_array[1], a))
+        {
+            fprintf(stderr, "Failed root2 of poly2\n");
+            flint_abort();
+        }
+
+        /* 146434129 * x^2 - 134751 * x + 31 */
+        /* roots: 0.0004601002 and 0.0004601155 */
+        fmpz_poly_set_coeff_si(p, 0, 31);
+        fmpz_poly_set_coeff_si(p, 1, -134751);
+        fmpz_poly_set_coeff_si(p, 2, 146434129);
+
+        n_exact = n_interval = 0;
+        fmpz_poly_isolate_real_roots(exact_roots, &n_exact,
+                c_array, k_array, &n_interval, p);
+
+        if (n_exact != 0 || n_interval != 2)
+        {
+            fprintf(stderr, "wrong number of isolated roots\n");
+            flint_abort();
+        }
+
+        fmpq_set_si(a, WORD(381890), WORD(830014731));
+        if (check_isolation(c_array, k_array[0], a))
+        {
+            fprintf(stderr, "Failed root1 of poly2\n");
+            flint_abort();
+        }
+        fmpq_set_si(a, WORD(456915), WORD(993044056));
+        if (check_isolation(c_array + 1, k_array[1], a))
+        {
+            fprintf(stderr, "Failed root2 of poly2\n");
+            flint_abort();
+        }
+
+        _fmpq_vec_clear(exact_roots, 5);
+        _fmpz_vec_clear(c_array, 5);
+        flint_free(k_array);
+        fmpq_clear(a);
+        fmpz_poly_clear(p);
+    }
+
+    {
+        int iter;
+
+        for (iter = 0; iter < 500; iter++)
+        {
+            fmpq vec[30];
+            fmpz c_array[30];
+            slong k_array[30];
+            fmpq exact_array[30];
+            fmpz_poly_t p,q;
+
+            slong n = (slong)n_randint(state, 30);      /* real roots            */
+            slong nc = 1 + (slong)n_randint(state, 30); /* complex roots */
+            slong i;
+            slong n_exact, n_interval;
+
+            if (n + nc == 0) continue;
+
+            for(i = 0; i < 30; ++i)
+            {
+                fmpq_init(vec + i);
+                fmpz_init(c_array + i);
+                fmpq_init(exact_array + i);
+            }
+
+            _fmpq_vec_randtest_uniq_sorted(vec, state, n, 30);
+
+            fmpz_poly_init(p);
+            fmpz_poly_from_fmpq_roots(p, vec, n);
+
+            fmpz_poly_init(q);
+            fmpz_poly_randtest_no_real_root(q, state, nc, 100);
+            fmpz_poly_mul(p, p, q);
+
+            fmpz_poly_isolate_real_roots(exact_array, &n_exact, c_array, k_array, &n_interval, p);
+
+            check_intervals(vec, n, exact_array, n_exact, c_array, k_array, n_interval);
+
+            fmpz_poly_clear(p);
+            fmpz_poly_clear(q);
+            for(i = 0; i < 30; ++i)
+            {
+                fmpq_clear(vec + i);
+                fmpz_clear(c_array + i);
+                fmpq_clear(exact_array + i);
+            }
+        }
+    }
+
+    TEST_FUNCTION_END(state);
+}
+

--- a/src/fmpz_poly/test/t-num_real_roots_0_1.c
+++ b/src/fmpz_poly/test/t-num_real_roots_0_1.c
@@ -1,0 +1,55 @@
+/*
+    Copyright (C) 2016 Vincent Delecroix
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "fmpz_poly.h"
+
+TEST_FUNCTION_START(fmpz_poly_num_real_roots_0_1, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
+    {
+        fmpz_poly_t p;
+        slong k1, k2;
+
+        fmpz_poly_init(p);
+
+        if (iter == 0)
+        {
+          // e-antic issue #301
+          fmpz_poly_set_coeff_si(p, 0, 52);
+          fmpz_poly_set_coeff_si(p, 3, -304);
+          fmpz_poly_set_coeff_si(p, 8, -23);
+        }
+        else
+        {
+          do{
+            fmpz_poly_randtest(p, state, 10, 10);
+          } while (fmpz_poly_is_zero(p) || !fmpz_poly_is_squarefree(p));
+        }
+
+        k1 = fmpz_poly_num_real_roots_0_1_vca(p);
+        k2 = fmpz_poly_num_real_roots_0_1_sturm(p);
+        if (k1 != k2)
+        {
+            flint_printf("ERROR:\n");
+            flint_printf("vca and Sturm disagree\n");
+            flint_printf("p = "); fmpz_poly_print(p); flint_printf("\n");
+            flint_printf("(vca) k1 = %wd  (Sturm) k2 = %wd\n", k1, k2);
+            flint_abort();
+        }
+
+        fmpz_poly_clear(p);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/fmpz_poly/test/t-num_real_roots_upper_bound.c
+++ b/src/fmpz_poly/test/t-num_real_roots_upper_bound.c
@@ -1,0 +1,59 @@
+/*
+    Copyright (C) 2016 Vincent Delecroix
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "fmpz_poly.h"
+
+TEST_FUNCTION_START(fmpz_poly_num_real_roots_upper_bound, state)
+{
+    slong iter;
+
+    /* test polynomials with random rational roots */
+    for( iter = 0; iter <= 1000; iter++ )
+    {
+        slong n_real_roots, n_complex_roots;
+        fmpq * real_roots;
+
+        slong bound;
+        fmpz_poly_t p,q;
+
+        n_real_roots = (slong)n_randint(state, 30);
+        n_complex_roots = 1 + (slong)n_randint(state, 20);
+
+        real_roots = _fmpq_vec_init(n_real_roots);
+
+        _fmpq_vec_randtest(real_roots, state, n_real_roots, 100);
+
+        fmpz_poly_init(p);
+        fmpz_poly_init(q);
+        fmpz_poly_randtest_no_real_root(p, state, n_complex_roots, 40);
+        fmpz_poly_product_roots_fmpq_vec(q, real_roots, n_real_roots);
+        fmpz_poly_mul(p, p, q);
+
+        bound = fmpz_poly_num_real_roots_upper_bound(p);
+
+        if (n_real_roots > bound)
+        {
+            flint_printf("FAIL:\n");
+            flint_printf("p = "); fmpz_poly_print(p); flint_printf("\n");
+            flint_printf("n_real_roots = %ld\n", n_real_roots);
+            flint_printf("n_complex_roots  = %ld\n", n_complex_roots);
+            flint_printf("got bound = %wd\n", bound);
+            flint_abort();
+        }
+
+        _fmpq_vec_clear(real_roots, n_real_roots);
+        fmpz_poly_clear(p);
+        fmpz_poly_clear(q);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/fmpz_poly/test/t-num_real_roots_vca.c
+++ b/src/fmpz_poly/test/t-num_real_roots_vca.c
@@ -1,0 +1,76 @@
+/*
+    Copyright (C) 2016 Vincent Delecroix
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "fmpz_poly.h"
+
+TEST_FUNCTION_START(fmpz_poly_num_real_roots_vca, state)
+{
+    slong iter;
+
+    /* call with random nonzero polynomials */
+    for (iter = 0; iter < 100; iter++)
+    {
+        slong k;
+        fmpz_poly_t p;
+
+        fmpz_poly_init(p);
+        fmpz_poly_randtest_not_zero(p, state, 20, 10 + n_randint(state, 100));
+        k = fmpz_poly_num_real_roots_vca(p);
+        if (k < 0 || k > fmpz_poly_degree(p))
+        {
+            flint_printf("ERROR:\n");
+            flint_printf("got k in wrong range k = %wd\n", k);
+            flint_printf("p = "); fmpz_poly_print(p); flint_printf("\n");
+            flint_abort();
+        }
+
+        fmpz_poly_clear(p);
+    }
+
+    /* we check on products of the form               */
+    /*   Prod (X - r_i) x  R                          */
+    /* where r_i are rationals and R has no real root */
+    for (iter = 0; iter < 200; iter++)
+    {
+        slong k, n;
+        fmpz_poly_t p,q;
+        fmpq * vec;
+
+        n = 1 + (slong)n_randint(state, 10);
+
+        vec = _fmpq_vec_init(n);
+        _fmpq_vec_randtest_uniq_sorted(vec, state, n, 80);
+
+        fmpz_poly_init(p);
+        fmpz_poly_init(q);
+        fmpz_poly_product_roots_fmpq_vec(p, vec, n);
+        fmpz_poly_randtest_no_real_root(q, state, 1 + (slong)n_randint(state, 5), 80);
+        /* note: should we check that q is squarefree? */
+        fmpz_poly_mul(p, p, q);
+
+        k = fmpz_poly_num_real_roots_vca(p);
+        if (k != n)
+        {
+            flint_printf("ERROR:\n");
+            flint_printf("found k = %wd instead of n = %wd\n", k, n);
+            flint_printf("vec = "); _fmpq_vec_print(vec, n); flint_printf("\n");
+            flint_printf("p = "); fmpz_poly_print(p); flint_printf("\n");
+            flint_abort();
+        }
+
+        _fmpq_vec_clear(vec, n);
+        fmpz_poly_clear(p);
+        fmpz_poly_clear(q);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/fmpz_poly/test/t-positive_root_upper_bound_2exp.c
+++ b/src/fmpz_poly/test/t-positive_root_upper_bound_2exp.c
@@ -1,0 +1,101 @@
+/*
+    Copyright (C) 2016 Vincent Delecroix
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "fmpz_poly.h"
+
+TEST_FUNCTION_START(fmpz_poly_positive_root_upper_bound_2exp, state)
+{
+    slong iter;
+
+    /* test polynomials with random Gaussian integer roots */
+    for (iter = 0; iter <= 5000; iter++)
+    {
+        slong num_real_roots;
+        int i;
+        fmpq_t a, max_root;
+        slong bound;
+        fmpz_poly_t p,q;
+
+        fmpz_poly_init(p);
+        fmpz_poly_init(q);
+        fmpq_init(a);
+        fmpq_init(max_root);
+
+
+        fmpz_poly_one(p);
+
+        /* generate random rational roots a/b: (b x - a)*/
+        fmpq_set_si(max_root, -1, 1);
+        num_real_roots = (slong)n_randint(state, 50);
+        for (i = 0; i < num_real_roots; i++)
+        {
+            fmpq_randtest(a, state, 1 + n_randint(state, 100));
+            if(fmpq_cmp(max_root, a) < 0)
+                fmpq_set(max_root, a);
+            fmpq_neg(a, a);
+            fmpz_poly_set_coeff_fmpz(q, 0, fmpq_numref(a));
+            fmpz_poly_set_coeff_fmpz(q, 1, fmpq_denref(a));
+
+            fmpz_poly_mul(p, p, q);
+        }
+
+        if (fmpz_poly_degree(p) != num_real_roots)
+        {
+            flint_printf("FAIL:\n");
+            flint_abort();
+        }
+
+        fmpz_poly_randtest_no_real_root(q, state, 1 + (slong)n_randint(state, 50), 10 + n_randint(state, 100));
+        fmpz_poly_mul(p, p, q);
+
+        bound = fmpz_poly_positive_root_upper_bound_2exp(p);
+
+        if (bound == WORD_MIN)
+        {
+           if (fmpq_sgn(max_root) > 0)
+            {
+                flint_printf("FAIL:\n");
+                flint_printf("got bound = -1 for p = ");
+                fmpz_poly_print(p);
+                flint_printf("\n");
+                flint_printf("but max_root = "); fmpq_print(max_root); flint_printf("\n");
+                flint_abort();
+            }
+        }
+        else
+        {
+            fmpq_one(a);
+
+            if (bound > 0)
+                fmpq_mul_2exp(a, a, (ulong)bound);
+            else if (bound < 0)
+                fmpq_div_2exp(a, a, (ulong)-bound);
+
+            if (fmpq_cmp(a, max_root) < 0)
+            {
+                flint_printf("FAIL:\n");
+                flint_printf("p = "); fmpz_poly_print(p); flint_printf("\n");
+                flint_printf("max_real_root = "); fmpq_print(max_root); flint_printf("\n");
+                flint_printf("got bound = %wd\n", bound);
+                flint_abort();
+            }
+        }
+
+        fmpq_clear(a);
+        fmpq_clear(max_root);
+        fmpz_poly_clear(p);
+        fmpz_poly_clear(q);
+    }
+
+
+    TEST_FUNCTION_END(state);
+}


### PR DESCRIPTION
Add functions for counting and isolating real roots of an `fmpz_poly`.

All code is by @videlec (partially based on original code by Elias Tsigaridas), and ported with permission from e-antic (https://flatsurf.github.io/e-antic/c_fmpz_poly_extra.html).

The VCA-based root counting is sometimes faster than our existing Sturm algorithm, but this depends on the input; we will need some profiling to attempt to select the best method automatically.

The real root isolation should eventually be integrated with `arb_fmpz_poly_complex_roots` and elsewhere.

This PR doesn't port all utility methods from e-antic, just the ones directly related to root counting and isolation.

The code is mostly copied verbatim but I've fixed some minor things (missing `const` and so on). A minor bug fix is that `fmpz_poly_num_real_roots_0_1_sturm` was inconsistent with `fmpz_poly_num_real_roots_0_1_vca` about counting the root at 1.
