### PR TITLE
fix(acb_dft): build DFT plan root tables at internal guard precision

### DIFF
--- a/doc/source/acb_dft.rst
+++ b/doc/source/acb_dft.rst
@@ -45,6 +45,11 @@ If `G=\mathbb Z/n\mathbb Z`, we compute the DFT according to the usual conventio
 If several computations are to be done on the same group, the FFT scheme
 should be reused.
 
+The precomputed schemes build their internal tables of roots of unity at the
+precision passed to their *init* function. Build a scheme at (at least) the
+precision at which you intend to evaluate transforms; *acb_dft* and the
+precomputed schemes then return results accurate to about *prec* bits.
+
 .. type:: acb_dft_pre_struct
 
 .. type:: acb_dft_pre_t
@@ -96,7 +101,7 @@ We assume that `f` is given by a vector of length `\prod n_i` corresponding
 to a lexicographic ordering of the values `y_1,\dots y_r`, and the computation
 returns the same indexing for values of `\hat f`.
 
-.. function:: void acb_dirichlet_dft_prod(acb_ptr w, acb_srcptr v, slong * cyc, slong num, slong prec)
+.. function:: void acb_dft_prod(acb_ptr w, acb_srcptr v, slong * cyc, slong num, slong prec)
 
    Computes the DFT on the group product of *num* cyclic components of sizes *cyc*. Assume the entries
    of *v* are indexed according to lexicographic ordering of the cyclic
@@ -119,10 +124,10 @@ returns the same indexing for values of `\hat f`.
 
    Clears *t*.
 
-.. function:: void acb_dirichlet_dft_prod_precomp(acb_ptr w, acb_srcptr v, const acb_dft_prod_t prod, slong prec)
+.. function:: void acb_dft_prod_precomp(acb_ptr w, acb_srcptr v, const acb_dft_prod_t prod, slong prec)
 
    Sets *w* to the DFT of *v*. Assume the entries are lexicographically
-   ordered according to the product of cyclic groups initialized in *t*.
+   ordered according to the product of cyclic groups initialized in *prod*.
 
 Convolution
 -------------------------------------------------------------------------------
@@ -254,10 +259,10 @@ Radix 2 decomposition
    Computes the DFT of *v* into *w*, where *v* and *w* have size `2^e`,
    using a radix 2 FFT.
 
-.. function:: void acb_dft_inverse_rad2(acb_ptr w, acb_srcptr v, int e, slong prec)
+.. function:: void acb_dft_inverse_rad2_precomp_inplace(acb_ptr v, const acb_dft_rad2_t t, slong prec)
 
-   Computes the inverse DFT of *v* into *w*, where *v* and *w* have size `2^e`,
-   using a radix 2 FFT.
+   Computes the inverse DFT of *v* in place, of size *t->n*, using the
+   precomputed radix 2 scheme *t*.
 
 .. type:: acb_dft_rad2_struct
 

--- a/doc/source/history.rst
+++ b/doc/source/history.rst
@@ -38,6 +38,16 @@ Bug fixes
   [FJ, `#2652 <https://github.com/flintlib/flint/pull/2652>`_].
 * Fix virtual memory usage fetchers for OpenBSD [AA reported by Oliver Krüger,
   `#2653 <https://github.com/flintlib/flint/pull/2653>`_].
+* Fix ``acb_dft`` plan accuracy: the precomputed root-of-unity tables
+  (``_acb_vec_unit_roots`` and the Bluestein factor table) built their base
+  root at the call precision and raised it to powers, amplifying the base-root
+  error roughly linearly in the index, so plan output radii grew like ``O(n)``
+  (rad2/dft about 11 bits too wide at ``n = 2^16``; Bluestein far worse for
+  prime lengths). Build the base root at an internal guard precision and round
+  the stored table back to ``prec``. Also fix a pre-existing leak in
+  ``acb_dft_bluestein_precomp``, which cleared only ``n`` of its ``np``
+  allocated scratch entries
+  [EC, `#2756 <https://github.com/flintlib/flint/pull/2756>`_].
 
 
 2026-04-24 -- FLINT 3.5.0

--- a/src/acb/vec_unit_roots.c
+++ b/src/acb/vec_unit_roots.c
@@ -42,7 +42,11 @@ _acb_vec_unit_roots(acb_ptr res, slong n, slong len, slong prec)
     wp = prec + 6 + 2 * FLINT_BIT_COUNT(len1);
 
     acb_init(t);
