### PR TITLE
Radix-based p-adic exponential function

### DIFF
--- a/doc/source/padic_radix.rst
+++ b/doc/source/padic_radix.rst
@@ -156,6 +156,9 @@ The following methods mainly implement the :ref:`generics <gr>` interface.
               int padic_radix_rsqrt(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx)
               truth_t padic_radix_is_square(const padic_radix_t x, gr_ctx_t ctx)
 
+Dot products
+--------------------------------------------------------------------------------
+
 .. function:: int padic_radix_dot_strided_delayed(padic_radix_t res, const padic_radix_t initial, int subtract, const padic_radix_struct * vec1, slong stride1, const padic_radix_struct * vec2, slong stride2, slong len, gr_ctx_t ctx)
               int padic_radix_dot_strided_naive(padic_radix_t res, const padic_radix_t initial, int subtract, const padic_radix_struct * vec1, slong stride1, const padic_radix_struct * vec2, slong stride2, slong len, gr_ctx_t ctx)
               int padic_radix_dot_strided(padic_radix_t res, const padic_radix_t initial, int subtract, const padic_radix_struct * vec1, slong stride1, const padic_radix_struct * vec2, slong stride2, slong len, gr_ctx_t ctx)
@@ -172,4 +175,43 @@ The following methods mainly implement the :ref:`generics <gr>` interface.
 
     Wrappers for :func:`padic_radix_dot_strided`.
 
+Transcendental functions
+--------------------------------------------------------------------------------
+
+.. function:: slong _padic_radix_exp_bound(slong v, slong N, ulong p)
+
+    Returns the number of terms `n` such that the tail of the exponential
+    series for `x = p^v u` has valuation at least `N`, i.e. the smallest `n`
+    with `nv - v_p(n!) \ge N`:
+
+    .. math ::
+
+        n = \max(1, \left \lceil \frac{N(p-1) - 1}{v(p-1) - 1} \right \rceil)
+
+    Assumes (not checked) that `v` is large enough for the series to converge.
+
+.. function:: int _padic_radix_exp_rectangular(radix_integer_t rop, const radix_integer_t u, slong v, slong N, const radix_t radix)
+              int _padic_radix_exp_balanced(radix_integer_t rop, const radix_integer_t u, slong v, slong N, const radix_t radix)
+              int _padic_radix_exp(radix_integer_t rop, const radix_integer_t u, slong v, slong N, const radix_t radix)
+
+    Given a unit `u` and a valuation `v` such that `v \ge 1` if `p \ne 2`
+    and `v \ge 2` if `p = 2` (not checked), sets *rop* to `\exp(u p^v)`
+    truncated to precision `p^N`.
+
+    The *rectangular* algorithm uses rectangular splitting.
+    The *balanced* algorithm uses the `p`-adic bit-burst algorithm with
+    binary splitting. The default function chooses an algorithm automatically.
+
+    The *rectangular* algorithm can return ``GR_UNABLE`` if `N` is too large
+    for the implementation; the *balanced* algorithm and the default
+    algorithm always succeed and return ``GR_SUCCESS`` (given valid input).
+
+.. function:: int padic_radix_exp_rectangular(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx)
+              int padic_radix_exp_balanced(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx)
+              int padic_radix_exp(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx)
+
+    Sets *res* to the `p`-adic exponential function `\exp(x)`.
+    Returns ``GR_DOMAIN`` if the series does not converge
+    and ``GR_UNABLE`` if this convergence cannot be determined or if the
+    precision is too large for the implementation.
 

--- a/doc/source/radix.rst
+++ b/doc/source/radix.rst
@@ -527,9 +527,15 @@ Memory-managed integers
     and returns 1. The sign of the input is preserved.
     If *x* is not invertible, returns 0.
 
+.. function:: int radix_integer_divmod_limbs(radix_integer_t res, const radix_integer_t x, const radix_integer y, slong n, const radix_t radix)
+
+    If *y* is invertible modulo `B^n`, sets *res* to the quotient
+    `x / y` modulo `B^n` and returns 1. The sign of the inputs is preserved.
+    If *y* is not invertible, returns 0.
+
 .. function:: int radix_integer_rsqrtmod_limbs(radix_integer_t res, const radix_integer_t x, slong n, const radix_t radix)
               int radix_integer_sqrtmod_limbs(radix_integer_t res, const radix_integer_t x, slong n, const radix_t radix)
 
     Square root modulo `B^n`: see :func:`radix_sqrtmod_bn` and
-    :func:`radic_rsqrtmod_bn`.
+    :func:`radix_rsqrtmod_bn`.
 

--- a/doc/source/radix.rst
+++ b/doc/source/radix.rst
@@ -478,14 +478,16 @@ Memory-managed integers
     In the special case `x = 0`, returns zero.
 
 .. function:: void radix_integer_trunc_limbs(radix_integer_t res, const radix_integer_t x, slong n, const radix_t radix)
+              void radix_integer_trunc_digits(radix_integer_t res, const radix_integer_t x, slong n, const radix_t radix)
 
-    Sets *res* to *x* with the absolute value reduced modulo `B^n`, preserving
-    the sign of *x*.
+    Sets *res* to *x* with the absolute value reduced modulo `B^n` (respectively `b^n`),
+    preserving the sign of *x*.
 
 .. function:: void radix_integer_mod_limbs(radix_integer_t res, const radix_integer_t x, slong n, const radix_t radix)
+              void radix_integer_mod_digits(radix_integer_t res, const radix_integer_t x, slong n, const radix_t radix)
 
-    Sets *res* to *x* reduced modulo `B^n`, returning the unique
-    unsigned representative in `[0, B^n-1]`.
+    Sets *res* to *x* reduced modulo `B^n` (respectively `b^n`), returning the unique
+    unsigned representative in `[0, B^n-1]` (respectively `[0, b^n-1]`).
 
 .. function:: void radix_integer_smod_limbs(radix_integer_t res, const radix_integer_t x, slong n, const radix_t radix)
 

--- a/src/padic_radix.h
+++ b/src/padic_radix.h
@@ -70,6 +70,8 @@ typedef padic_radix_ctx_struct padic_radix_ctx_t[1];
 
 /* Context management */
 int gr_ctx_init_padic_radix(gr_ctx_t ctx, ulong p, slong prec_rel, slong prec_abs, int flags);
+int gr_ctx_init_padic_radix_randtest(gr_ctx_t ctx, flint_rand_t state, slong maxprec);
+
 void padic_radix_ctx_clear(gr_ctx_t ctx);
 int padic_radix_ctx_write(gr_stream_t out, gr_ctx_t ctx);
 
@@ -106,6 +108,10 @@ int padic_radix_inv(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx);
 int padic_radix_div(padic_radix_t res, const padic_radix_t x, const padic_radix_t y, gr_ctx_t ctx);
 int padic_radix_sqrt(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx);
 int padic_radix_rsqrt(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx);
+int _padic_radix_exp_rectangular(radix_integer_t rop, const radix_integer_t u, slong v, slong N, const radix_t radix);
+int padic_radix_exp_rectangular(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx);
+int _padic_radix_exp_balanced(radix_integer_t rop, const radix_integer_t u, slong v, slong N, const radix_t radix);
+int padic_radix_exp_balanced(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx);
 truth_t padic_radix_is_square(const padic_radix_t x, gr_ctx_t ctx);
 
 truth_t padic_radix_is_zero(const padic_radix_t x, gr_ctx_t ctx);
@@ -130,6 +136,16 @@ int padic_radix_dot_strided_delayed(padic_radix_t res, const padic_radix_t initi
 int padic_radix_dot_strided_naive(padic_radix_t res, const padic_radix_t initial,
     int subtract, const padic_radix_struct * vec1, slong stride1,
     const padic_radix_struct * vec2, slong stride2, slong len, gr_ctx_t ctx);
+
+slong _padic_radix_exp_bound(slong v, slong N, ulong p);
+
+int _padic_radix_exp_rectangular(radix_integer_t rop, const radix_integer_t u, slong v, slong N, const radix_t radix);
+int _padic_radix_exp_balanced(radix_integer_t rop, const radix_integer_t u, slong v, slong N, const radix_t radix);
+int _padic_radix_exp(radix_integer_t rop, const radix_integer_t u, slong v, slong N, const radix_t radix);
+
+int padic_radix_exp_rectangular(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx);
+int padic_radix_exp_balanced(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx);
+int padic_radix_exp(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx);
 
 /* For testing */
 int _padic_radix_add_sub_reference(padic_radix_t res, const padic_radix_t x, const padic_radix_t y, int sub, gr_ctx_t ctx);

--- a/src/padic_radix/exp.c
+++ b/src/padic_radix/exp.c
@@ -1,0 +1,170 @@
+/*
+    Copyright (C) 2012 Sebastian Pancratz
+    Copyright (C) 2012, 2014, 2022, 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "ulong_extras.h"
+#include "fmpz.h"
+#include "padic_radix.h"
+#include "gr.h"
+
+slong
+_padic_radix_exp_bound(slong v, slong N, ulong p)
+{
+    ulong p1 = p - 1;
+    ulong Nhi, Nlo, vhi, vlo, D, q = 0, r = 0;
+    int use_fast = 0;
+
+    umul_ppmm(vhi, vlo, (ulong) v, p1);          /* v*(p-1) */
+
+    if (vhi == 0 && vlo > 1)                      /* D = v*(p-1) - 1 >= 1 */
+    {
+        D = vlo - 1;
+        umul_ppmm(Nhi, Nlo, (ulong) N, p1);       /* N*(p-1) */
+
+        if (Nhi == 0)
+        {
+            ulong A = Nlo - 1;                    /* N>=1, p>=2 => Nlo>=1 */
+            q = A / D;
+            r = A - q * D;
+            use_fast = 1;
+        }
+        else
+        {
+            ulong Ahi = Nhi - (Nlo == 0);         /* (Nhi:Nlo) - 1 */
+            ulong Alo = Nlo - 1;
+            if (Ahi < D)                          /* ensures the quotient is a limb */
+            {
+                udiv_qrnnd(q, r, Ahi, Alo, D);
+                use_fast = 1;
+            }
+        }
+    }
+
+    if (use_fast)
+        return FLINT_MAX((slong) (q + (r != 0)), 1);
+
+    {
+        fmpz_t num, den, qq;
+        slong n;
+
+        fmpz_init(num);
+        fmpz_init(den);
+        fmpz_init(qq);
+
+        fmpz_set_ui(qq, p - 1);
+        fmpz_mul_si(num, qq, N);
+        fmpz_sub_ui(num, num, 1);
+        fmpz_mul_si(den, qq, v);
+        fmpz_sub_ui(den, den, 1);
+        fmpz_cdiv_q(qq, num, den);
+        n = fmpz_get_si(qq);
+
+        fmpz_clear(num);
+        fmpz_clear(den);
+        fmpz_clear(qq);
+
+        return FLINT_MAX(n, 1);
+    }
+}
+
+int
+_padic_radix_exp(radix_integer_t rop, const radix_integer_t u,
+    slong v, slong N, const radix_t radix)
+{
+    slong cutoff;
+    ulong pbits;
+
+    pbits = NMOD_BITS(radix->b);
+
+    if (pbits <= 21)
+        cutoff = 200;
+    else if (pbits <= 32)
+        cutoff = 150;
+    else
+        cutoff = 80;
+
+    if (N < cutoff && _padic_radix_exp_rectangular(rop, u, v, N, radix) == GR_SUCCESS)
+        return GR_SUCCESS;
+
+    return _padic_radix_exp_balanced(rop, u, v, N, radix);
+}
+
+static int
+_padic_radix_exp_wrapper(padic_radix_t res, const padic_radix_t x, int algorithm, gr_ctx_t ctx)
+{
+    radix_struct * radix = PADIC_RADIX_CTX_RADIX(ctx);
+    ulong p = GR_PADIC_RADIX_CTX(ctx)->p;
+    slong vx = x->v, Nx = x->N;
+    int status;
+
+    slong prec_abs = PADIC_RADIX_CTX_PREC_ABS(ctx);
+    slong prec_rel = PADIC_RADIX_CTX_PREC_REL(ctx);
+    slong prec = FLINT_MIN(prec_rel, prec_abs);
+
+    /* 0            -> 1 */
+    /* 0 + O(x)     -> unable (p >= 3) */
+    /* 0 + O(x^2)   -> unable (p == 2) */
+    /* 0 + O(x^3)   -> 1 + O(x^5) */
+
+    if (radix_integer_is_zero(&x->u, radix))
+    {
+        if (Nx == PADIC_RADIX_EXACT)
+            return padic_radix_one(res, ctx);
+
+        if (Nx < ((p == 2) ? 2 : 1) || prec == PADIC_RADIX_PREC_INF)
+            return GR_UNABLE;
+
+        radix_integer_one(&res->u, radix);
+        res->v = 0;
+        res->N = Nx;
+        return _padic_radix_finalize(res, ctx);
+    }
+
+    if (vx < ((p == 2) ? 2 : 1))
+        return GR_DOMAIN;
+
+    if (prec == PADIC_RADIX_PREC_INF)
+        return GR_UNABLE;
+
+    if (Nx != PADIC_RADIX_EXACT)
+        prec = FLINT_MIN(prec, Nx);
+
+    if (algorithm == 0)
+        status = _padic_radix_exp(&res->u, &x->u, vx, prec, radix);
+    else if (algorithm == 1)
+        status = _padic_radix_exp_rectangular(&res->u, &x->u, vx, prec, radix);
+    else
+        status = _padic_radix_exp_balanced(&res->u, &x->u, vx, prec, radix);
+
+    res->v = 0;
+    res->N = prec;
+    status |= _padic_radix_finalize(res, ctx);
+    return status;
+}
+
+int
+padic_radix_exp(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx)
+{
+    return _padic_radix_exp_wrapper(res, x, 0, ctx);
+}
+
+int
+padic_radix_exp_rectangular(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx)
+{
+    return _padic_radix_exp_wrapper(res, x, 1, ctx);
+}
+
+int
+padic_radix_exp_balanced(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx)
+{
+    return _padic_radix_exp_wrapper(res, x, 2, ctx);
+}
+

