### PR TITLE
docs: document unchecked input preconditions across FLINT

### DIFF
--- a/doc/source/acb_mat.rst
+++ b/doc/source/acb_mat.rst
@@ -445,6 +445,9 @@ Gaussian elimination and solving
     `UX = B`, respectively. If *unit* is set, the main diagonal of *L* or *U*
     is taken to consist of all ones, and in that case the actual entries on
     the diagonal are not read at all and can contain other data.
+    *L* (respectively *U*) is assumed to be lower (respectively upper)
+    triangular with nonzero diagonal entries; this is not checked, and
+    entries in the unused triangle are ignored.
 
     The *classical* versions perform the computations iteratively while the
     *recursive* versions perform the computations in a block recursive
@@ -454,6 +457,8 @@ Gaussian elimination and solving
 .. function:: void acb_mat_solve_lu_precomp(acb_mat_t X, const slong * perm, const acb_mat_t LU, const acb_mat_t B, slong prec)
 
     Solves `AX = B` given the precomputed nonsingular LU decomposition `A = PLU`.
+    The factorization (*perm* and *LU*) is assumed valid, as produced by the
+    corresponding routine, and is not re-checked.
     The matrices `X` and `B` are allowed to be aliased with each other,
     but `X` is not allowed to be aliased with `LU`.
 
@@ -544,6 +549,11 @@ Gaussian elimination and solving
     the use of block recursive strategies for large matrices), and the
     output matrices are set to the approximate floating-point results with
     zeroed error bounds.
+
+    The triangular solves assume the relevant operand is triangular with
+    nonzero diagonal; this is not checked. For *approx_solve_lu_precomp*,
+    *perm* and the factored matrix are assumed to come from the corresponding
+    *approx_lu*; this is not checked.
 
 Characteristic polynomial and companion matrix
 -------------------------------------------------------------------------------

--- a/doc/source/arb_mat.rst
+++ b/doc/source/arb_mat.rst
@@ -451,6 +451,9 @@ Gaussian elimination and solving
     `UX = B`, respectively. If *unit* is set, the main diagonal of *L* or *U*
     is taken to consist of all ones, and in that case the actual entries on
     the diagonal are not read at all and can contain other data.
+    *L* (respectively *U*) is assumed to be lower (respectively upper)
+    triangular with nonzero diagonal entries; this is not checked, and
+    entries in the unused triangle are ignored.
 
     The *classical* versions perform the computations iteratively while the
     *recursive* versions perform the computations in a block recursive
@@ -460,6 +463,8 @@ Gaussian elimination and solving
 .. function:: void arb_mat_solve_lu_precomp(arb_mat_t X, const slong * perm, const arb_mat_t LU, const arb_mat_t B, slong prec)
 
     Solves `AX = B` given the precomputed nonsingular LU decomposition `A = PLU`.
+    The factorization (*perm* and *LU*) is assumed valid, as produced by the
+    corresponding routine, and is not re-checked.
     The matrices `X` and `B` are allowed to be aliased with each other,
     but `X` is not allowed to be aliased with `LU`.
 
@@ -565,6 +570,11 @@ Gaussian elimination and solving
     output matrices are set to the approximate floating-point results with
     zeroed error bounds.
 
+    The triangular solves assume the relevant operand is triangular with
+    nonzero diagonal; this is not checked. For *approx_solve_lu_precomp*,
+    *perm* and the factored matrix are assumed to come from the corresponding
+    *approx_lu*; this is not checked.
+
     Approximate solutions are useful for computing preconditioning matrices
     for certified solutions. Some users may also find these methods useful
     for doing ordinary numerical linear algebra in applications where
@@ -594,6 +604,8 @@ Cholesky decomposition and solving
 .. function:: void arb_mat_solve_cho_precomp(arb_mat_t X, const arb_mat_t L, const arb_mat_t B, slong prec)
 
     Solves `AX = B` given the precomputed Cholesky decomposition `A = L L^T`.
+    The factor *L* is assumed to be a valid Cholesky factor, as produced by
+    :func:`arb_mat_cho`, and is not re-checked.
     The matrices *X* and *B* are allowed to be aliased with each other,
     but *X* is not allowed to be aliased with *L*.
 
@@ -614,7 +626,7 @@ Cholesky decomposition and solving
 
     Sets `X = A^{-1}` where `A` is a symmetric positive definite matrix
     whose Cholesky decomposition *L* has been computed with
-    :func:`arb_mat_cho`.
+    :func:`arb_mat_cho`, which is assumed and not re-checked.
     The inverse is calculated using the method of [Kri2013]_ which is more
     efficient than solving `AX = I` with :func:`arb_mat_solve_cho_precomp`.
 
@@ -659,14 +671,16 @@ Cholesky decomposition and solving
 .. function:: void arb_mat_solve_ldl_precomp(arb_mat_t X, const arb_mat_t L, const arb_mat_t B, slong prec)
 
     Solves `AX = B` given the precomputed `A = LDL^T` decomposition
-    encoded by *L*.  The matrices *X* and *B* are allowed to be aliased
+    encoded by *L*.  The factor *L* is assumed to be a valid LDL factor,
+    as produced by :func:`arb_mat_ldl`, and is not re-checked.
+    The matrices *X* and *B* are allowed to be aliased
     with each other, but *X* is not allowed to be aliased with *L*.
 
 .. function:: void arb_mat_inv_ldl_precomp(arb_mat_t X, const arb_mat_t L, slong prec)
 
     Sets `X = A^{-1}` where `A` is a symmetric positive definite matrix
     whose `LDL^T` decomposition encoded by *L* has been computed with
-    :func:`arb_mat_ldl`.
+    :func:`arb_mat_ldl`, which is assumed and not re-checked.
     The inverse is calculated using the method of [Kri2013]_ which is more
     efficient than solving `AX = I` with :func:`arb_mat_solve_ldl_precomp`.
 
@@ -792,8 +806,10 @@ LLL reduction
 
 .. function:: int arb_mat_spd_is_lll_reduced(const arb_mat_t A, double delta, double eta, slong prec)
 
-    Given a symmetric positive definite matrix *A*, returns nonzero iff *A* is
-    certainly LLL-reduced for the given LLL parameters `\eta, \delta`, meaning
+    Given a symmetric positive definite matrix *A* (only the lower triangular
+    part is read and these properties are not checked), returns nonzero iff
+    *A* is certainly LLL-reduced for the given LLL parameters `\eta, \delta`,
+    meaning
     that it satisfies the inequalities `|\mu_{j,k}|\leq \eta` and `\delta
     \lVert b_{k-1}^*\rVert^2 \leq \lVert b_k^*\rVert^2 + \mu_{k,k-1}^2 \lVert
     b_{k-1}^*\rVert^2` (with the usual notation).

--- a/doc/source/ca_mat.rst
+++ b/doc/source/ca_mat.rst
@@ -272,7 +272,7 @@ Powers
 .. function:: void ca_mat_pow_ui_binexp(ca_mat_t B, const ca_mat_t A, ulong exp, ca_ctx_t ctx)
 
     Sets *B* to *A* raised to the power *exp*, evaluated using
-    binary exponentiation.
+    binary exponentiation. Requires (not checked) that *A* is a square matrix.
 
 
 Polynomial evaluation
@@ -390,7 +390,8 @@ Solving and inverse
               void ca_mat_solve_triu(ca_mat_t X, const ca_mat_t U, const ca_mat_t B, int unit, ca_ctx_t ctx)
 
     Solves the lower triangular system `LX = B` or the upper triangular system
-    `UX = B`, respectively. It is assumed (not checked) that the diagonal
+    `UX = B`, respectively. It is assumed (not checked) that *L* is lower
+    triangular (respectively *U* upper triangular) and that the diagonal
     entries are nonzero. If *unit* is set, the main diagonal of *L* or *U*
     is taken to consist of all ones, and in that case the actual entries on
     the diagonal are not read at all and can contain other data.
@@ -404,7 +405,8 @@ Solving and inverse
               void ca_mat_solve_lu_precomp(ca_mat_t X, const slong * P, const ca_mat_t LU, const ca_mat_t B, ca_ctx_t ctx)
 
     Solves `AX = B` given the precomputed nonsingular LU decomposition `A = PLU`
-    or fraction-free LU decomposition with denominator *den*.
+    or fraction-free LU decomposition with denominator *den*, which are assumed
+    (not checked) to be valid factorization data.
     The matrices `X` and `B` are allowed to be aliased with each other,
     but `X` is not allowed to be aliased with `LU`.
 

--- a/doc/source/fmpq.rst
+++ b/doc/source/fmpq.rst
@@ -19,7 +19,9 @@ overhead.
 A fraction is said to be in canonical form if the numerator and denominator
 have no common factor and the denominator is positive. Except where otherwise
 noted, all functions in the :type:`fmpq` module assume that inputs are in
-canonical form, and produce outputs in canonical form. The user can manipulate
+canonical form, and produce outputs in canonical form. This is not checked;
+passing a non-canonical :type:`fmpq_t` gives undefined results. The user can
+manipulate
 the numerator and denominator of an :type:`fmpq_t` as arbitrary integers, but
 then becomes responsible for canonicalising the number (for example by calling
 ``fmpq_canonicalise``) before passing it to any library function.

--- a/doc/source/fmpq_mat.rst
+++ b/doc/source/fmpq_mat.rst
@@ -428,7 +428,8 @@ Trace
 .. function:: void fmpq_mat_trace(fmpq_t trace, const fmpq_mat_t mat)
 
     Computes the trace of the matrix, i.e. the sum of the entries on
-    the main diagonal. The matrix is required to be square.
+    the main diagonal. The matrix is required to be square, which is not
+    checked.
 
 
 Determinant
@@ -448,8 +449,9 @@ Permanent
 
 .. function:: int fmpq_mat_permanent(fmpq_t res, const fmpq_mat_t A)
 
-    Sets ``res`` to the permanent of the square matrix *A*, returning 1
-    on success. If the matrix is too large, returns 0.
+    Sets ``res`` to the permanent of the square matrix *A* (squareness is
+    not checked), returning 1 on success. If the matrix is too large,
+    returns 0.
 
 
 Nonsingular solving
@@ -523,7 +525,8 @@ Inverse
 .. function:: int fmpq_mat_inv(fmpq_mat_t B, const fmpq_mat_t A)
 
     Sets ``B`` to the inverse matrix of ``A`` and returns nonzero.
-    Returns zero if ``A`` is singular. ``A`` must be a square matrix.
+    Returns zero if ``A`` is singular. ``A`` must be a square matrix,
+    which is not checked.
 
 
 
@@ -579,6 +582,8 @@ Transforms
 .. function:: void fmpq_mat_similarity(fmpq_mat_t A, slong r, fmpq_t d)
 
     Applies a similarity transform to the `n\times n` matrix `M` in-place.
+    The matrix is assumed to be square and ``r`` to satisfy
+    `0 \le r < n`; this is not checked.
 
     If `P` is the `n\times n` identity matrix the zero entries of whose row
     `r` (`0`-indexed) have been replaced by `d`, this transform is equivalent

--- a/doc/source/fmpq_poly.rst
+++ b/doc/source/fmpq_poly.rst
@@ -230,7 +230,7 @@ Assignment, swap, negation
 .. function:: void fmpq_poly_set_fmpq(fmpq_poly_t poly, const fmpq_t x)
 
     Sets ``poly`` to the rational `x`, which is assumed to be
-    given in lowest terms.
+    given in lowest terms, which is not checked.
 
 .. function:: void fmpq_poly_set_fmpz_poly(fmpq_poly_t rop, const fmpz_poly_t op)
 
@@ -247,14 +247,15 @@ Assignment, swap, negation
     Sets the coefficients of ``rop`` to the coefficients in the denominator of ``op``,
     reduced by the modulus of ``rop``. The result is multiplied by the inverse of the
     denominator of ``op``. It is assumed that the reduction of the denominator of ``op``
-    is invertible.
+    is invertible, which is not checked.
 
 .. function:: void fmpq_poly_get_nmod_poly_den(nmod_poly_t rop, const fmpq_poly_t op, int den)
 
     Sets the coefficients of ``rop`` to the coefficients in the denominator
     of ``op``, reduced by the modulus of ``rop``. If ``den == 1``, the result is
     multiplied by the inverse of the denominator of ``op``. In this case it is
-    assumed that the reduction of the denominator of ``op`` is invertible.
+    assumed that the reduction of the denominator of ``op`` is invertible,
+    which is not checked.
 
 .. function:: int _fmpq_poly_set_str(fmpz * poly, fmpz_t den, const char * str, slong len)
 
