### PR TITLE
Speed up `nmod_poly_evaluate_nmod` asymptotically

### DIFF
--- a/doc/source/nmod_poly.rst
+++ b/doc/source/nmod_poly.rst
@@ -1369,22 +1369,23 @@ Evaluation
     multiplications done as in :func:`n_mulmod_shoup` using the precomputed
     ``c_precomp`` obtained via :func:`n_mulmod_precomp_shoup`.
 
-.. function:: ulong _nmod_poly_evaluate_nmod(nn_srcptr poly, slong len, ulong c, nmod_t mod)
+.. function:: ulong _nmod_poly_evaluate_nmod_horner(nn_srcptr poly, slong len, ulong c, nmod_t mod)
+              ulong _nmod_poly_evaluate_nmod_rectangular(nn_srcptr poly, slong len, ulong c, nmod_t mod)
+              ulong _nmod_poly_evaluate_nmod(nn_srcptr poly, slong len, ulong c, nmod_t mod)
 
     Evaluates ``poly`` at the value ``c`` and reduces modulo the given modulus
-    of ``poly``. The value ``c`` should be reduced modulo the modulus. The
-    algorithm used is Horner's method, with multiplications done via
-    :func:`nmod_mul`.
+    of ``poly``. The value ``c`` should be reduced modulo the modulus.
+    The implemented algorithms are Horner's method and rectangular splitting.
+    The default function :func:`_nmod_poly_evaluate_nmod` selects
+    automatically between :func:`_nmod_poly_evaluate_nmod_horner`,
+    :func:`_nmod_poly_evaluate_nmod_rectangular`
+    :func:`_nmod_poly_evaluate_nmod_precomp`, and
+    :func:`_nmod_poly_evaluate_nmod_precomp_lazy`.
 
 .. function:: ulong nmod_poly_evaluate_nmod(const nmod_poly_t poly, ulong c)
 
     Evaluates ``poly`` at the value ``c`` and reduces modulo the modulus of
-    ``poly``. The value ``c`` should be reduced modulo the modulus. The
-    algorithm used is Horner's method, with multiplications and additions done
-    differently depending on the modulus ``poly->mod`` and on the degree (calls
-    one of :func:`_nmod_poly_evaluate_nmod`,
-    :func:`_nmod_poly_evaluate_nmod_precomp`,
-    :func:`_nmod_poly_evaluate_nmod_precomp_lazy`).
+    ``poly``. The value ``c`` should be reduced modulo the modulus.
 
 .. function:: void nmod_poly_evaluate_mat_horner(nmod_mat_t dest, const nmod_poly_t poly, const nmod_mat_t c)
 

--- a/src/nmod_poly.h
+++ b/src/nmod_poly.h
@@ -554,6 +554,8 @@ void nmod_poly_integral(nmod_poly_t x_int, const nmod_poly_t x);
 
 /* Evaluation  ***************************************************************/
 
+ulong _nmod_poly_evaluate_nmod_horner(nn_srcptr poly, slong len, ulong c, nmod_t mod);
+ulong _nmod_poly_evaluate_nmod_rectangular(nn_srcptr poly, slong len, ulong c, nmod_t mod);
 ulong _nmod_poly_evaluate_nmod(nn_srcptr poly, slong len, ulong c, nmod_t mod);
 ulong _nmod_poly_evaluate_nmod_precomp(nn_srcptr poly, slong len, ulong c, ulong c_precomp, ulong modn);
 ulong _nmod_poly_evaluate_nmod_precomp_lazy(nn_srcptr poly, slong len, ulong c, ulong c_precomp, ulong modn);

