### PR TITLE
Multithreaded `gr_mpoly` division + exact division

### DIFF
--- a/doc/source/gr_mpoly.rst
+++ b/doc/source/gr_mpoly.rst
@@ -364,6 +364,7 @@ Division
     If invertibility cannot be decided, returns ``GR_UNABLE``.
 
 .. function:: int gr_mpoly_divides_heap(gr_mpoly_t Q, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx)
+              int gr_mpoly_divides_heap_threaded(gr_mpoly_t Q, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx)
               int gr_mpoly_divides(gr_mpoly_t Q, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx)
 
     Standard checked, exact division.
@@ -372,10 +373,17 @@ Division
     If divisibility cannot be decided, returns ``GR_UNABLE``.
 
     The *heap* version implements the Monagan-Pearce heap algorithm.
-    The default version currently only delegates to the heap algorithm
-    except for trivial special cases.
+    The *heap_threaded* version implements a multithreaded version of the
+    same algorithm, using multiple threads when the inputs are large
+    and the coefficient ring supports concurrent access
+    (see :func:`gr_ctx_is_threadsafe`); for small inputs or a
+    non-threadsafe coefficient ring it falls back on the single-threaded
+    *heap* algorithm.
+    The default version currently only delegates to the (possibly
+    multithreaded) heap algorithm except for trivial special cases.
 
 .. function:: int gr_mpoly_divrem_heap(gr_mpoly_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx)
+              int gr_mpoly_divrem_heap_threaded(gr_mpoly_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx)
               int gr_mpoly_divrem(gr_mpoly_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx)
 
     Standard multivariate division with remainder, typically used
@@ -389,9 +397,15 @@ Division
     succeeds in the execution of the division algorithm. If any non-exact
     division is encountered, returns ``GR_DOMAIN``.
 
-.. function:: int gr_mpoly_div(gr_mpoly_t Q, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx)
+    The *heap_threaded* version is a multithreaded version of the *heap*
+    algorithm, used automatically by the default version for large,
+    threadsafe inputs, analogously to :func:`gr_mpoly_divides_heap_threaded`.
 
-    Like :func:`gr_mpoly_divrem`, but discarding the remainder.
+.. function:: int gr_mpoly_div(gr_mpoly_t Q, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx)
+              int gr_mpoly_div_heap_threaded(gr_mpoly_t Q, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx)
+
+    Like :func:`gr_mpoly_divrem` and :func:`gr_mpoly_divrem_heap_threaded`
+    respectively, but discarding the remainder.
 
 .. function:: int gr_mpoly_divrem_ideal(gr_mpoly_vec_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_vec_t B, gr_mpoly_ctx_t ctx)
 
@@ -401,13 +415,16 @@ Division
     any leading monomial in *B*.
 
 .. function:: int gr_mpoly_div_weak(gr_mpoly_t Q, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx)
+              int gr_mpoly_div_weak_heap_threaded(gr_mpoly_t Q, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx)
               int gr_mpoly_divrem_weak(gr_mpoly_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx)
+              int gr_mpoly_divrem_weak_heap_threaded(gr_mpoly_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx)
               int gr_mpoly_divrem_ideal_weak(gr_mpoly_vec_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_vec_t B, gr_mpoly_ctx_t ctx)
 
-    Like the ``divrem`` functions, producing quotient and remainder
-    satisfying `A = Q B + R` (or `A = \sum_i Q_i B_i + R` in the ideal case),
-    except that if a nonexact coefficient division is encountered,
-    instead of halting and returning ``GR_DOMAIN``,
+    Like the ``divrem`` and ``div`` functions (respectively their
+    *heap_threaded* multithreaded versions), producing quotient and
+    remainder satisfying `A = Q B + R` (or `A = \sum_i Q_i B_i + R` in the
+    ideal case), except that if a nonexact coefficient division is
+    encountered, instead of halting and returning ``GR_DOMAIN``,
     we divide the coefficients with remainder and accumulate the
     remainder. This produces a polynomial remainder which is partially
     reduced, but where monomials in *R* may still be divisible (ignoring

--- a/doc/source/gr_mpoly.rst
+++ b/doc/source/gr_mpoly.rst
@@ -382,6 +382,12 @@ Division
     The default version currently only delegates to the (possibly
     multithreaded) heap algorithm except for trivial special cases.
 
+.. function:: int gr_mpoly_divexact(gr_mpoly_t Q, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx)
+              int gr_mpoly_divexact_heap_threaded(gr_mpoly_t Q, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx)
+
+    Compute `Q = A / B`, assuming (without checking) that *B* divides *A*
+    exactly.
+
 .. function:: int gr_mpoly_divrem_heap(gr_mpoly_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx)
               int gr_mpoly_divrem_heap_threaded(gr_mpoly_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx)
               int gr_mpoly_divrem(gr_mpoly_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx)
@@ -408,6 +414,7 @@ Division
     respectively, but discarding the remainder.
 
 .. function:: int gr_mpoly_divrem_ideal(gr_mpoly_vec_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_vec_t B, gr_mpoly_ctx_t ctx)
+              int gr_mpoly_divrem_ideal_heap_threaded(gr_mpoly_vec_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_vec_t B, gr_mpoly_ctx_t ctx)
 
     Like :func:`gr_mpoly_divrem`, but takes a vector *B* of divisor polynomials
     and outputs a vector *Q* of quotient polynomials such that
@@ -419,6 +426,7 @@ Division
               int gr_mpoly_divrem_weak(gr_mpoly_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx)
               int gr_mpoly_divrem_weak_heap_threaded(gr_mpoly_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx)
               int gr_mpoly_divrem_ideal_weak(gr_mpoly_vec_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_vec_t B, gr_mpoly_ctx_t ctx)
+              int gr_mpoly_divrem_ideal_weak_heap_threaded(gr_mpoly_vec_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_vec_t B, gr_mpoly_ctx_t ctx)
 
     Like the ``divrem`` and ``div`` functions (respectively their
     *heap_threaded* multithreaded versions), producing quotient and

--- a/src/fmpz_mpoly/select_exps.c
+++ b/src/fmpz_mpoly/select_exps.c
@@ -86,8 +86,14 @@ int mpoly_divides_select_exps(fmpz_mpoly_t S, fmpz_mpoly_ctx_t zctx,
 
     T0 = (ulong *) TMP_ALLOC(N*sizeof(ulong));
     T1 = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_monomial_sub_mp(T0, Aexp + N*0, Bexp + N*0, N);
-    mpoly_monomial_sub_mp(T1, Aexp + N*(Alen - 1), Bexp + N*(Blen - 1), N);
+    if (bits <= FLINT_BITS)
+        mpoly_monomial_sub(T0, Aexp + N*0, Bexp + N*0, N);
+    else
+        mpoly_monomial_sub_mp(T0, Aexp + N*0, Bexp + N*0, N);
+    if (bits <= FLINT_BITS)
+        mpoly_monomial_sub(T1, Aexp + N*(Alen - 1), Bexp + N*(Blen - 1), N);
+    else
+        mpoly_monomial_sub_mp(T1, Aexp + N*(Alen - 1), Bexp + N*(Blen - 1), N);
     if (bits <= FLINT_BITS)
     {
         if (   mpoly_monomial_overflows(T0, N, mask)
@@ -116,16 +122,28 @@ int mpoly_divides_select_exps(fmpz_mpoly_t S, fmpz_mpoly_ctx_t zctx,
         j = FLINT_MAX(j, WORD(0));
         j = FLINT_MIN(j, Blen - 1);
 
-        mpoly_monomial_sub_mp(Sexp + N*Slen, Aexp + N*0, Bexp + N*0, N);
-        mpoly_monomial_add_mp(Sexp + N*Slen, Sexp + N*Slen, Bexp + N*j, N);
+        if (bits <= FLINT_BITS)
+            mpoly_monomial_sub(Sexp + N*Slen, Aexp + N*0, Bexp + N*0, N);
+        else
+            mpoly_monomial_sub_mp(Sexp + N*Slen, Aexp + N*0, Bexp + N*0, N);
+        if (bits <= FLINT_BITS)
+            mpoly_monomial_add(Sexp + N*Slen, Sexp + N*Slen, Bexp + N*j, N);
+        else
+            mpoly_monomial_add_mp(Sexp + N*Slen, Sexp + N*Slen, Bexp + N*j, N);
         fmpz_one(Scoeff + Slen);
         if (bits <= FLINT_BITS)
             Slen += !(mpoly_monomial_overflows(Sexp + N*Slen, N, mask));
         else
             Slen += !(mpoly_monomial_overflows_mp(Sexp + N*Slen, N, bits));
 
-        mpoly_monomial_sub_mp(Sexp + N*Slen, Aexp + N*(Alen - 1), Bexp + N*(Blen - 1), N);
-        mpoly_monomial_add_mp(Sexp + N*Slen, Sexp + N*Slen, Bexp + N*j, N);
+        if (bits <= FLINT_BITS)
+            mpoly_monomial_sub(Sexp + N*Slen, Aexp + N*(Alen - 1), Bexp + N*(Blen - 1), N);
+        else
+            mpoly_monomial_sub_mp(Sexp + N*Slen, Aexp + N*(Alen - 1), Bexp + N*(Blen - 1), N);
+        if (bits <= FLINT_BITS)
+            mpoly_monomial_add(Sexp + N*Slen, Sexp + N*Slen, Bexp + N*j, N);
+        else
+            mpoly_monomial_add_mp(Sexp + N*Slen, Sexp + N*Slen, Bexp + N*j, N);
         fmpz_one(Scoeff + Slen);
         if (bits <= FLINT_BITS)
             Slen += !(mpoly_monomial_overflows(Sexp + N*Slen, N, mask));

--- a/src/gr_mpoly.h
+++ b/src/gr_mpoly.h
@@ -311,12 +311,19 @@ WARN_UNUSED_RESULT int gr_mpoly_sqr_commutative_heap_threaded(gr_mpoly_t poly1, 
 
 WARN_UNUSED_RESULT int gr_mpoly_divides(gr_mpoly_t Q, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mpoly_divides_heap(gr_mpoly_t Q, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_mpoly_divides_heap_threaded(gr_mpoly_t Q, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx);
 
 WARN_UNUSED_RESULT int gr_mpoly_div(gr_mpoly_t Q, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mpoly_div_weak(gr_mpoly_t Q, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_mpoly_div_heap_threaded(gr_mpoly_t Q, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mpoly_divrem(gr_mpoly_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx);
-WARN_UNUSED_RESULT int gr_mpoly_divrem_weak(gr_mpoly_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mpoly_divrem_heap(gr_mpoly_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_mpoly_divrem_heap_threaded(gr_mpoly_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx);
+
+WARN_UNUSED_RESULT int gr_mpoly_div_weak(gr_mpoly_t Q, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_mpoly_div_weak_heap_threaded(gr_mpoly_t Q, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_mpoly_divrem_weak(gr_mpoly_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_mpoly_divrem_weak_heap(gr_mpoly_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_mpoly_divrem_weak_heap_threaded(gr_mpoly_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx);
 
 WARN_UNUSED_RESULT int gr_mpoly_divrem_ideal(gr_mpoly_vec_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_vec_t B, gr_mpoly_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mpoly_divrem_ideal_weak(gr_mpoly_vec_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_vec_t B, gr_mpoly_ctx_t ctx);

--- a/src/gr_mpoly.h
+++ b/src/gr_mpoly.h
@@ -313,6 +313,9 @@ WARN_UNUSED_RESULT int gr_mpoly_divides(gr_mpoly_t Q, const gr_mpoly_t A, const 
 WARN_UNUSED_RESULT int gr_mpoly_divides_heap(gr_mpoly_t Q, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mpoly_divides_heap_threaded(gr_mpoly_t Q, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx);
 
+WARN_UNUSED_RESULT int gr_mpoly_divexact(gr_mpoly_t Q, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_mpoly_divexact_heap_threaded(gr_mpoly_t Q, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx);
+
 WARN_UNUSED_RESULT int gr_mpoly_div(gr_mpoly_t Q, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mpoly_div_heap_threaded(gr_mpoly_t Q, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mpoly_divrem(gr_mpoly_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx);
@@ -326,7 +329,9 @@ WARN_UNUSED_RESULT int gr_mpoly_divrem_weak_heap(gr_mpoly_t Q, gr_mpoly_t R, con
 WARN_UNUSED_RESULT int gr_mpoly_divrem_weak_heap_threaded(gr_mpoly_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx);
 
 WARN_UNUSED_RESULT int gr_mpoly_divrem_ideal(gr_mpoly_vec_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_vec_t B, gr_mpoly_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_mpoly_divrem_ideal_heap_threaded(gr_mpoly_vec_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_vec_t B, gr_mpoly_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mpoly_divrem_ideal_weak(gr_mpoly_vec_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_vec_t B, gr_mpoly_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_mpoly_divrem_ideal_weak_heap_threaded(gr_mpoly_vec_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_vec_t B, gr_mpoly_ctx_t ctx);
 
 WARN_UNUSED_RESULT int gr_mpoly_quasidiv(gr_ptr scale, gr_mpoly_t Q, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_mpoly_quasidivrem(gr_ptr scale, gr_mpoly_t Q, gr_mpoly_t R, const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx);

--- a/src/gr_mpoly/divexact.c
+++ b/src/gr_mpoly/divexact.c
@@ -1,0 +1,157 @@
+/*
+    Copyright (C) 2017 William Hart
+    Copyright (C) 2017 Daniel Schultz
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "mpoly.h"
+#include "gr_mpoly.h"
+#include "threaded_divmod.h" /* for the exposed _gr_mpoly_divrem_mp kernel */
+
+static int
+_gr_mpoly_divexact_monomial(gr_mpoly_t Q,
+    const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx)
+{
+    mpoly_ctx_struct * mctx = GR_MPOLY_MCTX(ctx);
+    gr_ctx_struct * cctx = GR_MPOLY_CCTX(ctx);
+    slong sz = cctx->sizeof_elem;
+    slong i, qlen, N, Alen = A->length;
+    flint_bitcnt_t exp_bits;
+    ulong * Aexps = A->exps, * Bexps = B->exps;
+    gr_srcptr Bc = B->coeffs;
+    int freeA = 0, freeB = 0, lc_is_unit, lc_is_one;
+    ulong mask;
+    gr_ptr inv;
+    int status = GR_SUCCESS;
+    gr_mpoly_t T;
+
+    FLINT_ASSERT(B->length == 1);
+
+    if (gr_is_zero(B->coeffs, cctx) != T_FALSE)
+        return GR_UNABLE;
+
+    exp_bits = FLINT_MAX(A->bits, B->bits);
+    N = mpoly_words_per_exp(exp_bits, mctx);
+
+    if (exp_bits > A->bits)
+    {
+        Aexps = (ulong *) flint_malloc(N*Alen*sizeof(ulong));
+        mpoly_repack_monomials(Aexps, exp_bits, A->exps, A->bits, Alen, mctx);
+        freeA = 1;
+    }
+
+    if (exp_bits > B->bits)
+    {
+        Bexps = (ulong *) flint_malloc(N*sizeof(ulong));
+        mpoly_repack_monomials(Bexps, exp_bits, B->exps, B->bits, 1, mctx);
+        freeB = 1;
+    }
+
+    /* mask with the high bit of each exponent field set (single-word fields) */
+    mask = 0;
+    if (exp_bits <= FLINT_BITS)
+    {
+        flint_bitcnt_t j;
+        for (j = 0; j < FLINT_BITS/exp_bits; j++)
+            mask = (mask << exp_bits) + (UWORD(1) << (exp_bits - 1));
+    }
+
+    gr_mpoly_init3(T, Alen, exp_bits, ctx);
+
+    GR_TMP_INIT(inv, cctx);
+    lc_is_one = (gr_is_one(Bc, cctx) == T_TRUE);
+    lc_is_unit = lc_is_one || (gr_inv(inv, Bc, cctx) == GR_SUCCESS);
+
+    qlen = 0;
+    for (i = 0; i < Alen; i++)
+    {
+        int divides, cstatus;
+
+        if (exp_bits <= FLINT_BITS)
+            divides = mpoly_monomial_divides(T->exps + N*qlen, Aexps + N*i, Bexps, N, mask);
+        else
+            divides = mpoly_monomial_divides_mp(T->exps + N*qlen, Aexps + N*i, Bexps, N, exp_bits);
+
+        /* Since the division is known to be exact, spurious terms must correspond
+           to inexact/unproved representation of actual zeros, which are thus
+           safe to discard (e.g. we must have [+/-0.1]*x / y -> 0). */
+        if (!divides)
+            continue;
+
+        if (lc_is_one)
+            cstatus = gr_set(GR_ENTRY(T->coeffs, qlen, sz), GR_ENTRY(A->coeffs, i, sz), cctx);
+        else if (lc_is_unit)
+            cstatus = gr_mul(GR_ENTRY(T->coeffs, qlen, sz), GR_ENTRY(A->coeffs, i, sz), inv, cctx);
+        else
+            cstatus = gr_divexact(GR_ENTRY(T->coeffs, qlen, sz), GR_ENTRY(A->coeffs, i, sz), Bc, cctx);
+
+        if (cstatus != GR_SUCCESS)
+        {
+            status |= cstatus;
+            break;
+        }
+
+        qlen++;
+    }
+
+    GR_TMP_CLEAR(inv, cctx);
+
+    if (status == GR_SUCCESS)
+    {
+        _gr_mpoly_set_length(T, qlen, ctx);
+        gr_mpoly_swap(Q, T, ctx);
+    }
+    else
+    {
+        GR_IGNORE(gr_mpoly_zero(Q, ctx));
+    }
+
+    gr_mpoly_clear(T, ctx);
+
+    if (freeA)
+        flint_free(Aexps);
+    if (freeB)
+        flint_free(Bexps);
+
+    return status;
+}
+
+
+int
+gr_mpoly_divexact(gr_mpoly_t Q,
+    const gr_mpoly_t A, const gr_mpoly_t B, gr_mpoly_ctx_t ctx)
+{
+    gr_ctx_struct * cctx = GR_MPOLY_CCTX(ctx);
+
+    if (B->length == 0)
+    {
+        truth_t zero = gr_ctx_is_zero_ring(cctx);
+
+        if (zero == T_FALSE)
+            return GR_DOMAIN;
+        else if (zero == T_TRUE)
+            return GR_SUCCESS;
+        else
+            return GR_UNABLE;
+    }
+
+    if (A->length == 0)
+        return gr_mpoly_zero(Q, ctx);
+
+    if (B->length == 1)
+        return _gr_mpoly_divexact_monomial(Q, A, B, ctx);
+
+    if (A->length > 500 && B->length > 2 &&
+            gr_ctx_is_threadsafe(cctx) == T_TRUE &&
+            flint_get_num_available_threads() > 1)
+        return gr_mpoly_divexact_heap_threaded(Q, A, B, ctx);
+
+    return _gr_mpoly_divrem_mp(Q, NULL, A, B, 0, 1, ctx);
+}

--- a/src/gr_mpoly/divides.c
+++ b/src/gr_mpoly/divides.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "thread_support.h"
 #include "mpoly.h"
 #include "gr_mpoly.h"
 
@@ -133,20 +134,17 @@ _gr_mpoly_divides_monomial(gr_mpoly_t Q,
     return status;
 }
 
-/*
-    TODO: dispatch to gr_mpoly_divides_heap_threaded (port of
-    fmpz_mpoly_divides_heap_threaded) for large A when the coefficient ring is
-    threadsafe; for now the serial Monagan-Pearce algorithm is used.
-*/
 int
 gr_mpoly_divides(gr_mpoly_t Q,
     const gr_mpoly_t A,
     const gr_mpoly_t B,
     gr_mpoly_ctx_t ctx)
 {
+    gr_ctx_struct * cctx = GR_MPOLY_CCTX(ctx);
+
     if (B->length == 0)
     {
-        truth_t zero = gr_ctx_is_zero_ring(GR_MPOLY_CCTX(ctx));
+        truth_t zero = gr_ctx_is_zero_ring(cctx);
 
         if (zero == T_FALSE)
             return GR_DOMAIN;
@@ -165,8 +163,13 @@ gr_mpoly_divides(gr_mpoly_t Q,
 
     /* This method is used to overload gr_div, so it should be conservative
        when ctx is something weird. */
-    if (gr_ctx_is_integral_domain(GR_MPOLY_CCTX(ctx)) != T_TRUE)
+    if (gr_ctx_is_integral_domain(cctx) != T_TRUE)
         return GR_UNABLE;
+
+    if (A->length > 500 && B->length > 2 &&
+            gr_ctx_is_threadsafe(cctx) == T_TRUE &&
+            flint_get_num_available_threads() > 1)
+        return gr_mpoly_divides_heap_threaded(Q, A, B, ctx);
 
     return gr_mpoly_divides_heap(Q, A, B, ctx);
 }

--- a/src/gr_mpoly/divides_heap.c
+++ b/src/gr_mpoly/divides_heap.c
@@ -327,7 +327,10 @@ cleanup:
 
 not_exact_division:
     *lenout = 0;
-    status = GR_DOMAIN;
+    /* preserve any GR_UNABLE accumulated while computing this term's acc:
+       if an earlier operation could not decide, this term's apparent
+       non-exactness may just be an artifact of that, not a genuine proof. */
+    status |= GR_DOMAIN;
     goto cleanup;
 
 unable:
@@ -628,7 +631,10 @@ cleanup:
 
 not_exact_division:
     *lenout = 0;
-    status = GR_DOMAIN;
+    /* preserve any GR_UNABLE accumulated while computing this term's acc:
+       if an earlier operation could not decide, this term's apparent
+       non-exactness may just be an artifact of that, not a genuine proof. */
+    status |= GR_DOMAIN;
     goto cleanup;
 
 unable:

--- a/src/gr_mpoly/divides_heap_threaded.c
+++ b/src/gr_mpoly/divides_heap_threaded.c
@@ -698,13 +698,19 @@ slong _gr_mpoly_mulsub_stripe(
     {
         if (startidx < Clen)
         {
-            mpoly_monomial_add_mp(texp, Bexp + N*i, Cexp + N*startidx, N);
+            if (bits <= FLINT_BITS)
+                mpoly_monomial_add(texp, Bexp + N*i, Cexp + N*startidx, N);
+            else
+                mpoly_monomial_add_mp(texp, Bexp + N*i, Cexp + N*startidx, N);
             FLINT_ASSERT(mpoly_monomial_cmp(emax, texp, N, S->cmpmask)
                                                                > -upperclosed);
         }
         while (startidx > 0)
         {
-            mpoly_monomial_add_mp(texp, Bexp + N*i, Cexp + N*(startidx - 1), N);
+            if (bits <= FLINT_BITS)
+                mpoly_monomial_add(texp, Bexp + N*i, Cexp + N*(startidx - 1), N);
+            else
+                mpoly_monomial_add_mp(texp, Bexp + N*i, Cexp + N*(startidx - 1), N);
             if (mpoly_monomial_cmp(emax, texp, N, S->cmpmask) <= -upperclosed)
                 break;
             startidx--;
@@ -712,12 +718,18 @@ slong _gr_mpoly_mulsub_stripe(
 
         if (endidx < Clen)
         {
-            mpoly_monomial_add_mp(texp, Bexp + N*i, Cexp + N*endidx, N);
+            if (bits <= FLINT_BITS)
+                mpoly_monomial_add(texp, Bexp + N*i, Cexp + N*endidx, N);
+            else
+                mpoly_monomial_add_mp(texp, Bexp + N*i, Cexp + N*endidx, N);
             FLINT_ASSERT(mpoly_monomial_cmp(emin, texp, N, S->cmpmask) > 0);
         }
         while (endidx > 0)
         {
-            mpoly_monomial_add_mp(texp, Bexp + N*i, Cexp + N*(endidx - 1), N);
+            if (bits <= FLINT_BITS)
+                mpoly_monomial_add(texp, Bexp + N*i, Cexp + N*(endidx - 1), N);
+            else
+                mpoly_monomial_add_mp(texp, Bexp + N*i, Cexp + N*(endidx - 1), N);
             if (mpoly_monomial_cmp(emin, texp, N, S->cmpmask) <= 0)
                 break;
             endidx--;
@@ -734,7 +746,11 @@ slong _gr_mpoly_mulsub_stripe(
             x->next = NULL;
             hind[x->i] = 2*(x->j + 1) + 0;
 
-            mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
+            if (bits <= FLINT_BITS)
+                mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i,
+                                                      Cexp + N*x->j, N);
+            else
+                mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
                                                       Cexp + N*x->j, N);
 
             exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
@@ -848,7 +864,11 @@ slong _gr_mpoly_mulsub_stripe(
                 x->next = NULL;
                 hind[x->i] = 2*(x->j + 1) + 0;
 
-                mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
+                if (bits <= FLINT_BITS)
+                    mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i,
+                                                          Cexp + N*x->j, N);
+                else
+                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
                                                           Cexp + N*x->j, N);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
@@ -865,7 +885,11 @@ slong _gr_mpoly_mulsub_stripe(
                 x->next = NULL;
                 hind[x->i] = 2*(x->j + 1) + 0;
 
-                mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
+                if (bits <= FLINT_BITS)
+                    mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i,
+                                                          Cexp + N*x->j, N);
+                else
+                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
                                                           Cexp + N*x->j, N);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
@@ -1388,7 +1412,11 @@ static slong _gr_mpoly_divides_stripe(
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
+                    if (bits <= FLINT_BITS)
+                        mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i,
+                                                              Qexp + N*x->j, N);
+                    else
+                        mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
                                                               Qexp + N*x->j, N);
 
                     if (mpoly_monomial_cmp(exp_list[exp_next], S->emin, N, S->cmpmask) >= 0)
@@ -1411,7 +1439,11 @@ static slong _gr_mpoly_divides_stripe(
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
+                    if (bits <= FLINT_BITS)
+                        mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i,
+                                                              Qexp + N*x->j, N);
+                    else
+                        mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
                                                               Qexp + N*x->j, N);
 
                     if (mpoly_monomial_cmp(exp_list[exp_next], S->emin, N, S->cmpmask) >= 0)
@@ -1455,7 +1487,10 @@ static slong _gr_mpoly_divides_stripe(
             x->next = NULL;
             hind[x->i] = 2*(x->j + 1) + 0;
 
-            mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i, Qexp + N*x->j, N);
+            if (bits <= FLINT_BITS)
+                mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i, Qexp + N*x->j, N);
+            else
+                mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i, Qexp + N*x->j, N);
 
             if (mpoly_monomial_cmp(exp_list[exp_next], S->emin, N, S->cmpmask) >= 0)
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
@@ -2126,11 +2161,17 @@ static int _gr_mpoly_divides_heap_threaded_pool(
     texps = (ulong *) TMP_ALLOC(N*sizeof(ulong));
     qexps = (ulong *) TMP_ALLOC(N*sizeof(ulong));
 
-    mpoly_monomial_sub_mp(qexps + N*0, Aexp + N*0, Bexp + N*0, N);
+    if (exp_bits <= FLINT_BITS)
+        mpoly_monomial_sub(qexps + N*0, Aexp + N*0, Bexp + N*0, N);
+    else
+        mpoly_monomial_sub_mp(qexps + N*0, Aexp + N*0, Bexp + N*0, N);
 
     gr_mpoly_ts_init(H->polyQ, qcoeff, qexps, 1, H->bits, H->N, cctx);
 
-    mpoly_monomial_add_mp(texps, qexps + N*0, Bexp + N*1, N);
+    if (exp_bits <= FLINT_BITS)
+        mpoly_monomial_add(texps, qexps + N*0, Bexp + N*1, N);
+    else
+        mpoly_monomial_add_mp(texps, qexps + N*0, Bexp + N*1, N);
 
     mask = 0;
     for (i = 0; (flint_bitcnt_t) i < FLINT_BITS/exp_bits; i++)

--- a/src/gr_mpoly/divides_heap_threaded.c
+++ b/src/gr_mpoly/divides_heap_threaded.c
@@ -217,7 +217,7 @@ void gr_mpoly_ts_append(gr_mpoly_ts_t A,
         {
             /* NOTE: fmpz_mpoly_ts_append uses a shallow set here.
                This should be possible in the GR setting too but would
-               require some care regarding how we free/clear
+               require some care regarding how we init/clear
                the coefficients. */
             GR_MUST_SUCCEED(gr_set(GR_ENTRY(newcoeffs, i, sz), GR_ENTRY(oldcoeffs, i, sz), cctx));
             mpoly_monomial_set(newexps + N*i, oldexps + N*i, N);
@@ -289,7 +289,7 @@ int divides_heap_base_clear(gr_mpoly_t Q, gr_mpoly_t R, divides_heap_base_t H)
 
     if (H->have_domain)
         status = GR_DOMAIN;
-    else if (H->have_unable)
+    else if (H->have_unable || H->overflowed)
         status = GR_UNABLE;
     else
         status = GR_SUCCESS;
@@ -361,7 +361,7 @@ slong _gr_mpoly_mulsub_stripe1(
     gr_srcptr Dcoeff, const ulong * Dexp, slong Dlen, int saveD,
     gr_srcptr Bcoeff, const ulong * Bexp, slong Blen,
     gr_srcptr Ccoeff, const ulong * Cexp, slong Clen,
-    const _gr_mpoly_stripe_t S, int * res_status)
+    const _gr_mpoly_stripe_t S, int * res_status, int * overflowed)
 {
     gr_mpoly_ctx_struct * ctx = S->ctx;
     gr_ctx_struct * cctx = S->cctx;
@@ -371,6 +371,7 @@ slong _gr_mpoly_mulsub_stripe1(
     slong startidx, endidx;
     ulong prev_startidx;
     ulong maskhi = S->cmpmask[0];
+    ulong mask = mpoly_overflow_mask_sp(S->bits);
     ulong emax, emin;
     slong i, j;
     slong next_loc = Blen + 4;
@@ -392,6 +393,8 @@ slong _gr_mpoly_mulsub_stripe1(
     gr_ptr pp, dot_a, dot_b;
     slong dot_len;
     int status = GR_SUCCESS;
+
+    *overflowed = 0;
 
     FLINT_ASSERT(S->N == 1);
 
@@ -474,6 +477,12 @@ slong _gr_mpoly_mulsub_stripe1(
     while (heap_len > 1)
     {
         exp = heap[1].exp;
+
+        if (mpoly_monomial_overflows1(exp, mask))
+        {
+            *overflowed = 1;
+            goto cleanup;
+        }
 
         while (Di < Dlen && mpoly_monomial_gt1(Dexp[Di], exp, maskhi))
         {
@@ -577,17 +586,8 @@ slong _gr_mpoly_mulsub_stripe1(
             }
         }
 
-        /* an unknown zero-status is kept as a (possibly redundant) term
-           rather than causing an abort -- this mirrors the "acc" checks
-           fixed for divrem/divexact (see the discussion at
-           gr_mpoly_divexact), and is unconditionally safe here regardless
-           of that discussion's open questions for gr_mpoly_divides itself:
-           mulsub_stripe never makes any exactness determination, it only
-           chooses a (possibly non-maximally-reduced) representation of the
-           difference D - stripe(B*C). This was already keeping the term in
-           the "unknown" case; the only change is to stop also tainting the
-           overall status with GR_UNABLE merely for being unable to prove
-           it away. */
+        /* Note: the zero status of this coefficient does not affect divisibility
+           testing at this point. */
         if (gr_is_zero(GR_ENTRY(Acoeff, Alen, sz), cctx) != T_TRUE)
             Alen++;
     }
@@ -600,6 +600,8 @@ slong _gr_mpoly_mulsub_stripe1(
         _gr_vec_swap(GR_ENTRY(Acoeff, Alen, sz), (gr_ptr) GR_ENTRY(Dcoeff, Di, sz), Dlen - Di, cctx);
     mpoly_copy_monomials(Aexp + Alen, Dexp + Di, Dlen - Di, 1);
     Alen += Dlen - Di;
+
+cleanup:
 
     GR_TMP_CLEAR(pp, cctx);
     flint_free(dot_a);
@@ -619,7 +621,7 @@ slong _gr_mpoly_mulsub_stripe(
     gr_srcptr Dcoeff, const ulong * Dexp, slong Dlen, int saveD,
     gr_srcptr Bcoeff, const ulong * Bexp, slong Blen,
     gr_srcptr Ccoeff, const ulong * Cexp, slong Clen,
-    const _gr_mpoly_stripe_t S, int * res_status)
+    const _gr_mpoly_stripe_t S, int * res_status, int * overflowed)
 {
     gr_mpoly_ctx_struct * ctx = S->ctx;
     gr_ctx_struct * cctx = S->cctx;
@@ -631,6 +633,8 @@ slong _gr_mpoly_mulsub_stripe(
     ulong * emax = S->emax;
     ulong * emin = S->emin;
     slong N = S->N;
+    flint_bitcnt_t bits = S->bits;
+    ulong mask = bits <= FLINT_BITS ? mpoly_overflow_mask_sp(bits) : 0;
     slong i, j;
     slong next_loc = Blen + 4;
     slong heap_len = 1;
@@ -653,6 +657,8 @@ slong _gr_mpoly_mulsub_stripe(
     gr_ptr pp, dot_a, dot_b;
     slong dot_len;
     int status = GR_SUCCESS;
+
+    *overflowed = 0;
 
     i = 0;
     hind = (slong *)(S->big_mem + i);
@@ -746,6 +752,14 @@ slong _gr_mpoly_mulsub_stripe(
     while (heap_len > 1)
     {
         exp = heap[1].exp;
+
+        if (bits <= FLINT_BITS
+                ? mpoly_monomial_overflows(exp, N, mask)
+                : mpoly_monomial_overflows_mp(exp, N, bits))
+        {
+            *overflowed = 1;
+            goto cleanup;
+        }
 
         while (Di < Dlen && mpoly_monomial_gt(Dexp + N*Di, exp, N, S->cmpmask))
         {
@@ -859,8 +873,17 @@ slong _gr_mpoly_mulsub_stripe(
             }
         }
 
-        /* Note: the zero status of this coefficient does not affect divisibility
-           testing at this point. */
+        /* an unknown zero-status is kept as a (possibly redundant) term
+           rather than causing an abort -- this mirrors the "acc" checks
+           fixed for divrem/divexact (see the discussion at
+           gr_mpoly_divexact), and is unconditionally safe here regardless
+           of that discussion's open questions for gr_mpoly_divides itself:
+           mulsub_stripe never makes any exactness determination, it only
+           chooses a (possibly non-maximally-reduced) representation of the
+           difference D - stripe(B*C). This was already keeping the term in
+           the "unknown" case; the only change is to stop also tainting the
+           overall status with GR_UNABLE merely for being unable to prove
+           it away. */
         if (gr_is_zero(GR_ENTRY(Acoeff, Alen, sz), cctx) != T_TRUE)
             Alen++;
     }
@@ -873,6 +896,8 @@ slong _gr_mpoly_mulsub_stripe(
         _gr_vec_swap(GR_ENTRY(Acoeff, Alen, sz), (gr_ptr) GR_ENTRY(Dcoeff, Di, sz), Dlen - Di, cctx);
     mpoly_copy_monomials(Aexp + N*Alen, Dexp + N*Di, Dlen - Di, N);
     Alen += Dlen - Di;
+
+cleanup:
 
     GR_TMP_CLEAR(pp, cctx);
     flint_free(dot_a);
@@ -1564,6 +1589,7 @@ void chunk_mulsub(worker_arg_t W, divides_heap_chunk_t L, slong q_prev_length)
     gr_mpoly_struct * T1 = W->polyT1;
     _gr_mpoly_stripe_struct * S = W->S;
     int status;
+    int overflowed;
 
     S->startidx = &L->startidx;
     S->endidx = &L->endidx;
@@ -1582,7 +1608,7 @@ void chunk_mulsub(worker_arg_t W, divides_heap_chunk_t L, slong q_prev_length)
                     C->coeffs, C->exps, C->length, 1,
                     GR_ENTRY(Q->coeffs, L->mq, cctx->sizeof_elem), Q->exps + N*L->mq, q_prev_length - L->mq,
                     B->coeffs, B->exps, B->length,
-                    S, &status);
+                    S, &status, &overflowed);
         }
         else
         {
@@ -1591,9 +1617,10 @@ void chunk_mulsub(worker_arg_t W, divides_heap_chunk_t L, slong q_prev_length)
                     C->coeffs, C->exps, C->length, 1,
                     GR_ENTRY(Q->coeffs, L->mq, cctx->sizeof_elem), Q->exps + N*L->mq, q_prev_length - L->mq,
                     B->coeffs, B->exps, B->length,
-                    S, &status);
+                    S, &status, &overflowed);
         }
-        gr_mpoly_swap(C, T1, H->ctx);
+        if (!overflowed)
+            gr_mpoly_swap(C, T1, H->ctx);
     }
     else
     {
@@ -1619,7 +1646,7 @@ void chunk_mulsub(worker_arg_t W, divides_heap_chunk_t L, slong q_prev_length)
                     GR_ENTRY(A->coeffs, startidx, cctx->sizeof_elem), A->exps + N*startidx, stopidx - startidx, 1,
                     GR_ENTRY(Q->coeffs, L->mq, cctx->sizeof_elem), Q->exps + N*L->mq, q_prev_length - L->mq,
                     B->coeffs, B->exps, B->length,
-                    S, &status);
+                    S, &status, &overflowed);
         }
         else
         {
@@ -1628,8 +1655,21 @@ void chunk_mulsub(worker_arg_t W, divides_heap_chunk_t L, slong q_prev_length)
                     GR_ENTRY(A->coeffs, startidx, cctx->sizeof_elem), A->exps + N*startidx, stopidx - startidx, 1,
                     GR_ENTRY(Q->coeffs, L->mq, cctx->sizeof_elem), Q->exps + N*L->mq, q_prev_length - L->mq,
                     B->coeffs, B->exps, B->length,
-                    S, &status);
+                    S, &status, &overflowed);
         }
+    }
+
+    if (overflowed)
+    {
+#if FLINT_USES_PTHREAD
+        pthread_mutex_lock(&H->mutex);
+#endif
+        H->overflowed = 1;
+        H->failed = 1;
+#if FLINT_USES_PTHREAD
+        pthread_mutex_unlock(&H->mutex);
+#endif
+        return;
     }
 
     if (status != GR_SUCCESS)
@@ -1763,6 +1803,7 @@ void trychunk(worker_arg_t W, divides_heap_chunk_t L)
                    terms -- they are routed to the remainder instead. */
                 gr_mpoly_struct * T3 = W->polyT3;
                 slong Wlen;
+                int overflowed;
 
                 if (N == 1)
                 {
@@ -1770,7 +1811,7 @@ void trychunk(worker_arg_t W, divides_heap_chunk_t L)
                                         &T2->coeffs, &T2->exps, &T2->coeffs_alloc, &T2->exps_alloc,
                                         &T3->coeffs, &T3->exps, &T3->coeffs_alloc, &T3->exps_alloc, &Wlen,
                                            Rcoeff, Rexp, Rlen,
-                                           B->coeffs, B->exps, B->length, S, &rstatus);
+                                           B->coeffs, B->exps, B->length, S, &rstatus, &overflowed);
                 }
                 else
                 {
@@ -1778,7 +1819,20 @@ void trychunk(worker_arg_t W, divides_heap_chunk_t L)
                                         &T2->coeffs, &T2->exps, &T2->coeffs_alloc, &T2->exps_alloc,
                                         &T3->coeffs, &T3->exps, &T3->coeffs_alloc, &T3->exps_alloc, &Wlen,
                                            Rcoeff, Rexp, Rlen,
-                                           B->coeffs, B->exps, B->length, S, &rstatus);
+                                           B->coeffs, B->exps, B->length, S, &rstatus, &overflowed);
+                }
+
+                if (overflowed)
+                {
+#if FLINT_USES_PTHREAD
+                    pthread_mutex_lock(&H->mutex);
+#endif
+                    H->overflowed = 1;
+                    H->failed = 1;
+#if FLINT_USES_PTHREAD
+                    pthread_mutex_unlock(&H->mutex);
+#endif
+                    return;
                 }
 
                 if (rstatus != GR_SUCCESS)
@@ -2043,6 +2097,7 @@ static int _gr_mpoly_divides_heap_threaded_pool(
     H->failed = 0;
     H->have_domain = 0;
     H->have_unable = 0;
+    H->overflowed = 0;
 
     for (i = 0; i + 1 < S->length; i++)
     {

--- a/src/gr_mpoly/divides_heap_threaded.c
+++ b/src/gr_mpoly/divides_heap_threaded.c
@@ -1,0 +1,2212 @@
+/*
+    Copyright (C) 2019 Daniel Schultz
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdint.h>
+#include <string.h>
+#include "thread_pool.h"
+#include "thread_support.h"
+#include "fmpz.h"
+#include "fmpz_vec.h"
+#include "fmpz_mpoly.h"
+#include "mpoly.h"
+#include "gr_generic.h"
+#include "gr_mpoly.h"
+#include "threaded_divmod.h"
+
+/*
+    GR port of fmpz_mpoly_divides_heap_threaded (equivalently
+    nmod_mpoly_divides_heap_threaded).
+
+    The dividend A is split, by monomial, into a number of chunks (using the
+    same purely exponent-based selection routine, mpoly_divides_select_exps,
+    used by the fmpz/nmod versions).  Each chunk is responsible for producing
+    the quotient terms whose monomial lies in its exponent range.  A chunk can
+    only start producing terms once all quotient terms of every higher chunk
+    are known, since those may contribute (via multiplication by B) to the
+    remainder in the current chunk; this dependency is realised by a singly
+    linked list of chunks together with a lock-protected "producer" flag,
+    exactly as in the fmpz/nmod code.
+
+    As in gr_mpoly_divides_heap and gr_mpoly_mul_heap_threaded, the two
+    small/large coefficient code paths used by the fmpz version (packing the
+    accumulator into two or three words) correspond here to the two
+    accumulation strategies of the generic GR heap arithmetic: a fast path
+    that gathers the operands of a diagonal into two shallow vectors and
+    accumulates with a single _gr_vec_dot call (used when the coefficient
+    ring overloads VEC_DOT), and a generic path that accumulates term by term
+    using a single preallocated product temporary.
+
+    Exact division of coefficients follows gr_poly_divexact/gr_mpoly_divides_heap:
+    if the leading coefficient of B is a unit, we invert it once (in the
+    calling thread, before any workers are started) and multiply; otherwise
+    we fall back to gr_div, which over an integral domain such as Z returns
+    GR_DOMAIN exactly when the division has a nonzero remainder.
+
+    Status handling: ring operations can return GR_UNABLE (undecidable, e.g.
+    over an inexact ring) in addition to GR_SUCCESS/GR_DOMAIN.  A definite
+    GR_DOMAIN (the division is provably not exact) takes priority and causes
+    all workers to stop as soon as they notice; GR_UNABLE is recorded but by
+    itself also causes the computation to stop early, since none of the
+    partial results can be trusted at that point (the same as with a
+    definite failure).  The two conditions are tracked separately in the
+    base structure so that the correct final status can be reported.
+*/
+
+/* shallow copy helpers (SET_SHALLOW*), MULSUB_FETCH_NODE, and the
+   gr_mpoly_ts_* / divides_heap_chunk_struct / divides_heap_base_struct /
+   _gr_mpoly_stripe_struct / worker_arg_struct types now live in
+   threaded_divmod.h, shared with divrem_heap_threaded.c. */
+
+/* gather product node (Bcoeff[i], Qcoeff[j]) into dot_a/dot_b; record
+   dividend node (used by the divides stripe functions) */
+#define STRIPE_DIVIDES_FETCH_NODE(SET_SHALLOW) \
+    do { \
+        store[store_len++] = x->i; \
+        store[store_len++] = x->j; \
+        if (x->i == -UWORD(1)) \
+        { \
+            have_dividend = 1; \
+            dividend_j = x->j; \
+        } \
+        else \
+        { \
+            hind[x->i] |= WORD(1); \
+            SET_SHALLOW(dot_a, dot_len, Bcoeff, x->i); \
+            SET_SHALLOW(dot_b, dot_len, Qcoeff, x->j); \
+            dot_len++; \
+        } \
+    } while (0)
+
+/*
+    Divide the accumulated value by the leading coefficient of B, storing the
+    quotient coefficient in GR_ENTRY(Qcoeff, Qlen, sz).  Mirrors the
+    DIVIDES_COEFF macro of gr_mpoly/divides_heap.c.
+*/
+#define STRIPE_DIVIDES_COEFF(acc) \
+    (lc_is_one  ? gr_set(GR_ENTRY(Qcoeff, Qlen, sz), acc, cctx) \
+     : lc_is_unit ? gr_mul(GR_ENTRY(Qcoeff, Qlen, sz), acc, lc_inv, cctx) \
+                  : gr_div(GR_ENTRY(Qcoeff, Qlen, sz), acc, Bcoeff, cctx))
+
+/*
+    gr_mpoly_ts_struct/gr_mpoly_ts_t is declared in threaded_divmod.h; the
+    functions below (used by both this file and divrem_heap_threaded.c) are
+    defined here with external linkage.
+*/
+
+/* Bcoeff is emptied (its elements are moved into A) */
+void gr_mpoly_ts_init(gr_mpoly_ts_t A,
+        gr_ptr Bcoeff, ulong * Bexp, slong Blen,
+        flint_bitcnt_t bits, slong N, gr_ctx_t cctx)
+{
+    slong i;
+    slong sz = cctx->sizeof_elem;
+    flint_bitcnt_t idx = FLINT_BIT_COUNT(Blen);
+    idx = (idx <= 8) ? 0 : idx - 8;
+    for (i = 0; i < FLINT_BITS; i++)
+    {
+        A->exp_array[i] = NULL;
+        A->coeff_array[i] = NULL;
+    }
+    A->bits = bits;
+    A->N = N;
+    A->idx = idx;
+    A->alloc = WORD(256) << idx;
+    A->exps = A->exp_array[idx]
+            = (ulong *) flint_malloc(N*A->alloc*sizeof(ulong));
+    A->coeffs = A->coeff_array[idx]
+              = (gr_ptr) flint_malloc(A->alloc*sz);
+    _gr_vec_init(A->coeffs, A->alloc, cctx);
+    A->length = Blen;
+    for (i = 0; i < Blen; i++)
+    {
+        gr_swap(GR_ENTRY(A->coeffs, i, sz), GR_ENTRY(Bcoeff, i, sz), cctx);
+        mpoly_monomial_set(A->exps + N*i, Bexp + N*i, N);
+    }
+}
+
+void gr_mpoly_ts_clear(gr_mpoly_ts_t A, gr_ctx_t cctx)
+{
+    slong i;
+
+    for (i = 0; i < FLINT_BITS; i++)
+    {
+        if (A->exp_array[i] != NULL)
+        {
+            slong level_alloc = UWORD(256) << i;
+            FLINT_ASSERT(A->coeff_array[i] != NULL);
+            _gr_vec_clear(A->coeff_array[i], level_alloc, cctx);
+            flint_free(A->coeff_array[i]);
+            flint_free(A->exp_array[i]);
+        }
+    }
+}
+
+void gr_mpoly_ts_clear_poly(gr_mpoly_t Q, gr_mpoly_ts_t A, gr_ctx_t cctx)
+{
+    if (Q->coeffs_alloc != 0)
+    {
+        _gr_vec_clear(Q->coeffs, Q->coeffs_alloc, cctx);
+        flint_free(Q->coeffs);
+    }
+    if (Q->exps_alloc != 0)
+        flint_free(Q->exps);
+
+    Q->exps = A->exps;
+    Q->coeffs = A->coeffs;
+    Q->bits = A->bits;
+    Q->coeffs_alloc = A->alloc;
+    Q->exps_alloc = A->N * A->alloc;
+    Q->length = A->length;
+
+    A->coeff_array[A->idx] = NULL;
+    A->exp_array[A->idx] = NULL;
+    gr_mpoly_ts_clear(A, cctx);
+}
+
+/* put B on the end of A -- Bcoeff is emptied */
+void gr_mpoly_ts_append(gr_mpoly_ts_t A,
+                gr_ptr Bcoeff, ulong * Bexps, slong Blen, slong N, gr_ctx_t cctx)
+{
+/* TODO: this needs barriers on non-x86 */
+
+    slong i;
+    slong sz = cctx->sizeof_elem;
+    ulong * oldexps = A->exps;
+    gr_ptr oldcoeffs = A->coeffs;
+    slong oldlength = A->length;
+    slong newlength = A->length + Blen;
+
+    if (newlength <= A->alloc)
+    {
+        /* write new terms first */
+        for (i = 0; i < Blen; i++)
+        {
+            gr_swap(GR_ENTRY(oldcoeffs, oldlength + i, sz),
+                    GR_ENTRY(Bcoeff, i, sz), cctx);
+            mpoly_monomial_set(oldexps + N*(oldlength + i), Bexps + N*i, N);
+        }
+    }
+    else
+    {
+        slong newalloc;
+        ulong * newexps;
+        gr_ptr newcoeffs;
+        flint_bitcnt_t newidx;
+        newidx = FLINT_BIT_COUNT(newlength - 1);
+        newidx = (newidx > 8) ? newidx - 8 : 0;
+        FLINT_ASSERT(newidx > A->idx);
+
+        newalloc = UWORD(256) << newidx;
+        FLINT_ASSERT(newlength <= newalloc);
+        newexps = A->exp_array[newidx]
+                = (ulong *) flint_malloc(N*newalloc*sizeof(ulong));
+        newcoeffs = A->coeff_array[newidx]
+                  = (gr_ptr) flint_malloc(newalloc*sz);
+        _gr_vec_init(newcoeffs, newalloc, cctx);
+
+        for (i = 0; i < oldlength; i++)
+        {
+            /* NOTE: this must be a copy, not a swap/move: other threads may
+               still be concurrently reading through a stale pointer to the
+               old array (we deliberately never free it -- see below), so we
+               must not disturb its contents. This mirrors the plain word
+               copy used for this step by fmpz_mpoly_ts_append. */
+            GR_IGNORE(gr_set(GR_ENTRY(newcoeffs, i, sz), GR_ENTRY(oldcoeffs, i, sz), cctx));
+            mpoly_monomial_set(newexps + N*i, oldexps + N*i, N);
+        }
+        for (i = 0; i < Blen; i++)
+        {
+            gr_swap(GR_ENTRY(newcoeffs, oldlength + i, sz),
+                    GR_ENTRY(Bcoeff, i, sz), cctx);
+            mpoly_monomial_set(newexps + N*(oldlength + i), Bexps + N*i, N);
+        }
+
+        A->alloc = newalloc;
+        A->exps = newexps;
+        A->coeffs = newcoeffs;
+        A->idx = newidx;
+
+        /* do not free oldcoeffs/oldexps as other threads may be using them */
+    }
+
+    /* update length at the very end */
+    A->length = newlength;
+}
+
+
+/*
+    divides_heap_chunk_struct / divides_heap_base_struct / worker_arg_struct
+    and _gr_mpoly_stripe_struct are declared in threaded_divmod.h.
+*/
+
+void divides_heap_base_init(divides_heap_base_t H)
+{
+    H->head = NULL;
+    H->tail = NULL;
+    H->cur = NULL;
+    H->ctx = NULL;
+    H->length = 0;
+    H->N = 0;
+    H->bits = 0;
+    H->cmpmask = NULL;
+}
+
+void divides_heap_chunk_clear(divides_heap_chunk_t L, divides_heap_base_t H)
+{
+    if (L->Cinited)
+        gr_mpoly_clear(L->polyC, H->ctx);
+}
+
+int divides_heap_base_clear(gr_mpoly_t Q, gr_mpoly_t R, divides_heap_base_t H)
+{
+    divides_heap_chunk_struct * L = H->head;
+    int status;
+
+    FLINT_ASSERT((R != NULL) == H->want_remainder);
+
+    while (L != NULL)
+    {
+        divides_heap_chunk_struct * nextL = L->next;
+        divides_heap_chunk_clear(L, H);
+        flint_free(L);
+        L = nextL;
+    }
+    H->head = NULL;
+    H->tail = NULL;
+    H->cur = NULL;
+    H->length = 0;
+    H->N = 0;
+    H->bits = 0;
+    H->cmpmask = NULL;
+
+    if (H->have_domain)
+        status = GR_DOMAIN;
+    else if (H->have_unable)
+        status = GR_UNABLE;
+    else
+        status = GR_SUCCESS;
+
+    if (status != GR_SUCCESS)
+    {
+        GR_IGNORE(gr_mpoly_zero(Q, H->ctx));
+        gr_mpoly_ts_clear(H->polyQ, H->cctx);
+        if (H->want_remainder)
+        {
+            GR_IGNORE(gr_mpoly_zero(R, H->ctx));
+            gr_mpoly_ts_clear(H->polyR, H->cctx);
+        }
+    }
+    else
+    {
+        gr_mpoly_ts_clear_poly(Q, H->polyQ, H->cctx);
+        if (H->want_remainder)
+            gr_mpoly_ts_clear_poly(R, H->polyR, H->cctx);
+    }
+
+    return status;
+}
+
+void divides_heap_base_add_chunk(divides_heap_base_t H, divides_heap_chunk_t L)
+{
+    L->next = NULL;
+
+    if (H->tail == NULL)
+    {
+        FLINT_ASSERT(H->head == NULL);
+        H->tail = L;
+        H->head = L;
+    }
+    else
+    {
+        divides_heap_chunk_struct * tail = H->tail;
+        FLINT_ASSERT(tail->next == NULL);
+        tail->next = L;
+        H->tail = L;
+    }
+    H->length++;
+}
+
+
+/*
+    A = D - (a stripe of B * C), single-word exponent version.
+
+    B is the small "increment" -- the newly available slice of the growing
+    quotient -- and is swept afresh on every call (S->big_mem is sized
+    relative to Blen).  C is the actual, fixed divisor; S->startidx/S->endidx
+    are persistent (monotonically shrinking) indices into C, valid provided
+    B keeps decreasing (i.e. this chunk's exponent window keeps narrowing)
+    while C stays the same across calls.  This (initially confusing) choice
+    of roles mirrors fmpz_mpoly_divides_heap_threaded / nmod_mpoly_divides_heap_threaded,
+    where it is an important optimisation: the per-call heap setup is O(Blen)
+    (the small increment) rather than O(Clen) (the possibly much larger B).
+
+    saveD: 0 means the coefficients of D may be moved out of D (D is a
+           scratch remainder), 1 means D must be left undisturbed (D may be
+           a slice of the original dividend, shared with other chunks).
+
+    Returns the length of A and writes GR_SUCCESS/GR_UNABLE to *res_status
+    (this routine, unlike the plain division, cannot detect that a division
+    is impossible -- it is simply forming a difference of products).
+*/
+slong _gr_mpoly_mulsub_stripe1(
+    gr_ptr * A_coeff, ulong ** A_exp, slong * A_alloc, slong * A_exps_alloc,
+    gr_srcptr Dcoeff, const ulong * Dexp, slong Dlen, int saveD,
+    gr_srcptr Bcoeff, const ulong * Bexp, slong Blen,
+    gr_srcptr Ccoeff, const ulong * Cexp, slong Clen,
+    const _gr_mpoly_stripe_t S, int * res_status)
+{
+    gr_mpoly_ctx_struct * ctx = S->ctx;
+    gr_ctx_struct * cctx = S->cctx;
+    slong sz = S->sz;
+    int have_fast_dot = S->have_fast_dot;
+    int upperclosed;
+    slong startidx, endidx;
+    ulong prev_startidx;
+    ulong maskhi = S->cmpmask[0];
+    ulong emax, emin;
+    slong i, j;
+    slong next_loc = Blen + 4;
+    slong heap_len = 1;
+    mpoly_heap1_s * heap;
+    mpoly_heap_t * chain;
+    slong * store, * store_base, store_len;
+    mpoly_heap_t * x;
+    slong Di;
+    slong Alen;
+    slong Aalloc = *A_alloc;
+    slong Aexps_alloc = *A_exps_alloc;
+    gr_ptr Acoeff = *A_coeff;
+    ulong * Aexp = *A_exp;
+    ulong exp;
+    slong * ends;
+    ulong texp;
+    slong * hind;
+    gr_ptr pp, dot_a, dot_b;
+    slong dot_len;
+    int status = GR_SUCCESS;
+
+    FLINT_ASSERT(S->N == 1);
+
+    i = 0;
+    hind = (slong *)(S->big_mem + i);
+    i += Blen*sizeof(slong);
+    ends = (slong *)(S->big_mem + i);
+    i += Blen*sizeof(slong);
+    store = store_base = (slong *) (S->big_mem + i);
+    i += 2*Blen*sizeof(slong);
+    heap = (mpoly_heap1_s *)(S->big_mem + i);
+    i += (Blen + 1)*sizeof(mpoly_heap1_s);
+    chain = (mpoly_heap_t *)(S->big_mem + i);
+    i += Blen*sizeof(mpoly_heap_t);
+    FLINT_ASSERT(i <= S->big_mem_alloc);
+
+    GR_TMP_INIT(pp, cctx);
+    dot_a = flint_malloc(2 * Blen * sz);
+    dot_b = GR_ENTRY(dot_a, Blen, sz);
+
+    startidx = *S->startidx;
+    endidx = *S->endidx;
+    upperclosed = S->upperclosed;
+    emax = S->emax[0];
+    emin = S->emin[0];
+
+    /* put all the starting nodes on the heap */
+    prev_startidx = -UWORD(1);
+    for (i = 0; i < Blen; i++)
+    {
+        if (startidx < Clen)
+        {
+            texp = Bexp[i] + Cexp[startidx];
+            FLINT_ASSERT(mpoly_monomial_cmp1(emax, texp, maskhi)
+                                                               > -upperclosed);
+        }
+        while (startidx > 0)
+        {
+            texp = Bexp[i] + Cexp[startidx - 1];
+            if (mpoly_monomial_cmp1(emax, texp, maskhi) <= -upperclosed)
+                break;
+            startidx--;
+        }
+
+        if (endidx < Clen)
+        {
+            texp = Bexp[i] + Cexp[endidx];
+            FLINT_ASSERT(mpoly_monomial_cmp1(emin, texp, maskhi) > 0);
+        }
+        while (endidx > 0)
+        {
+            texp = Bexp[i] + Cexp[endidx - 1];
+            if (mpoly_monomial_cmp1(emin, texp, maskhi) <= 0)
+                break;
+            endidx--;
+        }
+
+        ends[i] = endidx;
+        hind[i] = 2*startidx + 1;
+
+        if ((startidx < endidx) && (((ulong) startidx) < prev_startidx))
+        {
+            x = chain + i;
+            x->i = i;
+            x->j = startidx;
+            x->next = NULL;
+            hind[x->i] = 2*(x->j + 1) + 0;
+            _mpoly_heap_insert1(heap, Bexp[x->i] + Cexp[x->j], x,
+                                      &next_loc, &heap_len, maskhi);
+        }
+
+        prev_startidx = startidx;
+    }
+
+    *S->startidx = startidx;
+    *S->endidx = endidx;
+
+    Alen = 0;
+    Di = 0;
+    while (heap_len > 1)
+    {
+        exp = heap[1].exp;
+
+        while (Di < Dlen && mpoly_monomial_gt1(Dexp[Di], exp, maskhi))
+        {
+            _gr_mpoly_fit_length(&Acoeff, &Aalloc, &Aexp, &Aexps_alloc, 1, Alen + 1, ctx);
+            Aexp[Alen] = Dexp[Di];
+            if (saveD)
+                status |= gr_set(GR_ENTRY(Acoeff, Alen, sz), GR_ENTRY(Dcoeff, Di, sz), cctx);
+            else
+                gr_swap(GR_ENTRY(Acoeff, Alen, sz), GR_ENTRY(Dcoeff, Di, sz), cctx);
+            Alen++;
+            Di++;
+        }
+
+        _gr_mpoly_fit_length(&Acoeff, &Aalloc, &Aexp, &Aexps_alloc, 1, Alen + 1, ctx);
+
+        Aexp[Alen] = exp;
+
+        store_len = 0;
+
+        if (have_fast_dot)
+        {
+            int have_D;
+
+            dot_len = 0;
+            do
+            {
+                x = _mpoly_heap_pop1(heap, &heap_len, maskhi);
+                do
+                {
+                    if (sz == 1)       { MULSUB_FETCH_NODE(SET_SHALLOW1); }
+                    else if (sz == 2)  { MULSUB_FETCH_NODE(SET_SHALLOW2); }
+                    else if (sz == 4)  { MULSUB_FETCH_NODE(SET_SHALLOW4); }
+                    else if (sz == 8)  { MULSUB_FETCH_NODE(SET_SHALLOW8); }
+                    else if (sz == 16) { MULSUB_FETCH_NODE(SET_SHALLOW16); }
+                    else               { MULSUB_FETCH_NODE(SET_SHALLOW_GENERIC); }
+                } while ((x = x->next) != NULL);
+            } while (heap_len > 1 && heap[1].exp == exp);
+
+            have_D = (Di < Dlen && Dexp[Di] == exp);
+            status |= _gr_vec_dot(GR_ENTRY(Acoeff, Alen, sz),
+                        have_D ? GR_ENTRY(Dcoeff, Di, sz) : NULL, 1,
+                        dot_a, dot_b, dot_len, cctx);
+            if (have_D)
+                Di++;
+        }
+        else
+        {
+            if (Di < Dlen && Dexp[Di] == exp)
+            {
+                status |= gr_set(GR_ENTRY(Acoeff, Alen, sz), GR_ENTRY(Dcoeff, Di, sz), cctx);
+                Di++;
+            }
+            else
+            {
+                status |= gr_zero(GR_ENTRY(Acoeff, Alen, sz), cctx);
+            }
+
+            do
+            {
+                x = _mpoly_heap_pop1(heap, &heap_len, maskhi);
+                do
+                {
+                    hind[x->i] |= WORD(1);
+                    store[store_len++] = x->i;
+                    store[store_len++] = x->j;
+                    status |= gr_mul(pp, GR_ENTRY(Bcoeff, x->i, sz), GR_ENTRY(Ccoeff, x->j, sz), cctx);
+                    status |= gr_sub(GR_ENTRY(Acoeff, Alen, sz), GR_ENTRY(Acoeff, Alen, sz), pp, cctx);
+                } while ((x = x->next) != NULL);
+            } while (heap_len > 1 && heap[1].exp == exp);
+        }
+
+        /* process nodes taken from the heap */
+        while (store_len > 0)
+        {
+            j = store_base[--store_len];
+            i = store_base[--store_len];
+
+            /* should we go right? */
+            if ((i + 1 < Blen) && (j + 0 < ends[i + 1]) && (hind[i + 1] == 2*j + 1))
+            {
+                x = chain + i + 1;
+                x->i = i + 1;
+                x->j = j;
+                x->next = NULL;
+                hind[x->i] = 2*(x->j + 1) + 0;
+                _mpoly_heap_insert1(heap, Bexp[x->i] + Cexp[x->j], x,
+                                                 &next_loc, &heap_len, maskhi);
+            }
+
+            /* should we go up? */
+            if ((j + 1 < ends[i + 0]) && ((hind[i] & 1) == 1) &&
+                ((i == 0) || (hind[i - 1] >= 2*(j + 2) + 1)))
+            {
+                x = chain + i;
+                x->i = i;
+                x->j = j + 1;
+                x->next = NULL;
+                hind[x->i] = 2*(x->j + 1) + 0;
+                _mpoly_heap_insert1(heap, Bexp[x->i] + Cexp[x->j], x,
+                                                 &next_loc, &heap_len, maskhi);
+            }
+        }
+
+        switch (gr_is_zero(GR_ENTRY(Acoeff, Alen, sz), cctx))
+        {
+            case T_TRUE:
+                break;
+            case T_FALSE:
+                Alen++;
+                break;
+            default:
+                status |= GR_UNABLE;
+                Alen++;
+                break;
+        }
+    }
+
+    FLINT_ASSERT(Di <= Dlen);
+    _gr_mpoly_fit_length(&Acoeff, &Aalloc, &Aexp, &Aexps_alloc, 1, Alen + Dlen - Di, ctx);
+    if (saveD)
+        status |= _gr_vec_set(GR_ENTRY(Acoeff, Alen, sz), GR_ENTRY(Dcoeff, Di, sz), Dlen - Di, cctx);
+    else
+        _gr_vec_swap(GR_ENTRY(Acoeff, Alen, sz), (gr_ptr) GR_ENTRY(Dcoeff, Di, sz), Dlen - Di, cctx);
+    mpoly_copy_monomials(Aexp + Alen, Dexp + Di, Dlen - Di, 1);
+    Alen += Dlen - Di;
+
+    GR_TMP_CLEAR(pp, cctx);
+    flint_free(dot_a);
+
+    *A_coeff = Acoeff;
+    *A_exp = Aexp;
+    *A_alloc = Aalloc;
+    *A_exps_alloc = Aexps_alloc;
+    *res_status = status;
+    return Alen;
+}
+
+
+/* Multi-word exponent version of the above. */
+slong _gr_mpoly_mulsub_stripe(
+    gr_ptr * A_coeff, ulong ** A_exp, slong * A_alloc, slong * A_exps_alloc,
+    gr_srcptr Dcoeff, const ulong * Dexp, slong Dlen, int saveD,
+    gr_srcptr Bcoeff, const ulong * Bexp, slong Blen,
+    gr_srcptr Ccoeff, const ulong * Cexp, slong Clen,
+    const _gr_mpoly_stripe_t S, int * res_status)
+{
+    gr_mpoly_ctx_struct * ctx = S->ctx;
+    gr_ctx_struct * cctx = S->cctx;
+    slong sz = S->sz;
+    int have_fast_dot = S->have_fast_dot;
+    int upperclosed;
+    slong startidx, endidx;
+    ulong prev_startidx;
+    ulong * emax = S->emax;
+    ulong * emin = S->emin;
+    slong N = S->N;
+    slong i, j;
+    slong next_loc = Blen + 4;
+    slong heap_len = 1;
+    mpoly_heap_s * heap;
+    mpoly_heap_t * chain;
+    slong * store, * store_base, store_len;
+    mpoly_heap_t * x;
+    slong Di;
+    slong Alen;
+    slong Aalloc = *A_alloc;
+    slong Aexps_alloc = *A_exps_alloc;
+    gr_ptr Acoeff = *A_coeff;
+    ulong * Aexp = *A_exp;
+    ulong * exp, * exps;
+    ulong ** exp_list;
+    slong exp_next;
+    slong * ends;
+    ulong * texp;
+    slong * hind;
+    gr_ptr pp, dot_a, dot_b;
+    slong dot_len;
+    int status = GR_SUCCESS;
+
+    i = 0;
+    hind = (slong *)(S->big_mem + i);
+    i += Blen*sizeof(slong);
+    ends = (slong *)(S->big_mem + i);
+    i += Blen*sizeof(slong);
+    store = store_base = (slong *) (S->big_mem + i);
+    i += 2*Blen*sizeof(slong);
+    heap = (mpoly_heap_s *)(S->big_mem + i);
+    i += (Blen + 1)*sizeof(mpoly_heap_s);
+    chain = (mpoly_heap_t *)(S->big_mem + i);
+    i += Blen*sizeof(mpoly_heap_t);
+    exps = (ulong *)(S->big_mem + i);
+    i +=  Blen*N*sizeof(ulong);
+    exp_list = (ulong **)(S->big_mem + i);
+    i +=  Blen*sizeof(ulong *);
+    texp = (ulong *)(S->big_mem + i);
+    i +=  N*sizeof(ulong);
+    FLINT_ASSERT(i <= S->big_mem_alloc);
+
+    GR_TMP_INIT(pp, cctx);
+    dot_a = flint_malloc(2 * Blen * sz);
+    dot_b = GR_ENTRY(dot_a, Blen, sz);
+
+    exp_next = 0;
+
+    startidx = *S->startidx;
+    endidx = *S->endidx;
+    upperclosed = S->upperclosed;
+
+    for (i = 0; i < Blen; i++)
+        exp_list[i] = exps + i*N;
+
+    /* put all the starting nodes on the heap */
+    prev_startidx = -UWORD(1);
+    for (i = 0; i < Blen; i++)
+    {
+        if (startidx < Clen)
+        {
+            mpoly_monomial_add_mp(texp, Bexp + N*i, Cexp + N*startidx, N);
+            FLINT_ASSERT(mpoly_monomial_cmp(emax, texp, N, S->cmpmask)
+                                                               > -upperclosed);
+        }
+        while (startidx > 0)
+        {
+            mpoly_monomial_add_mp(texp, Bexp + N*i, Cexp + N*(startidx - 1), N);
+            if (mpoly_monomial_cmp(emax, texp, N, S->cmpmask) <= -upperclosed)
+                break;
+            startidx--;
+        }
+
+        if (endidx < Clen)
+        {
+            mpoly_monomial_add_mp(texp, Bexp + N*i, Cexp + N*endidx, N);
+            FLINT_ASSERT(mpoly_monomial_cmp(emin, texp, N, S->cmpmask) > 0);
+        }
+        while (endidx > 0)
+        {
+            mpoly_monomial_add_mp(texp, Bexp + N*i, Cexp + N*(endidx - 1), N);
+            if (mpoly_monomial_cmp(emin, texp, N, S->cmpmask) <= 0)
+                break;
+            endidx--;
+        }
+
+        ends[i] = endidx;
+        hind[i] = 2*startidx + 1;
+
+        if ((startidx < endidx) && (((ulong) startidx) < prev_startidx))
+        {
+            x = chain + i;
+            x->i = i;
+            x->j = startidx;
+            x->next = NULL;
+            hind[x->i] = 2*(x->j + 1) + 0;
+
+            mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
+                                                      Cexp + N*x->j, N);
+
+            exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
+                                          &next_loc, &heap_len, N, S->cmpmask);
+        }
+
+        prev_startidx = startidx;
+    }
+
+    *S->startidx = startidx;
+    *S->endidx = endidx;
+
+    Alen = 0;
+    Di = 0;
+    while (heap_len > 1)
+    {
+        exp = heap[1].exp;
+
+        while (Di < Dlen && mpoly_monomial_gt(Dexp + N*Di, exp, N, S->cmpmask))
+        {
+            _gr_mpoly_fit_length(&Acoeff, &Aalloc, &Aexp, &Aexps_alloc, N, Alen + 1, ctx);
+            mpoly_monomial_set(Aexp + N*Alen, Dexp + N*Di, N);
+            if (saveD)
+                status |= gr_set(GR_ENTRY(Acoeff, Alen, sz), GR_ENTRY(Dcoeff, Di, sz), cctx);
+            else
+                gr_swap(GR_ENTRY(Acoeff, Alen, sz), GR_ENTRY(Dcoeff, Di, sz), cctx);
+            Alen++;
+            Di++;
+        }
+
+        _gr_mpoly_fit_length(&Acoeff, &Aalloc, &Aexp, &Aexps_alloc, N, Alen + 1, ctx);
+
+        mpoly_monomial_set(Aexp + N*Alen, exp, N);
+
+        store_len = 0;
+
+        if (have_fast_dot)
+        {
+            int have_D;
+
+            dot_len = 0;
+            do
+            {
+                exp_list[--exp_next] = heap[1].exp;
+                x = _mpoly_heap_pop(heap, &heap_len, N, S->cmpmask);
+                do
+                {
+                    if (sz == 1)       { MULSUB_FETCH_NODE(SET_SHALLOW1); }
+                    else if (sz == 2)  { MULSUB_FETCH_NODE(SET_SHALLOW2); }
+                    else if (sz == 4)  { MULSUB_FETCH_NODE(SET_SHALLOW4); }
+                    else if (sz == 8)  { MULSUB_FETCH_NODE(SET_SHALLOW8); }
+                    else if (sz == 16) { MULSUB_FETCH_NODE(SET_SHALLOW16); }
+                    else               { MULSUB_FETCH_NODE(SET_SHALLOW_GENERIC); }
+                } while ((x = x->next) != NULL);
+            } while (heap_len > 1 && mpoly_monomial_equal(heap[1].exp, exp, N));
+
+            have_D = (Di < Dlen && mpoly_monomial_equal(Dexp + N*Di, exp, N));
+            status |= _gr_vec_dot(GR_ENTRY(Acoeff, Alen, sz),
+                        have_D ? GR_ENTRY(Dcoeff, Di, sz) : NULL, 1,
+                        dot_a, dot_b, dot_len, cctx);
+            if (have_D)
+                Di++;
+        }
+        else
+        {
+            if (Di < Dlen && mpoly_monomial_equal(Dexp + N*Di, exp, N))
+            {
+                status |= gr_set(GR_ENTRY(Acoeff, Alen, sz), GR_ENTRY(Dcoeff, Di, sz), cctx);
+                Di++;
+            }
+            else
+            {
+                status |= gr_zero(GR_ENTRY(Acoeff, Alen, sz), cctx);
+            }
+
+            do
+            {
+                exp_list[--exp_next] = heap[1].exp;
+                x = _mpoly_heap_pop(heap, &heap_len, N, S->cmpmask);
+                do
+                {
+                    hind[x->i] |= WORD(1);
+                    store[store_len++] = x->i;
+                    store[store_len++] = x->j;
+                    status |= gr_mul(pp, GR_ENTRY(Bcoeff, x->i, sz), GR_ENTRY(Ccoeff, x->j, sz), cctx);
+                    status |= gr_sub(GR_ENTRY(Acoeff, Alen, sz), GR_ENTRY(Acoeff, Alen, sz), pp, cctx);
+                } while ((x = x->next) != NULL);
+            } while (heap_len > 1 && mpoly_monomial_equal(heap[1].exp, exp, N));
+        }
+
+        /* process nodes taken from the heap */
+        while (store_len > 0)
+        {
+            j = store_base[--store_len];
+            i = store_base[--store_len];
+
+            /* should we go right? */
+            if ((i + 1 < Blen) && (j + 0 < ends[i + 1]) && (hind[i + 1] == 2*j + 1))
+            {
+                x = chain + i + 1;
+                x->i = i + 1;
+                x->j = j;
+                x->next = NULL;
+                hind[x->i] = 2*(x->j + 1) + 0;
+
+                mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
+                                                          Cexp + N*x->j, N);
+
+                exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
+                                          &next_loc, &heap_len, N, S->cmpmask);
+            }
+
+            /* should we go up? */
+            if ((j + 1 < ends[i + 0]) && ((hind[i] & 1) == 1) &&
+                ((i == 0) || (hind[i - 1] >= 2*(j + 2) + 1)))
+            {
+                x = chain + i;
+                x->i = i;
+                x->j = j + 1;
+                x->next = NULL;
+                hind[x->i] = 2*(x->j + 1) + 0;
+
+                mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
+                                                          Cexp + N*x->j, N);
+
+                exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
+                                          &next_loc, &heap_len, N, S->cmpmask);
+            }
+        }
+
+        switch (gr_is_zero(GR_ENTRY(Acoeff, Alen, sz), cctx))
+        {
+            case T_TRUE:
+                break;
+            case T_FALSE:
+                Alen++;
+                break;
+            default:
+                status |= GR_UNABLE;
+                Alen++;
+                break;
+        }
+    }
+
+    FLINT_ASSERT(Di <= Dlen);
+    _gr_mpoly_fit_length(&Acoeff, &Aalloc, &Aexp, &Aexps_alloc, N, Alen + Dlen - Di, ctx);
+    if (saveD)
+        status |= _gr_vec_set(GR_ENTRY(Acoeff, Alen, sz), GR_ENTRY(Dcoeff, Di, sz), Dlen - Di, cctx);
+    else
+        _gr_vec_swap(GR_ENTRY(Acoeff, Alen, sz), (gr_ptr) GR_ENTRY(Dcoeff, Di, sz), Dlen - Di, cctx);
+    mpoly_copy_monomials(Aexp + N*Alen, Dexp + N*Di, Dlen - Di, N);
+    Alen += Dlen - Di;
+
+    GR_TMP_CLEAR(pp, cctx);
+    flint_free(dot_a);
+
+    *A_coeff = Acoeff;
+    *A_exp = Aexp;
+    *A_alloc = Aalloc;
+    *A_exps_alloc = Aexps_alloc;
+    *res_status = status;
+    return Alen;
+}
+
+
+/*
+    Q = stripe of R/B (single-word exponent version), assuming R != 0.
+
+    New quotient terms/heap nodes are only produced while their exponent
+    stays within [S->emin, infinity) (the fmpz/nmod analogue restricts the
+    heap to a chunk's exponent window in the same way): nodes whose exponent
+    would fall below S->emin are never inserted (see the "should we go
+    right/up" logic below), matching the fact that lower quotient terms are
+    the responsibility of a different chunk.
+
+    Returns Qlen and writes GR_SUCCESS / GR_DOMAIN / GR_UNABLE to
+    *res_status.  Qlen is meaningful only when *res_status == GR_SUCCESS.
+*/
+static slong _gr_mpoly_divides_stripe1(
+    gr_ptr * Q_coeff, ulong ** Q_exp, slong * Q_alloc, slong * Q_exps_alloc,
+    gr_srcptr Acoeff, const ulong * Aexp, slong Alen,
+    gr_srcptr Bcoeff, const ulong * Bexp, slong Blen,
+    const _gr_mpoly_stripe_t S, int * res_status)
+{
+    gr_mpoly_ctx_struct * ctx = S->ctx;
+    gr_ctx_struct * cctx = S->cctx;
+    slong sz = S->sz;
+    int have_fast_dot = S->have_fast_dot;
+    int lc_is_one = S->lc_is_one;
+    int lc_is_unit = S->lc_is_unit;
+    gr_srcptr lc_inv = S->lc_inv;
+    flint_bitcnt_t bits = S->bits;
+    ulong emin = S->emin[0];
+    ulong cmpmask = S->cmpmask[0];
+    ulong texp;
+    int lt_divides;
+    slong i, j, s;
+    slong next_loc, heap_len;
+    mpoly_heap1_s * heap;
+    mpoly_heap_t * chain;
+    slong * store, * store_base, store_len;
+    mpoly_heap_t * x;
+    slong Qlen;
+    slong Qalloc = *Q_alloc;
+    slong Qexps_alloc = *Q_exps_alloc;
+    gr_ptr Qcoeff = *Q_coeff;
+    ulong * Qexp = *Q_exp;
+    ulong exp;
+    ulong mask;
+    slong * hind;
+    gr_ptr acc, pp, dot_a, dot_b;
+    slong dot_len;
+    int have_dividend, cstatus;
+    slong dividend_j = 0;
+    int status = GR_SUCCESS;
+
+    FLINT_ASSERT(Alen > 0);
+    FLINT_ASSERT(Blen > 0);
+    FLINT_ASSERT(S->N == 1);
+
+    next_loc = Blen + 4;
+
+    i = 0;
+    hind = (slong *)(S->big_mem + i);
+    i += Blen*sizeof(slong);
+    store = store_base = (slong *) (S->big_mem + i);
+    i += 2*Blen*sizeof(slong);
+    heap = (mpoly_heap1_s *)(S->big_mem + i);
+    i += (Blen + 1)*sizeof(mpoly_heap1_s);
+    chain = (mpoly_heap_t *)(S->big_mem + i);
+    i += Blen*sizeof(mpoly_heap_t);
+    FLINT_ASSERT(i <= S->big_mem_alloc);
+
+    GR_TMP_INIT2(acc, pp, cctx);
+    dot_a = flint_malloc(2 * Blen * sz);
+    dot_b = GR_ENTRY(dot_a, Blen, sz);
+
+    for (i = 0; i < Blen; i++)
+        hind[i] = 1;
+
+    mask = mpoly_overflow_mask_sp(bits);
+
+    Qlen = 0;
+    s = Blen;
+
+    heap_len = 2;
+    x = chain + 0;
+    x->i = -WORD(1);
+    x->j = 0;
+    x->next = NULL;
+    heap[1].next = x;
+    HEAP_ASSIGN(heap[1], Aexp[0], x);
+
+    FLINT_ASSERT(mpoly_monomial_cmp1(Aexp[0], emin, cmpmask) >= 0);
+
+    while (heap_len > 1)
+    {
+        exp = heap[1].exp;
+
+        if (mpoly_monomial_overflows1(exp, mask))
+            goto not_exact_division;
+
+        FLINT_ASSERT(mpoly_monomial_cmp1(exp, emin, cmpmask) >= 0);
+
+        _gr_mpoly_fit_length(&Qcoeff, &Qalloc, &Qexp, &Qexps_alloc, 1, Qlen + 1, ctx);
+
+        lt_divides = mpoly_monomial_divides1(Qexp + Qlen, exp, Bexp[0], mask);
+
+        dot_len = 0;
+        have_dividend = 0;
+        store_len = 0;
+
+        if (have_fast_dot)
+        {
+            do
+            {
+                x = _mpoly_heap_pop1(heap, &heap_len, cmpmask);
+                do
+                {
+                    if (sz == 1)       { STRIPE_DIVIDES_FETCH_NODE(SET_SHALLOW1); }
+                    else if (sz == 2)  { STRIPE_DIVIDES_FETCH_NODE(SET_SHALLOW2); }
+                    else if (sz == 4)  { STRIPE_DIVIDES_FETCH_NODE(SET_SHALLOW4); }
+                    else if (sz == 8)  { STRIPE_DIVIDES_FETCH_NODE(SET_SHALLOW8); }
+                    else if (sz == 16) { STRIPE_DIVIDES_FETCH_NODE(SET_SHALLOW16); }
+                    else               { STRIPE_DIVIDES_FETCH_NODE(SET_SHALLOW_GENERIC); }
+                } while ((x = x->next) != NULL);
+            } while (heap_len > 1 && heap[1].exp == exp);
+
+            status |= _gr_vec_dot(acc,
+                        have_dividend ? GR_ENTRY(Acoeff, dividend_j, sz) : NULL,
+                        1, dot_a, dot_b, dot_len, cctx);
+        }
+        else
+        {
+            status |= gr_zero(acc, cctx);
+            do
+            {
+                x = _mpoly_heap_pop1(heap, &heap_len, cmpmask);
+                do
+                {
+                    store[store_len++] = x->i;
+                    store[store_len++] = x->j;
+                    if (x->i == -UWORD(1))
+                    {
+                        status |= gr_add(acc, acc, GR_ENTRY(Acoeff, x->j, sz), cctx);
+                    }
+                    else
+                    {
+                        hind[x->i] |= WORD(1);
+                        status |= gr_mul(pp, GR_ENTRY(Bcoeff, x->i, sz), GR_ENTRY(Qcoeff, x->j, sz), cctx);
+                        status |= gr_sub(acc, acc, pp, cctx);
+                    }
+                } while ((x = x->next) != NULL);
+            } while (heap_len > 1 && heap[1].exp == exp);
+        }
+
+        /* process nodes taken from the heap */
+        while (store_len > 0)
+        {
+            j = store_base[--store_len];
+            i = store_base[--store_len];
+
+            if (i == -WORD(1))
+            {
+                if (j + 1 < Alen)
+                {
+                    x = chain + 0;
+                    x->i = i;
+                    x->j = j + 1;
+                    x->next = NULL;
+
+                    FLINT_ASSERT(mpoly_monomial_cmp1(Aexp[x->j], emin, cmpmask) >= 0);
+
+                    _mpoly_heap_insert1(heap, Aexp[x->j], x,
+                                                &next_loc, &heap_len, cmpmask);
+                }
+            }
+            else
+            {
+                /* should we go right? */
+                if ((i + 1 < Blen) && (hind[i + 1] == 2*j + 1))
+                {
+                    x = chain + i + 1;
+                    x->i = i + 1;
+                    x->j = j;
+                    x->next = NULL;
+                    hind[x->i] = 2*(x->j + 1) + 0;
+
+                    texp = Bexp[x->i] + Qexp[x->j];
+                    if (mpoly_monomial_cmp1(texp, emin, cmpmask) >= 0)
+                        _mpoly_heap_insert1(heap, texp, x, &next_loc, &heap_len, cmpmask);
+                    else
+                        hind[x->i] |= 1;
+                }
+                /* should we go up? */
+                if (j + 1 == Qlen)
+                {
+                    s++;
+                }
+                else if (((hind[i] & 1) == 1) &&
+                         ((i == 1) || (hind[i - 1] >= 2*(j + 2) + 1)))
+                {
+                    x = chain + i;
+                    x->i = i;
+                    x->j = j + 1;
+                    x->next = NULL;
+                    hind[x->i] = 2*(x->j + 1) + 0;
+
+                    texp = Bexp[x->i] + Qexp[x->j];
+                    if (mpoly_monomial_cmp1(texp, emin, cmpmask) >= 0)
+                        _mpoly_heap_insert1(heap, texp, x, &next_loc, &heap_len, cmpmask);
+                    else
+                        hind[x->i] |= 1;
+                }
+            }
+        }
+
+        switch (gr_is_zero(acc, cctx))
+        {
+            case T_TRUE:
+                continue;
+            case T_FALSE:
+                break;
+            default:
+                status |= GR_UNABLE;
+                goto unable;
+        }
+
+        cstatus = STRIPE_DIVIDES_COEFF(acc);
+        if (cstatus == GR_DOMAIN)
+            goto not_exact_division;
+        if (cstatus != GR_SUCCESS)
+        {
+            status |= cstatus;
+            goto unable;
+        }
+
+        if (!lt_divides)
+            goto not_exact_division;
+
+        if (s > 1)
+        {
+            i = 1;
+            x = chain + i;
+            x->i = i;
+            x->j = Qlen;
+            x->next = NULL;
+            hind[x->i] = 2*(x->j + 1) + 0;
+
+            texp = Bexp[x->i] + Qexp[x->j];
+            if (mpoly_monomial_cmp1(texp, emin, cmpmask) >= 0)
+                _mpoly_heap_insert1(heap, texp, x, &next_loc, &heap_len, cmpmask);
+            else
+                hind[x->i] |= 1;
+        }
+        s = 1;
+        Qlen++;
+    }
+
+    *res_status = status;
+    goto cleanup;
+
+not_exact_division:
+    Qlen = 0;
+    /* preserve any GR_UNABLE accumulated while computing this term's acc:
+       if an earlier operation could not decide, this term's apparent
+       non-exactness may just be an artifact of that, not a genuine proof --
+       see the analogous fix in gr_mpoly_divides_heap. */
+    status |= GR_DOMAIN;
+    *res_status = status;
+    goto cleanup;
+
+unable:
+    Qlen = 0;
+    *res_status = status;
+
+cleanup:
+
+    GR_TMP_CLEAR2(acc, pp, cctx);
+    flint_free(dot_a);
+
+    *Q_coeff = Qcoeff;
+    *Q_exp = Qexp;
+    *Q_alloc = Qalloc;
+    *Q_exps_alloc = Qexps_alloc;
+
+    return Qlen;
+}
+
+/* Multi-word exponent version of the above. */
+static slong _gr_mpoly_divides_stripe(
+    gr_ptr * Q_coeff, ulong ** Q_exp, slong * Q_alloc, slong * Q_exps_alloc,
+    gr_srcptr Acoeff, const ulong * Aexp, slong Alen,
+    gr_srcptr Bcoeff, const ulong * Bexp, slong Blen,
+    const _gr_mpoly_stripe_t S, int * res_status)
+{
+    gr_mpoly_ctx_struct * ctx = S->ctx;
+    gr_ctx_struct * cctx = S->cctx;
+    slong sz = S->sz;
+    int have_fast_dot = S->have_fast_dot;
+    int lc_is_one = S->lc_is_one;
+    int lc_is_unit = S->lc_is_unit;
+    gr_srcptr lc_inv = S->lc_inv;
+    flint_bitcnt_t bits = S->bits;
+    slong N = S->N;
+    int lt_divides;
+    slong i, j, s;
+    slong next_loc, heap_len;
+    mpoly_heap_s * heap;
+    mpoly_heap_t * chain;
+    slong * store, * store_base, store_len;
+    mpoly_heap_t * x;
+    slong Qlen;
+    slong Qalloc = *Q_alloc;
+    slong Qexps_alloc = *Q_exps_alloc;
+    gr_ptr Qcoeff = *Q_coeff;
+    ulong * Qexp = *Q_exp;
+    ulong * exp, * exps;
+    ulong ** exp_list;
+    slong exp_next;
+    ulong mask;
+    slong * hind;
+    gr_ptr acc, pp, dot_a, dot_b;
+    slong dot_len;
+    int have_dividend, cstatus;
+    slong dividend_j = 0;
+    int status = GR_SUCCESS;
+
+    FLINT_ASSERT(Alen > 0);
+    FLINT_ASSERT(Blen > 0);
+
+    next_loc = Blen + 4;
+
+    i = 0;
+    hind = (slong *) (S->big_mem + i);
+    i += Blen*sizeof(slong);
+    store = store_base = (slong *) (S->big_mem + i);
+    i += 2*Blen*sizeof(slong);
+    heap = (mpoly_heap_s *)(S->big_mem + i);
+    i += (Blen + 1)*sizeof(mpoly_heap_s);
+    chain = (mpoly_heap_t *)(S->big_mem + i);
+    i += Blen*sizeof(mpoly_heap_t);
+    exps = (ulong *)(S->big_mem + i);
+    i +=  Blen*N*sizeof(ulong);
+    exp_list = (ulong **)(S->big_mem + i);
+    i +=  Blen*sizeof(ulong *);
+    exp = (ulong *)(S->big_mem + i);
+    i +=  N*sizeof(ulong);
+    FLINT_ASSERT(i <= S->big_mem_alloc);
+
+    GR_TMP_INIT2(acc, pp, cctx);
+    dot_a = flint_malloc(2 * Blen * sz);
+    dot_b = GR_ENTRY(dot_a, Blen, sz);
+
+    exp_next = 0;
+    for (i = 0; i < Blen; i++)
+        exp_list[i] = exps + i*N;
+
+    for (i = 0; i < Blen; i++)
+        hind[i] = 1;
+
+    mask = bits <= FLINT_BITS ? mpoly_overflow_mask_sp(bits) : 0;
+
+    Qlen = 0;
+    s = Blen;
+
+    heap_len = 2;
+    x = chain + 0;
+    x->i = -WORD(1);
+    x->j = 0;
+    x->next = NULL;
+    heap[1].next = x;
+    heap[1].exp = exp_list[exp_next++];
+
+    FLINT_ASSERT(mpoly_monomial_cmp(Aexp + N*0, S->emin, N, S->cmpmask) >= 0);
+
+    mpoly_monomial_set(heap[1].exp, Aexp + N*0, N);
+
+    while (heap_len > 1)
+    {
+        _gr_mpoly_fit_length(&Qcoeff, &Qalloc, &Qexp, &Qexps_alloc, N, Qlen + 1, ctx);
+
+        mpoly_monomial_set(exp, heap[1].exp, N);
+
+        if (bits <= FLINT_BITS)
+        {
+            if (mpoly_monomial_overflows(exp, N, mask))
+                goto not_exact_division;
+            lt_divides = mpoly_monomial_divides(Qexp + N*Qlen, exp, Bexp + N*0, N, mask);
+        }
+        else
+        {
+            if (mpoly_monomial_overflows_mp(exp, N, bits))
+                goto not_exact_division;
+            lt_divides = mpoly_monomial_divides_mp(Qexp + N*Qlen, exp, Bexp + N*0, N, bits);
+        }
+
+        FLINT_ASSERT(mpoly_monomial_cmp(exp, S->emin, N, S->cmpmask) >= 0);
+
+        dot_len = 0;
+        have_dividend = 0;
+        store_len = 0;
+
+        if (have_fast_dot)
+        {
+            do
+            {
+                exp_list[--exp_next] = heap[1].exp;
+                x = _mpoly_heap_pop(heap, &heap_len, N, S->cmpmask);
+                do
+                {
+                    if (sz == 1)       { STRIPE_DIVIDES_FETCH_NODE(SET_SHALLOW1); }
+                    else if (sz == 2)  { STRIPE_DIVIDES_FETCH_NODE(SET_SHALLOW2); }
+                    else if (sz == 4)  { STRIPE_DIVIDES_FETCH_NODE(SET_SHALLOW4); }
+                    else if (sz == 8)  { STRIPE_DIVIDES_FETCH_NODE(SET_SHALLOW8); }
+                    else if (sz == 16) { STRIPE_DIVIDES_FETCH_NODE(SET_SHALLOW16); }
+                    else               { STRIPE_DIVIDES_FETCH_NODE(SET_SHALLOW_GENERIC); }
+                } while ((x = x->next) != NULL);
+            } while (heap_len > 1 && mpoly_monomial_equal(heap[1].exp, exp, N));
+
+            status |= _gr_vec_dot(acc,
+                        have_dividend ? GR_ENTRY(Acoeff, dividend_j, sz) : NULL,
+                        1, dot_a, dot_b, dot_len, cctx);
+        }
+        else
+        {
+            status |= gr_zero(acc, cctx);
+            do
+            {
+                exp_list[--exp_next] = heap[1].exp;
+                x = _mpoly_heap_pop(heap, &heap_len, N, S->cmpmask);
+                do
+                {
+                    store[store_len++] = x->i;
+                    store[store_len++] = x->j;
+                    if (x->i == -UWORD(1))
+                    {
+                        status |= gr_add(acc, acc, GR_ENTRY(Acoeff, x->j, sz), cctx);
+                    }
+                    else
+                    {
+                        hind[x->i] |= WORD(1);
+                        status |= gr_mul(pp, GR_ENTRY(Bcoeff, x->i, sz), GR_ENTRY(Qcoeff, x->j, sz), cctx);
+                        status |= gr_sub(acc, acc, pp, cctx);
+                    }
+                } while ((x = x->next) != NULL);
+            } while (heap_len > 1 && mpoly_monomial_equal(heap[1].exp, exp, N));
+        }
+
+        /* process nodes taken from the heap */
+        while (store_len > 0)
+        {
+            j = store_base[--store_len];
+            i = store_base[--store_len];
+
+            if (i == -WORD(1))
+            {
+                if (j + 1 < Alen)
+                {
+                    x = chain + 0;
+                    x->i = i;
+                    x->j = j + 1;
+                    x->next = NULL;
+                    mpoly_monomial_set(exp_list[exp_next], Aexp + x->j*N, N);
+
+                    FLINT_ASSERT(mpoly_monomial_cmp(exp_list[exp_next], S->emin, N, S->cmpmask) >= 0);
+
+                    exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
+                                          &next_loc, &heap_len, N, S->cmpmask);
+                }
+            }
+            else
+            {
+                /* should we go right? */
+                if ((i + 1 < Blen) && (hind[i + 1] == 2*j + 1))
+                {
+                    x = chain + i + 1;
+                    x->i = i + 1;
+                    x->j = j;
+                    x->next = NULL;
+                    hind[x->i] = 2*(x->j + 1) + 0;
+
+                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
+                                                              Qexp + N*x->j, N);
+
+                    if (mpoly_monomial_cmp(exp_list[exp_next], S->emin, N, S->cmpmask) >= 0)
+                        exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
+                                          &next_loc, &heap_len, N, S->cmpmask);
+                    else
+                        hind[x->i] |= 1;
+                }
+                /* should we go up? */
+                if (j + 1 == Qlen)
+                {
+                    s++;
+                }
+                else if (((hind[i] & 1) == 1) &&
+                         ((i == 1) || (hind[i - 1] >= 2*(j + 2) + 1)))
+                {
+                    x = chain + i;
+                    x->i = i;
+                    x->j = j + 1;
+                    x->next = NULL;
+                    hind[x->i] = 2*(x->j + 1) + 0;
+
+                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
+                                                              Qexp + N*x->j, N);
+
+                    if (mpoly_monomial_cmp(exp_list[exp_next], S->emin, N, S->cmpmask) >= 0)
+                        exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
+                                          &next_loc, &heap_len, N, S->cmpmask);
+                    else
+                        hind[x->i] |= 1;
+                }
+            }
+        }
+
+        switch (gr_is_zero(acc, cctx))
+        {
+            case T_TRUE:
+                continue;
+            case T_FALSE:
+                break;
+            default:
+                status |= GR_UNABLE;
+                goto unable;
+        }
+
+        cstatus = STRIPE_DIVIDES_COEFF(acc);
+        if (cstatus == GR_DOMAIN)
+            goto not_exact_division;
+        if (cstatus != GR_SUCCESS)
+        {
+            status |= cstatus;
+            goto unable;
+        }
+
+        if (!lt_divides)
+            goto not_exact_division;
+
+        if (s > 1)
+        {
+            i = 1;
+            x = chain + i;
+            x->i = i;
+            x->j = Qlen;
+            x->next = NULL;
+            hind[x->i] = 2*(x->j + 1) + 0;
+
+            mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i, Qexp + N*x->j, N);
+
+            if (mpoly_monomial_cmp(exp_list[exp_next], S->emin, N, S->cmpmask) >= 0)
+                exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
+                                          &next_loc, &heap_len, N, S->cmpmask);
+            else
+                hind[x->i] |= 1;
+        }
+        s = 1;
+        Qlen++;
+    }
+
+    *res_status = status;
+    goto cleanup;
+
+not_exact_division:
+    Qlen = 0;
+    /* preserve any GR_UNABLE accumulated while computing this term's acc:
+       if an earlier operation could not decide, this term's apparent
+       non-exactness may just be an artifact of that, not a genuine proof --
+       see the analogous fix in gr_mpoly_divides_heap. */
+    status |= GR_DOMAIN;
+    *res_status = status;
+    goto cleanup;
+
+unable:
+    Qlen = 0;
+    *res_status = status;
+
+cleanup:
+
+    GR_TMP_CLEAR2(acc, pp, cctx);
+    flint_free(dot_a);
+
+    *Q_coeff = Qcoeff;
+    *Q_exp = Qexp;
+    *Q_alloc = Qalloc;
+    *Q_exps_alloc = Qexps_alloc;
+
+    return Qlen;
+}
+
+
+slong chunk_find_exp(ulong * exp, slong a,
+                     const ulong * Aexp, slong Alen, slong N, const ulong * cmpmask)
+{
+    slong b = Alen;
+
+try_again:
+    FLINT_ASSERT(b >= a);
+
+    FLINT_ASSERT(a > 0);
+    FLINT_ASSERT(mpoly_monomial_cmp(Aexp + N*(a - 1), exp, N, cmpmask) >= 0);
+    FLINT_ASSERT(b >= Alen
+                  ||  mpoly_monomial_cmp(Aexp + N*b, exp, N, cmpmask) < 0);
+
+    if (b - a < 5)
+    {
+        slong i = a;
+        while (i < b
+                && mpoly_monomial_cmp(Aexp + N*i, exp, N, cmpmask) >= 0)
+        {
+            i++;
+        }
+        return i;
+    }
+    else
+    {
+        slong c = a + (b - a)/2;
+        if (mpoly_monomial_cmp(Aexp + N*c, exp, N, cmpmask) < 0)
+            b = c;
+        else
+            a = c;
+        goto try_again;
+    }
+}
+
+void stripe_fit_length(_gr_mpoly_stripe_struct * S, slong new_len)
+{
+    slong N = S->N;
+    slong new_alloc;
+    new_alloc = 0;
+    if (N == 1)
+    {
+        new_alloc += new_len*sizeof(slong);
+        new_alloc += new_len*sizeof(slong);
+        new_alloc += 2*new_len*sizeof(slong);
+        new_alloc += (new_len + 1)*sizeof(mpoly_heap1_s);
+        new_alloc += new_len*sizeof(mpoly_heap_t);
+    }
+    else
+    {
+        new_alloc += new_len*sizeof(slong);
+        new_alloc += new_len*sizeof(slong);
+        new_alloc += 2*new_len*sizeof(slong);
+        new_alloc += (new_len + 1)*sizeof(mpoly_heap_s);
+        new_alloc += new_len*sizeof(mpoly_heap_t);
+        new_alloc += new_len*N*sizeof(ulong);
+        new_alloc += new_len*sizeof(ulong *);
+        new_alloc += N*sizeof(ulong);
+    }
+
+    if (S->big_mem_alloc >= new_alloc)
+        return;
+
+    new_alloc = FLINT_MAX(new_alloc, S->big_mem_alloc + S->big_mem_alloc/4);
+    S->big_mem_alloc = new_alloc;
+
+    if (S->big_mem != NULL)
+        S->big_mem = (char *) flint_realloc(S->big_mem, new_alloc);
+    else
+        S->big_mem = (char *) flint_malloc(new_alloc);
+}
+
+
+/*
+    Set L->polyC = D - (a stripe of B*Q_new), where Q_new is the newly
+    available part of the quotient (indices [L->mq, q_prev_length) of
+    H->polyQ), and D is the previous L->polyC (if L->Cinited) or, the first
+    time this chunk is touched, the slice of the original dividend A lying
+    in this chunk's exponent window.
+*/
+void chunk_mulsub(worker_arg_t W, divides_heap_chunk_t L, slong q_prev_length)
+{
+    divides_heap_base_struct * H = W->H;
+    slong N = H->N;
+    gr_ctx_struct * cctx = H->cctx;
+    gr_mpoly_struct * C = L->polyC;
+    const gr_mpoly_struct * B = H->polyB;
+    const gr_mpoly_struct * A = H->polyA;
+    gr_mpoly_ts_struct * Q = H->polyQ;
+    gr_mpoly_struct * T1 = W->polyT1;
+    _gr_mpoly_stripe_struct * S = W->S;
+    int status;
+
+    S->startidx = &L->startidx;
+    S->endidx = &L->endidx;
+    S->emin = L->emin;
+    S->emax = L->emax;
+    S->upperclosed = L->upperclosed;
+    FLINT_ASSERT(S->N == N);
+    stripe_fit_length(S, q_prev_length - L->mq);
+
+    if (L->Cinited)
+    {
+        if (N == 1)
+        {
+            T1->length = _gr_mpoly_mulsub_stripe1(
+                    &T1->coeffs, &T1->exps, &T1->coeffs_alloc, &T1->exps_alloc,
+                    C->coeffs, C->exps, C->length, 1,
+                    GR_ENTRY(Q->coeffs, L->mq, cctx->sizeof_elem), Q->exps + N*L->mq, q_prev_length - L->mq,
+                    B->coeffs, B->exps, B->length,
+                    S, &status);
+        }
+        else
+        {
+            T1->length = _gr_mpoly_mulsub_stripe(
+                    &T1->coeffs, &T1->exps, &T1->coeffs_alloc, &T1->exps_alloc,
+                    C->coeffs, C->exps, C->length, 1,
+                    GR_ENTRY(Q->coeffs, L->mq, cctx->sizeof_elem), Q->exps + N*L->mq, q_prev_length - L->mq,
+                    B->coeffs, B->exps, B->length,
+                    S, &status);
+        }
+        gr_mpoly_swap(C, T1, H->ctx);
+    }
+    else
+    {
+        slong startidx, stopidx;
+        if (L->upperclosed)
+        {
+            startidx = 0;
+            stopidx = chunk_find_exp(L->emin, 1, H->polyA->exps, H->polyA->length, H->N, H->cmpmask);
+        }
+        else
+        {
+            startidx = chunk_find_exp(L->emax, 1, H->polyA->exps, H->polyA->length, H->N, H->cmpmask);
+            stopidx = chunk_find_exp(L->emin, startidx, H->polyA->exps, H->polyA->length, H->N, H->cmpmask);
+        }
+
+        L->Cinited = 1;
+        gr_mpoly_init3(C, 16 + stopidx - startidx, H->bits, H->ctx); /* any is OK */
+
+        if (N == 1)
+        {
+            C->length = _gr_mpoly_mulsub_stripe1(
+                    &C->coeffs, &C->exps, &C->coeffs_alloc, &C->exps_alloc,
+                    GR_ENTRY(A->coeffs, startidx, cctx->sizeof_elem), A->exps + N*startidx, stopidx - startidx, 1,
+                    GR_ENTRY(Q->coeffs, L->mq, cctx->sizeof_elem), Q->exps + N*L->mq, q_prev_length - L->mq,
+                    B->coeffs, B->exps, B->length,
+                    S, &status);
+        }
+        else
+        {
+            C->length = _gr_mpoly_mulsub_stripe(
+                    &C->coeffs, &C->exps, &C->coeffs_alloc, &C->exps_alloc,
+                    GR_ENTRY(A->coeffs, startidx, cctx->sizeof_elem), A->exps + N*startidx, stopidx - startidx, 1,
+                    GR_ENTRY(Q->coeffs, L->mq, cctx->sizeof_elem), Q->exps + N*L->mq, q_prev_length - L->mq,
+                    B->coeffs, B->exps, B->length,
+                    S, &status);
+        }
+    }
+
+    if (status != GR_SUCCESS)
+    {
+#if FLINT_USES_PTHREAD
+        pthread_mutex_lock(&H->mutex);
+#endif
+        H->have_unable = 1;
+#if FLINT_USES_PTHREAD
+        pthread_mutex_unlock(&H->mutex);
+#endif
+    }
+
+    L->mq = q_prev_length;
+}
+
+void trychunk(worker_arg_t W, divides_heap_chunk_t L)
+{
+    divides_heap_base_struct * H = W->H;
+    slong N = H->N;
+    gr_ctx_struct * cctx = H->cctx;
+    gr_mpoly_struct * C = L->polyC;
+    slong q_prev_length;
+    const gr_mpoly_struct * B = H->polyB;
+    const gr_mpoly_struct * A = H->polyA;
+    gr_mpoly_ts_struct * Q = H->polyQ;
+    gr_mpoly_struct * T2 = W->polyT2;
+
+    /* return if this section has already finished processing */
+    if (L->mq < 0)
+        return;
+
+    /* process more quotient terms if available */
+    q_prev_length = Q->length;
+    if (q_prev_length > L->mq)
+    {
+        if (L->producer == 0 && q_prev_length - L->mq < 20)
+            return;
+
+        chunk_mulsub(W, L, q_prev_length);
+    }
+
+    if (L->producer == 1)
+    {
+        divides_heap_chunk_struct * next;
+        gr_srcptr Rcoeff;
+        ulong * Rexp;
+        slong Rlen;
+
+        /* process the remaining quotient terms */
+        q_prev_length = Q->length;
+        if (q_prev_length > L->mq)
+            chunk_mulsub(W, L, q_prev_length);
+
+        /* find location of remaining terms */
+        if (L->Cinited)
+        {
+            Rlen = C->length;
+            Rexp = C->exps;
+            Rcoeff = C->coeffs;
+        }
+        else
+        {
+            slong startidx, stopidx;
+            if (L->upperclosed)
+            {
+                startidx = 0;
+                stopidx = chunk_find_exp(L->emin, 1, H->polyA->exps, H->polyA->length, H->N, H->cmpmask);
+            }
+            else
+            {
+                startidx = chunk_find_exp(L->emax, 1, H->polyA->exps, H->polyA->length, H->N, H->cmpmask);
+                stopidx = chunk_find_exp(L->emin, startidx, H->polyA->exps, H->polyA->length, H->N, H->cmpmask);
+            }
+            Rlen = stopidx - startidx;
+            Rcoeff = GR_ENTRY(A->coeffs, startidx, cctx->sizeof_elem);
+            Rexp = A->exps + N*startidx;
+        }
+
+        /* if we have remaining terms, add to quotient (and remainder) */
+        if (Rlen > 0)
+        {
+            int rstatus;
+            _gr_mpoly_stripe_struct * S = W->S;
+            S->startidx = &L->startidx;
+            S->endidx = &L->endidx;
+            S->emin = L->emin;
+            S->emax = L->emax;
+            S->upperclosed = L->upperclosed;
+
+            if (H->require_exact)
+            {
+                if (N == 1)
+                {
+                    T2->length = _gr_mpoly_divides_stripe1(
+                                        &T2->coeffs, &T2->exps, &T2->coeffs_alloc, &T2->exps_alloc,
+                                           Rcoeff, Rexp, Rlen,
+                                           B->coeffs, B->exps, B->length, S, &rstatus);
+                }
+                else
+                {
+                    T2->length = _gr_mpoly_divides_stripe(
+                                        &T2->coeffs, &T2->exps, &T2->coeffs_alloc, &T2->exps_alloc,
+                                           Rcoeff, Rexp, Rlen,
+                                           B->coeffs, B->exps, B->length, S, &rstatus);
+                }
+
+                if (rstatus != GR_SUCCESS)
+                {
+#if FLINT_USES_PTHREAD
+                    pthread_mutex_lock(&H->mutex);
+#endif
+                    if (rstatus == GR_DOMAIN)
+                        H->have_domain = 1;
+                    else
+                        H->have_unable = 1;
+                    H->failed = 1;
+#if FLINT_USES_PTHREAD
+                    pthread_mutex_unlock(&H->mutex);
+#endif
+                    return;
+                }
+                else
+                {
+                    gr_mpoly_ts_append(H->polyQ, T2->coeffs, T2->exps, T2->length, N, cctx);
+                }
+            }
+            else
+            {
+                /* divrem family: never a hard failure on non-reducible
+                   terms -- they are routed to the remainder instead. */
+                gr_mpoly_struct * T3 = W->polyT3;
+                slong Wlen;
+
+                if (N == 1)
+                {
+                    T2->length = _gr_mpoly_divrem_stripe1(
+                                        &T2->coeffs, &T2->exps, &T2->coeffs_alloc, &T2->exps_alloc,
+                                        &T3->coeffs, &T3->exps, &T3->coeffs_alloc, &T3->exps_alloc, &Wlen,
+                                           Rcoeff, Rexp, Rlen,
+                                           B->coeffs, B->exps, B->length, S, &rstatus);
+                }
+                else
+                {
+                    T2->length = _gr_mpoly_divrem_stripe(
+                                        &T2->coeffs, &T2->exps, &T2->coeffs_alloc, &T2->exps_alloc,
+                                        &T3->coeffs, &T3->exps, &T3->coeffs_alloc, &T3->exps_alloc, &Wlen,
+                                           Rcoeff, Rexp, Rlen,
+                                           B->coeffs, B->exps, B->length, S, &rstatus);
+                }
+
+                if (rstatus != GR_SUCCESS)
+                {
+                    /* GR_DOMAIN: an exactly-reducible-by-monomial term's
+                       coefficient did not divide exactly (nonfield == 0
+                       only -- see _gr_mpoly_divrem_stripe1/stripe).
+                       Otherwise GR_UNABLE. */
+#if FLINT_USES_PTHREAD
+                    pthread_mutex_lock(&H->mutex);
+#endif
+                    if (rstatus == GR_DOMAIN)
+                        H->have_domain = 1;
+                    else
+                        H->have_unable = 1;
+                    H->failed = 1;
+#if FLINT_USES_PTHREAD
+                    pthread_mutex_unlock(&H->mutex);
+#endif
+                    return;
+                }
+
+                if (T2->length > 0)
+                    gr_mpoly_ts_append(H->polyQ, T2->coeffs, T2->exps, T2->length, N, cctx);
+                if (H->want_remainder && Wlen > 0)
+                    gr_mpoly_ts_append(H->polyR, T3->coeffs, T3->exps, Wlen, N, cctx);
+            }
+        }
+
+        next = L->next;
+        H->length--;
+        H->cur = next;
+
+        if (next != NULL)
+            next->producer = 1;
+
+        L->producer = 0;
+        L->mq = -1;
+    }
+
+    return;
+}
+
+
+void worker_loop(void * varg)
+{
+    worker_arg_struct * W = (worker_arg_struct *) varg;
+    divides_heap_base_struct * H = W->H;
+    _gr_mpoly_stripe_struct * S = W->S;
+    const gr_mpoly_struct * B = H->polyB;
+    gr_mpoly_struct * T1 = W->polyT1;
+    gr_mpoly_struct * T2 = W->polyT2;
+    gr_mpoly_struct * T3 = W->polyT3;
+    slong N = H->N;
+    slong Blen = B->length;
+
+    /* initialize stripe working memory */
+    S->N = N;
+    S->bits = H->bits;
+    S->ctx = H->ctx;
+    S->cctx = H->cctx;
+    S->sz = H->cctx->sizeof_elem;
+    S->cmpmask = H->cmpmask;
+    S->have_fast_dot = (GR_VEC_DOT_OP(H->cctx, VEC_DOT) != (gr_method_vec_dot_op) gr_generic_vec_dot);
+    S->lc_is_one = H->lc_is_one;
+    S->lc_is_unit = H->lc_is_unit;
+    S->lc_inv = H->lc_inv;
+    S->nonfield = H->nonfield;
+    S->big_mem_alloc = 0;
+    S->big_mem = NULL;
+
+    stripe_fit_length(S, Blen);
+
+    gr_mpoly_init3(T1, 16, H->bits, H->ctx);
+    gr_mpoly_init3(T2, 16, H->bits, H->ctx);
+    gr_mpoly_init3(T3, 16, H->bits, H->ctx);
+
+    while (!H->failed)
+    {
+        divides_heap_chunk_struct * L;
+        L = H->cur;
+
+        if (L == NULL)
+            break;
+
+        while (L != NULL)
+        {
+#if FLINT_USES_PTHREAD
+            pthread_mutex_lock(&H->mutex);
+#endif
+            if (L->lock != -1)
+            {
+                L->lock = -1;
+#if FLINT_USES_PTHREAD
+                pthread_mutex_unlock(&H->mutex);
+#endif
+                trychunk(W, L);
+#if FLINT_USES_PTHREAD
+                pthread_mutex_lock(&H->mutex);
+#endif
+                L->lock = 0;
+#if FLINT_USES_PTHREAD
+                pthread_mutex_unlock(&H->mutex);
+#endif
+                break;
+            }
+            else
+            {
+#if FLINT_USES_PTHREAD
+                pthread_mutex_unlock(&H->mutex);
+#endif
+            }
+
+            L = L->next;
+        }
+    }
+
+    gr_mpoly_clear(T1, H->ctx);
+    gr_mpoly_clear(T2, H->ctx);
+    gr_mpoly_clear(T3, H->ctx);
+    flint_free(S->big_mem);
+
+    return;
+}
+
+
+/*
+    return the overall GR status (GR_SUCCESS / GR_DOMAIN / GR_UNABLE).
+    The leading coefficient of B need not be a unit; gr_div is used as a
+    fallback exact-division test (see gr_mpoly_divides_heap / DIVIDES_COEFF).
+*/
+static int _gr_mpoly_divides_heap_threaded_pool(
+    gr_mpoly_t Q,
+    const gr_mpoly_t A,
+    const gr_mpoly_t B,
+    gr_mpoly_ctx_t ctx,
+    const thread_pool_handle * handles,
+    slong num_handles)
+{
+    mpoly_ctx_struct * mctx = GR_MPOLY_MCTX(ctx);
+    gr_ctx_struct * cctx = GR_MPOLY_CCTX(ctx);
+    slong sz = cctx->sizeof_elem;
+    ulong mask;
+    int status;
+    fmpz_mpoly_ctx_t zctx;
+    fmpz_mpoly_t S;
+    slong i, k, N;
+    flint_bitcnt_t exp_bits;
+    ulong * cmpmask;
+    ulong * Aexp, * Bexp;
+    int freeAexp, freeBexp;
+    worker_arg_struct * worker_args;
+    gr_ptr qcoeff, lc_inv;
+    ulong * texps, * qexps;
+    divides_heap_base_t H;
+    int lc_is_one, lc_is_unit;
+    int cstatus;
+    TMP_INIT;
+
+    if (B->length < 2 || A->length < 2)
+        return gr_mpoly_divides_heap(Q, A, B, ctx);
+
+    TMP_START;
+
+    GR_TMP_INIT2(qcoeff, lc_inv, cctx);
+
+    exp_bits = MPOLY_MIN_BITS;
+    exp_bits = FLINT_MAX(exp_bits, A->bits);
+    exp_bits = FLINT_MAX(exp_bits, B->bits);
+    exp_bits = mpoly_fix_bits(exp_bits, mctx);
+
+    N = mpoly_words_per_exp(exp_bits, mctx);
+    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
+    mpoly_get_cmpmask(cmpmask, N, exp_bits, mctx);
+
+    /* ensure input exponents packed to same size as output exponents */
+    Aexp = A->exps;
+    freeAexp = 0;
+    if (exp_bits > A->bits)
+    {
+        freeAexp = 1;
+        Aexp = (ulong *) flint_malloc(N*A->length*sizeof(ulong));
+        mpoly_repack_monomials(Aexp, exp_bits, A->exps, A->bits,
+                                                        A->length, mctx);
+    }
+
+    Bexp = B->exps;
+    freeBexp = 0;
+    if (exp_bits > B->bits)
+    {
+        freeBexp = 1;
+        Bexp = (ulong *) flint_malloc(N*B->length*sizeof(ulong));
+        mpoly_repack_monomials(Bexp, exp_bits, B->exps, B->bits,
+                                                    B->length, mctx);
+    }
+
+    fmpz_mpoly_ctx_init(zctx, mctx->nvars, mctx->ord);
+    fmpz_mpoly_init(S, zctx);
+
+    /* precompute 1/lc(B) if it is a unit, and the first quotient coeff */
+    lc_is_one = (gr_is_one(B->coeffs, cctx) == T_TRUE);
+    lc_is_unit = lc_is_one || (gr_inv(lc_inv, B->coeffs, cctx) == GR_SUCCESS);
+
+    cstatus = lc_is_one    ? gr_set(qcoeff, A->coeffs, cctx)
+              : lc_is_unit ? gr_mul(qcoeff, A->coeffs, lc_inv, cctx)
+                           : gr_div(qcoeff, A->coeffs, B->coeffs, cctx);
+    if (cstatus == GR_DOMAIN)
+    {
+        status = GR_DOMAIN;
+        GR_IGNORE(gr_mpoly_zero(Q, ctx));
+        goto cleanup1;
+    }
+    if (cstatus != GR_SUCCESS)
+    {
+        status = GR_UNABLE;
+        GR_IGNORE(gr_mpoly_zero(Q, ctx));
+        goto cleanup1;
+    }
+
+    if (mpoly_divides_select_exps(S, zctx, num_handles,
+                                   Aexp, A->length, Bexp, B->length, exp_bits))
+    {
+        status = GR_DOMAIN;
+        GR_IGNORE(gr_mpoly_zero(Q, ctx));
+        goto cleanup1;
+    }
+
+    /*
+        At this point A and B both have at least two terms, the leading
+        coefficient of A divides that of B, and the exponent selection did
+        not give an easy exit.
+    */
+    divides_heap_base_init(H);
+
+    H->polyA->coeffs = A->coeffs;
+    H->polyA->exps = Aexp;
+    H->polyA->bits = exp_bits;
+    H->polyA->length = A->length;
+    H->polyA->coeffs_alloc = A->coeffs_alloc;
+    H->polyA->exps_alloc = N*A->length;
+
+    H->polyB->coeffs = B->coeffs;
+    H->polyB->exps = Bexp;
+    H->polyB->bits = exp_bits;
+    H->polyB->length = B->length;
+    H->polyB->coeffs_alloc = B->coeffs_alloc;
+    H->polyB->exps_alloc = N*B->length;
+
+    H->ctx = ctx;
+    H->cctx = cctx;
+    H->bits = exp_bits;
+    H->N = N;
+    H->cmpmask = cmpmask;
+    H->lc_is_one = lc_is_one;
+    H->lc_is_unit = lc_is_unit;
+    H->lc_inv = lc_inv;
+    H->require_exact = 1;
+    H->want_remainder = 0;
+    H->nonfield = 0;
+    H->failed = 0;
+    H->have_domain = 0;
+    H->have_unable = 0;
+
+    for (i = 0; i + 1 < S->length; i++)
+    {
+        divides_heap_chunk_struct * L;
+        L = (divides_heap_chunk_struct *) flint_malloc(
+                                            sizeof(divides_heap_chunk_struct));
+        L->ma = 0;
+        L->mq = 0;
+        L->emax = S->exps + N*i;
+        L->emin = S->exps + N*(i + 1);
+        L->upperclosed = 0;
+        L->startidx = B->length;
+        L->endidx = B->length;
+        L->producer = 0;
+        L->Cinited = 0;
+        L->lock = -2;
+        divides_heap_base_add_chunk(H, L);
+    }
+
+    H->head->upperclosed = 1;
+    H->head->producer = 1;
+    H->cur = H->head;
+
+    /* generate at least the first quotient term */
+
+    texps = (ulong *) TMP_ALLOC(N*sizeof(ulong));
+    qexps = (ulong *) TMP_ALLOC(N*sizeof(ulong));
+
+    mpoly_monomial_sub_mp(qexps + N*0, Aexp + N*0, Bexp + N*0, N);
+
+    gr_mpoly_ts_init(H->polyQ, qcoeff, qexps, 1, H->bits, H->N, cctx);
+
+    mpoly_monomial_add_mp(texps, qexps + N*0, Bexp + N*1, N);
+
+    mask = 0;
+    for (i = 0; (flint_bitcnt_t) i < FLINT_BITS/exp_bits; i++)
+        mask = (mask << exp_bits) + (UWORD(1) << (exp_bits - 1));
+
+    k = 1;
+    while (k < A->length && mpoly_monomial_gt(Aexp + N*k, texps, N, cmpmask))
+    {
+        int lt_divides;
+        if (exp_bits <= FLINT_BITS)
+            lt_divides = mpoly_monomial_divides(qexps, Aexp + N*k,
+                                                      Bexp + N*0, N, mask);
+        else
+            lt_divides = mpoly_monomial_divides_mp(qexps, Aexp + N*k,
+                                                      Bexp + N*0, N, exp_bits);
+        if (!lt_divides)
+        {
+            H->failed = 1;
+            H->have_domain = 1;
+            break;
+        }
+
+        cstatus = lc_is_one    ? gr_set(qcoeff, GR_ENTRY(A->coeffs, k, sz), cctx)
+                  : lc_is_unit ? gr_mul(qcoeff, GR_ENTRY(A->coeffs, k, sz), lc_inv, cctx)
+                               : gr_div(qcoeff, GR_ENTRY(A->coeffs, k, sz), B->coeffs, cctx);
+        if (cstatus == GR_DOMAIN)
+        {
+            H->failed = 1;
+            H->have_domain = 1;
+            break;
+        }
+        if (cstatus != GR_SUCCESS)
+        {
+            H->failed = 1;
+            H->have_unable = 1;
+            break;
+        }
+
+        gr_mpoly_ts_append(H->polyQ, qcoeff, qexps, 1, H->N, cctx);
+        k++;
+    }
+
+    /* start the workers */
+
+#if FLINT_USES_PTHREAD
+    pthread_mutex_init(&H->mutex, NULL);
+#endif
+
+    worker_args = (worker_arg_struct *) flint_malloc((num_handles + 1)
+                                                        *sizeof(worker_arg_t));
+
+    for (i = 0; i < num_handles; i++)
+    {
+        (worker_args + i)->H = H;
+        thread_pool_wake(global_thread_pool, handles[i], 0,
+                                                 worker_loop, worker_args + i);
+    }
+    (worker_args + num_handles)->H = H;
+    worker_loop(worker_args + num_handles);
+    for (i = 0; i < num_handles; i++)
+        thread_pool_wait(global_thread_pool, handles[i]);
+
+    flint_free(worker_args);
+
+#if FLINT_USES_PTHREAD
+    pthread_mutex_destroy(&H->mutex);
+#endif
+
+    status = divides_heap_base_clear(Q, NULL, H);
+
+cleanup1:
+
+    fmpz_mpoly_clear(S, zctx);
+    fmpz_mpoly_ctx_clear(zctx);
+
+    if (freeAexp)
+        flint_free(Aexp);
+
+    if (freeBexp)
+        flint_free(Bexp);
+
+    GR_TMP_CLEAR2(qcoeff, lc_inv, cctx);
+
+    TMP_END;
+
+    return status;
+}
+
+
+int gr_mpoly_divides_heap_threaded(
+    gr_mpoly_t Q,
+    const gr_mpoly_t A,
+    const gr_mpoly_t B,
+    gr_mpoly_ctx_t ctx)
+{
+    gr_ctx_struct * cctx = GR_MPOLY_CCTX(ctx);
+    thread_pool_handle * handles;
+    slong num_handles;
+    slong thread_limit;
+    int status;
+
+    if (B->length == 0)
+        return GR_DOMAIN;     /* division by zero: not divisible */
+
+    if (A->length == 0)
+        return gr_mpoly_zero(Q, ctx);
+
+    /* The leading monomials must be known */
+    if (gr_is_zero(B->coeffs, cctx) != T_FALSE ||
+        gr_is_zero(A->coeffs, cctx) != T_FALSE)
+        return GR_UNABLE;
+
+    /* fall back to the single-threaded algorithm for small inputs, or when
+       the coefficient ring does not allow concurrent operations */
+    if (B->length < 2 || A->length < 2 || gr_ctx_is_threadsafe(cctx) != T_TRUE)
+        return gr_mpoly_divides_heap(Q, A, B, ctx);
+
+    thread_limit = A->length/32;
+
+    num_handles = flint_request_threads(&handles, thread_limit);
+
+    status = _gr_mpoly_divides_heap_threaded_pool(Q, A, B, ctx,
+                                                         handles, num_handles);
+
+    flint_give_back_threads(handles, num_handles);
+
+    return status;
+}

--- a/src/gr_mpoly/divides_heap_threaded.c
+++ b/src/gr_mpoly/divides_heap_threaded.c
@@ -578,18 +578,19 @@ slong _gr_mpoly_mulsub_stripe1(
             }
         }
 
-        switch (gr_is_zero(GR_ENTRY(Acoeff, Alen, sz), cctx))
-        {
-            case T_TRUE:
-                break;
-            case T_FALSE:
-                Alen++;
-                break;
-            default:
-                status |= GR_UNABLE;
-                Alen++;
-                break;
-        }
+        /* an unknown zero-status is kept as a (possibly redundant) term
+           rather than causing an abort -- this mirrors the "acc" checks
+           fixed for divrem/divexact (see the discussion at
+           gr_mpoly_divexact), and is unconditionally safe here regardless
+           of that discussion's open questions for gr_mpoly_divides itself:
+           mulsub_stripe never makes any exactness determination, it only
+           chooses a (possibly non-maximally-reduced) representation of the
+           difference D - stripe(B*C). This was already keeping the term in
+           the "unknown" case; the only change is to stop also tainting the
+           overall status with GR_UNABLE merely for being unable to prove
+           it away. */
+        if (gr_is_zero(GR_ENTRY(Acoeff, Alen, sz), cctx) != T_TRUE)
+            Alen++;
     }
 
     FLINT_ASSERT(Di <= Dlen);
@@ -859,18 +860,19 @@ slong _gr_mpoly_mulsub_stripe(
             }
         }
 
-        switch (gr_is_zero(GR_ENTRY(Acoeff, Alen, sz), cctx))
-        {
-            case T_TRUE:
-                break;
-            case T_FALSE:
-                Alen++;
-                break;
-            default:
-                status |= GR_UNABLE;
-                Alen++;
-                break;
-        }
+        /* an unknown zero-status is kept as a (possibly redundant) term
+           rather than causing an abort -- this mirrors the "acc" checks
+           fixed for divrem/divexact (see the discussion at
+           gr_mpoly_divexact), and is unconditionally safe here regardless
+           of that discussion's open questions for gr_mpoly_divides itself:
+           mulsub_stripe never makes any exactness determination, it only
+           chooses a (possibly non-maximally-reduced) representation of the
+           difference D - stripe(B*C). This was already keeping the term in
+           the "unknown" case; the only change is to stop also tainting the
+           overall status with GR_UNABLE merely for being unable to prove
+           it away. */
+        if (gr_is_zero(GR_ENTRY(Acoeff, Alen, sz), cctx) != T_TRUE)
+            Alen++;
     }
 
     FLINT_ASSERT(Di <= Dlen);

--- a/src/gr_mpoly/divides_heap_threaded.c
+++ b/src/gr_mpoly/divides_heap_threaded.c
@@ -1855,6 +1855,7 @@ void worker_loop(void * varg)
     S->lc_is_unit = H->lc_is_unit;
     S->lc_inv = H->lc_inv;
     S->nonfield = H->nonfield;
+    S->unchecked = H->unchecked;
     S->big_mem_alloc = 0;
     S->big_mem = NULL;
 
@@ -2046,6 +2047,7 @@ static int _gr_mpoly_divides_heap_threaded_pool(
     H->require_exact = 1;
     H->want_remainder = 0;
     H->nonfield = 0;
+    H->unchecked = 0;
     H->failed = 0;
     H->have_domain = 0;
     H->have_unable = 0;

--- a/src/gr_mpoly/divides_heap_threaded.c
+++ b/src/gr_mpoly/divides_heap_threaded.c
@@ -215,12 +215,11 @@ void gr_mpoly_ts_append(gr_mpoly_ts_t A,
 
         for (i = 0; i < oldlength; i++)
         {
-            /* NOTE: this must be a copy, not a swap/move: other threads may
-               still be concurrently reading through a stale pointer to the
-               old array (we deliberately never free it -- see below), so we
-               must not disturb its contents. This mirrors the plain word
-               copy used for this step by fmpz_mpoly_ts_append. */
-            GR_IGNORE(gr_set(GR_ENTRY(newcoeffs, i, sz), GR_ENTRY(oldcoeffs, i, sz), cctx));
+            /* NOTE: fmpz_mpoly_ts_append uses a shallow set here.
+               This should be possible in the GR setting too but would
+               require some care regarding how we free/clear
+               the coefficients. */
+            GR_MUST_SUCCEED(gr_set(GR_ENTRY(newcoeffs, i, sz), GR_ENTRY(oldcoeffs, i, sz), cctx));
             mpoly_monomial_set(newexps + N*i, oldexps + N*i, N);
         }
         for (i = 0; i < Blen; i++)
@@ -860,17 +859,8 @@ slong _gr_mpoly_mulsub_stripe(
             }
         }
 
-        /* an unknown zero-status is kept as a (possibly redundant) term
-           rather than causing an abort -- this mirrors the "acc" checks
-           fixed for divrem/divexact (see the discussion at
-           gr_mpoly_divexact), and is unconditionally safe here regardless
-           of that discussion's open questions for gr_mpoly_divides itself:
-           mulsub_stripe never makes any exactness determination, it only
-           chooses a (possibly non-maximally-reduced) representation of the
-           difference D - stripe(B*C). This was already keeping the term in
-           the "unknown" case; the only change is to stop also tainting the
-           overall status with GR_UNABLE merely for being unable to prove
-           it away. */
+        /* Note: the zero status of this coefficient does not affect divisibility
+           testing at this point. */
         if (gr_is_zero(GR_ENTRY(Acoeff, Alen, sz), cctx) != T_TRUE)
             Alen++;
     }

--- a/src/gr_mpoly/divrem_heap.c
+++ b/src/gr_mpoly/divrem_heap.c
@@ -13,12 +13,14 @@
 
 #include <stdint.h>
 #include <string.h>
+#include "thread_support.h"
 #include "fmpz.h"
 #include "fmpz_vec.h"
 #include "mpoly.h"
 #include "gr_vec.h"
 #include "gr_generic.h"
 #include "gr_mpoly.h"
+#include "threaded_divmod.h"
 
 /*
     GR port of fmpz_mpoly_divrem_monagan_pearce.
@@ -670,7 +672,7 @@ cleanup:
 }
 
 
-static int _gr_mpoly_divrem_mp(
+int _gr_mpoly_divrem_mp(
     gr_mpoly_t Q, gr_mpoly_t R,
     const gr_mpoly_t A, const gr_mpoly_t B, int nonfield,
     gr_mpoly_ctx_t ctx)
@@ -827,12 +829,38 @@ int gr_mpoly_divrem_heap(
 }
 
 
+/*
+    Dispatch to the multithreaded engine (gr_mpoly/divrem_heap_threaded.c)
+    for large, thread-safe instances; the threshold mirrors gr_mpoly_divides.
+*/
+GR_MPOLY_INLINE int
+_gr_mpoly_divrem_dispatch(gr_mpoly_t Q, gr_mpoly_t R,
+    const gr_mpoly_t A, const gr_mpoly_t B, int nonfield, gr_mpoly_ctx_t ctx)
+{
+    gr_ctx_struct * cctx = GR_MPOLY_CCTX(ctx);
+
+    if (A->length > 500 && B->length > 2 &&
+            gr_ctx_is_threadsafe(cctx) == T_TRUE &&
+            flint_get_num_available_threads() > 1)
+    {
+        if (R != NULL)
+            return nonfield ? gr_mpoly_divrem_weak_heap_threaded(Q, R, A, B, ctx)
+                             : gr_mpoly_divrem_heap_threaded(Q, R, A, B, ctx);
+        else
+            return nonfield ? gr_mpoly_div_weak_heap_threaded(Q, A, B, ctx)
+                             : gr_mpoly_div_heap_threaded(Q, A, B, ctx);
+    }
+
+    return _gr_mpoly_divrem_mp(Q, R, A, B, nonfield, ctx);
+}
+
+
 int gr_mpoly_divrem(
     gr_mpoly_t Q, gr_mpoly_t R,
     const gr_mpoly_t A, const gr_mpoly_t B,
     gr_mpoly_ctx_t ctx)
 {
-    return _gr_mpoly_divrem_mp(Q, R, A, B, 0, ctx);
+    return _gr_mpoly_divrem_dispatch(Q, R, A, B, 0, ctx);
 }
 
 
@@ -841,7 +869,7 @@ int gr_mpoly_divrem_weak(
     const gr_mpoly_t A, const gr_mpoly_t B,
     gr_mpoly_ctx_t ctx)
 {
-    return _gr_mpoly_divrem_mp(Q, R, A, B, 1, ctx);
+    return _gr_mpoly_divrem_dispatch(Q, R, A, B, 1, ctx);
 }
 
 
@@ -851,7 +879,7 @@ int gr_mpoly_div(
     gr_mpoly_ctx_t ctx)
 {
     /* remainder-free: the kernel skips all remainder writes when R is NULL */
-    return _gr_mpoly_divrem_mp(Q, NULL, A, B, 0, ctx);
+    return _gr_mpoly_divrem_dispatch(Q, NULL, A, B, 0, ctx);
 }
 
 
@@ -860,5 +888,6 @@ int gr_mpoly_div_weak(
     const gr_mpoly_t A, const gr_mpoly_t B,
     gr_mpoly_ctx_t ctx)
 {
-    return _gr_mpoly_divrem_mp(Q, NULL, A, B, 1, ctx);
+    return _gr_mpoly_divrem_dispatch(Q, NULL, A, B, 1, ctx);
 }
+

--- a/src/gr_mpoly/divrem_heap.c
+++ b/src/gr_mpoly/divrem_heap.c
@@ -13,7 +13,6 @@
 
 #include <stdint.h>
 #include <string.h>
-#include "thread_support.h"
 #include "fmpz.h"
 #include "fmpz_vec.h"
 #include "mpoly.h"
@@ -71,11 +70,14 @@
         } \
     } while (0)
 
-/* quotient coefficient = acc / lc(B) (field-like: must be exact) */
+/* quotient coefficient = acc / lc(B) (field-like: must be exact, unless
+   unchecked, in which case we trust the caller and use gr_divexact for
+   the non-unit case -- see gr_mpoly_divexact) */
 #define DIVREM_QCOEFF(dst, acc) \
     (lc_is_one  ? gr_set(dst, acc, cctx) \
      : lc_is_unit ? gr_mul(dst, acc, lc_inv, cctx) \
-                  : gr_div(dst, acc, coeff3, cctx))
+     : unchecked ? gr_divexact(dst, acc, coeff3, cctx) \
+                 : gr_div(dst, acc, coeff3, cctx))
 
 /* append a remainder term (val) * x^exp; skipped entirely when R is absent
    (write_r == 0), which is how the remainder-free div variants are obtained */
@@ -106,11 +108,13 @@
     Sets commit = 1 if a quotient term GR_ENTRY(q_coeff, q_len, sz) was produced.
 
     Field-like (nonfield == 0): the coefficient division must be exact
-    (returning GR_DOMAIN otherwise); terms not reducible go to R.
+    (returning GR_DOMAIN otherwise, unless unchecked -- see DIVREM_QCOEFF);
+    terms not reducible go to R.
 
     Non-field (nonfield == 1): the coefficient is divided with remainder via
     gr_euclidean_divrem (the analogue of fmpz_fdiv_qr); the excess remainder is
     added to R, so a monomial divisible by lm(B) may still contribute to R.
+    (unchecked is not meaningful together with nonfield.)
 */
 #define DIVREM_COEFF_STEP(ADD_R_TERM) \
 { \
@@ -143,7 +147,7 @@
 
 
 static int _gr_mpoly_divrem_heap1(
-    gr_mpoly_t Q, gr_mpoly_t R, int * overflowed, int nonfield,
+    gr_mpoly_t Q, gr_mpoly_t R, int * overflowed, int nonfield, int unchecked,
     gr_srcptr coeff2, const ulong * exp2, slong len2,
     gr_srcptr coeff3, const ulong * exp3, slong len3,
     flint_bitcnt_t bits, ulong maskhi,
@@ -383,7 +387,7 @@ cleanup:
 
 
 static int _gr_mpoly_divrem_heap(
-    gr_mpoly_t Q, gr_mpoly_t R, int * overflowed, int nonfield,
+    gr_mpoly_t Q, gr_mpoly_t R, int * overflowed, int nonfield, int unchecked,
     gr_srcptr coeff2, const ulong * exp2, slong len2,
     gr_srcptr coeff3, const ulong * exp3, slong len3,
     flint_bitcnt_t bits, slong N, const ulong * cmpmask,
@@ -417,7 +421,7 @@ static int _gr_mpoly_divrem_heap(
     TMP_INIT;
 
     if (N == 1)
-        return _gr_mpoly_divrem_heap1(Q, R, overflowed, nonfield,
+        return _gr_mpoly_divrem_heap1(Q, R, overflowed, nonfield, unchecked,
                    coeff2, exp2, len2, coeff3, exp3, len3, bits, cmpmask[0], ctx);
 
     have_fast_dot = (GR_VEC_DOT_OP(cctx, VEC_DOT) != (gr_method_vec_dot_op) gr_generic_vec_dot);
@@ -672,9 +676,18 @@ cleanup:
 }
 
 
+/*
+    The guaranteed-serial divrem kernel (never dispatches to threading).
+    External linkage so that divrem_heap_threaded.c can call it directly as
+    a fallback -- calling the *public* gr_mpoly_div/divrem/_weak functions
+    instead would be wrong, since those may route large instances straight
+    back into the threaded engine, risking infinite recursion whenever the
+    threaded engine's own fallback paths are hit (e.g. mpoly_divides_select_exps
+    failing to find a clean partition on a large instance).
+*/
 int _gr_mpoly_divrem_mp(
     gr_mpoly_t Q, gr_mpoly_t R,
-    const gr_mpoly_t A, const gr_mpoly_t B, int nonfield,
+    const gr_mpoly_t A, const gr_mpoly_t B, int nonfield, int unchecked,
     gr_mpoly_ctx_t ctx)
 {
     mpoly_ctx_struct * mctx = GR_MPOLY_MCTX(ctx);
@@ -756,7 +769,7 @@ int _gr_mpoly_divrem_mp(
         if (r != NULL)
             r->bits = exp_bits;
 
-        status = _gr_mpoly_divrem_heap(q, r, &overflowed, nonfield,
+        status = _gr_mpoly_divrem_heap(q, r, &overflowed, nonfield, unchecked,
                             A->coeffs, exp2, A->length,
                             B->coeffs, exp3, B->length, exp_bits, N, cmpmask, ctx);
 
@@ -825,7 +838,7 @@ int gr_mpoly_divrem_heap(
     const gr_mpoly_t A, const gr_mpoly_t B,
     gr_mpoly_ctx_t ctx)
 {
-    return _gr_mpoly_divrem_mp(Q, R, A, B, 0, ctx);
+    return _gr_mpoly_divrem_mp(Q, R, A, B, 0, 0, ctx);
 }
 
 
@@ -840,8 +853,7 @@ _gr_mpoly_divrem_dispatch(gr_mpoly_t Q, gr_mpoly_t R,
     gr_ctx_struct * cctx = GR_MPOLY_CCTX(ctx);
 
     if (A->length > 500 && B->length > 2 &&
-            gr_ctx_is_threadsafe(cctx) == T_TRUE &&
-            flint_get_num_available_threads() > 1)
+            gr_ctx_is_threadsafe(cctx) == T_TRUE)
     {
         if (R != NULL)
             return nonfield ? gr_mpoly_divrem_weak_heap_threaded(Q, R, A, B, ctx)
@@ -851,7 +863,7 @@ _gr_mpoly_divrem_dispatch(gr_mpoly_t Q, gr_mpoly_t R,
                              : gr_mpoly_div_heap_threaded(Q, A, B, ctx);
     }
 
-    return _gr_mpoly_divrem_mp(Q, R, A, B, nonfield, ctx);
+    return _gr_mpoly_divrem_mp(Q, R, A, B, nonfield, 0, ctx);
 }
 
 
@@ -890,4 +902,3 @@ int gr_mpoly_div_weak(
 {
     return _gr_mpoly_divrem_dispatch(Q, NULL, A, B, 1, ctx);
 }
-

--- a/src/gr_mpoly/divrem_heap.c
+++ b/src/gr_mpoly/divrem_heap.c
@@ -126,12 +126,11 @@
     { \
         cstatus = gr_euclidean_divrem(GR_ENTRY(q_coeff, q_len, sz), rem, acc, coeff3, cctx); \
         if (cstatus != GR_SUCCESS) { status |= cstatus; goto cleanup; } \
-        switch (gr_is_zero(rem, cctx)) \
-        { \
-            case T_TRUE: break; \
-            case T_FALSE: ADD_R_TERM(rem); break; \
-            default: status |= GR_UNABLE; goto cleanup; \
-        } \
+        /* an unknown zero-status is treated as "not zero" (i.e. kept in \
+           R): we only need the euclidean division itself to succeed, not \
+           to know for certain whether its remainder happens to vanish. */ \
+        if (gr_is_zero(rem, cctx) != T_TRUE) \
+            ADD_R_TERM(rem); \
         commit = (gr_is_zero(GR_ENTRY(q_coeff, q_len, sz), cctx) != T_TRUE); \
     } \
     else \
@@ -321,16 +320,12 @@ static int _gr_mpoly_divrem_heap1(
         }
 
         /* if accumulated coefficient is zero, this term vanishes */
-        switch (gr_is_zero(acc, cctx))
-        {
-            case T_TRUE:
-                continue;
-            case T_FALSE:
-                break;
-            default:
-                status |= GR_UNABLE;
-                goto cleanup;
-        }
+        /* an unknown zero-status is treated as "not zero" -- see the
+           discussion at gr_mpoly_divexact for why this is safe: we only
+           need the coefficient division below to succeed, not to know for
+           certain that acc is nonzero. */
+        if (gr_is_zero(acc, cctx) == T_TRUE)
+            continue;
 
         commit = 0;
         DIVREM_COEFF_STEP(ADD_R_TERM1);
@@ -606,16 +601,12 @@ static int _gr_mpoly_divrem_heap(
             }
         }
 
-        switch (gr_is_zero(acc, cctx))
-        {
-            case T_TRUE:
-                continue;
-            case T_FALSE:
-                break;
-            default:
-                status |= GR_UNABLE;
-                goto cleanup;
-        }
+        /* an unknown zero-status is treated as "not zero" -- see the
+           discussion at gr_mpoly_divexact for why this is safe: we only
+           need the coefficient division below to succeed, not to know for
+           certain that acc is nonzero. */
+        if (gr_is_zero(acc, cctx) == T_TRUE)
+            continue;
 
         commit = 0;
         DIVREM_COEFF_STEP(ADD_R_TERMN);
@@ -853,7 +844,8 @@ _gr_mpoly_divrem_dispatch(gr_mpoly_t Q, gr_mpoly_t R,
     gr_ctx_struct * cctx = GR_MPOLY_CCTX(ctx);
 
     if (A->length > 500 && B->length > 2 &&
-            gr_ctx_is_threadsafe(cctx) == T_TRUE)
+            gr_ctx_is_threadsafe(cctx) == T_TRUE &&
+            flint_get_num_available_threads() > 1)
     {
         if (R != NULL)
             return nonfield ? gr_mpoly_divrem_weak_heap_threaded(Q, R, A, B, ctx)

--- a/src/gr_mpoly/divrem_heap_threaded.c
+++ b/src/gr_mpoly/divrem_heap_threaded.c
@@ -171,7 +171,7 @@ slong _gr_mpoly_divrem_stripe1(
     slong * Wlen_out,
     gr_srcptr Acoeff, const ulong * Aexp, slong Alen,
     gr_srcptr Bcoeff, const ulong * Bexp, slong Blen,
-    const _gr_mpoly_stripe_t S, int * res_status)
+    const _gr_mpoly_stripe_t S, int * res_status, int * overflowed)
 {
     gr_mpoly_ctx_struct * ctx = S->ctx;
     gr_ctx_struct * cctx = S->cctx;
@@ -204,6 +204,9 @@ slong _gr_mpoly_divrem_stripe1(
     int have_dividend, cstatus;
     slong dividend_j = 0;
     int status = GR_SUCCESS;
+
+    *overflowed = 0;
+
 
     FLINT_ASSERT(Alen > 0);
     FLINT_ASSERT(Blen > 0);
@@ -249,14 +252,23 @@ slong _gr_mpoly_divrem_stripe1(
     {
         exp = heap[1].exp;
 
-        /* An exponent window is chosen (by the caller, via
-           mpoly_divides_select_exps) from the actual monomials appearing
-           in A and B, so this cannot overflow in practice; treat it like
-           any other "cannot proceed" condition rather than introducing a
-           GR_DOMAIN-shaped abort that the divrem family has no use for. */
+        /*
+            exp here is either a genuine monomial of A (from the dividend
+            chain) or a candidate B[i]+Q[j] sum generated while exploring
+            the heap; either way, whatever gets inserted into the heap is
+            eventually popped and checked here before being used for
+            anything. The B[i]+Q[j] sums matter: two individually valid
+            packed exponents (each comfortably fitting the current bit
+            width) can legitimately overflow a shared field when added,
+            even though every "real" monomial of A, B and the quotient
+            fits fine. This is not a "cannot proceed" condition in the
+            GR_UNABLE sense -- it just means the whole computation must be
+            redone at a wider bit width (see the retry loop in
+            gr_mpoly_divrem_heap_threaded).
+        */
         if (mpoly_monomial_overflows1(exp, mask))
         {
-            status |= GR_UNABLE;
+            *overflowed = 1;
             goto unable;
         }
 
@@ -436,7 +448,7 @@ slong _gr_mpoly_divrem_stripe(
     slong * Wlen_out,
     gr_srcptr Acoeff, const ulong * Aexp, slong Alen,
     gr_srcptr Bcoeff, const ulong * Bexp, slong Blen,
-    const _gr_mpoly_stripe_t S, int * res_status)
+    const _gr_mpoly_stripe_t S, int * res_status, int * overflowed)
 {
     gr_mpoly_ctx_struct * ctx = S->ctx;
     gr_ctx_struct * cctx = S->cctx;
@@ -469,6 +481,8 @@ slong _gr_mpoly_divrem_stripe(
     int have_dividend, cstatus;
     slong dividend_j = 0;
     int status = GR_SUCCESS;
+
+    *overflowed = 0;
 
     FLINT_ASSERT(Alen > 0);
     FLINT_ASSERT(Blen > 0);
@@ -527,11 +541,14 @@ slong _gr_mpoly_divrem_stripe(
 
         mpoly_monomial_set(exp, heap[1].exp, N);
 
+        /* see the comment on the single-word overflow check above:
+           this can legitimately happen even for well-chosen bits, and
+           means "redo everything wider", not GR_UNABLE. */
         if (bits <= FLINT_BITS)
         {
             if (mpoly_monomial_overflows(exp, N, mask))
             {
-                status |= GR_UNABLE;
+                *overflowed = 1;
                 goto unable;
             }
             lt_divides = mpoly_monomial_divides(Qexp + N*Qlen, exp, Bexp + N*0, N, mask);
@@ -540,7 +557,7 @@ slong _gr_mpoly_divrem_stripe(
         {
             if (mpoly_monomial_overflows_mp(exp, N, bits))
             {
-                status |= GR_UNABLE;
+                *overflowed = 1;
                 goto unable;
             }
             lt_divides = mpoly_monomial_divides_mp(Qexp + N*Qlen, exp, Bexp + N*0, N, bits);
@@ -770,12 +787,9 @@ static int _gr_mpoly_divrem_heap_threaded_pool(
     gr_ptr lc_inv;
     divides_heap_base_t H;
     int lc_is_one, lc_is_unit;
-    TMP_INIT;
 
     if (B->length < 2 || A->length < 2)
         return _gr_mpoly_divrem_serial(Q, R, A, B, nonfield, unchecked, ctx);
-
-    TMP_START;
 
     GR_TMP_INIT(lc_inv, cctx);
 
@@ -785,7 +799,7 @@ static int _gr_mpoly_divrem_heap_threaded_pool(
     exp_bits = mpoly_fix_bits(exp_bits, mctx);
 
     N = mpoly_words_per_exp(exp_bits, mctx);
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
+    cmpmask = (ulong *) flint_malloc(N*sizeof(ulong));
     mpoly_get_cmpmask(cmpmask, N, exp_bits, mctx);
 
     /* ensure input exponents packed to same size as output exponents */
@@ -809,9 +823,6 @@ static int _gr_mpoly_divrem_heap_threaded_pool(
                                                     B->length, mctx);
     }
 
-    fmpz_mpoly_ctx_init(zctx, mctx->nvars, mctx->ord);
-    fmpz_mpoly_init(S, zctx);
-
     lc_is_one = lc_is_unit = 0;
     if (!nonfield)
     {
@@ -819,122 +830,175 @@ static int _gr_mpoly_divrem_heap_threaded_pool(
         lc_is_unit = lc_is_one || (gr_inv(lc_inv, B->coeffs, cctx) == GR_SUCCESS);
     }
 
-    /*
-        mpoly_divides_select_exps's failure return only ever means "this
-        division is provably not exact" -- irrelevant for div/divrem, which
-        have no notion of an "impossible" division. Rather than try to
-        patch up a partition in that case, just fall back to the serial
-        engine (this can only happen on genuinely pathological / huge
-        exponent spreads).
-    */
-    if (mpoly_divides_select_exps(S, zctx, num_handles,
-                                   Aexp, A->length, Bexp, B->length, exp_bits))
+    while (1)
     {
-        status = _gr_mpoly_divrem_serial(Q, R, A, B, nonfield, unchecked, ctx);
-        goto cleanup1;
-    }
+        fmpz_mpoly_ctx_init(zctx, mctx->nvars, mctx->ord);
+        fmpz_mpoly_init(S, zctx);
 
-    divides_heap_base_init(H);
+        /*
+            mpoly_divides_select_exps's failure return only ever means "this
+            division is provably not exact" -- irrelevant for div/divrem,
+            which have no notion of an "impossible" division. Rather than
+            try to patch up a partition in that case, just fall back to the
+            serial engine (this can only happen on genuinely pathological /
+            huge exponent spreads).
+        */
+        if (mpoly_divides_select_exps(S, zctx, num_handles,
+                                       Aexp, A->length, Bexp, B->length, exp_bits))
+        {
+            status = _gr_mpoly_divrem_serial(Q, R, A, B, nonfield, unchecked, ctx);
+            fmpz_mpoly_clear(S, zctx);
+            fmpz_mpoly_ctx_clear(zctx);
+            goto cleanup1;
+        }
 
-    H->polyA->coeffs = A->coeffs;
-    H->polyA->exps = Aexp;
-    H->polyA->bits = exp_bits;
-    H->polyA->length = A->length;
-    H->polyA->coeffs_alloc = A->coeffs_alloc;
-    H->polyA->exps_alloc = N*A->length;
+        divides_heap_base_init(H);
 
-    H->polyB->coeffs = B->coeffs;
-    H->polyB->exps = Bexp;
-    H->polyB->bits = exp_bits;
-    H->polyB->length = B->length;
-    H->polyB->coeffs_alloc = B->coeffs_alloc;
-    H->polyB->exps_alloc = N*B->length;
+        H->polyA->coeffs = A->coeffs;
+        H->polyA->exps = Aexp;
+        H->polyA->bits = exp_bits;
+        H->polyA->length = A->length;
+        H->polyA->coeffs_alloc = A->coeffs_alloc;
+        H->polyA->exps_alloc = N*A->length;
 
-    H->ctx = ctx;
-    H->cctx = cctx;
-    H->bits = exp_bits;
-    H->N = N;
-    H->cmpmask = cmpmask;
-    H->lc_is_one = lc_is_one;
-    H->lc_is_unit = lc_is_unit;
-    H->lc_inv = lc_inv;
-    H->require_exact = 0;
-    H->want_remainder = (R != NULL);
-    H->nonfield = nonfield;
-    H->unchecked = unchecked;
-    H->failed = 0;
-    H->have_domain = 0;
-    H->have_unable = 0;
+        H->polyB->coeffs = B->coeffs;
+        H->polyB->exps = Bexp;
+        H->polyB->bits = exp_bits;
+        H->polyB->length = B->length;
+        H->polyB->coeffs_alloc = B->coeffs_alloc;
+        H->polyB->exps_alloc = N*B->length;
 
-    for (i = 0; i + 1 < S->length; i++)
-    {
-        divides_heap_chunk_struct * L;
-        L = (divides_heap_chunk_struct *) flint_malloc(
-                                            sizeof(divides_heap_chunk_struct));
-        L->ma = 0;
-        L->mq = 0;
-        L->emax = S->exps + N*i;
-        L->emin = S->exps + N*(i + 1);
-        L->upperclosed = 0;
-        L->startidx = B->length;
-        L->endidx = B->length;
-        L->producer = 0;
-        L->Cinited = 0;
-        L->lock = -2;
-        divides_heap_base_add_chunk(H, L);
-    }
+        H->ctx = ctx;
+        H->cctx = cctx;
+        H->bits = exp_bits;
+        H->N = N;
+        H->cmpmask = cmpmask;
+        H->lc_is_one = lc_is_one;
+        H->lc_is_unit = lc_is_unit;
+        H->lc_inv = lc_inv;
+        H->require_exact = 0;
+        H->want_remainder = (R != NULL);
+        H->nonfield = nonfield;
+        H->unchecked = unchecked;
+        H->failed = 0;
+        H->have_domain = 0;
+        H->have_unable = 0;
+        H->overflowed = 0;
 
-    H->head->upperclosed = 1;
-    H->head->producer = 1;
-    H->cur = H->head;
+        for (i = 0; i + 1 < S->length; i++)
+        {
+            divides_heap_chunk_struct * L;
+            L = (divides_heap_chunk_struct *) flint_malloc(
+                                                sizeof(divides_heap_chunk_struct));
+            L->ma = 0;
+            L->mq = 0;
+            L->emax = S->exps + N*i;
+            L->emin = S->exps + N*(i + 1);
+            L->upperclosed = 0;
+            L->startidx = B->length;
+            L->endidx = B->length;
+            L->producer = 0;
+            L->Cinited = 0;
+            L->lock = -2;
+            divides_heap_base_add_chunk(H, L);
+        }
 
-    /*
-        Unlike gr_mpoly_divides_heap_threaded, no "generate an initial
-        burst of leading terms" pre-pass is needed here: that pre-pass is
-        purely a latency optimisation there (so that H->polyQ has *some*
-        content before the thread pool is woken), never a correctness
-        requirement -- a chunk that is not waiting on any higher quotient
-        terms (the head chunk, here marked as producer from the start) can
-        always be fully resolved on first touch, regardless of how many
-        terms of A it covers, via the ordinary stripe finalisation path in
-        trychunk. So we simply seed both thread-safe arrays empty.
-    */
-    gr_mpoly_ts_init(H->polyQ, NULL, NULL, 0, H->bits, H->N, cctx);
-    if (H->want_remainder)
-        gr_mpoly_ts_init(H->polyR, NULL, NULL, 0, H->bits, H->N, cctx);
+        H->head->upperclosed = 1;
+        H->head->producer = 1;
+        H->cur = H->head;
 
-    /* start the workers */
+        /*
+            Unlike gr_mpoly_divides_heap_threaded, no "generate an initial
+            burst of leading terms" pre-pass is needed here: that pre-pass is
+            purely a latency optimisation there (so that H->polyQ has *some*
+            content before the thread pool is woken), never a correctness
+            requirement -- a chunk that is not waiting on any higher quotient
+            terms (the head chunk, here marked as producer from the start) can
+            always be fully resolved on first touch, regardless of how many
+            terms of A it covers, via the ordinary stripe finalisation path in
+            trychunk. So we simply seed both thread-safe arrays empty.
+        */
+        gr_mpoly_ts_init(H->polyQ, NULL, NULL, 0, H->bits, H->N, cctx);
+        if (H->want_remainder)
+            gr_mpoly_ts_init(H->polyR, NULL, NULL, 0, H->bits, H->N, cctx);
+
+        /* start the workers */
 
 #if FLINT_USES_PTHREAD
-    pthread_mutex_init(&H->mutex, NULL);
+        pthread_mutex_init(&H->mutex, NULL);
 #endif
 
-    worker_args = (worker_arg_struct *) flint_malloc((num_handles + 1)
-                                                        *sizeof(worker_arg_t));
+        worker_args = (worker_arg_struct *) flint_malloc((num_handles + 1)
+                                                            *sizeof(worker_arg_t));
 
-    for (i = 0; i < num_handles; i++)
-    {
-        (worker_args + i)->H = H;
-        thread_pool_wake(global_thread_pool, handles[i], 0,
-                                                 worker_loop, worker_args + i);
-    }
-    (worker_args + num_handles)->H = H;
-    worker_loop(worker_args + num_handles);
-    for (i = 0; i < num_handles; i++)
-        thread_pool_wait(global_thread_pool, handles[i]);
+        for (i = 0; i < num_handles; i++)
+        {
+            (worker_args + i)->H = H;
+            thread_pool_wake(global_thread_pool, handles[i], 0,
+                                                     worker_loop, worker_args + i);
+        }
+        (worker_args + num_handles)->H = H;
+        worker_loop(worker_args + num_handles);
+        for (i = 0; i < num_handles; i++)
+            thread_pool_wait(global_thread_pool, handles[i]);
 
-    flint_free(worker_args);
+        flint_free(worker_args);
 
 #if FLINT_USES_PTHREAD
-    pthread_mutex_destroy(&H->mutex);
+        pthread_mutex_destroy(&H->mutex);
 #endif
 
-    status = divides_heap_base_clear(Q, R, H);
+        if (H->overflowed)
+        {
+            /*
+                An internal exponent computation overflowed the bit width
+                chosen for this attempt (see the long comment on
+                _gr_mpoly_mulsub_stripe1 in threaded_divmod.h): discard
+                everything from this attempt (nothing was transferred to Q
+                or R) and redo the whole computation at a wider bit width,
+                exactly like the retry loop in _gr_mpoly_divrem_mp
+                (divrem_heap.c) does for the single-threaded algorithm.
+            */
+            GR_IGNORE(divides_heap_base_clear(Q, R, H));
+
+            fmpz_mpoly_clear(S, zctx);
+            fmpz_mpoly_ctx_clear(zctx);
+
+            {
+                slong old_exp_bits = exp_bits;
+                ulong * old_Aexp = Aexp;
+                ulong * old_Bexp = Bexp;
+
+                exp_bits = mpoly_fix_bits(exp_bits + 1, mctx);
+                N = mpoly_words_per_exp(exp_bits, mctx);
+                cmpmask = (ulong *) flint_realloc(cmpmask, N*sizeof(ulong));
+                mpoly_get_cmpmask(cmpmask, N, exp_bits, mctx);
+
+                Aexp = (ulong *) flint_malloc(N*A->length*sizeof(ulong));
+                mpoly_repack_monomials(Aexp, exp_bits, old_Aexp, old_exp_bits, A->length, mctx);
+                if (freeAexp)
+                    flint_free(old_Aexp);
+                freeAexp = 1;
+
+                Bexp = (ulong *) flint_malloc(N*B->length*sizeof(ulong));
+                mpoly_repack_monomials(Bexp, exp_bits, old_Bexp, old_exp_bits, B->length, mctx);
+                if (freeBexp)
+                    flint_free(old_Bexp);
+                freeBexp = 1;
+            }
+
+            continue;
+        }
+
+        status = divides_heap_base_clear(Q, R, H);
+
+        fmpz_mpoly_clear(S, zctx);
+        fmpz_mpoly_ctx_clear(zctx);
+
+        break;
+    }
 
 cleanup1:
-
-    fmpz_mpoly_clear(S, zctx);
-    fmpz_mpoly_ctx_clear(zctx);
 
     if (freeAexp)
         flint_free(Aexp);
@@ -942,9 +1006,9 @@ cleanup1:
     if (freeBexp)
         flint_free(Bexp);
 
-    GR_TMP_CLEAR(lc_inv, cctx);
+    flint_free(cmpmask);
 
-    TMP_END;
+    GR_TMP_CLEAR(lc_inv, cctx);
 
     return status;
 }

--- a/src/gr_mpoly/divrem_heap_threaded.c
+++ b/src/gr_mpoly/divrem_heap_threaded.c
@@ -94,12 +94,14 @@
     } while (0)
 
 /* exact-coefficient path: same as STRIPE_DIVIDES_COEFF in
-   divides_heap_threaded.c, duplicated here (a one-line macro) so that this
-   file has no compile-time dependency on that file's private macros. */
+   divides_heap_threaded.c, except for the extra "unchecked" branch used by
+   gr_mpoly_divexact_heap_threaded (S->unchecked implies S->nonfield == 0,
+   i.e. the two are mutually exclusive -- see the base struct comment). */
 #define STRIPE_DIVREM_QCOEFF(acc) \
     (lc_is_one  ? gr_set(GR_ENTRY(Qcoeff, Qlen, sz), acc, cctx) \
      : lc_is_unit ? gr_mul(GR_ENTRY(Qcoeff, Qlen, sz), acc, lc_inv, cctx) \
-                  : gr_div(GR_ENTRY(Qcoeff, Qlen, sz), acc, Bcoeff, cctx))
+     : S->unchecked ? gr_divexact(GR_ENTRY(Qcoeff, Qlen, sz), acc, Bcoeff, cctx) \
+                    : gr_div(GR_ENTRY(Qcoeff, Qlen, sz), acc, Bcoeff, cctx))
 
 /*
     Decide the fate of the accumulated coefficient acc at monomial exp:
@@ -732,7 +734,8 @@ cleanup:
 
 static int
 _gr_mpoly_divrem_serial(gr_mpoly_t Q, gr_mpoly_t R,
-    const gr_mpoly_t A, const gr_mpoly_t B, int nonfield, gr_mpoly_ctx_t ctx)
+    const gr_mpoly_t A, const gr_mpoly_t B, int nonfield, int unchecked,
+    gr_mpoly_ctx_t ctx)
 {
     /*
         Call the guaranteed-serial kernel directly, NOT the public
@@ -741,7 +744,7 @@ _gr_mpoly_divrem_serial(gr_mpoly_t Q, gr_mpoly_t R,
         recurse indefinitely whenever this function is reached as a
         fallback from within the threaded engine itself (A, B unchanged).
     */
-    return _gr_mpoly_divrem_mp(Q, R, A, B, nonfield, ctx);
+    return _gr_mpoly_divrem_mp(Q, R, A, B, nonfield, unchecked, ctx);
 }
 
 /*
@@ -758,6 +761,7 @@ static int _gr_mpoly_divrem_heap_threaded_pool(
     const gr_mpoly_t B,
     gr_mpoly_ctx_t ctx,
     int nonfield,
+    int unchecked,
     const thread_pool_handle * handles,
     slong num_handles)
 {
@@ -778,7 +782,7 @@ static int _gr_mpoly_divrem_heap_threaded_pool(
     TMP_INIT;
 
     if (B->length < 2 || A->length < 2)
-        return _gr_mpoly_divrem_serial(Q, R, A, B, nonfield, ctx);
+        return _gr_mpoly_divrem_serial(Q, R, A, B, nonfield, unchecked, ctx);
 
     TMP_START;
 
@@ -835,7 +839,7 @@ static int _gr_mpoly_divrem_heap_threaded_pool(
     if (mpoly_divides_select_exps(S, zctx, num_handles,
                                    Aexp, A->length, Bexp, B->length, exp_bits))
     {
-        status = _gr_mpoly_divrem_serial(Q, R, A, B, nonfield, ctx);
+        status = _gr_mpoly_divrem_serial(Q, R, A, B, nonfield, unchecked, ctx);
         goto cleanup1;
     }
 
@@ -866,6 +870,7 @@ static int _gr_mpoly_divrem_heap_threaded_pool(
     H->require_exact = 0;
     H->want_remainder = (R != NULL);
     H->nonfield = nonfield;
+    H->unchecked = unchecked;
     H->failed = 0;
     H->have_domain = 0;
     H->have_unable = 0;
@@ -960,7 +965,8 @@ static int _gr_mpoly_divrem_heap_threaded_dispatch(
     const gr_mpoly_t A,
     const gr_mpoly_t B,
     gr_mpoly_ctx_t ctx,
-    int nonfield)
+    int nonfield,
+    int unchecked)
 {
     gr_ctx_struct * cctx = GR_MPOLY_CCTX(ctx);
     thread_pool_handle * handles;
@@ -985,14 +991,14 @@ static int _gr_mpoly_divrem_heap_threaded_dispatch(
     /* fall back to the single-threaded algorithm for small inputs, or when
        the coefficient ring does not allow concurrent operations */
     if (B->length < 2 || A->length < 2 || gr_ctx_is_threadsafe(cctx) != T_TRUE)
-        return _gr_mpoly_divrem_serial(Q, R, A, B, nonfield, ctx);
+        return _gr_mpoly_divrem_serial(Q, R, A, B, nonfield, unchecked, ctx);
 
     thread_limit = A->length/32;
 
     num_handles = flint_request_threads(&handles, thread_limit);
 
     status = _gr_mpoly_divrem_heap_threaded_pool(Q, R, A, B, ctx,
-                                                nonfield, handles, num_handles);
+                                    nonfield, unchecked, handles, num_handles);
 
     flint_give_back_threads(handles, num_handles);
 
@@ -1005,7 +1011,7 @@ int gr_mpoly_divrem_heap_threaded(
     const gr_mpoly_t A, const gr_mpoly_t B,
     gr_mpoly_ctx_t ctx)
 {
-    return _gr_mpoly_divrem_heap_threaded_dispatch(Q, R, A, B, ctx, 0);
+    return _gr_mpoly_divrem_heap_threaded_dispatch(Q, R, A, B, ctx, 0, 0);
 }
 
 
@@ -1014,7 +1020,7 @@ int gr_mpoly_divrem_weak_heap_threaded(
     const gr_mpoly_t A, const gr_mpoly_t B,
     gr_mpoly_ctx_t ctx)
 {
-    return _gr_mpoly_divrem_heap_threaded_dispatch(Q, R, A, B, ctx, 1);
+    return _gr_mpoly_divrem_heap_threaded_dispatch(Q, R, A, B, ctx, 1, 0);
 }
 
 
@@ -1023,7 +1029,7 @@ int gr_mpoly_div_heap_threaded(
     const gr_mpoly_t A, const gr_mpoly_t B,
     gr_mpoly_ctx_t ctx)
 {
-    return _gr_mpoly_divrem_heap_threaded_dispatch(Q, NULL, A, B, ctx, 0);
+    return _gr_mpoly_divrem_heap_threaded_dispatch(Q, NULL, A, B, ctx, 0, 0);
 }
 
 
@@ -1032,5 +1038,14 @@ int gr_mpoly_div_weak_heap_threaded(
     const gr_mpoly_t A, const gr_mpoly_t B,
     gr_mpoly_ctx_t ctx)
 {
-    return _gr_mpoly_divrem_heap_threaded_dispatch(Q, NULL, A, B, ctx, 1);
+    return _gr_mpoly_divrem_heap_threaded_dispatch(Q, NULL, A, B, ctx, 1, 0);
+}
+
+
+int gr_mpoly_divexact_heap_threaded(
+    gr_mpoly_t Q,
+    const gr_mpoly_t A, const gr_mpoly_t B,
+    gr_mpoly_ctx_t ctx)
+{
+    return _gr_mpoly_divrem_heap_threaded_dispatch(Q, NULL, A, B, ctx, 0, 1);
 }

--- a/src/gr_mpoly/divrem_heap_threaded.c
+++ b/src/gr_mpoly/divrem_heap_threaded.c
@@ -648,8 +648,12 @@ slong _gr_mpoly_divrem_stripe(
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                              Qexp + N*x->j, N);
+                    if (bits <= FLINT_BITS)
+                        mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i,
+                                                                  Qexp + N*x->j, N);
+                    else
+                        mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
+                                                                  Qexp + N*x->j, N);
 
                     if (mpoly_monomial_cmp(exp_list[exp_next], S->emin, N, S->cmpmask) >= 0)
                         exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
@@ -671,8 +675,12 @@ slong _gr_mpoly_divrem_stripe(
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                              Qexp + N*x->j, N);
+                    if (bits <= FLINT_BITS)
+                        mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i,
+                                                                  Qexp + N*x->j, N);
+                    else
+                        mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
+                                                                  Qexp + N*x->j, N);
 
                     if (mpoly_monomial_cmp(exp_list[exp_next], S->emin, N, S->cmpmask) >= 0)
                         exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
@@ -704,7 +712,10 @@ slong _gr_mpoly_divrem_stripe(
                 x->next = NULL;
                 hind[x->i] = 2*(x->j + 1) + 0;
 
-                mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i, Qexp + N*x->j, N);
+                if (bits <= FLINT_BITS)
+                    mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i, Qexp + N*x->j, N);
+                else
+                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i, Qexp + N*x->j, N);
 
                 if (mpoly_monomial_cmp(exp_list[exp_next], S->emin, N, S->cmpmask) >= 0)
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
@@ -787,9 +798,46 @@ static int _gr_mpoly_divrem_heap_threaded_pool(
     gr_ptr lc_inv;
     divides_heap_base_t H;
     int lc_is_one, lc_is_unit;
+    gr_mpoly_t TQ, TR;
+    gr_mpoly_struct * q, * r;
 
     if (B->length < 2 || A->length < 2)
         return _gr_mpoly_divrem_serial(Q, R, A, B, nonfield, unchecked, ctx);
+
+    /*
+        Use temporaries to handle aliasing of Q, R with A, B: the retry
+        loop below re-reads A->length/A->exps/B->length/B->exps on every
+        pass (in particular via mpoly_divides_select_exps and the H->polyA/
+        H->polyB setup), while divides_heap_base_clear zeroes Q (and R) on
+        any non-successful attempt, including the ordinary overflow-retry
+        case. If Q or R is the same object as A or B, that zeroing would
+        corrupt the operand out from under the very next loop iteration --
+        exactly mirroring the aliasing guard already used by the serial
+        kernel in _gr_mpoly_divrem_mp (divrem_heap.c).
+    */
+    if (Q == A || Q == B)
+    {
+        gr_mpoly_init(TQ, ctx);
+        q = TQ;
+    }
+    else
+    {
+        q = Q;
+    }
+
+    if (R == NULL)
+    {
+        r = NULL;
+    }
+    else if (R == A || R == B)
+    {
+        gr_mpoly_init(TR, ctx);
+        r = TR;
+    }
+    else
+    {
+        r = R;
+    }
 
     GR_TMP_INIT(lc_inv, cctx);
 
@@ -849,6 +897,10 @@ static int _gr_mpoly_divrem_heap_threaded_pool(
             status = _gr_mpoly_divrem_serial(Q, R, A, B, nonfield, unchecked, ctx);
             fmpz_mpoly_clear(S, zctx);
             fmpz_mpoly_ctx_clear(zctx);
+            if (q == TQ)
+                gr_mpoly_clear(TQ, ctx);
+            if (r == TR)
+                gr_mpoly_clear(TR, ctx);
             goto cleanup1;
         }
 
@@ -959,7 +1011,7 @@ static int _gr_mpoly_divrem_heap_threaded_pool(
                 exactly like the retry loop in _gr_mpoly_divrem_mp
                 (divrem_heap.c) does for the single-threaded algorithm.
             */
-            GR_IGNORE(divides_heap_base_clear(Q, R, H));
+            GR_IGNORE(divides_heap_base_clear(q, r, H));
 
             fmpz_mpoly_clear(S, zctx);
             fmpz_mpoly_ctx_clear(zctx);
@@ -990,12 +1042,23 @@ static int _gr_mpoly_divrem_heap_threaded_pool(
             continue;
         }
 
-        status = divides_heap_base_clear(Q, R, H);
+        status = divides_heap_base_clear(q, r, H);
 
         fmpz_mpoly_clear(S, zctx);
         fmpz_mpoly_ctx_clear(zctx);
 
         break;
+    }
+
+    if (q == TQ)
+    {
+        gr_mpoly_swap(Q, TQ, ctx);
+        gr_mpoly_clear(TQ, ctx);
+    }
+    if (r == TR)
+    {
+        gr_mpoly_swap(R, TR, ctx);
+        gr_mpoly_clear(TR, ctx);
     }
 
 cleanup1:

--- a/src/gr_mpoly/divrem_heap_threaded.c
+++ b/src/gr_mpoly/divrem_heap_threaded.c
@@ -123,12 +123,11 @@
     { \
         cstatus = gr_euclidean_divrem(GR_ENTRY(Qcoeff, Qlen, sz), rem, acc, Bcoeff, cctx); \
         if (cstatus != GR_SUCCESS) { status |= cstatus; goto unable; } \
-        switch (gr_is_zero(rem, cctx)) \
-        { \
-            case T_TRUE: break; \
-            case T_FALSE: ADD_W_TERM(rem); break; \
-            default: status |= GR_UNABLE; goto unable; \
-        } \
+        /* an unknown zero-status is treated as "not zero" (i.e. kept in \
+           W): we only need the euclidean division itself to succeed, not \
+           to know for certain whether its remainder happens to vanish. */ \
+        if (gr_is_zero(rem, cctx) != T_TRUE) \
+            ADD_W_TERM(rem); \
         commit = (gr_is_zero(GR_ENTRY(Qcoeff, Qlen, sz), cctx) != T_TRUE); \
     } \
     else \
@@ -376,16 +375,12 @@ slong _gr_mpoly_divrem_stripe1(
             }
         }
 
-        switch (gr_is_zero(acc, cctx))
-        {
-            case T_TRUE:
-                continue;
-            case T_FALSE:
-                break;
-            default:
-                status |= GR_UNABLE;
-                goto unable;
-        }
+        /* an unknown zero-status is treated as "not zero" -- see the
+           discussion at gr_mpoly_divexact for why this is safe: we only
+           need the coefficient division below to succeed, not to know for
+           certain that acc is nonzero. */
+        if (gr_is_zero(acc, cctx) == T_TRUE)
+            continue;
 
         commit = 0;
         STRIPE_DIVREM_COEFF_STEP(STRIPE_ADD_W_TERM1);
@@ -671,16 +666,12 @@ slong _gr_mpoly_divrem_stripe(
             }
         }
 
-        switch (gr_is_zero(acc, cctx))
-        {
-            case T_TRUE:
-                continue;
-            case T_FALSE:
-                break;
-            default:
-                status |= GR_UNABLE;
-                goto unable;
-        }
+        /* an unknown zero-status is treated as "not zero" -- see the
+           discussion at gr_mpoly_divexact for why this is safe: we only
+           need the coefficient division below to succeed, not to know for
+           certain that acc is nonzero. */
+        if (gr_is_zero(acc, cctx) == T_TRUE)
+            continue;
 
         commit = 0;
         STRIPE_DIVREM_COEFF_STEP(STRIPE_ADD_W_TERMN);

--- a/src/gr_mpoly/divrem_heap_threaded.c
+++ b/src/gr_mpoly/divrem_heap_threaded.c
@@ -1,0 +1,1036 @@
+/*
+    Copyright (C) 2017 William Hart
+    Copyright (C) 2018 Daniel Schultz
+    Copyright (C) 2019 Daniel Schultz
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdint.h>
+#include <string.h>
+#include "thread_pool.h"
+#include "thread_support.h"
+#include "fmpz.h"
+#include "fmpz_vec.h"
+#include "fmpz_mpoly.h"
+#include "mpoly.h"
+#include "gr_generic.h"
+#include "gr_mpoly.h"
+#include "threaded_divmod.h"
+
+/*
+    Multithreaded gr_mpoly_divrem_heap / gr_mpoly_div / gr_mpoly_div_weak /
+    gr_mpoly_divrem_weak, sharing the chunked producer/consumer pipeline
+    (gr_mpoly_ts, _gr_mpoly_mulsub_stripe*, the chunk/base structs,
+    chunk_mulsub, trychunk, worker_loop) defined in divides_heap_threaded.c
+    and declared in threaded_divmod.h.
+
+    The only new pieces here are:
+
+        - _gr_mpoly_divrem_stripe1 / _gr_mpoly_divrem_stripe: the bounded
+          ("stripe") analogue of _gr_mpoly_divrem_heap1 / _gr_mpoly_divrem_heap
+          (src/gr_mpoly/divrem_heap.c), i.e. exactly the transformation that
+          already turns _gr_mpoly_divides_heap1/heap into
+          _gr_mpoly_divides_stripe1/stripe in divides_heap_threaded.c: add an
+          S->emin lower bound below which heap nodes are never (re)inserted.
+          Unlike the divides stripe leaves, these never abort on a
+          non-reducible term -- it is routed to a local remainder output
+          instead -- so they always fully drain their input.
+
+        - _gr_mpoly_divrem_heap_threaded_pool and the four public entry
+          points. This mirrors _gr_mpoly_divides_heap_threaded_pool /
+          gr_mpoly_divides_heap_threaded, with two differences forced by
+          "does not require exactness": mpoly_divides_select_exps's failure
+          return (which only detects "provably not exact") is treated as
+          "could not find a clean partition, fall back to the serial
+          engine" rather than GR_DOMAIN, and the initial burst of leading
+          terms routes non-reducible terms to R instead of failing.
+*/
+
+/* gather product node (Bcoeff[i], Qcoeff[j]) into dot_a/dot_b; record
+   dividend node. Identical in shape to STRIPE_DIVIDES_FETCH_NODE in
+   divides_heap_threaded.c (kept as a separate, tiny macro rather than
+   shared, exactly as the serial divides_heap.c / divrem_heap.c already
+   each keep their own copy of this pattern). */
+#define STRIPE_DIVREM_FETCH_NODE(SET_SHALLOW) \
+    do { \
+        store[store_len++] = x->i; \
+        store[store_len++] = x->j; \
+        if (x->i == -UWORD(1)) \
+        { \
+            have_dividend = 1; \
+            dividend_j = x->j; \
+        } \
+        else \
+        { \
+            hind[x->i] |= WORD(1); \
+            SET_SHALLOW(dot_a, dot_len, Bcoeff, x->i); \
+            SET_SHALLOW(dot_b, dot_len, Qcoeff, x->j); \
+            dot_len++; \
+        } \
+    } while (0)
+
+/* append acc (or rem) as a new remainder term at monomial exp/expN */
+#define STRIPE_ADD_W_TERM1(val) \
+    do { \
+        _gr_mpoly_fit_length(W_coeff, W_alloc, W_exp, W_exps_alloc, 1, Wlen + 1, ctx); \
+        status |= gr_set(GR_ENTRY(*W_coeff, Wlen, sz), val, cctx); \
+        (*W_exp)[Wlen] = exp; \
+        Wlen++; \
+    } while (0)
+
+#define STRIPE_ADD_W_TERMN(val) \
+    do { \
+        _gr_mpoly_fit_length(W_coeff, W_alloc, W_exp, W_exps_alloc, N, Wlen + 1, ctx); \
+        status |= gr_set(GR_ENTRY(*W_coeff, Wlen, sz), val, cctx); \
+        mpoly_monomial_set(*W_exp + Wlen*N, exp, N); \
+        Wlen++; \
+    } while (0)
+
+/* exact-coefficient path: same as STRIPE_DIVIDES_COEFF in
+   divides_heap_threaded.c, duplicated here (a one-line macro) so that this
+   file has no compile-time dependency on that file's private macros. */
+#define STRIPE_DIVREM_QCOEFF(acc) \
+    (lc_is_one  ? gr_set(GR_ENTRY(Qcoeff, Qlen, sz), acc, cctx) \
+     : lc_is_unit ? gr_mul(GR_ENTRY(Qcoeff, Qlen, sz), acc, lc_inv, cctx) \
+                  : gr_div(GR_ENTRY(Qcoeff, Qlen, sz), acc, Bcoeff, cctx))
+
+/*
+    Decide the fate of the accumulated coefficient acc at monomial exp:
+    commit a quotient term (bumping Qlen after the caller inserts the
+    follow-up heap node) or route val to the remainder via ADD_W_TERM.
+    Mirrors DIVREM_COEFF_STEP in gr_mpoly/divrem_heap.c, restricted to a
+    single term (the heap bookkeeping around it is identical for a
+    committed or a non-committed term, so it lives outside this macro,
+    exactly as in _gr_mpoly_divides_stripe1/stripe).
+*/
+#define STRIPE_DIVREM_COEFF_STEP(ADD_W_TERM) \
+{ \
+    if (!lt_divides) \
+    { \
+        ADD_W_TERM(acc); \
+        commit = 0; \
+    } \
+    else if (S->nonfield) \
+    { \
+        cstatus = gr_euclidean_divrem(GR_ENTRY(Qcoeff, Qlen, sz), rem, acc, Bcoeff, cctx); \
+        if (cstatus != GR_SUCCESS) { status |= cstatus; goto unable; } \
+        switch (gr_is_zero(rem, cctx)) \
+        { \
+            case T_TRUE: break; \
+            case T_FALSE: ADD_W_TERM(rem); break; \
+            default: status |= GR_UNABLE; goto unable; \
+        } \
+        commit = (gr_is_zero(GR_ENTRY(Qcoeff, Qlen, sz), cctx) != T_TRUE); \
+    } \
+    else \
+    { \
+        cstatus = STRIPE_DIVREM_QCOEFF(acc); \
+        if (cstatus != GR_SUCCESS) \
+        { \
+            status |= cstatus; goto unable; \
+        } \
+        else if (gr_is_zero(GR_ENTRY(Qcoeff, Qlen, sz), cctx) == T_TRUE) \
+        { \
+            ADD_W_TERM(acc); \
+            commit = 0; \
+        } \
+        else \
+        { \
+            commit = 1; \
+        } \
+    } \
+}
+
+
+/*
+    Bounded ("stripe") division-with-remainder, single-word exponent
+    version, assuming Alen > 0. This is _gr_mpoly_divrem_heap1
+    (gr_mpoly/divrem_heap.c) restricted to exponents >= S->emin, in exactly
+    the same way _gr_mpoly_divides_stripe1 restricts _gr_mpoly_divides_heap1.
+
+    Never aborts merely because a term is not divisible by lm(B) (that is
+    precisely what routes it to W instead of Q). For the non-weak variant
+    (nonfield == 0), an exactly-reducible-by-monomial term whose
+    coefficient does not divide exactly *is* a hard abort, exactly as in
+    the serial gr_mpoly_divrem_heap kernel (see the doc comment at the top
+    of gr_mpoly/divrem_heap.c): *res_status is then GR_DOMAIN. Otherwise
+    *res_status is GR_SUCCESS, or GR_UNABLE if some ring operation could
+    not decide.
+*/
+slong _gr_mpoly_divrem_stripe1(
+    gr_ptr * Q_coeff, ulong ** Q_exp, slong * Q_alloc, slong * Q_exps_alloc,
+    gr_ptr * W_coeff, ulong ** W_exp, slong * W_alloc, slong * W_exps_alloc,
+    slong * Wlen_out,
+    gr_srcptr Acoeff, const ulong * Aexp, slong Alen,
+    gr_srcptr Bcoeff, const ulong * Bexp, slong Blen,
+    const _gr_mpoly_stripe_t S, int * res_status)
+{
+    gr_mpoly_ctx_struct * ctx = S->ctx;
+    gr_ctx_struct * cctx = S->cctx;
+    slong sz = S->sz;
+    int have_fast_dot = S->have_fast_dot;
+    int lc_is_one = S->lc_is_one;
+    int lc_is_unit = S->lc_is_unit;
+    gr_srcptr lc_inv = S->lc_inv;
+    flint_bitcnt_t bits = S->bits;
+    ulong emin = S->emin[0];
+    ulong cmpmask = S->cmpmask[0];
+    ulong texp;
+    int lt_divides, commit;
+    slong i, j, s;
+    slong next_loc, heap_len;
+    mpoly_heap1_s * heap;
+    mpoly_heap_t * chain;
+    slong * store, * store_base, store_len;
+    mpoly_heap_t * x;
+    slong Qlen, Wlen;
+    slong Qalloc = *Q_alloc;
+    slong Qexps_alloc = *Q_exps_alloc;
+    gr_ptr Qcoeff = *Q_coeff;
+    ulong * Qexp = *Q_exp;
+    ulong exp;
+    ulong mask;
+    slong * hind;
+    gr_ptr acc, pp, rem, dot_a, dot_b;
+    slong dot_len;
+    int have_dividend, cstatus;
+    slong dividend_j = 0;
+    int status = GR_SUCCESS;
+
+    FLINT_ASSERT(Alen > 0);
+    FLINT_ASSERT(Blen > 0);
+    FLINT_ASSERT(S->N == 1);
+
+    next_loc = Blen + 4;
+
+    i = 0;
+    hind = (slong *)(S->big_mem + i);
+    i += Blen*sizeof(slong);
+    store = store_base = (slong *) (S->big_mem + i);
+    i += 2*Blen*sizeof(slong);
+    heap = (mpoly_heap1_s *)(S->big_mem + i);
+    i += (Blen + 1)*sizeof(mpoly_heap1_s);
+    chain = (mpoly_heap_t *)(S->big_mem + i);
+    i += Blen*sizeof(mpoly_heap_t);
+    FLINT_ASSERT(i <= S->big_mem_alloc);
+
+    GR_TMP_INIT3(acc, pp, rem, cctx);
+    dot_a = flint_malloc(2 * Blen * sz);
+    dot_b = GR_ENTRY(dot_a, Blen, sz);
+
+    for (i = 0; i < Blen; i++)
+        hind[i] = 1;
+
+    mask = mpoly_overflow_mask_sp(bits);
+
+    Qlen = 0;
+    Wlen = 0;
+    s = Blen;
+
+    heap_len = 2;
+    x = chain + 0;
+    x->i = -WORD(1);
+    x->j = 0;
+    x->next = NULL;
+    heap[1].next = x;
+    HEAP_ASSIGN(heap[1], Aexp[0], x);
+
+    FLINT_ASSERT(mpoly_monomial_cmp1(Aexp[0], emin, cmpmask) >= 0);
+
+    while (heap_len > 1)
+    {
+        exp = heap[1].exp;
+
+        /* An exponent window is chosen (by the caller, via
+           mpoly_divides_select_exps) from the actual monomials appearing
+           in A and B, so this cannot overflow in practice; treat it like
+           any other "cannot proceed" condition rather than introducing a
+           GR_DOMAIN-shaped abort that the divrem family has no use for. */
+        if (mpoly_monomial_overflows1(exp, mask))
+        {
+            status |= GR_UNABLE;
+            goto unable;
+        }
+
+        FLINT_ASSERT(mpoly_monomial_cmp1(exp, emin, cmpmask) >= 0);
+
+        _gr_mpoly_fit_length(&Qcoeff, &Qalloc, &Qexp, &Qexps_alloc, 1, Qlen + 1, ctx);
+
+        lt_divides = mpoly_monomial_divides1(Qexp + Qlen, exp, Bexp[0], mask);
+
+        dot_len = 0;
+        have_dividend = 0;
+        store_len = 0;
+
+        if (have_fast_dot)
+        {
+            do
+            {
+                x = _mpoly_heap_pop1(heap, &heap_len, cmpmask);
+                do
+                {
+                    if (sz == 1)       { STRIPE_DIVREM_FETCH_NODE(SET_SHALLOW1); }
+                    else if (sz == 2)  { STRIPE_DIVREM_FETCH_NODE(SET_SHALLOW2); }
+                    else if (sz == 4)  { STRIPE_DIVREM_FETCH_NODE(SET_SHALLOW4); }
+                    else if (sz == 8)  { STRIPE_DIVREM_FETCH_NODE(SET_SHALLOW8); }
+                    else if (sz == 16) { STRIPE_DIVREM_FETCH_NODE(SET_SHALLOW16); }
+                    else               { STRIPE_DIVREM_FETCH_NODE(SET_SHALLOW_GENERIC); }
+                } while ((x = x->next) != NULL);
+            } while (heap_len > 1 && heap[1].exp == exp);
+
+            status |= _gr_vec_dot(acc,
+                        have_dividend ? GR_ENTRY(Acoeff, dividend_j, sz) : NULL,
+                        1, dot_a, dot_b, dot_len, cctx);
+        }
+        else
+        {
+            status |= gr_zero(acc, cctx);
+            do
+            {
+                x = _mpoly_heap_pop1(heap, &heap_len, cmpmask);
+                do
+                {
+                    store[store_len++] = x->i;
+                    store[store_len++] = x->j;
+                    if (x->i == -UWORD(1))
+                    {
+                        status |= gr_add(acc, acc, GR_ENTRY(Acoeff, x->j, sz), cctx);
+                    }
+                    else
+                    {
+                        hind[x->i] |= WORD(1);
+                        status |= gr_mul(pp, GR_ENTRY(Bcoeff, x->i, sz), GR_ENTRY(Qcoeff, x->j, sz), cctx);
+                        status |= gr_sub(acc, acc, pp, cctx);
+                    }
+                } while ((x = x->next) != NULL);
+            } while (heap_len > 1 && heap[1].exp == exp);
+        }
+
+        /* process nodes taken from the heap */
+        while (store_len > 0)
+        {
+            j = store_base[--store_len];
+            i = store_base[--store_len];
+
+            if (i == -WORD(1))
+            {
+                if (j + 1 < Alen)
+                {
+                    x = chain + 0;
+                    x->i = i;
+                    x->j = j + 1;
+                    x->next = NULL;
+
+                    FLINT_ASSERT(mpoly_monomial_cmp1(Aexp[x->j], emin, cmpmask) >= 0);
+
+                    _mpoly_heap_insert1(heap, Aexp[x->j], x,
+                                                &next_loc, &heap_len, cmpmask);
+                }
+            }
+            else
+            {
+                /* should we go right? */
+                if ((i + 1 < Blen) && (hind[i + 1] == 2*j + 1))
+                {
+                    x = chain + i + 1;
+                    x->i = i + 1;
+                    x->j = j;
+                    x->next = NULL;
+                    hind[x->i] = 2*(x->j + 1) + 0;
+
+                    texp = Bexp[x->i] + Qexp[x->j];
+                    if (mpoly_monomial_cmp1(texp, emin, cmpmask) >= 0)
+                        _mpoly_heap_insert1(heap, texp, x, &next_loc, &heap_len, cmpmask);
+                    else
+                        hind[x->i] |= 1;
+                }
+                /* should we go up? */
+                if (j + 1 == Qlen)
+                {
+                    s++;
+                }
+                else if (((hind[i] & 1) == 1) &&
+                         ((i == 1) || (hind[i - 1] >= 2*(j + 2) + 1)))
+                {
+                    x = chain + i;
+                    x->i = i;
+                    x->j = j + 1;
+                    x->next = NULL;
+                    hind[x->i] = 2*(x->j + 1) + 0;
+
+                    texp = Bexp[x->i] + Qexp[x->j];
+                    if (mpoly_monomial_cmp1(texp, emin, cmpmask) >= 0)
+                        _mpoly_heap_insert1(heap, texp, x, &next_loc, &heap_len, cmpmask);
+                    else
+                        hind[x->i] |= 1;
+                }
+            }
+        }
+
+        switch (gr_is_zero(acc, cctx))
+        {
+            case T_TRUE:
+                continue;
+            case T_FALSE:
+                break;
+            default:
+                status |= GR_UNABLE;
+                goto unable;
+        }
+
+        commit = 0;
+        STRIPE_DIVREM_COEFF_STEP(STRIPE_ADD_W_TERM1);
+
+        if (commit)
+        {
+            if (s > 1)
+            {
+                i = 1;
+                x = chain + i;
+                x->i = i;
+                x->j = Qlen;
+                x->next = NULL;
+                hind[x->i] = 2*(x->j + 1) + 0;
+
+                texp = Bexp[x->i] + Qexp[x->j];
+                if (mpoly_monomial_cmp1(texp, emin, cmpmask) >= 0)
+                    _mpoly_heap_insert1(heap, texp, x, &next_loc, &heap_len, cmpmask);
+                else
+                    hind[x->i] |= 1;
+            }
+            s = 1;
+            Qlen++;
+        }
+    }
+
+    *res_status = status;
+    goto cleanup;
+
+unable:
+    Qlen = 0;
+    Wlen = 0;
+    *res_status = status;
+
+cleanup:
+
+    GR_TMP_CLEAR3(acc, pp, rem, cctx);
+    flint_free(dot_a);
+
+    *Q_coeff = Qcoeff;
+    *Q_exp = Qexp;
+    *Q_alloc = Qalloc;
+    *Q_exps_alloc = Qexps_alloc;
+    *Wlen_out = Wlen;
+
+    return Qlen;
+}
+
+/* Multi-word exponent version of the above. */
+slong _gr_mpoly_divrem_stripe(
+    gr_ptr * Q_coeff, ulong ** Q_exp, slong * Q_alloc, slong * Q_exps_alloc,
+    gr_ptr * W_coeff, ulong ** W_exp, slong * W_alloc, slong * W_exps_alloc,
+    slong * Wlen_out,
+    gr_srcptr Acoeff, const ulong * Aexp, slong Alen,
+    gr_srcptr Bcoeff, const ulong * Bexp, slong Blen,
+    const _gr_mpoly_stripe_t S, int * res_status)
+{
+    gr_mpoly_ctx_struct * ctx = S->ctx;
+    gr_ctx_struct * cctx = S->cctx;
+    slong sz = S->sz;
+    int have_fast_dot = S->have_fast_dot;
+    int lc_is_one = S->lc_is_one;
+    int lc_is_unit = S->lc_is_unit;
+    gr_srcptr lc_inv = S->lc_inv;
+    flint_bitcnt_t bits = S->bits;
+    slong N = S->N;
+    int lt_divides, commit;
+    slong i, j, s;
+    slong next_loc, heap_len;
+    mpoly_heap_s * heap;
+    mpoly_heap_t * chain;
+    slong * store, * store_base, store_len;
+    mpoly_heap_t * x;
+    slong Qlen, Wlen;
+    slong Qalloc = *Q_alloc;
+    slong Qexps_alloc = *Q_exps_alloc;
+    gr_ptr Qcoeff = *Q_coeff;
+    ulong * Qexp = *Q_exp;
+    ulong * exp, * exps;
+    ulong ** exp_list;
+    slong exp_next;
+    ulong mask;
+    slong * hind;
+    gr_ptr acc, pp, rem, dot_a, dot_b;
+    slong dot_len;
+    int have_dividend, cstatus;
+    slong dividend_j = 0;
+    int status = GR_SUCCESS;
+
+    FLINT_ASSERT(Alen > 0);
+    FLINT_ASSERT(Blen > 0);
+
+    next_loc = Blen + 4;
+
+    i = 0;
+    hind = (slong *) (S->big_mem + i);
+    i += Blen*sizeof(slong);
+    store = store_base = (slong *) (S->big_mem + i);
+    i += 2*Blen*sizeof(slong);
+    heap = (mpoly_heap_s *)(S->big_mem + i);
+    i += (Blen + 1)*sizeof(mpoly_heap_s);
+    chain = (mpoly_heap_t *)(S->big_mem + i);
+    i += Blen*sizeof(mpoly_heap_t);
+    exps = (ulong *)(S->big_mem + i);
+    i +=  Blen*N*sizeof(ulong);
+    exp_list = (ulong **)(S->big_mem + i);
+    i +=  Blen*sizeof(ulong *);
+    exp = (ulong *)(S->big_mem + i);
+    i +=  N*sizeof(ulong);
+    FLINT_ASSERT(i <= S->big_mem_alloc);
+
+    GR_TMP_INIT3(acc, pp, rem, cctx);
+    dot_a = flint_malloc(2 * Blen * sz);
+    dot_b = GR_ENTRY(dot_a, Blen, sz);
+
+    exp_next = 0;
+    for (i = 0; i < Blen; i++)
+        exp_list[i] = exps + i*N;
+
+    for (i = 0; i < Blen; i++)
+        hind[i] = 1;
+
+    mask = bits <= FLINT_BITS ? mpoly_overflow_mask_sp(bits) : 0;
+
+    Qlen = 0;
+    Wlen = 0;
+    s = Blen;
+
+    heap_len = 2;
+    x = chain + 0;
+    x->i = -WORD(1);
+    x->j = 0;
+    x->next = NULL;
+    heap[1].next = x;
+    heap[1].exp = exp_list[exp_next++];
+
+    FLINT_ASSERT(mpoly_monomial_cmp(Aexp + N*0, S->emin, N, S->cmpmask) >= 0);
+
+    mpoly_monomial_set(heap[1].exp, Aexp + N*0, N);
+
+    while (heap_len > 1)
+    {
+        _gr_mpoly_fit_length(&Qcoeff, &Qalloc, &Qexp, &Qexps_alloc, N, Qlen + 1, ctx);
+
+        mpoly_monomial_set(exp, heap[1].exp, N);
+
+        if (bits <= FLINT_BITS)
+        {
+            if (mpoly_monomial_overflows(exp, N, mask))
+            {
+                status |= GR_UNABLE;
+                goto unable;
+            }
+            lt_divides = mpoly_monomial_divides(Qexp + N*Qlen, exp, Bexp + N*0, N, mask);
+        }
+        else
+        {
+            if (mpoly_monomial_overflows_mp(exp, N, bits))
+            {
+                status |= GR_UNABLE;
+                goto unable;
+            }
+            lt_divides = mpoly_monomial_divides_mp(Qexp + N*Qlen, exp, Bexp + N*0, N, bits);
+        }
+
+        FLINT_ASSERT(mpoly_monomial_cmp(exp, S->emin, N, S->cmpmask) >= 0);
+
+        dot_len = 0;
+        have_dividend = 0;
+        store_len = 0;
+
+        if (have_fast_dot)
+        {
+            do
+            {
+                exp_list[--exp_next] = heap[1].exp;
+                x = _mpoly_heap_pop(heap, &heap_len, N, S->cmpmask);
+                do
+                {
+                    if (sz == 1)       { STRIPE_DIVREM_FETCH_NODE(SET_SHALLOW1); }
+                    else if (sz == 2)  { STRIPE_DIVREM_FETCH_NODE(SET_SHALLOW2); }
+                    else if (sz == 4)  { STRIPE_DIVREM_FETCH_NODE(SET_SHALLOW4); }
+                    else if (sz == 8)  { STRIPE_DIVREM_FETCH_NODE(SET_SHALLOW8); }
+                    else if (sz == 16) { STRIPE_DIVREM_FETCH_NODE(SET_SHALLOW16); }
+                    else               { STRIPE_DIVREM_FETCH_NODE(SET_SHALLOW_GENERIC); }
+                } while ((x = x->next) != NULL);
+            } while (heap_len > 1 && mpoly_monomial_equal(heap[1].exp, exp, N));
+
+            status |= _gr_vec_dot(acc,
+                        have_dividend ? GR_ENTRY(Acoeff, dividend_j, sz) : NULL,
+                        1, dot_a, dot_b, dot_len, cctx);
+        }
+        else
+        {
+            status |= gr_zero(acc, cctx);
+            do
+            {
+                exp_list[--exp_next] = heap[1].exp;
+                x = _mpoly_heap_pop(heap, &heap_len, N, S->cmpmask);
+                do
+                {
+                    store[store_len++] = x->i;
+                    store[store_len++] = x->j;
+                    if (x->i == -UWORD(1))
+                    {
+                        status |= gr_add(acc, acc, GR_ENTRY(Acoeff, x->j, sz), cctx);
+                    }
+                    else
+                    {
+                        hind[x->i] |= WORD(1);
+                        status |= gr_mul(pp, GR_ENTRY(Bcoeff, x->i, sz), GR_ENTRY(Qcoeff, x->j, sz), cctx);
+                        status |= gr_sub(acc, acc, pp, cctx);
+                    }
+                } while ((x = x->next) != NULL);
+            } while (heap_len > 1 && mpoly_monomial_equal(heap[1].exp, exp, N));
+        }
+
+        /* process nodes taken from the heap */
+        while (store_len > 0)
+        {
+            j = store_base[--store_len];
+            i = store_base[--store_len];
+
+            if (i == -WORD(1))
+            {
+                if (j + 1 < Alen)
+                {
+                    x = chain + 0;
+                    x->i = i;
+                    x->j = j + 1;
+                    x->next = NULL;
+                    mpoly_monomial_set(exp_list[exp_next], Aexp + x->j*N, N);
+
+                    FLINT_ASSERT(mpoly_monomial_cmp(exp_list[exp_next], S->emin, N, S->cmpmask) >= 0);
+
+                    exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
+                                          &next_loc, &heap_len, N, S->cmpmask);
+                }
+            }
+            else
+            {
+                /* should we go right? */
+                if ((i + 1 < Blen) && (hind[i + 1] == 2*j + 1))
+                {
+                    x = chain + i + 1;
+                    x->i = i + 1;
+                    x->j = j;
+                    x->next = NULL;
+                    hind[x->i] = 2*(x->j + 1) + 0;
+
+                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
+                                                              Qexp + N*x->j, N);
+
+                    if (mpoly_monomial_cmp(exp_list[exp_next], S->emin, N, S->cmpmask) >= 0)
+                        exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
+                                          &next_loc, &heap_len, N, S->cmpmask);
+                    else
+                        hind[x->i] |= 1;
+                }
+                /* should we go up? */
+                if (j + 1 == Qlen)
+                {
+                    s++;
+                }
+                else if (((hind[i] & 1) == 1) &&
+                         ((i == 1) || (hind[i - 1] >= 2*(j + 2) + 1)))
+                {
+                    x = chain + i;
+                    x->i = i;
+                    x->j = j + 1;
+                    x->next = NULL;
+                    hind[x->i] = 2*(x->j + 1) + 0;
+
+                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
+                                                              Qexp + N*x->j, N);
+
+                    if (mpoly_monomial_cmp(exp_list[exp_next], S->emin, N, S->cmpmask) >= 0)
+                        exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
+                                          &next_loc, &heap_len, N, S->cmpmask);
+                    else
+                        hind[x->i] |= 1;
+                }
+            }
+        }
+
+        switch (gr_is_zero(acc, cctx))
+        {
+            case T_TRUE:
+                continue;
+            case T_FALSE:
+                break;
+            default:
+                status |= GR_UNABLE;
+                goto unable;
+        }
+
+        commit = 0;
+        STRIPE_DIVREM_COEFF_STEP(STRIPE_ADD_W_TERMN);
+
+        if (commit)
+        {
+            if (s > 1)
+            {
+                i = 1;
+                x = chain + i;
+                x->i = i;
+                x->j = Qlen;
+                x->next = NULL;
+                hind[x->i] = 2*(x->j + 1) + 0;
+
+                mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i, Qexp + N*x->j, N);
+
+                if (mpoly_monomial_cmp(exp_list[exp_next], S->emin, N, S->cmpmask) >= 0)
+                    exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
+                                          &next_loc, &heap_len, N, S->cmpmask);
+                else
+                    hind[x->i] |= 1;
+            }
+            s = 1;
+            Qlen++;
+        }
+    }
+
+    *res_status = status;
+    goto cleanup;
+
+unable:
+    Qlen = 0;
+    Wlen = 0;
+    *res_status = status;
+
+cleanup:
+
+    GR_TMP_CLEAR3(acc, pp, rem, cctx);
+    flint_free(dot_a);
+
+    *Q_coeff = Qcoeff;
+    *Q_exp = Qexp;
+    *Q_alloc = Qalloc;
+    *Q_exps_alloc = Qexps_alloc;
+    *Wlen_out = Wlen;
+
+    return Qlen;
+}
+
+
+static int
+_gr_mpoly_divrem_serial(gr_mpoly_t Q, gr_mpoly_t R,
+    const gr_mpoly_t A, const gr_mpoly_t B, int nonfield, gr_mpoly_ctx_t ctx)
+{
+    /*
+        Call the guaranteed-serial kernel directly, NOT the public
+        gr_mpoly_div/gr_mpoly_divrem/... dispatchers: those may route large
+        instances straight back into this threaded engine, which would
+        recurse indefinitely whenever this function is reached as a
+        fallback from within the threaded engine itself (A, B unchanged).
+    */
+    return _gr_mpoly_divrem_mp(Q, R, A, B, nonfield, ctx);
+}
+
+/*
+    R may be NULL, in which case the remainder is not written at all (the
+    gr_mpoly_div(_weak)_heap_threaded case) rather than merely discarded --
+    this matches how _gr_mpoly_divrem_mp handles R == NULL in the serial
+    engine, and lets a chunk skip producing/appending remainder terms
+    entirely rather than computing and immediately throwing them away.
+*/
+static int _gr_mpoly_divrem_heap_threaded_pool(
+    gr_mpoly_t Q,
+    gr_mpoly_t R,
+    const gr_mpoly_t A,
+    const gr_mpoly_t B,
+    gr_mpoly_ctx_t ctx,
+    int nonfield,
+    const thread_pool_handle * handles,
+    slong num_handles)
+{
+    mpoly_ctx_struct * mctx = GR_MPOLY_MCTX(ctx);
+    gr_ctx_struct * cctx = GR_MPOLY_CCTX(ctx);
+    int status;
+    fmpz_mpoly_ctx_t zctx;
+    fmpz_mpoly_t S;
+    slong i, N;
+    flint_bitcnt_t exp_bits;
+    ulong * cmpmask;
+    ulong * Aexp, * Bexp;
+    int freeAexp, freeBexp;
+    worker_arg_struct * worker_args;
+    gr_ptr lc_inv;
+    divides_heap_base_t H;
+    int lc_is_one, lc_is_unit;
+    TMP_INIT;
+
+    if (B->length < 2 || A->length < 2)
+        return _gr_mpoly_divrem_serial(Q, R, A, B, nonfield, ctx);
+
+    TMP_START;
+
+    GR_TMP_INIT(lc_inv, cctx);
+
+    exp_bits = MPOLY_MIN_BITS;
+    exp_bits = FLINT_MAX(exp_bits, A->bits);
+    exp_bits = FLINT_MAX(exp_bits, B->bits);
+    exp_bits = mpoly_fix_bits(exp_bits, mctx);
+
+    N = mpoly_words_per_exp(exp_bits, mctx);
+    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
+    mpoly_get_cmpmask(cmpmask, N, exp_bits, mctx);
+
+    /* ensure input exponents packed to same size as output exponents */
+    Aexp = A->exps;
+    freeAexp = 0;
+    if (exp_bits > A->bits)
+    {
+        freeAexp = 1;
+        Aexp = (ulong *) flint_malloc(N*A->length*sizeof(ulong));
+        mpoly_repack_monomials(Aexp, exp_bits, A->exps, A->bits,
+                                                        A->length, mctx);
+    }
+
+    Bexp = B->exps;
+    freeBexp = 0;
+    if (exp_bits > B->bits)
+    {
+        freeBexp = 1;
+        Bexp = (ulong *) flint_malloc(N*B->length*sizeof(ulong));
+        mpoly_repack_monomials(Bexp, exp_bits, B->exps, B->bits,
+                                                    B->length, mctx);
+    }
+
+    fmpz_mpoly_ctx_init(zctx, mctx->nvars, mctx->ord);
+    fmpz_mpoly_init(S, zctx);
+
+    lc_is_one = lc_is_unit = 0;
+    if (!nonfield)
+    {
+        lc_is_one = (gr_is_one(B->coeffs, cctx) == T_TRUE);
+        lc_is_unit = lc_is_one || (gr_inv(lc_inv, B->coeffs, cctx) == GR_SUCCESS);
+    }
+
+    /*
+        mpoly_divides_select_exps's failure return only ever means "this
+        division is provably not exact" -- irrelevant for div/divrem, which
+        have no notion of an "impossible" division. Rather than try to
+        patch up a partition in that case, just fall back to the serial
+        engine (this can only happen on genuinely pathological / huge
+        exponent spreads).
+    */
+    if (mpoly_divides_select_exps(S, zctx, num_handles,
+                                   Aexp, A->length, Bexp, B->length, exp_bits))
+    {
+        status = _gr_mpoly_divrem_serial(Q, R, A, B, nonfield, ctx);
+        goto cleanup1;
+    }
+
+    divides_heap_base_init(H);
+
+    H->polyA->coeffs = A->coeffs;
+    H->polyA->exps = Aexp;
+    H->polyA->bits = exp_bits;
+    H->polyA->length = A->length;
+    H->polyA->coeffs_alloc = A->coeffs_alloc;
+    H->polyA->exps_alloc = N*A->length;
+
+    H->polyB->coeffs = B->coeffs;
+    H->polyB->exps = Bexp;
+    H->polyB->bits = exp_bits;
+    H->polyB->length = B->length;
+    H->polyB->coeffs_alloc = B->coeffs_alloc;
+    H->polyB->exps_alloc = N*B->length;
+
+    H->ctx = ctx;
+    H->cctx = cctx;
+    H->bits = exp_bits;
+    H->N = N;
+    H->cmpmask = cmpmask;
+    H->lc_is_one = lc_is_one;
+    H->lc_is_unit = lc_is_unit;
+    H->lc_inv = lc_inv;
+    H->require_exact = 0;
+    H->want_remainder = (R != NULL);
+    H->nonfield = nonfield;
+    H->failed = 0;
+    H->have_domain = 0;
+    H->have_unable = 0;
+
+    for (i = 0; i + 1 < S->length; i++)
+    {
+        divides_heap_chunk_struct * L;
+        L = (divides_heap_chunk_struct *) flint_malloc(
+                                            sizeof(divides_heap_chunk_struct));
+        L->ma = 0;
+        L->mq = 0;
+        L->emax = S->exps + N*i;
+        L->emin = S->exps + N*(i + 1);
+        L->upperclosed = 0;
+        L->startidx = B->length;
+        L->endidx = B->length;
+        L->producer = 0;
+        L->Cinited = 0;
+        L->lock = -2;
+        divides_heap_base_add_chunk(H, L);
+    }
+
+    H->head->upperclosed = 1;
+    H->head->producer = 1;
+    H->cur = H->head;
+
+    /*
+        Unlike gr_mpoly_divides_heap_threaded, no "generate an initial
+        burst of leading terms" pre-pass is needed here: that pre-pass is
+        purely a latency optimisation there (so that H->polyQ has *some*
+        content before the thread pool is woken), never a correctness
+        requirement -- a chunk that is not waiting on any higher quotient
+        terms (the head chunk, here marked as producer from the start) can
+        always be fully resolved on first touch, regardless of how many
+        terms of A it covers, via the ordinary stripe finalisation path in
+        trychunk. So we simply seed both thread-safe arrays empty.
+    */
+    gr_mpoly_ts_init(H->polyQ, NULL, NULL, 0, H->bits, H->N, cctx);
+    if (H->want_remainder)
+        gr_mpoly_ts_init(H->polyR, NULL, NULL, 0, H->bits, H->N, cctx);
+
+    /* start the workers */
+
+#if FLINT_USES_PTHREAD
+    pthread_mutex_init(&H->mutex, NULL);
+#endif
+
+    worker_args = (worker_arg_struct *) flint_malloc((num_handles + 1)
+                                                        *sizeof(worker_arg_t));
+
+    for (i = 0; i < num_handles; i++)
+    {
+        (worker_args + i)->H = H;
+        thread_pool_wake(global_thread_pool, handles[i], 0,
+                                                 worker_loop, worker_args + i);
+    }
+    (worker_args + num_handles)->H = H;
+    worker_loop(worker_args + num_handles);
+    for (i = 0; i < num_handles; i++)
+        thread_pool_wait(global_thread_pool, handles[i]);
+
+    flint_free(worker_args);
+
+#if FLINT_USES_PTHREAD
+    pthread_mutex_destroy(&H->mutex);
+#endif
+
+    status = divides_heap_base_clear(Q, R, H);
+
+cleanup1:
+
+    fmpz_mpoly_clear(S, zctx);
+    fmpz_mpoly_ctx_clear(zctx);
+
+    if (freeAexp)
+        flint_free(Aexp);
+
+    if (freeBexp)
+        flint_free(Bexp);
+
+    GR_TMP_CLEAR(lc_inv, cctx);
+
+    TMP_END;
+
+    return status;
+}
+
+
+static int _gr_mpoly_divrem_heap_threaded_dispatch(
+    gr_mpoly_t Q,
+    gr_mpoly_t R,
+    const gr_mpoly_t A,
+    const gr_mpoly_t B,
+    gr_mpoly_ctx_t ctx,
+    int nonfield)
+{
+    gr_ctx_struct * cctx = GR_MPOLY_CCTX(ctx);
+    thread_pool_handle * handles;
+    slong num_handles;
+    slong thread_limit;
+    int status;
+
+    if (B->length == 0)
+        return GR_DOMAIN;
+
+    if (A->length == 0)
+    {
+        status = gr_mpoly_zero(Q, ctx);
+        if (R != NULL)
+            status |= gr_mpoly_zero(R, ctx);
+        return status;
+    }
+
+    if (gr_is_zero(B->coeffs, cctx) != T_FALSE)
+        return GR_UNABLE;
+
+    /* fall back to the single-threaded algorithm for small inputs, or when
+       the coefficient ring does not allow concurrent operations */
+    if (B->length < 2 || A->length < 2 || gr_ctx_is_threadsafe(cctx) != T_TRUE)
+        return _gr_mpoly_divrem_serial(Q, R, A, B, nonfield, ctx);
+
+    thread_limit = A->length/32;
+
+    num_handles = flint_request_threads(&handles, thread_limit);
+
+    status = _gr_mpoly_divrem_heap_threaded_pool(Q, R, A, B, ctx,
+                                                nonfield, handles, num_handles);
+
+    flint_give_back_threads(handles, num_handles);
+
+    return status;
+}
+
+
+int gr_mpoly_divrem_heap_threaded(
+    gr_mpoly_t Q, gr_mpoly_t R,
+    const gr_mpoly_t A, const gr_mpoly_t B,
+    gr_mpoly_ctx_t ctx)
+{
+    return _gr_mpoly_divrem_heap_threaded_dispatch(Q, R, A, B, ctx, 0);
+}
+
+
+int gr_mpoly_divrem_weak_heap_threaded(
+    gr_mpoly_t Q, gr_mpoly_t R,
+    const gr_mpoly_t A, const gr_mpoly_t B,
+    gr_mpoly_ctx_t ctx)
+{
+    return _gr_mpoly_divrem_heap_threaded_dispatch(Q, R, A, B, ctx, 1);
+}
+
+
+int gr_mpoly_div_heap_threaded(
+    gr_mpoly_t Q,
+    const gr_mpoly_t A, const gr_mpoly_t B,
+    gr_mpoly_ctx_t ctx)
+{
+    return _gr_mpoly_divrem_heap_threaded_dispatch(Q, NULL, A, B, ctx, 0);
+}
+
+
+int gr_mpoly_div_weak_heap_threaded(
+    gr_mpoly_t Q,
+    const gr_mpoly_t A, const gr_mpoly_t B,
+    gr_mpoly_ctx_t ctx)
+{
+    return _gr_mpoly_divrem_heap_threaded_dispatch(Q, NULL, A, B, ctx, 1);
+}

--- a/src/gr_mpoly/divrem_ideal.c
+++ b/src/gr_mpoly/divrem_ideal.c
@@ -12,7 +12,6 @@
 
 #include <stdint.h>
 #include <string.h>
-#include "thread_support.h"
 #include "mpoly.h"
 #include "gr_vec.h"
 #include "gr_generic.h"
@@ -292,16 +291,12 @@ static int _gr_mpoly_divrem_ideal_mp1(
             }
         }
 
-        switch (gr_is_zero(acc, cctx))
-        {
-            case T_TRUE:
-                continue;
-            case T_FALSE:
-                break;
-            default:
-                status |= GR_UNABLE;
-                goto cleanup;
-        }
+        /* an unknown zero-status is treated as "not zero" -- see the
+           discussion at gr_mpoly_divexact for why this is safe: we only
+           need the coefficient division below to succeed, not to know for
+           certain that acc is nonzero. */
+        if (gr_is_zero(acc, cctx) == T_TRUE)
+            continue;
 
         /* try to reduce the term acc*x^exp by the divisors in order */
         {
@@ -657,16 +652,12 @@ static int _gr_mpoly_divrem_ideal_mp(
         }
 
         /* if the accumulated coefficient is zero, the term vanishes */
-        switch (gr_is_zero(acc, cctx))
-        {
-            case T_TRUE:
-                continue;
-            case T_FALSE:
-                break;
-            default:
-                status |= GR_UNABLE;
-                goto cleanup;
-        }
+        /* an unknown zero-status is treated as "not zero" -- see the
+           discussion at gr_mpoly_divexact for why this is safe: we only
+           need the coefficient division below to succeed, not to know for
+           certain that acc is nonzero. */
+        if (gr_is_zero(acc, cctx) == T_TRUE)
+            continue;
 
         /* try to reduce the term acc*x^exp by the divisors in order */
         {

--- a/src/gr_mpoly/divrem_ideal.c
+++ b/src/gr_mpoly/divrem_ideal.c
@@ -12,10 +12,12 @@
 
 #include <stdint.h>
 #include <string.h>
+#include "thread_support.h"
 #include "mpoly.h"
 #include "gr_vec.h"
 #include "gr_generic.h"
 #include "gr_mpoly.h"
+#include "threaded_divmod.h"
 
 /*
     GR port of fmpz_mpoly_divrem_ideal_monagan_pearce.
@@ -783,7 +785,16 @@ cleanup:
 }
 
 
-static int _gr_mpoly_divrem_ideal(
+/*
+    The guaranteed-serial divrem_ideal kernel (never dispatches to
+    threading). External linkage so that divrem_ideal_heap_threaded.c can
+    call it directly as a fallback -- calling the *public*
+    gr_mpoly_divrem_ideal/_weak functions instead would be wrong, since
+    those may route large instances straight back into the threaded
+    engine, risking infinite recursion (see the analogous fix for
+    gr_mpoly_div/gr_mpoly_divrem in divrem_heap_threaded.c).
+*/
+int _gr_mpoly_divrem_ideal(
     gr_mpoly_struct ** Q, gr_mpoly_t R,
     const gr_mpoly_t A, gr_mpoly_struct * const * B, slong len,
     int nonfield, gr_mpoly_ctx_t ctx)
@@ -978,12 +989,33 @@ _gr_mpoly_divrem_ideal_vec(gr_mpoly_vec_t Q, gr_mpoly_t R,
     return status;
 }
 
+/*
+    Dispatch to the multithreaded engine (gr_mpoly/divrem_ideal_heap_threaded.c)
+    for large, thread-safe instances, mirroring gr_mpoly_divrem.
+*/
+GR_MPOLY_INLINE int
+_gr_mpoly_divrem_ideal_dispatch(gr_mpoly_vec_t Q, gr_mpoly_t R,
+    const gr_mpoly_t A, const gr_mpoly_vec_t B, int nonfield, gr_mpoly_ctx_t ctx)
+{
+    gr_ctx_struct * cctx = GR_MPOLY_CCTX(ctx);
+
+    if (B->length > 0 && A->length > 500 && B->entries[0].length > 2 &&
+            gr_ctx_is_threadsafe(cctx) == T_TRUE &&
+            flint_get_num_available_threads() > 1)
+    {
+        return nonfield ? gr_mpoly_divrem_ideal_weak_heap_threaded(Q, R, A, B, ctx)
+                         : gr_mpoly_divrem_ideal_heap_threaded(Q, R, A, B, ctx);
+    }
+
+    return _gr_mpoly_divrem_ideal_vec(Q, R, A, B, nonfield, ctx);
+}
+
 int gr_mpoly_divrem_ideal(
     gr_mpoly_vec_t Q, gr_mpoly_t R,
     const gr_mpoly_t A, const gr_mpoly_vec_t B,
     gr_mpoly_ctx_t ctx)
 {
-    return _gr_mpoly_divrem_ideal_vec(Q, R, A, B, 0, ctx);
+    return _gr_mpoly_divrem_ideal_dispatch(Q, R, A, B, 0, ctx);
 }
 
 int gr_mpoly_divrem_ideal_weak(
@@ -991,5 +1023,5 @@ int gr_mpoly_divrem_ideal_weak(
     const gr_mpoly_t A, const gr_mpoly_vec_t B,
     gr_mpoly_ctx_t ctx)
 {
-    return _gr_mpoly_divrem_ideal_vec(Q, R, A, B, 1, ctx);
+    return _gr_mpoly_divrem_ideal_dispatch(Q, R, A, B, 1, ctx);
 }

--- a/src/gr_mpoly/divrem_ideal_heap_threaded.c
+++ b/src/gr_mpoly/divrem_ideal_heap_threaded.c
@@ -133,6 +133,10 @@ typedef struct
     int nonfield;
     volatile int failed;
     volatile int have_unable;
+    volatile int overflowed;  /* see the comment on the same field in
+                                 divides_heap_base_struct (threaded_divmod.h);
+                                 the divrem_ideal pool function retries at a
+                                 wider bit width when this is set. */
 } ideal_base_struct;
 
 typedef ideal_base_struct ideal_base_t[1];
@@ -194,7 +198,7 @@ static int ideal_base_clear(gr_mpoly_struct * const * Q, gr_mpoly_t R, ideal_bas
     H->cur = NULL;
     H->length = 0;
 
-    status = H->have_unable ? GR_UNABLE : GR_SUCCESS;
+    status = (H->have_unable || H->overflowed) ? GR_UNABLE : GR_SUCCESS;
 
     if (status != GR_SUCCESS)
     {
@@ -274,7 +278,7 @@ static void _gr_mpoly_divrem_ideal_stripe1(
     gr_mpoly_struct * const * poly3, slong len,
     ulong emin, ulong cmpmask, flint_bitcnt_t bits,
     int nonfield, int * lc_is_one, int * lc_is_unit, gr_srcptr lc_inv,
-    gr_mpoly_ctx_t ctx, int * res_status)
+    gr_mpoly_ctx_t ctx, int * res_status, int * overflowed)
 {
     gr_ctx_struct * cctx = GR_MPOLY_CCTX(ctx);
     slong sz = cctx->sizeof_elem;
@@ -299,6 +303,8 @@ static void _gr_mpoly_divrem_ideal_stripe1(
     slong r_len;
     int status = GR_SUCCESS;
     TMP_INIT;
+
+    *overflowed = 0;
 
     TMP_START;
 
@@ -360,7 +366,7 @@ static void _gr_mpoly_divrem_ideal_stripe1(
 
         if (mpoly_monomial_overflows1(exp, mask))
         {
-            status |= GR_UNABLE;
+            *overflowed = 1;
             goto unable;
         }
 
@@ -599,7 +605,7 @@ static void _gr_mpoly_divrem_ideal_stripe(
     gr_mpoly_struct * const * poly3, slong len,
     const ulong * emin, const ulong * cmpmask, slong N, flint_bitcnt_t bits,
     int nonfield, int * lc_is_one, int * lc_is_unit, gr_srcptr lc_inv,
-    gr_mpoly_ctx_t ctx, int * res_status)
+    gr_mpoly_ctx_t ctx, int * res_status, int * overflowed)
 {
     gr_ctx_struct * cctx = GR_MPOLY_CCTX(ctx);
     slong sz = cctx->sizeof_elem;
@@ -626,6 +632,8 @@ static void _gr_mpoly_divrem_ideal_stripe(
     slong r_len;
     int status = GR_SUCCESS;
     TMP_INIT;
+
+    *overflowed = 0;
 
     TMP_START;
 
@@ -699,7 +707,7 @@ static void _gr_mpoly_divrem_ideal_stripe(
         {
             if (mpoly_monomial_overflows(exp, N, mask))
             {
-                status |= GR_UNABLE;
+                *overflowed = 1;
                 goto unable;
             }
         }
@@ -707,7 +715,7 @@ static void _gr_mpoly_divrem_ideal_stripe(
         {
             if (mpoly_monomial_overflows_mp(exp, N, bits))
             {
-                status |= GR_UNABLE;
+                *overflowed = 1;
                 goto unable;
             }
         }
@@ -1042,6 +1050,7 @@ static void ideal_chunk_mulsub(ideal_worker_arg_t W, ideal_chunk_t L, const slon
         slong mq = L->mq[w];
         slong new_length = q_prev_length[w];
         int status;
+        int overflowed;
 
         if (new_length <= mq)
             continue;
@@ -1057,7 +1066,7 @@ static void ideal_chunk_mulsub(ideal_worker_arg_t W, ideal_chunk_t L, const slon
                     C->coeffs, C->exps, C->length, 1,
                     GR_ENTRY(Q->coeffs, mq, sz), Q->exps + N*mq, new_length - mq,
                     B->coeffs, B->exps, B->length,
-                    S, &status);
+                    S, &status, &overflowed);
         }
         else
         {
@@ -1066,7 +1075,20 @@ static void ideal_chunk_mulsub(ideal_worker_arg_t W, ideal_chunk_t L, const slon
                     C->coeffs, C->exps, C->length, 1,
                     GR_ENTRY(Q->coeffs, mq, sz), Q->exps + N*mq, new_length - mq,
                     B->coeffs, B->exps, B->length,
-                    S, &status);
+                    S, &status, &overflowed);
+        }
+
+        if (overflowed)
+        {
+#if FLINT_USES_PTHREAD
+            pthread_mutex_lock(&H->mutex);
+#endif
+            H->overflowed = 1;
+            H->failed = 1;
+#if FLINT_USES_PTHREAD
+            pthread_mutex_unlock(&H->mutex);
+#endif
+            return;
         }
 
         gr_mpoly_swap(C, T1, H->ctx);
@@ -1177,6 +1199,7 @@ static void ideal_trychunk(ideal_worker_arg_t W, ideal_chunk_t L)
             ideal_stripe_out_t * Qout;
             ideal_stripe_out_t Wout;
             int rstatus;
+            int overflowed;
 
             Qout = (ideal_stripe_out_t *) flint_malloc(H->len*sizeof(ideal_stripe_out_t));
             for (w = 0; w < H->len; w++)
@@ -1198,13 +1221,13 @@ static void ideal_trychunk(ideal_worker_arg_t W, ideal_chunk_t L)
                         Rcoeff, Rexp, Rlen, H->polyB, H->len,
                         L->emin[0], H->cmpmask[0], H->bits,
                         H->nonfield, H->lc_is_one, H->lc_is_unit, H->lc_inv,
-                        H->ctx, &rstatus);
+                        H->ctx, &rstatus, &overflowed);
             else
                 _gr_mpoly_divrem_ideal_stripe(Qout, Wout,
                         Rcoeff, Rexp, Rlen, H->polyB, H->len,
                         L->emin, H->cmpmask, N, H->bits,
                         H->nonfield, H->lc_is_one, H->lc_is_unit, H->lc_inv,
-                        H->ctx, &rstatus);
+                        H->ctx, &rstatus, &overflowed);
 
             for (w = 0; w < H->len; w++)
             {
@@ -1221,6 +1244,19 @@ static void ideal_trychunk(ideal_worker_arg_t W, ideal_chunk_t L)
             T3->length = Wout->len;
 
             flint_free(Qout);
+
+            if (overflowed)
+            {
+#if FLINT_USES_PTHREAD
+                pthread_mutex_lock(&H->mutex);
+#endif
+                H->overflowed = 1;
+                H->failed = 1;
+#if FLINT_USES_PTHREAD
+                pthread_mutex_unlock(&H->mutex);
+#endif
+                return;
+            }
 
             if (rstatus != GR_SUCCESS)
             {
@@ -1383,12 +1419,32 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_pool(
     ideal_base_t H;
     gr_mpoly_struct * polyB_storage;
     gr_mpoly_struct ** polyB_ptrs;
-    TMP_INIT;
+    gr_ptr lc_inv;
+    int * lc_is_one, * lc_is_unit;
 
     if (A->length < 2 || B[0]->length < 2)
         return _gr_mpoly_divrem_ideal_serial(Q, R, A, B, len, nonfield, ctx);
 
-    TMP_START;
+    /*
+        lc_is_one/lc_is_unit/lc_inv depend only on the ring elements
+        lc(B[w]), never on the exponent bit width, so (unlike everything
+        else set up below) they only need computing once, outside the
+        retry-on-overflow loop.
+    */
+    lc_inv = flint_malloc(len*sz);
+    _gr_vec_init(lc_inv, len, cctx);
+    lc_is_one = (int *) flint_malloc(len*sizeof(int));
+    lc_is_unit = (int *) flint_malloc(len*sizeof(int));
+    for (w = 0; w < len; w++)
+    {
+        lc_is_one[w] = lc_is_unit[w] = 0;
+        if (!nonfield)
+        {
+            lc_is_one[w] = (gr_is_one(GR_ENTRY(B[w]->coeffs, 0, sz), cctx) == T_TRUE);
+            lc_is_unit[w] = lc_is_one[w] ||
+                (gr_inv(GR_ENTRY(lc_inv, w, sz), GR_ENTRY(B[w]->coeffs, 0, sz), cctx) == GR_SUCCESS);
+        }
+    }
 
     exp_bits = MPOLY_MIN_BITS;
     exp_bits = FLINT_MAX(exp_bits, A->bits);
@@ -1397,7 +1453,7 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_pool(
     exp_bits = mpoly_fix_bits(exp_bits, mctx);
 
     N = mpoly_words_per_exp(exp_bits, mctx);
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
+    cmpmask = (ulong *) flint_malloc(N*sizeof(ulong));
     mpoly_get_cmpmask(cmpmask, N, exp_bits, mctx);
 
     Aexp = A->exps;
@@ -1409,8 +1465,8 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_pool(
         mpoly_repack_monomials(Aexp, exp_bits, A->exps, A->bits, A->length, mctx);
     }
 
-    Bexp = (ulong **) TMP_ALLOC(len*sizeof(ulong *));
-    freeBexp = (int *) TMP_ALLOC(len*sizeof(int));
+    Bexp = (ulong **) flint_malloc(len*sizeof(ulong *));
+    freeBexp = (int *) flint_malloc(len*sizeof(int));
     for (w = 0; w < len; w++)
     {
         Bexp[w] = B[w]->exps;
@@ -1423,165 +1479,214 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_pool(
         }
     }
 
-    polyB_storage = (gr_mpoly_struct *) flint_malloc(len*sizeof(gr_mpoly_struct));
-    polyB_ptrs = (gr_mpoly_struct **) flint_malloc(len*sizeof(gr_mpoly_struct *));
-    for (w = 0; w < len; w++)
+    while (1)
     {
-        polyB_ptrs[w] = polyB_storage + w;
-        polyB_storage[w].coeffs = B[w]->coeffs;
-        polyB_storage[w].exps = Bexp[w];
-        polyB_storage[w].bits = exp_bits;
-        polyB_storage[w].length = B[w]->length;
-        polyB_storage[w].coeffs_alloc = B[w]->coeffs_alloc;
-        polyB_storage[w].exps_alloc = N*B[w]->length;
-    }
-
-    fmpz_mpoly_ctx_init(zctx, mctx->nvars, mctx->ord);
-    fmpz_mpoly_init(S, zctx);
-
-    /*
-        mpoly_divides_select_exps only needs *a* representative divisor to
-        pick reasonable chunk boundaries -- these are purely a load
-        balancing hint (unlike the plain-divide case, correctness never
-        depends on them), so B[0] is a fine, simple choice regardless of
-        how many divisors there are.
-    */
-    if (mpoly_divides_select_exps(S, zctx, num_handles,
-                                   Aexp, A->length, Bexp[0], B[0]->length, exp_bits))
-    {
-        /* select_exps's failure notion ("provably not exact") does not
-           apply to divrem_ideal (which always succeeds via the
-           remainder), but a degenerate/pathological exponent spread is
-           not worth trying to patch up -- fall back to the serial engine. */
-        status = _gr_mpoly_divrem_ideal_serial(Q, R, A, B, len, nonfield, ctx);
-        goto cleanup1;
-    }
-
-    ideal_base_init(H);
-
-    H->polyA->coeffs = A->coeffs;
-    H->polyA->exps = Aexp;
-    H->polyA->bits = exp_bits;
-    H->polyA->length = A->length;
-    H->polyA->coeffs_alloc = A->coeffs_alloc;
-    H->polyA->exps_alloc = N*A->length;
-
-    H->polyB = polyB_ptrs;
-    H->len = len;
-    H->ctx = ctx;
-    H->cctx = cctx;
-    H->bits = exp_bits;
-    H->N = N;
-    H->cmpmask = cmpmask;
-    H->nonfield = nonfield;
-    H->failed = 0;
-    H->have_unable = 0;
-
-    H->polyQ = (gr_mpoly_ts_struct *) flint_malloc(len*sizeof(gr_mpoly_ts_struct));
-    for (w = 0; w < len; w++)
-        gr_mpoly_ts_init(H->polyQ + w, NULL, NULL, 0, exp_bits, N, cctx);
-    gr_mpoly_ts_init(H->polyR, NULL, NULL, 0, exp_bits, N, cctx);
-
-    H->lc_inv = flint_malloc(len*sz);
-    _gr_vec_init(H->lc_inv, len, cctx);
-    H->lc_is_one = (int *) flint_malloc(len*sizeof(int));
-    H->lc_is_unit = (int *) flint_malloc(len*sizeof(int));
-    for (w = 0; w < len; w++)
-    {
-        H->lc_is_one[w] = H->lc_is_unit[w] = 0;
-        if (!nonfield)
-        {
-            H->lc_is_one[w] = (gr_is_one(GR_ENTRY(B[w]->coeffs, 0, sz), cctx) == T_TRUE);
-            H->lc_is_unit[w] = H->lc_is_one[w] ||
-                (gr_inv(GR_ENTRY(H->lc_inv, w, sz), GR_ENTRY(B[w]->coeffs, 0, sz), cctx) == GR_SUCCESS);
-        }
-    }
-
-    for (i = 0; i + 1 < S->length; i++)
-    {
-        ideal_chunk_struct * L;
-        L = (ideal_chunk_struct *) flint_malloc(sizeof(ideal_chunk_struct));
-        L->startidx = (slong *) flint_malloc(3*len*sizeof(slong));
-        L->endidx = L->startidx + len;
-        L->mq = L->startidx + 2*len;
+        polyB_storage = (gr_mpoly_struct *) flint_malloc(len*sizeof(gr_mpoly_struct));
+        polyB_ptrs = (gr_mpoly_struct **) flint_malloc(len*sizeof(gr_mpoly_struct *));
         for (w = 0; w < len; w++)
         {
-            L->startidx[w] = B[w]->length;
-            L->endidx[w] = B[w]->length;
-            L->mq[w] = 0;
+            polyB_ptrs[w] = polyB_storage + w;
+            polyB_storage[w].coeffs = B[w]->coeffs;
+            polyB_storage[w].exps = Bexp[w];
+            polyB_storage[w].bits = exp_bits;
+            polyB_storage[w].length = B[w]->length;
+            polyB_storage[w].coeffs_alloc = B[w]->coeffs_alloc;
+            polyB_storage[w].exps_alloc = N*B[w]->length;
         }
-        L->emax = S->exps + N*i;
-        L->emin = S->exps + N*(i + 1);
-        L->upperclosed = 0;
-        L->producer = 0;
-        L->Cinited = 0;
-        L->done = 0;
-        L->lock = -2;
-        ideal_base_add_chunk(H, L);
-    }
 
-    H->head->upperclosed = 1;
-    H->head->producer = 1;
-    H->cur = H->head;
+        fmpz_mpoly_ctx_init(zctx, mctx->nvars, mctx->ord);
+        fmpz_mpoly_init(S, zctx);
 
-    /*
-        No "initial burst" pre-pass here, for the same reason
-        gr_mpoly_divrem_heap_threaded doesn't need one (see the long
-        comment there): the head chunk, already marked as producer, can be
-        fully resolved from scratch on first touch regardless of how many
-        terms of A it covers.
-    */
+        /*
+            mpoly_divides_select_exps only needs *a* representative divisor to
+            pick reasonable chunk boundaries -- these are purely a load
+            balancing hint (unlike the plain-divide case, correctness never
+            depends on them), so B[0] is a fine, simple choice regardless of
+            how many divisors there are.
+        */
+        if (mpoly_divides_select_exps(S, zctx, num_handles,
+                                       Aexp, A->length, Bexp[0], B[0]->length, exp_bits))
+        {
+            /* select_exps's failure notion ("provably not exact") does not
+               apply to divrem_ideal (which always succeeds via the
+               remainder), but a degenerate/pathological exponent spread is
+               not worth trying to patch up -- fall back to the serial engine. */
+            status = _gr_mpoly_divrem_ideal_serial(Q, R, A, B, len, nonfield, ctx);
+            fmpz_mpoly_clear(S, zctx);
+            fmpz_mpoly_ctx_clear(zctx);
+            flint_free(polyB_storage);
+            flint_free(polyB_ptrs);
+            goto cleanup1;
+        }
+
+        ideal_base_init(H);
+
+        H->polyA->coeffs = A->coeffs;
+        H->polyA->exps = Aexp;
+        H->polyA->bits = exp_bits;
+        H->polyA->length = A->length;
+        H->polyA->coeffs_alloc = A->coeffs_alloc;
+        H->polyA->exps_alloc = N*A->length;
+
+        H->polyB = polyB_ptrs;
+        H->len = len;
+        H->ctx = ctx;
+        H->cctx = cctx;
+        H->bits = exp_bits;
+        H->N = N;
+        H->cmpmask = cmpmask;
+        H->nonfield = nonfield;
+        H->failed = 0;
+        H->have_unable = 0;
+        H->overflowed = 0;
+        H->lc_inv = lc_inv;
+        H->lc_is_one = lc_is_one;
+        H->lc_is_unit = lc_is_unit;
+
+        H->polyQ = (gr_mpoly_ts_struct *) flint_malloc(len*sizeof(gr_mpoly_ts_struct));
+        for (w = 0; w < len; w++)
+            gr_mpoly_ts_init(H->polyQ + w, NULL, NULL, 0, exp_bits, N, cctx);
+        gr_mpoly_ts_init(H->polyR, NULL, NULL, 0, exp_bits, N, cctx);
+
+        for (i = 0; i + 1 < S->length; i++)
+        {
+            ideal_chunk_struct * L;
+            L = (ideal_chunk_struct *) flint_malloc(sizeof(ideal_chunk_struct));
+            L->startidx = (slong *) flint_malloc(3*len*sizeof(slong));
+            L->endidx = L->startidx + len;
+            L->mq = L->startidx + 2*len;
+            for (w = 0; w < len; w++)
+            {
+                L->startidx[w] = B[w]->length;
+                L->endidx[w] = B[w]->length;
+                L->mq[w] = 0;
+            }
+            L->emax = S->exps + N*i;
+            L->emin = S->exps + N*(i + 1);
+            L->upperclosed = 0;
+            L->producer = 0;
+            L->Cinited = 0;
+            L->done = 0;
+            L->lock = -2;
+            ideal_base_add_chunk(H, L);
+        }
+
+        H->head->upperclosed = 1;
+        H->head->producer = 1;
+        H->cur = H->head;
+
+        /*
+            No "initial burst" pre-pass here, for the same reason
+            gr_mpoly_divrem_heap_threaded doesn't need one (see the long
+            comment there): the head chunk, already marked as producer, can be
+            fully resolved from scratch on first touch regardless of how many
+            terms of A it covers.
+        */
 
 #if FLINT_USES_PTHREAD
-    pthread_mutex_init(&H->mutex, NULL);
+        pthread_mutex_init(&H->mutex, NULL);
 #endif
 
-    worker_args = (ideal_worker_arg_struct *) flint_malloc((num_handles + 1)
-                                                        *sizeof(ideal_worker_arg_struct));
-    for (i = 0; i < num_handles; i++)
-    {
-        (worker_args + i)->H = H;
-        (worker_args + i)->polyT2 = (gr_mpoly_struct *) flint_malloc(len*sizeof(gr_mpoly_struct));
-        thread_pool_wake(global_thread_pool, handles[i], 0,
-                                                 ideal_worker_loop, worker_args + i);
-    }
-    (worker_args + num_handles)->H = H;
-    (worker_args + num_handles)->polyT2 = (gr_mpoly_struct *) flint_malloc(len*sizeof(gr_mpoly_struct));
-    ideal_worker_loop(worker_args + num_handles);
-    for (i = 0; i < num_handles; i++)
-        thread_pool_wait(global_thread_pool, handles[i]);
+        worker_args = (ideal_worker_arg_struct *) flint_malloc((num_handles + 1)
+                                                            *sizeof(ideal_worker_arg_struct));
+        for (i = 0; i < num_handles; i++)
+        {
+            (worker_args + i)->H = H;
+            (worker_args + i)->polyT2 = (gr_mpoly_struct *) flint_malloc(len*sizeof(gr_mpoly_struct));
+            thread_pool_wake(global_thread_pool, handles[i], 0,
+                                                     ideal_worker_loop, worker_args + i);
+        }
+        (worker_args + num_handles)->H = H;
+        (worker_args + num_handles)->polyT2 = (gr_mpoly_struct *) flint_malloc(len*sizeof(gr_mpoly_struct));
+        ideal_worker_loop(worker_args + num_handles);
+        for (i = 0; i < num_handles; i++)
+            thread_pool_wait(global_thread_pool, handles[i]);
 
-    for (i = 0; i <= num_handles; i++)
-        flint_free((worker_args + i)->polyT2);
-    flint_free(worker_args);
+        for (i = 0; i <= num_handles; i++)
+            flint_free((worker_args + i)->polyT2);
+        flint_free(worker_args);
 
 #if FLINT_USES_PTHREAD
-    pthread_mutex_destroy(&H->mutex);
+        pthread_mutex_destroy(&H->mutex);
 #endif
 
-    status = ideal_base_clear(Q, R, H);
+        if (H->overflowed)
+        {
+            /*
+                An internal exponent computation overflowed the bit width
+                chosen for this attempt (see the long comment on
+                _gr_mpoly_mulsub_stripe1 in threaded_divmod.h): discard
+                everything from this attempt (nothing was transferred to any
+                Q[w] or R) and redo the whole computation at a wider bit
+                width, exactly like the retry loop in
+                gr_mpoly_divrem_heap_threaded / _gr_mpoly_divrem_mp.
+            */
+            GR_IGNORE(ideal_base_clear(Q, R, H));
 
-    flint_free(H->polyQ);
-    _gr_vec_clear(H->lc_inv, len, cctx);
-    flint_free(H->lc_inv);
-    flint_free(H->lc_is_one);
-    flint_free(H->lc_is_unit);
+            flint_free(H->polyQ);
+
+            fmpz_mpoly_clear(S, zctx);
+            fmpz_mpoly_ctx_clear(zctx);
+            flint_free(polyB_storage);
+            flint_free(polyB_ptrs);
+
+            {
+                slong old_exp_bits = exp_bits;
+                ulong * old_Aexp = Aexp;
+
+                exp_bits = mpoly_fix_bits(exp_bits + 1, mctx);
+                N = mpoly_words_per_exp(exp_bits, mctx);
+                cmpmask = (ulong *) flint_realloc(cmpmask, N*sizeof(ulong));
+                mpoly_get_cmpmask(cmpmask, N, exp_bits, mctx);
+
+                Aexp = (ulong *) flint_malloc(N*A->length*sizeof(ulong));
+                mpoly_repack_monomials(Aexp, exp_bits, old_Aexp, old_exp_bits, A->length, mctx);
+                if (freeAexp)
+                    flint_free(old_Aexp);
+                freeAexp = 1;
+
+                for (w = 0; w < len; w++)
+                {
+                    ulong * old_Bexp_w = Bexp[w];
+                    Bexp[w] = (ulong *) flint_malloc(N*B[w]->length*sizeof(ulong));
+                    mpoly_repack_monomials(Bexp[w], exp_bits, old_Bexp_w, old_exp_bits, B[w]->length, mctx);
+                    if (freeBexp[w])
+                        flint_free(old_Bexp_w);
+                    freeBexp[w] = 1;
+                }
+            }
+
+            continue;
+        }
+
+        status = ideal_base_clear(Q, R, H);
+
+        flint_free(H->polyQ);
+
+        fmpz_mpoly_clear(S, zctx);
+        fmpz_mpoly_ctx_clear(zctx);
+        flint_free(polyB_storage);
+        flint_free(polyB_ptrs);
+
+        break;
+    }
 
 cleanup1:
 
-    fmpz_mpoly_clear(S, zctx);
-    fmpz_mpoly_ctx_clear(zctx);
-
-    flint_free(polyB_storage);
-    flint_free(polyB_ptrs);
+    _gr_vec_clear(lc_inv, len, cctx);
+    flint_free(lc_inv);
+    flint_free(lc_is_one);
+    flint_free(lc_is_unit);
 
     if (freeAexp)
         flint_free(Aexp);
     for (w = 0; w < len; w++)
         if (freeBexp[w])
             flint_free(Bexp[w]);
+    flint_free(Bexp);
+    flint_free(freeBexp);
 
-    TMP_END;
+    flint_free(cmpmask);
 
     return status;
 }

--- a/src/gr_mpoly/divrem_ideal_heap_threaded.c
+++ b/src/gr_mpoly/divrem_ideal_heap_threaded.c
@@ -1,0 +1,1698 @@
+/*
+    Copyright (C) 2018 Daniel Schultz
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdint.h>
+#include <string.h>
+#include "thread_pool.h"
+#include "thread_support.h"
+#include "fmpz_mpoly.h"
+#include "mpoly.h"
+#include "gr_generic.h"
+#include "gr_mpoly.h"
+#include "threaded_divmod.h"
+
+/*
+    Multithreaded gr_mpoly_divrem_ideal / gr_mpoly_divrem_ideal_weak: divide A
+    by a list of divisors B[0..len-1], producing quotients Q[0..len-1] and a
+    remainder R with A = sum_w Q[w]*B[w] + R, where a leading term is reduced
+    by the first divisor whose leading monomial divides it (and, field-like,
+    whose leading coefficient divides the term coefficient exactly); a term
+    that no divisor can reduce is moved to R. See gr_mpoly/divrem_ideal.c for
+    the serial algorithm and semantics (in particular: unlike plain divrem,
+    an inexact field-like coefficient division is not a hard GR_DOMAIN error
+    here -- it just means *that* divisor cannot reduce the term, so the term
+    falls through to the next candidate divisor and ultimately to R if none
+    work; this routine therefore never returns GR_DOMAIN).
+
+    This shares the chunked producer/consumer pipeline infrastructure
+    (gr_mpoly_ts, _gr_mpoly_mulsub_stripe1/stripe, stripe_fit_length,
+    chunk_find_exp) from threaded_divmod.h / divides_heap_threaded.c, but
+    uses its own chunk/base/worker-arg types (defined locally, not shared):
+    a chunk's running partial remainder must be reduced against *every*
+    divisor's newly available quotient increment (so chunk_mulsub below
+    simply calls the existing, unmodified _gr_mpoly_mulsub_stripe1/stripe
+    once per divisor, chaining the output of one call into the next), and a
+    chunk's finalisation step must run a genuinely new bounded multi-chain
+    heap (_gr_mpoly_divrem_ideal_stripe1/stripe below, a direct descendant
+    of _gr_mpoly_divrem_ideal_mp1/mp in divrem_ideal.c with the same
+    "restrict to exponents >= emin" transformation already used to derive
+    the single-divisor stripe leaves from their heap1/heap counterparts).
+*/
+
+/* gather one heap node tagged with which divisor (p) it belongs to; the
+   single dividend node (if any, always p == -1) becomes the dot initial
+   value. Mirrors IDEAL_FETCH_NODE in divrem_ideal.c. */
+#define IDEAL_STRIPE_FETCH_NODE(SET_SHALLOW) \
+    do { \
+        store[store_len++] = x->i; \
+        store[store_len++] = x->j; \
+        store[store_len++] = x->p; \
+        if (x->i == -UWORD(1)) \
+        { \
+            have_dividend = 1; \
+            dividend_j = x->j; \
+        } \
+        else \
+        { \
+            hinds[x->p][x->i] |= WORD(1); \
+            SET_SHALLOW(dot_a, dot_len, poly3[x->p]->coeffs, x->i); \
+            SET_SHALLOW(dot_b, dot_len, Qcoeff[x->p], x->j); \
+            dot_len++; \
+        } \
+    } while (0)
+
+/* field-like exact quotient coefficient = val / lc(B[w]) */
+#define IDEAL_STRIPE_QCOEFF(dst, w, val) \
+    (lc_is_one[w]  ? gr_set(dst, val, cctx) \
+     : lc_is_unit[w] ? gr_mul(dst, val, GR_ENTRY(lc_inv, w, sz), cctx) \
+                     : gr_div(dst, val, GR_ENTRY(poly3[w]->coeffs, 0, sz), cctx))
+
+
+/*
+    A chunk holds an exponent range on the dividend, exactly like
+    divides_heap_chunk_struct, except that the persistent per-B-term
+    "startidx"/"endidx" state used by chunk_mulsub (see the comment there)
+    now needs one entry per divisor, since a chunk is reduced against
+    *every* divisor's growing quotient.
+*/
+typedef struct _ideal_chunk_struct
+{
+    gr_mpoly_t polyC;
+    struct _ideal_chunk_struct * next;
+    ulong * emin;
+    ulong * emax;
+    slong * startidx;  /* array of length H->len */
+    slong * endidx;    /* array of length H->len */
+    slong * mq;        /* array of length H->len: consumed-so-far per divisor */
+    int upperclosed;
+    volatile int lock;
+    volatile int producer;
+    volatile int done;
+    int Cinited;
+} ideal_chunk_struct;
+
+typedef ideal_chunk_struct ideal_chunk_t[1];
+
+/*
+    The base struct: a linked list of chunks, one thread-safe growable
+    quotient array per divisor, one thread-safe growable remainder array,
+    and the divisor data (shallow, repacked to a common bit width) and
+    precomputed per-divisor leading-coefficient data.
+*/
+typedef struct
+{
+#if FLINT_USES_PTHREAD
+    pthread_mutex_t mutex;
+#endif
+    ideal_chunk_struct * head;
+    ideal_chunk_struct * tail;
+    ideal_chunk_struct * volatile cur;
+    gr_mpoly_t polyA;
+    gr_mpoly_struct * const * polyB; /* array of length `len`, shallow */
+    gr_mpoly_ts_struct * polyQ;      /* array of length `len` */
+    gr_mpoly_ts_t polyR;
+    gr_mpoly_ctx_struct * ctx;
+    gr_ctx_struct * cctx;
+    slong len;                        /* number of divisors */
+    slong length;                     /* number of chunks (unrelated to len) */
+    slong N;
+    flint_bitcnt_t bits;
+    ulong * cmpmask;
+    int * lc_is_one;    /* array of length `len` */
+    int * lc_is_unit;   /* array of length `len` */
+    gr_ptr lc_inv;      /* vector of length `len` */
+    int nonfield;
+    volatile int failed;
+    volatile int have_unable;
+} ideal_base_struct;
+
+typedef ideal_base_struct ideal_base_t[1];
+
+/*
+    The worker struct has the (shared, unmodified) stripe scratch memory
+    used for chunk_mulsub, plus one scratch poly per divisor (for a newly
+    finalised quotient increment) and one for a newly finalised remainder
+    increment.
+*/
+typedef struct
+{
+    ideal_base_struct * H;
+    _gr_mpoly_stripe_t S;
+    gr_mpoly_t polyT1;   /* chunk_mulsub scratch, reused per divisor */
+    gr_mpoly_struct * polyT2; /* array of length H->len */
+    gr_mpoly_t polyT3;   /* remainder increment scratch */
+} ideal_worker_arg_struct;
+
+typedef ideal_worker_arg_struct ideal_worker_arg_t[1];
+
+
+static void ideal_base_init(ideal_base_t H)
+{
+    H->head = NULL;
+    H->tail = NULL;
+    H->cur = NULL;
+    H->ctx = NULL;
+    H->length = 0;
+    H->N = 0;
+    H->bits = 0;
+    H->cmpmask = NULL;
+}
+
+static void ideal_chunk_clear(ideal_chunk_t L, ideal_base_t H)
+{
+    if (L->Cinited)
+        gr_mpoly_clear(L->polyC, H->ctx);
+}
+
+/* Finalise H into (Q[0..len-1], R). Always clears/frees H's chunk list and
+   thread-safe arrays. */
+static int ideal_base_clear(gr_mpoly_struct * const * Q, gr_mpoly_t R, ideal_base_t H)
+{
+    ideal_chunk_struct * L = H->head;
+    slong w;
+    int status;
+
+    while (L != NULL)
+    {
+        ideal_chunk_struct * nextL = L->next;
+        ideal_chunk_clear(L, H);
+        flint_free(L->startidx);
+        flint_free(L);
+        L = nextL;
+    }
+    H->head = NULL;
+    H->tail = NULL;
+    H->cur = NULL;
+    H->length = 0;
+
+    status = H->have_unable ? GR_UNABLE : GR_SUCCESS;
+
+    if (status != GR_SUCCESS)
+    {
+        for (w = 0; w < H->len; w++)
+        {
+            GR_IGNORE(gr_mpoly_zero(Q[w], H->ctx));
+            gr_mpoly_ts_clear(H->polyQ + w, H->cctx);
+        }
+        GR_IGNORE(gr_mpoly_zero(R, H->ctx));
+        gr_mpoly_ts_clear(H->polyR, H->cctx);
+    }
+    else
+    {
+        for (w = 0; w < H->len; w++)
+            gr_mpoly_ts_clear_poly(Q[w], H->polyQ + w, H->cctx);
+        gr_mpoly_ts_clear_poly(R, H->polyR, H->cctx);
+    }
+
+    return status;
+}
+
+static void ideal_base_add_chunk(ideal_base_t H, ideal_chunk_t L)
+{
+    L->next = NULL;
+
+    if (H->tail == NULL)
+    {
+        FLINT_ASSERT(H->head == NULL);
+        H->tail = L;
+        H->head = L;
+    }
+    else
+    {
+        ideal_chunk_struct * tail = H->tail;
+        FLINT_ASSERT(tail->next == NULL);
+        tail->next = L;
+        H->tail = L;
+    }
+    H->length++;
+}
+
+
+/* Bundles the (coeffs, exps, alloc, exps_alloc, length) quintuple for one
+   growable output array (a quotient increment for one divisor, or the
+   remainder increment), avoiding a long parallel-array parameter list. */
+typedef struct
+{
+    gr_ptr coeffs;
+    ulong * exps;
+    slong alloc;
+    slong exps_alloc;
+    slong len;
+} ideal_stripe_out_struct;
+
+typedef ideal_stripe_out_struct ideal_stripe_out_t[1];
+
+
+/*
+    Bounded ("stripe") multi-divisor division-with-remainder, single-word
+    exponent version: a direct descendant of _gr_mpoly_divrem_ideal_mp1
+    (divrem_ideal.c), restricted to exponents >= emin in exactly the way
+    the single-divisor stripe leaves restrict _gr_mpoly_divrem_heap1, and
+    producing fresh local output increments (Qout[0..len-1], Wout) instead
+    of writing into shared/growing state.
+
+    Never a hard failure due to "no divisor reduces this term" (that is
+    precisely what routes it to Wout instead); *res_status only ever
+    reports GR_SUCCESS or GR_UNABLE (this routine, like
+    _gr_mpoly_divrem_ideal_mp1, never returns GR_DOMAIN -- an inexact
+    field-like coefficient division for one candidate divisor just means
+    that divisor cannot reduce the term, not that the whole computation is
+    impossible).
+*/
+static void _gr_mpoly_divrem_ideal_stripe1(
+    ideal_stripe_out_t * Qout, ideal_stripe_out_t Wout,
+    gr_srcptr Acoeff, const ulong * Aexp, slong Alen,
+    gr_mpoly_struct * const * poly3, slong len,
+    ulong emin, ulong cmpmask, flint_bitcnt_t bits,
+    int nonfield, int * lc_is_one, int * lc_is_unit, gr_srcptr lc_inv,
+    gr_mpoly_ctx_t ctx, int * res_status)
+{
+    gr_ctx_struct * cctx = GR_MPOLY_CCTX(ctx);
+    slong sz = cctx->sizeof_elem;
+    int have_fast_dot = (GR_VEC_DOT_OP(cctx, VEC_DOT) != (gr_method_vec_dot_op) gr_generic_vec_dot);
+    slong i, j, p, w, len3 = 0;
+    slong next_loc, heap_len = 2;
+    mpoly_heap1_s * heap;
+    mpoly_nheap_t ** chains, * chains_ptr;
+    slong ** hinds, * hinds_ptr;
+    mpoly_nheap_t * x;
+    ulong texp;
+    ulong mask;
+    slong * store, * store_base, store_len;
+    slong * k, * s;
+    gr_ptr acc, pp, rem, dot_a, dot_b;
+    slong dot_len;
+    int have_dividend, cstatus;
+    slong dividend_j = 0;
+    gr_ptr * Qcoeff;
+    gr_ptr r_coeff;
+    ulong * r_exp;
+    slong r_len;
+    int status = GR_SUCCESS;
+    TMP_INIT;
+
+    TMP_START;
+
+    GR_TMP_INIT3(acc, pp, rem, cctx);
+
+    Qcoeff = (gr_ptr *) TMP_ALLOC(len*sizeof(gr_ptr));
+    for (w = 0; w < len; w++)
+        Qcoeff[w] = Qout[w]->coeffs;
+    r_coeff = Wout->coeffs;
+    r_exp = Wout->exps;
+    r_len = 0;
+
+    chains = (mpoly_nheap_t **) TMP_ALLOC(len*sizeof(mpoly_nheap_t *));
+    hinds = (slong **) TMP_ALLOC(len*sizeof(slong *));
+    for (w = 0; w < len; w++)
+        len3 += poly3[w]->length;
+    chains_ptr = (mpoly_nheap_t *) TMP_ALLOC(len3*sizeof(mpoly_nheap_t));
+    hinds_ptr = (slong *) TMP_ALLOC(len3*sizeof(slong));
+
+    len3 = 0;
+    for (w = 0; w < len; w++)
+    {
+        chains[w] = chains_ptr + len3;
+        hinds[w] = hinds_ptr + len3;
+        len3 += poly3[w]->length;
+        for (i = 0; i < poly3[w]->length; i++)
+            hinds[w][i] = 1;
+    }
+
+    next_loc = len3 + 4;
+    heap = (mpoly_heap1_s *) TMP_ALLOC((len3 + 1)*sizeof(mpoly_heap1_s));
+    store = store_base = (slong *) TMP_ALLOC(3*len3*sizeof(slong));
+
+    dot_a = flint_malloc(2 * len3 * sz);
+    dot_b = GR_ENTRY(dot_a, len3, sz);
+
+    k = (slong *) TMP_ALLOC(len*sizeof(slong));
+    s = (slong *) TMP_ALLOC(len*sizeof(slong));
+    for (w = 0; w < len; w++)
+    {
+        k[w] = -WORD(1);
+        s[w] = poly3[w]->length;
+    }
+
+    mask = mpoly_overflow_mask_sp(bits);
+
+    x = chains[0] + 0;
+    x->i = -UWORD(1);
+    x->j = 0;
+    x->p = -WORD(1);
+    x->next = NULL;
+    HEAP_ASSIGN(heap[1], Aexp[0], x);
+
+    FLINT_ASSERT(mpoly_monomial_cmp1(Aexp[0], emin, cmpmask) >= 0);
+
+    while (heap_len > 1)
+    {
+        ulong exp = heap[1].exp;
+
+        if (mpoly_monomial_overflows1(exp, mask))
+        {
+            status |= GR_UNABLE;
+            goto unable;
+        }
+
+        FLINT_ASSERT(mpoly_monomial_cmp1(exp, emin, cmpmask) >= 0);
+
+        store_len = 0;
+        dot_len = 0;
+        have_dividend = 0;
+
+        if (have_fast_dot)
+        {
+            do
+            {
+                x = _mpoly_heap_pop1(heap, &heap_len, cmpmask);
+                do
+                {
+                    if (sz == 1)       { IDEAL_STRIPE_FETCH_NODE(SET_SHALLOW1); }
+                    else if (sz == 2)  { IDEAL_STRIPE_FETCH_NODE(SET_SHALLOW2); }
+                    else if (sz == 4)  { IDEAL_STRIPE_FETCH_NODE(SET_SHALLOW4); }
+                    else if (sz == 8)  { IDEAL_STRIPE_FETCH_NODE(SET_SHALLOW8); }
+                    else if (sz == 16) { IDEAL_STRIPE_FETCH_NODE(SET_SHALLOW16); }
+                    else               { IDEAL_STRIPE_FETCH_NODE(SET_SHALLOW_GENERIC); }
+                } while ((x = x->next) != NULL);
+            } while (heap_len > 1 && heap[1].exp == exp);
+
+            status |= _gr_vec_dot(acc,
+                        have_dividend ? GR_ENTRY(Acoeff, dividend_j, sz) : NULL,
+                        1, dot_a, dot_b, dot_len, cctx);
+        }
+        else
+        {
+            status |= gr_zero(acc, cctx);
+            do
+            {
+                x = _mpoly_heap_pop1(heap, &heap_len, cmpmask);
+                do
+                {
+                    store[store_len++] = x->i;
+                    store[store_len++] = x->j;
+                    store[store_len++] = x->p;
+                    if (x->i == -UWORD(1))
+                        status |= gr_add(acc, acc, GR_ENTRY(Acoeff, x->j, sz), cctx);
+                    else
+                    {
+                        hinds[x->p][x->i] |= WORD(1);
+                        status |= gr_mul(pp, GR_ENTRY(poly3[x->p]->coeffs, x->i, sz),
+                                             GR_ENTRY(Qcoeff[x->p], x->j, sz), cctx);
+                        status |= gr_sub(acc, acc, pp, cctx);
+                    }
+                } while ((x = x->next) != NULL);
+            } while (heap_len > 1 && heap[1].exp == exp);
+        }
+
+        /* process popped nodes */
+        while (store_len > 0)
+        {
+            p = store_base[--store_len];
+            j = store_base[--store_len];
+            i = store_base[--store_len];
+
+            if (i == -WORD(1))
+            {
+                if (j + 1 < Alen)
+                {
+                    x = chains[0] + 0;
+                    x->i = -UWORD(1);
+                    x->j = j + 1;
+                    x->p = p;
+                    x->next = NULL;
+
+                    FLINT_ASSERT(mpoly_monomial_cmp1(Aexp[x->j], emin, cmpmask) >= 0);
+
+                    _mpoly_heap_insert1(heap, Aexp[x->j], x,
+                                                &next_loc, &heap_len, cmpmask);
+                }
+            }
+            else
+            {
+                if ((i + 1 < poly3[p]->length) && (hinds[p][i + 1] == 2*j + 1))
+                {
+                    x = chains[p] + i + 1;
+                    x->i = i + 1;
+                    x->j = j;
+                    x->p = p;
+                    x->next = NULL;
+                    hinds[p][x->i] = 2*(x->j + 1) + 0;
+
+                    texp = poly3[p]->exps[x->i] + Qout[p]->exps[x->j];
+                    if (mpoly_monomial_cmp1(texp, emin, cmpmask) >= 0)
+                        _mpoly_heap_insert1(heap, texp, x, &next_loc, &heap_len, cmpmask);
+                    else
+                        hinds[p][x->i] |= 1;
+                }
+                if (j == k[p])
+                {
+                    s[p]++;
+                }
+                else if (((hinds[p][i] & 1) == 1) &&
+                         ((i == 1) || (hinds[p][i - 1] >= 2*(j + 2) + 1)))
+                {
+                    x = chains[p] + i;
+                    x->i = i;
+                    x->j = j + 1;
+                    x->p = p;
+                    x->next = NULL;
+                    hinds[p][x->i] = 2*(x->j + 1) + 0;
+
+                    texp = poly3[p]->exps[x->i] + Qout[p]->exps[x->j];
+                    if (mpoly_monomial_cmp1(texp, emin, cmpmask) >= 0)
+                        _mpoly_heap_insert1(heap, texp, x, &next_loc, &heap_len, cmpmask);
+                    else
+                        hinds[p][x->i] |= 1;
+                }
+            }
+        }
+
+        switch (gr_is_zero(acc, cctx))
+        {
+            case T_TRUE:
+                continue;
+            case T_FALSE:
+                break;
+            default:
+                status |= GR_UNABLE;
+                goto unable;
+        }
+
+        /* try to reduce the term acc*x^exp by the divisors in order */
+        {
+            int div_flag = 0;
+
+            for (w = 0; w < len; w++)
+            {
+                int d1, d2;
+
+                d1 = mpoly_monomial_divides1(&texp, exp, poly3[w]->exps[0], mask);
+
+                if (!d1)
+                    continue;
+
+                _gr_mpoly_fit_length(&Qcoeff[w], &Qout[w]->alloc,
+                                     &Qout[w]->exps, &Qout[w]->exps_alloc, 1, k[w] + 2, ctx);
+
+                if (nonfield)
+                {
+                    cstatus = gr_euclidean_divrem(GR_ENTRY(Qcoeff[w], k[w] + 1, sz),
+                                     rem, acc, GR_ENTRY(poly3[w]->coeffs, 0, sz), cctx);
+                    if (cstatus != GR_SUCCESS) { status |= cstatus; goto unable; }
+                    gr_swap(acc, rem, cctx);
+                    d2 = (gr_is_zero(GR_ENTRY(Qcoeff[w], k[w] + 1, sz), cctx) != T_TRUE);
+                }
+                else
+                {
+                    cstatus = IDEAL_STRIPE_QCOEFF(GR_ENTRY(Qcoeff[w], k[w] + 1, sz), w, acc);
+                    if (cstatus == GR_DOMAIN)
+                        continue;
+                    if (cstatus != GR_SUCCESS) { status |= cstatus; goto unable; }
+                    d2 = (gr_is_zero(GR_ENTRY(Qcoeff[w], k[w] + 1, sz), cctx) != T_TRUE);
+                }
+
+                if (d2)
+                {
+                    k[w]++;
+                    Qout[w]->exps[k[w]] = texp;
+
+                    if (s[w] > 1)
+                    {
+                        x = chains[w] + 1;
+                        x->i = 1;
+                        x->j = k[w];
+                        x->p = w;
+                        x->next = NULL;
+                        hinds[w][x->i] = 2*(x->j + 1) + 0;
+
+                        texp = poly3[w]->exps[1] + Qout[w]->exps[k[w]];
+                        if (mpoly_monomial_cmp1(texp, emin, cmpmask) >= 0)
+                            _mpoly_heap_insert1(heap, texp, x, &next_loc, &heap_len, cmpmask);
+                        else
+                            hinds[w][x->i] |= 1;
+                    }
+                    s[w] = 1;
+                }
+
+                if (nonfield)
+                {
+                    if (gr_is_zero(acc, cctx) == T_TRUE)
+                    {
+                        div_flag = 1;
+                        break;
+                    }
+                }
+                else
+                {
+                    div_flag = 1;
+                    break;
+                }
+            }
+
+            if (!div_flag)
+            {
+                _gr_mpoly_fit_length(&r_coeff, &Wout->alloc, &r_exp, &Wout->exps_alloc, 1, r_len + 1, ctx);
+                status |= gr_set(GR_ENTRY(r_coeff, r_len, sz), acc, cctx);
+                r_exp[r_len] = exp;
+                r_len++;
+            }
+        }
+    }
+
+    *res_status = status;
+    goto cleanup;
+
+unable:
+    for (w = 0; w < len; w++)
+        k[w] = -1;
+    r_len = 0;
+    *res_status = status;
+
+cleanup:
+
+    GR_TMP_CLEAR3(acc, pp, rem, cctx);
+    flint_free(dot_a);
+
+    for (w = 0; w < len; w++)
+    {
+        Qout[w]->coeffs = Qcoeff[w];
+        Qout[w]->len = k[w] + 1;
+    }
+    Wout->coeffs = r_coeff;
+    Wout->exps = r_exp;
+    Wout->len = r_len;
+
+    TMP_END;
+}
+
+
+/* Multi-word exponent version of the above. */
+static void _gr_mpoly_divrem_ideal_stripe(
+    ideal_stripe_out_t * Qout, ideal_stripe_out_t Wout,
+    gr_srcptr Acoeff, const ulong * Aexp, slong Alen,
+    gr_mpoly_struct * const * poly3, slong len,
+    const ulong * emin, const ulong * cmpmask, slong N, flint_bitcnt_t bits,
+    int nonfield, int * lc_is_one, int * lc_is_unit, gr_srcptr lc_inv,
+    gr_mpoly_ctx_t ctx, int * res_status)
+{
+    gr_ctx_struct * cctx = GR_MPOLY_CCTX(ctx);
+    slong sz = cctx->sizeof_elem;
+    int have_fast_dot = (GR_VEC_DOT_OP(cctx, VEC_DOT) != (gr_method_vec_dot_op) gr_generic_vec_dot);
+    slong i, j, p, w, len3 = 0;
+    slong next_loc, heap_len = 2;
+    mpoly_heap_s * heap;
+    mpoly_nheap_t ** chains, * chains_ptr;
+    slong ** hinds, * hinds_ptr;
+    mpoly_nheap_t * x;
+    ulong * exp, * exps, * texp;
+    ulong ** exp_list;
+    slong exp_next;
+    ulong mask;
+    slong * store, * store_base, store_len;
+    slong * k, * s;
+    gr_ptr acc, pp, rem, dot_a, dot_b;
+    slong dot_len;
+    int have_dividend, cstatus;
+    slong dividend_j = 0;
+    gr_ptr * Qcoeff;
+    gr_ptr r_coeff;
+    ulong * r_exp;
+    slong r_len;
+    int status = GR_SUCCESS;
+    TMP_INIT;
+
+    TMP_START;
+
+    GR_TMP_INIT3(acc, pp, rem, cctx);
+
+    Qcoeff = (gr_ptr *) TMP_ALLOC(len*sizeof(gr_ptr));
+    for (w = 0; w < len; w++)
+        Qcoeff[w] = Qout[w]->coeffs;
+    r_coeff = Wout->coeffs;
+    r_exp = Wout->exps;
+    r_len = 0;
+
+    chains = (mpoly_nheap_t **) TMP_ALLOC(len*sizeof(mpoly_nheap_t *));
+    hinds = (slong **) TMP_ALLOC(len*sizeof(slong *));
+    for (w = 0; w < len; w++)
+        len3 += poly3[w]->length;
+    chains_ptr = (mpoly_nheap_t *) TMP_ALLOC(len3*sizeof(mpoly_nheap_t));
+    hinds_ptr = (slong *) TMP_ALLOC(len3*sizeof(slong));
+
+    len3 = 0;
+    for (w = 0; w < len; w++)
+    {
+        chains[w] = chains_ptr + len3;
+        hinds[w] = hinds_ptr + len3;
+        len3 += poly3[w]->length;
+        for (i = 0; i < poly3[w]->length; i++)
+            hinds[w][i] = 1;
+    }
+
+    next_loc = len3 + 4;
+    heap = (mpoly_heap_s *) TMP_ALLOC((len3 + 1)*sizeof(mpoly_heap_s));
+    store = store_base = (slong *) TMP_ALLOC(3*len3*sizeof(slong));
+
+    dot_a = flint_malloc(2 * len3 * sz);
+    dot_b = GR_ENTRY(dot_a, len3, sz);
+
+    exps = (ulong *) TMP_ALLOC(len3*N*sizeof(ulong));
+    exp_list = (ulong **) TMP_ALLOC(len3*sizeof(ulong *));
+    exp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
+    texp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
+    exp_next = 0;
+    for (i = 0; i < len3; i++)
+        exp_list[i] = exps + i*N;
+
+    k = (slong *) TMP_ALLOC(len*sizeof(slong));
+    s = (slong *) TMP_ALLOC(len*sizeof(slong));
+    for (w = 0; w < len; w++)
+    {
+        k[w] = -WORD(1);
+        s[w] = poly3[w]->length;
+    }
+
+    mask = bits <= FLINT_BITS ? mpoly_overflow_mask_sp(bits) : 0;
+
+    x = chains[0] + 0;
+    x->i = -UWORD(1);
+    x->j = 0;
+    x->p = -WORD(1);
+    x->next = NULL;
+    heap[1].next = x;
+    heap[1].exp = exp_list[exp_next++];
+    mpoly_monomial_set(heap[1].exp, Aexp, N);
+
+    FLINT_ASSERT(mpoly_monomial_cmp(Aexp, emin, N, cmpmask) >= 0);
+
+    while (heap_len > 1)
+    {
+        mpoly_monomial_set(exp, heap[1].exp, N);
+
+        if (bits <= FLINT_BITS)
+        {
+            if (mpoly_monomial_overflows(exp, N, mask))
+            {
+                status |= GR_UNABLE;
+                goto unable;
+            }
+        }
+        else
+        {
+            if (mpoly_monomial_overflows_mp(exp, N, bits))
+            {
+                status |= GR_UNABLE;
+                goto unable;
+            }
+        }
+
+        FLINT_ASSERT(mpoly_monomial_cmp(exp, emin, N, cmpmask) >= 0);
+
+        store_len = 0;
+        dot_len = 0;
+        have_dividend = 0;
+
+        if (have_fast_dot)
+        {
+            do
+            {
+                exp_list[--exp_next] = heap[1].exp;
+                x = _mpoly_heap_pop(heap, &heap_len, N, cmpmask);
+                do
+                {
+                    if (sz == 1)       { IDEAL_STRIPE_FETCH_NODE(SET_SHALLOW1); }
+                    else if (sz == 2)  { IDEAL_STRIPE_FETCH_NODE(SET_SHALLOW2); }
+                    else if (sz == 4)  { IDEAL_STRIPE_FETCH_NODE(SET_SHALLOW4); }
+                    else if (sz == 8)  { IDEAL_STRIPE_FETCH_NODE(SET_SHALLOW8); }
+                    else if (sz == 16) { IDEAL_STRIPE_FETCH_NODE(SET_SHALLOW16); }
+                    else               { IDEAL_STRIPE_FETCH_NODE(SET_SHALLOW_GENERIC); }
+                } while ((x = x->next) != NULL);
+            } while (heap_len > 1 && mpoly_monomial_equal(heap[1].exp, exp, N));
+
+            status |= _gr_vec_dot(acc,
+                        have_dividend ? GR_ENTRY(Acoeff, dividend_j, sz) : NULL,
+                        1, dot_a, dot_b, dot_len, cctx);
+        }
+        else
+        {
+            status |= gr_zero(acc, cctx);
+            do
+            {
+                exp_list[--exp_next] = heap[1].exp;
+                x = _mpoly_heap_pop(heap, &heap_len, N, cmpmask);
+                do
+                {
+                    store[store_len++] = x->i;
+                    store[store_len++] = x->j;
+                    store[store_len++] = x->p;
+                    if (x->i == -UWORD(1))
+                        status |= gr_add(acc, acc, GR_ENTRY(Acoeff, x->j, sz), cctx);
+                    else
+                    {
+                        hinds[x->p][x->i] |= WORD(1);
+                        status |= gr_mul(pp, GR_ENTRY(poly3[x->p]->coeffs, x->i, sz),
+                                             GR_ENTRY(Qcoeff[x->p], x->j, sz), cctx);
+                        status |= gr_sub(acc, acc, pp, cctx);
+                    }
+                } while ((x = x->next) != NULL);
+            } while (heap_len > 1 && mpoly_monomial_equal(heap[1].exp, exp, N));
+        }
+
+        /* process popped nodes */
+        while (store_len > 0)
+        {
+            p = store_base[--store_len];
+            j = store_base[--store_len];
+            i = store_base[--store_len];
+
+            if (i == -WORD(1))
+            {
+                if (j + 1 < Alen)
+                {
+                    x = chains[0] + 0;
+                    x->i = -UWORD(1);
+                    x->j = j + 1;
+                    x->p = p;
+                    x->next = NULL;
+                    mpoly_monomial_set(exp_list[exp_next], Aexp + x->j*N, N);
+
+                    FLINT_ASSERT(mpoly_monomial_cmp(exp_list[exp_next], emin, N, cmpmask) >= 0);
+
+                    exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
+                                             &next_loc, &heap_len, N, cmpmask);
+                }
+            }
+            else
+            {
+                if ((i + 1 < poly3[p]->length) && (hinds[p][i + 1] == 2*j + 1))
+                {
+                    x = chains[p] + i + 1;
+                    x->i = i + 1;
+                    x->j = j;
+                    x->p = p;
+                    x->next = NULL;
+                    hinds[p][x->i] = 2*(x->j + 1) + 0;
+
+                    mpoly_monomial_add_mp(exp_list[exp_next], poly3[p]->exps + x->i*N,
+                                                        Qout[p]->exps + x->j*N, N);
+
+                    if (mpoly_monomial_cmp(exp_list[exp_next], emin, N, cmpmask) >= 0)
+                        exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
+                                                 &next_loc, &heap_len, N, cmpmask);
+                    else
+                        hinds[p][x->i] |= 1;
+                }
+                if (j == k[p])
+                {
+                    s[p]++;
+                }
+                else if (((hinds[p][i] & 1) == 1) &&
+                         ((i == 1) || (hinds[p][i - 1] >= 2*(j + 2) + 1)))
+                {
+                    x = chains[p] + i;
+                    x->i = i;
+                    x->j = j + 1;
+                    x->p = p;
+                    x->next = NULL;
+                    hinds[p][x->i] = 2*(x->j + 1) + 0;
+
+                    mpoly_monomial_add_mp(exp_list[exp_next], poly3[p]->exps + x->i*N,
+                                                        Qout[p]->exps + x->j*N, N);
+
+                    if (mpoly_monomial_cmp(exp_list[exp_next], emin, N, cmpmask) >= 0)
+                        exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
+                                                 &next_loc, &heap_len, N, cmpmask);
+                    else
+                        hinds[p][x->i] |= 1;
+                }
+            }
+        }
+
+        switch (gr_is_zero(acc, cctx))
+        {
+            case T_TRUE:
+                continue;
+            case T_FALSE:
+                break;
+            default:
+                status |= GR_UNABLE;
+                goto unable;
+        }
+
+        /* try to reduce the term acc*x^exp by the divisors in order */
+        {
+            int div_flag = 0;
+
+            for (w = 0; w < len; w++)
+            {
+                int d1, d2;
+
+                if (bits <= FLINT_BITS)
+                    d1 = mpoly_monomial_divides(texp, exp, poly3[w]->exps, N, mask);
+                else
+                    d1 = mpoly_monomial_divides_mp(texp, exp, poly3[w]->exps, N, bits);
+
+                if (!d1)
+                    continue;
+
+                _gr_mpoly_fit_length(&Qcoeff[w], &Qout[w]->alloc,
+                                     &Qout[w]->exps, &Qout[w]->exps_alloc, N, k[w] + 2, ctx);
+
+                if (nonfield)
+                {
+                    cstatus = gr_euclidean_divrem(GR_ENTRY(Qcoeff[w], k[w] + 1, sz),
+                                     rem, acc, GR_ENTRY(poly3[w]->coeffs, 0, sz), cctx);
+                    if (cstatus != GR_SUCCESS) { status |= cstatus; goto unable; }
+                    gr_swap(acc, rem, cctx);
+                    d2 = (gr_is_zero(GR_ENTRY(Qcoeff[w], k[w] + 1, sz), cctx) != T_TRUE);
+                }
+                else
+                {
+                    cstatus = IDEAL_STRIPE_QCOEFF(GR_ENTRY(Qcoeff[w], k[w] + 1, sz), w, acc);
+                    if (cstatus == GR_DOMAIN)
+                        continue;
+                    if (cstatus != GR_SUCCESS) { status |= cstatus; goto unable; }
+                    d2 = (gr_is_zero(GR_ENTRY(Qcoeff[w], k[w] + 1, sz), cctx) != T_TRUE);
+                }
+
+                if (d2)
+                {
+                    k[w]++;
+                    mpoly_monomial_set(Qout[w]->exps + k[w]*N, texp, N);
+
+                    if (s[w] > 1)
+                    {
+                        x = chains[w] + 1;
+                        x->i = 1;
+                        x->j = k[w];
+                        x->p = w;
+                        x->next = NULL;
+                        hinds[w][x->i] = 2*(x->j + 1) + 0;
+
+                        mpoly_monomial_add_mp(exp_list[exp_next], poly3[w]->exps + N,
+                                                            Qout[w]->exps + k[w]*N, N);
+
+                        if (mpoly_monomial_cmp(exp_list[exp_next], emin, N, cmpmask) >= 0)
+                            exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
+                                                     &next_loc, &heap_len, N, cmpmask);
+                        else
+                            hinds[w][x->i] |= 1;
+                    }
+                    s[w] = 1;
+                }
+
+                if (nonfield)
+                {
+                    if (gr_is_zero(acc, cctx) == T_TRUE)
+                    {
+                        div_flag = 1;
+                        break;
+                    }
+                }
+                else
+                {
+                    div_flag = 1;
+                    break;
+                }
+            }
+
+            if (!div_flag)
+            {
+                _gr_mpoly_fit_length(&r_coeff, &Wout->alloc, &r_exp, &Wout->exps_alloc, N, r_len + 1, ctx);
+                status |= gr_set(GR_ENTRY(r_coeff, r_len, sz), acc, cctx);
+                mpoly_monomial_set(r_exp + r_len*N, exp, N);
+                r_len++;
+            }
+        }
+    }
+
+    *res_status = status;
+    goto cleanup;
+
+unable:
+    for (w = 0; w < len; w++)
+        k[w] = -1;
+    r_len = 0;
+    *res_status = status;
+
+cleanup:
+
+    GR_TMP_CLEAR3(acc, pp, rem, cctx);
+    flint_free(dot_a);
+
+    for (w = 0; w < len; w++)
+    {
+        Qout[w]->coeffs = Qcoeff[w];
+        Qout[w]->len = k[w] + 1;
+    }
+    Wout->coeffs = r_coeff;
+    Wout->exps = r_exp;
+    Wout->len = r_len;
+
+    TMP_END;
+}
+
+
+static slong ideal_chunk_find_exp(ulong * exp, slong a, const ideal_base_t H)
+{
+    return chunk_find_exp(exp, a, H->polyA->exps, H->polyA->length, H->N, H->cmpmask);
+}
+
+/*
+    Reduce L->polyC by every divisor's newly available quotient increment,
+    one divisor at a time, chaining the output of one call into the input
+    of the next. Each call is exactly the existing, unmodified
+    _gr_mpoly_mulsub_stripe1/stripe (see divides_heap_threaded.c): this
+    routine has no notion of "ideal" beyond looping over the divisor list.
+*/
+static void ideal_chunk_mulsub(ideal_worker_arg_t W, ideal_chunk_t L, const slong * q_prev_length)
+{
+    ideal_base_struct * H = W->H;
+    slong N = H->N;
+    gr_ctx_struct * cctx = H->cctx;
+    slong sz = cctx->sizeof_elem;
+    const gr_mpoly_struct * A = H->polyA;
+    gr_mpoly_struct * C;
+    gr_mpoly_struct * T1 = W->polyT1;
+    _gr_mpoly_stripe_struct * S = W->S;
+    slong w;
+
+    S->emin = L->emin;
+    S->emax = L->emax;
+    S->upperclosed = L->upperclosed;
+    FLINT_ASSERT(S->N == N);
+
+    if (!L->Cinited)
+    {
+        /*
+            First touch: L->polyC has never been initialised. Seed it with
+            the slice of the original dividend A lying in this chunk's
+            exponent window, exactly like the single-divisor chunk_mulsub
+            (divides_heap_threaded.c) does for its own first-touch case.
+            (For simplicity we always do this as a plain copy rather than
+            trying to fold it into the first divisor's mulsub call as the
+            single-divisor version does -- this chunk-lifetime-one-off copy
+            is not worth the extra complexity of special-casing "whichever
+            divisor happens to have a pending increment first".)
+        */
+        slong startidx, stopidx, Alen;
+        int status;
+
+        if (L->upperclosed)
+        {
+            startidx = 0;
+            stopidx = ideal_chunk_find_exp(L->emin, 1, H);
+        }
+        else
+        {
+            startidx = ideal_chunk_find_exp(L->emax, 1, H);
+            stopidx = ideal_chunk_find_exp(L->emin, startidx, H);
+        }
+        Alen = stopidx - startidx;
+
+        L->Cinited = 1;
+        gr_mpoly_init3(L->polyC, 16 + Alen, H->bits, H->ctx);
+        C = L->polyC;
+
+        gr_mpoly_fit_length(C, Alen, H->ctx);
+        status = _gr_vec_set(C->coeffs, GR_ENTRY(A->coeffs, startidx, sz), Alen, cctx);
+        mpoly_copy_monomials(C->exps, A->exps + N*startidx, Alen, N);
+        C->length = Alen;
+
+        if (status != GR_SUCCESS)
+        {
+#if FLINT_USES_PTHREAD
+            pthread_mutex_lock(&H->mutex);
+#endif
+            H->have_unable = 1;
+#if FLINT_USES_PTHREAD
+            pthread_mutex_unlock(&H->mutex);
+#endif
+        }
+    }
+
+    C = L->polyC;
+
+    for (w = 0; w < H->len; w++)
+    {
+        gr_mpoly_struct * B = H->polyB[w];
+        gr_mpoly_ts_struct * Q = H->polyQ + w;
+        slong mq = L->mq[w];
+        slong new_length = q_prev_length[w];
+        int status;
+
+        if (new_length <= mq)
+            continue;
+
+        stripe_fit_length(S, new_length - mq);
+        S->startidx = &L->startidx[w];
+        S->endidx = &L->endidx[w];
+
+        if (N == 1)
+        {
+            T1->length = _gr_mpoly_mulsub_stripe1(
+                    &T1->coeffs, &T1->exps, &T1->coeffs_alloc, &T1->exps_alloc,
+                    C->coeffs, C->exps, C->length, 1,
+                    GR_ENTRY(Q->coeffs, mq, sz), Q->exps + N*mq, new_length - mq,
+                    B->coeffs, B->exps, B->length,
+                    S, &status);
+        }
+        else
+        {
+            T1->length = _gr_mpoly_mulsub_stripe(
+                    &T1->coeffs, &T1->exps, &T1->coeffs_alloc, &T1->exps_alloc,
+                    C->coeffs, C->exps, C->length, 1,
+                    GR_ENTRY(Q->coeffs, mq, sz), Q->exps + N*mq, new_length - mq,
+                    B->coeffs, B->exps, B->length,
+                    S, &status);
+        }
+
+        gr_mpoly_swap(C, T1, H->ctx);
+
+        if (status != GR_SUCCESS)
+        {
+#if FLINT_USES_PTHREAD
+            pthread_mutex_lock(&H->mutex);
+#endif
+            H->have_unable = 1;
+#if FLINT_USES_PTHREAD
+            pthread_mutex_unlock(&H->mutex);
+#endif
+        }
+
+        L->mq[w] = new_length;
+    }
+}
+
+static void ideal_trychunk(ideal_worker_arg_t W, ideal_chunk_t L)
+{
+    ideal_base_struct * H = W->H;
+    slong N = H->N;
+    gr_ctx_struct * cctx = H->cctx;
+    slong sz = cctx->sizeof_elem;
+    gr_mpoly_struct * C = L->polyC;
+    slong * q_prev_length;
+    const gr_mpoly_struct * A = H->polyA;
+    slong w;
+
+    if (L->done)
+        return;
+
+    q_prev_length = (slong *) flint_malloc(H->len*sizeof(slong));
+
+    for (w = 0; w < H->len; w++)
+        q_prev_length[w] = (H->polyQ + w)->length;
+
+    for (w = 0; w < H->len; w++)
+        if (q_prev_length[w] > L->mq[w])
+            break;
+
+    if (w < H->len)
+    {
+        if (L->producer == 0)
+        {
+            /* only bother with a small trickle if we are not the producer */
+            slong total = 0;
+            for (w = 0; w < H->len; w++)
+                total += q_prev_length[w] - L->mq[w];
+            if (total < 20)
+            {
+                flint_free(q_prev_length);
+                return;
+            }
+        }
+
+        ideal_chunk_mulsub(W, L, q_prev_length);
+    }
+
+    if (L->producer == 1)
+    {
+        ideal_chunk_struct * next;
+        gr_srcptr Rcoeff;
+        ulong * Rexp;
+        slong Rlen;
+
+        /* process any further quotient terms that trickled in */
+        for (w = 0; w < H->len; w++)
+            q_prev_length[w] = (H->polyQ + w)->length;
+        for (w = 0; w < H->len; w++)
+            if (q_prev_length[w] > L->mq[w])
+                break;
+        if (w < H->len)
+            ideal_chunk_mulsub(W, L, q_prev_length);
+
+        flint_free(q_prev_length);
+
+        /* find location of remaining terms */
+        if (L->Cinited)
+        {
+            Rlen = C->length;
+            Rexp = C->exps;
+            Rcoeff = C->coeffs;
+        }
+        else
+        {
+            slong startidx, stopidx;
+            if (L->upperclosed)
+            {
+                startidx = 0;
+                stopidx = ideal_chunk_find_exp(L->emin, 1, H);
+            }
+            else
+            {
+                startidx = ideal_chunk_find_exp(L->emax, 1, H);
+                stopidx = ideal_chunk_find_exp(L->emin, startidx, H);
+            }
+            Rlen = stopidx - startidx;
+            Rcoeff = GR_ENTRY(A->coeffs, startidx, sz);
+            Rexp = A->exps + N*startidx;
+        }
+
+        if (Rlen > 0)
+        {
+            gr_mpoly_struct * T2 = W->polyT2;
+            gr_mpoly_struct * T3 = W->polyT3;
+            ideal_stripe_out_t * Qout;
+            ideal_stripe_out_t Wout;
+            int rstatus;
+
+            Qout = (ideal_stripe_out_t *) flint_malloc(H->len*sizeof(ideal_stripe_out_t));
+            for (w = 0; w < H->len; w++)
+            {
+                Qout[w]->coeffs = T2[w].coeffs;
+                Qout[w]->exps = T2[w].exps;
+                Qout[w]->alloc = T2[w].coeffs_alloc;
+                Qout[w]->exps_alloc = T2[w].exps_alloc;
+                Qout[w]->len = 0;
+            }
+            Wout->coeffs = T3->coeffs;
+            Wout->exps = T3->exps;
+            Wout->alloc = T3->coeffs_alloc;
+            Wout->exps_alloc = T3->exps_alloc;
+            Wout->len = 0;
+
+            if (N == 1)
+                _gr_mpoly_divrem_ideal_stripe1(Qout, Wout,
+                        Rcoeff, Rexp, Rlen, H->polyB, H->len,
+                        L->emin[0], H->cmpmask[0], H->bits,
+                        H->nonfield, H->lc_is_one, H->lc_is_unit, H->lc_inv,
+                        H->ctx, &rstatus);
+            else
+                _gr_mpoly_divrem_ideal_stripe(Qout, Wout,
+                        Rcoeff, Rexp, Rlen, H->polyB, H->len,
+                        L->emin, H->cmpmask, N, H->bits,
+                        H->nonfield, H->lc_is_one, H->lc_is_unit, H->lc_inv,
+                        H->ctx, &rstatus);
+
+            for (w = 0; w < H->len; w++)
+            {
+                T2[w].coeffs = Qout[w]->coeffs;
+                T2[w].exps = Qout[w]->exps;
+                T2[w].coeffs_alloc = Qout[w]->alloc;
+                T2[w].exps_alloc = Qout[w]->exps_alloc;
+                T2[w].length = Qout[w]->len;
+            }
+            T3->coeffs = Wout->coeffs;
+            T3->exps = Wout->exps;
+            T3->coeffs_alloc = Wout->alloc;
+            T3->exps_alloc = Wout->exps_alloc;
+            T3->length = Wout->len;
+
+            flint_free(Qout);
+
+            if (rstatus != GR_SUCCESS)
+            {
+#if FLINT_USES_PTHREAD
+                pthread_mutex_lock(&H->mutex);
+#endif
+                H->have_unable = 1;
+                H->failed = 1;
+#if FLINT_USES_PTHREAD
+                pthread_mutex_unlock(&H->mutex);
+#endif
+                return;
+            }
+
+            for (w = 0; w < H->len; w++)
+                if (T2[w].length > 0)
+                    gr_mpoly_ts_append(H->polyQ + w, T2[w].coeffs, T2[w].exps, T2[w].length, N, cctx);
+            if (T3->length > 0)
+                gr_mpoly_ts_append(H->polyR, T3->coeffs, T3->exps, T3->length, N, cctx);
+        }
+
+        next = L->next;
+        H->length--;
+        H->cur = next;
+
+        if (next != NULL)
+            next->producer = 1;
+
+        L->producer = 0;
+        L->done = 1;
+    }
+    else
+    {
+        flint_free(q_prev_length);
+    }
+}
+
+static void ideal_worker_loop(void * varg)
+{
+    ideal_worker_arg_struct * W = (ideal_worker_arg_struct *) varg;
+    ideal_base_struct * H = W->H;
+    _gr_mpoly_stripe_struct * S = W->S;
+    gr_mpoly_struct * T1 = W->polyT1;
+    gr_mpoly_struct * T2 = W->polyT2;
+    slong N = H->N;
+    slong w, maxBlen = 0;
+
+    S->N = N;
+    S->bits = H->bits;
+    S->ctx = H->ctx;
+    S->cctx = H->cctx;
+    S->sz = H->cctx->sizeof_elem;
+    S->cmpmask = H->cmpmask;
+    S->have_fast_dot = (GR_VEC_DOT_OP(H->cctx, VEC_DOT) != (gr_method_vec_dot_op) gr_generic_vec_dot);
+    S->lc_is_one = 0;
+    S->lc_is_unit = 0;
+    S->lc_inv = NULL;
+    S->nonfield = H->nonfield;
+    S->unchecked = 0;
+    S->big_mem_alloc = 0;
+    S->big_mem = NULL;
+
+    for (w = 0; w < H->len; w++)
+        maxBlen = FLINT_MAX(maxBlen, H->polyB[w]->length);
+    stripe_fit_length(S, maxBlen);
+
+    gr_mpoly_init3(T1, 16, H->bits, H->ctx);
+    for (w = 0; w < H->len; w++)
+        gr_mpoly_init3(T2 + w, 16, H->bits, H->ctx);
+    gr_mpoly_init3(W->polyT3, 16, H->bits, H->ctx);
+
+    while (!H->failed)
+    {
+        ideal_chunk_struct * L;
+        L = H->cur;
+
+        if (L == NULL)
+            break;
+
+        while (L != NULL)
+        {
+#if FLINT_USES_PTHREAD
+            pthread_mutex_lock(&H->mutex);
+#endif
+            if (L->lock != -1)
+            {
+                L->lock = -1;
+#if FLINT_USES_PTHREAD
+                pthread_mutex_unlock(&H->mutex);
+#endif
+                ideal_trychunk(W, L);
+#if FLINT_USES_PTHREAD
+                pthread_mutex_lock(&H->mutex);
+#endif
+                L->lock = 0;
+#if FLINT_USES_PTHREAD
+                pthread_mutex_unlock(&H->mutex);
+#endif
+                break;
+            }
+            else
+            {
+#if FLINT_USES_PTHREAD
+                pthread_mutex_unlock(&H->mutex);
+#endif
+            }
+
+            L = L->next;
+        }
+    }
+
+    gr_mpoly_clear(T1, H->ctx);
+    for (w = 0; w < H->len; w++)
+        gr_mpoly_clear(T2 + w, H->ctx);
+    gr_mpoly_clear(W->polyT3, H->ctx);
+    flint_free(S->big_mem);
+}
+
+
+static int
+_gr_mpoly_divrem_ideal_serial(gr_mpoly_struct * const * Q, gr_mpoly_t R,
+    const gr_mpoly_t A, gr_mpoly_struct * const * B, slong len,
+    int nonfield, gr_mpoly_ctx_t ctx)
+{
+    /*
+        Call the guaranteed-serial kernel directly, NOT the public
+        gr_mpoly_divrem_ideal/_weak dispatchers: those may route large
+        instances straight back into this threaded engine, which would
+        recurse indefinitely whenever this function is reached as a
+        fallback from within the threaded engine itself (A, B unchanged).
+    */
+    return _gr_mpoly_divrem_ideal((gr_mpoly_struct **) Q, R, A, B, len, nonfield, ctx);
+}
+
+
+static int _gr_mpoly_divrem_ideal_heap_threaded_pool(
+    gr_mpoly_struct * const * Q,
+    gr_mpoly_t R,
+    const gr_mpoly_t A,
+    gr_mpoly_struct * const * B,
+    slong len,
+    gr_mpoly_ctx_t ctx,
+    int nonfield,
+    const thread_pool_handle * handles,
+    slong num_handles)
+{
+    mpoly_ctx_struct * mctx = GR_MPOLY_MCTX(ctx);
+    gr_ctx_struct * cctx = GR_MPOLY_CCTX(ctx);
+    slong sz = cctx->sizeof_elem;
+    int status;
+    fmpz_mpoly_ctx_t zctx;
+    fmpz_mpoly_t S;
+    slong i, w, N;
+    flint_bitcnt_t exp_bits;
+    ulong * cmpmask;
+    ulong * Aexp;
+    ulong ** Bexp;
+    int freeAexp, * freeBexp;
+    ideal_worker_arg_struct * worker_args;
+    ideal_base_t H;
+    gr_mpoly_struct * polyB_storage;
+    gr_mpoly_struct ** polyB_ptrs;
+    TMP_INIT;
+
+    if (A->length < 2 || B[0]->length < 2)
+        return _gr_mpoly_divrem_ideal_serial(Q, R, A, B, len, nonfield, ctx);
+
+    TMP_START;
+
+    exp_bits = MPOLY_MIN_BITS;
+    exp_bits = FLINT_MAX(exp_bits, A->bits);
+    for (w = 0; w < len; w++)
+        exp_bits = FLINT_MAX(exp_bits, B[w]->bits);
+    exp_bits = mpoly_fix_bits(exp_bits, mctx);
+
+    N = mpoly_words_per_exp(exp_bits, mctx);
+    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
+    mpoly_get_cmpmask(cmpmask, N, exp_bits, mctx);
+
+    Aexp = A->exps;
+    freeAexp = 0;
+    if (exp_bits > A->bits)
+    {
+        freeAexp = 1;
+        Aexp = (ulong *) flint_malloc(N*A->length*sizeof(ulong));
+        mpoly_repack_monomials(Aexp, exp_bits, A->exps, A->bits, A->length, mctx);
+    }
+
+    Bexp = (ulong **) TMP_ALLOC(len*sizeof(ulong *));
+    freeBexp = (int *) TMP_ALLOC(len*sizeof(int));
+    for (w = 0; w < len; w++)
+    {
+        Bexp[w] = B[w]->exps;
+        freeBexp[w] = 0;
+        if (exp_bits > B[w]->bits)
+        {
+            freeBexp[w] = 1;
+            Bexp[w] = (ulong *) flint_malloc(N*B[w]->length*sizeof(ulong));
+            mpoly_repack_monomials(Bexp[w], exp_bits, B[w]->exps, B[w]->bits, B[w]->length, mctx);
+        }
+    }
+
+    polyB_storage = (gr_mpoly_struct *) flint_malloc(len*sizeof(gr_mpoly_struct));
+    polyB_ptrs = (gr_mpoly_struct **) flint_malloc(len*sizeof(gr_mpoly_struct *));
+    for (w = 0; w < len; w++)
+    {
+        polyB_ptrs[w] = polyB_storage + w;
+        polyB_storage[w].coeffs = B[w]->coeffs;
+        polyB_storage[w].exps = Bexp[w];
+        polyB_storage[w].bits = exp_bits;
+        polyB_storage[w].length = B[w]->length;
+        polyB_storage[w].coeffs_alloc = B[w]->coeffs_alloc;
+        polyB_storage[w].exps_alloc = N*B[w]->length;
+    }
+
+    fmpz_mpoly_ctx_init(zctx, mctx->nvars, mctx->ord);
+    fmpz_mpoly_init(S, zctx);
+
+    /*
+        mpoly_divides_select_exps only needs *a* representative divisor to
+        pick reasonable chunk boundaries -- these are purely a load
+        balancing hint (unlike the plain-divide case, correctness never
+        depends on them), so B[0] is a fine, simple choice regardless of
+        how many divisors there are.
+    */
+    if (mpoly_divides_select_exps(S, zctx, num_handles,
+                                   Aexp, A->length, Bexp[0], B[0]->length, exp_bits))
+    {
+        /* select_exps's failure notion ("provably not exact") does not
+           apply to divrem_ideal (which always succeeds via the
+           remainder), but a degenerate/pathological exponent spread is
+           not worth trying to patch up -- fall back to the serial engine. */
+        status = _gr_mpoly_divrem_ideal_serial(Q, R, A, B, len, nonfield, ctx);
+        goto cleanup1;
+    }
+
+    ideal_base_init(H);
+
+    H->polyA->coeffs = A->coeffs;
+    H->polyA->exps = Aexp;
+    H->polyA->bits = exp_bits;
+    H->polyA->length = A->length;
+    H->polyA->coeffs_alloc = A->coeffs_alloc;
+    H->polyA->exps_alloc = N*A->length;
+
+    H->polyB = polyB_ptrs;
+    H->len = len;
+    H->ctx = ctx;
+    H->cctx = cctx;
+    H->bits = exp_bits;
+    H->N = N;
+    H->cmpmask = cmpmask;
+    H->nonfield = nonfield;
+    H->failed = 0;
+    H->have_unable = 0;
+
+    H->polyQ = (gr_mpoly_ts_struct *) flint_malloc(len*sizeof(gr_mpoly_ts_struct));
+    for (w = 0; w < len; w++)
+        gr_mpoly_ts_init(H->polyQ + w, NULL, NULL, 0, exp_bits, N, cctx);
+    gr_mpoly_ts_init(H->polyR, NULL, NULL, 0, exp_bits, N, cctx);
+
+    H->lc_inv = flint_malloc(len*sz);
+    _gr_vec_init(H->lc_inv, len, cctx);
+    H->lc_is_one = (int *) flint_malloc(len*sizeof(int));
+    H->lc_is_unit = (int *) flint_malloc(len*sizeof(int));
+    for (w = 0; w < len; w++)
+    {
+        H->lc_is_one[w] = H->lc_is_unit[w] = 0;
+        if (!nonfield)
+        {
+            H->lc_is_one[w] = (gr_is_one(GR_ENTRY(B[w]->coeffs, 0, sz), cctx) == T_TRUE);
+            H->lc_is_unit[w] = H->lc_is_one[w] ||
+                (gr_inv(GR_ENTRY(H->lc_inv, w, sz), GR_ENTRY(B[w]->coeffs, 0, sz), cctx) == GR_SUCCESS);
+        }
+    }
+
+    for (i = 0; i + 1 < S->length; i++)
+    {
+        ideal_chunk_struct * L;
+        L = (ideal_chunk_struct *) flint_malloc(sizeof(ideal_chunk_struct));
+        L->startidx = (slong *) flint_malloc(3*len*sizeof(slong));
+        L->endidx = L->startidx + len;
+        L->mq = L->startidx + 2*len;
+        for (w = 0; w < len; w++)
+        {
+            L->startidx[w] = B[w]->length;
+            L->endidx[w] = B[w]->length;
+            L->mq[w] = 0;
+        }
+        L->emax = S->exps + N*i;
+        L->emin = S->exps + N*(i + 1);
+        L->upperclosed = 0;
+        L->producer = 0;
+        L->Cinited = 0;
+        L->done = 0;
+        L->lock = -2;
+        ideal_base_add_chunk(H, L);
+    }
+
+    H->head->upperclosed = 1;
+    H->head->producer = 1;
+    H->cur = H->head;
+
+    /*
+        No "initial burst" pre-pass here, for the same reason
+        gr_mpoly_divrem_heap_threaded doesn't need one (see the long
+        comment there): the head chunk, already marked as producer, can be
+        fully resolved from scratch on first touch regardless of how many
+        terms of A it covers.
+    */
+
+#if FLINT_USES_PTHREAD
+    pthread_mutex_init(&H->mutex, NULL);
+#endif
+
+    worker_args = (ideal_worker_arg_struct *) flint_malloc((num_handles + 1)
+                                                        *sizeof(ideal_worker_arg_struct));
+    for (i = 0; i < num_handles; i++)
+    {
+        (worker_args + i)->H = H;
+        (worker_args + i)->polyT2 = (gr_mpoly_struct *) flint_malloc(len*sizeof(gr_mpoly_struct));
+        thread_pool_wake(global_thread_pool, handles[i], 0,
+                                                 ideal_worker_loop, worker_args + i);
+    }
+    (worker_args + num_handles)->H = H;
+    (worker_args + num_handles)->polyT2 = (gr_mpoly_struct *) flint_malloc(len*sizeof(gr_mpoly_struct));
+    ideal_worker_loop(worker_args + num_handles);
+    for (i = 0; i < num_handles; i++)
+        thread_pool_wait(global_thread_pool, handles[i]);
+
+    for (i = 0; i <= num_handles; i++)
+        flint_free((worker_args + i)->polyT2);
+    flint_free(worker_args);
+
+#if FLINT_USES_PTHREAD
+    pthread_mutex_destroy(&H->mutex);
+#endif
+
+    status = ideal_base_clear(Q, R, H);
+
+    flint_free(H->polyQ);
+    _gr_vec_clear(H->lc_inv, len, cctx);
+    flint_free(H->lc_inv);
+    flint_free(H->lc_is_one);
+    flint_free(H->lc_is_unit);
+
+cleanup1:
+
+    fmpz_mpoly_clear(S, zctx);
+    fmpz_mpoly_ctx_clear(zctx);
+
+    flint_free(polyB_storage);
+    flint_free(polyB_ptrs);
+
+    if (freeAexp)
+        flint_free(Aexp);
+    for (w = 0; w < len; w++)
+        if (freeBexp[w])
+            flint_free(Bexp[w]);
+
+    TMP_END;
+
+    return status;
+}
+
+
+static int _gr_mpoly_divrem_ideal_heap_threaded_dispatch(
+    gr_mpoly_struct * const * Q,
+    gr_mpoly_t R,
+    const gr_mpoly_t A,
+    gr_mpoly_struct * const * B,
+    slong len,
+    gr_mpoly_ctx_t ctx,
+    int nonfield)
+{
+    gr_ctx_struct * cctx = GR_MPOLY_CCTX(ctx);
+    thread_pool_handle * handles;
+    slong num_handles;
+    slong thread_limit;
+    slong w;
+    int status;
+
+    for (w = 0; w < len; w++)
+    {
+        if (B[w]->length == 0)
+            return GR_DOMAIN;
+        if (gr_is_zero(B[w]->coeffs, cctx) != T_FALSE)
+            return GR_UNABLE;
+    }
+
+    if (A->length == 0)
+    {
+        status = GR_SUCCESS;
+        for (w = 0; w < len; w++)
+            status |= gr_mpoly_zero(Q[w], ctx);
+        status |= gr_mpoly_zero(R, ctx);
+        return status;
+    }
+
+    /* fall back to the single-threaded algorithm for small inputs, or when
+       the coefficient ring does not allow concurrent operations */
+    if (A->length < 2 || B[0]->length < 2 || gr_ctx_is_threadsafe(cctx) != T_TRUE)
+        return _gr_mpoly_divrem_ideal_serial(Q, R, A, B, len, nonfield, ctx);
+
+    thread_limit = A->length/32;
+
+    num_handles = flint_request_threads(&handles, thread_limit);
+
+    status = _gr_mpoly_divrem_ideal_heap_threaded_pool(Q, R, A, B, len, ctx,
+                                                nonfield, handles, num_handles);
+
+    flint_give_back_threads(handles, num_handles);
+
+    return status;
+}
+
+
+static int
+_gr_mpoly_divrem_ideal_vec_threaded(gr_mpoly_vec_t Q, gr_mpoly_t R,
+    const gr_mpoly_t A, const gr_mpoly_vec_t B, int nonfield, gr_mpoly_ctx_t ctx)
+{
+    slong w, len = B->length;
+    gr_mpoly_struct ** Qptr;
+    gr_mpoly_struct ** Bptr;
+    int status;
+
+    if (len == 0)
+    {
+        gr_mpoly_vec_set_length(Q, 0, ctx);
+        return gr_mpoly_set(R, A, ctx);
+    }
+
+    gr_mpoly_vec_set_length(Q, len, ctx);
+
+    Qptr = (gr_mpoly_struct **) flint_malloc(len*sizeof(gr_mpoly_struct *));
+    Bptr = (gr_mpoly_struct **) flint_malloc(len*sizeof(gr_mpoly_struct *));
+    for (w = 0; w < len; w++)
+    {
+        Qptr[w] = Q->entries + w;
+        Bptr[w] = B->entries + w;
+    }
+
+    status = _gr_mpoly_divrem_ideal_heap_threaded_dispatch(Qptr, R, A, Bptr, len, ctx, nonfield);
+
+    flint_free(Qptr);
+    flint_free(Bptr);
+
+    return status;
+}
+
+
+int gr_mpoly_divrem_ideal_heap_threaded(
+    gr_mpoly_vec_t Q, gr_mpoly_t R,
+    const gr_mpoly_t A, const gr_mpoly_vec_t B,
+    gr_mpoly_ctx_t ctx)
+{
+    return _gr_mpoly_divrem_ideal_vec_threaded(Q, R, A, B, 0, ctx);
+}
+
+
+int gr_mpoly_divrem_ideal_weak_heap_threaded(
+    gr_mpoly_vec_t Q, gr_mpoly_t R,
+    const gr_mpoly_t A, const gr_mpoly_vec_t B,
+    gr_mpoly_ctx_t ctx)
+{
+    return _gr_mpoly_divrem_ideal_vec_threaded(Q, R, A, B, 1, ctx);
+}

--- a/src/gr_mpoly/divrem_ideal_heap_threaded.c
+++ b/src/gr_mpoly/divrem_ideal_heap_threaded.c
@@ -477,16 +477,12 @@ static void _gr_mpoly_divrem_ideal_stripe1(
             }
         }
 
-        switch (gr_is_zero(acc, cctx))
-        {
-            case T_TRUE:
-                continue;
-            case T_FALSE:
-                break;
-            default:
-                status |= GR_UNABLE;
-                goto unable;
-        }
+        /* an unknown zero-status is treated as "not zero" -- see the
+           discussion at gr_mpoly_divexact for why this is safe: we only
+           need the coefficient division below to succeed, not to know for
+           certain that acc is nonzero. */
+        if (gr_is_zero(acc, cctx) == T_TRUE)
+            continue;
 
         /* try to reduce the term acc*x^exp by the divisors in order */
         {
@@ -838,16 +834,12 @@ static void _gr_mpoly_divrem_ideal_stripe(
             }
         }
 
-        switch (gr_is_zero(acc, cctx))
-        {
-            case T_TRUE:
-                continue;
-            case T_FALSE:
-                break;
-            default:
-                status |= GR_UNABLE;
-                goto unable;
-        }
+        /* an unknown zero-status is treated as "not zero" -- see the
+           discussion at gr_mpoly_divexact for why this is safe: we only
+           need the coefficient division below to succeed, not to know for
+           certain that acc is nonzero. */
+        if (gr_is_zero(acc, cctx) == T_TRUE)
+            continue;
 
         /* try to reduce the term acc*x^exp by the divisors in order */
         {

--- a/src/gr_mpoly/divrem_ideal_heap_threaded.c
+++ b/src/gr_mpoly/divrem_ideal_heap_threaded.c
@@ -807,7 +807,11 @@ static void _gr_mpoly_divrem_ideal_stripe(
                     x->next = NULL;
                     hinds[p][x->i] = 2*(x->j + 1) + 0;
 
-                    mpoly_monomial_add_mp(exp_list[exp_next], poly3[p]->exps + x->i*N,
+                    if (bits <= FLINT_BITS)
+                        mpoly_monomial_add(exp_list[exp_next], poly3[p]->exps + x->i*N,
+                                                        Qout[p]->exps + x->j*N, N);
+                    else
+                        mpoly_monomial_add_mp(exp_list[exp_next], poly3[p]->exps + x->i*N,
                                                         Qout[p]->exps + x->j*N, N);
 
                     if (mpoly_monomial_cmp(exp_list[exp_next], emin, N, cmpmask) >= 0)
@@ -830,7 +834,11 @@ static void _gr_mpoly_divrem_ideal_stripe(
                     x->next = NULL;
                     hinds[p][x->i] = 2*(x->j + 1) + 0;
 
-                    mpoly_monomial_add_mp(exp_list[exp_next], poly3[p]->exps + x->i*N,
+                    if (bits <= FLINT_BITS)
+                        mpoly_monomial_add(exp_list[exp_next], poly3[p]->exps + x->i*N,
+                                                        Qout[p]->exps + x->j*N, N);
+                    else
+                        mpoly_monomial_add_mp(exp_list[exp_next], poly3[p]->exps + x->i*N,
                                                         Qout[p]->exps + x->j*N, N);
 
                     if (mpoly_monomial_cmp(exp_list[exp_next], emin, N, cmpmask) >= 0)
@@ -899,7 +907,11 @@ static void _gr_mpoly_divrem_ideal_stripe(
                         x->next = NULL;
                         hinds[w][x->i] = 2*(x->j + 1) + 0;
 
-                        mpoly_monomial_add_mp(exp_list[exp_next], poly3[w]->exps + N,
+                        if (bits <= FLINT_BITS)
+                            mpoly_monomial_add(exp_list[exp_next], poly3[w]->exps + N,
+                                                            Qout[w]->exps + k[w]*N, N);
+                        else
+                            mpoly_monomial_add_mp(exp_list[exp_next], poly3[w]->exps + N,
                                                             Qout[w]->exps + k[w]*N, N);
 
                         if (mpoly_monomial_cmp(exp_list[exp_next], emin, N, cmpmask) >= 0)
@@ -1421,9 +1433,52 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_pool(
     gr_mpoly_struct ** polyB_ptrs;
     gr_ptr lc_inv;
     int * lc_is_one, * lc_is_unit;
+    gr_mpoly_struct * TQarr;
+    gr_mpoly_struct ** q;
+    gr_mpoly_t TR;
+    gr_mpoly_struct * r;
 
     if (A->length < 2 || B[0]->length < 2)
         return _gr_mpoly_divrem_ideal_serial(Q, R, A, B, len, nonfield, ctx);
+
+    /*
+        Use temporaries to handle aliasing of any Q[w] or R with A or any
+        B[w']: the retry loop below re-reads A->length/A->exps and
+        B[w]->length/B[w]->exps on every pass, while ideal_base_clear
+        zeroes every Q[w] and R on any non-successful attempt, including
+        the ordinary overflow-retry case. If some Q[w] or R is the same
+        object as A or a B[w'], that zeroing would corrupt the operand out
+        from under the very next loop iteration -- exactly mirroring the
+        aliasing guard already used by gr_mpoly_divrem_heap_threaded (and,
+        for R against A, the serial _gr_mpoly_divrem_ideal kernel).
+    */
+    TQarr = (gr_mpoly_struct *) flint_malloc(len*sizeof(gr_mpoly_struct));
+    q = (gr_mpoly_struct **) flint_malloc(len*sizeof(gr_mpoly_struct *));
+    for (w = 0; w < len; w++)
+    {
+        int alias = (Q[w] == A);
+        for (i = 0; !alias && i < len; i++)
+            alias = (Q[w] == B[i]);
+
+        gr_mpoly_init(TQarr + w, ctx);
+        q[w] = alias ? (TQarr + w) : Q[w];
+    }
+
+    {
+        int alias_R = (R == A);
+        for (w = 0; !alias_R && w < len; w++)
+            alias_R = (R == B[w]);
+
+        if (alias_R)
+        {
+            gr_mpoly_init(TR, ctx);
+            r = TR;
+        }
+        else
+        {
+            r = R;
+        }
+    }
 
     /*
         lc_is_one/lc_is_unit/lc_inv depend only on the ring elements
@@ -1516,6 +1571,12 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_pool(
             fmpz_mpoly_ctx_clear(zctx);
             flint_free(polyB_storage);
             flint_free(polyB_ptrs);
+            for (w = 0; w < len; w++)
+                gr_mpoly_clear(TQarr + w, ctx);
+            flint_free(TQarr);
+            flint_free(q);
+            if (r == TR)
+                gr_mpoly_clear(TR, ctx);
             goto cleanup1;
         }
 
@@ -1621,7 +1682,7 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_pool(
                 width, exactly like the retry loop in
                 gr_mpoly_divrem_heap_threaded / _gr_mpoly_divrem_mp.
             */
-            GR_IGNORE(ideal_base_clear(Q, R, H));
+            GR_IGNORE(ideal_base_clear(q, r, H));
 
             flint_free(H->polyQ);
 
@@ -1659,7 +1720,7 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_pool(
             continue;
         }
 
-        status = ideal_base_clear(Q, R, H);
+        status = ideal_base_clear(q, r, H);
 
         flint_free(H->polyQ);
 
@@ -1669,6 +1730,21 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_pool(
         flint_free(polyB_ptrs);
 
         break;
+    }
+
+    for (w = 0; w < len; w++)
+    {
+        if (q[w] == TQarr + w)
+            gr_mpoly_swap(Q[w], TQarr + w, ctx);
+        gr_mpoly_clear(TQarr + w, ctx);
+    }
+    flint_free(TQarr);
+    flint_free(q);
+
+    if (r == TR)
+    {
+        gr_mpoly_swap(R, TR, ctx);
+        gr_mpoly_clear(TR, ctx);
     }
 
 cleanup1:

--- a/src/gr_mpoly/mul.c
+++ b/src/gr_mpoly/mul.c
@@ -10,6 +10,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "thread_support.h"
 #include "gr_mpoly.h"
 
 int gr_mpoly_mul(gr_mpoly_t poly1,
@@ -36,7 +37,7 @@ int gr_mpoly_mul(gr_mpoly_t poly1,
             if (len2 * len2 > ctx->size_limit)
                 return GR_UNABLE | gr_mpoly_zero(poly1, ctx);
 
-            if (len2 > 100)
+            if (len2 > 100 && flint_get_num_available_threads() > 1)
                 return gr_mpoly_sqr_commutative_heap_threaded(poly1, poly2, ctx);
             else
                 return gr_mpoly_sqr_commutative_heap(poly1, poly2, ctx);
@@ -53,7 +54,7 @@ int gr_mpoly_mul(gr_mpoly_t poly1,
     if (len2 * len3 > ctx->size_limit)
         return GR_UNABLE | gr_mpoly_zero(poly1, ctx);
 
-    if (len2 * len3 > 10000 && len2 > 2 && len3 > 2)
+    if (len2 * len3 > 10000 && len2 > 2 && len3 > 2 && flint_get_num_available_threads() > 1)
         return gr_mpoly_mul_heap_threaded(poly1, poly2, poly3, ctx);
     else
         return gr_mpoly_mul_heap(poly1, poly2, poly3, ctx);

--- a/src/gr_mpoly/test/main.c
+++ b/src/gr_mpoly/test/main.c
@@ -15,11 +15,13 @@
 #include "t-gen.c"
 #include "t-get_set_coeff.c"
 #include "t-integral.c"
+#include "t-divexact.c"
 #include "t-divides.c"
 #include "t-divides_heap_threaded.c"
 #include "t-divrem.c"
 #include "t-divrem_heap_threaded.c"
 #include "t-divrem_ideal.c"
+#include "t-divrem_ideal_heap_threaded.c"
 #include "t-quasidivrem.c"
 #include "t-quasidivrem_ideal.c"
 #include "t-vec.c"
@@ -39,11 +41,13 @@ test_struct tests[] =
     TEST_FUNCTION(gr_mpoly_gen),
     TEST_FUNCTION(gr_mpoly_get_set_coeff),
     TEST_FUNCTION(gr_mpoly_integral),
+    TEST_FUNCTION(gr_mpoly_divexact),
     TEST_FUNCTION(gr_mpoly_divides),
     TEST_FUNCTION(gr_mpoly_divides_heap_threaded),
     TEST_FUNCTION(gr_mpoly_divrem),
     TEST_FUNCTION(gr_mpoly_divrem_heap_threaded),
     TEST_FUNCTION(gr_mpoly_divrem_ideal),
+    TEST_FUNCTION(gr_mpoly_divrem_ideal_heap_threaded),
     TEST_FUNCTION(gr_mpoly_quasidivrem),
     TEST_FUNCTION(gr_mpoly_quasidivrem_ideal),
     TEST_FUNCTION(gr_mpoly_vec),

--- a/src/gr_mpoly/test/main.c
+++ b/src/gr_mpoly/test/main.c
@@ -16,7 +16,9 @@
 #include "t-get_set_coeff.c"
 #include "t-integral.c"
 #include "t-divides.c"
+#include "t-divides_heap_threaded.c"
 #include "t-divrem.c"
+#include "t-divrem_heap_threaded.c"
 #include "t-divrem_ideal.c"
 #include "t-quasidivrem.c"
 #include "t-quasidivrem_ideal.c"
@@ -38,7 +40,9 @@ test_struct tests[] =
     TEST_FUNCTION(gr_mpoly_get_set_coeff),
     TEST_FUNCTION(gr_mpoly_integral),
     TEST_FUNCTION(gr_mpoly_divides),
+    TEST_FUNCTION(gr_mpoly_divides_heap_threaded),
     TEST_FUNCTION(gr_mpoly_divrem),
+    TEST_FUNCTION(gr_mpoly_divrem_heap_threaded),
     TEST_FUNCTION(gr_mpoly_divrem_ideal),
     TEST_FUNCTION(gr_mpoly_quasidivrem),
     TEST_FUNCTION(gr_mpoly_quasidivrem_ideal),

--- a/src/gr_mpoly/test/t-divexact.c
+++ b/src/gr_mpoly/test/t-divexact.c
@@ -245,5 +245,118 @@ TEST_FUNCTION_START(gr_mpoly_divexact, state)
         gr_ctx_clear(R);
     }
 
+    /*
+        Regression test: an "unknown" gr_is_zero verdict on the running
+        accumulator, while reducing a term whose monomial *does* divide
+        that of the (non-monomial) divisor, must not abort gr_mpoly_divexact
+        or gr_mpoly_divrem with GR_UNABLE. We only need the coefficient
+        division itself to succeed; an accumulator that cannot be proven
+        zero is simply kept as a (possibly redundant, wide) term instead
+        of being dropped, exactly like gr_poly_divrem already does for
+        univariate polynomials.
+
+        Concretely: a = y, b = (1/3)*x + 1, c = a*b = (1/3)*x*y + y.
+        Dividing c by b (whose leading coefficient 1/3 is a unit but not
+        exactly representable) is expected to succeed with quotient y,
+        even though intermediate arb accumulators along the way straddle
+        zero without being provably zero.
+    */
+    {
+        gr_ctx_t R;
+        gr_mpoly_ctx_t Rx;
+        gr_mpoly_t a, b, c, q, q2, r2;
+        int status;
+
+        gr_ctx_init_real_arb(R, 64);
+        gr_mpoly_ctx_init(Rx, R, 2, ORD_LEX);
+
+        {
+            const char * ss[] = {"x", "y"};
+            GR_MUST_SUCCEED(gr_ctx_set_gen_names(Rx, ss));
+        }
+
+        gr_mpoly_init(a, Rx);
+        gr_mpoly_init(b, Rx);
+        gr_mpoly_init(c, Rx);
+        gr_mpoly_init(q, Rx);
+        gr_mpoly_init(q2, Rx);
+        gr_mpoly_init(r2, Rx);
+
+        status = GR_SUCCESS;
+        status |= gr_mpoly_gen(a, 1, Rx);                    /* a = y */
+        status |= gr_set_str(b, "(1/3)*x + 1", Rx);          /* b = (1/3)x + 1 */
+        status |= gr_mpoly_mul(c, a, b, Rx);                 /* c = a*b */
+
+        if (status != GR_SUCCESS)
+        {
+            flint_printf("FAIL: unexpected failure setting up divexact/arb test\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        status = gr_mpoly_divexact(q, c, b, Rx);
+        if (status != GR_SUCCESS)
+        {
+            flint_printf("FAIL: gr_mpoly_divexact(a*b, b) over arb returned "
+                         "%d (expected GR_SUCCESS)\n", status);
+            fflush(stdout);
+            flint_abort();
+        }
+        if (gr_mpoly_equal(q, a, Rx) == T_FALSE)
+        {
+            flint_printf("FAIL: gr_mpoly_divexact(a*b, b) over arb gave a "
+                         "quotient inconsistent with a = y: ");
+            gr_mpoly_print_pretty(q, Rx);
+            flint_printf("\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        status = gr_mpoly_divrem(q2, r2, c, b, Rx);
+        if (status != GR_SUCCESS)
+        {
+            flint_printf("FAIL: gr_mpoly_divrem(a*b, b) over arb returned "
+                         "%d (expected GR_SUCCESS)\n", status);
+            fflush(stdout);
+            flint_abort();
+        }
+        if (gr_mpoly_equal(q2, a, Rx) == T_FALSE)
+        {
+            flint_printf("FAIL: gr_mpoly_divrem(a*b, b) over arb gave a "
+                         "quotient inconsistent with a = y: ");
+            gr_mpoly_print_pretty(q2, Rx);
+            flint_printf("\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        /* by contrast, gr_mpoly_divides is allowed (expected) to report
+           GR_UNABLE here, since exactness genuinely cannot be certified
+           over an inexact ring; this is a deliberate difference in
+           semantics from gr_mpoly_div(exact)/gr_mpoly_divrem, not a bug */
+        {
+            gr_mpoly_t qd;
+            gr_mpoly_init(qd, Rx);
+            status = gr_mpoly_divides(qd, c, b, Rx);
+            if (status == GR_DOMAIN)
+            {
+                flint_printf("FAIL: gr_mpoly_divides(a*b, b) over arb "
+                             "incorrectly reported GR_DOMAIN\n");
+                fflush(stdout);
+                flint_abort();
+            }
+            gr_mpoly_clear(qd, Rx);
+        }
+
+        gr_mpoly_clear(a, Rx);
+        gr_mpoly_clear(b, Rx);
+        gr_mpoly_clear(c, Rx);
+        gr_mpoly_clear(q, Rx);
+        gr_mpoly_clear(q2, Rx);
+        gr_mpoly_clear(r2, Rx);
+        gr_mpoly_ctx_clear(Rx);
+        gr_ctx_clear(R);
+    }
+
     TEST_FUNCTION_END(state);
 }

--- a/src/gr_mpoly/test/t-divexact.c
+++ b/src/gr_mpoly/test/t-divexact.c
@@ -13,8 +13,6 @@
 #include "arb.h"
 #include "gr_mpoly.h"
 
-FLINT_DLL extern gr_static_method_table _ca_methods;
-
 TEST_FUNCTION_START(gr_mpoly_divexact, state)
 {
     slong i;
@@ -23,14 +21,17 @@ TEST_FUNCTION_START(gr_mpoly_divexact, state)
     {
         gr_ctx_t cctx;
         gr_mpoly_ctx_t ctx;
-        gr_mpoly_t f, g, h, q1, q2, q3, q4;
+        gr_mpoly_t f, g, h, q, r;
         slong lenf, leng;
         flint_bitcnt_t exp_bits;
-        int status, s1, s2, s3, s4;
+        int status, s1;
         int monomial_case = (n_randint(state, 4) == 0);
         int big = (!monomial_case && n_randint(state, 8) == 0);
 
-        switch (n_randint(state, 4))
+        gr_ctx_t ctx1;
+        gr_ctx_init_nmod8(ctx1, n_randprime(state, 8, 1));
+
+        switch (n_randint(state, 5))
         {
             case 0:
                 gr_ctx_init_random_finite_field(cctx, state);
@@ -41,20 +42,21 @@ TEST_FUNCTION_START(gr_mpoly_divexact, state)
             case 2:
                 gr_ctx_init_fmpq(cctx);
                 break;
+            case 3:
+                gr_ctx_init_real_arb(cctx, 2 + n_randint(state, 200));
+                break;
             default:
-                gr_ctx_init_nmod(cctx, n_randtest_prime(state, 1));
+                gr_ctx_init_debug(cctx, ctx1, n_randint(state, 2), n_randint(state, 2) ? 0.0 : 0.001);
                 break;
         }
 
-        gr_mpoly_ctx_init_rand(ctx, state, cctx, 4);
+        gr_mpoly_ctx_init_rand(ctx, state, cctx, 12);
 
         gr_mpoly_init(f, ctx);
         gr_mpoly_init(g, ctx);
         gr_mpoly_init(h, ctx);
-        gr_mpoly_init(q1, ctx);
-        gr_mpoly_init(q2, ctx);
-        gr_mpoly_init(q3, ctx);
-        gr_mpoly_init(q4, ctx);
+        gr_mpoly_init(q, ctx);
+        gr_mpoly_init(r, ctx);
 
         flint_set_num_threads(1 + n_randint(state, 4));
 
@@ -65,7 +67,7 @@ TEST_FUNCTION_START(gr_mpoly_divexact, state)
            would otherwise make gr_mpoly_divexact stay serial */
         lenf = n_randint(state, big ? 400 : 20) + 1;
         leng = monomial_case ? 1 : (n_randint(state, big ? 80 : 10) + 3);
-        exp_bits = n_randint(state, big ? 12 : 4) + 2;
+        exp_bits = n_randint(state, big ? 8 : 4) + 2;
 
         status = GR_SUCCESS;
         status |= gr_mpoly_randtest_bits(f, state, lenf, exp_bits, ctx);
@@ -80,70 +82,52 @@ TEST_FUNCTION_START(gr_mpoly_divexact, state)
 
             if (status == GR_SUCCESS)
             {
-                s1 = gr_mpoly_divides(q1, h, g, ctx);
-                s2 = gr_mpoly_div(q2, h, g, ctx);
-                s3 = gr_mpoly_divexact(q3, h, g, ctx);
-                if (monomial_case)
-                {
-                    s4 = s3;
-                    GR_IGNORE(gr_mpoly_set(q4, q3, ctx));
-                }
-                else
-                {
-                    s4 = gr_mpoly_divexact_heap_threaded(q4, h, g, ctx);
-                }
+                int alg;
 
-                if (s1 == GR_DOMAIN)
+                for (alg = 0; alg < 6; alg++)
                 {
-                    /* g always divides h = f*g exactly */
-                    flint_printf("FAIL: exact division reported GR_DOMAIN "
-                                 "by gr_mpoly_divides\n");
-                    flint_printf("i = %wd\n", i);
-                    gr_ctx_println(cctx);
-                    fflush(stdout);
-                    flint_abort();
-                }
+                    if (alg == 0)
+                        s1 = gr_mpoly_divides(q, h, g, ctx);
+                    else if (alg == 1)
+                        s1 = gr_mpoly_div(q, h, g, ctx);
+                    else if (alg == 2)
+                        s1 = gr_mpoly_divexact(q, h, g, ctx);
+                    else if (alg == 3)
+                        s1 = gr_mpoly_divexact_heap_threaded(q, h, g, ctx);
+                    else if (alg == 4)
+                        s1 = gr_mpoly_divrem(q, r, h, g, ctx);
+                    else if (alg == 5)
+                        s1 = gr_mpoly_divrem_heap_threaded(q, r, h, g, ctx);
 
-                if (s1 == GR_SUCCESS &&
-                    (s2 != GR_SUCCESS || s3 != GR_SUCCESS || s4 != GR_SUCCESS))
-                {
-                    flint_printf("FAIL: exact division but "
-                                 "div = %d, divexact = %d, "
-                                 "divexact_heap_threaded = %d\n", s2, s3, s4);
-                    flint_printf("i = %wd\n", i);
-                    gr_ctx_println(cctx);
-                    fflush(stdout);
-                    flint_abort();
-                }
+                    gr_mpoly_assert_canonical(q, ctx);
 
-                if (s1 == GR_SUCCESS)
-                {
-                    gr_mpoly_assert_canonical(q1, ctx);
-                    gr_mpoly_assert_canonical(q2, ctx);
-                    gr_mpoly_assert_canonical(q3, ctx);
-                    gr_mpoly_assert_canonical(q4, ctx);
-
-                    if (gr_mpoly_equal(q1, q2, ctx) == T_FALSE ||
-                        gr_mpoly_equal(q1, q3, ctx) == T_FALSE ||
-                        gr_mpoly_equal(q1, q4, ctx) == T_FALSE)
+                    if (s1 == GR_DOMAIN)
                     {
-                        flint_printf("FAIL: quotient mismatch "
-                                     "(monomial_case = %d, big = %d)\n",
-                                     monomial_case, big);
-                        flint_printf("i = %wd\n", i);
-                        gr_ctx_println(cctx);
-                        flint_printf("divides               = "); gr_mpoly_print_pretty(q1, ctx); flint_printf("\n");
-                        flint_printf("div                   = "); gr_mpoly_print_pretty(q2, ctx); flint_printf("\n");
-                        flint_printf("divexact              = "); gr_mpoly_print_pretty(q3, ctx); flint_printf("\n");
-                        flint_printf("divexact_heap_threaded = "); gr_mpoly_print_pretty(q4, ctx); flint_printf("\n");
+                        /* g always divides h = f*g exactly */
+                        flint_printf("FAIL: exact division reported GR_DOMAIN\n");
+                        flint_printf("alg = %d\n", alg);
+                        gr_ctx_println(ctx);
                         fflush(stdout);
                         flint_abort();
                     }
 
-                    if (gr_mpoly_equal(q1, f, ctx) == T_FALSE)
+                    if (cctx->which_ring != GR_CTX_DEBUG &&
+                        !(alg == 0 && cctx->which_ring == GR_CTX_RR_ARB) &&
+                        s1 != GR_SUCCESS &&
+                        gr_is_invertible(g->coeffs, cctx) == T_TRUE)
+                    {
+                        flint_printf("FAIL: division unable although lc(g) is invertible\n");
+                        flint_printf("alg = %d\n", alg);
+                        gr_ctx_println(ctx);
+                        fflush(stdout);
+                        flint_abort();
+                    }
+
+                    if (s1 == GR_SUCCESS && gr_mpoly_equal(q, f, ctx) == T_FALSE)
                     {
                         flint_printf("FAIL: quotient != f\n");
-                        flint_printf("i = %wd\n", i);
+                        flint_printf("alg = %d\n", alg);
+                        gr_ctx_println(ctx);
                         fflush(stdout);
                         flint_abort();
                     }
@@ -154,208 +138,11 @@ TEST_FUNCTION_START(gr_mpoly_divexact, state)
         gr_mpoly_clear(f, ctx);
         gr_mpoly_clear(g, ctx);
         gr_mpoly_clear(h, ctx);
-        gr_mpoly_clear(q1, ctx);
-        gr_mpoly_clear(q2, ctx);
-        gr_mpoly_clear(q3, ctx);
-        gr_mpoly_clear(q4, ctx);
+        gr_mpoly_clear(q, ctx);
+        gr_mpoly_clear(r, ctx);
         gr_mpoly_ctx_clear(ctx);
         gr_ctx_clear(cctx);
-    }
-
-    /*
-        Regression test: divexact against a monomial divisor must not
-        confuse "not divisible by the monomial" with "not exact". If B is
-        a single term x^beta, and A is genuinely divisible by B, then
-        *every* term of A must be divisible by x^beta -- a term that is
-        not can only be a spurious near-zero artifact of an inexact ring
-        (there is no possibility of cancellation between distinct terms
-        of the quotient when multiplying by a single monomial). Such a
-        term must be silently dropped, not reported as GR_DOMAIN or
-        GR_UNABLE, exactly like the discarded remainder of the general
-        (non-monomial) case.
-    */
-    {
-        gr_ctx_t R;
-        gr_mpoly_ctx_t Rx;
-        gr_mpoly_t A, B, Q;
-        ulong exp[2];
-        gr_ptr c;
-        int status;
-
-        gr_ctx_init_real_arb(R, 64);
-        gr_mpoly_ctx_init(Rx, R, 2, ORD_LEX);
-
-        gr_mpoly_init(A, Rx);
-        gr_mpoly_init(B, Rx);
-        gr_mpoly_init(Q, Rx);
-
-        /* A = ([+/- eps]) * x^3 + y^2, a ball straddling zero but not
-           provably zero */
-        GR_TMP_INIT(c, R);
-
-        exp[0] = 3; exp[1] = 0;
-        status = gr_zero(c, R);
-        arb_add_error_2exp_si((arb_struct *) c, -3 - n_randint(state, 20));
-        status |= gr_mpoly_push_term_scalar_ui(A, c, exp, Rx);
-
-        exp[0] = 0; exp[1] = 2;
-        status |= gr_one(c, R);
-        status |= gr_mpoly_push_term_scalar_ui(A, c, exp, Rx);
-
-        GR_TMP_CLEAR(c, R);
-
-        gr_mpoly_sort_terms(A, Rx);
-        status |= gr_mpoly_combine_like_terms(A, Rx);
-
-        /* B = y */
-        status |= gr_mpoly_gen(B, 1, Rx);
-
-        if (status != GR_SUCCESS)
-        {
-            flint_printf("FAIL: unexpected failure setting up ball test\n");
-            fflush(stdout);
-            flint_abort();
-        }
-
-        status = gr_mpoly_divexact(Q, A, B, Rx);
-
-        if (status != GR_SUCCESS)
-        {
-            flint_printf("FAIL: gr_mpoly_divexact on ball input with a "
-                         "spurious non-dividing term returned %d "
-                         "(expected GR_SUCCESS)\n", status);
-            flint_printf("A = "); gr_mpoly_print_pretty(A, Rx); flint_printf("\n");
-            fflush(stdout);
-            flint_abort();
-        }
-
-        if (gr_mpoly_equal(Q, B, Rx) == T_FALSE)
-        {
-            flint_printf("FAIL: expected quotient y, got ");
-            gr_mpoly_print_pretty(Q, Rx);
-            flint_printf("\n");
-            fflush(stdout);
-            flint_abort();
-        }
-
-        gr_mpoly_clear(A, Rx);
-        gr_mpoly_clear(B, Rx);
-        gr_mpoly_clear(Q, Rx);
-        gr_mpoly_ctx_clear(Rx);
-        gr_ctx_clear(R);
-    }
-
-    /*
-        Regression test: an "unknown" gr_is_zero verdict on the running
-        accumulator, while reducing a term whose monomial *does* divide
-        that of the (non-monomial) divisor, must not abort gr_mpoly_divexact
-        or gr_mpoly_divrem with GR_UNABLE. We only need the coefficient
-        division itself to succeed; an accumulator that cannot be proven
-        zero is simply kept as a (possibly redundant, wide) term instead
-        of being dropped, exactly like gr_poly_divrem already does for
-        univariate polynomials.
-
-        Concretely: a = y, b = (1/3)*x + 1, c = a*b = (1/3)*x*y + y.
-        Dividing c by b (whose leading coefficient 1/3 is a unit but not
-        exactly representable) is expected to succeed with quotient y,
-        even though intermediate arb accumulators along the way straddle
-        zero without being provably zero.
-    */
-    {
-        gr_ctx_t R;
-        gr_mpoly_ctx_t Rx;
-        gr_mpoly_t a, b, c, q, q2, r2;
-        int status;
-
-        gr_ctx_init_real_arb(R, 64);
-        gr_mpoly_ctx_init(Rx, R, 2, ORD_LEX);
-
-        {
-            const char * ss[] = {"x", "y"};
-            GR_MUST_SUCCEED(gr_ctx_set_gen_names(Rx, ss));
-        }
-
-        gr_mpoly_init(a, Rx);
-        gr_mpoly_init(b, Rx);
-        gr_mpoly_init(c, Rx);
-        gr_mpoly_init(q, Rx);
-        gr_mpoly_init(q2, Rx);
-        gr_mpoly_init(r2, Rx);
-
-        status = GR_SUCCESS;
-        status |= gr_mpoly_gen(a, 1, Rx);                    /* a = y */
-        status |= gr_set_str(b, "(1/3)*x + 1", Rx);          /* b = (1/3)x + 1 */
-        status |= gr_mpoly_mul(c, a, b, Rx);                 /* c = a*b */
-
-        if (status != GR_SUCCESS)
-        {
-            flint_printf("FAIL: unexpected failure setting up divexact/arb test\n");
-            fflush(stdout);
-            flint_abort();
-        }
-
-        status = gr_mpoly_divexact(q, c, b, Rx);
-        if (status != GR_SUCCESS)
-        {
-            flint_printf("FAIL: gr_mpoly_divexact(a*b, b) over arb returned "
-                         "%d (expected GR_SUCCESS)\n", status);
-            fflush(stdout);
-            flint_abort();
-        }
-        if (gr_mpoly_equal(q, a, Rx) == T_FALSE)
-        {
-            flint_printf("FAIL: gr_mpoly_divexact(a*b, b) over arb gave a "
-                         "quotient inconsistent with a = y: ");
-            gr_mpoly_print_pretty(q, Rx);
-            flint_printf("\n");
-            fflush(stdout);
-            flint_abort();
-        }
-
-        status = gr_mpoly_divrem(q2, r2, c, b, Rx);
-        if (status != GR_SUCCESS)
-        {
-            flint_printf("FAIL: gr_mpoly_divrem(a*b, b) over arb returned "
-                         "%d (expected GR_SUCCESS)\n", status);
-            fflush(stdout);
-            flint_abort();
-        }
-        if (gr_mpoly_equal(q2, a, Rx) == T_FALSE)
-        {
-            flint_printf("FAIL: gr_mpoly_divrem(a*b, b) over arb gave a "
-                         "quotient inconsistent with a = y: ");
-            gr_mpoly_print_pretty(q2, Rx);
-            flint_printf("\n");
-            fflush(stdout);
-            flint_abort();
-        }
-
-        /* by contrast, gr_mpoly_divides is allowed (expected) to report
-           GR_UNABLE here, since exactness genuinely cannot be certified
-           over an inexact ring; this is a deliberate difference in
-           semantics from gr_mpoly_div(exact)/gr_mpoly_divrem, not a bug */
-        {
-            gr_mpoly_t qd;
-            gr_mpoly_init(qd, Rx);
-            status = gr_mpoly_divides(qd, c, b, Rx);
-            if (status == GR_DOMAIN)
-            {
-                flint_printf("FAIL: gr_mpoly_divides(a*b, b) over arb "
-                             "incorrectly reported GR_DOMAIN\n");
-                fflush(stdout);
-                flint_abort();
-            }
-            gr_mpoly_clear(qd, Rx);
-        }
-
-        gr_mpoly_clear(a, Rx);
-        gr_mpoly_clear(b, Rx);
-        gr_mpoly_clear(c, Rx);
-        gr_mpoly_clear(q, Rx);
-        gr_mpoly_clear(q2, Rx);
-        gr_mpoly_clear(r2, Rx);
-        gr_mpoly_ctx_clear(Rx);
-        gr_ctx_clear(R);
+        gr_ctx_clear(ctx1);
     }
 
     TEST_FUNCTION_END(state);

--- a/src/gr_mpoly/test/t-divexact.c
+++ b/src/gr_mpoly/test/t-divexact.c
@@ -1,0 +1,249 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "arb.h"
+#include "gr_mpoly.h"
+
+FLINT_DLL extern gr_static_method_table _ca_methods;
+
+TEST_FUNCTION_START(gr_mpoly_divexact, state)
+{
+    slong i;
+
+    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    {
+        gr_ctx_t cctx;
+        gr_mpoly_ctx_t ctx;
+        gr_mpoly_t f, g, h, q1, q2, q3, q4;
+        slong lenf, leng;
+        flint_bitcnt_t exp_bits;
+        int status, s1, s2, s3, s4;
+        int monomial_case = (n_randint(state, 4) == 0);
+        int big = (!monomial_case && n_randint(state, 8) == 0);
+
+        switch (n_randint(state, 4))
+        {
+            case 0:
+                gr_ctx_init_random_finite_field(cctx, state);
+                break;
+            case 1:
+                gr_ctx_init_fmpz(cctx);
+                break;
+            case 2:
+                gr_ctx_init_fmpq(cctx);
+                break;
+            default:
+                gr_ctx_init_nmod(cctx, n_randtest_prime(state, 1));
+                break;
+        }
+
+        gr_mpoly_ctx_init_rand(ctx, state, cctx, 4);
+
+        gr_mpoly_init(f, ctx);
+        gr_mpoly_init(g, ctx);
+        gr_mpoly_init(h, ctx);
+        gr_mpoly_init(q1, ctx);
+        gr_mpoly_init(q2, ctx);
+        gr_mpoly_init(q3, ctx);
+        gr_mpoly_init(q4, ctx);
+
+        flint_set_num_threads(1 + n_randint(state, 4));
+
+        /* occasionally big enough to actually exercise the threaded
+           dispatch inside gr_mpoly_divexact (A->length > 500, B->length
+           > 2), and always call gr_mpoly_divexact_heap_threaded directly
+           too, regardless of size, to exercise it even when small inputs
+           would otherwise make gr_mpoly_divexact stay serial */
+        lenf = n_randint(state, big ? 400 : 20) + 1;
+        leng = monomial_case ? 1 : (n_randint(state, big ? 80 : 10) + 3);
+        exp_bits = n_randint(state, big ? 12 : 4) + 2;
+
+        status = GR_SUCCESS;
+        status |= gr_mpoly_randtest_bits(f, state, lenf, exp_bits, ctx);
+        status |= gr_mpoly_randtest_bits(g, state, leng, exp_bits, ctx);
+        if (gr_mpoly_is_zero(g, ctx) != T_FALSE)
+            status |= gr_mpoly_one(g, ctx);
+
+        if (status == GR_SUCCESS)
+        {
+            /* h = f * g, so g divides h exactly with quotient f */
+            status = gr_mpoly_mul(h, f, g, ctx);
+
+            if (status == GR_SUCCESS)
+            {
+                s1 = gr_mpoly_divides(q1, h, g, ctx);
+                s2 = gr_mpoly_div(q2, h, g, ctx);
+                s3 = gr_mpoly_divexact(q3, h, g, ctx);
+                if (monomial_case)
+                {
+                    s4 = s3;
+                    GR_IGNORE(gr_mpoly_set(q4, q3, ctx));
+                }
+                else
+                {
+                    s4 = gr_mpoly_divexact_heap_threaded(q4, h, g, ctx);
+                }
+
+                if (s1 == GR_DOMAIN)
+                {
+                    /* g always divides h = f*g exactly */
+                    flint_printf("FAIL: exact division reported GR_DOMAIN "
+                                 "by gr_mpoly_divides\n");
+                    flint_printf("i = %wd\n", i);
+                    gr_ctx_println(cctx);
+                    fflush(stdout);
+                    flint_abort();
+                }
+
+                if (s1 == GR_SUCCESS &&
+                    (s2 != GR_SUCCESS || s3 != GR_SUCCESS || s4 != GR_SUCCESS))
+                {
+                    flint_printf("FAIL: exact division but "
+                                 "div = %d, divexact = %d, "
+                                 "divexact_heap_threaded = %d\n", s2, s3, s4);
+                    flint_printf("i = %wd\n", i);
+                    gr_ctx_println(cctx);
+                    fflush(stdout);
+                    flint_abort();
+                }
+
+                if (s1 == GR_SUCCESS)
+                {
+                    gr_mpoly_assert_canonical(q1, ctx);
+                    gr_mpoly_assert_canonical(q2, ctx);
+                    gr_mpoly_assert_canonical(q3, ctx);
+                    gr_mpoly_assert_canonical(q4, ctx);
+
+                    if (gr_mpoly_equal(q1, q2, ctx) == T_FALSE ||
+                        gr_mpoly_equal(q1, q3, ctx) == T_FALSE ||
+                        gr_mpoly_equal(q1, q4, ctx) == T_FALSE)
+                    {
+                        flint_printf("FAIL: quotient mismatch "
+                                     "(monomial_case = %d, big = %d)\n",
+                                     monomial_case, big);
+                        flint_printf("i = %wd\n", i);
+                        gr_ctx_println(cctx);
+                        flint_printf("divides               = "); gr_mpoly_print_pretty(q1, ctx); flint_printf("\n");
+                        flint_printf("div                   = "); gr_mpoly_print_pretty(q2, ctx); flint_printf("\n");
+                        flint_printf("divexact              = "); gr_mpoly_print_pretty(q3, ctx); flint_printf("\n");
+                        flint_printf("divexact_heap_threaded = "); gr_mpoly_print_pretty(q4, ctx); flint_printf("\n");
+                        fflush(stdout);
+                        flint_abort();
+                    }
+
+                    if (gr_mpoly_equal(q1, f, ctx) == T_FALSE)
+                    {
+                        flint_printf("FAIL: quotient != f\n");
+                        flint_printf("i = %wd\n", i);
+                        fflush(stdout);
+                        flint_abort();
+                    }
+                }
+            }
+        }
+
+        gr_mpoly_clear(f, ctx);
+        gr_mpoly_clear(g, ctx);
+        gr_mpoly_clear(h, ctx);
+        gr_mpoly_clear(q1, ctx);
+        gr_mpoly_clear(q2, ctx);
+        gr_mpoly_clear(q3, ctx);
+        gr_mpoly_clear(q4, ctx);
+        gr_mpoly_ctx_clear(ctx);
+        gr_ctx_clear(cctx);
+    }
+
+    /*
+        Regression test: divexact against a monomial divisor must not
+        confuse "not divisible by the monomial" with "not exact". If B is
+        a single term x^beta, and A is genuinely divisible by B, then
+        *every* term of A must be divisible by x^beta -- a term that is
+        not can only be a spurious near-zero artifact of an inexact ring
+        (there is no possibility of cancellation between distinct terms
+        of the quotient when multiplying by a single monomial). Such a
+        term must be silently dropped, not reported as GR_DOMAIN or
+        GR_UNABLE, exactly like the discarded remainder of the general
+        (non-monomial) case.
+    */
+    {
+        gr_ctx_t R;
+        gr_mpoly_ctx_t Rx;
+        gr_mpoly_t A, B, Q;
+        ulong exp[2];
+        gr_ptr c;
+        int status;
+
+        gr_ctx_init_real_arb(R, 64);
+        gr_mpoly_ctx_init(Rx, R, 2, ORD_LEX);
+
+        gr_mpoly_init(A, Rx);
+        gr_mpoly_init(B, Rx);
+        gr_mpoly_init(Q, Rx);
+
+        /* A = ([+/- eps]) * x^3 + y^2, a ball straddling zero but not
+           provably zero */
+        GR_TMP_INIT(c, R);
+
+        exp[0] = 3; exp[1] = 0;
+        status = gr_zero(c, R);
+        arb_add_error_2exp_si((arb_struct *) c, -3 - n_randint(state, 20));
+        status |= gr_mpoly_push_term_scalar_ui(A, c, exp, Rx);
+
+        exp[0] = 0; exp[1] = 2;
+        status |= gr_one(c, R);
+        status |= gr_mpoly_push_term_scalar_ui(A, c, exp, Rx);
+
+        GR_TMP_CLEAR(c, R);
+
+        gr_mpoly_sort_terms(A, Rx);
+        status |= gr_mpoly_combine_like_terms(A, Rx);
+
+        /* B = y */
+        status |= gr_mpoly_gen(B, 1, Rx);
+
+        if (status != GR_SUCCESS)
+        {
+            flint_printf("FAIL: unexpected failure setting up ball test\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        status = gr_mpoly_divexact(Q, A, B, Rx);
+
+        if (status != GR_SUCCESS)
+        {
+            flint_printf("FAIL: gr_mpoly_divexact on ball input with a "
+                         "spurious non-dividing term returned %d "
+                         "(expected GR_SUCCESS)\n", status);
+            flint_printf("A = "); gr_mpoly_print_pretty(A, Rx); flint_printf("\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        if (gr_mpoly_equal(Q, B, Rx) == T_FALSE)
+        {
+            flint_printf("FAIL: expected quotient y, got ");
+            gr_mpoly_print_pretty(Q, Rx);
+            flint_printf("\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        gr_mpoly_clear(A, Rx);
+        gr_mpoly_clear(B, Rx);
+        gr_mpoly_clear(Q, Rx);
+        gr_mpoly_ctx_clear(Rx);
+        gr_ctx_clear(R);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/gr_mpoly/test/t-divides.c
+++ b/src/gr_mpoly/test/t-divides.c
@@ -191,8 +191,11 @@ TEST_FUNCTION_START(gr_mpoly_divides, state)
         gr_mpoly_ctx_t ctx;
         int big = (n_randint(state, 8) == 0);
 
+        gr_ctx_t ctx1;
+        gr_ctx_init_nmod8(ctx1, n_randprime(state, 8, 1));
+
         /* commutative rings only: choose a field or integral domain */
-        switch (n_randint(state, 5))
+        switch (n_randint(state, 8))
         {
             case 0:
                 gr_ctx_init_fmpz(cctx);
@@ -207,7 +210,7 @@ TEST_FUNCTION_START(gr_mpoly_divides, state)
                 gr_ctx_init_real_arb(cctx, 2 + n_randint(state, 200));
                 break;
             default:
-                gr_ctx_init_nmod(cctx, n_randtest_prime(state, 1));
+                gr_ctx_init_debug(cctx, ctx1, n_randint(state, 2), n_randint(state, 2) ? 0.0 : 0.001);
                 break;
         }
 
@@ -219,6 +222,7 @@ TEST_FUNCTION_START(gr_mpoly_divides, state)
 
         gr_mpoly_ctx_clear(ctx);
         gr_ctx_clear(cctx);
+        gr_ctx_clear(ctx1);
     }
 
     TEST_FUNCTION_END(state);

--- a/src/gr_mpoly/test/t-divides_heap_threaded.c
+++ b/src/gr_mpoly/test/t-divides_heap_threaded.c
@@ -1,0 +1,248 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "gr_mpoly.h"
+
+FLINT_DLL extern gr_static_method_table _ca_methods;
+
+TEST_FUNCTION_START(gr_mpoly_divides_heap_threaded, state)
+{
+    slong i, j;
+
+    gr_ctx_t ctx1;
+    gr_ctx_init_nmod(ctx1, 17);
+
+    /* Check that the threaded quotient matches the serial heap quotient */
+    for (i = 0; i < 20 * flint_test_multiplier(); i++)
+    {
+        gr_ctx_t cctx;
+        gr_ctx_t debug_base_ctx;
+        int used_debug_base = 0;
+        gr_mpoly_ctx_t ctx;
+        gr_mpoly_t f, g, h, q1, q2;
+        slong lenf, leng;
+        flint_bitcnt_t exp_bits;
+        int status, aliasing;
+        int big = (n_randint(state, 8) == 0);
+
+        switch (n_randint(state, 5))
+        {
+            case 0:
+                gr_ctx_init_random_finite_field(cctx, state);
+                break;
+            case 1:
+                gr_ctx_init_fmpz(cctx);
+                break;
+            case 2:
+                gr_ctx_init_fmpq(cctx);
+                break;
+            case 3:
+                /* Regression coverage: a ring whose operations can
+                   randomly return GR_UNABLE must never cause a spurious
+                   GR_DOMAIN verdict on an exactly-divisible instance (the
+                   "not exact" detection must OR GR_DOMAIN into any status
+                   already accumulated while computing the tainted term,
+                   not overwrite it -- see gr_mpoly_divides_heap). Keep
+                   sizes modest here: GR_DEBUG_WRAP gives every coefficient
+                   a real heap allocation, making "big" instances far
+                   heavier per-term than for the other rings tested above. */
+                gr_ctx_init_nmod8(debug_base_ctx, 251);
+                used_debug_base = 1;
+                gr_ctx_init_debug(cctx, debug_base_ctx, n_randint(state, 2),
+                                   n_randint(state, 2) ? 0.0 : 0.001);
+                big = 0;
+                break;
+            default:
+                gr_ctx_init_nmod(cctx, n_randtest_prime(state, 1));
+                break;
+        }
+
+        gr_mpoly_ctx_init_rand(ctx, state, cctx, 4);
+
+        gr_mpoly_init(f, ctx);
+        gr_mpoly_init(g, ctx);
+        gr_mpoly_init(h, ctx);
+        gr_mpoly_init(q1, ctx);
+        gr_mpoly_init(q2, ctx);
+
+        flint_set_num_threads(1 + n_randint(state, 4));
+
+        lenf = n_randint(state, big ? 80 : 20) + 1;
+        leng = n_randint(state, big ? 30 : 10) + 1;
+        exp_bits = n_randint(state, big ? 12 : 4) + 2;
+
+        for (j = 0; j < 2; j++)
+        {
+            status = GR_SUCCESS;
+
+            status |= gr_mpoly_randtest_bits(f, state, lenf, exp_bits, ctx);
+            status |= gr_mpoly_randtest_bits(g, state, leng, exp_bits, ctx);
+
+            if (gr_mpoly_is_zero(g, ctx) != T_FALSE)
+                status |= gr_mpoly_one(g, ctx);
+
+            /* h = f * g, so g is guaranteed to divide h with quotient f */
+            status |= gr_mpoly_mul(h, f, g, ctx);
+
+            if (status != GR_SUCCESS)
+                continue;
+
+            status = GR_SUCCESS;
+            status |= gr_mpoly_randtest_bits(q1, state, n_randint(state, 3),
+                                                   n_randint(state, 4) + 2, ctx);
+            status |= gr_mpoly_randtest_bits(q2, state, n_randint(state, 3),
+                                                   n_randint(state, 4) + 2, ctx);
+
+            {
+                int dstatus1 = gr_mpoly_divides_heap(q1, h, g, ctx);
+                int dstatus2;
+
+                aliasing = n_randint(state, 3);
+
+                switch (aliasing)
+                {
+                    case 0:
+                        dstatus2 = gr_mpoly_divides_heap_threaded(q2, h, g, ctx);
+                        break;
+                    case 1:
+                        status |= gr_mpoly_set(q2, h, ctx);
+                        dstatus2 = gr_mpoly_divides_heap_threaded(q2, q2, g, ctx);
+                        break;
+                    default:
+                        status |= gr_mpoly_set(q2, g, ctx);
+                        dstatus2 = gr_mpoly_divides_heap_threaded(q2, h, q2, ctx);
+                        break;
+                }
+
+                if (status != GR_SUCCESS)
+                    continue;
+
+                if (dstatus1 == GR_SUCCESS && dstatus2 == GR_SUCCESS)
+                {
+                    gr_mpoly_assert_canonical(q1, ctx);
+                    gr_mpoly_assert_canonical(q2, ctx);
+
+                    if (gr_mpoly_equal(q1, q2, ctx) == T_FALSE)
+                    {
+                        flint_printf("FAIL: threaded != heap\n");
+                        flint_printf("i = %wd, j = %wd, aliasing = %d\n", i, j, aliasing);
+                        gr_ctx_println(cctx);
+                        flint_printf("f = "); gr_mpoly_print_pretty(f, ctx); flint_printf("\n");
+                        flint_printf("g = "); gr_mpoly_print_pretty(g, ctx); flint_printf("\n");
+                        flint_printf("heap     = "); gr_mpoly_print_pretty(q1, ctx); flint_printf("\n");
+                        flint_printf("threaded = "); gr_mpoly_print_pretty(q2, ctx); flint_printf("\n");
+                        fflush(stdout);
+                        flint_abort();
+                    }
+
+                    if (gr_mpoly_equal(q1, f, ctx) == T_FALSE)
+                    {
+                        flint_printf("FAIL: quotient != f\n");
+                        flint_printf("i = %wd, j = %wd\n", i, j);
+                        gr_ctx_println(cctx);
+                        fflush(stdout);
+                        flint_abort();
+                    }
+                }
+                else if (dstatus1 == GR_DOMAIN || dstatus2 == GR_DOMAIN)
+                {
+                    /* g always divides h = f*g exactly; a definite GR_DOMAIN
+                       verdict from either algorithm would be a bug */
+                    flint_printf("FAIL: exact division incorrectly reported as GR_DOMAIN\n");
+                    flint_printf("i = %wd, j = %wd, dstatus1 = %d, dstatus2 = %d\n",
+                                                            i, j, dstatus1, dstatus2);
+                    gr_ctx_println(cctx);
+                    fflush(stdout);
+                    flint_abort();
+                }
+            }
+        }
+
+        gr_mpoly_clear(f, ctx);
+        gr_mpoly_clear(g, ctx);
+        gr_mpoly_clear(h, ctx);
+        gr_mpoly_clear(q1, ctx);
+        gr_mpoly_clear(q2, ctx);
+
+        gr_mpoly_ctx_clear(ctx);
+        gr_ctx_clear(cctx);
+        if (used_debug_base)
+            gr_ctx_clear(debug_base_ctx);
+    }
+
+    /* Also check on arbitrary (not necessarily divisible) inputs that the
+       two algorithms never disagree when both succeed */
+    for (i = 0; i < 20 * flint_test_multiplier(); i++)
+    {
+        gr_mpoly_ctx_t ctx;
+        gr_mpoly_t f, g, q1, q2;
+        int status, dstatus1, dstatus2;
+        int big = (n_randint(state, 8) == 0);
+
+        gr_mpoly_ctx_init_rand(ctx, state, ctx1, 4);
+
+        gr_mpoly_init(f, ctx);
+        gr_mpoly_init(g, ctx);
+        gr_mpoly_init(q1, ctx);
+        gr_mpoly_init(q2, ctx);
+
+        flint_set_num_threads(1 + n_randint(state, 4));
+
+        status = GR_SUCCESS;
+        status |= gr_mpoly_randtest_bits(f, state, n_randint(state, big ? 100 : 20) + 1,
+                                                n_randint(state, big ? 12 : 4) + 2, ctx);
+        status |= gr_mpoly_randtest_bits(g, state, n_randint(state, big ? 30 : 10) + 1,
+                                                n_randint(state, big ? 12 : 4) + 2, ctx);
+        if (gr_mpoly_is_zero(g, ctx) != T_FALSE)
+            status |= gr_mpoly_one(g, ctx);
+
+        if (status == GR_SUCCESS)
+        {
+            dstatus1 = gr_mpoly_divides_heap(q1, f, g, ctx);
+            dstatus2 = gr_mpoly_divides_heap_threaded(q2, f, g, ctx);
+
+            if (dstatus1 != dstatus2)
+            {
+                flint_printf("FAIL: status mismatch (heap=%d, threaded=%d)\n",
+                                                            dstatus1, dstatus2);
+                flint_printf("f = "); gr_mpoly_print_pretty(f, ctx); flint_printf("\n");
+                flint_printf("g = "); gr_mpoly_print_pretty(g, ctx); flint_printf("\n");
+                fflush(stdout);
+                flint_abort();
+            }
+
+            if (dstatus1 == GR_SUCCESS)
+            {
+                gr_mpoly_assert_canonical(q1, ctx);
+                gr_mpoly_assert_canonical(q2, ctx);
+
+                if (gr_mpoly_equal(q1, q2, ctx) == T_FALSE)
+                {
+                    flint_printf("FAIL: threaded != heap (arbitrary inputs)\n");
+                    fflush(stdout);
+                    flint_abort();
+                }
+            }
+        }
+
+        gr_mpoly_clear(f, ctx);
+        gr_mpoly_clear(g, ctx);
+        gr_mpoly_clear(q1, ctx);
+        gr_mpoly_clear(q2, ctx);
+
+        gr_mpoly_ctx_clear(ctx);
+    }
+
+    gr_ctx_clear(ctx1);
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/gr_mpoly/test/t-divides_heap_threaded.c
+++ b/src/gr_mpoly/test/t-divides_heap_threaded.c
@@ -12,8 +12,6 @@
 #include "test_helpers.h"
 #include "gr_mpoly.h"
 
-FLINT_DLL extern gr_static_method_table _ca_methods;
-
 TEST_FUNCTION_START(gr_mpoly_divides_heap_threaded, state)
 {
     slong i, j;
@@ -22,7 +20,7 @@ TEST_FUNCTION_START(gr_mpoly_divides_heap_threaded, state)
     gr_ctx_init_nmod(ctx1, 17);
 
     /* Check that the threaded quotient matches the serial heap quotient */
-    for (i = 0; i < 20 * flint_test_multiplier(); i++)
+    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
     {
         gr_ctx_t cctx;
         gr_ctx_t debug_base_ctx;
@@ -32,7 +30,7 @@ TEST_FUNCTION_START(gr_mpoly_divides_heap_threaded, state)
         slong lenf, leng;
         flint_bitcnt_t exp_bits;
         int status, aliasing;
-        int big = (n_randint(state, 8) == 0);
+        int big = (n_randint(state, 10) == 0);
 
         switch (n_randint(state, 5))
         {
@@ -78,7 +76,7 @@ TEST_FUNCTION_START(gr_mpoly_divides_heap_threaded, state)
 
         lenf = n_randint(state, big ? 80 : 20) + 1;
         leng = n_randint(state, big ? 30 : 10) + 1;
-        exp_bits = n_randint(state, big ? 12 : 4) + 2;
+        exp_bits = n_randint(state, big ? 6 : 4) + 2;
 
         for (j = 0; j < 2; j++)
         {
@@ -98,9 +96,9 @@ TEST_FUNCTION_START(gr_mpoly_divides_heap_threaded, state)
 
             status = GR_SUCCESS;
             status |= gr_mpoly_randtest_bits(q1, state, n_randint(state, 3),
-                                                   n_randint(state, 4) + 2, ctx);
+                                                   n_randint(state, 6) + 2, ctx);
             status |= gr_mpoly_randtest_bits(q2, state, n_randint(state, 3),
-                                                   n_randint(state, 4) + 2, ctx);
+                                                   n_randint(state, 6) + 2, ctx);
 
             {
                 int dstatus1 = gr_mpoly_divides_heap(q1, h, g, ctx);
@@ -181,14 +179,14 @@ TEST_FUNCTION_START(gr_mpoly_divides_heap_threaded, state)
 
     /* Also check on arbitrary (not necessarily divisible) inputs that the
        two algorithms never disagree when both succeed */
-    for (i = 0; i < 20 * flint_test_multiplier(); i++)
+    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
     {
         gr_mpoly_ctx_t ctx;
         gr_mpoly_t f, g, q1, q2;
         int status, dstatus1, dstatus2;
-        int big = (n_randint(state, 8) == 0);
+        int big = (n_randint(state, 100) == 0);
 
-        gr_mpoly_ctx_init_rand(ctx, state, ctx1, 4);
+        gr_mpoly_ctx_init_rand(ctx, state, ctx1, 12);
 
         gr_mpoly_init(f, ctx);
         gr_mpoly_init(g, ctx);
@@ -199,9 +197,9 @@ TEST_FUNCTION_START(gr_mpoly_divides_heap_threaded, state)
 
         status = GR_SUCCESS;
         status |= gr_mpoly_randtest_bits(f, state, n_randint(state, big ? 100 : 20) + 1,
-                                                n_randint(state, big ? 12 : 4) + 2, ctx);
+                                                n_randint(state, big ? 8 : 4) + 2, ctx);
         status |= gr_mpoly_randtest_bits(g, state, n_randint(state, big ? 30 : 10) + 1,
-                                                n_randint(state, big ? 12 : 4) + 2, ctx);
+                                                n_randint(state, big ? 8 : 4) + 2, ctx);
         if (gr_mpoly_is_zero(g, ctx) != T_FALSE)
             status |= gr_mpoly_one(g, ctx);
 

--- a/src/gr_mpoly/test/t-divrem.c
+++ b/src/gr_mpoly/test/t-divrem.c
@@ -141,6 +141,16 @@ TEST_FUNCTION_START(gr_mpoly_divrem, state)
             flint_abort();
         }
 
+        if (cctx->which_ring != GR_CTX_DEBUG &&
+            status != GR_SUCCESS &&
+            gr_is_invertible(b->coeffs, cctx) == T_TRUE)
+        {
+            flint_printf("FAIL: division unable although lc(g) is invertible\n");
+            gr_ctx_println(ctx);
+            fflush(stdout);
+            flint_abort();
+        }
+
         /* nonfield (euclidean) variant: a == q*b + r always */
         status = gr_mpoly_divrem_weak(q, r, a, b, ctx);
         if (status == GR_SUCCESS)

--- a/src/gr_mpoly/test/t-divrem.c
+++ b/src/gr_mpoly/test/t-divrem.c
@@ -26,6 +26,9 @@ TEST_FUNCTION_START(gr_mpoly_divrem, state)
         int status, big;
         truth_t is_field;
 
+        gr_ctx_t ctx1;
+        gr_ctx_init_nmod8(ctx1, n_randprime(state, 8, 1));
+
         big = (n_randint(state, 4) == 0);
 
         if (big)
@@ -42,8 +45,10 @@ TEST_FUNCTION_START(gr_mpoly_divrem, state)
             gr_ctx_init_fmpq(cctx);
         else if (n_randint(state, 2))
             gr_ctx_init_real_arb(cctx, 2 + n_randint(state, 200));
-        else
+        else if (n_randint(state, 2))
             gr_ctx_init_nmod(cctx, n_randtest_prime(state, 1));
+        else
+            gr_ctx_init_debug(cctx, ctx1, n_randint(state, 2), n_randint(state, 2) ? 0.0 : 0.001);
 
         gr_mpoly_ctx_init_rand(ctx, state, cctx, 15);
         is_field = gr_mpoly_ctx_is_field(ctx);
@@ -188,6 +193,7 @@ next:
         gr_mpoly_clear(u, ctx);
         gr_mpoly_ctx_clear(ctx);
         gr_ctx_clear(cctx);
+        gr_ctx_clear(ctx1);
     }
 
     TEST_FUNCTION_END(state);

--- a/src/gr_mpoly/test/t-divrem_heap_threaded.c
+++ b/src/gr_mpoly/test/t-divrem_heap_threaded.c
@@ -1,0 +1,191 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "gr_mpoly.h"
+
+FLINT_DLL extern gr_static_method_table _ca_methods;
+
+TEST_FUNCTION_START(gr_mpoly_divrem_heap_threaded, state)
+{
+    slong i;
+
+    /* Check that the threaded div/divrem family matches the serial kernel,
+       for both the exact-coefficient and Euclidean ("weak") variants, with
+       and without a remainder. */
+    for (i = 0; i < 30 * flint_test_multiplier(); i++)
+    {
+        gr_ctx_t cctx;
+        gr_ctx_t debug_base_ctx;
+        int used_debug_base = 0;
+        gr_mpoly_ctx_t ctx;
+        gr_mpoly_t f, g, q1, q2, r1, r2, t;
+        slong lenf, leng;
+        flint_bitcnt_t exp_bits;
+        int status, nonfield, want_r;
+        int s1, s2;
+        int big = (n_randint(state, 8) == 0);
+
+        switch (n_randint(state, 5))
+        {
+            case 0:
+                gr_ctx_init_random_finite_field(cctx, state);
+                break;
+            case 1:
+                gr_ctx_init_fmpz(cctx);
+                break;
+            case 2:
+                gr_ctx_init_fmpq(cctx);
+                break;
+            case 3:
+                /* Regression coverage: a ring whose operations can
+                   randomly return GR_UNABLE must never cause a spurious
+                   GR_DOMAIN verdict on an exactly-divisible instance --
+                   see the analogous case in t-divides_heap_threaded.c and
+                   the "status |= cstatus" pattern in
+                   STRIPE_DIVREM_COEFF_STEP / DIVREM_COEFF_STEP. Keep sizes
+                   modest: GR_DEBUG_WRAP gives every coefficient a real
+                   heap allocation, making "big" instances far heavier per
+                   term than for the other rings tested above. */
+                gr_ctx_init_nmod8(debug_base_ctx, 251);
+                used_debug_base = 1;
+                gr_ctx_init_debug(cctx, debug_base_ctx, n_randint(state, 2),
+                                   n_randint(state, 2) ? 0.0 : 0.001);
+                big = 0;
+                break;
+            default:
+                gr_ctx_init_nmod(cctx, n_randtest_prime(state, 1));
+                break;
+        }
+
+        gr_mpoly_ctx_init_rand(ctx, state, cctx, 4);
+
+        gr_mpoly_init(f, ctx);
+        gr_mpoly_init(g, ctx);
+        gr_mpoly_init(q1, ctx);
+        gr_mpoly_init(q2, ctx);
+        gr_mpoly_init(r1, ctx);
+        gr_mpoly_init(r2, ctx);
+        gr_mpoly_init(t, ctx);
+
+        flint_set_num_threads(1 + n_randint(state, 4));
+
+        lenf = n_randint(state, big ? 80 : 20) + 1;
+        leng = n_randint(state, big ? 30 : 10) + 1;
+        exp_bits = n_randint(state, big ? 12 : 4) + 2;
+
+        status = GR_SUCCESS;
+        status |= gr_mpoly_randtest_bits(f, state, lenf, exp_bits, ctx);
+        status |= gr_mpoly_randtest_bits(g, state, leng, exp_bits, ctx);
+        if (gr_mpoly_is_zero(g, ctx) != T_FALSE)
+            status |= gr_mpoly_one(g, ctx);
+
+        if (status != GR_SUCCESS)
+        {
+            gr_mpoly_clear(f, ctx); gr_mpoly_clear(g, ctx);
+            gr_mpoly_clear(q1, ctx); gr_mpoly_clear(q2, ctx);
+            gr_mpoly_clear(r1, ctx); gr_mpoly_clear(r2, ctx);
+            gr_mpoly_clear(t, ctx);
+            gr_mpoly_ctx_clear(ctx); gr_ctx_clear(cctx);
+            if (used_debug_base) gr_ctx_clear(debug_base_ctx);
+            continue;
+        }
+
+        nonfield = n_randint(state, 2);
+        want_r = n_randint(state, 2);
+
+        if (want_r)
+        {
+            s1 = nonfield ? gr_mpoly_divrem_weak(q1, r1, f, g, ctx)
+                          : gr_mpoly_divrem_heap(q1, r1, f, g, ctx);
+            s2 = nonfield ? gr_mpoly_divrem_weak_heap_threaded(q2, r2, f, g, ctx)
+                          : gr_mpoly_divrem_heap_threaded(q2, r2, f, g, ctx);
+        }
+        else
+        {
+            s1 = nonfield ? gr_mpoly_div_weak(q1, f, g, ctx)
+                          : gr_mpoly_div(q1, f, g, ctx);
+            s2 = nonfield ? gr_mpoly_div_weak_heap_threaded(q2, f, g, ctx)
+                          : gr_mpoly_div_heap_threaded(q2, f, g, ctx);
+        }
+
+        if (s1 != s2)
+        {
+            flint_printf("FAIL: status mismatch serial=%d threaded=%d "
+                         "nonfield=%d want_r=%d\n", s1, s2, nonfield, want_r);
+            flint_printf("i = %wd\n", i);
+            gr_ctx_println(cctx);
+            flint_printf("f = "); gr_mpoly_print_pretty(f, ctx); flint_printf("\n");
+            flint_printf("g = "); gr_mpoly_print_pretty(g, ctx); flint_printf("\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        if (s1 == GR_SUCCESS)
+        {
+            gr_mpoly_assert_canonical(q1, ctx);
+            gr_mpoly_assert_canonical(q2, ctx);
+
+            if (gr_mpoly_equal(q1, q2, ctx) == T_FALSE)
+            {
+                flint_printf("FAIL: quotient mismatch nonfield=%d want_r=%d\n",
+                                                            nonfield, want_r);
+                flint_printf("i = %wd\n", i);
+                gr_ctx_println(cctx);
+                fflush(stdout);
+                flint_abort();
+            }
+
+            if (want_r)
+            {
+                gr_mpoly_assert_canonical(r1, ctx);
+                gr_mpoly_assert_canonical(r2, ctx);
+
+                if (gr_mpoly_equal(r1, r2, ctx) == T_FALSE)
+                {
+                    flint_printf("FAIL: remainder mismatch nonfield=%d\n", nonfield);
+                    flint_printf("i = %wd\n", i);
+                    gr_ctx_println(cctx);
+                    fflush(stdout);
+                    flint_abort();
+                }
+
+                /* reconstruction: q2*g + r2 == f */
+                if (gr_mpoly_mul(t, q2, g, ctx) == GR_SUCCESS &&
+                    gr_mpoly_add(t, t, r2, ctx) == GR_SUCCESS)
+                {
+                    if (gr_mpoly_equal(t, f, ctx) == T_FALSE)
+                    {
+                        flint_printf("FAIL: q*g + r != f\n");
+                        flint_printf("i = %wd\n", i);
+                        gr_ctx_println(cctx);
+                        fflush(stdout);
+                        flint_abort();
+                    }
+                }
+            }
+        }
+
+        gr_mpoly_clear(f, ctx);
+        gr_mpoly_clear(g, ctx);
+        gr_mpoly_clear(q1, ctx);
+        gr_mpoly_clear(q2, ctx);
+        gr_mpoly_clear(r1, ctx);
+        gr_mpoly_clear(r2, ctx);
+        gr_mpoly_clear(t, ctx);
+        gr_mpoly_ctx_clear(ctx);
+        gr_ctx_clear(cctx);
+        if (used_debug_base)
+            gr_ctx_clear(debug_base_ctx);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/gr_mpoly/test/t-divrem_heap_threaded.c
+++ b/src/gr_mpoly/test/t-divrem_heap_threaded.c
@@ -16,11 +16,8 @@ FLINT_DLL extern gr_static_method_table _ca_methods;
 
 TEST_FUNCTION_START(gr_mpoly_divrem_heap_threaded, state)
 {
-    slong i;
+    slong i, iter;
 
-    /* Check that the threaded div/divrem family matches the serial kernel,
-       for both the exact-coefficient and Euclidean ("weak") variants, with
-       and without a remainder. */
     for (i = 0; i < 30 * flint_test_multiplier(); i++)
     {
         gr_ctx_t cctx;
@@ -185,6 +182,198 @@ TEST_FUNCTION_START(gr_mpoly_divrem_heap_threaded, state)
         gr_ctx_clear(cctx);
         if (used_debug_base)
             gr_ctx_clear(debug_base_ctx);
+    }
+
+    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
+    {
+        gr_ctx_t cctx;
+        gr_mpoly_ctx_t ctx;
+        gr_mpoly_t a, b, q, r, t, u;
+        slong len, blen;
+        flint_bitcnt_t ebits;
+        int status, big;
+        truth_t is_field;
+
+        flint_set_num_threads(1 + n_randint(state, 4));
+
+        gr_ctx_t ctx1;
+        gr_ctx_init_nmod8(ctx1, n_randprime(state, 8, 1));
+
+        big = (n_randint(state, 4) == 0);
+
+        if (big)
+        {
+            /* bounded-coefficient ring + large exponents (few terms) to
+               exercise the overflow retry without coefficient blow-up */
+            gr_ctx_init_nmod(cctx, n_randprime(state, 5 + n_randint(state, 10), 1));
+        }
+        else if (n_randint(state, 2))
+            gr_ctx_init_random_finite_field(cctx, state);
+        else if (n_randint(state, 3) == 0)
+            gr_ctx_init_fmpz(cctx);
+        else if (n_randint(state, 2))
+            gr_ctx_init_fmpq(cctx);
+        else if (n_randint(state, 2))
+            gr_ctx_init_real_arb(cctx, 2 + n_randint(state, 200));
+        else if (n_randint(state, 2))
+            gr_ctx_init_nmod(cctx, n_randtest_prime(state, 1));
+        else
+            gr_ctx_init_debug(cctx, ctx1, n_randint(state, 2), n_randint(state, 2) ? 0.0 : 0.001);
+
+        gr_mpoly_ctx_init_rand(ctx, state, cctx, 15);
+        is_field = gr_mpoly_ctx_is_field(ctx);
+
+        gr_mpoly_init(a, ctx);
+        gr_mpoly_init(b, ctx);
+        gr_mpoly_init(q, ctx);
+        gr_mpoly_init(r, ctx);
+        gr_mpoly_init(t, ctx);
+        gr_mpoly_init(u, ctx);
+
+        if (big)
+        {
+            len = 1 + n_randint(state, 4);
+            blen = 1 + n_randint(state, 4);
+            ebits = 2 + n_randint(state, 10);
+        }
+        else
+        {
+            len = 1 + n_randint(state, 12);
+            blen = 1 + n_randint(state, 12);
+            ebits = 2 + n_randint(state, 4);
+        }
+
+        status = GR_SUCCESS;
+        status |= gr_mpoly_randtest_bits(a, state, len, ebits, ctx);
+        status |= gr_mpoly_randtest_bits(b, state, blen, ebits, ctx);
+
+        if (gr_mpoly_is_zero(b, ctx) != T_FALSE)
+            status |= gr_mpoly_one(b, ctx);
+
+        if (status != GR_SUCCESS)
+            goto next;
+
+        switch (n_randint(state, 4))
+        {
+            case 0:
+                status = gr_mpoly_divrem_heap_threaded(q, r, a, b, ctx);
+                break;
+            case 1:
+                status = gr_mpoly_set(q, b, ctx);
+                status |= gr_mpoly_divrem_heap_threaded(q, r, a, q, ctx);
+                break;
+            case 2:
+                status = gr_mpoly_set(r, a, ctx);
+                status |= gr_mpoly_divrem_heap_threaded(q, r, r, b, ctx);
+                break;
+            default:
+                status = gr_mpoly_set(r, a, ctx);
+                status = gr_mpoly_set(q, b, ctx);
+                status |= gr_mpoly_divrem_heap_threaded(q, r, r, q, ctx);
+                break;
+        }
+
+        if (status == GR_SUCCESS)
+        {
+            gr_mpoly_assert_canonical(q, ctx);
+            gr_mpoly_assert_canonical(r, ctx);
+
+            /* check a == q*b + r */
+            if (gr_mpoly_mul(t, q, b, ctx) == GR_SUCCESS &&
+                gr_mpoly_add(t, t, r, ctx) == GR_SUCCESS &&
+                gr_mpoly_equal(t, a, ctx) == T_FALSE)
+            {
+                flint_printf("FAIL: a != q*b + r\n");
+                gr_ctx_println(cctx);
+                flint_printf("a = "); gr_mpoly_print_pretty(a, ctx); flint_printf("\n");
+                flint_printf("b = "); gr_mpoly_print_pretty(b, ctx); flint_printf("\n");
+                flint_printf("q = "); gr_mpoly_print_pretty(q, ctx); flint_printf("\n");
+                flint_printf("r = "); gr_mpoly_print_pretty(r, ctx); flint_printf("\n");
+                fflush(stdout);
+                flint_abort();
+            }
+
+            /* div must agree with divrem on the quotient */
+            if (gr_mpoly_div_heap_threaded(t, a, b, ctx) == GR_SUCCESS &&
+                gr_mpoly_equal(t, q, ctx) == T_FALSE)
+            {
+                flint_printf("FAIL: div != divrem quotient\n");
+                gr_ctx_println(cctx);
+                fflush(stdout);
+                flint_abort();
+            }
+        }
+        else if (is_field == T_TRUE && status == GR_DOMAIN)
+        {
+            flint_printf("FAIL: divrem returned GR_DOMAIN over a field\n");
+            gr_ctx_println(cctx);
+            fflush(stdout);
+            flint_abort();
+        }
+
+        if (cctx->which_ring != GR_CTX_DEBUG &&
+            status != GR_SUCCESS &&
+            gr_is_invertible(b->coeffs, cctx) == T_TRUE)
+        {
+            flint_printf("FAIL: division unable although lc(g) is invertible\n");
+            gr_ctx_println(ctx);
+            fflush(stdout);
+            flint_abort();
+        }
+
+        /* nonfield (euclidean) variant: a == q*b + r always */
+        status = gr_mpoly_divrem_weak_heap_threaded(q, r, a, b, ctx);
+        if (status == GR_SUCCESS)
+        {
+            gr_mpoly_assert_canonical(q, ctx);
+            gr_mpoly_assert_canonical(r, ctx);
+
+            if (gr_mpoly_mul(t, q, b, ctx) == GR_SUCCESS &&
+                gr_mpoly_add(t, t, r, ctx) == GR_SUCCESS &&
+                gr_mpoly_equal(t, a, ctx) == T_FALSE)
+            {
+                flint_printf("FAIL: weak a != q*b + r\n");
+                gr_ctx_println(cctx);
+                flint_printf("a = "); gr_mpoly_print_pretty(a, ctx); flint_printf("\n");
+                flint_printf("b = "); gr_mpoly_print_pretty(b, ctx); flint_printf("\n");
+                flint_printf("q = "); gr_mpoly_print_pretty(q, ctx); flint_printf("\n");
+                flint_printf("r = "); gr_mpoly_print_pretty(r, ctx); flint_printf("\n");
+                fflush(stdout);
+                flint_abort();
+            }
+
+            if (gr_mpoly_div_weak_heap_threaded(t, a, b, ctx) == GR_SUCCESS &&
+                gr_mpoly_equal(t, q, ctx) == T_FALSE)
+            {
+                flint_printf("FAIL: div_weak != divrem_weak quotient\n");
+                gr_ctx_println(cctx);
+                fflush(stdout);
+                flint_abort();
+            }
+
+            /* over a field the two variants coincide */
+            if (is_field == T_TRUE &&
+                gr_mpoly_divrem(t, u, a, b, ctx) == GR_SUCCESS &&
+                (gr_mpoly_equal(t, q, ctx) == T_FALSE ||
+                 gr_mpoly_equal(u, r, ctx) == T_FALSE))
+            {
+                flint_printf("FAIL: field/weak disagree over a field\n");
+                gr_ctx_println(cctx);
+                fflush(stdout);
+                flint_abort();
+            }
+        }
+
+next:
+        gr_mpoly_clear(a, ctx);
+        gr_mpoly_clear(b, ctx);
+        gr_mpoly_clear(q, ctx);
+        gr_mpoly_clear(r, ctx);
+        gr_mpoly_clear(t, ctx);
+        gr_mpoly_clear(u, ctx);
+        gr_mpoly_ctx_clear(ctx);
+        gr_ctx_clear(cctx);
+        gr_ctx_clear(ctx1);
     }
 
     TEST_FUNCTION_END(state);

--- a/src/gr_mpoly/test/t-divrem_heap_threaded.c
+++ b/src/gr_mpoly/test/t-divrem_heap_threaded.c
@@ -114,7 +114,7 @@ TEST_FUNCTION_START(gr_mpoly_divrem_heap_threaded, state)
                           : gr_mpoly_div_heap_threaded(q2, f, g, ctx);
         }
 
-        if (s1 != s2)
+        if (!used_debug_base && (s1 != s2))
         {
             flint_printf("FAIL: status mismatch serial=%d threaded=%d "
                          "nonfield=%d want_r=%d\n", s1, s2, nonfield, want_r);

--- a/src/gr_mpoly/test/t-divrem_ideal.c
+++ b/src/gr_mpoly/test/t-divrem_ideal.c
@@ -61,12 +61,16 @@ TEST_FUNCTION_START(gr_mpoly_divrem_ideal, state)
 
         big = (n_randint(state, 4) == 0);
 
-        switch (n_randint(state, 4))
+        gr_ctx_t ctx1;
+        gr_ctx_init_nmod8(ctx1, n_randprime(state, 8, 1));
+
+        switch (n_randint(state, 5))
         {
             case 0: gr_ctx_init_fmpz(cctx); break;
             case 1: gr_ctx_init_fmpq(cctx); break;
             case 2: gr_ctx_init_random_finite_field(cctx, state); break;
-            default: gr_ctx_init_nmod(cctx, n_randtest_prime(state, 1)); break;
+            case 3: gr_ctx_init_nmod(cctx, n_randtest_prime(state, 1)); break;
+            default: gr_ctx_init_debug(cctx, ctx1, n_randint(state, 2), n_randint(state, 2) ? 0.0 : 0.001);
         }
 
         gr_mpoly_ctx_init_rand(ctx, state, cctx, big ? 3 : 10);
@@ -143,6 +147,7 @@ TEST_FUNCTION_START(gr_mpoly_divrem_ideal, state)
 
         gr_mpoly_ctx_clear(ctx);
         gr_ctx_clear(cctx);
+        gr_ctx_clear(ctx1);
     }
 
     TEST_FUNCTION_END(state);

--- a/src/gr_mpoly/test/t-divrem_ideal_heap_threaded.c
+++ b/src/gr_mpoly/test/t-divrem_ideal_heap_threaded.c
@@ -12,13 +12,11 @@
 #include "test_helpers.h"
 #include "gr_mpoly.h"
 
-FLINT_DLL extern gr_static_method_table _ca_methods;
-
 TEST_FUNCTION_START(gr_mpoly_divrem_ideal_heap_threaded, state)
 {
     slong iter;
 
-    for (iter = 0; iter < 30 * flint_test_multiplier(); iter++)
+    for (iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
     {
         gr_ctx_t cctx;
         gr_mpoly_ctx_t ctx;
@@ -29,23 +27,19 @@ TEST_FUNCTION_START(gr_mpoly_divrem_ideal_heap_threaded, state)
         int status, s1, s2, nonfield;
         int big = (n_randint(state, 8) == 0);
 
-        switch (n_randint(state, 4))
+        gr_ctx_t ctx1;
+        gr_ctx_init_nmod8(ctx1, n_randprime(state, 8, 1));
+
+        switch (n_randint(state, 5))
         {
-            case 0:
-                gr_ctx_init_random_finite_field(cctx, state);
-                break;
-            case 1:
-                gr_ctx_init_fmpz(cctx);
-                break;
-            case 2:
-                gr_ctx_init_fmpq(cctx);
-                break;
-            default:
-                gr_ctx_init_nmod(cctx, n_randtest_prime(state, 1));
-                break;
+            case 0: gr_ctx_init_fmpz(cctx); break;
+            case 1: gr_ctx_init_fmpq(cctx); break;
+            case 2: gr_ctx_init_random_finite_field(cctx, state); break;
+            case 3: gr_ctx_init_nmod(cctx, n_randtest_prime(state, 1)); break;
+            default: gr_ctx_init_debug(cctx, ctx1, n_randint(state, 2), n_randint(state, 2) ? 0.0 : 0.001);
         }
 
-        gr_mpoly_ctx_init_rand(ctx, state, cctx, 4);
+        gr_mpoly_ctx_init_rand(ctx, state, cctx, 12);
 
         gr_mpoly_init(A, ctx);
         gr_mpoly_init(R1, ctx);
@@ -162,6 +156,7 @@ TEST_FUNCTION_START(gr_mpoly_divrem_ideal_heap_threaded, state)
         gr_mpoly_vec_clear(Q2, ctx);
         gr_mpoly_ctx_clear(ctx);
         gr_ctx_clear(cctx);
+        gr_ctx_clear(ctx1);
     }
 
     TEST_FUNCTION_END(state);

--- a/src/gr_mpoly/test/t-divrem_ideal_heap_threaded.c
+++ b/src/gr_mpoly/test/t-divrem_ideal_heap_threaded.c
@@ -1,0 +1,168 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "gr_mpoly.h"
+
+FLINT_DLL extern gr_static_method_table _ca_methods;
+
+TEST_FUNCTION_START(gr_mpoly_divrem_ideal_heap_threaded, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 30 * flint_test_multiplier(); iter++)
+    {
+        gr_ctx_t cctx;
+        gr_mpoly_ctx_t ctx;
+        gr_mpoly_t A, R1, R2, recon, t;
+        gr_mpoly_vec_t B, Q1, Q2;
+        slong lenA, lenB, len, w;
+        flint_bitcnt_t exp_bits;
+        int status, s1, s2, nonfield;
+        int big = (n_randint(state, 8) == 0);
+
+        switch (n_randint(state, 4))
+        {
+            case 0:
+                gr_ctx_init_random_finite_field(cctx, state);
+                break;
+            case 1:
+                gr_ctx_init_fmpz(cctx);
+                break;
+            case 2:
+                gr_ctx_init_fmpq(cctx);
+                break;
+            default:
+                gr_ctx_init_nmod(cctx, n_randtest_prime(state, 1));
+                break;
+        }
+
+        gr_mpoly_ctx_init_rand(ctx, state, cctx, 4);
+
+        gr_mpoly_init(A, ctx);
+        gr_mpoly_init(R1, ctx);
+        gr_mpoly_init(R2, ctx);
+        gr_mpoly_init(recon, ctx);
+        gr_mpoly_init(t, ctx);
+        gr_mpoly_vec_init(B, 0, ctx);
+        gr_mpoly_vec_init(Q1, 0, ctx);
+        gr_mpoly_vec_init(Q2, 0, ctx);
+
+        flint_set_num_threads(1 + n_randint(state, 4));
+
+        len = 2 + n_randint(state, 3);
+        gr_mpoly_vec_set_length(B, len, ctx);
+
+        /*
+            Keep the exponent bit width modest even in the "big" case: a
+            sparse dividend with a very wide exponent range reduced by a
+            divisor whose leading term has small degree in some variable
+            can legitimately need a huge number of quotient terms (the
+            multivariate analogue of dividing x^(10^6) by (x - 1)) -- this
+            is a real worst case of the algorithm, not a bug, but it is not
+            something a routine regression test should try to exercise.
+        */
+        lenA = n_randint(state, big ? 150 : 20) + 1;
+        lenB = n_randint(state, big ? 12 : 8) + 3;
+        exp_bits = n_randint(state, big ? 5 : 3) + 2;
+        nonfield = n_randint(state, 2);
+
+        status = GR_SUCCESS;
+        status |= gr_mpoly_randtest_bits(A, state, lenA, exp_bits, ctx);
+        for (w = 0; w < len; w++)
+        {
+            status |= gr_mpoly_randtest_bits(gr_mpoly_vec_entry_ptr(B, w, ctx),
+                                              state, lenB, exp_bits, ctx);
+            if (gr_mpoly_is_zero(gr_mpoly_vec_entry_ptr(B, w, ctx), ctx) != T_FALSE)
+                status |= gr_mpoly_one(gr_mpoly_vec_entry_ptr(B, w, ctx), ctx);
+        }
+
+        if (status == GR_SUCCESS)
+        {
+            s1 = nonfield ? gr_mpoly_divrem_ideal_weak(Q1, R1, A, B, ctx)
+                          : gr_mpoly_divrem_ideal(Q1, R1, A, B, ctx);
+            s2 = nonfield ? gr_mpoly_divrem_ideal_weak_heap_threaded(Q2, R2, A, B, ctx)
+                          : gr_mpoly_divrem_ideal_heap_threaded(Q2, R2, A, B, ctx);
+
+            if (s1 != s2)
+            {
+                flint_printf("FAIL: status mismatch serial=%d threaded=%d\n", s1, s2);
+                flint_printf("iter = %wd\n", iter);
+                gr_ctx_println(cctx);
+                fflush(stdout);
+                flint_abort();
+            }
+
+            if (s1 == GR_SUCCESS)
+            {
+                gr_mpoly_assert_canonical(R1, ctx);
+                gr_mpoly_assert_canonical(R2, ctx);
+
+                if (gr_mpoly_equal(R1, R2, ctx) == T_FALSE)
+                {
+                    flint_printf("FAIL: remainder mismatch\n");
+                    flint_printf("iter = %wd\n", iter);
+                    gr_ctx_println(cctx);
+                    fflush(stdout);
+                    flint_abort();
+                }
+
+                for (w = 0; w < len; w++)
+                {
+                    gr_mpoly_struct * q1w = gr_mpoly_vec_entry_ptr(Q1, w, ctx);
+                    gr_mpoly_struct * q2w = gr_mpoly_vec_entry_ptr(Q2, w, ctx);
+                    gr_mpoly_assert_canonical(q1w, ctx);
+                    gr_mpoly_assert_canonical(q2w, ctx);
+                    if (gr_mpoly_equal(q1w, q2w, ctx) == T_FALSE)
+                    {
+                        flint_printf("FAIL: quotient[%wd] mismatch\n", w);
+                        flint_printf("iter = %wd\n", iter);
+                        gr_ctx_println(cctx);
+                        fflush(stdout);
+                        flint_abort();
+                    }
+                }
+
+                /* verify the defining identity: A == sum_w Q1[w]*B[w] + R1 */
+                status = gr_mpoly_zero(recon, ctx);
+                for (w = 0; w < len; w++)
+                {
+                    status |= gr_mpoly_mul(t, gr_mpoly_vec_entry_ptr(Q1, w, ctx),
+                                               gr_mpoly_vec_entry_ptr(B, w, ctx), ctx);
+                    status |= gr_mpoly_add(recon, recon, t, ctx);
+                }
+                status |= gr_mpoly_add(recon, recon, R1, ctx);
+
+                if (status == GR_SUCCESS && gr_mpoly_equal(recon, A, ctx) == T_FALSE)
+                {
+                    flint_printf("FAIL: sum(Q_i*B_i) + R != A\n");
+                    flint_printf("iter = %wd\n", iter);
+                    gr_ctx_println(cctx);
+                    fflush(stdout);
+                    flint_abort();
+                }
+            }
+        }
+
+        gr_mpoly_clear(A, ctx);
+        gr_mpoly_clear(R1, ctx);
+        gr_mpoly_clear(R2, ctx);
+        gr_mpoly_clear(recon, ctx);
+        gr_mpoly_clear(t, ctx);
+        gr_mpoly_vec_clear(B, ctx);
+        gr_mpoly_vec_clear(Q1, ctx);
+        gr_mpoly_vec_clear(Q2, ctx);
+        gr_mpoly_ctx_clear(ctx);
+        gr_ctx_clear(cctx);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/gr_mpoly/test/t-divrem_ideal_heap_threaded.c
+++ b/src/gr_mpoly/test/t-divrem_ideal_heap_threaded.c
@@ -86,7 +86,7 @@ TEST_FUNCTION_START(gr_mpoly_divrem_ideal_heap_threaded, state)
             s2 = nonfield ? gr_mpoly_divrem_ideal_weak_heap_threaded(Q2, R2, A, B, ctx)
                           : gr_mpoly_divrem_ideal_heap_threaded(Q2, R2, A, B, ctx);
 
-            if (s1 != s2)
+            if (cctx->which_ring != GR_CTX_DEBUG && s1 != s2)
             {
                 flint_printf("FAIL: status mismatch serial=%d threaded=%d\n", s1, s2);
                 flint_printf("iter = %wd\n", iter);
@@ -95,7 +95,7 @@ TEST_FUNCTION_START(gr_mpoly_divrem_ideal_heap_threaded, state)
                 flint_abort();
             }
 
-            if (s1 == GR_SUCCESS)
+            if (s1 == GR_SUCCESS && s2 == GR_SUCCESS)
             {
                 gr_mpoly_assert_canonical(R1, ctx);
                 gr_mpoly_assert_canonical(R2, ctx);

--- a/src/gr_mpoly/test/t-quasidivrem.c
+++ b/src/gr_mpoly/test/t-quasidivrem.c
@@ -48,7 +48,7 @@ TEST_FUNCTION_START(gr_mpoly_quasidivrem, state)
 
         /* keep inputs small: over Z the scale grows like lc(B)^(#steps) */
         len = 1 + n_randint(state, 7);
-        ebits = 2 + n_randint(state, 8);
+        ebits = 2 + n_randint(state, 5);
 
         status = GR_SUCCESS;
         status |= gr_mpoly_randtest_bits(a, state, len, ebits, ctx);

--- a/src/gr_mpoly/threaded_divmod.h
+++ b/src/gr_mpoly/threaded_divmod.h
@@ -1,0 +1,331 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef GR_MPOLY_THREADED_DIVMOD_H
+#define GR_MPOLY_THREADED_DIVMOD_H
+
+#include "thread_pool.h"
+#include "thread_support.h"
+#include "gr_mpoly.h"
+
+/*
+    Infrastructure shared by gr_mpoly_divides_heap_threaded (in
+    divides_heap_threaded.c) and gr_mpoly_divrem_heap_threaded /
+    gr_mpoly_div_heap_threaded / gr_mpoly_div_weak_heap_threaded /
+    gr_mpoly_divrem_weak_heap_threaded (in divrem_heap_threaded.c).
+
+    Both algorithms partition the dividend A into exponent-range chunks and
+    resolve them top-down through the same producer/consumer chunk pipeline,
+    accumulating quotient terms (and, for the divrem family, remainder terms)
+    into thread-safe growable arrays.  Only the *leaf* computation performed
+    once a chunk becomes the producer differs:
+
+        - gr_mpoly_divides_heap_threaded requires every surviving term of a
+          finalized chunk to become a quotient term, and aborts (GR_DOMAIN)
+          otherwise; see _gr_mpoly_divides_stripe1/_gr_mpoly_divides_stripe
+          in divides_heap_threaded.c.
+
+        - the divrem family instead always succeeds (barring GR_UNABLE /
+          exponent overflow): terms that are not divisible by lm(B), or
+          whose coefficient does not divide exactly (unless the "weak"
+          Euclidean mode is requested), are routed to the remainder instead
+          of aborting; see _gr_mpoly_divrem_stripe1/_gr_mpoly_divrem_stripe
+          in divrem_heap_threaded.c.
+
+    Everything else -- the thread-safe quotient/remainder arrays, the
+    B-times-(quotient increment) subtraction used to keep each chunk's
+    partial remainder up to date, the chunk struct and its lock-protected
+    producer handoff, and the worker loop -- does not care which flavour of
+    leaf is used and is defined once, in divides_heap_threaded.c, with
+    linkage visible here so that divrem_heap_threaded.c can build its own
+    top-level dispatch on top of it.
+*/
+
+/* shallow copy helpers (see mul_johnson.c, gr_mpoly/divides_heap.c) */
+#define SET_SHALLOW_GENERIC(a,i,b,j) memcpy(GR_ENTRY(a, i, sz), GR_ENTRY(b, j, sz), sz)
+#define SET_SHALLOW1(a,i,b,j) ((uint8_t *) a)[i] = ((uint8_t *) b)[j]
+#define SET_SHALLOW2(a,i,b,j) ((uint16_t *) a)[i] = ((uint16_t *) b)[j]
+#define SET_SHALLOW4(a,i,b,j) ((uint32_t *) a)[i] = ((uint32_t *) b)[j]
+
+#if FLINT_BITS == 64
+#define SET_SHALLOW8(a,i,b,j) ((uint64_t *) a)[i] = ((uint64_t *) b)[j]
+#define SET_SHALLOW16(a,i,b,j) ((uint64_t *) a)[2 * (i)] = ((uint64_t *) b)[2 * (j)]; ((uint64_t *) a)[2 * (i) + 1] = ((uint64_t *) b)[2 * (j) + 1]
+#else
+#define SET_SHALLOW8(a,i,b,j) gr_set_shallow(GR_ENTRY(a, i, sz), GR_ENTRY(b, j, sz), cctx)
+#define SET_SHALLOW16(a,i,b,j) gr_set_shallow(GR_ENTRY(a, i, sz), GR_ENTRY(b, j, sz), cctx)
+#endif
+
+/* gather product node (Bcoeff[i], Ccoeff[j]) into dot_a/dot_b (used by the
+   mulsub stripe functions, where -- unlike the plain division heaps --
+   there is no dividend node to special-case) */
+#define MULSUB_FETCH_NODE(SET_SHALLOW) \
+    do { \
+        hind[x->i] |= WORD(1); \
+        store[store_len++] = x->i; \
+        store[store_len++] = x->j; \
+        SET_SHALLOW(dot_a, dot_len, Bcoeff, x->i); \
+        SET_SHALLOW(dot_b, dot_len, Ccoeff, x->j); \
+        dot_len++; \
+    } while (0)
+
+/*
+    A thread safe growable gr_mpoly.  Only three mutating operations are
+    supported:
+        - init from an array of terms
+        - append an array of terms (the only operation performed while other
+          threads may be concurrently reading)
+        - clear out contents to a normal gr_mpoly_t
+
+    Coefficients are moved by value (gr_swap) rather than copied, and gr
+    elements are assumed to be relocatable by memcpy (the same assumption
+    already made by the "shallow copy" helpers used throughout gr_mpoly),
+    which lets us grow the coefficient array with a plain flint_malloc-based
+    scheme just like the fmpz/nmod originals.
+
+    IMPORTANT: when the backing array has to grow, *already published*
+    entries must be migrated into the new buffer with a non-mutating copy
+    (gr_set), never a swap/move -- other threads may still be concurrently
+    reading through a stale pointer to the old buffer (which is
+    deliberately never freed), so the old buffer's contents must not be
+    disturbed. Only the newly incoming terms (which come from a private,
+    unshared scratch buffer) may be moved by swap.
+*/
+typedef struct _gr_mpoly_ts_struct
+{
+    gr_ptr volatile coeffs; /* this is coeff_array[idx] */
+    ulong * volatile exps;  /* this is exp_array[idx] */
+    volatile slong length;
+    slong alloc;
+    slong N;
+    flint_bitcnt_t bits;
+    flint_bitcnt_t idx;
+    ulong * exp_array[FLINT_BITS];
+    gr_ptr coeff_array[FLINT_BITS];
+} gr_mpoly_ts_struct;
+
+typedef gr_mpoly_ts_struct gr_mpoly_ts_t[1];
+
+void gr_mpoly_ts_init(gr_mpoly_ts_t A,
+        gr_ptr Bcoeff, ulong * Bexp, slong Blen,
+        flint_bitcnt_t bits, slong N, gr_ctx_t cctx);
+
+void gr_mpoly_ts_clear(gr_mpoly_ts_t A, gr_ctx_t cctx);
+
+void gr_mpoly_ts_clear_poly(gr_mpoly_t Q, gr_mpoly_ts_t A, gr_ctx_t cctx);
+
+void gr_mpoly_ts_append(gr_mpoly_ts_t A,
+                gr_ptr Bcoeff, ulong * Bexps, slong Blen, slong N, gr_ctx_t cctx);
+
+/*
+    A chunk holds an exponent range on the dividend.  Shared verbatim by
+    both algorithms: chunk_mulsub (which reduces L->polyC by newly available
+    quotient terms) has no notion of "divides" vs "divrem".
+*/
+typedef struct _divides_heap_chunk_struct
+{
+    gr_mpoly_t polyC;
+    struct _divides_heap_chunk_struct * next;
+    ulong * emin;
+    ulong * emax;
+    slong startidx;
+    slong endidx;
+    int upperclosed;
+    volatile int lock;
+    volatile int producer;
+    volatile slong ma;
+    volatile slong mq;
+    int Cinited;
+} divides_heap_chunk_struct;
+
+typedef divides_heap_chunk_struct divides_heap_chunk_t[1];
+
+/*
+    The base struct includes a linked list of chunks together with the
+    thread safe growable quotient (and, for the divrem family, remainder).
+
+    require_exact / want_remainder / nonfield select which algorithm
+    trychunk's producer-finalisation step runs:
+
+        require_exact = 1  ->  gr_mpoly_divides_heap_threaded semantics:
+                                a chunk with leftover, non-quotient terms is
+                                a hard failure (have_domain).  want_remainder
+                                and nonfield are unused; polyR is untouched.
+
+        require_exact = 0  ->  divrem family: leftover terms are routed to
+                                polyR (if want_remainder) or simply discarded
+                                (if !want_remainder, i.e. gr_mpoly_div(_weak)
+                                _heap_threaded).  nonfield selects exact
+                                (gr_div) vs Euclidean (gr_euclidean_divrem)
+                                coefficient handling, exactly like the
+                                serial gr_mpoly_divrem_heap kernel.
+*/
+typedef struct
+{
+#if FLINT_USES_PTHREAD
+    pthread_mutex_t mutex;
+#endif
+    divides_heap_chunk_struct * head;
+    divides_heap_chunk_struct * tail;
+    divides_heap_chunk_struct * volatile cur;
+    gr_mpoly_t polyA;
+    gr_mpoly_t polyB;
+    gr_mpoly_ts_t polyQ;
+    gr_mpoly_ts_t polyR;       /* only used/initialised if want_remainder */
+    gr_mpoly_ctx_struct * ctx;
+    gr_ctx_struct * cctx;
+    slong length;
+    slong N;
+    flint_bitcnt_t bits;
+    ulong * cmpmask;
+    int lc_is_one;
+    int lc_is_unit;
+    gr_srcptr lc_inv;    /* 1/lc(B), valid iff lc_is_unit */
+    int require_exact;   /* 1: gr_mpoly_divides semantics; 0: div/divrem */
+    int want_remainder;  /* 0: gr_mpoly_div(_weak); 1: gr_mpoly_divrem(_weak) */
+    int nonfield;         /* 1: Euclidean ("weak") per-term coefficient divrem */
+    volatile int failed;      /* stop: either not exact, or arithmetic unable */
+    volatile int have_domain; /* division is provably not exact (require_exact only) */
+    volatile int have_unable; /* some ring operation returned GR_UNABLE */
+} divides_heap_base_struct;
+
+typedef divides_heap_base_struct divides_heap_base_t[1];
+
+void divides_heap_base_init(divides_heap_base_t H);
+void divides_heap_chunk_clear(divides_heap_chunk_t L, divides_heap_base_t H);
+
+/*
+    Finalise H into (Q, R): R may be NULL (matches H->want_remainder == 0).
+    Returns the overall GR status.  Always clears/frees H's chunk list and
+    thread-safe arrays.
+*/
+int divides_heap_base_clear(gr_mpoly_t Q, gr_mpoly_t R, divides_heap_base_t H);
+
+void divides_heap_base_add_chunk(divides_heap_base_t H, divides_heap_chunk_t L);
+
+/*
+    Binary search for the first index >= a (in the caller-supplied,
+    monomial-decreasing array Aexp of length Alen) whose exponent no longer
+    exceeds exp. Generic over which gr_mpoly's exponent array is searched,
+    so it does not need to know about divides_heap_base_t.
+*/
+slong chunk_find_exp(ulong * exp, slong a,
+                     const ulong * Aexp, slong Alen, slong N, const ulong * cmpmask);
+
+/*
+    Per-worker scratch memory (analogous to fmpz_mpoly_stripe_t / the
+    _gr_mpoly_stripe_struct of gr_mpoly_mul_heap_threaded, extended with the
+    exponent-window and leading-coefficient data needed for division).
+*/
+typedef struct
+{
+    char * big_mem;
+    slong big_mem_alloc;
+    slong N;
+    flint_bitcnt_t bits;
+    const ulong * cmpmask;
+    slong * startidx;
+    slong * endidx;
+    ulong * emin;
+    ulong * emax;
+    int upperclosed;
+    gr_mpoly_ctx_struct * ctx;
+    gr_ctx_struct * cctx;
+    slong sz;
+    int have_fast_dot;
+    int lc_is_one;
+    int lc_is_unit;
+    gr_srcptr lc_inv;
+    int nonfield;   /* only consulted by the divrem-family stripe leaves */
+} _gr_mpoly_stripe_struct;
+
+typedef _gr_mpoly_stripe_struct _gr_mpoly_stripe_t[1];
+
+void stripe_fit_length(_gr_mpoly_stripe_struct * S, slong new_len);
+
+/* A = D - (a stripe of B * C); see the long comment at its definition in
+   divides_heap_threaded.c. Shared verbatim: has no notion of "divides" vs
+   "divrem", it just forms a difference of products. */
+slong _gr_mpoly_mulsub_stripe1(
+    gr_ptr * A_coeff, ulong ** A_exp, slong * A_alloc, slong * A_exps_alloc,
+    gr_srcptr Dcoeff, const ulong * Dexp, slong Dlen, int saveD,
+    gr_srcptr Bcoeff, const ulong * Bexp, slong Blen,
+    gr_srcptr Ccoeff, const ulong * Cexp, slong Clen,
+    const _gr_mpoly_stripe_t S, int * res_status);
+
+slong _gr_mpoly_mulsub_stripe(
+    gr_ptr * A_coeff, ulong ** A_exp, slong * A_alloc, slong * A_exps_alloc,
+    gr_srcptr Dcoeff, const ulong * Dexp, slong Dlen, int saveD,
+    gr_srcptr Bcoeff, const ulong * Bexp, slong Blen,
+    gr_srcptr Ccoeff, const ulong * Cexp, slong Clen,
+    const _gr_mpoly_stripe_t S, int * res_status);
+
+/*
+    Bounded ("stripe") division-with-remainder leaves, defined in
+    divrem_heap_threaded.c, analogous to _gr_mpoly_divides_stripe1/
+    _gr_mpoly_divides_stripe in divides_heap_threaded.c but never aborting
+    on a non-reducible term: it is routed to the local remainder output
+    (Wcoeff/Wexp/Wlen) instead. *res_status only ever reports GR_SUCCESS or
+    GR_UNABLE (never GR_DOMAIN -- that concept does not apply once
+    require_exact == 0).
+*/
+slong _gr_mpoly_divrem_stripe1(
+    gr_ptr * Q_coeff, ulong ** Q_exp, slong * Q_alloc, slong * Q_exps_alloc,
+    gr_ptr * W_coeff, ulong ** W_exp, slong * W_alloc, slong * W_exps_alloc,
+    slong * Wlen_out,
+    gr_srcptr Acoeff, const ulong * Aexp, slong Alen,
+    gr_srcptr Bcoeff, const ulong * Bexp, slong Blen,
+    const _gr_mpoly_stripe_t S, int * res_status);
+
+slong _gr_mpoly_divrem_stripe(
+    gr_ptr * Q_coeff, ulong ** Q_exp, slong * Q_alloc, slong * Q_exps_alloc,
+    gr_ptr * W_coeff, ulong ** W_exp, slong * W_alloc, slong * W_exps_alloc,
+    slong * Wlen_out,
+    gr_srcptr Acoeff, const ulong * Aexp, slong Alen,
+    gr_srcptr Bcoeff, const ulong * Bexp, slong Blen,
+    const _gr_mpoly_stripe_t S, int * res_status);
+
+/*
+    The worker struct has the stripe scratch memory and three polys for
+    workspace: T1/T2 as before (mulsub output / newly finalised quotient
+    increment), T3 an additional scratch poly used to hold a newly
+    finalised *remainder* increment when H->want_remainder.
+*/
+typedef struct _worker_arg_struct
+{
+    divides_heap_base_struct * H;
+    _gr_mpoly_stripe_t S;
+    gr_mpoly_t polyT1;
+    gr_mpoly_t polyT2;
+    gr_mpoly_t polyT3;
+} worker_arg_struct;
+
+typedef worker_arg_struct worker_arg_t[1];
+
+/* the chunk pipeline itself: defined in divides_heap_threaded.c, mode-aware
+   via H->require_exact / H->want_remainder / H->nonfield */
+void trychunk(worker_arg_t W, divides_heap_chunk_t L);
+void worker_loop(void * varg);
+void chunk_mulsub(worker_arg_t W, divides_heap_chunk_t L, slong q_prev_length);
+
+/*
+    The guaranteed-serial kernel for gr_mpoly_div(_weak)/gr_mpoly_divrem(_weak),
+    defined in divrem_heap.c (R == NULL for the div/div_weak case). Declared
+    here so that the threaded engine in divrem_heap_threaded.c can fall back
+    to it directly, rather than through the public dispatchers (gr_mpoly_div,
+    gr_mpoly_divrem, ...), which may route large instances straight back into
+    the threaded engine.
+*/
+int _gr_mpoly_divrem_mp(
+    gr_mpoly_t Q, gr_mpoly_t R,
+    const gr_mpoly_t A, const gr_mpoly_t B, int nonfield,
+    gr_mpoly_ctx_t ctx);
+
+#endif

--- a/src/gr_mpoly/threaded_divmod.h
+++ b/src/gr_mpoly/threaded_divmod.h
@@ -165,7 +165,14 @@ typedef divides_heap_chunk_struct divides_heap_chunk_t[1];
                                 _heap_threaded).  nonfield selects exact
                                 (gr_div) vs Euclidean (gr_euclidean_divrem)
                                 coefficient handling, exactly like the
-                                serial gr_mpoly_divrem_heap kernel.
+                                serial gr_mpoly_divrem_heap kernel.  unchecked
+                                (only meaningful when nonfield == 0) instead
+                                selects gr_divexact for a non-unit lc(B),
+                                i.e. gr_mpoly_divexact_heap_threaded; leftover
+                                terms are always discarded in that case
+                                (want_remainder == 0), matching the fact that
+                                gr_mpoly_divexact has no remainder-producing
+                                counterpart.
 */
 typedef struct
 {
@@ -191,6 +198,9 @@ typedef struct
     int require_exact;   /* 1: gr_mpoly_divides semantics; 0: div/divrem */
     int want_remainder;  /* 0: gr_mpoly_div(_weak); 1: gr_mpoly_divrem(_weak) */
     int nonfield;         /* 1: Euclidean ("weak") per-term coefficient divrem */
+    int unchecked;        /* 1: gr_mpoly_divexact -- gr_divexact instead of
+                              gr_div for a non-unit lc(B); mutually exclusive
+                              with nonfield (both require_exact == 0) */
     volatile int failed;      /* stop: either not exact, or arithmetic unable */
     volatile int have_domain; /* division is provably not exact (require_exact only) */
     volatile int have_unable; /* some ring operation returned GR_UNABLE */
@@ -243,6 +253,8 @@ typedef struct
     int lc_is_one;
     int lc_is_unit;
     gr_srcptr lc_inv;
+    int unchecked;  /* only consulted by the divrem-family stripe leaves,
+                       and only meaningful together with nonfield == 0 */
     int nonfield;   /* only consulted by the divrem-family stripe leaves */
 } _gr_mpoly_stripe_struct;
 
@@ -325,7 +337,17 @@ void chunk_mulsub(worker_arg_t W, divides_heap_chunk_t L, slong q_prev_length);
 */
 int _gr_mpoly_divrem_mp(
     gr_mpoly_t Q, gr_mpoly_t R,
-    const gr_mpoly_t A, const gr_mpoly_t B, int nonfield,
+    const gr_mpoly_t A, const gr_mpoly_t B, int nonfield, int unchecked,
     gr_mpoly_ctx_t ctx);
+
+/*
+    The guaranteed-serial divrem_ideal kernel, defined in divrem_ideal.c.
+    Declared here so that divrem_ideal_heap_threaded.c can fall back to it
+    directly, for the same reason _gr_mpoly_divrem_mp is exposed above.
+*/
+int _gr_mpoly_divrem_ideal(
+    gr_mpoly_struct ** Q, gr_mpoly_t R,
+    const gr_mpoly_t A, gr_mpoly_struct * const * B, slong len,
+    int nonfield, gr_mpoly_ctx_t ctx);
 
 #endif

--- a/src/gr_mpoly/threaded_divmod.h
+++ b/src/gr_mpoly/threaded_divmod.h
@@ -204,6 +204,22 @@ typedef struct
     volatile int failed;      /* stop: either not exact, or arithmetic unable */
     volatile int have_domain; /* division is provably not exact (require_exact only) */
     volatile int have_unable; /* some ring operation returned GR_UNABLE */
+    volatile int overflowed;  /* an internal exponent computation overflowed
+                                  the current bit width (see the comment on
+                                  _gr_mpoly_mulsub_stripe1 above): the whole
+                                  computation must be redone at a wider bit
+                                  width, it cannot be salvaged in place.
+                                  Setting this also sets failed, to stop all
+                                  workers immediately, exactly like
+                                  have_domain/have_unable. Whether this is
+                                  acted on (retried) or just folded into an
+                                  UNABLE verdict depends on the caller: the
+                                  require_exact (gr_mpoly_divides) pool
+                                  function does the latter (unchanged
+                                  behaviour, now merely made safe rather than
+                                  silently undetected -- see the long comment
+                                  at _gr_mpoly_mulsub_stripe1), while the
+                                  divrem/divrem_ideal pool functions retry. */
 } divides_heap_base_struct;
 
 typedef divides_heap_base_struct divides_heap_base_t[1];
@@ -264,20 +280,30 @@ void stripe_fit_length(_gr_mpoly_stripe_struct * S, slong new_len);
 
 /* A = D - (a stripe of B * C); see the long comment at its definition in
    divides_heap_threaded.c. Shared verbatim: has no notion of "divides" vs
-   "divrem", it just forms a difference of products. */
+   "divrem", it just forms a difference of products.
+
+   *overflowed is set to 1 (and *res_status/the returned length should be
+   ignored -- they are not meaningful) if an exponent computed internally
+   (e.g. as a sum of a term of B and a term of C) does not fit in the
+   current bit width. This can happen even when every term of D, B and C
+   individually fits, since two individually-valid packed exponents can
+   overflow a shared field when added; the caller must repack to a wider
+   bit width and redo the whole computation -- there is no way to recover
+   in place. See the retry loops in gr_mpoly_divrem_heap_threaded /
+   gr_mpoly_divrem_ideal_heap_threaded. */
 slong _gr_mpoly_mulsub_stripe1(
     gr_ptr * A_coeff, ulong ** A_exp, slong * A_alloc, slong * A_exps_alloc,
     gr_srcptr Dcoeff, const ulong * Dexp, slong Dlen, int saveD,
     gr_srcptr Bcoeff, const ulong * Bexp, slong Blen,
     gr_srcptr Ccoeff, const ulong * Cexp, slong Clen,
-    const _gr_mpoly_stripe_t S, int * res_status);
+    const _gr_mpoly_stripe_t S, int * res_status, int * overflowed);
 
 slong _gr_mpoly_mulsub_stripe(
     gr_ptr * A_coeff, ulong ** A_exp, slong * A_alloc, slong * A_exps_alloc,
     gr_srcptr Dcoeff, const ulong * Dexp, slong Dlen, int saveD,
     gr_srcptr Bcoeff, const ulong * Bexp, slong Blen,
     gr_srcptr Ccoeff, const ulong * Cexp, slong Clen,
-    const _gr_mpoly_stripe_t S, int * res_status);
+    const _gr_mpoly_stripe_t S, int * res_status, int * overflowed);
 
 /*
     Bounded ("stripe") division-with-remainder leaves, defined in
@@ -287,6 +313,10 @@ slong _gr_mpoly_mulsub_stripe(
     (Wcoeff/Wexp/Wlen) instead. *res_status only ever reports GR_SUCCESS or
     GR_UNABLE (never GR_DOMAIN -- that concept does not apply once
     require_exact == 0).
+
+    *overflowed has the same meaning as for _gr_mpoly_mulsub_stripe1 above:
+    an internal exponent computation overflowed the current bit width, and
+    *res_status / the returned Qlen / *Wlen_out are not meaningful.
 */
 slong _gr_mpoly_divrem_stripe1(
     gr_ptr * Q_coeff, ulong ** Q_exp, slong * Q_alloc, slong * Q_exps_alloc,
@@ -294,7 +324,7 @@ slong _gr_mpoly_divrem_stripe1(
     slong * Wlen_out,
     gr_srcptr Acoeff, const ulong * Aexp, slong Alen,
     gr_srcptr Bcoeff, const ulong * Bexp, slong Blen,
-    const _gr_mpoly_stripe_t S, int * res_status);
+    const _gr_mpoly_stripe_t S, int * res_status, int * overflowed);
 
 slong _gr_mpoly_divrem_stripe(
     gr_ptr * Q_coeff, ulong ** Q_exp, slong * Q_alloc, slong * Q_exps_alloc,
@@ -302,7 +332,7 @@ slong _gr_mpoly_divrem_stripe(
     slong * Wlen_out,
     gr_srcptr Acoeff, const ulong * Aexp, slong Alen,
     gr_srcptr Bcoeff, const ulong * Bexp, slong Blen,
-    const _gr_mpoly_stripe_t S, int * res_status);
+    const _gr_mpoly_stripe_t S, int * res_status, int * overflowed);
 
 /*
     The worker struct has the stripe scratch memory and three polys for


### PR DESCRIPTION
This PR adds multithreaded heap versions of `gr_mpoly` division functions (except for quasidivision) based on `fmpz_mpoly_divides_heap_threaded`.

Most code generated using Claude Sonnet 5.

Also adds `gr_mpoly_divexact`.

We also improve the `gr_mpoly_div`/`gr_mpoly_divrem` algorithms for inexact rings: failing zero tests would previously cause the division algorithm to terminate and return `GR_UNABLE`, but it works fine if we just accumulate such terms and keep going.

Further testing revealed subtle bugs in exponent overflow handling (some of which were present already in the serial code) that have been fixed. I've only been able to manifest these bugs when testing with `arb` rings where a lot of maybe-zero terms get created, but it's possible that they could be triggered over exact rings as well if one gets extremely unlucky.