### PR TITLE
Logarithm function for padic_radix

### DIFF
--- a/doc/source/padic.rst
+++ b/doc/source/padic.rst
@@ -470,8 +470,7 @@ Logarithm
 
     where `v \geq 1`.
 
-    Assumes that `1 \leq v < N` or `2 \leq v < N` when `p` is 
-    odd or `p = 2`, respectively, and also that `N < 2^{f-2}` 
+    Assumes that `1 \leq v < N`, and also that `N < 2^{f-2}`
     where `f` is ``FLINT_BITS``.
 
 .. function:: void _padic_log(fmpz_t z, const fmpz_t y, slong v, const fmpz_t p, slong N)
@@ -496,8 +495,7 @@ Logarithm
                 & = - \sum_{i=1}^{\infty} \frac{(1-x)^i}{i}.
 
     Assumes that `y = 1 - x` is non-zero and that `v = \operatorname{ord}_p(y)` 
-    is at least `1` when `p` is odd and at least `2` when `p = 2` 
-    so that the series converges.
+    is at least `1` so that the series converges.
 
     Assumes that `v < N`, and hence in particular `N \geq 2`.
 
@@ -515,8 +513,7 @@ Logarithm
 
         \log_p(x) = \sum_{i=1}^{\infty} (-1)^{i-1} \frac{(x-1)^i}{i}
 
-    but this only converges when `\operatorname{ord}_p(x - 1)` is at least `2`
-    or `1` when `p = 2` or `p > 2`, respectively.
+    but this only converges when `\operatorname{ord}_p(x - 1)` is at least `1`.
 
 .. function:: int padic_log_rectangular(padic_t rop, const padic_t op, const padic_ctx_t ctx)
 

--- a/doc/source/padic_radix.rst
+++ b/doc/source/padic_radix.rst
@@ -208,7 +208,7 @@ Transcendental functions
 
     Sets *res* to the `p`-adic exponential function `\exp(x)`.
     Returns ``GR_DOMAIN`` if the series does not converge
-    and ``GR_UNABLE`` if this convergence cannot be determined or if the
+    and ``GR_UNABLE`` if convergence cannot be determined or if the
     precision is too large for the implementation.
 
 .. function:: slong _padic_radix_log_bound(slong v, slong N, ulong p)
@@ -220,13 +220,17 @@ Transcendental functions
               void _padic_radix_log_balanced(radix_integer_t rop, const radix_integer_t y, slong N, const radix_t radix)
               void _padic_radix_log(radix_integer_t rop, const radix_integer_t y, slong N, const radix_t radix)
 
-    Given an integer `y` and a valuation `v` such that `v \ge 1` if `p \ne 2`
-    and `v \ge 2` if `p = 2` (not checked), sets *rop* to `\log(1-y)`
-    truncated to precision `p^N`.
+    Given an integer `y` with valuation `v \ge 1` (not checked),
+    sets *rop* to `\log(1-y)` truncated to precision `p^N`.
 
 .. function:: int padic_radix_log_rectangular(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx)
               int padic_radix_log_balanced(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx)
               int padic_radix_log(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx)
+
+    Sets *res* to the `p`-adic natural logarithm `\log(x)`.
+    Returns ``GR_DOMAIN`` if the series does not converge
+    and ``GR_UNABLE`` if convergence cannot be determined or if the
+    precision is too large for the implementation.
 
 
 

--- a/doc/source/padic_radix.rst
+++ b/doc/source/padic_radix.rst
@@ -180,9 +180,9 @@ Transcendental functions
 
 .. function:: slong _padic_radix_exp_bound(slong v, slong N, ulong p)
 
-    Returns the number of terms `n` such that the tail of the exponential
-    series for `x = p^v u` has valuation at least `N`, i.e. the smallest `n`
-    with `nv - v_p(n!) \ge N`:
+    Returns the smallest number of terms `n` such that the tail of the
+    exponential series for `x = p^v u` has valuation at least `N`, i.e.
+    the smallest `n` with `nv - v_p(n!) \ge N`:
 
     .. math ::
 
@@ -190,21 +190,17 @@ Transcendental functions
 
     Assumes (not checked) that `v` is large enough for the series to converge.
 
-.. function:: int _padic_radix_exp_rectangular(radix_integer_t rop, const radix_integer_t u, slong v, slong N, const radix_t radix)
-              int _padic_radix_exp_balanced(radix_integer_t rop, const radix_integer_t u, slong v, slong N, const radix_t radix)
-              int _padic_radix_exp(radix_integer_t rop, const radix_integer_t u, slong v, slong N, const radix_t radix)
+.. function:: void _padic_radix_exp_rectangular(radix_integer_t rop, const radix_integer_t u, slong v, slong N, const radix_t radix)
+              void _padic_radix_exp_balanced(radix_integer_t rop, const radix_integer_t u, slong v, slong N, const radix_t radix)
+              void _padic_radix_exp(radix_integer_t rop, const radix_integer_t u, slong v, slong N, const radix_t radix)
 
-    Given a unit `u` and a valuation `v` such that `v \ge 1` if `p \ne 2`
+    Given an integer `u` and a valuation `v` such that `v \ge 1` if `p \ne 2`
     and `v \ge 2` if `p = 2` (not checked), sets *rop* to `\exp(u p^v)`
     truncated to precision `p^N`.
 
     The *rectangular* algorithm uses rectangular splitting.
     The *balanced* algorithm uses the `p`-adic bit-burst algorithm with
     binary splitting. The default function chooses an algorithm automatically.
-
-    The *rectangular* algorithm can return ``GR_UNABLE`` if `N` is too large
-    for the implementation; the *balanced* algorithm and the default
-    algorithm always succeed and return ``GR_SUCCESS`` (given valid input).
 
 .. function:: int padic_radix_exp_rectangular(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx)
               int padic_radix_exp_balanced(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx)
@@ -214,4 +210,23 @@ Transcendental functions
     Returns ``GR_DOMAIN`` if the series does not converge
     and ``GR_UNABLE`` if this convergence cannot be determined or if the
     precision is too large for the implementation.
+
+.. function:: slong _padic_radix_log_bound(slong v, slong N, ulong p)
+
+    Returns the smallest number of terms `n` such that the tail of the
+    logarithm series for `1 + p^v u` has valuation at least `N`.
+
+.. function:: void _padic_radix_log_rectangular(radix_integer_t rop, const radix_integer_t y, slong N, const radix_t radix)
+              void _padic_radix_log_balanced(radix_integer_t rop, const radix_integer_t y, slong N, const radix_t radix)
+              void _padic_radix_log(radix_integer_t rop, const radix_integer_t y, slong N, const radix_t radix)
+
+    Given an integer `y` and a valuation `v` such that `v \ge 1` if `p \ne 2`
+    and `v \ge 2` if `p = 2` (not checked), sets *rop* to `\log(1-y)`
+    truncated to precision `p^N`.
+
+.. function:: int padic_radix_log_rectangular(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx)
+              int padic_radix_log_balanced(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx)
+              int padic_radix_log(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx)
+
+
 

--- a/src/gr_generic/set_str_expr.c
+++ b/src/gr_generic/set_str_expr.c
@@ -722,10 +722,26 @@ static int _gr_parse_parse(gr_parse_t E, void * poly, const char * s, slong slen
             }
             else
             {
-                if (++s >= send || !('0' <= *s && *s <= '9'))
+                /* Try to parse exponent as an fmpz. TODO: this only supports
+                   literals for now. Implement parsing expressions,
+                   and allow fmpq. */
+
+                int neg = 0;
+
+                s++;
+
+                if (s < send && *s == '-')
+                {
+                    neg = 1;
+                    s++;
+                }
+
+                if (s >= send || !('0' <= *s && *s <= '9'))
                     goto failed;
 
                 s = _parse_int(c, s, send);
+                if (neg)
+                    fmpz_neg(c, c);
 
                 if (_gr_parse_pop_prec(E, PREC_POWER))
                     goto failed;

--- a/src/padic/log.c
+++ b/src/padic/log.c
@@ -14,14 +14,13 @@
 #include "ulong_extras.h"
 
 /*
-    Assumes that $1 \leq v$ or $2 \leq v$ as $p$ is even
-    or odd, respectively, and that $v < N < 2^{f-2}$ where
-    $f$ is \code{FLINT_BITS}.
+    Assumes that $1 \leq v < N < 2^{f-2}$ where $f$ is \code{FLINT_BITS}.
+    (The series $\sum_{i \geq 1} \pm y^i / i$ converges for $v \geq 1$ for every
+    prime $p$, since $i v - \ord_p(i) \geq i - \log_p i \to \infty$.)
 
-    Under the assumption that $1 \leq v < N$, or $2 \leq v < N$,
-    one can easily prove that with $c = N - \floor{\log_p v}$
-    the number $b = \ceil{(c + \ceil{\log_p c} + 1) / b}$ is such
-    that for all $i \geq b$, $i v - \ord_p(i) \geq N$.
+    Under the assumption that $1 \leq v < N$, one can easily prove that with
+    $c = N - \floor{\log_p v}$ the number $b = \ceil{(c + \ceil{\log_p c} + 1) / b}$
+    is such that for all $i \geq b$, $i v - \ord_p(i) \geq N$.
 
     Under the additional condition that $N < 2^{f-2}$ one can
     show that the code branch for primes that fit into a
@@ -118,7 +117,7 @@ int padic_log(padic_t rop, const padic_t op, const padic_ctx_t ctx)
             v = fmpz_remove(t, x, p);
             fmpz_clear(t);
 
-            if (v >= 2 || (!fmpz_equal_ui(p, 2) && v >= 1))
+            if (v >= 1)
             {
                 if (v >= N)
                 {

--- a/src/padic/log_balanced.c
+++ b/src/padic/log_balanced.c
@@ -182,7 +182,7 @@ int padic_log_balanced(padic_t rop, const padic_t op, const padic_ctx_t ctx)
             v = fmpz_remove(t, x, p);
             fmpz_clear(t);
 
-            if (v >= 2 || (!fmpz_equal_ui(p, 2) && v >= 1))
+            if (v >= 1)
             {
                 if (v >= N)
                 {

--- a/src/padic/log_rectangular.c
+++ b/src/padic/log_rectangular.c
@@ -134,6 +134,8 @@ void _padic_log_rectangular(fmpz_t z, const fmpz_t y, slong v, const fmpz_t p, s
     _padic_log_rectangular_series(z, y, n, p, N, pN);
 
     fmpz_sub(z, pN, z);
+    if (fmpz_equal(z, pN))
+        fmpz_zero(z);
     fmpz_clear(pN);
 }
 
@@ -171,7 +173,7 @@ int padic_log_rectangular(padic_t rop, const padic_t op, const padic_ctx_t ctx)
             v = fmpz_remove(t, x, p);
             fmpz_clear(t);
 
-            if (v >= 2 || (!fmpz_equal_ui(p, 2) && v >= 1))
+            if (v >= 1)
             {
                 if (v >= N)
                 {

--- a/src/padic/log_satoh.c
+++ b/src/padic/log_satoh.c
@@ -82,7 +82,7 @@ int padic_log_satoh(padic_t rop, const padic_t op, const padic_ctx_t ctx)
             v = fmpz_remove(t, y, ctx->p);
             fmpz_clear(t);
 
-            if (v >= 2 || (!fmpz_equal_ui(p, 2) && v >= 1))
+            if (v >= 1)
             {
                 if (v >= N)
                 {

--- a/src/padic_radix.h
+++ b/src/padic_radix.h
@@ -108,10 +108,6 @@ int padic_radix_inv(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx);
 int padic_radix_div(padic_radix_t res, const padic_radix_t x, const padic_radix_t y, gr_ctx_t ctx);
 int padic_radix_sqrt(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx);
 int padic_radix_rsqrt(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx);
-int _padic_radix_exp_rectangular(radix_integer_t rop, const radix_integer_t u, slong v, slong N, const radix_t radix);
-int padic_radix_exp_rectangular(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx);
-int _padic_radix_exp_balanced(radix_integer_t rop, const radix_integer_t u, slong v, slong N, const radix_t radix);
-int padic_radix_exp_balanced(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx);
 truth_t padic_radix_is_square(const padic_radix_t x, gr_ctx_t ctx);
 
 truth_t padic_radix_is_zero(const padic_radix_t x, gr_ctx_t ctx);
@@ -139,13 +135,23 @@ int padic_radix_dot_strided_naive(padic_radix_t res, const padic_radix_t initial
 
 slong _padic_radix_exp_bound(slong v, slong N, ulong p);
 
-int _padic_radix_exp_rectangular(radix_integer_t rop, const radix_integer_t u, slong v, slong N, const radix_t radix);
-int _padic_radix_exp_balanced(radix_integer_t rop, const radix_integer_t u, slong v, slong N, const radix_t radix);
-int _padic_radix_exp(radix_integer_t rop, const radix_integer_t u, slong v, slong N, const radix_t radix);
+void _padic_radix_exp_rectangular(radix_integer_t rop, const radix_integer_t u, slong v, slong N, const radix_t radix);
+void _padic_radix_exp_balanced(radix_integer_t rop, const radix_integer_t u, slong v, slong N, const radix_t radix);
+void _padic_radix_exp(radix_integer_t rop, const radix_integer_t u, slong v, slong N, const radix_t radix);
 
 int padic_radix_exp_rectangular(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx);
 int padic_radix_exp_balanced(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx);
 int padic_radix_exp(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx);
+
+slong _padic_radix_log_bound(slong v, slong N, ulong p);
+
+void _padic_radix_log_rectangular(radix_integer_t rop, const radix_integer_t y, slong N, const radix_t radix);
+void _padic_radix_log_balanced(radix_integer_t rop, const radix_integer_t y, slong N, const radix_t radix);
+void _padic_radix_log(radix_integer_t rop, const radix_integer_t y, slong N, const radix_t radix);
+
+int padic_radix_log_rectangular(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx);
+int padic_radix_log_balanced(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx);
+int padic_radix_log(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx);
 
 /* For testing */
 int _padic_radix_add_sub_reference(padic_radix_t res, const padic_radix_t x, const padic_radix_t y, int sub, gr_ctx_t ctx);

--- a/src/padic_radix/exp.c
+++ b/src/padic_radix/exp.c
@@ -75,7 +75,7 @@ _padic_radix_exp_bound(slong v, slong N, ulong p)
     }
 }
 
