### PR TITLE
Add `gr_vec_set_str` and `gr_mat_set_str`

### DIFF
--- a/doc/source/gr_mat.rst
+++ b/doc/source/gr_mat.rst
@@ -139,6 +139,27 @@ Input and output
 
     Prints *mat* to standard output.
 
+.. function:: int gr_mat_set_str(gr_mat_t mat, const char * s, int resize, gr_ctx_t ctx)
+
+    Sets *mat* to the matrix described by the string *s*, which must have the
+    form ``[[expr11, ..., expr1n], ..., [exprm1, ..., exprmn]]``, where each row
+    is a bracketed list parsed as in :func:`gr_vec_set_str` and each entry
+    expression is parsed with :func:`gr_set_str` over *ctx*. All rows must have
+    the same number of entries; otherwise ``GR_DOMAIN`` is returned. Whitespace
+    around the brackets and separators (including the line breaks produced by
+    :func:`gr_mat_write`) is ignored.
+
+    If *resize* is 1, *mat* is resized to the detected number of rows and
+    columns. If *resize* is 0, returns ``GR_DOMAIN`` when the detected shape
+    does not match the current shape of *mat*. Returns ``GR_UNABLE`` if *s* is
+    not a well-formed list of rows.
+
+    The string ``[]`` denotes a matrix with zero rows but an ambiguous number of
+    columns. With *resize* equal to 1 it produces a `0 \times 0` matrix; with
+    *resize* equal to 0 it is accepted for any `0 \times c` matrix. A matrix
+    with `n > 0` rows and zero columns is unambiguous and is written as
+    ``[[], ..., []]`` with *n* empty rows.
+
 Comparisons
 -------------------------------------------------------------------------------
 

--- a/doc/source/gr_vec.rst
+++ b/doc/source/gr_vec.rst
@@ -58,6 +58,36 @@ Types and basic operations
               int gr_vec_write(gr_stream_t out, const gr_vec_t vec, gr_ctx_t ctx)
               int gr_vec_print(const gr_vec_t vec, gr_ctx_t ctx)
 
+.. function:: int gr_vec_set_str(gr_vec_t vec, const char * s, int resize, gr_ctx_t ctx)
+
+    Sets *vec* to the vector described by the string *s*, which must have the
+    form ``[expr1, expr2, ..., exprn]`` (or ``[]`` for the empty vector). Each
+    entry expression is parsed with :func:`gr_set_str` over *ctx*. Whitespace
+    around the brackets and separators is ignored, and commas appearing inside
+    parentheses, brackets or braces of an entry are treated as part of that
+    entry rather than as separators. If *resize* is 1, *vec* is resized to the
+    number of entries found. If *resize* is 0, returns ``GR_DOMAIN`` when that
+    number differs from the current length of *vec*. Returns ``GR_UNABLE`` if
+    *s* is not a well-formed list, and propagates any failure from parsing an
+    individual entry.
+
+.. function:: int gr_vec_str_count_entries(slong * count, const char * s, gr_ctx_t ctx)
+
+    Sets *count* to the number of top-level entries of the bracketed list at the
+    start of *s*, without evaluating them. Nesting depth of parentheses,
+    brackets and braces is tracked so that only separators at the outermost
+    level are counted. Any characters following the matching closing bracket are
+    ignored. Returns ``GR_UNABLE`` if the list is not well-formed.
+
+.. function:: int _gr_vec_set_str(gr_ptr res, const char * s, slong len, gr_ctx_t ctx)
+
+    Evaluates the bracketed list at the start of *s* into the preallocated array
+    *res*, which must hold *len* initialized elements, parsing each entry with
+    :func:`gr_set_str`. Returns ``GR_DOMAIN`` if the number of entries found
+    differs from *len*. Any characters following the matching closing bracket
+    are ignored, which allows this function to be applied to a row lying within
+    a larger matrix string.
+
 .. macro:: GR_ENTRY(vec, i, size)
 
     Macro to access the *i*-th entry of a ``gr_ptr`` or ``gr_srcptr``

--- a/src/gr/matrix.c
+++ b/src/gr/matrix.c
@@ -196,6 +196,15 @@ matrix_write(gr_stream_t out, gr_mat_t mat, gr_ctx_t ctx)
 }
 
 static int
+matrix_set_str(gr_mat_t res, const char * s, gr_ctx_t ctx)
+{
+    if (MATRIX_CTX(ctx)->all_sizes)
+        return gr_mat_set_str(res, s, 1, MATRIX_CTX(ctx)->base_ring);
+    else
+        return gr_mat_set_str(res, s, 0, MATRIX_CTX(ctx)->base_ring);
+}
+
+static int
 matrix_randtest(gr_mat_t res, flint_rand_t state, gr_ctx_t ctx)
 {
     if (MATRIX_CTX(ctx)->all_sizes)
@@ -616,6 +625,7 @@ gr_method_tab_input _gr_mat_methods_input[] =
     {GR_METHOD_SET_SHALLOW, (gr_funcptr) matrix_set_shallow},
     {GR_METHOD_RANDTEST,    (gr_funcptr) matrix_randtest},
     {GR_METHOD_WRITE,       (gr_funcptr) matrix_write},
+    {GR_METHOD_SET_STR,     (gr_funcptr) matrix_set_str},
     {GR_METHOD_ZERO,        (gr_funcptr) matrix_zero},
     {GR_METHOD_ONE,         (gr_funcptr) matrix_one},
     {GR_METHOD_IS_ZERO,     (gr_funcptr) matrix_is_zero},

--- a/src/gr/vector.c
+++ b/src/gr/vector.c
@@ -156,6 +156,15 @@ vector_gr_vec_write(gr_stream_t out, gr_vec_t vec, gr_ctx_t ctx)
 }
 
 static int
