### PR TITLE
Minor optimizations for multiplication with acb as well as arb and acb vectors

### DIFF
--- a/doc/source/acb.rst
+++ b/doc/source/acb.rst
@@ -465,6 +465,8 @@ Arithmetic
 
 .. function:: void acb_mul_fmpz(acb_t z, const acb_t x, const fmpz_t y, slong prec)
 
+.. function:: void acb_mul_arf(acb_t z, const acb_t x, const arf_t y, slong prec)
+
 .. function:: void acb_mul_arb(acb_t z, const acb_t x, const arb_t y, slong prec)
 
     Sets *z* to the product of *x* and *y*.

--- a/doc/source/acb.rst
+++ b/doc/source/acb.rst
@@ -1231,9 +1231,15 @@ Vector functions
 
 .. function:: void _acb_vec_scalar_mul(acb_ptr res, acb_srcptr vec, slong len, const acb_t c, slong prec)
 
-.. function:: void _acb_vec_scalar_mul_si(acb_ptr res, acb_srcptr vec, slong len, slong c, slong prec)
+.. function:: void _acb_vec_scalar_mul_arb(acb_ptr res, acb_srcptr vec, slong len, const arb_t c, slong prec)
+
+.. function:: void _acb_vec_scalar_mul_arf(acb_ptr res, acb_srcptr vec, slong len, const arf_t c, slong prec)
 
 .. function:: void _acb_vec_scalar_mul_ui(acb_ptr res, acb_srcptr vec, slong len, ulong c, slong prec)
+
+.. function:: void _acb_vec_scalar_mul_si(acb_ptr res, acb_srcptr vec, slong len, slong c, slong prec)
+
+.. function:: void _acb_vec_scalar_mul_fmpz(acb_ptr res, acb_srcptr vec, slong len, const fmpz_t c, slong prec)
 
 .. function:: void _acb_vec_scalar_mul_2exp_si(acb_ptr res, acb_srcptr vec, slong len, slong c)
 
@@ -1243,11 +1249,7 @@ Vector functions
 
 .. function:: void _acb_vec_scalar_div(acb_ptr res, acb_srcptr vec, slong len, const acb_t c, slong prec)
 
-.. function:: void _acb_vec_scalar_mul_arb(acb_ptr res, acb_srcptr vec, slong len, const arb_t c, slong prec)
-
 .. function:: void _acb_vec_scalar_div_arb(acb_ptr res, acb_srcptr vec, slong len, const arb_t c, slong prec)
-
-.. function:: void _acb_vec_scalar_mul_fmpz(acb_ptr res, acb_srcptr vec, slong len, const fmpz_t c, slong prec)
 
 .. function:: void _acb_vec_scalar_div_fmpz(acb_ptr res, acb_srcptr vec, slong len, const fmpz_t c, slong prec)
 

--- a/doc/source/arb.rst
+++ b/doc/source/arb.rst
@@ -1977,13 +1977,15 @@ Vector functions
 
 .. function:: void _arb_vec_scalar_mul_arf(arb_ptr res, arb_srcptr vec, slong len, const arf_t c, slong prec)
 
-.. function:: void _arb_vec_scalar_div(arb_ptr res, arb_srcptr vec, slong len, const arb_t c, slong prec)
-
-.. function:: void _arb_vec_scalar_mul_fmpz(arb_ptr res, arb_srcptr vec, slong len, const fmpz_t c, slong prec)
+.. function:: void _arb_vec_scalar_mul_ui(arb_ptr res, arb_srcptr vec, slong len, ulong c, slong prec)
 
 .. function:: void _arb_vec_scalar_mul_si(arb_ptr res, arb_srcptr vec, slong len, slong c, slong prec)
 
+.. function:: void _arb_vec_scalar_mul_fmpz(arb_ptr res, arb_srcptr vec, slong len, const fmpz_t c, slong prec)
+
 .. function:: void _arb_vec_scalar_mul_2exp_si(arb_ptr res, arb_srcptr src, slong len, slong c)
+
+.. function:: void _arb_vec_scalar_div(arb_ptr res, arb_srcptr vec, slong len, const arb_t c, slong prec)
 
 .. function:: void _arb_vec_scalar_addmul(arb_ptr res, arb_srcptr vec, slong len, const arb_t c, slong prec)
 

