### PR TITLE
Some cleanup of gr_mpoly division functions

### DIFF
--- a/src/gr_mpoly/divides_heap_threaded.c
+++ b/src/gr_mpoly/divides_heap_threaded.c
@@ -22,6 +22,10 @@
 #include "gr_mpoly.h"
 #include "threaded_divmod.h"
 
+#if FLINT_USES_PTHREAD
+# include <stdatomic.h>
+#endif
+
 /*
     GR port of fmpz_mpoly_divides_heap_threaded (equivalently
     nmod_mpoly_divides_heap_threaded).
@@ -176,8 +180,6 @@ void gr_mpoly_ts_clear_poly(gr_mpoly_t Q, gr_mpoly_ts_t A, gr_ctx_t cctx)
 void gr_mpoly_ts_append(gr_mpoly_ts_t A,
                 gr_ptr Bcoeff, ulong * Bexps, slong Blen, slong N, gr_ctx_t cctx)
 {
-/* TODO: this needs barriers on non-x86 */
-
     slong i;
     slong sz = cctx->sizeof_elem;
     ulong * oldexps = A->exps;
@@ -236,6 +238,24 @@ void gr_mpoly_ts_append(gr_mpoly_ts_t A,
 
         /* do not free oldcoeffs/oldexps as other threads may be using them */
     }
+
+    /* Other threads may read A->length (see the matching acquire fence
+       at each call site below) to decide how much of A->coeffs/A->exps
+       is safe to consume, without holding H->mutex -- this is deliberate
+       (a full lock here would serialize every single append). On
+       strongly-ordered hardware (x86) plain stores already become
+       visible to other cores in program order, but on weakly-ordered
+       hardware like ARM, the data writes above (and, when we just
+       reallocated, the A->exps/A->coeffs/A->alloc/A->idx updates too) could
+       otherwise become visible to another core *after* the A->length store
+       below, letting a concurrent reader see a length that claims more terms
+       are available than are actually visible yet.
+
+       TODO: port this guard to fmpz_mpoly / nmod_mpoly (where threaded
+       division is currently disabled on ARM). */
+#if FLINT_USES_PTHREAD
+    atomic_thread_fence(memory_order_release);
+#endif
 
     /* update length at the very end */
     A->length = newlength;
@@ -1688,6 +1708,13 @@ void trychunk(worker_arg_t W, divides_heap_chunk_t L)
 
     /* process more quotient terms if available */
     q_prev_length = Q->length;
