### PR TITLE
Refactor branchy mpoly code with helper functions and add asserts

### DIFF
--- a/src/fmpz_mod_mpoly/div_monagan_pearce.c
+++ b/src/fmpz_mod_mpoly/div_monagan_pearce.c
@@ -90,20 +90,9 @@ static int _fmpz_mod_mpoly_div_monagan_pearce(
 
         mpoly_monomial_set(exp, heap[1].exp, N);
 
-        if (bits <= FLINT_BITS)
-        {
-            if (mpoly_monomial_overflows(exp, N, mask))
-                goto exp_overflow;
-
-            lt_divides = mpoly_monomial_divides(Qexps + q_len*N, exp, Bexps, N, mask);
-        }
-        else
-        {
-            if (mpoly_monomial_overflows_mp(exp, N, bits))
-                goto exp_overflow;
-
-            lt_divides = mpoly_monomial_divides_mp(Qexps + q_len*N, exp, Bexps, N, bits);
-        }
+        if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
+            goto exp_overflow;
+        lt_divides = mpoly_monomial_divides_any_bits(Qexps + q_len*N, exp, Bexps, N, mask, bits);
 
         fmpz_zero(acc);
 

--- a/src/fmpz_mod_mpoly/divides_monagan_pearce.c
+++ b/src/fmpz_mod_mpoly/divides_monagan_pearce.c
@@ -329,22 +329,9 @@ static int _fmpz_mod_mpoly_divides_monagan_pearce(
 
         mpoly_monomial_set(exp, heap[1].exp, N);
 
-        if (bits <= FLINT_BITS)
-        {
-            if (mpoly_monomial_overflows(exp, N, mask))
-                goto not_exact_division;
-
-            lt_divides = mpoly_monomial_divides(Qexps + Qlen*N, exp, Bexps,
-                                                                      N, mask);
-        }
-        else
-        {
-            if (mpoly_monomial_overflows_mp(exp, N, bits))
-                goto not_exact_division;
-
-            lt_divides = mpoly_monomial_divides_mp(Qexps + Qlen*N, exp, Bexps,
-                                                                      N, bits);
-        }
+        if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
+            goto not_exact_division;
+        lt_divides = mpoly_monomial_divides_any_bits(Qexps + Qlen*N, exp, Bexps, N, mask, bits);
 
         mpz_set_ui(acc, 0);
         acc_sm[2] = acc_sm[1] = acc_sm[0] = 0;

--- a/src/fmpz_mod_mpoly/divrem_monagan_pearce.c
+++ b/src/fmpz_mod_mpoly/divrem_monagan_pearce.c
@@ -498,20 +498,9 @@ static int _fmpz_mod_mpoly_divrem_monagan_pearce(
 
         mpoly_monomial_set(exp, heap[1].exp, N);
 
-        if (bits <= FLINT_BITS)
-        {
-            if (mpoly_monomial_overflows(exp, N, mask))
-                goto exp_overflow2;
-
-            lt_divides = mpoly_monomial_divides(Qexps + Qlen*N, exp, Bexps, N, mask);
-        }
-        else
-        {
-            if (mpoly_monomial_overflows_mp(exp, N, bits))
-                goto exp_overflow2;
-
-            lt_divides = mpoly_monomial_divides_mp(Qexps + Qlen*N, exp, Bexps, N, bits);
-        }
+        if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
+            goto exp_overflow2;
+        lt_divides = mpoly_monomial_divides_any_bits(Qexps + Qlen*N, exp, Bexps, N, mask, bits);
 
         mpz_set_ui(acc, 0);
         acc_sm[2] = acc_sm[1] = acc_sm[0] = 0;

--- a/src/fmpz_mod_mpoly/get_set_is_fmpz_mod_poly.c
+++ b/src/fmpz_mod_mpoly/get_set_is_fmpz_mod_poly.c
@@ -111,10 +111,7 @@ void _fmpz_mod_mpoly_set_fmpz_mod_poly(
 
         FLINT_ASSERT(Alen < A->coeffs_alloc);
         fmpz_set(A->coeffs+ Alen, Bcoeffs + i);
-        if (Abits <= FLINT_BITS)
-            mpoly_monomial_mul_ui(A->exps + N*Alen, genexp, N, i);
-        else
-            mpoly_monomial_mul_ui_mp(A->exps + N*Alen, genexp, N, i);
+        mpoly_monomial_mul_ui_any_bits(A->exps + N*Alen, genexp, N, i, Abits);
         Alen++;
     }
     A->length = Alen;

--- a/src/fmpz_mod_mpoly/sqrt_heap.c
+++ b/src/fmpz_mod_mpoly/sqrt_heap.c
@@ -431,10 +431,7 @@ FLINT_ASSERT(fmpz_mod_is_canonical(Acoeffs + 0, fctx));
     fmpz_mod_add(lc_inv, Qcoeffs + 0, Qcoeffs + 0, fctx);
     fmpz_mod_inv(lc_inv, lc_inv, fctx);
 
-    if (bits <= FLINT_BITS)
-        halves = mpoly_monomial_halves(Qexps + 0, Aexps + 0, N, mask);
-    else
-        halves = mpoly_monomial_halves_mp(Qexps + 0, Aexps + 0, N, bits);
+    halves = mpoly_monomial_halves_any_bits(Qexps + 0, Aexps + 0, N, mask, bits);
 
     if (!halves)
         goto not_sqrt; /* exponent is not square */
@@ -444,18 +441,12 @@ FLINT_ASSERT(fmpz_mod_is_canonical(Acoeffs + 0, fctx));
         if (fmpz_jacobi(Acoeffs + Alen - 1, fmpz_mod_ctx_modulus(fctx)) < 0)
             goto not_sqrt;
 
-        if (bits <= FLINT_BITS)
-            halves = mpoly_monomial_halves(exp3, Aexps + (Alen - 1)*N, N, mask);
-        else
-            halves = mpoly_monomial_halves_mp(exp3, Aexps + (Alen - 1)*N, N, bits);
+                    halves = mpoly_monomial_halves_any_bits(exp3, Aexps + (Alen - 1)*N, N, mask, bits);
 
         if (!halves)
             goto not_sqrt; /* exponent is not square */
 
-        if (bits <= FLINT_BITS)
-            mpoly_monomial_add(exp3, exp3, Qexps + 0, N);
-        else
-            mpoly_monomial_add_mp(exp3, exp3, Qexps + 0, N);
+                    mpoly_monomial_add_any_bits(exp3, exp3, Qexps + 0, N, bits);
     }
 
     while (heap_len > 1 || Ai < Alen)
@@ -477,8 +468,7 @@ FLINT_ASSERT(fmpz_mod_is_canonical(Acoeffs + 0, fctx));
             /* take only from heap */
             mpoly_monomial_set(exp, heap[1].exp, N);
             s = &zero;
-            if (bits <= FLINT_BITS ? mpoly_monomial_overflows(exp, N, mask)
-                                   : mpoly_monomial_overflows_mp(exp, N, bits))
+            if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
                 goto not_sqrt;
         }
         else
@@ -552,12 +542,7 @@ FLINT_ASSERT(fmpz_mod_is_canonical(Acoeffs + 0, fctx));
                 x->j = j + 1;
                 x->next = NULL;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], Qexps + N*x->i,
-                                                            Qexps + N*x->j, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], Qexps + N*x->i,
-                                                            Qexps + N*x->j, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], Qexps + N*x->i, Qexps + N*x->j, N, bits);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -570,12 +555,7 @@ FLINT_ASSERT(fmpz_mod_is_canonical(Acoeffs + 0, fctx));
         if (fmpz_is_zero(Qcoeffs + Qlen))
             continue;
 
-        if (bits <= FLINT_BITS)
-            lt_divides = mpoly_monomial_divides(Qexps + N*Qlen,
-                                                exp, Qexps + N*0, N, mask);
-        else
-            lt_divides = mpoly_monomial_divides_mp(Qexps + N*Qlen,
-                                                exp, Qexps + N*0, N, bits);
+                    lt_divides = mpoly_monomial_divides_any_bits(Qexps + N*Qlen, exp, Qexps + N*0, N, mask, bits);
         if (!lt_divides)
             goto not_sqrt;
 
@@ -611,12 +591,7 @@ FLINT_ASSERT(fmpz_mod_is_canonical(Acoeffs + 0, fctx));
         x->j = 1;
         x->next = NULL;
 
-        if (bits <= FLINT_BITS)
-            mpoly_monomial_add(exp_list[exp_next], Qexps + x->i*N,
-                                                      Qexps + x->j*N, N);
-        else
-            mpoly_monomial_add_mp(exp_list[exp_next], Qexps + x->i*N,
-                                                         Qexps + x->j*N, N);
+        mpoly_monomial_add_any_bits(exp_list[exp_next], Qexps + x->i*N, Qexps + x->j*N, N, bits);
 
         exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                          &next_loc, &heap_len, N, cmpmask);

--- a/src/fmpz_mod_mpoly_factor/eval.c
+++ b/src/fmpz_mod_mpoly_factor/eval.c
@@ -234,10 +234,7 @@ void _fmpz_mod_mpoly_set_fmpz_mod_bpoly_var1_zero(
         if (fmpz_is_zero(A->coeffs + Alen))
             continue;
 
-        if (Abits <= FLINT_BITS)
-            mpoly_monomial_mul_ui(A->exps + N*Alen, genexp, N, i);
-        else
-            mpoly_monomial_mul_ui_mp(A->exps + N*Alen, genexp, N, i);
+                    mpoly_monomial_mul_ui_any_bits(A->exps + N*Alen, genexp, N, i, Abits);
         Alen++;
     }
 

--- a/src/fmpz_mpoly/div_monagan_pearce.c
+++ b/src/fmpz_mpoly/div_monagan_pearce.c
@@ -437,10 +437,7 @@ slong _fmpz_mpoly_div_monagan_pearce(fmpz ** polyq,
 
         _fmpz_mpoly_fit_length(&q_coeff, &q_exp, allocq, q_len + 1, N);
 
-        if (bits <= FLINT_BITS)
-            lt_divides = mpoly_monomial_divides(q_exp + q_len*N, exp, exp3, N, mask);
-        else
-            lt_divides = mpoly_monomial_divides_mp(q_exp + q_len*N, exp, exp3, N, bits);
+        lt_divides = mpoly_monomial_divides_any_bits(q_exp + q_len*N, exp, exp3, N, mask, bits);
 
         /* take nodes from heap with exponent matching exp */
 
@@ -547,12 +544,7 @@ slong _fmpz_mpoly_div_monagan_pearce(fmpz ** polyq,
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
-                                                            q_exp + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N,
-                                                            q_exp + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N, bits);
 
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -571,12 +563,7 @@ slong _fmpz_mpoly_div_monagan_pearce(fmpz ** polyq,
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
-                                                              q_exp + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N,
-                                                                 q_exp + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N, bits);
 
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -659,12 +646,7 @@ large_lt_divides:
             x->next = NULL;
             hind[x->i] = 2*(x->j + 1) + 0;
 
-            if (bits <= FLINT_BITS)
-                mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
-                                                      q_exp + x->j*N, N);
-            else
-                mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N,
-                                                         q_exp + x->j*N, N);
+            mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N, bits);
 
             exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);