--- a/src/acb.h
+++ b/src/acb.h
@@ -851,13 +851,15 @@ void _acb_vec_sub(acb_ptr res, acb_srcptr vec1, acb_srcptr vec2, slong len, slon
 void _acb_vec_scalar_submul(acb_ptr res, acb_srcptr vec, slong len, const acb_t c, slong prec);
 void _acb_vec_scalar_addmul(acb_ptr res, acb_srcptr vec, slong len, const acb_t c, slong prec);
 void _acb_vec_scalar_mul(acb_ptr res, acb_srcptr vec, slong len, const acb_t c, slong prec);
-void _acb_vec_scalar_mul_si(acb_ptr res, acb_srcptr vec, slong len, slong c, slong prec);
+void _acb_vec_scalar_mul_arb(acb_ptr res, acb_srcptr vec, slong len, const arb_t c, slong prec);
+void _acb_vec_scalar_mul_arf(acb_ptr res, acb_srcptr vec, slong len, const arf_t c, slong prec);
 void _acb_vec_scalar_mul_ui(acb_ptr res, acb_srcptr vec, slong len, ulong c, slong prec);
+void _acb_vec_scalar_mul_si(acb_ptr res, acb_srcptr vec, slong len, slong c, slong prec);
+void _acb_vec_scalar_mul_fmpz(acb_ptr res, acb_srcptr vec, slong len, const fmpz_t c, slong prec);
 void _acb_vec_scalar_mul_2exp_si(acb_ptr res, acb_srcptr vec, slong len, slong c);
 void _acb_vec_scalar_mul_onei(acb_ptr res, acb_srcptr vec, slong len);
 void _acb_vec_scalar_div_ui(acb_ptr res, acb_srcptr vec, slong len, ulong c, slong prec);
 void _acb_vec_scalar_div(acb_ptr res, acb_srcptr vec, slong len, const acb_t c, slong prec);
-void _acb_vec_scalar_mul_arb(acb_ptr res, acb_srcptr vec, slong len, const arb_t c, slong prec);
 void _acb_vec_scalar_div_arb(acb_ptr res, acb_srcptr vec, slong len, const arb_t c, slong prec);
 void _acb_vec_scalar_mul_fmpz(acb_ptr res, acb_srcptr vec, slong len, const fmpz_t c, slong prec);
 void _acb_vec_scalar_div_fmpz(acb_ptr res, acb_srcptr vec, slong len, const fmpz_t c, slong prec);

--- a/src/acb.h
+++ b/src/acb.h
@@ -452,24 +452,36 @@ acb_abs(arb_t u, const acb_t z, slong prec)
 }
 
 ACB_INLINE void
+acb_mul_arf(acb_t z, const acb_t x, const arf_t y, slong prec)
+{
+    arb_mul_arf(acb_realref(z), acb_realref(x), y, prec);
+    arb_mul_arf(acb_imagref(z), acb_imagref(x), y, prec);
+}
+
+ACB_INLINE void
 acb_mul_ui(acb_t z, const acb_t x, ulong y, slong prec)
 {
-    arb_mul_ui(acb_realref(z), acb_realref(x), y, prec);
-    arb_mul_ui(acb_imagref(z), acb_imagref(x), y, prec);
+    arf_t t;
+    arf_init_set_ui(t, y); /* no need to free */
+    acb_mul_arf(z, x, t, prec);
 }
 
 ACB_INLINE void
 acb_mul_si(acb_t z, const acb_t x, slong y, slong prec)
 {
-    arb_mul_si(acb_realref(z), acb_realref(x), y, prec);
-    arb_mul_si(acb_imagref(z), acb_imagref(x), y, prec);
+    arf_t t;
+    arf_init_set_si(t, y); /* no need to free */
+    acb_mul_arf(z, x, t, prec);
 }
 
 ACB_INLINE void
 acb_mul_fmpz(acb_t z, const acb_t x, const fmpz_t y, slong prec)
 {
-    arb_mul_fmpz(acb_realref(z), acb_realref(x), y, prec);
-    arb_mul_fmpz(acb_imagref(z), acb_imagref(x), y, prec);
+    arf_t t;
+    arf_init(t);
+    arf_set_fmpz(t, y);
+    acb_mul_arf(z, x, t, prec);
+    arf_clear(t);
 }
 
 ACB_INLINE void

--- a/src/acb/vec.c
+++ b/src/acb/vec.c
@@ -141,11 +141,63 @@ void func_name(S rp, T ap, slong len, U b, slong prec) \
         OP(rp + ix, ap + ix, b, prec); \
 }
 