@@ -866,14 +867,15 @@ Power series division
 
     The result is produced in canonical form.
 
-    Assumes that `n \geq 1` and that ``poly`` has non-zero constant term.
+    Assumes that `n \geq 1` and that ``poly`` has non-zero constant term;
+    this is not checked.
     Does not support aliasing.
 
 .. function:: void fmpq_poly_inv_series_newton(fmpq_poly_t res, const fmpq_poly_t poly, slong n)
 
     Computes the first `n` terms of the inverse power series
     of ``poly`` using Newton iteration, assuming that ``poly``
-    has non-zero constant term and `n \geq 1`.
+    has non-zero constant term and `n \geq 1`; this is not checked.
 
 .. function:: void _fmpq_poly_inv_series(fmpz * rpoly, fmpz_t rden, const fmpz * poly, const fmpz_t den, slong den_len, slong n)
 
@@ -882,19 +884,21 @@ Power series division
 
     The result is produced in canonical form.
 
-    Assumes that `n \geq 1` and that ``poly`` has non-zero constant term.
+    Assumes that `n \geq 1` and that ``poly`` has non-zero constant term;
+    this is not checked.
     Does not support aliasing.
 
 .. function:: void fmpq_poly_inv_series(fmpq_poly_t res, const fmpq_poly_t poly, slong n)
 
     Computes the first `n` terms of the inverse power series of ``poly``,
-    assuming that ``poly`` has non-zero constant term and `n \geq 1`.
+    assuming that ``poly`` has non-zero constant term and `n \geq 1`;
+    this is not checked.
 
 .. function:: void _fmpq_poly_div_series(fmpz * Q, fmpz_t denQ, const fmpz * A, const fmpz_t denA, slong lenA, const fmpz * B, const fmpz_t denB, slong lenB, slong n)
 
     Divides ``(A, denA, lenA)`` by ``(B, denB, lenB)`` as power series
     over `\mathbb{Q}`, assuming `B` has non-zero constant term and that
-    all lengths are positive.
+    all lengths are positive. The constant term is not checked.
 
     Aliasing is not supported.
 
@@ -906,7 +910,7 @@ Power series division
     Performs power series division in `\mathbb{Q}[[x]] / (x^n)`.  The function
     considers the polynomials `A` and `B` as power series of length `n`
     starting with the constant terms.  The function assumes that `B` has
-    non-zero constant term and `n \geq 1`.
+    non-zero constant term and `n \geq 1`. The constant term is not checked.
 
 
 Greatest common divisor

--- a/doc/source/fmpz.rst
+++ b/doc/source/fmpz.rst
@@ -474,7 +474,7 @@ Conversion
 
     Sets `f` to the signed remainder `y \equiv x \bmod m` satisfying
     `-m/2 < y \leq m/2`, given `x` which is assumed to satisfy
-    `0 \leq x < m`.
+    `0 \leq x < m` (this is not checked).
 
 .. function:: void flint_mpz_init_set_readonly(mpz_t z, const fmpz_t f)
 
@@ -887,13 +887,15 @@ Basic arithmetic
 
     Sets `f` to the quotient of `g` and `h`, assuming that the
     division is exact, i.e. `g` is a multiple of `h`.  If `h`
-    is `0` an exception is raised.
+    is `0` an exception is raised. The exactness of the division is
+    not checked; if it is not exact the result is undefined.
 
 .. function:: void fmpz_divexact2_uiui(fmpz_t f, const fmpz_t g, ulong x, ulong y)
 
     Sets `f` to the quotient of `g` and `h = x \times y`, assuming that
     the division is exact, i.e. `g` is a multiple of `h`.
-    If `x` or `y` is `0` an exception is raised.
+    If `x` or `y` is `0` an exception is raised. The exactness of the
+    division is not checked; if it is not exact the result is undefined.
 
 .. function:: int fmpz_divisible(const fmpz_t f, const fmpz_t g)
 
@@ -988,7 +990,7 @@ Basic arithmetic
     If `p` is not prime the return value is with high probability `0`,
     indicating that `p` is not prime, or `a` is not a square modulo `p`.
     If `p` is not prime and the return value is `1`, the value of `b` is
-    meaningless.
+    meaningless. Primality of ``p`` is assumed and not checked.
 
 .. function:: void fmpz_sqrt(fmpz_t f, const fmpz_t g)
 
@@ -1188,11 +1190,13 @@ Modular arithmetic
 
 .. function:: void fmpz_negmod(fmpz_t f, const fmpz_t g, const fmpz_t h)
 
-    Sets `f` to `-g \pmod{h}`, assuming `g` is reduced modulo `h`.
+    Sets `f` to `-g \pmod{h}`, assuming `g` is reduced modulo `h`
+    (this is not checked).
 
 .. function:: int fmpz_jacobi(const fmpz_t a, const fmpz_t n)
 
     Computes the Jacobi symbol `\left(\frac{a}{n}\right)` for any `a` and odd positive `n`.
+    The parity and sign of ``n`` are not checked.
 
 .. function:: int fmpz_kronecker(const fmpz_t a, const fmpz_t n)
 
@@ -1314,6 +1318,7 @@ The ``fmpz_multi_CRT`` class is similar to ``fmpz_multi_CRT_ui`` except that it 
 
     If sign = 0, it is assumed that `0 \le r_1 < m_1` and `0 \le r_2 < m_2`.
     Otherwise, it is assumed that `-m_1 \le r_1 < m_1` and `0 \le r_2 < m_2`.
+    These assumptions are not checked.
 
 .. function:: void fmpz_CRT(fmpz_t out, const fmpz_t r1, const fmpz_t m1, const fmpz_t r2, const fmpz_t m2, int sign)
 

--- a/doc/source/fmpz_lll.rst
+++ b/doc/source/fmpz_lll.rst
@@ -13,6 +13,11 @@ LLL parameters \delta and \eta, the representation type of the input matrix
 (whether it is a lattice basis or a Gram matrix), and the type of Gram
 matrix to be used during L^2 (approximate or exact).
 
+Throughout this module, the contents of ``B`` (or ``FM``) must be consistent
+with ``fl->rt`` (a lattice basis when ``fl->rt`` is `Z\_BASIS`, or a symmetric
+positive semidefinite Gram matrix when ``fl->rt`` is `GRAM`) and with
+``fl->gt``. This consistency is the caller's responsibility and is not checked.
+
 .. function:: void fmpz_lll_context_init_default(fmpz_lll_t fl)
 
     Sets ``fl->delta``, ``fl->eta``, ``fl->rt`` and ``fl->gt`` to

--- a/doc/source/fmpz_mat.rst
+++ b/doc/source/fmpz_mat.rst
@@ -780,7 +780,8 @@ Determinant
 
 .. function:: void fmpz_mat_det_modular_given_divisor(fmpz_t det, const fmpz_mat_t A, const fmpz_t d, int proved)
 
-    Given a positive divisor `d` of `\det(A)`, sets ``det`` to the
+    Given a positive divisor `d` of `\det(A)` (this is not checked), sets
+    ``det`` to the
     determinant of the square matrix `A` (if ``proved`` = 1), or a
     probabilistic value for the determinant (``proved`` = 0), computed
     using a multimodular algorithm.
@@ -820,8 +821,9 @@ Permanent
 
 .. function:: int fmpz_mat_permanent(fmpz_t res, const fmpz_mat_t A)
 
-    Sets ``res`` to the permanent of the square matrix *A*, returning 1
-    on success. If the matrix is too large, returns 0.
+    Sets ``res`` to the permanent of the square matrix *A* (squareness is
+    not checked), returning 1 on success. If the matrix is too large,
+    returns 0.
 
 
 Transforms
@@ -831,6 +833,8 @@ Transforms
 .. function:: void fmpz_mat_similarity(fmpz_mat_t A, slong r, fmpz_t d)
 
     Applies a similarity transform to the `n\times n` matrix `M` in-place.
+    The matrix is assumed to be square and ``r`` to satisfy `0 \le r < n`;
+    this is not checked.
 
     If `P` is the `n\times n` identity matrix the zero entries of whose row
     `r` (`0`-indexed) have been replaced by `d`, this transform is equivalent
@@ -847,7 +851,7 @@ Characteristic polynomial
 
     Compute a bound for the absolute value of the coefficients `c_k` of the
     characteristic polynomial of `A` which is required to be an `n \times n`
-    (square) matrix. We use the fact that
+    (square) matrix, which is not checked. We use the fact that
 
     .. math ::
 
@@ -876,7 +880,9 @@ Characteristic polynomial
               void fmpz_mat_charpoly(fmpz_poly_t cp, const fmpz_mat_t mat)
 
     Compute the characteristic polynomial of an `n \times n` square matrix.
-    The underscore methods write `n + 1` coefficients.
+    The underscore methods write `n + 1` coefficients. The *berkowitz* and
+    *modular* methods assume the matrix is square and do not check it;
+    ``fmpz_mat_charpoly`` itself raises an exception on a non-square matrix.
 
     The *berkowitz* algorithm is a wrapper of :func:`gr_mat_charpoly_berkowitz`.
     The *modular* algorithm computes the characteristic polynomial modulo
@@ -899,6 +905,7 @@ Minimal polynomial
 .. function:: void fmpz_mat_minpoly_modular(fmpz_poly_t cp, const fmpz_mat_t mat)
 
     Computes the minimal polynomial of an `n \times n` square matrix.
+    Squareness is assumed and not checked.
     Uses a modular method based on an average time `O(n^3)`, worst case
     `O(n^4)` method over `\mathbb{Z}/n\mathbb{Z}`.
 
@@ -980,7 +987,9 @@ allowed between arguments.
 .. function:: int fmpz_mat_solve_fflu_precomp(fmpz_mat_t X, const slong * perm, const fmpz_mat_t FFLU, const fmpz_mat_t B)
 
     Performs fraction-free forward and back substitution given a precomputed
-    fraction-free LU decomposition and corresponding permutation. If no
+    fraction-free LU decomposition and corresponding permutation. ``FFLU`` and
+    ``perm`` are assumed to be the output of :func:`fmpz_mat_fflu` for the
+    system matrix; this is not checked. If no
     impossible division is encountered, the function returns `1`. This does not
     mean the system has a solution, however a return value of `0` can only
     occur if the system is insoluble.
@@ -1286,7 +1295,8 @@ Hermite normal form
     Computes an integer matrix ``H`` such that ``H`` is the unique (row)
     Hermite normal form of the `m\times n` matrix ``A``, where ``A`` is
     assumed to be of rank `n` and ``D`` is known to be a positive multiple of
-    the determinant of the non-zero rows of ``H``. The algorithm used here is
+    the determinant of the non-zero rows of ``H``. Neither assumption is
+    checked. The algorithm used here is
     due to Domich, Kannan and Trotter [DomKanTro1987]_ and is also described
     in [Algorithm 2.4.8] [Coh1996]_.
 
@@ -1297,16 +1307,17 @@ Hermite normal form
 
     Transforms the `m\times n` matrix ``A`` into Hermite normal form,
     where ``A`` is assumed to be of rank `n` and ``D`` is known to be a
-    positive multiple of the largest elementary divisor of ``A``.
+    positive multiple of the largest elementary divisor of ``A``. Neither
+    assumption is checked.
     The algorithm used here is described in [FieHof2014]_.
 
 .. function:: void fmpz_mat_hnf_minors(fmpz_mat_t H, const fmpz_mat_t A)
 
     Computes an integer matrix ``H`` such that ``H`` is the unique (row)
     Hermite normal form of the `m\times n` matrix ``A``, where ``A`` is
-    assumed to be of rank `n`. The algorithm used here is due to Kannan and
-    Bachem [KanBac1979]_ and takes the principal minors to Hermite normal
-    form in turn.
+    assumed to be of rank `n`, which is not checked. The algorithm used here
+    is due to Kannan and Bachem [KanBac1979]_ and takes the principal minors
+    to Hermite normal form in turn.
 
     Aliasing of ``H`` and ``A`` is allowed. The size of ``H`` must be
     the same as that of ``A``.
@@ -1344,8 +1355,10 @@ Smith normal form
 .. function:: void fmpz_mat_snf_diagonal(fmpz_mat_t S, const fmpz_mat_t A)
 
     Computes an integer matrix ``S`` such that ``S`` is the unique Smith
