### PR TITLE
style(acb_dft): drop superfluous guard-precision comments

### DIFF
--- a/src/acb/vec_unit_roots.c
+++ b/src/acb/vec_unit_roots.c
@@ -42,10 +42,6 @@ _acb_vec_unit_roots(acb_ptr res, slong n, slong len, slong prec)
     wp = prec + 6 + 2 * FLINT_BIT_COUNT(len1);
 
     acb_init(t);
-    /* Base root at wp, not prec: _acb_vec_set_powers raises it to powers by
-       binary powering, amplifying the base-root error ~linearly in the
-       index, so a prec-accurate base would leave the largest stored roots
-       only ~prec - log2(len1) bits accurate. Rounded back to prec below. */
     acb_unit_root(t, n, wp);
     _acb_vec_set_powers(res, t, len1, wp);
     acb_clear(t);

--- a/src/acb_dft/bluestein.c
+++ b/src/acb_dft/bluestein.c
@@ -64,11 +64,6 @@ _acb_vec_bluestein_factors(acb_ptr z, slong n, slong prec)
         }
         acb_modular_fill_addseq(v, n);
 
-        /* Build the base root and the addition-sequence products at wp, not
-           prec: the addseq raises the base root to powers via products of
-           earlier entries, amplifying the base-root error ~linearly in the
-           index. The factor table z is rounded back to prec after the
-           (exact) copy-out below. */
         wp = prec + 6 + 2 * FLINT_BIT_COUNT(2 * n);
 
         acb_one(t + 0);


### PR DESCRIPTION
Follow-up to #2756. Per review feedback there, building the `acb_dft` root-of-unity table (`_acb_vec_unit_roots`) and the Bluestein factor table (`_acb_vec_bluestein_factors`) at an elevated working precision and rounding back to `prec` is idiomatic, so the comments that were added to explain it are superfluous. This removes them; the `prec` to `wp` change itself is unchanged.

Comment-only, no functional change.