-SCALAR_OP(_acb_vec_scalar_mul_si,   acb_ptr, acb_srcptr, slong,        acb_mul_si)
-SCALAR_OP(_acb_vec_scalar_mul_ui,   acb_ptr, acb_srcptr, ulong,        acb_mul_ui)
-SCALAR_OP(_acb_vec_scalar_mul_fmpz, acb_ptr, acb_srcptr, const fmpz_t, acb_mul_fmpz)
-SCALAR_OP(_acb_vec_scalar_mul_arb,  acb_ptr, acb_srcptr, const arb_t,  acb_mul_arb)
-SCALAR_OP(_acb_vec_scalar_mul,      acb_ptr, acb_srcptr, const acb_t,  acb_mul)
+SCALAR_OP(_acb_vec_scalar_mul_arf,  acb_ptr, acb_srcptr, const arf_t,  acb_mul_arf)
+
+void
+_acb_vec_scalar_mul(acb_ptr res, acb_srcptr vec, slong len, const acb_t c, slong prec)
+{
+    if (acb_is_real(c))
+    {
+	_acb_vec_scalar_mul_arb(res, vec, len, acb_realref(c), prec);
+    }
+    else
+    {
+	slong ix;
+	for (ix = 0; ix < len; ix++)
+	    acb_mul(res + ix, vec + ix, c, prec);
+    }
+}
+
+void
+_acb_vec_scalar_mul_arb(acb_ptr res, acb_srcptr vec, slong len, const arb_t c, slong prec)
+{
+    if (arb_is_exact(c))
+    {
+	_acb_vec_scalar_mul_arf(res, vec, len, arb_midref(c), prec);
+    }
+    else
+    {
+	slong ix;
+	for (ix = 0; ix < len; ix++)
+	    acb_mul_arb(res + ix, vec + ix, c, prec);
+    }
+}
+
+void
+_acb_vec_scalar_mul_ui(acb_ptr res, acb_srcptr vec, slong len, ulong c, slong prec)
+{
+    arf_t t;
+    arf_init_set_ui(t, c); /* no need to free */
+    _acb_vec_scalar_mul_arf(res, vec, len, t, prec);
+}
+
+void
+_acb_vec_scalar_mul_si(acb_ptr res, acb_srcptr vec, slong len, slong c, slong prec)
+{
+    arf_t t;
+    arf_init_set_si(t, c); /* no need to free */
+    _acb_vec_scalar_mul_arf(res, vec, len, t, prec);
+}
+
+void
+_acb_vec_scalar_mul_fmpz(acb_ptr res, acb_srcptr vec, slong len, const fmpz_t c, slong prec)
+{
+    arf_t t;
+    arf_init(t);
+    arf_set_fmpz(t, c);
+    _acb_vec_scalar_mul_arf(res, vec, len, t, prec);
+    arf_clear(t);
+}
 
 SCALAR_OP(_acb_vec_scalar_div_ui,   acb_ptr, acb_srcptr, ulong,        acb_div_ui)
 SCALAR_OP(_acb_vec_scalar_div_fmpz, acb_ptr, acb_srcptr, const fmpz_t, acb_div_fmpz)

--- a/src/arb.h
+++ b/src/arb.h
@@ -664,8 +664,9 @@ void _arb_vec_add(arb_ptr C, arb_srcptr A, arb_srcptr B, slong n, slong prec);
 
 void _arb_vec_scalar_mul(arb_ptr res, arb_srcptr vec, slong len, const arb_t c, slong prec);
 void _arb_vec_scalar_mul_arf(arb_ptr res, arb_srcptr vec, slong len, const arf_t c, slong prec);
-void _arb_vec_scalar_mul_fmpz(arb_ptr res, arb_srcptr vec, slong len, const fmpz_t c, slong prec);
+void _arb_vec_scalar_mul_ui(arb_ptr res, arb_srcptr vec, slong len, ulong c, slong prec);
 void _arb_vec_scalar_mul_si(arb_ptr res, arb_srcptr vec, slong len, slong c, slong prec);
+void _arb_vec_scalar_mul_fmpz(arb_ptr res, arb_srcptr vec, slong len, const fmpz_t c, slong prec);
 void _arb_vec_scalar_mul_2exp_si(arb_ptr res, arb_srcptr src, slong len, slong c);
 void _arb_vec_scalar_div(arb_ptr res, arb_srcptr vec, slong len, const arb_t c, slong prec);
 void _arb_vec_scalar_addmul(arb_ptr res, arb_srcptr vec, slong len, const arb_t c, slong prec);