--- a/src/fmpz_mpoly/divides_heap_threaded.c
+++ b/src/fmpz_mpoly/divides_heap_threaded.c
@@ -627,6 +627,7 @@ static slong _fmpz_mpoly_mulsub_stripe(fmpz ** A_coeff, ulong ** A_exp, slong * 
     ulong * emax = S->emax;
     ulong * emin = S->emin;
     slong N = S->N;
+    flint_bitcnt_t bits = S->bits;
     slong i, j;
     slong next_loc = Blen + 4;   /* something bigger than heap can ever be */
     slong heap_len = 1; /* heap zero index unused */
@@ -682,13 +683,13 @@ static slong _fmpz_mpoly_mulsub_stripe(fmpz ** A_coeff, ulong ** A_exp, slong * 
     {
         if (startidx < Clen)
         {
-            mpoly_monomial_add_mp(texp, Bexp + N*i, Cexp + N*startidx, N);
+            mpoly_monomial_add_any_bits(texp, Bexp + N*i, Cexp + N*startidx, N, bits);
             FLINT_ASSERT(mpoly_monomial_cmp(emax, texp, N, S->cmpmask)
                                                                > -upperclosed);
         }
         while (startidx > 0)
         {
-            mpoly_monomial_add_mp(texp, Bexp + N*i, Cexp + N*(startidx - 1), N);
+            mpoly_monomial_add_any_bits(texp, Bexp + N*i, Cexp + N*(startidx - 1), N, bits);
             if (mpoly_monomial_cmp(emax, texp, N, S->cmpmask) <= -upperclosed)
             {
                 break;
@@ -698,12 +699,12 @@ static slong _fmpz_mpoly_mulsub_stripe(fmpz ** A_coeff, ulong ** A_exp, slong * 
 
         if (endidx < Clen)
         {
-            mpoly_monomial_add_mp(texp, Bexp + N*i, Cexp + N*endidx, N);
+            mpoly_monomial_add_any_bits(texp, Bexp + N*i, Cexp + N*endidx, N, bits);
             FLINT_ASSERT(mpoly_monomial_cmp(emin, texp, N, S->cmpmask) > 0);
         }
         while (endidx > 0)
         {
-            mpoly_monomial_add_mp(texp, Bexp + N*i, Cexp + N*(endidx - 1), N);
+            mpoly_monomial_add_any_bits(texp, Bexp + N*i, Cexp + N*(endidx - 1), N, bits);
             if (mpoly_monomial_cmp(emin, texp, N, S->cmpmask) <= 0)
             {
                 break;
@@ -725,8 +726,7 @@ static slong _fmpz_mpoly_mulsub_stripe(fmpz ** A_coeff, ulong ** A_exp, slong * 
             x->next = NULL;
             hind[x->i] = 2*(x->j + 1) + 0;
 
-            mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                      Cexp + N*x->j, N);
+            mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Cexp + N*x->j, N, bits);
 
             exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                           &next_loc, &heap_len, N, S->cmpmask);
@@ -869,8 +869,7 @@ static slong _fmpz_mpoly_mulsub_stripe(fmpz ** A_coeff, ulong ** A_exp, slong * 
 
                 hind[x->i] = 2*(x->j + 1) + 0;
 
-                mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                          Cexp + N*x->j, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Cexp + N*x->j, N, bits);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                           &next_loc, &heap_len, N, S->cmpmask);
@@ -891,8 +890,7 @@ static slong _fmpz_mpoly_mulsub_stripe(fmpz ** A_coeff, ulong ** A_exp, slong * 
 
                 hind[x->i] = 2*(x->j + 1) + 0;
 
-                mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                          Cexp + N*x->j, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Cexp + N*x->j, N, bits);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                           &next_loc, &heap_len, N, S->cmpmask);
@@ -1367,20 +1365,9 @@ static slong _fmpz_mpoly_divides_stripe(
 
         mpoly_monomial_set(exp, heap[1].exp, N);
 
-        if (bits <= FLINT_BITS)
-        {
-            if (mpoly_monomial_overflows(exp, N, mask))
-                goto not_exact_division;
-            lt_divides = mpoly_monomial_divides(Qexp + N*Qlen, exp,
-                                                         Bexp + N*0, N, mask);
-        }
-        else
-        {
-            if (mpoly_monomial_overflows_mp(exp, N, bits))
-                goto not_exact_division;
-            lt_divides = mpoly_monomial_divides_mp(Qexp + N*Qlen, exp,
-                                                         Bexp + N*0, N, bits);
-        }
+        if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
+            goto not_exact_division;
+        lt_divides = mpoly_monomial_divides_any_bits(Qexp + N*Qlen, exp, Bexp + N*0, N, mask, bits);
 
         FLINT_ASSERT(mpoly_monomial_cmp(exp, S->emin, N, S->cmpmask) >= 0);
 
@@ -1469,8 +1456,7 @@ static slong _fmpz_mpoly_divides_stripe(
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                              Qexp + N*x->j, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Qexp + N*x->j, N, bits);
 
                     if (mpoly_monomial_cmp(exp_list[exp_next], S->emin, N,
                                                               S->cmpmask) >= 0)
@@ -1497,8 +1483,7 @@ static slong _fmpz_mpoly_divides_stripe(
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                              Qexp + N*x->j, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Qexp + N*x->j, N, bits);
 
                     if (mpoly_monomial_cmp(exp_list[exp_next], S->emin, N,
                                                               S->cmpmask) >= 0)
@@ -1589,8 +1574,7 @@ static slong _fmpz_mpoly_divides_stripe(
             x->next = NULL;
             hind[x->i] = 2*(x->j + 1) + 0;
 
-            mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                             Qexp + N*x->j, N);
+            mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Qexp + N*x->j, N, bits);
 
             if (mpoly_monomial_cmp(exp_list[exp_next], S->emin, N, S->cmpmask)
                                                                           >= 0)
@@ -2127,12 +2111,12 @@ int _fmpz_mpoly_divides_heap_threaded_pool(
     texps = (ulong *) TMP_ALLOC(N*sizeof(ulong));
     qexps = (ulong *) TMP_ALLOC(N*sizeof(ulong));
 
-    mpoly_monomial_sub_mp(qexps + N*0, Aexp + N*0, Bexp + N*0, N);
+    mpoly_monomial_sub_any_bits(qexps + N*0, Aexp + N*0, Bexp + N*0, N, exp_bits);
     fmpz_divexact(qcoeff, A->coeffs + 0, B->coeffs + 0); /* already checked */
 
     fmpz_mpoly_ts_init(H->polyQ, qcoeff, qexps, 1, H->bits, H->N);
 
-    mpoly_monomial_add_mp(texps, qexps + N*0, Bexp + N*1, N);
+    mpoly_monomial_add_any_bits(texps, qexps + N*0, Bexp + N*1, N, exp_bits);
 
     mask = 0;
     for (i = 0; (flint_bitcnt_t) i < FLINT_BITS/exp_bits; i++)
@@ -2142,12 +2126,7 @@ int _fmpz_mpoly_divides_heap_threaded_pool(
     while (k < A->length && mpoly_monomial_gt(Aexp + N*k, texps, N, cmpmask))
     {
         int lt_divides;
-        if (exp_bits <= FLINT_BITS)
-            lt_divides = mpoly_monomial_divides(qexps, Aexp + N*k,
-                                                      Bexp + N*0, N, mask);
-        else
-            lt_divides = mpoly_monomial_divides_mp(qexps, Aexp + N*k,
-                                                      Bexp + N*0, N, exp_bits);
+        lt_divides = mpoly_monomial_divides_any_bits(qexps, Aexp + N*k, Bexp + N*0, N, mask, exp_bits);
         if (!lt_divides)
         {
             H->failed = 1;

--- a/src/fmpz_mpoly/divides_monagan_pearce.c
+++ b/src/fmpz_mpoly/divides_monagan_pearce.c
@@ -404,10 +404,7 @@ slong _fmpz_mpoly_divides_monagan_pearce(fmpz ** poly1, ulong ** exp1,
         k++;
         _fmpz_mpoly_fit_length(&p1, &e1, alloc, k + 1, N);
 
-        if (bits <= FLINT_BITS)
-            lt_divides = mpoly_monomial_divides(e1 + k*N, exp, exp3, N, mask);
-        else
-            lt_divides = mpoly_monomial_divides_mp(e1 + k*N, exp, exp3, N, bits);
+        lt_divides = mpoly_monomial_divides_any_bits(e1 + k*N, exp, exp3, N, mask, bits);
 
         if (small)
         {
@@ -483,12 +480,7 @@ slong _fmpz_mpoly_divides_monagan_pearce(fmpz ** poly1, ulong ** exp1,
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
-                                                               e1 + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N,
-                                                               e1 + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, e1 + x->j*N, N, bits);
 
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -507,12 +499,7 @@ slong _fmpz_mpoly_divides_monagan_pearce(fmpz ** poly1, ulong ** exp1,
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
-                                                               e1 + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N,
-                                                               e1 + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, e1 + x->j*N, N, bits);
 
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -590,12 +577,7 @@ slong _fmpz_mpoly_divides_monagan_pearce(fmpz ** poly1, ulong ** exp1,
             x->next = NULL;
             hind[x->i] = 2*(x->j + 1) + 0;
 
-            if (bits <= FLINT_BITS)
-                mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
-                                                               e1 + x->j*N, N);
-            else
-                mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N,
-                                                               e1 + x->j*N, N);
+            mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, e1 + x->j*N, N, bits);
 
             exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);

--- a/src/fmpz_mpoly/divrem.c
+++ b/src/fmpz_mpoly/divrem.c
@@ -470,10 +470,7 @@ slong _fmpz_mpoly_divrem_monagan_pearce(slong * lenr,
 
         _fmpz_mpoly_fit_length(&q_coeff, &q_exp, allocq, q_len + 1, N);
 
-        if (bits <= FLINT_BITS)
-            lt_divides = mpoly_monomial_divides(q_exp + q_len*N, exp, exp3, N, mask);
-        else
-            lt_divides = mpoly_monomial_divides_mp(q_exp + q_len*N, exp, exp3, N, bits);
+        lt_divides = mpoly_monomial_divides_any_bits(q_exp + q_len*N, exp, exp3, N, mask, bits);
 
         /* take nodes from heap with exponent matching exp */
         if (small)
@@ -550,12 +547,7 @@ slong _fmpz_mpoly_divrem_monagan_pearce(slong * lenr,
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
-                                                            q_exp + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N,
-                                                            q_exp + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N, bits);
 
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -574,12 +566,7 @@ slong _fmpz_mpoly_divrem_monagan_pearce(slong * lenr,
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
-                                                           q_exp   + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N,
-                                                           q_exp   + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N, bits);
 
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -690,12 +677,7 @@ large_lt_divides:
             x->next = NULL;
             hind[x->i] = 2*(x->j + 1) + 0;
 
-            if (bits <= FLINT_BITS)
-                mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
-                                                      q_exp + x->j*N, N);
-            else
-                mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N,
-                                                         q_exp + x->j*N, N);
+            mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N, bits);
 
             exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);

--- a/src/fmpz_mpoly/divrem_ideal.c
+++ b/src/fmpz_mpoly/divrem_ideal.c
@@ -571,10 +571,7 @@ slong _fmpz_mpoly_divrem_ideal_monagan_pearce(fmpz_mpoly_struct ** polyq,
             div_flag = 0;
             for (w = 0; w < len; w++)
             {
-                if (bits <= FLINT_BITS)
-                    d1 = mpoly_monomial_divides(texp, exp, exp3[w], N, mask);
-                else
-                    d1 = mpoly_monomial_divides_mp(texp, exp, exp3[w], N, bits);
+                                    d1 = mpoly_monomial_divides_any_bits(texp, exp, exp3[w], N, mask, bits);
 
                 if (d1)
                 {

--- a/src/fmpz_mpoly/get_set_is_fmpz_poly.c
+++ b/src/fmpz_mpoly/get_set_is_fmpz_poly.c
@@ -112,10 +112,7 @@ void _fmpz_mpoly_set_fmpz_poly(
 
         FLINT_ASSERT(Alen < A->alloc);
         fmpz_set(A->coeffs + Alen, Bcoeffs + i);
-        if (Abits <= FLINT_BITS)
-            mpoly_monomial_mul_ui(A->exps + N*Alen, genexp, N, i);
-        else
-            mpoly_monomial_mul_ui_mp(A->exps + N*Alen, genexp, N, i);
+        mpoly_monomial_mul_ui_any_bits(A->exps + N*Alen, genexp, N, i, Abits);
         Alen++;
     }
     _fmpz_mpoly_set_length(A, Alen, ctx);

--- a/src/fmpz_mpoly/mul_heap_threaded.c
+++ b/src/fmpz_mpoly/mul_heap_threaded.c
@@ -242,12 +242,7 @@ static slong _fmpz_mpoly_mul_heap_part(fmpz ** A_coeff, ulong ** A_exp, slong * 
             x->j = start[i];
             x->next = NULL;
             hind[x->i] = 2*(x->j + 1) + 0;
-            if (bits <= FLINT_BITS)
-                mpoly_monomial_add(exp_list[exp_next], Bexp + x->i*N,
-                                                       Cexp + x->j*N, N);
-            else
-                mpoly_monomial_add_mp(exp_list[exp_next], Bexp + x->i*N,
-                                                          Cexp + x->j*N, N);
+            mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + x->i*N, Cexp + x->j*N, N, bits);
 
             exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -330,12 +325,7 @@ static slong _fmpz_mpoly_mul_heap_part(fmpz ** A_coeff, ulong ** A_exp, slong * 
 
                 hind[x->i] = 2*(x->j + 1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], Bexp + x->i*N,
-                                                           Cexp + x->j*N, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + x->i*N,
-                                                              Cexp + x->j*N, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + x->i*N, Cexp + x->j*N, N, bits);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -356,12 +346,7 @@ static slong _fmpz_mpoly_mul_heap_part(fmpz ** A_coeff, ulong ** A_exp, slong * 
 
                 hind[x->i] = 2*(x->j + 1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], Bexp + x->i*N,
-                                                           Cexp + x->j*N, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + x->i*N,
-                                                              Cexp + x->j*N, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + x->i*N, Cexp + x->j*N, N, bits);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);

--- a/src/fmpz_mpoly/mul_johnson.c
+++ b/src/fmpz_mpoly/mul_johnson.c
@@ -284,10 +284,7 @@ slong _fmpz_mpoly_mul_johnson(fmpz ** poly1, ulong ** exp1, slong * alloc,
    heap[1].next = x;
    heap[1].exp = exp_list[exp_next++];
 
-    if (bits <= FLINT_BITS)
-        mpoly_monomial_add(heap[1].exp, exp2, exp3, N);
-    else
-        mpoly_monomial_add_mp(heap[1].exp, exp2, exp3, N);
+            mpoly_monomial_add_any_bits(heap[1].exp, exp2, exp3, N, bits);
 
     hind[0] = 2*1 + 0;
 
@@ -404,10 +401,7 @@ slong _fmpz_mpoly_mul_johnson(fmpz ** poly1, ulong ** exp1, slong * alloc,
 
             hind[x->i] = 2*(x->j+1) + 0;
 
-            if (bits <= FLINT_BITS)
-                mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
-            else
-                mpoly_monomial_add_mp(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
+            mpoly_monomial_add_any_bits(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N, bits);
 
             if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
                                       &next_loc, &heap_len, N, cmpmask))
@@ -430,10 +424,7 @@ slong _fmpz_mpoly_mul_johnson(fmpz ** poly1, ulong ** exp1, slong * alloc,
 
             hind[x->i] = 2*(x->j+1) + 0;
 
-            if (bits <= FLINT_BITS)
-                mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
-            else
-                mpoly_monomial_add_mp(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
+            mpoly_monomial_add_any_bits(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N, bits);
 
             if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
                                       &next_loc, &heap_len, N, cmpmask))

--- a/src/fmpz_mpoly/quasidiv_heap.c
+++ b/src/fmpz_mpoly/quasidiv_heap.c
@@ -491,21 +491,9 @@ static slong _fmpz_mpoly_quasidiv_heap(fmpz_t scale,
 
         mpoly_monomial_set(exp, heap[1].exp, N);
 
-        if (bits <= FLINT_BITS)
-        {
-            if (mpoly_monomial_overflows(exp, N, mask))
-                goto exp_overflow;
-
-            lt_divides = mpoly_monomial_divides(q_exp + q_len*N, exp, exp3, N, mask);
-
-        }
-        else
-        {
-            if (mpoly_monomial_overflows_mp(exp, N, bits))
-                goto exp_overflow;
-
-            lt_divides = mpoly_monomial_divides_mp(q_exp + q_len*N, exp, exp3, N, bits);
-        }
+        if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
+            goto exp_overflow;
+        lt_divides = mpoly_monomial_divides_any_bits(q_exp + q_len*N, exp, exp3, N, mask, bits);
 
         if (!lt_divides)
         {
@@ -637,12 +625,7 @@ static slong _fmpz_mpoly_quasidiv_heap(fmpz_t scale,
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], exp3  + x->i*N,
-                                                           q_exp + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], exp3  + x->i*N,
-                                                           q_exp + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N, bits);
 
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -660,12 +643,7 @@ static slong _fmpz_mpoly_quasidiv_heap(fmpz_t scale,
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], exp3  + x->i*N,
-                                                           q_exp + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], exp3  + x->i*N,
-                                                           q_exp + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N, bits);
 
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -742,12 +720,7 @@ large_lt_divides:
             x->next = NULL;
             hind[x->i] = 2*(x->j + 1) + 0;
 
-            if (bits <= FLINT_BITS)
-                mpoly_monomial_add(exp_list[exp_next], exp3  + x->i*N,
-                                                       q_exp + x->j*N, N);
-            else
-                mpoly_monomial_add_mp(exp_list[exp_next], exp3  + x->i*N,
-                                                          q_exp + x->j*N, N);
+            mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N, bits);
 
             exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);

--- a/src/fmpz_mpoly/quasidivrem_heap.c
+++ b/src/fmpz_mpoly/quasidivrem_heap.c
@@ -486,20 +486,9 @@ static slong _fmpz_mpoly_quasidivrem_heap(fmpz_t scale, slong * lenr,
         }
 
         mpoly_monomial_set(exp, heap[1].exp, N);
-        if (bits <= FLINT_BITS)
-        {
-            if (mpoly_monomial_overflows(exp, N, mask))
-                goto exp_overflow;
-
-            lt_divides = mpoly_monomial_divides(q_exp + q_len*N, exp, exp3, N, mask);
-        }
-        else
-        {
-            if (mpoly_monomial_overflows_mp(exp, N, bits))
-                goto exp_overflow;
-
-            lt_divides = mpoly_monomial_divides_mp(q_exp + q_len*N, exp, exp3, N, bits);
-        }
+        if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
+            goto exp_overflow;
+        lt_divides = mpoly_monomial_divides_any_bits(q_exp + q_len*N, exp, exp3, N, mask, bits);
 
         /* accumulate terms from highest terms on heap */
         if (small)
@@ -573,12 +562,7 @@ static slong _fmpz_mpoly_quasidivrem_heap(fmpz_t scale, slong * lenr,
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
-                                                              q_exp + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N,
-                                                                 q_exp + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N, bits);
 
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -596,12 +580,7 @@ static slong _fmpz_mpoly_quasidivrem_heap(fmpz_t scale, slong * lenr,
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
-                                                              q_exp + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N,
-                                                                 q_exp + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N, bits);
 
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -689,12 +668,7 @@ large_lt_divides:
             x->next = NULL;
             hind[x->i] = 2*(x->j + 1) + 0;
 
-            if (bits <= FLINT_BITS)
-                mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
-                                                      q_exp + x->j*N, N);
-            else
-                mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N,
-                                                         q_exp + x->j*N, N);
+            mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N, bits);
 
             exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);

