### PR TITLE
fmpz_mat, fmpq_mat: use Dixon solve for small RHS counts (#2743)

### DIFF
--- a/src/fmpq_mat/solve.c
+++ b/src/fmpq_mat/solve.c
@@ -17,8 +17,8 @@ fmpq_mat_solve_fmpz_mat(fmpq_mat_t X, const fmpz_mat_t A, const fmpz_mat_t B)
 {
     if (fmpz_mat_nrows(A) <= 15)
         return fmpq_mat_solve_fmpz_mat_fraction_free(X, A, B);
-    else if (fmpz_mat_ncols(B) == 1)
-    	return fmpq_mat_solve_fmpz_mat_dixon(X, A, B);
+    else if (fmpz_mat_ncols(B) <= 32)
+        return fmpq_mat_solve_fmpz_mat_dixon(X, A, B);
     else
         return fmpq_mat_solve_fmpz_mat_multi_mod(X, A, B);
 }
@@ -28,8 +28,8 @@ fmpq_mat_solve(fmpq_mat_t X, const fmpq_mat_t A, const fmpq_mat_t B)
 {
     if (fmpq_mat_nrows(A) <= 15)
         return fmpq_mat_solve_fraction_free(X, A, B);
-    else if (fmpq_mat_ncols(B) == 1)
-    	return fmpq_mat_solve_dixon(X, A, B);
+    else if (fmpq_mat_ncols(B) <= 32)
+        return fmpq_mat_solve_dixon(X, A, B);
     else
         return fmpq_mat_solve_multi_mod(X, A, B);
 }

--- a/src/fmpz_mat/solve.c
+++ b/src/fmpz_mat/solve.c
@@ -20,7 +20,7 @@ fmpz_mat_solve(fmpz_mat_t X, fmpz_t den,
         return fmpz_mat_solve_cramer(X, den, A, B);
     else if (fmpz_mat_nrows(A) <= 15)
         return fmpz_mat_solve_fflu(X, den, A, B);
-    else if (fmpz_mat_ncols(B) == 1)
+    else if (fmpz_mat_ncols(B) <= 32)
         return fmpz_mat_solve_dixon_den(X, den, A, B);
     else
         return fmpz_mat_solve_multi_mod_den(X, den, A, B);


### PR DESCRIPTION
## Summary

Fixes #2743. `fmpz_mat_nullspace` reaches `fmpz_mat_solve` through
`fmpz_mat_rref` / `fmpz_mat_rref_mul`. In `rref_mul`, the exact solve is already
formed with only `n - rank` right-hand sides:

```c
fmpz_mat_init(E2, rank, n - rank);
if (!fmpz_mat_solve(E2, den, B, C))
```

This PR does not change that structure. It only changes which solve backend is
selected for existing small-RHS exact solves.

The previous dispatchers used Dixon only for a single RHS column, so nullity-2
cases were sent to the multimodular solver. This changes the crossover from
`ncols(B) == 1` to `ncols(B) <= 32` in:

- `fmpz_mat_solve`
- `fmpq_mat_solve_fmpz_mat`
- `fmpq_mat_solve`

Small-RHS exact solves now route to the existing Dixon backend, while wider RHS
systems still use the existing multimodular path.

## Benchmark

Timing `fmpz_mat_nullspace` on random `n x (n+2)` matrices with generic nullity
2.

**4-bit entries:**

| n | original | this PR | speedup |
|---:|---:|---:|---:|
| 100 | 11.7 ms | 4.2 ms | 2.8x |
| 200 | 112.1 ms | 25.3 ms | 4.4x |
| 300 | 493.8 ms | 79.0 ms | 6.3x |
| 400 | 1454.2 ms | 179.4 ms | 8.1x |

**32-bit entries:**

| n | original | this PR | speedup |
|---:|---:|---:|---:|
| 100 | 50.1 ms | 13.7 ms | 3.7x |
| 200 | 541.4 ms | 95.7 ms | 5.7x |
| 300 | 2357.4 ms | 308.1 ms | 7.7x |
| 400 | 6884.4 ms | 688.8 ms | 10.0x |

## Tests

- `make -j$(nproc)`
- `./build/fmpz_mat/test/main fmpz_mat_solve fmpz_mat_solve_dixon_den fmpz_mat_nullspace fmpz_mat_rref fmpz_mat_rref_mul`
- `./build/fmpq_mat/test/main`
- `./build/fmpz_mat/test/main fmpz_mat_solve`
- `git diff --check`