--- a/src/arb/vec.c
+++ b/src/arb/vec.c
@@ -143,13 +143,11 @@ SCALAR_OP(_arb_vec_scalar_div,      arb_ptr, arb_srcptr, const arb_t,  arb_div)
 SCALAR_OP(_arb_vec_scalar_addmul,   arb_ptr, arb_srcptr, const arb_t, arb_addmul)
 
 void
-_arb_vec_scalar_mul_fmpz(arb_ptr res, arb_srcptr vec, slong len, const fmpz_t c, slong prec)
+_arb_vec_scalar_mul_ui(arb_ptr res, arb_srcptr vec, slong len, ulong c, slong prec)
 {
     arf_t t;
-    arf_init(t);
-    arf_set_fmpz(t, c);
+    arf_init_set_ui(t, c); /* no need to free */
     _arb_vec_scalar_mul_arf(res, vec, len, t, prec);
-    arf_clear(t);
 }
 
 void
@@ -159,6 +157,17 @@ _arb_vec_scalar_mul_si(arb_ptr res, arb_srcptr vec, slong len, slong c, slong pr
     arf_init_set_si(t, c); /* no need to free */
     _arb_vec_scalar_mul_arf(res, vec, len, t, prec);
 }
+
+void
+_arb_vec_scalar_mul_fmpz(arb_ptr res, arb_srcptr vec, slong len, const fmpz_t c, slong prec)
+{
+    arf_t t;
+    arf_init(t);
+    arf_set_fmpz(t, c);
+    _arb_vec_scalar_mul_arf(res, vec, len, t, prec);
+    arf_clear(t);
+}
+
 
 #define COMPARISON_OP(func_name, S, T, OP) \
 int func_name(S ap, T bp, slong len)\

--- a/src/arb/vec.c
+++ b/src/arb/vec.c
@@ -137,10 +137,24 @@ void func_name(S rp, T ap, slong len, U b, slong prec) \
         OP(rp + ix, ap + ix, b, prec); \
 }
 
-SCALAR_OP(_arb_vec_scalar_mul,      arb_ptr, arb_srcptr, const arb_t,  arb_mul)
 SCALAR_OP(_arb_vec_scalar_mul_arf,  arb_ptr, arb_srcptr, const arf_t,  arb_mul_arf)
 SCALAR_OP(_arb_vec_scalar_div,      arb_ptr, arb_srcptr, const arb_t,  arb_div)
 SCALAR_OP(_arb_vec_scalar_addmul,   arb_ptr, arb_srcptr, const arb_t, arb_addmul)
+
+void
+_arb_vec_scalar_mul(arb_ptr res, arb_srcptr vec, slong len, const arb_t c, slong prec)
+{
+    if (arb_is_exact(c))
+    {
+	_arb_vec_scalar_mul_arf(res, vec, len, arb_midref(c), prec);
+    }
+    else
+    {
+	slong ix;
+	for (ix = 0; ix < len; ix++)
+	    arb_mul(res + ix, vec + ix, c, prec);
+    }
+}
 
 void
 _arb_vec_scalar_mul_ui(arb_ptr res, arb_srcptr vec, slong len, ulong c, slong prec)


### PR DESCRIPTION
This adds the functions

- `acb_mul_arf`
- ` _acb_vec_scalar_mul_arf`
- ` _acb_vec_scalar_mul_si`
- ` _acb_vec_scalar_mul_fmpz`
- ` _arb_vec_scalar_mul_ui` 

It optimizes `acb_mul_ui`, `acb_mul_si` and `acb_mul_fmpz` by converting the integer to an `arf` and calling `acb_mul_arf`. This avoids converting the integers twice. At low precision I saw about a 5% speedup for `acb_mul_si`. If the `acb` value was zero I saw about a 20% speedup.

It optimizes several of the scalar multiplication functions. The `ui`, `si` and `fmpz` versions convert the scalar to an `arf` once. The `arb` versions checks for an exact scalar and calls the `arf` version in that case. The `acb` version checks for real input and calls the `arb` version in that case. For the integer versions I saw about 5-10% speedup at low precision. For the other cases the speedup was smaller, but the new versions would simplify handling special input such as exact powers of 2 (as mentioned in #2671)  since they only have to be implemented for the `arf` version.

I tried to optimize the scalar `acb` multiplication for imaginary input by calling the `arb` and `onei` versions. However, the extra overhead of iterating over the vector twice seemed to not make it worth it.