-    normal form of the diagonal matrix ``A``. The algorithm used simply takes
-    gcds of pairs on the diagonal in turn until the Smith form is obtained.
+    normal form of the diagonal matrix ``A``. Only the diagonal entries of
+    ``A`` affect the result; that ``A`` is diagonal is assumed and not
+    checked. The algorithm used simply takes gcds of pairs on the diagonal
+    in turn until the Smith form is obtained.
 
     Aliasing of ``S`` and ``A`` is allowed. The size of ``S`` must be
     the same as that of ``A``.
@@ -1362,8 +1375,11 @@ Smith normal form
 .. function:: void fmpz_mat_snf_iliopoulos(fmpz_mat_t S, const fmpz_mat_t A, const fmpz_t mod)
 
     Computes an integer matrix ``S`` such that ``S`` is the unique Smith
-    normal form of the nonsingular `n\times n` matrix ``A``. The algorithm
-    used is due to Iliopoulos [Iliopoulos1989]_.
+    normal form of the nonsingular `n\times n` matrix ``A``. It is assumed
+    that ``A`` is nonsingular and that ``mod`` is a positive multiple of the
+    largest elementary divisor of ``A`` (for example a multiple of
+    `\det(A)`); this is not checked. The algorithm used is due to Iliopoulos
+    [Iliopoulos1989]_.
 
     Aliasing of ``S`` and ``A`` is allowed. The size of ``S`` must be
     the same as that of ``A``.
@@ -1468,7 +1484,8 @@ Cholesky Decomposition
 .. function:: void fmpz_mat_chol_d(d_mat_t R, const fmpz_mat_t A)
 
     Computes ``R``, the Cholesky factor of a symmetric, positive definite