--- a/src/nmod_poly/evaluate_nmod.c
+++ b/src/nmod_poly/evaluate_nmod.c
@@ -1,6 +1,7 @@
 /*
     Copyright (C) 2010 William Hart
     Copyright (C) 2024 Vincent Neiger
+    Copyright (C) 2026 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -12,11 +13,96 @@
 
 #include "flint-mparam.h"
 #include "ulong_extras.h"
+#include "nmod_vec.h"
 #include "nmod_poly.h"
 #include "nmod.h"
 
+static void
+_nmod_vec_set_powers(nn_ptr res, ulong x, slong len, nmod_t mod)
+{
+    slong i;
+    res[0] = 1;
+    res[1] = x;
+
+    for (i = 2; i < len; i++)
+        res[i] = nmod_mul(res[i - 1], x, mod);
+}
+
+static void
+_nmod_vec_set_powers_precomp(nn_ptr res, ulong x, slong len, nmod_t mod)
+{
+    slong i;
+    res[0] = 1;
+    res[1] = x;
+    ulong xpre = n_mulmod_precomp_shoup(x, mod.n);
+
+    for (i = 2; i < len; i++)
+        res[i] = n_mulmod_shoup(x, res[i - 1], xpre, mod.n);
+}
+
 ulong
-_nmod_poly_evaluate_nmod(nn_srcptr poly, slong len, ulong c, nmod_t mod)
+_nmod_poly_evaluate_nmod_rectangular(nn_srcptr poly,
+    slong len, ulong x, nmod_t mod)
+{
+    slong i, m, r;
+    nn_ptr xs;
+    ulong s, y, xmpre;
+    TMP_INIT;
+
+    if (len == 0)
+        return 0;
+    if (len == 1 || x == 0)
+        return poly[0];
+    if (len == 2)
+        return nmod_addmul(poly[0], poly[1], x, mod);
+
+    m = n_sqrt(len) + 1;
+    m = FLINT_MIN(m, 1024);
+    r = (len + m - 1) / m;
+
+    dot_params_t params = _nmod_vec_dot_params(m - 1, mod);
+
+    TMP_START;
+    xs = TMP_ALLOC((m + 1) * sizeof(ulong));
+
+    if (NMOD_CAN_USE_SHOUP(mod))
+    {
+        _nmod_vec_set_powers_precomp(xs, x, m + 1, mod);
+        xmpre = n_mulmod_precomp_shoup(xs[m], mod.n);
+
+        y = _nmod_vec_dot(poly + (r - 1) * m + 1, xs + 1, len - (r - 1) * m - 1, mod, params);
+        y = nmod_add(y, poly[(r - 1) * m], mod);
+
+        for (i = r - 2; i >= 0; i--)
+        {
+            s = _nmod_vec_dot(poly + i * m + 1, xs + 1, m - 1, mod, params);
+            s = nmod_add(s, poly[i * m], mod);
+            y = n_mulmod_shoup(xs[m], y, xmpre, mod.n);
+            y = nmod_add(y, s, mod);
+        }
+    }
+    else
+    {
+        _nmod_vec_set_powers(xs, x, m + 1, mod);
+        y = _nmod_vec_dot(poly + (r - 1) * m + 1, xs + 1, len - (r - 1) * m - 1, mod, params);
+        y = nmod_add(y, poly[(r - 1) * m], mod);
+
+        for (i = r - 2; i >= 0; i--)
+        {
+            s = _nmod_vec_dot(poly + i * m + 1, xs + 1, m - 1, mod, params);
+            s = nmod_add(s, poly[i * m], mod);
+            y = nmod_mul(xs[m], y, mod);
+            y = nmod_add(y, s, mod);
+        }
+    }
+
+    TMP_END;
+
+    return y;
+}
+
+ulong
+_nmod_poly_evaluate_nmod_horner(nn_srcptr poly, slong len, ulong c, nmod_t mod)
 {
     slong m;
     ulong val;
@@ -98,53 +184,59 @@ _nmod_poly_evaluate_nmod_precomp_lazy(nn_srcptr poly, slong len, ulong c, ulong 
     return val;
 }
 
+/* if 3*mod.n - 1 <= 2**FLINT_BITS, can use the lazy variant */
+#if FLINT_BITS == 64
+#define LAZY_MAX UWORD(6148914691236517205)
+#else
+#define LAZY_MAX UWORD(1431655765)
+#endif
+
+ulong
+_nmod_poly_evaluate_nmod(nn_srcptr poly, slong len, ulong c, nmod_t mod)
+{
+    if (len == 0)
+        return 0;
+
+    if (len == 1 || c == 0)
+        return poly[0];
+
+    if (!NMOD_CAN_USE_SHOUP(mod))
+    {
+        if (len <= 13)
+            return _nmod_poly_evaluate_nmod_horner(poly, len, c, mod);
+        else
+            return _nmod_poly_evaluate_nmod_rectangular(poly, len, c, mod);
+    }
+
+    if (len < FLINT_MULMOD_SHOUP_THRESHOLD)
+        return _nmod_poly_evaluate_nmod_horner(poly, len, c, mod);
+
+    if (len > 50)
+        return _nmod_poly_evaluate_nmod_rectangular(poly, len, c, mod);
+
+    const ulong modn = mod.n;
+
+    if (modn <= LAZY_MAX)
+    {
+        const ulong c_precomp = n_mulmod_precomp_shoup(c, modn);
+        ulong val = _nmod_poly_evaluate_nmod_precomp_lazy(poly, len, c, c_precomp, modn);
+        /* Correct excess. */
+        if (val >= 2*modn)
+            val -= 2*modn;
+        else if (val >= modn)
+            val -= modn;
+        return val;
+    }
+    else
+    {
+        const ulong c_precomp = n_mulmod_precomp_shoup(c, modn);
+        return _nmod_poly_evaluate_nmod_precomp(poly, len, c, c_precomp, modn);
+    }
+}
+
 ulong
 nmod_poly_evaluate_nmod(const nmod_poly_t poly, ulong c)
 {
-    if (poly->length == 0)
-        return 0;
-
-    if (poly->length == 1 || c == 0)
-        return poly->coeffs[0];
-
-    // if degree below the n_mulmod_shoup threshold
-    // or modulus forbids n_mulmod_shoup usage, use nmod_mul
-#if FLINT_MULMOD_SHOUP_THRESHOLD <= 2
-    if (poly->mod.norm == 0)  // here poly->length >= threshold
-#else
-    if ((poly->length < FLINT_MULMOD_SHOUP_THRESHOLD)
-           || (poly->mod.norm == 0))
-#endif
-    {
-        return _nmod_poly_evaluate_nmod(poly->coeffs, poly->length, c, poly->mod);
-    }
-
-    // if 3*mod.n - 1 <= 2**FLINT_BITS, use n_mulmod_shoup, lazy variant
-    else
-    {
-        const ulong modn = poly->mod.n;
-
-#if FLINT_BITS == 64
-        if (modn <= UWORD(6148914691236517205))
-#else // FLINT_BITS == 32
-        if (modn <= UWORD(1431655765))
-#endif
-        {
-            const ulong c_precomp = n_mulmod_precomp_shoup(c, modn);
-            ulong val = _nmod_poly_evaluate_nmod_precomp_lazy(poly->coeffs, poly->length, c, c_precomp, modn);
-            // correct excess
-            if (val >= 2*modn)
-                val -= 2*modn;
-            else if (val >= modn)
-                val -= modn;
-            return val;
-        }
-
-        // use n_mulmod_shoup, non-lazy variant
-        else
-        {
-            const ulong c_precomp = n_mulmod_precomp_shoup(c, modn);
-            return _nmod_poly_evaluate_nmod_precomp(poly->coeffs, poly->length, c, c_precomp, modn);
-        }
-    }
+    return _nmod_poly_evaluate_nmod(poly->coeffs, poly->length, c, poly->mod);
 }