--- a/src/fmpz_mpoly/quasidivrem_ideal_heap.c
+++ b/src/fmpz_mpoly/quasidivrem_ideal_heap.c
@@ -497,10 +497,7 @@ static slong _fmpz_mpoly_quasidivrem_ideal_heap(fmpz_t scale, fmpz_mpoly_struct 
         {
             int divides;
 
-            if (bits <= FLINT_BITS)
-                divides = mpoly_monomial_divides(texp, exp, exp3[w] + N*0, N, mask);
-            else
-                divides = mpoly_monomial_divides_mp(texp, exp, exp3[w] + N*0, N, bits);
+            divides = mpoly_monomial_divides_any_bits(texp, exp, exp3[w] + N*0, N, mask, bits);
 
             if (divides)
             {

--- a/src/fmpz_mpoly/select_exps.c
+++ b/src/fmpz_mpoly/select_exps.c
@@ -86,33 +86,14 @@ int mpoly_divides_select_exps(fmpz_mpoly_t S, fmpz_mpoly_ctx_t zctx,
 
     T0 = (ulong *) TMP_ALLOC(N*sizeof(ulong));
     T1 = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    if (bits <= FLINT_BITS)
-        mpoly_monomial_sub(T0, Aexp + N*0, Bexp + N*0, N);
-    else
-        mpoly_monomial_sub_mp(T0, Aexp + N*0, Bexp + N*0, N);
-    if (bits <= FLINT_BITS)
-        mpoly_monomial_sub(T1, Aexp + N*(Alen - 1), Bexp + N*(Blen - 1), N);
-    else
-        mpoly_monomial_sub_mp(T1, Aexp + N*(Alen - 1), Bexp + N*(Blen - 1), N);
-    if (bits <= FLINT_BITS)
+    mpoly_monomial_sub_any_bits(T0, Aexp + N*0, Bexp + N*0, N, bits);
+    mpoly_monomial_sub_any_bits(T1, Aexp + N*(Alen - 1), Bexp + N*(Blen - 1), N, bits);
+    if (   mpoly_monomial_overflows_any_bits(T0, N, mask, bits)
+        || mpoly_monomial_overflows_any_bits(T1, N, mask, bits))
     {
-        if (   mpoly_monomial_overflows(T0, N, mask)
-            || mpoly_monomial_overflows(T1, N, mask))
-        {
-            failure = 1;
-            goto cleanup;
-        }
+        failure = 1;
+        goto cleanup;
     }
-    else
-    {
-        if (   mpoly_monomial_overflows_mp(T0, N, bits)
-            || mpoly_monomial_overflows_mp(T1, N, bits))
-        {
-            failure = 1;
-            goto cleanup;
-        }
-    }
-
 
     for (i = 1; i < nB; i++)
     {
@@ -122,33 +103,19 @@ int mpoly_divides_select_exps(fmpz_mpoly_t S, fmpz_mpoly_ctx_t zctx,
         j = FLINT_MAX(j, WORD(0));
         j = FLINT_MIN(j, Blen - 1);
 
-        if (bits <= FLINT_BITS)
-            mpoly_monomial_sub(Sexp + N*Slen, Aexp + N*0, Bexp + N*0, N);
-        else
-            mpoly_monomial_sub_mp(Sexp + N*Slen, Aexp + N*0, Bexp + N*0, N);
-        if (bits <= FLINT_BITS)
-            mpoly_monomial_add(Sexp + N*Slen, Sexp + N*Slen, Bexp + N*j, N);
-        else
-            mpoly_monomial_add_mp(Sexp + N*Slen, Sexp + N*Slen, Bexp + N*j, N);
+        /* Aexp[0] - Bexp[0] is exactly T0, already validated above, so
+           the subsequent += Bexp[j] below is adding to a known-valid
+           operand. */
+        mpoly_monomial_sub_any_bits(Sexp + N*Slen, Aexp + N*0, Bexp + N*0, N, bits);
+        mpoly_monomial_add_any_bits(Sexp + N*Slen, Sexp + N*Slen, Bexp + N*j, N, bits);
         fmpz_one(Scoeff + Slen);
-        if (bits <= FLINT_BITS)
-            Slen += !(mpoly_monomial_overflows(Sexp + N*Slen, N, mask));
-        else
-            Slen += !(mpoly_monomial_overflows_mp(Sexp + N*Slen, N, bits));
+        Slen += !(mpoly_monomial_overflows_any_bits(Sexp + N*Slen, N, mask, bits));
 
-        if (bits <= FLINT_BITS)
-            mpoly_monomial_sub(Sexp + N*Slen, Aexp + N*(Alen - 1), Bexp + N*(Blen - 1), N);
-        else
-            mpoly_monomial_sub_mp(Sexp + N*Slen, Aexp + N*(Alen - 1), Bexp + N*(Blen - 1), N);
-        if (bits <= FLINT_BITS)
-            mpoly_monomial_add(Sexp + N*Slen, Sexp + N*Slen, Bexp + N*j, N);
-        else
-            mpoly_monomial_add_mp(Sexp + N*Slen, Sexp + N*Slen, Bexp + N*j, N);
+        /* likewise, Aexp[Alen-1] - Bexp[Blen-1] is exactly T1 */
+        mpoly_monomial_sub_any_bits(Sexp + N*Slen, Aexp + N*(Alen - 1), Bexp + N*(Blen - 1), N, bits);
+        mpoly_monomial_add_any_bits(Sexp + N*Slen, Sexp + N*Slen, Bexp + N*j, N, bits);
         fmpz_one(Scoeff + Slen);
-        if (bits <= FLINT_BITS)
-            Slen += !(mpoly_monomial_overflows(Sexp + N*Slen, N, mask));
-        else
-            Slen += !(mpoly_monomial_overflows_mp(Sexp + N*Slen, N, bits));
+        Slen += !(mpoly_monomial_overflows_any_bits(Sexp + N*Slen, N, mask, bits));
     }
 
     /* get a lower bound on the exponents of A */

--- a/src/fmpz_mpoly/sqrt_heap.c
+++ b/src/fmpz_mpoly/sqrt_heap.c
@@ -690,10 +690,7 @@ slong _fmpz_mpoly_sqrt_heap(
         lc_lg = COEFF_TO_PTR(Qcoeffs[0]);
     }
 
-    if (bits <= FLINT_BITS)
-        halves = mpoly_monomial_halves(Qexps + 0, Aexps + 0, N, mask);
-    else
-        halves = mpoly_monomial_halves_mp(Qexps + 0, Aexps + 0, N, bits);
+    halves = mpoly_monomial_halves_any_bits(Qexps + 0, Aexps + 0, N, mask, bits);
 
     if (!halves)
         goto not_sqrt; /* exponent is not square */
@@ -703,18 +700,12 @@ slong _fmpz_mpoly_sqrt_heap(
         if (!fmpz_is_square(Acoeffs + Alen - 1))
             goto not_sqrt;
 
-        if (bits <= FLINT_BITS)
-            halves = mpoly_monomial_halves(exp3, Aexps + (Alen - 1)*N, N, mask);
-        else
-            halves = mpoly_monomial_halves_mp(exp3, Aexps + (Alen - 1)*N, N, bits);
+                    halves = mpoly_monomial_halves_any_bits(exp3, Aexps + (Alen - 1)*N, N, mask, bits);
 
         if (!halves)
             goto not_sqrt; /* exponent is not square */
 
-        if (bits <= FLINT_BITS)
-            mpoly_monomial_add(exp3, exp3, Qexps + 0, N);
-        else
-            mpoly_monomial_add_mp(exp3, exp3, Qexps + 0, N);
+                    mpoly_monomial_add_any_bits(exp3, exp3, Qexps + 0, N, bits);
     }
 
     while (heap_len > 1 || Ai < Alen)
@@ -739,8 +730,7 @@ slong _fmpz_mpoly_sqrt_heap(
             acc_lg = acc;
             acc_sm[2] = acc_sm[1] = acc_sm[0] = 0;
 
-            if (bits <= FLINT_BITS ? mpoly_monomial_overflows(exp, N, mask)
-                                   : mpoly_monomial_overflows_mp(exp, N, bits))
+            if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
                 goto not_sqrt;
 
             use_heap = 1;
@@ -760,12 +750,7 @@ slong _fmpz_mpoly_sqrt_heap(
             use_heap = 0;
         }
 
-        if (bits <= FLINT_BITS)
-            lt_divides = mpoly_monomial_divides(Qexps + N*Qlen,
-                                                      exp, Qexps + 0, N, mask);
-        else
-            lt_divides = mpoly_monomial_divides_mp(Qexps + N*Qlen,
-                                                      exp, Qexps + 0, N, bits);
+        lt_divides = mpoly_monomial_divides_any_bits(Qexps + N*Qlen, exp, Qexps + 0, N, mask, bits);
 
         if (!use_heap)
             goto skip_heap;
@@ -910,12 +895,7 @@ slong _fmpz_mpoly_sqrt_heap(
                 x->j = j + 1;
                 x->next = NULL;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], Qexps + x->i*N,
-                                                          Qexps + x->j*N, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], Qexps + x->i*N,
-                                                             Qexps + x->j*N, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], Qexps + x->i*N, Qexps + x->j*N, N, bits);
                 if (check || !mpoly_monomial_gt(exp3 + 0, exp_list[exp_next], N, cmpmask))
                 {
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
@@ -1039,12 +1019,7 @@ slong _fmpz_mpoly_sqrt_heap(
         x->j = 1;
         x->next = NULL;
 
-        if (bits <= FLINT_BITS)
-            mpoly_monomial_add(exp_list[exp_next], Qexps + x->i*N,
-                                                      Qexps + x->j*N, N);
-        else
-            mpoly_monomial_add_mp(exp_list[exp_next], Qexps + x->i*N,
-                                                         Qexps + x->j*N, N);
+        mpoly_monomial_add_any_bits(exp_list[exp_next], Qexps + x->i*N, Qexps + x->j*N, N, bits);
 
         if (check || !mpoly_monomial_gt(exp3 + 0, exp_list[exp_next], N, cmpmask))
         {

--- a/src/fq_nmod_mpoly/div_monagan_pearce.c
+++ b/src/fq_nmod_mpoly/div_monagan_pearce.c
@@ -92,20 +92,9 @@ static int _fq_nmod_mpoly_div_monagan_pearce(
 
         mpoly_monomial_set(exp, heap[1].exp, N);
 
-        if (bits <= FLINT_BITS)
-        {
-            if (mpoly_monomial_overflows(exp, N, mask))
-                goto exp_overflow;
-
-            lt_divides = mpoly_monomial_divides(Qexps + N*Qlen, exp, Bexps, N, mask);
-        }
-        else
-        {
-            if (mpoly_monomial_overflows_mp(exp, N, bits))
-                goto exp_overflow;
-
-            lt_divides = mpoly_monomial_divides_mp(Qexps + N*Qlen, exp, Bexps, N, bits);
-        }
+        if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
+            goto exp_overflow;
+        lt_divides = mpoly_monomial_divides_any_bits(Qexps + N*Qlen, exp, Bexps, N, mask, bits);
 
         _n_fq_zero(Qcoeffs + d*Qlen, d);
         do {

--- a/src/fq_nmod_mpoly/divides_monagan_pearce.c
+++ b/src/fq_nmod_mpoly/divides_monagan_pearce.c
@@ -323,18 +323,9 @@ int _fq_nmod_mpoly_divides_monagan_pearce(
 
         mpoly_monomial_set(exp, heap[1].exp, N);
 
-        if (bits <= FLINT_BITS)
-        {
-            if (mpoly_monomial_overflows(exp, N, mask))
-                goto not_exact_division;
-            lt_divides = mpoly_monomial_divides(Qexps + N*Qlen, exp, Bexps, N, mask);
-        }
-        else
-        {
-            if (mpoly_monomial_overflows_mp(exp, N, bits))
-                goto not_exact_division;
-            lt_divides = mpoly_monomial_divides_mp(Qexps + N*Qlen, exp, Bexps, N, bits);
-        }
+        if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
+            goto not_exact_division;
+        lt_divides = mpoly_monomial_divides_any_bits(Qexps + N*Qlen, exp, Bexps, N, mask, bits);
 
         _n_fq_zero(Qcoeffs + d*Qlen, d);
         _nmod_vec_zero(t, 6*d);
@@ -428,12 +419,7 @@ case n:                                                                       \
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], Bexps + N*x->i,
-                                                            Qexps + N*x->j, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], Bexps + N*x->i,
-                                                            Qexps + N*x->j, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], Bexps + N*x->i, Qexps + N*x->j, N, bits);
 
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -452,12 +438,7 @@ case n:                                                                       \
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], Bexps + N*x->i,
-                                                            Qexps + N*x->j, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], Bexps + N*x->i,
-                                                            Qexps + N*x->j, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], Bexps + N*x->i, Qexps + N*x->j, N, bits);
 
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -487,12 +468,7 @@ case n:                                                                       \
             x->next = NULL;
             hind[x->i] = 2*(x->j + 1) + 0;
 
-            if (bits <= FLINT_BITS)
-                mpoly_monomial_add(exp_list[exp_next], Bexps + N*x->i,
-                                                       Qexps + N*x->j, N);
-            else
-                mpoly_monomial_add_mp(exp_list[exp_next], Bexps + N*x->i,
-                                                          Qexps + N*x->j, N);
+            mpoly_monomial_add_any_bits(exp_list[exp_next], Bexps + N*x->i, Qexps + N*x->j, N, bits);
 
             exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);

