### PR TITLE
Fix use of parentheses in `gr_mpoly_write`

### DIFF
--- a/src/gr_mpoly/write.c
+++ b/src/gr_mpoly/write.c
@@ -25,8 +25,28 @@ static char * _gr_mpoly_default_vars[8] = {
 static int
 want_parens(const char * s)
 {
-    if (s[0] == '(' || s[0] == '[' || s[0] == '{')
-        return 0;
+    /* Try to determine if the expression is already enclosed by
+       brackets or parentheses. */
+    if (s[0] == '[' || s[0] == '(' || s[0] == '}')
+    {
+        slong depth = 1;
+
+        char open = s[0];
+        char close = (open == '[') ? ']' : (open == '(' ? ')' : '}');
+
+        s++;
+        while (s[0] != '\0')
+        {
+            if (s[0] == open)
+                depth++;
+            else if (s[0] == close)
+                depth--;
+
+            s++;
+            if (depth == 0)
+                return s[0] != '\0';
+        }
+    }
 
     if (s[0] == '-')
         s++;

--- a/src/python/flint_ctypes.py
+++ b/src/python/flint_ctypes.py
@@ -9465,6 +9465,10 @@ def test_mpoly():
     assert raises(lambda: x / (x**0 - y**0), FlintDomainError)
     assert raises(lambda: (x**4 * y**3) / (RR("0 +/- 0.1")*(x**3 * y**2)), FlintUnableError)
 
+    R = PolynomialRing_gr_mpoly(QQx, 1, "y");
+    f = R("(x/3 + x^2/5)*y^2")
+    assert f == R(str(f))
+
 
 def test_fmpq_mpoly():
     QQxyz = PolynomialRing_fmpq_mpoly(3)


### PR DESCRIPTION
Fix `gr_mpoly_write` sometimes not wrapping coefficients in parentheses when it should.

`gr_poly_write` already had this fix but for some reason it hadn't been applied to `gr_mpoly` as well.