-    acb_unit_root(t, n, prec);
+    /* Base root at wp, not prec: _acb_vec_set_powers raises it to powers by
+       binary powering, amplifying the base-root error ~linearly in the
+       index, so a prec-accurate base would leave the largest stored roots
+       only ~prec - log2(len1) bits accurate. Rounded back to prec below. */
+    acb_unit_root(t, n, wp);
     _acb_vec_set_powers(res, t, len1, wp);
     acb_clear(t);
     _acb_vec_set_round(res, res, len1, prec);

--- a/src/acb_dft/bluestein.c
+++ b/src/acb_dft/bluestein.c
@@ -129,12 +129,13 @@ _acb_dft_bluestein_init(acb_dft_bluestein_t t, slong dv, slong n, slong prec)
 void
 acb_dft_bluestein_precomp(acb_ptr w, acb_srcptr v, const acb_dft_bluestein_t t, slong prec)
 {
-    slong n = t->n, np = t->rad2->n, dv = t->dv;
+    slong n = t->n, dv = t->dv, np;
     acb_ptr fp;
 
     if (n == 0)
         return;
 
+    np = t->rad2->n;
     fp = _acb_vec_init(np);
     _acb_vec_kronecker_mul_step(fp, t->z, v, dv, n, prec);
 
@@ -145,7 +146,7 @@ acb_dft_bluestein_precomp(acb_ptr w, acb_srcptr v, const acb_dft_bluestein_t t, 
 
     _acb_vec_kronecker_mul(w, t->z, fp, n, prec);
 
-    _acb_vec_clear(fp, n);
+    _acb_vec_clear(fp, np);
 }
 
 void

--- a/src/acb_dft/bluestein.c
+++ b/src/acb_dft/bluestein.c
@@ -41,7 +41,7 @@ _acb_vec_bluestein_factors(acb_ptr z, slong n, slong prec)
     else
     {
         nmod_t n2;
-        slong k, k2, dk;
+        slong k, k2, dk, wp;
         slong * v, * s;
         acb_ptr t;
         s = flint_malloc(n * sizeof(slong));
@@ -64,13 +64,20 @@ _acb_vec_bluestein_factors(acb_ptr z, slong n, slong prec)
         }
         acb_modular_fill_addseq(v, n);
 
+        /* Build the base root and the addition-sequence products at wp, not
+           prec: the addseq raises the base root to powers via products of
+           earlier entries, amplifying the base-root error ~linearly in the
+           index. The factor table z is rounded back to prec after the
+           (exact) copy-out below. */
+        wp = prec + 6 + 2 * FLINT_BIT_COUNT(2 * n);
+
         acb_one(t + 0);
-        acb_unit_root(t + 1, 2 * n, prec);
+        acb_unit_root(t + 1, 2 * n, wp);
         acb_conj(t + 1, t + 1);
         acb_set_si(t + n, -1);
         for (k = 2; k < n; k++)
             if (v[k])
-                acb_mul(t + k, t + v[k], t + k - v[k], prec);
+                acb_mul(t + k, t + v[k], t + k - v[k], wp);
         for (k = 0; k < n; k++)
         {
             if (s[k] <= n)
@@ -78,6 +85,7 @@ _acb_vec_bluestein_factors(acb_ptr z, slong n, slong prec)
             else
                 acb_conj(z + k, t + 2 * n - s[k]);
         }
+        _acb_vec_set_round(z, z, n, prec);
         _acb_vec_clear(t, n + 1);
         flint_free(s);
         flint_free(v);

--- a/src/acb_dft/test/main.c
+++ b/src/acb_dft/test/main.c
@@ -11,6 +11,7 @@
 
 /* Include functions *********************************************************/
 
+#include "t-accuracy.c"
 #include "t-convol.c"
 #include "t-dft.c"
 
@@ -18,6 +19,7 @@
 
 test_struct tests[] =
 {
+    TEST_FUNCTION(acb_dft_accuracy),
     TEST_FUNCTION(acb_dft_convol),
     TEST_FUNCTION(acb_dft)
 };

--- a/src/acb_dft/test/t-accuracy.c
+++ b/src/acb_dft/test/t-accuracy.c
@@ -1,0 +1,253 @@
+/*
+    Copyright (C) 2026 Edgar Costa
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "acb.h"
+#include "acb_dft.h"
+
+/* Regression guard for the acb_dft plan root/factor tables (issue #2709).
+
+   Every acb_dft plan builds its roots of unity by raising a base root to
+   powers. When the base root was built at the call precision, the powering
+   amplified its error roughly in proportion to the root index, so the stored
+   roots near the top of the table carried about (index) * 2^-prec of error and
+   the transform inherited it: the output radius grew about linearly in n
+   (about 2490x looser than achievable at n = 2^16, prec = 128 for rad2, and
+   more for the bluestein factor table used at prime lengths).
+
+   With exact integer input (zero input radius) the output radius is purely the
+   transform error, so we isolate the plan table by holding the transform
+   arithmetic at prec while building the plan once at prec and once at prec+64,
+   and comparing the output radii. A loose table makes rad(plan=prec) grow with
+   n relative to rad(plan=prec+64); a tight table keeps the ratio a small
+   constant. Comparing acb_dft at prec vs prec+64 would instead vary the
+   arithmetic and is dominated by the working-precision gap, so we always vary
+   only the plan precision. acb_dft_naive is intentionally not checked: it has
+   its own O(n) summation widening, independent of the root table. */
+
+#define RATIO_MAX  8.0   /* fixed: rad2 ~1.5x, bluestein ~2-4x; broken: >= 24x */
+#define GROWTH_MAX 4.0   /* fixed: ~1x; broken: ~54x over 2^8..2^14           */
+
+static void
+fill_pattern(acb_ptr v, slong n)
+{
+    slong i;
+
+    for (i = 0; i < n; i++)
+    {
+        /* exact integers: zero input radius */
+        arb_set_si(acb_realref(v + i), (i % 19) - 9);
+        arb_set_si(acb_imagref(v + i), (i % 13) - 6);
+    }
+}
+
+static double
+max_rad(acb_srcptr v, slong n)
+{
+    arb_t m, r;
+    double d;
+    slong i;
+
+    arb_init(m);
+    arb_init(r);
+    for (i = 0; i < n; i++)
+    {
+        arb_get_rad_arb(r, acb_realref(v + i));
+        if (arb_gt(r, m))
+            arb_set(m, r);
+        arb_get_rad_arb(r, acb_imagref(v + i));
+        if (arb_gt(r, m))
+            arb_set(m, r);
+    }
+    d = arf_get_d(arb_midref(m), ARF_RND_NEAR);
+    arb_clear(m);
+    arb_clear(r);
+    return d;
+}
+
+static void
+check_overlap(acb_srcptr a, acb_srcptr b, slong n, const char * what)
+{
+    slong i;
+
+    for (i = 0; i < n; i++)
+    {
+        if (!acb_overlaps(a + i, b + i))
+        {
+            flint_printf("FAIL (overlap): %s, index %wd\n", what, i);
+            flint_abort();
+        }
+    }
+}
+
+static void
+check_ratio(double ratio, double bound, const char * what)
+{
+    if (ratio > bound)
+    {
+        flint_printf("FAIL (looseness): %s : ratio %g > %g (see issue #2709)\n",
+                     what, ratio, bound);
+        flint_abort();
+    }
+}
+
+/* rad2 plan built at prec vs prec+64, both transforms run at prec. */
+static double
+rad2_plan_ratio(int e, slong prec)
+{
+    slong n = WORD(1) << e;
+    acb_ptr in = _acb_vec_init(n);
+    acb_ptr lo = _acb_vec_init(n);
+    acb_ptr hi = _acb_vec_init(n);
+    acb_dft_rad2_t plo, phi;
+    double rlo, rhi;
+
+    fill_pattern(in, n);
+    acb_dft_rad2_init(plo, e, prec);
+    acb_dft_rad2_init(phi, e, prec + 64);
+    acb_dft_rad2_precomp(lo, in, plo, prec);
+    acb_dft_rad2_precomp(hi, in, phi, prec);
+    acb_dft_rad2_clear(plo);
+    acb_dft_rad2_clear(phi);
+
+    check_overlap(lo, hi, n, "rad2 plan prec vs prec+64");
+    rlo = max_rad(lo, n);
+    rhi = max_rad(hi, n);
+
+    _acb_vec_clear(in, n);
+    _acb_vec_clear(lo, n);
+    _acb_vec_clear(hi, n);
+    return (rhi > 0.0) ? rlo / rhi : 1.0;
+}
+
+/* bluestein plan (any length >= 30) built at prec vs prec+64, run at prec. */
+static double
+bluestein_plan_ratio(slong n, slong prec)
+{
+    acb_ptr in = _acb_vec_init(n);
+    acb_ptr lo = _acb_vec_init(n);
+    acb_ptr hi = _acb_vec_init(n);
+    acb_dft_bluestein_t plo, phi;
+    double rlo, rhi;
+
+    fill_pattern(in, n);
+    acb_dft_bluestein_init(plo, n, prec);
+    acb_dft_bluestein_init(phi, n, prec + 64);
+    acb_dft_bluestein_precomp(lo, in, plo, prec);
+    acb_dft_bluestein_precomp(hi, in, phi, prec);
+    acb_dft_bluestein_clear(plo);
+    acb_dft_bluestein_clear(phi);
+
+    check_overlap(lo, hi, n, "bluestein plan prec vs prec+64");
+    rlo = max_rad(lo, n);
+    rhi = max_rad(hi, n);
+
+    _acb_vec_clear(in, n);
+    _acb_vec_clear(lo, n);
+    _acb_vec_clear(hi, n);
+    return (rhi > 0.0) ? rlo / rhi : 1.0;
+}
+
+/* the public acb_dft dispatcher at prec vs a tight reference plan (same kind,
+   built at prec+64, run at prec). kind 0 = rad2 (power of two), 1 = bluestein. */
+static double
+dispatcher_ratio(slong n, int e, slong prec, int kind)
+{
+    acb_ptr in = _acb_vec_init(n);
+    acb_ptr wd = _acb_vec_init(n);
+    acb_ptr ref = _acb_vec_init(n);
+    double rd, rr;
+
+    fill_pattern(in, n);
+    acb_dft(wd, in, n, prec);
+
+    if (kind == 0)
+    {
+        acb_dft_rad2_t p;
+        acb_dft_rad2_init(p, e, prec + 64);
+        acb_dft_rad2_precomp(ref, in, p, prec);
+        acb_dft_rad2_clear(p);
+    }
+    else
+    {
+        acb_dft_bluestein_t p;
+        acb_dft_bluestein_init(p, n, prec + 64);
+        acb_dft_bluestein_precomp(ref, in, p, prec);
+        acb_dft_bluestein_clear(p);
+    }
+
+    check_overlap(wd, ref, n, "acb_dft dispatcher vs tight reference");
+    rd = max_rad(wd, n);
+    rr = max_rad(ref, n);
+
+    _acb_vec_clear(in, n);
+    _acb_vec_clear(wd, n);
+    _acb_vec_clear(ref, n);
+    return (rr > 0.0) ? rd / rr : 1.0;
+}
+
+TEST_FUNCTION_START(acb_dft_accuracy, state)
+{
+    slong prec = 128;
+    int es[5] = { 8, 11, 12, 14, 16 };
+    int ne = 4;                 /* default tops out at 2^14 (~0.1s)           */
+    int ehi, e_disp, i;
+    slong nb;
+    double r_lo, r_hi = 0.0;
+
+    if (flint_test_multiplier() > 1)
+        ne = 5;                 /* exercise the headline n = 2^16 too         */
+    ehi = es[ne - 1];
+
+    /* (A) rad2 plan tightness, isolated, plus (B) the ratio must not grow
+       with n (a ratio of ratios, so per-platform rounding cancels). */
+    r_lo = rad2_plan_ratio(es[0], prec);
+    for (i = 0; i < ne; i++)
+    {
+        double ratio = rad2_plan_ratio(es[i], prec);
+
+        check_ratio(ratio, RATIO_MAX, "rad2 plan");
+        if (es[i] == ehi)
+            r_hi = ratio;
+    }
+    if (r_hi > GROWTH_MAX * r_lo)
+    {
+        flint_printf("FAIL (growth): rad2 ratio(2^%d)=%g vs ratio(2^%d)=%g "
+                     "(factor %g > %g) (see issue #2709)\n",
+                     ehi, r_hi, es[0], r_lo,
+                     r_lo > 0 ? r_hi / r_lo : 0.0, GROWTH_MAX);
+        flint_abort();
+    }
+
+    /* tiny n and small precision exercise the worst guard margin */
+    for (i = 1; i <= 3; i++)
+        check_ratio(rad2_plan_ratio(i, prec), RATIO_MAX, "rad2 plan tiny n");
+    check_ratio(rad2_plan_ratio(10, 8), RATIO_MAX, "rad2 plan small prec");
+
+    /* (.5) bluestein factor table: a prime >= 100 and a prime in [30, 100) */
+    nb = (flint_test_multiplier() > 1) ? 16411 : 1009;
+    check_ratio(bluestein_plan_ratio(nb, prec), RATIO_MAX, "bluestein large prime");
+    check_ratio(bluestein_plan_ratio(97, prec), RATIO_MAX, "bluestein n=97");
+    check_ratio(bluestein_plan_ratio(29, prec), RATIO_MAX, "bluestein n=29");
+
+    /* prec > 128 forces heap-allocated mantissas: this case additionally lets
+       `make valgrind` catch a regression of the np-length scratch clear in
+       acb_dft_bluestein_precomp (which only leaks above the inline limb cap). */
+    check_ratio(bluestein_plan_ratio(1009, 256), RATIO_MAX, "bluestein prec 256");
+
+    /* the public acb_dft dispatcher is tight on both routed paths */
+    e_disp = (flint_test_multiplier() > 1) ? 16 : 14;
+    check_ratio(dispatcher_ratio(WORD(1) << e_disp, e_disp, prec, 0), RATIO_MAX,
+                "acb_dft power of two");
+    check_ratio(dispatcher_ratio(nb, 0, prec, 1), RATIO_MAX, "acb_dft prime");
+
+    TEST_FUNCTION_END(state);
+}


### PR DESCRIPTION
`acb_dft` plans build their roots of unity by raising a base root to powers. The base root was computed at the call precision, and the repeated squaring in `_acb_vec_set_powers` amplifies its error roughly linearly in the root index, so plan roots near the top of the table carried about `index * 2^-prec` of error and every transform inherited it. Output radii were about 2490x (~11 bits) too wide at n = 2^16 for rad2/dft, and about 1e7x too wide for prime lengths via Bluestein, growing linearly in n. Results stayed rigorous (`acb_overlaps` holds), so this is an accuracy/tightness fix, not a correctness bug.

Signature: at prec = 128, n = 2^16, exact integer input, `acb_dft_rad2` output radius is 5.55e-29 versus 2.23e-32 achievable at the same working precision; the only difference is the precision of the plan root table.

## Changes

- `src/acb/vec_unit_roots.c`: build the base root at the already-computed guard precision `wp = prec + 6 + 2*bitcount(len1)` instead of `prec`. Fixes rad2, naive, cyc and the small-n Bluestein path, which all route through this helper. Roots are still stored at `prec`, so memory and arithmetic cost are unchanged.
- `src/acb_dft/bluestein.c`: build the large-n (n >= 30) addition-sequence factor table at `wp` and round it back to `prec` (a sibling site reached by `acb_dft` for prime lengths >= 100); and clear the full `np`-length scratch in `acb_dft_bluestein_precomp` (a pre-existing leak of the trailing `np - n` entries above the inline-mantissa cap, prec > 128).
- `src/acb_dft/test/t-accuracy.c` (+ `main.c`): regression test. With exact input it isolates the plan table by holding the transform arithmetic at `prec` and building the plan at `prec` vs `prec+64`, asserting the output-radius ratio is a small constant (not O(n)) with an anti-vacuity growth bound, across rad2, the `acb_dft` dispatcher (power of two and prime), and Bluestein. A prec-256 Bluestein case also makes `make valgrind` catch a regression of the scratch-clear length.
- `doc/source/acb_dft.rst`: document that schemes build their root tables at the init precision (build a scheme at the precision you will run it at); fix three documented signatures that named nonexistent symbols (`acb_dirichlet_dft_prod[_precomp]` -> `acb_dft_prod[_precomp]`, `acb_dft_inverse_rad2` -> the implemented `acb_dft_inverse_rad2_precomp_inplace`).

## Verification

- `t-accuracy.c` fails on the unfixed helper (ratio 10.5 > 8 at the first size, grows with n) and passes after the fix (about 0.16s at the default multiplier).
- `make check MOD=acb_dft` and `MOD=acb` pass; `make valgrind MOD=acb_dft` is clean (no leaks, 0 errors), including the prec-256 Bluestein case that leaked before the scratch-clear fix.
- The change only tightens returned roots (rigorous balls stay enclosing), so dependent suites are unaffected: acb_dirichlet, acb_theta, acb_modular and arb_fmpz_poly pass.

Fixes #2709