--- a/src/padic_radix/exp_balanced.c
+++ b/src/padic_radix/exp_balanced.c
@@ -1,0 +1,473 @@
+/*
+    Copyright (C) 2012 Sebastian Pancratz
+    Copyright (C) 2012, 2014, 2022, 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "ulong_extras.h"
+#include "fmpz.h"
+#include "arb/impl.h"
+#include "padic_radix.h"
+#include "gr.h"
+
+/*
+    Port of padic_exp_balanced (src/padic/exp_balanced.c) to the padic_radix
+    module, with the multiprecision arithmetic carried out in radix_integer_t.
+
+    The input is split additively at the digit boundaries p, p^2, p^4, p^8, ...
+    (blocks covering the digit ranges [0,2), [2,4), [4,8), ...) and exp is the
+    product of the pieces,
+
+        exp(x) = prod_i exp(r_i),   x = sum_i r_i  (mod p^N).
+
+    The exact cut sequence is a tuning factor; only the block extraction would
+    change to retune it.
+
+    Each exp(r_i) is evaluated by binary splitting of its Taylor series.  A block
+    at digit valuation w has only n = O((N - w)/w) surviving terms, and the
+    series evaluation exploits that valuation directly: writing r = p^w ru with
+    ru a unit, binary splitting runs on ru while the geometric factor p^w is
+    tracked as a digit shift, so a block's working precision is only (N - w) plus
+    a small guard.
+
+    The binary splitting uses the power-table scheme of _arb_exp_sum_bs_powtab:
+    only (T, Q) are threaded through the tree, while the powers ru^step needed by
+    the merges (step = (b-a)/2) are precomputed once into a table.  This avoids
+    recomputing repeated powers and never forms the unused top-level power.
+*/
+
+/* res = digits [a, b) of x, shifted down to position 0
+   (= floor(|x| / p^a) mod p^{b-a}), as a nonnegative residue.  Requires
+   0 <= a <= b.  Used to pull a block out of the argument without first
+   materialising its low zero digits. */
+static void
+_radix_integer_slice_digits(radix_integer_t res, const radix_integer_t x,
+    slong a, slong b, const radix_t radix)
+{
+    radix_integer_mod_digits(res, x, b, radix);
+    if (a > 0)
+        radix_integer_rshift_digits(res, res, a, radix);
+}
+
+/* For 2 <= b - a < this bound, and when x = p^vr ru fits in a single limb, the
+   binary-splitting leaf is evaluated by an iterative mpn accumulation (below)
+   rather than by recursion.  Tuning parameter. */
+#define PADIC_RADIX_EXP_BSPLIT_BASECASE 64
+#define PADIC_RADIX_EXP_BC_LIMBS (2 * PADIC_RADIX_EXP_BSPLIT_BASECASE + 4)
+
+/* Digit width of the smallest block, i.e. the last (lowest-valuation) series
+   evaluated in the reverse-order accumulation.  Must be a power of two. */
+#define PADIC_RADIX_EXP_SMALLEST_BLOCK 4
+
+/*
+    Iterative basecase for x = p^vr ru that fits in a single limb (so xl = x and
+    ru_l = ru are single limbs).  Computes the unit-factored (Tu, Q) for the
+    interval [a, b) by accumulating in plain mpn limbs and converting to radix
+    once at the end -- the same technique as the e binary splitting in
+    radix/profile/p-constants.c.
+
+    With U = sum_{j=0}^{b-a-1} (b-1)!/(a+j)! * x^j, one has Tu = ru * U, and U, Q
+    satisfy the single-limb-multiplier recurrence (Xp tracks x^{J-a})
+
+        U <- U*J + Xp,   Q <- Q*J,   Xp <- Xp*x   (J = a+1, ..., b-1),
+
+    started from U = 1, Q = a, Xp = x.  Every multiplier (J, x, ru) is one limb,
+    so mpn_mul_1 / mpn_add suffice.
+*/
+static void
+_bsplit_basecase_mpn(radix_integer_t Tu, radix_integer_t Q, slong a, slong b,
+    ulong xl, ulong ru_l, slong l, const radix_t radix)
+{
+    ulong U[PADIC_RADIX_EXP_BC_LIMBS];
+    ulong QQ[PADIC_RADIX_EXP_BC_LIMBS];
+    ulong Xp[PADIC_RADIX_EXP_BC_LIMBS];
+    slong Un, Qn, Xpn, J, need;
+    ulong hi, cy;
+    nn_ptr d;
+
+    U[0] = 1;       Un = 1;
+    QQ[0] = (ulong) a;  Qn = 1;
+    Xp[0] = xl;     Xpn = 1;
+
+    for (J = a + 1; J < b; J++)
+    {
+        /* U = U*J + Xp */
+        hi = mpn_mul_1(U, U, Un, (ulong) J);
+        U[Un] = hi; Un += (hi != 0);
+        if (Un >= Xpn)
+            cy = mpn_add(U, U, Un, Xp, Xpn);
+        else
+        {
+            cy = mpn_add(U, Xp, Xpn, U, Un);
+            Un = Xpn;
+        }
+        U[Un] = cy; Un += (cy != 0);
+
+        /* Q = Q*J */
+        hi = mpn_mul_1(QQ, QQ, Qn, (ulong) J);
+        QQ[Qn] = hi; Qn += (hi != 0);
+
+        /* Xp = Xp*x  (skip the final, unused update) */
+        if (J + 1 < b)
+        {
+            hi = mpn_mul_1(Xp, Xp, Xpn, xl);
+            Xp[Xpn] = hi; Xpn += (hi != 0);
+        }
+    }
+
+    /* Tu = ru * U */
+    hi = mpn_mul_1(U, U, Un, ru_l);
+    U[Un] = hi; Un += (hi != 0);
+
+    need = radix_set_mpn_need_alloc(Un, radix);
+    d = radix_integer_fit_limbs(Tu, need, radix);
+    Tu->size = radix_set_mpn(d, U, Un, radix);
+    radix_integer_mod_limbs(Tu, Tu, l, radix);
+
+    need = radix_set_mpn_need_alloc(Qn, radix);
+    d = radix_integer_fit_limbs(Q, need, radix);
+    Q->size = radix_set_mpn(d, QQ, Qn, radix);
+    radix_integer_mod_limbs(Q, Q, l, radix);
+}
+
+/*
+    Binary splitting of sum_{i=a}^{b-1} x^i / i! with x = p^vr ru, returning the
+    unit-factored (Tu, Q): Q = (b-1)!/(a-1)! and Tu = T / p^vr, where T is the
+    upstream numerator (T has valuation >= vr).  All reduced modulo B^l.  The
+    merge
+
+        Tu = Tu_L Q_R + p^{vr*step} (ru^step) Tu_R,   step = (b-a)/2,
+
+    reads ru^step from the precomputed table xpow; the second term is skipped
+    once the shift reaches the working precision.  P is never threaded.
+*/
+static void
+_bsplit(radix_integer_t Tu, radix_integer_t Q, slong a, slong b,
+    const slong * xexp, const radix_integer_struct * xpow, slong vr, slong l,
+    ulong xl, ulong ru_l, int xl_fits, const radix_t radix)
+{
+    slong e = radix->exp;
+
+    if (xl_fits && (b - a) < PADIC_RADIX_EXP_BSPLIT_BASECASE)
+    {
+        /* 1 <= b - a < tuning, and x fits in a limb: iterative mpn leaf.  This
+           also covers b - a == 1 (the loop is then empty, giving Tu = ru), so
+           the power table is never consulted along this path. */
+        _bsplit_basecase_mpn(Tu, Q, a, b, xl, ru_l, l, radix);
+    }
+    else if (b - a == 1)
+    {
+        radix_integer_set(Tu, xpow + 0, radix);         /* ru^1 */
+        radix_integer_set_ui(Q, (ulong) a, radix);
+    }
+    else if (b - a == 2)
+    {
+        slong i2 = _arb_get_exp_pos(xexp, 2);
+        radix_integer_t tmp;
+        radix_integer_init(tmp, radix);
+
+        /* Tu = ru*(a+1) + p^vr * ru^2 */
+        radix_integer_set_ui(tmp, (ulong) (a + 1), radix);
+        radix_integer_mullow_limbs(Tu, xpow + 0, tmp, l, radix);
+        radix_integer_lshift_digits(tmp, xpow + i2, vr, radix);
+        radix_integer_mod_limbs(tmp, tmp, l, radix);
+        radix_integer_add(Tu, Tu, tmp, radix);
+        radix_integer_mod_limbs(Tu, Tu, l, radix);
+
+        /* Q = a(a+1) */
+        radix_integer_set_ui(Q, (ulong) a, radix);
+        radix_integer_set_ui(tmp, (ulong) (a + 1), radix);
+        radix_integer_mullow_limbs(Q, Q, tmp, l, radix);
+
+        radix_integer_clear(tmp, radix);
+    }
+    else
+    {
+        slong step = (b - a) / 2;
+        slong m = a + step;
+        slong el = e * l;
+        slong shift;
+        int include;
+        radix_integer_t TuR, QR, t2;
+
+        radix_integer_init(TuR, radix);
+        radix_integer_init(QR, radix);
+        radix_integer_init(t2, radix);
+
+        _bsplit(Tu, Q, a, m, xexp, xpow, vr, l, xl, ru_l, xl_fits, radix);
+        _bsplit(TuR, QR, m, b, xexp, xpow, vr, l, xl, ru_l, xl_fits, radix);
+
+        /* Tu = Tu*QR + p^{vr*step} * ru^step * TuR */
+        radix_integer_mullow_limbs(Tu, Tu, QR, l, radix);
+
+        if (step != 0 && vr > el / step)
+            include = 0;
+        else
+        {
+            shift = vr * step;
+            include = (shift < el);
+        }
+
+        if (include)
+        {
+            slong is = _arb_get_exp_pos(xexp, step);
+            radix_integer_mullow_limbs(t2, xpow + is, TuR, l, radix);
+            radix_integer_lshift_digits(t2, t2, shift, radix);
+            radix_integer_mod_limbs(t2, t2, l, radix);
+            radix_integer_add(Tu, Tu, t2, radix);
+            radix_integer_mod_limbs(Tu, Tu, l, radix);
+        }
+
+        radix_integer_mullow_limbs(Q, Q, QR, l, radix);
+
+        radix_integer_clear(TuR, radix);
+        radix_integer_clear(QR, radix);
+        radix_integer_clear(t2, radix);
+    }
+}
+
+/* exp(p^voff * s) = pnum / pden modulo p^N, where s is the slice of block
+   digits already shifted down to position 0 and voff is the digit offset of the
+   block within the argument (so the block value is p^voff * s).  Both pnum and
+   pden are returned as units (the common power of p stripped).  Requires s != 0
+   and that exp converges at the block.  Caller divides the accumulated products
+   once at the end. */
+static void
+_bsplit_block_numden(radix_integer_t pnum, radix_integer_t pden,
+    const radix_integer_t s, slong voff, slong N, const radix_t radix)
+{
+    ulong p = DIGIT_RADIX(radix);
+    slong e = radix->exp;
+    slong vs, vr, n, k, l, w, length, i;
+    slong * xexp;
+    radix_integer_struct * xpow;
+    radix_integer_t ru, Q, Tu;
+    ulong xl = 0, ru_l = 0;
+    int xl_fits, use_table;
+
+    vs = radix_integer_valuation_digits(s, radix);    /* valuation within slice */
+    vr = voff + vs;                                   /* true block valuation */
+    if (vr >= N)
+    {
+        radix_integer_one(pnum, radix);
+        radix_integer_one(pden, radix);
+        return;
+    }
+
+    n = _padic_radix_exp_bound(vr, N, p);
+    if (n == 1)
+    {
+        radix_integer_one(pnum, radix);
+        radix_integer_one(pden, radix);
+        return;
+    }
+
+    k = (n >= 2) ? (n - 2) / (slong) (p - 1) : 0;     /* guard >= v_p((n-1)!) */
+    /* Deferred division: the numerator and denominator are needed to the full
+       target precision (not just the N - vr relevant for a divided block), so
+       work to N + k digits. */
+    l = (N + k + e - 1) / e;
+
+    radix_integer_init(ru, radix);
+    radix_integer_init(Q, radix);
+    radix_integer_init(Tu, radix);
+
+    radix_integer_rshift_digits(ru, s, vs, radix);    /* unit part of the block */
+    radix_integer_mod_limbs(ru, ru, l, radix);
+
+    /* The block value p^vr * ru fits in a single radix limb exactly when
+       vr < e and the unit is below p^{e-vr}; then both the block value xl and
+       the unit ru_l are single limbs and the iterative mpn basecase can be used
+       for the small splitting leaves. */
+    ru_l = (ru->size == 0) ? 0 : ru->d[0];
+    xl_fits = (FLINT_ABS(ru->size) <= 1) && (vr < e) && (ru_l < radix->bpow[e - vr]);
+    if (xl_fits)
+        xl = radix->bpow[vr] * ru_l;                  /* block value, < B */
+    else
+        ru_l = 0;
+
+    /* When the block fits in a limb and the whole series [1, n) is shorter than
+       the basecase threshold, _bsplit takes the iterative leaf immediately and
+       never consults the power table, so we skip building it entirely. */
+    use_table = !(xl_fits && (n - 1) < PADIC_RADIX_EXP_BSPLIT_BASECASE);
+
+    xexp = NULL;
+    xpow = NULL;
+    length = 0;
+
+    if (use_table)
+    {
+        /* Power table ru^xexp[i] for the binary splitting over [1, n) (width n-1). */
+        xexp = flint_calloc(2 * FLINT_BITS, sizeof(slong));
+        length = _arb_compute_bs_exponents(xexp, n - 1);
+        xpow = flint_malloc(sizeof(radix_integer_struct) * length);
+        for (i = 0; i < length; i++)
+            radix_integer_init(xpow + i, radix);
+
+        radix_integer_set(xpow + 0, ru, radix);           /* ru^1 */
+        for (i = 1; i < length; i++)
+        {
+            if (xexp[i] == 2 * xexp[i - 1])
+                radix_integer_mullow_limbs(xpow + i, xpow + i - 1, xpow + i - 1, l, radix);
+            else if (xexp[i] == 2 * xexp[i - 2])
+                radix_integer_mullow_limbs(xpow + i, xpow + i - 2, xpow + i - 2, l, radix);
+            else if (xexp[i] == 2 * xexp[i - 1] + 1)
+            {
+                radix_integer_mullow_limbs(xpow + i, xpow + i - 1, xpow + i - 1, l, radix);
+                radix_integer_mullow_limbs(xpow + i, xpow + i, ru, l, radix);
+            }
+            else if (xexp[i] == 2 * xexp[i - 2] + 1)
+            {
+                radix_integer_mullow_limbs(xpow + i, xpow + i - 2, xpow + i - 2, l, radix);
+                radix_integer_mullow_limbs(xpow + i, xpow + i, ru, l, radix);
+            }
+            else
+                flint_throw(FLINT_ERROR, "padic_radix exp: power table malformed\n");
+        }
+    }
+
+    _bsplit(Tu, Q, 1, n, xexp, xpow, vr, l, xl, ru_l, xl_fits, radix);
+
+    /* Strip the common power of p (= v_p(Q) = v_p(Tu)) so that the numerator
+       Q + p^vr Tu and denominator Q are returned as units. */
+    w = radix_integer_valuation_digits(Tu, radix);
+    if (w > 0)
+    {
+        radix_integer_rshift_digits(Tu, Tu, w, radix);
+        radix_integer_rshift_digits(Q, Q, radix_integer_valuation_digits(Q, radix), radix);
+    }
+
+    /* pden = Q (unit), pnum = Q + p^vr Tu (unit), both mod p^N */
+    radix_integer_mod_digits(pden, Q, N, radix);
+    radix_integer_lshift_digits(pnum, Tu, vr, radix);
+    radix_integer_add(pnum, pnum, Q, radix);
+    radix_integer_mod_digits(pnum, pnum, N, radix);
+
+    if (use_table)
+    {
+        for (i = 0; i < length; i++)
+            radix_integer_clear(xpow + i, radix);
+        flint_free(xpow);
+        flint_free(xexp);
+    }
+    radix_integer_clear(ru, radix);
+    radix_integer_clear(Q, radix);
+    radix_integer_clear(Tu, radix);
+}
+
+/*
+    rop = unit of exp(p^v u) modulo p^N, with u treated as an exact integer.
+
+    The result is a 1-unit (valuation 0); rop is its nonnegative residue modulo
+    p^N.  Requires v >= 1 (odd p) or v >= 2 (p = 2) and N >= 1.  Always returns
+    GR_SUCCESS (an internal invariant failure aborts via flint_throw).
+*/
+int
+_padic_radix_exp_balanced(radix_integer_t rop, const radix_integer_t u,
+    slong v, slong N, const radix_t radix)
+{
+    const slong S = PADIC_RADIX_EXP_SMALLEST_BLOCK;
+    ulong p = DIGIT_RADIX(radix);
+    slong e = radix->exp;
+    slong lN, D, jmax, j, tl, td;
+    ulong top;
+    radix_integer_t t, s, Pnum, Pden, pnum, pden;
+
+    if (N <= 0)
+    {
+        radix_integer_zero(rop, radix);
+        return GR_SUCCESS;
+    }
+
+    if (v >= N || radix_integer_is_zero(u, radix))
+    {
+        radix_integer_one(rop, radix);
+        return GR_SUCCESS;
+    }
+
+    lN = (N + e - 1) / e;
+
+    radix_integer_init(t, radix);
+
+    /* t = p^v u  (mod p^N) */
+    radix_integer_lshift_digits(t, u, v, radix);
+    radix_integer_mod_digits(t, t, N, radix);
+
+    if (t->size == 0)            /* exp of a value with valuation >= N is 1 */
+    {
+        radix_integer_one(rop, radix);
+        radix_integer_clear(t, radix);
+        return GR_SUCCESS;
+    }
+
+    /* Digit length D of t.  Blocks are [0,S), [S,2S), [2S,4S), [4S,8S), ...
+       (smallest width S, then doubling), so they need to cover [0, S*2^{jmax-1})
+       with S*2^{jmax-1} >= D. */
+    tl = FLINT_ABS(t->size);
+    top = t->d[tl - 1];
+    td = 0;
+    while (top != 0)
+    {
+        top /= p;
+        td++;
+    }
+    D = (tl - 1) * e + td;
+
+    jmax = 1;
+    while ((S << (jmax - 1)) < D)
+        jmax++;
+
+    radix_integer_init(s, radix);
+    radix_integer_init(Pnum, radix);
+    radix_integer_init(Pden, radix);
+    radix_integer_init(pnum, radix);
+    radix_integer_init(pden, radix);
+    radix_integer_one(Pnum, radix);
+    radix_integer_one(Pden, radix);
+
+    /* exp(x) = prod_j exp(block_j) = (prod_j pnum_j) / (prod_j pden_j).  Instead
+       of dividing each block by its factorial, accumulate the unit numerator
+       and denominator products and divide once.  Blocks are extracted on the
+       fly highest valuation first (j = jmax down to 1), each shifted down to
+       position 0 with the low zeros already removed; processing from the
+       smallest contributions up keeps the running product growing downward. */
+    for (j = jmax; j >= 1; j--)
+    {
+        slong a = (j == 1) ? 0 : (S << (j - 2));
+        slong b = S << (j - 1);
+
+        _radix_integer_slice_digits(s, t, a, b, radix);
+        if (s->size != 0)
+        {
+            _bsplit_block_numden(pnum, pden, s, a, N, radix);
+            radix_integer_mullow_limbs(Pnum, Pnum, pnum, lN, radix);
+            radix_integer_mullow_limbs(Pden, Pden, pden, lN, radix);
+        }
+    }
+
+    radix_integer_mod_digits(Pnum, Pnum, N, radix);
+    radix_integer_mod_digits(Pden, Pden, N, radix);
+
+    /* rop = Pnum / Pden  (mod p^N); both are units, so no stripping is needed. */
+    if (!radix_integer_divmod_limbs(rop, Pnum, Pden, lN, radix))
+        flint_throw(FLINT_ERROR, "_padic_radix_exp_balanced: denominator "
+            "product is not invertible\n");
+
+    radix_integer_mod_digits(rop, rop, N, radix);
+
+    radix_integer_clear(t, radix);
+    radix_integer_clear(s, radix);
+    radix_integer_clear(Pnum, radix);
+    radix_integer_clear(Pden, radix);
+    radix_integer_clear(pnum, radix);
+    radix_integer_clear(pden, radix);
+
+    return GR_SUCCESS;
+}
+