-    matrix ``A`` using the Cholesky decomposition process. (Sets ``R``
+    matrix ``A`` (this property is assumed and not checked) using the Cholesky
+    decomposition process. (Sets ``R``
     such that `A = RR^{T}` where ``R`` is a lower triangular matrix.)
 
 .. note::

--- a/doc/source/fmpz_mod.rst
+++ b/doc/source/fmpz_mod.rst
@@ -119,7 +119,7 @@ Discrete Logarithms via Pohlig-Hellman
 
 .. function:: double fmpz_mod_discrete_log_pohlig_hellman_precompute_prime(fmpz_mod_discrete_log_pohlig_hellman_t L, const fmpz_t p)
 
-    Configure ``L`` for discrete logarithms modulo ``p`` to an internally chosen base. It is assumed that ``p`` is prime.
+    Configure ``L`` for discrete logarithms modulo ``p`` to an internally chosen base. It is assumed that ``p`` is prime (not checked).
     The return is an estimate on the number of multiplications needed for one run.
 
 .. function:: const fmpz * fmpz_mod_discrete_log_pohlig_hellman_primitive_root(fmpz_mod_discrete_log_pohlig_hellman_t L)
@@ -128,7 +128,7 @@ Discrete Logarithms via Pohlig-Hellman
 
 .. function:: void fmpz_mod_discrete_log_pohlig_hellman_run(fmpz_t x, const fmpz_mod_discrete_log_pohlig_hellman_t L, const fmpz_t y)
 
-    Set ``x`` to the logarithm of ``y`` with respect to the internally stored base. ``y`` is expected to be reduced modulo the ``p``.
+    Set ``x`` to the logarithm of ``y`` with respect to the internally stored base. ``y`` is expected to be reduced modulo the ``p`` (this is not checked).
     The function is undefined if the logarithm does not exist.
 
 

--- a/doc/source/fmpz_mod_mat.rst
+++ b/doc/source/fmpz_mod_mat.rst
@@ -294,7 +294,7 @@ Gaussian elimination
     Sets ``res`` to the reduced row echelon form of ``mat``
     and returns the rank.
 
-    The modulus is assumed to be prime.
+    The modulus is assumed to be prime, which is not checked.
 
 
 Strong echelon form and Howell form
@@ -329,7 +329,7 @@ Inverse
 
     `A` and `B` must be square matrices with the same dimensions.
 
-    The modulus is assumed to be prime.
+    The modulus is assumed to be prime, which is not checked.
 
 
 LU decomposition
@@ -356,7 +356,7 @@ LU decomposition
     will abandon the output matrix in an undefined state and return 0
     if `A` is detected to be rank-deficient.
 
-    The modulus is assumed to be prime.
+    The modulus is assumed to be prime, which is not checked.
 
 
 Triangular solving
@@ -372,7 +372,8 @@ Triangular solving
     is allowed. Automatically chooses between the classical and
     recursive algorithms.
 
-    The modulus is assumed to be prime.
+    The modulus is assumed to be prime, and ``L`` is assumed to have the
+    stated triangular shape; neither is checked.
 
 .. function:: void fmpz_mod_mat_solve_triu(fmpz_mod_mat_t X, const fmpz_mod_mat_t U, const fmpz_mod_mat_t B, int unit, const fmpz_mod_ctx_t ctx)
 
@@ -383,7 +384,8 @@ Triangular solving
     is allowed. Automatically chooses between the classical and
     recursive algorithms.
 
-    The modulus is assumed to be prime.
+    The modulus is assumed to be prime, and ``U`` is assumed to have the
+    stated triangular shape; neither is checked.
 
 
 Solving
@@ -399,7 +401,7 @@ Solving
 
     The matrix `A` must be square.
 
-    The modulus is assumed to be prime.
+    The modulus is assumed to be prime, which is not checked.
 
 .. function:: int fmpz_mod_mat_can_solve(fmpz_mod_mat_t X, const fmpz_mod_mat_t A, const fmpz_mod_mat_t B, const fmpz_mod_ctx_t ctx)
 
@@ -411,7 +413,7 @@ Solving
 
     There are no restrictions on the shape of `A` and it may be singular.
 
-    The modulus is assumed to be prime.
+    The modulus is assumed to be prime, which is not checked.
 
 
 Transforms
@@ -454,4 +456,4 @@ Minimal polynomial
     Compute the minimal polynomial `p` of the matrix `M`. The matrix
     is required to be square, otherwise an exception is raised.
 
-    The modulus is assumed to be prime.
+    The modulus is assumed to be prime, which is not checked.

--- a/doc/source/fmpz_mod_mpoly.rst
+++ b/doc/source/fmpz_mod_mpoly.rst
@@ -490,7 +490,7 @@ Powering
 Division
 --------------------------------------------------------------------------------
 
-The division functions assume that the modulus is prime.
+The division functions assume that the modulus is prime, which is not checked.
 
 .. function:: int fmpz_mod_mpoly_divides(fmpz_mod_mpoly_t Q, const fmpz_mod_mpoly_t A, const fmpz_mod_mpoly_t B, const fmpz_mod_mpoly_ctx_t ctx)
 
@@ -512,6 +512,9 @@ The division functions assume that the modulus is prime.
 
 Greatest Common Divisor
 --------------------------------------------------------------------------------
+
+The greatest common divisor functions assume that the modulus is prime,
+which is not checked.
 
 .. function:: void fmpz_mod_mpoly_term_content(fmpz_mod_mpoly_t M, const fmpz_mod_mpoly_t A, const fmpz_mod_mpoly_ctx_t ctx)
 
@@ -552,7 +555,8 @@ Greatest Common Divisor
 Square Root
 --------------------------------------------------------------------------------
 
-The square root functions assume that the modulus is prime for correct operation.
+The square root functions assume that the modulus is prime for correct
+operation, which is not checked.
 
 .. function:: int fmpz_mod_mpoly_sqrt(fmpz_mod_mpoly_t Q, const fmpz_mod_mpoly_t A, const fmpz_mod_mpoly_ctx_t ctx)
 

--- a/doc/source/fmpz_mod_mpoly_factor.rst
+++ b/doc/source/fmpz_mod_mpoly_factor.rst
@@ -62,6 +62,9 @@ Basic manipulation
 Factorisation
 --------------------------------------------------------------------------------
 
+    The factorisation functions assume that the modulus is prime, which is
+    not checked.
+
     A return of `1` indicates that the function was successful. Otherwise,
     the return is `0` and *f* is undefined. None of these functions
     multiply *f* by *A*: *f* is simply set to a factorisation of *A*, and thus

--- a/doc/source/fmpz_mod_mpoly_q.rst
+++ b/doc/source/fmpz_mod_mpoly_q.rst
@@ -8,6 +8,9 @@ An :type:`fmpz_mod_mpoly_q_t` represents an element of
 multivariate polynomials (:type:`fmpz_mod_mpoly_t`).
 Instances are always kept in canonical form by ensuring that the GCD
 of numerator and denominator is 1 and then normalizing denominator to a monic polynomial.
+All functions assume their inputs are in canonical form and produce
+canonical output; this is not checked. Use
+:func:`fmpz_mod_mpoly_q_canonicalise` on any directly constructed value.
 
 The user must create a multivariate polynomial context
 (:type:`fmpz_mod_mpoly_ctx_t`) specifying the prime number *m* for the field `\mathbb{F}_m` 

--- a/doc/source/fmpz_mod_poly.rst
+++ b/doc/source/fmpz_mod_poly.rst
@@ -34,6 +34,11 @@ be normalised and all coefficients to be reduced modulo `n`, and
 unless otherwise specified they produce output that is normalised with
 coefficients reduced modulo `n`.
 
+Many functions in this module (greatest common divisors and extended
+gcds, modular inverses, minimal polynomials, division as if over a
+field, square roots, factorisation and irreducibility testing) require
+the modulus to be prime. This is assumed and not checked.
+
 Simple example
 --------------
 
@@ -806,7 +811,7 @@ Division
     `0 \leq \operatorname{len}(R) < \operatorname{len}(B)`.
 
     Assumes that the leading coefficient of `B` is invertible
-    modulo `p`.
+    modulo `p`, which is not checked.
 
 .. function:: void _fmpz_mod_poly_divrem_newton_n_preinv (fmpz * Q, fmpz * R, const fmpz * A, slong lenA, const fmpz * B, slong lenB, const fmpz * Binv, slong lenBinv, const fmpz_mod_ctx_t ctx)
 
@@ -992,7 +997,8 @@ Power series inversion
 
     Sets ``Qinv`` to the inverse of ``Q`` modulo `x^n`,
     where `n \geq 1`, assuming that the bottom coefficient of
-    `Q` is a unit.
+    `Q` is a unit. A non-unit bottom coefficient (a zero or, over a
+    composite modulus, a nonzero non-invertible value) raises an exception.
 
 .. function:: void fmpz_mod_poly_inv_series_f(fmpz_t f, fmpz_mod_poly_t Qinv, const fmpz_mod_poly_t Q, slong n, const fmpz_mod_ctx_t ctx)
 
@@ -1015,7 +1021,8 @@ Power series division
 
     Set `Q` to the quotient of the series `A` by `B`, thinking of the series as
     though they were of length `n`. We assume that the bottom coefficient of
-    `B` is a unit.
+    `B` is a unit. A non-unit bottom coefficient (a zero or, over a
+    composite modulus, a nonzero non-invertible value) raises an exception.
 
 
 Greatest common divisor
@@ -1053,7 +1060,8 @@ Greatest common divisor
 
     In general, the greatest common divisor is defined in the polynomial
     ring `(\mathbf{Z}/(p \mathbf{Z}))[X]` if and only if `p` is a prime
-    number.  Thus, this function assumes that `p` is prime.
+    number.  Thus, this function assumes that `p` is prime, which is not
+    checked.
 
 .. function:: slong _fmpz_mod_poly_gcd_euclidean_f(fmpz_t f, fmpz * G, const fmpz * A, slong lenA, const fmpz * B, slong lenB, const fmpz_mod_ctx_t ctx)
 
@@ -1240,7 +1248,7 @@ Greatest common divisor
 
     Attempts to set `A` to the inverse of `B` modulo `P` in the polynomial
     ring `(\mathbf{Z}/p\mathbf{Z})[X]`, where we assume that `p` is a prime
-    number.
+    number, which is not checked.
 
     If `\deg(P) < 2`, raises an exception.
 
@@ -1266,16 +1274,16 @@ Minpoly
 
     The return value equals the length of ``poly``.
 
-    It is assumed that `p` is prime and ``poly`` has space for at least
-    `len+1` coefficients. No aliasing between inputs and outputs is
-    allowed.
+    It is assumed that `p` is prime, which is not checked, and that
+    ``poly`` has space for at least `len+1` coefficients. No aliasing
+    between inputs and outputs is allowed.
 
 .. function:: void fmpz_mod_poly_minpoly_bm(fmpz_mod_poly_t poly, const fmpz * seq, slong len, const fmpz_mod_ctx_t ctx)
 
     Sets ``poly`` to a minimal generating polynomial for sequence
     ``seq`` of length ``len``.
 
-    Assumes that the modulus is prime.
+    Assumes that the modulus is prime, which is not checked.
 
     This version uses the Berlekamp-Massey algorithm, whose running time
     is proportional to ``len`` times the size of the minimal generator.
@@ -1287,16 +1295,16 @@ Minpoly
 
     The return value equals the length of ``poly``.
 
-    It is assumed that `p` is prime and ``poly`` has space for at least
-    `len+1` coefficients. No aliasing between inputs and outputs is
-    allowed.
+    It is assumed that `p` is prime, which is not checked, and that
+    ``poly`` has space for at least `len+1` coefficients. No aliasing
+    between inputs and outputs is allowed.
 
 .. function:: void fmpz_mod_poly_minpoly_hgcd(fmpz_mod_poly_t poly, const fmpz * seq, slong len, const fmpz_mod_ctx_t ctx)
 
     Sets ``poly`` to a minimal generating polynomial for sequence
     ``seq`` of length ``len``.
 
-    Assumes that the modulus is prime.
+    Assumes that the modulus is prime, which is not checked.
 
     This version uses the HGCD algorithm, whose running time is
     `O(n \log^2 n)` field operations, regardless of the actual size of
@@ -1309,9 +1317,9 @@ Minpoly
 
     The return value equals the length of ``poly``.
 
-    It is assumed that `p` is prime and ``poly`` has space for at least
-    `len+1` coefficients. No aliasing between inputs and outputs is
-    allowed.
+    It is assumed that `p` is prime, which is not checked, and that
+    ``poly`` has space for at least `len+1` coefficients. No aliasing
+    between inputs and outputs is allowed.
 
 .. function:: void fmpz_mod_poly_minpoly(fmpz_mod_poly_t poly, const fmpz * seq, slong len, const fmpz_mod_ctx_t ctx)
 
@@ -1325,7 +1333,7 @@ Minpoly
 
     `seq_i = -\sum_{j=0}^{d-1} seq_{i+j}*f_j.`
 
-    Assumes that the modulus is prime.
+    Assumes that the modulus is prime, which is not checked.
 
     This version automatically chooses the fastest underlying
     implementation based on ``len`` and the size of the modulus.

--- a/doc/source/fmpz_mod_poly_factor.rst
+++ b/doc/source/fmpz_mod_poly_factor.rst
@@ -18,6 +18,9 @@ Types, macros and constants
 Factorisation
 --------------------------------------------------------------------------------
 
+The factorisation, irreducibility and squarefreeness functions in this
+module assume that the modulus is prime. This is not checked.
+
 
 .. function:: void fmpz_mod_poly_factor_init(fmpz_mod_poly_factor_t fac, const fmpz_mod_ctx_t ctx)
 
@@ -122,13 +125,15 @@ Factorisation
     placed in ``factor`` and 1 is returned, otherwise 0 is returned and
     the value of factor is undetermined.
 
-    Requires that ``pol`` be monic, non-constant and squarefree.
+    Requires that ``pol`` be monic, non-constant and squarefree. These
+    requirements are not checked.
 
 .. function:: void fmpz_mod_poly_factor_equal_deg(fmpz_mod_poly_factor_t factors, const fmpz_mod_poly_t pol, slong d, const fmpz_mod_ctx_t ctx)
 
     Assuming ``pol`` is a product of irreducible factors all of
     degree ``d``, finds all those factors and places them in factors.
-    Requires that ``pol`` be monic, non-constant and squarefree.
+    Requires that ``pol`` be monic, non-constant and squarefree. These
+    requirements are not checked.
 
 .. function:: void fmpz_mod_poly_factor_distinct_deg(fmpz_mod_poly_factor_t res, const fmpz_mod_poly_t poly, slong * const * degs, const fmpz_mod_ctx_t ctx)
 
@@ -137,7 +142,8 @@ Factorisation
     `f[d]` is the product of the monic irreducible factors of ``poly``
     of degree `d`. Factors `f[d]` are stored in ``res``, and the degree `d`
     of the irreducible factors is stored in ``degs`` in the same order
-    as the factors.
+    as the factors. The monic, non-constant and squarefree assumptions
+    on ``poly`` are not checked.
 
     Requires that ``degs`` has enough space for `(n/2)+1 * sizeof(slong)`.
 

--- a/doc/source/fmpz_mpoly_q.rst
+++ b/doc/source/fmpz_mpoly_q.rst
@@ -9,6 +9,9 @@ multivariate polynomials (:type:`fmpz_mpoly_t`).
 Instances are always kept in canonical form by ensuring that the GCD
 of numerator and denominator is 1 and that the coefficient
 of the leading term of the denominator is positive.
+All functions assume their inputs are in canonical form and produce
+canonical output; this is not checked. Use
+:func:`fmpz_mpoly_q_canonicalise` on any directly constructed value.
 
 The user must create a multivariate polynomial context
 (:type:`fmpz_mpoly_ctx_t`) specifying the number of variables *n* and

--- a/doc/source/fmpz_poly.rst
+++ b/doc/source/fmpz_poly.rst
@@ -1822,7 +1822,8 @@ Euclidean division
 .. function:: void _fmpz_poly_div_root_fmpz(fmpz * Q, const fmpz * A, slong len, const fmpz_t c)
 
     Computes the quotient ``(Q, len-1)`` of ``(A, len)`` upon
-    division by `x - c`.
+    division by `x - c`. Assumes the division is exact, which is not
+    checked.
 
     Supports aliasing of ``Q`` and ``A``, but the result is
     undefined in case of partial overlap.
@@ -1830,17 +1831,20 @@ Euclidean division
 .. function:: void fmpz_poly_div_root_fmpz(fmpz_poly_t Q, const fmpz_poly_t A, const fmpz_t c)
 
     Computes the quotient ``(Q, len-1)`` of ``(A, len)`` upon
-    division by `x - c`.
+    division by `x - c`. Assumes the division is exact, which is not
+    checked.
 
 .. function:: void _fmpz_poly_divexact(fmpz * Q, const fmpz * A, slong lenA, const fmpz * B, slong lenB)
               void fmpz_poly_divexact(fmpz_poly_t Q, const fmpz_poly_t A, const fmpz_poly_t B)
 
     Like :func:`fmpz_poly_div`, but assumes that the division is exact.
+    This is not checked; the result is undefined if the division is inexact.
 
 .. function:: void _fmpz_poly_divexact_root_fmpq(fmpz * Q, const fmpz * A, slong len, const fmpq_t c)
 
     Computes the quotient ``(Q, len-1)`` of ``(A, len)`` upon
-    division by `q x - p` where `c = p/q`. Assumes the division is exact.
+    division by `q x - p` where `c = p/q`. Assumes the division is exact,
+    which is not checked.
 
     Supports aliasing of ``Q`` and ``A``, but the result is
     undefined in case of partial overlap.
@@ -1848,7 +1852,8 @@ Euclidean division
 .. function:: void fmpz_poly_divexact_root_fmpq(fmpz_poly_t Q, const fmpz_poly_t A, const fmpq_t c)
 
     Computes the quotient ``(Q, len-1)`` of ``(A, len)`` upon
-    division by `q x - p` where `c = p/q`. Assumes the division is exact.
+    division by `q x - p` where `c = p/q`. Assumes the division is exact,
+    which is not checked.
 
 Division with precomputed inverse
 --------------------------------------------------------------------------------
@@ -1969,8 +1974,8 @@ Division mod p
     division is exact modulo `p`. The computed coefficients are reduced modulo
     `p` using the symmetric remainder system. We require `f` to be at least `n`
     in length. The function can handle trailing zeroes, but the low nonzero
-    coefficient of `g` must be coprime to `p`. This is a bespoke function used
-    by factoring.
+    coefficient of `g` must be coprime to `p`, which is not checked. This is a
+    bespoke function used by factoring.
 
 .. function:: void fmpz_poly_divhigh_smodp(fmpz * res, const fmpz_poly_t f, const fmpz_poly_t g, const fmpz_t p, slong n)
 
@@ -1979,7 +1984,7 @@ Division mod p
     `p` using the symmetric remainder system. We require `f` to be as output
     by ``fmpz_poly_mulhigh_n`` given polynomials `g` and a polynomial of
     length `n` as inputs. The leading coefficient of `g` must be coprime to
-    `p`. This is a bespoke function used by factoring.
+    `p`, which is not checked. This is a bespoke function used by factoring.
 
 
 Power series division
@@ -1991,40 +1996,45 @@ Power series division
     Computes the first `n` terms of the inverse power series of
     ``(Q, lenQ)`` using a recurrence.
 
-    Assumes that `n \geq 1` and that `Q` has constant term `\pm 1`.
+    Assumes that `n \geq 1` and that `Q` has constant term `\pm 1`;
+    the constant term is not checked.
     Does not support aliasing.
 
 .. function:: void fmpz_poly_inv_series_basecase(fmpz_poly_t Qinv, const fmpz_poly_t Q, slong n)
 
     Computes the first `n` terms of the inverse power series of `Q`
     using a recurrence, assuming that `Q` has constant term `\pm 1`
-    and `n \geq 1`.
+    and `n \geq 1`; the constant term is not checked.
 
 .. function:: void _fmpz_poly_inv_series_newton(fmpz * Qinv, const fmpz * Q, slong Qlen, slong n)
 
     Computes the first `n` terms of the inverse power series of
     ``(Q, lenQ)`` using Newton iteration.
 
-    Assumes that `n \geq 1` and that `Q` has constant term `\pm 1`.
+    Assumes that `n \geq 1` and that `Q` has constant term `\pm 1`;
+    the constant term is not checked.
     Does not support aliasing.
 
 .. function:: void fmpz_poly_inv_series_newton(fmpz_poly_t Qinv, const fmpz_poly_t Q, slong n)
 
     Computes the first `n` terms of the inverse power series of `Q` using
-    Newton iteration, assuming `Q` has constant term `\pm 1` and `n \geq 1`.
+    Newton iteration, assuming `Q` has constant term `\pm 1` and `n \geq 1`;
+    the constant term is not checked.
 
 .. function:: void _fmpz_poly_inv_series(fmpz * Qinv, const fmpz * Q, slong Qlen, slong n)
 
     Computes the first `n` terms of the inverse power series of
     ``(Q, lenQ)``.
 
-    Assumes that `n \geq 1` and that `Q` has constant term `\pm 1`.
+    Assumes that `n \geq 1` and that `Q` has constant term `\pm 1`;
+    the constant term is not checked.
     Does not support aliasing.
 
 .. function:: void fmpz_poly_inv_series(fmpz_poly_t Qinv, const fmpz_poly_t Q, slong n)
 
     Computes the first `n` terms of the inverse power series of `Q`,
-    assuming `Q` has constant term `\pm 1` and `n \geq 1`.
+    assuming `Q` has constant term `\pm 1` and `n \geq 1`; the constant
+    term is not checked.
 
 .. function:: void _fmpz_poly_div_series_basecase(fmpz * Q, const fmpz * A, slong Alen, const fmpz * B, slong Blen, slong n)
 
@@ -2033,7 +2043,8 @@ Power series division
 .. function:: void _fmpz_poly_div_series(fmpz * Q, const fmpz * A, slong Alen, const fmpz * B, slong Blen, slong n)
 
     Divides ``(A, Alen)`` by ``(B, Blen)`` as power series over `\mathbb{Z}`,
-    assuming `B` has constant term `\pm 1` and `n \geq 1`.
+    assuming `B` has constant term `\pm 1` and `n \geq 1`; the constant
+    term is not checked.
     Aliasing is not supported.
 
 .. function:: void fmpz_poly_div_series_basecase(fmpz_poly_t Q, const fmpz_poly_t A, const fmpz_poly_t B, slong n)
@@ -2045,7 +2056,7 @@ Power series division
     Performs power series division in `\mathbb{Z}[[x]] / (x^n)`.  The function
     considers the polynomials `A` and `B` as power series of length `n`
     starting with the constant terms.  The function assumes that `B` has
-    constant term `\pm 1` and `n \geq 1`.
+    constant term `\pm 1` and `n \geq 1`; the constant term is not checked.
 
 
 Pseudo division
@@ -2629,7 +2640,7 @@ Power series reversion
     Sets ``Qinv`` to the compositional inverse or reversion of ``Q``
     as a power series, i.e. computes `Q^{-1}` such that
     `Q(Q^{-1}(x)) = Q^{-1}(Q(x)) = x \bmod x^n`.
-    It is required that `Q_0 = 0` and `Q_1 = \pm 1`.
+    It is required that `Q_0 = 0` and `Q_1 = \pm 1`. This is not checked.
 
     Wraps :func:`_gr_poly_revert_series` which chooses automatically
     between various algorithms.

--- a/doc/source/fmpz_poly_factor.rst
+++ b/doc/source/fmpz_poly_factor.rst
@@ -52,7 +52,8 @@ Manipulating factors
 
     Adds the primitive polynomial `p^e` to the factorisation ``fac``.
 
-    Assumes that `\deg(p) \geq 2` and `e \neq 0`.
+    Assumes that `\deg(p) \geq 2` and `e \neq 0`. These conditions are not
+    checked.
 
 .. function:: void fmpz_poly_factor_concat(fmpz_poly_factor_t res, const fmpz_poly_factor_t fac)
 
@@ -119,7 +120,8 @@ Factoring algorithms
 
     Assumes that the constant coefficient of `f` is non-zero.  Note that
     this can be easily achieved by taking out factors of the form `x^k`
-    before calling this routine.
+    before calling this routine.  Neither the primitivity of `f` nor the
+    non-zero constant coefficient is checked.
 
     If the final flag is set, the function will use the van Hoeij factorisation
     algorithm with gradual feeding and mod `2^k` data truncation to find
@@ -138,7 +140,8 @@ Factoring algorithms
 
     Inserts the factorisation of the quadratic (resp. cubic) polynomial *f* into *fac* with
     multiplicity *exp*. This function requires that the content of *f* has
-    been removed, and does not update the content of *fac*.
+    been removed (this is not checked), and does not update the content of
+    *fac*.
     The factorization is calculated over `\mathbb{R}` or `\mathbb{Q}_2` and then tested over `\mathbb{Z}`.
 
 .. function:: void fmpz_poly_factor(fmpz_poly_factor_t final_fac, const fmpz_poly_t F)

--- a/doc/source/fmpz_poly_mat.rst
+++ b/doc/source/fmpz_poly_mat.rst
@@ -402,7 +402,8 @@ Trace
 .. function:: void fmpz_poly_mat_trace(fmpz_poly_t trace, const fmpz_poly_mat_t mat)
 
     Computes the trace of the matrix, i.e. the sum of the entries on
-    the main diagonal. The matrix is required to be square.
+    the main diagonal. The matrix is required to be square, which is not
+    checked.
 
 
 Determinant and rank
@@ -443,6 +444,7 @@ Inverse
 
     Sets (``Ainv``, ``den``) to the inverse matrix of ``A``.
     Returns 1 if ``A`` is nonsingular and 0 if ``A`` is singular.
+    ``A`` must be a square matrix, which is not checked.
     Aliasing of ``Ainv`` and ``A`` is allowed.
 
     More precisely, ``det`` will be set to the determinant of ``A``
@@ -482,6 +484,7 @@ Solving
 
     Solves the equation `AX = B` for nonsingular `A`. More precisely, computes
     (``X``, ``den``) such that `AX = B \times \operatorname{den}`.
+    ``A`` is assumed to be square; this is not checked.
     Returns 1 if `A` is nonsingular and 0 if `A` is singular.
     The computed denominator will not generally be minimal.
 
@@ -492,6 +495,7 @@ Solving
 
     Solves the equation `AX = B` for nonsingular `A`. More precisely, computes
     (``X``, ``den``) such that `AX = B \times \operatorname{den}`.
+    ``A`` is assumed to be square; this is not checked.
     Returns 1 if `A` is nonsingular and 0 if `A` is singular.
     The computed denominator will not generally be minimal.
 
@@ -502,3 +506,6 @@ Solving
 
     Performs fraction-free forward and back substitution given a precomputed
     fraction-free LU decomposition and corresponding permutation.
+    The decomposition ``FFLU`` and permutation ``perm`` are assumed to come
+    from :func:`fmpz_poly_mat_fflu` applied to a nonsingular square matrix;
+    this is not checked.

--- a/doc/source/fmpz_vec.rst
+++ b/doc/source/fmpz_vec.rst
@@ -313,17 +313,20 @@ Scalar multiplication and division
 .. function:: void _fmpz_vec_scalar_divexact_fmpz(fmpz * vec1, const fmpz * vec2, slong len2, const fmpz_t x)
 
     Sets ``(vec1, len2)`` to ``(vec2, len2)`` divided by `x`, where the
-    division is assumed to be exact for every entry in ``vec2``.
+    division is assumed to be exact for every entry in ``vec2``
+    (this is not checked).
 
 .. function:: void _fmpz_vec_scalar_divexact_si(fmpz * vec1, const fmpz * vec2, slong len2, slong c)
 
     Sets ``(vec1, len2)`` to ``(vec2, len2)`` divided by `x`, where the
-    division is assumed to be exact for every entry in ``vec2``.
+    division is assumed to be exact for every entry in ``vec2``
+    (this is not checked).
 
 .. function:: void _fmpz_vec_scalar_divexact_ui(fmpz * vec1, const fmpz * vec2, slong len2, ulong c)
 
     Sets ``(vec1, len2)`` to ``(vec2, len2)`` divided by `x`, where the
-    division is assumed to be exact for every entry in ``vec2``.
+    division is assumed to be exact for every entry in ``vec2``
+    (this is not checked).
 
 .. function:: void _fmpz_vec_scalar_fdiv_q_fmpz(fmpz * vec1, const fmpz * vec2, slong len2, const fmpz_t c)
 

--- a/doc/source/fq_default_mat.rst
+++ b/doc/source/fq_default_mat.rst
@@ -365,7 +365,9 @@ Triangular solving
 
     Sets `X = L^{-1} B` where `L` is a full rank lower triangular
     square matrix. If ``unit`` = 1, `L` is assumed to have ones on
-    its main diagonal, and the main diagonal will not be read.  `X`
+    its main diagonal, and the main diagonal will not be read.  It is
+    assumed that `L` is lower triangular with invertible diagonal (or
+    unit diagonal when ``unit`` = 1); this is not checked.  `X`
     and `B` are allowed to be the same matrix, but no other aliasing
     is allowed. Automatically chooses between the classical and
     recursive algorithms.
@@ -374,7 +376,9 @@ Triangular solving
 
     Sets `X = U^{-1} B` where `U` is a full rank upper triangular
     square matrix. If ``unit`` = 1, `U` is assumed to have ones on
-    its main diagonal, and the main diagonal will not be read.  `X`
+    its main diagonal, and the main diagonal will not be read.  It is
+    assumed that `U` is upper triangular with invertible diagonal (or
+    unit diagonal when ``unit`` = 1); this is not checked.  `X`
     and `B` are allowed to be the same matrix, but no other aliasing
     is allowed. Automatically chooses between the classical and
     recursive algorithms.

--- a/doc/source/fq_default_poly_factor.rst
+++ b/doc/source/fq_default_poly_factor.rst
@@ -114,20 +114,22 @@ Factorisation
     Assuming ``pol`` is a product of irreducible factors all of
     degree ``d``, finds all those factors and places them in
     factors.  Requires that ``pol`` be monic, non-constant and
-    squarefree.
+    squarefree (this is not checked).
 
 .. function:: void fq_default_poly_factor_split_single(fq_default_poly_t linfactor, const fq_default_poly_t input, const fq_default_ctx_t ctx)
 
     Assuming ``input`` is a product of factors all of degree 1, finds a single
     linear factor of ``input`` and places it in ``linfactor``.
-    Requires that ``input`` be monic and non-constant.
+    Requires that ``input`` be monic and non-constant (this is not
+    checked).
 
 .. function:: void fq_default_poly_factor_distinct_deg(fq_default_poly_factor_t res, const fq_default_poly_t poly, slong * const * degs, const fq_default_ctx_t ctx)
 
     Factorises a monic non-constant squarefree polynomial ``poly``
     of degree `n` into factors `f[d]` such that for `1 \leq d \leq n`
     `f[d]` is the product of the monic irreducible factors of
-    ``poly`` of degree `d`. Factors are stored in ``res``,
+    ``poly`` of degree `d` (squarefreeness is assumed and not
+    checked). Factors are stored in ``res``,
     associated powers of irreducible polynomials are stored in
     ``degs`` in the same order as factors.
 

--- a/doc/source/fq_mat.rst
+++ b/doc/source/fq_mat.rst
@@ -401,7 +401,9 @@ Triangular solving
 
     Sets `X = L^{-1} B` where `L` is a full rank lower triangular
     square matrix. If ``unit`` = 1, `L` is assumed to have ones on
-    its main diagonal, and the main diagonal will not be read.  `X`
+    its main diagonal, and the main diagonal will not be read.  It is
+    assumed that `L` is lower triangular with invertible diagonal (or
+    unit diagonal when ``unit`` = 1); this is not checked.  `X`
     and `B` are allowed to be the same matrix, but no other aliasing
     is allowed. Automatically chooses between the classical and
     recursive algorithms.
@@ -410,7 +412,9 @@ Triangular solving
 
     Sets `X = U^{-1} B` where `U` is a full rank upper triangular
     square matrix. If ``unit`` = 1, `U` is assumed to have ones on
-    its main diagonal, and the main diagonal will not be read.  `X`
+    its main diagonal, and the main diagonal will not be read.  It is
+    assumed that `U` is upper triangular with invertible diagonal (or
+    unit diagonal when ``unit`` = 1); this is not checked.  `X`
     and `B` are allowed to be the same matrix, but no other aliasing
     is allowed. Automatically chooses between the classical and
     recursive algorithms.

--- a/doc/source/fq_nmod_mat.rst
+++ b/doc/source/fq_nmod_mat.rst
@@ -400,7 +400,9 @@ Triangular solving
 
     Sets `X = L^{-1} B` where `L` is a full rank lower triangular
     square matrix. If ``unit`` = 1, `L` is assumed to have ones on
-    its main diagonal, and the main diagonal will not be read.  `X`
+    its main diagonal, and the main diagonal will not be read.  It is
+    assumed that `L` is lower triangular with invertible diagonal (or
+    unit diagonal when ``unit`` = 1); this is not checked.  `X`
     and `B` are allowed to be the same matrix, but no other aliasing
     is allowed. Automatically chooses between the classical and
     recursive algorithms.
@@ -409,7 +411,9 @@ Triangular solving
 
     Sets `X = U^{-1} B` where `U` is a full rank upper triangular
     square matrix. If ``unit`` = 1, `U` is assumed to have ones on
-    its main diagonal, and the main diagonal will not be read.  `X`
+    its main diagonal, and the main diagonal will not be read.  It is
+    assumed that `U` is upper triangular with invertible diagonal (or
+    unit diagonal when ``unit`` = 1); this is not checked.  `X`
     and `B` are allowed to be the same matrix, but no other aliasing
     is allowed. Automatically chooses between the classical and
     recursive algorithms.

--- a/doc/source/fq_nmod_poly_factor.rst
+++ b/doc/source/fq_nmod_poly_factor.rst
@@ -121,27 +121,30 @@ Factorisation
     placed in factor and 1 is returned, otherwise 0 is returned and
     the value of factor is undetermined.
 
-    Requires that ``pol`` be monic, non-constant and squarefree.
+    Requires that ``pol`` be monic, non-constant and squarefree (this
+    is not checked).
 
 .. function:: void fq_nmod_poly_factor_equal_deg(fq_nmod_poly_factor_t factors, const fq_nmod_poly_t pol, slong d, const fq_nmod_ctx_t ctx)
 
     Assuming ``pol`` is a product of irreducible factors all of
     degree ``d``, finds all those factors and places them in
     factors.  Requires that ``pol`` be monic, non-constant and
-    squarefree.
+    squarefree (this is not checked).
 
 .. function:: void fq_nmod_poly_factor_split_single(fq_nmod_poly_t linfactor, const fq_nmod_poly_t input, const fq_nmod_ctx_t ctx)
 
     Assuming ``input`` is a product of factors all of degree 1, finds a single
     linear factor of ``input`` and places it in ``linfactor``.
-    Requires that ``input`` be monic and non-constant.
+    Requires that ``input`` be monic and non-constant (this is not
+    checked).
 
 .. function:: void fq_nmod_poly_factor_distinct_deg(fq_nmod_poly_factor_t res, const fq_nmod_poly_t poly, slong * const * degs, const fq_nmod_ctx_t ctx)
 
     Factorises a monic non-constant squarefree polynomial ``poly``
     of degree `n` into factors `f[d]` such that for `1 \leq d \leq n`
     `f[d]` is the product of the monic irreducible factors of
-    ``poly`` of degree `d`. Factors are stored in ``res``,
+    ``poly`` of degree `d` (squarefreeness is assumed and not
+    checked). Factors are stored in ``res``,
     associated powers of irreducible polynomials are stored in
     ``degs`` in the same order as factors.
 

--- a/doc/source/fq_poly_factor.rst
+++ b/doc/source/fq_poly_factor.rst
@@ -121,27 +121,30 @@ Factorisation
     placed in factor and 1 is returned, otherwise 0 is returned and
     the value of factor is undetermined.
 
-    Requires that ``pol`` be monic, non-constant and squarefree.
+    Requires that ``pol`` be monic, non-constant and squarefree (this
+    is not checked).
 
 .. function:: void fq_poly_factor_equal_deg(fq_poly_factor_t factors, const fq_poly_t pol, slong d, const fq_ctx_t ctx)
 
     Assuming ``pol`` is a product of irreducible factors all of
     degree ``d``, finds all those factors and places them in
     factors.  Requires that ``pol`` be monic, non-constant and
-    squarefree.
+    squarefree (this is not checked).
 
 .. function:: void fq_poly_factor_split_single(fq_poly_t linfactor, const fq_poly_t input, const fq_ctx_t ctx)
 
     Assuming ``input`` is a product of factors all of degree 1, finds a single
     linear factor of ``input`` and places it in ``linfactor``.
-    Requires that ``input`` be monic and non-constant.
+    Requires that ``input`` be monic and non-constant (this is not
+    checked).
 
 .. function:: void fq_poly_factor_distinct_deg(fq_poly_factor_t res, const fq_poly_t poly, slong * const * degs, const fq_ctx_t ctx)
 
     Factorises a monic non-constant squarefree polynomial ``poly``
     of degree `n` into factors `f[d]` such that for `1 \leq d \leq n`
     `f[d]` is the product of the monic irreducible factors of
-    ``poly`` of degree `d`. Factors are stored in ``res``,
+    ``poly`` of degree `d` (squarefreeness is assumed and not
+    checked). Factors are stored in ``res``,
     associated powers of irreducible polynomials are stored in
     ``degs`` in the same order as factors.
 

--- a/doc/source/fq_zech_mat.rst
+++ b/doc/source/fq_zech_mat.rst
@@ -353,7 +353,9 @@ Triangular solving
 
     Sets `X = L^{-1} B` where `L` is a full rank lower triangular
     square matrix. If ``unit`` = 1, `L` is assumed to have ones on
-    its main diagonal, and the main diagonal will not be read.  `X`
+    its main diagonal, and the main diagonal will not be read.  It is
+    assumed that `L` is lower triangular with invertible diagonal (or
+    unit diagonal when ``unit`` = 1); this is not checked.  `X`
     and `B` are allowed to be the same matrix, but no other aliasing
     is allowed. Automatically chooses between the classical and
     recursive algorithms.
@@ -362,7 +364,9 @@ Triangular solving
 
     Sets `X = U^{-1} B` where `U` is a full rank upper triangular
     square matrix. If ``unit`` = 1, `U` is assumed to have ones on
-    its main diagonal, and the main diagonal will not be read.  `X`
+    its main diagonal, and the main diagonal will not be read.  It is
+    assumed that `U` is upper triangular with invertible diagonal (or
+    unit diagonal when ``unit`` = 1); this is not checked.  `X`
     and `B` are allowed to be the same matrix, but no other aliasing
     is allowed. Automatically chooses between the classical and
     recursive algorithms.

--- a/doc/source/fq_zech_poly_factor.rst
+++ b/doc/source/fq_zech_poly_factor.rst
@@ -122,27 +122,30 @@ Factorisation
     placed in factor and 1 is returned, otherwise 0 is returned and
     the value of factor is undetermined.
 
-    Requires that ``pol`` be monic, non-constant and squarefree.
+    Requires that ``pol`` be monic, non-constant and squarefree (this
+    is not checked).
 
 .. function:: void fq_zech_poly_factor_equal_deg(fq_zech_poly_factor_t factors, const fq_zech_poly_t pol, slong d, const fq_zech_ctx_t ctx)
 
     Assuming ``pol`` is a product of irreducible factors all of
     degree ``d``, finds all those factors and places them in
     factors.  Requires that ``pol`` be monic, non-constant and
-    squarefree.
+    squarefree (this is not checked).
 
 .. function:: void fq_zech_poly_factor_split_single(fq_zech_poly_t linfactor, const fq_zech_poly_t input, const fq_zech_ctx_t ctx)
 
     Assuming ``input`` is a product of factors all of degree 1, finds a single
     linear factor of ``input`` and places it in ``linfactor``.
-    Requires that ``input`` be monic and non-constant.
+    Requires that ``input`` be monic and non-constant (this is not
+    checked).
 
 .. function:: void fq_zech_poly_factor_distinct_deg(fq_zech_poly_factor_t res, const fq_zech_poly_t poly, slong * const * degs, const fq_zech_ctx_t ctx)
 
     Factorises a monic non-constant squarefree polynomial ``poly``
     of degree `n` into factors `f[d]` such that for `1 \leq d \leq n`
     `f[d]` is the product of the monic irreducible factors of
-    ``poly`` of degree `d`. Factors are stored in ``res``,
+    ``poly`` of degree `d` (squarefreeness is assumed and not
+    checked). Factors are stored in ``res``,
     associated powers of irreducible polynomials are stored in
     ``degs`` in the same order as factors.
 

--- a/doc/source/gr_mat.rst
+++ b/doc/source/gr_mat.rst
@@ -517,7 +517,9 @@ Solving
               int gr_mat_nonsingular_solve_triu(gr_mat_t X, const gr_mat_t U, const gr_mat_t B, int unit, gr_ctx_t ctx)
 
     Solves the lower triangular system `LX = B` or the upper triangular system
-    `UX = B`, respectively. Division by the the diagonal entries must
+    `UX = B`, respectively. It is assumed but not checked that *L* is lower
+    triangular (respectively *U* upper triangular); only the relevant triangle
+    is read. Division by the diagonal entries must
     be possible; if not a division fails, ``GR_DOMAIN`` is returned
     even if the system is solvable.
     If *unit* is set, the main diagonal of *L* or *U*
@@ -540,6 +542,9 @@ Solving
               int gr_mat_nonsingular_solve_lu_precomp(gr_mat_t X, const slong * perm, const gr_mat_t LU, const gr_mat_t B, gr_ctx_t ctx)
 
     Solves `AX = B` given a precomputed FFLU or LU factorization of *A*.
+    The factorization data *perm* and the combined factor are assumed (not
+    checked) to be valid, as produced by the corresponding factorization
+    routine.
 
 .. function:: int gr_mat_nonsingular_solve_den_fflu(gr_mat_t X, gr_ptr den, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx)
               int gr_mat_nonsingular_solve_den(gr_mat_t X, gr_ptr den, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx)
@@ -825,7 +830,8 @@ Companion matrix
     Sets the *n* by *n* matrix *res* to the companion matrix of the polynomial
     *poly* which must have degree *n*.
     The underscore method reads `n + 1` input coefficients.
-    The algorithm assumes that the leading coefficient of *poly* is invertible.
+    The algorithm assumes that the leading coefficient of *poly* is invertible,
+    which is not checked.
 
 .. function:: int _gr_mat_companion_fraction(gr_mat_t res_num, gr_ptr res_den, gr_srcptr poly, gr_ctx_t ctx)
               int gr_mat_companion_fraction(gr_mat_t res_num, gr_ptr res_den, const gr_poly_t poly, gr_ctx_t ctx)

--- a/doc/source/nmod.rst
+++ b/doc/source/nmod.rst
@@ -49,6 +49,10 @@ Generic rings
 Modular reduction and arithmetic
 --------------------------------------------------------------------------------
 
+Many of the functions below assume that their operands are already
+reduced modulo ``mod.n``. These reduced-operand assumptions are not
+checked.
+
 .. function:: void nmod_init(nmod_t * mod, ulong n)
 
     Initialises the given ``nmod_t`` structure for reduction modulo `n`

--- a/doc/source/nmod_mat.rst
+++ b/doc/source/nmod_mat.rst
@@ -29,7 +29,8 @@ modulus. The modulus is assumed to be a prime number in functions that
 perform some kind of division, solving, or Gaussian elimination
 (including computation of rank and determinant), but can be composite
 in functions that only perform basic manipulation and ring operations
-(e.g. transpose and matrix multiplication).
+(e.g. transpose and matrix multiplication). None of these primality
+assumptions are checked.
 
 Unless indicated, functions may assume that the stored values are in the range `[0, n)`. The user can manipulate matrix entries directly, but must assume responsibility for normalising all values to the range `[0, n)`.
 
@@ -446,7 +447,8 @@ Determinant and rank
 
 .. function:: slong nmod_mat_rank(const nmod_mat_t A)
 
-    Returns the rank of `A`. The modulus of `A` must be a prime number.
+    Returns the rank of `A`. The modulus of `A` must be a prime number;
+    this is not checked.
 
 
 
@@ -461,7 +463,7 @@ Inverse
     `B` to undefined values.
 
     `A` and `B` must be square matrices with the same dimensions
-    and modulus. The modulus must be prime.
+    and modulus. The modulus must be prime; this is not checked.
 
 
 
@@ -478,6 +480,9 @@ Triangular solving
     aliasing is allowed. Automatically chooses between the classical and
     recursive algorithms.
 
+    The triangular shape is assumed and not checked. A non-invertible
+    diagonal entry (when ``unit`` is 0) raises an exception.
+
 .. function:: void nmod_mat_solve_tril_classical(nmod_mat_t X, const nmod_mat_t L, const nmod_mat_t B, int unit)
 
     Sets `X = L^{-1} B` where `L` is a full rank lower triangular square
@@ -485,6 +490,9 @@ Triangular solving
     main diagonal, and the main diagonal will not be read.
     `X` and `B` are allowed to be the same matrix, but no other
     aliasing is allowed. Uses forward substitution.
+
+    The triangular shape is assumed and not checked. A non-invertible
+    diagonal entry (when ``unit`` is 0) raises an exception.
 
 .. function:: void nmod_mat_solve_tril_recursive(nmod_mat_t X, const nmod_mat_t L, const nmod_mat_t B, int unit)
 
@@ -505,6 +513,9 @@ Triangular solving
     to reduce the problem to matrix multiplication and triangular solving
     of smaller systems.
 
+    The triangular shape is assumed and not checked. A non-invertible
+    diagonal entry (when ``unit`` is 0) raises an exception.
+
 .. function:: void nmod_mat_solve_triu(nmod_mat_t X, const nmod_mat_t U, const nmod_mat_t B, int unit)
 
     Sets `X = U^{-1} B` where `U` is a full rank upper triangular square
@@ -514,6 +525,9 @@ Triangular solving
     aliasing is allowed. Automatically chooses between the classical and
     recursive algorithms.
 
+    The triangular shape is assumed and not checked. A non-invertible
+    diagonal entry (when ``unit`` is 0) raises an exception.
+
 .. function:: void nmod_mat_solve_triu_classical(nmod_mat_t X, const nmod_mat_t U, const nmod_mat_t B, int unit)
 
     Sets `X = U^{-1} B` where `U` is a full rank upper triangular square
@@ -521,6 +535,9 @@ Triangular solving
     main diagonal, and the main diagonal will not be read.
     `X` and `B` are allowed to be the same matrix, but no other
     aliasing is allowed. Uses forward substitution.
+
+    The triangular shape is assumed and not checked. A non-invertible
+    diagonal entry (when ``unit`` is 0) raises an exception.
 
 .. function:: void nmod_mat_solve_triu_recursive(nmod_mat_t X, const nmod_mat_t U, const nmod_mat_t B, int unit)
 
@@ -541,6 +558,9 @@ Triangular solving
     to reduce the problem to matrix multiplication and triangular solving
     of smaller systems.
 
+    The triangular shape is assumed and not checked. A non-invertible
+    diagonal entry (when ``unit`` is 0) raises an exception.
+
 
 
 Nonsingular square solving
@@ -550,8 +570,8 @@ Nonsingular square solving
 .. function:: int nmod_mat_solve(nmod_mat_t X, const nmod_mat_t A, const nmod_mat_t B)
 
     Solves the matrix-matrix equation `AX = B` over `\mathbb{Z} / p \mathbb{Z}` where `p`
-    is the modulus of `X` which must be a prime number. `X`, `A`, and `B`
-    should have the same moduli.
+    is the modulus of `X` which must be a prime number; this is not
+    checked. `X`, `A`, and `B` should have the same moduli.
 
     Returns `1` if `A` has full rank; otherwise returns `0` and sets the
     elements of `X` to undefined values.
@@ -572,8 +592,8 @@ Nonsingular square solving
 .. function:: int nmod_mat_can_solve(nmod_mat_t X, const nmod_mat_t A, const nmod_mat_t B)
 
     Solves the matrix-matrix equation `AX = B` over `\mathbb{Z} / p \mathbb{Z}` where `p`
-    is the modulus of `X` which must be a prime number. `X`, `A`, and `B`
-    should have the same moduli.
+    is the modulus of `X` which must be a prime number; this is not
+    checked. `X`, `A`, and `B` should have the same moduli.
 
     Returns `1` if a solution exists; otherwise returns `0` and sets the
     elements of `X` to zero. If more than one solution exists, one of the
@@ -584,7 +604,8 @@ Nonsingular square solving
 .. function:: int nmod_mat_solve_vec(nn_ptr x, const nmod_mat_t A, nn_srcptr b)
 
     Solves the matrix-vector equation `Ax = b` over `\mathbb{Z} / p \mathbb{Z}` where `p`
-    is the modulus of `A` which must be a prime number.
+    is the modulus of `A` which must be a prime number; this is not
+    checked.
 
     Returns `1` if `A` has full rank; otherwise returns `0` and sets the
     elements of `x` to undefined values.

--- a/doc/source/nmod_mpoly.rst
+++ b/doc/source/nmod_mpoly.rst
@@ -486,7 +486,7 @@ Powering
 Division
 --------------------------------------------------------------------------------
 
-The division functions assume that the modulus is prime.
+The division functions assume that the modulus is prime, which is not checked.
 
 .. function:: int nmod_mpoly_divides(nmod_mpoly_t Q, const nmod_mpoly_t A, const nmod_mpoly_t B, const nmod_mpoly_ctx_t ctx)
 
@@ -538,7 +538,8 @@ The division functions assume that the modulus is prime.
 Greatest Common Divisor
 --------------------------------------------------------------------------------
 
-The greatest common divisor functions assume that the modulus is prime.
+The greatest common divisor functions assume that the modulus is prime,
+which is not checked.
 
 .. function:: void nmod_mpoly_term_content(nmod_mpoly_t M, const nmod_mpoly_t A, const nmod_mpoly_ctx_t ctx)
 
@@ -577,7 +578,8 @@ The greatest common divisor functions assume that the modulus is prime.
 Square Root
 --------------------------------------------------------------------------------
 
-The square root functions assume that the modulus is prime for correct operation.
+The square root functions assume that the modulus is prime for correct
+operation, which is not checked.
 
 .. function:: int nmod_mpoly_sqrt(nmod_mpoly_t Q, const nmod_mpoly_t A, const nmod_mpoly_ctx_t ctx)
 

--- a/doc/source/nmod_mpoly_factor.rst
+++ b/doc/source/nmod_mpoly_factor.rst
@@ -62,6 +62,9 @@ Basic manipulation
 Factorisation
 --------------------------------------------------------------------------------
 
+    The factorisation functions assume that the modulus is prime, which is
+    not checked.
+
     A return of `1` indicates that the function was successful. Otherwise,
     the return is `0` and *f* is undefined. None of these functions
     multiply *f* by *A*: *f* is simply set to a factorisation of *A*, and thus

--- a/doc/source/nmod_poly.rst
+++ b/doc/source/nmod_poly.rst
@@ -37,6 +37,12 @@ It is recommended that users do not access the fields of an
 :type:`nmod_poly_t` or its coefficient data directly, but make use of
 the functions designed for this purpose, detailed below.
 
+Many functions in this module (greatest common divisors, modular
+inverses, division as if over a field, resultants and discriminants,
+factorisation, irreducibility testing, root finding, square roots, and
+the transcendental series) require the modulus to be prime. This is
+assumed and not checked.
+
 Functions in ``nmod_poly`` do all the memory management for the user.
 One does not need to specify the maximum length in advance before
 using a polynomial object. FLINT reallocates space automatically as
@@ -237,7 +243,7 @@ Randomization
 Construction of irreducible polynomials
 --------------------------------------------------------------------------------
 
-The following functions assume a prime modulus.
+The following functions assume a prime modulus, which is not checked.
 
 .. function:: void nmod_poly_minimal_irreducible(nmod_poly_t res, ulong n)
 
@@ -1320,13 +1326,15 @@ Derivative and integral
     The constant term of ``x_int`` is set to zero.
     It is assumed that ``len > 0``. The result is only well-defined
     if the modulus is a prime number strictly larger than the degree of
-    ``x``. Supports aliasing between the two polynomials.
+    ``x``; these conditions are not checked. Supports aliasing between
+    the two polynomials.
 
 .. function:: void nmod_poly_integral(nmod_poly_t x_int, const nmod_poly_t x)
 
     Set ``x_int`` to the indefinite integral of ``x`` with constant
     term zero. The result is only well-defined if the modulus
-    is a prime number strictly larger than the degree of ``x``.
+    is a prime number strictly larger than the degree of ``x``; these
+    conditions are not checked.
 
 
 
@@ -1703,23 +1711,25 @@ Taylor shift
 
     Performs the Taylor shift composing ``poly`` by `x+c` in-place.
     Writes the composition as a single convolution with cost `O(M(n))`.
-    We require that the modulus is a prime at least as large as the length.
+    We require that the modulus is a prime at least as large as the
+    length (this is not checked).
 
 .. function:: void nmod_poly_taylor_shift_convolution(nmod_poly_t g, const nmod_poly_t f, ulong c)
 
     Performs the Taylor shift composing ``f`` by `x+c`.
     Writes the composition as a single convolution with cost `O(M(n))`.
-    We require that the modulus is a prime at least as large as the length.
+    We require that the modulus is a prime at least as large as the
+    length (this is not checked).
 
 .. function:: void _nmod_poly_taylor_shift(nn_ptr poly, ulong c, slong len, nmod_t mod)
 
     Performs the Taylor shift composing ``poly`` by `x+c` in-place.
-    We require that the modulus is a prime.
+    We require that the modulus is a prime (this is not checked).
 
 .. function:: void nmod_poly_taylor_shift(nmod_poly_t g, const nmod_poly_t f, ulong c)
 
     Performs the Taylor shift composing ``f`` by `x+c`.
-    We require that the modulus is a prime.
+    We require that the modulus is a prime (this is not checked).
 
 
 Modular composition
@@ -2193,7 +2203,7 @@ Greatest common divisor
 
     Attempts to set `A` to the inverse of `B` modulo `P` in the polynomial
     ring `(\mathbf{Z}/p\mathbf{Z})[X]`, where we assume that `p` is a prime
-    number.
+    number (this is not checked).
 
     If `\operatorname{len}(P) < 2`, raises an exception.
 
@@ -2292,7 +2302,7 @@ It is assumed that `h` has constant term `1` and that the coefficients
 .. function:: void nmod_poly_sqrt_series(nmod_poly_t g, const nmod_poly_t h, slong n)
 
     Set `g` to the series expansion of `\sqrt{h}` to order `O(x^n)`.
-    It is assumed that `h` has constant term 1.
+    It is assumed that `h` has constant term 1 (this is not checked).
 
 .. function:: int _nmod_poly_sqrt(nn_ptr s, nn_srcptr p, slong n, nmod_t mod)
 
@@ -2399,6 +2409,8 @@ must therefore be a prime satisfying `p \ge n`. Further, we always
 require that `p > 2` in order to be able to multiply by `1/2` for
 internal purposes.
 If the input does not satisfy all these conditions, results are undefined.
+These conditions on the modulus are not checked (the required constant
+term is checked).
 Except where otherwise noted, functions are implemented with optimal
 (up to constants) complexity `O(M(n))`, where `M(n)` is the cost
 of polynomial multiplication.
@@ -2578,7 +2590,7 @@ Products
 .. function:: int nmod_poly_find_distinct_nonzero_roots(ulong * roots, const nmod_poly_t A)
 
     If ``A`` has `\deg(A)` distinct nonzero roots in `\mathbb{F}_p`, write these roots out to ``roots[0]`` to ``roots[deg(A) - 1]`` and return ``1``.
-    Otherwise, return ``0``. It is assumed that ``A`` is nonzero and that the modulus of ``A`` is prime.
+    Otherwise, return ``0``. It is assumed that ``A`` is nonzero and that the modulus of ``A`` is prime (the primality is not checked).
     This function uses Rabin's probabilistic method via gcd's with `(x + \delta)^{\frac{p-1}{2}} - 1`.
 
 

--- a/doc/source/nmod_poly_factor.rst
+++ b/doc/source/nmod_poly_factor.rst
@@ -13,6 +13,8 @@ Types, macros and constants
 Factorisation
 --------------------------------------------------------------------------------
 
+The factorisation and irreducibility functions in this module assume
+that the modulus is prime. This is not checked.
 
 .. function:: void nmod_poly_factor_init(nmod_poly_factor_t fac)
 
@@ -101,13 +103,15 @@ Factorisation
     placed in factor and 1 is returned, otherwise 0 is returned and
     the value of factor is undetermined.
 
-    Requires that ``pol`` be monic, non-constant and squarefree.
+    Requires that ``pol`` be monic, non-constant and squarefree. These
+    requirements are not checked.
 
 .. function:: void nmod_poly_factor_equal_deg(nmod_poly_factor_t factors, const nmod_poly_t pol, slong d)
 
     Assuming ``pol`` is a product of irreducible factors all of
     degree ``d``, finds all those factors and places them in factors.
-    Requires that ``pol`` be monic, non-constant and squarefree.
+    Requires that ``pol`` be monic, non-constant and squarefree. These
+    requirements are not checked.
 
 .. function:: void nmod_poly_factor_distinct_deg(nmod_poly_factor_t res, const nmod_poly_t poly, slong * const * degs)
 
@@ -116,7 +120,7 @@ Factorisation
     `f[d]` is the product of the monic irreducible factors of ``poly``
     of degree `d`. Factors `f[d]` are stored in ``res``, and the degree `d`
     of the irreducible factors is stored in ``degs`` in the same order
-    as the factors.
+    as the factors. The squarefree requirement is not checked.
 
     Requires that ``degs`` has enough space for ``(n/2)+1 * sizeof(slong)``.
 
@@ -132,7 +136,8 @@ Factorisation
 .. function:: void nmod_poly_factor_berlekamp(nmod_poly_factor_t res, const nmod_poly_t f)
 
     Factorises a non-constant, squarefree polynomial ``f`` into monic
-    irreducible factors using the Berlekamp algorithm.
+    irreducible factors using the Berlekamp algorithm. The squarefree
+    requirement is not checked.
 
 .. function:: void nmod_poly_factor_kaltofen_shoup(nmod_poly_factor_t res, const nmod_poly_t poly)
 

--- a/doc/source/nmod_poly_mat.rst
+++ b/doc/source/nmod_poly_mat.rst
@@ -436,7 +436,8 @@ Trace
 .. function:: void nmod_poly_mat_trace(nmod_poly_t trace, const nmod_poly_mat_t mat)
 
     Computes the trace of the matrix, i.e. the sum of the entries on
-    the main diagonal. The matrix is required to be square.
+    the main diagonal. The matrix is required to be square, which is not
+    checked.
 
 
 Determinant and rank
@@ -481,6 +482,7 @@ Inverse
 
     Sets (``Ainv``, ``den``) to the inverse matrix of ``A``.
     Returns 1 if ``A`` is nonsingular and 0 if ``A`` is singular.
+    ``A`` must be a square matrix, which is not checked.
     Aliasing of ``Ainv`` and ``A`` is allowed.
 
     More precisely, ``det`` will be set to the determinant of ``A``
@@ -520,6 +522,7 @@ Solving
 
     Solves the equation `AX = B` for nonsingular `A`. More precisely, computes
     (``X``, ``den``) such that `AX = B \times \operatorname{den}`.
+    ``A`` is assumed to be square; this is not checked.
     Returns 1 if `A` is nonsingular and 0 if `A` is singular.
     The computed denominator will not generally be minimal.
 
@@ -530,6 +533,7 @@ Solving
 
     Solves the equation `AX = B` for nonsingular `A`. More precisely, computes
     (``X``, ``den``) such that `AX = B \times \operatorname{den}`.
+    ``A`` is assumed to be square; this is not checked.
     Returns 1 if `A` is nonsingular and 0 if `A` is singular.
     The computed denominator will not generally be minimal.
 
@@ -540,3 +544,6 @@ Solving
 
     Performs fraction-free forward and back substitution given a precomputed
     fraction-free LU decomposition and corresponding permutation.
+    The decomposition ``FFLU`` and permutation ``perm`` are assumed to come
+    from :func:`nmod_poly_mat_fflu` applied to a nonsingular square matrix;
+    this is not checked.

--- a/doc/source/nmod_vec.rst
+++ b/doc/source/nmod_vec.rst
@@ -113,32 +113,34 @@ Arithmetic operations
 
     Sets each entry of ``(res, len)`` to the modular inverse of the
     corresponding entry in ``(vec, len)``. Assumes all entries in
-    ``vec`` are invertible modulo `mod.n`. Aliasing of ``res`` and ``vec`` is
-    allowed.
+    ``vec`` are invertible modulo `mod.n`; this is not checked. Aliasing
+    of ``res`` and ``vec`` is allowed.
 
 .. function:: void _nmod_vec_scalar_mul_nmod(nn_ptr res, nn_srcptr vec, slong len, ulong c, nmod_t mod)
 
     Sets ``(res, len)`` to ``(vec, len)`` multiplied by `c`. The element
-    `c` and all elements of ``vec`` are assumed to be less than ``mod.n``.
+    `c` and all elements of ``vec`` are assumed to be less than ``mod.n``
+    (this is not checked).
 
 .. function:: void _nmod_vec_scalar_mul_nmod_shoup(nn_ptr res, nn_srcptr vec, slong len, ulong c, nmod_t mod)
 
     Sets ``(res, len)`` to ``(vec, len)`` multiplied by `c` using
     :func:`n_mulmod_shoup`. ``mod.n`` should be less than
-    `2^{\mathtt{FLINT\_BITS} - 1}`, and `c` should be less than ``mod.n``.
-    There is no constraint on elements of ``vec``.
+    `2^{\mathtt{FLINT\_BITS} - 1}`, and `c` should be less than ``mod.n``
+    (this is not checked). There is no constraint on elements of ``vec``.
 
 .. function:: void _nmod_vec_scalar_mul_nmod_redc(nn_ptr res, nn_srcptr vec, slong len, ulong c, nmod_t mod)
 
     Sets ``(res, len)`` to ``(vec, len)`` multiplied by `c` using
     Montgomery multiplication. Requires that ``mod.n`` is odd.
     The element `c` and all elements of ``vec`` are assumed to be less
-    than ``mod.n``.
+    than ``mod.n`` (this is not checked).
 
 .. function:: void _nmod_vec_scalar_addmul_nmod(nn_ptr res, nn_srcptr vec, slong len, ulong c, nmod_t mod)
 
     Adds ``(vec, len)`` times `c` to the vector ``(res, len)``. The element
-    `c` and all elements of ``vec`` are assumed to be less than ``mod.n``.
+    `c` and all elements of ``vec`` are assumed to be less than ``mod.n``
+    (this is not checked).
 
 
 Arithmetic operations without reduction
@@ -233,7 +235,7 @@ performed at the very end of the computation.
     Returns the dot product of (``vec1``, ``len``) and (``vec2``, ``len``). The
     input ``params`` has type ``dot_params_t`` and must have been computed via
     ``_nmod_vec_dot_params`` with the specified ``mod`` and with a length
-    greater than or equal to ``len``.
+    greater than or equal to ``len`` (this is not checked).
 
 .. function:: ulong _nmod_vec_dot_rev(nn_srcptr vec1, nn_srcptr vec2, slong len, nmod_t mod, dot_params_t params)
 
@@ -250,7 +252,8 @@ performed at the very end of the computation.
     Returns the dot product of (``vec1``, ``len``) and the values at
     ``vec2[i][offset]``. The input ``params`` has type ``dot_params_t`` and
     must have been computed via ``_nmod_vec_dot_params`` with the specified
-    ``mod`` and with a length greater than or equal to ``len``.
+    ``mod`` and with a length greater than or equal to ``len`` (this is not
+    checked).
 
 .. macro:: NMOD_VEC_DOT(res, i, len, expr1, expr2, mod, params)
 
@@ -263,7 +266,7 @@ performed at the very end of the computation.
     but with the arithmetic performed modulo ``mod``. The input ``params`` has
     type ``dot_params_t`` and must have been computed via
     ``_nmod_vec_dot_params`` with the specified ``mod`` and with a length
-    greater than or equal to ``len``.
+    greater than or equal to ``len`` (this is not checked).
 
     ``nmod.h`` has to be included in order for this macro to work (order of
     inclusions does not matter).

--- a/doc/source/padic_mat.rst
+++ b/doc/source/padic_mat.rst
@@ -176,7 +176,9 @@ Comparison
 
 .. function:: int padic_mat_equal(const padic_mat_t A, const padic_mat_t B)
 
-    Returns whether the two matrices `A` and `B` are equal.
+    Returns whether the two matrices `A` and `B` are equal. The matrices are
+    assumed to be in canonical form; this is not checked. (Two equal matrices
+    that are not both in canonical form may compare as unequal.)
 
 .. function:: int padic_mat_is_zero(const padic_mat_t A)
 
@@ -236,8 +238,10 @@ Addition and subtraction
 
 .. function:: void _padic_mat_add(padic_mat_t C, const padic_mat_t A, const padic_mat_t B, const padic_ctx_t ctx)
 
-    Sets `C` to the exact sum `A + B`, ensuring that the result is in 
-    canonical form.
+    Sets `C` to the exact sum `A + B`, ensuring that the result is in
+    canonical form. Assumes that `\operatorname{ord}_p(A) \ge
+    \operatorname{ord}_p(B)`; this is not checked. Use :func:`padic_mat_add`
+    if this cannot be guaranteed.
 
 .. function:: void padic_mat_add(padic_mat_t C, const padic_mat_t A, const padic_mat_t B, const padic_ctx_t ctx)
 

--- a/doc/source/ulong_extras.rst
+++ b/doc/source/ulong_extras.rst
@@ -30,6 +30,10 @@ use the ``n_blah2_preinv`` variants.
 Some functions with the ``n_ll_`` or ``n_lll_`` prefix accept
 parameters of two or three limbs respectively.
 
+Throughout, a precomputed inverse is assumed to correspond to the
+stated modulus, and operands passed to the modular routines are
+assumed to be already reduced modulo `n`; none of this is checked.
+
 Simple example
 --------------
 
@@ -501,10 +505,12 @@ Jacobi and Kronecker symbols
 .. function:: int n_jacobi(slong x, ulong y)
 
     Computes the Jacobi symbol `\left(\frac{x}{y}\right)` for any `x` and odd `y`.
+    It is assumed that ``y`` is odd; this is not checked.
 
 .. function:: int n_jacobi_unsigned(ulong x, ulong y)
 
     Computes the Jacobi symbol, allowing `x` to go up to a full limb.
+    It is assumed that ``y`` is odd; this is not checked.
 
 
 Modular arithmetic
@@ -611,7 +617,8 @@ Modular arithmetic
 
     If `p` is not prime the result is with high probability `0`, indicating
     that `p` is not prime, or `a` is not a square modulo `p`. Otherwise the
-    result is meaningless.
+    result is meaningless. It is assumed that ``p`` is prime; this is not
+    checked.
 
     Assumes that `a` is reduced modulo `p`.
 
@@ -635,7 +642,7 @@ Modular arithmetic
     ``flint_free``. The number of roots is returned by the function. If
     ``a`` is not a quadratic residue modulo ``p^exp`` then 0 is
     returned by the function and the location ``sqrt`` points to is set to
-    NULL.
+    NULL. The supplied prime ``p`` is assumed correct; this is not checked.
 
 .. function:: slong n_sqrtmodn(ulong ** sqrt, ulong a, n_factor_t * fac)
 
@@ -646,7 +653,8 @@ Modular arithmetic
     cleaned up by the user by calling :func:`flint_free`. The number of roots
     is returned by the function. If ``a`` is not a quadratic residue modulo
     ``m`` then 0 is returned by the function and the location ``sqrt``
-    points to is set to NULL.
+    points to is set to NULL. The supplied factorisation ``fac`` is assumed
+    correct; this is not checked.
 
 
 Modular arithmetic with fixed operand
@@ -1179,6 +1187,7 @@ Chinese remaindering
 
     It is assumed that `m_1` and `m_2` are positive integers greater
     than `1` and coprime. It is assumed that `0 \le r_1 < m_1` and `0 \le r_2 < m_2`.
+    None of this is checked.
 
 
 Square root and perfect power testing
@@ -1323,7 +1332,8 @@ Factorisation
 
     Removes the highest possible power of `p` from `n`, replacing
     `n` with the quotient. The return value is the highest
-    power of `p` that divided `n`. Assumes `n` is not `0`.
+    power of `p` that divided `n`. Assumes `n` is not `0`. It is
+    assumed that ``p`` is greater than `1`; this is not checked.
 
     For `p = 2` trailing zeroes are counted. For other primes
     `p` is repeatedly squared and stored in a table of powers
@@ -1338,7 +1348,8 @@ Factorisation
     `n` with the quotient. The return value is the highest
     power of `p` that divided `n`. Assumes `n` is not `0`. We require
     ``ppre`` to be set to a precomputed inverse of `p` computed
-    with :func:`n_precompute_inverse`.
+    with :func:`n_precompute_inverse`. It is assumed that ``p`` is
+    greater than `1`; this is not checked.
 
     For `p = 2` trailing zeroes are counted. For other primes
     `p` we make repeated use of :func:`n_divrem2_precomp` until division


### PR DESCRIPTION
Many FLINT functions deliberately do not validate structural or algebraic
preconditions on their inputs (the caller is responsible), but the
documentation often did not say so. This adds a light "(this is not checked)"
note at the point of use wherever a function silently relies on such a
preconditio.

## Why

Prompted by the flint-devel thread on `fmpz_mat_snf_diagonal`, which computes a
Smith normal form assuming its input is diagonal but does not check it. The
consensus there was that FLINT intentionally skips such checks for performance,
but the docstring could reflect this better. This PR applies that consistently
across the library.

## What is documented

Recurring unchecked preconditions, by theme:

- **Matrix shape / regularity**: diagonal, nonsingular, rank, square,
  triangular, symmetric-positive-definite (fmpz_mat SNF/HNF, the triangular
  solvers across all matrix modules, charpoly/minpoly/permanent/similarity,
  precomputed factorizations, Cholesky).
- **Prime modulus** (`Z/nZ` is a field only then): nmod_mat / fmpz_mod_mat,
  nmod_poly / fmpz_mod_poly (+ their factor modules), nmod_mpoly /
  fmpz_mod_mpoly (+ factor). Pervasive, so mostly module/section-level notes.
- **Power-series constant term** (inv/div/revert/sqrt series): fmpz_poly,
  fmpq_poly, nmod_poly, fmpz_mod_poly.
- **Exact division / coprimality**: `fmpz_divexact*`, `_fmpz_vec_scalar_divexact*`,
  fmpz_poly divexact/div_root, `n_CRT`/`fmpz_CRT_ui`.
- **Squarefree / monic / primitive** factor inputs: fmpz/nmod/fmpz_mod poly
  factor and the fq(/_nmod/_zech/_default) poly-factor modules.
- **Scalar number theory**: prime modulus (`n_sqrtmod`, `fmpz_sqrtmod`), odd
  argument (`n_jacobi`, `fmpz_jacobi`), supplied factorisation
  (`n_sqrtmodn`), reduced operands / precomputed inverses (ulong_extras, nmod,
  nmod_vec).
- **Canonical form**: fmpq, fmpz_mpoly_q, fmpz_mod_mpoly_q (module-level notes).

Strategy: section/module-level notes for pervasive themes (prime modulus,
reduced operands, canonical form), per-function tags for localized extras.

## Scope / non-goals

Only preconditions that are genuinely assumed and unchecked are tagged. Inputs
that are already detected and reported are left alone (e.g. `fmpz_mat_solve*`
setting `den = 0`, the `*_can_solve` family, the throwing `det`/`charpoly`,
nmod/fmpz_mod division by a non-invertible leading coefficient which throws,
`*_divides`, fq_poly series over a field, `fmpz_invmod`, `fmpz_multi_CRT`). A
handful of preconditions guarded only by debug-only `FLINT_ASSERT` (checked
when assertions are enabled) are deliberately deferred, since "checked in debug
builds" is a different statement from "not checked".