-int
+void
 _padic_radix_exp(radix_integer_t rop, const radix_integer_t u,
     slong v, slong N, const radix_t radix)
 {
@@ -91,10 +91,10 @@ _padic_radix_exp(radix_integer_t rop, const radix_integer_t u,
     else
         cutoff = 80;
 
-    if (N < cutoff && _padic_radix_exp_rectangular(rop, u, v, N, radix) == GR_SUCCESS)
-        return GR_SUCCESS;
-
-    return _padic_radix_exp_balanced(rop, u, v, N, radix);
+    if (N < cutoff)
+        _padic_radix_exp_rectangular(rop, u, v, N, radix);
+    else
+        _padic_radix_exp_balanced(rop, u, v, N, radix);
 }
 
 static int
@@ -103,7 +103,6 @@ _padic_radix_exp_wrapper(padic_radix_t res, const padic_radix_t x, int algorithm
     radix_struct * radix = PADIC_RADIX_CTX_RADIX(ctx);
     ulong p = GR_PADIC_RADIX_CTX(ctx)->p;
     slong vx = x->v, Nx = x->N;
-    int status;
 
     slong prec_abs = PADIC_RADIX_CTX_PREC_ABS(ctx);
     slong prec_rel = PADIC_RADIX_CTX_PREC_REL(ctx);
@@ -138,16 +137,15 @@ _padic_radix_exp_wrapper(padic_radix_t res, const padic_radix_t x, int algorithm
         prec = FLINT_MIN(prec, Nx);
 
     if (algorithm == 0)
-        status = _padic_radix_exp(&res->u, &x->u, vx, prec, radix);
+        _padic_radix_exp(&res->u, &x->u, vx, prec, radix);
     else if (algorithm == 1)
-        status = _padic_radix_exp_rectangular(&res->u, &x->u, vx, prec, radix);
+        _padic_radix_exp_rectangular(&res->u, &x->u, vx, prec, radix);
     else
-        status = _padic_radix_exp_balanced(&res->u, &x->u, vx, prec, radix);
+        _padic_radix_exp_balanced(&res->u, &x->u, vx, prec, radix);
 
     res->v = 0;
     res->N = prec;
-    status |= _padic_radix_finalize(res, ctx);
-    return status;
+    return _padic_radix_finalize(res, ctx);
 }
 
 int

--- a/src/padic_radix/exp_balanced.c
+++ b/src/padic_radix/exp_balanced.c
@@ -368,7 +368,7 @@ _bsplit_block_numden(radix_integer_t pnum, radix_integer_t pden,
     p^N.  Requires v >= 1 (odd p) or v >= 2 (p = 2) and N >= 1.  Always returns
     GR_SUCCESS (an internal invariant failure aborts via flint_throw).
 */
-int
+void
 _padic_radix_exp_balanced(radix_integer_t rop, const radix_integer_t u,
     slong v, slong N, const radix_t radix)
 {
@@ -382,13 +382,13 @@ _padic_radix_exp_balanced(radix_integer_t rop, const radix_integer_t u,
     if (N <= 0)
     {
         radix_integer_zero(rop, radix);
-        return GR_SUCCESS;
+        return;
     }
 
     if (v >= N || radix_integer_is_zero(u, radix))
     {
         radix_integer_one(rop, radix);
-        return GR_SUCCESS;
+        return;
     }
 
     lN = (N + e - 1) / e;
@@ -403,7 +403,7 @@ _padic_radix_exp_balanced(radix_integer_t rop, const radix_integer_t u,
     {
         radix_integer_one(rop, radix);
         radix_integer_clear(t, radix);
-        return GR_SUCCESS;
+        return;
     }
 
     /* Digit length D of t.  Blocks are [0,S), [S,2S), [2S,4S), [4S,8S), ...
@@ -467,7 +467,5 @@ _padic_radix_exp_balanced(radix_integer_t rop, const radix_integer_t u,
     radix_integer_clear(Pden, radix);
     radix_integer_clear(pnum, radix);
     radix_integer_clear(pden, radix);
-
-    return GR_SUCCESS;
 }
 

--- a/src/padic_radix/exp_rectangular.c
+++ b/src/padic_radix/exp_rectangular.c
@@ -110,7 +110,7 @@ _radix_array_valuation_digits(nn_srcptr a, slong n, const radix_t radix)
     GR_SUCCESS, or GR_UNABLE only on the (degenerate) failure of the final
     inversion.
 */
-int
+void
 _padic_radix_exp_rectangular(radix_integer_t rop, const radix_integer_t u,
     slong v, slong N, const radix_t radix)
 {
@@ -128,13 +128,13 @@ _padic_radix_exp_rectangular(radix_integer_t rop, const radix_integer_t u,
     if (N <= 0)
     {
         radix_integer_zero(rop, radix);
-        return GR_SUCCESS;
+        return;
     }
 
     if (v >= N || radix_integer_is_zero(u, radix))
     {
         radix_integer_one(rop, radix);
-        return GR_SUCCESS;
+        return;
     }
 
     n = _padic_radix_exp_bound(v, N, p);
@@ -190,7 +190,7 @@ _padic_radix_exp_rectangular(radix_integer_t rop, const radix_integer_t u,
             res = res % radix->bpow[N];          /* reduce to N digits (N <= e) */
 
             radix_integer_set_ui(rop, res, radix);
-            return GR_SUCCESS;
+            return;
         }
     }
 
@@ -219,8 +219,12 @@ _padic_radix_exp_rectangular(radix_integer_t rop, const radix_integer_t u,
         }
     }
 
+    /* Probably an artificially small limb radix, not supported by the implementation */
     if (npows_fit < 1)
-        return GR_UNABLE;
+    {
+        _padic_radix_exp_balanced(rop, u, v, N, radix);
+        return;
+    }
 
     npows = (slong) n_sqrt((ulong) n);
     if (npows < 1)
@@ -381,7 +385,5 @@ _padic_radix_exp_rectangular(radix_integer_t rop, const radix_integer_t u,
     radix_integer_mod_digits(rop, rop, N, radix);
 
     flint_free(scratch);
-
-    return GR_SUCCESS;
 }
 

--- a/src/padic_radix/log.c
+++ b/src/padic_radix/log.c
@@ -71,7 +71,7 @@ _padic_radix_log_wrapper(padic_radix_t res, const padic_radix_t x, int algorithm
 {
     radix_struct * radix = PADIC_RADIX_CTX_RADIX(ctx);
     ulong p = GR_PADIC_RADIX_CTX(ctx)->p;
-    slong thr = (p == 2) ? 2 : 1;
+    slong thr = 1;    /* log converges for valuation >= 1 for every p */
     slong Nx = x->N;
     slong prec_abs = PADIC_RADIX_CTX_PREC_ABS(ctx);
     slong prec_rel = PADIC_RADIX_CTX_PREC_REL(ctx);

--- a/src/padic_radix/log.c
+++ b/src/padic_radix/log.c
@@ -1,0 +1,206 @@
+/*
+    Copyright (C) 2012 Sebastian Pancratz
+    Copyright (C) 2012, 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "ulong_extras.h"
+#include "padic_radix.h"
+#include "gr.h"
+
+/*
+    Smallest n such that for all i >= n, i v - ord_p(i) >= N, so that the tail
+    of  sum_{i>=1} x^i / i  with ord_p(x) >= v is below p^N.  Word-sized p (a
+    radix digit always fits a word); port of the corresponding branch of
+    _padic_log_bound.
+*/
+slong
+_padic_radix_log_bound(slong v, slong N, ulong p)
+{
+    slong b, c;
+
+    c = N - (slong) n_flog((ulong) v, p);
+    c = FLINT_MAX(c, 1);
+    b = ((c + (slong) n_clog((ulong) c, p) + 1) + (v - 1)) / v;
+
+    while (--b >= 2)
+    {
+        slong t = b * v - (slong) n_clog((ulong) b, p);
+
+        if (t < N)
+            return b + 1;
+    }
+
+    return 2;
+}
+
+void
+_padic_radix_log(radix_integer_t rop, const radix_integer_t y, slong N,
+    const radix_t radix)
+{
+    slong cutoff;
+    ulong pbits = NMOD_BITS(radix->b);
+
+    if (pbits <= 5)
+        cutoff = 350;
+    else if (pbits <= 9)
+        cutoff = 280;
+    else if (pbits <= 21)
+        cutoff = 240;
+    else if (pbits <= 32)
+        cutoff = 160;
+    else if (pbits <= 46)
+        cutoff = 120;
+    else
+        cutoff = 80;
+
+    if (N < cutoff)
+        _padic_radix_log_rectangular(rop, y, N, radix);
+    else
+        _padic_radix_log_balanced(rop, y, N, radix);
+}
+
+static int
+_padic_radix_log_wrapper(padic_radix_t res, const padic_radix_t x, int algorithm, gr_ctx_t ctx)
+{
+    radix_struct * radix = PADIC_RADIX_CTX_RADIX(ctx);
+    ulong p = GR_PADIC_RADIX_CTX(ctx)->p;
+    slong thr = (p == 2) ? 2 : 1;
+    slong Nx = x->N;
+    slong prec_abs = PADIC_RADIX_CTX_PREC_ABS(ctx);
+    slong prec_rel = PADIC_RADIX_CTX_PREC_REL(ctx);
+    slong prec = FLINT_MIN(prec_rel, prec_abs);
+    radix_integer_t y, one;
+    slong vy;
+
+    /*
+        op = u p^v with u a unit.  log converges only for a 1-unit, i.e.
+        op == 1 (mod p), which forces v == 0.  Any v != 0 (op divisible by p,
+        or non-integral) is outside the domain; handling it here also avoids
+        materialising u p^v for a large valuation.
+    */
+    if (radix_integer_is_zero(&x->u, radix))
+    {
+        /*
+            op == 0 (mod p^Nx): the valuation is only known to be >= Nx.  If
+            Nx >= 1 the valuation is positive, so op is not a unit and log is
+            undefined (this includes exact zero, Nx == EXACT).  If Nx <= 0
+            (e.g. O(p^0) or O(p^{-1})) op may still be a 1-unit, so we cannot
+            decide whether the series converges.
+        */
+        if (Nx <= 0)
+            return GR_UNABLE;
+        return GR_DOMAIN;
+    }
+
+    if (x->v != 0)
+        return GR_DOMAIN;
+
+    /* log(1) = 0 exactly (op == 1 to its stored precision). */
+    if (radix_integer_is_one(&x->u, radix))
+    {
+        radix_integer_zero(&res->u, radix);
+        res->v = 0;
+        res->N = Nx;
+        return _padic_radix_finalize(res, ctx);
+    }
+
+    /* Resolve the working absolute precision. */
+    if (prec == PADIC_RADIX_PREC_INF)
+    {
+        if (Nx == PADIC_RADIX_EXACT)
+            return GR_UNABLE;
+        prec = Nx;
+    }
+    else if (Nx != PADIC_RADIX_EXACT)
+    {
+        prec = FLINT_MIN(prec, Nx);
+    }
+
+    if (prec > PADIC_RADIX_ERR_MAX)
+        prec = PADIC_RADIX_ERR_MAX;
+
+    if (prec <= 0)
+    {
+        radix_integer_zero(&res->u, radix);
+        res->v = 0;
+        res->N = prec;
+        return _padic_radix_finalize(res, ctx);
+    }
+
+    /* y = 1 - op = 1 - u  (mod p^prec); op = u since v == 0 */
+    radix_integer_init(y, radix);
+    radix_integer_init(one, radix);
+    radix_integer_one(one, radix);
+
+    radix_integer_mod_digits(y, &x->u, prec, radix);      /* u mod p^prec */
+    radix_integer_sub(y, one, y, radix);
+    radix_integer_mod_digits(y, y, prec, radix);          /* nonnegative residue */
+
+    if (radix_integer_is_zero(y, radix))                  /* op == 1 (mod p^prec) */
+    {
+        radix_integer_zero(&res->u, radix);
+        res->v = 0;
+        res->N = prec;
+        radix_integer_clear(y, radix);
+        radix_integer_clear(one, radix);
+        return _padic_radix_finalize(res, ctx);
+    }
+
+    vy = radix_integer_valuation_digits(y, radix);
+
+    if (vy < thr)                                         /* does not converge */
+    {
+        radix_integer_clear(y, radix);
+        radix_integer_clear(one, radix);
+        return GR_DOMAIN;
+    }
+
+    if (vy >= prec)                                       /* log == 0 (mod p^prec) */
+    {
+        radix_integer_zero(&res->u, radix);
+        res->v = 0;
+        res->N = prec;
+        radix_integer_clear(y, radix);
+        radix_integer_clear(one, radix);
+        return _padic_radix_finalize(res, ctx);
+    }
+
+    if (algorithm == 0)
+        _padic_radix_log(&res->u, y, prec, radix);
+    else if (algorithm == 1)
+        _padic_radix_log_rectangular(&res->u, y, prec, radix);
+    else
+        _padic_radix_log_balanced(&res->u, y, prec, radix);
+
+    radix_integer_clear(y, radix);
+    radix_integer_clear(one, radix);
+
+    res->v = 0;
+    res->N = prec;
+    return _padic_radix_finalize(res, ctx);
+}
+
+int
+padic_radix_log(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx)
+{
+    return _padic_radix_log_wrapper(res, x, 0, ctx);
+}
+
+int
+padic_radix_log_balanced(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx)
+{
+    return _padic_radix_log_wrapper(res, x, 2, ctx);
+}
+
+int
+padic_radix_log_rectangular(padic_radix_t res, const padic_radix_t x, gr_ctx_t ctx)
+{
+    return _padic_radix_log_wrapper(res, x, 1, ctx);
+}

--- a/src/padic_radix/log_balanced.c
+++ b/src/padic_radix/log_balanced.c
@@ -1,0 +1,419 @@
+/*
+    Copyright (C) 2012 Sebastian Pancratz
+    Copyright (C) 2012, 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "ulong_extras.h"
+#include "padic_radix.h"
+#include "arb/impl.h"
+#include "gr.h"
+
+/* For 2 <= b - a < this bound, and when the block value x = p^vr ru fits in a
+   single limb, the binary-splitting leaf is evaluated by an iterative mpn
+   accumulation rather than by recursion.  Tuning parameter. */
+#define PADIC_RADIX_LOG_BSPLIT_BASECASE 64
+#define PADIC_RADIX_LOG_BC_LIMBS (2 * PADIC_RADIX_LOG_BSPLIT_BASECASE + 4)
+
+/* Digit width of the first (lowest-valuation) block peeled from the argument.
+   Tuning parameter; must be a power of two. */
+#define PADIC_RADIX_LOG_SMALLEST_BLOCK 4
+
+/*
+    Iterative basecase for a block whose value x = p^vr ru fits in a single limb
+    xl = p^vr ru.  Accumulates the binary-splitting leaf (Tu, B) for [a, b) in
+    plain mpn limbs and converts to radix once at the end.
+
+    For the series sum_{i=a}^{b-1} x^i / i (local powers), T/B = sum with B the
+    product a(a+1)...(b-1).  Tracking BXp = B * x^m (m = number of terms so far)
+    keeps every multiplier single-limb:
+
+        T   <- J*T + BXp*x,   B <- J*B,   BXp <- BXp*J*x   (J = a+1, ..., b-1),
+
+    started from T = x, B = a, BXp = a*x.  The accumulated T is the full
+    numerator p^vr Tu, so Tu is recovered by a final shift down by vr digits.
+*/
+static void
+_padic_radix_log_bsplit_basecase_mpn(radix_integer_t Tu, radix_integer_t B,
+    slong a, slong b, ulong xl, slong vr, slong l, const radix_t radix)
+{
+    ulong T[PADIC_RADIX_LOG_BC_LIMBS];
+    ulong BB[PADIC_RADIX_LOG_BC_LIMBS];
+    ulong BXp[PADIC_RADIX_LOG_BC_LIMBS];
+    slong Tn, Bn, BXpn, J, need;
+    ulong hi, lo, cy;
+    nn_ptr d;
+
+    /* index a:  T = x,  B = a,  BXp = a*x */
+    T[0] = xl;          Tn = 1;
+    BB[0] = (ulong) a;  Bn = 1;
+    umul_ppmm(hi, lo, (ulong) a, xl);
+    BXp[0] = lo;
+    BXp[1] = hi;
+    BXpn = 1 + (hi != 0);
+
+    for (J = a + 1; J < b; J++)
+    {
+        /* T = J*T + BXp*x:  scale T by J, then fuse the BXp*x add in one pass
+           over the (usually equal-length) overlap with mpn_addmul_1. */
+        hi = mpn_mul_1(T, T, Tn, (ulong) J);
+        T[Tn] = hi;  Tn += (hi != 0);
+
+        if (Tn < BXpn)
+        {
+            flint_mpn_zero(T + Tn, BXpn - Tn);
+            Tn = BXpn;
+        }
+        cy = mpn_addmul_1(T, BXp, BXpn, xl);
+        if (cy != 0)
+        {
+            if (Tn > BXpn)
+                cy = mpn_add_1(T + BXpn, T + BXpn, Tn - BXpn, cy);
+            if (cy != 0)
+            {
+                T[Tn] = cy;  Tn++;
+            }
+        }
+
+        /* B = J*B */
+        hi = mpn_mul_1(BB, BB, Bn, (ulong) J);
+        BB[Bn] = hi;  Bn += (hi != 0);
+
+        /* BXp = BXp*J*x  (skip the final, unused update); one mul_1 if J*x fits */
+        if (J + 1 < b)
+        {
+            umul_ppmm(hi, lo, (ulong) J, xl);
+            if (hi == 0)
+            {
+                hi = mpn_mul_1(BXp, BXp, BXpn, lo);
+                BXp[BXpn] = hi;  BXpn += (hi != 0);
+            }
+            else
+            {
+                hi = mpn_mul_1(BXp, BXp, BXpn, (ulong) J);
+                BXp[BXpn] = hi;  BXpn += (hi != 0);
+                hi = mpn_mul_1(BXp, BXp, BXpn, xl);
+                BXp[BXpn] = hi;  BXpn += (hi != 0);
+            }
+        }
+    }
+
+    /* Tu = T / p^vr (T has valuation vr in p-adic digits, vr < e). */
+    need = radix_set_mpn_need_alloc(Tn, radix);
+    d = radix_integer_fit_limbs(Tu, need, radix);
+    Tu->size = radix_set_mpn(d, T, Tn, radix);
+    if (vr > 0)
+        radix_integer_rshift_digits(Tu, Tu, vr, radix);
+    radix_integer_mod_limbs(Tu, Tu, l, radix);
+
+    need = radix_set_mpn_need_alloc(Bn, radix);
+    d = radix_integer_fit_limbs(B, need, radix);
+    B->size = radix_set_mpn(d, BB, Bn, radix);
+    radix_integer_mod_limbs(B, B, l, radix);
+}
+
+/*
+    Binary splitting of  sum_{i=a}^{b-1} x^i / i  for a block x = p^vr * ru,
+    where ru is a unit.  The factor of p^vr carried by every power of x is kept
+    out of the multiplications: the series numerator T = p^vr * Tu is returned
+    through its unit-scaled part Tu, and B = (b-1)!/(a-1)! is the denominator.
+    Powers ru^step are read from the precomputed table xpow (indexed through the
+    bs-exponent table xexp); the p^vr factors enter as digit shifts.  All values
+    are modulo B^l.  Identities, with T = p^vr Tu and S(a,b) = T/B:
+
+        Tu(a,a+1) = ru,                         B(a,a+1) = a
+        Tu(a,a+2) = (a+1) ru + a p^vr ru^2,     B(a,a+2) = a(a+1)
+        Tu        = Tu_L B_R + p^{vr step} ru^step B_L Tu_R,   step = (b-a)/2
+        B         = B_L B_R
+*/
+static void
+_padic_radix_log_bsplit(radix_integer_t Tu, radix_integer_t B,
+    slong a, slong b, const slong * xexp, const radix_integer_struct * xpow,
+    slong vr, slong l, ulong xl, int xl_fits, const radix_t radix)
+{
+    slong e = radix->exp;
+    slong el = e * l;
+
+    if (xl_fits && (b - a) < PADIC_RADIX_LOG_BSPLIT_BASECASE)
+    {
+        /* 1 <= b - a < tuning, block fits a limb: iterative mpn leaf.  This
+           also covers b - a == 1 (empty loop, Tu = ru), so the power table is
+           never consulted along this path. */
+        _padic_radix_log_bsplit_basecase_mpn(Tu, B, a, b, xl, vr, l, radix);
+    }
+    else if (b - a == 1)
+    {
+        radix_integer_set(Tu, xpow + 0, radix);          /* ru^1 */
+        radix_integer_set_ui(B, (ulong) a, radix);
+    }
+    else if (b - a == 2)
+    {
+        slong i2 = _arb_get_exp_pos(xexp, 2);
+        radix_integer_t tmp;
+        radix_integer_init(tmp, radix);
+
+        /* Tu = (a+1) ru + a p^vr ru^2 */
+        radix_integer_set_ui(tmp, (ulong) (a + 1), radix);
+        radix_integer_mullow_limbs(Tu, xpow + 0, tmp, l, radix);
+        if (vr < el)
+        {
+            radix_integer_set_ui(tmp, (ulong) a, radix);
+            radix_integer_mullow_limbs(tmp, xpow + i2, tmp, l, radix);  /* a ru^2 */
+            radix_integer_lshift_digits(tmp, tmp, vr, radix);
+            radix_integer_mod_limbs(tmp, tmp, l, radix);
+            radix_integer_add(Tu, Tu, tmp, radix);
+            radix_integer_mod_limbs(Tu, Tu, l, radix);
+        }
+
+        /* B = a(a+1) */
+        radix_integer_set_ui(B, (ulong) a, radix);
+        radix_integer_set_ui(tmp, (ulong) (a + 1), radix);
+        radix_integer_mullow_limbs(B, B, tmp, l, radix);
+
+        radix_integer_clear(tmp, radix);
+    }
+    else
+    {
+        slong step = (b - a) / 2;
+        slong m = a + step;
+        slong shift;
+        int include;
+        radix_integer_t TuR, BR, t2;
+
+        radix_integer_init(TuR, radix);
+        radix_integer_init(BR, radix);
+        radix_integer_init(t2, radix);
+
+        _padic_radix_log_bsplit(Tu, B, a, m, xexp, xpow, vr, l, xl, xl_fits, radix);
+        _padic_radix_log_bsplit(TuR, BR, m, b, xexp, xpow, vr, l, xl, xl_fits, radix);
+
+        /* Tu = Tu_L B_R + p^{vr step} ru^step B_L Tu_R */
+        radix_integer_mullow_limbs(Tu, Tu, BR, l, radix);   /* Tu_L B_R */
+
+        if (step != 0 && vr > el / step)
+            include = 0;
+        else
+        {
+            shift = vr * step;
+            include = (shift < el);
+        }
+
+        if (include)
+        {
+            slong is = _arb_get_exp_pos(xexp, step);
+            radix_integer_mullow_limbs(t2, xpow + is, B, l, radix);   /* ru^step B_L */
+            radix_integer_mullow_limbs(t2, t2, TuR, l, radix);        /* * Tu_R */
+            radix_integer_lshift_digits(t2, t2, shift, radix);
+            radix_integer_mod_limbs(t2, t2, l, radix);
+            radix_integer_add(Tu, Tu, t2, radix);
+            radix_integer_mod_limbs(Tu, Tu, l, radix);
+        }
+
+        radix_integer_mullow_limbs(B, B, BR, l, radix);     /* B_L B_R */
+
+        radix_integer_clear(TuR, radix);
+        radix_integer_clear(BR, radix);
+        radix_integer_clear(t2, radix);
+    }
+}
+
+/*
+    rop = sum_{i>=1} x^i / i  modulo p^N, the negative of log(1 - x), for a
+    block x of p-adic valuation at least w (1 <= w < N).  The result is the
+    nonnegative residue and carries the valuation vr = v_p(x): only the unit
+    part ru = x / p^vr enters the multiplications, and the result is shifted up
+    by vr at the end, so the series is evaluated to the reduced precision
+    N - vr.
+*/
+static void
+_padic_radix_log_bsplit_block(radix_integer_t rop, const radix_integer_t x,
+    slong w, slong N, const radix_t radix)
+{
+    ulong p = DIGIT_RADIX(radix);
+    slong e = radix->exp;
+    slong vr, Nr, n, k, l, lNr, kk, length, i;
+    slong * xexp;
+    radix_integer_struct * xpow;
+    radix_integer_t ru, Tu, B, ub;
+    ulong xl = 0, ru_l;
+    int xl_fits, use_table;
+
+    vr = radix_integer_valuation_digits(x, radix);
+    if (vr >= N)                                  /* contribution below p^N */
+    {
+        radix_integer_zero(rop, radix);
+        return;
+    }
+
+    Nr = N - vr;                                  /* relevant precision */
+
+    n = _padic_radix_log_bound(FLINT_MAX(w, vr), N, p);
+    n = FLINT_MAX(n, 2);
+
+    k = (n >= 2) ? (n - 2) / (slong) (p - 1) : 0; /* guard >= v_p((n-1)!) */
+    lNr = (Nr + e - 1) / e;
+    l = lNr + (k + e - 1) / e;                    /* room for the p^kk strip */
+
+    radix_integer_init(ru, radix);
+    radix_integer_init(Tu, radix);
+    radix_integer_init(B, radix);
+    radix_integer_init(ub, radix);
+
+    radix_integer_rshift_digits(ru, x, vr, radix);    /* unit part */
+    radix_integer_mod_limbs(ru, ru, l, radix);
+
+    /* The block value p^vr ru fits in a single limb exactly when vr < e and the
+       unit is below p^{e-vr}; the iterative mpn leaf then applies. */
+    ru_l = (ru->size == 0) ? 0 : ru->d[0];
+    xl_fits = (FLINT_ABS(ru->size) <= 1) && (vr < e) && (ru_l < radix->bpow[e - vr]);
+    if (xl_fits)
+        xl = radix->bpow[vr] * ru_l;              /* block value, < B */
+
+    /* The power table is only consulted by the recursive/leaf paths; if the
+       whole series [1, n) is taken by the iterative basecase, skip building it. */
+    use_table = !(xl_fits && (n - 1) < PADIC_RADIX_LOG_BSPLIT_BASECASE);
+
+    xexp = NULL;
+    xpow = NULL;
+    length = 0;
+
+    if (use_table)
+    {
+        /* Power table ru^xexp[i] for the binary splitting over [1, n). */
+        xexp = flint_calloc(2 * FLINT_BITS, sizeof(slong));
+        length = _arb_compute_bs_exponents(xexp, n - 1);
+        xpow = flint_malloc(sizeof(radix_integer_struct) * length);
+        for (i = 0; i < length; i++)
+            radix_integer_init(xpow + i, radix);
+
+        radix_integer_set(xpow + 0, ru, radix);           /* ru^1 */
+        for (i = 1; i < length; i++)
+        {
+            if (xexp[i] == 2 * xexp[i - 1])
+                radix_integer_mullow_limbs(xpow + i, xpow + i - 1, xpow + i - 1, l, radix);
+            else if (xexp[i] == 2 * xexp[i - 2])
+                radix_integer_mullow_limbs(xpow + i, xpow + i - 2, xpow + i - 2, l, radix);
+            else if (xexp[i] == 2 * xexp[i - 1] + 1)
+            {
+                radix_integer_mullow_limbs(xpow + i, xpow + i - 1, xpow + i - 1, l, radix);
+                radix_integer_mullow_limbs(xpow + i, xpow + i, ru, l, radix);
+            }
+            else if (xexp[i] == 2 * xexp[i - 2] + 1)
+            {
+                radix_integer_mullow_limbs(xpow + i, xpow + i - 2, xpow + i - 2, l, radix);
+                radix_integer_mullow_limbs(xpow + i, xpow + i, ru, l, radix);
+            }
+            else
+                flint_throw(FLINT_ERROR, "padic_radix log: power table malformed\n");
+        }
+    }
+
+    _padic_radix_log_bsplit(Tu, B, 1, n, xexp, xpow, vr, l, xl, xl_fits, radix);
+
+    /* Strip the common power of p (= v_p(B) = v_p(Tu)) so both are units. */
+    kk = radix_integer_valuation_digits(B, radix);
+    if (kk > 0)
+    {
+        radix_integer_rshift_digits(B, B, kk, radix);
+        radix_integer_rshift_digits(Tu, Tu, kk, radix);
+    }
+
+    /* ub = Tu / B  (mod p^Nr); rop = p^vr * ub. */
+    if (!radix_integer_divmod_limbs(ub, Tu, B, lNr, radix))
+        flint_throw(FLINT_ERROR, "_padic_radix_log_bsplit_block: series "
+            "denominator is not invertible after stripping\n");
+
+    radix_integer_mod_digits(ub, ub, Nr, radix);
+    radix_integer_lshift_digits(rop, ub, vr, radix);
+    radix_integer_mod_digits(rop, rop, N, radix);
+
+    if (use_table)
+    {
+        for (i = 0; i < length; i++)
+            radix_integer_clear(xpow + i, radix);
+        flint_free(xpow);
+        flint_free(xexp);
+    }
+    radix_integer_clear(ru, radix);
+    radix_integer_clear(Tu, radix);
+    radix_integer_clear(B, radix);
+    radix_integer_clear(ub, radix);
+}
+
+/*
+    rop = log(1 - y) modulo p^N, with y treated as an exact integer of p-adic
+    valuation at least the convergence threshold and less than N.
+
+    Uses the balanced decomposition 1 - y = prod_j (1 - r_j), where each r_j is
+    a doubling-width block peeled off the running cofactor t and the cofactor is
+    corrected by (1 - r_j)^{-1}; then log(1 - y) = sum_j log(1 - r_j).  The
+    nonnegative residue is returned.  Always returns GR_SUCCESS (an internal
+    invariant failure aborts via flint_throw).
+*/
+void
+_padic_radix_log_balanced(radix_integer_t rop, const radix_integer_t y, slong N,
+    const radix_t radix)
+{
+    slong e = radix->exp;
+    slong lN, bound, w;
+    radix_integer_t t, r, om, blk, z;
+
+    if (N <= 0)
+    {
+        radix_integer_zero(rop, radix);
+        return;
+    }
+
+    lN = (N + e - 1) / e;
+
+    radix_integer_init(t, radix);
+    radix_integer_init(r, radix);
+    radix_integer_init(om, radix);
+    radix_integer_init(blk, radix);
+    radix_integer_init(z, radix);
+
+    radix_integer_mod_digits(t, y, N, radix);     /* t = y mod p^N */
+    radix_integer_zero(z, radix);
+
+    bound = PADIC_RADIX_LOG_SMALLEST_BLOCK;   /* truncation p^bound of first block */
+    w = 1;                                     /* valuation lower bound of first block */
+    while (!radix_integer_is_zero(t, radix))
+    {
+        radix_integer_mod_digits(r, t, bound, radix);   /* low block */
+        radix_integer_sub(t, t, r, radix);              /* zero low `bound` digits */
+
+        if (!radix_integer_is_zero(t, radix))
+        {
+            /* t <- (t - r) / (1 - r)  (mod p^N); 1 - r is a 1-unit */
+            radix_integer_one(om, radix);
+            radix_integer_sub(om, om, r, radix);
+            if (!radix_integer_divmod_limbs(t, t, om, lN, radix))
+                flint_throw(FLINT_ERROR, "_padic_radix_log_balanced: 1 - r is "
+                    "not invertible\n");
+            radix_integer_mod_digits(t, t, N, radix);
+        }
+
+        if (!radix_integer_is_zero(r, radix))
+        {
+            _padic_radix_log_bsplit_block(blk, r, w, N, radix);   /* sum r^i/i */
+            radix_integer_sub(z, z, blk, radix);            /* += log(1 - r) */
+        }
+
+        w = bound;
+        bound *= 2;
+    }
+
+    radix_integer_mod_digits(rop, z, N, radix);
+
+    radix_integer_clear(t, radix);
+    radix_integer_clear(r, radix);
+    radix_integer_clear(om, radix);
+    radix_integer_clear(blk, radix);
+    radix_integer_clear(z, radix);
+}

--- a/src/padic_radix/log_rectangular.c
+++ b/src/padic_radix/log_rectangular.c
@@ -1,0 +1,536 @@
+/*
+    Copyright (C) 2012 Sebastian Pancratz
+    Copyright (C) 2012, 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "ulong_extras.h"
+#include "longlong.h"
+#include "mpn_extras.h"
+#include "padic_radix.h"
+#include "gr.h"
+#include "nmod_poly.h"
+
+/* Compressed table of lcm(1, ..., n) / i for small n. */
+
+#if FLINT_BITS == 64
+#define LOG_LCMTAB_MAXN 46
+static const ulong log_lcm_data[449] = {
+    UWORD(0), UWORD(1), UWORD(0), UWORD(2), UWORD(1), UWORD(0),
+    UWORD(6), UWORD(3), UWORD(2), UWORD(0), UWORD(12), UWORD(6),
+    UWORD(4), UWORD(3), UWORD(0), UWORD(60), UWORD(30), UWORD(20),
+    UWORD(15), UWORD(12), UWORD(10), UWORD(0), UWORD(420), UWORD(210),
+    UWORD(140), UWORD(105), UWORD(84), UWORD(70), UWORD(60), UWORD(0),
+    UWORD(840), UWORD(420), UWORD(280), UWORD(210), UWORD(168), UWORD(140),
+    UWORD(120), UWORD(105), UWORD(0), UWORD(2520), UWORD(1260), UWORD(840),
+    UWORD(630), UWORD(504), UWORD(420), UWORD(360), UWORD(315), UWORD(280),
+    UWORD(252), UWORD(0), UWORD(27720), UWORD(13860), UWORD(9240), UWORD(6930),
+    UWORD(5544), UWORD(4620), UWORD(3960), UWORD(3465), UWORD(3080), UWORD(2772),
+    UWORD(2520), UWORD(2310), UWORD(0), UWORD(360360), UWORD(180180), UWORD(120120),
+    UWORD(90090), UWORD(72072), UWORD(60060), UWORD(51480), UWORD(45045), UWORD(40040),
+    UWORD(36036), UWORD(32760), UWORD(30030), UWORD(27720), UWORD(25740), UWORD(24024),
+    UWORD(0), UWORD(720720), UWORD(360360), UWORD(240240), UWORD(180180), UWORD(144144),
+    UWORD(120120), UWORD(102960), UWORD(90090), UWORD(80080), UWORD(72072), UWORD(65520),
+    UWORD(60060), UWORD(55440), UWORD(51480), UWORD(48048), UWORD(45045), UWORD(0),
+    UWORD(12252240), UWORD(6126120), UWORD(4084080), UWORD(3063060), UWORD(2450448), UWORD(2042040),
+    UWORD(1750320), UWORD(1531530), UWORD(1361360), UWORD(1225224), UWORD(1113840), UWORD(1021020),
+    UWORD(942480), UWORD(875160), UWORD(816816), UWORD(765765), UWORD(720720), UWORD(680680),
+    UWORD(0), UWORD(232792560), UWORD(116396280), UWORD(77597520), UWORD(58198140), UWORD(46558512),
+    UWORD(38798760), UWORD(33256080), UWORD(29099070), UWORD(25865840), UWORD(23279256), UWORD(21162960),
+    UWORD(19399380), UWORD(17907120), UWORD(16628040), UWORD(15519504), UWORD(14549535), UWORD(13693680),
+    UWORD(12932920), UWORD(12252240), UWORD(11639628), UWORD(11085360), UWORD(10581480), UWORD(0),
+    UWORD(5354228880), UWORD(2677114440), UWORD(1784742960), UWORD(1338557220), UWORD(1070845776), UWORD(892371480),
+    UWORD(764889840), UWORD(669278610), UWORD(594914320), UWORD(535422888), UWORD(486748080), UWORD(446185740),
+    UWORD(411863760), UWORD(382444920), UWORD(356948592), UWORD(334639305), UWORD(314954640), UWORD(297457160),
+    UWORD(281801520), UWORD(267711444), UWORD(254963280), UWORD(243374040), UWORD(232792560), UWORD(223092870),
+    UWORD(0), UWORD(26771144400), UWORD(13385572200), UWORD(8923714800), UWORD(6692786100), UWORD(5354228880),
+    UWORD(4461857400), UWORD(3824449200), UWORD(3346393050), UWORD(2974571600), UWORD(2677114440), UWORD(2433740400),
+    UWORD(2230928700), UWORD(2059318800), UWORD(1912224600), UWORD(1784742960), UWORD(1673196525), UWORD(1574773200),
+    UWORD(1487285800), UWORD(1409007600), UWORD(1338557220), UWORD(1274816400), UWORD(1216870200), UWORD(1163962800),
+    UWORD(1115464350), UWORD(1070845776), UWORD(1029659400), UWORD(0), UWORD(80313433200), UWORD(40156716600),
+    UWORD(26771144400), UWORD(20078358300), UWORD(16062686640), UWORD(13385572200), UWORD(11473347600), UWORD(10039179150),
+    UWORD(8923714800), UWORD(8031343320), UWORD(7301221200), UWORD(6692786100), UWORD(6177956400), UWORD(5736673800),
+    UWORD(5354228880), UWORD(5019589575), UWORD(4724319600), UWORD(4461857400), UWORD(4227022800), UWORD(4015671660),
+    UWORD(3824449200), UWORD(3650610600), UWORD(3491888400), UWORD(3346393050), UWORD(3212537328), UWORD(3088978200),
+    UWORD(2974571600), UWORD(2868336900), UWORD(0), UWORD(2329089562800), UWORD(1164544781400), UWORD(776363187600),
+    UWORD(582272390700), UWORD(465817912560), UWORD(388181593800), UWORD(332727080400), UWORD(291136195350), UWORD(258787729200),
+    UWORD(232908956280), UWORD(211735414800), UWORD(194090796900), UWORD(179160735600), UWORD(166363540200), UWORD(155272637520),
+    UWORD(145568097675), UWORD(137005268400), UWORD(129393864600), UWORD(122583661200), UWORD(116454478140), UWORD(110909026800),
+    UWORD(105867707400), UWORD(101264763600), UWORD(97045398450), UWORD(93163582512), UWORD(89580367800), UWORD(86262576400),
+    UWORD(83181770100), UWORD(80313433200), UWORD(77636318760), UWORD(0), UWORD(72201776446800), UWORD(36100888223400),
+    UWORD(24067258815600), UWORD(18050444111700), UWORD(14440355289360), UWORD(12033629407800), UWORD(10314539492400), UWORD(9025222055850),
+    UWORD(8022419605200), UWORD(7220177644680), UWORD(6563797858800), UWORD(6016814703900), UWORD(5553982803600), UWORD(5157269746200),
+    UWORD(4813451763120), UWORD(4512611027925), UWORD(4247163320400), UWORD(4011209802600), UWORD(3800093497200), UWORD(3610088822340),
+    UWORD(3438179830800), UWORD(3281898929400), UWORD(3139207671600), UWORD(3008407351950), UWORD(2888071057872), UWORD(2776991401800),
+    UWORD(2674139868400), UWORD(2578634873100), UWORD(2489716429200), UWORD(2406725881560), UWORD(2329089562800), UWORD(0),
+    UWORD(144403552893600), UWORD(72201776446800), UWORD(48134517631200), UWORD(36100888223400), UWORD(28880710578720), UWORD(24067258815600),
+    UWORD(20629078984800), UWORD(18050444111700), UWORD(16044839210400), UWORD(14440355289360), UWORD(13127595717600), UWORD(12033629407800),
+    UWORD(11107965607200), UWORD(10314539492400), UWORD(9626903526240), UWORD(9025222055850), UWORD(8494326640800), UWORD(8022419605200),
+    UWORD(7600186994400), UWORD(7220177644680), UWORD(6876359661600), UWORD(6563797858800), UWORD(6278415343200), UWORD(6016814703900),
+    UWORD(5776142115744), UWORD(5553982803600), UWORD(5348279736800), UWORD(5157269746200), UWORD(4979432858400), UWORD(4813451763120),
+    UWORD(4658179125600), UWORD(4512611027925), UWORD(4375865239200), UWORD(4247163320400), UWORD(4125815796960), UWORD(4011209802600),
+    UWORD(0), UWORD(5342931457063200), UWORD(2671465728531600), UWORD(1780977152354400), UWORD(1335732864265800), UWORD(1068586291412640),
+    UWORD(890488576177200), UWORD(763275922437600), UWORD(667866432132900), UWORD(593659050784800), UWORD(534293145706320), UWORD(485721041551200),
+    UWORD(445244288088600), UWORD(410994727466400), UWORD(381637961218800), UWORD(356195430470880), UWORD(333933216066450), UWORD(314290085709600),
+    UWORD(296829525392400), UWORD(281206918792800), UWORD(267146572853160), UWORD(254425307479200), UWORD(242860520775600), UWORD(232301367698400),
+    UWORD(222622144044300), UWORD(213717258282528), UWORD(205497363733200), UWORD(197886350261600), UWORD(190818980609400), UWORD(184239015760800),
+    UWORD(178097715235440), UWORD(172352627647200), UWORD(166966608033225), UWORD(161907013850400), UWORD(157145042854800), UWORD(152655184487520),
+    UWORD(148414762696200), UWORD(144403552893600), UWORD(140603459396400), UWORD(136998242488800), UWORD(133573286426580), UWORD(0),
+    UWORD(219060189739591200), UWORD(109530094869795600), UWORD(73020063246530400), UWORD(54765047434897800), UWORD(43812037947918240), UWORD(36510031623265200),
+    UWORD(31294312819941600), UWORD(27382523717448900), UWORD(24340021082176800), UWORD(21906018973959120), UWORD(19914562703599200), UWORD(18255015811632600),
+    UWORD(16850783826122400), UWORD(15647156409970800), UWORD(14604012649306080), UWORD(13691261858724450), UWORD(12885893514093600), UWORD(12170010541088400),
+    UWORD(11529483670504800), UWORD(10953009486979560), UWORD(10431437606647200), UWORD(9957281351799600), UWORD(9524356075634400), UWORD(9127507905816300),
+    UWORD(8762407589583648), UWORD(8425391913061200), UWORD(8113340360725600), UWORD(7823578204985400), UWORD(7553799646192800), UWORD(7302006324653040),
+    UWORD(7066457733535200), UWORD(6845630929362225), UWORD(6638187567866400), UWORD(6442946757046800), UWORD(6258862563988320), UWORD(6085005270544200),
+    UWORD(5920545668637600), UWORD(5764741835252400), UWORD(5616927942040800), UWORD(5476504743489780), UWORD(5342931457063200), UWORD(5215718803323600),
+    UWORD(0), UWORD(9419588158802421600), UWORD(4709794079401210800), UWORD(3139862719600807200), UWORD(2354897039700605400), UWORD(1883917631760484320),
+    UWORD(1569931359800403600), UWORD(1345655451257488800), UWORD(1177448519850302700), UWORD(1046620906533602400), UWORD(941958815880242160), UWORD(856326196254765600),
+    UWORD(784965679900201800), UWORD(724583704523263200), UWORD(672827725628744400), UWORD(627972543920161440), UWORD(588724259925151350), UWORD(554093421106024800),
+    UWORD(523310453266801200), UWORD(495767797831706400), UWORD(470979407940121080), UWORD(448551817085829600), UWORD(428163098127382800), UWORD(409547311252279200),
+    UWORD(392482839950100900), UWORD(376783526352096864), UWORD(362291852261631600), UWORD(348873635511200800), UWORD(336413862814372200), UWORD(324813384786290400),
+    UWORD(313986271960080720), UWORD(303857682542013600), UWORD(294362129962575675), UWORD(285442065418255200), UWORD(277046710553012400), UWORD(269131090251497760),
+    UWORD(261655226633400600), UWORD(254583463751416800), UWORD(247883898915853200), UWORD(241527901507754400), UWORD(235489703970060540), UWORD(229746052653717600),
+    UWORD(224275908542914800), UWORD(219060189739591200), UWORD(214081549063691400), UWORD(209324181306720480), UWORD(204773655626139600),
+};
+static const unsigned short log_lcm_off[LOG_LCMTAB_MAXN + 1] = { 0, 0, 2, 5, 9, 14, 14, 21, 29, 38, 38, 49, 49, 62, 62, 62, 78, 95, 95, 114, 114, 114, 114, 137, 137, 162, 162, 189, 189, 218, 218, 249, 281, 281, 281, 281, 281, 318, 318, 318, 318, 359, 359, 402, 402, 402, 402 };
+#endif
+
+#if FLINT_BITS == 32
+#define LOG_LCMTAB_MAXN 22
+static const ulong log_lcm_data[137] = {
+    UWORD(0), UWORD(1), UWORD(0), UWORD(2), UWORD(1), UWORD(0),
+    UWORD(6), UWORD(3), UWORD(2), UWORD(0), UWORD(12), UWORD(6),
+    UWORD(4), UWORD(3), UWORD(0), UWORD(60), UWORD(30), UWORD(20),
+    UWORD(15), UWORD(12), UWORD(10), UWORD(0), UWORD(420), UWORD(210),
+    UWORD(140), UWORD(105), UWORD(84), UWORD(70), UWORD(60), UWORD(0),
+    UWORD(840), UWORD(420), UWORD(280), UWORD(210), UWORD(168), UWORD(140),
+    UWORD(120), UWORD(105), UWORD(0), UWORD(2520), UWORD(1260), UWORD(840),
+    UWORD(630), UWORD(504), UWORD(420), UWORD(360), UWORD(315), UWORD(280),
+    UWORD(252), UWORD(0), UWORD(27720), UWORD(13860), UWORD(9240), UWORD(6930),
+    UWORD(5544), UWORD(4620), UWORD(3960), UWORD(3465), UWORD(3080), UWORD(2772),
+    UWORD(2520), UWORD(2310), UWORD(0), UWORD(360360), UWORD(180180), UWORD(120120),
+    UWORD(90090), UWORD(72072), UWORD(60060), UWORD(51480), UWORD(45045), UWORD(40040),
+    UWORD(36036), UWORD(32760), UWORD(30030), UWORD(27720), UWORD(25740), UWORD(24024),
+    UWORD(0), UWORD(720720), UWORD(360360), UWORD(240240), UWORD(180180), UWORD(144144),
+    UWORD(120120), UWORD(102960), UWORD(90090), UWORD(80080), UWORD(72072), UWORD(65520),
+    UWORD(60060), UWORD(55440), UWORD(51480), UWORD(48048), UWORD(45045), UWORD(0),
+    UWORD(12252240), UWORD(6126120), UWORD(4084080), UWORD(3063060), UWORD(2450448), UWORD(2042040),
+    UWORD(1750320), UWORD(1531530), UWORD(1361360), UWORD(1225224), UWORD(1113840), UWORD(1021020),
+    UWORD(942480), UWORD(875160), UWORD(816816), UWORD(765765), UWORD(720720), UWORD(680680),
+    UWORD(0), UWORD(232792560), UWORD(116396280), UWORD(77597520), UWORD(58198140), UWORD(46558512),
+    UWORD(38798760), UWORD(33256080), UWORD(29099070), UWORD(25865840), UWORD(23279256), UWORD(21162960),
+    UWORD(19399380), UWORD(17907120), UWORD(16628040), UWORD(15519504), UWORD(14549535), UWORD(13693680),
+    UWORD(12932920), UWORD(12252240), UWORD(11639628), UWORD(11085360), UWORD(10581480),
+};
+static const unsigned short log_lcm_off[LOG_LCMTAB_MAXN + 1] = { 0, 0, 2, 5, 9, 14, 14, 21, 29, 38, 38, 49, 49, 62, 62, 62, 78, 95, 95, 114, 114, 114, 114 };
+#endif
+
+/* a <- a / p^d  (a divisible by p^d), in place on an l-limb array mod B^l. */
+static void
+_arr_rshift_digits(nn_ptr a, slong l, slong d, const radix_t radix)
+{
+    slong e = radix->exp;
+    slong dl = d / e, t;
+    unsigned int dr = (unsigned int) (d % e);
+
+    if (dl > 0)
+    {
+        for (t = 0; t + dl < l; t++)
+            a[t] = a[t + dl];
+        for (; t < l; t++)
+            a[t] = 0;
+    }
+    if (dr > 0)
+        radix_rshift_digits(a, a, l, dr, radix);
+}
+
+/* a <- (a * p^d) mod B^l, in place on an l-limb array. */
+static void
+_arr_lshift_digits(nn_ptr a, slong l, slong d, const radix_t radix)
+{
+    slong e = radix->exp;
+    slong dl = d / e, t;
+    unsigned int dr = (unsigned int) (d % e);
+
+    if (dl > 0)
+    {
+        for (t = l - 1; t >= dl; t--)
+            a[t] = a[t - dl];
+        for (; t >= 0; t--)
+            a[t] = 0;
+    }
+    if (dr > 0)
+        radix_lshift_digits(a, a, l, dr, radix);
+}
+
+/* pows[0] = 1, pows[1] = y mod B^l, pows[i] = y^i mod B^l for i = 2, ..., b. */
+static void
+_build_pows(nn_ptr * pows, slong b, const radix_integer_t y, slong l,
+    const radix_t radix)
+{
+    slong e = radix->exp, i, t;
+    radix_integer_t xi;
+
+    radix_integer_init(xi, radix);
+    radix_integer_mod_digits(xi, y, e * l, radix);
+    for (t = 0; t < l; t++)
+        pows[1][t] = (t < xi->size) ? xi->d[t] : 0;
+    radix_integer_clear(xi, radix);
+
+    for (t = 0; t < l; t++)
+        pows[0][t] = 0;
+    pows[0][0] = 1;
+    for (i = 2; i <= b; i++)
+        radix_mulmid(pows[i], pows[i - 1], l, pows[1], l, 0, l, radix);
+}
+
+/* cc = sum_{i=1}^{hi} coef[i] * pows[i]  (mod B^l), with single-limb
+   coefficients coef[1..hi], accumulated in plain limbs through a three-word
+   delayed-carry accumulator acc (3*l words); one mpn reduction per limb. */
+static void
+_block_inner_sum(nn_ptr cc, nn_ptr acc, nn_ptr * pows, slong hi,
+    const ulong * coef, slong l, nmod_t Bmod)
+{
+    slong i, t;
+    ulong cy[3];
+
+    for (t = 0; t < 3 * l; t++)
+        acc[t] = 0;
+    for (i = 1; i <= hi; i++)
+    {
+        ulong c = coef[i];
+        nn_srcptr pi = pows[i];
+
+        for (t = 0; t < l; t++)
+        {
+            ulong phi, plo;
+            umul_ppmm(phi, plo, pi[t], c);
+            add_sssaaaaaa(acc[3 * t + 2], acc[3 * t + 1], acc[3 * t],
+                          acc[3 * t + 2], acc[3 * t + 1], acc[3 * t],
+                          (ulong) 0, phi, plo);
+        }
+    }
+
+    cy[0] = cy[1] = cy[2] = 0;
+    if (Bmod.norm == 0)
+        for (t = 0; t < l; t++)
+        {
+            add_sssaaaaaa(cy[2], cy[1], cy[0], cy[2], cy[1], cy[0],
+                          acc[3 * t + 2], acc[3 * t + 1], acc[3 * t]);
+            cc[t] = flint_mpn_divrem_3_1_preinv_norm(cy, cy, Bmod.n, Bmod.ninv);
+        }
+    else
+        for (t = 0; t < l; t++)
+        {
+            add_sssaaaaaa(cy[2], cy[1], cy[0], cy[2], cy[1], cy[0],
+                          acc[3 * t + 2], acc[3 * t + 1], acc[3 * t]);
+            cc[t] = flint_mpn_divrem_3_1_preinv_unnorm(cy, cy, Bmod.n, Bmod.ninv, Bmod.norm);
+        }
+}
+
+/*
+    z = sum_{i=1}^{n} y^i / i  modulo p^N, by rectangular splitting
+
+        sum_{i=1}^{n} y^i/i
+            = sum_{j} ( sum_{i=1}^{b} y^i/(i+jb) ) y^{jb},
+
+    evaluated by Horner in y^b.  Inner sums are single-limb-coefficient
+    combinations of the precomputed powers y^i, accumulated with a three-word
+    delayed-carry accumulator.  There are three paths.
+
+    When n <= LOG_LCMTAB_MAXN the common denominator L = lcm(1, ..., n) fits one
+    radix limb, so the numerator sum_{i=1}^{n} (L/i) y^i can be evaluated
+    directly from the table (coefficients L/i) and divided by L exactly once at
+    the end -- no per-block inversion, and b is free of the single-limb block
+    constraint.  If in addition the working precision N + v_p(L) fits one limb,
+    the numerator is a single Horner evaluation (the fast path).  Otherwise it
+    is the multi-limb rectangular evaluation with one final division.
+
+    When n > LOG_LCMTAB_MAXN the lcm exceeds the limb radix, so the sum is
+    carried scaled by p^k (k = floor(log_p n) >= v_p(i) for i <= n) with a block
+    denominator f = (1+jb)...(hi+jb) that fits a limb: each block needs one
+    Hensel inversion and a digit shift by k - v_p(f), and p^k is stripped at the
+    end.  The block width is b = min(floor(sqrt(n)), largest m with n^m < B) and
+    l covers N + k + g digits, where g = b/(p-1) bounds a block's k - v_p(f)
+    loss.  Does not support aliasing of z with y.
+*/
+static void
+_padic_radix_log_rectangular_series(radix_integer_t z, const radix_integer_t y,
+    slong n, slong N, const radix_t radix)
+{
+    ulong p = DIGIT_RADIX(radix);
+    ulong B = LIMB_RADIX(radix);
+    nmod_t Bmod = radix->B;
+    slong e = radix->exp;
+    slong b, bfit, k, g, lN, l, i, j, t, nsums;
+    nn_ptr scratch, zarr, cc, tmp, acc, cf;
+    nn_ptr * pows;
+    radix_integer_struct zv;
+
+    if (n <= 0)
+    {
+        radix_integer_zero(z, radix);
+        return;
+    }
+
+    if (n == 1)
+    {
+        radix_integer_mod_digits(z, y, N, radix);
+        return;
+    }
+
+    if (n <= LOG_LCMTAB_MAXN)
+    {
+        const ulong * row = log_lcm_data + log_lcm_off[n]; /* row[i] = lcm(1..n)/i */
+        ulong L = row[1];                                  /* L = lcm(1..n)        */
+
+        if (L < B)
+        {
+            ulong Lu;                                      /* L = p^w * Lu, Lu unit */
+            slong w;
+
+            if (p == 2)
+            {
+                w = flint_ctz(L);
+                Lu = L >> w;
+            }
+            else
+            {
+                w = (slong) _radix_valuation_digits_1(L, radix);
+                Lu = L * radix->bpow_oddinv[w].a;
+            }
+
+            /* Single-limb fast path: N + v_p(L) fits one limb. */
+            if (N + w <= e)
+            {
+                ulong yl, num, num_u, res, mag0;
+
+                mag0 = (y->size == 0) ? 0 : y->d[0];       /* |y| mod B */
+                yl = (y->size >= 0) ? mag0 : (mag0 == 0 ? 0 : B - mag0);
+
+                num = _nmod_poly_evaluate_nmod(row, n + 1, yl, Bmod);
+                num_u = (p == 2) ? (num >> w) : (num * radix->bpow_oddinv[w].a);
+
+                if (!radix_divmod_bn_1(&res, NULL, &num_u, 1, Lu, 1, radix))
+                    flint_throw(FLINT_ERROR, "_padic_radix_log_rectangular_series: "
+                        "denominator is not invertible after stripping\n");
+
+                res = res % radix->bpow[N];                /* reduce to N digits */
+                radix_integer_set_ui(z, res, radix);
+                return;
+            }
+
+            /* Multi-limb path with the lcm as a single common denominator:
+               evaluate the numerator sum_{i=1}^{n} (L/i) y^i mod B^l, then strip
+               p^w and divide by Lu once. */
+            b = (slong) n_sqrt((ulong) n);
+            if (b < 1)
+                b = 1;
+            lN = (N + e - 1) / e;
+            l = lN + (w + e - 1) / e;                      /* covers N + w digits */
+
+            /* pows[0..b] (b+1), zarr, cc, tmp (3), acc (3) -> b+7 slots */
+            scratch = flint_malloc(sizeof(ulong) * (size_t) (b + 7) * (size_t) l);
+            pows = flint_malloc(sizeof(nn_ptr) * (b + 1));
+            for (i = 0; i <= b; i++)
+                pows[i] = scratch + (slong) i * l;
+            zarr = scratch + (slong) (b + 1) * l;
+            cc   = scratch + (slong) (b + 2) * l;
+            tmp  = scratch + (slong) (b + 3) * l;
+            acc  = scratch + (slong) (b + 4) * l;
+
+            _build_pows(pows, b, y, l, radix);
+
+            for (t = 0; t < l; t++)
+                zarr[t] = 0;
+            nsums = (n + b - 1) / b;
+
+            for (j = nsums - 1; j >= 0; j--)
+            {
+                slong base = j * b;
+                slong hi = FLINT_MIN(b, n - base);
+
+                /* cc = sum_{i=1}^{hi} (L/(i+base)) y^i = sum row[base+i] y^i */
+                _block_inner_sum(cc, acc, pows, hi, row + base, l, Bmod);
+
+                /* zarr <- zarr * y^b + cc */
+                radix_mulmid(tmp, zarr, l, pows[b], l, 0, l, radix);
+                radix_add(zarr, tmp, l, cc, l, radix);
+            }
+
+            flint_free(pows);
+
+            /* zarr = sum (L/i) y^i = p^w Lu * sum y^i/i; strip p^w, divide by Lu */
+            if (w > 0)
+                _arr_rshift_digits(zarr, l, w, radix);
+            if (!radix_divmod_bn_1(cc, NULL, zarr, l, Lu, lN, radix))
+                flint_throw(FLINT_ERROR, "_padic_radix_log_rectangular_series: "
+                    "denominator is not invertible after stripping\n");
+
+            zv.d = cc;
+            zv.alloc = lN;
+            zv.size = lN;
+            while (zv.size > 0 && zv.d[zv.size - 1] == 0)
+                zv.size--;
+            radix_integer_mod_digits(z, &zv, N, radix);
+
+            flint_free(scratch);
+            return;
+        }
+    }
+
+    /* General per-block loop: n > LOG_LCMTAB_MAXN (or lcm >= B). */
+    {
+        ulong prod = 1, hh, ll;
+        bfit = 0;
+        for (;;)
+        {
+            umul_ppmm(hh, ll, prod, (ulong) n);
+            if (hh != 0 || ll >= B)
+                break;
+            prod = ll;
+            bfit++;
+        }
+    }
+
+    b = (slong) n_sqrt((ulong) n);
+    if (b < 1)
+        b = 1;
+    if (b > bfit)
+        b = bfit;
+
+    k = (slong) n_flog((ulong) n, p);             /* >= v_p(i) for all i <= n */
+    g = b / (slong) (p - 1) + 1;                  /* bound on a block's w - k  */
+    lN = (N + e - 1) / e;
+    l = lN + (k + g + e - 1) / e;                 /* limbs covering N + k + g  */
+
+    /* pows[0..b] (b+1), zarr, cc, tmp (3), acc (3) -> b+7 slots; cf separate. */
+    scratch = flint_malloc(sizeof(ulong) * (size_t) (b + 7) * (size_t) l);
+    pows = flint_malloc(sizeof(nn_ptr) * (b + 1));
+    cf = flint_malloc(sizeof(ulong) * (b + 1));
+    for (i = 0; i <= b; i++)
+        pows[i] = scratch + (slong) i * l;
+    zarr = scratch + (slong) (b + 1) * l;
+    cc   = scratch + (slong) (b + 2) * l;
+    tmp  = scratch + (slong) (b + 3) * l;
+    acc  = scratch + (slong) (b + 4) * l;
+
+    _build_pows(pows, b, y, l, radix);
+
+    for (t = 0; t < l; t++)
+        zarr[t] = 0;
+    nsums = (n + b - 1) / b;
+
+    for (j = nsums - 1; j >= 0; j--)
+    {
+        slong base = j * b;
+        slong hi = FLINT_MIN(b, n - base);
+        slong w;
+        ulong f, fu;
+
+        /* f = (1+base)...(hi+base); cf[i] = f/(i+base), all single limbs */
+        f = 1;
+        for (i = 1; i <= hi; i++)
+            f *= (ulong) (i + base);
+        for (i = 1; i <= hi; i++)
+            cf[i] = f / (ulong) (i + base);
+
+        _block_inner_sum(cc, acc, pows, hi, cf, l, Bmod);
+
+        /* f = p^w * fu (fu a unit) */
+        w = 0;
+        fu = f;
+        while (fu % p == 0)
+        {
+            fu /= p;
+            w++;
+        }
+
+        /* cc <- cc * p^{k-w} */
+        if (w > k)
+            _arr_rshift_digits(cc, l, w - k, radix);
+        else if (w < k)
+            _arr_lshift_digits(cc, l, k - w, radix);
+
+        /* block contribution tmp = cc / fu  (mod B^l), fu a single-limb unit */
+        if (!radix_divmod_bn_1(tmp, NULL, cc, l, fu, l, radix))
+            flint_throw(FLINT_ERROR, "_padic_radix_log_rectangular_series: "
+                "denominator is not invertible after stripping\n");
+
+        /* zarr <- zarr * y^b + tmp */
+        radix_mulmid(cc, pows[b], l, zarr, l, 0, l, radix);
+        radix_add(zarr, cc, l, tmp, l, radix);
+    }
+
+    flint_free(pows);
+    flint_free(cf);
+
+    /* zarr holds p^k * sum y^i/i; strip the guard and reduce to p^N. */
+    if (k > 0)
+        _arr_rshift_digits(zarr, l, k, radix);
+
+    zv.d = zarr;
+    zv.alloc = l;
+    zv.size = l;
+    while (zv.size > 0 && zv.d[zv.size - 1] == 0)
+        zv.size--;
+
+    radix_integer_mod_digits(z, &zv, N, radix);
+
+    flint_free(scratch);
+}
+/*
+    rop = log(1 - y) modulo p^N by rectangular splitting, with y an exact
+    integer of p-adic valuation at least the convergence threshold and < N.
+    The nonnegative residue is returned.
+*/
+void
+_padic_radix_log_rectangular(radix_integer_t rop, const radix_integer_t y,
+    slong N, const radix_t radix)
+{
+    ulong p = DIGIT_RADIX(radix);
+    ulong B = LIMB_RADIX(radix);
+    slong vr, n;
+    radix_integer_t s, zero;
+
+    if (N <= 0)
+    {
+        radix_integer_zero(rop, radix);
+        return;
+    }
+
+    vr = radix_integer_valuation_digits(y, radix);
+    if (vr >= N)
+    {
+        radix_integer_zero(rop, radix);
+        return;
+    }
+
+    n = _padic_radix_log_bound(vr, N, p) - 1;
+
+    /* Probably an artificially small limb radix, not supported by the implementation */
+    if (n >= 2 && (ulong) n >= B)
+    {
+        _padic_radix_log_balanced(rop, y, N, radix);
+        return;
+    }
+
+    radix_integer_init(s, radix);
+    radix_integer_init(zero, radix);
+
+    _padic_radix_log_rectangular_series(s, y, n, N, radix);
+
+    /* log(1 - y) = - sum_{i>=1} y^i/i */
+    radix_integer_zero(zero, radix);
+    radix_integer_sub(rop, zero, s, radix);
+    radix_integer_mod_digits(rop, rop, N, radix);
+
+    radix_integer_clear(s, radix);
+    radix_integer_clear(zero, radix);
+}

--- a/src/padic_radix/padic.c
+++ b/src/padic_radix/padic.c
@@ -2018,6 +2018,7 @@ gr_method_tab_input _padic_radix_methods_input[] =
     {GR_METHOD_RSQRT,           (gr_funcptr) padic_radix_rsqrt},
     {GR_METHOD_IS_SQUARE,       (gr_funcptr) padic_radix_is_square},
     {GR_METHOD_EXP,             (gr_funcptr) padic_radix_exp},
+    {GR_METHOD_LOG,             (gr_funcptr) padic_radix_log},
     {GR_METHOD_VEC_DOT,         (gr_funcptr) padic_radix_dot},
     {GR_METHOD_VEC_DOT_REV,     (gr_funcptr) padic_radix_dot_rev},
     {GR_METHOD_VEC_DOT_STRIDED, (gr_funcptr) padic_radix_dot_strided},

--- a/src/padic_radix/profile/p-log.c
+++ b/src/padic_radix/profile/p-log.c
@@ -37,7 +37,7 @@ int main()
 
         flint_printf("precision %wu^n, limb radix = %wu^%wd\n\n", p, p, radix->exp);
 
-        for (n = 10; n <= 11000000; n *= 2)
+        for (n = 10; n <= 1500000; n *= 2)
         {
             gr_ctx_t ctx;
             radix_integer_t x, y;
@@ -78,33 +78,42 @@ int main()
             rx->v = 1;
             rx->N += 1;
 
-            double t1, t2 = 0.0, t3, t4, FLINT_SET_BUT_UNUSED(__);
+            double t1, t2, t3, t4, t5, FLINT_SET_BUT_UNUSED(__);
+
+            padic_exp(py, px, pctx);
+            padic_set(px, py, pctx);
 
             TIMEIT_START;
-            padic_exp(py, px, pctx);
+            padic_log(py, px, pctx);
             TIMEIT_STOP_VALUES(__, t1);
+
+            TIMEIT_START;
+            padic_radix_exp(ry, rx, ctx);
+            TIMEIT_STOP_VALUES(__, t2);
+
+            padic_radix_set(rx, ry, ctx);
 
             if (n < 1000)
             {
                 TIMEIT_START;
-                padic_radix_exp_rectangular(ry, rx, ctx);
-                TIMEIT_STOP_VALUES(__, t2);
+                padic_radix_log_rectangular(ry, rx, ctx);
+                TIMEIT_STOP_VALUES(__, t3);
             }
             else
-                t2 = D_NAN;
+                t3 = D_NAN;
 
             TIMEIT_START;
-            padic_radix_exp_balanced(ry, rx, ctx);
-            TIMEIT_STOP_VALUES(__, t3);
-
-            TIMEIT_START;
-            padic_radix_exp(ry, rx, ctx);
+            padic_radix_log_balanced(ry, rx, ctx);
             TIMEIT_STOP_VALUES(__, t4);
 
-            if (n == 10)
-                flint_printf("       n      padic     rectangular   balanced    default   speedup\n");
+            TIMEIT_START;
+            padic_radix_log(ry, rx, ctx);
+            TIMEIT_STOP_VALUES(__, t5);
 
-            flint_printf("%8wd   %10g  %10g  %10g  %10g  %6.3fx\n", n, t1, t2, t3, t4, t1 / t4);
+            if (n == 10)
+                flint_printf("       n      padic       exp       rectangular   balanced     log       speedup\n");
+
+            flint_printf("%8wd   %10g  %10g  %10g  %10g  %10g   %6.3fx\n", n, t1, t2, t3, t4, t5, t1 / t5);
 
             padic_radix_clear(rx, ctx);
             padic_radix_clear(ry, ctx);
@@ -130,7 +139,6 @@ int main()
         flint_printf("\n");
     }
 
-    radix_clear(radix);
     flint_rand_clear(state);
     flint_cleanup_master();
     return 0;

--- a/src/padic_radix/test/main.c
+++ b/src/padic_radix/test/main.c
@@ -15,6 +15,9 @@
 #include "t-exp.c"
 #include "t-exp_balanced.c"
 #include "t-exp_rectangular.c"
+#include "t-log.c"
+#include "t-log_balanced.c"
+#include "t-log_rectangular.c"
 #include "t-padic.c"
 
 /* Array of test functions ***************************************************/
@@ -25,6 +28,9 @@ test_struct tests[] =
     TEST_FUNCTION(padic_radix_exp),
     TEST_FUNCTION(padic_radix_exp_balanced),
     TEST_FUNCTION(padic_radix_exp_rectangular),
+    TEST_FUNCTION(padic_radix_log),
+    TEST_FUNCTION(padic_radix_log_balanced),
+    TEST_FUNCTION(padic_radix_log_rectangular),
     TEST_FUNCTION(padic_radix),
 };
 

--- a/src/padic_radix/test/t-exp.c
+++ b/src/padic_radix/test/t-exp.c
@@ -87,7 +87,6 @@ TEST_FUNCTION_START(padic_radix_exp, state)
         slong thr, v, N;
         fmpz_t uf, pf, ref, got;
         radix_integer_t u, g;
-        int status;
 
         radix_init_randtest_prime(radix, state);
         p = DIGIT_RADIX(radix);
@@ -112,13 +111,7 @@ TEST_FUNCTION_START(padic_radix_exp, state)
         radix_integer_init(g, radix);
         radix_integer_set_fmpz(u, uf, radix);
 
-        status = _padic_radix_exp(g, u, v, N, radix);
-
-        if (status != GR_SUCCESS)
-        {
-            flint_printf("FAIL: unexpected status %d (p = %wu, e = %wu)\n", status, p, radix->exp);
-            flint_abort();
-        }
+        _padic_radix_exp(g, u, v, N, radix);
 
         _padic_exp(ref, uf, v, pf, N);
         radix_integer_get_fmpz(got, g, radix);

--- a/src/padic_radix/test/t-exp_balanced.c
+++ b/src/padic_radix/test/t-exp_balanced.c
@@ -81,7 +81,6 @@ TEST_FUNCTION_START(padic_radix_exp_balanced, state)
         slong thr, v, N;
         fmpz_t uf, pf, ref, got;
         radix_integer_t u, g;
-        int status;
 
         radix_init_randtest_prime(radix, state);
         p = DIGIT_RADIX(radix);
@@ -107,13 +106,7 @@ TEST_FUNCTION_START(padic_radix_exp_balanced, state)
         radix_integer_init(g, radix);
         radix_integer_set_fmpz(u, uf, radix);
 
-        status = _padic_radix_exp_balanced(g, u, v, N, radix);
-
-        if (status != GR_SUCCESS)
-        {
-            flint_printf("FAIL: unexpected status %d (p = %wu, e = %wu)\n", status, p, radix->exp);
-            flint_abort();
-        }
+        _padic_radix_exp_balanced(g, u, v, N, radix);
 
         _padic_exp(ref, uf, v, pf, N);
         radix_integer_get_fmpz(got, g, radix);

--- a/src/padic_radix/test/t-exp_rectangular.c
+++ b/src/padic_radix/test/t-exp_rectangular.c
@@ -80,7 +80,6 @@ TEST_FUNCTION_START(padic_radix_exp_rectangular, state)
         slong thr, v, N;
         fmpz_t uf, pf, ref, got;
         radix_integer_t u, g;
-        int status;
 
         radix_init_randtest_prime(radix, state);
         p = DIGIT_RADIX(radix);
@@ -105,29 +104,18 @@ TEST_FUNCTION_START(padic_radix_exp_rectangular, state)
         radix_integer_init(g, radix);
         radix_integer_set_fmpz(u, uf, radix);
 
-        status = _padic_radix_exp_rectangular(g, u, v, N, radix);
+        _padic_radix_exp_rectangular(g, u, v, N, radix);
 
-        if (status == GR_SUCCESS)
-        {
-            _padic_exp(ref, uf, v, pf, N);
-            radix_integer_get_fmpz(got, g, radix);
+        _padic_exp(ref, uf, v, pf, N);
+        radix_integer_get_fmpz(got, g, radix);
 
-            if (!fmpz_equal(ref, got))
-            {
-                flint_printf("FAIL: _padic_radix_exp_balanced vs _padic_exp\n");
-                flint_printf("p = %wu, e = %wu, v = %wd, N = %wd\n", p, radix->exp, v, N);
-                flint_printf("u = "); fmpz_print(uf); flint_printf("\n");
-                flint_printf("ref = "); fmpz_print(ref); flint_printf("\n");
-                flint_printf("got = "); fmpz_print(got); flint_printf("\n");
-                flint_abort();
-            }
-        }
-        else if (status == GR_UNABLE)
+        if (!fmpz_equal(ref, got))
         {
-        }
-        else
-        {
-            flint_printf("FAIL: unexpected status %d (p = %wu, e = %wu)\n", status, p, radix->exp);
+            flint_printf("FAIL: _padic_radix_exp_balanced vs _padic_exp\n");
+            flint_printf("p = %wu, e = %wu, v = %wd, N = %wd\n", p, radix->exp, v, N);
+            flint_printf("u = "); fmpz_print(uf); flint_printf("\n");
+            flint_printf("ref = "); fmpz_print(ref); flint_printf("\n");
+            flint_printf("got = "); fmpz_print(got); flint_printf("\n");
             flint_abort();
         }
 

--- a/src/padic_radix/test/t-log.c
+++ b/src/padic_radix/test/t-log.c
@@ -89,7 +89,7 @@ TEST_FUNCTION_START(padic_radix_log, state)
         radix_init_randtest_prime(radix, state);
         p = DIGIT_RADIX(radix);
 
-        thr = (p == 2) ? 2 : 1;
+        thr = 1;   /* log converges for valuation >= 1 for every p */
         v = thr + (slong) n_randint(state, 6);
         N = 1 + (slong) n_randint(state, n_randint(state, 2) ? 60 : 250);
 

--- a/src/padic_radix/test/t-log.c
+++ b/src/padic_radix/test/t-log.c
@@ -1,0 +1,212 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "longlong.h"
+#include "ulong_extras.h"
+#include "fmpz.h"
+#include "radix.h"
+#include "padic.h"
+#include "padic_radix.h"
+#include "gr.h"
+
+
+TEST_FUNCTION_START(padic_radix_log, state)
+{
+    slong iter;
+
+    /* log(x y) == log(x) + log(y) on 1-units (built via exp for coverage) */
+    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
+    {
+        gr_ctx_t ctx;
+        padic_radix_t a, b, x, y, xy, lx, ly, lxly, lxy;
+        int status = GR_SUCCESS;
+
+        gr_ctx_init_padic_radix_randtest(ctx, state, 10);
+
+        padic_radix_init(a, ctx);
+        padic_radix_init(b, ctx);
+        padic_radix_init(x, ctx);
+        padic_radix_init(y, ctx);
+        padic_radix_init(xy, ctx);
+        padic_radix_init(lx, ctx);
+        padic_radix_init(ly, ctx);
+        padic_radix_init(lxly, ctx);
+        padic_radix_init(lxy, ctx);
+
+        GR_IGNORE(gr_randtest(a, state, ctx));
+        GR_IGNORE(gr_randtest(b, state, ctx));
+
+        status |= padic_radix_exp(x, a, ctx);
+        status |= padic_radix_exp(y, b, ctx);
+        status |= padic_radix_mul(xy, x, y, ctx);
+
+        status |= padic_radix_log_rectangular(lx, x, ctx);
+        status |= padic_radix_set(ly, y, ctx);      /* aliasing */
+        status |= padic_radix_log_rectangular(ly, ly, ctx);
+        status |= padic_radix_log_rectangular(lxy, xy, ctx);
+        status |= padic_radix_add(lxly, lx, ly, ctx);
+
+        if (status == GR_SUCCESS && padic_radix_equal(lxy, lxly, ctx) == T_FALSE)
+        {
+            flint_printf("FAIL: padic_radix_log_rectangular (homomorphism)\n");
+            flint_printf("x = "); gr_println(x, ctx);
+            flint_printf("y = "); gr_println(y, ctx);
+            flint_printf("lxy = "); gr_println(lxy, ctx);
+            flint_printf("lxly = "); gr_println(lxly, ctx);
+            flint_abort();
+        }
+
+        padic_radix_clear(a, ctx);
+        padic_radix_clear(b, ctx);
+        padic_radix_clear(x, ctx);
+        padic_radix_clear(y, ctx);
+        padic_radix_clear(xy, ctx);
+        padic_radix_clear(lx, ctx);
+        padic_radix_clear(ly, ctx);
+        padic_radix_clear(lxly, ctx);
+        padic_radix_clear(lxy, ctx);
+
+        gr_ctx_clear(ctx);
+    }
+
+    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
+    {
+        ulong p;
+        radix_t radix;
+        slong thr, v, N;
+        fmpz_t uf, pf, pv, yf, ref, got, pN;
+        radix_integer_t y, g;
+
+        radix_init_randtest_prime(radix, state);
+        p = DIGIT_RADIX(radix);
+
+        thr = (p == 2) ? 2 : 1;
+        v = thr + (slong) n_randint(state, 6);
+        N = 1 + (slong) n_randint(state, n_randint(state, 2) ? 60 : 250);
+
+        if (v >= N)
+        {
+            radix_clear(radix);
+            continue;
+        }
+
+        fmpz_init(uf);
+        fmpz_init(pf);
+        fmpz_init(pv);
+        fmpz_init(yf);
+        fmpz_init(ref);
+        fmpz_init(got);
+        fmpz_init(pN);
+        fmpz_set_ui(pf, p);
+
+        fmpz_randtest_unsigned(uf, state, 1 + n_randint(state, 400));
+        if (fmpz_is_zero(uf))
+            fmpz_one(uf);
+        if (fmpz_divisible(uf, pf))
+            fmpz_add_ui(uf, uf, 1);
+
+        fmpz_pow_ui(pv, pf, v);
+        fmpz_mul(yf, uf, pv);
+
+        radix_integer_init(y, radix);
+        radix_integer_init(g, radix);
+        radix_integer_set_fmpz(y, yf, radix);
+
+        _padic_radix_log_rectangular(g, y, N, radix);
+
+        _padic_log(ref, yf, v, pf, N);
+        fmpz_pow_ui(pN, pf, N);
+        fmpz_mod(ref, ref, pN);
+
+        radix_integer_get_fmpz(got, g, radix);
+
+        if (!fmpz_equal(ref, got))
+        {
+            flint_printf("FAIL: _padic_radix_log_rectangular vs _padic_log\n");
+            flint_printf("p = %wu, e = %wu, v = %wd, N = %wd\n", p, radix->exp, v, N);
+            flint_printf("y = "); fmpz_print(yf); flint_printf("\n");
+            flint_printf("ref = "); fmpz_print(ref); flint_printf("\n");
+            flint_printf("got = "); fmpz_print(got); flint_printf("\n");
+            flint_abort();
+        }
+
+        radix_integer_clear(y, radix);
+        radix_integer_clear(g, radix);
+        fmpz_clear(uf);
+        fmpz_clear(pf);
+        fmpz_clear(pv);
+        fmpz_clear(yf);
+        fmpz_clear(ref);
+        fmpz_clear(got);
+        fmpz_clear(pN);
+        radix_clear(radix);
+    }
+
+    /* domain handling of the log wrapper for low-precision / zero-unit inputs */
+    for (iter = 0; iter < 100 * flint_test_multiplier(); iter++)
+    {
+        gr_ctx_t ctx;
+        radix_struct * radix;
+        padic_radix_t x, r;
+
+        gr_ctx_init_padic_radix_randtest(ctx, state, 20);
+        radix = PADIC_RADIX_CTX_RADIX(ctx);
+        padic_radix_init(x, ctx);
+        padic_radix_init(r, ctx);
+
+        /* O(p^Nx) with Nx <= 0 cannot be told apart from a 1-unit -> UNABLE */
+        radix_integer_zero(&x->u, radix);
+        x->v = 0;
+        x->N = -(slong) n_randint(state, 3);   /* 0, -1, -2 */
+        if (padic_radix_log(r, x, ctx) != GR_UNABLE)
+        {
+            flint_printf("FAIL: log(O(p^%wd)) should be GR_UNABLE\n", x->N);
+            flint_abort();
+        }
+
+        /* O(p^Nx) with Nx >= 1 has positive valuation -> not a unit -> DOMAIN */
+        radix_integer_zero(&x->u, radix);
+        x->N = 1 + (slong) n_randint(state, 5);
+        x->v = x->N;
+        if (padic_radix_log(r, x, ctx) != GR_DOMAIN)
+        {
+            flint_printf("FAIL: log(O(p^%wd)) should be GR_DOMAIN\n", x->N);
+            flint_abort();
+        }
+
+        /* exact zero -> DOMAIN */
+        radix_integer_zero(&x->u, radix);
+        x->v = 0;
+        x->N = PADIC_RADIX_EXACT;
+        if (padic_radix_log(r, x, ctx) != GR_DOMAIN)
+        {
+            flint_printf("FAIL: log(0) should be GR_DOMAIN\n");
+            flint_abort();
+        }
+
+        /* u p^v + O(p^Nx) with a known v != 0 -> not a 1-unit -> DOMAIN */
+        radix_integer_one(&x->u, radix);
+        x->v = -3;
+        x->N = 0;
+        if (padic_radix_log(r, x, ctx) != GR_DOMAIN)
+        {
+            flint_printf("FAIL: log(p^-3 + O(p^0)) should be GR_DOMAIN\n");
+            flint_abort();
+        }
+
+        padic_radix_clear(x, ctx);
+        padic_radix_clear(r, ctx);
+        gr_ctx_clear(ctx);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/padic_radix/test/t-log_balanced.c
+++ b/src/padic_radix/test/t-log_balanced.c
@@ -1,0 +1,158 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "longlong.h"
+#include "ulong_extras.h"
+#include "fmpz.h"
+#include "radix.h"
+#include "padic.h"
+#include "padic_radix.h"
+#include "gr.h"
+
+
+TEST_FUNCTION_START(padic_radix_log_balanced, state)
+{
+    slong iter;
+
+    /* log(x y) == log(x) + log(y) on 1-units (built via exp for coverage) */
+    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
+    {
+        gr_ctx_t ctx;
+        padic_radix_t a, b, x, y, xy, lx, ly, lxly, lxy;
+        int status = GR_SUCCESS;
+
+        gr_ctx_init_padic_radix_randtest(ctx, state, n_randint(state, 4) ? 10 : 100);
+
+        padic_radix_init(a, ctx);
+        padic_radix_init(b, ctx);
+        padic_radix_init(x, ctx);
+        padic_radix_init(y, ctx);
+        padic_radix_init(xy, ctx);
+        padic_radix_init(lx, ctx);
+        padic_radix_init(ly, ctx);
+        padic_radix_init(lxly, ctx);
+        padic_radix_init(lxy, ctx);
+
+        GR_IGNORE(gr_randtest(a, state, ctx));
+        GR_IGNORE(gr_randtest(b, state, ctx));
+
+        /* x, y are 1-units whenever exp converges */
+        status |= padic_radix_exp(x, a, ctx);
+        status |= padic_radix_exp(y, b, ctx);
+        status |= padic_radix_mul(xy, x, y, ctx);
+
+        status |= padic_radix_log_balanced(lx, x, ctx);
+        status |= padic_radix_set(ly, y, ctx);      /* aliasing */
+        status |= padic_radix_log_balanced(ly, ly, ctx);
+        status |= padic_radix_log_balanced(lxy, xy, ctx);
+        status |= padic_radix_add(lxly, lx, ly, ctx);
+
+        if (status == GR_SUCCESS && padic_radix_equal(lxy, lxly, ctx) == T_FALSE)
+        {
+            flint_printf("FAIL: padic_radix_log_balanced (homomorphism)\n");
+            flint_printf("x = "); gr_println(x, ctx);
+            flint_printf("y = "); gr_println(y, ctx);
+            flint_printf("xy = "); gr_println(xy, ctx);
+            flint_printf("lxy = "); gr_println(lxy, ctx);
+            flint_printf("lxly = "); gr_println(lxly, ctx);
+            flint_abort();
+        }
+
+        padic_radix_clear(a, ctx);
+        padic_radix_clear(b, ctx);
+        padic_radix_clear(x, ctx);
+        padic_radix_clear(y, ctx);
+        padic_radix_clear(xy, ctx);
+        padic_radix_clear(lx, ctx);
+        padic_radix_clear(ly, ctx);
+        padic_radix_clear(lxly, ctx);
+        padic_radix_clear(lxy, ctx);
+
+        gr_ctx_clear(ctx);
+    }
+
+    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
+    {
+        ulong p;
+        radix_t radix;
+        slong thr, v, N;
+        fmpz_t uf, pf, pv, yf, ref, got, pN;
+        radix_integer_t y, g;
+
+        radix_init_randtest_prime(radix, state);
+        p = DIGIT_RADIX(radix);
+
+        thr = (p == 2) ? 2 : 1;
+        v = thr + (slong) n_randint(state, 6);
+        N = 1 + (slong) n_randint(state, n_randint(state, 2) ? 80 : 200);
+
+        if (v >= N)
+        {
+            radix_clear(radix);
+            continue;
+        }
+
+        fmpz_init(uf);
+        fmpz_init(pf);
+        fmpz_init(pv);
+        fmpz_init(yf);
+        fmpz_init(ref);
+        fmpz_init(got);
+        fmpz_init(pN);
+        fmpz_set_ui(pf, p);
+
+        fmpz_randtest_unsigned(uf, state, 1 + n_randint(state, 300));
+        if (fmpz_is_zero(uf))
+            fmpz_one(uf);
+        if (fmpz_divisible(uf, pf))
+            fmpz_add_ui(uf, uf, 1);
+
+        /* y = u p^v has valuation exactly v */
+        fmpz_pow_ui(pv, pf, v);
+        fmpz_mul(yf, uf, pv);
+
+        _padic_log(ref, yf, v, pf, N);
+        fmpz_pow_ui(pN, pf, N);
+        fmpz_mod(ref, ref, pN);
+
+        radix_integer_init(y, radix);
+        radix_integer_init(g, radix);
+        radix_integer_set_fmpz(y, yf, radix);
+
+        _padic_radix_log_balanced(g, y, N, radix);
+
+        radix_integer_get_fmpz(got, g, radix);
+
+        if (!fmpz_equal(ref, got))
+        {
+            flint_printf("FAIL: _padic_radix_log_balanced vs _padic_log\n");
+            flint_printf("p = %wu, e = %wu, v = %wd, N = %wd\n", p, radix->exp, v, N);
+            flint_printf("y = "); fmpz_print(yf); flint_printf("\n");
+            flint_printf("ref = "); fmpz_print(ref); flint_printf("\n");
+            flint_printf("got = "); fmpz_print(got); flint_printf("\n");
+            flint_abort();
+        }
+
+        radix_integer_clear(y, radix);
+        radix_integer_clear(g, radix);
+        fmpz_clear(uf);
+        fmpz_clear(pf);
+        fmpz_clear(pv);
+        fmpz_clear(yf);
+        fmpz_clear(ref);
+        fmpz_clear(got);
+        fmpz_clear(pN);
+        radix_clear(radix);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/padic_radix/test/t-log_rectangular.c
+++ b/src/padic_radix/test/t-log_rectangular.c
@@ -1,0 +1,155 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "longlong.h"
+#include "ulong_extras.h"
+#include "fmpz.h"
+#include "radix.h"
+#include "padic.h"
+#include "padic_radix.h"
+#include "gr.h"
+
+
+TEST_FUNCTION_START(padic_radix_log_rectangular, state)
+{
+    slong iter;
+
+    /* log(x y) == log(x) + log(y) on 1-units (built via exp for coverage) */
+    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
+    {
+        gr_ctx_t ctx;
+        padic_radix_t a, b, x, y, xy, lx, ly, lxly, lxy;
+        int status = GR_SUCCESS;
+
+        gr_ctx_init_padic_radix_randtest(ctx, state, 10);
+
+        padic_radix_init(a, ctx);
+        padic_radix_init(b, ctx);
+        padic_radix_init(x, ctx);
+        padic_radix_init(y, ctx);
+        padic_radix_init(xy, ctx);
+        padic_radix_init(lx, ctx);
+        padic_radix_init(ly, ctx);
+        padic_radix_init(lxly, ctx);
+        padic_radix_init(lxy, ctx);
+
+        GR_IGNORE(gr_randtest(a, state, ctx));
+        GR_IGNORE(gr_randtest(b, state, ctx));
+
+        status |= padic_radix_exp(x, a, ctx);
+        status |= padic_radix_exp(y, b, ctx);
+        status |= padic_radix_mul(xy, x, y, ctx);
+
+        status |= padic_radix_log_rectangular(lx, x, ctx);
+        status |= padic_radix_set(ly, y, ctx);      /* aliasing */
+        status |= padic_radix_log_rectangular(ly, ly, ctx);
+        status |= padic_radix_log_rectangular(lxy, xy, ctx);
+        status |= padic_radix_add(lxly, lx, ly, ctx);
+
+        if (status == GR_SUCCESS && padic_radix_equal(lxy, lxly, ctx) == T_FALSE)
+        {
+            flint_printf("FAIL: padic_radix_log_rectangular (homomorphism)\n");
+            flint_printf("x = "); gr_println(x, ctx);
+            flint_printf("y = "); gr_println(y, ctx);
+            flint_printf("lxy = "); gr_println(lxy, ctx);
+            flint_printf("lxly = "); gr_println(lxly, ctx);
+            flint_abort();
+        }
+
+        padic_radix_clear(a, ctx);
+        padic_radix_clear(b, ctx);
+        padic_radix_clear(x, ctx);
+        padic_radix_clear(y, ctx);
+        padic_radix_clear(xy, ctx);
+        padic_radix_clear(lx, ctx);
+        padic_radix_clear(ly, ctx);
+        padic_radix_clear(lxly, ctx);
+        padic_radix_clear(lxy, ctx);
+
+        gr_ctx_clear(ctx);
+    }
+
+    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
+    {
+        ulong p;
+        radix_t radix;
+        slong thr, v, N;
+        fmpz_t uf, pf, pv, yf, ref, got, pN;
+        radix_integer_t y, g;
+
+        radix_init_randtest_prime(radix, state);
+        p = DIGIT_RADIX(radix);
+
+        thr = (p == 2) ? 2 : 1;
+        v = thr + (slong) n_randint(state, 6);
+        N = 1 + (slong) n_randint(state, n_randint(state, 2) ? 60 : 200);
+
+        if (v >= N)
+        {
+            radix_clear(radix);
+            continue;
+        }
+
+        fmpz_init(uf);
+        fmpz_init(pf);
+        fmpz_init(pv);
+        fmpz_init(yf);
+        fmpz_init(ref);
+        fmpz_init(got);
+        fmpz_init(pN);
+        fmpz_set_ui(pf, p);
+
+        fmpz_randtest_unsigned(uf, state, 1 + n_randint(state, 300));
+        if (fmpz_is_zero(uf))
+            fmpz_one(uf);
+        if (fmpz_divisible(uf, pf))
+            fmpz_add_ui(uf, uf, 1);
+
+        fmpz_pow_ui(pv, pf, v);
+        fmpz_mul(yf, uf, pv);
+
+        radix_integer_init(y, radix);
+        radix_integer_init(g, radix);
+        radix_integer_set_fmpz(y, yf, radix);
+
+        _padic_radix_log_rectangular(g, y, N, radix);
+
+        _padic_log(ref, yf, v, pf, N);
+        fmpz_pow_ui(pN, pf, N);
+        fmpz_mod(ref, ref, pN);
+
+        radix_integer_get_fmpz(got, g, radix);
+
+        if (!fmpz_equal(ref, got))
+        {
+            flint_printf("FAIL: _padic_radix_log_rectangular vs _padic_log\n");
+            flint_printf("p = %wu, e = %wu, v = %wd, N = %wd\n", p, radix->exp, v, N);
+            flint_printf("y = "); fmpz_print(yf); flint_printf("\n");
+            flint_printf("ref = "); fmpz_print(ref); flint_printf("\n");
+            flint_printf("got = "); fmpz_print(got); flint_printf("\n");
+            flint_abort();
+        }
+
+        radix_integer_clear(y, radix);
+        radix_integer_clear(g, radix);
+        fmpz_clear(uf);
+        fmpz_clear(pf);
+        fmpz_clear(pv);
+        fmpz_clear(yf);
+        fmpz_clear(ref);
+        fmpz_clear(got);
+        fmpz_clear(pN);
+        radix_clear(radix);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/python/flint_ctypes.py
+++ b/src/python/flint_ctypes.py
@@ -9859,6 +9859,19 @@ def test_padic():
     assert str(Q7("0 + O(7^1)").exp()) == "1 + O(7^1)"
     assert raises(Q7("0 + O(7^0)").exp, FlintUnableError)
     assert raises(Q7("0 + O(7^-1)").exp, FlintUnableError)
+    assert raises((Q7(7)**(-5) + Q7("O(7^-2)")).exp, FlintDomainError)
+
+    assert Q7(1).log() == 0
+    assert str(Q7("1 + O(7^5)").log()) == "0 + O(7^5)"
+    assert str(Q7(1000 * 7).exp().log()) == "(1000) * 7^1 + O(7^10)"
+    assert raises(Q7(2).log, FlintDomainError)
+    assert raises(Q7(0).log, FlintDomainError)
+    assert str(Q7("1 + O(7)").log()) == "0 + O(7^1)"
+
+    assert raises(Q7("O(7)").log, FlintDomainError)
+    assert raises(Q7("0 + O(7^0)").log, FlintUnableError)
+    assert raises(Q7("0 + O(7^-1)").log, FlintUnableError)
+    assert raises((Q7(7)**(-5) + Q7("O(7^-2)")).log, FlintDomainError)
 
     assert Q2(0).exp() == 1
     assert str(Q2(4).exp()) == "333 + O(2^10)"

--- a/src/python/flint_ctypes.py
+++ b/src/python/flint_ctypes.py
@@ -9867,11 +9867,10 @@ def test_padic():
     assert raises(Q7(2).log, FlintDomainError)
     assert raises(Q7(0).log, FlintDomainError)
     assert str(Q7("1 + O(7)").log()) == "0 + O(7^1)"
-
     assert raises(Q7("O(7)").log, FlintDomainError)
     assert raises(Q7("0 + O(7^0)").log, FlintUnableError)
     assert raises(Q7("0 + O(7^-1)").log, FlintUnableError)
-    assert raises((Q7(7)**(-5) + Q7("O(7^-2)")).log, FlintDomainError)
+    assert raises(Q7("7^-5 + O(7^-2)").log, FlintDomainError)
 
     assert Q2(0).exp() == 1
     assert str(Q2(4).exp()) == "333 + O(2^10)"
@@ -9881,6 +9880,26 @@ def test_padic():
     assert raises(Q2("0 + O(2^1)").exp, FlintUnableError)
     assert raises(Q2("0 + O(2^0)").exp, FlintUnableError)
     assert raises(Q2("0 + O(2^1)").exp, FlintUnableError)
+
+    assert Q2(1).log() == 0
+    assert str(Q2("1 + O(2^5)").log()) == "0 + O(2^5)"
+    assert str(Q2("1 + 2 * 3").log()) == "(59) * 2^3 + O(2^10)"
+    assert str(Q2(123 * 4).exp().log()) == "(123) * 2^2 + O(2^10)"
+    assert raises(Q2(2).log, FlintDomainError)
+    assert raises(Q2(0).log, FlintDomainError)
+    assert str(Q2("1 + O(2)").log()) == "0 + O(2^1)"
+    assert raises(Q2("O(2)").log, FlintDomainError)
+    assert raises(Q2("0 + O(2^0)").log, FlintUnableError)
+    assert raises(Q2("0 + O(2^-1)").log, FlintUnableError)
+    assert raises(Q2("2^-5 + O(2^-2)").log, FlintDomainError)
+
+    Q5 = Qp_padic_radix(5, rel_prec=10)
+    f = PowerSeriesRing(Q5)("5 * 1234 + x")
+    ef = f.exp()
+    stref = "(1779246 + O(5^10)) + (1779246 + O(5^10))*x + (889623 + O(5^10))*x^2 + (296541 + O(5^10))*x^3 + (7398354 + O(5^10))*x^4 + ((7398354) * 5^-1 + O(5^9))*x^5 + O(x^6)"
+    assert str(ef) == stref
+    assert str((PowerSeriesRing(Q5))(stref)) == stref
+    assert str(f.exp() * (-f).exp()) == "(1 + O(5^10)) + (0 + O(5^10))*x + (0 + O(5^10))*x^2 + (0 + O(5^10))*x^3 + (0 + O(5^10))*x^4 + (0 + O(5^9))*x^5 + O(x^6)"
 
 
 def test_big_o():


### PR DESCRIPTION
Following up #2757 with the analogous `padic_radix_log`, plus some cleanup.

Timings:

```
padic = padic_log
exp = padic_radix_exp
rectangular = padic_radix_log_rectangular
balanced = padic_radix_log_balanced
log = padic_radix_log
speedup is vs padic_log
```

```
$ build/padic_radix/profile/p-log
precision 7^n, limb radix = 7^22

       n      padic       exp       rectangular   balanced     log       speedup
      10     1.24e-06    9.94e-08    2.13e-07    1.23e-06    2.19e-07    5.662x
      20     2.48e-06    6.77e-07    2.33e-07    1.81e-06    2.36e-07   10.508x
      40     5.27e-06    1.33e-06    1.02e-06    3.43e-06    1.02e-06    5.167x
      80     1.08e-05    2.97e-06    3.16e-06    8.24e-06    3.19e-06    3.386x
     160     2.48e-05       1e-05    9.59e-06    1.65e-05    9.58e-06    2.589x
     320     5.88e-05    3.23e-05    3.68e-05    4.23e-05     3.7e-05    1.589x
     640     0.000149    7.71e-05    0.000172    0.000103    0.000104    1.433x
    1280     0.000424    0.000205        -nan    0.000273    0.000275    1.542x
    2560      0.00123    0.000613        -nan    0.000788    0.000787    1.563x
    5120      0.00371     0.00159        -nan     0.00209     0.00208    1.784x
   10240       0.0096     0.00377        -nan     0.00487     0.00487    1.971x
   20480       0.0293     0.00921        -nan      0.0129      0.0128    2.289x
   40960       0.0682      0.0217        -nan      0.0272      0.0271    2.517x
   81920        0.195      0.0537        -nan      0.0736      0.0736    2.649x
  163840         0.46       0.127        -nan       0.171       0.168    2.738x
  327680        0.984         0.3        -nan       0.374       0.374    2.631x
  655360        2.569       0.668        -nan       0.886       0.888    2.893x
 1310720        5.909       1.578        -nan       2.065       2.043    2.892x

precision 9223372036854775837^n, limb radix = 9223372036854775837^1

       n      padic       exp       rectangular   balanced     log       speedup
      10     9.51e-06    1.58e-06    1.49e-06    5.22e-06    1.44e-06    6.604x
      20     2.23e-05    4.79e-06    3.76e-06    1.36e-05    3.81e-06    5.853x
      40     6.66e-05    1.56e-05    1.32e-05    3.46e-05    1.32e-05    5.045x
      80     0.000213    9.58e-05    0.000105    9.45e-05    9.45e-05    2.254x
     160     0.000684    0.000272    0.000353    0.000297    0.000297    2.303x
     320      0.00229    0.000702     0.00122    0.000823    0.000821    2.789x
     640      0.00743     0.00184     0.00546      0.0022     0.00219    3.393x
    1280       0.0216     0.00456        -nan     0.00555     0.00559    3.864x
    2560        0.056      0.0112        -nan      0.0137      0.0138    4.058x
    5120        0.135      0.0271        -nan      0.0336      0.0337    4.006x
   10240        0.319      0.0646        -nan      0.0814      0.0822    3.881x
   20480        0.742       0.154        -nan       0.194       0.193    3.845x
   40960        1.698       0.363        -nan       0.457       0.456    3.724x
   81920          3.9       0.849        -nan       1.063       1.066    3.659x
  163840        8.985       2.015        -nan       2.515        2.53    3.551x
  327680       20.784       4.671        -nan       5.827       5.854    3.550x
  655360       47.289      11.035        -nan      13.502      13.635    3.468x
 1310720      111.443      26.813        -nan      32.788      31.725    3.513x
```