### PR TITLE
Replace mpoly boilerplate with macros/functions

### DIFF
--- a/src/fmpq_mpoly/get_coeff_fmpq_fmpz.c
+++ b/src/fmpq_mpoly/get_coeff_fmpq_fmpz.c
@@ -33,10 +33,7 @@ void _fmpq_mpoly_get_coeff_fmpq_fmpz(fmpq_t c, const fmpq_mpoly_t qpoly,
 
     TMP_START;
 
-    N = mpoly_words_per_exp(poly->bits, ctx->minfo);
-
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, poly->bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, poly->bits, ctx->minfo);
 
     packed_exp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
     mpoly_set_monomial_ffmpz(packed_exp, exp, poly->bits, ctx->minfo);

--- a/src/fmpq_mpoly/set_coeff_fmpq_fmpz.c
+++ b/src/fmpq_mpoly/set_coeff_fmpq_fmpz.c
@@ -30,9 +30,7 @@ void _fmpq_mpoly_set_coeff_fmpq_fmpz(fmpq_mpoly_t qpoly,
     exp_bits = mpoly_fix_bits(exp_bits, ctx->minfo);
     fmpz_mpoly_fit_bits(poly, exp_bits, ctx);
 
-    N = mpoly_words_per_exp(poly->bits, ctx->minfo);
-    cmpmask = (ulong*) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, poly->bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, poly->bits, ctx->minfo);
 
     packed_exp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
 