--- a/src/padic_radix/exp_rectangular.c
+++ b/src/padic_radix/exp_rectangular.c
@@ -276,8 +276,6 @@ _padic_radix_exp_rectangular(radix_integer_t rop, const radix_integer_t u,
         ulong carry;
         ulong cy[3];
 
-        FLINT_ASSERT(hi > lo);
-
         /* s = sum over the block of pows[hi-lo] * c, accumulated with delayed
            carries: limbs 3*t, 3*t+1, 3*t+2 of acc hold the unreduced
            contribution to limb t of s.  Each term adds pows[hi-lo][t]*c (a two

--- a/src/padic_radix/exp_rectangular.c
+++ b/src/padic_radix/exp_rectangular.c
@@ -1,0 +1,389 @@
+/*
+    Copyright (C) 2012 Sebastian Pancratz
+    Copyright (C) 2012, 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "ulong_extras.h"
+#include "fmpz.h"
+#include "padic_radix.h"
+#include "gr.h"
+#include "longlong.h"
+#include "mpn_extras.h"
+#include "nmod_poly.h"
+
+/*
+    Port of padic_exp_rectangular (src/padic/exp_rectangular.c) to the
+    padic_radix module.
+
+    The series
+
+        exp(x) = sum_{i=0}^{n-1} x^i / i!,   x = p^v u,
+
+    is evaluated by rectangular splitting.  All of the heavy arithmetic is
+    done in fixed point with radix_integer_t, working modulo (p^e)^l = B^l,
+    where l is the minimal limb precision required to reach the working digit
+    precision.  Reciprocals of the factorials are deferred: the splitting
+    builds an integer numerator S together with a denominator F (a running
+    product of the integers being divided out), both modulo B^l, and a single
+    Hensel inversion of F recovers the unit at the end.
+
+    The working digit precision is N + k, where k bounds v_p((n-1)!) (the
+    p-adic valuation of the denominator that is divided out).  Carrying these k
+    guard digits is purely internal: the answer is returned modulo p^N, and the
+    caller's input only needs to be known to N digits.
+*/
+
+/* exp_factab[m][i] = m!/i! for 0 <= i <= m for factorials that fit a
+   limb: 20! < 2^64 and 12! < 2^32. */
+
+#if FLINT_BITS == 64
+#define EXP_FACTAB_MAXM 20
+static const ulong exp_factab[EXP_FACTAB_MAXM + 1][EXP_FACTAB_MAXM + 1] = {
+    { UWORD(1), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+    { UWORD(1), UWORD(1), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+    { UWORD(2), UWORD(2), UWORD(1), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+    { UWORD(6), UWORD(6), UWORD(3), UWORD(1), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+    { UWORD(24), UWORD(24), UWORD(12), UWORD(4), UWORD(1), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+    { UWORD(120), UWORD(120), UWORD(60), UWORD(20), UWORD(5), UWORD(1), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+    { UWORD(720), UWORD(720), UWORD(360), UWORD(120), UWORD(30), UWORD(6), UWORD(1), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+    { UWORD(5040), UWORD(5040), UWORD(2520), UWORD(840), UWORD(210), UWORD(42), UWORD(7), UWORD(1), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+    { UWORD(40320), UWORD(40320), UWORD(20160), UWORD(6720), UWORD(1680), UWORD(336), UWORD(56), UWORD(8), UWORD(1), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+    { UWORD(362880), UWORD(362880), UWORD(181440), UWORD(60480), UWORD(15120), UWORD(3024), UWORD(504), UWORD(72), UWORD(9), UWORD(1), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+    { UWORD(3628800), UWORD(3628800), UWORD(1814400), UWORD(604800), UWORD(151200), UWORD(30240), UWORD(5040), UWORD(720), UWORD(90), UWORD(10), UWORD(1), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+    { UWORD(39916800), UWORD(39916800), UWORD(19958400), UWORD(6652800), UWORD(1663200), UWORD(332640), UWORD(55440), UWORD(7920), UWORD(990), UWORD(110), UWORD(11), UWORD(1), 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+    { UWORD(479001600), UWORD(479001600), UWORD(239500800), UWORD(79833600), UWORD(19958400), UWORD(3991680), UWORD(665280), UWORD(95040), UWORD(11880), UWORD(1320), UWORD(132), UWORD(12), UWORD(1), 0, 0, 0, 0, 0, 0, 0, 0 },
+    { UWORD(6227020800), UWORD(6227020800), UWORD(3113510400), UWORD(1037836800), UWORD(259459200), UWORD(51891840), UWORD(8648640), UWORD(1235520), UWORD(154440), UWORD(17160), UWORD(1716), UWORD(156), UWORD(13), UWORD(1), 0, 0, 0, 0, 0, 0, 0 },
+    { UWORD(87178291200), UWORD(87178291200), UWORD(43589145600), UWORD(14529715200), UWORD(3632428800), UWORD(726485760), UWORD(121080960), UWORD(17297280), UWORD(2162160), UWORD(240240), UWORD(24024), UWORD(2184), UWORD(182), UWORD(14), UWORD(1), 0, 0, 0, 0, 0, 0 },
+    { UWORD(1307674368000), UWORD(1307674368000), UWORD(653837184000), UWORD(217945728000), UWORD(54486432000), UWORD(10897286400), UWORD(1816214400), UWORD(259459200), UWORD(32432400), UWORD(3603600), UWORD(360360), UWORD(32760), UWORD(2730), UWORD(210), UWORD(15), UWORD(1), 0, 0, 0, 0, 0 },
+    { UWORD(20922789888000), UWORD(20922789888000), UWORD(10461394944000), UWORD(3487131648000), UWORD(871782912000), UWORD(174356582400), UWORD(29059430400), UWORD(4151347200), UWORD(518918400), UWORD(57657600), UWORD(5765760), UWORD(524160), UWORD(43680), UWORD(3360), UWORD(240), UWORD(16), UWORD(1), 0, 0, 0, 0 },
+    { UWORD(355687428096000), UWORD(355687428096000), UWORD(177843714048000), UWORD(59281238016000), UWORD(14820309504000), UWORD(2964061900800), UWORD(494010316800), UWORD(70572902400), UWORD(8821612800), UWORD(980179200), UWORD(98017920), UWORD(8910720), UWORD(742560), UWORD(57120), UWORD(4080), UWORD(272), UWORD(17), UWORD(1), 0, 0, 0 },
+    { UWORD(6402373705728000), UWORD(6402373705728000), UWORD(3201186852864000), UWORD(1067062284288000), UWORD(266765571072000), UWORD(53353114214400), UWORD(8892185702400), UWORD(1270312243200), UWORD(158789030400), UWORD(17643225600), UWORD(1764322560), UWORD(160392960), UWORD(13366080), UWORD(1028160), UWORD(73440), UWORD(4896), UWORD(306), UWORD(18), UWORD(1), 0, 0 },
+    { UWORD(121645100408832000), UWORD(121645100408832000), UWORD(60822550204416000), UWORD(20274183401472000), UWORD(5068545850368000), UWORD(1013709170073600), UWORD(168951528345600), UWORD(24135932620800), UWORD(3016991577600), UWORD(335221286400), UWORD(33522128640), UWORD(3047466240), UWORD(253955520), UWORD(19535040), UWORD(1395360), UWORD(93024), UWORD(5814), UWORD(342), UWORD(19), UWORD(1), 0 },
+    { UWORD(2432902008176640000), UWORD(2432902008176640000), UWORD(1216451004088320000), UWORD(405483668029440000), UWORD(101370917007360000), UWORD(20274183401472000), UWORD(3379030566912000), UWORD(482718652416000), UWORD(60339831552000), UWORD(6704425728000), UWORD(670442572800), UWORD(60949324800), UWORD(5079110400), UWORD(390700800), UWORD(27907200), UWORD(1860480), UWORD(116280), UWORD(6840), UWORD(380), UWORD(20), UWORD(1) },
+};
+#else
+#define EXP_FACTAB_MAXM 12
+static const ulong exp_factab[EXP_FACTAB_MAXM + 1][EXP_FACTAB_MAXM + 1] = {
+    { UWORD(1), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+    { UWORD(1), UWORD(1), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+    { UWORD(2), UWORD(2), UWORD(1), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+    { UWORD(6), UWORD(6), UWORD(3), UWORD(1), 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+    { UWORD(24), UWORD(24), UWORD(12), UWORD(4), UWORD(1), 0, 0, 0, 0, 0, 0, 0, 0 },
+    { UWORD(120), UWORD(120), UWORD(60), UWORD(20), UWORD(5), UWORD(1), 0, 0, 0, 0, 0, 0, 0 },
+    { UWORD(720), UWORD(720), UWORD(360), UWORD(120), UWORD(30), UWORD(6), UWORD(1), 0, 0, 0, 0, 0, 0 },
+    { UWORD(5040), UWORD(5040), UWORD(2520), UWORD(840), UWORD(210), UWORD(42), UWORD(7), UWORD(1), 0, 0, 0, 0, 0 },
+    { UWORD(40320), UWORD(40320), UWORD(20160), UWORD(6720), UWORD(1680), UWORD(336), UWORD(56), UWORD(8), UWORD(1), 0, 0, 0, 0 },
+    { UWORD(362880), UWORD(362880), UWORD(181440), UWORD(60480), UWORD(15120), UWORD(3024), UWORD(504), UWORD(72), UWORD(9), UWORD(1), 0, 0, 0 },
+    { UWORD(3628800), UWORD(3628800), UWORD(1814400), UWORD(604800), UWORD(151200), UWORD(30240), UWORD(5040), UWORD(720), UWORD(90), UWORD(10), UWORD(1), 0, 0 },
+    { UWORD(39916800), UWORD(39916800), UWORD(19958400), UWORD(6652800), UWORD(1663200), UWORD(332640), UWORD(55440), UWORD(7920), UWORD(990), UWORD(110), UWORD(11), UWORD(1), 0 },
+    { UWORD(479001600), UWORD(479001600), UWORD(239500800), UWORD(79833600), UWORD(19958400), UWORD(3991680), UWORD(665280), UWORD(95040), UWORD(11880), UWORD(1320), UWORD(132), UWORD(12), UWORD(1) },
+};
+#endif
+
+/* p-adic valuation in digits of a nonnegative radix array; 0 when a == 0. */
+static slong
+_radix_array_valuation_digits(nn_srcptr a, slong n, const radix_t radix)
+{
+    slong j = 0;
+
+    while (j < n && a[j] == 0)
+        j++;
+
+    if (j == n)
+        return 0;
+
+    return j * radix->exp + (slong) _radix_valuation_digits_1(a[j], radix);
+}
+
+/*
+    rop = unit of exp(p^v u) modulo p^N, with u treated as an exact integer.
+
+    The result is a 1-unit (valuation 0); rop is its nonnegative residue modulo
+    p^N.  Requires v >= 1 (odd p) or v >= 2 (p = 2) and N >= 1.  Returns
+    GR_SUCCESS, or GR_UNABLE only on the (degenerate) failure of the final
+    inversion.
+*/
+int
+_padic_radix_exp_rectangular(radix_integer_t rop, const radix_integer_t u,
+    slong v, slong N, const radix_t radix)
+{
+    ulong p = DIGIT_RADIX(radix);
+    ulong B = LIMB_RADIX(radix);
+    nmod_t Bmod = radix->B;
+    slong e = radix->exp;
+    slong n, k, M, l, lN, npows, npows_fit, nsums, i, j;
+    slong fn, w;
+    ulong nm1, c;
+    nn_ptr scratch, x, s, summ, tmp, f, acc;
+    nn_ptr * pows;
+    radix_integer_t xi, summ_ri, f_ri;
+
+    if (N <= 0)
+    {
+        radix_integer_zero(rop, radix);
+        return GR_SUCCESS;
+    }
+
+    if (v >= N || radix_integer_is_zero(u, radix))
+    {
+        radix_integer_one(rop, radix);
+        return GR_SUCCESS;
+    }
+
+    n = _padic_radix_exp_bound(v, N, p);
+
+    /* k >= v_p((n-1)!): guard digits divided out at the end.  Using the bound
+       (n-2)/(p-1) >= ((n-1) - s_p(n-1))/(p-1) = v_p((n-1)!). */
+    k = (n >= 2) ? (n - 2) / (slong) (p - 1) : 0;
+
+    M = N + k;                       /* working digit precision */
+    l = (M + e - 1) / e;             /* minimal limb precision: l = ceil(M/e) */
+    lN = (N + e - 1) / e;            /* limbs covering the target precision N */
+
+    /* Fast path for the smallest precisions: a single limb of working precision
+       and a denominator (n-1)! that fits the limb radix. Then the whole series
+       numerator is one Horner evaluation of the table row against x mod B, the
+       row's first entry is (n-1)!, and one inversion + multiplication finishes. */
+    if (l == 1 && n - 1 <= EXP_FACTAB_MAXM)
+    {
+        const ulong * row = exp_factab[n - 1];     /* coefficients (n-1)!/i! */
+        ulong den = row[0];                        /* (n-1)! */
+
+        if (den < B)
+        {
+            ulong xl, num, den_u, num_u, dinv, res;
+            ulong mag0, ulo;
+
+            /* x = p^v u  (mod B), nonnegative single limb */
+            mag0 = (u->size == 0) ? 0 : u->d[0];           /* |u| mod B */
+            ulo = (u->size >= 0) ? mag0 : (mag0 == 0 ? 0 : B - mag0);
+            xl = (v >= e) ? 0 : nmod_mul(ulo, radix->bpow[v], Bmod);
+
+            /* numerator = sum_i (n-1)!/i! * x^i   (mod B) */
+            num = _nmod_poly_evaluate_nmod(row, n, xl, Bmod);
+
+            /* Strip the common p-power (= v_p((n-1)!) = v_p(num)) from both. */
+            if (p == 2)
+            {
+                w = flint_ctz(num);
+                num_u = num >> w;
+                den_u = den >> w;
+            }
+            else
+            {
+                w = (slong) _radix_valuation_digits_1(num, radix);
+                num_u = num * radix->bpow_oddinv[w].a;
+                den_u = den * radix->bpow_oddinv[w].a;
+            }
+
+            if (!radix_invmod_bn(&dinv, &den_u, 1, 1, radix))
+                flint_abort();
+
+            res = nmod_mul(num_u, dinv, Bmod);   /* exp unit (mod B) */
+            res = res % radix->bpow[N];          /* reduce to N digits (N <= e) */
+
+            radix_integer_set_ui(rop, res, radix);
+            return GR_SUCCESS;
+        }
+    }
+
+    /* Choose npows so that a whole block factorial (a product of up to npows of
+       the series indices, each < n) fits in a single radix limb: then the
+       coefficient recurrence is plain ulong arithmetic and every multiplication
+       by c is a radix_mul_1.  npows_fit is the largest m with (n-1)^m < B.  If
+       even one index can reach B (n - 1 >= B) no such m >= 1 exists; we decline
+       and let the balanced algorithm handle it. */
+    nm1 = (ulong) (n - 1);
+    if (nm1 <= 1)
+    {
+        npows_fit = n;               /* factors are 0/1: never overflow */
+    }
+    else
+    {
+        ulong prod = 1, hh, ll;
+        npows_fit = 0;
+        for (;;)
+        {
+            umul_ppmm(hh, ll, prod, nm1);
+            if (hh != 0 || ll >= B)
+                break;
+            prod = ll;
+            npows_fit++;
+        }
+    }
+
+    if (npows_fit < 1)
+        return GR_UNABLE;
+
+    npows = (slong) n_sqrt((ulong) n);
+    if (npows < 1)
+        npows = 1;
+    if (npows > npows_fit)
+        npows = npows_fit;
+    nsums = (n + npows - 1) / npows;
+
+    /* One allocation for every multi-limb temporary: x, s, summ, tmp, f, the
+       power table pows[0..npows] (each l limbs), and the 3-words-per-limb
+       delayed-carry accumulator acc (3*l limbs). */
+    scratch = flint_malloc(sizeof(ulong) * (npows + 9) * (size_t) l);
+    x    = scratch + (slong) 0 * l;
+    s    = scratch + (slong) 1 * l;
+    summ = scratch + (slong) 2 * l;
+    tmp  = scratch + (slong) 3 * l;
+    f    = scratch + (slong) 4 * l;
+    pows = flint_malloc(sizeof(nn_ptr) * (npows + 1));
+    for (i = 0; i <= npows; i++)
+        pows[i] = scratch + (slong) (5 + i) * l;
+    acc  = scratch + (slong) (npows + 6) * l;
+
+    /* x = p^v u  (mod B^l), as a nonnegative residue, copied into the array. */
+    radix_integer_init(xi, radix);
+    radix_integer_mod_digits(xi, u, e * l, radix);
+    radix_integer_lshift_digits(xi, xi, v, radix);
+    radix_integer_mod_limbs(xi, xi, l, radix);
+    for (i = 0; i < l; i++)
+        x[i] = (i < xi->size) ? xi->d[i] : 0;
+    radix_integer_clear(xi, radix);
+
+    /* pows[i] = x^i  (mod B^l),  i = 0, ..., npows */
+    for (i = 0; i < l; i++)
+        pows[0][i] = 0;
+    pows[0][0] = 1;
+    flint_mpn_copyi(pows[1], x, l);
+    for (i = 2; i <= npows; i++)
+        radix_mulmid(pows[i], pows[i - 1], l, pows[1], l, 0, l, radix);
+
+    /* Horner over blocks of npows terms; summ is the numerator, f the running
+       denominator, both modulo B^l.  f is kept to its used length fn. */
+    for (i = 0; i < l; i++)
+        summ[i] = 0;
+    for (i = 0; i < l; i++)
+        f[i] = 0;
+    f[0] = 1;
+    fn = 1;
+
+    for (i = nsums - 1; i >= 0; i--)
+    {
+        slong lo = i * npows;
+        slong hi = FLINT_MIN(n - 1, lo + npows - 1);
+        ulong carry;
+        ulong cy[3];
+
+        FLINT_ASSERT(hi > lo);
+
+        /* s = sum over the block of pows[hi-lo] * c, accumulated with delayed
+           carries: limbs 3*t, 3*t+1, 3*t+2 of acc hold the unreduced
+           contribution to limb t of s.  Each term adds pows[hi-lo][t]*c (a two
+           word product) into the three accumulator words for slot t. */
+        for (j = 0; j < 3 * l; j++)
+        {
+            acc[j] = 0;
+        }
+        c = 1;
+
+        for ( ; hi >= lo; hi--)
+        {
+            nn_srcptr pj = pows[hi - lo];
+
+            for (j = 0; j < l; j++)
+            {
+                ulong phi, plo;
+                umul_ppmm(phi, plo, pj[j], c);
+                add_sssaaaaaa(acc[3 * j + 2], acc[3 * j + 1], acc[3 * j],
+                              acc[3 * j + 2], acc[3 * j + 1], acc[3 * j],
+                              (ulong) 0, phi, plo);
+            }
+
+            if (hi != 0)
+                c *= (ulong) hi;       /* stays < B by the npows constraint */
+        }
+
+        /* Reconstruct s by carry-propagating acc and reducing mod B, keeping the
+           low l limbs (mod B^l); the carry past limb l is discarded. */
+        cy[0] = cy[1] = cy[2] = 0;
+        if (Bmod.norm == 0)
+        {
+            for (j = 0; j < l; j++)
+            {
+                add_sssaaaaaa(cy[2], cy[1], cy[0], cy[2], cy[1], cy[0],
+                              acc[3 * j + 2], acc[3 * j + 1], acc[3 * j]);
+                s[j] = flint_mpn_divrem_3_1_preinv_norm(cy, cy, Bmod.n, Bmod.ninv);
+            }
+        }
+        else
+        {
+            for (j = 0; j < l; j++)
+            {
+                add_sssaaaaaa(cy[2], cy[1], cy[0], cy[2], cy[1], cy[0],
+                              acc[3 * j + 2], acc[3 * j + 1], acc[3 * j]);
+                s[j] = flint_mpn_divrem_3_1_preinv_unnorm(cy, cy, Bmod.n, Bmod.ninv, Bmod.norm);
+            }
+        }
+
+        /* summ = s * f + pows[npows] * summ   (mod B^l) */
+        radix_mulmid(tmp, pows[npows], l, summ, l, 0, l, radix);
+        radix_mulmid(summ, s, l, f, fn, 0, l, radix);
+        radix_add(summ, summ, l, tmp, l, radix);
+
+        /* f *= c   (in place; grow the used length by the carry limb) */
+        carry = radix_mul_1(f, f, fn, c, radix);
+        if (fn < l && carry != 0)
+        {
+            f[fn] = carry;
+            fn++;
+        }
+    }
+
+    flint_free(pows);
+
+    /* Divide out the factorial. Since exp is a unit, v_p(summ) = v_p(f); strip
+       the common power of p from each, then form summ / f modulo p^N. */
+    {
+        nn_ptr sp = summ, fp = f;
+        slong slen = l, flen = l;
+
+        w = _radix_array_valuation_digits(summ, l, radix);
+        if (w > 0)
+        {
+            slong wf = _radix_array_valuation_digits(f, l, radix);
+            slong wl, wr;
+
+            wl = w / e;  wr = w % e;
+            sp = summ + wl;  slen = l - wl;
+            if (wr > 0)
+                radix_rshift_digits(sp, sp, slen, (unsigned int) wr, radix);
+
+            wl = wf / e; wr = wf % e;
+            fp = f + wl;  flen = l - wl;
+            if (wr > 0)
+                radix_rshift_digits(fp, fp, flen, (unsigned int) wr, radix);
+        }
+
+        while (slen > 0 && sp[slen - 1] == 0)
+            slen--;
+        while (flen > 0 && fp[flen - 1] == 0)
+            flen--;
+
+        summ_ri->d = sp;  summ_ri->size = slen;  summ_ri->alloc = l - (slong) (sp - summ);
+        f_ri->d    = fp;  f_ri->size    = flen;  f_ri->alloc    = l - (slong) (fp - f);
+
+        /* rop = summ / f  (mod p^N) */
+        if (!radix_integer_divmod_limbs(rop, summ_ri, f_ri, lN, radix))
+            flint_throw(FLINT_ERROR, "_padic_radix_exp_rectangular: "
+                "factorial denominator is not invertible after stripping\n");
+    }
+
+    radix_integer_mod_digits(rop, rop, N, radix);
+
+    flint_free(scratch);
+
+    return GR_SUCCESS;
+}
+

--- a/src/padic_radix/padic.c
+++ b/src/padic_radix/padic.c
@@ -18,52 +18,6 @@
 /*    Internal helpers                                                       */
 /* ------------------------------------------------------------------------- */
 
-/* Normalise a limb array length. */
-static slong
-_norm(nn_srcptr d, slong n)
-{
-    while (n > 0 && d[n - 1] == 0)
-        n--;
-    return n;
-}
-
-/*
-    res = (nonnegative residue of x) mod p^k, as a radix_integer with digit
-    range [0, k). Built from a limb-level modulo plus a partial reduction of
-    the top limb. Handles negative x (the residue is the nonnegative
-    representative in [0, p^k)).
-*/
-static void
-radix_integer_mod_digits_nonneg(radix_integer_t res, const radix_integer_t x,
-    slong k, const radix_t radix)
-{
-    slong e = radix->exp;
-    slong limbs, rem, tot;
-
-    if (k <= 0)
-    {
-        radix_integer_zero(res, radix);
-        return;
-    }
-
-    limbs = k / e;
-    rem = k - limbs * e;       /* 0 <= rem < e */
-    tot = limbs + (rem != 0);
-
-    radix_integer_mod_limbs(res, x, tot, radix);   /* nonnegative, size <= tot */
-
-    if (rem != 0 && res->size == tot)
-    {
-        /* reduce the top limb (index `limbs`) modulo p^rem */
-        ulong top = res->d[limbs];
-        ulong m = radix->bpow[rem];
-        ulong t = n_rem_precomp(top, m, radix->bpow_div + rem);
-
-        res->d[limbs] = t;
-        res->size = _norm(res->d, tot);
-    }
-}
-
 /*
     Whether |x| < p^k (i.e. x fits in k digits), determined without counting
     digits: we only look at the limb sitting on the digit boundary and compare
@@ -174,8 +128,8 @@ _radix_units_congruent_mod(const radix_integer_t ux, const radix_integer_t uy,
     /* k is now bounded by 'content' (a few limbs); compare nonnegative residues */
     radix_integer_init(rx, radix);
     radix_integer_init(ry, radix);
-    radix_integer_mod_digits_nonneg(rx, ux, k, radix);
-    radix_integer_mod_digits_nonneg(ry, uy, k, radix);
+    radix_integer_mod_digits(rx, ux, k, radix);
+    radix_integer_mod_digits(ry, uy, k, radix);
     res = radix_integer_equal(rx, ry, radix);
     radix_integer_clear(rx, radix);
     radix_integer_clear(ry, radix);
@@ -348,7 +302,7 @@ _padic_radix_reduce(padic_radix_t x, gr_ctx_t ctx)
         return;
 
     /* otherwise the result is inexact: store the nonnegative residue */
-    radix_integer_mod_digits_nonneg(&x->u, &x->u, r, radix);
+    radix_integer_mod_digits(&x->u, &x->u, r, radix);
     if (x->u.size == 0)
         x->v = 0;
     x->N = FLINT_MIN(Neff, PADIC_RADIX_ERR_MAX);
@@ -612,7 +566,7 @@ padic_radix_neg(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx)
         }
         else
         {
-            radix_integer_mod_digits_nonneg(&res->u, &res->u, r, radix);
+            radix_integer_mod_digits(&res->u, &res->u, r, radix);
             if (res->u.size == 0)
                 res->v = 0;
         }
@@ -1570,7 +1524,7 @@ padic_radix_sqrt(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx)
     /* Materialise the unit's nonnegative residue modulo p^{e*nlimbs} (this also
        resolves a signed exact unit), then take its square root. */
     radix_integer_init(unit, radix);
-    radix_integer_mod_digits_nonneg(unit, &x->u, e * nlimbs, radix);
+    radix_integer_mod_digits(unit, &x->u, e * nlimbs, radix);
     issquare = radix_integer_sqrtmod_limbs(&res->u, unit, nlimbs, radix);
     radix_integer_clear(unit, radix);
 
@@ -1733,7 +1687,7 @@ padic_radix_rsqrt(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx)
         nlimbs = (kin + e - 1) / e;
 
     radix_integer_init(unit, radix);
-    radix_integer_mod_digits_nonneg(unit, &x->u, e * nlimbs, radix);
+    radix_integer_mod_digits(unit, &x->u, e * nlimbs, radix);
     issquare = radix_integer_rsqrtmod_limbs(&res->u, unit, nlimbs, radix);
     radix_integer_clear(unit, radix);
 
@@ -2063,6 +2017,7 @@ gr_method_tab_input _padic_radix_methods_input[] =
     {GR_METHOD_SQRT,            (gr_funcptr) padic_radix_sqrt},
     {GR_METHOD_RSQRT,           (gr_funcptr) padic_radix_rsqrt},
     {GR_METHOD_IS_SQUARE,       (gr_funcptr) padic_radix_is_square},
+    {GR_METHOD_EXP,             (gr_funcptr) padic_radix_exp},
     {GR_METHOD_VEC_DOT,         (gr_funcptr) padic_radix_dot},
     {GR_METHOD_VEC_DOT_REV,     (gr_funcptr) padic_radix_dot_rev},
     {GR_METHOD_VEC_DOT_STRIDED, (gr_funcptr) padic_radix_dot_strided},
@@ -2112,4 +2067,45 @@ gr_ctx_init_padic_radix(gr_ctx_t ctx, ulong p, slong prec_rel, slong prec_abs, i
 
     return GR_SUCCESS;
 }
+
+int
+gr_ctx_init_padic_radix_randtest(gr_ctx_t ctx, flint_rand_t state, slong maxprec)
+{
+    ulong p = n_randtest_prime(state, 0);
+    slong prec_abs, prec_rel;
+    int flags = 0;
+
+    if (n_randint(state, 2))
+        flags |= PADIC_RADIX_SIGNED;
+
+    switch (n_randint(state, 4))
+    {
+        case 0:   /* classic padic: absolute precision only */
+            prec_abs = 1 + n_randint(state, maxprec);
+            prec_rel = PADIC_RADIX_PREC_INF;
+            break;
+        case 1:   /* relative precision only */
+            prec_abs = PADIC_RADIX_PREC_INF;
+            prec_rel = 1 + n_randint(state, maxprec);
+            break;
+        case 2:   /* both */
+            prec_abs = 1 + n_randint(state, maxprec);
+            prec_rel = 1 + n_randint(state, maxprec);
+            break;
+        default:  /* exact ring */
+            prec_abs = PADIC_RADIX_PREC_INF;
+            prec_rel = PADIC_RADIX_PREC_INF;
+            break;
+    }
+
+    if (n_randint(state, 2))
+        flags |= PADIC_RADIX_TEST_LIMITS;
+
+    /* allow e.g. get_fmpz roundtrip to return unable for huge test values */
+    if (flags & PADIC_RADIX_TEST_LIMITS)
+        ctx->size_limit = (1 << 16);
+
+    return gr_ctx_init_padic_radix(ctx, p, prec_rel, prec_abs, flags);
+}
+
 

--- a/src/padic_radix/profile/p-exp.c
+++ b/src/padic_radix/profile/p-exp.c
@@ -1,0 +1,129 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdint.h>
+#include "double_extras.h"
+#include "fmpz.h"
+#include "gr.h"
+#include "profiler.h"
+#include "radix.h"
+#include "padic_radix.h"
+#include "padic.h"
+#include "nmod.h"
+
+int main()
+{
+    flint_rand_t state;
+    ulong p;
+    slong n;
+
+    flint_rand_init(state);
+    radix_t radix;
+
+    p = 7;
+
+    radix_init(radix, p, 0);
+
+    flint_printf("precision %wu^n, limb radix = %wu^%wd\n\n", p, p, radix->exp);
+
+    for (n = 10; n <= 11000000; n *= 2)
+    {
+        gr_ctx_t ctx;
+        radix_integer_t x, y;
+        padic_radix_t rx, ry;
+        padic_ctx_t pctx;
+        padic_t px, py;
+        fmpz_t fp, pn, fx, fy;
+
+        fmpz_init_set_ui(fp, p);
+        fmpz_init(pn);
+        fmpz_ui_pow_ui(pn, p, n);
+
+        padic_ctx_init(pctx, fp, n - 1, n + 1, PADIC_SERIES);
+        gr_ctx_init_padic_radix(ctx, p, n, PADIC_RADIX_PREC_INF, 0);
+
+        radix_integer_init(x, radix);
+        radix_integer_init(y, radix);
+
+        padic_init2(px, n);
+        padic_init2(py, n);
+
+        fmpz_init(fx);
+        fmpz_init(fy);
+
+        padic_radix_init(rx, ctx);
+        padic_radix_init(ry, ctx);
+
+        do
+        {
+            fmpz_randm(fx, state, pn);
+        } while (fmpz_divisible_ui(fx, p));
+
+        padic_set_fmpz(px, fx, pctx);
+        padic_shift(px, px, 1, pctx);
+
+        padic_radix_set_fmpz(rx, fx, ctx);
+        rx->N = n;
+        rx->v = 1;
+        rx->N += 1;
+
+        double t1, t2 = 0.0, t3, t4, FLINT_SET_BUT_UNUSED(__);
+
+        TIMEIT_START;
+        padic_exp(py, px, pctx);
+        TIMEIT_STOP_VALUES(__, t1);
+
+        if (n < 1000)
+        {
+            TIMEIT_START;
+            padic_radix_exp_rectangular(ry, rx, ctx);
+            TIMEIT_STOP_VALUES(__, t2);
+        }
+        else
+            t2 = D_NAN;
+
+        TIMEIT_START;
+        padic_radix_exp_balanced(ry, rx, ctx);
+        TIMEIT_STOP_VALUES(__, t3);
+
+        TIMEIT_START;
+        padic_radix_exp(ry, rx, ctx);
+        TIMEIT_STOP_VALUES(__, t4);
+
+        if (n == 10)
+            flint_printf("       n      padic     rectangular   balanced    default   speedup\n");
+
+        flint_printf("%8wd   %10g  %10g  %10g  %10g  %6.3fx\n", n, t1, t2, t3, t4, t1 / t4);
+
+        padic_radix_clear(rx, ctx);
+        padic_radix_clear(ry, ctx);
+
+        padic_clear(px);
+        padic_clear(py);
+
+        radix_integer_clear(x, radix);
+        radix_integer_clear(y, radix);
+
+        fmpz_clear(fx);
+        fmpz_clear(fy);
+
+        gr_ctx_clear(ctx);
+        padic_ctx_clear(pctx);
+
+        fmpz_clear(pn);
+        fmpz_clear(fp);
+    }
+
+    radix_clear(radix);
+    flint_rand_clear(state);
+    flint_cleanup_master();
+    return 0;
+}

--- a/src/padic_radix/test/main.c
+++ b/src/padic_radix/test/main.c
@@ -12,6 +12,9 @@
 /* Include functions *********************************************************/
 
 #include "t-dot.c"
+#include "t-exp.c"
+#include "t-exp_balanced.c"
+#include "t-exp_rectangular.c"
 #include "t-padic.c"
 
 /* Array of test functions ***************************************************/
@@ -19,6 +22,9 @@
 test_struct tests[] =
 {
     TEST_FUNCTION(padic_radix_dot),
+    TEST_FUNCTION(padic_radix_exp),
+    TEST_FUNCTION(padic_radix_exp_balanced),
+    TEST_FUNCTION(padic_radix_exp_rectangular),
     TEST_FUNCTION(padic_radix),
 };
 

--- a/src/padic_radix/test/t-exp.c
+++ b/src/padic_radix/test/t-exp.c
@@ -1,0 +1,144 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "longlong.h"
+#include "ulong_extras.h"
+#include "fmpz.h"
+#include "radix.h"
+#include "padic.h"
+#include "padic_radix.h"
+#include "gr.h"
+
+
+TEST_FUNCTION_START(padic_radix_exp, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
+    {
+        gr_ctx_t ctx;
+        padic_radix_t x, y, xy, ex, ey, exey, exy;
+        int status = GR_SUCCESS;
+
+        gr_ctx_init_padic_radix_randtest(ctx, state, n_randint(state, 4) ? 10 : 100);
+
+        padic_radix_init(x, ctx);
+        padic_radix_init(y, ctx);
+        padic_radix_init(xy, ctx);
+        padic_radix_init(ex, ctx);
+        padic_radix_init(ey, ctx);
+        padic_radix_init(exy, ctx);
+        padic_radix_init(exey, ctx);
+
+        GR_IGNORE(gr_randtest(x, state, ctx));
+        GR_IGNORE(gr_randtest(y, state, ctx));
+        status |= padic_radix_add(xy, x, y, ctx);
+        GR_IGNORE(gr_randtest(ex, state, ctx));
+
+        switch (n_randint(state, 3))
+        {
+            case 0: status |= padic_radix_exp(ex, x, ctx); break;
+            case 1: status |= padic_radix_exp_balanced(ex, x, ctx); break;
+            default: status |= padic_radix_exp(ex, x, ctx);
+        }
+
+        status |= padic_radix_set(ey, y, ctx);  /* aliasing */
+        status |= padic_radix_exp(ey, ey, ctx);
+        status |= padic_radix_exp(exy, xy, ctx);
+        status |= padic_radix_mul(exey, ex, ey, ctx);
+
+        if (status == GR_SUCCESS && padic_radix_equal(exy, exey, ctx) == T_FALSE)
+        {
+            flint_printf("FAIL: padic_radix_exp\n");
+            flint_printf("x = "); gr_println(x, ctx);
+            flint_printf("y = "); gr_println(y, ctx);
+            flint_printf("xy = "); gr_println(xy, ctx);
+            flint_printf("ex = "); gr_println(ex, ctx);
+            flint_printf("ey = "); gr_println(ey, ctx);
+            flint_printf("exy = "); gr_println(exy, ctx);
+            flint_printf("exey = "); gr_println(exey, ctx);
+            flint_abort();
+        }
+
+        padic_radix_clear(x, ctx);
+        padic_radix_clear(y, ctx);
+        padic_radix_clear(xy, ctx);
+        padic_radix_clear(ex, ctx);
+        padic_radix_clear(ey, ctx);
+        padic_radix_clear(exy, ctx);
+        padic_radix_clear(exey, ctx);
+    }
+
+    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
+    {
+        ulong p;
+        radix_t radix;
+        slong thr, v, N;
+        fmpz_t uf, pf, ref, got;
+        radix_integer_t u, g;
+        int status;
+
+        radix_init_randtest_prime(radix, state);
+        p = DIGIT_RADIX(radix);
+
+        thr = (p == 2) ? 2 : 1;
+        v = thr + (slong) n_randint(state, 6);
+        N = 1 + (slong) n_randint(state, n_randint(state, 2) ? 80 : 400);
+
+        fmpz_init(uf);
+        fmpz_init(pf);
+        fmpz_init(ref);
+        fmpz_init(got);
+        fmpz_set_ui(pf, p);
+
+        fmpz_randtest_unsigned(uf, state, 1 + n_randint(state, 500));
+        if (fmpz_is_zero(uf))
+            fmpz_one(uf);
+        if (fmpz_divisible(uf, pf))
+            fmpz_add_ui(uf, uf, 1);
+
+        radix_integer_init(u, radix);
+        radix_integer_init(g, radix);
+        radix_integer_set_fmpz(u, uf, radix);
+
+        status = _padic_radix_exp(g, u, v, N, radix);
+
+        if (status != GR_SUCCESS)
+        {
+            flint_printf("FAIL: unexpected status %d (p = %wu, e = %wu)\n", status, p, radix->exp);
+            flint_abort();
+        }
+
+        _padic_exp(ref, uf, v, pf, N);
+        radix_integer_get_fmpz(got, g, radix);
+
+        if (!fmpz_equal(ref, got))
+        {
+            flint_printf("FAIL: _padic_radix_exp vs _padic_exp\n");
+            flint_printf("p = %wu, e = %wu, v = %wd, N = %wd\n", p, radix->exp, v, N);
+            flint_printf("u = "); fmpz_print(uf); flint_printf("\n");
+            flint_printf("ref = "); fmpz_print(ref); flint_printf("\n");
+            flint_printf("got = "); fmpz_print(got); flint_printf("\n");
+            flint_abort();
+        }
+
+        radix_integer_clear(u, radix);
+        radix_integer_clear(g, radix);
+        fmpz_clear(uf);
+        fmpz_clear(pf);
+        fmpz_clear(ref);
+        fmpz_clear(got);
+        radix_clear(radix);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/padic_radix/test/t-exp.c
+++ b/src/padic_radix/test/t-exp.c
@@ -76,6 +76,8 @@ TEST_FUNCTION_START(padic_radix_exp, state)
         padic_radix_clear(ey, ctx);
         padic_radix_clear(exy, ctx);
         padic_radix_clear(exey, ctx);
+
+        gr_ctx_clear(ctx);
     }
 
     for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)

--- a/src/padic_radix/test/t-exp_balanced.c
+++ b/src/padic_radix/test/t-exp_balanced.c
@@ -70,6 +70,8 @@ TEST_FUNCTION_START(padic_radix_exp_balanced, state)
         padic_radix_clear(ey, ctx);
         padic_radix_clear(exy, ctx);
         padic_radix_clear(exey, ctx);
+
+        gr_ctx_clear(ctx);
     }
 
     for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)

--- a/src/padic_radix/test/t-exp_balanced.c
+++ b/src/padic_radix/test/t-exp_balanced.c
@@ -1,0 +1,139 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "longlong.h"
+#include "ulong_extras.h"
+#include "fmpz.h"
+#include "radix.h"
+#include "padic.h"
+#include "padic_radix.h"
+#include "gr.h"
+
+
+TEST_FUNCTION_START(padic_radix_exp_balanced, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
+    {
+        gr_ctx_t ctx;
+        padic_radix_t x, y, xy, ex, ey, exey, exy;
+        int status = GR_SUCCESS;
+
+        gr_ctx_init_padic_radix_randtest(ctx, state, n_randint(state, 4) ? 10 : 100);
+
+        padic_radix_init(x, ctx);
+        padic_radix_init(y, ctx);
+        padic_radix_init(xy, ctx);
+        padic_radix_init(ex, ctx);
+        padic_radix_init(ey, ctx);
+        padic_radix_init(exy, ctx);
+        padic_radix_init(exey, ctx);
+
+        GR_IGNORE(gr_randtest(x, state, ctx));
+        GR_IGNORE(gr_randtest(y, state, ctx));
+        status |= padic_radix_add(xy, x, y, ctx);
+        GR_IGNORE(gr_randtest(ex, state, ctx));
+
+        status |= padic_radix_exp_balanced(ex, x, ctx);
+        status |= padic_radix_set(ey, y, ctx);  /* aliasing */
+        status |= padic_radix_exp_balanced(ey, ey, ctx);
+        status |= padic_radix_exp_balanced(exy, xy, ctx);
+        status |= padic_radix_mul(exey, ex, ey, ctx);
+
+        if (status == GR_SUCCESS && padic_radix_equal(exy, exey, ctx) == T_FALSE)
+        {
+            flint_printf("FAIL: padic_radix_exp_balanced\n");
+            flint_printf("x = "); gr_println(x, ctx);
+            flint_printf("y = "); gr_println(y, ctx);
+            flint_printf("xy = "); gr_println(xy, ctx);
+            flint_printf("ex = "); gr_println(ex, ctx);
+            flint_printf("ey = "); gr_println(ey, ctx);
+            flint_printf("exy = "); gr_println(exy, ctx);
+            flint_printf("exey = "); gr_println(exey, ctx);
+            flint_abort();
+        }
+
+        padic_radix_clear(x, ctx);
+        padic_radix_clear(y, ctx);
+        padic_radix_clear(xy, ctx);
+        padic_radix_clear(ex, ctx);
+        padic_radix_clear(ey, ctx);
+        padic_radix_clear(exy, ctx);
+        padic_radix_clear(exey, ctx);
+    }
+
+    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
+    {
+        ulong p;
+        radix_t radix;
+        slong thr, v, N;
+        fmpz_t uf, pf, ref, got;
+        radix_integer_t u, g;
+        int status;
+
+        radix_init_randtest_prime(radix, state);
+        p = DIGIT_RADIX(radix);
+
+        thr = (p == 2) ? 2 : 1;
+        v = thr + (slong) n_randint(state, 6);
+        /* a wider N range so the balanced split / power table is exercised */
+        N = 1 + (slong) n_randint(state, n_randint(state, 2) ? 80 : 400);
+
+        fmpz_init(uf);
+        fmpz_init(pf);
+        fmpz_init(ref);
+        fmpz_init(got);
+        fmpz_set_ui(pf, p);
+
+        fmpz_randtest_unsigned(uf, state, 1 + n_randint(state, 500));
+        if (fmpz_is_zero(uf))
+            fmpz_one(uf);
+        if (fmpz_divisible(uf, pf))
+            fmpz_add_ui(uf, uf, 1);
+
+        radix_integer_init(u, radix);
+        radix_integer_init(g, radix);
+        radix_integer_set_fmpz(u, uf, radix);
+
+        status = _padic_radix_exp_balanced(g, u, v, N, radix);
+
+        if (status != GR_SUCCESS)
+        {
+            flint_printf("FAIL: unexpected status %d (p = %wu, e = %wu)\n", status, p, radix->exp);
+            flint_abort();
+        }
+
+        _padic_exp(ref, uf, v, pf, N);
+        radix_integer_get_fmpz(got, g, radix);
+
+        if (!fmpz_equal(ref, got))
+        {
+            flint_printf("FAIL: _padic_radix_exp_balanced vs _padic_exp\n");
+            flint_printf("p = %wu, e = %wu, v = %wd, N = %wd\n", p, radix->exp, v, N);
+            flint_printf("u = "); fmpz_print(uf); flint_printf("\n");
+            flint_printf("ref = "); fmpz_print(ref); flint_printf("\n");
+            flint_printf("got = "); fmpz_print(got); flint_printf("\n");
+            flint_abort();
+        }
+
+        radix_integer_clear(u, radix);
+        radix_integer_clear(g, radix);
+        fmpz_clear(uf);
+        fmpz_clear(pf);
+        fmpz_clear(ref);
+        fmpz_clear(got);
+        radix_clear(radix);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/padic_radix/test/t-exp_rectangular.c
+++ b/src/padic_radix/test/t-exp_rectangular.c
@@ -69,6 +69,8 @@ TEST_FUNCTION_START(padic_radix_exp_rectangular, state)
         padic_radix_clear(ey, ctx);
         padic_radix_clear(exy, ctx);
         padic_radix_clear(exey, ctx);
+
+        gr_ctx_clear(ctx);
     }
 
     for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)

--- a/src/padic_radix/test/t-exp_rectangular.c
+++ b/src/padic_radix/test/t-exp_rectangular.c
@@ -1,0 +1,142 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "longlong.h"
+#include "ulong_extras.h"
+#include "fmpz.h"
+#include "radix.h"
+#include "padic.h"
+#include "padic_radix.h"
+#include "gr.h"
+
+TEST_FUNCTION_START(padic_radix_exp_rectangular, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
+    {
+        gr_ctx_t ctx;
+        padic_radix_t x, y, xy, ex, ey, exey, exy;
+        int status = GR_SUCCESS;
+
+        gr_ctx_init_padic_radix_randtest(ctx, state, n_randint(state, 4) ? 10 : 100);
+
+        padic_radix_init(x, ctx);
+        padic_radix_init(y, ctx);
+        padic_radix_init(xy, ctx);
+        padic_radix_init(ex, ctx);
+        padic_radix_init(ey, ctx);
+        padic_radix_init(exy, ctx);
+        padic_radix_init(exey, ctx);
+
+        GR_IGNORE(gr_randtest(x, state, ctx));
+        GR_IGNORE(gr_randtest(y, state, ctx));
+        status |= padic_radix_add(xy, x, y, ctx);
+        GR_IGNORE(gr_randtest(ex, state, ctx));
+
+        status |= padic_radix_exp_rectangular(ex, x, ctx);
+        status |= padic_radix_set(ey, y, ctx);  /* aliasing */
+        status |= padic_radix_exp_rectangular(ey, ey, ctx);
+        status |= padic_radix_exp_rectangular(exy, xy, ctx);
+        status |= padic_radix_mul(exey, ex, ey, ctx);
+
+        if (status == GR_SUCCESS && padic_radix_equal(exy, exey, ctx) == T_FALSE)
+        {
+            flint_printf("FAIL: padic_radix_exp_rectangular\n");
+            flint_printf("x = "); gr_println(x, ctx);
+            flint_printf("y = "); gr_println(y, ctx);
+            flint_printf("xy = "); gr_println(xy, ctx);
+            flint_printf("ex = "); gr_println(ex, ctx);
+            flint_printf("ey = "); gr_println(ey, ctx);
+            flint_printf("exy = "); gr_println(exy, ctx);
+            flint_printf("exey = "); gr_println(exey, ctx);
+            flint_abort();
+        }
+
+        padic_radix_clear(x, ctx);
+        padic_radix_clear(y, ctx);
+        padic_radix_clear(xy, ctx);
+        padic_radix_clear(ex, ctx);
+        padic_radix_clear(ey, ctx);
+        padic_radix_clear(exy, ctx);
+        padic_radix_clear(exey, ctx);
+    }
+
+    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
+    {
+        ulong p;
+        radix_t radix;
+        slong thr, v, N;
+        fmpz_t uf, pf, ref, got;
+        radix_integer_t u, g;
+        int status;
+
+        radix_init_randtest_prime(radix, state);
+        p = DIGIT_RADIX(radix);
+
+        thr = (p == 2) ? 2 : 1;
+        v = thr + (slong) n_randint(state, 6);
+        N = 1 + (slong) n_randint(state, 80);
+
+        fmpz_init(uf);
+        fmpz_init(pf);
+        fmpz_init(ref);
+        fmpz_init(got);
+        fmpz_set_ui(pf, p);
+
+        fmpz_randtest_unsigned(uf, state, 1 + n_randint(state, 400));
+        if (fmpz_is_zero(uf))
+            fmpz_one(uf);
+        if (fmpz_divisible(uf, pf))
+            fmpz_add_ui(uf, uf, 1);
+
+        radix_integer_init(u, radix);
+        radix_integer_init(g, radix);
+        radix_integer_set_fmpz(u, uf, radix);
+
+        status = _padic_radix_exp_rectangular(g, u, v, N, radix);
+
+        if (status == GR_SUCCESS)
+        {
+            _padic_exp(ref, uf, v, pf, N);
+            radix_integer_get_fmpz(got, g, radix);
+
+            if (!fmpz_equal(ref, got))
+            {
+                flint_printf("FAIL: _padic_radix_exp_balanced vs _padic_exp\n");
+                flint_printf("p = %wu, e = %wu, v = %wd, N = %wd\n", p, radix->exp, v, N);
+                flint_printf("u = "); fmpz_print(uf); flint_printf("\n");
+                flint_printf("ref = "); fmpz_print(ref); flint_printf("\n");
+                flint_printf("got = "); fmpz_print(got); flint_printf("\n");
+                flint_abort();
+            }
+        }
+        else if (status == GR_UNABLE)
+        {
+        }
+        else
+        {
+            flint_printf("FAIL: unexpected status %d (p = %wu, e = %wu)\n", status, p, radix->exp);
+            flint_abort();
+        }
+
+        radix_integer_clear(u, radix);
+        radix_integer_clear(g, radix);
+        fmpz_clear(uf);
+        fmpz_clear(pf);
+        fmpz_clear(ref);
+        fmpz_clear(got);
+        radix_clear(radix);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/padic_radix/test/t-padic.c
+++ b/src/padic_radix/test/t-padic.c
@@ -22,41 +22,8 @@ TEST_FUNCTION_START(padic_radix, state)
     for (iter = 0; iter < 100 * flint_test_multiplier(); iter++)
     {
         gr_ctx_t ctx;
-        ulong p = n_randtest_prime(state, 0);
-        slong prec_abs, prec_rel;
-        int flags = 0;
 
-        if (n_randint(state, 2))
-            flags |= PADIC_RADIX_SIGNED;
-
-        switch (n_randint(state, 4))
-        {
-            case 0:   /* classic padic: absolute precision only */
-                prec_abs = 1 + n_randint(state, 20);
-                prec_rel = PADIC_RADIX_PREC_INF;
-                break;
-            case 1:   /* relative precision only */
-                prec_abs = PADIC_RADIX_PREC_INF;
-                prec_rel = 1 + n_randint(state, 20);
-                break;
-            case 2:   /* both */
-                prec_abs = 1 + n_randint(state, 20);
-                prec_rel = 1 + n_randint(state, 20);
-                break;
-            default:  /* exact ring */
-                prec_abs = PADIC_RADIX_PREC_INF;
-                prec_rel = PADIC_RADIX_PREC_INF;
-                break;
-        }
-
-        if (n_randint(state, 2))
-            flags |= PADIC_RADIX_TEST_LIMITS;
-
-        gr_ctx_init_padic_radix(ctx, p, prec_rel, prec_abs, flags);
-
-        /* allow get_fmpz roundtrip to return unable for huge test values */
-        if (flags & PADIC_RADIX_TEST_LIMITS)
-            ctx->size_limit = (1 << 16);
+        gr_ctx_init_padic_radix_randtest(ctx, state, 20);
 
         gr_test_ring(ctx, 30, 0);
 

--- a/src/python/flint_ctypes.py
+++ b/src/python/flint_ctypes.py
@@ -9839,15 +9839,36 @@ def test_is_vector_space():
 
 def test_padic():
     Q7 = Qp_padic_radix(7, rel_prec=10)
+    Q2 = Qp_padic_radix(2, rel_prec=10)
+
     assert str(Q7(7) * Q7(7)) == "(1) * 7^2"
     assert Q7(0).sqrt() == 0
     assert Q7(1).sqrt() == 1
     assert Q7(4).sqrt() == 2
     assert str(Q7(2).sqrt()) == "266983762 + O(7^10)"
     assert str((1/(1/Q7(4))).sqrt()) == "2 + O(7^10)"
-    assert raises(lambda: Q7(3).sqrt(), FlintDomainError)
-    assert raises(lambda: Q7(5).sqrt(), FlintDomainError)
-    assert raises(lambda: Q7(6).sqrt(), FlintDomainError)
+    assert raises(Q7(3).sqrt, FlintDomainError)
+    assert raises(Q7(5).sqrt, FlintDomainError)
+    assert raises(Q7(6).sqrt, FlintDomainError)
+
+    assert Q7(0).exp() == 1
+    assert str(Q7(7).exp()) == "182289612 + O(7^10)"
+    assert str(Q7("7 + O(7^11)").exp()) == "182289612 + O(7^10)"
+    assert str(Q7("7 + O(7^9)").exp()) == "20875184 + O(7^9)"
+    assert str(Q7("0 + O(7^2)").exp()) == "1 + O(7^2)"
+    assert str(Q7("0 + O(7^1)").exp()) == "1 + O(7^1)"
+    assert raises(Q7("0 + O(7^0)").exp, FlintUnableError)
+    assert raises(Q7("0 + O(7^-1)").exp, FlintUnableError)
+
+    assert Q2(0).exp() == 1
+    assert str(Q2(4).exp()) == "333 + O(2^10)"
+    assert str(Q2("4 + O(2^12)").exp()) == "333 + O(2^10)"
+    assert str(Q2("4 + O(2^8)").exp()) == "77 + O(2^8)"
+    assert str(Q2("0 + O(2^2)").exp()) == "1 + O(2^2)"
+    assert raises(Q2("0 + O(2^1)").exp, FlintUnableError)
+    assert raises(Q2("0 + O(2^0)").exp, FlintUnableError)
+    assert raises(Q2("0 + O(2^1)").exp, FlintUnableError)
+
 
 def test_big_o():
     Q = Qp_padic_radix(7, rel_prec=3)

--- a/src/radix.h
+++ b/src/radix.h
@@ -412,6 +412,9 @@ void radix_integer_trunc_limbs(radix_integer_t res, const radix_integer_t x, slo
 void radix_integer_mod_limbs(radix_integer_t res, const radix_integer_t x, slong n, const radix_t radix);
 void radix_integer_smod_limbs(radix_integer_t res, const radix_integer_t x, slong n, const radix_t radix);
 
+void radix_integer_trunc_digits(radix_integer_t res, const radix_integer_t x, slong n, const radix_t radix);
+void radix_integer_mod_digits(radix_integer_t res, const radix_integer_t x, slong n, const radix_t radix);
+
 void radix_integer_mullow_limbs(radix_integer_t res, const radix_integer_t x, const radix_integer_t y, slong n, const radix_t radix);
 int radix_integer_invmod_limbs(radix_integer_t res, const radix_integer_t x, slong n, const radix_t radix);
 int radix_integer_divmod_limbs(radix_integer_t res, const radix_integer_t a, const radix_integer_t b, slong n, const radix_t radix);

--- a/src/radix.h
+++ b/src/radix.h
@@ -414,6 +414,7 @@ void radix_integer_smod_limbs(radix_integer_t res, const radix_integer_t x, slon
 
 void radix_integer_mullow_limbs(radix_integer_t res, const radix_integer_t x, const radix_integer_t y, slong n, const radix_t radix);
 int radix_integer_invmod_limbs(radix_integer_t res, const radix_integer_t x, slong n, const radix_t radix);
+int radix_integer_divmod_limbs(radix_integer_t res, const radix_integer_t a, const radix_integer_t b, slong n, const radix_t radix);
 int radix_integer_rsqrtmod_limbs(radix_integer_t res, const radix_integer_t x, slong n, const radix_t radix);
 int radix_integer_sqrtmod_limbs(radix_integer_t res, const radix_integer_t x, slong n, const radix_t radix);
 

--- a/src/radix/integer.c
+++ b/src/radix/integer.c
@@ -1188,6 +1188,9 @@ radix_integer_invmod_limbs(radix_integer_t res, const radix_integer_t x, slong n
         invertible = radix_invmod_bn(rd, xd, xn, n, radix);
     }
 
+    if (!invertible)
+        rn = 0;
+
     MPN_NORM(rd, rn);
     res->size = (xsize > 0) ? rn : -rn;
     return invertible;

--- a/src/radix/integer.c
+++ b/src/radix/integer.c
@@ -1029,6 +1029,70 @@ radix_integer_smod_limbs(radix_integer_t res, const radix_integer_t x, slong n, 
 }
 
 void
+radix_integer_trunc_digits(radix_integer_t res, const radix_integer_t x, slong n, const radix_t radix)
+{
+    slong e = radix->exp;
+    slong limbs, rem, tot;
+
+    if (n <= 0)
+    {
+        radix_integer_zero(res, radix);
+        return;
+    }
+
+    limbs = n / e;
+    rem = n - limbs * e;
+    tot = limbs + (rem != 0);
+
+    radix_integer_trunc_limbs(res, x, tot, radix);
+
+    if (rem != 0 && FLINT_ABS(res->size) == tot)
+    {
+        ulong top = res->d[limbs];
+        ulong m = radix->bpow[rem];
+        ulong t = n_rem_precomp(top, m, radix->bpow_div + rem);
+
+        res->d[limbs] = t;
+
+        while (tot > 0 && res->d[tot - 1] == 0)
+            tot--;
+        res->size = (res->size >= 0) ?  tot : -tot;
+    }
+}
+
+void
+radix_integer_mod_digits(radix_integer_t res, const radix_integer_t x, slong n, const radix_t radix)
+{
+    slong e = radix->exp;
+    slong limbs, rem, tot;
+
+    if (n <= 0)
+    {
+        radix_integer_zero(res, radix);
+        return;
+    }
+
+    limbs = n / e;
+    rem = n - limbs * e;
+    tot = limbs + (rem != 0);
+
+    radix_integer_mod_limbs(res, x, tot, radix);
+
+    if (rem != 0 && FLINT_ABS(res->size) == tot)
+    {
+        ulong top = res->d[limbs];
+        ulong m = radix->bpow[rem];
+        ulong t = n_rem_precomp(top, m, radix->bpow_div + rem);
+
+        res->d[limbs] = t;
+
+        while (tot > 0 && res->d[tot - 1] == 0)
+            tot--;
+        res->size = tot;
+    }
+}
+
+void
 radix_integer_mullow_limbs(radix_integer_t res, const radix_integer_t x, const radix_integer_t y, slong n, const radix_t radix)
 {
     slong xsize = x->size;

--- a/src/radix/integer.c
+++ b/src/radix/integer.c
@@ -1129,6 +1129,74 @@ radix_integer_invmod_limbs(radix_integer_t res, const radix_integer_t x, slong n
     return invertible;
 }
 
+int
+radix_integer_divmod_limbs(radix_integer_t res, const radix_integer_t a,
+    const radix_integer_t b, slong n, const radix_t radix)
+{
+    slong asize = a->size;
+    slong bsize = b->size;
+    slong an, bn, rn, sgn;
+    nn_ptr rd;
+    int invertible;
+
+    if (n == 0)
+    {
+        radix_integer_zero(res, radix);
+        return 1;
+    }
+
+    if (bsize == 0)
+    {
+        radix_integer_zero(res, radix);
+        return 0;
+    }
+
+    if (asize == 0)
+    {
+        ulong tmp = b->d[0];
+        radix_integer_zero(res, radix);
+        return radix_invmod_bn(&tmp, &tmp, 1, 1, radix);
+    }
+
+    an = FLINT_MIN(FLINT_ABS(asize), n);
+    bn = FLINT_MIN(FLINT_ABS(bsize), n);
+    sgn = asize ^ bsize;
+
+    if (bn == 1 && b->d[0] == 1)
+    {
+        radix_integer_trunc_limbs(res, a, n, radix);
+        res->size = (sgn >= 0) ? FLINT_ABS(res->size) : -FLINT_ABS(res->size);
+        return 1;
+    }
+
+    rd = radix_integer_fit_limbs(res, n, radix);
+
+    if (res == b)
+    {
+        TMP_INIT;
+        TMP_START;
+        nn_ptr tmp = TMP_ALLOC(sizeof(ulong) * bn);
+        flint_mpn_copyi(tmp, b->d, bn);
+        invertible = radix_divmod_bn(rd, NULL, a->d, an, tmp, bn, n, radix);
+        TMP_END;
+    }
+    else
+    {
+        invertible = radix_divmod_bn(rd, NULL, a->d, an, b->d, bn, n, radix);
+    }
+
+    if (!invertible)
+    {
+        radix_integer_zero(res, radix);
+        return 0;
+    }
+
+    rn = n;
+    MPN_NORM(rd, rn);
+    res->size = (rn == 0) ? 0 : ((sgn >= 0) ? rn : -rn);
+    return 1;
+}
+
 /* res = a reciprocal square root of x modulo B^n, i.e. res^2 x == 1 (mod B^n).
    x must be a unit (x->d[0] coprime to p). Returns 1 on success, 0 if x is zero
    or not a square modulo p (in which case res is set to zero). */

--- a/src/radix/test/t-integer.c
+++ b/src/radix/test/t-integer.c
@@ -589,6 +589,74 @@ TEST_FUNCTION_START(radix_integer, state)
         radix_clear(radix);
     }
 
+    /* divmod */
+    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
+    {
+        radix_t radix;
+        radix_integer_t x, y, z, w;
+        slong n;
+        int invertible1, invertible2;
+
+        radix_init_randtest(radix, state);
+        radix_integer_init(x, radix);
+        radix_integer_init(y, radix);
+        radix_integer_init(z, radix);
+        radix_integer_init(w, radix);
+
+        radix_integer_randtest_limbs(x, state, 4, radix);
+        radix_integer_randtest_limbs(y, state, 4, radix);
+        radix_integer_randtest_limbs(z, state, 4, radix);
+
+        n = n_randint(state, 4);
+
+        switch (n_randint(state, 5))
+        {
+            case 0:
+                invertible2 = radix_integer_divmod_limbs(z, x, y, n, radix);
+                break;
+            case 1:
+                radix_integer_set(y, x, radix);
+                invertible2 = radix_integer_divmod_limbs(z, x, x, n, radix);
+                break;
+            case 2:
+                radix_integer_set(z, x, radix);
+                invertible2 = radix_integer_divmod_limbs(z, z, y, n, radix);
+                break;
+            case 3:
+                radix_integer_set(z, y, radix);
+                invertible2 = radix_integer_divmod_limbs(z, x, z, n, radix);
+                break;
+            default:
+                radix_integer_set(y, x, radix);
+                radix_integer_set(z, x, radix);
+                invertible2 = radix_integer_divmod_limbs(z, z, z, n, radix);
+                break;
+        }
+
+        invertible1 = radix_integer_invmod_limbs(w, y, n, radix);
+        radix_integer_mullow_limbs(w, x, w, n, radix);
+
+        if (invertible1 != invertible2 || (invertible1 && !radix_integer_equal(w, z, radix)) ||
+            !radix_integer_is_normalised(z, radix))
+        {
+            flint_printf("FAIL: divmod_limbs\n");
+            flint_printf("radix %wu ^ %u = %wu\n", DIGIT_RADIX(radix), radix->exp, LIMB_RADIX(radix));
+            flint_printf("invertible1 = %d, invertible2 = %d\n", invertible1, invertible2);
+            flint_printf("x = (%wd %wd %{ulong*})\n", x->size, x->alloc, x->d, radix_integer_size_limbs(x, radix));
+            flint_printf("y = (%wd %wd %{ulong*})\n", y->size, y->alloc, y->d, radix_integer_size_limbs(y, radix));
+            flint_printf("z = (%wd %wd %{ulong*})\n", z->size, z->alloc, z->d, radix_integer_size_limbs(z, radix));
+            flint_printf("w = (%wd %wd %{ulong*})\n", w->size, w->alloc, w->d, radix_integer_size_limbs(w, radix));
+            flint_printf("n = %wd\n", n);
+            flint_abort();
+        }
+
+        radix_integer_clear(x, radix);
+        radix_integer_clear(y, radix);
+        radix_integer_clear(z, radix);
+        radix_integer_clear(w, radix);
+        radix_clear(radix);
+    }
+
     /* tdiv_qr, fdiv_qr */
     for (iter = 0; iter < 10000 * flint_test_multiplier(); iter++)
     {

--- a/src/radix/test/t-integer.c
+++ b/src/radix/test/t-integer.c
@@ -422,6 +422,96 @@ TEST_FUNCTION_START(radix_integer, state)
         radix_clear(radix);
     }
 
+    /* trunc_digits */
+    for (iter = 0; iter < 10000 * flint_test_multiplier(); iter++)
+    {
+        radix_t radix;
+        radix_integer_t x, y, z;
+        slong n;
+
+        radix_init_randtest(radix, state);
+        radix_integer_init(x, radix);
+        radix_integer_init(y, radix);
+        radix_integer_init(z, radix);
+
+        radix_integer_randtest_limbs(x, state, 5, radix);
+        radix_integer_randtest_limbs(y, state, 5, radix);
+        radix_integer_randtest_limbs(z, state, 5, radix);
+
+        n = n_randint(state, 30);
+
+        radix_integer_trunc_digits(y, x, n, radix);
+        radix_integer_lshift_digits(z, z, n, radix);
+        radix_integer_abs(z, z, radix);
+        if (radix_integer_sgn(x, radix) >= 0)
+            radix_integer_add(z, x, z, radix);
+        else
+            radix_integer_sub(z, x, z, radix);
+        radix_integer_trunc_digits(z, z, n, radix);
+
+        if (!radix_integer_equal(y, z, radix) ||
+            !radix_integer_is_normalised(y, radix) ||
+            !radix_integer_is_normalised(z, radix) ||
+            (!radix_integer_is_zero(y, radix) && (radix_integer_sgn(y, radix) != radix_integer_sgn(x, radix))))
+        {
+            flint_printf("FAIL: trunc_digits\n");
+            flint_printf("radix %wu ^ %u = %wu\n", DIGIT_RADIX(radix), radix->exp, LIMB_RADIX(radix));
+            flint_printf("x = (%wd %wd %{ulong*})\n", x->size, x->alloc, x->d, radix_integer_size_limbs(x, radix));
+            flint_printf("y = (%wd %wd %{ulong*})\n", y->size, y->alloc, y->d, radix_integer_size_limbs(y, radix));
+            flint_printf("z = (%wd %wd %{ulong*})\n", z->size, z->alloc, z->d, radix_integer_size_limbs(z, radix));
+            flint_printf("n = %wd\n", n);
+            flint_abort();
+        }
+
+        radix_integer_clear(x, radix);
+        radix_integer_clear(y, radix);
+        radix_integer_clear(z, radix);
+        radix_clear(radix);
+    }
+
+    /* mod_digits */
+    for (iter = 0; iter < 10000 * flint_test_multiplier(); iter++)
+    {
+        radix_t radix;
+        radix_integer_t x, y, z;
+        slong n;
+
+        radix_init_randtest(radix, state);
+        radix_integer_init(x, radix);
+        radix_integer_init(y, radix);
+        radix_integer_init(z, radix);
+
+        radix_integer_randtest_limbs(x, state, 5, radix);
+        radix_integer_randtest_limbs(y, state, 5, radix);
+        radix_integer_randtest_limbs(z, state, 5, radix);
+
+        n = n_randint(state, 30);
+
+        radix_integer_mod_digits(y, x, n, radix);
+        radix_integer_lshift_digits(z, z, n, radix);
+        radix_integer_add(z, z, x, radix);
+        radix_integer_mod_digits(z, z, n, radix);
+
+        if (!radix_integer_equal(y, z, radix) ||
+            !radix_integer_is_normalised(y, radix) ||
+            !radix_integer_is_normalised(z, radix) ||
+            radix_integer_sgn(y, radix) < 0)
+        {
+            flint_printf("FAIL: mod_digits\n");
+            flint_printf("radix %wu ^ %u = %wu\n", DIGIT_RADIX(radix), radix->exp, LIMB_RADIX(radix));
+            flint_printf("x = (%wd %wd %{ulong*})\n", x->size, x->alloc, x->d, radix_integer_size_limbs(x, radix));
+            flint_printf("y = (%wd %wd %{ulong*})\n", y->size, y->alloc, y->d, radix_integer_size_limbs(y, radix));
+            flint_printf("z = (%wd %wd %{ulong*})\n", z->size, z->alloc, z->d, radix_integer_size_limbs(z, radix));
+            flint_printf("n = %wd\n", n);
+            flint_abort();
+        }
+
+        radix_integer_clear(x, radix);
+        radix_integer_clear(y, radix);
+        radix_integer_clear(z, radix);
+        radix_clear(radix);
+    }
+
     /* smod_limbs */
     for (iter = 0; iter < 10000 * flint_test_multiplier(); iter++)
     {


### PR DESCRIPTION
Implements `padic_radix_exp` for computing $\exp(x)$ over $\mathbb{Q}_p$ and overloads `gr_exp`.

```
>>> Q5 = Qp_padic_radix(5, rel_prec=10)
>>> Q5(0).exp()
1
 >>> Q5("0 + O(5^3)").exp()
1 + O(5^3)
>>> Q5("5 * 1234").exp()
1779246 + O(5^10)
>>> Q5("1234").exp()   # non-convergent
Traceback (most recent call last):
  ...
FlintDomainError: exp(x) is not an element of {Radix 5-adic numbers (rel prec 10, abs prec inf)} for {x = 1234}
>>> Q5("1234 + O(5^0)").exp()   # unable to tell if convergent
Traceback (most recent call last):
  ...
FlintUnableError: failed to compute exp(x) in {Radix 5-adic numbers (rel prec 10, abs prec inf)} for {x = 0 + O(5^0)}
>>> f = PowerSeriesRing(Q5)("5 * 1234 + x")
>>> f.exp()
(1779246 + O(5^10)) + (1779246 + O(5^10))*x + (889623 + O(5^10))*x^2 + (296541 + O(5^10))*x^3 + (7398354 + O(5^10))*x^4 + ((7398354) * 5^-1 + O(5^9))*x^5 + O(x^6)
>>> f.exp() * (-f).exp()
(1 + O(5^10)) + (0 + O(5^10))*x + (0 + O(5^10))*x^2 + (0 + O(5^10))*x^3 + (0 + O(5^10))*x^4 + (0 + O(5^9))*x^5 + O(x^6)
```

Mirroring `padic_exp`, there are two algorithms: "rectangular" splitting and "balanced" splitting (i.e. the p-adic analog of the bit-burst algorithm), and an automatic dispatcher between these. The binary splitting series evaluation in the balanced algorithm has been optimized by incorporating the power table trick from the Arb version and including an `mpn` basecase for single-limb leaves. The rectangular variant also has an `nmod`-based fast path for single-limb working precision. Most of the coding was done using Claude Opus (first translating from the `padic` code, then adding more improvements).

This can no doubt be improved further, especially in medium precision; my initial goal was to match `padic_exp`. Profile results below. Speedup is for "default" (`padic_radix_exp`) vs "padic" (`padic_exp`):

```
$ build/padic_radix/profile/p-exp 
precision 7^n, limb radix = 7^22

       n      padic     rectangular   balanced    default   speedup
      10     3.84e-07    1.04e-07    8.62e-07    1.03e-07   3.728x
      20     1.61e-06    6.15e-07    1.33e-06    6.21e-07   2.593x
      40     3.25e-06    1.27e-06    2.53e-06    1.28e-06   2.539x
      80     6.02e-06     2.9e-06    6.72e-06    2.89e-06   2.083x
     160     1.39e-05   1.027e-05    1.38e-05    1.04e-05   1.337x
     320     4.37e-05    5.31e-05    3.22e-05     3.2e-05   1.366x
     640     0.000171    0.000276    7.68e-05    7.69e-05   2.224x
    1280     0.000382        -nan    0.000201    0.000202   1.891x
    2560      0.00113        -nan    0.000602    0.000603   1.874x
    5120      0.00332        -nan     0.00156     0.00156   2.128x
   10240      0.00976        -nan     0.00374     0.00372   2.624x
   20480       0.0257        -nan     0.00911     0.00913   2.815x
   40960       0.0685        -nan      0.0215      0.0214   3.201x
   81920        0.169        -nan      0.0531      0.0532   3.177x
  163840         0.42        -nan       0.127       0.127   3.307x
  327680        1.041        -nan        0.29        0.29   3.590x
  655360        2.544        -nan       0.665       0.661   3.849x
 1310720        6.274        -nan       1.538       1.543   4.066x
 2621440       15.258        -nan       3.577       3.592   4.248x
 5242880       36.699        -nan       8.018       7.986   4.595x
10485760       90.236        -nan      19.484      19.475   4.633x
```

Also with a large prime:

```
precision 9223372036854775837^n, limb radix = 9223372036854775837^1

       n      padic     rectangular   balanced    default   speedup
      10     2.49e-06    1.55e-06    4.48e-06    1.54e-06   1.617x
      20     6.68e-06    4.69e-06     1.1e-05    4.72e-06   1.415x
      40     2.42e-05    1.52e-05    2.78e-05    1.52e-05   1.592x
      80     9.42e-05    0.000102    9.55e-05    9.44e-05   0.998x
     160     0.000416    0.000363    0.000268    0.000267   1.558x
     320       0.0018      0.0013    0.000703    0.000688   2.616x
     640      0.00781     0.00634     0.00182     0.00185   4.222x
    1280       0.0182        -nan     0.00458     0.00467   3.897x
    2560       0.0433        -nan      0.0114      0.0114   3.798x
    5120        0.109        -nan      0.0273      0.0273   3.993x
   10240        0.244        -nan      0.0653      0.0657   3.714x
   20480        0.559        -nan       0.159       0.155   3.606x
   40960        1.305        -nan       0.372       0.366   3.566x
   81920        2.996        -nan       0.874        0.86   3.484x
  163840        6.978        -nan       2.063       2.022   3.451x
  327680       16.264        -nan       4.925       4.926   3.302x
```

The PR also adds a couple of `radix_integer` helper functions.