+#if FLINT_USES_PTHREAD
+    /* pairs with the release fence in gr_mpoly_ts_append: guarantees that
+       everything the producer wrote before publishing this length (the
+       new terms' coeffs/exps, and, after a growth, Q->coeffs/Q->exps
+       themselves) is visible before we read them via chunk_mulsub below */
+    atomic_thread_fence(memory_order_acquire);
+#endif
     if (q_prev_length > L->mq)
     {
         if (L->producer == 0 && q_prev_length - L->mq < 20)
@@ -1705,6 +1732,9 @@ void trychunk(worker_arg_t W, divides_heap_chunk_t L)
 
         /* process the remaining quotient terms */
         q_prev_length = Q->length;
+#if FLINT_USES_PTHREAD
+        atomic_thread_fence(memory_order_acquire);
+#endif
         if (q_prev_length > L->mq)
             chunk_mulsub(W, L, q_prev_length);
 

--- a/src/gr_mpoly/divrem_heap.c
+++ b/src/gr_mpoly/divrem_heap.c
@@ -469,21 +469,10 @@ static int _gr_mpoly_divrem_heap(
     {
         mpoly_monomial_set(exp, heap[1].exp, N);
 
-        if (bits <= FLINT_BITS)
+        if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
         {
-            if (mpoly_monomial_overflows(exp, N, mask))
-            {
-                *overflowed = 1;
-                goto cleanup;
-            }
-        }
-        else
-        {
-            if (mpoly_monomial_overflows_mp(exp, N, bits))
-            {
-                *overflowed = 1;
-                goto cleanup;
-            }
+            *overflowed = 1;
+            goto cleanup;
         }
 
         _gr_mpoly_fit_length(&q_coeff, &Q->coeffs_alloc, &q_exp, &Q->exps_alloc, N, q_len + 1, ctx);

--- a/src/gr_mpoly/divrem_heap_threaded.c
+++ b/src/gr_mpoly/divrem_heap_threaded.c
@@ -544,24 +544,12 @@ slong _gr_mpoly_divrem_stripe(
         /* see the comment on the single-word overflow check above:
            this can legitimately happen even for well-chosen bits, and
            means "redo everything wider", not GR_UNABLE. */
-        if (bits <= FLINT_BITS)
+        if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
         {
-            if (mpoly_monomial_overflows(exp, N, mask))
-            {
-                *overflowed = 1;
-                goto unable;
-            }
-            lt_divides = mpoly_monomial_divides(Qexp + N*Qlen, exp, Bexp + N*0, N, mask);
+            *overflowed = 1;
+            goto unable;
         }
-        else
-        {
-            if (mpoly_monomial_overflows_mp(exp, N, bits))
-            {
-                *overflowed = 1;
-                goto unable;
-            }
-            lt_divides = mpoly_monomial_divides_mp(Qexp + N*Qlen, exp, Bexp + N*0, N, bits);
-        }
+        lt_divides = mpoly_monomial_divides_any_bits(Qexp + N*Qlen, exp, Bexp + N*0, N, mask, bits);
 
         FLINT_ASSERT(mpoly_monomial_cmp(exp, S->emin, N, S->cmpmask) >= 0);
 

--- a/src/gr_mpoly/divrem_ideal.c
+++ b/src/gr_mpoly/divrem_ideal.c
@@ -74,8 +74,8 @@
         else \
         { \
             hinds[x->p][x->i] |= WORD(1); \
-            SET_SHALLOW(dot_a, dot_len, poly3[x->p]->coeffs, x->i); \
-            SET_SHALLOW(dot_b, dot_len, Q[x->p]->coeffs, x->j); \
+            SET_SHALLOW(dot_a, dot_len, poly3[x->p].coeffs, x->i); \
+            SET_SHALLOW(dot_b, dot_len, Q[x->p].coeffs, x->j); \
             dot_len++; \
         } \
     } while (0)
@@ -84,14 +84,14 @@
 #define IDEAL_QCOEFF(dst, w, val) \
     (lc_is_one[w]  ? gr_set(dst, val, cctx) \
      : lc_is_unit[w] ? gr_mul(dst, val, GR_ENTRY(lc_inv, w, sz), cctx) \
-                     : gr_div(dst, val, GR_ENTRY(poly3[w]->coeffs, 0, sz), cctx))
+                     : gr_div(dst, val, GR_ENTRY(poly3[w].coeffs, 0, sz), cctx))
 
 
 /* single-word exponent version */
 static int _gr_mpoly_divrem_ideal_mp1(
-    gr_mpoly_struct ** Q, gr_mpoly_t R, int * overflowed, int nonfield,
+    gr_mpoly_struct * Q, gr_mpoly_t R, int * overflowed, int nonfield,
     gr_srcptr coeff2, const ulong * exp2, slong len2,
-    gr_mpoly_struct * const * poly3, ulong * const * exp3, slong len,
+    const gr_mpoly_struct * poly3, ulong * const * exp3, slong len,
     flint_bitcnt_t bits, ulong maskhi,
     gr_mpoly_ctx_t ctx)
 {
@@ -128,7 +128,7 @@ static int _gr_mpoly_divrem_ideal_mp1(
     chains = (mpoly_nheap_t **) TMP_ALLOC(len*sizeof(mpoly_nheap_t *));
     hinds = (slong **) TMP_ALLOC(len*sizeof(slong *));
     for (w = 0; w < len; w++)
-        len3 += poly3[w]->length;
+        len3 += poly3[w].length;
     chains_ptr = (mpoly_nheap_t *) TMP_ALLOC(len3*sizeof(mpoly_nheap_t));
     hinds_ptr = (slong *) TMP_ALLOC(len3*sizeof(slong));
 
@@ -137,8 +137,8 @@ static int _gr_mpoly_divrem_ideal_mp1(
     {
         chains[w] = chains_ptr + len3;
         hinds[w] = hinds_ptr + len3;
-        len3 += poly3[w]->length;
-        for (i = 0; i < poly3[w]->length; i++)
+        len3 += poly3[w].length;
+        for (i = 0; i < poly3[w].length; i++)
             hinds[w][i] = 1;
     }
 
@@ -154,7 +154,7 @@ static int _gr_mpoly_divrem_ideal_mp1(
     for (w = 0; w < len; w++)
     {
         k[w] = -WORD(1);
-        s[w] = poly3[w]->length;
+        s[w] = poly3[w].length;
     }
 
     lc_inv = flint_malloc(len * sz);
@@ -166,9 +166,9 @@ static int _gr_mpoly_divrem_ideal_mp1(
         lc_is_one[w] = lc_is_unit[w] = 0;
         if (!nonfield)
         {
-            lc_is_one[w] = (gr_is_one(GR_ENTRY(poly3[w]->coeffs, 0, sz), cctx) == T_TRUE);
+            lc_is_one[w] = (gr_is_one(GR_ENTRY(poly3[w].coeffs, 0, sz), cctx) == T_TRUE);
             lc_is_unit[w] = lc_is_one[w] ||
-                (gr_inv(GR_ENTRY(lc_inv, w, sz), GR_ENTRY(poly3[w]->coeffs, 0, sz), cctx) == GR_SUCCESS);
+                (gr_inv(GR_ENTRY(lc_inv, w, sz), GR_ENTRY(poly3[w].coeffs, 0, sz), cctx) == GR_SUCCESS);
         }
     }
 
@@ -231,8 +231,8 @@ static int _gr_mpoly_divrem_ideal_mp1(
                     else
                     {
                         hinds[x->p][x->i] |= WORD(1);
-                        status |= gr_mul(pp, GR_ENTRY(poly3[x->p]->coeffs, x->i, sz),
-                                             GR_ENTRY(Q[x->p]->coeffs, x->j, sz), cctx);
+                        status |= gr_mul(pp, GR_ENTRY(poly3[x->p].coeffs, x->i, sz),
+                                             GR_ENTRY(Q[x->p].coeffs, x->j, sz), cctx);
                         status |= gr_sub(acc, acc, pp, cctx);
                     }
                 } while ((x = x->next) != NULL);
@@ -261,7 +261,7 @@ static int _gr_mpoly_divrem_ideal_mp1(
             }
             else
             {
-                if ((i + 1 < poly3[p]->length) && (hinds[p][i + 1] == 2*j + 1))
+                if ((i + 1 < poly3[p].length) && (hinds[p][i + 1] == 2*j + 1))
                 {
                     x = chains[p] + i + 1;
                     x->i = i + 1;
@@ -269,7 +269,7 @@ static int _gr_mpoly_divrem_ideal_mp1(
                     x->p = p;
                     x->next = NULL;
                     hinds[p][x->i] = 2*(x->j + 1) + 0;
-                    _mpoly_heap_insert1(heap, exp3[p][x->i] + Q[p]->exps[x->j], x,
+                    _mpoly_heap_insert1(heap, exp3[p][x->i] + Q[p].exps[x->j], x,
                                              &next_loc, &heap_len, maskhi);
                 }
                 if (j == k[p])
@@ -285,7 +285,7 @@ static int _gr_mpoly_divrem_ideal_mp1(
                     x->p = p;
                     x->next = NULL;
                     hinds[p][x->i] = 2*(x->j + 1) + 0;
-                    _mpoly_heap_insert1(heap, exp3[p][x->i] + Q[p]->exps[x->j], x,
+                    _mpoly_heap_insert1(heap, exp3[p][x->i] + Q[p].exps[x->j], x,
                                              &next_loc, &heap_len, maskhi);
                 }
             }
@@ -311,30 +311,30 @@ static int _gr_mpoly_divrem_ideal_mp1(
                 if (!d1)
                     continue;
 
-                _gr_mpoly_fit_length(&Q[w]->coeffs, &Q[w]->coeffs_alloc,
-                                     &Q[w]->exps, &Q[w]->exps_alloc, 1, k[w] + 2, ctx);
+                _gr_mpoly_fit_length(&Q[w].coeffs, &Q[w].coeffs_alloc,
+                                     &Q[w].exps, &Q[w].exps_alloc, 1, k[w] + 2, ctx);
 
                 if (nonfield)
                 {
-                    cstatus = gr_euclidean_divrem(GR_ENTRY(Q[w]->coeffs, k[w] + 1, sz),
-                                     rem, acc, GR_ENTRY(poly3[w]->coeffs, 0, sz), cctx);
+                    cstatus = gr_euclidean_divrem(GR_ENTRY(Q[w].coeffs, k[w] + 1, sz),
+                                     rem, acc, GR_ENTRY(poly3[w].coeffs, 0, sz), cctx);
                     if (cstatus != GR_SUCCESS) { status |= cstatus; goto cleanup; }
                     gr_swap(acc, rem, cctx);
-                    d2 = (gr_is_zero(GR_ENTRY(Q[w]->coeffs, k[w] + 1, sz), cctx) != T_TRUE);
+                    d2 = (gr_is_zero(GR_ENTRY(Q[w].coeffs, k[w] + 1, sz), cctx) != T_TRUE);
                 }
                 else
                 {
-                    cstatus = IDEAL_QCOEFF(GR_ENTRY(Q[w]->coeffs, k[w] + 1, sz), w, acc);
+                    cstatus = IDEAL_QCOEFF(GR_ENTRY(Q[w].coeffs, k[w] + 1, sz), w, acc);
                     if (cstatus == GR_DOMAIN)
                         continue;
                     if (cstatus != GR_SUCCESS) { status |= cstatus; goto cleanup; }
-                    d2 = (gr_is_zero(GR_ENTRY(Q[w]->coeffs, k[w] + 1, sz), cctx) != T_TRUE);
+                    d2 = (gr_is_zero(GR_ENTRY(Q[w].coeffs, k[w] + 1, sz), cctx) != T_TRUE);
                 }
 
                 if (d2)
                 {
                     k[w]++;
-                    Q[w]->exps[k[w]] = texp;
+                    Q[w].exps[k[w]] = texp;
 
                     if (s[w] > 1)
                     {
@@ -344,7 +344,7 @@ static int _gr_mpoly_divrem_ideal_mp1(
                         x->p = w;
                         x->next = NULL;
                         hinds[w][x->i] = 2*(x->j + 1) + 0;
-                        _mpoly_heap_insert1(heap, exp3[w][1] + Q[w]->exps[k[w]], x,
+                        _mpoly_heap_insert1(heap, exp3[w][1] + Q[w].exps[k[w]], x,
                                                  &next_loc, &heap_len, maskhi);
                     }
                     s[w] = 1;
@@ -388,13 +388,13 @@ cleanup:
     if (*overflowed || status != GR_SUCCESS)
     {
         for (w = 0; w < len; w++)
-            Q[w]->length = 0;
+            Q[w].length = 0;
         R->length = 0;
     }
     else
     {
         for (w = 0; w < len; w++)
-            Q[w]->length = k[w] + 1;
+            Q[w].length = k[w] + 1;
         R->length = r_len;
     }
 
@@ -405,9 +405,9 @@ cleanup:
 
 
 static int _gr_mpoly_divrem_ideal_mp(
-    gr_mpoly_struct ** Q, gr_mpoly_t R, int * overflowed, int nonfield,
+    gr_mpoly_struct * Q, gr_mpoly_t R, int * overflowed, int nonfield,
     gr_srcptr coeff2, const ulong * exp2, slong len2,
-    gr_mpoly_struct * const * poly3, ulong * const * exp3, slong len,
+    const gr_mpoly_struct * poly3, ulong * const * exp3, slong len,
     flint_bitcnt_t bits, slong N, const ulong * cmpmask,
     gr_mpoly_ctx_t ctx)
 {
@@ -452,7 +452,7 @@ static int _gr_mpoly_divrem_ideal_mp(
     chains = (mpoly_nheap_t **) TMP_ALLOC(len*sizeof(mpoly_nheap_t *));
     hinds = (slong **) TMP_ALLOC(len*sizeof(slong *));
     for (w = 0; w < len; w++)
-        len3 += poly3[w]->length;
+        len3 += poly3[w].length;
     chains_ptr = (mpoly_nheap_t *) TMP_ALLOC(len3*sizeof(mpoly_nheap_t));
     hinds_ptr = (slong *) TMP_ALLOC(len3*sizeof(slong));
 
@@ -461,8 +461,8 @@ static int _gr_mpoly_divrem_ideal_mp(
     {
         chains[w] = chains_ptr + len3;
         hinds[w] = hinds_ptr + len3;
-        len3 += poly3[w]->length;
-        for (i = 0; i < poly3[w]->length; i++)
+        len3 += poly3[w].length;
+        for (i = 0; i < poly3[w].length; i++)
             hinds[w][i] = 1;
     }
 
@@ -486,7 +486,7 @@ static int _gr_mpoly_divrem_ideal_mp(
     for (w = 0; w < len; w++)
     {
         k[w] = -WORD(1);
-        s[w] = poly3[w]->length;
+        s[w] = poly3[w].length;
     }
 
     lc_inv = flint_malloc(len * sz);
@@ -498,9 +498,9 @@ static int _gr_mpoly_divrem_ideal_mp(
         lc_is_one[w] = lc_is_unit[w] = 0;
         if (!nonfield)
         {
-            lc_is_one[w] = (gr_is_one(GR_ENTRY(poly3[w]->coeffs, 0, sz), cctx) == T_TRUE);
+            lc_is_one[w] = (gr_is_one(GR_ENTRY(poly3[w].coeffs, 0, sz), cctx) == T_TRUE);
             lc_is_unit[w] = lc_is_one[w] ||
-                (gr_inv(GR_ENTRY(lc_inv, w, sz), GR_ENTRY(poly3[w]->coeffs, 0, sz), cctx) == GR_SUCCESS);
+                (gr_inv(GR_ENTRY(lc_inv, w, sz), GR_ENTRY(poly3[w].coeffs, 0, sz), cctx) == GR_SUCCESS);
         }
     }
 
@@ -519,21 +519,10 @@ static int _gr_mpoly_divrem_ideal_mp(
     {
         mpoly_monomial_set(exp, heap[1].exp, N);
 
-        if (bits <= FLINT_BITS)
+        if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
         {
-            if (mpoly_monomial_overflows(exp, N, mask))
-            {
-                *overflowed = 1;
-                goto cleanup;
-            }
-        }
-        else
-        {
-            if (mpoly_monomial_overflows_mp(exp, N, bits))
-            {
-                *overflowed = 1;
-                goto cleanup;
-            }
+            *overflowed = 1;
+            goto cleanup;
         }
 
         store_len = 0;
@@ -578,8 +567,8 @@ static int _gr_mpoly_divrem_ideal_mp(
                     else
                     {
                         hinds[x->p][x->i] |= WORD(1);
-                        status |= gr_mul(pp, GR_ENTRY(poly3[x->p]->coeffs, x->i, sz),
-                                             GR_ENTRY(Q[x->p]->coeffs, x->j, sz), cctx);
+                        status |= gr_mul(pp, GR_ENTRY(poly3[x->p].coeffs, x->i, sz),
+                                             GR_ENTRY(Q[x->p].coeffs, x->j, sz), cctx);
                         status |= gr_sub(acc, acc, pp, cctx);
                     }
                 } while ((x = x->next) != NULL);
@@ -609,7 +598,7 @@ static int _gr_mpoly_divrem_ideal_mp(
             }
             else
             {
-                if ((i + 1 < poly3[p]->length) && (hinds[p][i + 1] == 2*j + 1))
+                if ((i + 1 < poly3[p].length) && (hinds[p][i + 1] == 2*j + 1))
                 {
                     x = chains[p] + i + 1;
                     x->i = i + 1;
@@ -617,7 +606,7 @@ static int _gr_mpoly_divrem_ideal_mp(
                     x->p = p;
                     x->next = NULL;
                     hinds[p][x->i] = 2*(x->j + 1) + 0;
-                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3[p] + x->i*N, Q[p]->exps + x->j*N, N, bits);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3[p] + x->i*N, Q[p].exps + x->j*N, N, bits);
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
                 }
@@ -634,7 +623,7 @@ static int _gr_mpoly_divrem_ideal_mp(
                     x->p = p;
                     x->next = NULL;
                     hinds[p][x->i] = 2*(x->j + 1) + 0;
-                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3[p] + x->i*N, Q[p]->exps + x->j*N, N, bits);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3[p] + x->i*N, Q[p].exps + x->j*N, N, bits);
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
                 }
@@ -662,30 +651,30 @@ static int _gr_mpoly_divrem_ideal_mp(
                 if (!d1)
                     continue;
 
-                _gr_mpoly_fit_length(&Q[w]->coeffs, &Q[w]->coeffs_alloc,
-                                     &Q[w]->exps, &Q[w]->exps_alloc, N, k[w] + 2, ctx);
+                _gr_mpoly_fit_length(&Q[w].coeffs, &Q[w].coeffs_alloc,
+                                     &Q[w].exps, &Q[w].exps_alloc, N, k[w] + 2, ctx);
 
                 if (nonfield)
                 {
-                    cstatus = gr_euclidean_divrem(GR_ENTRY(Q[w]->coeffs, k[w] + 1, sz),
-                                     rem, acc, GR_ENTRY(poly3[w]->coeffs, 0, sz), cctx);
+                    cstatus = gr_euclidean_divrem(GR_ENTRY(Q[w].coeffs, k[w] + 1, sz),
+                                     rem, acc, GR_ENTRY(poly3[w].coeffs, 0, sz), cctx);
                     if (cstatus != GR_SUCCESS) { status |= cstatus; goto cleanup; }
                     gr_swap(acc, rem, cctx);   /* acc <- euclidean remainder */
-                    d2 = (gr_is_zero(GR_ENTRY(Q[w]->coeffs, k[w] + 1, sz), cctx) != T_TRUE);
+                    d2 = (gr_is_zero(GR_ENTRY(Q[w].coeffs, k[w] + 1, sz), cctx) != T_TRUE);
                 }
                 else
                 {
-                    cstatus = IDEAL_QCOEFF(GR_ENTRY(Q[w]->coeffs, k[w] + 1, sz), w, acc);
+                    cstatus = IDEAL_QCOEFF(GR_ENTRY(Q[w].coeffs, k[w] + 1, sz), w, acc);
                     if (cstatus == GR_DOMAIN)
                         continue;   /* this divisor cannot divide exactly */
                     if (cstatus != GR_SUCCESS) { status |= cstatus; goto cleanup; }
-                    d2 = (gr_is_zero(GR_ENTRY(Q[w]->coeffs, k[w] + 1, sz), cctx) != T_TRUE);
+                    d2 = (gr_is_zero(GR_ENTRY(Q[w].coeffs, k[w] + 1, sz), cctx) != T_TRUE);
                 }
 
                 if (d2)
                 {
                     k[w]++;
-                    mpoly_monomial_set(Q[w]->exps + k[w]*N, texp, N);
+                    mpoly_monomial_set(Q[w].exps + k[w]*N, texp, N);
 
                     if (s[w] > 1)
                     {
@@ -695,7 +684,7 @@ static int _gr_mpoly_divrem_ideal_mp(
                         x->p = w;
                         x->next = NULL;
                         hinds[w][x->i] = 2*(x->j + 1) + 0;
-                        mpoly_monomial_add_any_bits(exp_list[exp_next], exp3[w] + N, Q[w]->exps + k[w]*N, N, bits);
+                        mpoly_monomial_add_any_bits(exp_list[exp_next], exp3[w] + N, Q[w].exps + k[w]*N, N, bits);
                         exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                                  &next_loc, &heap_len, N, cmpmask);
                     }
@@ -742,13 +731,13 @@ cleanup:
     if (*overflowed || status != GR_SUCCESS)
     {
         for (w = 0; w < len; w++)
-            Q[w]->length = 0;
+            Q[w].length = 0;
         R->length = 0;
     }
     else
     {
         for (w = 0; w < len; w++)
-            Q[w]->length = k[w] + 1;
+            Q[w].length = k[w] + 1;
         R->length = r_len;
     }
 
@@ -768,8 +757,8 @@ cleanup:
     gr_mpoly_div/gr_mpoly_divrem in divrem_heap_threaded.c).
 */
 int _gr_mpoly_divrem_ideal(
-    gr_mpoly_struct ** Q, gr_mpoly_t R,
-    const gr_mpoly_t A, gr_mpoly_struct * const * B, slong len,
+    gr_mpoly_struct * Q, gr_mpoly_t R,
+    const gr_mpoly_t A, const gr_mpoly_struct * B, slong len,
     int nonfield, gr_mpoly_ctx_t ctx)
 {
     mpoly_ctx_struct * mctx = GR_MPOLY_MCTX(ctx);
@@ -782,24 +771,37 @@ int _gr_mpoly_divrem_ideal(
     int free2 = 0, * free3, overflowed;
     gr_mpoly_t TR;
     gr_mpoly_struct * r;
+    gr_mpoly_struct * q;
+    gr_mpoly_struct * TQarr = NULL;
     int status = GR_SUCCESS;
     TMP_INIT;
 
     for (i = 0; i < len; i++)
     {
-        if (B[i]->length == 0)
+        if (B[i].length == 0)
             return GR_DOMAIN;   /* division by zero */
-        if (gr_is_zero(B[i]->coeffs, cctx) != T_FALSE)
+        if (gr_is_zero(B[i].coeffs, cctx) != T_FALSE)
             return GR_UNABLE;
-        len3 = FLINT_MAX(len3, B[i]->length);
+        len3 = FLINT_MAX(len3, B[i].length);
     }
 
     if (A->length == 0)
     {
         for (i = 0; i < len; i++)
-            status |= gr_mpoly_zero(Q[i], ctx);
+            status |= gr_mpoly_zero(&Q[i], ctx);
         status |= gr_mpoly_zero(R, ctx);
         return status;
+    }
+
+    FLINT_ASSERT(Q != (gr_mpoly_struct *) A);
+    q = (Q == B) ? NULL : Q;   /* NULL signals: aliased, switch to TQarr below */
+
+    if (q == NULL)
+    {
+        TQarr = (gr_mpoly_struct *) flint_malloc(len*sizeof(gr_mpoly_struct));
+        for (i = 0; i < len; i++)
+            gr_mpoly_init(TQarr + i, ctx);
+        q = TQarr;
     }
 
     TMP_START;
@@ -809,7 +811,7 @@ int _gr_mpoly_divrem_ideal(
 
     exp_bits = A->bits;
     for (i = 0; i < len; i++)
-        exp_bits = FLINT_MAX(exp_bits, B[i]->bits);
+        exp_bits = FLINT_MAX(exp_bits, B[i].bits);
     exp_bits = mpoly_fix_bits(exp_bits, mctx);
 
     MPOLY_GET_CMPMASK_FLINT_MALLOC(cmpmask, N, exp_bits, mctx);
@@ -824,16 +826,16 @@ int _gr_mpoly_divrem_ideal(
 
     for (i = 0; i < len; i++)
     {
-        exp3[i] = B[i]->exps;
+        exp3[i] = B[i].exps;
         free3[i] = 0;
-        if (exp_bits > B[i]->bits)
+        if (exp_bits > B[i].bits)
         {
             free3[i] = 1;
-            exp3[i] = (ulong *) flint_malloc(N*B[i]->length*sizeof(ulong));
-            mpoly_repack_monomials(exp3[i], exp_bits, B[i]->exps, B[i]->bits,
-                                                            B[i]->length, mctx);
+            exp3[i] = (ulong *) flint_malloc(N*B[i].length*sizeof(ulong));
+            mpoly_repack_monomials(exp3[i], exp_bits, B[i].exps, B[i].bits,
+                                                            B[i].length, mctx);
         }
-        gr_mpoly_fit_length_reset_bits(Q[i], 1, exp_bits, ctx);
+        gr_mpoly_fit_length_reset_bits(&q[i], 1, exp_bits, ctx);
     }
 
     /* if lm(A) < lm(B[i]) for all i, the quotients are zero and R = A */
@@ -847,11 +849,18 @@ int _gr_mpoly_divrem_ideal(
     {
         status |= gr_mpoly_set(R, A, ctx);
         for (i = 0; i < len; i++)
-            status |= gr_mpoly_zero(Q[i], ctx);
+            status |= gr_mpoly_zero(&Q[i], ctx);
+        if (q == TQarr)
+        {
+            for (i = 0; i < len; i++)
+                gr_mpoly_clear(TQarr + i, ctx);
+            flint_free(TQarr);
+        }
         goto cleanup;
     }
 
-    /* handle aliasing of R with A */
+    FLINT_ASSERT(R < B || R >= B + len);
+
     if (R == A)
     {
         gr_mpoly_init3(TR, len3, exp_bits, ctx);
@@ -867,7 +876,7 @@ int _gr_mpoly_divrem_ideal(
     {
         r->bits = exp_bits;
 
-        status = _gr_mpoly_divrem_ideal_mp(Q, r, &overflowed, nonfield,
+        status = _gr_mpoly_divrem_ideal_mp(q, r, &overflowed, nonfield,
                             A->coeffs, exp2, A->length,
                             B, exp3, len, exp_bits, N, cmpmask, ctx);
 
@@ -891,14 +900,24 @@ int _gr_mpoly_divrem_ideal(
             for (i = 0; i < len; i++)
             {
                 old_exp3 = exp3[i];
-                exp3[i] = (ulong *) flint_malloc(N*B[i]->length*sizeof(ulong));
+                exp3[i] = (ulong *) flint_malloc(N*B[i].length*sizeof(ulong));
                 mpoly_repack_monomials(exp3[i], exp_bits, old_exp3, old_exp_bits,
-                                                            B[i]->length, mctx);
+                                                            B[i].length, mctx);
                 if (free3[i]) flint_free(old_exp3);
                 free3[i] = 1;
-                gr_mpoly_fit_length_reset_bits(Q[i], 1, exp_bits, ctx);
+                gr_mpoly_fit_length_reset_bits(&q[i], 1, exp_bits, ctx);
             }
         }
+    }
+
+    if (q == TQarr)
+    {
+        for (i = 0; i < len; i++)
+        {
+            gr_mpoly_swap(&Q[i], TQarr + i, ctx);
+            gr_mpoly_clear(TQarr + i, ctx);
+        }
+        flint_free(TQarr);
     }
 
     if (r == TR)
@@ -910,7 +929,7 @@ int _gr_mpoly_divrem_ideal(
     if (status != GR_SUCCESS)
     {
         for (i = 0; i < len; i++)
-            GR_IGNORE(gr_mpoly_zero(Q[i], ctx));
+            GR_IGNORE(gr_mpoly_zero(&Q[i], ctx));
         GR_IGNORE(gr_mpoly_zero(R, ctx));
     }
 
@@ -931,31 +950,18 @@ cleanup:
 }
 
 
-/* build pointer arrays from the quotient/divisor vectors and run the kernel */
+/* gr_mpoly_vec_t's entries are already one contiguous gr_mpoly_struct
+   array, matching what the kernel wants directly -- no pointer-array
+   repacking needed. */
 static int
 _gr_mpoly_divrem_ideal_vec(gr_mpoly_vec_t Q, gr_mpoly_t R,
     const gr_mpoly_t A, const gr_mpoly_vec_t B, int nonfield, gr_mpoly_ctx_t ctx)
 {
-    slong w, len = B->length;
-    gr_mpoly_struct ** Qptr, ** Bptr;
-    int status;
+    slong len = B->length;
 
     gr_mpoly_vec_set_length(Q, len, ctx);
 
-    Qptr = (gr_mpoly_struct **) flint_malloc(len*sizeof(gr_mpoly_struct *));
-    Bptr = (gr_mpoly_struct **) flint_malloc(len*sizeof(gr_mpoly_struct *));
-    for (w = 0; w < len; w++)
-    {
-        Qptr[w] = Q->entries + w;
-        Bptr[w] = B->entries + w;
-    }
-
-    status = _gr_mpoly_divrem_ideal(Qptr, R, A, Bptr, len, nonfield, ctx);
-
-    flint_free(Qptr);
-    flint_free(Bptr);
-
-    return status;
+    return _gr_mpoly_divrem_ideal(Q->entries, R, A, B->entries, len, nonfield, ctx);
 }
 
 /*

--- a/src/gr_mpoly/divrem_ideal_heap_threaded.c
+++ b/src/gr_mpoly/divrem_ideal_heap_threaded.c
@@ -64,7 +64,7 @@
         else \
         { \
             hinds[x->p][x->i] |= WORD(1); \
-            SET_SHALLOW(dot_a, dot_len, poly3[x->p]->coeffs, x->i); \
+            SET_SHALLOW(dot_a, dot_len, poly3[x->p].coeffs, x->i); \
             SET_SHALLOW(dot_b, dot_len, Qcoeff[x->p], x->j); \
             dot_len++; \
         } \
@@ -74,7 +74,7 @@
 #define IDEAL_STRIPE_QCOEFF(dst, w, val) \
     (lc_is_one[w]  ? gr_set(dst, val, cctx) \
      : lc_is_unit[w] ? gr_mul(dst, val, GR_ENTRY(lc_inv, w, sz), cctx) \
-                     : gr_div(dst, val, GR_ENTRY(poly3[w]->coeffs, 0, sz), cctx))
+                     : gr_div(dst, val, GR_ENTRY(poly3[w].coeffs, 0, sz), cctx))
 
 
 /*
@@ -117,7 +117,7 @@ typedef struct
     ideal_chunk_struct * tail;
     ideal_chunk_struct * volatile cur;
     gr_mpoly_t polyA;
-    gr_mpoly_struct * const * polyB; /* array of length `len`, shallow */
+    const gr_mpoly_struct * polyB;   /* array of length `len`, shallow */
     gr_mpoly_ts_struct * polyQ;      /* array of length `len` */
     gr_mpoly_ts_t polyR;
     gr_mpoly_ctx_struct * ctx;
@@ -275,7 +275,7 @@ typedef ideal_stripe_out_struct ideal_stripe_out_t[1];
 static void _gr_mpoly_divrem_ideal_stripe1(
     ideal_stripe_out_t * Qout, ideal_stripe_out_t Wout,
     gr_srcptr Acoeff, const ulong * Aexp, slong Alen,
-    gr_mpoly_struct * const * poly3, slong len,
+    const gr_mpoly_struct * poly3, slong len,
     ulong emin, ulong cmpmask, flint_bitcnt_t bits,
     int nonfield, int * lc_is_one, int * lc_is_unit, gr_srcptr lc_inv,
     gr_mpoly_ctx_t ctx, int * res_status, int * overflowed)
@@ -320,7 +320,7 @@ static void _gr_mpoly_divrem_ideal_stripe1(
     chains = (mpoly_nheap_t **) TMP_ALLOC(len*sizeof(mpoly_nheap_t *));
     hinds = (slong **) TMP_ALLOC(len*sizeof(slong *));
     for (w = 0; w < len; w++)
-        len3 += poly3[w]->length;
+        len3 += poly3[w].length;
     chains_ptr = (mpoly_nheap_t *) TMP_ALLOC(len3*sizeof(mpoly_nheap_t));
     hinds_ptr = (slong *) TMP_ALLOC(len3*sizeof(slong));
 
@@ -329,8 +329,8 @@ static void _gr_mpoly_divrem_ideal_stripe1(
     {
         chains[w] = chains_ptr + len3;
         hinds[w] = hinds_ptr + len3;
-        len3 += poly3[w]->length;
-        for (i = 0; i < poly3[w]->length; i++)
+        len3 += poly3[w].length;
+        for (i = 0; i < poly3[w].length; i++)
             hinds[w][i] = 1;
     }
 
@@ -346,7 +346,7 @@ static void _gr_mpoly_divrem_ideal_stripe1(
     for (w = 0; w < len; w++)
     {
         k[w] = -WORD(1);
-        s[w] = poly3[w]->length;
+        s[w] = poly3[w].length;
     }
 
     mask = mpoly_overflow_mask_sp(bits);
@@ -412,7 +412,7 @@ static void _gr_mpoly_divrem_ideal_stripe1(
                     else
                     {
                         hinds[x->p][x->i] |= WORD(1);
-                        status |= gr_mul(pp, GR_ENTRY(poly3[x->p]->coeffs, x->i, sz),
+                        status |= gr_mul(pp, GR_ENTRY(poly3[x->p].coeffs, x->i, sz),
                                              GR_ENTRY(Qcoeff[x->p], x->j, sz), cctx);
                         status |= gr_sub(acc, acc, pp, cctx);
                     }
@@ -445,7 +445,7 @@ static void _gr_mpoly_divrem_ideal_stripe1(
             }
             else
             {
-                if ((i + 1 < poly3[p]->length) && (hinds[p][i + 1] == 2*j + 1))
+                if ((i + 1 < poly3[p].length) && (hinds[p][i + 1] == 2*j + 1))
                 {
                     x = chains[p] + i + 1;
                     x->i = i + 1;
@@ -454,7 +454,7 @@ static void _gr_mpoly_divrem_ideal_stripe1(
                     x->next = NULL;
                     hinds[p][x->i] = 2*(x->j + 1) + 0;
 
-                    texp = poly3[p]->exps[x->i] + Qout[p]->exps[x->j];
+                    texp = poly3[p].exps[x->i] + Qout[p]->exps[x->j];
                     if (mpoly_monomial_cmp1(texp, emin, cmpmask) >= 0)
                         _mpoly_heap_insert1(heap, texp, x, &next_loc, &heap_len, cmpmask);
                     else
@@ -474,7 +474,7 @@ static void _gr_mpoly_divrem_ideal_stripe1(
                     x->next = NULL;
                     hinds[p][x->i] = 2*(x->j + 1) + 0;
 
-                    texp = poly3[p]->exps[x->i] + Qout[p]->exps[x->j];
+                    texp = poly3[p].exps[x->i] + Qout[p]->exps[x->j];
                     if (mpoly_monomial_cmp1(texp, emin, cmpmask) >= 0)
                         _mpoly_heap_insert1(heap, texp, x, &next_loc, &heap_len, cmpmask);
                     else
@@ -498,7 +498,7 @@ static void _gr_mpoly_divrem_ideal_stripe1(
             {
                 int d1, d2;
 
-                d1 = mpoly_monomial_divides1(&texp, exp, poly3[w]->exps[0], mask);
+                d1 = mpoly_monomial_divides1(&texp, exp, poly3[w].exps[0], mask);
 
                 if (!d1)
                     continue;
@@ -509,7 +509,7 @@ static void _gr_mpoly_divrem_ideal_stripe1(
                 if (nonfield)
                 {
                     cstatus = gr_euclidean_divrem(GR_ENTRY(Qcoeff[w], k[w] + 1, sz),
-                                     rem, acc, GR_ENTRY(poly3[w]->coeffs, 0, sz), cctx);
+                                     rem, acc, GR_ENTRY(poly3[w].coeffs, 0, sz), cctx);
                     if (cstatus != GR_SUCCESS) { status |= cstatus; goto unable; }
                     gr_swap(acc, rem, cctx);
                     d2 = (gr_is_zero(GR_ENTRY(Qcoeff[w], k[w] + 1, sz), cctx) != T_TRUE);
@@ -537,7 +537,7 @@ static void _gr_mpoly_divrem_ideal_stripe1(
                         x->next = NULL;
                         hinds[w][x->i] = 2*(x->j + 1) + 0;
 
-                        texp = poly3[w]->exps[1] + Qout[w]->exps[k[w]];
+                        texp = poly3[w].exps[1] + Qout[w]->exps[k[w]];
                         if (mpoly_monomial_cmp1(texp, emin, cmpmask) >= 0)
                             _mpoly_heap_insert1(heap, texp, x, &next_loc, &heap_len, cmpmask);
                         else
@@ -602,7 +602,7 @@ cleanup:
 static void _gr_mpoly_divrem_ideal_stripe(
     ideal_stripe_out_t * Qout, ideal_stripe_out_t Wout,
     gr_srcptr Acoeff, const ulong * Aexp, slong Alen,
-    gr_mpoly_struct * const * poly3, slong len,
+    const gr_mpoly_struct * poly3, slong len,
     const ulong * emin, const ulong * cmpmask, slong N, flint_bitcnt_t bits,
     int nonfield, int * lc_is_one, int * lc_is_unit, gr_srcptr lc_inv,
     gr_mpoly_ctx_t ctx, int * res_status, int * overflowed)
@@ -649,7 +649,7 @@ static void _gr_mpoly_divrem_ideal_stripe(
     chains = (mpoly_nheap_t **) TMP_ALLOC(len*sizeof(mpoly_nheap_t *));
     hinds = (slong **) TMP_ALLOC(len*sizeof(slong *));
     for (w = 0; w < len; w++)
-        len3 += poly3[w]->length;
+        len3 += poly3[w].length;
     chains_ptr = (mpoly_nheap_t *) TMP_ALLOC(len3*sizeof(mpoly_nheap_t));
     hinds_ptr = (slong *) TMP_ALLOC(len3*sizeof(slong));
 
@@ -658,8 +658,8 @@ static void _gr_mpoly_divrem_ideal_stripe(
     {
         chains[w] = chains_ptr + len3;
         hinds[w] = hinds_ptr + len3;
-        len3 += poly3[w]->length;
-        for (i = 0; i < poly3[w]->length; i++)
+        len3 += poly3[w].length;
+        for (i = 0; i < poly3[w].length; i++)
             hinds[w][i] = 1;
     }
 
@@ -683,7 +683,7 @@ static void _gr_mpoly_divrem_ideal_stripe(
     for (w = 0; w < len; w++)
     {
         k[w] = -WORD(1);
-        s[w] = poly3[w]->length;
+        s[w] = poly3[w].length;
     }
 
     mask = bits <= FLINT_BITS ? mpoly_overflow_mask_sp(bits) : 0;
@@ -703,21 +703,10 @@ static void _gr_mpoly_divrem_ideal_stripe(
     {
         mpoly_monomial_set(exp, heap[1].exp, N);
 
-        if (bits <= FLINT_BITS)
+        if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
         {
-            if (mpoly_monomial_overflows(exp, N, mask))
-            {
-                *overflowed = 1;
-                goto unable;
-            }
-        }
-        else
-        {
-            if (mpoly_monomial_overflows_mp(exp, N, bits))
-            {
-                *overflowed = 1;
-                goto unable;
-            }
+            *overflowed = 1;
+            goto unable;
         }
 
         FLINT_ASSERT(mpoly_monomial_cmp(exp, emin, N, cmpmask) >= 0);
@@ -764,7 +753,7 @@ static void _gr_mpoly_divrem_ideal_stripe(
                     else
                     {
                         hinds[x->p][x->i] |= WORD(1);
-                        status |= gr_mul(pp, GR_ENTRY(poly3[x->p]->coeffs, x->i, sz),
+                        status |= gr_mul(pp, GR_ENTRY(poly3[x->p].coeffs, x->i, sz),
                                              GR_ENTRY(Qcoeff[x->p], x->j, sz), cctx);
                         status |= gr_sub(acc, acc, pp, cctx);
                     }
@@ -798,7 +787,7 @@ static void _gr_mpoly_divrem_ideal_stripe(
             }
             else
             {
-                if ((i + 1 < poly3[p]->length) && (hinds[p][i + 1] == 2*j + 1))
+                if ((i + 1 < poly3[p].length) && (hinds[p][i + 1] == 2*j + 1))
                 {
                     x = chains[p] + i + 1;
                     x->i = i + 1;
@@ -807,7 +796,7 @@ static void _gr_mpoly_divrem_ideal_stripe(
                     x->next = NULL;
                     hinds[p][x->i] = 2*(x->j + 1) + 0;
 
-                    mpoly_monomial_add_any_bits(exp_list[exp_next], poly3[p]->exps + x->i*N, Qout[p]->exps + x->j*N, N, bits);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], poly3[p].exps + x->i*N, Qout[p]->exps + x->j*N, N, bits);
 
                     if (mpoly_monomial_cmp(exp_list[exp_next], emin, N, cmpmask) >= 0)
                         exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
@@ -829,7 +818,7 @@ static void _gr_mpoly_divrem_ideal_stripe(
                     x->next = NULL;
                     hinds[p][x->i] = 2*(x->j + 1) + 0;
 
-                    mpoly_monomial_add_any_bits(exp_list[exp_next], poly3[p]->exps + x->i*N, Qout[p]->exps + x->j*N, N, bits);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], poly3[p].exps + x->i*N, Qout[p]->exps + x->j*N, N, bits);
 
                     if (mpoly_monomial_cmp(exp_list[exp_next], emin, N, cmpmask) >= 0)
                         exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
@@ -855,7 +844,7 @@ static void _gr_mpoly_divrem_ideal_stripe(
             {
                 int d1, d2;
 
-                d1 = mpoly_monomial_divides_any_bits(texp, exp, poly3[w]->exps, N, mask, bits);
+                d1 = mpoly_monomial_divides_any_bits(texp, exp, poly3[w].exps, N, mask, bits);
 
                 if (!d1)
                     continue;
@@ -866,7 +855,7 @@ static void _gr_mpoly_divrem_ideal_stripe(
                 if (nonfield)
                 {
                     cstatus = gr_euclidean_divrem(GR_ENTRY(Qcoeff[w], k[w] + 1, sz),
-                                     rem, acc, GR_ENTRY(poly3[w]->coeffs, 0, sz), cctx);
+                                     rem, acc, GR_ENTRY(poly3[w].coeffs, 0, sz), cctx);
                     if (cstatus != GR_SUCCESS) { status |= cstatus; goto unable; }
                     gr_swap(acc, rem, cctx);
                     d2 = (gr_is_zero(GR_ENTRY(Qcoeff[w], k[w] + 1, sz), cctx) != T_TRUE);
@@ -894,7 +883,7 @@ static void _gr_mpoly_divrem_ideal_stripe(
                         x->next = NULL;
                         hinds[w][x->i] = 2*(x->j + 1) + 0;
 
-                        mpoly_monomial_add_any_bits(exp_list[exp_next], poly3[w]->exps + N, Qout[w]->exps + k[w]*N, N, bits);
+                        mpoly_monomial_add_any_bits(exp_list[exp_next], poly3[w].exps + N, Qout[w]->exps + k[w]*N, N, bits);
 
                         if (mpoly_monomial_cmp(exp_list[exp_next], emin, N, cmpmask) >= 0)
                             exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
@@ -1039,7 +1028,7 @@ static void ideal_chunk_mulsub(ideal_worker_arg_t W, ideal_chunk_t L, const slon
 
     for (w = 0; w < H->len; w++)
     {
-        gr_mpoly_struct * B = H->polyB[w];
+        const gr_mpoly_struct * B = H->polyB + w;
         gr_mpoly_ts_struct * Q = H->polyQ + w;
         slong mq = L->mq[w];
         slong new_length = q_prev_length[w];
@@ -1314,7 +1303,7 @@ static void ideal_worker_loop(void * varg)
     S->big_mem = NULL;
 
     for (w = 0; w < H->len; w++)
-        maxBlen = FLINT_MAX(maxBlen, H->polyB[w]->length);
+        maxBlen = FLINT_MAX(maxBlen, H->polyB[w].length);
     stripe_fit_length(S, maxBlen);
 
     gr_mpoly_init3(T1, 16, H->bits, H->ctx);
@@ -1371,8 +1360,8 @@ static void ideal_worker_loop(void * varg)
 
 
 static int
-_gr_mpoly_divrem_ideal_serial(gr_mpoly_struct * const * Q, gr_mpoly_t R,
-    const gr_mpoly_t A, gr_mpoly_struct * const * B, slong len,
+_gr_mpoly_divrem_ideal_serial(gr_mpoly_struct * Q, gr_mpoly_t R,
+    const gr_mpoly_t A, const gr_mpoly_struct * B, slong len,
     int nonfield, gr_mpoly_ctx_t ctx)
 {
     /*
@@ -1382,15 +1371,15 @@ _gr_mpoly_divrem_ideal_serial(gr_mpoly_struct * const * Q, gr_mpoly_t R,
         recurse indefinitely whenever this function is reached as a
         fallback from within the threaded engine itself (A, B unchanged).
     */
-    return _gr_mpoly_divrem_ideal((gr_mpoly_struct **) Q, R, A, B, len, nonfield, ctx);
+    return _gr_mpoly_divrem_ideal(Q, R, A, B, len, nonfield, ctx);
 }
 
 
 static int _gr_mpoly_divrem_ideal_heap_threaded_pool(
-    gr_mpoly_struct * const * Q,
+    gr_mpoly_struct * Q,
     gr_mpoly_t R,
     const gr_mpoly_t A,
-    gr_mpoly_struct * const * B,
+    const gr_mpoly_struct * B,
     slong len,
     gr_mpoly_ctx_t ctx,
     int nonfield,
@@ -1412,7 +1401,6 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_pool(
     ideal_worker_arg_struct * worker_args;
     ideal_base_t H;
     gr_mpoly_struct * polyB_storage;
-    gr_mpoly_struct ** polyB_ptrs;
     gr_ptr lc_inv;
     int * lc_is_one, * lc_is_unit;
     gr_mpoly_struct * TQarr;
@@ -1420,38 +1408,26 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_pool(
     gr_mpoly_t TR;
     gr_mpoly_struct * r;
 
-    if (A->length < 2 || B[0]->length < 2)
+    if (A->length < 2 || B[0].length < 2)
         return _gr_mpoly_divrem_ideal_serial(Q, R, A, B, len, nonfield, ctx);
 
-    /*
-        Use temporaries to handle aliasing of any Q[w] or R with A or any
-        B[w']: the retry loop below re-reads A->length/A->exps and
-        B[w]->length/B[w]->exps on every pass, while ideal_base_clear
-        zeroes every Q[w] and R on any non-successful attempt, including
-        the ordinary overflow-retry case. If some Q[w] or R is the same
-        object as A or a B[w'], that zeroing would corrupt the operand out
-        from under the very next loop iteration -- exactly mirroring the
-        aliasing guard already used by gr_mpoly_divrem_heap_threaded (and,
-        for R against A, the serial _gr_mpoly_divrem_ideal kernel).
-    */
-    TQarr = (gr_mpoly_struct *) flint_malloc(len*sizeof(gr_mpoly_struct));
-    q = (gr_mpoly_struct **) flint_malloc(len*sizeof(gr_mpoly_struct *));
-    for (w = 0; w < len; w++)
+    FLINT_ASSERT(Q != (gr_mpoly_struct *) A);
     {
-        int alias = (Q[w] == A);
-        for (i = 0; !alias && i < len; i++)
-            alias = (Q[w] == B[i]);
+        int alias = (Q == B);
 
-        gr_mpoly_init(TQarr + w, ctx);
-        q[w] = alias ? (TQarr + w) : Q[w];
+        TQarr = (gr_mpoly_struct *) flint_malloc(len*sizeof(gr_mpoly_struct));
+        q = (gr_mpoly_struct **) flint_malloc(len*sizeof(gr_mpoly_struct *));
+        for (w = 0; w < len; w++)
+        {
+            gr_mpoly_init(TQarr + w, ctx);
+            q[w] = alias ? (TQarr + w) : &Q[w];
+        }
     }
 
     {
-        int alias_R = (R == A);
-        for (w = 0; !alias_R && w < len; w++)
-            alias_R = (R == B[w]);
+        FLINT_ASSERT(R < B || R >= B + len);
 
-        if (alias_R)
+        if (R == A)
         {
             gr_mpoly_init(TR, ctx);
             r = TR;
@@ -1477,16 +1453,16 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_pool(
         lc_is_one[w] = lc_is_unit[w] = 0;
         if (!nonfield)
         {
-            lc_is_one[w] = (gr_is_one(GR_ENTRY(B[w]->coeffs, 0, sz), cctx) == T_TRUE);
+            lc_is_one[w] = (gr_is_one(GR_ENTRY(B[w].coeffs, 0, sz), cctx) == T_TRUE);
             lc_is_unit[w] = lc_is_one[w] ||
-                (gr_inv(GR_ENTRY(lc_inv, w, sz), GR_ENTRY(B[w]->coeffs, 0, sz), cctx) == GR_SUCCESS);
+                (gr_inv(GR_ENTRY(lc_inv, w, sz), GR_ENTRY(B[w].coeffs, 0, sz), cctx) == GR_SUCCESS);
         }
     }
 
     exp_bits = MPOLY_MIN_BITS;
     exp_bits = FLINT_MAX(exp_bits, A->bits);
     for (w = 0; w < len; w++)
-        exp_bits = FLINT_MAX(exp_bits, B[w]->bits);
+        exp_bits = FLINT_MAX(exp_bits, B[w].bits);
     exp_bits = mpoly_fix_bits(exp_bits, mctx);
 
     MPOLY_GET_CMPMASK_FLINT_MALLOC(cmpmask, N, exp_bits, mctx);
@@ -1504,29 +1480,27 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_pool(
     freeBexp = (int *) flint_malloc(len*sizeof(int));
     for (w = 0; w < len; w++)
     {
-        Bexp[w] = B[w]->exps;
+        Bexp[w] = B[w].exps;
         freeBexp[w] = 0;
-        if (exp_bits > B[w]->bits)
+        if (exp_bits > B[w].bits)
         {
             freeBexp[w] = 1;
-            Bexp[w] = (ulong *) flint_malloc(N*B[w]->length*sizeof(ulong));
-            mpoly_repack_monomials(Bexp[w], exp_bits, B[w]->exps, B[w]->bits, B[w]->length, mctx);
+            Bexp[w] = (ulong *) flint_malloc(N*B[w].length*sizeof(ulong));
+            mpoly_repack_monomials(Bexp[w], exp_bits, B[w].exps, B[w].bits, B[w].length, mctx);
         }
     }
 
     while (1)
     {
         polyB_storage = (gr_mpoly_struct *) flint_malloc(len*sizeof(gr_mpoly_struct));
-        polyB_ptrs = (gr_mpoly_struct **) flint_malloc(len*sizeof(gr_mpoly_struct *));
         for (w = 0; w < len; w++)
         {
-            polyB_ptrs[w] = polyB_storage + w;
-            polyB_storage[w].coeffs = B[w]->coeffs;
+            polyB_storage[w].coeffs = B[w].coeffs;
             polyB_storage[w].exps = Bexp[w];
             polyB_storage[w].bits = exp_bits;
-            polyB_storage[w].length = B[w]->length;
-            polyB_storage[w].coeffs_alloc = B[w]->coeffs_alloc;
-            polyB_storage[w].exps_alloc = N*B[w]->length;
+            polyB_storage[w].length = B[w].length;
+            polyB_storage[w].coeffs_alloc = B[w].coeffs_alloc;
+            polyB_storage[w].exps_alloc = N*B[w].length;
         }
 
         fmpz_mpoly_ctx_init(zctx, mctx->nvars, mctx->ord);
@@ -1540,7 +1514,7 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_pool(
             how many divisors there are.
         */
         if (mpoly_divides_select_exps(S, zctx, num_handles,
-                                       Aexp, A->length, Bexp[0], B[0]->length, exp_bits))
+                                       Aexp, A->length, Bexp[0], B[0].length, exp_bits))
         {
             /* select_exps's failure notion ("provably not exact") does not
                apply to divrem_ideal (which always succeeds via the
@@ -1550,7 +1524,6 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_pool(
             fmpz_mpoly_clear(S, zctx);
             fmpz_mpoly_ctx_clear(zctx);
             flint_free(polyB_storage);
-            flint_free(polyB_ptrs);
             for (w = 0; w < len; w++)
                 gr_mpoly_clear(TQarr + w, ctx);
             flint_free(TQarr);
@@ -1569,7 +1542,7 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_pool(
         H->polyA->coeffs_alloc = A->coeffs_alloc;
         H->polyA->exps_alloc = N*A->length;
 
-        H->polyB = polyB_ptrs;
+        H->polyB = polyB_storage;
         H->len = len;
         H->ctx = ctx;
         H->cctx = cctx;
@@ -1598,8 +1571,8 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_pool(
             L->mq = L->startidx + 2*len;
             for (w = 0; w < len; w++)
             {
-                L->startidx[w] = B[w]->length;
-                L->endidx[w] = B[w]->length;
+                L->startidx[w] = B[w].length;
+                L->endidx[w] = B[w].length;
                 L->mq[w] = 0;
             }
             L->emax = S->exps + N*i;
@@ -1669,7 +1642,6 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_pool(
             fmpz_mpoly_clear(S, zctx);
             fmpz_mpoly_ctx_clear(zctx);
             flint_free(polyB_storage);
-            flint_free(polyB_ptrs);
 
             {
                 slong old_exp_bits = exp_bits;
@@ -1688,8 +1660,8 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_pool(
                 for (w = 0; w < len; w++)
                 {
                     ulong * old_Bexp_w = Bexp[w];
-                    Bexp[w] = (ulong *) flint_malloc(N*B[w]->length*sizeof(ulong));
-                    mpoly_repack_monomials(Bexp[w], exp_bits, old_Bexp_w, old_exp_bits, B[w]->length, mctx);
+                    Bexp[w] = (ulong *) flint_malloc(N*B[w].length*sizeof(ulong));
+                    mpoly_repack_monomials(Bexp[w], exp_bits, old_Bexp_w, old_exp_bits, B[w].length, mctx);
                     if (freeBexp[w])
                         flint_free(old_Bexp_w);
                     freeBexp[w] = 1;
@@ -1706,7 +1678,6 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_pool(
         fmpz_mpoly_clear(S, zctx);
         fmpz_mpoly_ctx_clear(zctx);
         flint_free(polyB_storage);
-        flint_free(polyB_ptrs);
 
         break;
     }
@@ -1714,7 +1685,7 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_pool(
     for (w = 0; w < len; w++)
     {
         if (q[w] == TQarr + w)
-            gr_mpoly_swap(Q[w], TQarr + w, ctx);
+            gr_mpoly_swap(&Q[w], TQarr + w, ctx);
         gr_mpoly_clear(TQarr + w, ctx);
     }
     flint_free(TQarr);
@@ -1748,10 +1719,10 @@ cleanup1:
 
 
 static int _gr_mpoly_divrem_ideal_heap_threaded_dispatch(
-    gr_mpoly_struct * const * Q,
+    gr_mpoly_struct * Q,
     gr_mpoly_t R,
     const gr_mpoly_t A,
-    gr_mpoly_struct * const * B,
+    const gr_mpoly_struct * B,
     slong len,
     gr_mpoly_ctx_t ctx,
     int nonfield)
@@ -1765,9 +1736,9 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_dispatch(
 
     for (w = 0; w < len; w++)
     {
-        if (B[w]->length == 0)
+        if (B[w].length == 0)
             return GR_DOMAIN;
-        if (gr_is_zero(B[w]->coeffs, cctx) != T_FALSE)
+        if (gr_is_zero(B[w].coeffs, cctx) != T_FALSE)
             return GR_UNABLE;
     }
 
@@ -1775,14 +1746,14 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_dispatch(
     {
         status = GR_SUCCESS;
         for (w = 0; w < len; w++)
-            status |= gr_mpoly_zero(Q[w], ctx);
+            status |= gr_mpoly_zero(&Q[w], ctx);
         status |= gr_mpoly_zero(R, ctx);
         return status;
     }
 
     /* fall back to the single-threaded algorithm for small inputs, or when
        the coefficient ring does not allow concurrent operations */
-    if (A->length < 2 || B[0]->length < 2 || gr_ctx_is_threadsafe(cctx) != T_TRUE)
+    if (A->length < 2 || B[0].length < 2 || gr_ctx_is_threadsafe(cctx) != T_TRUE)
         return _gr_mpoly_divrem_ideal_serial(Q, R, A, B, len, nonfield, ctx);
 
     thread_limit = A->length/32;
@@ -1802,10 +1773,7 @@ static int
 _gr_mpoly_divrem_ideal_vec_threaded(gr_mpoly_vec_t Q, gr_mpoly_t R,
     const gr_mpoly_t A, const gr_mpoly_vec_t B, int nonfield, gr_mpoly_ctx_t ctx)
 {
-    slong w, len = B->length;
-    gr_mpoly_struct ** Qptr;
-    gr_mpoly_struct ** Bptr;
-    int status;
+    slong len = B->length;
 
     if (len == 0)
     {
@@ -1815,20 +1783,7 @@ _gr_mpoly_divrem_ideal_vec_threaded(gr_mpoly_vec_t Q, gr_mpoly_t R,
 
     gr_mpoly_vec_set_length(Q, len, ctx);
 
-    Qptr = (gr_mpoly_struct **) flint_malloc(len*sizeof(gr_mpoly_struct *));
-    Bptr = (gr_mpoly_struct **) flint_malloc(len*sizeof(gr_mpoly_struct *));
-    for (w = 0; w < len; w++)
-    {
-        Qptr[w] = Q->entries + w;
-        Bptr[w] = B->entries + w;
-    }
-
-    status = _gr_mpoly_divrem_ideal_heap_threaded_dispatch(Qptr, R, A, Bptr, len, ctx, nonfield);
-
-    flint_free(Qptr);
-    flint_free(Bptr);
-
-    return status;
+    return _gr_mpoly_divrem_ideal_heap_threaded_dispatch(Q->entries, R, A, B->entries, len, ctx, nonfield);
 }
 
 

--- a/src/gr_mpoly/divrem_ideal_heap_threaded.c
+++ b/src/gr_mpoly/divrem_ideal_heap_threaded.c
@@ -18,6 +18,10 @@
 #include "mpoly.h"
 #include "gr_generic.h"
 #include "gr_mpoly.h"
+
+#if FLINT_USES_PTHREAD
+# include <stdatomic.h>
+#endif
 #include "threaded_divmod.h"
 
 /*
@@ -1109,6 +1113,14 @@ static void ideal_trychunk(ideal_worker_arg_t W, ideal_chunk_t L)
 
     for (w = 0; w < H->len; w++)
         q_prev_length[w] = (H->polyQ + w)->length;
+#if FLINT_USES_PTHREAD
+    /* pairs with the release fence in gr_mpoly_ts_append: guarantees that
+       everything each producer wrote before publishing these lengths (the
+       new terms' coeffs/exps, and, after a growth, the corresponding
+       polyQ[w]->coeffs/exps themselves) is visible before we read them
+       via ideal_chunk_mulsub below */
+    atomic_thread_fence(memory_order_acquire);
+#endif
 
     for (w = 0; w < H->len; w++)
         if (q_prev_length[w] > L->mq[w])
@@ -1142,6 +1154,9 @@ static void ideal_trychunk(ideal_worker_arg_t W, ideal_chunk_t L)
         /* process any further quotient terms that trickled in */
         for (w = 0; w < H->len; w++)
             q_prev_length[w] = (H->polyQ + w)->length;
+#if FLINT_USES_PTHREAD
+        atomic_thread_fence(memory_order_acquire);
+#endif
         for (w = 0; w < H->len; w++)
             if (q_prev_length[w] > L->mq[w])
                 break;

--- a/src/gr_mpoly/quasidivrem_heap.c
+++ b/src/gr_mpoly/quasidivrem_heap.c
@@ -135,24 +135,12 @@ static int _gr_mpoly_quasidivrem_heap(
 
         mpoly_monomial_set(exp, heap[1].exp, N);
 
-        if (bits <= FLINT_BITS)
+        if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
         {
-            if (mpoly_monomial_overflows(exp, N, mask))
-            {
-                *overflowed = 1;
-                goto cleanup;
-            }
-            lt_divides = mpoly_monomial_divides(q_exp + q_len*N, exp, exp3, N, mask);
+            *overflowed = 1;
+            goto cleanup;
         }
-        else
-        {
-            if (mpoly_monomial_overflows_mp(exp, N, bits))
-            {
-                *overflowed = 1;
-                goto cleanup;
-            }
-            lt_divides = mpoly_monomial_divides_mp(q_exp + q_len*N, exp, exp3, N, bits);
-        }
+        lt_divides = mpoly_monomial_divides_any_bits(q_exp + q_len*N, exp, exp3, N, mask, bits);
 
         store_len = 0;
         status |= gr_zero(acc, cctx);

--- a/src/gr_mpoly/quasidivrem_ideal_heap.c
+++ b/src/gr_mpoly/quasidivrem_ideal_heap.c
@@ -48,9 +48,9 @@ _gr_vec_grow(gr_ptr * vec, slong * alloc, slong len, gr_ctx_t cctx)
 }
 
 static int _gr_mpoly_quasidivrem_ideal_heap(
-    gr_ptr scale, gr_mpoly_struct ** Q, gr_mpoly_t R, int * overflowed,
+    gr_ptr scale, gr_mpoly_struct * Q, gr_mpoly_t R, int * overflowed,
     gr_srcptr coeff2, const ulong * exp2, slong len2,
-    gr_mpoly_struct * const * poly3, ulong * const * exp3, slong len,
+    const gr_mpoly_struct * poly3, ulong * const * exp3, slong len,
     flint_bitcnt_t bits, slong N, const ulong * cmpmask,
     gr_mpoly_ctx_t ctx)
 {
@@ -89,7 +89,7 @@ static int _gr_mpoly_quasidivrem_ideal_heap(
     chains = (mpoly_nheap_t **) TMP_ALLOC(len*sizeof(mpoly_nheap_t *));
     hinds = (slong **) TMP_ALLOC(len*sizeof(slong *));
     for (w = 0; w < len; w++)
-        len3 += poly3[w]->length;
+        len3 += poly3[w].length;
     chains_ptr = (mpoly_nheap_t *) TMP_ALLOC(len3*sizeof(mpoly_nheap_t));
     hinds_ptr = (slong *) TMP_ALLOC(len3*sizeof(slong));
 
@@ -98,8 +98,8 @@ static int _gr_mpoly_quasidivrem_ideal_heap(
     {
         chains[w] = chains_ptr + len3;
         hinds[w] = hinds_ptr + len3;
-        len3 += poly3[w]->length;
-        for (i = 0; i < poly3[w]->length; i++)
+        len3 += poly3[w].length;
+        for (i = 0; i < poly3[w].length; i++)
             hinds[w][i] = 1;
     }
 
@@ -124,7 +124,7 @@ static int _gr_mpoly_quasidivrem_ideal_heap(
     for (w = 0; w < len; w++)
     {
         k[w] = WORD(0);
-        s[w] = poly3[w]->length;
+        s[w] = poly3[w].length;
         qs_alloc[w] = 16;
         qs[w] = flint_malloc(qs_alloc[w] * sz);
         _gr_vec_init(qs[w], qs_alloc[w], cctx);
@@ -148,21 +148,10 @@ static int _gr_mpoly_quasidivrem_ideal_heap(
     {
         mpoly_monomial_set(exp, heap[1].exp, N);
 
-        if (bits <= FLINT_BITS)
+        if (mpoly_monomial_overflows_any_bits(exp, N, mask, bits))
         {
-            if (mpoly_monomial_overflows(exp, N, mask))
-            {
-                *overflowed = 1;
-                goto cleanup;
-            }
-        }
-        else
-        {
-            if (mpoly_monomial_overflows_mp(exp, N, bits))
-            {
-                *overflowed = 1;
-                goto cleanup;
-            }
+            *overflowed = 1;
+            goto cleanup;
         }
 
         store_len = 0;
@@ -196,15 +185,15 @@ static int _gr_mpoly_quasidivrem_ideal_heap(
                     /* quotient term: - poly3[p][i] * (scale/qs[p][j]) * Q[p][j] */
                     if (scaleis1)
                     {
-                        status |= gr_mul(pp, GR_ENTRY(poly3[x->p]->coeffs, x->i, sz),
-                                             GR_ENTRY(Q[x->p]->coeffs, x->j, sz), cctx);
+                        status |= gr_mul(pp, GR_ENTRY(poly3[x->p].coeffs, x->i, sz),
+                                             GR_ENTRY(Q[x->p].coeffs, x->j, sz), cctx);
                         status |= gr_sub(acc, acc, pp, cctx);
                     }
                     else
                     {
                         status |= gr_divexact(tp, scale, GR_ENTRY(qs[x->p], x->j, sz), cctx);
-                        status |= gr_mul(tp, tp, GR_ENTRY(Q[x->p]->coeffs, x->j, sz), cctx);
-                        status |= gr_mul(pp, GR_ENTRY(poly3[x->p]->coeffs, x->i, sz), tp, cctx);
+                        status |= gr_mul(tp, tp, GR_ENTRY(Q[x->p].coeffs, x->j, sz), cctx);
+                        status |= gr_mul(pp, GR_ENTRY(poly3[x->p].coeffs, x->i, sz), tp, cctx);
                         status |= gr_sub(acc, acc, pp, cctx);
                     }
                 }
@@ -234,7 +223,7 @@ static int _gr_mpoly_quasidivrem_ideal_heap(
             }
             else
             {
-                if ((i + 1 < poly3[p]->length) && (hinds[p][i + 1] == 2*j + 1))
+                if ((i + 1 < poly3[p].length) && (hinds[p][i + 1] == 2*j + 1))
                 {
                     x = chains[p] + i + 1;
                     x->i = i + 1;
@@ -242,7 +231,7 @@ static int _gr_mpoly_quasidivrem_ideal_heap(
                     x->p = p;
                     x->next = NULL;
                     hinds[p][x->i] = 2*(x->j + 1) + 0;
-                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3[p] + x->i*N, Q[p]->exps + x->j*N, N, bits);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3[p] + x->i*N, Q[p].exps + x->j*N, N, bits);
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
                 }
@@ -259,7 +248,7 @@ static int _gr_mpoly_quasidivrem_ideal_heap(
                     x->p = p;
                     x->next = NULL;
                     hinds[p][x->i] = 2*(x->j + 1) + 0;
-                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3[p] + x->i*N, Q[p]->exps + x->j*N, N, bits);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3[p] + x->i*N, Q[p].exps + x->j*N, N, bits);
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
                 }
@@ -290,30 +279,30 @@ static int _gr_mpoly_quasidivrem_ideal_heap(
                 if (!d1)
                     continue;
 
-                _gr_mpoly_fit_length(&Q[w]->coeffs, &Q[w]->coeffs_alloc,
-                                     &Q[w]->exps, &Q[w]->exps_alloc, N, k[w] + 1, ctx);
+                _gr_mpoly_fit_length(&Q[w].coeffs, &Q[w].coeffs_alloc,
+                                     &Q[w].exps, &Q[w].exps_alloc, N, k[w] + 1, ctx);
                 _gr_vec_grow(&qs[w], &qs_alloc[w], k[w] + 1, cctx);
 
                 /* pseudo-quotient coefficient, scaling up if inexact */
-                cstatus = gr_div(GR_ENTRY(Q[w]->coeffs, k[w], sz), acc,
-                                     GR_ENTRY(poly3[w]->coeffs, 0, sz), cctx);
+                cstatus = gr_div(GR_ENTRY(Q[w].coeffs, k[w], sz), acc,
+                                     GR_ENTRY(poly3[w].coeffs, 0, sz), cctx);
                 if (cstatus == GR_SUCCESS)
                 {
                     status |= gr_set(GR_ENTRY(qs[w], k[w], sz), scale, cctx);
                 }
                 else if (cstatus == GR_DOMAIN)
                 {
-                    gr_srcptr lc = GR_ENTRY(poly3[w]->coeffs, 0, sz);
+                    gr_srcptr lc = GR_ENTRY(poly3[w].coeffs, 0, sz);
 
                     if (gr_gcd(g, acc, lc, cctx) == GR_SUCCESS)
                     {
-                        status |= gr_divexact(GR_ENTRY(Q[w]->coeffs, k[w], sz), acc, g, cctx);
+                        status |= gr_divexact(GR_ENTRY(Q[w].coeffs, k[w], sz), acc, g, cctx);
                         status |= gr_divexact(ns, lc, g, cctx);
                         status |= gr_mul(scale, scale, ns, cctx);
                     }
                     else
                     {
-                        status |= gr_set(GR_ENTRY(Q[w]->coeffs, k[w], sz), acc, cctx);
+                        status |= gr_set(GR_ENTRY(Q[w].coeffs, k[w], sz), acc, cctx);
                         status |= gr_mul(scale, scale, lc, cctx);
                     }
                     status |= gr_set(GR_ENTRY(qs[w], k[w], sz), scale, cctx);
@@ -325,7 +314,7 @@ static int _gr_mpoly_quasidivrem_ideal_heap(
                     goto cleanup;
                 }
 
-                mpoly_monomial_set(Q[w]->exps + k[w]*N, texp, N);
+                mpoly_monomial_set(Q[w].exps + k[w]*N, texp, N);
 
                 if (s[w] > 1)
                 {
@@ -335,7 +324,7 @@ static int _gr_mpoly_quasidivrem_ideal_heap(
                     x->p = w;
                     x->next = NULL;
                     hinds[w][x->i] = 2*(x->j + 1) + 0;
-                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3[w] + N, Q[w]->exps + k[w]*N, N, bits);
+                    mpoly_monomial_add_any_bits(exp_list[exp_next], exp3[w] + N, Q[w].exps + k[w]*N, N, bits);
                     exp_next += _mpoly_heap_insert(heap, exp_list[exp_next], x,
                                              &next_loc, &heap_len, N, cmpmask);
                 }
@@ -364,7 +353,7 @@ static int _gr_mpoly_quasidivrem_ideal_heap(
         for (i = 0; i < k[w] && status == GR_SUCCESS; i++)
         {
             status |= gr_divexact(tp, scale, GR_ENTRY(qs[w], i, sz), cctx);
-            status |= gr_mul(GR_ENTRY(Q[w]->coeffs, i, sz), GR_ENTRY(Q[w]->coeffs, i, sz), tp, cctx);
+            status |= gr_mul(GR_ENTRY(Q[w].coeffs, i, sz), GR_ENTRY(Q[w].coeffs, i, sz), tp, cctx);
         }
     }
     for (i = 0; i < r_len && status == GR_SUCCESS; i++)
@@ -390,13 +379,13 @@ cleanup:
     if (*overflowed || status != GR_SUCCESS)
     {
         for (w = 0; w < len; w++)
-            Q[w]->length = 0;
+            Q[w].length = 0;
         R->length = 0;
     }
     else
     {
         for (w = 0; w < len; w++)
-            Q[w]->length = k[w];
+            Q[w].length = k[w];
         R->length = r_len;
     }
 
@@ -407,8 +396,8 @@ cleanup:
 
 
 static int _gr_mpoly_quasidivrem_ideal_arr(
-    gr_ptr scale, gr_mpoly_struct ** Q, gr_mpoly_t R,
-    const gr_mpoly_t A, gr_mpoly_struct * const * B, slong len,
+    gr_ptr scale, gr_mpoly_struct * Q, gr_mpoly_t R,
+    const gr_mpoly_t A, const gr_mpoly_struct * B, slong len,
     gr_mpoly_ctx_t ctx)
 {
     mpoly_ctx_struct * mctx = GR_MPOLY_MCTX(ctx);
@@ -421,25 +410,38 @@ static int _gr_mpoly_quasidivrem_ideal_arr(
     int free2 = 0, * free3, overflowed;
     gr_mpoly_t TR;
     gr_mpoly_struct * r;
+    gr_mpoly_struct * q;
+    gr_mpoly_struct * TQarr = NULL;
     int status = GR_SUCCESS;
     TMP_INIT;
 
     for (i = 0; i < len; i++)
     {
-        if (B[i]->length == 0)
+        if (B[i].length == 0)
             return GR_DOMAIN;
-        if (gr_is_zero(B[i]->coeffs, cctx) != T_FALSE)
+        if (gr_is_zero(B[i].coeffs, cctx) != T_FALSE)
             return GR_UNABLE;
-        len3 = FLINT_MAX(len3, B[i]->length);
+        len3 = FLINT_MAX(len3, B[i].length);
     }
 
     if (A->length == 0)
     {
         status = gr_one(scale, cctx);
         for (i = 0; i < len; i++)
-            status |= gr_mpoly_zero(Q[i], ctx);
+            status |= gr_mpoly_zero(&Q[i], ctx);
         status |= gr_mpoly_zero(R, ctx);
         return status;
+    }
+
+    FLINT_ASSERT(Q != (gr_mpoly_struct *) A);
+    q = (Q == B) ? NULL : Q;   /* NULL signals: aliased, switch to TQarr below */
+
+    if (q == NULL)
+    {
+        TQarr = (gr_mpoly_struct *) flint_malloc(len*sizeof(gr_mpoly_struct));
+        for (i = 0; i < len; i++)
+            gr_mpoly_init(TQarr + i, ctx);
+        q = TQarr;
     }
 
     TMP_START;
@@ -449,7 +451,7 @@ static int _gr_mpoly_quasidivrem_ideal_arr(
 
     exp_bits = A->bits;
     for (i = 0; i < len; i++)
-        exp_bits = FLINT_MAX(exp_bits, B[i]->bits);
+        exp_bits = FLINT_MAX(exp_bits, B[i].bits);
     exp_bits = mpoly_fix_bits(exp_bits, mctx);
 
     MPOLY_GET_CMPMASK_FLINT_MALLOC(cmpmask, N, exp_bits, mctx);
@@ -464,16 +466,16 @@ static int _gr_mpoly_quasidivrem_ideal_arr(
 
     for (i = 0; i < len; i++)
     {
-        exp3[i] = B[i]->exps;
+        exp3[i] = B[i].exps;
         free3[i] = 0;
-        if (exp_bits > B[i]->bits)
+        if (exp_bits > B[i].bits)
         {
             free3[i] = 1;
-            exp3[i] = (ulong *) flint_malloc(N*B[i]->length*sizeof(ulong));
-            mpoly_repack_monomials(exp3[i], exp_bits, B[i]->exps, B[i]->bits,
-                                                            B[i]->length, mctx);
+            exp3[i] = (ulong *) flint_malloc(N*B[i].length*sizeof(ulong));
+            mpoly_repack_monomials(exp3[i], exp_bits, B[i].exps, B[i].bits,
+                                                            B[i].length, mctx);
         }
-        gr_mpoly_fit_length_reset_bits(Q[i], 1, exp_bits, ctx);
+        gr_mpoly_fit_length_reset_bits(&q[i], 1, exp_bits, ctx);
     }
 
     /* if lm(A) < lm(B[i]) for all i, quotients are zero and R = A */
@@ -488,9 +490,17 @@ static int _gr_mpoly_quasidivrem_ideal_arr(
         status |= gr_one(scale, cctx);
         status |= gr_mpoly_set(R, A, ctx);
         for (i = 0; i < len; i++)
-            status |= gr_mpoly_zero(Q[i], ctx);
+            status |= gr_mpoly_zero(&Q[i], ctx);
+        if (q == TQarr)
+        {
+            for (i = 0; i < len; i++)
+                gr_mpoly_clear(TQarr + i, ctx);
+            flint_free(TQarr);
+        }
         goto cleanup;
     }
+
+    FLINT_ASSERT(R < B || R >= B + len);
 
     if (R == A)
     {
@@ -507,7 +517,7 @@ static int _gr_mpoly_quasidivrem_ideal_arr(
     {
         r->bits = exp_bits;
 
-        status = _gr_mpoly_quasidivrem_ideal_heap(scale, Q, r, &overflowed,
+        status = _gr_mpoly_quasidivrem_ideal_heap(scale, q, r, &overflowed,
                             A->coeffs, exp2, A->length,
                             B, exp3, len, exp_bits, N, cmpmask, ctx);
 
@@ -531,14 +541,24 @@ static int _gr_mpoly_quasidivrem_ideal_arr(
             for (i = 0; i < len; i++)
             {
                 old_exp3 = exp3[i];
-                exp3[i] = (ulong *) flint_malloc(N*B[i]->length*sizeof(ulong));
+                exp3[i] = (ulong *) flint_malloc(N*B[i].length*sizeof(ulong));
                 mpoly_repack_monomials(exp3[i], exp_bits, old_exp3, old_exp_bits,
-                                                            B[i]->length, mctx);
+                                                            B[i].length, mctx);
                 if (free3[i]) flint_free(old_exp3);
                 free3[i] = 1;
-                gr_mpoly_fit_length_reset_bits(Q[i], 1, exp_bits, ctx);
+                gr_mpoly_fit_length_reset_bits(&q[i], 1, exp_bits, ctx);
             }
         }
+    }
+
+    if (q == TQarr)
+    {
+        for (i = 0; i < len; i++)
+        {
+            gr_mpoly_swap(&Q[i], TQarr + i, ctx);
+            gr_mpoly_clear(TQarr + i, ctx);
+        }
+        flint_free(TQarr);
     }
 
     if (r == TR)
@@ -550,7 +570,7 @@ static int _gr_mpoly_quasidivrem_ideal_arr(
     if (status != GR_SUCCESS)
     {
         for (i = 0; i < len; i++)
-            GR_IGNORE(gr_mpoly_zero(Q[i], ctx));
+            GR_IGNORE(gr_mpoly_zero(&Q[i], ctx));
         GR_IGNORE(gr_mpoly_zero(R, ctx));
         GR_IGNORE(gr_one(scale, cctx));
     }
@@ -577,24 +597,9 @@ int gr_mpoly_quasidivrem_ideal(
     const gr_mpoly_t A, const gr_mpoly_vec_t B,
     gr_mpoly_ctx_t ctx)
 {
-    slong w, len = B->length;
-    gr_mpoly_struct ** Qptr, ** Bptr;
-    int status;
+    slong len = B->length;
 
     gr_mpoly_vec_set_length(Q, len, ctx);
 
-    Qptr = (gr_mpoly_struct **) flint_malloc(len*sizeof(gr_mpoly_struct *));
-    Bptr = (gr_mpoly_struct **) flint_malloc(len*sizeof(gr_mpoly_struct *));
-    for (w = 0; w < len; w++)
-    {
-        Qptr[w] = Q->entries + w;
-        Bptr[w] = B->entries + w;
-    }
-
-    status = _gr_mpoly_quasidivrem_ideal_arr(scale, Qptr, R, A, Bptr, len, ctx);
-
-    flint_free(Qptr);
-    flint_free(Bptr);
-
-    return status;
+    return _gr_mpoly_quasidivrem_ideal_arr(scale, Q->entries, R, A, B->entries, len, ctx);
 }

--- a/src/gr_mpoly/test/t-divrem_ideal.c
+++ b/src/gr_mpoly/test/t-divrem_ideal.c
@@ -101,7 +101,7 @@ TEST_FUNCTION_START(gr_mpoly_divrem_ideal, state)
             status = gr_mpoly_divrem_ideal(Q, R, A, B, ctx);
 
             /* field-like */
-            switch (n_randint(state, 4) * 0)
+            switch (n_randint(state, 4))
             {
                 case 0:
                     status = gr_mpoly_divrem_ideal(Q, R, A, B, ctx);

--- a/src/gr_mpoly/test/t-divrem_ideal_heap_threaded.c
+++ b/src/gr_mpoly/test/t-divrem_ideal_heap_threaded.c
@@ -83,8 +83,35 @@ TEST_FUNCTION_START(gr_mpoly_divrem_ideal_heap_threaded, state)
         {
             s1 = nonfield ? gr_mpoly_divrem_ideal_weak(Q1, R1, A, B, ctx)
                           : gr_mpoly_divrem_ideal(Q1, R1, A, B, ctx);
-            s2 = nonfield ? gr_mpoly_divrem_ideal_weak_heap_threaded(Q2, R2, A, B, ctx)
-                          : gr_mpoly_divrem_ideal_heap_threaded(Q2, R2, A, B, ctx);
+
+            /* exercise aliasing of the threaded call's own Q2/R2 with its
+               own A/B arguments (Q2 == B, or R2 == A); B and A themselves
+               are never mutated here (Q2/R2 receive copies beforehand),
+               so the later comparisons against Q1/R1/B/A below remain
+               valid regardless of which case is taken */
+            switch (n_randint(state, 4))
+            {
+                case 0:
+                    s2 = nonfield ? gr_mpoly_divrem_ideal_weak_heap_threaded(Q2, R2, A, B, ctx)
+                                  : gr_mpoly_divrem_ideal_heap_threaded(Q2, R2, A, B, ctx);
+                    break;
+                case 1:
+                    status |= gr_mpoly_vec_set(Q2, B, ctx);
+                    s2 = nonfield ? gr_mpoly_divrem_ideal_weak_heap_threaded(Q2, R2, A, Q2, ctx)
+                                  : gr_mpoly_divrem_ideal_heap_threaded(Q2, R2, A, Q2, ctx);
+                    break;
+                case 2:
+                    status |= gr_mpoly_set(R2, A, ctx);
+                    s2 = nonfield ? gr_mpoly_divrem_ideal_weak_heap_threaded(Q2, R2, R2, B, ctx)
+                                  : gr_mpoly_divrem_ideal_heap_threaded(Q2, R2, R2, B, ctx);
+                    break;
+                default:
+                    status |= gr_mpoly_set(R2, A, ctx);
+                    status |= gr_mpoly_vec_set(Q2, B, ctx);
+                    s2 = nonfield ? gr_mpoly_divrem_ideal_weak_heap_threaded(Q2, R2, R2, Q2, ctx)
+                                  : gr_mpoly_divrem_ideal_heap_threaded(Q2, R2, R2, Q2, ctx);
+                    break;
+            }
 
             if (cctx->which_ring != GR_CTX_DEBUG && s1 != s2)
             {

--- a/src/gr_mpoly/test/t-quasidivrem_ideal.c
+++ b/src/gr_mpoly/test/t-quasidivrem_ideal.c
@@ -64,7 +64,7 @@ TEST_FUNCTION_START(gr_mpoly_quasidivrem_ideal, state)
 
         if (status == GR_SUCCESS)
         {
-            switch (n_randint(state, 4) * 0)
+            switch (n_randint(state, 4))
             {
                 case 0:
                     status = gr_mpoly_quasidivrem_ideal(scale, Q, R, A, B, ctx);

--- a/src/gr_mpoly/threaded_divmod.h
+++ b/src/gr_mpoly/threaded_divmod.h
@@ -376,8 +376,8 @@ int _gr_mpoly_divrem_mp(
     directly, for the same reason _gr_mpoly_divrem_mp is exposed above.
 */
 int _gr_mpoly_divrem_ideal(
-    gr_mpoly_struct ** Q, gr_mpoly_t R,
-    const gr_mpoly_t A, gr_mpoly_struct * const * B, slong len,
+    gr_mpoly_struct * Q, gr_mpoly_t R,
+    const gr_mpoly_t A, const gr_mpoly_struct * B, slong len,
     int nonfield, gr_mpoly_ctx_t ctx);
 
 #endif


### PR DESCRIPTION
Followup patch to recent commits:
* Avoid temporary of array of pointers to ideal entries (data structure inherited from the original `fmpz_mpoly`/`nmod_mpoly` code, no longer needed here)
* Fix and test some aliasing cases
* Use helper functions instead of duplicated code in a few places missed previously