--- a/src/fmpz_mod_mpoly/add.c
+++ b/src/fmpz_mod_mpoly/add.c
@@ -96,9 +96,7 @@ void fmpz_mod_mpoly_add(
 
     TMP_START;
     Abits = FLINT_MAX(B->bits, C->bits);
-    N = mpoly_words_per_exp(Abits, ctx->minfo);
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, Abits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, Abits, ctx->minfo);
 
     if (Abits != B->bits)
     {

--- a/src/fmpz_mod_mpoly/divrem_monagan_pearce.c
+++ b/src/fmpz_mod_mpoly/divrem_monagan_pearce.c
@@ -729,9 +729,7 @@ void fmpz_mod_mpoly_divrem_monagan_pearce(
     QRbits = FLINT_MAX(A->bits, B->bits);
     QRbits = mpoly_fix_bits(QRbits, ctx->minfo);
 
-    N = mpoly_words_per_exp(QRbits, ctx->minfo);
-    cmpmask = (ulong *) flint_malloc(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, QRbits, ctx->minfo);
+    MPOLY_GET_CMPMASK_FLINT_MALLOC(cmpmask, N, QRbits, ctx->minfo);
 
     /* ensure input exponents packed to same size as output exponents */
     if (QRbits != A->bits)

--- a/src/fmpz_mod_mpoly/mul_johnson.c
+++ b/src/fmpz_mod_mpoly/mul_johnson.c
@@ -465,9 +465,7 @@ void _fmpz_mod_mpoly_mul_johnson_maxfields(
     Abits = FLINT_MAX(Abits, C->bits);
     Abits = mpoly_fix_bits(Abits, ctx->minfo);
 
-    N = mpoly_words_per_exp(Abits, ctx->minfo);
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, Abits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, Abits, ctx->minfo);
 
     /* ensure input exponents are packed into same sized fields as output */
     if (Abits != B->bits)

--- a/src/fmpz_mod_mpoly/scalar_addmul_fmpz.c
+++ b/src/fmpz_mod_mpoly/scalar_addmul_fmpz.c
@@ -172,9 +172,7 @@ void fmpz_mod_mpoly_scalar_addmul_fmpz(
 
     TMP_START;
     Abits = FLINT_MAX(B->bits, C->bits);
-    N = mpoly_words_per_exp(Abits, ctx->minfo);
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, Abits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, Abits, ctx->minfo);
 
     if (Abits != B->bits)
     {

--- a/src/fmpz_mod_mpoly/set_coeff_fmpz_fmpz.c
+++ b/src/fmpz_mod_mpoly/set_coeff_fmpz_fmpz.c
@@ -39,9 +39,7 @@ void _fmpz_mod_mpoly_set_coeff_fmpz_fmpz(
     exp_bits = mpoly_fix_bits(exp_bits, ctx->minfo);
     fmpz_mod_mpoly_fit_length_fit_bits(A, A->length, exp_bits, ctx);
 
-    N = mpoly_words_per_exp(A->bits, ctx->minfo);
-    cmpmask = (ulong*) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, A->bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, A->bits, ctx->minfo);
 
     packed_exp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
 

--- a/src/fmpz_mod_mpoly/sort_terms.c
+++ b/src/fmpz_mod_mpoly/sort_terms.c
@@ -191,9 +191,7 @@ void fmpz_mod_mpoly_sort_terms(fmpz_mod_mpoly_t A, const fmpz_mod_mpoly_ctx_t ct
     TMP_INIT;
 
     TMP_START;
-    N = mpoly_words_per_exp(A->bits, ctx->minfo);
-    ptempexp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(ptempexp, N, A->bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(ptempexp, N, A->bits, ctx->minfo);
 
     himask = 0;
     for (i = 0; i < A->length; i++)

--- a/src/fmpz_mod_mpoly/sub.c
+++ b/src/fmpz_mod_mpoly/sub.c
@@ -96,9 +96,7 @@ void fmpz_mod_mpoly_sub(
 
     TMP_START;
     Abits = FLINT_MAX(B->bits, C->bits);
-    N = mpoly_words_per_exp(Abits, ctx->minfo);
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, Abits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, Abits, ctx->minfo);
 
     if (Abits != B->bits)
     {

--- a/src/fmpz_mpoly/add.c
+++ b/src/fmpz_mpoly/add.c
@@ -268,9 +268,7 @@ void fmpz_mpoly_add(fmpz_mpoly_t A, const fmpz_mpoly_t B,
 
     TMP_START;
     Abits = FLINT_MAX(B->bits, C->bits);
-    N = mpoly_words_per_exp(Abits, ctx->minfo);
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, Abits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, Abits, ctx->minfo);
 
     if (Abits > B->bits)
     {

--- a/src/fmpz_mpoly/div_monagan_pearce.c
+++ b/src/fmpz_mpoly/div_monagan_pearce.c
@@ -702,9 +702,7 @@ void fmpz_mpoly_div_monagan_pearce(fmpz_mpoly_t q, const fmpz_mpoly_t poly2,
    /* maximum bits in quotient exps and inputs is max for poly2 and poly3 */
    exp_bits = FLINT_MAX(poly2->bits, poly3->bits);
 
-    N = mpoly_words_per_exp(exp_bits, ctx->minfo);
-    cmpmask = (ulong *) flint_malloc(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_FLINT_MALLOC(cmpmask, N, exp_bits, ctx->minfo);
 
    /* ensure input exponents packed to same size as output exponents */
    if (exp_bits > poly2->bits)
@@ -754,15 +752,10 @@ void fmpz_mpoly_div_monagan_pearce(fmpz_mpoly_t q, const fmpz_mpoly_t poly2,
       ulong * old_exp2 = exp2, * old_exp3 = exp3;
       slong old_exp_bits = exp_bits;
 
-      exp_bits = mpoly_fix_bits(exp_bits + 1, ctx->minfo);
-
-      N = mpoly_words_per_exp(exp_bits, ctx->minfo);
-      cmpmask = (ulong *) flint_realloc(cmpmask, N*sizeof(ulong));
-      mpoly_get_cmpmask(cmpmask, N, exp_bits, ctx->minfo);
-
-      exp2 = (ulong *) flint_malloc(N*poly2->length*sizeof(ulong));
-      mpoly_repack_monomials(exp2, exp_bits, old_exp2, old_exp_bits,
-                                                    poly2->length, ctx->minfo);
+      exp2 = mpoly_monomials_repack_wider_cmpmask(&exp_bits,
+                                                  &N, &cmpmask, old_exp2,
+                                                  old_exp_bits, poly2->length,
+                                                  poly2->length, ctx->minfo);
 
       exp3 = (ulong *) flint_malloc(N*poly3->length*sizeof(ulong));
       mpoly_repack_monomials(exp3, exp_bits, old_exp3, old_exp_bits,

--- a/src/fmpz_mpoly/divides_heap_threaded.c
+++ b/src/fmpz_mpoly/divides_heap_threaded.c
@@ -2012,9 +2012,7 @@ int _fmpz_mpoly_divides_heap_threaded_pool(
     exp_bits = FLINT_MAX(exp_bits, B->bits);
     exp_bits = mpoly_fix_bits(exp_bits, ctx->minfo);
 
-    N = mpoly_words_per_exp(exp_bits, ctx->minfo);
-    cmpmask = (ulong*) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, exp_bits, ctx->minfo);
 
     /* ensure input exponents packed to same size as output exponents */
     Aexp = A->exps;

--- a/src/fmpz_mpoly/divides_monagan_pearce.c
+++ b/src/fmpz_mpoly/divides_monagan_pearce.c
@@ -676,9 +676,7 @@ int fmpz_mpoly_divides_monagan_pearce(fmpz_mpoly_t poly1,
         goto cleanup;
     }
 
-    N = mpoly_words_per_exp(exp_bits, ctx->minfo);
-    cmpmask = (ulong*) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, exp_bits, ctx->minfo);
 
    /* temporary space to check leading monomials divide */
    expq = (ulong *) TMP_ALLOC(N*sizeof(ulong));

--- a/src/fmpz_mpoly/divrem.c
+++ b/src/fmpz_mpoly/divrem.c
@@ -740,9 +740,7 @@ void fmpz_mpoly_divrem_monagan_pearce(fmpz_mpoly_t q, fmpz_mpoly_t r,
     exp_bits = FLINT_MAX(poly2->bits, poly3->bits);
     exp_bits = mpoly_fix_bits(exp_bits, ctx->minfo);
 
-    N = mpoly_words_per_exp(exp_bits, ctx->minfo);
-    cmpmask = (ulong *) flint_malloc(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_FLINT_MALLOC(cmpmask, N, exp_bits, ctx->minfo);
 
    /* ensure input exponents packed to same size as output exponents */
    if (exp_bits > poly2->bits)
@@ -808,15 +806,10 @@ void fmpz_mpoly_divrem_monagan_pearce(fmpz_mpoly_t q, fmpz_mpoly_t r,
       ulong * old_exp2 = exp2, * old_exp3 = exp3;
       slong old_exp_bits = exp_bits;
 
-      exp_bits = mpoly_fix_bits(exp_bits + 1, ctx->minfo);
-
-      N = mpoly_words_per_exp(exp_bits, ctx->minfo);
-      cmpmask = (ulong *) flint_realloc(cmpmask, N*sizeof(ulong));
-      mpoly_get_cmpmask(cmpmask, N, exp_bits, ctx->minfo);
-
-      exp2 = (ulong *) flint_malloc(N*poly2->length*sizeof(ulong));
-      mpoly_repack_monomials(exp2, exp_bits, old_exp2, old_exp_bits,
-                                                    poly2->length, ctx->minfo);
+      exp2 = mpoly_monomials_repack_wider_cmpmask(&exp_bits,
+                                                  &N, &cmpmask, old_exp2,
+                                                  old_exp_bits, poly2->length,
+                                                  poly2->length, ctx->minfo);
 
       exp3 = (ulong *) flint_malloc(N*poly3->length*sizeof(ulong));
       mpoly_repack_monomials(exp3, exp_bits, old_exp3, old_exp_bits,

--- a/src/fmpz_mpoly/divrem_ideal.c
+++ b/src/fmpz_mpoly/divrem_ideal.c
@@ -748,9 +748,7 @@ void fmpz_mpoly_divrem_ideal_monagan_pearce(fmpz_mpoly_struct ** q, fmpz_mpoly_t
 
     exp_bits = mpoly_fix_bits(exp_bits, ctx->minfo);
 
-    N = mpoly_words_per_exp(exp_bits, ctx->minfo);
-    cmpmask = (ulong *) flint_malloc(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_FLINT_MALLOC(cmpmask, N, exp_bits, ctx->minfo);
 
    /* ensure input exponents packed to same size as output exponents */
    exp2 = poly2->exps;
@@ -825,14 +823,10 @@ void fmpz_mpoly_divrem_ideal_monagan_pearce(fmpz_mpoly_struct ** q, fmpz_mpoly_t
       if (lenr >= 0) /* check if division was successful */
          break;
 
-      exp_bits = mpoly_fix_bits(exp_bits + 1, ctx->minfo);
-      N = mpoly_words_per_exp(exp_bits, ctx->minfo);
-      cmpmask = (ulong *) flint_realloc(cmpmask, N*sizeof(ulong));
-      mpoly_get_cmpmask(cmpmask, N, exp_bits, ctx->minfo);
-
-      exp2 = (ulong *) flint_malloc(N*poly2->length*sizeof(ulong));
-      mpoly_repack_monomials(exp2, exp_bits, old_exp2, old_exp_bits,
-                                                    poly2->length, ctx->minfo);
+      exp2 = mpoly_monomials_repack_wider_cmpmask(&exp_bits,
+                                                  &N, &cmpmask, old_exp2,
+                                                  old_exp_bits, poly2->length,
+                                                  poly2->length, ctx->minfo);
 
       if (free2)
          flint_free(old_exp2);

--- a/src/fmpz_mpoly/mul_heap_threaded.c
+++ b/src/fmpz_mpoly/mul_heap_threaded.c
@@ -810,9 +810,7 @@ void _fmpz_mpoly_mul_heap_threaded_pool_maxfields(
     exp_bits = FLINT_MAX(exp_bits, C->bits);
     exp_bits = mpoly_fix_bits(exp_bits, ctx->minfo);
 
-    N = mpoly_words_per_exp(exp_bits, ctx->minfo);
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, exp_bits, ctx->minfo);
 
     /* ensure input exponents are packed into same sized fields as output */
     freeBexp = 0;

--- a/src/fmpz_mpoly/mul_johnson.c
+++ b/src/fmpz_mpoly/mul_johnson.c
@@ -474,9 +474,7 @@ void _fmpz_mpoly_mul_johnson_maxfields(
     Abits = FLINT_MAX(Abits, C->bits);
     Abits = mpoly_fix_bits(Abits, ctx->minfo);
 
-    N = mpoly_words_per_exp(Abits, ctx->minfo);
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, Abits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, Abits, ctx->minfo);
 
     /* ensure input exponents are packed into same sized fields as output */
     freeBexp = 0;

--- a/src/fmpz_mpoly/mul_monomial.c
+++ b/src/fmpz_mpoly/mul_monomial.c
@@ -96,14 +96,12 @@ void fmpz_mpoly_mul_monomial(
     /* slightly dirty: repack monomials can handle 1-bit overfown fields */
     if (overflowed)
     {
-        ulong * newAexps;
-        flint_bitcnt_t newAbits = mpoly_fix_bits(Abits + 1, ctx->minfo);
-        N = mpoly_words_per_exp(newAbits, ctx->minfo);
-        newAexps = FLINT_ARRAY_ALLOC(N*A->alloc, ulong);
-        mpoly_repack_monomials(newAexps, newAbits, A->exps, Abits, Blen, ctx->minfo);
+        ulong * newAexps = mpoly_monomials_repack_wider(&Abits, &N,
+                                                        A->exps, Abits, Blen,
+                                                        A->alloc, ctx->minfo);
         flint_free(A->exps);
         A->exps = newAexps;
-        A->bits = newAbits;
+        A->bits = Abits;
     }
 
     _fmpz_vec_scalar_mul_fmpz(A->coeffs, B->coeffs, Blen, &Ccoeff0);

--- a/src/fmpz_mpoly/quasidiv_heap.c
+++ b/src/fmpz_mpoly/quasidiv_heap.c
@@ -788,9 +788,7 @@ void fmpz_mpoly_quasidiv_heap(fmpz_t scale, fmpz_mpoly_t q,
     }
 
     exp_bits = FLINT_MAX(poly2->bits, poly3->bits);
-    N = mpoly_words_per_exp(exp_bits, ctx->minfo);
-    cmpmask = (ulong *) flint_malloc(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_FLINT_MALLOC(cmpmask, N, exp_bits, ctx->minfo);
 
     /* ensure input exponents packed to same size as output exponents */
     if (exp_bits > poly2->bits)
@@ -842,15 +840,10 @@ void fmpz_mpoly_quasidiv_heap(fmpz_t scale, fmpz_mpoly_t q,
       ulong * old_exp2 = exp2, * old_exp3 = exp3;
       slong old_exp_bits = exp_bits;
 
-      exp_bits = mpoly_fix_bits(exp_bits + 1, ctx->minfo);
-
-      N = mpoly_words_per_exp(exp_bits, ctx->minfo);
-      cmpmask = (ulong *) flint_realloc(cmpmask, N*sizeof(ulong));
-      mpoly_get_cmpmask(cmpmask, N, exp_bits, ctx->minfo);
-
-      exp2 = (ulong *) flint_malloc(N*poly2->length*sizeof(ulong));
-      mpoly_repack_monomials(exp2, exp_bits, old_exp2, old_exp_bits,
-                                                    poly2->length, ctx->minfo);
+      exp2 = mpoly_monomials_repack_wider_cmpmask(&exp_bits,
+                                                  &N, &cmpmask, old_exp2,
+                                                  old_exp_bits, poly2->length,
+                                                  poly2->length, ctx->minfo);
 
       exp3 = (ulong *) flint_malloc(N*poly3->length*sizeof(ulong));
       mpoly_repack_monomials(exp3, exp_bits, old_exp3, old_exp_bits,

--- a/src/fmpz_mpoly/quasidivrem_heap.c
+++ b/src/fmpz_mpoly/quasidivrem_heap.c
@@ -754,9 +754,7 @@ void fmpz_mpoly_quasidivrem_heap(fmpz_t scale, fmpz_mpoly_t q, fmpz_mpoly_t r,
     exp_bits = FLINT_MAX(poly2->bits, poly3->bits);
     exp_bits = mpoly_fix_bits(exp_bits, ctx->minfo);
 
-    N = mpoly_words_per_exp(exp_bits, ctx->minfo);
-    cmpmask = (ulong *) flint_malloc(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_FLINT_MALLOC(cmpmask, N, exp_bits, ctx->minfo);
 
     /* ensure input exponents packed to same size as output exponents */
     if (exp_bits > poly2->bits)
@@ -826,15 +824,10 @@ void fmpz_mpoly_quasidivrem_heap(fmpz_t scale, fmpz_mpoly_t q, fmpz_mpoly_t r,
       ulong * old_exp2 = exp2, * old_exp3 = exp3;
       slong old_exp_bits = exp_bits;
 
-      exp_bits = mpoly_fix_bits(exp_bits + 1, ctx->minfo);
-
-      N = mpoly_words_per_exp(exp_bits, ctx->minfo);
-      cmpmask = (ulong *) flint_realloc(cmpmask, N*sizeof(ulong));
-      mpoly_get_cmpmask(cmpmask, N, exp_bits, ctx->minfo);
-
-      exp2 = (ulong *) flint_malloc(N*poly2->length*sizeof(ulong));
-      mpoly_repack_monomials(exp2, exp_bits, old_exp2, old_exp_bits,
-                                                    poly2->length, ctx->minfo);
+      exp2 = mpoly_monomials_repack_wider_cmpmask(&exp_bits,
+                                                  &N, &cmpmask, old_exp2,
+                                                  old_exp_bits, poly2->length,
+                                                  poly2->length, ctx->minfo);
 
       exp3 = (ulong *) flint_malloc(N*poly3->length*sizeof(ulong));
       mpoly_repack_monomials(exp3, exp_bits, old_exp3, old_exp_bits,

--- a/src/fmpz_mpoly/quasidivrem_ideal_heap.c
+++ b/src/fmpz_mpoly/quasidivrem_ideal_heap.c
@@ -667,9 +667,7 @@ void fmpz_mpoly_quasidivrem_ideal_heap(fmpz_t scale,
 
     exp_bits = mpoly_fix_bits(exp_bits, ctx->minfo);
 
-    N = mpoly_words_per_exp(exp_bits, ctx->minfo);
-    cmpmask = (ulong *) flint_malloc(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_FLINT_MALLOC(cmpmask, N, exp_bits, ctx->minfo);
 
     /* ensure input exponents packed to same size as output exponents */
     exp2 = poly2->exps;
@@ -743,13 +741,10 @@ void fmpz_mpoly_quasidivrem_ideal_heap(fmpz_t scale,
         if (lenr >= 0) /* check if division was successful */
             break;
 
-        exp_bits = mpoly_fix_bits(exp_bits + 1, ctx->minfo);
-        N = mpoly_words_per_exp(exp_bits, ctx->minfo);
-        cmpmask = (ulong *) flint_realloc(cmpmask, N*sizeof(ulong));
-        mpoly_get_cmpmask(cmpmask, N, exp_bits, ctx->minfo);
-
-        exp2 = (ulong *) flint_malloc(N*poly2->length*sizeof(ulong));
-        mpoly_repack_monomials(exp2, exp_bits, old_exp2, old_exp_bits,
+        exp2 = mpoly_monomials_repack_wider_cmpmask(&exp_bits,
+                                                    &N, &cmpmask, old_exp2,
+                                                    old_exp_bits,
+                                                    poly2->length,
                                                     poly2->length, ctx->minfo);
 
         if (free2)

--- a/src/fmpz_mpoly/set_coeff_fmpz_fmpz.c
+++ b/src/fmpz_mpoly/set_coeff_fmpz_fmpz.c
@@ -29,9 +29,7 @@ void _fmpz_mpoly_set_coeff_fmpz_fmpz(fmpz_mpoly_t poly,
     exp_bits = mpoly_fix_bits(exp_bits, ctx->minfo);
     fmpz_mpoly_fit_bits(poly, exp_bits, ctx);
 
-    N = mpoly_words_per_exp(poly->bits, ctx->minfo);
-    cmpmask = (ulong*) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, poly->bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, poly->bits, ctx->minfo);
 
     packed_exp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
 

--- a/src/fmpz_mpoly/sort_terms.c
+++ b/src/fmpz_mpoly/sort_terms.c
@@ -139,9 +139,7 @@ void fmpz_mpoly_sort_terms(fmpz_mpoly_t A, const fmpz_mpoly_ctx_t ctx)
     TMP_INIT;
 
     TMP_START;
-    N = mpoly_words_per_exp(A->bits, ctx->minfo);
-    ptempexp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(ptempexp, N, A->bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(ptempexp, N, A->bits, ctx->minfo);
 
     himask = 0;
     for (i = 0; i < A->length; i++)

--- a/src/fmpz_mpoly/sub.c
+++ b/src/fmpz_mpoly/sub.c
@@ -257,9 +257,7 @@ void fmpz_mpoly_sub(fmpz_mpoly_t A, const fmpz_mpoly_t B,
 
     TMP_START;
     Abits = FLINT_MAX(B->bits, C->bits);
-    N = mpoly_words_per_exp(Abits, ctx->minfo);
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, Abits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, Abits, ctx->minfo);
 
     if (Abits > B->bits)
     {

--- a/src/fq_nmod_mpoly/div_monagan_pearce.c
+++ b/src/fq_nmod_mpoly/div_monagan_pearce.c
@@ -250,9 +250,7 @@ void fq_nmod_mpoly_div_monagan_pearce(
     Qbits = FLINT_MAX(A->bits, B->bits);
     Qbits = mpoly_fix_bits(Qbits, ctx->minfo);
 
-    N = mpoly_words_per_exp(Qbits, ctx->minfo);
-    cmpmask = (ulong *) flint_malloc(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, Qbits, ctx->minfo);
+    MPOLY_GET_CMPMASK_FLINT_MALLOC(cmpmask, N, Qbits, ctx->minfo);
 
     /* ensure input exponents packed to same size as output exponents */
     if (Qbits > A->bits)

--- a/src/fq_nmod_mpoly/divides_monagan_pearce.c
+++ b/src/fq_nmod_mpoly/divides_monagan_pearce.c
@@ -560,9 +560,7 @@ int fq_nmod_mpoly_divides_monagan_pearce(
         goto cleanup;
     }
 
-    N = mpoly_words_per_exp(Qbits, ctx->minfo);
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, Qbits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, Qbits, ctx->minfo);
 
     /* temporary space to check leading monomials divide */
     expq = (ulong *) TMP_ALLOC(N*sizeof(ulong));

--- a/src/fq_nmod_mpoly/divrem_ideal_monagan_pearce.c
+++ b/src/fq_nmod_mpoly/divrem_ideal_monagan_pearce.c
@@ -335,9 +335,7 @@ void fq_nmod_mpoly_divrem_ideal_monagan_pearce(
         QRbits = FLINT_MAX(QRbits, B[i]->bits);
     QRbits = mpoly_fix_bits(QRbits, ctx->minfo);
 
-    N = mpoly_words_per_exp(QRbits, ctx->minfo);
-    cmpmask = (ulong *) flint_malloc(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, QRbits, ctx->minfo);
+    MPOLY_GET_CMPMASK_FLINT_MALLOC(cmpmask, N, QRbits, ctx->minfo);
 
     /* ensure input exponents packed to same size as output exponents */
     Aexps = A->exps;

--- a/src/fq_nmod_mpoly/divrem_monagan_pearce.c
+++ b/src/fq_nmod_mpoly/divrem_monagan_pearce.c
@@ -709,9 +709,7 @@ void fq_nmod_mpoly_divrem_monagan_pearce(
     QRbits = FLINT_MAX(A->bits, B->bits);
     QRbits = mpoly_fix_bits(QRbits, ctx->minfo);
 
-    N = mpoly_words_per_exp(QRbits, ctx->minfo);
-    cmpmask = (ulong *) flint_malloc(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, QRbits, ctx->minfo);
+    MPOLY_GET_CMPMASK_FLINT_MALLOC(cmpmask, N, QRbits, ctx->minfo);
 
     /* ensure input exponents packed to same size as output exponents */
     if (QRbits != A->bits)

--- a/src/fq_nmod_mpoly/mpolyu_divides.c
+++ b/src/fq_nmod_mpoly/mpolyu_divides.c
@@ -283,9 +283,7 @@ int fq_nmod_mpolyuu_divides(
 
     TMP_START;
 
-    N = mpoly_words_per_exp(bits, ctx->minfo);
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, bits, ctx->minfo);
 
     /* alloc array of heap nodes which can be chained together */
     next_loc = Blen + 4;   /* something bigger than heap can ever be */

--- a/src/fq_nmod_mpoly/mul_johnson.c
+++ b/src/fq_nmod_mpoly/mul_johnson.c
@@ -423,9 +423,7 @@ void fq_nmod_mpoly_mul_johnson(
         fmpz_clear(Cmaxfields + i);
     }
 
-    N = mpoly_words_per_exp(Abits, ctx->minfo);
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, Abits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, Abits, ctx->minfo);
 
     /* ensure input exponents are packed into same sized fields as output */
     if (Abits != B->bits)

--- a/src/fq_nmod_mpoly/quadratic_root.c
+++ b/src/fq_nmod_mpoly/quadratic_root.c
@@ -485,9 +485,7 @@ int fq_nmod_mpoly_quadratic_root(
 
     Qbits = FLINT_MAX(A->bits, B->bits);
     Qbits = mpoly_fix_bits(Qbits, ctx->minfo);
-    N = mpoly_words_per_exp(Qbits, ctx->minfo);
-    cmpmask = (ulong*) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, Qbits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, Qbits, ctx->minfo);
 
     /* ensure input exponents packed to same size as output exponents */
     if (Qbits > A->bits)

--- a/src/fq_nmod_mpoly/set_coeff_fq_nmod_fmpz.c
+++ b/src/fq_nmod_mpoly/set_coeff_fq_nmod_fmpz.c
@@ -35,9 +35,7 @@ void _fq_nmod_mpoly_set_coeff_fq_nmod_fmpz(
     exp_bits = mpoly_fix_bits(exp_bits, ctx->minfo);
     fq_nmod_mpoly_fit_length_fit_bits(A, A->length, exp_bits, ctx);
 
-    N = mpoly_words_per_exp(A->bits, ctx->minfo);
-    cmpmask = (ulong*) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, A->bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, A->bits, ctx->minfo);
 
     packed_exp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
 

--- a/src/fq_nmod_mpoly/sort_terms.c
+++ b/src/fq_nmod_mpoly/sort_terms.c
@@ -155,9 +155,7 @@ void fq_nmod_mpoly_sort_terms(fq_nmod_mpoly_t A, const fq_nmod_mpoly_ctx_t ctx)
     TMP_INIT;
 
     TMP_START;
-    N = mpoly_words_per_exp(A->bits, ctx->minfo);
-    ptempexp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(ptempexp, N, A->bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(ptempexp, N, A->bits, ctx->minfo);
 
     himask = 0;
     for (i = 0; i < A->length; i++)

--- a/src/fq_zech_mpoly/add.c
+++ b/src/fq_zech_mpoly/add.c
@@ -96,9 +96,7 @@ void fq_zech_mpoly_add(
 
     TMP_START;
     Abits = FLINT_MAX(B->bits, C->bits);
-    N = mpoly_words_per_exp(Abits, ctx->minfo);
-    cmpmask = (ulong*) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, Abits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, Abits, ctx->minfo);
 
     if (Abits != B->bits)
     {

--- a/src/fq_zech_mpoly/divides_monagan_pearce.c
+++ b/src/fq_zech_mpoly/divides_monagan_pearce.c
@@ -290,9 +290,7 @@ int fq_zech_mpoly_divides_monagan_pearce(fq_zech_mpoly_t poly1,
         goto cleanup;
     }
 
-    N = mpoly_words_per_exp(exp_bits, ctx->minfo);
-    cmpmask = (ulong*) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, exp_bits, ctx->minfo);
 
     /* temporary space to check leading monomials divide */
     expq = (ulong *) TMP_ALLOC(N*sizeof(ulong));

--- a/src/fq_zech_mpoly/divrem_monagan_pearce.c
+++ b/src/fq_zech_mpoly/divrem_monagan_pearce.c
@@ -262,9 +262,7 @@ void fq_zech_mpoly_divrem_monagan_pearce(fq_zech_mpoly_t q, fq_zech_mpoly_t r,
     exp_bits = FLINT_MAX(poly2->bits, poly3->bits);
     exp_bits = mpoly_fix_bits(exp_bits, ctx->minfo);
 
-    N = mpoly_words_per_exp(exp_bits, ctx->minfo);
-    cmpmask = (ulong *) flint_malloc(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_FLINT_MALLOC(cmpmask, N, exp_bits, ctx->minfo);
 
     /* ensure input exponents packed to same size as output exponents */
     if (exp_bits > poly2->bits)
@@ -332,14 +330,10 @@ void fq_zech_mpoly_divrem_monagan_pearce(fq_zech_mpoly_t q, fq_zech_mpoly_t r,
         ulong * old_exp2 = exp2, * old_exp3 = exp3;
         slong old_exp_bits = exp_bits;
 
-        exp_bits = mpoly_fix_bits(exp_bits + 1, ctx->minfo);
-
-        N = mpoly_words_per_exp(exp_bits, ctx->minfo);
-        cmpmask = (ulong *) flint_realloc(cmpmask, N*sizeof(ulong));
-        mpoly_get_cmpmask(cmpmask, N, exp_bits, ctx->minfo);
-
-        exp2 = (ulong *) flint_malloc(N*poly2->length*sizeof(ulong));
-        mpoly_repack_monomials(exp2, exp_bits, old_exp2, old_exp_bits,
+        exp2 = mpoly_monomials_repack_wider_cmpmask(&exp_bits,
+                                                    &N, &cmpmask, old_exp2,
+                                                    old_exp_bits,
+                                                    poly2->length,
                                                     poly2->length, ctx->minfo);
 
         exp3 = (ulong *) flint_malloc(N*poly3->length*sizeof(ulong));

--- a/src/fq_zech_mpoly/mul_johnson.c
+++ b/src/fq_zech_mpoly/mul_johnson.c
@@ -212,9 +212,7 @@ void fq_zech_mpoly_mul_johnson(
         fmpz_clear(max_fields3 + i);
     }
 
-    N = mpoly_words_per_exp(exp_bits, ctx->minfo);
-    cmpmask = (ulong*) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, exp_bits, ctx->minfo);
 
     /* ensure input exponents are packed into same sized fields as output */
     if (exp_bits > poly2->bits)

--- a/src/fq_zech_mpoly/scalar.c
+++ b/src/fq_zech_mpoly/scalar.c
@@ -106,9 +106,7 @@ void fq_zech_mpoly_scalar_addmul_fq_zech(
 
     TMP_START;
     Abits = FLINT_MAX(B->bits, C->bits);
-    N = mpoly_words_per_exp(Abits, ctx->minfo);
-    cmpmask = (ulong*) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, Abits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, Abits, ctx->minfo);
 
     if (Abits != B->bits)
     {

--- a/src/fq_zech_mpoly/sort_terms.c
+++ b/src/fq_zech_mpoly/sort_terms.c
@@ -176,9 +176,7 @@ void fq_zech_mpoly_sort_terms(fq_zech_mpoly_t A, const fq_zech_mpoly_ctx_t ctx)
     TMP_INIT;
 
     TMP_START;
-    N = mpoly_words_per_exp(A->bits, ctx->minfo);
-    ptempexp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(ptempexp, N, A->bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(ptempexp, N, A->bits, ctx->minfo);
 
     himask = 0;
     for (i = 0; i < A->length; i++)

--- a/src/gr_mpoly/add.c
+++ b/src/gr_mpoly/add.c
@@ -100,9 +100,7 @@ int gr_mpoly_add(gr_mpoly_t A, const gr_mpoly_t B, const gr_mpoly_t C, gr_mpoly_
 
     TMP_START;
     Abits = FLINT_MAX(B->bits, C->bits);
-    N = mpoly_words_per_exp(Abits, mctx);
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, Abits, mctx);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, Abits, mctx);
 
     if (Abits != B->bits)
     {

--- a/src/gr_mpoly/divides_heap.c
+++ b/src/gr_mpoly/divides_heap.c
@@ -694,9 +694,7 @@ int gr_mpoly_divides_heap(
         return GR_DOMAIN;
     }
 
-    N = mpoly_words_per_exp(exp_bits, mctx);
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, mctx);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, exp_bits, mctx);
 
     expq = (ulong *) TMP_ALLOC(N*sizeof(ulong));
 

--- a/src/gr_mpoly/divides_heap_threaded.c
+++ b/src/gr_mpoly/divides_heap_threaded.c
@@ -1989,9 +1989,7 @@ static int _gr_mpoly_divides_heap_threaded_pool(
     exp_bits = FLINT_MAX(exp_bits, B->bits);
     exp_bits = mpoly_fix_bits(exp_bits, mctx);
 
-    N = mpoly_words_per_exp(exp_bits, mctx);
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, mctx);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, exp_bits, mctx);
 
     /* ensure input exponents packed to same size as output exponents */
     Aexp = A->exps;

--- a/src/gr_mpoly/divrem_heap.c
+++ b/src/gr_mpoly/divrem_heap.c
@@ -691,9 +691,7 @@ int _gr_mpoly_divrem_mp(
     exp_bits = FLINT_MAX(A->bits, B->bits);
     exp_bits = mpoly_fix_bits(exp_bits, mctx);
 
-    N = mpoly_words_per_exp(exp_bits, mctx);
-    cmpmask = (ulong *) flint_malloc(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, mctx);
+    MPOLY_GET_CMPMASK_FLINT_MALLOC(cmpmask, N, exp_bits, mctx);
 
     if (exp_bits > A->bits)
     {
@@ -755,13 +753,11 @@ int _gr_mpoly_divrem_mp(
             ulong * old_exp2 = exp2;
             ulong * old_exp3 = exp3;
 
-            exp_bits = mpoly_fix_bits(exp_bits + 1, mctx);
-            N = mpoly_words_per_exp(exp_bits, mctx);
-            cmpmask = (ulong *) flint_realloc(cmpmask, N*sizeof(ulong));
-            mpoly_get_cmpmask(cmpmask, N, exp_bits, mctx);
-
-            exp2 = (ulong *) flint_malloc(N*A->length*sizeof(ulong));
-            mpoly_repack_monomials(exp2, exp_bits, old_exp2, old_exp_bits, A->length, mctx);
+            exp2 = mpoly_monomials_repack_wider_cmpmask(&exp_bits,
+                                                        &N, &cmpmask, old_exp2,
+                                                        old_exp_bits,
+                                                        A->length, A->length,
+                                                        mctx);
             if (free2)
                 flint_free(old_exp2);
             free2 = 1;

--- a/src/gr_mpoly/divrem_heap_threaded.c
+++ b/src/gr_mpoly/divrem_heap_threaded.c
@@ -833,9 +833,7 @@ static int _gr_mpoly_divrem_heap_threaded_pool(
     exp_bits = FLINT_MAX(exp_bits, B->bits);
     exp_bits = mpoly_fix_bits(exp_bits, mctx);
 
-    N = mpoly_words_per_exp(exp_bits, mctx);
-    cmpmask = (ulong *) flint_malloc(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, mctx);
+    MPOLY_GET_CMPMASK_FLINT_MALLOC(cmpmask, N, exp_bits, mctx);
 
     /* ensure input exponents packed to same size as output exponents */
     Aexp = A->exps;
@@ -1008,13 +1006,12 @@ static int _gr_mpoly_divrem_heap_threaded_pool(
                 ulong * old_Aexp = Aexp;
                 ulong * old_Bexp = Bexp;
 
-                exp_bits = mpoly_fix_bits(exp_bits + 1, mctx);
-                N = mpoly_words_per_exp(exp_bits, mctx);
-                cmpmask = (ulong *) flint_realloc(cmpmask, N*sizeof(ulong));
-                mpoly_get_cmpmask(cmpmask, N, exp_bits, mctx);
-
-                Aexp = (ulong *) flint_malloc(N*A->length*sizeof(ulong));
-                mpoly_repack_monomials(Aexp, exp_bits, old_Aexp, old_exp_bits, A->length, mctx);
+                Aexp = mpoly_monomials_repack_wider_cmpmask(&exp_bits,
+                                                            &N, &cmpmask,
+                                                            old_Aexp,
+                                                            old_exp_bits,
+                                                            A->length,
+                                                            A->length, mctx);
                 if (freeAexp)
                     flint_free(old_Aexp);
                 freeAexp = 1;

--- a/src/gr_mpoly/divrem_ideal.c
+++ b/src/gr_mpoly/divrem_ideal.c
@@ -812,9 +812,7 @@ int _gr_mpoly_divrem_ideal(
         exp_bits = FLINT_MAX(exp_bits, B[i]->bits);
     exp_bits = mpoly_fix_bits(exp_bits, mctx);
 
-    N = mpoly_words_per_exp(exp_bits, mctx);
-    cmpmask = (ulong *) flint_malloc(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, mctx);
+    MPOLY_GET_CMPMASK_FLINT_MALLOC(cmpmask, N, exp_bits, mctx);
 
     exp2 = A->exps;
     if (exp_bits > A->bits)
@@ -880,13 +878,11 @@ int _gr_mpoly_divrem_ideal(
             slong old_exp_bits = exp_bits;
             ulong * old_exp2 = exp2, * old_exp3;
 
-            exp_bits = mpoly_fix_bits(exp_bits + 1, mctx);
-            N = mpoly_words_per_exp(exp_bits, mctx);
-            cmpmask = (ulong *) flint_realloc(cmpmask, N*sizeof(ulong));
-            mpoly_get_cmpmask(cmpmask, N, exp_bits, mctx);
-
-            exp2 = (ulong *) flint_malloc(N*A->length*sizeof(ulong));
-            mpoly_repack_monomials(exp2, exp_bits, old_exp2, old_exp_bits, A->length, mctx);
+            exp2 = mpoly_monomials_repack_wider_cmpmask(&exp_bits,
+                                                        &N, &cmpmask, old_exp2,
+                                                        old_exp_bits,
+                                                        A->length, A->length,
+                                                        mctx);
             if (free2) flint_free(old_exp2);
             free2 = 1;
 

--- a/src/gr_mpoly/divrem_ideal_heap_threaded.c
+++ b/src/gr_mpoly/divrem_ideal_heap_threaded.c
@@ -1489,9 +1489,7 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_pool(
         exp_bits = FLINT_MAX(exp_bits, B[w]->bits);
     exp_bits = mpoly_fix_bits(exp_bits, mctx);
 
-    N = mpoly_words_per_exp(exp_bits, mctx);
-    cmpmask = (ulong *) flint_malloc(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, mctx);
+    MPOLY_GET_CMPMASK_FLINT_MALLOC(cmpmask, N, exp_bits, mctx);
 
     Aexp = A->exps;
     freeAexp = 0;
@@ -1677,13 +1675,12 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_pool(
                 slong old_exp_bits = exp_bits;
                 ulong * old_Aexp = Aexp;
 
-                exp_bits = mpoly_fix_bits(exp_bits + 1, mctx);
-                N = mpoly_words_per_exp(exp_bits, mctx);
-                cmpmask = (ulong *) flint_realloc(cmpmask, N*sizeof(ulong));
-                mpoly_get_cmpmask(cmpmask, N, exp_bits, mctx);
-
-                Aexp = (ulong *) flint_malloc(N*A->length*sizeof(ulong));
-                mpoly_repack_monomials(Aexp, exp_bits, old_Aexp, old_exp_bits, A->length, mctx);
+                Aexp = mpoly_monomials_repack_wider_cmpmask(&exp_bits,
+                                                            &N, &cmpmask,
+                                                            old_Aexp,
+                                                            old_exp_bits,
+                                                            A->length,
+                                                            A->length, mctx);
                 if (freeAexp)
                     flint_free(old_Aexp);
                 freeAexp = 1;

--- a/src/gr_mpoly/mul_heap.c
+++ b/src/gr_mpoly/mul_heap.c
@@ -483,9 +483,7 @@ int gr_mpoly_mul_heap(
         fmpz_clear(max_fields3 + i);
     }
 
-    N = mpoly_words_per_exp(exp_bits, mctx);
-    cmpmask = (ulong*) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, mctx);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, exp_bits, mctx);
 
     /* ensure input exponents are packed into same sized fields as output */
     if (exp_bits > poly2->bits)

--- a/src/gr_mpoly/mul_heap_threaded.c
+++ b/src/gr_mpoly/mul_heap_threaded.c
@@ -928,9 +928,7 @@ static int _gr_mpoly_mul_heap_threaded_maxfields(
     exp_bits = FLINT_MAX(exp_bits, C->bits);
     exp_bits = mpoly_fix_bits(exp_bits, mctx);
 
-    N = mpoly_words_per_exp(exp_bits, mctx);
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, mctx);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, exp_bits, mctx);
 
     /* ensure input exponents are packed into same sized fields as output */
     freeBexp = 0;

--- a/src/gr_mpoly/mul_monomial.c
+++ b/src/gr_mpoly/mul_monomial.c
@@ -102,14 +102,12 @@ int gr_mpoly_mul_monomial(
     /* slightly dirty: repack monomials can handle 1-bit overflown fields */
     if (overflowed)
     {
-        ulong * newAexps;
-        flint_bitcnt_t newAbits = mpoly_fix_bits(Abits + 1, mctx);
-        N = mpoly_words_per_exp(newAbits, mctx);
-        newAexps = FLINT_ARRAY_ALLOC(N*A->coeffs_alloc, ulong);
-        mpoly_repack_monomials(newAexps, newAbits, A->exps, Abits, Blen, mctx);
+        ulong * newAexps = mpoly_monomials_repack_wider(&Abits, &N,
+                                                        A->exps, Abits, Blen,
+                                                        A->coeffs_alloc, mctx);
         flint_free(A->exps);
         A->exps = newAexps;
-        A->bits = newAbits;
+        A->bits = Abits;
         A->exps_alloc = N*A->coeffs_alloc;
     }
 

--- a/src/gr_mpoly/quasidivrem_heap.c
+++ b/src/gr_mpoly/quasidivrem_heap.c
@@ -405,9 +405,7 @@ int gr_mpoly_quasidivrem_heap(
     exp_bits = FLINT_MAX(A->bits, B->bits);
     exp_bits = mpoly_fix_bits(exp_bits, mctx);
 
-    N = mpoly_words_per_exp(exp_bits, mctx);
-    cmpmask = (ulong *) flint_malloc(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, mctx);
+    MPOLY_GET_CMPMASK_FLINT_MALLOC(cmpmask, N, exp_bits, mctx);
 
     if (exp_bits > A->bits)
     {
@@ -480,13 +478,11 @@ int gr_mpoly_quasidivrem_heap(
             ulong * old_exp2 = exp2;
             ulong * old_exp3 = exp3;
 
-            exp_bits = mpoly_fix_bits(exp_bits + 1, mctx);
-            N = mpoly_words_per_exp(exp_bits, mctx);
-            cmpmask = (ulong *) flint_realloc(cmpmask, N*sizeof(ulong));
-            mpoly_get_cmpmask(cmpmask, N, exp_bits, mctx);
-
-            exp2 = (ulong *) flint_malloc(N*A->length*sizeof(ulong));
-            mpoly_repack_monomials(exp2, exp_bits, old_exp2, old_exp_bits, A->length, mctx);
+            exp2 = mpoly_monomials_repack_wider_cmpmask(&exp_bits,
+                                                        &N, &cmpmask, old_exp2,
+                                                        old_exp_bits,
+                                                        A->length, A->length,
+                                                        mctx);
             if (free2) flint_free(old_exp2);
             free2 = 1;
 

--- a/src/gr_mpoly/quasidivrem_ideal_heap.c
+++ b/src/gr_mpoly/quasidivrem_ideal_heap.c
@@ -452,9 +452,7 @@ static int _gr_mpoly_quasidivrem_ideal_arr(
         exp_bits = FLINT_MAX(exp_bits, B[i]->bits);
     exp_bits = mpoly_fix_bits(exp_bits, mctx);
 
-    N = mpoly_words_per_exp(exp_bits, mctx);
-    cmpmask = (ulong *) flint_malloc(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, mctx);
+    MPOLY_GET_CMPMASK_FLINT_MALLOC(cmpmask, N, exp_bits, mctx);
 
     exp2 = A->exps;
     if (exp_bits > A->bits)
@@ -520,13 +518,11 @@ static int _gr_mpoly_quasidivrem_ideal_arr(
             slong old_exp_bits = exp_bits;
             ulong * old_exp2 = exp2, * old_exp3;
 
-            exp_bits = mpoly_fix_bits(exp_bits + 1, mctx);
-            N = mpoly_words_per_exp(exp_bits, mctx);
-            cmpmask = (ulong *) flint_realloc(cmpmask, N*sizeof(ulong));
-            mpoly_get_cmpmask(cmpmask, N, exp_bits, mctx);
-
-            exp2 = (ulong *) flint_malloc(N*A->length*sizeof(ulong));
-            mpoly_repack_monomials(exp2, exp_bits, old_exp2, old_exp_bits, A->length, mctx);
+            exp2 = mpoly_monomials_repack_wider_cmpmask(&exp_bits,
+                                                        &N, &cmpmask, old_exp2,
+                                                        old_exp_bits,
+                                                        A->length, A->length,
+                                                        mctx);
             if (free2) flint_free(old_exp2);
             free2 = 1;
 

--- a/src/gr_mpoly/set_coeff_scalar_fmpz.c
+++ b/src/gr_mpoly/set_coeff_scalar_fmpz.c
@@ -44,9 +44,7 @@ int gr_mpoly_set_coeff_scalar_fmpz(
     exp_bits = mpoly_fix_bits(exp_bits, mctx);
     gr_mpoly_fit_length_fit_bits(A, A->length, exp_bits, ctx);
 
-    N = mpoly_words_per_exp(A->bits, mctx);
-    cmpmask = (ulong*) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, A->bits, mctx);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, A->bits, mctx);
 
     packed_exp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
 

--- a/src/gr_mpoly/sort_terms.c
+++ b/src/gr_mpoly/sort_terms.c
@@ -199,9 +199,7 @@ void gr_mpoly_sort_terms(gr_mpoly_t A, gr_mpoly_ctx_t ctx)
     TMP_INIT;
 
     TMP_START;
-    N = mpoly_words_per_exp(A->bits, mctx);
-    ptempexp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(ptempexp, N, A->bits, mctx);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(ptempexp, N, A->bits, mctx);
 
     himask = 0;
     for (i = 0; i < A->length; i++)

--- a/src/gr_mpoly/sqr_commutative_heap.c
+++ b/src/gr_mpoly/sqr_commutative_heap.c
@@ -562,9 +562,7 @@ int gr_mpoly_sqr_commutative_heap(
     for (i = 0; i < mctx->nfields; i++)
         fmpz_clear(max_fields2 + i);
 
-    N = mpoly_words_per_exp(exp_bits, mctx);
-    cmpmask = (ulong*) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, mctx);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, exp_bits, mctx);
 
     /* ensure input exponents are packed into same sized fields as output */
     if (exp_bits > poly2->bits)

--- a/src/gr_mpoly/sqr_commutative_heap_threaded.c
+++ b/src/gr_mpoly/sqr_commutative_heap_threaded.c
@@ -999,9 +999,7 @@ static int _gr_mpoly_sqr_commutative_heap_threaded_maxfields(
     exp_bits = FLINT_MAX(exp_bits, B->bits);
     exp_bits = mpoly_fix_bits(exp_bits, mctx);
 
-    N = mpoly_words_per_exp(exp_bits, mctx);
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, mctx);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, exp_bits, mctx);
 
     /* ensure input exponents are packed into same sized fields as output */
     freeBexp = 0;

--- a/src/gr_mpoly/sqr_monomial.c
+++ b/src/gr_mpoly/sqr_monomial.c
@@ -69,14 +69,12 @@ int gr_mpoly_sqr_monomial(
     /* slightly dirty: repack monomials can handle 1-bit overflown fields */
     if (overflowed)
     {
-        ulong * newAexps;
-        flint_bitcnt_t newAbits = mpoly_fix_bits(Abits + 1, mctx);
-        N = mpoly_words_per_exp(newAbits, mctx);
-        newAexps = FLINT_ARRAY_ALLOC(N*A->coeffs_alloc, ulong);
-        mpoly_repack_monomials(newAexps, newAbits, A->exps, Abits, 1, mctx);
+        ulong * newAexps = mpoly_monomials_repack_wider(&Abits, &N,
+                                                        A->exps, Abits, 1,
+                                                        A->coeffs_alloc, mctx);
         flint_free(A->exps);
         A->exps = newAexps;
-        A->bits = newAbits;
+        A->bits = Abits;
         A->exps_alloc = N*A->coeffs_alloc;
     }
 

--- a/src/gr_mpoly/sub.c
+++ b/src/gr_mpoly/sub.c
@@ -101,9 +101,7 @@ int gr_mpoly_sub(gr_mpoly_t A, const gr_mpoly_t B, const gr_mpoly_t C, gr_mpoly_
 
     TMP_START;
     Abits = FLINT_MAX(B->bits, C->bits);
-    N = mpoly_words_per_exp(Abits, mctx);
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, Abits, mctx);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, Abits, mctx);
 
     if (Abits != B->bits)
     {

--- a/src/mpoly.h
+++ b/src/mpoly.h
@@ -1107,6 +1107,57 @@ void mpoly_set_monomial_ffmpz(ulong * exp1, const fmpz * exp2, flint_bitcnt_t bi
 void mpoly_set_monomial_pfmpz(ulong * exp1, fmpz * const * exp2, flint_bitcnt_t bits, const mpoly_ctx_t mctx);
 
 int mpoly_repack_monomials(ulong * exps1, flint_bitcnt_t bits1, const ulong * exps2, flint_bitcnt_t bits2, slong len, const mpoly_ctx_t mctx);
+
+/*
+    N + CMPMASK SETUP, AND OVERFLOW -> WIDER REPACK, HELPERS.
+
+    Two more recurring boilerplate blocks throughout the mpoly modules:
+
+    1. Computing N for a given bits/mctx and immediately deriving a
+       cmpmask array for it -- almost always into TMP_ALLOC'd storage,
+       so this has to be a macro (not a function) to keep the
+       allocation in the caller's own TMP_INIT/TMP_START/TMP_END scope:
+
+           N = mpoly_words_per_exp(bits, mctx);
+           cmpmask = (ulong *) TMP_ALLOC(N * sizeof(ulong));
+           mpoly_get_cmpmask(cmpmask, N, bits, mctx);
+
+       MPOLY_GET_CMPMASK_TMP_ALLOC below is exactly this, and must only
+       be used within such a TMP_ALLOC scope.
+
+    2. On overflow, widening the current packing width by (at least)
+       one field and repacking previously-computed monomials into
+       freshly allocated storage sized for it -- see
+       mpoly_monomials_repack_wider and
+       mpoly_monomials_repack_wider_cmpmask below.
+*/
+
+#define MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, bits, mctx)        \
+    do {                                                          \
+        (N) = mpoly_words_per_exp((bits), (mctx));                 \
+        (cmpmask) = (ulong *) TMP_ALLOC((N) * sizeof(ulong));      \
+        mpoly_get_cmpmask((cmpmask), (N), (bits), (mctx));          \
+    } while (0)
+
+/* As above, but for the (less common) case where cmpmask needs to
+   outlive the caller's own TMP_ALLOC scope (e.g. because it is handed
+   off to worker threads), so it must be a real flint_malloc allocation
+   that the caller remains responsible for flint_free-ing. */
+#define MPOLY_GET_CMPMASK_FLINT_MALLOC(cmpmask, N, bits, mctx)     \
+    do {                                                          \
+        (N) = mpoly_words_per_exp((bits), (mctx));                 \
+        (cmpmask) = (ulong *) flint_malloc((N) * sizeof(ulong));   \
+        mpoly_get_cmpmask((cmpmask), (N), (bits), (mctx));          \
+    } while (0)
+
+ulong * mpoly_monomials_repack_wider(flint_bitcnt_t * bits_ptr, slong * N_ptr,
+        const ulong * old_exps, flint_bitcnt_t old_bits, slong len,
+        slong alloc, const mpoly_ctx_t mctx);
+
+ulong * mpoly_monomials_repack_wider_cmpmask(flint_bitcnt_t * bits_ptr,
+        slong * N_ptr, ulong ** cmpmask_ptr, const ulong * old_exps,
+        flint_bitcnt_t old_bits, slong len, slong alloc,
+        const mpoly_ctx_t mctx);
 void mpoly_pack_monomials_tight(ulong * exp1, const ulong * exp2, slong len, const slong * mults, slong num, slong bits);
 void mpoly_unpack_monomials_tight(ulong * e1, ulong * e2, slong len, slong * mults, slong num, slong bits);
 

--- a/src/mpoly/monomial_index.c
+++ b/src/mpoly/monomial_index.c
@@ -65,10 +65,7 @@ slong mpoly_monomial_index_ui(const ulong * Aexps, flint_bitcnt_t Abits,
 
     TMP_START;
 
-    N = mpoly_words_per_exp(Abits, mctx);
-
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, Abits, mctx);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, Abits, mctx);
 
     packed_exp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
     mpoly_set_monomial_ui(packed_exp, exp, Abits, mctx);
@@ -98,10 +95,7 @@ slong mpoly_monomial_index_pfmpz(const ulong * Aexps, flint_bitcnt_t Abits,
 
     TMP_START;
 
-    N = mpoly_words_per_exp(Abits, mctx);
-
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, Abits, mctx);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, Abits, mctx);
 
     packed_exp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
     mpoly_set_monomial_pfmpz(packed_exp, exp, Abits, mctx);
@@ -127,10 +121,7 @@ slong mpoly_monomial_index_monomial(const ulong * Aexps, flint_bitcnt_t Abits,
 
     TMP_START;
 
-    N = mpoly_words_per_exp(Abits, mctx);
-
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, Abits, mctx);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, Abits, mctx);
 
     if (Mbits == Abits)
     {

--- a/src/mpoly/monomials_repack_wider.c
+++ b/src/mpoly/monomials_repack_wider.c
@@ -1,0 +1,71 @@
+/*
+    Copyright (C) 2026 FLINT contributors
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "mpoly.h"
+
+/*
+    A recurring idiom throughout the mpoly modules: an in-progress
+    computation discovers (via an overflowed guard bit) that the current
+    packing width is not wide enough, and needs to widen it by at least
+    one bit, reallocate storage sized for that wider packing, and repack
+    the monomials computed so far into it. This function does exactly
+    that: it increases *bits_ptr (rounded up to whatever width mctx
+    actually supports via mpoly_fix_bits), recomputes *N_ptr for the new
+    width, and returns a freshly flint_malloc'd array holding `len`
+    monomials repacked from `old_exps` (which was packed at `old_bits`),
+    with room for `alloc` monomials in total.
+
+    The caller owns the returned array. `old_exps` is left untouched --
+    it is very often part of an input polynomial the caller does not
+    own, so freeing it (when it is safe to do so) remains the caller's
+    responsibility, exactly as before this helper existed.
+*/
+ulong * mpoly_monomials_repack_wider(flint_bitcnt_t * bits_ptr, slong * N_ptr,
+        const ulong * old_exps, flint_bitcnt_t old_bits, slong len,
+        slong alloc, const mpoly_ctx_t mctx)
+{
+    ulong * new_exps;
+
+    *bits_ptr = mpoly_fix_bits(*bits_ptr + 1, mctx);
+    *N_ptr = mpoly_words_per_exp(*bits_ptr, mctx);
+
+    new_exps = FLINT_ARRAY_ALLOC(*N_ptr * alloc, ulong);
+    mpoly_repack_monomials(new_exps, *bits_ptr, old_exps, old_bits, len, mctx);
+
+    return new_exps;
+}
+
+/*
+    As mpoly_monomials_repack_wider, and additionally grows *cmpmask_ptr
+    (via flint_realloc) to match the new bits/N and refreshes its
+    contents. This covers the common combined idiom where a cmpmask
+    array tracking the same packing width needs to stay in sync with
+    the repack; *cmpmask_ptr must already be a flint_malloc/flint_realloc
+    (not TMP_ALLOC) allocation, since it is grown with flint_realloc here.
+*/
+ulong * mpoly_monomials_repack_wider_cmpmask(flint_bitcnt_t * bits_ptr,
+        slong * N_ptr, ulong ** cmpmask_ptr, const ulong * old_exps,
+        flint_bitcnt_t old_bits, slong len, slong alloc,
+        const mpoly_ctx_t mctx)
+{
+    ulong * new_exps;
+
+    *bits_ptr = mpoly_fix_bits(*bits_ptr + 1, mctx);
+    *N_ptr = mpoly_words_per_exp(*bits_ptr, mctx);
+
+    *cmpmask_ptr = (ulong *) flint_realloc(*cmpmask_ptr, *N_ptr * sizeof(ulong));
+    mpoly_get_cmpmask(*cmpmask_ptr, *N_ptr, *bits_ptr, mctx);
+
+    new_exps = FLINT_ARRAY_ALLOC(*N_ptr * alloc, ulong);
+    mpoly_repack_monomials(new_exps, *bits_ptr, old_exps, old_bits, len, mctx);
+
+    return new_exps;
+}

--- a/src/nmod_mpoly/add.c
+++ b/src/nmod_mpoly/add.c
@@ -146,9 +146,7 @@ void nmod_mpoly_add(nmod_mpoly_t A, const nmod_mpoly_t B,
 
     TMP_START;
     Abits = FLINT_MAX(B->bits, C->bits);
-    N = mpoly_words_per_exp(Abits, ctx->minfo);
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, Abits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, Abits, ctx->minfo);
 
     if (Abits != B->bits)
     {

--- a/src/nmod_mpoly/div_monagan_pearce.c
+++ b/src/nmod_mpoly/div_monagan_pearce.c
@@ -504,9 +504,7 @@ void nmod_mpoly_div_monagan_pearce(
     Qbits = FLINT_MAX(A->bits, B->bits);
     Qbits = mpoly_fix_bits(Qbits, ctx->minfo);
 
-    N = mpoly_words_per_exp(Qbits, ctx->minfo);
-    cmpmask = (ulong *) flint_malloc(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, Qbits, ctx->minfo);
+    MPOLY_GET_CMPMASK_FLINT_MALLOC(cmpmask, N, Qbits, ctx->minfo);
 
     /* ensure input exponents packed to same size as output exponents */
     if (Qbits > A->bits)

--- a/src/nmod_mpoly/divides_heap_threaded.c
+++ b/src/nmod_mpoly/divides_heap_threaded.c
@@ -1719,9 +1719,7 @@ int _nmod_mpoly_divides_heap_threaded_pool(
     exp_bits = FLINT_MAX(exp_bits, B->bits);
     exp_bits = mpoly_fix_bits(exp_bits, ctx->minfo);
 
-    N = mpoly_words_per_exp(exp_bits, ctx->minfo);
-    cmpmask = (ulong*) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, exp_bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, exp_bits, ctx->minfo);
 
     /* ensure input exponents packed to same size as output exponents */
     Aexp = A->exps;

--- a/src/nmod_mpoly/divides_monagan_pearce.c
+++ b/src/nmod_mpoly/divides_monagan_pearce.c
@@ -499,9 +499,7 @@ int nmod_mpoly_divides_monagan_pearce(
         goto cleanup;
     }
 
-    N = mpoly_words_per_exp(Qbits, ctx->minfo);
-    cmpmask = (ulong*) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, Qbits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, Qbits, ctx->minfo);
 
     /* temporary space to check leading monomials divide */
     expq = (ulong *) TMP_ALLOC(N*sizeof(ulong));

--- a/src/nmod_mpoly/divrem_ideal_monagan_pearce.c
+++ b/src/nmod_mpoly/divrem_ideal_monagan_pearce.c
@@ -564,9 +564,7 @@ void nmod_mpoly_divrem_ideal_monagan_pearce(
         QRbits = FLINT_MAX(QRbits, B[i]->bits);
     QRbits = mpoly_fix_bits(QRbits, ctx->minfo);
 
-    N = mpoly_words_per_exp(QRbits, ctx->minfo);
-    cmpmask = (ulong *) flint_malloc(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, QRbits, ctx->minfo);
+    MPOLY_GET_CMPMASK_FLINT_MALLOC(cmpmask, N, QRbits, ctx->minfo);
 
     /* ensure input exponents packed to same size as output exponents */
     Aexps = A->exps;

--- a/src/nmod_mpoly/divrem_monagan_pearce.c
+++ b/src/nmod_mpoly/divrem_monagan_pearce.c
@@ -623,9 +623,7 @@ void nmod_mpoly_divrem_monagan_pearce(
     QRbits = FLINT_MAX(A->bits, B->bits);
     QRbits = mpoly_fix_bits(QRbits, ctx->minfo);
 
-    N = mpoly_words_per_exp(QRbits, ctx->minfo);
-    cmpmask = (ulong *) flint_malloc(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, QRbits, ctx->minfo);
+    MPOLY_GET_CMPMASK_FLINT_MALLOC(cmpmask, N, QRbits, ctx->minfo);
 
     /* ensure input exponents packed to same size as output exponents */
     if (QRbits != A->bits)

--- a/src/nmod_mpoly/get_term_ui_fmpz.c
+++ b/src/nmod_mpoly/get_term_ui_fmpz.c
@@ -31,10 +31,7 @@ ulong _nmod_mpoly_get_term_ui_fmpz(const nmod_mpoly_t poly,
 
     TMP_START;
 
-    N = mpoly_words_per_exp(poly->bits, ctx->minfo);
-
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, poly->bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, poly->bits, ctx->minfo);
 
     packed_exp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
     mpoly_set_monomial_ffmpz(packed_exp, exp, poly->bits, ctx->minfo);

--- a/src/nmod_mpoly/mpolyu_divides.c
+++ b/src/nmod_mpoly/mpolyu_divides.c
@@ -402,9 +402,7 @@ int nmod_mpolyuu_divides(
 
     TMP_START;
 
-    N = mpoly_words_per_exp(bits, ctx->minfo);
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, bits, ctx->minfo);
 
     /* alloc array of heap nodes which can be chained together */
     next_loc = Blen + 4;   /* something bigger than heap can ever be */

--- a/src/nmod_mpoly/mpolyun_divides.c
+++ b/src/nmod_mpoly/mpolyun_divides.c
@@ -552,9 +552,7 @@ int nmod_mpolyun_divides(
     FLINT_ASSERT(bits == B->bits);
     FLINT_ASSERT(bits == Q->bits);
 
-    N = mpoly_words_per_exp(bits, ctx->minfo);
-    cmpmask = (ulong *) flint_malloc(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_FLINT_MALLOC(cmpmask, N, bits, ctx->minfo);
 
     /* alloc array of heap nodes which can be chained together */
     next_loc = Blen + 4;   /* something bigger than heap can ever be */

--- a/src/nmod_mpoly/mul_heap_threaded.c
+++ b/src/nmod_mpoly/mul_heap_threaded.c
@@ -731,9 +731,7 @@ void _nmod_mpoly_mul_heap_threaded_pool_maxfields(
     Abits = FLINT_MAX(Abits, C->bits);
     Abits = mpoly_fix_bits(Abits, ctx->minfo);
 
-    N = mpoly_words_per_exp(Abits, ctx->minfo);
-    cmpmask = (ulong*) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, Abits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, Abits, ctx->minfo);
 
     /* ensure input exponents are packed into same sized fields as output */
     freeBexp = 0;

--- a/src/nmod_mpoly/mul_johnson.c
+++ b/src/nmod_mpoly/mul_johnson.c
@@ -322,9 +322,7 @@ void _nmod_mpoly_mul_johnson_maxfields(
     Abits = FLINT_MAX(Abits, C->bits);
     Abits = mpoly_fix_bits(Abits, ctx->minfo);
 
-    N = mpoly_words_per_exp(Abits, ctx->minfo);
-    cmpmask = (ulong*) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, Abits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, Abits, ctx->minfo);
 
     /* ensure input exponents are packed into same sized fields as output */
     if (Abits != B->bits)

--- a/src/nmod_mpoly/quadratic_root.c
+++ b/src/nmod_mpoly/quadratic_root.c
@@ -367,9 +367,7 @@ int nmod_mpoly_quadratic_root(
 
     Qbits = FLINT_MAX(A->bits, B->bits);
     Qbits = mpoly_fix_bits(Qbits, ctx->minfo);
-    N = mpoly_words_per_exp(Qbits, ctx->minfo);
-    cmpmask = (ulong*) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, Qbits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, Qbits, ctx->minfo);
 
     /* ensure input exponents packed to same size as output exponents */
     if (Qbits > A->bits)

--- a/src/nmod_mpoly/scalar.c
+++ b/src/nmod_mpoly/scalar.c
@@ -165,9 +165,7 @@ void nmod_mpoly_scalar_addmul_ui(
 
     TMP_START;
     Abits = FLINT_MAX(B->bits, C->bits);
-    N = mpoly_words_per_exp(Abits, ctx->minfo);
-    cmpmask = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, Abits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, Abits, ctx->minfo);
 
     if (Abits != B->bits)
     {

--- a/src/nmod_mpoly/set_coeff.c
+++ b/src/nmod_mpoly/set_coeff.c
@@ -36,9 +36,7 @@ void _nmod_mpoly_set_coeff_ui_fmpz(
     exp_bits = mpoly_fix_bits(exp_bits, ctx->minfo);
     nmod_mpoly_fit_length_fit_bits(A, A->length, exp_bits, ctx);
 
-    N = mpoly_words_per_exp(A->bits, ctx->minfo);
-    cmpmask = (ulong*) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(cmpmask, N, A->bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(cmpmask, N, A->bits, ctx->minfo);
 
     packed_exp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
 

--- a/src/nmod_mpoly/sort_terms.c
+++ b/src/nmod_mpoly/sort_terms.c
@@ -148,9 +148,7 @@ void nmod_mpoly_sort_terms(nmod_mpoly_t A, const nmod_mpoly_ctx_t ctx)
     TMP_INIT;
 
     TMP_START;
-    N = mpoly_words_per_exp(A->bits, ctx->minfo);
-    ptempexp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
-    mpoly_get_cmpmask(ptempexp, N, A->bits, ctx->minfo);
+    MPOLY_GET_CMPMASK_TMP_ALLOC(ptempexp, N, A->bits, ctx->minfo);
 
     himask = 0;
     for (i = 0; i < A->length; i++)


### PR DESCRIPTION
Introduce macros and functions to compress some recurring multi-line `mpoly` idioms.

Patch generated with Claude.