+

--- a/src/nmod_poly/profile/p-evaluate_nmod.c
+++ b/src/nmod_poly/profile/p-evaluate_nmod.c
@@ -57,7 +57,7 @@ void sample_interface(void * arg, ulong count)
     FLINT_TEST_CLEAR(state);
 }
 
-void sample_generic(void * arg, ulong count)
+void sample_horner(void * arg, ulong count)
 {
     ulong n;
     nmod_t mod;
@@ -87,7 +87,7 @@ void sample_generic(void * arg, ulong count)
 
         prof_start();
         for (j = 0; j < 100; j++)
-            _nmod_poly_evaluate_nmod(poly, length, pt, mod);
+            _nmod_poly_evaluate_nmod_horner(poly, length, pt, mod);
         prof_stop();
     }
 
@@ -184,76 +184,116 @@ void sample_precomp_lazy(void * arg, ulong count)
     FLINT_TEST_CLEAR(state);
 }
 
+void sample_rectangular(void * arg, ulong count)
+{
+    ulong n;
+    nmod_t mod;
+    info_t * info = (info_t *) arg;
+    flint_bitcnt_t bits = info->bits;
+    slong length = info->length;
+    slong i, j;
+
+    ulong * poly;
+    ulong pt;
+
+    FLINT_TEST_INIT(state);
+
+    poly = _nmod_vec_init(length);
+
+    for (i = 0; i < count; i++)
+    {
+        n = n_randbits(state, bits);
+        if (n == UWORD(0)) n++;
+
+        nmod_init(&mod, n);
+
+        for (j = 0; j < length; j++)
+            poly[j] = n_randint(state, n);
+
+        pt = n_randint(state, n);
+
+        prof_start();
+        for (j = 0; j < 100; j++)
+        {
+            _nmod_poly_evaluate_nmod_rectangular(poly, length, pt, mod);
+        }
+        prof_stop();
+    }
+
+    _nmod_vec_clear(poly);
+
+    FLINT_TEST_CLEAR(state);
+}
+
+#define NUM_LENGTHS 19
+#define NUM_BITS 5
+
 int main(void)
 {
-    slong lengths[18] = {1, 2, 3, 4, 6, 8,
-                         10, 12, 16, 20, 32, 45,
+    slong lengths[NUM_LENGTHS] = {1, 2, 3, 4, 6, 8,
+                         10, 12, 16, 20, 32, 45, 56,
                          64, 128, 256, 1024, 8192, 65536};
+    int bits[NUM_BITS] = { 16, 60, 62, 63, 64 };
+    int ibits;
 
     double min, max;
-    double mins[18]; // note: max seems to be consistently identical or extremely close to min
-    double mins_generic[18];
-    double mins_precomp[18];
-    double mins_precomp_lazy[18];
+    double mins[NUM_LENGTHS]; // note: max seems to be consistently identical or extremely close to min
+    double mins_horner[NUM_LENGTHS];
+    double mins_precomp[NUM_LENGTHS];
+    double mins_precomp_lazy[NUM_LENGTHS];
+    double mins_rectangular[NUM_LENGTHS];
     info_t info;
     flint_bitcnt_t i;
+    
 
     flint_printf("unit: all measurements in c/l\n");
-    flint_printf("profiled: interface | generic | precomp | precomp_lazy\n");
+    flint_printf("profiled: interface | horner | precomp | precomp_lazy | rectangular\n");
 
-    for (i = 62; i <= FLINT_BITS; i++)
+    for (ibits = 0; ibits < NUM_BITS; ibits++)
     {
+        i = bits[ibits];
         info.bits = i;
 
         printf("nbits = %ld\n", i);
-        for (int len = 0; len < 18; ++len)
+        for (int len = 0; len < NUM_LENGTHS; ++len)
         {
             info.length = lengths[len];
 
             prof_repeat(&min, &max, sample_interface, (void *) &info);
-            mins[len-1] = min;
-            prof_repeat(&min, &max, sample_generic, (void *) &info);
-            mins_generic[len-1] = min;
+            mins[len] = min;
+            prof_repeat(&min, &max, sample_horner, (void *) &info);
+            mins_horner[len] = min;
             prof_repeat(&min, &max, sample_precomp, (void *) &info);
-            mins_precomp[len-1] = min;
+            mins_precomp[len] = min;
             prof_repeat(&min, &max, sample_precomp_lazy, (void *) &info);
-            mins_precomp_lazy[len-1] = min;
+            mins_precomp_lazy[len] = min;
+            prof_repeat(&min, &max, sample_rectangular, (void *) &info);
+            mins_rectangular[len] = min;
         }
 
-        if (i < FLINT_BITS-1)
+        if (i < FLINT_BITS)
         {
-            for (int len = 0; len < 18; ++len)
+            for (int len = 0; len < NUM_LENGTHS; ++len)
             {
-                flint_printf("   len %ld\t%.2lf\t%.2lf\t%.2lf\t%.2lf",
+                flint_printf("   len %ld\t%.2lf\t%.2lf\t%.2lf\t%.2lf\t%.2lf",
                         lengths[len],
-                        (mins[len-1]/(double)FLINT_CLOCK_SCALE_FACTOR)/(lengths[len]*100),
-                        (mins_generic[len-1]/(double)FLINT_CLOCK_SCALE_FACTOR)/(lengths[len]*100),
-                        (mins_precomp[len-1]/(double)FLINT_CLOCK_SCALE_FACTOR)/(lengths[len]*100),
-                        (mins_precomp_lazy[len-1]/(double)FLINT_CLOCK_SCALE_FACTOR)/(lengths[len]*100));
+                        (mins[len]/(double)FLINT_CLOCK_SCALE_FACTOR)/(lengths[len]*100),
+                        (mins_horner[len]/(double)FLINT_CLOCK_SCALE_FACTOR)/(lengths[len]*100),
+                        (mins_precomp[len]/(double)FLINT_CLOCK_SCALE_FACTOR)/(lengths[len]*100),
+                        (mins_precomp_lazy[len]/(double)FLINT_CLOCK_SCALE_FACTOR)/(lengths[len]*100),
+                        (mins_rectangular[len]/(double)FLINT_CLOCK_SCALE_FACTOR)/(lengths[len]*100));
                 flint_printf("\n");
             }
         }
-        else if (i < FLINT_BITS)
+        else
         {
-            for (int len = 0; len < 18; ++len)
+            for (int len = 0; len < NUM_LENGTHS; ++len)
             {
-                flint_printf("   len %ld\t%.2lf\t%.2lf\t%.2lf\t na",
+                flint_printf("   len %ld\t%.2lf\t%.2lf\t na \t na\t%.2lf",
                         lengths[len],
-                        (mins[len-1]/(double)FLINT_CLOCK_SCALE_FACTOR)/(lengths[len]*100),
-                        (mins_generic[len-1]/(double)FLINT_CLOCK_SCALE_FACTOR)/(lengths[len]*100),
-                        (mins_precomp[len-1]/(double)FLINT_CLOCK_SCALE_FACTOR)/(lengths[len]*100),
-                        (mins_precomp_lazy[len-1]/(double)FLINT_CLOCK_SCALE_FACTOR)/(lengths[len]*100));
-                flint_printf("\n");
-            }
-        }
-        else  // i == FLINT_BITS
-        {
-            for (int len = 0; len < 18; ++len)
-            {
-                flint_printf("   len %ld\t%.2lf\t%.2lf\t na \t na",
-                        lengths[len],
-                        (mins[len-1]/(double)FLINT_CLOCK_SCALE_FACTOR)/(lengths[len]*100),
-                        (mins_generic[len-1]/(double)FLINT_CLOCK_SCALE_FACTOR)/(lengths[len]*100));
+                        (mins[len]/(double)FLINT_CLOCK_SCALE_FACTOR)/(lengths[len]*100),
+                        (mins_horner[len]/(double)FLINT_CLOCK_SCALE_FACTOR)/(lengths[len]*100),
+                        (mins_rectangular[len]/(double)FLINT_CLOCK_SCALE_FACTOR)/(lengths[len]*100));
                 flint_printf("\n");
             }
         }

--- a/src/nmod_poly/test/t-evaluate_nmod.c
+++ b/src/nmod_poly/test/t-evaluate_nmod.c
@@ -104,7 +104,7 @@ TEST_FUNCTION_START(nmod_poly_evaluate_nmod, state)
 
         // variants
         nmod_poly_set(a, acopy);
-        eval1_v1 = _nmod_poly_evaluate_nmod(a->coeffs, a->length, c, a->mod);
+        eval1_v1 = _nmod_poly_evaluate_nmod_horner(a->coeffs, a->length, c, a->mod);
         eval1_v1 = n_addmod(eval1_v1, _nmod_poly_evaluate_nmod(b->coeffs, b->length, c, b->mod), n);
 
         if (a->mod.norm > 0)
@@ -145,7 +145,7 @@ TEST_FUNCTION_START(nmod_poly_evaluate_nmod, state)
         }
 
         nmod_poly_add(a, a, b);
-        eval2_v1 = _nmod_poly_evaluate_nmod(a->coeffs, a->length, c, a->mod);
+        eval2_v1 = _nmod_poly_evaluate_nmod_horner(a->coeffs, a->length, c, a->mod);
         if (a->mod.norm > 0)
         {
             ulong c_precomp = n_mulmod_precomp_shoup(c, n);


### PR DESCRIPTION
Rectangular splitting makes `nmod_poly_evaluate_nmod` as fast as dot products asymptotically. On Zen 3 this is 14x faster for small moduli, 3x faster for 62/63-bit moduli, and 7x faster for 64-bit moduli.

Also, algorithm selection is moved to the underscore method.

The crossover at length 50 could be fine-tuned.

This is might obsolete some of the optimizations proposed in #2492 (others may be complementary).

```
unit: all measurements in c/l
profiled: interface | horner | precomp | precomp_lazy | rectangular
nbits = 16
   len 1	7.10	5.83	5.30	5.30	10.79
   len 2	5.98	4.05	3.41	2.93	10.78
   len 3	4.81	3.75	2.76	2.12	16.87
   len 4	4.58	4.25	2.93	2.25	13.90
   len 6	5.39	4.96	3.46	2.41	9.55
   len 8	6.24	5.47	3.61	2.36	7.51
   len 10	2.80	6.27	3.84	2.31	6.50
   len 12	2.93	6.88	4.02	2.29	5.35
   len 16	3.18	7.52	4.50	2.64	4.61
   len 20	3.36	7.94	4.76	2.90	3.90
   len 32	3.56	8.67	5.18	3.30	3.15
   len 45	3.67	8.87	5.42	3.52	2.63
   len 56	2.30	9.05	5.53	3.57	2.26
   len 64	2.35	9.12	5.57	3.60	2.19
   len 128	1.57	9.39	5.75	3.84	1.56
   len 256	1.36	9.55	5.75	3.89	1.34
   len 1024	0.71	9.60	5.92	4.01	0.70
   len 8192	0.38	9.65	5.91	4.00	0.38
  len 65536	0.28	9.69	5.95	4.04	0.28

nbits = 60
   len 1	7.00	5.70	5.23	5.27	10.56
   len 2	5.80	3.90	3.30	2.86	10.55
   len 3	4.67	3.65	2.69	2.08	16.51
   len 4	4.45	4.14	2.84	2.20	13.61
   len 6	5.31	4.92	3.42	2.35	9.97
   len 8	6.22	5.45	3.59	2.34	8.94
   len 10	2.74	6.31	3.82	2.27	7.67
   len 12	2.90	6.83	4.03	2.28	6.76
   len 16	3.19	7.54	4.44	2.63	5.66
   len 20	3.32	7.99	4.81	2.95	4.94
   len 32	3.60	8.68	5.17	3.31	4.28
   len 45	3.71	8.83	5.44	3.56	3.58
   len 56	3.13	8.98	5.49	3.60	3.13
   len 64	2.89	9.13	5.60	3.70	2.88
   len 128	2.22	9.30	5.73	3.87	2.21
   len 256	2.11	9.56	5.83	3.95	2.10
   len 1024	1.45	9.59	5.94	4.03	1.45
   len 8192	1.07	9.69	5.97	4.06	1.06
  len 65536	0.96	9.64	5.97	4.06	0.94

nbits = 62
   len 1	6.99	5.74	5.24	5.29	10.73
   len 2	5.88	3.99	3.34	2.86	10.59
   len 3	4.74	3.70	2.72	2.11	16.73
   len 4	4.50	4.17	2.85	2.21	13.66
   len 6	5.31	4.91	3.43	2.38	10.10
   len 8	6.25	5.30	3.52	2.34	9.07
   len 10	2.76	6.31	3.87	2.29	7.71
   len 12	2.89	6.67	3.97	2.29	6.82
   len 16	3.20	7.61	4.53	2.70	5.77
   len 20	3.33	7.82	4.74	2.95	4.99
   len 32	3.58	8.67	5.17	3.36	4.31
   len 45	3.69	8.68	5.43	3.57	3.66
   len 56	3.19	9.10	5.58	3.64	3.16
   len 64	2.90	9.12	5.64	3.72	2.95
   len 128	2.27	9.44	5.79	3.83	2.26
   len 256	2.14	9.56	5.84	3.96	2.17
   len 1024	1.61	9.66	5.92	4.01	1.60
   len 8192	1.22	9.68	5.99	4.07	1.23
  len 65536	1.06	9.65	5.99	4.08	1.05

nbits = 63
   len 1	7.10	5.78	5.31	5.28	10.78
   len 2	5.98	4.00	3.42	2.90	10.72
   len 3	4.77	3.72	2.75	2.13	17.00
   len 4	4.55	4.20	2.90	2.24	13.82
   len 6	5.31	4.98	3.46	2.40	10.19
   len 8	6.17	5.43	3.54	2.33	9.10
   len 10	3.79	6.33	3.86	2.27	7.79
   len 12	4.04	6.86	4.00	2.26	6.87
   len 16	4.31	7.54	4.52	2.66	5.85
   len 20	4.54	7.96	4.78	2.93	5.08
   len 32	4.81	8.73	5.21	3.37	4.63
   len 45	5.03	8.99	5.42	3.54	3.98
   len 56	3.56	9.17	5.60	3.69	3.52
   len 64	3.35	9.07	5.48	3.69	3.36
   len 128	2.75	9.46	5.82	3.86	2.71
   len 256	2.69	9.57	5.81	3.98	2.69
   len 1024	1.85	9.70	5.99	4.02	1.86
   len 8192	1.34	9.54	5.90	4.00	1.34
  len 65536	1.22	9.77	5.96	4.08	1.19

nbits = 64
   len 1	7.12	5.80	 na 	 na	10.86
   len 2	5.52	4.04	 na 	 na	10.71
   len 3	4.48	3.74	 na 	 na	14.14
   len 4	4.54	4.23	 na 	 na	12.87
   len 6	5.34	4.95	 na 	 na	9.88
   len 8	5.95	5.44	 na 	 na	9.00
   len 10	6.61	6.23	 na 	 na	7.99
   len 12	7.31	6.86	 na 	 na	6.97
   len 16	6.46	7.46	 na 	 na	6.31
   len 20	5.80	7.98	 na 	 na	5.57
   len 32	4.78	8.55	 na 	 na	4.74
   len 45	4.16	8.94	 na 	 na	4.12
   len 56	3.64	9.09	 na 	 na	3.61
   len 64	3.52	9.21	 na 	 na	3.46
   len 128	2.67	9.48	 na 	 na	2.65
   len 256	2.82	9.66	 na 	 na	2.78
   len 1024	1.99	9.64	 na 	 na	1.99
   len 8192	1.47	9.69	 na 	 na	1.44
  len 65536	1.29	9.76	 na 	 na	1.26
```