--- a/src/fq_nmod_mpoly/divrem_ideal_monagan_pearce.c
+++ b/src/fq_nmod_mpoly/divrem_ideal_monagan_pearce.c
@@ -221,10 +221,7 @@ static int _fq_nmod_mpoly_divrem_ideal_monagan_pearce(
         {
             int divides;
 
-            if (bits <= FLINT_BITS)
-                divides = mpoly_monomial_divides(texp, exp, exp3[w] + N*0, N, mask);
-            else
-                divides = mpoly_monomial_divides_mp(texp, exp, exp3[w] + N*0, N, bits);
+            divides = mpoly_monomial_divides_any_bits(texp, exp, exp3[w] + N*0, N, mask, bits);
 
             if (divides)
             {

--- a/src/fq_nmod_mpoly/divrem_monagan_pearce.c
+++ b/src/fq_nmod_mpoly/divrem_monagan_pearce.c
@@ -532,20 +532,9 @@ static int _fq_nmod_mpoly_divrem_monagan_pearce(
 
         mpoly_monomial_set(exp, heap[1].exp, N);
 
-        if (bits <= FLINT_BITS)
-        {
-            if (mpoly_monomial_overflows(exp, N, mask))
-                goto exp_overflow;
-
-            lt_divides = mpoly_monomial_divides(Qexps + N*Qlen, exp, Bexps, N, mask);
-        }
-        else
-        {
-            if (mpoly_monomial_overflows_mp(exp, N, bits))
-                goto exp_overflow;
-
-            lt_divides = mpoly_monomial_divides_mp(Qexps + N*Qlen, exp, Bexps, N, bits);
-        }
+        if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
+            goto exp_overflow;
+        lt_divides = mpoly_monomial_divides_any_bits(Qexps + N*Qlen, exp, Bexps, N, mask, bits);
 
         _n_fq_zero(Qcoeffs + d*Qlen, d);
         do {

--- a/src/fq_nmod_mpoly/get_set_is_fq_nmod_poly.c
+++ b/src/fq_nmod_mpoly/get_set_is_fq_nmod_poly.c
@@ -139,10 +139,7 @@ void _fq_nmod_mpoly_set_fq_nmod_poly(
         FLINT_ASSERT(d*Alen < A->coeffs_alloc);
         FLINT_ASSERT(N*Alen < A->exps_alloc);
         n_fq_set_fq_nmod(A->coeffs + d*Alen, Bcoeffs + i, ctx->fqctx);
-        if (Abits <= FLINT_BITS)
-            mpoly_monomial_mul_ui(A->exps + N*Alen, genexp, N, i);
-        else
-            mpoly_monomial_mul_ui_mp(A->exps + N*Alen, genexp, N, i);
+        mpoly_monomial_mul_ui_any_bits(A->exps + N*Alen, genexp, N, i, Abits);
         Alen++;
     }
     A->length = Alen;

--- a/src/fq_nmod_mpoly/mpolyu_divides.c
+++ b/src/fq_nmod_mpoly/mpolyu_divides.c
@@ -75,10 +75,7 @@ static void _fq_nmod_mpoly_mulsub(fq_nmod_mpoly_t A,
     heap[1].next = x;
     heap[1].exp = exp_list[exp_next++];
 
-    if (bits <= FLINT_BITS)
-        mpoly_monomial_add(heap[1].exp, Bexp + N*0, Cexp + N*0, N);
-    else
-        mpoly_monomial_add_mp(heap[1].exp, Bexp + N*0, Cexp + N*0, N);
+    mpoly_monomial_add_any_bits(heap[1].exp, Bexp + N*0, Cexp + N*0, N, bits);
 
     hind[0] = 2*1 + 0;
 
@@ -197,12 +194,7 @@ static void _fq_nmod_mpoly_mulsub(fq_nmod_mpoly_t A,
 
                 hind[x->i] = 2*(x->j+1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i,
-                                                           Cexp + N*x->j, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                              Cexp + N*x->j, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Cexp + N*x->j, N, bits);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -221,12 +213,7 @@ static void _fq_nmod_mpoly_mulsub(fq_nmod_mpoly_t A,
 
                 hind[x->i] = 2*(x->j+1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i,
-                                                           Cexp + N*x->j, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                              Cexp + N*x->j, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Cexp + N*x->j, N, bits);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);

--- a/src/fq_nmod_mpoly/mul_johnson.c
+++ b/src/fq_nmod_mpoly/mul_johnson.c
@@ -249,10 +249,7 @@ void _fq_nmod_mpoly_mul_johnson(
     heap[1].next = x;
     heap[1].exp = exp_list[exp_next++];
 
-    if (bits <= FLINT_BITS)
-        mpoly_monomial_add(heap[1].exp, Bexps + N*0, Cexps + N*0, N);
-    else
-        mpoly_monomial_add_mp(heap[1].exp, Bexps + N*0, Cexps + N*0, N);
+    mpoly_monomial_add_any_bits(heap[1].exp, Bexps + N*0, Cexps + N*0, N, bits);
 
     hind[0] = 2*1 + 0;
 
@@ -347,12 +344,7 @@ void _fq_nmod_mpoly_mul_johnson(
 
                 hind[x->i] = 2*(x->j + 1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], Bexps + x->i*N,
-                                                           Cexps + x->j*N, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], Bexps + x->i*N,
-                                                              Cexps + x->j*N, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], Bexps + x->i*N, Cexps + x->j*N, N, bits);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -371,12 +363,7 @@ void _fq_nmod_mpoly_mul_johnson(
 
                 hind[x->i] = 2*(x->j + 1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], Bexps + x->i*N,
-                                                           Cexps + x->j*N, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], Bexps + x->i*N,
-                                                              Cexps + x->j*N, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], Bexps + x->i*N, Cexps + x->j*N, N, bits);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);

--- a/src/fq_nmod_mpoly/sqrt_heap.c
+++ b/src/fq_nmod_mpoly/sqrt_heap.c
@@ -183,10 +183,7 @@ static int _fq_nmod_mpoly_sqrt_heap(
     _n_fq_add(t2, Qcoeffs + d*0, Qcoeffs + d*0, d, fqctx->mod);
     _n_fq_inv(lc_inv, t2, fqctx, t);
 
-    if (bits <= FLINT_BITS)
-        halves = mpoly_monomial_halves(Qexps + 0, Aexps + 0, N, mask);
-    else
-        halves = mpoly_monomial_halves_mp(Qexps + 0, Aexps + 0, N, bits);
+    halves = mpoly_monomial_halves_any_bits(Qexps + 0, Aexps + 0, N, mask, bits);
 
     if (!halves)
         goto not_sqrt; /* exponent is not square */
@@ -196,18 +193,12 @@ static int _fq_nmod_mpoly_sqrt_heap(
         if (!n_fq_sqrt(t, Acoeffs + d*(Alen - 1), fqctx))
             goto not_sqrt;
 
-        if (bits <= FLINT_BITS)
-            halves = mpoly_monomial_halves(exp3, Aexps + (Alen - 1)*N, N, mask);
-        else
-            halves = mpoly_monomial_halves_mp(exp3, Aexps + (Alen - 1)*N, N, bits);
+                    halves = mpoly_monomial_halves_any_bits(exp3, Aexps + (Alen - 1)*N, N, mask, bits);
 
         if (!halves)
             goto not_sqrt; /* exponent is not square */
 
-        if (bits <= FLINT_BITS)
-            mpoly_monomial_add(exp3, exp3, Qexps + 0, N);
-        else
-            mpoly_monomial_add_mp(exp3, exp3, Qexps + 0, N);
+                    mpoly_monomial_add_any_bits(exp3, exp3, Qexps + 0, N, bits);
     }
 
     while (heap_len > 1 || Ai < Alen)
@@ -230,8 +221,7 @@ static int _fq_nmod_mpoly_sqrt_heap(
             mpoly_monomial_set(exp, heap[1].exp, N);
             _n_fq_zero(Qcoeffs + d*Qlen, d);
 
-            if (bits <= FLINT_BITS ? mpoly_monomial_overflows(exp, N, mask)
-                                   : mpoly_monomial_overflows_mp(exp, N, bits))
+            if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
                 goto not_sqrt;
         }
         else
@@ -283,12 +273,7 @@ static int _fq_nmod_mpoly_sqrt_heap(
                 x->j = j + 1;
                 x->next = NULL;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], Qexps + N*x->i,
-                                                            Qexps + N*x->j, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], Qexps + N*x->i,
-                                                            Qexps + N*x->j, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], Qexps + N*x->i, Qexps + N*x->j, N, bits);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -300,12 +285,7 @@ static int _fq_nmod_mpoly_sqrt_heap(
 
     skip_heap:
 
-        if (bits <= FLINT_BITS)
-            lt_divides = mpoly_monomial_divides(Qexps + N*Qlen,
-                                                exp, Qexps + N*0, N, mask);
-        else
-            lt_divides = mpoly_monomial_divides_mp(Qexps + N*Qlen,
-                                                exp, Qexps + N*0, N, bits);
+                    lt_divides = mpoly_monomial_divides_any_bits(Qexps + N*Qlen, exp, Qexps + N*0, N, mask, bits);
         if (!lt_divides)
             goto not_sqrt;
 
@@ -343,12 +323,7 @@ static int _fq_nmod_mpoly_sqrt_heap(
         x->j = 1;
         x->next = NULL;
 
-        if (bits <= FLINT_BITS)
-            mpoly_monomial_add(exp_list[exp_next], Qexps + x->i*N,
-                                                      Qexps + x->j*N, N);
-        else
-            mpoly_monomial_add_mp(exp_list[exp_next], Qexps + x->i*N,
-                                                         Qexps + x->j*N, N);
+        mpoly_monomial_add_any_bits(exp_list[exp_next], Qexps + x->i*N, Qexps + x->j*N, N, bits);
 
         exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                          &next_loc, &heap_len, N, cmpmask);

--- a/src/fq_nmod_mpoly_factor/eval.c
+++ b/src/fq_nmod_mpoly_factor/eval.c
@@ -239,10 +239,7 @@ void _fq_nmod_mpoly_set_n_fq_bpoly_gen1_zero(
         if (_n_fq_is_zero(A->coeffs + d*Alen, d))
             continue;
 
-        if (Abits <= FLINT_BITS)
-            mpoly_monomial_mul_ui(A->exps + N*Alen, genexp, N, i);
-        else
-            mpoly_monomial_mul_ui_mp(A->exps + N*Alen, genexp, N, i);
+                    mpoly_monomial_mul_ui_any_bits(A->exps + N*Alen, genexp, N, i, Abits);
         Alen++;
     }
     A->length = Alen;

--- a/src/fq_zech_mpoly/divides_monagan_pearce.c
+++ b/src/fq_zech_mpoly/divides_monagan_pearce.c
@@ -91,18 +91,9 @@ static slong _fq_zech_mpoly_divides_monagan_pearce(
 
         mpoly_monomial_set(exp, heap[1].exp, N);
 
-        if (bits <= FLINT_BITS)
-        {
-            if (mpoly_monomial_overflows(exp, N, mask))
-                goto not_exact_division;
-            lt_divides = mpoly_monomial_divides(q_exp + q_len*N, exp, exp3, N, mask);
-        }
-        else
-        {
-            if (mpoly_monomial_overflows_mp(exp, N, bits))
-                goto not_exact_division;
-            lt_divides = mpoly_monomial_divides_mp(q_exp + q_len*N, exp, exp3, N, bits);
-        }
+        if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
+            goto not_exact_division;
+        lt_divides = mpoly_monomial_divides_any_bits(q_exp + q_len*N, exp, exp3, N, mask, bits);
 
         fq_zech_zero(q_coeff + q_len, fqctx);
         do {
@@ -157,12 +148,7 @@ static slong _fq_zech_mpoly_divides_monagan_pearce(
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
-                                                              q_exp + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N,
-                                                                 q_exp + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N, bits);
 
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -182,12 +168,7 @@ static slong _fq_zech_mpoly_divides_monagan_pearce(
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
-                                                              q_exp + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N,
-                                                                 q_exp + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N, bits);
 
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -217,10 +198,7 @@ static slong _fq_zech_mpoly_divides_monagan_pearce(
             x->next = NULL;
             hind[x->i] = 2*(x->j + 1) + 0;
 
-            if (bits <= FLINT_BITS)
-                mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N);
-            else
-                mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N);
+            mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N, bits);
 
             exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);

--- a/src/fq_zech_mpoly/divrem_monagan_pearce.c
+++ b/src/fq_zech_mpoly/divrem_monagan_pearce.c
@@ -93,18 +93,9 @@ static slong _fq_zech_mpoly_divrem_monagan_pearce(slong * lenr,
 
         mpoly_monomial_set(exp, heap[1].exp, N);
 
-        if (bits <= FLINT_BITS)
-        {
-            if (mpoly_monomial_overflows(exp, N, mask))
-                goto exp_overflow2;
-            lt_divides = mpoly_monomial_divides(q_exp + q_len*N, exp, exp3, N, mask);
-        }
-        else
-        {
-            if (mpoly_monomial_overflows_mp(exp, N, bits))
-                goto exp_overflow2;
-            lt_divides = mpoly_monomial_divides_mp(q_exp + q_len*N, exp, exp3, N, bits);
-        }
+        if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
+            goto exp_overflow2;
+        lt_divides = mpoly_monomial_divides_any_bits(q_exp + q_len*N, exp, exp3, N, mask, bits);
 
         fq_zech_zero(q_coeff + q_len, fqctx);
         do {

--- a/src/fq_zech_mpoly/mul_johnson.c
+++ b/src/fq_zech_mpoly/mul_johnson.c
@@ -69,10 +69,7 @@ slong _fq_zech_mpoly_mul_johnson(
     heap[1].next = x;
     heap[1].exp = exp_list[exp_next++];
 
-    if (bits <= FLINT_BITS)
-        mpoly_monomial_add(heap[1].exp, exp2, exp3, N);
-    else
-        mpoly_monomial_add_mp(heap[1].exp, exp2, exp3, N);
+    mpoly_monomial_add_any_bits(heap[1].exp, exp2, exp3, N, bits);
 
     hind[0] = 2*1 + 0;
 
@@ -128,10 +125,7 @@ slong _fq_zech_mpoly_mul_johnson(
 
                 hind[x->i] = 2*(x->j+1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N, bits);
 
                 if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
                                       &next_loc, &heap_len, N, cmpmask))
@@ -153,10 +147,7 @@ slong _fq_zech_mpoly_mul_johnson(
 
                 hind[x->i] = 2*(x->j+1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N, bits);
 
                 if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
                                       &next_loc, &heap_len, N, cmpmask))

--- a/src/fq_zech_mpoly_factor/eval.c
+++ b/src/fq_zech_mpoly_factor/eval.c
@@ -237,10 +237,7 @@ void _fq_zech_mpoly_set_fq_zech_bpoly_var1_zero(
         if (fq_zech_is_zero(A->coeffs + Alen, ctx->fqctx))
             continue;
 
-        if (Abits <= FLINT_BITS)
-            mpoly_monomial_mul_ui(A->exps + N*Alen, genexp, N, i);
-        else
-            mpoly_monomial_mul_ui_mp(A->exps + N*Alen, genexp, N, i);
+                    mpoly_monomial_mul_ui_any_bits(A->exps + N*Alen, genexp, N, i, Abits);
         Alen++;
     }
     A->length = Alen;

--- a/src/fq_zech_mpoly_factor/get_set_is_fq_nmod_poly.c
+++ b/src/fq_zech_mpoly_factor/get_set_is_fq_nmod_poly.c
@@ -113,10 +113,7 @@ void _fq_zech_mpoly_set_fq_zech_poly(
 
         FLINT_ASSERT(Alen < A->alloc);
         fq_zech_set(A->coeffs + Alen, Bcoeffs + i, ctx->fqctx);
-        if (Abits <= FLINT_BITS)
-            mpoly_monomial_mul_ui(A->exps + N*Alen, genexp, N, i);
-        else
-            mpoly_monomial_mul_ui_mp(A->exps + N*Alen, genexp, N, i);
+        mpoly_monomial_mul_ui_any_bits(A->exps + N*Alen, genexp, N, i, Abits);
         Alen++;
     }
     A->length = Alen;

--- a/src/gr_mpoly/divexact.c
+++ b/src/gr_mpoly/divexact.c
@@ -74,10 +74,7 @@ _gr_mpoly_divexact_monomial(gr_mpoly_t Q,
     {
         int divides, cstatus;
 
-        if (exp_bits <= FLINT_BITS)
-            divides = mpoly_monomial_divides(T->exps + N*qlen, Aexps + N*i, Bexps, N, mask);
-        else
-            divides = mpoly_monomial_divides_mp(T->exps + N*qlen, Aexps + N*i, Bexps, N, exp_bits);
+        divides = mpoly_monomial_divides_any_bits(T->exps + N*qlen, Aexps + N*i, Bexps, N, mask, exp_bits);
 
         /* Since the division is known to be exact, spurious terms must correspond
            to inexact/unproved representation of actual zeros, which are thus

--- a/src/gr_mpoly/divides.c
+++ b/src/gr_mpoly/divides.c
@@ -79,10 +79,7 @@ _gr_mpoly_divides_monomial(gr_mpoly_t Q,
     {
         int divides, cstatus;
 
-        if (exp_bits <= FLINT_BITS)
-            divides = mpoly_monomial_divides(T->exps + N*i, Aexps + N*i, Bexps, N, mask);
-        else
-            divides = mpoly_monomial_divides_mp(T->exps + N*i, Aexps + N*i, Bexps, N, exp_bits);
+        divides = mpoly_monomial_divides_any_bits(T->exps + N*i, Aexps + N*i, Bexps, N, mask, exp_bits);
 
         if (!divides)
         {

--- a/src/gr_mpoly/divides_heap.c
+++ b/src/gr_mpoly/divides_heap.c
@@ -439,10 +439,7 @@ static int _gr_mpoly_divides_heap(
         k++;
         _gr_mpoly_fit_length(&p1, alloc, &e1, exps_alloc, N, k + 1, ctx);
 
-        if (bits <= FLINT_BITS)
-            lt_divides = mpoly_monomial_divides(e1 + k*N, exp, exp3, N, mask);
-        else
-            lt_divides = mpoly_monomial_divides_mp(e1 + k*N, exp, exp3, N, bits);
+        lt_divides = mpoly_monomial_divides_any_bits(e1 + k*N, exp, exp3, N, mask, bits);
 
         dot_len = 0;
         have_dividend = 0;
@@ -525,12 +522,7 @@ static int _gr_mpoly_divides_heap(
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
-                                                               e1 + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N,
-                                                               e1 + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, e1 + x->j*N, N, bits);
 
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -549,12 +541,7 @@ static int _gr_mpoly_divides_heap(
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
-                                                               e1 + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N,
-                                                               e1 + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, e1 + x->j*N, N, bits);
 
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -596,12 +583,7 @@ static int _gr_mpoly_divides_heap(
             x->next = NULL;
             hind[x->i] = 2*(x->j + 1) + 0;
 
-            if (bits <= FLINT_BITS)
-                mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
-                                                               e1 + x->j*N, N);
-            else
-                mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N,
-                                                               e1 + x->j*N, N);
+            mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, e1 + x->j*N, N, bits);
 
             exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);

--- a/src/gr_mpoly/divides_heap_threaded.c
+++ b/src/gr_mpoly/divides_heap_threaded.c
@@ -698,19 +698,13 @@ slong _gr_mpoly_mulsub_stripe(
     {
         if (startidx < Clen)
         {
-            if (bits <= FLINT_BITS)
-                mpoly_monomial_add(texp, Bexp + N*i, Cexp + N*startidx, N);
-            else
-                mpoly_monomial_add_mp(texp, Bexp + N*i, Cexp + N*startidx, N);
+                            mpoly_monomial_add_any_bits(texp, Bexp + N*i, Cexp + N*startidx, N, bits);
             FLINT_ASSERT(mpoly_monomial_cmp(emax, texp, N, S->cmpmask)
                                                                > -upperclosed);
         }
         while (startidx > 0)
         {
-            if (bits <= FLINT_BITS)
-                mpoly_monomial_add(texp, Bexp + N*i, Cexp + N*(startidx - 1), N);
-            else
-                mpoly_monomial_add_mp(texp, Bexp + N*i, Cexp + N*(startidx - 1), N);
+                            mpoly_monomial_add_any_bits(texp, Bexp + N*i, Cexp + N*(startidx - 1), N, bits);
             if (mpoly_monomial_cmp(emax, texp, N, S->cmpmask) <= -upperclosed)
                 break;
             startidx--;
@@ -718,18 +712,12 @@ slong _gr_mpoly_mulsub_stripe(
 
         if (endidx < Clen)
         {
-            if (bits <= FLINT_BITS)
-                mpoly_monomial_add(texp, Bexp + N*i, Cexp + N*endidx, N);
-            else
-                mpoly_monomial_add_mp(texp, Bexp + N*i, Cexp + N*endidx, N);
+                            mpoly_monomial_add_any_bits(texp, Bexp + N*i, Cexp + N*endidx, N, bits);
             FLINT_ASSERT(mpoly_monomial_cmp(emin, texp, N, S->cmpmask) > 0);
         }
         while (endidx > 0)
         {
-            if (bits <= FLINT_BITS)
-                mpoly_monomial_add(texp, Bexp + N*i, Cexp + N*(endidx - 1), N);
-            else
-                mpoly_monomial_add_mp(texp, Bexp + N*i, Cexp + N*(endidx - 1), N);
+                            mpoly_monomial_add_any_bits(texp, Bexp + N*i, Cexp + N*(endidx - 1), N, bits);
             if (mpoly_monomial_cmp(emin, texp, N, S->cmpmask) <= 0)
                 break;
             endidx--;
@@ -746,12 +734,7 @@ slong _gr_mpoly_mulsub_stripe(
             x->next = NULL;
             hind[x->i] = 2*(x->j + 1) + 0;
 
-            if (bits <= FLINT_BITS)
-                mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i,
-                                                      Cexp + N*x->j, N);
-            else
-                mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                      Cexp + N*x->j, N);
+            mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Cexp + N*x->j, N, bits);
 
             exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                           &next_loc, &heap_len, N, S->cmpmask);
@@ -769,9 +752,7 @@ slong _gr_mpoly_mulsub_stripe(
     {
         exp = heap[1].exp;
 
-        if (bits <= FLINT_BITS
-                ? mpoly_monomial_overflows(exp, N, mask)
-                : mpoly_monomial_overflows_mp(exp, N, bits))
+        if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
         {
             *overflowed = 1;
             goto cleanup;
@@ -864,12 +845,7 @@ slong _gr_mpoly_mulsub_stripe(
                 x->next = NULL;
                 hind[x->i] = 2*(x->j + 1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i,
-                                                          Cexp + N*x->j, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                          Cexp + N*x->j, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Cexp + N*x->j, N, bits);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                           &next_loc, &heap_len, N, S->cmpmask);
@@ -885,12 +861,7 @@ slong _gr_mpoly_mulsub_stripe(
                 x->next = NULL;
                 hind[x->i] = 2*(x->j + 1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i,
-                                                          Cexp + N*x->j, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                          Cexp + N*x->j, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Cexp + N*x->j, N, bits);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                           &next_loc, &heap_len, N, S->cmpmask);
@@ -1314,18 +1285,9 @@ static slong _gr_mpoly_divides_stripe(
 
         mpoly_monomial_set(exp, heap[1].exp, N);
 
-        if (bits <= FLINT_BITS)
-        {
-            if (mpoly_monomial_overflows(exp, N, mask))
-                goto not_exact_division;
-            lt_divides = mpoly_monomial_divides(Qexp + N*Qlen, exp, Bexp + N*0, N, mask);
-        }
-        else
-        {
-            if (mpoly_monomial_overflows_mp(exp, N, bits))
-                goto not_exact_division;
-            lt_divides = mpoly_monomial_divides_mp(Qexp + N*Qlen, exp, Bexp + N*0, N, bits);
-        }
+        if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
+            goto not_exact_division;
+        lt_divides = mpoly_monomial_divides_any_bits(Qexp + N*Qlen, exp, Bexp + N*0, N, mask, bits);
 
         FLINT_ASSERT(mpoly_monomial_cmp(exp, S->emin, N, S->cmpmask) >= 0);
 
@@ -1412,12 +1374,7 @@ static slong _gr_mpoly_divides_stripe(
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i,
-                                                              Qexp + N*x->j, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                              Qexp + N*x->j, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Qexp + N*x->j, N, bits);
 
                     if (mpoly_monomial_cmp(exp_list[exp_next], S->emin, N, S->cmpmask) >= 0)
                         exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
@@ -1439,12 +1396,7 @@ static slong _gr_mpoly_divides_stripe(
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i,
-                                                              Qexp + N*x->j, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                              Qexp + N*x->j, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Qexp + N*x->j, N, bits);
 
                     if (mpoly_monomial_cmp(exp_list[exp_next], S->emin, N, S->cmpmask) >= 0)
                         exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
@@ -1487,10 +1439,7 @@ static slong _gr_mpoly_divides_stripe(
             x->next = NULL;
             hind[x->i] = 2*(x->j + 1) + 0;
 
-            if (bits <= FLINT_BITS)
-                mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i, Qexp + N*x->j, N);
-            else
-                mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i, Qexp + N*x->j, N);
+            mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Qexp + N*x->j, N, bits);
 
             if (mpoly_monomial_cmp(exp_list[exp_next], S->emin, N, S->cmpmask) >= 0)
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
@@ -2161,17 +2110,11 @@ static int _gr_mpoly_divides_heap_threaded_pool(
     texps = (ulong *) TMP_ALLOC(N*sizeof(ulong));
     qexps = (ulong *) TMP_ALLOC(N*sizeof(ulong));
 
-    if (exp_bits <= FLINT_BITS)
-        mpoly_monomial_sub(qexps + N*0, Aexp + N*0, Bexp + N*0, N);
-    else
-        mpoly_monomial_sub_mp(qexps + N*0, Aexp + N*0, Bexp + N*0, N);
+    mpoly_monomial_sub_any_bits(qexps + N*0, Aexp + N*0, Bexp + N*0, N, exp_bits);
 
     gr_mpoly_ts_init(H->polyQ, qcoeff, qexps, 1, H->bits, H->N, cctx);
 
-    if (exp_bits <= FLINT_BITS)
-        mpoly_monomial_add(texps, qexps + N*0, Bexp + N*1, N);
-    else
-        mpoly_monomial_add_mp(texps, qexps + N*0, Bexp + N*1, N);
+    mpoly_monomial_add_any_bits(texps, qexps + N*0, Bexp + N*1, N, exp_bits);
 
     mask = 0;
     for (i = 0; (flint_bitcnt_t) i < FLINT_BITS/exp_bits; i++)
@@ -2181,12 +2124,7 @@ static int _gr_mpoly_divides_heap_threaded_pool(
     while (k < A->length && mpoly_monomial_gt(Aexp + N*k, texps, N, cmpmask))
     {
         int lt_divides;
-        if (exp_bits <= FLINT_BITS)
-            lt_divides = mpoly_monomial_divides(qexps, Aexp + N*k,
-                                                      Bexp + N*0, N, mask);
-        else
-            lt_divides = mpoly_monomial_divides_mp(qexps, Aexp + N*k,
-                                                      Bexp + N*0, N, exp_bits);
+        lt_divides = mpoly_monomial_divides_any_bits(qexps, Aexp + N*k, Bexp + N*0, N, mask, exp_bits);
         if (!lt_divides)
         {
             H->failed = 1;

--- a/src/gr_mpoly/divrem_heap.c
+++ b/src/gr_mpoly/divrem_heap.c
@@ -488,10 +488,7 @@ static int _gr_mpoly_divrem_heap(
 
         _gr_mpoly_fit_length(&q_coeff, &Q->coeffs_alloc, &q_exp, &Q->exps_alloc, N, q_len + 1, ctx);
 
-        if (bits <= FLINT_BITS)
-            lt_divides = mpoly_monomial_divides(q_exp + q_len*N, exp, exp3, N, mask);
-        else
-            lt_divides = mpoly_monomial_divides_mp(q_exp + q_len*N, exp, exp3, N, bits);
+        lt_divides = mpoly_monomial_divides_any_bits(q_exp + q_len*N, exp, exp3, N, mask, bits);
 
         dot_len = 0;
         have_dividend = 0;
@@ -568,12 +565,7 @@ static int _gr_mpoly_divrem_heap(
                     x->j = j;
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
-                                                               q_exp + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N,
-                                                               q_exp + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N, bits);
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
                 }
@@ -589,12 +581,7 @@ static int _gr_mpoly_divrem_heap(
                     x->j = j + 1;
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
-                                                               q_exp + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N,
-                                                               q_exp + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N, bits);
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
                 }
@@ -621,12 +608,7 @@ static int _gr_mpoly_divrem_heap(
                 x->j = q_len;
                 x->next = NULL;
                 hind[x->i] = 2*(x->j + 1) + 0;
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
-                                                           q_exp + x->j*N, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N,
-                                                           q_exp + x->j*N, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N, bits);
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                                  &next_loc, &heap_len, N, cmpmask);
             }

--- a/src/gr_mpoly/divrem_heap_threaded.c
+++ b/src/gr_mpoly/divrem_heap_threaded.c
@@ -648,12 +648,7 @@ slong _gr_mpoly_divrem_stripe(
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i,
-                                                                  Qexp + N*x->j, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                                  Qexp + N*x->j, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Qexp + N*x->j, N, bits);
 
                     if (mpoly_monomial_cmp(exp_list[exp_next], S->emin, N, S->cmpmask) >= 0)
                         exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
@@ -675,12 +670,7 @@ slong _gr_mpoly_divrem_stripe(
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i,
-                                                                  Qexp + N*x->j, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                                  Qexp + N*x->j, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Qexp + N*x->j, N, bits);
 
                     if (mpoly_monomial_cmp(exp_list[exp_next], S->emin, N, S->cmpmask) >= 0)
                         exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
@@ -712,10 +702,7 @@ slong _gr_mpoly_divrem_stripe(
                 x->next = NULL;
                 hind[x->i] = 2*(x->j + 1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i, Qexp + N*x->j, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i, Qexp + N*x->j, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Qexp + N*x->j, N, bits);
 
                 if (mpoly_monomial_cmp(exp_list[exp_next], S->emin, N, S->cmpmask) >= 0)
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,

--- a/src/gr_mpoly/divrem_ideal.c
+++ b/src/gr_mpoly/divrem_ideal.c
@@ -617,12 +617,7 @@ static int _gr_mpoly_divrem_ideal_mp(
                     x->p = p;
                     x->next = NULL;
                     hinds[p][x->i] = 2*(x->j + 1) + 0;
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], exp3[p] + x->i*N,
-                                                            Q[p]->exps + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], exp3[p] + x->i*N,
-                                                               Q[p]->exps + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3[p] + x->i*N, Q[p]->exps + x->j*N, N, bits);
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
                 }
@@ -639,12 +634,7 @@ static int _gr_mpoly_divrem_ideal_mp(
                     x->p = p;
                     x->next = NULL;
                     hinds[p][x->i] = 2*(x->j + 1) + 0;
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], exp3[p] + x->i*N,
-                                                            Q[p]->exps + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], exp3[p] + x->i*N,
-                                                               Q[p]->exps + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3[p] + x->i*N, Q[p]->exps + x->j*N, N, bits);
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
                 }
@@ -667,10 +657,7 @@ static int _gr_mpoly_divrem_ideal_mp(
             {
                 int d1, d2;
 
-                if (bits <= FLINT_BITS)
-                    d1 = mpoly_monomial_divides(texp, exp, exp3[w], N, mask);
-                else
-                    d1 = mpoly_monomial_divides_mp(texp, exp, exp3[w], N, bits);
+                d1 = mpoly_monomial_divides_any_bits(texp, exp, exp3[w], N, mask, bits);
 
                 if (!d1)
                     continue;
@@ -708,12 +695,7 @@ static int _gr_mpoly_divrem_ideal_mp(
                         x->p = w;
                         x->next = NULL;
                         hinds[w][x->i] = 2*(x->j + 1) + 0;
-                        if (bits <= FLINT_BITS)
-                            mpoly_monomial_add(exp_list[exp_next], exp3[w] + N,
-                                                                Q[w]->exps + k[w]*N, N);
-                        else
-                            mpoly_monomial_add_mp(exp_list[exp_next], exp3[w] + N,
-                                                                Q[w]->exps + k[w]*N, N);
+                        mpoly_monomial_add_any_bits(exp_list[exp_next], exp3[w] + N, Q[w]->exps + k[w]*N, N, bits);
                         exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                                  &next_loc, &heap_len, N, cmpmask);
                     }

--- a/src/gr_mpoly/divrem_ideal_heap_threaded.c
+++ b/src/gr_mpoly/divrem_ideal_heap_threaded.c
@@ -807,12 +807,7 @@ static void _gr_mpoly_divrem_ideal_stripe(
                     x->next = NULL;
                     hinds[p][x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], poly3[p]->exps + x->i*N,
-                                                        Qout[p]->exps + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], poly3[p]->exps + x->i*N,
-                                                        Qout[p]->exps + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], poly3[p]->exps + x->i*N, Qout[p]->exps + x->j*N, N, bits);
 
                     if (mpoly_monomial_cmp(exp_list[exp_next], emin, N, cmpmask) >= 0)
                         exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
@@ -834,12 +829,7 @@ static void _gr_mpoly_divrem_ideal_stripe(
                     x->next = NULL;
                     hinds[p][x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], poly3[p]->exps + x->i*N,
-                                                        Qout[p]->exps + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], poly3[p]->exps + x->i*N,
-                                                        Qout[p]->exps + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], poly3[p]->exps + x->i*N, Qout[p]->exps + x->j*N, N, bits);
 
                     if (mpoly_monomial_cmp(exp_list[exp_next], emin, N, cmpmask) >= 0)
                         exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
@@ -865,10 +855,7 @@ static void _gr_mpoly_divrem_ideal_stripe(
             {
                 int d1, d2;
 
-                if (bits <= FLINT_BITS)
-                    d1 = mpoly_monomial_divides(texp, exp, poly3[w]->exps, N, mask);
-                else
-                    d1 = mpoly_monomial_divides_mp(texp, exp, poly3[w]->exps, N, bits);
+                d1 = mpoly_monomial_divides_any_bits(texp, exp, poly3[w]->exps, N, mask, bits);
 
                 if (!d1)
                     continue;
@@ -907,12 +894,7 @@ static void _gr_mpoly_divrem_ideal_stripe(
                         x->next = NULL;
                         hinds[w][x->i] = 2*(x->j + 1) + 0;
 
-                        if (bits <= FLINT_BITS)
-                            mpoly_monomial_add(exp_list[exp_next], poly3[w]->exps + N,
-                                                            Qout[w]->exps + k[w]*N, N);
-                        else
-                            mpoly_monomial_add_mp(exp_list[exp_next], poly3[w]->exps + N,
-                                                            Qout[w]->exps + k[w]*N, N);
+                        mpoly_monomial_add_any_bits(exp_list[exp_next], poly3[w]->exps + N, Qout[w]->exps + k[w]*N, N, bits);
 
                         if (mpoly_monomial_cmp(exp_list[exp_next], emin, N, cmpmask) >= 0)
                             exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,

--- a/src/gr_mpoly/mul_heap.c
+++ b/src/gr_mpoly/mul_heap.c
@@ -325,10 +325,7 @@ static int _gr_mpoly_mul_heap(
     heap[1].next = x;
     heap[1].exp = exp_list[exp_next++];
 
-    if (bits <= FLINT_BITS)
-        mpoly_monomial_add(heap[1].exp, exp2, exp3, N);
-    else
-        mpoly_monomial_add_mp(heap[1].exp, exp2, exp3, N);
+    mpoly_monomial_add_any_bits(heap[1].exp, exp2, exp3, N, bits);
 
     hind[0] = 2*1 + 0;
 
@@ -401,10 +398,7 @@ static int _gr_mpoly_mul_heap(
 
                 hind[x->i] = 2*(x->j+1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N, bits);
 
                 if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
                                       &next_loc, &heap_len, N, cmpmask))
@@ -421,10 +415,7 @@ static int _gr_mpoly_mul_heap(
 
                 hind[x->i] = 2*(x->j+1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N, bits);
 
                 if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
                                       &next_loc, &heap_len, N, cmpmask))

--- a/src/gr_mpoly/mul_heap_threaded.c
+++ b/src/gr_mpoly/mul_heap_threaded.c
@@ -371,12 +371,7 @@ static slong _gr_mpoly_mul_heap_part(
             x->j = start[i];
             x->next = NULL;
             hind[x->i] = 2*(x->j + 1) + 0;
-            if (bits <= FLINT_BITS)
-                mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N,
-                                                       exp3 + x->j*N, N);
-            else
-                mpoly_monomial_add_mp(exp_list[exp_next], exp2 + x->i*N,
-                                                          exp3 + x->j*N, N);
+            mpoly_monomial_add_any_bits(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N, bits);
 
             exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -454,12 +449,7 @@ static slong _gr_mpoly_mul_heap_part(
                 x->next = NULL;
                 hind[x->i] = 2*(x->j + 1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N,
-                                                           exp3 + x->j*N, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], exp2 + x->i*N,
-                                                              exp3 + x->j*N, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N, bits);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -475,12 +465,7 @@ static slong _gr_mpoly_mul_heap_part(
                 x->next = NULL;
                 hind[x->i] = 2*(x->j + 1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N,
-                                                           exp3 + x->j*N, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], exp2 + x->i*N,
-                                                              exp3 + x->j*N, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N, bits);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);

--- a/src/gr_mpoly/quasidivrem_heap.c
+++ b/src/gr_mpoly/quasidivrem_heap.c
@@ -224,10 +224,7 @@ static int _gr_mpoly_quasidivrem_heap(
                     x->j = j;
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N, bits);
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
                 }
@@ -243,10 +240,7 @@ static int _gr_mpoly_quasidivrem_heap(
                     x->j = j + 1;
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N, bits);
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
                 }
@@ -322,10 +316,7 @@ static int _gr_mpoly_quasidivrem_heap(
             x->j = q_len;
             x->next = NULL;
             hind[x->i] = 2*(x->j + 1) + 0;
-            if (bits <= FLINT_BITS)
-                mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N);
-            else
-                mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N);
+            mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N, bits);
             exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                      &next_loc, &heap_len, N, cmpmask);
         }

--- a/src/gr_mpoly/quasidivrem_ideal_heap.c
+++ b/src/gr_mpoly/quasidivrem_ideal_heap.c
@@ -242,12 +242,7 @@ static int _gr_mpoly_quasidivrem_ideal_heap(
                     x->p = p;
                     x->next = NULL;
                     hinds[p][x->i] = 2*(x->j + 1) + 0;
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], exp3[p] + x->i*N,
-                                                            Q[p]->exps + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], exp3[p] + x->i*N,
-                                                               Q[p]->exps + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3[p] + x->i*N, Q[p]->exps + x->j*N, N, bits);
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
                 }
@@ -264,12 +259,7 @@ static int _gr_mpoly_quasidivrem_ideal_heap(
                     x->p = p;
                     x->next = NULL;
                     hinds[p][x->i] = 2*(x->j + 1) + 0;
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], exp3[p] + x->i*N,
-                                                            Q[p]->exps + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], exp3[p] + x->i*N,
-                                                               Q[p]->exps + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3[p] + x->i*N, Q[p]->exps + x->j*N, N, bits);
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
                 }
@@ -295,10 +285,7 @@ static int _gr_mpoly_quasidivrem_ideal_heap(
             {
                 int d1;
 
-                if (bits <= FLINT_BITS)
-                    d1 = mpoly_monomial_divides(texp, exp, exp3[w], N, mask);
-                else
-                    d1 = mpoly_monomial_divides_mp(texp, exp, exp3[w], N, bits);
+                d1 = mpoly_monomial_divides_any_bits(texp, exp, exp3[w], N, mask, bits);
 
                 if (!d1)
                     continue;
@@ -348,12 +335,7 @@ static int _gr_mpoly_quasidivrem_ideal_heap(
                     x->p = w;
                     x->next = NULL;
                     hinds[w][x->i] = 2*(x->j + 1) + 0;
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], exp3[w] + N,
-                                                            Q[w]->exps + k[w]*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], exp3[w] + N,
-                                                            Q[w]->exps + k[w]*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3[w] + N, Q[w]->exps + k[w]*N, N, bits);
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
                 }

--- a/src/gr_mpoly/sqr_commutative_heap.c
+++ b/src/gr_mpoly/sqr_commutative_heap.c
@@ -409,10 +409,7 @@ static int _gr_mpoly_sqr_commutative_heap(
     heap[1].next = x;
     heap[1].exp = exp_list[exp_next++];
 
-    if (bits <= FLINT_BITS)
-        mpoly_monomial_add(heap[1].exp, exp2, exp2, N);
-    else
-        mpoly_monomial_add_mp(heap[1].exp, exp2, exp2, N);
+    mpoly_monomial_add_any_bits(heap[1].exp, exp2, exp2, N, bits);
 
     hind[0] = 2*1 + 0;
 
@@ -488,10 +485,7 @@ static int _gr_mpoly_sqr_commutative_heap(
 
                 hind[x->i] = 2*(x->j+1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N, exp2 + x->j*N, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], exp2 + x->i*N, exp2 + x->j*N, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], exp2 + x->i*N, exp2 + x->j*N, N, bits);
 
                 if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
                                       &next_loc, &heap_len, N, cmpmask))
@@ -508,10 +502,7 @@ static int _gr_mpoly_sqr_commutative_heap(
 
                 hind[x->i] = 2*(x->j+1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N, exp2 + x->j*N, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], exp2 + x->i*N, exp2 + x->j*N, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], exp2 + x->i*N, exp2 + x->j*N, N, bits);
 
                 if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
                                       &next_loc, &heap_len, N, cmpmask))

--- a/src/gr_mpoly/sqr_commutative_heap_threaded.c
+++ b/src/gr_mpoly/sqr_commutative_heap_threaded.c
@@ -452,12 +452,7 @@ static slong _gr_mpoly_sqr_commutative_heap_part(
             x->j = start[i];
             x->next = NULL;
             hind[x->i] = 2*(x->j + 1) + 0;
-            if (bits <= FLINT_BITS)
-                mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N,
-                                                       exp2 + x->j*N, N);
-            else
-                mpoly_monomial_add_mp(exp_list[exp_next], exp2 + x->i*N,
-                                                          exp2 + x->j*N, N);
+            mpoly_monomial_add_any_bits(exp_list[exp_next], exp2 + x->i*N, exp2 + x->j*N, N, bits);
 
             exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -539,12 +534,7 @@ static slong _gr_mpoly_sqr_commutative_heap_part(
                 x->next = NULL;
                 hind[x->i] = 2*(x->j + 1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N,
-                                                           exp2 + x->j*N, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], exp2 + x->i*N,
-                                                              exp2 + x->j*N, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], exp2 + x->i*N, exp2 + x->j*N, N, bits);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -560,12 +550,7 @@ static slong _gr_mpoly_sqr_commutative_heap_part(
                 x->next = NULL;
                 hind[x->i] = 2*(x->j + 1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N,
-                                                           exp2 + x->j*N, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], exp2 + x->i*N,
-                                                              exp2 + x->j*N, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], exp2 + x->i*N, exp2 + x->j*N, N, bits);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);

--- a/src/mpoly.h
+++ b/src/mpoly.h
@@ -579,6 +579,152 @@ void mpoly_monomial_mul_ui_mp(ulong * exp2, const ulong * exp3, slong N, ulong c
     __gmpn_mul_1(exp2, exp3, N, c);
 }
 
+/* Check that the operand has not overflowed into the guard bit */
+FLINT_FORCE_INLINE
+int mpoly_monomial_valid_any_bits(const ulong * exp, slong N,
+                                                        flint_bitcnt_t bits)
+{
+    if (bits <= FLINT_BITS)
+        return !mpoly_monomial_overflows((ulong *) exp, N,
+                                                    mpoly_overflow_mask_sp(bits));
+    else
+        return !mpoly_monomial_overflows_mp((ulong *) exp, N, bits);
+}
+
+FLINT_FORCE_INLINE
+void mpoly_monomial_add_any_bits(ulong * exp1, const ulong * exp2,
+                            const ulong * exp3, slong N, flint_bitcnt_t bits)
+{
+    FLINT_ASSERT(mpoly_monomial_valid_any_bits(exp2, N, bits));
+    FLINT_ASSERT(mpoly_monomial_valid_any_bits(exp3, N, bits));
+
+    if (bits <= FLINT_BITS)
+        mpoly_monomial_add(exp1, exp2, exp3, N);
+    else
+        mpoly_monomial_add_mp(exp1, exp2, exp3, N);
+}
+
+FLINT_FORCE_INLINE
+void mpoly_monomial_sub_any_bits(ulong * exp1, const ulong * exp2,
+                            const ulong * exp3, slong N, flint_bitcnt_t bits)
+{
+    FLINT_ASSERT(mpoly_monomial_valid_any_bits(exp2, N, bits));
+    FLINT_ASSERT(mpoly_monomial_valid_any_bits(exp3, N, bits));
+
+    if (bits <= FLINT_BITS)
+        mpoly_monomial_sub(exp1, exp2, exp3, N);
+    else
+        mpoly_monomial_sub_mp(exp1, exp2, exp3, N);
+}
+
+FLINT_FORCE_INLINE
+void mpoly_monomial_madd_any_bits(ulong * exp1, const ulong * exp2,
+                ulong scalar, const ulong * exp3, slong N, flint_bitcnt_t bits)
+{
+    /* Only the inputs are asserted here; exp2 + scalar*exp3 can
+       legitimately need to overflow-check its own *result*, which
+       remains the caller's responsibility as usual. */
+    FLINT_ASSERT(mpoly_monomial_valid_any_bits(exp2, N, bits));
+    FLINT_ASSERT(mpoly_monomial_valid_any_bits(exp3, N, bits));
+
+    if (bits <= FLINT_BITS)
+        mpoly_monomial_madd(exp1, exp2, scalar, exp3, N);
+    else
+        mpoly_monomial_madd_mp(exp1, exp2, scalar, exp3, N);
+}
+
+FLINT_FORCE_INLINE
+void mpoly_monomial_msub_any_bits(ulong * exp1, const ulong * exp2,
+                ulong scalar, const ulong * exp3, slong N, flint_bitcnt_t bits)
+{
+    FLINT_ASSERT(mpoly_monomial_valid_any_bits(exp2, N, bits));
+    FLINT_ASSERT(mpoly_monomial_valid_any_bits(exp3, N, bits));
+
+    if (bits <= FLINT_BITS)
+        mpoly_monomial_msub(exp1, exp2, scalar, exp3, N);
+    else
+        mpoly_monomial_msub_mp(exp1, exp2, scalar, exp3, N);
+}
+
+FLINT_FORCE_INLINE
+void mpoly_monomial_max_any_bits(ulong * exp1, const ulong * exp2,
+             const ulong * exp3, flint_bitcnt_t bits, slong N, ulong mask)
+{
+    FLINT_ASSERT(mpoly_monomial_valid_any_bits(exp2, N, bits));
+    FLINT_ASSERT(mpoly_monomial_valid_any_bits(exp3, N, bits));
+
+    if (bits <= FLINT_BITS)
+        mpoly_monomial_max(exp1, exp2, exp3, bits, N, mask);
+    else
+        mpoly_monomial_max_mp(exp1, exp2, exp3, bits, N);
+}
+
+FLINT_FORCE_INLINE
+void mpoly_monomial_min_any_bits(ulong * exp1, const ulong * exp2,
+             const ulong * exp3, flint_bitcnt_t bits, slong N, ulong mask)
+{
+    FLINT_ASSERT(mpoly_monomial_valid_any_bits(exp2, N, bits));
+    FLINT_ASSERT(mpoly_monomial_valid_any_bits(exp3, N, bits));
+
+    if (bits <= FLINT_BITS)
+        mpoly_monomial_min(exp1, exp2, exp3, bits, N, mask);
+    else
+        mpoly_monomial_min_mp(exp1, exp2, exp3, bits, N);
+}
+
+FLINT_FORCE_INLINE
+int mpoly_monomial_overflows_any_bits(ulong * exp, slong N, ulong mask,
+                                                        flint_bitcnt_t bits)
+{
+    /* No precondition to assert here: this function's entire purpose is
+       to determine whether `exp` has overflowed, so `exp` is not
+       expected to be valid on entry. */
+    if (bits <= FLINT_BITS)
+        return mpoly_monomial_overflows(exp, N, mask);
+    else
+        return mpoly_monomial_overflows_mp(exp, N, bits);
+}
+
+FLINT_FORCE_INLINE
+int mpoly_monomial_divides_any_bits(ulong * exp_ptr, const ulong * exp2,
+                    const ulong * exp3, slong N, ulong mask, flint_bitcnt_t bits)
+{
+    FLINT_ASSERT(mpoly_monomial_valid_any_bits(exp2, N, bits));
+    FLINT_ASSERT(mpoly_monomial_valid_any_bits(exp3, N, bits));
+
+    if (bits <= FLINT_BITS)
+        return mpoly_monomial_divides(exp_ptr, exp2, exp3, N, mask);
+    else
+        return mpoly_monomial_divides_mp(exp_ptr, exp2, exp3, N, bits);
+}
+
+FLINT_FORCE_INLINE
+int mpoly_monomial_halves_any_bits(ulong * exp_ptr, const ulong * exp2,
+                                slong N, ulong mask, flint_bitcnt_t bits)
+{
+    FLINT_ASSERT(mpoly_monomial_valid_any_bits(exp2, N, bits));
+
+    if (bits <= FLINT_BITS)
+        return mpoly_monomial_halves(exp_ptr, exp2, N, mask);
+    else
+        return mpoly_monomial_halves_mp(exp_ptr, exp2, N, bits);
+}
+
+FLINT_FORCE_INLINE
+void mpoly_monomial_mul_ui_any_bits(ulong * exp2, const ulong * exp3,
+                                      slong N, ulong c, flint_bitcnt_t bits)
+{
+    /* Only exp3 (the input) is asserted; exp3*c can legitimately need
+       to overflow-check its own *result*, which remains the caller's
+       responsibility as usual. */
+    FLINT_ASSERT(mpoly_monomial_valid_any_bits(exp3, N, bits));
+
+    if (bits <= FLINT_BITS)
+        mpoly_monomial_mul_ui(exp2, exp3, N, c);
+    else
+        mpoly_monomial_mul_ui_mp(exp2, exp3, N, c);
+}
+
 void mpoly_monomial_mul_fmpz(ulong * exp2, const ulong * exp3, slong N, const fmpz_t c);
 
 FLINT_FORCE_INLINE

--- a/src/nmod_mpoly/div_monagan_pearce.c
+++ b/src/nmod_mpoly/div_monagan_pearce.c
@@ -308,20 +308,9 @@ static int _nmod_mpoly_div_monagan_pearce(
 
         mpoly_monomial_set(exp, heap[1].exp, N);
 
-        if (bits <= FLINT_BITS)
-        {
-            if (mpoly_monomial_overflows(exp, N, mask))
-                goto exp_overflow;
-
-            lt_divides = mpoly_monomial_divides(Qexps + q_len*N, exp, Bexps, N, mask);
-        }
-        else
-        {
-            if (mpoly_monomial_overflows_mp(exp, N, bits))
-                goto exp_overflow;
-
-            lt_divides = mpoly_monomial_divides_mp(Qexps + q_len*N, exp, Bexps, N, bits);
-        }
+        if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
+            goto exp_overflow;
+        lt_divides = mpoly_monomial_divides_any_bits(Qexps + q_len*N, exp, Bexps, N, mask, bits);
 
         acc0 = acc1 = acc2 = 0;
 
@@ -408,12 +397,7 @@ static int _nmod_mpoly_div_monagan_pearce(
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], Bexps + x->i*N,
-                                                           Qexps + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], Bexps + x->i*N,
-                                                           Qexps + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], Bexps + x->i*N, Qexps + x->j*N, N, bits);
 
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -432,12 +416,7 @@ static int _nmod_mpoly_div_monagan_pearce(
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], Bexps + x->i*N,
-                                                           Qexps + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], Bexps + x->i*N,
-                                                           Qexps + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], Bexps + x->i*N, Qexps + x->j*N, N, bits);
 
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);