+vector_gr_vec_set_str(gr_vec_t res, const char * s, gr_ctx_t ctx)
+{
+    if (VECTOR_CTX(ctx)->all_sizes)
+        return gr_vec_set_str(res, s, 1, ENTRY_CTX(ctx));
+    else
+        return gr_vec_set_str(res, s, 0, ENTRY_CTX(ctx));
+}
+
+static int
 vector_gr_vec_randtest(gr_vec_t res, flint_rand_t state, gr_ctx_t ctx)
 {
     slong i, n;
@@ -750,6 +759,7 @@ gr_method_tab_input _gr_vec_methods_input[] =
     {GR_METHOD_SWAP,        (gr_funcptr) vector_gr_vec_swap},
     {GR_METHOD_RANDTEST,    (gr_funcptr) vector_gr_vec_randtest},
     {GR_METHOD_WRITE,       (gr_funcptr) vector_gr_vec_write},
+    {GR_METHOD_SET_STR,     (gr_funcptr) vector_gr_vec_set_str},
     {GR_METHOD_EQUAL,       (gr_funcptr) vector_gr_vec_equal},
     {GR_METHOD_SET,         (gr_funcptr) vector_gr_vec_set},
     {GR_METHOD_SET_OTHER,   (gr_funcptr) vector_gr_vec_set_other},

--- a/src/gr_mat.h
+++ b/src/gr_mat.h
@@ -141,6 +141,8 @@ WARN_UNUSED_RESULT int gr_mat_concat_vertical(gr_mat_t res, const gr_mat_t mat1,
 int gr_mat_write(gr_stream_t out, const gr_mat_t mat, gr_ctx_t ctx);
 int gr_mat_print(const gr_mat_t mat, gr_ctx_t ctx);
 
+WARN_UNUSED_RESULT int gr_mat_set_str(gr_mat_t mat, const char * s, int resize, gr_ctx_t ctx);
+
 WARN_UNUSED_RESULT int gr_mat_randtest(gr_mat_t mat, flint_rand_t state, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mat_randops(gr_mat_t mat, flint_rand_t state, slong count, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mat_randpermdiag(int * parity, gr_mat_t mat, flint_rand_t state, gr_ptr diag, slong n, gr_ctx_t ctx);

--- a/src/gr_mat/set_str.c
+++ b/src/gr_mat/set_str.c
@@ -1,0 +1,99 @@
+/*
+    Copyright (C) 2025 FLINT contributors
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "gr_mat.h"
+#include "gr_vec.h"
+
+int
+gr_mat_set_str(gr_mat_t mat, const char * s, int resize, gr_ctx_t ctx)
+{
+    const char * lo;
+    const char * hi;
+    const char * seg;
+    slong r, c, i;
+    int status;
+
+    /* Strict validation of the outer brackets. */
+    status = _gr_str_strip_brackets(&lo, &hi, s, '[', ']');
+    if (status != GR_SUCCESS)
+        return status;
+
+    /* Empty matrix "[]": zero rows, ambiguous column count. With resize it
+       becomes 0 x 0; without resize it is compatible with any 0 x c shape. */
+    if (_gr_str_blank(lo, hi))
+    {
+        if (resize)
+        {
+            gr_mat_clear(mat, ctx);
+            gr_mat_init(mat, 0, 0, ctx);
+            return GR_SUCCESS;
+        }
+
+        return (gr_mat_nrows(mat, ctx) == 0) ? GR_SUCCESS : GR_DOMAIN;
+    }
+
+    /* Number of rows = number of top-level entries of the whole string. */
+    status = gr_vec_str_count_entries(&r, s, ctx);
+    if (status != GR_SUCCESS)
+        return status;
+
+    /* Number of columns = number of entries in the first row. The first-row
+       pointer carries trailing characters (the remaining rows), which
+       gr_vec_str_count_entries ignores. */
+    {
+        const char * p = lo;
+        while (p < hi && _gr_str_is_space(*p))
+            p++;
+        status = gr_vec_str_count_entries(&c, p, ctx);
+        if (status != GR_SUCCESS)
+            return status;
+    }
+
+    if (resize)
+    {
+        if (mat->r != r || mat->c != c)
+        {
+            gr_mat_clear(mat, ctx);
+            gr_mat_init(mat, r, c, ctx);
+        }
+    }
+    else if (gr_mat_nrows(mat, ctx) != r || gr_mat_ncols(mat, ctx) != c)
+    {
+        return GR_DOMAIN;
+    }
+
+    /* Evaluate each row directly into the matrix's (contiguous) row storage.
+       _gr_vec_set_str enforces that every row has exactly c entries. */
+    seg = lo;
+    for (i = 0; i < r; i++)
+    {
+        int err = 0;
+        const char * sep = _gr_str_find_sep(seg, hi, &err);
+        const char * a = seg;
+        const char * b = sep;
+
+        _gr_str_trim(&a, &b);   /* a points at this row's '[' */
+
+        status = _gr_vec_set_str(gr_mat_entry_ptr(mat, i, 0, ctx), a, c, ctx);
+        if (status != GR_SUCCESS)
+            break;
+
+        seg = sep + 1;
+    }
+
+    if (status != GR_SUCCESS && resize)
+    {
+        gr_mat_clear(mat, ctx);
+        gr_mat_init(mat, 0, 0, ctx);
+    }
+
+    return status;
+}

--- a/src/gr_mat/set_str.c
+++ b/src/gr_mat/set_str.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2025 FLINT contributors
+    Copyright (C) 2026 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -21,7 +21,7 @@ gr_mat_set_str(gr_mat_t mat, const char * s, int resize, gr_ctx_t ctx)
     slong r, c, i;
     int status;
 
-    /* Strict validation of the outer brackets. */
+    /* Validate the outer brackets. */
     status = _gr_str_strip_brackets(&lo, &hi, s, '[', ']');
     if (status != GR_SUCCESS)
         return status;
@@ -70,8 +70,7 @@ gr_mat_set_str(gr_mat_t mat, const char * s, int resize, gr_ctx_t ctx)
         return GR_DOMAIN;
     }
 
-    /* Evaluate each row directly into the matrix's (contiguous) row storage.
-       _gr_vec_set_str enforces that every row has exactly c entries. */
+    /* Evaluate each row. _gr_vec_set_str enforces exactly c entries. */
     seg = lo;
     for (i = 0; i < r; i++)
     {

--- a/src/gr_mat/test/main.c
+++ b/src/gr_mat/test/main.c
@@ -60,6 +60,7 @@
 #include "t-rref_den_fflu.c"
 #include "t-rref_fflu.c"
 #include "t-rref_lu.c"
+#include "t-set_str.c"
 #include "t-scalar.c"
 #include "t-solve.c"
 #include "t-solve_den.c"
@@ -127,6 +128,7 @@ test_struct tests[] =
     TEST_FUNCTION(gr_mat_rref_fflu),
     TEST_FUNCTION(gr_mat_rref_lu),
     TEST_FUNCTION(gr_mat_scalar),
+    TEST_FUNCTION(gr_mat_set_str),
     TEST_FUNCTION(gr_mat_solve),
     TEST_FUNCTION(gr_mat_solve_den),
     TEST_FUNCTION(gr_mat_solve_den_fflu),

--- a/src/gr_mat/test/t-set_str.c
+++ b/src/gr_mat/test/t-set_str.c
@@ -1,0 +1,172 @@
+/*
+    Copyright (C) 2025 FLINT contributors
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "gr.h"
+#include "gr_mat.h"
+
+static char *
+mat_to_str(const gr_mat_t m, gr_ctx_t ctx)
+{
+    gr_stream_t out;
+    gr_stream_init_str(out);
+    GR_MUST_SUCCEED(gr_mat_write(out, m, ctx));
+    return out->s;
+}
+
+TEST_FUNCTION_START(gr_mat_set_str, state)
+{
+    slong iter;
+
+    /* Fixed cases over ZZ. */
+    {
+        gr_ctx_t ZZ;
+        gr_mat_t m, expected;
+
+        gr_ctx_init_fmpz(ZZ);
+
+        /* 2x2 value check, including the newline form produced by the printer */
+        {
+            const char * forms[] = {
+                "[[1, 2], [3, 4]]",
+                "[[1, 2],\n[3, 4]]",
+                "[ [1, 2] , [3, 4] ]",
+                NULL,
+            };
+            slong i;
+
+            gr_mat_init(expected, 2, 2, ZZ);
+            GR_MUST_SUCCEED(gr_set_si(gr_mat_entry_ptr(expected, 0, 0, ZZ), 1, ZZ));
+            GR_MUST_SUCCEED(gr_set_si(gr_mat_entry_ptr(expected, 0, 1, ZZ), 2, ZZ));
+            GR_MUST_SUCCEED(gr_set_si(gr_mat_entry_ptr(expected, 1, 0, ZZ), 3, ZZ));
+            GR_MUST_SUCCEED(gr_set_si(gr_mat_entry_ptr(expected, 1, 1, ZZ), 4, ZZ));
+
+            gr_mat_init(m, 0, 0, ZZ);
+            for (i = 0; forms[i] != NULL; i++)
+            {
+                if (gr_mat_set_str(m, forms[i], 1, ZZ) != GR_SUCCESS)
+                    TEST_FUNCTION_FAIL("expected success: %s\n", forms[i]);
+                if (gr_mat_equal(m, expected, ZZ) != T_TRUE)
+                    TEST_FUNCTION_FAIL("wrong value for %s\n", forms[i]);
+            }
+            gr_mat_clear(m, ZZ);
+            gr_mat_clear(expected, ZZ);
+        }
+
+        /* Shapes. */
+        {
+            gr_mat_init(m, 0, 0, ZZ);
+
+            if (gr_mat_set_str(m, "[[1, 2, 3]]", 1, ZZ) != GR_SUCCESS ||
+                gr_mat_nrows(m, ZZ) != 1 || gr_mat_ncols(m, ZZ) != 3)
+                TEST_FUNCTION_FAIL("expected a 1x3 matrix\n");
+
+            if (gr_mat_set_str(m, "[[1], [2], [3]]", 1, ZZ) != GR_SUCCESS ||
+                gr_mat_nrows(m, ZZ) != 3 || gr_mat_ncols(m, ZZ) != 1)
+                TEST_FUNCTION_FAIL("expected a 3x1 matrix\n");
+
+            if (gr_mat_set_str(m, "[]", 1, ZZ) != GR_SUCCESS ||
+                gr_mat_nrows(m, ZZ) != 0 || gr_mat_ncols(m, ZZ) != 0)
+                TEST_FUNCTION_FAIL("expected a 0x0 matrix\n");
+
+            /* n x 0 is unambiguous: n empty rows. */
+            if (gr_mat_set_str(m, "[[], [], []]", 1, ZZ) != GR_SUCCESS ||
+                gr_mat_nrows(m, ZZ) != 3 || gr_mat_ncols(m, ZZ) != 0)
+                TEST_FUNCTION_FAIL("expected a 3x0 matrix\n");
+
+            gr_mat_clear(m, ZZ);
+        }
+
+        /* Rejected input. */
+        {
+            const char * bad[] = {
+                "[[1, 2], [3]]",     /* non-rectangular */
+                "[[1, 2], 3]",       /* row not bracketed */
+                "[1, 2, 3]",         /* a vector, not a matrix */
+                "[[1, 2]",           /* unbalanced */
+                "[[1, 2]] junk",     /* trailing junk */
+                NULL,
+            };
+            slong i;
+
+            gr_mat_init(m, 0, 0, ZZ);
+            for (i = 0; bad[i] != NULL; i++)
+                if (gr_mat_set_str(m, bad[i], 1, ZZ) == GR_SUCCESS)
+                    TEST_FUNCTION_FAIL("expected failure: %s\n", bad[i]);
+            gr_mat_clear(m, ZZ);
+        }
+
+        /* resize = 0: the parsed shape must match the pre-initialized shape,
+           with "[]" compatible with any 0 x c. */
+        {
+            gr_mat_init(m, 2, 2, ZZ);
+            if (gr_mat_set_str(m, "[[1, 2], [3, 4]]", 0, ZZ) != GR_SUCCESS)
+                TEST_FUNCTION_FAIL("resize=0 matching shape should succeed\n");
+            if (gr_mat_nrows(m, ZZ) != 2 || gr_mat_ncols(m, ZZ) != 2)
+                TEST_FUNCTION_FAIL("resize=0 must not change the shape\n");
+            if (gr_mat_set_str(m, "[[1, 2, 3]]", 0, ZZ) != GR_DOMAIN)
+                TEST_FUNCTION_FAIL("resize=0 wrong shape should return GR_DOMAIN\n");
+            if (gr_mat_set_str(m, "[]", 0, ZZ) != GR_DOMAIN)
+                TEST_FUNCTION_FAIL("resize=0 [] into a 2x2 should return GR_DOMAIN\n");
+            gr_mat_clear(m, ZZ);
+
+            /* "[]" is compatible with any 0 x c when resize = 0. */
+            gr_mat_init(m, 0, 5, ZZ);
+            if (gr_mat_set_str(m, "[]", 0, ZZ) != GR_SUCCESS)
+                TEST_FUNCTION_FAIL("resize=0 [] into a 0x5 should succeed\n");
+            if (gr_mat_nrows(m, ZZ) != 0 || gr_mat_ncols(m, ZZ) != 5)
+                TEST_FUNCTION_FAIL("resize=0 [] must leave the 0x5 shape intact\n");
+            gr_mat_clear(m, ZZ);
+
+            /* n x 0 is exact, not the degenerate case. */
+            gr_mat_init(m, 3, 0, ZZ);
+            if (gr_mat_set_str(m, "[[], [], []]", 0, ZZ) != GR_SUCCESS)
+                TEST_FUNCTION_FAIL("resize=0 3x0 matching should succeed\n");
+            if (gr_mat_set_str(m, "[[], []]", 0, ZZ) != GR_DOMAIN)
+                TEST_FUNCTION_FAIL("resize=0 2x0 into 3x0 should return GR_DOMAIN\n");
+            gr_mat_clear(m, ZZ);
+        }
+
+        gr_ctx_clear(ZZ);
+    }
+    for (iter = 0; iter < 200 * flint_test_multiplier(); iter++)
+    {
+        gr_ctx_t ZZ;
+        gr_mat_t a, b;
+        char * str;
+        slong r, c;
+
+        gr_ctx_init_fmpz(ZZ);
+        r = n_randint(state, 5);
+        c = n_randint(state, 5);
+        if (r == 0 || c == 0)
+            r = c = 0;   /* a 0xc or rx0 matrix prints as "[]"; normalize */
+
+        gr_mat_init(a, r, c, ZZ);
+        gr_mat_init(b, 0, 0, ZZ);
+        GR_MUST_SUCCEED(gr_mat_randtest(a, state, ZZ));
+
+        str = mat_to_str(a, ZZ);
+
+        if (gr_mat_set_str(b, str, 1, ZZ) != GR_SUCCESS)
+            TEST_FUNCTION_FAIL("round-trip parse failed: %s\n", str);
+
+        if (gr_mat_equal(a, b, ZZ) != T_TRUE)
+            TEST_FUNCTION_FAIL("round-trip mismatch: %s\n", str);
+
+        flint_free(str);
+        gr_mat_clear(a, ZZ);
+        gr_mat_clear(b, ZZ);
+        gr_ctx_clear(ZZ);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/gr_mat/test/t-set_str.c
+++ b/src/gr_mat/test/t-set_str.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2025 FLINT contributors
+    Copyright (C) 2026 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -12,15 +12,6 @@
 #include "test_helpers.h"
 #include "gr.h"
 #include "gr_mat.h"
-
-static char *
-mat_to_str(const gr_mat_t m, gr_ctx_t ctx)
-{
-    gr_stream_t out;
-    gr_stream_init_str(out);
-    GR_MUST_SUCCEED(gr_mat_write(out, m, ctx));
-    return out->s;
-}
 
 TEST_FUNCTION_START(gr_mat_set_str, state)
 {
@@ -137,24 +128,26 @@ TEST_FUNCTION_START(gr_mat_set_str, state)
 
         gr_ctx_clear(ZZ);
     }
-    for (iter = 0; iter < 200 * flint_test_multiplier(); iter++)
+
+    for (iter = 0; iter < 100 * flint_test_multiplier(); iter++)
     {
-        gr_ctx_t ZZ;
+        gr_ctx_t ZZ, ZZM;
         gr_mat_t a, b;
         char * str;
         slong r, c;
 
         gr_ctx_init_fmpz(ZZ);
+        gr_ctx_init_matrix_domain(ZZM, ZZ);
         r = n_randint(state, 5);
         c = n_randint(state, 5);
-        if (r == 0 || c == 0)
-            r = c = 0;   /* a 0xc or rx0 matrix prints as "[]"; normalize */
+        if (r == 0)
+            c = 0;   /* a 0xc matrix prints as "[]"; normalize */
 
         gr_mat_init(a, r, c, ZZ);
         gr_mat_init(b, 0, 0, ZZ);
         GR_MUST_SUCCEED(gr_mat_randtest(a, state, ZZ));
 
-        str = mat_to_str(a, ZZ);
+        GR_MUST_SUCCEED(gr_get_str(&str, a, ZZM));
 
         if (gr_mat_set_str(b, str, 1, ZZ) != GR_SUCCESS)
             TEST_FUNCTION_FAIL("round-trip parse failed: %s\n", str);
@@ -162,9 +155,18 @@ TEST_FUNCTION_START(gr_mat_set_str, state)
         if (gr_mat_equal(a, b, ZZ) != T_TRUE)
             TEST_FUNCTION_FAIL("round-trip mismatch: %s\n", str);
 
+        GR_MUST_SUCCEED(gr_mat_randtest(b, state, ZZ));
+
+        if (gr_set_str(b, str, ZZM) != GR_SUCCESS)
+            TEST_FUNCTION_FAIL("round-trip parse failed 2: %s\n", str);
+
+        if (gr_mat_equal(a, b, ZZ) != T_TRUE)
+            TEST_FUNCTION_FAIL("round-trip mismatch 2: %s\n", str);
+
         flint_free(str);
         gr_mat_clear(a, ZZ);
         gr_mat_clear(b, ZZ);
+        gr_ctx_clear(ZZM);
         gr_ctx_clear(ZZ);
     }
 

--- a/src/gr_vec.h
+++ b/src/gr_vec.h
@@ -78,6 +78,23 @@ int gr_vec_write(gr_stream_t out, const gr_vec_t vec, gr_ctx_t ctx);
 int _gr_vec_print(gr_srcptr vec, slong len, gr_ctx_t ctx);
 int gr_vec_print(const gr_vec_t vec, gr_ctx_t ctx);
 
+WARN_UNUSED_RESULT int gr_vec_set_str(gr_vec_t vec, const char * s, int resize, gr_ctx_t ctx);
+
+/* Determine the entry count (shape) of a bracketed list string. */
+WARN_UNUSED_RESULT int gr_vec_str_count_entries(slong * count, const char * s, gr_ctx_t ctx);
+/* Evaluate a bracketed list at s into the preallocated array res of length len,
+   returning GR_DOMAIN if the number of entries differs from len. Characters
+   following the matching closing bracket are ignored. */
+WARN_UNUSED_RESULT int _gr_vec_set_str(gr_ptr res, const char * s, slong len, gr_ctx_t ctx);
+
+/* Internal string-splitting helpers shared with gr_mat_set_str. Separators are
+   resolved by tracking the nesting depth of (), [] and {}. */
+int _gr_str_is_space(char c);
+const char * _gr_str_find_sep(const char * s, const char * end, int * err);
+int _gr_str_strip_brackets(const char ** content_begin, const char ** content_end, const char * s, char open, char close);
+int _gr_str_blank(const char * s, const char * end);
+void _gr_str_trim(const char ** s, const char ** end);
+
 GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_zero(gr_ptr vec, slong len, gr_ctx_t ctx) { return GR_VEC_CONSTANT_OP(ctx, VEC_ZERO)(vec, len, ctx); }
 GR_VEC_INLINE WARN_UNUSED_RESULT int _gr_vec_set(gr_ptr res, gr_srcptr src, slong len, gr_ctx_t ctx) { return GR_VEC_OP(ctx, VEC_SET)(res, src, len, ctx); }
 GR_VEC_INLINE void _gr_vec_set_shallow(gr_ptr dest, gr_srcptr src, slong len, gr_ctx_t ctx) { memcpy(dest, src, len * ctx->sizeof_elem); }

--- a/src/gr_vec/set_str.c
+++ b/src/gr_vec/set_str.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2025 FLINT contributors
+    Copyright (C) 2026 Fredrik Johansson
 
     This file is part of FLINT.
 

--- a/src/gr_vec/set_str.c
+++ b/src/gr_vec/set_str.c
@@ -1,0 +1,280 @@
+/*
+    Copyright (C) 2025 FLINT contributors
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <string.h>
+#include "gr_vec.h"
+
+int
+_gr_str_is_space(char c)
+{
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
+}
+
+/* Scan [s, end) for the next top-level ',' (at bracket depth 0), treating
+   commas nested inside (), [] or {} as part of an entry. Returns a pointer to
+   the separating comma, or end if there is none. Sets *err on unbalanced
+   delimiters. */
+const char *
+_gr_str_find_sep(const char * s, const char * end, int * err)
+{
+    slong depth = 0;
+
+    for (; s < end; s++)
+    {
+        char c = *s;
+
+        if (c == '(' || c == '[' || c == '{')
+            depth++;
+        else if (c == ')' || c == ']' || c == '}')
+        {
+            if (depth == 0)
+            {
+                *err = 1;
+                return end;
+            }
+            depth--;
+        }
+        else if (c == ',' && depth == 0)
+            return s;
+    }
+
+    if (depth != 0)
+        *err = 1;
+
+    return end;
+}
+
+/* Locate the content strictly between a leading 'open' bracket and its matching
+   'close' bracket. Characters following the closing bracket are ignored. */
+static int
+_gr_str_bracket_content(const char ** content_begin, const char ** content_end,
+        const char * s, char open, char close)
+{
+    const char * end = s + strlen(s);
+    const char * p;
+    slong depth;
+
+    while (s < end && _gr_str_is_space(*s))
+        s++;
+
+    if (s >= end || *s != open)
+        return GR_UNABLE;
+
+    depth = 0;
+    for (p = s; p < end; p++)
+    {
+        char c = *p;
+        if (c == '(' || c == '[' || c == '{')
+            depth++;
+        else if (c == ')' || c == ']' || c == '}')
+        {
+            depth--;
+            if (depth == 0)
+                break;
+        }
+    }
+
+    if (p >= end || *p != close)
+        return GR_UNABLE;
+
+    *content_begin = s + 1;
+    *content_end = p;
+    return GR_SUCCESS;
+}
+
+/* As above, but only whitespace may follow the closing bracket. */
+int
+_gr_str_strip_brackets(const char ** content_begin, const char ** content_end,
+        const char * s, char open, char close)
+{
+    const char * q;
+    int status = _gr_str_bracket_content(content_begin, content_end, s, open, close);
+
+    if (status != GR_SUCCESS)
+        return status;
+
+    for (q = *content_end + 1; *q != '\0'; q++)
+        if (!_gr_str_is_space(*q))
+            return GR_UNABLE;
+
+    return GR_SUCCESS;
+}
+
+/* True if [s, end) is empty or all whitespace. */
+int
+_gr_str_blank(const char * s, const char * end)
+{
+    for (; s < end; s++)
+        if (!_gr_str_is_space(*s))
+            return 0;
+    return 1;
+}
+
+/* Trim leading and trailing whitespace from [*s, *end). */
+void
+_gr_str_trim(const char ** s, const char ** end)
+{
+    const char * a = *s;
+    const char * b = *end;
+
+    while (a < b && _gr_str_is_space(*a))
+        a++;
+    while (b > a && _gr_str_is_space(b[-1]))
+        b--;
+
+    *s = a;
+    *end = b;
+}
+
+/* Count top-level comma-separated entries in [lo, hi); 0 if blank. */
+static int
+_gr_str_count_in_range(slong * count, const char * lo, const char * hi)
+{
+    slong n;
+    const char * seg;
+
+    if (_gr_str_blank(lo, hi))
+    {
+        *count = 0;
+        return GR_SUCCESS;
+    }
+
+    n = 0;
+    seg = lo;
+    while (1)
+    {
+        int err = 0;
+        const char * sep = _gr_str_find_sep(seg, hi, &err);
+        if (err)
+            return GR_UNABLE;
+        n++;
+        if (sep == hi)
+            break;
+        seg = sep + 1;
+    }
+
+    *count = n;
+    return GR_SUCCESS;
+}
+
+int
+gr_vec_str_count_entries(slong * count, const char * s, gr_ctx_t FLINT_UNUSED(ctx))
+{
+    const char * lo;
+    const char * hi;
+    int status = _gr_str_bracket_content(&lo, &hi, s, '[', ']');
+
+    if (status != GR_SUCCESS)
+        return status;
+
+    return _gr_str_count_in_range(count, lo, hi);
+}
+
+int
+_gr_vec_set_str(gr_ptr res, const char * s, slong len, gr_ctx_t ctx)
+{
+    const char * lo;
+    const char * hi;
+    const char * seg;
+    char * buf;
+    slong i, sz = ctx->sizeof_elem;
+    int status;
+
+    status = _gr_str_bracket_content(&lo, &hi, s, '[', ']');
+    if (status != GR_SUCCESS)
+        return status;
+
+    if (_gr_str_blank(lo, hi))
+        return (len == 0) ? GR_SUCCESS : GR_DOMAIN;
+
+    buf = flint_malloc((slong) (hi - lo) + 1);
+
+    status = GR_SUCCESS;
+    seg = lo;
+    i = 0;
+    while (1)
+    {
+        int err = 0;
+        const char * sep = _gr_str_find_sep(seg, hi, &err);
+        const char * a = seg;
+        const char * b = sep;
+        slong elen;
+
+        if (err)
+        {
+            status = GR_UNABLE;
+            break;
+        }
+
+        if (i >= len)   /* more entries than expected */
+        {
+            status = GR_DOMAIN;
+            break;
+        }
+
+        _gr_str_trim(&a, &b);
+        elen = (slong) (b - a);
+        if (elen <= 0)   /* empty entry */
+        {
+            status = GR_UNABLE;
+            break;
+        }
+
+        memcpy(buf, a, elen);
+        buf[elen] = '\0';
+
+        status = gr_set_str(GR_ENTRY(res, i, sz), buf, ctx);
+        if (status != GR_SUCCESS)
+            break;
+
+        i++;
+        if (sep == hi)
+            break;
+        seg = sep + 1;
+    }
+
+    flint_free(buf);
+
+    if (status == GR_SUCCESS && i != len)   /* fewer entries than expected */
+        status = GR_DOMAIN;
+
+    return status;
+}
+
+int
+gr_vec_set_str(gr_vec_t vec, const char * s, int resize, gr_ctx_t ctx)
+{
+    const char * lo;
+    const char * hi;
+    slong count;
+    int status;
+
+    /* Strict validation: a single bracketed list with no trailing junk. */
+    status = _gr_str_strip_brackets(&lo, &hi, s, '[', ']');
+    if (status != GR_SUCCESS)
+        return status;
+
+    status = _gr_str_count_in_range(&count, lo, hi);
+    if (status != GR_SUCCESS)
+        return status;
+
+    if (resize)
+        gr_vec_set_length(vec, count, ctx);
+    else if (gr_vec_length(vec, ctx) != count)
+        return GR_DOMAIN;
+
+    status = _gr_vec_set_str(vec->entries, s, count, ctx);
+
+    if (status != GR_SUCCESS && resize)
+        gr_vec_set_length(vec, 0, ctx);
+
+    return status;
+}

--- a/src/gr_vec/test/main.c
+++ b/src/gr_vec/test/main.c
@@ -13,6 +13,7 @@
 
 #include "t-permute.c"
 #include "t-product.c"
+#include "t-set_str.c"
 #include "t-sort.c"
 #include "t-sum.c"
 
@@ -22,6 +23,7 @@ test_struct tests[] =
 {
     TEST_FUNCTION(gr_vec_permute),
     TEST_FUNCTION(gr_vec_product),
+    TEST_FUNCTION(gr_vec_set_str),
     TEST_FUNCTION(gr_vec_sort),
     TEST_FUNCTION(gr_vec_sum)
 };

--- a/src/gr_vec/test/t-set_str.c
+++ b/src/gr_vec/test/t-set_str.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2025 FLINT contributors
+    Copyright (C) 2026 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -13,15 +13,6 @@
 #include "gr.h"
 #include "gr_vec.h"
 #include "gr_series.h"
-
-static char *
-vec_to_str(const gr_vec_t v, gr_ctx_t ctx)
-{
-    gr_stream_t out;
-    gr_stream_init_str(out);
-    GR_MUST_SUCCEED(gr_vec_write(out, v, ctx));
-    return out->s;
-}
 
 TEST_FUNCTION_START(gr_vec_set_str, state)
 {
@@ -146,21 +137,22 @@ TEST_FUNCTION_START(gr_vec_set_str, state)
     }
 
     /* Random round-trip over ZZ: write, then parse back. */
-    for (iter = 0; iter < 200 * flint_test_multiplier(); iter++)
+    for (iter = 0; iter < 10 * flint_test_multiplier(); iter++)
     {
-        gr_ctx_t ZZ;
+        gr_ctx_t ZZ, ZZx;
         gr_vec_t a, b;
         char * str;
         slong n;
 
         gr_ctx_init_fmpz(ZZ);
+        gr_ctx_init_vector_gr_vec(ZZx, ZZ);
         n = n_randint(state, 8);
 
         gr_vec_init(a, n, ZZ);
         gr_vec_init(b, 0, ZZ);
         GR_MUST_SUCCEED(_gr_vec_randtest(a->entries, state, n, ZZ));
 
-        str = vec_to_str(a, ZZ);
+        GR_MUST_SUCCEED(gr_get_str(&str, a, ZZx));
 
         if (gr_vec_set_str(b, str, 1, ZZ) != GR_SUCCESS)
             TEST_FUNCTION_FAIL("round-trip parse failed: %s\n", str);
@@ -168,9 +160,18 @@ TEST_FUNCTION_START(gr_vec_set_str, state)
         if (b->length != n || _gr_vec_equal(a->entries, b->entries, n, ZZ) != T_TRUE)
             TEST_FUNCTION_FAIL("round-trip mismatch: %s\n", str);
 
+        GR_MUST_SUCCEED(gr_randtest(b, state, ZZx));
+
+        if (gr_set_str(b, str, ZZx) != GR_SUCCESS)
+            TEST_FUNCTION_FAIL("round-trip parse failed 2: %s\n", str);
+
+        if (b->length != n || _gr_vec_equal(a->entries, b->entries, n, ZZ) != T_TRUE)
+            TEST_FUNCTION_FAIL("round-trip mismatch 2: %s\n", str);
+
         flint_free(str);
         gr_vec_clear(a, ZZ);
         gr_vec_clear(b, ZZ);
+        gr_ctx_clear(ZZx);
         gr_ctx_clear(ZZ);
     }
 

--- a/src/gr_vec/test/t-set_str.c
+++ b/src/gr_vec/test/t-set_str.c
@@ -1,0 +1,178 @@
+/*
+    Copyright (C) 2025 FLINT contributors
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "gr.h"
+#include "gr_vec.h"
+#include "gr_series.h"
+
+static char *
+vec_to_str(const gr_vec_t v, gr_ctx_t ctx)
+{
+    gr_stream_t out;
+    gr_stream_init_str(out);
+    GR_MUST_SUCCEED(gr_vec_write(out, v, ctx));
+    return out->s;
+}
+
+TEST_FUNCTION_START(gr_vec_set_str, state)
+{
+    slong iter;
+
+    /* Fixed cases over ZZ, plus malformed input. */
+    {
+        gr_ctx_t ZZ;
+        gr_vec_t v;
+        slong i;
+
+        const char * good[] = {
+            "[1, 2, 3]",
+            "[]",
+            "[ 7 ]",
+            "[ 1 ,2,  3 ]",
+            "[-5]",
+            NULL,
+        };
+        const slong good_len[] = { 3, 0, 1, 3, 1 };
+
+        const char * bad[] = {
+            "1, 2, 3",      /* no brackets */
+            "[1, 2",        /* unterminated */
+            "[1, , 2]",     /* empty entry */
+            "[1, 2]]",      /* trailing junk */
+            "[1, 2] x",     /* trailing junk */
+            "[[1, 2]",      /* unbalanced */
+            NULL,
+        };
+
+        gr_ctx_init_fmpz(ZZ);
+        gr_vec_init(v, 0, ZZ);
+
+        for (i = 0; good[i] != NULL; i++)
+        {
+            if (gr_vec_set_str(v, good[i], 1, ZZ) != GR_SUCCESS)
+                TEST_FUNCTION_FAIL("expected success: %s\n", good[i]);
+            if (gr_vec_length(v, ZZ) != good_len[i])
+                TEST_FUNCTION_FAIL("wrong length for %s: got %wd\n", good[i], gr_vec_length(v, ZZ));
+        }
+
+        for (i = 0; bad[i] != NULL; i++)
+            if (gr_vec_set_str(v, bad[i], 1, ZZ) == GR_SUCCESS)
+                TEST_FUNCTION_FAIL("expected failure: %s\n", bad[i]);
+
+        gr_vec_clear(v, ZZ);
+        gr_ctx_clear(ZZ);
+    }
+
+    /* resize = 0: the parsed length must match the pre-initialized length. */
+    {
+        gr_ctx_t ZZ;
+        gr_vec_t v;
+
+        gr_ctx_init_fmpz(ZZ);
+
+        gr_vec_init(v, 3, ZZ);
+        if (gr_vec_set_str(v, "[10, 20, 30]", 0, ZZ) != GR_SUCCESS)
+            TEST_FUNCTION_FAIL("resize=0 with matching length should succeed\n");
+        if (gr_vec_length(v, ZZ) != 3)
+            TEST_FUNCTION_FAIL("resize=0 must not change the length\n");
+        if (gr_vec_set_str(v, "[1, 2]", 0, ZZ) != GR_DOMAIN)
+            TEST_FUNCTION_FAIL("resize=0 with wrong length should return GR_DOMAIN\n");
+        gr_vec_clear(v, ZZ);
+
+        gr_vec_init(v, 0, ZZ);
+        if (gr_vec_set_str(v, "[]", 0, ZZ) != GR_SUCCESS)
+            TEST_FUNCTION_FAIL("resize=0 empty into length-0 should succeed\n");
+        gr_vec_clear(v, ZZ);
+
+        gr_ctx_clear(ZZ);
+    }
+
+    /* Direct exercise of the shape/evaluation helpers used by gr_mat_set_str. */
+    {
+        gr_ctx_t ZZ;
+        gr_vec_t v;
+        slong count;
+
+        gr_ctx_init_fmpz(ZZ);
+
+        if (gr_vec_str_count_entries(&count, "[10, 20, 30]", ZZ) != GR_SUCCESS || count != 3)
+            TEST_FUNCTION_FAIL("count_entries [10, 20, 30] should be 3\n");
+        if (gr_vec_str_count_entries(&count, "[]", ZZ) != GR_SUCCESS || count != 0)
+            TEST_FUNCTION_FAIL("count_entries [] should be 0\n");
+        /* trailing characters after the matching ']' are ignored */
+        if (gr_vec_str_count_entries(&count, "[1, 2], [3, 4]]", ZZ) != GR_SUCCESS || count != 2)
+            TEST_FUNCTION_FAIL("count_entries should ignore trailing characters\n");
+
+        gr_vec_init(v, 2, ZZ);
+        if (_gr_vec_set_str(v->entries, "[5, 6]", 2, ZZ) != GR_SUCCESS)
+            TEST_FUNCTION_FAIL("_gr_vec_set_str with len 2 should succeed\n");
+        if (_gr_vec_set_str(v->entries, "[5, 6, 7]", 2, ZZ) != GR_DOMAIN)
+            TEST_FUNCTION_FAIL("_gr_vec_set_str too many entries should be GR_DOMAIN\n");
+        if (_gr_vec_set_str(v->entries, "[5]", 2, ZZ) != GR_DOMAIN)
+            TEST_FUNCTION_FAIL("_gr_vec_set_str too few entries should be GR_DOMAIN\n");
+        gr_vec_clear(v, ZZ);
+
+        gr_ctx_clear(ZZ);
+    }
+
+    /* A top-level comma must be detected even when entries contain parentheses:
+       O(x^5) etc. exercises paren-depth tracking. */
+    {
+        gr_ctx_t QQ, Rx;
+        gr_vec_t v;
+
+        gr_ctx_init_fmpq(QQ);
+        gr_ctx_init_gr_series(Rx, QQ, 20);
+        GR_MUST_SUCCEED(gr_ctx_set_gen_name(Rx, "x"));
+
+        gr_vec_init(v, 0, Rx);
+        if (gr_vec_set_str(v, "[x + O(x^5), 1 + O(x^3)]", 1, Rx) != GR_SUCCESS)
+            TEST_FUNCTION_FAIL("failed to parse vector of series\n");
+        if (gr_vec_length(v, Rx) != 2)
+            TEST_FUNCTION_FAIL("expected 2 series entries, got %wd\n", gr_vec_length(v, Rx));
+        gr_vec_clear(v, Rx);
+
+        gr_ctx_clear(Rx);
+        gr_ctx_clear(QQ);
+    }
+
+    /* Random round-trip over ZZ: write, then parse back. */
+    for (iter = 0; iter < 200 * flint_test_multiplier(); iter++)
+    {
+        gr_ctx_t ZZ;
+        gr_vec_t a, b;
+        char * str;
+        slong n;
+
+        gr_ctx_init_fmpz(ZZ);
+        n = n_randint(state, 8);
+
+        gr_vec_init(a, n, ZZ);
+        gr_vec_init(b, 0, ZZ);
+        GR_MUST_SUCCEED(_gr_vec_randtest(a->entries, state, n, ZZ));
+
+        str = vec_to_str(a, ZZ);
+
+        if (gr_vec_set_str(b, str, 1, ZZ) != GR_SUCCESS)
+            TEST_FUNCTION_FAIL("round-trip parse failed: %s\n", str);
+
+        if (b->length != n || _gr_vec_equal(a->entries, b->entries, n, ZZ) != T_TRUE)
+            TEST_FUNCTION_FAIL("round-trip mismatch: %s\n", str);
+
+        flint_free(str);
+        gr_vec_clear(a, ZZ);
+        gr_vec_clear(b, ZZ);
+        gr_ctx_clear(ZZ);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/python/flint_ctypes.py
+++ b/src/python/flint_ctypes.py
@@ -6235,6 +6235,23 @@ class Mat(gr_ctx):
         [[5, 0],
         [0, 5]]
 
+    Construction from strings:
+
+        >>> Mat(QQ)("[[1, 1/2], [1/3, 1/4]]")
+        [[1, 1/2],
+        [1/3, 1/4]]
+        >>> Mat(QQ)("[[0, 0, 0], [0, 0, 0]]")
+        [[0, 0, 0],
+        [0, 0, 0]]
+        >>> Mat(QQ, 2, 3)("[[0, 0, 0], [0, 0, 0]]")
+        [[0, 0, 0],
+        [0, 0, 0]]
+        >>> Mat(QQ, 2, 3)("[[0, 0], [0, 0]]")  # input does not match shape
+        Traceback (most recent call last):
+          ...
+        ValueError
+
+
     """
 
     def __init__(self, element_domain, nrows=None, ncols=None):
@@ -6269,6 +6286,7 @@ class gr_mat(gr_elem):
     _struct_type = gr_mat_struct
 
     def __init__(self, *args, **kwargs):
+
         context = kwargs['context']
         gr_elem.__init__(self, None, context)
         element_ring = context._element_ring
@@ -6298,6 +6316,8 @@ class gr_mat(gr_elem):
                                 x = element_ring(row[j])
                                 ijptr = libgr.gr_mat_entry_ptr(self._ref, i, j, x._ctx)
                                 status |= libgr.gr_set(ijptr, x._ref, x._ctx)
+                elif isinstance(val, str):
+                    status = libgr.gr_set_str(self._ref, ctypes.c_char_p(str(val).encode('ascii')), self._ctx)
                 elif libgr.gr_ctx_matrix_is_fixed_size(self._ctx) == T_TRUE:
                     if not isinstance(val, gr_elem):
                         val = element_ring(val)
@@ -7119,6 +7139,36 @@ libgr.gr_vec_entry_ptr.restype = ctypes.POINTER(ctypes.c_char)
 class Vec(gr_ctx):
     """
     Parent class for vector domains.
+
+        >>> Vec(ZZ)
+        Vectors (any length) over Integer ring (fmpz)
+        >>> Vec(ZZ, 5)
+        Space of length 5 vectors over Integer ring (fmpz)
+        >>> VecZZ([0, 5, 10])
+        [0, 5, 10]
+        >>> VecZZ(range(3, 20, 3))
+        [3, 6, 9, 12, 15, 18]
+
+    Construction of vectors from strings:
+
+        >>> Vec(QQ)("[1/3, 1/5]")
+        [1/3, 1/5]
+        >>> Vec(ZZ, 3)("[1, 2, 3]")
+        [1, 2, 3]
+        >>> Vec(ZZ, 3)("[1, 2]")     # input does not match size
+        Traceback (most recent call last):
+          ...
+        ValueError
+        >>> Vec(RR)("[1, 1/3, 1/3 +/- exp(-10)]")
+        [1, [0.3333333333333333 +/- 7.04e-17], [0.3333 +/- 7.88e-5]]
+        >>> v = Vec(Mat(QQ, 2, 2))("[[[1,0],[0,1]], [[0,1],[-1,0]]]")
+        >>> v[0]
+        [[1, 0],
+        [0, 1]]
+        >>> v[1]
+        [[0, 1],
+        [-1, 0]]
+
     """
 
     def __init__(self, element_domain, n=None):
@@ -7147,6 +7197,7 @@ class gr_vec(gr_elem):
             >>> VecZZ(range(3, 20, 3))
             [3, 6, 9, 12, 15, 18]
         """
+
         context = kwargs['context']
         gr_elem.__init__(self, None, context)
         element_ring = context._element_ring
@@ -7168,6 +7219,8 @@ class gr_vec(gr_elem):
                             status |= libgr.gr_set(iptr, x._ref, x._ctx)
                 elif isinstance(val, gr_elem):
                     status = libgr.gr_set_other(self._ref, val._ref, val._ctx, self._ctx)
+                elif isinstance(val, str):
+                    status = libgr.gr_set_str(self._ref, ctypes.c_char_p(str(val).encode('ascii')), self._ctx)
                 elif isinstance(val, range):
                     start = val.start
                     step = val.step


### PR DESCRIPTION
Allow parsing vectors and matrices from strings in the same format we print them (`[a, b, c]` for vectors, `[[a, b], [c, d]]` for matrices).

```
>>> Vec(ZZx)("[x+1, (x+1)^5]")
[x+1, x^5+5*x^4+10*x^3+10*x^2+5*x+1]

>>> Mat(RR)("[[1/3, 0], [[0 +/- 1], pi +/- 1/10^4]]")
[[[0.3333333333333333 +/- 7.04e-17], 0],
[[+/- 1.01], [3.142 +/- 5.08e-4]]]

>>> Mat(Qp_padic_radix(7))("[[1, 2], [3 + O(7^10), 4/5 - O(7^8)]]")
[[1, 2],
[3 + O(7^10), 1152961 + O(7^8)]]

>>> Vec(Mat(QQ, 2, 2))("[[[1,0],[0,1]], [[0,1],[-1,0]]]")
[[[1, 0],
[0, 1]], [[0, 1],
[-1, 0]]]
```

Straightforward, mostly AI-generated patch.

Note that `gr_set_str` is overloaded to call these methods for vector and matrix rings, but the generic `gr_set_str` doesn't yet handle vector or matrix subexpressions for generic rings. So it's still not possible to parse polynomials with matrix coefficients, for example.