--- a/src/nmod_mpoly/divides_heap_threaded.c
+++ b/src/nmod_mpoly/divides_heap_threaded.c
@@ -600,6 +600,7 @@ static void _nmod_mpoly_mulsub_stripe(
     ulong * emax = S->emax;
     ulong * emin = S->emin;
     slong N = S->N;
+    flint_bitcnt_t bits = S->bits;
     slong i, j;
     slong next_loc = Blen + 4;   /* something bigger than heap can ever be */
     slong heap_len = 1; /* heap zero index unused */
@@ -653,12 +654,12 @@ static void _nmod_mpoly_mulsub_stripe(
     {
         if (startidx < Clen)
         {
-            mpoly_monomial_add_mp(texp, Bexp + N*i, Cexp + N*startidx, N);
+            mpoly_monomial_add_any_bits(texp, Bexp + N*i, Cexp + N*startidx, N, bits);
             FLINT_ASSERT(mpoly_monomial_cmp(emax, texp, N, S->cmpmask) > -upperclosed);
         }
         while (startidx > 0)
         {
-            mpoly_monomial_add_mp(texp, Bexp + N*i, Cexp + N*(startidx - 1), N);
+            mpoly_monomial_add_any_bits(texp, Bexp + N*i, Cexp + N*(startidx - 1), N, bits);
             if (mpoly_monomial_cmp(emax, texp, N, S->cmpmask) <= -upperclosed)
             {
                 break;
@@ -668,12 +669,12 @@ static void _nmod_mpoly_mulsub_stripe(
 
         if (endidx < Clen)
         {
-            mpoly_monomial_add_mp(texp, Bexp + N*i, Cexp + N*endidx, N);
+            mpoly_monomial_add_any_bits(texp, Bexp + N*i, Cexp + N*endidx, N, bits);
             FLINT_ASSERT(mpoly_monomial_cmp(emin, texp, N, S->cmpmask) > 0);
         }
         while (endidx > 0)
         {
-            mpoly_monomial_add_mp(texp, Bexp + N*i, Cexp + N*(endidx - 1), N);
+            mpoly_monomial_add_any_bits(texp, Bexp + N*i, Cexp + N*(endidx - 1), N, bits);
             if (mpoly_monomial_cmp(emin, texp, N, S->cmpmask) <= 0)
             {
                 break;
@@ -695,7 +696,7 @@ static void _nmod_mpoly_mulsub_stripe(
             x->next = NULL;
             hind[x->i] = 2*(x->j + 1) + 0;
 
-            mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i, Cexp + N*x->j, N);
+            mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Cexp + N*x->j, N, bits);
 
             if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
                                       &next_loc, &heap_len, N, S->cmpmask))
@@ -784,7 +785,7 @@ static void _nmod_mpoly_mulsub_stripe(
 
                 hind[x->i] = 2*(x->j + 1) + 0;
 
-                mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i, Cexp + N*x->j, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Cexp + N*x->j, N, bits);
 
                 if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
                                       &next_loc, &heap_len, N, S->cmpmask))
@@ -806,7 +807,7 @@ static void _nmod_mpoly_mulsub_stripe(
 
                 hind[x->i] = 2*(x->j + 1) + 0;
 
-                mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i, Cexp + N*x->j, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Cexp + N*x->j, N, bits);
 
                 if (!_mpoly_heap_insert(heap, exp_list[exp_next++], x,
                                       &next_loc, &heap_len, N, S->cmpmask))
@@ -1141,18 +1142,9 @@ static int _nmod_mpoly_divides_stripe(
 
         mpoly_monomial_set(exp, heap[1].exp, N);
 
-        if (bits <= FLINT_BITS)
-        {
-            if (mpoly_monomial_overflows(exp, N, mask))
-                goto not_exact_division;
-            lt_divides = mpoly_monomial_divides(Qexp + N*Qlen, exp, Bexp + N*0, N, mask);
-        }
-        else
-        {
-            if (mpoly_monomial_overflows_mp(exp, N, bits))
-                goto not_exact_division;
-            lt_divides = mpoly_monomial_divides_mp(Qexp + N*Qlen, exp, Bexp + N*0, N, bits);
-        }
+        if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
+            goto not_exact_division;
+        lt_divides = mpoly_monomial_divides_any_bits(Qexp + N*Qlen, exp, Bexp + N*0, N, mask, bits);
 
         FLINT_ASSERT(mpoly_monomial_cmp(exp, S->emin, N, S->cmpmask) >= 0);
 
@@ -1216,8 +1208,7 @@ static int _nmod_mpoly_divides_stripe(
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                              Qexp + N*x->j, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Qexp + N*x->j, N, bits);
 
                     if (mpoly_monomial_cmp(exp_list[exp_next], S->emin, N, S->cmpmask) >= 0)
                     {
@@ -1243,8 +1234,7 @@ static int _nmod_mpoly_divides_stripe(
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                              Qexp + N*x->j, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Qexp + N*x->j, N, bits);
 
                     if (mpoly_monomial_cmp(exp_list[exp_next], S->emin, N, S->cmpmask) >= 0)
                     {
@@ -1279,7 +1269,7 @@ static int _nmod_mpoly_divides_stripe(
             x->next = NULL;
             hind[x->i] = 2*(x->j + 1) + 0;
 
-            mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i, Qexp + N*x->j, N);
+            mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Qexp + N*x->j, N, bits);
 
             if (mpoly_monomial_cmp(exp_list[exp_next], S->emin, N, S->cmpmask) >= 0)
             {
@@ -1824,12 +1814,12 @@ int _nmod_mpoly_divides_heap_threaded_pool(
     texps = (ulong *) TMP_ALLOC(N*sizeof(ulong));
     qexps = (ulong *) TMP_ALLOC(N*sizeof(ulong));
 
-    mpoly_monomial_sub_mp(qexps + N*0, Aexp + N*0, Bexp + N*0, N);
+    mpoly_monomial_sub_any_bits(qexps + N*0, Aexp + N*0, Bexp + N*0, N, exp_bits);
     qcoeff = nmod_mul(H->lc_inv, A->coeffs[0], ctx->mod);
 
     nmod_mpoly_ts_init(H->polyQ, &qcoeff, qexps, 1, H->bits, H->N);
 
-    mpoly_monomial_add_mp(texps, qexps + N*0, Bexp + N*1, N);
+    mpoly_monomial_add_any_bits(texps, qexps + N*0, Bexp + N*1, N, exp_bits);
 
     mask = 0;
     for (i = 0; (ulong) i < FLINT_BITS/exp_bits; i++)
@@ -1839,12 +1829,7 @@ int _nmod_mpoly_divides_heap_threaded_pool(
     while (k < A->length && mpoly_monomial_gt(Aexp + N*k, texps, N, cmpmask))
     {
         int lt_divides;
-        if (exp_bits <= FLINT_BITS)
-            lt_divides = mpoly_monomial_divides(qexps, Aexp + N*k,
-                                                      Bexp + N*0, N, mask);
-        else
-            lt_divides = mpoly_monomial_divides_mp(qexps, Aexp + N*k,
-                                                      Bexp + N*0, N, exp_bits);
+        lt_divides = mpoly_monomial_divides_any_bits(qexps, Aexp + N*k, Bexp + N*0, N, mask, exp_bits);
         if (!lt_divides)
         {
             H->failed = 1;

--- a/src/nmod_mpoly/divides_monagan_pearce.c
+++ b/src/nmod_mpoly/divides_monagan_pearce.c
@@ -283,18 +283,9 @@ int _nmod_mpoly_divides_monagan_pearce(
 
         mpoly_monomial_set(exp, heap[1].exp, N);
 
-        if (bits <= FLINT_BITS)
-        {
-            if (mpoly_monomial_overflows(exp, N, mask))
-                goto not_exact_division;
-            lt_divides = mpoly_monomial_divides(q_exp + q_len*N, exp, exp3, N, mask);
-        }
-        else
-        {
-            if (mpoly_monomial_overflows_mp(exp, N, bits))
-                goto not_exact_division;
-            lt_divides = mpoly_monomial_divides_mp(q_exp + q_len*N, exp, exp3, N, bits);
-        }
+        if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
+            goto not_exact_division;
+        lt_divides = mpoly_monomial_divides_any_bits(q_exp + q_len*N, exp, exp3, N, mask, bits);
 
         acc0 = acc1 = acc2 = 0;
         do {
@@ -353,12 +344,7 @@ int _nmod_mpoly_divides_monagan_pearce(
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
-                                                              q_exp + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N,
-                                                                 q_exp + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N, bits);
 
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -377,12 +363,7 @@ int _nmod_mpoly_divides_monagan_pearce(
                     x->next = NULL;
                     hind[x->i] = 2*(x->j + 1) + 0;
 
-                    if (bits <= FLINT_BITS)
-                        mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N,
-                                                              q_exp + x->j*N, N);
-                    else
-                        mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N,
-                                                                 q_exp + x->j*N, N);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N, bits);
 
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -412,10 +393,7 @@ int _nmod_mpoly_divides_monagan_pearce(
             x->next = NULL;
             hind[x->i] = 2*(x->j + 1) + 0;
 
-            if (bits <= FLINT_BITS)
-                mpoly_monomial_add(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N);
-            else
-                mpoly_monomial_add_mp(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N);
+            mpoly_monomial_add_any_bits(exp_list[exp_next], exp3 + x->i*N, q_exp + x->j*N, N, bits);
 
             exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);

--- a/src/nmod_mpoly/divrem_monagan_pearce.c
+++ b/src/nmod_mpoly/divrem_monagan_pearce.c
@@ -434,20 +434,9 @@ static int _nmod_mpoly_divrem_monagan_pearce(
 
         mpoly_monomial_set(exp, heap[1].exp, N);
 
-        if (bits <= FLINT_BITS)
-        {
-            if (mpoly_monomial_overflows(exp, N, mask))
-                goto exp_overflow2;
-
-            lt_divides = mpoly_monomial_divides(Qexps + Qlen*N, exp, Bexps, N, mask);
-        }
-        else
-        {
-            if (mpoly_monomial_overflows_mp(exp, N, bits))
-                goto exp_overflow2;
-
-            lt_divides = mpoly_monomial_divides_mp(Qexps + Qlen*N, exp, Bexps, N, bits);
-        }
+        if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
+            goto exp_overflow2;
+        lt_divides = mpoly_monomial_divides_any_bits(Qexps + Qlen*N, exp, Bexps, N, mask, bits);
 
         acc0 = acc1 = acc2 = 0;
         do {

--- a/src/nmod_mpoly/get_set_is_nmod_poly.c
+++ b/src/nmod_mpoly/get_set_is_nmod_poly.c
@@ -121,10 +121,7 @@ void _nmod_mpoly_set_nmod_poly(
 
         FLINT_ASSERT(Alen < A->coeffs_alloc);
         A->coeffs[Alen] = Bcoeffs[i];
-        if (Abits <= FLINT_BITS)
-            mpoly_monomial_mul_ui(A->exps + N*Alen, genexp, N, i);
-        else
-            mpoly_monomial_mul_ui_mp(A->exps + N*Alen, genexp, N, i);
+        mpoly_monomial_mul_ui_any_bits(A->exps + N*Alen, genexp, N, i, Abits);
         Alen++;
     }
     A->length = Alen;

--- a/src/nmod_mpoly/mpolyu_divides.c
+++ b/src/nmod_mpoly/mpolyu_divides.c
@@ -236,10 +236,7 @@ static void _nmod_mpoly_mulsub(nmod_mpoly_t A,
     heap[1].next = x;
     heap[1].exp = exp_list[exp_next++];
 
-    if (bits <= FLINT_BITS)
-        mpoly_monomial_add(heap[1].exp, Bexp + N*0, Cexp + N*0, N);
-    else
-        mpoly_monomial_add_mp(heap[1].exp, Bexp + N*0, Cexp + N*0, N);
+    mpoly_monomial_add_any_bits(heap[1].exp, Bexp + N*0, Cexp + N*0, N, bits);
 
     hind[0] = 2*1 + 0;
 
@@ -317,12 +314,7 @@ static void _nmod_mpoly_mulsub(nmod_mpoly_t A,
 
                 hind[x->i] = 2*(x->j+1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i,
-                                                           Cexp + N*x->j, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                              Cexp + N*x->j, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Cexp + N*x->j, N, bits);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -341,12 +333,7 @@ static void _nmod_mpoly_mulsub(nmod_mpoly_t A,
 
                 hind[x->i] = 2*(x->j+1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i,
-                                                           Cexp + N*x->j, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                              Cexp + N*x->j, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Cexp + N*x->j, N, bits);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);

--- a/src/nmod_mpoly/mpolyun_divides.c
+++ b/src/nmod_mpoly/mpolyun_divides.c
@@ -466,12 +466,7 @@ static void _nmod_mpolyn_mulsub(
 
                 hind[x->i] = 2*(x->j+1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i,
-                                                           Cexp + N*x->j, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                              Cexp + N*x->j, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Cexp + N*x->j, N, bits);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -490,12 +485,7 @@ static void _nmod_mpolyn_mulsub(
 
                 hind[x->i] = 2*(x->j+1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i,
-                                                           Cexp + N*x->j, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                              Cexp + N*x->j, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Cexp + N*x->j, N, bits);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);

--- a/src/nmod_mpoly/mul_heap_threaded.c
+++ b/src/nmod_mpoly/mul_heap_threaded.c
@@ -227,12 +227,7 @@ static void _nmod_mpoly_mul_heap_part(
             x->next = NULL;
             hind[x->i] = 2*(x->j + 1) + 0;
 
-            if (bits <= FLINT_BITS)
-                mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i,
-                                                       Cexp + N*x->j, N);
-            else
-                mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                          Cexp + N*x->j, N);
+            mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Cexp + N*x->j, N, bits);
 
             exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -294,12 +289,7 @@ static void _nmod_mpoly_mul_heap_part(
 
                 hind[x->i] = 2*(x->j + 1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i,
-                                                           Cexp + N*x->j, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                              Cexp + N*x->j, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Cexp + N*x->j, N, bits);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -320,12 +310,7 @@ static void _nmod_mpoly_mul_heap_part(
 
                 hind[x->i] = 2*(x->j + 1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], Bexp + N*x->i,
-                                                           Cexp + N*x->j, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], Bexp + N*x->i,
-                                                              Cexp + N*x->j, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], Bexp + N*x->i, Cexp + N*x->j, N, bits);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);

--- a/src/nmod_mpoly/mul_johnson.c
+++ b/src/nmod_mpoly/mul_johnson.c
@@ -202,10 +202,7 @@ slong _nmod_mpoly_mul_johnson(
     heap[1].next = x;
     heap[1].exp = exp_list[exp_next++];
 
-    if (bits <= FLINT_BITS)
-        mpoly_monomial_add(heap[1].exp, exp2, exp3, N);
-    else
-        mpoly_monomial_add_mp(heap[1].exp, exp2, exp3, N);
+    mpoly_monomial_add_any_bits(heap[1].exp, exp2, exp3, N, bits);
 
     hind[0] = 2*1 + 0;
 
@@ -263,10 +260,7 @@ slong _nmod_mpoly_mul_johnson(
 
                 hind[x->i] = 2*(x->j+1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N, bits);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -287,10 +281,7 @@ slong _nmod_mpoly_mul_johnson(
 
                 hind[x->i] = 2*(x->j+1) + 0;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], exp2 + x->i*N, exp3 + x->j*N, N, bits);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);

--- a/src/nmod_mpoly/sqrt_heap.c
+++ b/src/nmod_mpoly/sqrt_heap.c
@@ -447,10 +447,7 @@ static int _nmod_mpoly_sqrt_heap(
     /* precompute leading coefficient info */
     lc_minus_inv = mod.n - nmod_inv(nmod_add(Qcoeffs[0], Qcoeffs[0], mod), mod);
 
-    if (bits <= FLINT_BITS)
-        halves = mpoly_monomial_halves(Qexps + 0, Aexps + 0, N, mask);
-    else
-        halves = mpoly_monomial_halves_mp(Qexps + 0, Aexps + 0, N, bits);
+    halves = mpoly_monomial_halves_any_bits(Qexps + 0, Aexps + 0, N, mask, bits);
 
     if (!halves)
         goto not_sqrt; /* exponent is not square */
@@ -460,18 +457,12 @@ static int _nmod_mpoly_sqrt_heap(
         if (0 == n_sqrtmod(Acoeffs[Alen - 1], mod.n))
             goto not_sqrt;
 
-        if (bits <= FLINT_BITS)
-            halves = mpoly_monomial_halves(exp3, Aexps + (Alen - 1)*N, N, mask);
-        else
-            halves = mpoly_monomial_halves_mp(exp3, Aexps + (Alen - 1)*N, N, bits);
+        halves = mpoly_monomial_halves_any_bits(exp3, Aexps + (Alen - 1)*N, N, mask, bits);
 
         if (!halves)
             goto not_sqrt; /* exponent is not square */
 
-        if (bits <= FLINT_BITS)
-            mpoly_monomial_add(exp3, exp3, Qexps + 0, N);
-        else
-            mpoly_monomial_add_mp(exp3, exp3, Qexps + 0, N);
+        mpoly_monomial_add_any_bits(exp3, exp3, Qexps + 0, N, bits);
     }
 
     while (heap_len > 1 || Ai < Alen)
@@ -495,8 +486,7 @@ static int _nmod_mpoly_sqrt_heap(
             /* take only from heap */
             mpoly_monomial_set(exp, heap[1].exp, N);
 
-            if (bits <= FLINT_BITS ? mpoly_monomial_overflows(exp, N, mask)
-                                   : mpoly_monomial_overflows_mp(exp, N, bits))
+            if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
                 goto not_sqrt;
         }
         else
@@ -549,12 +539,7 @@ static int _nmod_mpoly_sqrt_heap(
                 x->j = j + 1;
                 x->next = NULL;
 
-                if (bits <= FLINT_BITS)
-                    mpoly_monomial_add(exp_list[exp_next], Qexps + N*x->i,
-                                                            Qexps + N*x->j, N);
-                else
-                    mpoly_monomial_add_mp(exp_list[exp_next], Qexps + N*x->i,
-                                                            Qexps + N*x->j, N);
+                mpoly_monomial_add_any_bits(exp_list[exp_next], Qexps + N*x->i, Qexps + N*x->j, N, bits);
 
                 exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
@@ -566,12 +551,7 @@ static int _nmod_mpoly_sqrt_heap(
 
     skip_heap:
 
-        if (bits <= FLINT_BITS)
-            lt_divides = mpoly_monomial_divides(Qexps + N*Qlen,
-                                                exp, Qexps + N*0, N, mask);
-        else
-            lt_divides = mpoly_monomial_divides_mp(Qexps + N*Qlen,
-                                                exp, Qexps + N*0, N, bits);
+                    lt_divides = mpoly_monomial_divides_any_bits(Qexps + N*Qlen, exp, Qexps + N*0, N, mask, bits);
         if (!lt_divides)
             goto not_sqrt;
 
@@ -609,12 +589,7 @@ static int _nmod_mpoly_sqrt_heap(
         x->j = 1;
         x->next = NULL;
 
-        if (bits <= FLINT_BITS)
-            mpoly_monomial_add(exp_list[exp_next], Qexps + x->i*N,
-                                                      Qexps + x->j*N, N);
-        else
-            mpoly_monomial_add_mp(exp_list[exp_next], Qexps + x->i*N,
-                                                         Qexps + x->j*N, N);
+        mpoly_monomial_add_any_bits(exp_list[exp_next], Qexps + x->i*N, Qexps + x->j*N, N, bits);
 
         exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                          &next_loc, &heap_len, N, cmpmask);

--- a/src/nmod_mpoly_factor/eval.c
+++ b/src/nmod_mpoly_factor/eval.c
@@ -235,10 +235,7 @@ void _nmod_mpoly_set_n_bpoly_var1_zero(
 
         FLINT_ASSERT(Alen < A->coeffs_alloc);
         A->coeffs[Alen] = c;
-        if (Abits <= FLINT_BITS)
-            mpoly_monomial_mul_ui(A->exps + N*Alen, genexp, N, i);
-        else
-            mpoly_monomial_mul_ui_mp(A->exps + N*Alen, genexp, N, i);
+        mpoly_monomial_mul_ui_any_bits(A->exps + N*Alen, genexp, N, i, Abits);
         Alen++;
     }
     A->length = Alen;


### PR DESCRIPTION
A recurring pattern in the mpoly modules is to branch a single operation depending on whether `bits <= FLINT_BITS`. Factor out many of these instances to helper functions, and take the opportunity to add asserts to these.