### PR TITLE
Generic DFT (gr_dft)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -224,7 +224,7 @@ HEADER_DIRS	:=	\
 															\
 		gr			gr_generic	gr_vec		gr_mat			\
 		gr_poly		gr_mpoly	gr_ore_poly					\
-		gr_series	gr_special								\
+		gr_series	gr_special	gr_dft						\
 															\
 		calcium												\
 															\

--- a/doc/source/gr_dft.rst
+++ b/doc/source/gr_dft.rst
@@ -1,0 +1,706 @@
+.. _gr-dft:
+
+**gr_dft.h** -- fast Fourier transforms over generic rings
+===============================================================================
+
+This module implements discrete Fourier transforms of arbitrary length
+over generic rings. Given a ring `R`, an integer `n \ge 1`, and a
+principal `n`-th root of unity `w \in R` (meaning that
+`\sum_{j=0}^{n-1} w^{jk} = 0` for every `k \not\equiv 0 \pmod n`;
+over an integral domain, any primitive `n`-th root of unity qualifies),
+the forward transform of `(x_0, \ldots, x_{n-1})` is
+
+.. math::
+
+    X_k = \sum_{j=0}^{n-1} x_j w^{jk}
+
+and the inverse transform is
+
+.. math::
+
+    x_j = \frac{1}{n} \sum_{k=0}^{n-1} X_k w^{-jk}.
+
+Over `\mathbb{C}`, taking `w = e^{-2\pi i/n}` (the default chosen by
+:func:`gr_dft_default_root`) recovers the classical DFT with the same
+convention as the :ref:`acb_dft <acb-dft>` module.
+
+The fast algorithms rely on the principality of `w` (concretely,
+identities such as `1 + w^{n/p} + w^{2n/p} + \cdots + w^{(p-1)n/p} = 0`
+for the primes `p \mid n`); this condition is only partially checked
+by the plan constructors, and using a non-principal root gives
+undefined results.
+
+Transforms are performed with respect to a precomputed *plan*
+(:type:`gr_dft_pre_t`) which stores the algorithm parameters together
+with a table of the roots of unity `w^0, w^1, \ldots, w^{n-1}` and,
+optionally, tables for complex Karatsuba multiplication (see below).
+
+Algorithms and flags
+-------------------------------------------------------------------------------
+
+The *alg* parameter of the plan constructors selects the algorithm:
+
+* ``GR_DFT_ALG_AUTO`` -- choose automatically based on the length.
+* ``GR_DFT_ALG_NAIVE`` -- direct `O(n^2)` evaluation.
+* ``GR_DFT_ALG_CT`` -- iterative radix-2 Cooley-Tukey, performing
+  `\tfrac{1}{2} n \log_2 n` multiplications by roots of unity.
+* ``GR_DFT_ALG_BAILEY`` -- the four-step (Bailey) algorithm, which
+  decomposes a transform of length `n = n_1 n_2` with
+  `n_1, n_2 \approx \sqrt{n}` into column transforms of length `n_2`,
+  pointwise twiddle multiplications, row transforms of length `n_1`,
+  and a final transposition. This is cache-friendlier than plain
+  Cooley-Tukey for transforms too large to fit in cache. The row and
+  column transforms currently use radix-2 Cooley-Tukey sub-plans.
+  This is the algorithm supporting multithreading (see below), and
+  ``GR_DFT_ALG_AUTO`` selects it for large power-of-two lengths.
+* ``GR_DFT_ALG_SPLIT`` -- recursive split-radix, performing about
+  `\tfrac{1}{3} n \log_2 n` multiplications by nontrivial roots of
+  unity when multiplication by `w^{n/4}` (playing the role of `-i`)
+  is free, as in complex mode. In complex mode with Karatsuba products
+  enabled, the number of real multiplications is `n \log_2 n - 3n + 4`,
+  which meets the minimal
+  counts of the Winograd small-FFT (WFTA) modules for
+  `n \in \{4, 8, 16\}` (`0`, `4` and `20` real multiplications) and
+  is within a few multiplications of the Heideman-Burrus lower bound
+  `4n - 2\log_2^2 n - 2\log_2 n - 4` beyond that. This algorithm
+  always produces natural ordering and works out of place internally.
+* ``GR_DFT_ALG_PFA`` -- the Good-Thomas prime factor algorithm for a
+  composite length `n = n_1 n_2` with `\gcd(n_1, n_2) = 1`. With the
+  input index map `j = (n_2 j_1 + n_1 j_2) \bmod n` and the CRT output
+  index map `k \equiv k_1 \pmod{n_1}`, `k \equiv k_2 \pmod{n_2}`,
+  the transform becomes a pure two-dimensional DFT of size
+  `n_1 \times n_2` with roots `w^{n_2}` and `w^{n_1}`, requiring *no*
+  twiddle factors between the two stages. The sub-transforms use
+  automatically chosen sub-plans; with ``GR_DFT_ALG_AUTO``, a general
+  length is decomposed recursively into its coprime prime power
+  components this way. Requires at least two distinct prime factors.
+* ``GR_DFT_ALG_MIXED`` -- recursive mixed-radix Cooley-Tukey
+  decimation in time, splitting off one prime factor `p` per
+  recursion level. Transforms of prime length `p` are computed by a
+  direct kernel using the identity `1 + v + \cdots + v^{p-1} = 0`
+  (with `v = w^{n/p}`) to eliminate one root power, which requires
+  `(p-1)(p-2)` multiplications by roots of unity instead of the naive
+  `(p-1)^2`; for `p = 3`, for instance,
+  `X_1 = (x_0 - x_2) + v (x_1 - x_2)` and
+  `X_2 = (x_0 - x_1) + v (x_2 - x_1)`. For a prime power `n = p^e`
+  with `p` large, a Bluestein sub-plan is used for the length-`p`
+  transforms when possible (see below).
+* ``GR_DFT_ALG_BLUESTEIN`` -- Bluestein's chirp-z algorithm for odd
+  lengths. Writing `t = (n+1)/2` (so that `2t \equiv 1 \pmod n`),
+  the identity `jk \equiv t (j^2 + k^2 - (j-k)^2) \pmod n` turns the
+  transform into a cyclic convolution of the chirped input
+  `w^{t j^2} x_j` with the even, `n`-periodic kernel `w^{-t j^2}`,
+  which is embedded in a cyclic convolution of power-of-two length
+  `\ge 2n - 1` and evaluated with a power-of-two sub-plan (two fast
+  transforms plus a pointwise multiplication by the precomputed
+  transformed kernel). All chirp factors are entries of the root
+  table. The power-of-two sub-plan requires a root of unity for the
+  convolution length, obtained with :func:`gr_dft_default_root`;
+  over rings where this fails (e.g. finite fields without roots of
+  the required order), Bluestein is unavailable and plans fall back
+  to direct prime kernels.
+
+The *flags* parameter is a bitwise combination of:
+
+* ``GR_DFT_SCRAMBLED`` -- the forward transform leaves the output in
+  scrambled order and the inverse transform expects its input in the
+  same scrambled order. This saves the reordering passes, which is
+  useful, for example, when computing convolutions
+  (forward transform, pointwise multiplication, inverse transform)
+  where the intermediate order is irrelevant. The scrambled order is
+  bit-reversed for ``GR_DFT_ALG_NAIVE`` and ``GR_DFT_ALG_CT`` and
+  a matrix transposition (a partial bit reversal) for
+  ``GR_DFT_ALG_BAILEY``; the precise permutation can be queried with
+  :func:`gr_dft_precomp_output_perm`. The flag is only supported for
+  power-of-two lengths with these three algorithms, and is cleared in
+  the plan (so that natural ordering is used) in all other cases.
+
+Complex mode and Karatsuba multiplication
+-------------------------------------------------------------------------------
+
+When the ring is a complex extension `C = R[i]` of a real ring `R`, with
+elements of `C` stored as a real and an imaginary part laid out
+contiguously as two elements of `R` (as with ``acb`` over ``arb``),
+plans can be constructed in *complex mode* with
+:func:`gr_dft_precomp_init_karatsuba`, passing the real ring `R` as
+*real_ctx* in addition to the ring `C` as *ctx*. It is the user's
+responsibility to ensure that the element layout assumption holds; the
+constructor verifies at least that the element size of *ctx* is twice
+that of *real_ctx*, returning ``GR_UNABLE`` otherwise.
+
+Complex mode always uses the standard root `w = e^{-2\pi i/n}` (there
+is no variant taking a user-supplied root), so the special powers of
+`w` are known structurally from their exponents, with no value
+inspection: the quarter points `\pm 1`, `\pm i` are free rotations,
+and the odd multiples of `n/8`, which are of the form `c(1 \pm i)`,
+require only 2 real multiplications. Note that no comparison of
+computed values could certify these forms over inexact rings such as
+``acb``, where the enclosure of, say, `d + c` is a ball around zero;
+the cheap multiplication formulas use at most the enclosure of `c`, so
+enclosures of the exact products are still obtained over ball rings.
+These special rotations are used at any precision. The root table is
+computed as `w^j = \operatorname{exp}(-2\pi i j/n)` directly when
+possible, giving tighter enclosures over inexact rings than a chain of
+multiplications.
+
+In addition, multiplications by the remaining (generic) roots of unity
+can be performed with 3 instead of 4 multiplications in `R`, using the
+complex Karatsuba formula (also attributed to Gauss) for multiplication
+by a precomputed complex constant: for a root `w = c + di` and an
+element `x = x_r + x_i i`,
+
+.. math::
+
+    k_1 = c (x_r + x_i), \quad
+    \operatorname{Re}(wx) = k_1 - x_i (d + c), \quad
+    \operatorname{Im}(wx) = k_1 + x_r (d - c),
+
+where the values `c`, `d - c` and `d + c` are stored in the plan. This
+trades one multiplication for three additions per root multiplication,
+which is profitable when multiplications in `R` are expensive compared
+to additions. The Karatsuba products are therefore only enabled over
+exact rings (where the number of multiplications is what matters) and
+over inexact rings at sufficiently high working precision, as reported
+by :func:`gr_ctx_get_real_prec`; at low precision, a native complex
+multiplication (a single multiplication in `C`) is used for the generic
+roots instead, which is faster e.g. for ``acb`` at machine-word
+precisions.
+
+Drop-in transforms for acb vectors
+-------------------------------------------------------------------------------
+
+The module provides drop-in replacements for :func:`acb_dft` and
+:func:`acb_dft_inverse` which compute correct enclosures of the DFT of
+an ``acb`` vector, using either ball arithmetic or the fixed-point
+contexts internally.
+
+.. function:: void gr_dft_acb(acb_ptr w, acb_srcptr v, slong n, slong prec)
+              void gr_dft_acb_inverse(acb_ptr w, acb_srcptr v, slong n, slong prec)
+              int _gr_dft_acb(acb_ptr w, acb_srcptr v, slong n, int inverse, int which, slong prec)
+
+    Sets `w_k = \sum_j v_j e^{-2\pi i jk/n}` (respectively the
+    inverse with the `1/n` scaling), where the output balls contain
+    the exact transform of every point of the input balls. *w* may
+    alias *v*. The underscore variant selects the internal arithmetic
+    (*which*: 0 automatic, 1 ``acb`` ball arithmetic, 2 fixed-point)
+    and returns ``GR_UNABLE`` if the requested path cannot handle the
+    input (e.g. non-finite midpoints or precision beyond the
+    fixed-point range); in automatic mode such inputs are routed to
+    the ball path.
+
+    In the fixed-point path, only the input midpoints pass through the
+    transform: they are scaled by an exact power of two, determined
+    from the magnitude bound of the plan so that every intermediate
+    value satisfies the `|t| < 1` requirement, and truncated to fixed
+    point with error below 1 ulp per component. The output radii are
+    the sum of two independently computed bounds: the fixed-point
+    roundoff and root-table error from
+    :func:`gr_dft_precomp_nfixed_bound`, and the effect of the input
+    radii, which is not propagated through the computation but bounded
+    directly by the DFT perturbation inequality
+    `|\Delta X_k| \le \sum_j |\Delta x_j|` (the transform matrix
+    and its unscaled inverse have unit-modulus entries), evaluated
+    once with upward rounding. This is both sharper and cheaper than
+    pushing intervals through the transform, and makes the radii of
+    the input independent of the working precision of the kernel.
+
+    The number of limbs is chosen exactly, with no over-provisioning:
+    the plan is first constructed as a layout only
+    (:func:`_gr_dft_precomp_init_layout`), whose magnitude and error
+    bounds are independent of the working precision, and the smallest
+    limb count for which the absolute roundoff error stays below
+    `2^{-\mathrm{prec}}` times the largest input magnitude is
+    computed from those bounds before any root of unity is evaluated;
+    only then is the plan realized over the fixed-point contexts of
+    the chosen precision. At *prec* = 64 this typically selects
+    2 limbs (the guard amounting to some tens of bits, growing
+    logarithmically with `n`). Output components at the scale of the
+    input then carry roughly *prec* relative bits of accuracy. (As
+    with any fixed-point scheme, components that are tiny due to
+    cancellation have correspondingly fewer relative bits, though
+    their enclosures remain correct.)
+
+    At low precision the transform itself is fast enough that the
+    surrounding linear work is significant, so it is streamlined and,
+    for large lengths, threaded. The conversions between ``arf``
+    midpoints and fixed-point components are performed directly on the
+    mantissa limbs (:func:`_arf_get_integer_mpn` on input;
+    :func:`_arf_set_mpn_fixed` on output, which also performs the
+    single rounding to the target precision, so no separate rounding
+    pass over the output is needed), the scratch vectors are treated
+    as plain limb blocks rather than generic ring vectors, and the
+    input is scanned in one pass that simultaneously checks
+    finiteness, accumulates the radius bound and locates the largest
+    midpoint by pointer. For the inverse, the `1/n` normalization is
+    folded into the output exponent for free when `n` is a power of
+    two, and otherwise performed as the single rounded division per
+    component during output conversion. When `2n` components meet the
+    internal threshold (8192) and multiple threads are available, the
+    scan and both conversion loops run on the thread pool; the scan
+    reduces over a fixed 16-chunk grid combined in canonical order, so
+    results (including the upward-rounded radius sums) are bitwise
+    independent of the number of threads.
+
+Fixed-point contexts and error bounds
+-------------------------------------------------------------------------------
+
+For numerical DFTs, the module provides real and complex fixed-point
+contexts as a faster alternative to ``arb`` and ``acb`` (following the
+arithmetic used by the fixed-point matrix multiplication in the
+``nfloat`` module). An element of the real context with `k`-limb
+precision consists of `k + 1` contiguous limbs: a sign limb (0 or 1)
+followed by `k` fraction limbs storing an absolute value in `[0, 1)`,
+so that representable values `t` satisfy `|t| < 1`. An element of the
+complex context consists of a real and an imaginary part laid out
+contiguously, matching the layout assumption of complex mode.
+
+Additions and subtractions are exact as long as the result remains in
+range. Arithmetic operations whose exact result would reach magnitude
+1 return ``GR_UNABLE``, leaving a wrapped value in the output; the
+detection is branch-free (the carry is shifted into the status word)
+and the flag is absorbed by the status accumulation that transforms
+perform anyway, so it costs nothing to intercept at the end of a
+large computation. A ``GR_SUCCESS`` status from a whole transform
+therefore certifies a posteriori that no intermediate value
+overflowed, which makes the guarantees of
+``gr_dft_precomp_nfixed_bound`` unconditional: callers need not trust
+their own compliance with the magnitude bounds, they can verify it.
+(The constants ``one`` and ``neg_one`` clamp to the largest
+representable magnitude `1 - \operatorname{ulp}`, a representational
+choice covered by the root-table error budgets.)
+Real multiplications compute the high product with
+``flint_mpn_mulhigh_n``, with error at most 2 ulp, where
+`\operatorname{ulp} = 2^{-64 k}`. The contexts install specialized
+method tables with fully inlined arithmetic kernels for 1, 2, 3 and 4
+limbs (using ``umul_ppmm`` and ``FLINT_MPN_MUL_2X2``, whose products
+are exactly truncated with error below 1 ulp) and generic ``mpn``
+based methods otherwise.
+
+Complex multiplications use the schoolbook formula with 4 real
+multiplications up to a limb-count cutoff (per-component error at most
+4 ulp, or 2 ulp for the exact 1- and 2-limb kernels): unlike the
+precomputed Karatsuba tables of complex mode (whose entries
+`d \pm c` can reach `\sqrt{2}`), all its intermediate values are
+bounded by the complex moduli of the operands, so plans over the
+fixed-point contexts always disable those tables while still using the
+free and cheap rotation classes. From the cutoff onward, the complex
+multiplication instead uses the 3-multiplication complex Karatsuba
+formula internally, with the sums `x_r + x_i` (of magnitude up to 2)
+held as carry-extended values with an extra high limb: the middle
+product is obtained from a single ``mulhigh`` on the fraction parts
+plus conditional exact additions selected by the carries, and the
+final combination runs in exact `(k+1)`-limb arithmetic before storing
+back to `k` limbs. This costs 3 instead of 4 ``mulhigh`` calls per
+complex product at a per-component error of at most 6 ulp. The default
+cutoff is 22 limbs, the measured crossover on x86-64 (where the extra
+additions and carry logic take that long to amortize against the saved
+multiplication); ``profile/p-gr_dft_nfixed.c`` benchmarks this and the
+other kernel-level implementation choices for retuning on other
+machines.
+
+The values `1`, `-1`, `i`, `-i` are not representable and are rounded
+to magnitude `1 - \operatorname{ulp}`; the transforms never multiply
+by these values explicitly. Consequently the contexts are not rings in
+the strict sense: ``is_one`` and ``is_neg_one`` return ``T_FALSE``,
+and integers of absolute value greater than 1 cannot be assigned. In
+particular :func:`gr_dft_inverse_precomp`, which scales by `1/n`,
+returns ``GR_DOMAIN`` over these contexts; use the unscaled inverse
+:func:`_gr_dft_precomp_raw` and incorporate the scaling into the
+caller's own normalization. For the same reason the Bluestein
+algorithm is not available over fixed-point contexts (its kernel
+normalization and convolution intermediates do not fit the
+representation); prime and prime-power lengths automatically fall
+back to the direct kernels of the mixed-radix algorithm.
+
+The root table of a fixed-point plan is built from a primitive root
+computed via ``arb`` at elevated internal precision, truncated to
+fixed point with error at most 2 ulp; the powers up to an eighth of
+the circle (or a quarter, or a half, depending on the divisibility of
+`n`) are computed as
+`w^j = w^{\lfloor j/2 \rfloor} w^{\lceil j/2 \rceil}` (with a
+2-multiplication complex squaring for even `j`), and the remaining
+entries are exact sign-flipped and part-swapped copies given by the
+eight-fold symmetry of the unit circle. The per-entry errors satisfy
+a linear recurrence with a closed-form bound of `O(j)` ulp, stored
+with the plan; the root tables of sub-plans are exact strided copies
+of the parent table and cost nothing to build, and canonical PFA
+plans, whose algorithm performs no multiplications by roots at all,
+build no table of their own (their ``roots`` field is ``NULL``; the
+sub-plans construct their own small tables directly). (Canonical tables over
+``acb`` are constructed analogously, from a running product at
+elevated precision with the same symmetry fills, rather than by
+per-entry exponentials.)
+
+It is the caller's responsibility to scale the input so that every
+input, intermediate and output value of the transform satisfies
+`|t| < 1`. To this end, :func:`gr_dft_precomp_nfixed_bound` computes,
+at plan-construction cost `O(\log n)` (using memoized affine
+recursions over the plan structure, evaluated in machine doubles with
+conservative fudge factors), a bound *peak* on the modulus of every
+value appearing in the computation, together with a bound on the
+output errors of the real and imaginary parts measured in ulp. The
+computation is safe from overflow if and only if *peak* is less
+than 1; since the bounds are linear in the input magnitude, a suitable
+input scale is obtained as `c / \operatorname{peak}(1)` for some
+margin `c < 1`. The peak includes a factor `\sqrt{2}` at every root
+multiplication, accounting for the intermediate sums inside the
+2-multiplication rotation classes at odd multiples of `n/8`.
+
+.. function:: int gr_dft_ctx_init_nfixed(gr_ctx_t ctx, slong nlimbs)
+              int gr_dft_ctx_init_nfixed_complex(gr_ctx_t ctx, slong nlimbs)
+
+    Initializes *ctx* as the real respectively complex fixed-point
+    context with *nlimbs*-limb precision, returning ``GR_UNABLE`` if
+    *nlimbs* is not between 1 and 64. The complex context is intended
+    to be passed as *ctx*, and the real context as *real_ctx*, to
+    :func:`gr_dft_precomp_init_karatsuba`.
+
+.. function:: int gr_dft_nfixed_set_arf(gr_ptr res, const arf_t x, gr_ctx_t ctx)
+              void gr_dft_nfixed_get_arf(arf_t res, gr_srcptr x, gr_ctx_t ctx)
+
+    Conversions between elements of a real fixed-point context and
+    ``arf`` values. Setting truncates toward zero (error less than
+    1 ulp) and saturates values with `|x| \ge 1` to magnitude
+    `1 - \operatorname{ulp}`, returning ``GR_DOMAIN`` only for
+    non-finite input; getting is exact. The real and imaginary parts
+    of a complex element can be converted by treating them as two
+    consecutive real elements.
+
+.. function:: void gr_dft_precomp_nfixed_bound(double * peak, double * err_ulps, double in_mag, double in_err_ulps, const gr_dft_pre_t P)
+
+    Given that the inputs of a transform have complex modulus at most
+    *in_mag* and componentwise errors of at most *in_err_ulps* ulp,
+    computes a bound *peak* on the modulus of all input, intermediate
+    and output values, and a bound *err_ulps* on the errors of the
+    real and imaginary parts of the output in ulp, for a forward or
+    unscaled inverse transform with the plan *P* executed in
+    fixed-point arithmetic. The transform is free of overflow iff
+    *peak* is less than 1. The model assumes exact additions and
+    ``mulhigh`` multiplications with at most 2 ulp error, uses the
+    per-component complex multiplication error of the plan's actual
+    context (2, 4 or 6 ulp; see above), and uses the root table error
+    bound stored in the plan; for plans over other rings the bounds
+    describe a hypothetical fixed-point execution with the worst-case
+    constants.
+
+.. function:: int _gr_dft_nfixed_roots(gr_ptr roots, ulong n, double * err_ulps, gr_ctx_t ctx)
+
+    Fills *roots* with fixed-point approximations of
+    `w^j, 0 \le j < n`, `w = e^{-2\pi i/n}`, over the complex
+    fixed-point context *ctx*, writing a bound (in ulp) for the
+    errors of the table entries to *err_ulps*. Used automatically by
+    the plan constructors over fixed-point contexts.
+
+.. function:: int gr_dft_acb_precomp_init(gr_dft_acb_pre_t Q, slong n, slong prec)
+              void gr_dft_acb_precomp_clear(gr_dft_acb_pre_t Q)
+              void gr_dft_acb_precomp(acb_ptr w, acb_srcptr v, const gr_dft_acb_pre_t Q, slong prec)
+              void gr_dft_acb_inverse_precomp(acb_ptr w, acb_srcptr v, const gr_dft_acb_pre_t Q, slong prec)
+              int _gr_dft_acb_precomp(acb_ptr w, acb_srcptr v, int inverse, const gr_dft_acb_pre_t Q, slong prec)
+
+    Precomputed variants, amortizing the internal precomputation over
+    repeated transforms of the same length: the object stores the
+    realized plan together with the input-independent constants of the
+    fixed-point scaling and error analysis (the power-of-two input
+    scale itself is chosen per transform from the input magnitudes,
+    so a single object serves inputs of arbitrary scale). The
+    accuracy is governed by the precision given at initialization;
+    the *prec* argument of the transforms only controls the rounding
+    of the results. Inputs the fixed-point path cannot handle fall
+    back to a one-shot ball transform. Since the plan construction is
+    amortized, the automatic backend selection routes large prime
+    factors to the ball path at a lower threshold than the one-shot
+    interface.
+
+Two-phase plan construction
+-------------------------------------------------------------------------------
+
+Internally, plans are built in two phases: a *layout* phase resolving
+the algorithm and the complete decomposition (including the layouts of
+all sub-plans) without touching any ring elements, and a *realize*
+phase binding the ring and computing the root tables, the complex mode
+tables and the convolution kernels. Because
+:func:`gr_dft_precomp_nfixed_bound` only depends on the layout (the
+root-table error of an unrealized layout is a worst-case estimate for
+the doubling construction, replaced by the actual bound at
+realization), cost and error bounds can be evaluated before choosing
+an internal working precision, as done by the ``acb`` drop-in
+transforms.
+
+.. function:: int _gr_dft_precomp_init_layout(gr_dft_pre_t P, ulong n, int alg, int flags, int complex_mode)
+
+    Initializes the layout of a plan of length *n* without computing
+    any tables. *complex_mode* indicates whether the plan will be
+    realized in complex mode (it affects the automatic algorithm
+    selection). The layout can be queried with
+    :func:`gr_dft_precomp_nfixed_bound` and must be freed with
+    :func:`gr_dft_precomp_clear` (or realized).
+
+.. function:: int _gr_dft_precomp_realize(gr_dft_pre_t P, gr_ctx_t real_ctx, gr_ctx_t ctx)
+
+    Realizes a layout over the ring *ctx* with canonical roots,
+    passing *real_ctx* (which may be ``NULL``) to enable complex mode,
+    after which the plan is ready for transforms. Returns
+    ``GR_UNABLE`` (clearing the plan) if the ring cannot provide the
+    canonical root table.
+
+Multithreading
+-------------------------------------------------------------------------------
+
+Plain Cooley-Tukey and complex-mode split-radix plans (without the
+complex Karatsuba tables, which only arise at high precision where
+transforms are compute-bound) store their twiddle factors packed per
+stage instead of as a serial table of all powers, in the same total
+memory: every table access during a transform is then a sequential
+walk, where strided reads into a length-`n` table miss the cache once
+per entry as soon as the stride exceeds a cache line (measured at
+about 28% of a fixed-point transform of length `2^{22}` before the
+change). Inverse transforms reuse the forward tables through the
+identities `w^{-j r} = -\,\mathrm{stage}_s[h_m - j]` (a reversed
+walk, with the negation folded into the butterfly) and, for
+split-radix, reversed pair walks with free quarter rotations.
+
+For power-of-two lengths the automatic algorithm selection uses
+split-radix in complex mode (fewest multiplications) and plain Cooley-Tukey
+otherwise (and whenever scrambled ordering is requested, which
+split-radix does not support). The Bailey four-step algorithm remains
+available explicitly; in measurements up to `n = 2^{20}` over ball,
+fixed-point and word-size modular rings its cache blocking did not
+outperform the plain transforms, serially or threaded.
+
+Transforms use worker threads from the global FLINT thread pool when
+the ring reports itself threadsafe: threads are requested at transform
+time (respecting ``flint_set_num_threads``), or borrowed handles can
+be attached with :func:`gr_dft_precomp_set_threads`. Each algorithm
+distributes its own structure across as many threads as it can use:
+
+* Cooley-Tukey distributes the top `\log_2(\mathrm{chunks})`
+  butterfly passes -- the only levels whose butterflies genuinely span
+  the array -- across the workers (one synchronization round per
+  pass), after which the array decomposes into independent contiguous
+  blocks and each worker runs all the remaining passes over its own
+  blocks without further synchronization, in a depth-first blocked
+  order (``GR_DFT_CT_BLOCK_BYTES``) so that cache-sized sub-blocks
+  complete all their levels while resident; the serial transform uses
+  the same order. (Sweeping every level across all workers instead is limited
+  by the shared memory bandwidth, which does not grow with the thread
+  count; this matters most over cheap rings such as word-size
+  modular arithmetic.)
+
+* Split-radix forks its independent sub-transforms (the half-length
+  one against the two quarter-length ones, recursively partitioning
+  the worker handles) and distributes the `n/4` independent
+  iterations of each combine pass.
+
+* Bailey's four-step algorithm distributes the work items of its
+  three phases (`n_1` column transforms, `n_2` twiddled rows); the
+  transpose is serial.
+
+The only tuning parameter is the granularity: work is divided into at
+most `n / \mathrm{serial\_block}` chunks per phase or pass, and
+threaded recursion stops below that size
+(``GR_DFT_SERIAL_BLOCK_DEFAULT`` = 8 elements by default, deliberately
+small; users of cheap rings should raise it with
+:func:`gr_dft_precomp_set_serial_block`). No algorithm switching is
+performed based on thread availability, so serial and threaded
+transforms of the same plan run the same arithmetic. The profile
+program ``p-gr_dft_threads`` measures the parallel speedup of each
+algorithm by thread count, and ``p-gr_dft_nfixed`` microbenchmarks
+the fixed-point arithmetic primitives (carry-chain styles, signed
+subtraction strategies, saturation costs, and the classical/Karatsuba
+complex multiplication crossover) for machine tuning of the
+implementation choices in ``nfixed.c``.
+
+.. function:: void gr_dft_precomp_fprint(FILE * out, const gr_dft_pre_t P)
+              void gr_dft_precomp_print(const gr_dft_pre_t P)
+
+    Prints a diagnostic description of the plan to *out* (respectively
+    to standard output): the algorithm and decomposition of each node
+    (with one indented block per sub-plan), the state of the root and
+    kernel tables, the fixed-point table error bounds, and the
+    threading configuration. Works on layouts as well as realized
+    plans.
+
+Types and macros
+-------------------------------------------------------------------------------
+
+.. type:: gr_dft_pre_struct
+
+.. type:: gr_dft_pre_t
+
+    A precomputed plan for transforms of a fixed length over a fixed
+    ring, storing the algorithm parameters, the table of roots of unity,
+    optional complex Karatsuba multiplication tables, and sub-plans and auxiliary
+    tables for the composite algorithms (four-step, prime factor,
+    mixed-radix and Bluestein).
+
+Plan construction
+-------------------------------------------------------------------------------
+
+.. function:: int gr_dft_default_root(gr_ptr w, ulong n, gr_ctx_t ctx)
+
+    Sets *w* to a default principal *n*-th root of unity: `1` for
+    `n = 1`, `-1` for `n = 2`, and `e^{-2 \pi i / n}` otherwise
+    (computed via ``exp_pi_i`` or, failing that, via ``pi``, ``i``
+    and ``exp``). Returns ``GR_UNABLE`` if the ring does not implement
+    the required operations, in which case a root must be supplied
+    manually to :func:`gr_dft_precomp_init_root`; this is typically
+    the case over finite fields.
+
+.. function:: int gr_dft_precomp_init_root(gr_dft_pre_t P, gr_srcptr w, ulong n, int alg, int flags, gr_ctx_t ctx)
+              int gr_dft_precomp_init(gr_dft_pre_t P, ulong n, int alg, int flags, gr_ctx_t ctx)
+              int gr_dft_precomp_init_karatsuba(gr_dft_pre_t P, ulong n, int alg, int flags, gr_ctx_t real_ctx, gr_ctx_t ctx)
+
+    Initializes *P* with a plan for transforms of length `n \ge 1`
+    over the ring *ctx*, using the given algorithm and flags.
+    ``GR_DOMAIN`` is returned if the algorithm does not support the
+    length: ``GR_DFT_ALG_CT``, ``GR_DFT_ALG_BAILEY`` and
+    ``GR_DFT_ALG_SPLIT`` require a power of two, ``GR_DFT_ALG_PFA``
+    requires at least two distinct prime factors, and
+    ``GR_DFT_ALG_BLUESTEIN`` requires an odd `n \ge 3` (and a ring
+    supporting :func:`gr_dft_default_root`, since a root of unity of
+    power-of-two order is needed for the underlying convolution;
+    ``GR_UNABLE`` is returned otherwise). With ``GR_DFT_ALG_AUTO``,
+    any length is supported: a power of two selects among the
+    power-of-two algorithms, a prime power selects
+    ``GR_DFT_ALG_MIXED``, and other composite lengths select
+    ``GR_DFT_ALG_PFA`` over the coprime prime power components. Over
+    rings where Bluestein is unavailable, transforms of lengths with
+    large prime factors `p` degrade gracefully to `O(p^2)` prime
+    kernels.
+
+    The *root* variant takes a principal *n*-th root of unity *w*,
+    treated as generic; the other variants use
+    :func:`gr_dft_default_root`. The *karatsuba* variant additionally
+    takes the real ring *real_ctx* and enables complex mode (with
+    Karatsuba multiplication where profitable) as described above. The constructors partially check that *w* is
+    a principal root (verifying `w^{n/2} = -1` for even `n` and
+    `w^{n/p} \ne 1` for odd primes `p \mid n`, when these conditions
+    are decidable in the ring), returning ``GR_DOMAIN`` on a definite
+    failure.
+
+    A sanity check `w^{n/2} = -1` is performed; if this can be decided
+    and is false, ``GR_DOMAIN`` is returned. If the return status is
+    not ``GR_SUCCESS``, the plan is left in a cleared state and must
+    not be used (calling :func:`gr_dft_precomp_clear` is harmless).
+
+    The plan retains pointers to *ctx* and *real_ctx*, which must
+    stay valid for the lifetime of the plan.
+
+.. function:: void gr_dft_precomp_clear(gr_dft_pre_t P)
+
+    Frees the data stored in the plan *P*.
+
+.. function:: void gr_dft_precomp_set_threads(gr_dft_pre_t P, thread_pool_handle * threads, slong num_threads)
+
+    Attaches the given worker threads to the plan and, recursively, to
+    its sub-plans. The handles are borrowed for the lifetime of the
+    plan: they are used by every subsequent transform, are *not* given
+    back to the thread pool by :func:`gr_dft_precomp_clear`, and remain
+    the responsibility of the caller (typically obtained with
+    :func:`flint_request_threads` and released with
+    :func:`flint_give_back_threads` after the plan has been cleared).
+    Passing *NULL*, 0 detaches the workers, restoring the default
+    behavior of requesting threads from the global thread pool during
+    each transform. Attached workers are only used when the ring is
+    certified thread-safe by :func:`gr_ctx_is_threadsafe` (see above).
+
+.. function:: void gr_dft_precomp_set_serial_block(gr_dft_pre_t P, slong serial_block)
+
+    Sets the threading granularity of the plan and, recursively, of its
+    sub-plans (see the discussion above). Passing zero restores the
+    default ``GR_DFT_SERIAL_BLOCK_DEFAULT``.
+
+.. function:: void gr_dft_precomp_output_perm(ulong * perm, const gr_dft_pre_t P)
+
+    Writes to *perm* the output permutation of the plan, defined so that
+    entry *i* of the forward output contains the DFT coefficient
+    `X_{\operatorname{perm}(i)}`. Similarly, the inverse transform
+    expects the coefficient `X_{\operatorname{perm}(i)}` in entry *i*
+    of its input. This is the identity permutation unless
+    ``GR_DFT_SCRAMBLED`` is set and the algorithm supports scrambled
+    ordering (other algorithms do not).
+
+Transforms
+-------------------------------------------------------------------------------
+
+.. function:: int gr_dft_precomp(gr_ptr res, gr_srcptr vec, const gr_dft_pre_t P, gr_ctx_t ctx)
+              int gr_dft_inverse_precomp(gr_ptr res, gr_srcptr vec, const gr_dft_pre_t P, gr_ctx_t ctx)
+
+    Sets *res* to the forward respectively inverse DFT of *vec*, both of
+    length `n`, using the plan *P*. Aliasing of *res* and *vec* is
+    allowed. The inverse transform includes the scaling by `1/n` and
+    returns ``GR_DOMAIN`` if `n` is not invertible in the ring.
+
+.. function:: int gr_dft(gr_ptr res, gr_srcptr vec, ulong n, gr_ctx_t ctx)
+              int gr_dft_inverse(gr_ptr res, gr_srcptr vec, ulong n, gr_ctx_t ctx)
+
+    Convenience functions performing a single forward or inverse
+    transform of length *n* with a temporary plan constructed with
+    default parameters.
+
+Internal functions
+-------------------------------------------------------------------------------
+
+.. function:: int _gr_dft_mul_root(gr_ptr res, gr_srcptr x, ulong e, int inverse, gr_ptr rtmp, const gr_dft_pre_t P)
+
+    Sets *res* to `w^e x` (or `w^{-e} x` if *inverse* is set) where
+    `0 \le e < n`, using the plain ring multiplication or the complex
+    Karatsuba tables depending on the plan. *res* must not alias *x*. In
+    complex Karatsuba
+    mode, *rtmp* must point to an initialized temporary element of the
+    real ring.
+
+.. function:: void _gr_dft_bit_reverse(gr_ptr x, slong stride, int depth, gr_ctx_t ctx)
+
+    Permutes the strided vector *x* of length `2^{depth}` in place by
+    the bit reversal permutation.
+
+.. function:: int _gr_dft_ct(gr_ptr x, slong stride, int inverse, int scrambled, const gr_dft_pre_t P, gr_ctx_t ctx)
+
+    In-place radix-2 Cooley-Tukey transform of the strided vector *x*.
+    The inverse transform omits the scaling by `1/n`.
+
+.. function:: int _gr_dft_bailey(gr_ptr x, int inverse, int scrambled, const gr_dft_pre_t P, gr_ctx_t ctx)
+
+    In-place four-step transform of the contiguous vector *x*.
+    The inverse transform omits the scaling by `1/n`.
+
+.. function:: int _gr_dft_split(gr_ptr res, gr_srcptr vec, int inverse, const gr_dft_pre_t P, gr_ctx_t ctx)
+
+    Split-radix transform of *vec*, written to *res* in natural order.
+    *res* must not alias *vec*. The inverse transform omits the
+    scaling by `1/n`.
+
+.. function:: int _gr_dft_mul_const(gr_ptr res, gr_srcptr x, gr_srcptr w, gr_srcptr wtab3, gr_ptr rtmp, const gr_dft_pre_t P)
+
+    Sets *res* to `w x` for a fixed plan constant *w*, using the
+    precomputed complex Karatsuba multiplication table entry *wtab3*
+    (three elements `c, d - c, d + c` of the real ring) if it is not
+    *NULL*, and a plain ring multiplication otherwise. *res* must not
+    alias *x*.
+
+.. function:: int _gr_dft_precomp_raw(gr_ptr res, gr_srcptr vec, int inverse, const gr_dft_pre_t P, gr_ctx_t ctx)
+
+    Applies the plan without the `1/n` scaling of the inverse
+    transform. Aliasing of *res* and *vec* is allowed.
+
+.. function:: int _gr_dft_naive(gr_ptr res, gr_srcptr vec, int inverse, int scrambled, const gr_dft_pre_t P, gr_ctx_t ctx)
+
+    Naive `O(n^2)` transform. *res* must not alias *vec*.
+    The inverse transform omits the scaling by `1/n`.
+
+.. function:: int _gr_dft_mixed(gr_ptr res, gr_srcptr vec, int inverse, const gr_dft_pre_t P, gr_ctx_t ctx)
+
+    Mixed-radix transform (``GR_DFT_ALG_MIXED``). *res* must not alias
+    *vec*.
+
+.. function:: int _gr_dft_pfa(gr_ptr res, gr_srcptr vec, int inverse, const gr_dft_pre_t P, gr_ctx_t ctx)
+
+    Good-Thomas prime factor transform (``GR_DFT_ALG_PFA``). *res*
+    must not alias *vec*.
+
+.. function:: int _gr_dft_bluestein(gr_ptr res, gr_srcptr vec, int inverse, const gr_dft_pre_t P, gr_ctx_t ctx)
+
+    Bluestein chirp-z transform (``GR_DFT_ALG_BLUESTEIN``). *res* must
+    not alias *vec*. The inverse transform is computed as the forward
+    transform of the cyclically reversed input.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -62,6 +62,7 @@ Generic rings
    gr_mpoly.rst
    gr_ore_poly.rst
    gr_series.rst
+   gr_dft.rst
 
 .. only:: not latex
 

--- a/src/gr_dft.h
+++ b/src/gr_dft.h
@@ -1,0 +1,254 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef GR_DFT_H
+#define GR_DFT_H
+
+#include "thread_pool.h"
+#include "gr.h"
+#include "arf_types.h"
+#include "acb_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Algorithm selection ******************************************************/
+
+#define GR_DFT_ALG_AUTO       0
+#define GR_DFT_ALG_NAIVE      1  /* O(n^2) evaluation (any length) */
+#define GR_DFT_ALG_CT         2  /* iterative radix-2 Cooley-Tukey (power of two) */
+#define GR_DFT_ALG_BAILEY     3  /* cache-friendly four-step (power of two) */
+#define GR_DFT_ALG_SPLIT      4  /* recursive split-radix (power of two) */
+#define GR_DFT_ALG_PFA        5  /* Good-Thomas prime factor algorithm over
+                                    coprime components (composite lengths) */
+#define GR_DFT_ALG_MIXED      6  /* recursive mixed-radix Cooley-Tukey with
+                                    prime basecases (any length) */
+#define GR_DFT_ALG_BLUESTEIN  7  /* chirp-z reduction to a power-of-two
+                                    convolution (odd lengths) */
+
+/* Flags ********************************************************************/
+
+/* Forward transform leaves the output in scrambled order (bit-reversed
+   for NAIVE/CT, transposed for BAILEY); the inverse transform expects
+   its input in the same scrambled order. Only supported for power-of-two
+   lengths with the NAIVE, CT and BAILEY algorithms; ignored otherwise. */
+#define GR_DFT_SCRAMBLED   1
+
+/* Default threading granularity (elements of work per serial block);
+   see gr_dft_precomp_set_serial_block. */
+/* default minimum number of elements of per-chunk work for the
+   threaded transforms (the number of chunks per phase or pass is at
+   most n / serial_block, and threaded recursion stops below this
+   size); deliberately small so that every algorithm uses as many
+   threads as it structurally can -- users of cheap rings should raise
+   it with gr_dft_precomp_set_serial_block */
+#define GR_DFT_SERIAL_BLOCK_DEFAULT 256
+
+/* blocks larger than this (in bytes) are processed depth-first by the
+   Cooley-Tukey transform, so that cache-sized sub-blocks complete all
+   their butterfly levels while resident instead of being streamed
+   from memory once per level (machine-tunable; should be at most
+   about half the per-core cache) */
+#define GR_DFT_CT_BLOCK_BYTES (UWORD(128) << 10)
+
+/* Precomputed plan *********************************************************/
+
+/* Cost classes of the roots in complex mode (internal). Since complex
+   mode always uses the standard root w = exp(-2 pi i / n), the classes
+   are determined structurally by the exponent: the quarter points are
+   free rotations and the odd multiples of n/8 are of the form
+   c (1 -+ i), requiring 2 real multiplications. */
+#define GR_DFT_ROOT_GENERIC   0  /* 3 real multiplications */
+#define GR_DFT_ROOT_DMC_ZERO  1  /* d = c:  w = c (1 + i), 2 multiplications */
+#define GR_DFT_ROOT_DPC_ZERO  2  /* d = -c: w = c (1 - i), 2 multiplications */
+#define GR_DFT_ROOT_NEG_ONE   3  /* w = -1, free */
+#define GR_DFT_ROOT_I         4  /* w = i, free */
+#define GR_DFT_ROOT_NEG_I     5  /* w = -i, free */
+
+typedef struct gr_dft_pre_struct
+{
+    ulong n;                    /* transform length */
+    int depth;                  /* n == 2^depth if n is a power of two, else -1 */
+    int alg;                    /* resolved algorithm (never AUTO) */
+    int flags;
+    gr_ctx_struct * ctx;        /* the ring R (or C = R'[i] in complex mode) */
+    gr_ctx_struct * real_ctx;   /* complex mode: the real ring R'; else NULL */
+    gr_ptr roots;               /* w^0, w^1, ..., w^(n-1), elements of ctx;
+                                   NULL for canonical PFA plans (which
+                                   perform no root multiplications) and
+                                   for plans with packed stage tables */
+    gr_ptr stage_tab;           /* CT and split-radix plans (without the
+                                   complex Karatsuba tables) store their
+                                   twiddles packed per stage instead of
+                                   the serial table, so that every table
+                                   access during a transform is a
+                                   sequential walk; same total size.
+                                   CT: stage s at offset n - 2^s with
+                                   entries w^(j n / 2^s), j < 2^(s-1).
+                                   Split: size-m section at offset n - m
+                                   with interleaved pairs
+                                   (w^(k n/m), w^(3 k n/m mod n)),
+                                   k < m/4. */
+    slong stage_len;
+    gr_ptr wtab;                /* complex Karatsuba tables (when enabled): 3n
+                                   elements of real_ctx, (c, d - c, d + c) for
+                                   each root c + d*i; else NULL */
+    unsigned char * wclass;     /* complex mode: cost class of each root */
+    ulong n1, n2;               /* BAILEY, PFA: n = n1 * n2 */
+    ulong pfa_a, pfa_b;         /* PFA: CRT output coefficients */
+    ulong * radices;            /* MIXED: prime radix of each recursion level */
+    slong num_radices;
+    ulong conv_len;             /* BLUESTEIN: power-of-two convolution length */
+    gr_ptr bl_kern;             /* BLUESTEIN: transformed convolution kernel,
+                                   conv_len elements, scaled by 1/conv_len */
+    gr_ptr bl_wtab;             /* BLUESTEIN, with Karatsuba tables enabled:
+                                   multiplication tables for bl_kern
+                                   (3 conv_len elements) */
+    struct gr_dft_pre_struct * P1;  /* BAILEY, PFA: sub-plan of length n1;
+                                       MIXED: optional plan for the prime
+                                       radix; BLUESTEIN: power-of-two plan
+                                       of length conv_len */
+    struct gr_dft_pre_struct * P2;  /* BAILEY, PFA: sub-plan of length n2 */
+    thread_pool_handle * threads;   /* attached worker threads (borrowed;
+                                       NULL: request from the global pool
+                                       during transforms) */
+    slong num_threads;              /* number of attached workers */
+    slong serial_block;             /* threading granularity (0: default) */
+    double nfixed_root_err;         /* nfixed contexts: ulp error bound of
+                                       the root table (see nfixed.c) */
+    int bl_shifted;                 /* BLUESTEIN over nfixed: the kernel
+                                       carries an extra 1/2, undone by
+                                       doubling the outputs */
+}
+gr_dft_pre_struct;
+
+typedef gr_dft_pre_struct gr_dft_pre_t[1];
+
+/* Plan initialization ******************************************************/
+
+WARN_UNUSED_RESULT int gr_dft_default_root(gr_ptr w, ulong n, gr_ctx_t ctx);
+
+WARN_UNUSED_RESULT int gr_dft_precomp_init_root(gr_dft_pre_t P, gr_srcptr w, ulong n, int alg, int flags, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_dft_precomp_init(gr_dft_pre_t P, ulong n, int alg, int flags, gr_ctx_t ctx);
+
+WARN_UNUSED_RESULT int gr_dft_precomp_init_karatsuba(gr_dft_pre_t P, ulong n, int alg, int flags, gr_ctx_t real_ctx, gr_ctx_t ctx);
+
+void gr_dft_precomp_set_threads(gr_dft_pre_t P, thread_pool_handle * threads, slong num_threads);
+void gr_dft_precomp_set_serial_block(gr_dft_pre_t P, slong serial_block);
+
+void gr_dft_precomp_clear(gr_dft_pre_t P);
+
+void gr_dft_precomp_output_perm(ulong * perm, const gr_dft_pre_t P);
+
+/* Transforms ***************************************************************/
+
+WARN_UNUSED_RESULT int gr_dft_precomp(gr_ptr res, gr_srcptr vec, const gr_dft_pre_t P, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_dft_inverse_precomp(gr_ptr res, gr_srcptr vec, const gr_dft_pre_t P, gr_ctx_t ctx);
+
+WARN_UNUSED_RESULT int gr_dft(gr_ptr res, gr_srcptr vec, ulong n, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_dft_inverse(gr_ptr res, gr_srcptr vec, ulong n, gr_ctx_t ctx);
+
+/* Fixed-point contexts for numerical DFTs (see nfixed.c) *******************/
+
+int gr_dft_ctx_init_nfixed(gr_ctx_t ctx, slong nlimbs);
+int gr_dft_ctx_init_nfixed_complex(gr_ctx_t ctx, slong nlimbs);
+int _gr_dft_ctx_is_nfixed(gr_ctx_t ctx);
+int _gr_dft_ctx_is_nfixed_complex(gr_ctx_t ctx);
+
+int gr_dft_nfixed_set_arf(gr_ptr res, const arf_t x, gr_ctx_t ctx);
+void gr_dft_nfixed_get_arf(arf_t res, gr_srcptr x, gr_ctx_t ctx);
+
+int _gr_dft_nfixed_roots(gr_ptr roots, ulong n, double * err_ulps, gr_ctx_t ctx);
+double _gr_dft_nfixed_cmul_err_ulps(gr_ctx_t ctx);
+double _gr_dft_nfixed_root_err_bound(ulong n, double kmul);
+/* forced complex-multiplication paths, for machine tuning of
+   GR_DFT_NFIXED_KARATSUBA_CUTOFF (see profile/p-gr_dft_nfixed) */
+int _gr_dft_nfixed_cmul_schoolbook(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx);
+int _gr_dft_nfixed_cmul_karatsuba(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx);
+
+/* Two-phase plan construction: the layout carries the complete
+   decomposition without any ring elements, so that cost and error
+   bounds can be inspected (e.g. to choose a fixed-point precision)
+   before the root tables are computed by the realize step, which
+   uses canonical roots. */
+int _gr_dft_precomp_init_layout(gr_dft_pre_t P, ulong n, int alg, int flags,
+        int complex_mode);
+int _gr_dft_precomp_realize(gr_dft_pre_t P, gr_ctx_struct * real_ctx,
+        gr_ctx_t ctx);
+
+void gr_dft_precomp_nfixed_bound(double * peak, double * err_ulps,
+        double in_mag, double in_err_ulps, const gr_dft_pre_t P);
+
+#define GR_DFT_NFIXED_MAX_NLIMBS 2048
+
+/* Drop-in replacements for acb_dft / acb_dft_inverse (see acb.c) */
+
+void gr_dft_acb(acb_ptr w, acb_srcptr v, slong n, slong prec);
+void gr_dft_acb_inverse(acb_ptr w, acb_srcptr v, slong n, slong prec);
+int _gr_dft_acb(acb_ptr w, acb_srcptr v, slong n, int inverse, int which,
+        slong prec);
+
+/* Precomputed variant, amortizing the plan construction over repeated
+   transforms of the same length and precision. which = 1: ball
+   arithmetic (arb/acb contexts); which = 2: fixed-point contexts,
+   together with the input-independent constants of the scaling and
+   error analysis (the input-dependent power-of-two scale is chosen
+   per transform). */
+typedef struct
+{
+    slong n;
+    slong prec;
+    int which;
+    slong nl;               /* fixed point: number of limbs */
+    slong p1e;              /* fixed point: peak(1) < 2^p1e */
+    double in_mag;          /* fixed point: scaled input bound */
+    double errulps;         /* fixed point: output roundoff, in ulp */
+    gr_ctx_struct rctx[1];
+    gr_ctx_struct cctx[1];
+    gr_dft_pre_t P;
+}
+gr_dft_acb_pre_struct;
+
+typedef gr_dft_acb_pre_struct gr_dft_acb_pre_t[1];
+
+WARN_UNUSED_RESULT int gr_dft_acb_precomp_init(gr_dft_acb_pre_t Q, slong n, slong prec);
+void gr_dft_acb_precomp_clear(gr_dft_acb_pre_t Q);
+void gr_dft_acb_precomp(acb_ptr w, acb_srcptr v, const gr_dft_acb_pre_t Q, slong prec);
+void gr_dft_acb_inverse_precomp(acb_ptr w, acb_srcptr v, const gr_dft_acb_pre_t Q, slong prec);
+int _gr_dft_acb_precomp(acb_ptr w, acb_srcptr v, int inverse, const gr_dft_acb_pre_t Q, slong prec);
+
+/* Internal functions *******************************************************/
+
+WARN_UNUSED_RESULT int _gr_dft_mul_root(gr_ptr res, gr_srcptr x, ulong e, int inverse, gr_ptr rtmp, const gr_dft_pre_t P);
+WARN_UNUSED_RESULT int _gr_dft_mul_const(gr_ptr res, gr_srcptr x, gr_srcptr w, gr_srcptr wtab3, gr_ptr rtmp, const gr_dft_pre_t P);
+void _gr_dft_bit_reverse(gr_ptr x, slong stride, int depth, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int _gr_dft_ct(gr_ptr x, slong stride, int inverse, int scrambled, const gr_dft_pre_t P, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int _gr_dft_ct_threaded(gr_ptr x, slong stride, int inverse, int scrambled, const gr_dft_pre_t P, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int _gr_dft_split(gr_ptr res, gr_srcptr vec, int inverse, const gr_dft_pre_t P, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int _gr_dft_split_threaded(gr_ptr res, gr_srcptr vec, int inverse, const gr_dft_pre_t P, gr_ctx_t ctx);
+#ifdef FLINT_HAVE_FILE
+void gr_dft_precomp_fprint(FILE * out, const gr_dft_pre_t P);
+#endif
+void gr_dft_precomp_print(const gr_dft_pre_t P);
+WARN_UNUSED_RESULT int _gr_dft_bailey(gr_ptr x, int inverse, int scrambled, const gr_dft_pre_t P, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int _gr_dft_naive(gr_ptr res, gr_srcptr vec, int inverse, int scrambled, const gr_dft_pre_t P, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int _gr_dft_mixed(gr_ptr res, gr_srcptr vec, int inverse, const gr_dft_pre_t P, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int _gr_dft_pfa(gr_ptr res, gr_srcptr vec, int inverse, const gr_dft_pre_t P, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int _gr_dft_bluestein(gr_ptr res, gr_srcptr vec, int inverse, const gr_dft_pre_t P, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int _gr_dft_precomp_raw(gr_ptr res, gr_srcptr vec, int inverse, const gr_dft_pre_t P, gr_ctx_t ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/gr_dft/acb.c
+++ b/src/gr_dft/acb.c
@@ -1,0 +1,789 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <math.h>
+#include <float.h>
+#include "ulong_extras.h"
+#include "arf.h"
+#include "arb.h"
+#include "acb.h"
+#include "gr.h"
+#include "gr_vec.h"
+#include "thread_pool.h"
+#include "thread_support.h"
+#include "gr_dft.h"
+
+/* Drop-in replacements for acb_dft and acb_dft_inverse, computing DFTs
+   of acb vectors through the generic plans of this module, using
+   either acb/arb ball arithmetic or the fixed-point contexts of
+   nfixed.c internally.
+
+   In the fixed-point path, only the input midpoints enter the
+   transform: they are scaled by an exact power of two chosen from the
+   plan's magnitude bound so that no intermediate value can overflow
+   the |t| < 1 representation, and truncated to fixed point (error
+   below 1 ulp per component). The output radii combine two
+   independent contributions:
+
+   1. the fixed-point roundoff and root-table errors, from
+      gr_dft_precomp_nfixed_bound applied to the actual input scale
+      and the 1 ulp conversion error;
+
+   2. the effect of the input radii, which is not propagated through
+      the transform at all but bounded directly by the standard DFT
+      perturbation result: since the DFT matrix (and the unscaled
+      inverse) has unit-modulus entries,
+
+          |Delta X_k| <= sum_j |Delta x_j|,
+
+      so a single magnitude R = sum_j hypot(rad re_j, rad im_j),
+      computed with upward rounding, bounds the output perturbation of
+      every component. (This is sharper than pushing intervals through
+      the computation, and independent of the fixed-point precision.)
+
+   The number of limbs is chosen from the requested precision plus
+   guard bits determined by the error bound of the plan, so that the
+   absolute output error from roundoff is below 2^-prec times the
+   largest input magnitude; outputs of that scale therefore carry
+   roughly prec relative bits. */
+
+/* perturbation bound R = sum_j hypot(rad re_j, rad im_j) */
+static int
+_gr_dft_acb_ball(acb_ptr w, acb_srcptr v, slong n, int inverse, slong prec)
+{
+    int status = GR_SUCCESS;
+    gr_ctx_t rctx, cctx;
+    gr_dft_pre_t P;
+
+    gr_ctx_init_real_arb(rctx, prec);
+    gr_ctx_init_complex_acb(cctx, prec);
+
+    status |= gr_dft_precomp_init_karatsuba(P, n, GR_DFT_ALG_AUTO, 0,
+            rctx, cctx);
+
+    if (status == GR_SUCCESS)
+    {
+        if (inverse)
+            status |= gr_dft_inverse_precomp((gr_ptr) w, (gr_srcptr) v,
+                    P, cctx);
+        else
+            status |= gr_dft_precomp((gr_ptr) w, (gr_srcptr) v, P, cctx);
+    }
+
+    gr_dft_precomp_clear(P);
+    gr_ctx_clear(rctx);
+    gr_ctx_clear(cctx);
+
+    return status;
+}
+
+static int
+_gr_dft_acb_nfixed_select(gr_dft_acb_pre_struct * Q, slong n, slong prec)
+{
+    int status = GR_SUCCESS;
+    double peak1, err0, peak;
+    slong nl, p1e;
+
+    prec = FLINT_MAX(prec, 2);
+
+    status = _gr_dft_precomp_init_layout(Q->P, n, GR_DFT_ALG_AUTO, 0, 1);
+    if (status != GR_SUCCESS)
+        return status;
+
+    {
+        int p1exp;
+        gr_dft_precomp_nfixed_bound(&peak1, &err0, 1.0, 0.0, Q->P);
+
+        /* the bound of a unit input is at least 1 and, for sane
+           transform lengths, far below 2^500; refuse defensively if
+           the double computation escaped that range (the comparison
+           is written so that NaN also fails). Besides protecting the
+           frexp below, the cap guarantees in_mag >= 2^-501, so that
+           every intermediate quantity inside the subsequent bound
+           evaluations stays comfortably within the normal double
+           range: an underflow to zero there would silently understate
+           the bound. */
+        if (!(peak1 >= 1.0 && peak1 <= ldexp(1.0, 500)))
+        {
+            gr_dft_precomp_clear(Q->P);
+            return GR_UNABLE;
+        }
+
+        frexp(peak1, &p1exp);   /* peak1 < 2^p1exp */
+        p1e = p1exp;
+    }
+    Q->p1e = p1e;
+    /* p1exp lies in [1, 1024] here, so this neither under- nor
+       overflows */
+    Q->in_mag = ldexp(1.0, -p1e - 1);
+
+    gr_dft_precomp_nfixed_bound(&peak, &Q->errulps, Q->in_mag, 1.0, Q->P);
+    if (!(peak < 1.0) ||
+        !(Q->errulps >= 1.0 && Q->errulps <= DBL_MAX))
+    {
+        gr_dft_precomp_clear(Q->P);
+        return GR_UNABLE;
+    }
+
+    /* guard bits: absolute roundoff errulps 2^(-64 nl) should stay
+       below 2^-(prec+2) in_mag */
+    nl = (prec + FLINT_BITS - 1) / FLINT_BITS;
+    {
+        double need = prec + 2.0 + log2(Q->errulps) - log2(Q->in_mag);
+        slong nl2 = (slong) (need / FLINT_BITS) + 1;
+        nl = FLINT_MAX(nl, nl2);
+    }
+    if (nl > GR_DFT_NFIXED_MAX_NLIMBS)
+    {
+        gr_dft_precomp_clear(Q->P);
+        return GR_UNABLE;
+    }
+    Q->nl = nl;
+
+    status |= gr_dft_ctx_init_nfixed(Q->rctx, nl);
+    status |= gr_dft_ctx_init_nfixed_complex(Q->cctx, nl);
+    status |= _gr_dft_precomp_realize(Q->P, Q->rctx, Q->cctx);
+    if (status != GR_SUCCESS)
+    {
+        /* realize cleared the plan already */
+        gr_ctx_clear(Q->rctx);
+        gr_ctx_clear(Q->cctx);
+        return status;
+    }
+
+    /* re-evaluate the error bound with the realized plan (actual
+       complex-multiplication constant and root-table error), for
+       tighter output radii */
+    gr_dft_precomp_nfixed_bound(&peak, &Q->errulps, Q->in_mag, 1.0, Q->P);
+    if (!(peak < 1.0) ||
+        !(Q->errulps >= 1.0 && Q->errulps <= DBL_MAX))
+    {
+        gr_dft_precomp_clear(Q->P);
+        gr_ctx_clear(Q->rctx);
+        gr_ctx_clear(Q->cctx);
+        return GR_UNABLE;
+    }
+
+    return GR_SUCCESS;
+}
+
+/* the per-call part of the fixed-point transform: scale, convert,
+   transform, assemble. Returns GR_UNABLE for inputs the fixed-point
+   path cannot handle (non-finite or extreme midpoints). */
+/* Fast conversions between arf midpoints and nfixed components
+   (sign limb + nl fraction limbs), following the pattern of
+   _nfloat_get_nfixed / _nfloat_set_nfixed: the input direction
+   extracts the integer part of |mid| 2^(64 nl - e) directly into the
+   fraction limbs with _arf_get_integer_mpn (truncation toward zero,
+   error below 1 ulp, matching gr_dft_nfixed_set_arf), and the output
+   direction builds the rounded arf at the target precision in one
+   step with _arf_set_mpn_fixed, so no temporary arf, no separate
+   rounding pass, and no arb_set_arf copy are needed. */
+
+static void
+_acb_dft_arf_to_nfixed(nn_ptr res, arf_srcptr mid, slong e, slong nl)
+{
+    slong rel;
+    nn_srcptr xp;
+    slong xn;
+
+    /* res is already zeroed (fresh gr vector) */
+    if (ARF_IS_SPECIAL(mid))
+        return;                     /* finite by the earlier scan: zero */
+
+    if (COEFF_IS_MPZ(ARF_EXP(mid)))
+        return;                     /* a bignum exponent must be hugely
+                                       negative here (a positive one
+                                       would contradict the caller's
+                                       magnitude bound EM, which is
+                                       checked to be far within slong
+                                       range): the value underflows to
+                                       zero, with error below 1 ulp */
+
+    rel = ARF_EXP(mid) - e;         /* < 0 by choice of e */
+    if (nl * FLINT_BITS + rel <= 0)
+        return;                     /* underflow */
+
+    res[0] = ARF_SGNBIT(mid);
+    ARF_GET_MPN_READONLY(xp, xn, mid);
+    _arf_get_integer_mpn(res + 1, xp, xn, nl * FLINT_BITS + rel);
+}
+
+/* part <- (component) 2^e / den, rounded to prec, with the rounding
+   error added to the radius (which the caller has preset); den = 0
+   means no division */
+static void
+_acb_dft_nfixed_to_arb(arb_ptr part, nn_srcptr comp, slong e, slong nl,
+        ulong den, slong prec)
+{
+    arf_ptr mid = arb_midref(part);
+    int inexact;
+
+    if (den != 0)
+    {
+        /* convert exactly (the fixed-point value has at most 64 nl
+           bits) so that the division performs the single rounding */
+        _arf_set_mpn_fixed(mid, comp + 1, nl, nl,
+                (int) comp[0], nl * FLINT_BITS, ARF_RND_DOWN);
+        arf_mul_2exp_si(mid, mid, e);
+        inexact = arf_div_ui(mid, mid, den, prec, ARF_RND_DOWN);
+    }
+    else
+    {
+        inexact = _arf_set_mpn_fixed(mid, comp + 1, nl, nl,
+                (int) comp[0], prec, ARF_RND_DOWN);
+        arf_mul_2exp_si(mid, mid, e);
+    }
+
+    if (inexact)
+        arf_mag_add_ulp(arb_radref(part), arb_radref(part), mid, prec);
+}
+
+/* Threaded input/output conversion: at low precision and large n the
+   linear passes cost as much as the transform itself, and once the
+   transform is threaded a serial conversion would dominate the wall
+   time; both loops are embarrassingly parallel over disjoint
+   components. */
+
+#define GR_DFT_ACB_CONV_SERIAL 8192
+
+typedef struct
+{
+    acb_srcptr v;
+    nn_ptr x;
+    acb_ptr w;
+    nn_srcptr y;
+    slong lo;
+    slong hi;             /* component (not coefficient) range */
+    slong e;
+    slong nl;
+    slong rsz;
+    ulong den;
+    slong prec;
+    const mag_struct * errmag;
+}
+_acb_dft_conv_work_t;
+
+static void
+_acb_dft_conv_in_worker(void * arg)
+{
+    _acb_dft_conv_work_t * a = arg;
+    slong j;
+
+    for (j = a->lo; j < a->hi; j++)
+    {
+        arf_srcptr mid = (j % 2)
+            ? arb_midref(acb_imagref(a->v + j / 2))
+            : arb_midref(acb_realref(a->v + j / 2));
+
+        _acb_dft_arf_to_nfixed((nn_ptr) ((char *) a->x + j * a->rsz),
+                mid, a->e, a->nl);
+    }
+}
+
+static void
+_acb_dft_conv_out_worker(void * arg)
+{
+    _acb_dft_conv_work_t * a = arg;
+    slong j;
+
+    for (j = a->lo; j < a->hi; j++)
+    {
+        arb_ptr part = (j % 2)
+            ? acb_imagref(a->w + j / 2)
+            : acb_realref(a->w + j / 2);
+
+        mag_set(arb_radref(part), a->errmag);
+        _acb_dft_nfixed_to_arb(part,
+                (nn_srcptr) ((const char *) a->y + j * a->rsz),
+                a->e, a->nl, a->den, a->prec);
+    }
+}
+
+static void
+_acb_dft_conv_run(int out, acb_srcptr v, nn_ptr x, acb_ptr w, nn_srcptr y,
+        slong ncomp, slong e, slong nl, slong rsz, ulong den, slong prec,
+        const mag_struct * errmag)
+{
+    thread_pool_handle * handles = NULL;
+    slong num_workers = 0, nchunks, i;
+    _acb_dft_conv_work_t args[16];
+
+    if (ncomp >= 2 * GR_DFT_ACB_CONV_SERIAL && flint_get_num_threads() > 1)
+        num_workers = flint_request_threads(&handles,
+                FLINT_MIN(flint_get_num_threads(), 16));
+
+    nchunks = num_workers + 1;
+
+    for (i = 0; i < nchunks; i++)
+    {
+        args[i].v = v; args[i].x = x; args[i].w = w; args[i].y = y;
+        args[i].lo = (ncomp * i) / nchunks;
+        args[i].hi = (ncomp * (i + 1)) / nchunks;
+        args[i].e = e; args[i].nl = nl; args[i].rsz = rsz;
+        args[i].den = den; args[i].prec = prec; args[i].errmag = errmag;
+
+        if (i < num_workers)
+            thread_pool_wake(global_thread_pool, handles[i], 0,
+                    out ? _acb_dft_conv_out_worker : _acb_dft_conv_in_worker,
+                    &args[i]);
+    }
+
+    if (out)
+        _acb_dft_conv_out_worker(&args[num_workers]);
+    else
+        _acb_dft_conv_in_worker(&args[num_workers]);
+
+    for (i = 0; i < num_workers; i++)
+        thread_pool_wait(global_thread_pool, handles[i]);
+
+    flint_give_back_threads(handles, num_workers);
+}
+
+/* Parallel input scan: per-worker partial reductions (finiteness
+   flag, radius row sum, pointer to the largest-abs midpoint),
+   combined by the caller. */
+typedef struct
+{
+    acb_srcptr v;
+    slong lo;
+    slong hi;             /* coefficient range */
+    arf_srcptr best;
+    mag_t R;
+    int finite;
+}
+_acb_dft_scan_work_t;
+
+static void
+_acb_dft_scan_worker(void * arg)
+{
+    _acb_dft_scan_work_t * a = arg;
+    arf_srcptr best = arb_midref(acb_realref(a->v + a->lo));
+    slong j;
+
+    a->finite = 1;
+
+    for (j = a->lo; j < a->hi; j++)
+    {
+        arf_srcptr re = arb_midref(acb_realref(a->v + j));
+        arf_srcptr im = arb_midref(acb_imagref(a->v + j));
+
+        if (!arf_is_finite(re) || !arf_is_finite(im))
+        {
+            a->finite = 0;
+            return;
+        }
+
+        mag_add(a->R, a->R, arb_radref(acb_realref(a->v + j)));
+        mag_add(a->R, a->R, arb_radref(acb_imagref(a->v + j)));
+
+        if (arf_cmpabs(re, best) > 0)
+            best = re;
+        if (arf_cmpabs(im, best) > 0)
+            best = im;
+    }
+
+    a->best = best;
+}
+
+/* executor: runs the chunks whose index is congruent to its id */
+typedef struct
+{
+    _acb_dft_scan_work_t * chunks;
+    slong nchunks;
+    slong id;
+    slong stride;
+}
+_acb_dft_scan_exec_t;
+
+static void
+_acb_dft_scan_exec(void * arg)
+{
+    _acb_dft_scan_exec_t * a = arg;
+    slong i;
+
+    for (i = a->id; i < a->nchunks; i += a->stride)
+        _acb_dft_scan_worker(&a->chunks[i]);
+}
+
+/* Returns 0 if any coefficient is non-finite; otherwise R and t
+   receive the radius row sum and the largest-abs midpoint. The
+   reduction uses a fixed 16-chunk grid combined in canonical order,
+   so the result (in particular the upward-rounded mag sum, which is
+   not associative) is independent of the number of threads. */
+static int
+_acb_dft_scan(mag_t R, arf_t t, acb_srcptr v, slong n)
+{
+    thread_pool_handle * handles = NULL;
+    slong num_workers = 0, nexec, nchunks, i;
+    _acb_dft_scan_work_t args[16];
+    _acb_dft_scan_exec_t execs[16];
+    int finite = 1;
+
+    nchunks = (n >= GR_DFT_ACB_CONV_SERIAL) ? 16 : 1;
+
+    for (i = 0; i < nchunks; i++)
+    {
+        args[i].v = v;
+        args[i].lo = (n * i) / nchunks;
+        args[i].hi = (n * (i + 1)) / nchunks;
+        args[i].best = NULL;
+        mag_init(args[i].R);
+    }
+
+    if (nchunks > 1 && flint_get_num_threads() > 1)
+        num_workers = flint_request_threads(&handles,
+                FLINT_MIN(flint_get_num_threads(), nchunks));
+
+    nexec = num_workers + 1;
+
+    for (i = 0; i < nexec; i++)
+    {
+        execs[i].chunks = args;
+        execs[i].nchunks = nchunks;
+        execs[i].id = i;
+        execs[i].stride = nexec;
+
+        if (i < num_workers)
+            thread_pool_wake(global_thread_pool, handles[i], 0,
+                    _acb_dft_scan_exec, &execs[i]);
+    }
+
+    _acb_dft_scan_exec(&execs[num_workers]);
+
+    for (i = 0; i < num_workers; i++)
+        thread_pool_wait(global_thread_pool, handles[i]);
+
+    flint_give_back_threads(handles, num_workers);
+
+    arf_zero(t);
+    for (i = 0; i < nchunks; i++)
+    {
+        if (!args[i].finite)
+            finite = 0;
+        else
+        {
+            mag_add(R, R, args[i].R);
+            if (arf_cmpabs(args[i].best, t) > 0)
+                arf_set(t, args[i].best);
+        }
+        mag_clear(args[i].R);
+    }
+
+    return finite;
+}
+
+static int
+_gr_dft_acb_nfixed_apply(acb_ptr w, acb_srcptr v, int inverse,
+        const gr_dft_acb_pre_struct * Q, slong prec)
+{
+    int status = GR_SUCCESS;
+    gr_ctx_struct * rctx = (gr_ctx_struct *) Q->rctx;
+    gr_ctx_struct * cctx = (gr_ctx_struct *) Q->cctx;
+    slong n = Q->n;
+    gr_ptr x, y;
+    mag_t R, errmag;
+    arf_t t;
+    slong j, e, EM, rsz;
+
+    mag_init(R);
+    mag_init(errmag);
+    arf_init(t);
+
+    /* one (parallel) pass over the input: finiteness, radius row
+       sum, and the largest-abs midpoint */
+    if (!_acb_dft_scan(R, t, v, n))
+    {
+        status = GR_UNABLE;
+        goto cleanup;
+    }
+
+    if (arf_is_zero(t))
+    {
+        /* all midpoints zero: output midpoints are zero, radii come
+           from the perturbation bound alone */
+        if (inverse)
+            mag_div_ui(R, R, n);
+        for (j = 0; j < n; j++)
+        {
+            acb_zero(w + j);
+            mag_set(arb_radref(acb_realref(w + j)), R);
+            mag_set(arb_radref(acb_imagref(w + j)), R);
+        }
+        status = GR_SUCCESS;
+        goto cleanup;
+    }
+
+    /* arf_abs_bound_lt_2exp_si saturates at +-ARF_PREC_EXACT for
+       out-of-slong (bignum) exponents, so extreme and adversarial
+       magnitudes are guaranteed to fail this test and be routed to
+       ball arithmetic. The margin also ensures that e below, the
+       relative exponents in the input conversion, and the shifts
+       applied to the error magnitude all stay far from slong
+       overflow, on 32-bit as well as 64-bit systems. It further
+       makes the input conversion's treatment of individual bignum
+       exponents safe: with EM in range, a coefficient whose
+       exponent does not fit in an slong can only be tiny (a huge
+       coefficient would contradict the bound EM), so truncating it
+       to zero is correct. */
+    EM = arf_abs_bound_lt_2exp_si(t);
+    if (FLINT_ABS(EM) > WORD_MAX / 4)
+    {
+        status = GR_UNABLE;
+        goto cleanup;
+    }
+
+    /* input scale 2^-e with (m 2^-e) peak(1) <= 1/2 */
+    e = EM + Q->p1e + 1;
+
+    rsz = rctx->sizeof_elem;
+
+    /* fixed-point elements are plain limb blocks: allocate directly
+       (x zeroed, since the input conversion leaves zero and
+       underflowing components untouched; y is fully written by the
+       transform) */
+    x = flint_calloc(2 * n, rsz);
+    y = flint_malloc(2 * (size_t) n * rsz);
+
+    /* scale (exactly) and truncate the midpoints, writing the
+       fraction limbs directly */
+    _acb_dft_conv_run(0, v, (nn_ptr) x, NULL, NULL, 2 * n, e, Q->nl,
+            rsz, 0, prec, NULL);
+
+    if (inverse)
+        status |= _gr_dft_precomp_raw(y, x, 1, Q->P, cctx);
+    else
+        status |= gr_dft_precomp(y, x, Q->P, cctx);
+
+    /* absolute roundoff error, back at the input scale */
+    mag_set_d(errmag, Q->errulps);
+    mag_mul_2exp_si(errmag, errmag, -Q->nl * FLINT_BITS + e);
+    mag_add(errmag, errmag, R);
+
+    /* the raw inverse omits the 1/n normalization: for power-of-two
+       lengths it is folded into the output exponent for free, and
+       otherwise performed by a single rounded division per component
+       during the output conversion; the shared error magnitude is
+       divided once */
+    {
+        slong eout = e;
+        ulong den = 0;
+
+        if (inverse)
+        {
+            if ((n & (n - 1)) == 0)
+            {
+                slong k = FLINT_BIT_COUNT(n) - 1;
+                eout = e - k;
+                mag_mul_2exp_si(errmag, errmag, -k);
+            }
+            else
+            {
+                den = n;
+                mag_div_ui(errmag, errmag, n);
+            }
+        }
+
+        _acb_dft_conv_run(1, NULL, NULL, w, (nn_srcptr) y, 2 * n, eout,
+                Q->nl, rsz, den, prec, errmag);
+    }
+
+    flint_free(x);
+    flint_free(y);
+
+cleanup:
+    mag_clear(R);
+    mag_clear(errmag);
+    arf_clear(t);
+
+    return status;
+}
+
+static int
+_gr_dft_acb_nfixed(acb_ptr w, acb_srcptr v, slong n, int inverse, slong prec)
+{
+    int status;
+    gr_dft_acb_pre_struct Q;
+
+    Q.n = n;
+    Q.prec = prec;
+    Q.which = 2;
+
+    status = _gr_dft_acb_nfixed_select(&Q, n, prec);
+    if (status != GR_SUCCESS)
+        return status;
+
+    status = _gr_dft_acb_nfixed_apply(w, v, inverse, &Q, prec);
+
+    gr_dft_precomp_clear(Q.P);
+    gr_ctx_clear(Q.rctx);
+    gr_ctx_clear(Q.cctx);
+
+    return status;
+}
+
+/* Precomputation interface *****************************************/
+
+int
+gr_dft_acb_precomp_init(gr_dft_acb_pre_t Q, slong n, slong prec)
+{
+    int status = GR_SUCCESS;
+    int use_nfixed = 1;
+
+    if (n <= 0)
+        return GR_DOMAIN;
+
+    prec = FLINT_MAX(prec, 2);
+
+    Q->n = n;
+    Q->prec = prec;
+
+    if (use_nfixed)
+    {
+        status = _gr_dft_acb_nfixed_select(Q, n, prec);
+        if (status == GR_SUCCESS)
+        {
+            Q->which = 2;
+            return GR_SUCCESS;
+        }
+    }
+
+    /* ball arithmetic */
+    gr_ctx_init_real_arb(Q->rctx, prec);
+    gr_ctx_init_complex_acb(Q->cctx, prec);
+    status = gr_dft_precomp_init_karatsuba(Q->P, n, GR_DFT_ALG_AUTO, 0,
+            Q->rctx, Q->cctx);
+    if (status != GR_SUCCESS)
+    {
+        gr_dft_precomp_clear(Q->P);
+        gr_ctx_clear(Q->rctx);
+        gr_ctx_clear(Q->cctx);
+        Q->which = 0;
+        return status;
+    }
+    Q->which = 1;
+
+    return GR_SUCCESS;
+}
+
+void
+gr_dft_acb_precomp_clear(gr_dft_acb_pre_t Q)
+{
+    if (Q->which != 0)
+    {
+        gr_dft_precomp_clear(Q->P);
+        gr_ctx_clear(Q->rctx);
+        gr_ctx_clear(Q->cctx);
+        Q->which = 0;
+    }
+}
+
+int
+_gr_dft_acb_precomp(acb_ptr w, acb_srcptr v, int inverse,
+        const gr_dft_acb_pre_t Q, slong prec)
+{
+    int status;
+    slong n = Q->n;
+
+    prec = FLINT_MAX(prec, 2);
+
+    if (Q->which == 2)
+    {
+        status = _gr_dft_acb_nfixed_apply(w, v, inverse, Q, prec);
+
+        /* inputs the fixed-point path cannot handle: fall back to a
+           one-shot ball transform */
+        if (status != GR_SUCCESS)
+            status = _gr_dft_acb_ball(w, v, n, inverse, prec);
+    }
+    else if (Q->which == 1)
+    {
+        if (inverse)
+            status = gr_dft_inverse_precomp((gr_ptr) w, (gr_srcptr) v,
+                    Q->P, (gr_ctx_struct *) Q->cctx);
+        else
+            status = gr_dft_precomp((gr_ptr) w, (gr_srcptr) v,
+                    Q->P, (gr_ctx_struct *) Q->cctx);
+    }
+    else
+    {
+        status = GR_UNABLE;
+    }
+
+    if (status != GR_SUCCESS)
+    {
+        slong j;
+        for (j = 0; j < n; j++)
+            acb_indeterminate(w + j);
+    }
+
+    return status;
+}
+
+void
+gr_dft_acb_precomp(acb_ptr w, acb_srcptr v, const gr_dft_acb_pre_t Q,
+        slong prec)
+{
+    GR_IGNORE(_gr_dft_acb_precomp(w, v, 0, Q, prec));
+}
+
+void
+gr_dft_acb_inverse_precomp(acb_ptr w, acb_srcptr v,
+        const gr_dft_acb_pre_t Q, slong prec)
+{
+    GR_IGNORE(_gr_dft_acb_precomp(w, v, 1, Q, prec));
+}
+
+/* which: 0 = automatic, 1 = force acb/arb ball arithmetic internally,
+   2 = force fixed-point arithmetic internally */
+int
+_gr_dft_acb(acb_ptr w, acb_srcptr v, slong n, int inverse, int which,
+        slong prec)
+{
+    int status;
+
+    if (n <= 0)
+        return (n == 0) ? GR_SUCCESS : GR_DOMAIN;
+
+    prec = FLINT_MAX(prec, 2);
+
+    if (which == 1)
+        return _gr_dft_acb_ball(w, v, n, inverse, prec);
+
+    status = _gr_dft_acb_nfixed(w, v, n, inverse, prec);
+
+    if (status != GR_SUCCESS && which == 0)
+        status = _gr_dft_acb_ball(w, v, n, inverse, prec);
+
+    if (status != GR_SUCCESS)
+    {
+        slong j;
+        for (j = 0; j < n; j++)
+            acb_indeterminate(w + j);
+    }
+
+    return status;
+}
+
+void
+gr_dft_acb(acb_ptr w, acb_srcptr v, slong n, slong prec)
+{
+    if (n > 0)
+        GR_IGNORE(_gr_dft_acb(w, v, n, 0, 0, prec));
+}
+
+void
+gr_dft_acb_inverse(acb_ptr w, acb_srcptr v, slong n, slong prec)
+{
+    if (n > 0)
+        GR_IGNORE(_gr_dft_acb(w, v, n, 1, 0, prec));
+}

--- a/src/gr_dft/bailey.c
+++ b/src/gr_dft/bailey.c
@@ -1,0 +1,260 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <string.h>
+#include "thread_pool.h"
+#include "thread_support.h"
+#include "gr.h"
+#include "gr_dft.h"
+
+/* Four-step (Bailey) algorithm. Write n = n1 * n2 with n1, n2 ~ sqrt(n)
+   and view the input as an n2 x n1 matrix M[j2][j1] = x[j2 * n1 + j1].
+   With j = j1 + n1 * j2 and k = k2 + n2 * k1,
+
+       X_k = sum_{j1} w^(j1 k2) [ sum_{j2} x_{j1 + n1 j2} (w^n1)^(j2 k2) ]
+                     (w^n2)^(j1 k1),
+
+   giving: (1) length-n2 transforms along the columns (root w^n1),
+   (2) pointwise twiddles w^(j1 k2), (3) length-n1 transforms along the
+   rows (root w^n2), (4) a final transpose from C[k2 * n1 + k1] to
+   X[k2 + n2 * k1], which is skipped in scrambled mode.
+
+   Phases (1)-(3) consist of independent units of work (columns for
+   (1), rows for (2) and (3)) and are optionally distributed over
+   worker threads, either attached to the plan or requested from the
+   global thread pool for the duration of the transform. Each phase is
+   a single scatter/join round, so a threaded transform requires only
+   three synchronization points. Threads are only used when
+   gr_ctx_is_threadsafe certifies that the operations of the ring (and
+   of the real ring, in complex Karatsuba mode) are safe for concurrent use of
+   the same context; otherwise the transform runs serially. */
+
+/* Relocate elements according to a transposition, using flat memory
+   moves (gr elements are relocatable). */
+static void
+_transpose(gr_ptr x, ulong n1, ulong n2, int inverse, gr_ctx_t ctx)
+{
+    slong sz = ctx->sizeof_elem;
+    ulong n = n1 * n2, k1, k2;
+    char * tmp = flint_malloc(n * sz);
+    char * xp = (char *) x;
+
+    if (!inverse)
+    {
+        /* tmp[k2 + n2 * k1] = x[k2 * n1 + k1] */
+        for (k2 = 0; k2 < n2; k2++)
+            for (k1 = 0; k1 < n1; k1++)
+                memcpy(tmp + (k2 + n2 * k1) * sz,
+                       xp + (k2 * n1 + k1) * sz, sz);
+    }
+    else
+    {
+        /* tmp[k2 * n1 + k1] = x[k2 + n2 * k1] */
+        for (k2 = 0; k2 < n2; k2++)
+            for (k1 = 0; k1 < n1; k1++)
+                memcpy(tmp + (k2 * n1 + k1) * sz,
+                       xp + (k2 + n2 * k1) * sz, sz);
+    }
+
+    memcpy(xp, tmp, n * sz);
+    flint_free(tmp);
+}
+
+#define GR_DFT_BAILEY_COLS    0  /* column transforms (sub-plan P2) */
+#define GR_DFT_BAILEY_TWIDDLE 1
+#define GR_DFT_BAILEY_ROWS    2  /* row transforms (sub-plan P1) */
+
+typedef struct
+{
+    gr_ptr x;
+    const gr_dft_pre_struct * P;
+    gr_ctx_struct * ctx;
+    slong lo;
+    slong hi;
+    int phase;
+    int inverse;
+    int status;
+}
+_gr_dft_bailey_work_t;
+
+static void
+_gr_dft_bailey_worker(void * varg)
+{
+    _gr_dft_bailey_work_t * arg = (_gr_dft_bailey_work_t *) varg;
+    int status = GR_SUCCESS;
+    gr_ctx_struct * ctx = arg->ctx;
+    const gr_dft_pre_struct * P = arg->P;
+    slong sz = ctx->sizeof_elem;
+    ulong n1 = P->n1;
+    slong i;
+
+    if (arg->phase == GR_DFT_BAILEY_COLS)
+    {
+        for (i = arg->lo; i < arg->hi; i++)
+            status |= _gr_dft_ct(GR_ENTRY(arg->x, i, sz), n1,
+                    arg->inverse, 0, P->P2, ctx);
+    }
+    else if (arg->phase == GR_DFT_BAILEY_ROWS)
+    {
+        for (i = arg->lo; i < arg->hi; i++)
+            status |= _gr_dft_ct(GR_ENTRY(arg->x, i * n1, sz), 1,
+                    arg->inverse, 0, P->P1, ctx);
+    }
+    else
+    {
+        gr_ptr t, rtmp = NULL;
+        slong j1;
+
+        GR_TMP_INIT(t, ctx);
+        if (P->real_ctx != NULL)
+            GR_TMP_INIT(rtmp, P->real_ctx);
+
+        for (i = FLINT_MAX(arg->lo, 1); i < arg->hi; i++)
+        {
+            for (j1 = 1; j1 < (slong) n1; j1++)
+            {
+                gr_ptr a = GR_ENTRY(arg->x, i * n1 + j1, sz);
+
+                /* j1 * k2 <= (n1 - 1)(n2 - 1) < n, no reduction needed */
+                status |= _gr_dft_mul_root(t, a, j1 * i,
+                        arg->inverse, rtmp, P);
+                status |= gr_set(a, t, ctx);
+            }
+        }
+
+        GR_TMP_CLEAR(t, ctx);
+        if (P->real_ctx != NULL)
+            GR_TMP_CLEAR(rtmp, P->real_ctx);
+    }
+
+    arg->status = status;
+}
+
+/* Run one phase, distributing the units [0, items) over the main
+   thread and at most num_workers workers, with at most max_chunks
+   chunks in total. */
+static int
+_gr_dft_bailey_phase(int phase, gr_ptr x, int inverse, slong items,
+        slong max_chunks, thread_pool_handle * handles, slong num_workers,
+        const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    slong nchunks, i;
+    _gr_dft_bailey_work_t * args;
+
+    nchunks = FLINT_MIN(num_workers + 1, items);
+    nchunks = FLINT_MIN(nchunks, max_chunks);
+    nchunks = FLINT_MAX(nchunks, 1);
+
+    args = flint_malloc(nchunks * sizeof(_gr_dft_bailey_work_t));
+
+    for (i = 0; i < nchunks; i++)
+    {
+        args[i].x = x;
+        args[i].P = P;
+        args[i].ctx = ctx;
+        args[i].lo = (items * i) / nchunks;
+        args[i].hi = (items * (i + 1)) / nchunks;
+        args[i].phase = phase;
+        args[i].inverse = inverse;
+        args[i].status = GR_SUCCESS;
+
+        if (i < nchunks - 1)
+            thread_pool_wake(global_thread_pool, handles[i], 0,
+                    _gr_dft_bailey_worker, &args[i]);
+        else
+            _gr_dft_bailey_worker(&args[i]);
+    }
+
+    for (i = 0; i < nchunks - 1; i++)
+        thread_pool_wait(global_thread_pool, handles[i]);
+
+    for (i = 0; i < nchunks; i++)
+        status |= args[i].status;
+
+    flint_free(args);
+    return status;
+}
+
+int
+_gr_dft_bailey(gr_ptr x, int inverse, int scrambled,
+        const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    ulong n1 = P->n1, n2 = P->n2;
+    slong blk, max_chunks;
+    int threadsafe;
+    thread_pool_handle * handles = P->threads;
+    slong num_workers = P->num_threads;
+    thread_pool_handle * pool_handles = NULL;
+    slong pool_workers = 0;
+
+    threadsafe = (gr_ctx_is_threadsafe(ctx) == T_TRUE) &&
+            (P->real_ctx == NULL ||
+             gr_ctx_is_threadsafe(P->real_ctx) == T_TRUE);
+
+    if (!threadsafe)
+    {
+        handles = NULL;
+        num_workers = 0;
+    }
+
+    /* threading granularity: at most n / serial_block chunks per phase */
+    blk = (P->serial_block > 0) ? P->serial_block : GR_DFT_SERIAL_BLOCK_DEFAULT;
+    max_chunks = (slong) (P->n / (ulong) blk);
+
+    if (threadsafe && handles == NULL && max_chunks >= 2 &&
+        flint_get_num_threads() > 1)
+    {
+        pool_workers = flint_request_threads(&pool_handles,
+                FLINT_MIN(max_chunks, (slong) FLINT_MAX(n1, n2)));
+        handles = pool_handles;
+        num_workers = pool_workers;
+    }
+
+    if (handles == NULL || num_workers < 1 || max_chunks < 2)
+    {
+        num_workers = 0;
+        handles = NULL;
+        max_chunks = 1;
+    }
+
+    if (!inverse)
+    {
+        status |= _gr_dft_bailey_phase(GR_DFT_BAILEY_COLS, x, 0, n1,
+                max_chunks, handles, num_workers, P, ctx);
+        status |= _gr_dft_bailey_phase(GR_DFT_BAILEY_TWIDDLE, x, 0, n2,
+                max_chunks, handles, num_workers, P, ctx);
+        status |= _gr_dft_bailey_phase(GR_DFT_BAILEY_ROWS, x, 0, n2,
+                max_chunks, handles, num_workers, P, ctx);
+
+        if (!scrambled)
+            _transpose(x, n1, n2, 0, ctx);
+    }
+    else
+    {
+        if (!scrambled)
+            _transpose(x, n1, n2, 1, ctx);
+
+        status |= _gr_dft_bailey_phase(GR_DFT_BAILEY_ROWS, x, 1, n2,
+                max_chunks, handles, num_workers, P, ctx);
+        status |= _gr_dft_bailey_phase(GR_DFT_BAILEY_TWIDDLE, x, 1, n2,
+                max_chunks, handles, num_workers, P, ctx);
+        status |= _gr_dft_bailey_phase(GR_DFT_BAILEY_COLS, x, 1, n1,
+                max_chunks, handles, num_workers, P, ctx);
+    }
+
+    if (pool_handles != NULL)
+        flint_give_back_threads(pool_handles, pool_workers);
+
+    return status;
+}

--- a/src/gr_dft/bit_reverse.c
+++ b/src/gr_dft/bit_reverse.c
@@ -1,0 +1,31 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "ulong_extras.h"
+#include "gr.h"
+#include "gr_dft.h"
+
+void
+_gr_dft_bit_reverse(gr_ptr x, slong stride, int depth, gr_ctx_t ctx)
+{
+    slong sz = ctx->sizeof_elem;
+    ulong i, j, n = UWORD(1) << depth;
+
+    for (i = 0; i < n; i++)
+    {
+        j = n_revbin(i, depth);
+
+        if (i < j)
+            gr_swap(GR_ENTRY(x, (slong) i * stride, sz),
+                    GR_ENTRY(x, (slong) j * stride, sz), ctx);
+    }
+}

--- a/src/gr_dft/bluestein.c
+++ b/src/gr_dft/bluestein.c
@@ -1,0 +1,106 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "ulong_extras.h"
+#include "gr.h"
+#include "gr_vec.h"
+#include "gr_dft.h"
+
+/* Bluestein's algorithm for odd n. With t = (n+1)/2 = 1/2 mod n we have
+   j k = t (j^2 + k^2 - (j-k)^2) mod n, so
+
+       X_k = w^(t k^2) sum_j (w^(t j^2) x_j) w^(-t (k-j)^2),
+
+   a cyclic convolution of length n of the chirped input with the even,
+   n-periodic kernel h_j = w^(-t j^2), embedded in a cyclic convolution
+   of power-of-two length conv_len >= 2n - 1 which is evaluated with
+   the sub-plan P->P1. The chirp factors are entries of the root table,
+   so in complex Karatsuba mode they enjoy the reduced-multiplication classes.
+   The transformed kernel P->bl_kern is precomputed with the 1/conv_len
+   scaling of the inverse sub-transform folded in, and is stored in the
+   (scrambled) output order of the sub-plan, so no reordering passes
+   are needed.
+
+   The inverse transform is the forward transform applied to the
+   cyclically reversed input, x'_j = x_((n - j) mod n).
+
+   res must not alias vec. */
+int
+_gr_dft_bluestein(gr_ptr res, gr_srcptr vec, int inverse,
+        const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    slong sz = ctx->sizeof_elem;
+    slong rsz = (P->real_ctx != NULL) ? P->real_ctx->sizeof_elem : 0;
+    ulong n = P->n, N = P->conv_len, j, k, e, t2, ninv;
+    gr_ptr bufA, bufB, rtmp = NULL;
+
+    bufA = flint_malloc(2 * N * sz);
+    _gr_vec_init(bufA, 2 * N, ctx);
+    bufB = GR_ENTRY(bufA, N, sz);
+
+    if (P->real_ctx != NULL)
+        GR_TMP_INIT(rtmp, P->real_ctx);
+
+    t2 = (n + 1) / 2;
+    ninv = n_preinvert_limb(n);
+
+    /* chirp the (possibly reversed) input */
+    for (j = 0; j < n; j++)
+    {
+        gr_srcptr src = GR_ENTRY(vec,
+                (inverse && j > 0) ? n - j : j, sz);
+
+        e = n_mulmod2_preinv(j, j, n, ninv);
+        e = n_mulmod2_preinv(e, t2, n, ninv);
+        status |= _gr_dft_mul_root(GR_ENTRY(bufA, j, sz), src, e, 0, rtmp, P);
+    }
+
+    status |= _gr_vec_zero(GR_ENTRY(bufA, n, sz), N - n, ctx);
+
+    /* convolve with the kernel */
+    status |= _gr_dft_precomp_raw(bufB, bufA, 0, P->P1, ctx);
+
+    for (k = 0; k < N; k++)
+        status |= _gr_dft_mul_const(GR_ENTRY(bufA, k, sz),
+                GR_ENTRY(bufB, k, sz),
+                GR_ENTRY(P->bl_kern, k, sz),
+                (P->bl_wtab != NULL) ? GR_ENTRY(P->bl_wtab, 3 * k, rsz) : NULL,
+                rtmp, P);
+
+    status |= _gr_dft_precomp_raw(bufB, bufA, 1, P->P1, ctx);
+
+    /* chirp the output */
+    for (k = 0; k < n; k++)
+    {
+        e = n_mulmod2_preinv(k, k, n, ninv);
+        e = n_mulmod2_preinv(e, t2, n, ninv);
+        status |= _gr_dft_mul_root(GR_ENTRY(res, k, sz),
+                GR_ENTRY(bufB, k, sz), e, 0, rtmp, P);
+    }
+
+    /* over the fixed-point contexts the kernel carries an extra
+       factor 1/2 (see the kernel construction); undo it with exact
+       doublings */
+    if (P->bl_shifted)
+        for (k = 0; k < n; k++)
+            status |= gr_add(GR_ENTRY(res, k, sz), GR_ENTRY(res, k, sz),
+                    GR_ENTRY(res, k, sz), ctx);
+
+    if (P->real_ctx != NULL)
+        GR_TMP_CLEAR(rtmp, P->real_ctx);
+
+    _gr_vec_clear(bufA, 2 * N, ctx);
+    flint_free(bufA);
+
+    return status;
+}

--- a/src/gr_dft/ct.c
+++ b/src/gr_dft/ct.c
@@ -1,0 +1,1003 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "thread_pool.h"
+#include "thread_support.h"
+#include "gr.h"
+#include "gr_dft.h"
+
+/* The butterfly loops are organized so that the inner loops perform no
+   w-dependent branching: within each block of a pass, the twiddle
+   indices j whose roots are special rotations sit at the known
+   positions j = 0, hm/4, hm/2, 3 hm/4 (exponents 0, n/8, n/4, 3n/8).
+   These few butterflies are handled individually through
+   _gr_dft_mul_root, and the remaining ranges of j run through plain
+   loops multiplying by a walking pointer into the root table (one
+   gr_mul per butterfly), or into the complex Karatsuba tables when
+   those are enabled. */
+
+/* DIF butterflies (t = a - b; a += b; b = w^e t) for j in [j0, j1)
+   within the block at base index kbase, with generic root
+   multiplications. Requires 1 <= j0 <= j1 <= hm and j1 * rstep <= n/2. */
+static int
+_gr_dft_ct_bflys_dif(gr_ptr x, slong stride, ulong kbase, ulong hm,
+        ulong j0, ulong j1, ulong rstep, int inverse,
+        gr_ptr t, gr_ptr rtmp, const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    slong sz = ctx->sizeof_elem;
+    slong xs = stride * sz;
+    gr_ptr a = GR_ENTRY(x, (slong) (kbase + j0) * stride, sz);
+    gr_ptr b = GR_ENTRY(x, (slong) (kbase + j0 + hm) * stride, sz);
+    ulong j, e0 = inverse ? P->n - j0 * rstep : j0 * rstep;
+    slong es = (inverse ? -(slong) rstep : (slong) rstep) * sz;
+    gr_srcptr w = GR_ENTRY(P->roots, e0, sz);
+
+    if (P->wtab == NULL)
+    {
+        for (j = j0; j < j1; j++)
+        {
+            status |= gr_sub(t, a, b, ctx);
+            status |= gr_add(a, a, b, ctx);
+            status |= gr_mul(b, t, w, ctx);
+
+            a = (gr_ptr) ((char *) a + xs);
+            b = (gr_ptr) ((char *) b + xs);
+            w = (gr_srcptr) ((char *) w + es);
+        }
+    }
+    else
+    {
+        gr_ctx_struct * rctx = P->real_ctx;
+        slong rsz = rctx->sizeof_elem;
+        slong cs = 3 * ((inverse ? -(slong) rstep : (slong) rstep) * rsz);
+        gr_srcptr c = GR_ENTRY(P->wtab, 3 * e0, rsz);
+
+        for (j = j0; j < j1; j++)
+        {
+            gr_srcptr tr = t, ti = GR_ENTRY(t, 1, rsz);
+            gr_ptr br = b, bi = GR_ENTRY(b, 1, rsz);
+
+            status |= gr_sub(t, a, b, ctx);
+            status |= gr_add(a, a, b, ctx);
+
+            /* 3-multiplication complex Karatsuba product b = w t,
+               with (c, d - c, d + c) at the walking table pointer */
+            status |= gr_add(rtmp, tr, ti, rctx);
+            status |= gr_mul(rtmp, rtmp, c, rctx);
+            status |= gr_mul(br, ti, GR_ENTRY(c, 2, rsz), rctx);
+            status |= gr_mul(bi, tr, GR_ENTRY(c, 1, rsz), rctx);
+            status |= gr_sub(br, rtmp, br, rctx);
+            status |= gr_add(bi, rtmp, bi, rctx);
+
+            a = (gr_ptr) ((char *) a + xs);
+            b = (gr_ptr) ((char *) b + xs);
+            c = (gr_srcptr) ((char *) c + cs);
+        }
+    }
+
+    return status;
+}
+
+/* DIT butterflies (t = w^e b; b = a - t; a += t), otherwise as above. */
+static int
+_gr_dft_ct_bflys_dit(gr_ptr x, slong stride, ulong kbase, ulong hm,
+        ulong j0, ulong j1, ulong rstep, int inverse,
+        gr_ptr t, gr_ptr rtmp, const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    slong sz = ctx->sizeof_elem;
+    slong xs = stride * sz;
+    gr_ptr a = GR_ENTRY(x, (slong) (kbase + j0) * stride, sz);
+    gr_ptr b = GR_ENTRY(x, (slong) (kbase + j0 + hm) * stride, sz);
+    ulong j, e0 = inverse ? P->n - j0 * rstep : j0 * rstep;
+    slong es = (inverse ? -(slong) rstep : (slong) rstep) * sz;
+    gr_srcptr w = GR_ENTRY(P->roots, e0, sz);
+
+    if (P->wtab == NULL)
+    {
+        for (j = j0; j < j1; j++)
+        {
+            status |= gr_mul(t, b, w, ctx);
+            status |= gr_sub(b, a, t, ctx);
+            status |= gr_add(a, a, t, ctx);
+
+            a = (gr_ptr) ((char *) a + xs);
+            b = (gr_ptr) ((char *) b + xs);
+            w = (gr_srcptr) ((char *) w + es);
+        }
+    }
+    else
+    {
+        gr_ctx_struct * rctx = P->real_ctx;
+        slong rsz = rctx->sizeof_elem;
+        slong cs = 3 * ((inverse ? -(slong) rstep : (slong) rstep) * rsz);
+        gr_srcptr c = GR_ENTRY(P->wtab, 3 * e0, rsz);
+
+        for (j = j0; j < j1; j++)
+        {
+            gr_srcptr br = b, bi = GR_ENTRY(b, 1, rsz);
+            gr_ptr tr = t, ti = GR_ENTRY(t, 1, rsz);
+
+            /* t = w b by complex Karatsuba */
+            status |= gr_add(rtmp, br, bi, rctx);
+            status |= gr_mul(rtmp, rtmp, c, rctx);
+            status |= gr_mul(tr, bi, GR_ENTRY(c, 2, rsz), rctx);
+            status |= gr_mul(ti, br, GR_ENTRY(c, 1, rsz), rctx);
+            status |= gr_sub(tr, rtmp, tr, rctx);
+            status |= gr_add(ti, rtmp, ti, rctx);
+
+            status |= gr_sub(b, a, t, ctx);
+            status |= gr_add(a, a, t, ctx);
+
+            a = (gr_ptr) ((char *) a + xs);
+            b = (gr_ptr) ((char *) b + xs);
+            c = (gr_srcptr) ((char *) c + cs);
+        }
+    }
+
+    return status;
+}
+
+/* One special butterfly at twiddle index j (a rotation handled through
+   the class dispatch of _gr_dft_mul_root). */
+static int
+_gr_dft_ct_bfly_special(int dit, gr_ptr x, slong stride, ulong kbase,
+        ulong hm, ulong j, ulong rstep, int inverse,
+        gr_ptr t, gr_ptr rtmp, const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    slong sz = ctx->sizeof_elem;
+    gr_ptr a = GR_ENTRY(x, (slong) (kbase + j) * stride, sz);
+    gr_ptr b = GR_ENTRY(x, (slong) (kbase + j + hm) * stride, sz);
+
+    if (dit)
+    {
+        status |= _gr_dft_mul_root(t, b, j * rstep, inverse, rtmp, P);
+        status |= gr_sub(b, a, t, ctx);
+        status |= gr_add(a, a, t, ctx);
+    }
+    else
+    {
+        status |= gr_sub(t, a, b, ctx);
+        status |= gr_add(a, a, b, ctx);
+        status |= _gr_dft_mul_root(b, t, j * rstep, inverse, rtmp, P);
+    }
+
+    return status;
+}
+
+/* Packed-table butterfly loops: the stage-s twiddles are contiguous
+   (stage_tab + n - 2^s, entries w^(j rstep), j < hm), so the forward
+   walk is sequential; the inverse multiplies by
+   w^(-j rstep) = -stage_s[hm - j], a reversed sequential walk with
+   the negation folded into the butterfly (swapping the roles of the
+   sum and difference), at no extra cost. */
+static int
+_gr_dft_ct_bflys_dif_packed(gr_ptr x, slong stride, ulong kbase, ulong hm,
+        ulong j0, ulong j1, int inverse, gr_srcptr stage,
+        gr_ptr t, const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    slong sz = ctx->sizeof_elem;
+    slong xs = stride * sz;
+    gr_ptr a = GR_ENTRY(x, (slong) (kbase + j0) * stride, sz);
+    gr_ptr b = GR_ENTRY(x, (slong) (kbase + j0 + hm) * stride, sz);
+    ulong j;
+
+    if (!inverse)
+    {
+        gr_srcptr w = GR_ENTRY(stage, j0, sz);
+
+        for (j = j0; j < j1; j++)
+        {
+            status |= gr_sub(t, a, b, ctx);
+            status |= gr_add(a, a, b, ctx);
+            status |= gr_mul(b, t, w, ctx);
+
+            a = (gr_ptr) ((char *) a + xs);
+            b = (gr_ptr) ((char *) b + xs);
+            w = (gr_srcptr) ((char *) w + sz);
+        }
+    }
+    else
+    {
+        gr_srcptr w = GR_ENTRY(stage, hm - j0, sz);
+
+        for (j = j0; j < j1; j++)
+        {
+            status |= gr_sub(t, b, a, ctx);     /* -(a - b) */
+            status |= gr_add(a, a, b, ctx);
+            status |= gr_mul(b, t, w, ctx);
+
+            a = (gr_ptr) ((char *) a + xs);
+            b = (gr_ptr) ((char *) b + xs);
+            w = (gr_srcptr) ((char *) w - sz);
+        }
+    }
+
+    return status;
+}
+
+static int
+_gr_dft_ct_bflys_dit_packed(gr_ptr x, slong stride, ulong kbase, ulong hm,
+        ulong j0, ulong j1, int inverse, gr_srcptr stage,
+        gr_ptr t, const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    slong sz = ctx->sizeof_elem;
+    slong xs = stride * sz;
+    gr_ptr a = GR_ENTRY(x, (slong) (kbase + j0) * stride, sz);
+    gr_ptr b = GR_ENTRY(x, (slong) (kbase + j0 + hm) * stride, sz);
+    ulong j;
+
+    if (!inverse)
+    {
+        gr_srcptr w = GR_ENTRY(stage, j0, sz);
+
+        for (j = j0; j < j1; j++)
+        {
+            status |= gr_mul(t, b, w, ctx);
+            status |= gr_sub(b, a, t, ctx);
+            status |= gr_add(a, a, t, ctx);
+
+            a = (gr_ptr) ((char *) a + xs);
+            b = (gr_ptr) ((char *) b + xs);
+            w = (gr_srcptr) ((char *) w + sz);
+        }
+    }
+    else
+    {
+        gr_srcptr w = GR_ENTRY(stage, hm - j0, sz);
+
+        for (j = j0; j < j1; j++)
+        {
+            status |= gr_mul(t, b, w, ctx);     /* -(b w^(-j rstep)) */
+            status |= gr_add(b, a, t, ctx);
+            status |= gr_sub(a, a, t, ctx);
+
+            a = (gr_ptr) ((char *) a + xs);
+            b = (gr_ptr) ((char *) b + xs);
+            w = (gr_srcptr) ((char *) w - sz);
+        }
+    }
+
+    return status;
+}
+
+/* Special rotations at the quarter and eighth positions of a stage
+   (complex mode): positional, using only the constant c (the real
+   part of w^(n/8), read from the packed entry at hm/4) and sign/swap
+   patterns; the inverse rotations are the conjugates. */
+static int
+_gr_dft_ct_rot_special_packed(gr_ptr r, gr_srcptr v, ulong hm, ulong j,
+        int inverse, gr_srcptr stage, gr_ptr rtmp,
+        const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    gr_ctx_struct * rctx = P->real_ctx;
+    slong rsz = rctx->sizeof_elem;
+    gr_srcptr xr = v, xi = GR_ENTRY(v, 1, rsz);
+    gr_ptr rr = r, ri = GR_ENTRY(r, 1, rsz);
+
+    if (2 * j == hm || hm == 2)
+    {
+        /* w^(n/4) = -i (forward), w^(-n/4) = i (inverse) */
+        if (!inverse)
+        {
+            status |= gr_set(rr, xi, rctx);
+            status |= gr_neg(ri, xr, rctx);
+        }
+        else
+        {
+            status |= gr_neg(rr, xi, rctx);
+            status |= gr_set(ri, xr, rctx);
+        }
+    }
+    else
+    {
+        gr_srcptr c = GR_ENTRY(stage, hm / 4, ctx->sizeof_elem);
+
+        if (4 * j == hm)
+        {
+            if (!inverse)
+            {
+                /* c (1 - i): rr = c (xr + xi), ri = c (xi - xr) */
+                status |= gr_add(rtmp, xr, xi, rctx);
+                status |= gr_mul(rr, c, rtmp, rctx);
+                status |= gr_sub(rtmp, xi, xr, rctx);
+                status |= gr_mul(ri, c, rtmp, rctx);
+            }
+            else
+            {
+                /* c (1 + i): rr = c (xr - xi), ri = c (xr + xi) */
+                status |= gr_sub(rtmp, xr, xi, rctx);
+                status |= gr_mul(rr, c, rtmp, rctx);
+                status |= gr_add(rtmp, xr, xi, rctx);
+                status |= gr_mul(ri, c, rtmp, rctx);
+            }
+        }
+        else    /* j = 3 hm / 4 */
+        {
+            if (!inverse)
+            {
+                /* -c (1 + i): rr = c (xi - xr), ri = -c (xr + xi) */
+                status |= gr_sub(rtmp, xi, xr, rctx);
+                status |= gr_mul(rr, c, rtmp, rctx);
+                status |= gr_add(rtmp, xr, xi, rctx);
+                status |= gr_mul(ri, c, rtmp, rctx);
+                status |= gr_neg(ri, ri, rctx);
+            }
+            else
+            {
+                /* -c (1 - i): rr = -c (xr + xi), ri = c (xr - xi) */
+                status |= gr_add(rtmp, xr, xi, rctx);
+                status |= gr_mul(rr, c, rtmp, rctx);
+                status |= gr_neg(rr, rr, rctx);
+                status |= gr_sub(rtmp, xr, xi, rctx);
+                status |= gr_mul(ri, c, rtmp, rctx);
+            }
+        }
+    }
+
+    return status;
+}
+
+static int
+_gr_dft_ct_bfly_special_packed(int dit, gr_ptr x, slong stride, ulong kbase,
+        ulong hm, ulong j, int inverse, gr_srcptr stage,
+        gr_ptr t, gr_ptr rtmp, const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    slong sz = ctx->sizeof_elem;
+    gr_ptr a = GR_ENTRY(x, (slong) (kbase + j) * stride, sz);
+    gr_ptr b = GR_ENTRY(x, (slong) (kbase + j + hm) * stride, sz);
+
+    if (dit)
+    {
+        status |= _gr_dft_ct_rot_special_packed(t, b, hm, j, inverse,
+                stage, rtmp, P, ctx);
+        status |= gr_sub(b, a, t, ctx);
+        status |= gr_add(a, a, t, ctx);
+    }
+    else
+    {
+        gr_ptr u = t;   /* difference, then rotated in place is unsafe;
+                           rotate from the freshly computed difference
+                           held in t into b directly */
+        status |= gr_sub(t, a, b, ctx);
+        status |= gr_add(a, a, b, ctx);
+        status |= _gr_dft_ct_rot_special_packed(b, u, hm, j, inverse,
+                stage, rtmp, P, ctx);
+    }
+
+    return status;
+}
+
+/* The butterflies of one block with twiddle indices in [jlo, jhi):
+   the free rotation at j = 0 (when jlo = 0), the special rotations at
+   j = hm/4, hm/2, 3 hm/4 (in complex mode), and plain loops in
+   between. The full block is [0, hm); sub-ranges are used by the
+   threaded driver. */
+static int
+_gr_dft_ct_jrange(int dit, gr_ptr x, slong stride, ulong kbase, ulong hm,
+        ulong jlo, ulong jhi, ulong rstep, int inverse,
+        gr_ptr t, gr_ptr rtmp, const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    ulong cur;
+
+    /* j = 0: (a, b) -> (a + b, a - b) in both directions */
+    if (jlo == 0)
+    {
+        gr_ptr a = GR_ENTRY(x, (slong) kbase * stride, ctx->sizeof_elem);
+        gr_ptr b = GR_ENTRY(x, (slong) (kbase + hm) * stride, ctx->sizeof_elem);
+
+        status |= gr_sub(t, a, b, ctx);
+        status |= gr_add(a, a, b, ctx);
+        status |= gr_set(b, t, ctx);
+    }
+
+    cur = FLINT_MAX(jlo, 1);
+    if (cur >= jhi)
+        return status;
+
+    if (P->stage_tab != NULL)
+    {
+        gr_srcptr stage = GR_ENTRY(P->stage_tab,
+                P->n - 2 * hm, ctx->sizeof_elem);
+
+        if (P->real_ctx == NULL)
+        {
+            if (dit)
+                status |= _gr_dft_ct_bflys_dit_packed(x, stride, kbase, hm,
+                        cur, jhi, inverse, stage, t, P, ctx);
+            else
+                status |= _gr_dft_ct_bflys_dif_packed(x, stride, kbase, hm,
+                        cur, jhi, inverse, stage, t, P, ctx);
+        }
+        else
+        {
+            ulong sp[3];
+            slong nsp = 0, i;
+
+            if (hm == 2)
+            {
+                sp[nsp++] = 1;
+            }
+            else if (hm >= 4)
+            {
+                ulong q = hm / 4;
+                sp[nsp++] = q;
+                sp[nsp++] = 2 * q;
+                sp[nsp++] = 3 * q;
+            }
+
+            for (i = 0; i < nsp && cur < jhi; i++)
+            {
+                ulong sj = sp[i];
+
+                if (sj < cur)
+                    continue;
+
+                if (cur < FLINT_MIN(sj, jhi))
+                {
+                    if (dit)
+                        status |= _gr_dft_ct_bflys_dit_packed(x, stride,
+                                kbase, hm, cur, FLINT_MIN(sj, jhi),
+                                inverse, stage, t, P, ctx);
+                    else
+                        status |= _gr_dft_ct_bflys_dif_packed(x, stride,
+                                kbase, hm, cur, FLINT_MIN(sj, jhi),
+                                inverse, stage, t, P, ctx);
+                }
+
+                if (sj < jhi)
+                    status |= _gr_dft_ct_bfly_special_packed(dit, x, stride,
+                            kbase, hm, sj, inverse, stage, t, rtmp, P, ctx);
+
+                cur = FLINT_MAX(cur, sj + 1);
+            }
+
+            if (cur < jhi)
+            {
+                if (dit)
+                    status |= _gr_dft_ct_bflys_dit_packed(x, stride, kbase,
+                            hm, cur, jhi, inverse, stage, t, P, ctx);
+                else
+                    status |= _gr_dft_ct_bflys_dif_packed(x, stride, kbase,
+                            hm, cur, jhi, inverse, stage, t, P, ctx);
+            }
+        }
+
+        return status;
+    }
+
+    if (P->wclass == NULL)
+    {
+        if (dit)
+            status |= _gr_dft_ct_bflys_dit(x, stride, kbase, hm, cur, jhi,
+                    rstep, inverse, t, rtmp, P, ctx);
+        else
+            status |= _gr_dft_ct_bflys_dif(x, stride, kbase, hm, cur, jhi,
+                    rstep, inverse, t, rtmp, P, ctx);
+    }
+    else
+    {
+        /* special twiddle positions within the block */
+        ulong sp[3];
+        slong nsp = 0, i;
+
+        if (hm == 2)
+        {
+            sp[nsp++] = 1;
+        }
+        else if (hm >= 4)
+        {
+            ulong q = hm / 4;
+            sp[nsp++] = q;
+            sp[nsp++] = 2 * q;
+            sp[nsp++] = 3 * q;
+        }
+
+        for (i = 0; i < nsp && cur < jhi; i++)
+        {
+            ulong sj = sp[i];
+
+            if (sj < cur)
+                continue;
+
+            if (cur < FLINT_MIN(sj, jhi))
+            {
+                if (dit)
+                    status |= _gr_dft_ct_bflys_dit(x, stride, kbase, hm,
+                            cur, FLINT_MIN(sj, jhi), rstep, inverse,
+                            t, rtmp, P, ctx);
+                else
+                    status |= _gr_dft_ct_bflys_dif(x, stride, kbase, hm,
+                            cur, FLINT_MIN(sj, jhi), rstep, inverse,
+                            t, rtmp, P, ctx);
+            }
+
+            if (sj < jhi)
+                status |= _gr_dft_ct_bfly_special(dit, x, stride, kbase,
+                        hm, sj, rstep, inverse, t, rtmp, P, ctx);
+
+            cur = FLINT_MAX(cur, sj + 1);
+        }
+
+        if (cur < jhi)
+        {
+            if (dit)
+                status |= _gr_dft_ct_bflys_dit(x, stride, kbase, hm,
+                        cur, jhi, rstep, inverse, t, rtmp, P, ctx);
+            else
+                status |= _gr_dft_ct_bflys_dif(x, stride, kbase, hm,
+                        cur, jhi, rstep, inverse, t, rtmp, P, ctx);
+        }
+    }
+
+    return status;
+}
+
+/* Decimation in frequency: natural order input, bit-reversed output. */
+/* All decimation levels s, ..., 1 over the aligned block
+   [kbase, kbase + 2^s), in a depth-first blocked order: blocks larger
+   than GR_DFT_CT_BLOCK_BYTES run their top pass, then recurse into
+   the two halves, so that each cache-sized sub-block completes all
+   its remaining levels while resident; the level-by-level order,
+   which would stream the block from memory once per level, is used
+   only once a block fits. The set of butterflies and their
+   dependency order are identical to the plain level-by-level
+   transform, so results are bitwise the same. */
+static int
+_gr_dft_ct_dif_range(gr_ptr x, slong stride, ulong kbase, int s,
+        int inverse, gr_ptr t, gr_ptr rtmp,
+        const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    ulong n = P->n;
+
+    if (s >= 2 &&
+        (UWORD(1) << s) * (ulong) ctx->sizeof_elem > GR_DFT_CT_BLOCK_BYTES)
+    {
+        ulong hm = UWORD(1) << (s - 1);
+
+        status |= _gr_dft_ct_jrange(0, x, stride, kbase, hm, 0, hm,
+                n >> s, inverse, t, rtmp, P, ctx);
+        status |= _gr_dft_ct_dif_range(x, stride, kbase, s - 1,
+                inverse, t, rtmp, P, ctx);
+        status |= _gr_dft_ct_dif_range(x, stride, kbase + hm, s - 1,
+                inverse, t, rtmp, P, ctx);
+    }
+    else
+    {
+        int ss;
+        ulong k, m;
+
+        for (ss = s; ss >= 1; ss--)
+        {
+            m = UWORD(1) << ss;
+            for (k = kbase; k < kbase + (UWORD(1) << s); k += m)
+                status |= _gr_dft_ct_jrange(0, x, stride, k, m >> 1,
+                        0, m >> 1, n >> ss, inverse, t, rtmp, P, ctx);
+        }
+    }
+
+    return status;
+}
+
+static int
+_gr_dft_ct_dit_range(gr_ptr x, slong stride, ulong kbase, int s,
+        int inverse, gr_ptr t, gr_ptr rtmp,
+        const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    ulong n = P->n;
+
+    if (s >= 2 &&
+        (UWORD(1) << s) * (ulong) ctx->sizeof_elem > GR_DFT_CT_BLOCK_BYTES)
+    {
+        ulong hm = UWORD(1) << (s - 1);
+
+        status |= _gr_dft_ct_dit_range(x, stride, kbase, s - 1,
+                inverse, t, rtmp, P, ctx);
+        status |= _gr_dft_ct_dit_range(x, stride, kbase + hm, s - 1,
+                inverse, t, rtmp, P, ctx);
+        status |= _gr_dft_ct_jrange(1, x, stride, kbase, hm, 0, hm,
+                n >> s, inverse, t, rtmp, P, ctx);
+    }
+    else
+    {
+        int ss;
+        ulong k, m;
+
+        for (ss = 1; ss <= s; ss++)
+        {
+            m = UWORD(1) << ss;
+            for (k = kbase; k < kbase + (UWORD(1) << s); k += m)
+                status |= _gr_dft_ct_jrange(1, x, stride, k, m >> 1,
+                        0, m >> 1, n >> ss, inverse, t, rtmp, P, ctx);
+        }
+    }
+
+    return status;
+}
+
+static int
+_gr_dft_ct_dif(gr_ptr x, slong stride, int inverse,
+        const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    gr_ptr t, rtmp = NULL;
+
+    GR_TMP_INIT(t, ctx);
+    if (P->real_ctx != NULL)
+        GR_TMP_INIT(rtmp, P->real_ctx);
+
+    status |= _gr_dft_ct_dif_range(x, stride, 0, P->depth,
+            inverse, t, rtmp, P, ctx);
+
+    GR_TMP_CLEAR(t, ctx);
+    if (P->real_ctx != NULL)
+        GR_TMP_CLEAR(rtmp, P->real_ctx);
+
+    return status;
+}
+
+/* Decimation in time: bit-reversed input, natural order output. */
+static int
+_gr_dft_ct_dit(gr_ptr x, slong stride, int inverse,
+        const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    gr_ptr t, rtmp = NULL;
+
+    GR_TMP_INIT(t, ctx);
+    if (P->real_ctx != NULL)
+        GR_TMP_INIT(rtmp, P->real_ctx);
+
+    status |= _gr_dft_ct_dit_range(x, stride, 0, P->depth,
+            inverse, t, rtmp, P, ctx);
+
+    GR_TMP_CLEAR(t, ctx);
+    if (P->real_ctx != NULL)
+        GR_TMP_CLEAR(rtmp, P->real_ctx);
+
+    return status;
+}
+
+/* In-place transform of the strided vector x[0], x[stride], ...,
+   x[(n-1)*stride]. If scrambled is set, the forward transform leaves
+   the output in bit-reversed order and the inverse transform expects
+   its input in bit-reversed order; otherwise both are in natural order.
+   The inverse transform omits the scaling by 1/n. */
+int
+_gr_dft_ct(gr_ptr x, slong stride, int inverse, int scrambled,
+        const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+
+    if (P->depth == 0)
+        return GR_SUCCESS;
+
+    if (!inverse)
+    {
+        status |= _gr_dft_ct_dif(x, stride, 0, P, ctx);
+        if (!scrambled)
+            _gr_dft_bit_reverse(x, stride, P->depth, ctx);
+    }
+    else
+    {
+        if (!scrambled)
+            _gr_dft_bit_reverse(x, stride, P->depth, ctx);
+        status |= _gr_dft_ct_dit(x, stride, 1, P, ctx);
+    }
+
+    return status;
+}
+
+/* Pass-parallel threaded execution (used for top-level transforms
+   only; the serial _gr_dft_ct above is also invoked for the
+   sub-transforms inside the Bailey workers and must never attempt to
+   acquire threads itself).
+
+   Within each pass all n/2 butterflies are independent; they are
+   indexed by flat units u in [0, n/2), u -> (block u / hm, twiddle
+   index u mod hm), so that contiguous unit ranges map to runs of
+   whole blocks with clipped ranges at the ends. This distributes the
+   work evenly both in the early passes of a DIF transform (one block
+   of n/2 butterflies, split by twiddle ranges) and in the late ones
+   (many small blocks). Each pass is one scatter/join round, giving
+   log2(n) synchronization points, in exchange for full parallel
+   width at any size (in contrast with the Bailey algorithm, whose
+   three phases have only n1 or n2 work items). */
+
+typedef struct
+{
+    gr_ptr x;
+    slong stride;
+    int dit;
+    int inverse;
+    ulong m;
+    ulong rstep;
+    ulong lo;
+    ulong hi;
+    const gr_dft_pre_struct * P;
+    gr_ctx_struct * ctx;
+    int status;
+}
+_gr_dft_ct_work_t;
+
+static void
+_gr_dft_ct_worker(void * arg)
+{
+    _gr_dft_ct_work_t * w = arg;
+    gr_ctx_struct * ctx = w->ctx;
+    const gr_dft_pre_struct * P = w->P;
+    int status = GR_SUCCESS;
+    ulong hm = w->m >> 1;
+    ulong kb, kb0 = w->lo / hm, kb1 = (w->hi - 1) / hm;
+    gr_ptr t, rtmp = NULL;
+
+    GR_TMP_INIT(t, ctx);
+    if (P->real_ctx != NULL)
+        GR_TMP_INIT(rtmp, P->real_ctx);
+
+    for (kb = kb0; kb <= kb1; kb++)
+    {
+        ulong jlo = (kb == kb0) ? w->lo - kb0 * hm : 0;
+        ulong jhi = (kb == kb1) ? w->hi - kb1 * hm : hm;
+
+        status |= _gr_dft_ct_jrange(w->dit, w->x, w->stride, kb * w->m,
+                hm, jlo, jhi, w->rstep, w->inverse, t, rtmp, P, ctx);
+    }
+
+    GR_TMP_CLEAR(t, ctx);
+    if (P->real_ctx != NULL)
+        GR_TMP_CLEAR(rtmp, P->real_ctx);
+
+    w->status = status;
+}
+
+static int
+_gr_dft_ct_pass_mt(int dit, gr_ptr x, slong stride, int s, int inverse,
+        slong nchunks, thread_pool_handle * handles,
+        const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    ulong n = P->n, units = n / 2;
+    slong i;
+    _gr_dft_ct_work_t * args;
+
+    args = flint_malloc(nchunks * sizeof(_gr_dft_ct_work_t));
+
+    for (i = 0; i < nchunks; i++)
+    {
+        args[i].x = x;
+        args[i].stride = stride;
+        args[i].dit = dit;
+        args[i].inverse = inverse;
+        args[i].m = UWORD(1) << s;
+        args[i].rstep = n >> s;
+        args[i].lo = (units * (ulong) i) / (ulong) nchunks;
+        args[i].hi = (units * (ulong) (i + 1)) / (ulong) nchunks;
+        args[i].P = P;
+        args[i].ctx = ctx;
+        args[i].status = GR_SUCCESS;
+
+        if (i < nchunks - 1)
+            thread_pool_wake(global_thread_pool, handles[i], 0,
+                    _gr_dft_ct_worker, &args[i]);
+    }
+
+    _gr_dft_ct_worker(&args[nchunks - 1]);
+
+    for (i = 0; i < nchunks - 1; i++)
+        thread_pool_wait(global_thread_pool, handles[i]);
+
+    for (i = 0; i < nchunks; i++)
+        status |= args[i].status;
+
+    flint_free(args);
+    return status;
+}
+
+/* Owner-computes tail: after the top t decimation levels, the array
+   decomposes into 2^t independent contiguous sub-blocks of size
+   2^(depth - t); a worker runs ALL the remaining passes over its own
+   range of blocks without further synchronization, keeping the data
+   in its private cache. (The pass-parallel top levels are the only
+   ones whose butterflies genuinely span the array; sweeping every
+   level across all workers instead is limited by the shared memory
+   bandwidth, which does not grow with the thread count.) */
+typedef struct
+{
+    gr_ptr x;
+    slong stride;
+    int dit;
+    int inverse;
+    int sdepth;             /* depth of one sub-block */
+    ulong blo;
+    ulong bhi;              /* range of sub-block indices */
+    const gr_dft_pre_struct * P;
+    gr_ctx_struct * ctx;
+    int status;
+}
+_gr_dft_ct_tail_work_t;
+
+static void
+_gr_dft_ct_tail_worker(void * arg)
+{
+    _gr_dft_ct_tail_work_t * w = arg;
+    gr_ctx_struct * ctx = w->ctx;
+    const gr_dft_pre_struct * P = w->P;
+    int status = GR_SUCCESS;
+    ulong b;
+    ulong bm = UWORD(1) << w->sdepth;
+    gr_ptr t, rtmp = NULL;
+
+    GR_TMP_INIT(t, ctx);
+    if (P->real_ctx != NULL)
+        GR_TMP_INIT(rtmp, P->real_ctx);
+
+    if (!w->dit)
+    {
+        for (b = w->blo; b < w->bhi; b++)
+            status |= _gr_dft_ct_dif_range(w->x, w->stride, b * bm,
+                    w->sdepth, w->inverse, t, rtmp, P, ctx);
+    }
+    else
+    {
+        for (b = w->blo; b < w->bhi; b++)
+            status |= _gr_dft_ct_dit_range(w->x, w->stride, b * bm,
+                    w->sdepth, w->inverse, t, rtmp, P, ctx);
+    }
+
+    GR_TMP_CLEAR(t, ctx);
+    if (P->real_ctx != NULL)
+        GR_TMP_CLEAR(rtmp, P->real_ctx);
+
+    w->status = status;
+}
+
+static int
+_gr_dft_ct_tail_mt(int dit, gr_ptr x, slong stride, int sdepth, int inverse,
+        slong nchunks, thread_pool_handle * handles,
+        const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    ulong nblocks = P->n >> sdepth;
+    slong i;
+    _gr_dft_ct_tail_work_t * args;
+
+    args = flint_malloc(nchunks * sizeof(_gr_dft_ct_tail_work_t));
+
+    for (i = 0; i < nchunks; i++)
+    {
+        args[i].x = x;
+        args[i].stride = stride;
+        args[i].dit = dit;
+        args[i].inverse = inverse;
+        args[i].sdepth = sdepth;
+        args[i].blo = (nblocks * (ulong) i) / (ulong) nchunks;
+        args[i].bhi = (nblocks * (ulong) (i + 1)) / (ulong) nchunks;
+        args[i].P = P;
+        args[i].ctx = ctx;
+        args[i].status = GR_SUCCESS;
+
+        if (i < nchunks - 1)
+            thread_pool_wake(global_thread_pool, handles[i], 0,
+                    _gr_dft_ct_tail_worker, &args[i]);
+    }
+
+    _gr_dft_ct_tail_worker(&args[nchunks - 1]);
+
+    for (i = 0; i < nchunks - 1; i++)
+        thread_pool_wait(global_thread_pool, handles[i]);
+
+    for (i = 0; i < nchunks; i++)
+        status |= args[i].status;
+
+    flint_free(args);
+    return status;
+}
+
+/* Top-level Cooley-Tukey transform with pass-parallel threading when
+   worker threads are available (falling back to the serial transform
+   otherwise). Must only be used for top-level transforms. */
+int
+_gr_dft_ct_threaded(gr_ptr x, slong stride, int inverse, int scrambled,
+        const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    slong blk, max_chunks, nchunks;
+    int threadsafe, s;
+    thread_pool_handle * handles = P->threads;
+    slong num_workers = P->num_threads;
+    thread_pool_handle * pool_handles = NULL;
+    slong pool_workers = 0;
+
+    if (P->depth == 0)
+        return GR_SUCCESS;
+
+    threadsafe = (gr_ctx_is_threadsafe(ctx) == T_TRUE) &&
+            (P->real_ctx == NULL ||
+             gr_ctx_is_threadsafe(P->real_ctx) == T_TRUE);
+
+    if (!threadsafe)
+    {
+        handles = NULL;
+        num_workers = 0;
+    }
+
+    /* threading granularity: at most n / serial_block chunks per pass */
+    blk = (P->serial_block > 0) ? P->serial_block : GR_DFT_SERIAL_BLOCK_DEFAULT;
+    max_chunks = (slong) (P->n / (ulong) blk);
+
+    if (threadsafe && handles == NULL && max_chunks >= 2 &&
+        flint_get_num_threads() > 1)
+    {
+        pool_workers = flint_request_threads(&pool_handles,
+                FLINT_MIN(max_chunks, (slong) (P->n / 2)));
+        handles = pool_handles;
+        num_workers = pool_workers;
+    }
+
+    if (handles == NULL || num_workers < 1 || max_chunks < 2)
+    {
+        if (pool_handles != NULL)
+            flint_give_back_threads(pool_handles, pool_workers);
+        return _gr_dft_ct(x, stride, inverse, scrambled, P, ctx);
+    }
+
+    nchunks = FLINT_MIN(num_workers + 1, max_chunks);
+    nchunks = FLINT_MIN(nchunks, (slong) (P->n / 2));
+    nchunks = FLINT_MAX(nchunks, 1);
+
+    /* the top t levels have butterflies spanning the array and run
+       pass-parallel; the remaining levels decompose into 2^t
+       independent blocks handled owner-computes by the workers */
+    {
+        int t = 0;
+        while ((slong) (UWORD(1) << t) < nchunks && t < P->depth)
+            t++;
+
+        if (!inverse)
+        {
+            for (s = P->depth; s >= P->depth - t + 1; s--)
+                status |= _gr_dft_ct_pass_mt(0, x, stride, s, 0,
+                        nchunks, handles, P, ctx);
+            if (P->depth - t >= 1)
+                status |= _gr_dft_ct_tail_mt(0, x, stride, P->depth - t, 0,
+                        nchunks, handles, P, ctx);
+            if (!scrambled)
+                _gr_dft_bit_reverse(x, stride, P->depth, ctx);
+        }
+        else
+        {
+            if (!scrambled)
+                _gr_dft_bit_reverse(x, stride, P->depth, ctx);
+            if (P->depth - t >= 1)
+                status |= _gr_dft_ct_tail_mt(1, x, stride, P->depth - t, 1,
+                        nchunks, handles, P, ctx);
+            for (s = P->depth - t + 1; s <= P->depth; s++)
+                status |= _gr_dft_ct_pass_mt(1, x, stride, s, 1,
+                        nchunks, handles, P, ctx);
+        }
+    }
+
+    if (pool_handles != NULL)
+        flint_give_back_threads(pool_handles, pool_workers);
+
+    return status;
+}

--- a/src/gr_dft/dft.c
+++ b/src/gr_dft/dft.c
@@ -1,0 +1,130 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "gr.h"
+#include "gr_vec.h"
+#include "gr_dft.h"
+
+/* NOTE: this dispatcher (and the raw entry below) must route the
+   Cooley-Tukey and split-radix algorithms through their _threaded
+   entries; the plain _gr_dft_ct and _gr_dft_split are the serial
+   kernels, also used for the sub-transforms inside worker threads,
+   and never acquire threads themselves. */
+static int
+_gr_dft_dispatch(gr_ptr res, gr_srcptr vec, int inverse, int scrambled,
+        const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    switch (P->alg)
+    {
+        case GR_DFT_ALG_SPLIT:
+            return _gr_dft_split_threaded(res, vec, inverse, P, ctx);
+        case GR_DFT_ALG_MIXED:
+            return _gr_dft_mixed(res, vec, inverse, P, ctx);
+        case GR_DFT_ALG_PFA:
+            return _gr_dft_pfa(res, vec, inverse, P, ctx);
+        case GR_DFT_ALG_BLUESTEIN:
+            return _gr_dft_bluestein(res, vec, inverse, P, ctx);
+        default:
+            return _gr_dft_naive(res, vec, inverse, scrambled, P, ctx);
+    }
+}
+
+/* Apply the plan without the 1/n scaling of the inverse transform. */
+int
+_gr_dft_precomp_raw(gr_ptr res, gr_srcptr vec, int inverse,
+        const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    int scrambled = (P->flags & GR_DFT_SCRAMBLED) != 0;
+
+    if (P->alg == GR_DFT_ALG_CT || P->alg == GR_DFT_ALG_BAILEY)
+    {
+        /* in-place algorithms */
+        if (res != vec)
+            status |= _gr_vec_set(res, vec, P->n, ctx);
+
+        if (P->alg == GR_DFT_ALG_BAILEY)
+            status |= _gr_dft_bailey(res, inverse, scrambled, P, ctx);
+        else
+            status |= _gr_dft_ct_threaded(res, 1, inverse, scrambled, P, ctx);
+    }
+    else
+    {
+        /* out-of-place algorithms */
+        if (res != vec)
+        {
+            status |= _gr_dft_dispatch(res, vec, inverse, scrambled, P, ctx);
+        }
+        else
+        {
+            gr_ptr tmp;
+            tmp = flint_malloc(P->n * ctx->sizeof_elem);
+            _gr_vec_init(tmp, P->n, ctx);
+            status |= _gr_dft_dispatch(tmp, vec, inverse, scrambled, P, ctx);
+            status |= _gr_vec_set(res, tmp, P->n, ctx);
+            _gr_vec_clear(tmp, P->n, ctx);
+            flint_free(tmp);
+        }
+    }
+
+    return status;
+}
+
+int
+gr_dft_precomp(gr_ptr res, gr_srcptr vec, const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    return _gr_dft_precomp_raw(res, vec, 0, P, ctx);
+}
+
+int
+gr_dft_inverse_precomp(gr_ptr res, gr_srcptr vec, const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+
+    status |= _gr_dft_precomp_raw(res, vec, 1, P, ctx);
+
+    /* scale by 1/n */
+    if (P->n >= 2)
+        status |= _gr_vec_div_scalar_ui(res, res, P->n, P->n, ctx);
+
+    return status;
+}
+
+int
+gr_dft(gr_ptr res, gr_srcptr vec, ulong n, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    gr_dft_pre_t P;
+
+    status |= gr_dft_precomp_init(P, n, GR_DFT_ALG_AUTO, 0, ctx);
+
+    if (status == GR_SUCCESS)
+        status |= gr_dft_precomp(res, vec, P, ctx);
+
+    gr_dft_precomp_clear(P);
+    return status;
+}
+
+int
+gr_dft_inverse(gr_ptr res, gr_srcptr vec, ulong n, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    gr_dft_pre_t P;
+
+    status |= gr_dft_precomp_init(P, n, GR_DFT_ALG_AUTO, 0, ctx);
+
+    if (status == GR_SUCCESS)
+        status |= gr_dft_inverse_precomp(res, vec, P, ctx);
+
+    gr_dft_precomp_clear(P);
+    return status;
+}

--- a/src/gr_dft/mixed.c
+++ b/src/gr_dft/mixed.c
@@ -1,0 +1,163 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "gr.h"
+#include "gr_vec.h"
+#include "gr_dft.h"
+
+/* Mixed-radix decimation in time: with len = p m and p prime,
+
+       X_(q + m r) = sum_b v^(b r) (w_len^(b q) Y_b(q)),   v = w_len^m,
+
+   where Y_b is the transform of length m of the b-th residue class
+   of the input. The recursion transforms the p residue classes into
+   the segments res[b m, (b+1) m), then for each column q combines the
+   twiddled values z_b with a transform of prime length p.
+
+   The prime transform uses the principality identity
+   1 + v + ... + v^(p-1) = 0 to eliminate the exponent p - 1: writing
+   e_b = b r mod p and b* for the index with e_(b*) = p - 1,
+
+       Y_r = sum_b v^(e_b) z_b = sum_(b != b*) v^(e_b) (z_b - z_(b*)),
+
+   which requires p - 2 root multiplications per output r != 0 (the
+   b = 0 term has e_0 = 0), hence (p-1)(p-2) in total instead of the
+   naive (p-1)^2. If a Bluestein sub-plan for the prime is present
+   (P->P1), it is used instead of the direct kernel.
+
+   All root exponents are taken in the table of the top-level plan P:
+   at a level with sub-length len, the root of the sub-transform is
+   w^rstep with rstep = n / len, twiddles use exponents b q rstep < n,
+   and the prime kernel uses exponents e_b (m rstep) = e_b (n / p) < n,
+   so no reductions are needed. */
+
+static int
+_mixed(gr_ptr res, gr_srcptr vec, slong stride, ulong rstep, ulong len,
+        slong lvl, int inverse, gr_ptr ztmp, gr_ptr ytmp,
+        gr_ptr t1, gr_ptr rtmp, const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    slong sz = ctx->sizeof_elem;
+    ulong p, m, b, q, r, e, bstar, kstep;
+
+    if (len == 1)
+        return gr_set(res, vec, ctx);
+
+    p = P->radices[lvl];
+    m = len / p;
+    kstep = m * rstep;   /* the transform of length p uses the root w^kstep */
+
+    for (b = 0; b < p; b++)
+        status |= _mixed(GR_ENTRY(res, b * m, sz), GR_ENTRY(vec, b * stride, sz),
+                p * stride, p * rstep, m, lvl + 1, inverse,
+                ztmp, ytmp, t1, rtmp, P, ctx);
+
+    for (q = 0; q < m; q++)
+    {
+        /* load and twiddle: z_b = w^(b q rstep) res[b m + q] */
+        status |= gr_set(ztmp, GR_ENTRY(res, q, sz), ctx);
+        for (b = 1, e = 0; b < p; b++)
+        {
+            e += q * rstep;
+            status |= _gr_dft_mul_root(GR_ENTRY(ztmp, b, sz),
+                    GR_ENTRY(res, b * m + q, sz), e, inverse, rtmp, P);
+        }
+
+        if (P->P1 != NULL && P->P1->n == p)
+        {
+            /* transform of length p by the Bluestein sub-plan */
+            status |= _gr_dft_bluestein(ytmp, ztmp, inverse, P->P1, ctx);
+            for (r = 0; r < p; r++)
+                status |= gr_set(GR_ENTRY(res, r * m + q, sz),
+                        GR_ENTRY(ytmp, r, sz), ctx);
+        }
+        else
+        {
+            /* direct kernel; the slots res[r m + q] have all been read */
+            gr_ptr acc = GR_ENTRY(res, q, sz);
+
+            status |= gr_set(acc, ztmp, ctx);
+            for (b = 1; b < p; b++)
+                status |= gr_add(acc, acc, GR_ENTRY(ztmp, b, sz), ctx);
+
+            for (r = 1; r < p; r++)
+            {
+                /* find b* with b* r = p - 1 mod p */
+                for (b = 1, e = r; e != p - 1; b++)
+                {
+                    e += r;
+                    if (e >= p)
+                        e -= p;
+                }
+                bstar = b;
+
+                acc = GR_ENTRY(res, r * m + q, sz);
+                status |= gr_sub(acc, ztmp, GR_ENTRY(ztmp, bstar, sz), ctx);
+
+                for (b = 1, e = 0; b < p; b++)
+                {
+                    e += r;
+                    if (e >= p)
+                        e -= p;
+
+                    if (b == bstar)
+                        continue;
+
+                    status |= gr_sub(t1, GR_ENTRY(ztmp, b, sz),
+                            GR_ENTRY(ztmp, bstar, sz), ctx);
+                    status |= _gr_dft_mul_root(GR_ENTRY(ytmp, 0, sz), t1,
+                            e * kstep, inverse, rtmp, P);
+                    status |= gr_add(acc, acc, GR_ENTRY(ytmp, 0, sz), ctx);
+                }
+            }
+        }
+    }
+
+    return status;
+}
+
+/* res must not alias vec */
+int
+_gr_dft_mixed(gr_ptr res, gr_srcptr vec, int inverse,
+        const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    slong i;
+    ulong pmax = 2;
+    gr_ptr ztmp, ytmp, t1, rtmp = NULL;
+
+    if (P->n == 1)
+        return gr_set(res, vec, ctx);
+
+    for (i = 0; i < P->num_radices; i++)
+        pmax = FLINT_MAX(pmax, P->radices[i]);
+
+    ztmp = flint_malloc(2 * pmax * ctx->sizeof_elem);
+    _gr_vec_init(ztmp, 2 * pmax, ctx);
+    ytmp = GR_ENTRY(ztmp, pmax, ctx->sizeof_elem);
+
+    GR_TMP_INIT(t1, ctx);
+    if (P->real_ctx != NULL)
+        GR_TMP_INIT(rtmp, P->real_ctx);
+
+    status |= _mixed(res, vec, 1, 1, P->n, 0, inverse,
+            ztmp, ytmp, t1, rtmp, P, ctx);
+
+    GR_TMP_CLEAR(t1, ctx);
+    if (P->real_ctx != NULL)
+        GR_TMP_CLEAR(rtmp, P->real_ctx);
+
+    _gr_vec_clear(ztmp, 2 * pmax, ctx);
+    flint_free(ztmp);
+
+    return status;
+}

--- a/src/gr_dft/mul_root.c
+++ b/src/gr_dft/mul_root.c
@@ -1,0 +1,151 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "gr.h"
+#include "gr_dft.h"
+
+/* Sets res = w^e * x (or w^(-e) * x if inverse is set), where w is the
+   root of unity of the plan P and 0 <= e < n. res must not alias x.
+
+   In complex mode, rtmp must point to an initialized temporary element
+   of P->real_ctx. Roots at the quarter and eighth points, known
+   structurally since complex mode uses the standard root
+   w = exp(-2 pi i / n), are handled with 0 or 2 real multiplications.
+   A general root c + d*i is handled with a single multiplication in
+   the complex ring, or, when the Karatsuba tables are enabled, with
+   3 real multiplications using the precomputed entries
+   (c, d - c, d + c):
+
+       k1 = c * (xr + xi)
+       re = k1 - xi * (d + c) = c * xr - d * xi
+       im = k1 + xr * (d - c) = c * xi + d * xr
+*/
+int
+_gr_dft_mul_root(gr_ptr res, gr_srcptr x, ulong e, int inverse,
+        gr_ptr rtmp, const gr_dft_pre_t P)
+{
+    int status = GR_SUCCESS;
+    gr_ctx_struct * rctx;
+    slong rsz;
+    gr_srcptr xr, xi, c;
+    gr_ptr rr, ri;
+
+    if (inverse && e != 0)
+        e = P->n - e;
+
+    if (e == 0)
+        return gr_set(res, x, P->ctx);
+
+    if (P->real_ctx == NULL)
+        return gr_mul(res, x,
+                GR_ENTRY(P->roots, e, P->ctx->sizeof_elem), P->ctx);
+
+    rctx = P->real_ctx;
+    rsz = rctx->sizeof_elem;
+    xr = x;
+    xi = GR_ENTRY(x, 1, rsz);
+    rr = res;
+    ri = GR_ENTRY(res, 1, rsz);
+    /* real part of the root, valid whether or not wtab is present */
+    c = GR_ENTRY(P->roots, e, P->ctx->sizeof_elem);
+
+    switch (P->wclass[e])
+    {
+        case GR_DFT_ROOT_NEG_ONE:
+            /* res = -x */
+            status |= gr_neg(rr, xr, rctx);
+            status |= gr_neg(ri, xi, rctx);
+            break;
+
+        case GR_DFT_ROOT_I:
+            /* i x = -xi + xr i */
+            status |= gr_neg(rr, xi, rctx);
+            status |= gr_set(ri, xr, rctx);
+            break;
+
+        case GR_DFT_ROOT_NEG_I:
+            /* -i x = xi - xr i */
+            status |= gr_set(rr, xi, rctx);
+            status |= gr_neg(ri, xr, rctx);
+            break;
+
+        case GR_DFT_ROOT_DMC_ZERO:
+            /* c (1 + i) x = c (xr - xi) + c (xr + xi) i */
+            status |= gr_sub(rtmp, xr, xi, rctx);
+            status |= gr_mul(rr, c, rtmp, rctx);
+            status |= gr_add(rtmp, xr, xi, rctx);
+            status |= gr_mul(ri, c, rtmp, rctx);
+            break;
+
+        case GR_DFT_ROOT_DPC_ZERO:
+            /* c (1 - i) x = c (xr + xi) + c (xi - xr) i */
+            status |= gr_add(rtmp, xr, xi, rctx);
+            status |= gr_mul(rr, c, rtmp, rctx);
+            status |= gr_sub(rtmp, xi, xr, rctx);
+            status |= gr_mul(ri, c, rtmp, rctx);
+            break;
+
+        default:
+            if (P->wtab != NULL)
+            {
+                /* 3-multiplication complex Karatsuba product */
+                status |= _gr_dft_mul_const(res, x, NULL,
+                        GR_ENTRY(P->wtab, 3 * e, rsz), rtmp, P);
+            }
+            else
+            {
+                status |= gr_mul(res, x,
+                        GR_ENTRY(P->roots, e, P->ctx->sizeof_elem), P->ctx);
+            }
+            break;
+    }
+
+    return status;
+}
+
+/* Sets res = w * x for a fixed plan constant w, given the precomputed
+   complex Karatsuba table entry wtab3 = (c, d - c, d + c) if it is not
+   NULL (in which case w may be NULL, and rtmp must point to an
+   initialized temporary element of P->real_ctx), or the constant w
+   itself with wtab3 == NULL otherwise. res must not alias x. */
+int
+_gr_dft_mul_const(gr_ptr res, gr_srcptr x, gr_srcptr w, gr_srcptr wtab3,
+        gr_ptr rtmp, const gr_dft_pre_t P)
+{
+    int status = GR_SUCCESS;
+    gr_ctx_struct * rctx;
+    slong rsz;
+    gr_srcptr xr, xi, c, dmc, dpc;
+    gr_ptr rr, ri;
+
+    if (wtab3 == NULL)
+        return gr_mul(res, x, w, P->ctx);
+
+    rctx = P->real_ctx;
+    rsz = rctx->sizeof_elem;
+    xr = x;
+    xi = GR_ENTRY(x, 1, rsz);
+    rr = res;
+    ri = GR_ENTRY(res, 1, rsz);
+    c = wtab3;
+    dmc = GR_ENTRY(c, 1, rsz);
+    dpc = GR_ENTRY(c, 2, rsz);
+
+    status |= gr_add(rtmp, xr, xi, rctx);
+    status |= gr_mul(rtmp, c, rtmp, rctx);      /* k1 */
+    status |= gr_mul(rr, xi, dpc, rctx);        /* k3 */
+    status |= gr_mul(ri, xr, dmc, rctx);        /* k2 */
+    status |= gr_sub(rr, rtmp, rr, rctx);
+    status |= gr_add(ri, rtmp, ri, rctx);
+
+    return status;
+}

--- a/src/gr_dft/naive.c
+++ b/src/gr_dft/naive.c
@@ -1,0 +1,59 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "ulong_extras.h"
+#include "gr.h"
+#include "gr_dft.h"
+
+/* res must not alias vec. Scrambled order for the naive algorithm is
+   bit-reversed, matching GR_DFT_ALG_CT. */
+int
+_gr_dft_naive(gr_ptr res, gr_srcptr vec, int inverse, int scrambled,
+        const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    slong sz = ctx->sizeof_elem;
+    ulong n = P->n, j, k, e;
+    gr_ptr t, rtmp = NULL;
+
+    GR_TMP_INIT(t, ctx);
+    if (P->real_ctx != NULL)
+        GR_TMP_INIT(rtmp, P->real_ctx);
+
+    for (k = 0; k < n; k++)
+    {
+        gr_ptr acc = GR_ENTRY(res,
+                (!inverse && scrambled) ? n_revbin(k, P->depth) : k, sz);
+
+        e = 0;
+        status |= gr_set(acc,
+                GR_ENTRY(vec, (inverse && scrambled) ? n_revbin(0, P->depth) : 0, sz), ctx);
+
+        for (j = 1; j < n; j++)
+        {
+            gr_srcptr src = GR_ENTRY(vec,
+                    (inverse && scrambled) ? n_revbin(j, P->depth) : j, sz);
+
+            e += k;
+            if (e >= n)
+                e -= n;
+            status |= _gr_dft_mul_root(t, src, e, inverse, rtmp, P);
+            status |= gr_add(acc, acc, t, ctx);
+        }
+    }
+
+    GR_TMP_CLEAR(t, ctx);
+    if (P->real_ctx != NULL)
+        GR_TMP_CLEAR(rtmp, P->real_ctx);
+
+    return status;
+}

--- a/src/gr_dft/nfixed.c
+++ b/src/gr_dft/nfixed.c
@@ -1,0 +1,1441 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <string.h>
+#include <stdio.h>
+#include "longlong.h"
+#include "mpn_extras.h"
+#include "fmpz.h"
+#include "fmpq.h"
+#include "arf.h"
+#include "arb.h"
+#include "gr.h"
+#include "gr_dft.h"
+
+/* Fixed-point real and complex GR contexts for numerical DFTs, modeled
+   on the arithmetic of nfloat/nfixed.c. An element of the real context
+   consists of nlimbs + 1 contiguous limbs: a sign limb (0 or 1)
+   followed by nlimbs fraction limbs representing an absolute value in
+   [0, 1). An element of the complex context consists of a real and an
+   imaginary part laid out contiguously (2 (nlimbs + 1) limbs), matching
+   the layout assumption of the complex mode of the DFT plans.
+
+   Additions and subtractions are exact as long as the result satisfies
+   |res| < 1; as a safety net (used by the root table construction,
+   where results can exceed 1 in magnitude by an ulp or two near the
+   quarter points), arithmetic operations whose exact result would
+   reach magnitude 1 return GR_UNABLE (leaving a wrapped value), so
+   that a successful status at the end of a computation certifies that
+   no overflow occurred and the error bounds hold unconditionally;
+   the constants one and neg_one clamp to the largest representable
+   value 1 - ulp instead of wrapping. Multiplications truncate the
+   exact product toward zero, with error less than 1 ulp (bounded by
+   2 ulp in all error analyses for safety). The values 1, -1, i, -i are
+   not representable and are "rounded" to magnitude 1 - ulp; the DFT
+   kernels never multiply by these values explicitly (they are handled
+   by the free rotation classes of complex mode).
+
+   These contexts implement only the operations required by the DFT
+   machinery and basic GR functionality; they are not rings in the
+   strict sense (there is no exact 1), and the predicates is_one and
+   is_neg_one always return T_FALSE. */
+
+typedef struct
+{
+    slong nlimbs;
+}
+_gr_dft_nfixed_ctx_struct;
+
+#define NFIXED_CTX_NLIMBS(ctx) (((_gr_dft_nfixed_ctx_struct *)(ctx))->nlimbs)
+
+/* Tuning: number of limbs from which the complex multiplication uses
+   the 3-multiplication Karatsuba formula with carry-extended internal
+   values (see _nfxc_mul_generic) instead of the 4-multiplication
+   schoolbook formula. Provisional value: the measured crossover with
+   a full-product stand-in for mulhigh is 12-16 limbs; the genuine
+   flint_mpn_mulhigh_n shifts it upward since the saved multiplication
+   is cheaper relative to the extra additions. */
+#define GR_DFT_NFIXED_KARATSUBA_CUTOFF 22
+
+/* Magnitude primitives *******************************************/
+
+static void
+_nfx_saturate(nn_ptr res, slong n)
+{
+    slong i;
+    for (i = 0; i < n; i++)
+        res[i] = ~UWORD(0);
+}
+
+/* res = |a| - |b| as a magnitude, returning 1 if the sign flips
+   (that is, |a| < |b|); computed as a single subtraction with a
+   conditional two's complement negation */
+static int
+_nfx_signed_sub(nn_ptr res, nn_srcptr a, nn_srcptr b, slong n)
+{
+    /* comparing first and subtracting in the right order beats an
+       unconditional subtraction with conditional two's-complement
+       negation at every generic size (see profile/p-gr_dft_nfixed):
+       the comparison usually resolves within the top limbs, while
+       the negation is a full second pass */
+    if (mpn_cmp(a, b, n) >= 0)
+    {
+        mpn_sub_n(res, a, b, n);
+        return 0;
+    }
+    else
+    {
+        mpn_sub_n(res, b, a, n);
+        return 1;
+    }
+}
+
+/* res = a + b; returns the carry (1 if the exact result has magnitude
+   at least 1, in which case res holds the wrapped value). Carries are
+   converted to GR_UNABLE by the operation entry points rather than
+   saturating: a GR_SUCCESS status from a computation then certifies
+   that all intermediate values stayed in range, making the error
+   bounds of gr_dft_precomp_nfixed_bound unconditionally valid. */
+static ulong
+_nfx_add(nn_ptr res, nn_srcptr a, nn_srcptr b, slong n)
+{
+    ulong asgn = a[0], bsgn = b[0];
+
+    if (asgn == bsgn)
+    {
+        res[0] = asgn;
+        return mpn_add_n(res + 1, a + 1, b + 1, n);
+    }
+    else
+    {
+        res[0] = asgn ^ (ulong) _nfx_signed_sub(res + 1, a + 1, b + 1, n);
+        return 0;
+    }
+}
+
+static ulong
+_nfx_sub(nn_ptr res, nn_srcptr a, nn_srcptr b, slong n)
+{
+    ulong asgn = a[0], bsgn = b[0];
+
+    if (asgn != bsgn)
+    {
+        res[0] = asgn;
+        return mpn_add_n(res + 1, a + 1, b + 1, n);
+    }
+    else
+    {
+        res[0] = asgn ^ (ulong) _nfx_signed_sub(res + 1, a + 1, b + 1, n);
+        return 0;
+    }
+}
+
+/* res = (sa, ma) + (sb, mb) for detached sign/magnitude operands,
+   writing a complete sign + magnitude element; returns the carry */
+static ulong
+_nfx_signed_combine(nn_ptr res, ulong sa, nn_srcptr ma,
+        ulong sb, nn_srcptr mb, slong n)
+{
+    if (sa == sb)
+    {
+        res[0] = sa;
+        return mpn_add_n(res + 1, ma, mb, n);
+    }
+    else
+    {
+        res[0] = sa ^ (ulong) _nfx_signed_sub(res + 1, ma, mb, n);
+        return 0;
+    }
+}
+
+/* Fully inlined magnitude kernels for 1-4 limbs. All results may
+   alias the inputs. The additions return a carry, the subtractions
+   compute |a - b| with a sign-flip flag via conditional negation, and
+   the multiplications return the high N limbs of the exact 2N-limb
+   product (truncation toward zero, error < 1 ulp). */
+
+/* The sums are performed by the carry chains from longlong.h (as in
+   nfloat), extended by a zero high word so that the carry out of the
+   magnitude lands in the top output; measured faster than portable-C
+   carry recovery at every size (increasingly so with the length of
+   the chain, e.g. 4.59 -> 2.82 ns at 4 limbs on x86-64). */
+
+#define MAG_ADD_1(cy, r, a, b) \
+    add_ssaaaa(cy, (r)[0], \
+            UWORD(0), (a)[0], UWORD(0), (b)[0])
+
+#define MAG_ADD_2(cy, r, a, b) \
+    add_sssaaaaaa(cy, (r)[1], (r)[0], \
+            UWORD(0), (a)[1], (a)[0], UWORD(0), (b)[1], (b)[0])
+
+#define MAG_ADD_3(cy, r, a, b) \
+    add_ssssaaaaaaaa(cy, (r)[2], (r)[1], (r)[0], \
+            UWORD(0), (a)[2], (a)[1], (a)[0], \
+            UWORD(0), (b)[2], (b)[1], (b)[0])
+
+#define MAG_ADD_4(cy, r, a, b) \
+    add_sssssaaaaaaaaaa(cy, (r)[3], (r)[2], (r)[1], (r)[0], \
+            UWORD(0), (a)[3], (a)[2], (a)[1], (a)[0], \
+            UWORD(0), (b)[3], (b)[2], (b)[1], (b)[0])
+
+#define MAG_NEG_1(r) do { (r)[0] = -(r)[0]; } while (0)
+#define MAG_NEG_2(r) \
+    do { \
+        (r)[0] = -(r)[0]; \
+        (r)[1] = ~(r)[1] + ((r)[0] == 0); \
+    } while (0)
+#define MAG_NEG_3(r) \
+    do { \
+        ulong _z; \
+        (r)[0] = -(r)[0]; _z = ((r)[0] == 0); \
+        (r)[1] = ~(r)[1] + _z; _z &= ((r)[1] == 0); \
+        (r)[2] = ~(r)[2] + _z; \
+    } while (0)
+#define MAG_NEG_4(r) \
+    do { \
+        ulong _z; \
+        (r)[0] = -(r)[0]; _z = ((r)[0] == 0); \
+        (r)[1] = ~(r)[1] + _z; _z &= ((r)[1] == 0); \
+        (r)[2] = ~(r)[2] + _z; _z &= ((r)[2] == 0); \
+        (r)[3] = ~(r)[3] + _z; \
+    } while (0)
+
+#define MAG_SSUB_1(bw, r, a, b) \
+    do { \
+        /* branchless ordered subtraction (measurably faster than
+           subtract-then-negate at one limb; see
+           profile/p-gr_dft_nfixed) */ \
+        ulong _a0 = (a)[0], _b0 = (b)[0]; \
+        (bw) = _a0 < _b0; \
+        (r)[0] = (bw) ? _b0 - _a0 : _a0 - _b0; \
+    } while (0)
+
+/* At 2-4 limbs the differences use the borrow chains from
+   longlong.h, extended by a zero high word: the top output is 0 or
+   all ones according to the sign of a - b, which is normalized to a
+   0/1 flip flag inside the (rare) negation branch. */
+
+#define MAG_SSUB_2(bw, r, a, b) \
+    do { \
+        sub_dddmmmsss(bw, (r)[1], (r)[0], \
+                UWORD(0), (a)[1], (a)[0], UWORD(0), (b)[1], (b)[0]); \
+        if (bw) { (bw) = 1; MAG_NEG_2(r); } \
+    } while (0)
+
+#define MAG_SSUB_3(bw, r, a, b) \
+    do { \
+        sub_ddddmmmmssss(bw, (r)[2], (r)[1], (r)[0], \
+                UWORD(0), (a)[2], (a)[1], (a)[0], \
+                UWORD(0), (b)[2], (b)[1], (b)[0]); \
+        if (bw) { (bw) = 1; MAG_NEG_3(r); } \
+    } while (0)
+
+#define MAG_SSUB_4(bw, r, a, b) \
+    do { \
+        sub_dddddmmmmmsssss(bw, (r)[3], (r)[2], (r)[1], (r)[0], \
+                UWORD(0), (a)[3], (a)[2], (a)[1], (a)[0], \
+                UWORD(0), (b)[3], (b)[2], (b)[1], (b)[0]); \
+        if (bw) { (bw) = 1; MAG_NEG_4(r); } \
+    } while (0)
+
+/* r must not alias a, b */
+#define MAG_MULHI_1(r, a, b) \
+    do { \
+        ulong _lo; \
+        umul_ppmm((r)[0], _lo, (a)[0], (b)[0]); \
+        (void) _lo; \
+    } while (0)
+
+#define MAG_MULHI_2(r, a, b) \
+    do { \
+        ulong _p1, _p0; \
+        FLINT_MPN_MUL_2X2((r)[1], (r)[0], _p1, _p0, \
+                (a)[1], (a)[0], (b)[1], (b)[0]); \
+        (void) _p1; (void) _p0; \
+    } while (0)
+
+#define MAG_MULHI_3(r, a, b) flint_mpn_mulhigh_n((r), (a), (b), 3)
+#define MAG_MULHI_4(r, a, b) flint_mpn_mulhigh_n((r), (a), (b), 4)
+
+/* Real ring methods (generic parts shared by all limb counts) ****/
+
+static int
+_nfx_add_op(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    /* branch-free overflow detection: GR_UNABLE == 2 */
+    return (int) (_nfx_add(res, x, y, NFIXED_CTX_NLIMBS(ctx)) << 1);
+}
+
+static int
+_nfx_sub_op(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    return (int) (_nfx_sub(res, x, y, NFIXED_CTX_NLIMBS(ctx)) << 1);
+}
+
+/* generic multiplication: mulhigh with truncation toward the exact
+   high product; error at most 2 ulp */
+static int
+_nfx_mul_op(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    slong n = NFIXED_CTX_NLIMBS(ctx);
+    nn_ptr r = res;
+    nn_srcptr a = x, b = y;
+
+    r[0] = a[0] ^ b[0];
+
+    if (res != x && res != y)
+    {
+        flint_mpn_mulhigh_n(r + 1, a + 1, b + 1, n);
+    }
+    else
+    {
+        ulong t[GR_DFT_NFIXED_MAX_NLIMBS];
+        slong i;
+        flint_mpn_mulhigh_n(t, a + 1, b + 1, n);
+        for (i = 0; i < n; i++)
+            r[i + 1] = t[i];
+    }
+
+    return GR_SUCCESS;
+}
+
+/* division by an unsigned integer: floor division of the magnitude,
+   hence truncation toward zero with error below 1 ulp */
+static int
+_nfx_div_ui_op(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx)
+{
+    slong n = NFIXED_CTX_NLIMBS(ctx);
+    nn_ptr r = res;
+    nn_srcptr a = x;
+
+    if (y == 0)
+        return GR_DOMAIN;
+
+    r[0] = a[0];
+    mpn_divrem_1(r + 1, 0, a + 1, n, y);
+
+    return GR_SUCCESS;
+}
+
+/* squaring: sqrhigh saves about half the limb products */
+static int
+_nfx_sqr_op(gr_ptr res, gr_srcptr x, gr_ctx_t ctx)
+{
+    slong n = NFIXED_CTX_NLIMBS(ctx);
+    nn_ptr r = res;
+    nn_srcptr a = x;
+
+    r[0] = 0;
+
+    if (res != x)
+    {
+        flint_mpn_sqrhigh(r + 1, a + 1, n);
+    }
+    else
+    {
+        ulong t[GR_DFT_NFIXED_MAX_NLIMBS];
+        slong i;
+        flint_mpn_sqrhigh(t, a + 1, n);
+        for (i = 0; i < n; i++)
+            r[i + 1] = t[i];
+    }
+
+    return GR_SUCCESS;
+}
+
+/* Sized real methods for 1-4 limbs *******************************/
+
+#define DEF_NFX_SIZED(N) \
+static int \
+_nfx_add_op_##N(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) \
+{ \
+    nn_ptr r = res; \
+    nn_srcptr a = x, b = y; \
+    if (a[0] == b[0]) \
+    { \
+        ulong cy; \
+        r[0] = a[0]; \
+        MAG_ADD_##N(cy, r + 1, a + 1, b + 1); \
+        return (int) (cy << 1);   /* GR_UNABLE on overflow */ \
+    } \
+    else \
+    { \
+        ulong bw; \
+        MAG_SSUB_##N(bw, r + 1, a + 1, b + 1); \
+        r[0] = a[0] ^ bw; \
+    } \
+    return GR_SUCCESS; \
+} \
+static int \
+_nfx_sub_op_##N(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) \
+{ \
+    nn_ptr r = res; \
+    nn_srcptr a = x, b = y; \
+    if (a[0] != b[0]) \
+    { \
+        ulong cy; \
+        r[0] = a[0]; \
+        MAG_ADD_##N(cy, r + 1, a + 1, b + 1); \
+        return (int) (cy << 1); \
+    } \
+    else \
+    { \
+        ulong bw; \
+        MAG_SSUB_##N(bw, r + 1, a + 1, b + 1); \
+        r[0] = a[0] ^ bw; \
+    } \
+    return GR_SUCCESS; \
+} \
+static int \
+_nfx_mul_op_##N(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) \
+{ \
+    nn_ptr r = res; \
+    nn_srcptr a = x, b = y; \
+    ulong t[N]; \
+    slong i; \
+    MAG_MULHI_##N(t, a + 1, b + 1); \
+    r[0] = a[0] ^ b[0]; \
+    for (i = 0; i < N; i++) \
+        r[i + 1] = t[i]; \
+    return GR_SUCCESS; \
+}
+
+DEF_NFX_SIZED(1)
+DEF_NFX_SIZED(2)
+DEF_NFX_SIZED(3)
+DEF_NFX_SIZED(4)
+
+/* Complex multiplication *****************************************/
+
+#define NFXC_IM(x, n) ((nn_ptr) (x) + ((n) + 1))
+#define NFXC_IM_SRC(x, n) ((nn_srcptr) (x) + ((n) + 1))
+
+static int
+_nfxc_div_ui_op(gr_ptr res, gr_srcptr x, ulong y, gr_ctx_t ctx)
+{
+    slong n = NFIXED_CTX_NLIMBS(ctx);
+    int status = GR_SUCCESS;
+
+    status |= _nfx_div_ui_op(res, x, y, ctx);
+    status |= _nfx_div_ui_op(NFXC_IM(res, n), NFXC_IM_SRC(x, n), y, ctx);
+
+    return status;
+}
+
+
+/* Sized schoolbook complex multiplication: all reads happen into
+   stack temporaries before any write, so aliasing is safe with no
+   copies of the result. Per-component error at most 2 ulp
+   (two exact-truncation products). */
+#define DEF_NFXC_MUL_SIZED(N) \
+static int \
+_nfxc_mul_op_##N(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) \
+{ \
+    nn_srcptr xr = x, xi = NFXC_IM_SRC(x, N); \
+    nn_srcptr yr = y, yi = NFXC_IM_SRC(y, N); \
+    nn_ptr rr = res, ri = NFXC_IM(res, N); \
+    ulong t1[N], t2[N], t3[N], t4[N]; \
+    ulong s1, s2, s3, s4, f; \
+    s1 = xr[0] ^ yr[0]; MAG_MULHI_##N(t1, xr + 1, yr + 1); \
+    s2 = xi[0] ^ yi[0]; MAG_MULHI_##N(t2, xi + 1, yi + 1); \
+    s3 = xr[0] ^ yi[0]; MAG_MULHI_##N(t3, xr + 1, yi + 1); \
+    s4 = xi[0] ^ yr[0]; MAG_MULHI_##N(t4, xi + 1, yr + 1); \
+    ulong ov = 0; \
+    /* re = t1 - t2 */ \
+    if (s1 != s2) \
+    { \
+        rr[0] = s1; \
+        MAG_ADD_##N(ov, rr + 1, t1, t2); \
+    } \
+    else \
+    { \
+        MAG_SSUB_##N(f, rr + 1, t1, t2); \
+        rr[0] = s1 ^ f; \
+    } \
+    /* im = t3 + t4 */ \
+    if (s3 == s4) \
+    { \
+        ulong cy; \
+        ri[0] = s3; \
+        MAG_ADD_##N(cy, ri + 1, t3, t4); \
+        ov |= cy; \
+    } \
+    else \
+    { \
+        MAG_SSUB_##N(f, ri + 1, t3, t4); \
+        ri[0] = s3 ^ f; \
+    } \
+    return (int) (ov << 1); \
+}
+
+DEF_NFXC_MUL_SIZED(1)
+DEF_NFXC_MUL_SIZED(2)
+DEF_NFXC_MUL_SIZED(3)
+DEF_NFXC_MUL_SIZED(4)
+
+/* Generic complex multiplication. Below the Karatsuba cutoff, the
+   schoolbook formula with 4 mulhighs (per-component error at most
+   4 ulp: two products of at most 2 ulp each, combined exactly).
+
+   From the cutoff onward, the complex Karatsuba formula
+
+       re = t1 - t2,  im = (xr + xi)(yr + yi) - t1 - t2,
+       t1 = xr yr, t2 = xi yi
+
+   with 3 mulhighs. The sums s = xr + xi (and likewise for y) can
+   reach 2 in magnitude and are kept as carry-extended sign-magnitude
+   values with an extra high limb: s = h 2^(64 n) + f, h in {0, 1}.
+   The middle product is then computed with a single mulhigh on the
+   fraction parts plus conditional exact additions,
+
+       s1 s2 / 2^(64 n) = h1 h2 2^(64 n) + h1 f2 + h2 f1
+                          + mulhigh(f1, f2) + O(2 ulp),
+
+   whose magnitude is below 4 and hence fits an (n+1)-limb extended
+   value (top limb at most 3). The final combination im = m - t1 - t2
+   runs in exact (n+1)-limb sign-magnitude arithmetic (an extra high
+   limb for the internal operations), and the result is stored back
+   to n limbs, saturating in case the caller violated the |t| < 1
+   contract. Per-component error at most 6 ulp (three mulhighs of at
+   most 2 ulp each, all other operations exact). */
+static int
+_nfxc_mul_impl(gr_ptr res, gr_srcptr x, gr_srcptr y, int use_karatsuba,
+        gr_ctx_t ctx)
+{
+    slong n = NFIXED_CTX_NLIMBS(ctx);
+    nn_srcptr xr = x, xi = NFXC_IM_SRC(x, n);
+    nn_srcptr yr = y, yi = NFXC_IM_SRC(y, n);
+    nn_ptr rr = res, ri = NFXC_IM(res, n);
+
+    if (!use_karatsuba)
+    {
+        ulong t1[GR_DFT_NFIXED_MAX_NLIMBS];
+        ulong t2[GR_DFT_NFIXED_MAX_NLIMBS];
+        ulong t3[GR_DFT_NFIXED_MAX_NLIMBS];
+        ulong t4[GR_DFT_NFIXED_MAX_NLIMBS];
+        ulong s1, s2, s3, s4;
+
+        s1 = xr[0] ^ yr[0]; flint_mpn_mulhigh_n(t1, xr + 1, yr + 1, n);
+        s2 = xi[0] ^ yi[0]; flint_mpn_mulhigh_n(t2, xi + 1, yi + 1, n);
+        s3 = xr[0] ^ yi[0]; flint_mpn_mulhigh_n(t3, xr + 1, yi + 1, n);
+        s4 = xi[0] ^ yr[0]; flint_mpn_mulhigh_n(t4, xi + 1, yr + 1, n);
+
+        ulong ov;
+
+        ov = _nfx_signed_combine(rr, s1, t1, s2 ^ 1, t2, n);
+        ov |= _nfx_signed_combine(ri, s3, t3, s4, t4, n);
+        return (int) (ov << 1);
+    }
+    else
+    {
+        /* sign + (n+1)-limb extended magnitudes */
+        ulong es1[GR_DFT_NFIXED_MAX_NLIMBS + 2];
+        ulong es2[GR_DFT_NFIXED_MAX_NLIMBS + 2];
+        ulong em[GR_DFT_NFIXED_MAX_NLIMBS + 2];
+        ulong et[GR_DFT_NFIXED_MAX_NLIMBS + 2];
+        ulong t1[GR_DFT_NFIXED_MAX_NLIMBS];
+        ulong t2[GR_DFT_NFIXED_MAX_NLIMBS];
+        ulong s1, s2, top;
+        slong i;
+
+        /* s1 = xr + xi, s2 = yr + yi */
+        if (xr[0] == xi[0])
+        {
+            es1[0] = xr[0];
+            es1[n + 1] = mpn_add_n(es1 + 1, xr + 1, xi + 1, n);
+        }
+        else
+        {
+            es1[0] = xr[0] ^ (ulong) _nfx_signed_sub(es1 + 1, xr + 1, xi + 1, n);
+            es1[n + 1] = 0;
+        }
+        if (yr[0] == yi[0])
+        {
+            es2[0] = yr[0];
+            es2[n + 1] = mpn_add_n(es2 + 1, yr + 1, yi + 1, n);
+        }
+        else
+        {
+            es2[0] = yr[0] ^ (ulong) _nfx_signed_sub(es2 + 1, yr + 1, yi + 1, n);
+            es2[n + 1] = 0;
+        }
+
+        s1 = xr[0] ^ yr[0]; flint_mpn_mulhigh_n(t1, xr + 1, yr + 1, n);
+        s2 = xi[0] ^ yi[0]; flint_mpn_mulhigh_n(t2, xi + 1, yi + 1, n);
+
+        /* m = s1 s2 = h1 h2 + h1 f2 + h2 f1 + mulhigh(f1, f2) */
+        em[0] = es1[0] ^ es2[0];
+        flint_mpn_mulhigh_n(em + 1, es1 + 1, es2 + 1, n);
+        top = es1[n + 1] & es2[n + 1];
+        if (es1[n + 1])
+            top += mpn_add_n(em + 1, em + 1, es2 + 1, n);
+        if (es2[n + 1])
+            top += mpn_add_n(em + 1, em + 1, es1 + 1, n);
+        em[n + 1] = top;
+
+        /* re = t1 - t2 */
+        ulong ov = _nfx_signed_combine(rr, s1, t1, s2 ^ 1, t2, n);
+
+        /* im = m - t1 - t2 in (n+1)-limb arithmetic */
+        et[0] = s1 ^ 1;
+        for (i = 0; i < n; i++)
+            et[i + 1] = t1[i];
+        et[n + 1] = 0;
+        (void) _nfx_add(em, em, et, n + 1);   /* cannot carry */
+        et[0] = s2 ^ 1;
+        for (i = 0; i < n; i++)
+            et[i + 1] = t2[i];
+        (void) _nfx_add(em, em, et, n + 1);   /* cannot carry */
+
+        ri[0] = em[0];
+        ov |= (em[n + 1] != 0);
+        for (i = 0; i < n; i++)
+            ri[i + 1] = em[i + 1];
+
+        return (int) (ov << 1);
+    }
+}
+
+static int
+_nfxc_mul_generic(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    return _nfxc_mul_impl(res, x, y,
+            NFIXED_CTX_NLIMBS(ctx) >= GR_DFT_NFIXED_KARATSUBA_CUTOFF, ctx);
+}
+
+/* forced-path entry points for tuning (see profile/p-gr_dft_nfixed) */
+int
+_gr_dft_nfixed_cmul_schoolbook(gr_ptr res, gr_srcptr x, gr_srcptr y,
+        gr_ctx_t ctx)
+{
+    return _nfxc_mul_impl(res, x, y, 0, ctx);
+}
+
+int
+_gr_dft_nfixed_cmul_karatsuba(gr_ptr res, gr_srcptr x, gr_srcptr y,
+        gr_ctx_t ctx)
+{
+    return _nfxc_mul_impl(res, x, y, 1, ctx);
+}
+
+/* Complex squaring with 2 real multiplications:
+
+       re = (a + b)(a - b),   im = 2 a b,
+
+   where the sums a +- b (of magnitude up to sqrt(2)) are held as
+   carry-extended sign-magnitude values with an extra high limb, and
+   their product is computed with a single mulhigh on the fraction
+   parts plus conditional exact additions selected by the carries, as
+   in the Karatsuba multiplication above. The doubling of a b is an
+   exact addition (saturating at the representation limit if the
+   caller violated the |t| < 1 contract). Per-component errors: at
+   most 2 ulp on the real part (one mulhigh), at most 4 ulp on the
+   imaginary part (a doubled mulhigh); both within the error constant
+   of the general complex multiplication. */
+static int
+_nfxc_sqr_generic(gr_ptr res, gr_srcptr x, gr_ctx_t ctx)
+{
+    slong n = NFIXED_CTX_NLIMBS(ctx);
+    nn_srcptr a = x, b = NFXC_IM_SRC(x, n);
+    nn_ptr rr = res, ri = NFXC_IM(res, n);
+    ulong es1[GR_DFT_NFIXED_MAX_NLIMBS + 2];
+    ulong es2[GR_DFT_NFIXED_MAX_NLIMBS + 2];
+    ulong em[GR_DFT_NFIXED_MAX_NLIMBS + 2];
+    ulong t[GR_DFT_NFIXED_MAX_NLIMBS];
+    ulong sim, top;
+    slong i;
+
+    /* s1 = a + b, s2 = a - b, carry-extended */
+    if (a[0] == b[0])
+    {
+        es1[0] = a[0];
+        es1[n + 1] = mpn_add_n(es1 + 1, a + 1, b + 1, n);
+        es2[0] = a[0] ^ (ulong) _nfx_signed_sub(es2 + 1, a + 1, b + 1, n);
+        es2[n + 1] = 0;
+    }
+    else
+    {
+        es1[0] = a[0] ^ (ulong) _nfx_signed_sub(es1 + 1, a + 1, b + 1, n);
+        es1[n + 1] = 0;
+        es2[0] = a[0];
+        es2[n + 1] = mpn_add_n(es2 + 1, a + 1, b + 1, n);
+    }
+
+    /* im = 2 a b, before res is written */
+    sim = a[0] ^ b[0];
+    flint_mpn_mulhigh_n(t, a + 1, b + 1, n);
+
+    /* re = s1 s2 */
+    rr[0] = es1[0] ^ es2[0];
+    flint_mpn_mulhigh_n(em + 1, es1 + 1, es2 + 1, n);
+    top = es1[n + 1] & es2[n + 1];
+    if (es1[n + 1])
+        top += mpn_add_n(em + 1, em + 1, es2 + 1, n);
+    if (es2[n + 1])
+        top += mpn_add_n(em + 1, em + 1, es1 + 1, n);
+    for (i = 0; i < n; i++)
+        rr[i + 1] = em[i + 1];
+
+    ri[0] = sim;
+
+    /* overflow of either component: GR_UNABLE, wrapped values */
+    return (int) ((((ulong) (top != 0)) |
+            mpn_add_n(ri + 1, t, t, n)) << 1);
+}
+
+/* per-component ulp error bound of one complex multiplication in the
+   given context (used by the root table construction and the DFT
+   bound computation) */
+double
+_gr_dft_nfixed_cmul_err_ulps(gr_ctx_t ctx)
+{
+    slong n = NFIXED_CTX_NLIMBS(ctx);
+
+    if (n <= 2)
+        return 2.0;   /* exact-truncation products */
+    if (n < GR_DFT_NFIXED_KARATSUBA_CUTOFF)
+        return 4.0;   /* schoolbook, 2 mulhighs per component */
+    return 6.0;       /* Karatsuba, 3 mulhighs on the im part */
+}
+
+/* Shared scalar methods (all limb counts) ************************/
+
+static int
+_nfx_ctx_write(gr_stream_t out, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Fixed-point numbers x, |x| < 1, with ");
+    status |= gr_stream_write_si(out, NFIXED_CTX_NLIMBS(ctx));
+    status |= gr_stream_write(out, "-limb precision (gr_dft_nfixed)");
+    return status;
+}
+
+static void
+_nfx_init(gr_ptr x, gr_ctx_t ctx)
+{
+    memset(x, 0, ctx->sizeof_elem);
+}
+
+static void
+_nfx_clear(gr_ptr x, gr_ctx_t ctx)
+{
+}
+
+static void
+_nfx_swap(gr_ptr x, gr_ptr y, gr_ctx_t ctx)
+{
+    slong i, len = ctx->sizeof_elem / sizeof(ulong);
+    nn_ptr xp = x, yp = y;
+    for (i = 0; i < len; i++)
+    {
+        ulong t = xp[i];
+        xp[i] = yp[i];
+        yp[i] = t;
+    }
+}
+
+static int
+_nfx_set(gr_ptr res, gr_srcptr x, gr_ctx_t ctx)
+{
+    if (res != x)
+        memcpy(res, x, ctx->sizeof_elem);
+    return GR_SUCCESS;
+}
+
+static int
+_nfx_zero(gr_ptr res, gr_ctx_t ctx)
+{
+    memset(res, 0, ctx->sizeof_elem);
+    return GR_SUCCESS;
+}
+
+static int
+_nfx_one(gr_ptr res, gr_ctx_t ctx)
+{
+    nn_ptr r = res;
+    r[0] = 0;
+    _nfx_saturate(r + 1, NFIXED_CTX_NLIMBS(ctx));
+    return GR_SUCCESS;
+}
+
+static int
+_nfx_neg_one(gr_ptr res, gr_ctx_t ctx)
+{
+    nn_ptr r = res;
+    r[0] = 1;
+    _nfx_saturate(r + 1, NFIXED_CTX_NLIMBS(ctx));
+    return GR_SUCCESS;
+}
+
+static int
+_nfx_set_si(gr_ptr res, slong x, gr_ctx_t ctx)
+{
+    if (x == 0)
+        return _nfx_zero(res, ctx);
+    if (x == 1)
+        return _nfx_one(res, ctx);
+    if (x == -1)
+        return _nfx_neg_one(res, ctx);
+    return GR_DOMAIN;
+}
+
+static int
+_nfx_set_ui(gr_ptr res, ulong x, gr_ctx_t ctx)
+{
+    if (x == 0)
+        return _nfx_zero(res, ctx);
+    if (x == 1)
+        return _nfx_one(res, ctx);
+    return GR_DOMAIN;
+}
+
+static int
+_nfx_neg(gr_ptr res, gr_srcptr x, gr_ctx_t ctx)
+{
+    if (res != x)
+        memcpy(res, x, ctx->sizeof_elem);
+    ((nn_ptr) res)[0] ^= 1;
+    return GR_SUCCESS;
+}
+
+static int
+_nfx_is_zero(nn_srcptr a, slong n)
+{
+    slong i;
+    for (i = 1; i <= n; i++)
+        if (a[i] != 0)
+            return 0;
+    return 1;
+}
+
+static truth_t
+_nfx_is_zero_op(gr_srcptr x, gr_ctx_t ctx)
+{
+    return _nfx_is_zero(x, NFIXED_CTX_NLIMBS(ctx)) ? T_TRUE : T_FALSE;
+}
+
+static truth_t
+_nfx_false_predicate(gr_srcptr x, gr_ctx_t ctx)
+{
+    return T_FALSE;
+}
+
+static truth_t
+_nfx_equal(gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    slong n = NFIXED_CTX_NLIMBS(ctx);
+    nn_srcptr xp = x, yp = y;
+
+    if (_nfx_is_zero(xp, n))
+        return _nfx_is_zero(yp, n) ? T_TRUE : T_FALSE;
+
+    if (xp[0] != yp[0])
+        return T_FALSE;
+
+    return (mpn_cmp(xp + 1, yp + 1, n) == 0) ? T_TRUE : T_FALSE;
+}
+
+/* writes exactly n + 1 limbs (one real part) */
+static void
+_nfx_randtest_limbs(nn_ptr r, flint_rand_t state, slong n)
+{
+    slong i;
+
+    if (n_randint(state, 8) == 0)
+    {
+        for (i = 0; i <= n; i++)
+            r[i] = 0;
+        return;
+    }
+
+    r[0] = n_randint(state, 2);
+    for (i = 1; i <= n; i++)
+        r[i] = n_randtest(state);
+    /* vary the magnitude */
+    r[n] >>= n_randint(state, FLINT_BITS);
+}
+
+static int
+_nfx_randtest(gr_ptr res, flint_rand_t state, gr_ctx_t ctx)
+{
+    _nfx_randtest_limbs(res, state, NFIXED_CTX_NLIMBS(ctx));
+    return GR_SUCCESS;
+}
+
+void
+gr_dft_nfixed_get_arf(arf_t res, gr_srcptr x, gr_ctx_t ctx)
+{
+    slong n = NFIXED_CTX_NLIMBS(ctx);
+    nn_srcptr xp = x;
+    fmpz_t t;
+
+    fmpz_init(t);
+    fmpz_set_ui_array(t, xp + 1, n);
+    if (xp[0])
+        fmpz_neg(t, t);
+    arf_set_fmpz(res, t);
+    arf_mul_2exp_si(res, res, -n * FLINT_BITS);
+    fmpz_clear(t);
+}
+
+int
+gr_dft_nfixed_set_arf(gr_ptr res, const arf_t x, gr_ctx_t ctx)
+{
+    slong n = NFIXED_CTX_NLIMBS(ctx);
+    nn_ptr r = res;
+    arf_t t;
+    fmpz_t z;
+
+    if (!arf_is_finite(x))
+        return GR_DOMAIN;
+
+    if (arf_cmpabs_2exp_si(x, 0) >= 0)
+    {
+        /* saturate values with |x| >= 1 */
+        r[0] = (arf_sgn(x) < 0);
+        _nfx_saturate(r + 1, n);
+        return GR_SUCCESS;
+    }
+
+    arf_init(t);
+    fmpz_init(z);
+
+    arf_mul_2exp_si(t, x, n * FLINT_BITS);
+    arf_get_fmpz(z, t, ARF_RND_DOWN);   /* toward zero */
+
+    r[0] = (fmpz_sgn(z) < 0);
+    fmpz_abs(z, z);
+    fmpz_get_ui_array(r + 1, n, z);
+
+    arf_clear(t);
+    fmpz_clear(z);
+
+    return GR_SUCCESS;
+}
+
+static int
+_nfx_write(gr_stream_t out, gr_srcptr x, gr_ctx_t ctx)
+{
+    arf_t t;
+    char buf[64];
+
+    int status;
+
+    arf_init(t);
+    gr_dft_nfixed_get_arf(t, x, ctx);
+    snprintf(buf, sizeof(buf), "%.17g", arf_get_d(t, ARF_RND_NEAR));
+    status = gr_stream_write(out, buf);
+    arf_clear(t);
+    return status;
+}
+
+static truth_t
+_nfx_ctx_predicate_true(gr_ctx_t ctx)
+{
+    return T_TRUE;
+}
+
+static int
+_nfx_ctx_get_real_prec(slong * res, gr_ctx_t ctx)
+{
+    *res = NFIXED_CTX_NLIMBS(ctx) * FLINT_BITS;
+    return GR_SUCCESS;
+}
+
+/* Complex shared methods *****************************************/
+
+static int
+_nfxc_ctx_write(gr_stream_t out, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Complex fixed-point numbers x, |re(x)|, |im(x)| < 1, with ");
+    status |= gr_stream_write_si(out, NFIXED_CTX_NLIMBS(ctx));
+    status |= gr_stream_write(out, "-limb precision (gr_dft_nfixed_complex)");
+    return status;
+}
+
+static int
+_nfxc_one(gr_ptr res, gr_ctx_t ctx)
+{
+    slong n = NFIXED_CTX_NLIMBS(ctx);
+    nn_ptr r = res;
+    r[0] = 0;
+    _nfx_saturate(r + 1, n);
+    memset(NFXC_IM(res, n), 0, (n + 1) * sizeof(ulong));
+    return GR_SUCCESS;
+}
+
+static int
+_nfxc_neg_one(gr_ptr res, gr_ctx_t ctx)
+{
+    slong n = NFIXED_CTX_NLIMBS(ctx);
+    nn_ptr r = res;
+    r[0] = 1;
+    _nfx_saturate(r + 1, n);
+    memset(NFXC_IM(res, n), 0, (n + 1) * sizeof(ulong));
+    return GR_SUCCESS;
+}
+
+static int
+_nfxc_set_si(gr_ptr res, slong x, gr_ctx_t ctx)
+{
+    if (x == 0)
+        return _nfx_zero(res, ctx);
+    if (x == 1)
+        return _nfxc_one(res, ctx);
+    if (x == -1)
+        return _nfxc_neg_one(res, ctx);
+    return GR_DOMAIN;
+}
+
+static int
+_nfxc_set_ui(gr_ptr res, ulong x, gr_ctx_t ctx)
+{
+    if (x == 0)
+        return _nfx_zero(res, ctx);
+    if (x == 1)
+        return _nfxc_one(res, ctx);
+    return GR_DOMAIN;
+}
+
+static int
+_nfxc_neg(gr_ptr res, gr_srcptr x, gr_ctx_t ctx)
+{
+    slong n = NFIXED_CTX_NLIMBS(ctx);
+    if (res != x)
+        memcpy(res, x, ctx->sizeof_elem);
+    ((nn_ptr) res)[0] ^= 1;
+    NFXC_IM(res, n)[0] ^= 1;
+    return GR_SUCCESS;
+}
+
+static int
+_nfxc_add_op(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    slong n = NFIXED_CTX_NLIMBS(ctx);
+    ulong ov;
+    ov = _nfx_add(res, x, y, n);
+    ov |= _nfx_add(NFXC_IM(res, n), NFXC_IM_SRC(x, n), NFXC_IM_SRC(y, n), n);
+    return (int) (ov << 1);
+}
+
+static int
+_nfxc_sub_op(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    slong n = NFIXED_CTX_NLIMBS(ctx);
+    ulong ov;
+    ov = _nfx_sub(res, x, y, n);
+    ov |= _nfx_sub(NFXC_IM(res, n), NFXC_IM_SRC(x, n), NFXC_IM_SRC(y, n), n);
+    return (int) (ov << 1);
+}
+
+/* sized componentwise complex add/sub via the sized real methods */
+#define DEF_NFXC_ADDSUB_SIZED(N) \
+static int \
+_nfxc_add_op_##N(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) \
+{ \
+    int status; \
+    status = _nfx_add_op_##N(res, x, y, ctx); \
+    status |= _nfx_add_op_##N(NFXC_IM(res, N), NFXC_IM_SRC(x, N), \
+            NFXC_IM_SRC(y, N), ctx); \
+    return status; \
+} \
+static int \
+_nfxc_sub_op_##N(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) \
+{ \
+    int status; \
+    status = _nfx_sub_op_##N(res, x, y, ctx); \
+    status |= _nfx_sub_op_##N(NFXC_IM(res, N), NFXC_IM_SRC(x, N), \
+            NFXC_IM_SRC(y, N), ctx); \
+    return status; \
+}
+
+DEF_NFXC_ADDSUB_SIZED(1)
+DEF_NFXC_ADDSUB_SIZED(2)
+DEF_NFXC_ADDSUB_SIZED(3)
+DEF_NFXC_ADDSUB_SIZED(4)
+
+static truth_t
+_nfxc_is_zero_op(gr_srcptr x, gr_ctx_t ctx)
+{
+    slong n = NFIXED_CTX_NLIMBS(ctx);
+    return (_nfx_is_zero(x, n) && _nfx_is_zero(NFXC_IM_SRC(x, n), n))
+        ? T_TRUE : T_FALSE;
+}
+
+static truth_t
+_nfxc_equal(gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    truth_t r1, r2;
+    slong n = NFIXED_CTX_NLIMBS(ctx);
+
+    r1 = _nfx_equal(x, y, ctx);
+    if (r1 == T_FALSE)
+        return T_FALSE;
+    r2 = _nfx_equal(NFXC_IM_SRC(x, n), NFXC_IM_SRC(y, n), ctx);
+    return (r1 == T_TRUE && r2 == T_TRUE) ? T_TRUE :
+           (r2 == T_FALSE ? T_FALSE : T_UNKNOWN);
+}
+
+static int
+_nfxc_randtest(gr_ptr res, flint_rand_t state, gr_ctx_t ctx)
+{
+    slong n = NFIXED_CTX_NLIMBS(ctx);
+    _nfx_randtest_limbs(res, state, n);
+    _nfx_randtest_limbs(NFXC_IM(res, n), state, n);
+    return GR_SUCCESS;
+}
+
+static int
+_nfxc_write(gr_stream_t out, gr_srcptr x, gr_ctx_t ctx)
+{
+    slong n = NFIXED_CTX_NLIMBS(ctx);
+    int status = GR_SUCCESS;
+    status |= _nfx_write(out, x, ctx);
+    status |= gr_stream_write(out, " + ");
+    status |= _nfx_write(out, NFXC_IM_SRC(x, n), ctx);
+    status |= gr_stream_write(out, "*I");
+    return status;
+}
+
+/* Method tables: one per hardcoded limb count 1-4 plus generic ****/
+
+#define NFX_TAB_COUNT 5
+
+static gr_static_method_table _nfx_methods_tab[NFX_TAB_COUNT];
+static gr_static_method_table _nfxc_methods_tab[NFX_TAB_COUNT];
+static int _nfx_methods_initialized = 0;
+
+#define NFX_COMMON_METHODS \
+    {GR_METHOD_CTX_WRITE,           (gr_funcptr) _nfx_ctx_write}, \
+    {GR_METHOD_CTX_IS_THREADSAFE,   (gr_funcptr) _nfx_ctx_predicate_true}, \
+    {GR_METHOD_CTX_GET_REAL_PREC,   (gr_funcptr) _nfx_ctx_get_real_prec}, \
+    {GR_METHOD_INIT,                (gr_funcptr) _nfx_init}, \
+    {GR_METHOD_CLEAR,               (gr_funcptr) _nfx_clear}, \
+    {GR_METHOD_SWAP,                (gr_funcptr) _nfx_swap}, \
+    {GR_METHOD_RANDTEST,            (gr_funcptr) _nfx_randtest}, \
+    {GR_METHOD_WRITE,               (gr_funcptr) _nfx_write}, \
+    {GR_METHOD_ZERO,                (gr_funcptr) _nfx_zero}, \
+    {GR_METHOD_ONE,                 (gr_funcptr) _nfx_one}, \
+    {GR_METHOD_NEG_ONE,             (gr_funcptr) _nfx_neg_one}, \
+    {GR_METHOD_IS_ZERO,             (gr_funcptr) _nfx_is_zero_op}, \
+    {GR_METHOD_IS_ONE,              (gr_funcptr) _nfx_false_predicate}, \
+    {GR_METHOD_IS_NEG_ONE,          (gr_funcptr) _nfx_false_predicate}, \
+    {GR_METHOD_EQUAL,               (gr_funcptr) _nfx_equal}, \
+    {GR_METHOD_SET,                 (gr_funcptr) _nfx_set}, \
+    {GR_METHOD_SET_SI,              (gr_funcptr) _nfx_set_si}, \
+    {GR_METHOD_SET_UI,              (gr_funcptr) _nfx_set_ui}, \
+    {GR_METHOD_DIV_UI,              (gr_funcptr) _nfx_div_ui_op}, \
+    {GR_METHOD_NEG,                 (gr_funcptr) _nfx_neg}
+
+#define DEF_NFX_INPUT(N) \
+static gr_method_tab_input _nfx_methods_input_##N[] = \
+{ \
+    NFX_COMMON_METHODS, \
+    {GR_METHOD_ADD,                 (gr_funcptr) _nfx_add_op_##N}, \
+    {GR_METHOD_SUB,                 (gr_funcptr) _nfx_sub_op_##N}, \
+    {GR_METHOD_MUL,                 (gr_funcptr) _nfx_mul_op_##N}, \
+    {0,                             (gr_funcptr) NULL} \
+};
+
+DEF_NFX_INPUT(1)
+DEF_NFX_INPUT(2)
+DEF_NFX_INPUT(3)
+DEF_NFX_INPUT(4)
+
+static gr_method_tab_input _nfx_methods_input_g[] =
+{
+    NFX_COMMON_METHODS,
+    {GR_METHOD_ADD,                 (gr_funcptr) _nfx_add_op},
+    {GR_METHOD_SUB,                 (gr_funcptr) _nfx_sub_op},
+    {GR_METHOD_MUL,                 (gr_funcptr) _nfx_mul_op},
+    {GR_METHOD_SQR,                 (gr_funcptr) _nfx_sqr_op},
+    {0,                             (gr_funcptr) NULL}
+};
+
+#define NFXC_COMMON_METHODS \
+    {GR_METHOD_CTX_WRITE,           (gr_funcptr) _nfxc_ctx_write}, \
+    {GR_METHOD_CTX_IS_THREADSAFE,   (gr_funcptr) _nfx_ctx_predicate_true}, \
+    {GR_METHOD_CTX_GET_REAL_PREC,   (gr_funcptr) _nfx_ctx_get_real_prec}, \
+    {GR_METHOD_INIT,                (gr_funcptr) _nfx_init}, \
+    {GR_METHOD_CLEAR,               (gr_funcptr) _nfx_clear}, \
+    {GR_METHOD_SWAP,                (gr_funcptr) _nfx_swap}, \
+    {GR_METHOD_RANDTEST,            (gr_funcptr) _nfxc_randtest}, \
+    {GR_METHOD_WRITE,               (gr_funcptr) _nfxc_write}, \
+    {GR_METHOD_ZERO,                (gr_funcptr) _nfx_zero}, \
+    {GR_METHOD_ONE,                 (gr_funcptr) _nfxc_one}, \
+    {GR_METHOD_NEG_ONE,             (gr_funcptr) _nfxc_neg_one}, \
+    {GR_METHOD_IS_ZERO,             (gr_funcptr) _nfxc_is_zero_op}, \
+    {GR_METHOD_IS_ONE,              (gr_funcptr) _nfx_false_predicate}, \
+    {GR_METHOD_IS_NEG_ONE,          (gr_funcptr) _nfx_false_predicate}, \
+    {GR_METHOD_EQUAL,               (gr_funcptr) _nfxc_equal}, \
+    {GR_METHOD_SET,                 (gr_funcptr) _nfx_set}, \
+    {GR_METHOD_SET_SI,              (gr_funcptr) _nfxc_set_si}, \
+    {GR_METHOD_SET_UI,              (gr_funcptr) _nfxc_set_ui}, \
+    {GR_METHOD_DIV_UI,              (gr_funcptr) _nfxc_div_ui_op}, \
+    {GR_METHOD_NEG,                 (gr_funcptr) _nfxc_neg}
+
+#define DEF_NFXC_INPUT(N) \
+static gr_method_tab_input _nfxc_methods_input_##N[] = \
+{ \
+    NFXC_COMMON_METHODS, \
+    {GR_METHOD_ADD,                 (gr_funcptr) _nfxc_add_op_##N}, \
+    {GR_METHOD_SUB,                 (gr_funcptr) _nfxc_sub_op_##N}, \
+    {GR_METHOD_MUL,                 (gr_funcptr) _nfxc_mul_op_##N}, \
+    {0,                             (gr_funcptr) NULL} \
+};
+
+DEF_NFXC_INPUT(1)
+DEF_NFXC_INPUT(2)
+DEF_NFXC_INPUT(3)
+DEF_NFXC_INPUT(4)
+
+static gr_method_tab_input _nfxc_methods_input_g[] =
+{
+    NFXC_COMMON_METHODS,
+    {GR_METHOD_ADD,                 (gr_funcptr) _nfxc_add_op},
+    {GR_METHOD_SUB,                 (gr_funcptr) _nfxc_sub_op},
+    {GR_METHOD_MUL,                 (gr_funcptr) _nfxc_mul_generic},
+    {GR_METHOD_SQR,                 (gr_funcptr) _nfxc_sqr_generic},
+    {0,                             (gr_funcptr) NULL}
+};
+
+static void
+_nfx_init_method_tables(void)
+{
+    if (!_nfx_methods_initialized)
+    {
+        gr_method_tab_init(_nfx_methods_tab[0], _nfx_methods_input_1);
+        gr_method_tab_init(_nfx_methods_tab[1], _nfx_methods_input_2);
+        gr_method_tab_init(_nfx_methods_tab[2], _nfx_methods_input_3);
+        gr_method_tab_init(_nfx_methods_tab[3], _nfx_methods_input_4);
+        gr_method_tab_init(_nfx_methods_tab[4], _nfx_methods_input_g);
+        gr_method_tab_init(_nfxc_methods_tab[0], _nfxc_methods_input_1);
+        gr_method_tab_init(_nfxc_methods_tab[1], _nfxc_methods_input_2);
+        gr_method_tab_init(_nfxc_methods_tab[2], _nfxc_methods_input_3);
+        gr_method_tab_init(_nfxc_methods_tab[3], _nfxc_methods_input_4);
+        gr_method_tab_init(_nfxc_methods_tab[4], _nfxc_methods_input_g);
+        _nfx_methods_initialized = 1;
+    }
+}
+
+static slong
+_nfx_tab_index(slong nlimbs)
+{
+    return (nlimbs <= 4) ? nlimbs - 1 : 4;
+}
+
+int
+gr_dft_ctx_init_nfixed(gr_ctx_t ctx, slong nlimbs)
+{
+    if (nlimbs < 1 || nlimbs > GR_DFT_NFIXED_MAX_NLIMBS)
+        return GR_UNABLE;
+
+    ctx->which_ring = GR_CTX_UNKNOWN_DOMAIN;
+    ctx->sizeof_elem = sizeof(ulong) * (nlimbs + 1);
+    ctx->size_limit = WORD_MAX;
+    NFIXED_CTX_NLIMBS(ctx) = nlimbs;
+
+    _nfx_init_method_tables();
+    ctx->methods = _nfx_methods_tab[_nfx_tab_index(nlimbs)];
+
+    return GR_SUCCESS;
+}
+
+int
+gr_dft_ctx_init_nfixed_complex(gr_ctx_t ctx, slong nlimbs)
+{
+    if (nlimbs < 1 || nlimbs > GR_DFT_NFIXED_MAX_NLIMBS)
+        return GR_UNABLE;
+
+    ctx->which_ring = GR_CTX_UNKNOWN_DOMAIN;
+    ctx->sizeof_elem = 2 * sizeof(ulong) * (nlimbs + 1);
+    ctx->size_limit = WORD_MAX;
+    NFIXED_CTX_NLIMBS(ctx) = nlimbs;
+
+    _nfx_init_method_tables();
+    ctx->methods = _nfxc_methods_tab[_nfx_tab_index(nlimbs)];
+
+    return GR_SUCCESS;
+}
+
+int
+_gr_dft_ctx_is_nfixed(gr_ctx_t ctx)
+{
+    slong i;
+    if (!_nfx_methods_initialized)
+        return 0;
+    for (i = 0; i < NFX_TAB_COUNT; i++)
+        if (ctx->methods == _nfx_methods_tab[i])
+            return 1;
+    return 0;
+}
+
+int
+_gr_dft_ctx_is_nfixed_complex(gr_ctx_t ctx)
+{
+    slong i;
+    if (!_nfx_methods_initialized)
+        return 0;
+    for (i = 0; i < NFX_TAB_COUNT; i++)
+        if (ctx->methods == _nfxc_methods_tab[i])
+            return 1;
+    return 0;
+}
+
+/* Root table *****************************************************/
+
+/* Error bound (in ulp, as a complex modulus and hence valid for both
+   the real and imaginary parts) for the entries of a root table of
+   length n built by the doubling products of _gr_dft_nfixed_roots,
+   where one complex multiplication contributes a modulus rounding of
+   at most kmul ulp. The recurrence E(1) = 2,
+   E(j) = E(floor(j/2)) + E(ceil(j/2)) + kmul has the exact solution
+   bound E(j) <= (2 + kmul) j - kmul, established by induction; the
+   factor below absorbs the fudge multipliers of the tracked
+   recurrence over up to 64 doubling levels. */
+double
+_gr_dft_nfixed_root_err_bound(ulong n, double kmul)
+{
+    if (n <= 1)
+        return 0.0;
+    return ((2.0 + kmul) * (double) (n - 1) - kmul) * (1.0 + 1e-7) + 2.0;
+}
+
+/* Fill roots[0], ..., roots[n-1] with fixed-point approximations of
+   w^j, w = exp(-2 pi i / n). The primitive root w is computed from
+   arb with elevated internal precision so that its rounding (toward
+   zero) to fixed point has error below 2 ulp; entries up to n/8 (or
+   n/4 or n/2, depending on the divisibility of n) are computed as
+   w^j = w^floor(j/2) w^ceil(j/2) (squarings for even j), giving the
+   error recurrence E(j) <= E(floor(j/2)) + E(ceil(j/2)) + K, hence
+   E(j) = O(j); the remaining entries are derived from the eight-fold
+   symmetry of the unit circle by sign flips and swaps of the parts,
+   which are exact. The maximum error over the table (a bound on
+   |computed - exact| for both the real and imaginary parts, measured
+   in ulp) is written to err_ulps. */
+int
+_gr_dft_nfixed_roots(gr_ptr roots, ulong n, double * err_ulps, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    slong nlimbs = NFIXED_CTX_NLIMBS(ctx);
+    slong sz = ctx->sizeof_elem;
+    slong prec = nlimbs * FLINT_BITS + 64;
+    arb_t s, c;
+    fmpq_t q;
+    ulong j, L;
+    /* rounding of one complex multiplication in this context,
+       converted from a per-component to a modulus bound */
+    const double KMUL = _gr_dft_nfixed_cmul_err_ulps(ctx) * 1.4142135623730951;
+
+    status |= _nfxc_one(roots, ctx);
+    *err_ulps = 0.0;
+
+    if (n == 1)
+        return status;
+
+    arb_init(s);
+    arb_init(c);
+    fmpq_init(q);
+
+    /* w = cos(-2 pi / n) + sin(-2 pi / n) i */
+    fmpq_set_si(q, -2, n);
+    arb_sin_cos_pi_fmpq(s, c, q, prec);
+
+    {
+        gr_ptr w1 = GR_ENTRY(roots, 1, sz);
+        status |= gr_dft_nfixed_set_arf((gr_ptr) w1,
+                arb_midref(c), ctx);   /* real part; real layout prefix */
+        status |= gr_dft_nfixed_set_arf(
+                (gr_ptr) NFXC_IM(w1, nlimbs), arb_midref(s), ctx);
+    }
+
+    arb_clear(s);
+    arb_clear(c);
+    fmpq_clear(q);
+
+    /* entries computed by products: up to an eighth of the circle
+       when 4 | n, a quarter when 2 | n, half (rounded down) for odd
+       n; the remaining entries follow by symmetry */
+    if (n % 4 == 0)
+        L = (n + 7) / 8;
+    else if (n % 2 == 0)
+        L = (n + 3) / 4;
+    else
+        L = n / 2;
+
+    for (j = 2; j <= L; j++)
+    {
+        ulong a = j / 2, b = j - a;
+
+        if (a == b)
+            status |= gr_sqr(GR_ENTRY(roots, j, sz),
+                    GR_ENTRY(roots, a, sz), ctx);
+        else
+            status |= gr_mul(GR_ENTRY(roots, j, sz),
+                    GR_ENTRY(roots, a, sz), GR_ENTRY(roots, b, sz), ctx);
+    }
+
+    /* symmetry fills (exact): writing w^j = x + y i,
+       w^(n/4 - j) = -y - x i, w^(n/2 - j) = -x + y i,
+       w^(n - j) = x - y i */
+    if (n % 4 == 0)
+    {
+        for (j = L + 1; j <= n / 4; j++)
+        {
+            nn_srcptr src = (nn_srcptr) GR_ENTRY(roots, n / 4 - j, sz);
+            nn_ptr dst = (nn_ptr) GR_ENTRY(roots, j, sz);
+            slong i;
+
+            for (i = 0; i <= nlimbs; i++)
+            {
+                dst[i] = src[nlimbs + 1 + i];             /* re = -im */
+                dst[nlimbs + 1 + i] = src[i];             /* im = -re */
+            }
+            dst[0] ^= 1;
+            dst[nlimbs + 1] ^= 1;
+        }
+    }
+    if (n % 2 == 0)
+    {
+        for (j = FLINT_MAX(L, n / 4) + 1; j <= n / 2; j++)
+        {
+            nn_srcptr src = (nn_srcptr) GR_ENTRY(roots, n / 2 - j, sz);
+            nn_ptr dst = (nn_ptr) GR_ENTRY(roots, j, sz);
+            slong i;
+
+            for (i = 0; i <= nlimbs; i++)
+            {
+                dst[i] = src[i];                          /* re = -re */
+                dst[nlimbs + 1 + i] = src[nlimbs + 1 + i];
+            }
+            dst[0] ^= 1;
+        }
+    }
+    for (j = n / 2 + 1; j < n; j++)
+    {
+        nn_srcptr src = (nn_srcptr) GR_ENTRY(roots, n - j, sz);
+        nn_ptr dst = (nn_ptr) GR_ENTRY(roots, j, sz);
+        slong i;
+
+        for (i = 0; i <= nlimbs; i++)
+        {
+            dst[i] = src[i];                              /* conjugate */
+            dst[nlimbs + 1 + i] = src[nlimbs + 1 + i];
+        }
+        dst[nlimbs + 1] ^= 1;
+    }
+
+    *err_ulps = _gr_dft_nfixed_root_err_bound(L + 1, KMUL);
+
+    return status;
+}

--- a/src/gr_dft/nfixed_bound.c
+++ b/src/gr_dft/nfixed_bound.c
@@ -1,0 +1,391 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "gr.h"
+#include "gr_dft.h"
+
+/* Bound computation for DFT plans executed in nfixed arithmetic
+   (see nfixed.c): additions and subtractions are exact, real
+   multiplications truncate with error at most 2 ulp, and every value t
+   appearing in the computation must satisfy |t| < 1.
+
+   The propagation tracks, per element, a bound B on the complex
+   modulus (which also bounds the real and imaginary parts) and a bound
+   D on the modulus of the accumulated error, measured in ulp; the
+   final D bounds the errors of the real and imaginary parts of the
+   output. A running peak records the largest modulus attained by any
+   input, intermediate or output value; the transform is safe from
+   overflow iff peak < 1. The peak includes a factor sqrt(2) at every
+   root multiplication, accounting for the intermediate sum x_r +- x_i
+   inside the 2-multiplication rotation classes.
+
+   The rules are (with Dw an ulp bound for the root table entries and
+   all updates inflated by a fudge factor covering the rounding of
+   these double-precision computations themselves):
+
+       add/sub:   B <- B_a + B_b,  D <- D_a + D_b        (exact)
+       rotation:  B <- B,          D <- D + Dw + K
+
+   the constant K bounding the modulus of the rounding of one complex
+   multiplication (sqrt(2) times the per-component bound reported by
+   _gr_dft_nfixed_cmul_err_ulps for the actual context: 2, 4 or 6 ulp
+   per component depending on the limb count and whether the Karatsuba
+   product is used), and Dw * B <= Dw absorbing the error of the root
+   itself.
+
+   All quantities are affine in the input (B, D), so the recursive
+   algorithms are propagated with memoized affine coefficients, giving
+   O(log n) cost. */
+
+#define NFB_FUDGE (1.0 + 1e-10)
+#define NFB_SQRT2 1.41421356237309515
+
+typedef struct
+{
+    double B;      /* modulus bound */
+    double D;      /* modulus error bound, ulp */
+    double peak;   /* running maximum modulus */
+    double K;      /* modulus rounding of one complex multiplication */
+}
+nfb_state;
+
+static void
+nfb_peak(nfb_state * st, double val)
+{
+    st->peak = FLINT_MAX(st->peak, val * NFB_FUDGE);
+}
+
+static double
+nfb_dw(const gr_dft_pre_t P)
+{
+    return FLINT_MAX(P->nfixed_root_err, 2.0);
+}
+
+/* multiplication by a root of unity */
+static void
+nfb_rot(nfb_state * st, double Dw)
+{
+    nfb_peak(st, NFB_SQRT2 * st->B);
+    st->D = (st->D + Dw + st->K) * NFB_FUDGE;
+}
+
+/* radix-2 Cooley-Tukey, depth levels */
+static void
+nfb_ct(nfb_state * st, int depth, double Dw)
+{
+    int lev;
+
+    for (lev = 0; lev < depth; lev++)
+    {
+        st->B = 2.0 * st->B * NFB_FUDGE;
+        st->D = 2.0 * st->D * NFB_FUDGE;
+        nfb_peak(st, st->B);
+        nfb_rot(st, Dw);
+    }
+}
+
+/* split radix: affine coefficients per depth, out = (Bm * B0,
+   Da * D0 + Db, peak = Pk * B0), memoized */
+static void
+nfb_split_coeffs(int depth, double Dw, double K,
+        double * Bm, double * Da, double * Db, double * Pk)
+{
+    double bm[FLINT_BITS + 1], da[FLINT_BITS + 1];
+    double db[FLINT_BITS + 1], pk[FLINT_BITS + 1];
+    int d;
+
+    for (d = 0; d <= depth; d++)
+    {
+        if (d <= 2)
+        {
+            /* small basecases: model as plain Cooley-Tukey; extract the
+               affine form D_out = Da D_0 + Db by evaluating at
+               D_0 = 0 and D_0 = 1 (the propagation is affine) */
+            nfb_state st0 = { 1.0, 0.0, 1.0, K };
+            nfb_state st1 = { 1.0, 1.0, 1.0, K };
+            nfb_ct(&st0, d, Dw);
+            nfb_ct(&st1, d, Dw);
+            bm[d] = st1.B;
+            db[d] = st0.D;
+            da[d] = st1.D - st0.D;
+            pk[d] = st1.peak;
+        }
+        else
+        {
+            /* combine: u1, u2 from the half transform; zk, zpk from
+               the quarter transforms; t1 = w^k zk, t2 = w^(3k) zpk;
+               t3 = t1 + t2; t1 = t1 - t2; t2 = -i t1 (free);
+               outputs u1 +- t3, u2 +- t2 */
+            double Bh = bm[d - 1], Bq = bm[d - 2];
+            double rotD = da[d - 2];      /* D of t1, t2: quarter + rot */
+            double rotDb = db[d - 2] + (Dw + K) * NFB_FUDGE;
+
+            bm[d] = (Bh + 2.0 * Bq) * NFB_FUDGE;
+            da[d] = (da[d - 1] + 2.0 * rotD) * NFB_FUDGE;
+            db[d] = (db[d - 1] + 2.0 * rotDb) * NFB_FUDGE;
+
+            pk[d] = FLINT_MAX(pk[d - 1], pk[d - 2]);
+            pk[d] = FLINT_MAX(pk[d], NFB_SQRT2 * Bq);   /* inside rotations */
+            pk[d] = FLINT_MAX(pk[d], 2.0 * Bq);         /* t3, t1 */
+            pk[d] = FLINT_MAX(pk[d], bm[d]);            /* outputs */
+            pk[d] *= NFB_FUDGE;
+        }
+    }
+
+    *Bm = bm[depth];
+    *Da = da[depth];
+    *Db = db[depth];
+    *Pk = pk[depth];
+}
+
+static void nfb_plan(nfb_state * st, const gr_dft_pre_t P);
+
+/* the direct prime kernel of the mixed-radix algorithm, radix p:
+   inputs z_0, ..., z_(p-1) (already twiddled), outputs
+   Y_0 = sum z_b and Y_r = (z_0 - z_b*) + sum w^e (z_b - z_b*) */
+static void
+nfb_prime_kernel(nfb_state * st, ulong p, double Dw)
+{
+    double B = st->B, D = st->D;
+    double Bd = 2.0 * B, Dd = 2.0 * D;
+    nfb_state rot = { Bd, Dd, st->peak, st->K };
+    double By, Dy;
+
+    /* Y_0 */
+    By = p * B;
+    Dy = p * D;
+
+    /* rotated differences */
+    nfb_rot(&rot, Dw);
+    st->peak = rot.peak;
+    nfb_peak(st, Bd);
+
+    /* Y_r: accumulation of one difference plus (p - 2) rotated
+       differences; the running sums are bounded by the final value */
+    By = FLINT_MAX(By, (p - 1) * Bd);
+    Dy = FLINT_MAX(Dy, Dd + (p - 2) * rot.D);
+
+    st->B = By * NFB_FUDGE;
+    st->D = Dy * NFB_FUDGE;
+    nfb_peak(st, st->B);
+}
+
+static void
+nfb_mixed(nfb_state * st, const gr_dft_pre_t P)
+{
+    double Dw = nfb_dw(P);
+    slong lvl;
+
+    /* propagate from the innermost level outward */
+    for (lvl = P->num_radices - 1; lvl >= 0; lvl--)
+    {
+        ulong p = P->radices[lvl];
+
+        /* twiddle */
+        nfb_rot(st, Dw);
+
+        if (P->P1 != NULL && P->P1->n == p)
+        {
+            nfb_plan(st, P->P1);
+        }
+        else
+        {
+            nfb_prime_kernel(st, p, Dw);
+        }
+    }
+}
+
+static void
+nfb_naive(nfb_state * st, const gr_dft_pre_t P)
+{
+    double Dw = nfb_dw(P);
+    ulong n = P->n;
+    nfb_state term = *st;
+
+    nfb_rot(&term, Dw);
+    st->peak = term.peak;
+
+    st->B = n * st->B * NFB_FUDGE;
+    st->D = n * term.D * NFB_FUDGE;
+    nfb_peak(st, st->B);
+}
+
+/* Bluestein over fixed-point arithmetic (modeling the shifted-kernel
+   variant used by the fixed-point contexts, where the transformed
+   kernel carries the folded scaling 1/(2 conv_len) and the outputs
+   are doubled at the end).
+
+   Writing z for the chirped input (modulus at most B_z per entry,
+   n nonzero entries), N = conv_len and h for the unit-modulus chirp
+   kernel scaled by 1/(2N):
+
+   - the forward transform of z follows the generic model (values up
+     to N B_z, rotation intermediates up to sqrt(2) N B_z);
+
+   - the transformed kernel satisfies |h^| <= (2n-1)/(2N) < 1/2
+     (2n - 1 nonzero unit entries scaled by 1/(2N); note 2n - 1 < N
+     strictly since N is a power of two), so the pointwise products
+     are bounded by N B_z (2n-1)/(2N);
+
+   - the values of the unscaled inverse transform -- including all its
+     intermediates -- are bounded by N ||z||_1 max|h| <= n B_z / 2:
+     each stage-s intermediate is an unscaled length-2^s inverse of a
+     subsampled spectrum, which by the aliasing identity equals
+     2^s times an alias sum of the true convolution u = z (*) h, and
+     since |u_k| <= ||z||_1 max|h| uniformly, any alias sum over
+     N / 2^s terms is at most (N / 2^s) ||z||_1 max|h|. This replaces
+     the generic stage-doubling bound (which would give N n B_z) and
+     is what makes Bluestein usable in fixed point;
+
+   - the final doubling and output chirp then give |X| <= n B_z as for
+     any DFT.
+
+   The error propagation uses the generic child model throughout
+   (error growth does follow the stage doubling); the kernel error is
+   modeled from the chirp table error scaled by 1/(2N) and pushed
+   through the child transform. */
+static void
+nfb_bluestein(nfb_state * st, const gr_dft_pre_t P)
+{
+    double Dw = nfb_dw(P);
+    double n = (double) P->n;
+    double N = (double) P->conv_len;
+    double Hmax = (2.0 * n - 1.0) / (2.0 * N);
+    double Bz, Dh, Bf;
+    nfb_state ch;
+
+    /* kernel error: chirp entries (table error Dw), scaled by
+       1/(2N) (errors scale down; truncation below 1 ulp per part),
+       then the forward child transform */
+    ch.B = (1.0 / (2.0 * N)) * NFB_FUDGE;
+    ch.D = (Dw / (2.0 * N) + NFB_SQRT2) * NFB_FUDGE;
+    ch.peak = ch.B;
+    ch.K = st->K;
+    nfb_plan(&ch, P->P1);
+    Dh = ch.D;
+
+    /* input chirp */
+    nfb_rot(st, Dw);
+    Bz = st->B;
+
+    /* forward convolution transform */
+    nfb_plan(st, P->P1);
+    Bf = st->B;
+
+    /* pointwise multiplication by the transformed kernel */
+    st->D = (Hmax * st->D + Bf * Dh + st->K) * NFB_FUDGE;
+    st->B = (Bf * Hmax) * NFB_FUDGE;
+    nfb_peak(st, st->B);
+
+    /* unscaled inverse convolution transform: generic model for the
+       errors, aliasing bound for the values */
+    {
+        nfb_state di = *st;
+        nfb_plan(&di, P->P1);
+        st->D = di.D;
+    }
+    st->B = (n * Bz / 2.0) * NFB_FUDGE;
+    nfb_peak(st, NFB_SQRT2 * st->B);
+
+    /* doubling (exact) */
+    st->B = 2.0 * st->B * NFB_FUDGE;
+    st->D = 2.0 * st->D * NFB_FUDGE;
+    nfb_peak(st, st->B);
+
+    /* output chirp */
+    nfb_rot(st, Dw);
+}
+
+static void
+nfb_plan(nfb_state * st, const gr_dft_pre_t P)
+{
+    double Dw = nfb_dw(P);
+
+    nfb_peak(st, st->B);
+
+    switch (P->alg)
+    {
+        case GR_DFT_ALG_CT:
+            nfb_ct(st, P->depth, Dw);
+            break;
+
+        case GR_DFT_ALG_SPLIT:
+            {
+                double Bm, Da, Db, Pk;
+                nfb_split_coeffs(P->depth, Dw, st->K, &Bm, &Da, &Db, &Pk);
+                nfb_peak(st, Pk * st->B);
+                st->D = (Da * st->D + Db) * NFB_FUDGE;
+                st->B = Bm * st->B * NFB_FUDGE;
+            }
+            break;
+
+        case GR_DFT_ALG_BAILEY:
+            /* column transforms, twiddles, row transforms; the final
+               transposition is exact */
+            nfb_plan(st, P->P2);
+            nfb_rot(st, Dw);
+            nfb_plan(st, P->P1);
+            break;
+
+        case GR_DFT_ALG_MIXED:
+            nfb_mixed(st, P);
+            break;
+
+        case GR_DFT_ALG_PFA:
+            /* no twiddles; gather/scatter are exact */
+            nfb_plan(st, P->P2);
+            nfb_plan(st, P->P1);
+            break;
+
+        case GR_DFT_ALG_BLUESTEIN:
+            nfb_bluestein(st, P);
+            break;
+
+        default:
+            nfb_naive(st, P);
+            break;
+    }
+
+    nfb_peak(st, st->B);
+}
+
+/* Computes a bound on the modulus of all input, intermediate and
+   output values (written to peak; the computation is free of overflow
+   in nfixed arithmetic iff this is < 1), and a bound on the errors of
+   the real and imaginary parts of the output measured in ulp (written
+   to err_ulps), for a forward or unscaled inverse transform with the
+   plan P executed in nfixed arithmetic, given that the input values
+   have complex modulus at most in_mag and componentwise errors of at
+   most in_err_ulps ulp. */
+void
+gr_dft_precomp_nfixed_bound(double * peak, double * err_ulps,
+        double in_mag, double in_err_ulps, const gr_dft_pre_t P)
+{
+    nfb_state st;
+
+    st.B = in_mag;
+    st.D = NFB_SQRT2 * in_err_ulps;   /* componentwise -> modulus */
+    st.peak = in_mag;
+
+    /* rounding of one complex multiplication, as a modulus: the exact
+       per-component error of the plan's context when it is a
+       fixed-point context, else the worst case of the model */
+    if (P->ctx != NULL && _gr_dft_ctx_is_nfixed_complex((gr_ctx_struct *) P->ctx))
+        st.K = NFB_SQRT2 * _gr_dft_nfixed_cmul_err_ulps((gr_ctx_struct *) P->ctx);
+    else
+        st.K = NFB_SQRT2 * 6.0;
+
+    nfb_plan(&st, P);
+
+    *peak = st.peak;
+    *err_ulps = st.D;
+}

--- a/src/gr_dft/pfa.c
+++ b/src/gr_dft/pfa.c
@@ -1,0 +1,103 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "gr.h"
+#include "gr_vec.h"
+#include "gr_dft.h"
+
+/* Good-Thomas prime factor algorithm for n = n1 n2 with gcd(n1, n2) = 1.
+   With the input index map j = (n2 j1 + n1 j2) mod n,
+
+       w^(j k) = (w^n2)^(j1 k1) (w^n1)^(j2 k2),
+
+   where k1 = k mod n1 and k2 = k mod n2, so the transform is a pure
+   two-dimensional DFT (no twiddle factors) with roots w^n2 (rows of
+   length n1, sub-plan P1) and w^n1 (columns of length n2, sub-plan P2),
+   followed by the CRT output map k = (pfa_a k1 + pfa_b k2) mod n. All
+   index maps are evaluated incrementally.
+
+   res must not alias vec. */
+int
+_gr_dft_pfa(gr_ptr res, gr_srcptr vec, int inverse,
+        const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    slong sz = ctx->sizeof_elem;
+    ulong n = P->n, n1 = P->n1, n2 = P->n2;
+    ulong j1, j2, k1, k2, jb, j, kb, k;
+    ulong L = FLINT_MAX(n1, n2);
+    gr_ptr mat, buf, buf2;
+
+    mat = flint_malloc((n + 2 * L) * sz);
+    _gr_vec_init(mat, n + 2 * L, ctx);
+    buf = GR_ENTRY(mat, n, sz);
+    buf2 = GR_ENTRY(buf, L, sz);
+
+    /* gather: mat[j1 n2 + j2] = vec[(n2 j1 + n1 j2) mod n] */
+    for (j1 = 0, jb = 0; j1 < n1; j1++)
+    {
+        for (j2 = 0, j = jb; j2 < n2; j2++)
+        {
+            status |= gr_set(GR_ENTRY(mat, j1 * n2 + j2, sz),
+                    GR_ENTRY(vec, j, sz), ctx);
+            j += n1;
+            if (j >= n)
+                j -= n;
+        }
+        jb += n2;
+        if (jb >= n)
+            jb -= n;
+    }
+
+    /* rows: n1 transforms of length n2 with sub-plan P2 */
+    for (j1 = 0; j1 < n1; j1++)
+    {
+        gr_ptr row = GR_ENTRY(mat, j1 * n2, sz);
+        status |= _gr_dft_precomp_raw(buf, row, inverse, P->P2, ctx);
+        status |= _gr_vec_set(row, buf, n2, ctx);
+    }
+
+    /* columns: n2 transforms of length n1 with sub-plan P1 */
+    for (j2 = 0; j2 < n2; j2++)
+    {
+        for (j1 = 0; j1 < n1; j1++)
+            status |= gr_set(GR_ENTRY(buf, j1, sz),
+                    GR_ENTRY(mat, j1 * n2 + j2, sz), ctx);
+
+        status |= _gr_dft_precomp_raw(buf2, buf, inverse, P->P1, ctx);
+
+        for (j1 = 0; j1 < n1; j1++)
+            status |= gr_set(GR_ENTRY(mat, j1 * n2 + j2, sz),
+                    GR_ENTRY(buf2, j1, sz), ctx);
+    }
+
+    /* scatter: res[(pfa_a k1 + pfa_b k2) mod n] = mat[k1 n2 + k2] */
+    for (k1 = 0, kb = 0; k1 < n1; k1++)
+    {
+        for (k2 = 0, k = kb; k2 < n2; k2++)
+        {
+            status |= gr_set(GR_ENTRY(res, k, sz),
+                    GR_ENTRY(mat, k1 * n2 + k2, sz), ctx);
+            k += P->pfa_b;
+            if (k >= n)
+                k -= n;
+        }
+        kb += P->pfa_a;
+        if (kb >= n)
+            kb -= n;
+    }
+
+    _gr_vec_clear(mat, n + 2 * L, ctx);
+    flint_free(mat);
+
+    return status;
+}

--- a/src/gr_dft/precomp.c
+++ b/src/gr_dft/precomp.c
@@ -1,0 +1,1043 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "ulong_extras.h"
+#include "fmpq.h"
+#include "arb.h"
+#include "acb.h"
+#include "gr.h"
+#include "gr_vec.h"
+#include "gr_special.h"
+#include "gr_dft.h"
+
+/* Tuning: with AUTO, switch from plain Cooley-Tukey to the four-step
+   algorithm at this depth. */
+
+/* Tuning: primes up to this bound use the direct O(p^2) kernel inside
+   the mixed-radix algorithm; larger primes attempt Bluestein. */
+#define GR_DFT_PRIME_CUTOFF 19
+
+/* Tuning: in complex Karatsuba mode over a ring with a working
+   precision (e.g. acb over arb), the 3-real-multiplication products
+   are only enabled at this precision and above; below it, a native
+   complex multiplication is faster than three multiplications plus
+   extra additions in the real ring. The special rotations (the classes
+   in wclass) are used at any precision. Over exact rings, where the
+   number of multiplications is what matters, Karatsuba products are
+   always enabled. */
+#define GR_DFT_KARATSUBA_CUTOFF_PREC 1024
+
+int
+gr_dft_default_root(gr_ptr w, ulong n, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+
+    if (n <= 1)
+    {
+        status |= gr_one(w, ctx);
+    }
+    else if (n == 2)
+    {
+        status |= gr_neg_one(w, ctx);
+    }
+    else
+    {
+        /* w = exp(-2 pi i / n), for rings which support exp_pi_i */
+        gr_ptr t, u;
+        fmpq_t q;
+        GR_TMP_INIT2(t, u, ctx);
+        fmpq_init(q);
+        fmpq_set_si(q, -2, n);
+        status |= gr_set_fmpq(t, q, ctx);
+        status |= gr_exp_pi_i(w, t, ctx);
+
+        if (status != GR_SUCCESS)
+        {
+            /* fallback for rings with pi, i and exp but no exp_pi_i */
+            status = GR_SUCCESS;
+            status |= gr_pi(t, ctx);
+            status |= gr_i(u, ctx);
+            status |= gr_mul(t, t, u, ctx);
+            status |= gr_mul_si(t, t, -2, ctx);
+            status |= gr_div_ui(t, t, n, ctx);
+            status |= gr_exp(w, t, ctx);
+        }
+
+        fmpq_clear(q);
+        GR_TMP_CLEAR2(t, u, ctx);
+    }
+
+    return status;
+}
+
+/* For the default root w = exp(-2 pi i / n), attempt to compute the table
+   entries directly as w^j = exp_pi_i(-2j/n). Besides giving tighter
+   enclosures than a power chain over inexact rings, this typically yields
+   the entries at the quarter points (1, -i, -1, i) exactly, allowing them
+   to be classified as free rotations in complex Karatsuba mode. */
+static int
+_gr_dft_roots_canonical(gr_ptr roots, ulong n, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    slong sz = ctx->sizeof_elem;
+    ulong j;
+    gr_ptr t;
+    fmpq_t q;
+
+    /* Fast path for acb: one primitive root computed at elevated
+       precision, the remaining entries by a running product rounded
+       back to the working precision, with exact values (and error
+       resets) at the quarter points. The running product accumulates
+       a radius of order j ulp at the elevated precision, so the
+       rounded entries have radii within a small factor of one ulp at
+       the working precision -- comparable to evaluating each entry
+       with exp, at a fraction of the cost. */
+    if (ctx->which_ring == GR_CTX_CC_ACB && sz == sizeof(acb_struct))
+    {
+        acb_ptr tab = (acb_ptr) roots;
+        acb_t r, w;
+        slong prec, eprec;
+        ulong L;
+
+        GR_MUST_SUCCEED(gr_ctx_get_real_prec(&prec, ctx));
+        eprec = prec + FLINT_BIT_COUNT(n) + 16;
+
+        acb_init(r);
+        acb_init(w);
+
+        fmpq_init(q);
+        fmpq_set_si(q, -2, n);
+        arb_sin_cos_pi_fmpq(acb_imagref(w), acb_realref(w), q, eprec);
+        fmpq_clear(q);
+
+        /* entries up to an eighth (4 | n), quarter (2 | n) or half
+           (odd n) of the circle by a running product; the rest by
+           the eight-fold symmetry */
+        if (n % 4 == 0)
+            L = (n + 7) / 8;
+        else if (n % 2 == 0)
+            L = (n + 3) / 4;
+        else
+            L = n / 2;
+
+        acb_one(r);
+        for (j = 0; j <= L; j++)
+        {
+            acb_set_round(tab + j, r, prec);
+            acb_mul(r, r, w, eprec);
+        }
+
+        /* w^(n/4 - j) = -y - x i, w^(n/2 - j) = -x + y i,
+           w^(n - j) = x - y i, for w^j = x + y i (exact copies) */
+        if (n % 4 == 0)
+        {
+            for (j = L + 1; j <= n / 4; j++)
+            {
+                arb_neg(acb_realref(tab + j), acb_imagref(tab + n / 4 - j));
+                arb_neg(acb_imagref(tab + j), acb_realref(tab + n / 4 - j));
+            }
+        }
+        if (n % 2 == 0)
+        {
+            for (j = FLINT_MAX(L, n / 4) + 1; j <= n / 2; j++)
+            {
+                arb_neg(acb_realref(tab + j), acb_realref(tab + n / 2 - j));
+                arb_set(acb_imagref(tab + j), acb_imagref(tab + n / 2 - j));
+            }
+        }
+        for (j = n / 2 + 1; j < n; j++)
+            acb_conj(tab + j, tab + n - j);
+
+        acb_clear(r);
+        acb_clear(w);
+
+        return GR_SUCCESS;
+    }
+
+    GR_TMP_INIT(t, ctx);
+    fmpq_init(q);
+
+    for (j = 0; j < n && status == GR_SUCCESS; j++)
+    {
+        fmpz_set_ui(fmpq_numref(q), 2 * j);
+        fmpz_neg(fmpq_numref(q), fmpq_numref(q));
+        fmpz_set_ui(fmpq_denref(q), n);
+        fmpq_canonicalise(q);
+
+        status |= gr_set_fmpq(t, q, ctx);
+        status |= gr_exp_pi_i(GR_ENTRY(roots, j, sz), t, ctx);
+    }
+
+    fmpq_clear(q);
+    GR_TMP_CLEAR(t, ctx);
+    return status;
+}
+
+static void
+_gr_dft_precomp_zero(gr_dft_pre_t P)
+{
+    P->n = 0;
+    P->depth = 0;
+    P->alg = GR_DFT_ALG_NAIVE;
+    P->flags = 0;
+    P->ctx = NULL;
+    P->real_ctx = NULL;
+    P->roots = NULL;
+    P->wtab = NULL;
+    P->wclass = NULL;
+    P->n1 = P->n2 = 0;
+    P->pfa_a = P->pfa_b = 0;
+    P->radices = NULL;
+    P->num_radices = 0;
+    P->conv_len = 0;
+    P->bl_kern = NULL;
+    P->bl_wtab = NULL;
+    P->P1 = P->P2 = NULL;
+    P->threads = NULL;
+    P->num_threads = 0;
+    P->serial_block = 0;
+    P->nfixed_root_err = 0.0;
+    P->bl_shifted = 0;
+    P->stage_tab = NULL;
+    P->stage_len = 0;
+}
+
+
+
+/* Phase 1 of plan construction: the layout. Resolves the algorithm
+   and computes the complete decomposition (sub-plan layouts included)
+   without touching any ring elements, so that cost and error bounds
+   (gr_dft_precomp_nfixed_bound) can be evaluated before an internal
+   working precision is chosen and before the root tables are
+   computed. complex_mode indicates whether the plan will be realized
+   in complex mode (it stands in for real_ctx != NULL in the automatic
+   algorithm selection). The nfixed_root_err field is filled with a
+   worst-case estimate for the doubling root-table construction, to be
+   replaced by the actual bound when the plan is realized over a
+   fixed-point context. */
+static int
+_gr_dft_layout(gr_dft_pre_t P, ulong n, int alg, int flags, int complex_mode)
+{
+    int status = GR_SUCCESS;
+    int pow2, i;
+    n_factor_t fac;
+
+    _gr_dft_precomp_zero(P);
+
+    if (n == 0)
+        return GR_DOMAIN;
+
+    pow2 = ((n & (n - 1)) == 0);
+
+    n_factor_init(&fac);
+    if (n >= 2 && !pow2)
+        n_factor(&fac, n, 0);
+
+    P->n = n;
+    P->depth = pow2 ? (int) FLINT_BIT_COUNT(n) - 1 : -1;
+
+    /* Resolve and validate the algorithm */
+    if (alg == GR_DFT_ALG_AUTO)
+    {
+        if (pow2)
+        {
+            /* split-radix saves multiplications in complex mode and,
+               like plain Cooley-Tukey, threads with full parallel
+               width; it does not support scrambled ordering. (The
+               Bailey algorithm remains available explicitly; in
+               measurements up to n = 2^20 its cache blocking did not
+               beat the plain transforms, serially or threaded.) */
+            if (complex_mode && !(flags & GR_DFT_SCRAMBLED))
+                alg = GR_DFT_ALG_SPLIT;
+            else
+                alg = GR_DFT_ALG_CT;
+        }
+        else
+        {
+            alg = (fac.num >= 2) ? GR_DFT_ALG_PFA : GR_DFT_ALG_MIXED;
+        }
+    }
+    else
+    {
+        if (!pow2 && (alg == GR_DFT_ALG_CT || alg == GR_DFT_ALG_BAILEY ||
+                      alg == GR_DFT_ALG_SPLIT))
+            return GR_DOMAIN;
+        if (alg == GR_DFT_ALG_PFA && (pow2 || fac.num < 2))
+            return GR_DOMAIN;
+        if (alg == GR_DFT_ALG_BLUESTEIN && (n < 3 || n % 2 == 0))
+            return GR_DOMAIN;
+        if (alg == GR_DFT_ALG_MIXED && pow2 && n >= 2)
+        {
+            /* supported, but requires the radix list */
+            fac.num = 1;
+            fac.p[0] = 2;
+            fac.exp[0] = P->depth;
+        }
+        if (alg == GR_DFT_ALG_MIXED && n < 2)
+            alg = GR_DFT_ALG_NAIVE;
+    }
+    if (alg == GR_DFT_ALG_BAILEY && P->depth < 2)
+        alg = GR_DFT_ALG_CT;
+    if (alg == GR_DFT_ALG_SPLIT && P->depth < 2)
+        alg = GR_DFT_ALG_CT;
+    P->alg = alg;
+
+    /* scrambled ordering is only supported by NAIVE, CT and BAILEY
+       (all power-of-two only, except NAIVE which supports it for
+       power-of-two lengths) */
+    if (alg != GR_DFT_ALG_NAIVE && alg != GR_DFT_ALG_CT &&
+        alg != GR_DFT_ALG_BAILEY)
+        flags &= ~GR_DFT_SCRAMBLED;
+    if (!pow2)
+        flags &= ~GR_DFT_SCRAMBLED;
+    P->flags = flags;
+
+    /* worst-case error estimate for a doubling-constructed root table
+       (see _gr_dft_nfixed_root_err_bound; the constant is the modulus
+       rounding of the most expensive complex multiplication) */
+    P->nfixed_root_err = _gr_dft_nfixed_root_err_bound(n, 6.0 * 1.4142135623730951);
+
+    /* Four-step decomposition n = n1 * n2 with sub-plans */
+    if (alg == GR_DFT_ALG_BAILEY)
+    {
+        ulong n1, n2;
+
+        n1 = UWORD(1) << (P->depth / 2);
+        n2 = n / n1;
+        P->n1 = n1;
+        P->n2 = n2;
+
+        P->P1 = flint_malloc(sizeof(gr_dft_pre_struct));
+        P->P2 = flint_malloc(sizeof(gr_dft_pre_struct));
+
+        /* The sub-plans always use plain Cooley-Tukey and natural
+           ordering. */
+        status |= _gr_dft_layout(P->P1, n1, GR_DFT_ALG_CT, 0, complex_mode);
+        status |= _gr_dft_layout(P->P2, n2, GR_DFT_ALG_CT, 0, complex_mode);
+    }
+
+    /* Good-Thomas decomposition n = n1 * n2 into coprime parts, with
+       n1 the full power of the smallest prime factor. There are no
+       twiddle factors; the input is gathered by j = (n2 j1 + n1 j2)
+       mod n and the output entry (k1, k2) is scattered to
+       k = (pfa_a k1 + pfa_b k2) mod n where pfa_a = 1 mod n1,
+       0 mod n2 and pfa_b = 0 mod n1, 1 mod n2. */
+    if (status == GR_SUCCESS && alg == GR_DFT_ALG_PFA)
+    {
+        ulong n1, n2;
+
+        n1 = fac.p[0];
+        for (i = 1; i < fac.exp[0]; i++)
+            n1 *= fac.p[0];
+        n2 = n / n1;
+        P->n1 = n1;
+        P->n2 = n2;
+        P->pfa_a = n2 * n_invmod(n2 % n1, n1);
+        P->pfa_b = n1 * n_invmod(n1 % n2, n2);
+
+        P->P1 = flint_malloc(sizeof(gr_dft_pre_struct));
+        P->P2 = flint_malloc(sizeof(gr_dft_pre_struct));
+
+        status |= _gr_dft_layout(P->P1, n1, GR_DFT_ALG_AUTO, 0, complex_mode);
+        status |= _gr_dft_layout(P->P2, n2, GR_DFT_ALG_AUTO, 0, complex_mode);
+    }
+
+    /* Mixed-radix: flatten the factorization into a list of prime
+       radices, one per recursion level. If n = p^e for a single prime
+       p exceeding the direct-kernel cutoff, lay out a Bluestein plan
+       for the length-p transforms; if it cannot be realized later
+       (e.g. when the ring cannot provide a root of unity for the
+       required power-of-two length), the realization falls back to
+       the direct kernel. */
+    if (status == GR_SUCCESS && alg == GR_DFT_ALG_MIXED)
+    {
+        slong num = 0, e;
+
+        for (i = 0; i < fac.num; i++)
+            num += fac.exp[i];
+
+        P->radices = flint_malloc(num * sizeof(ulong));
+        P->num_radices = num;
+
+        num = 0;
+        for (i = 0; i < fac.num; i++)
+            for (e = 0; e < fac.exp[i]; e++)
+                P->radices[num++] = fac.p[i];
+
+        if (fac.num == 1 && fac.p[0] > GR_DFT_PRIME_CUTOFF)
+        {
+            P->P1 = flint_malloc(sizeof(gr_dft_pre_struct));
+            status |= _gr_dft_layout(P->P1, fac.p[0],
+                    GR_DFT_ALG_BLUESTEIN, 0, complex_mode);
+        }
+    }
+
+    /* Bluestein: reduce to a cyclic convolution of power-of-two length
+       conv_len >= 2n - 1, computed with a power-of-two sub-plan (with
+       scrambled ordering; since the kernel is transformed by the same
+       sub-plan, the orderings are consistent and the reordering passes
+       are saved). */
+    if (status == GR_SUCCESS && alg == GR_DFT_ALG_BLUESTEIN)
+    {
+        ulong N = UWORD(1) << FLINT_BIT_COUNT(2 * n - 2);
+        P->conv_len = N;
+
+        P->P1 = flint_malloc(sizeof(gr_dft_pre_struct));
+        status |= _gr_dft_layout(P->P1, N, GR_DFT_ALG_AUTO,
+                GR_DFT_SCRAMBLED, complex_mode);
+    }
+
+    return status;
+}
+
+static int _gr_dft_bluestein_realize_kernel(gr_dft_pre_t P, gr_ctx_t ctx);
+
+/* Phase 2 of plan construction: bind the ring and compute the root
+   tables, the complex mode tables, and the convolution kernels, over
+   the layout produced by _gr_dft_layout. w is a principal n-th root
+   of unity, or NULL when canonical is set and the table can be built
+   directly (standard root over rings with exp, or the fixed-point
+   builder). Recurses into the sub-plan layouts, feeding them the
+   appropriate powers of w. */
+static int
+_gr_dft_realize(gr_dft_pre_t P, gr_srcptr w, int canonical,
+        gr_ctx_struct * real_ctx, gr_ctx_t ctx,
+        gr_srcptr rsrc, ulong rstride, double rsrc_err)
+{
+    int status = GR_SUCCESS;
+    slong sz = ctx->sizeof_elem;
+    ulong n = P->n;
+    int i;
+
+    P->ctx = ctx;
+    P->real_ctx = real_ctx;
+
+    /* Canonical PFA plans need no root table: the algorithm performs
+       no multiplications by roots (no twiddle factors), and the
+       sub-plans, being canonical themselves, build their own (small)
+       tables directly. (Plans with user-supplied roots keep the
+       table, from which the sub-plan roots are derived.) */
+    if (canonical && P->alg == GR_DFT_ALG_PFA)
+    {
+        status |= _gr_dft_realize(P->P1, NULL, 1, real_ctx, ctx,
+                NULL, 0, 0.0);
+        status |= _gr_dft_realize(P->P2, NULL, 1, real_ctx, ctx,
+                NULL, 0, 0.0);
+        return status;
+    }
+
+    /* Root table w^0, ..., w^(n-1) */
+    P->roots = flint_malloc(n * sz);
+    _gr_vec_init(P->roots, n, ctx);
+
+    if (rsrc != NULL)
+    {
+        /* the roots of a sub-transform of a length-m parent, using
+           the root w^(m/n), are strided entries of the parent table:
+           (w^(m/n))^j = w^(j m/n); copy them instead of recomputing */
+        ulong j;
+
+        for (j = 0; j < n; j++)
+            status |= gr_set(GR_ENTRY(P->roots, j, sz),
+                    GR_ENTRY(rsrc, j * rstride, sz), ctx);
+
+        P->nfixed_root_err = rsrc_err;
+    }
+    else if (_gr_dft_ctx_is_nfixed_complex(ctx))
+    {
+        /* fixed-point contexts: table built by binary-splitting
+           products from a high-precision primitive root, with a
+           computed ulp error bound; w is ignored (and may be NULL) */
+        status = _gr_dft_nfixed_roots(P->roots, n, &P->nfixed_root_err, ctx);
+    }
+    else if (canonical && n > 2)
+    {
+        status = _gr_dft_roots_canonical(P->roots, n, ctx);
+        if (status != GR_SUCCESS && w != NULL)
+            status = _gr_vec_set_powers(P->roots, w, n, ctx);
+    }
+    else if (w != NULL)
+    {
+        status |= _gr_vec_set_powers(P->roots, w, n, ctx);
+    }
+    else if (n > 2)
+    {
+        status = GR_UNABLE;
+    }
+    else
+    {
+        /* n <= 2: the table is 1 (and -1), independent of w */
+        if (n == 2)
+            status |= gr_neg_one(GR_ENTRY(P->roots, 1, sz), ctx);
+        status |= gr_one(P->roots, ctx);
+    }
+
+    /* Sanity checks for user-supplied roots: w should be a principal
+       n-th root of unity. In particular w^(n/2) = -1 for even n, and
+       w^(n/p) != 1 for every prime p dividing n. These may be
+       inconclusive (T_UNKNOWN) over inexact rings, in which case we
+       proceed. Canonical tables are correct by construction and are
+       not checked (over approximate rings such as the fixed-point
+       contexts, the checks could not certify anything anyway). */
+    if (status == GR_SUCCESS && !canonical && n % 2 == 0)
+    {
+        if (gr_is_neg_one(GR_ENTRY(P->roots, n / 2, sz), ctx) == T_FALSE)
+            status = GR_DOMAIN;
+    }
+    if (status == GR_SUCCESS && !canonical && n >= 2)
+    {
+        n_factor_t fac;
+        n_factor_init(&fac);
+        if ((n & (n - 1)) != 0)
+            n_factor(&fac, n, 0);
+        for (i = 0; i < fac.num; i++)
+        {
+            if (fac.p[i] != 2 &&
+                gr_is_one(GR_ENTRY(P->roots, n / fac.p[i], sz), ctx) == T_TRUE)
+                status = GR_DOMAIN;
+        }
+    }
+
+    /* Complex mode: classify the special rotations (wclass), and, when
+       profitable, precompute for each root c + d*i the table entries
+       (c, d - c, d + c) as elements of the real ring, allowing
+       multiplication by a generic root to be done with 3 instead of 4
+       real multiplications (complex Karatsuba). */
+    if (status == GR_SUCCESS && real_ctx != NULL)
+    {
+        slong rsz = real_ctx->sizeof_elem;
+        slong rprec;
+        int use_karatsuba;
+        ulong j;
+
+        /* Karatsuba trades one multiplication for three additions,
+           which loses at low precision where a native complex
+           multiplication is cheap. */
+        use_karatsuba = !(gr_ctx_get_real_prec(&rprec, ctx) == GR_SUCCESS
+                && rprec < GR_DFT_KARATSUBA_CUTOFF_PREC);
+
+        /* fixed-point contexts always use the schoolbook complex
+           product: the Karatsuba table entries d - c, d + c and the
+           intermediate sum x_r + x_i can reach sqrt(2) in magnitude,
+           which does not fit the representation */
+        if (_gr_dft_ctx_is_nfixed(real_ctx))
+            use_karatsuba = 0;
+
+        /* Elements of ctx must consist of a real and an imaginary part
+           stored contiguously as two elements of real_ctx. */
+        if (sz != 2 * rsz)
+        {
+            status = GR_UNABLE;
+        }
+        else
+        {
+            P->wclass = flint_malloc(n);
+            for (j = 0; j < n; j++)
+                P->wclass[j] = GR_DFT_ROOT_GENERIC;
+
+            if (use_karatsuba)
+            {
+                P->wtab = flint_malloc(3 * n * rsz);
+                _gr_vec_init(P->wtab, 3 * n, real_ctx);
+
+                for (j = 0; j < n; j++)
+                {
+                    gr_srcptr c = GR_ENTRY(P->roots, j, sz);
+                    gr_srcptr d = GR_ENTRY(c, 1, rsz);
+                    gr_ptr t = GR_ENTRY(P->wtab, 3 * j, rsz);
+
+                    status |= gr_set(t, c, real_ctx);
+                    status |= gr_sub(GR_ENTRY(t, 1, rsz), d, c, real_ctx);
+                    status |= gr_add(GR_ENTRY(t, 2, rsz), d, c, real_ctx);
+                }
+            }
+
+            /* Since complex mode always uses the standard root
+               w = exp(-2 pi i / n), the classes of the powers at the
+               quarter and eighth points (when these are integers) are
+               known structurally: w^(n/2) = -1, w^(n/4) = -i,
+               w^(3n/4) = i, and the odd multiples of n/8 have d = -c
+               or d = c exactly. No value inspection is needed (nor
+               could it certify these forms over inexact rings); the
+               cheap multiplication formulas use at most the enclosure
+               of c, so enclosures of the exact products are still
+               obtained over ball rings. */
+            if (n % 2 == 0)
+                P->wclass[n / 2] = GR_DFT_ROOT_NEG_ONE;
+            if (n % 4 == 0)
+            {
+                P->wclass[n / 4] = GR_DFT_ROOT_NEG_I;
+                P->wclass[3 * n / 4] = GR_DFT_ROOT_I;
+            }
+            if (n % 8 == 0)
+            {
+                P->wclass[n / 8] = GR_DFT_ROOT_DPC_ZERO;
+                P->wclass[3 * n / 8] = GR_DFT_ROOT_DMC_ZERO;
+                P->wclass[5 * n / 8] = GR_DFT_ROOT_DPC_ZERO;
+                P->wclass[7 * n / 8] = GR_DFT_ROOT_DMC_ZERO;
+            }
+        }
+    }
+
+    /* Pack the per-stage twiddle tables and drop the serial table:
+       plain Cooley-Tukey and (complex-mode) split-radix read their
+       twiddles in fixed strided sequences per stage, and packing
+       these contiguously makes every table access during a transform
+       a sequential walk, where the strided reads into a length-n
+       table miss the cache once per entry as soon as the stride
+       exceeds a line. The total size is the same as the serial table
+       (sum 2^(s-1) = n - 1). Inverse transforms use the identities
+       w^(-j rstep) = -stage_s[hm - j] (a reversed walk with the
+       negation folded into the butterfly) and, for split,
+       w^(-k r) = i w^((m/4-k) r), w^(-3k r) = -i w^(3(m/4-k) r)
+       (reversed pair walks with free quarter rotations), so no
+       inverse tables are needed. Plans using the complex Karatsuba
+       tables keep the serial layout: they only arise at high
+       precision, where transforms are compute-bound. */
+    if (status == GR_SUCCESS && P->wtab == NULL && P->depth >= 2 &&
+        (P->alg == GR_DFT_ALG_CT ||
+         (P->alg == GR_DFT_ALG_SPLIT && real_ctx != NULL)))
+    {
+        ulong j, m;
+        int s;
+
+        if (P->alg == GR_DFT_ALG_CT)
+        {
+            P->stage_len = n - 1;
+            P->stage_tab = flint_malloc(P->stage_len * sz);
+            _gr_vec_init(P->stage_tab, P->stage_len, ctx);
+
+            for (s = P->depth; s >= 1; s--)
+            {
+                gr_ptr base = GR_ENTRY(P->stage_tab, n - (UWORD(1) << s), sz);
+                ulong hm = UWORD(1) << (s - 1), rstep = n >> s;
+
+                for (j = 0; j < hm; j++)
+                    status |= gr_set(GR_ENTRY(base, j, sz),
+                            GR_ENTRY(P->roots, j * rstep, sz), ctx);
+            }
+        }
+        else
+        {
+            P->stage_len = n - 2;
+            P->stage_tab = flint_malloc(P->stage_len * sz);
+            _gr_vec_init(P->stage_tab, P->stage_len, ctx);
+
+            for (m = 4; m <= n; m *= 2)
+            {
+                gr_ptr base = GR_ENTRY(P->stage_tab, n - m, sz);
+                ulong q = m / 4, rstep = n / m, k, e;
+
+                for (k = 0; k < q; k++)
+                {
+                    status |= gr_set(GR_ENTRY(base, 2 * k, sz),
+                            GR_ENTRY(P->roots, k * rstep, sz), ctx);
+                    e = 3 * k * rstep;
+                    if (e >= n)
+                        e -= n;
+                    status |= gr_set(GR_ENTRY(base, 2 * k + 1, sz),
+                            GR_ENTRY(P->roots, e, sz), ctx);
+                }
+            }
+        }
+
+        _gr_vec_clear(P->roots, n, ctx);
+        flint_free(P->roots);
+        P->roots = NULL;
+
+        if (P->wclass != NULL)
+        {
+            flint_free(P->wclass);
+            P->wclass = NULL;
+        }
+    }
+
+    /* Sub-plans (their root tables are strided copies of ours) */
+    if (status == GR_SUCCESS &&
+        (P->alg == GR_DFT_ALG_BAILEY || P->alg == GR_DFT_ALG_PFA))
+    {
+        status |= _gr_dft_realize(P->P1, NULL, canonical, real_ctx, ctx,
+                P->roots, P->n2, P->nfixed_root_err);
+        status |= _gr_dft_realize(P->P2, NULL, canonical, real_ctx, ctx,
+                P->roots, P->n1, P->nfixed_root_err);
+    }
+
+    if (status == GR_SUCCESS && P->alg == GR_DFT_ALG_MIXED && P->P1 != NULL)
+    {
+        ulong p = P->P1->n;
+        int bstatus = _gr_dft_realize(P->P1, NULL, canonical, real_ctx, ctx,
+                P->roots, n / p, P->nfixed_root_err);
+
+        if (bstatus != GR_SUCCESS)
+        {
+            /* fall back to the direct kernel */
+            gr_dft_precomp_clear(P->P1);
+            flint_free(P->P1);
+            P->P1 = NULL;
+        }
+    }
+
+    if (status == GR_SUCCESS && P->alg == GR_DFT_ALG_BLUESTEIN)
+    {
+        /* the power-of-two sub-plan needs its own canonical root */
+        if (_gr_dft_ctx_is_nfixed_complex(ctx))
+        {
+            status |= _gr_dft_realize(P->P1, NULL, 1, real_ctx, ctx,
+                    NULL, 0, 0.0);
+        }
+        else
+        {
+            gr_ptr w2;
+            GR_TMP_INIT(w2, ctx);
+
+            status |= gr_dft_default_root(w2, P->conv_len, ctx);
+            if (status == GR_SUCCESS)
+                status |= _gr_dft_realize(P->P1, w2, 1, real_ctx, ctx,
+                        NULL, 0, 0.0);
+
+            GR_TMP_CLEAR(w2, ctx);
+        }
+
+        if (status == GR_SUCCESS)
+            status |= _gr_dft_bluestein_realize_kernel(P, ctx);
+    }
+
+    return status;
+}
+
+static int
+_gr_dft_precomp_init_root(gr_dft_pre_t P, gr_srcptr w, ulong n,
+        int alg, int flags, int canonical, gr_ctx_struct * real_ctx, gr_ctx_t ctx)
+{
+    int status = _gr_dft_layout(P, n, alg, flags, real_ctx != NULL);
+
+    if (status == GR_SUCCESS)
+        status |= _gr_dft_realize(P, w, canonical, real_ctx, ctx, NULL, 0, 0.0);
+
+    return status;
+}
+
+/* Public layout / realize interface (canonical roots), allowing cost
+   and error bounds to be inspected before an internal precision is
+   chosen and the tables are computed. */
+int
+_gr_dft_precomp_init_layout(gr_dft_pre_t P, ulong n, int alg, int flags,
+        int complex_mode)
+{
+    int status = _gr_dft_layout(P, n, alg, flags, complex_mode);
+
+    if (status != GR_SUCCESS)
+    {
+        gr_dft_precomp_clear(P);
+        _gr_dft_precomp_zero(P);
+    }
+
+    return status;
+}
+
+int
+_gr_dft_precomp_realize(gr_dft_pre_t P, gr_ctx_struct * real_ctx, gr_ctx_t ctx)
+{
+    int status = _gr_dft_realize(P, NULL, 1, real_ctx, ctx, NULL, 0, 0.0);
+
+    if (status != GR_SUCCESS)
+    {
+        gr_dft_precomp_clear(P);
+        _gr_dft_precomp_zero(P);
+    }
+
+    return status;
+}
+
+/* Bluestein kernel: writing t = (n+1)/2 = 1/2 mod n, we have
+   jk = t (j^2 + k^2 - (j-k)^2) mod n, so with the chirp
+   c_j = w^(t j^2) (entries of the root table),
+
+       X_k = c_k sum_j (c_j x_j) w^(-t (k-j)^2),
+
+   a cyclic convolution of length n of the chirped input with the
+   n-periodic even kernel h_j = w^(-t j^2). The convolution is embedded
+   into one of power-of-two length conv_len >= 2n - 1 and evaluated by
+   a forward transform, a pointwise multiplication by the transformed
+   kernel (precomputed here, with the 1/conv_len scaling of the inverse
+   transform folded in), and an inverse transform. */
+static int
+_gr_dft_bluestein_realize_kernel(gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    slong sz = ctx->sizeof_elem;
+    ulong n = P->n, N = P->conv_len, j, t2, e, ninv;
+    gr_ptr h;
+
+    /* kernel h, embedded with wraparound: h'_j = h_j for 0 <= j < n,
+       h'_(N-j) = h_j for 1 <= j < n, zero elsewhere */
+    h = flint_malloc(N * sz);
+    _gr_vec_init(h, N, ctx);
+    status |= _gr_vec_zero(h, N, ctx);
+
+    t2 = (n + 1) / 2;
+    ninv = n_preinvert_limb(n);
+
+    for (j = 0; j < n; j++)
+    {
+        e = n_mulmod2_preinv(j, j, n, ninv);
+        e = n_mulmod2_preinv(e, t2, n, ninv);
+        e = (e == 0) ? 0 : n - e;   /* h_j = w^(-t j^2) */
+
+        status |= gr_set(GR_ENTRY(h, j, sz), GR_ENTRY(P->roots, e, sz), ctx);
+        if (j > 0)
+            status |= gr_set(GR_ENTRY(h, N - j, sz), GR_ENTRY(h, j, sz), ctx);
+    }
+
+    if (_gr_dft_ctx_is_nfixed_complex(ctx))
+    {
+        /* Over the fixed-point contexts the folded scaling must be
+           applied before the transform of the kernel, so that its
+           intermediate values stay below 1; the extra factor 1/2
+           keeps the sqrt(2) rotation intermediates in range as well
+           (|h| <= 1/(2N) gives a transform peak of at most
+           sqrt(2)/2), and is undone by doubling the outputs of the
+           main transform (P->bl_shifted). The division truncates with
+           error below 1 ulp per part. */
+        status |= _gr_vec_div_scalar_ui(h, h, N, 2 * N, ctx);
+        P->bl_shifted = 1;
+    }
+
+    P->bl_kern = flint_malloc(N * sz);
+    _gr_vec_init(P->bl_kern, N, ctx);
+
+    status |= _gr_dft_precomp_raw(P->bl_kern, h, 0, P->P1, ctx);
+
+    _gr_vec_clear(h, N, ctx);
+    flint_free(h);
+
+    /* fold in the 1/conv_len scaling of the inverse sub-transform
+       (already included, together with the extra 1/2, over the
+       fixed-point contexts) */
+    if (!P->bl_shifted)
+        status |= _gr_vec_div_scalar_ui(P->bl_kern, P->bl_kern, N, N, ctx);
+
+    /* complex Karatsuba multiplication tables for the kernel entries,
+       matching the enablement decision of the main table */
+    if (status == GR_SUCCESS && P->wtab != NULL)
+    {
+        gr_ctx_struct * rctx = P->real_ctx;
+        slong rsz = rctx->sizeof_elem;
+
+        P->bl_wtab = flint_malloc(3 * N * rsz);
+        _gr_vec_init(P->bl_wtab, 3 * N, rctx);
+
+        for (j = 0; j < N; j++)
+        {
+            gr_srcptr c = GR_ENTRY(P->bl_kern, j, sz);
+            gr_srcptr d = GR_ENTRY(c, 1, rsz);
+            gr_ptr u = GR_ENTRY(P->bl_wtab, 3 * j, rsz);
+
+            status |= gr_set(u, c, rctx);
+            status |= gr_sub(GR_ENTRY(u, 1, rsz), d, c, rctx);
+            status |= gr_add(GR_ENTRY(u, 2, rsz), d, c, rctx);
+        }
+    }
+
+    return status;
+}
+
+static int
+_gr_dft_precomp_init_root_checked(gr_dft_pre_t P, gr_srcptr w, ulong n,
+        int alg, int flags, int canonical, gr_ctx_struct * real_ctx, gr_ctx_t ctx)
+{
+    int status = _gr_dft_precomp_init_root(P, w, n, alg, flags, canonical, real_ctx, ctx);
+
+    if (status != GR_SUCCESS)
+    {
+        gr_dft_precomp_clear(P);
+        _gr_dft_precomp_zero(P);
+    }
+
+    return status;
+}
+
+int
+gr_dft_precomp_init_root(gr_dft_pre_t P, gr_srcptr w, ulong n,
+        int alg, int flags, gr_ctx_t ctx)
+{
+    return _gr_dft_precomp_init_root_checked(P, w, n, alg, flags, 0, NULL, ctx);
+}
+
+int
+gr_dft_precomp_init(gr_dft_pre_t P, ulong n, int alg, int flags, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    gr_ptr w;
+
+    if (_gr_dft_ctx_is_nfixed_complex(ctx))
+        return _gr_dft_precomp_init_root_checked(P, NULL, n, alg, flags, 1, NULL, ctx);
+
+    GR_TMP_INIT(w, ctx);
+
+    status |= gr_dft_default_root(w, n, ctx);
+
+    if (status == GR_SUCCESS)
+        status |= _gr_dft_precomp_init_root_checked(P, w, n, alg, flags, 1, NULL, ctx);
+    else
+        _gr_dft_precomp_zero(P);
+
+    GR_TMP_CLEAR(w, ctx);
+    return status;
+}
+
+int
+gr_dft_precomp_init_karatsuba(gr_dft_pre_t P, ulong n, int alg, int flags,
+        gr_ctx_t real_ctx, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    gr_ptr w;
+
+    if (_gr_dft_ctx_is_nfixed_complex(ctx))
+        return _gr_dft_precomp_init_root_checked(P, NULL, n, alg, flags, 1, real_ctx, ctx);
+
+    GR_TMP_INIT(w, ctx);
+
+    status |= gr_dft_default_root(w, n, ctx);
+
+    if (status == GR_SUCCESS)
+        status |= _gr_dft_precomp_init_root_checked(P, w, n, alg, flags, 1, real_ctx, ctx);
+    else
+        _gr_dft_precomp_zero(P);
+
+    GR_TMP_CLEAR(w, ctx);
+    return status;
+}
+
+void
+gr_dft_precomp_clear(gr_dft_pre_t P)
+{
+    if (P->roots != NULL)
+    {
+        _gr_vec_clear(P->roots, P->n, P->ctx);
+        flint_free(P->roots);
+        P->roots = NULL;
+    }
+
+    if (P->stage_tab != NULL)
+    {
+        _gr_vec_clear(P->stage_tab, P->stage_len, P->ctx);
+        flint_free(P->stage_tab);
+        P->stage_tab = NULL;
+    }
+
+    if (P->wtab != NULL)
+    {
+        _gr_vec_clear(P->wtab, 3 * P->n, P->real_ctx);
+        flint_free(P->wtab);
+        P->wtab = NULL;
+    }
+
+    if (P->wclass != NULL)
+    {
+        flint_free(P->wclass);
+        P->wclass = NULL;
+    }
+
+    if (P->radices != NULL)
+    {
+        flint_free(P->radices);
+        P->radices = NULL;
+    }
+
+    if (P->bl_kern != NULL)
+    {
+        _gr_vec_clear(P->bl_kern, P->conv_len, P->ctx);
+        flint_free(P->bl_kern);
+        P->bl_kern = NULL;
+    }
+
+    if (P->bl_wtab != NULL)
+    {
+        _gr_vec_clear(P->bl_wtab, 3 * P->conv_len, P->real_ctx);
+        flint_free(P->bl_wtab);
+        P->bl_wtab = NULL;
+    }
+
+    if (P->P1 != NULL)
+    {
+        gr_dft_precomp_clear(P->P1);
+        flint_free(P->P1);
+        P->P1 = NULL;
+    }
+
+    if (P->P2 != NULL)
+    {
+        gr_dft_precomp_clear(P->P2);
+        flint_free(P->P2);
+        P->P2 = NULL;
+    }
+}
+
+/* Attach worker threads to the plan (and, recursively, its sub-plans).
+   The handles are borrowed for the lifetime of the plan: they are used
+   by every transform, are not given back to the thread pool by
+   gr_dft_precomp_clear, and remain the responsibility of the caller.
+   Passing NULL, 0 detaches, restoring the default behavior of
+   requesting workers from the global thread pool during transforms. */
+void
+gr_dft_precomp_set_threads(gr_dft_pre_t P, thread_pool_handle * threads,
+        slong num_threads)
+{
+    P->threads = threads;
+    P->num_threads = threads ? num_threads : 0;
+
+    if (P->P1 != NULL)
+        gr_dft_precomp_set_threads(P->P1, threads, num_threads);
+    if (P->P2 != NULL)
+        gr_dft_precomp_set_threads(P->P2, threads, num_threads);
+}
+
+/* Set the threading granularity (and that of the sub-plans): work is
+   divided into at most n / serial_block chunks, so in particular
+   transforms with n < 2 * serial_block run serially. Zero restores the
+   default GR_DFT_SERIAL_BLOCK_DEFAULT. */
+void
+gr_dft_precomp_set_serial_block(gr_dft_pre_t P, slong serial_block)
+{
+    P->serial_block = serial_block;
+
+    if (P->P1 != NULL)
+        gr_dft_precomp_set_serial_block(P->P1, serial_block);
+    if (P->P2 != NULL)
+        gr_dft_precomp_set_serial_block(P->P2, serial_block);
+}
+
+void
+gr_dft_precomp_output_perm(ulong * perm, const gr_dft_pre_t P)
+{
+    ulong i, n = P->n;
+
+    if (!(P->flags & GR_DFT_SCRAMBLED) || P->alg == GR_DFT_ALG_SPLIT)
+    {
+        for (i = 0; i < n; i++)
+            perm[i] = i;
+    }
+    else if (P->alg == GR_DFT_ALG_BAILEY)
+    {
+        /* entry i = k2 * n1 + k1 holds coefficient k2 + n2 * k1 */
+        ulong n1 = P->n1, n2 = P->n2;
+
+        for (i = 0; i < n; i++)
+            perm[i] = (i / n1) + n2 * (i % n1);
+    }
+    else
+    {
+        for (i = 0; i < n; i++)
+            perm[i] = n_revbin(i, P->depth);
+    }
+}

--- a/src/gr_dft/print.c
+++ b/src/gr_dft/print.c
@@ -1,0 +1,118 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include "gr.h"
+#include "gr_dft.h"
+
+/* Diagnostic printer: writes a description of the plan (algorithm,
+   decomposition, table state, threading configuration) with one
+   indented block per sub-plan. */
+
+static const char *
+_alg_name(int alg)
+{
+    switch (alg)
+    {
+        case GR_DFT_ALG_AUTO:       return "auto";
+        case GR_DFT_ALG_NAIVE:      return "naive";
+        case GR_DFT_ALG_CT:         return "ct";
+        case GR_DFT_ALG_BAILEY:     return "bailey";
+        case GR_DFT_ALG_SPLIT:      return "split";
+        case GR_DFT_ALG_PFA:        return "pfa";
+        case GR_DFT_ALG_MIXED:      return "mixed";
+        case GR_DFT_ALG_BLUESTEIN:  return "bluestein";
+        default:                    return "?";
+    }
+}
+
+static void
+_print_rec(FILE * out, const gr_dft_pre_t P, int indent, const char * label)
+{
+    slong i;
+
+    for (i = 0; i < indent; i++)
+        flint_fprintf(out, "  ");
+    flint_fprintf(out, "%s: n = %wu, alg = %s", label, P->n, _alg_name(P->alg));
+
+    if (P->depth >= 0)
+        flint_fprintf(out, ", depth = %d", P->depth);
+    if (P->flags & GR_DFT_SCRAMBLED)
+        flint_fprintf(out, ", scrambled");
+    if (P->ctx == NULL)
+        flint_fprintf(out, ", layout only");
+    flint_fprintf(out, "\n");
+
+    for (i = 0; i < indent; i++)
+        flint_fprintf(out, "  ");
+    flint_fprintf(out, "  tables: roots %s", (P->roots != NULL) ? "yes" :
+            (P->stage_tab != NULL) ? "packed stages" : "no");
+    if (P->wclass != NULL)
+        flint_fprintf(out, ", complex mode%s",
+                (P->wtab != NULL) ? " (karatsuba)" : "");
+    if (P->nfixed_root_err > 0.0)
+        flint_fprintf(out, ", root err %.3g ulp%s", P->nfixed_root_err,
+                (P->roots == NULL) ? " (est.)" : "");
+    if (P->bl_kern != NULL)
+        flint_fprintf(out, ", kernel (conv_len %wu%s)", P->conv_len,
+                P->bl_shifted ? ", shifted" : "");
+    flint_fprintf(out, "\n");
+
+    if (P->alg == GR_DFT_ALG_BAILEY || P->alg == GR_DFT_ALG_PFA)
+    {
+        for (i = 0; i < indent; i++)
+            flint_fprintf(out, "  ");
+        flint_fprintf(out, "  n1 = %wu, n2 = %wu", P->n1, P->n2);
+        if (P->alg == GR_DFT_ALG_PFA)
+            flint_fprintf(out, ", crt coefficients %wu, %wu", P->pfa_a, P->pfa_b);
+        flint_fprintf(out, "\n");
+    }
+
+    if (P->radices != NULL)
+    {
+        for (i = 0; i < indent; i++)
+            flint_fprintf(out, "  ");
+        flint_fprintf(out, "  radices:");
+        for (i = 0; i < P->num_radices; i++)
+            flint_fprintf(out, " %wu", P->radices[i]);
+        flint_fprintf(out, "\n");
+    }
+
+    if (P->num_threads > 0 || P->serial_block > 0)
+    {
+        for (i = 0; i < indent; i++)
+            flint_fprintf(out, "  ");
+        flint_fprintf(out, "  threading: %wd attached handles, serial block %wd\n",
+                P->num_threads, (P->serial_block > 0) ? P->serial_block :
+                (slong) GR_DFT_SERIAL_BLOCK_DEFAULT);
+    }
+
+    if (P->P1 != NULL)
+        _print_rec(out, P->P1,
+                indent + 1,
+                (P->alg == GR_DFT_ALG_MIXED ||
+                 P->alg == GR_DFT_ALG_BLUESTEIN) ? "child" : "sub-plan 1");
+    if (P->P2 != NULL)
+        _print_rec(out, P->P2, indent + 1, "sub-plan 2");
+}
+
+void
+gr_dft_precomp_fprint(FILE * out, const gr_dft_pre_t P)
+{
+    _print_rec(out, P, 0, "plan");
+}
+
+void
+gr_dft_precomp_print(const gr_dft_pre_t P)
+{
+    gr_dft_precomp_fprint(stdout, P);
+}

--- a/src/gr_dft/profile/p-gr_dft_acb.c
+++ b/src/gr_dft/profile/p-gr_dft_acb.c
@@ -1,0 +1,163 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdlib.h>
+#include "profiler.h"
+#include "acb.h"
+#include "acb_dft.h"
+#include "gr.h"
+#include "gr_dft.h"
+
+/* Compares acb_dft against the drop-in gr_dft_acb, reporting the
+   precomputation and per-transform times separately. Optional
+   arguments: max_n max_prec. */
+
+static double
+time_ms(void (*f)(void *), void * arg, slong min_reps)
+{
+    timeit_t tm;
+    slong r, reps = min_reps;
+
+    f(arg);   /* warm up */
+
+    for (;;)
+    {
+        timeit_start(tm);
+        for (r = 0; r < reps; r++)
+            f(arg);
+        timeit_stop(tm);
+        if (tm->wall >= 100 || reps >= 100000)
+            return (double) tm->wall / reps;
+        reps *= 4;
+    }
+}
+
+typedef struct
+{
+    acb_ptr w;
+    acb_srcptr v;
+    slong n;
+    slong prec;
+    acb_dft_pre_struct * apre;
+    gr_dft_acb_pre_struct * qpre;
+}
+args_t;
+
+static void f_acb_pre(void * p)
+{
+    args_t * a = p;
+    acb_dft_pre_t pre;
+    acb_dft_precomp_init(pre, a->n, a->prec);
+    acb_dft_precomp_clear(pre);
+}
+
+static void f_acb_dft(void * p)
+{
+    args_t * a = p;
+    acb_dft_precomp(a->w, a->v, a->apre, a->prec);
+}
+
+static void f_gr_pre(void * p)
+{
+    args_t * a = p;
+    gr_dft_acb_pre_t Q;
+    GR_IGNORE(gr_dft_acb_precomp_init(Q, a->n, a->prec));
+    gr_dft_acb_precomp_clear(Q);
+}
+
+static void f_gr_dft(void * p)
+{
+    args_t * a = p;
+    gr_dft_acb_precomp(a->w, a->v, (const gr_dft_acb_pre_struct *) a->qpre,
+            a->prec);
+}
+
+int
+main(int argc, char * argv[])
+{
+    flint_rand_t state;
+    slong max_n = 16384, max_prec = 65536;
+    const slong precs[] = { 128, 256, 1024, 4096, 65536, 0 };
+    const ulong ns[] = { 64, 100, 101, 256, 720, 729, 1000, 1009, 1024,
+        2310, 3125, 4096, 5040, 10000, 10007, 16384, 0 };
+    slong pi, ni;
+
+    if (argc > 1) max_n = atol(argv[1]);
+    if (argc > 2) max_prec = atol(argv[2]);
+
+    flint_set_num_threads(8);
+
+    flint_rand_init(state);
+
+    flint_printf("wall-clock ms; precomputation and transform reported "
+            "separately\n\n");
+
+    for (pi = 0; precs[pi] != 0; pi++)
+    {
+        slong prec = precs[pi];
+
+        if (prec > max_prec)
+            continue;
+
+        flint_printf("prec = %wd\n", prec);
+        flint_printf("%8s %12s %12s %12s %12s %10s\n", "n",
+                "acb pre", "acb dft", "gr pre", "gr dft", "dft ratio");
+
+        for (ni = 0; ns[ni] != 0; ni++)
+        {
+            ulong n = ns[ni];
+            slong j;
+            acb_ptr v, w;
+            acb_dft_pre_t apre;
+            gr_dft_acb_pre_t qpre;
+            args_t a;
+            double t_acb_pre, t_acb_dft, t_gr_pre, t_gr_dft;
+
+            if ((slong) n > max_n)
+                continue;
+
+            v = _acb_vec_init(n);
+            w = _acb_vec_init(n);
+            for (j = 0; j < (slong) n; j++)
+                acb_urandom(v + j, state, prec);
+
+            acb_dft_precomp_init(apre, n, prec);
+            GR_IGNORE(gr_dft_acb_precomp_init(qpre, n, prec));
+
+            a.w = w;
+            a.v = v;
+            a.n = n;
+            a.prec = prec;
+            a.apre = apre;
+            a.qpre = qpre;
+
+            t_acb_pre = time_ms(f_acb_pre, &a, 1);
+            t_acb_dft = time_ms(f_acb_dft, &a, 1);
+            t_gr_pre = time_ms(f_gr_pre, &a, 1);
+            t_gr_dft = time_ms(f_gr_dft, &a, 1);
+
+            flint_printf("%8wu %12.4g %12.4g %12.4g %12.4g %9.2fx\n",
+                    n, t_acb_pre, t_acb_dft, t_gr_pre, t_gr_dft,
+                    t_acb_dft / t_gr_dft);
+
+            acb_dft_precomp_clear(apre);
+            gr_dft_acb_precomp_clear(qpre);
+            _acb_vec_clear(v, n);
+            _acb_vec_clear(w, n);
+        }
+
+        flint_printf("\n");
+    }
+
+    flint_rand_clear(state);
+    return 0;
+}

--- a/src/gr_dft/profile/p-gr_dft_acb_accuracy.c
+++ b/src/gr_dft/profile/p-gr_dft_acb_accuracy.c
@@ -1,0 +1,182 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+/* Accuracy of the complex DFT: for various lengths, precisions and
+   input distributions, run both internal paths of gr_dft_acb (acb
+   ball arithmetic and fixed-point arithmetic) on the same input and
+   report the largest output radius together with the precision loss.
+
+   The loss is measured in bits at the scale of the output: an ideal
+   enclosure of an output vector of magnitude M at precision p would
+   have radii around M 2^-p, so
+
+       loss = prec - (log2 max_k |w_k| - log2 max_k rad(w_k)).
+
+   Components that are tiny due to cancellation carry fewer relative
+   bits than this scale-level measure indicates, in both modes alike.
+
+   Input distributions:
+
+       uniform    acb_urandom: unit-scale midpoints (a benign, flat
+                  magnitude profile)
+       randtest   acb_randtest with mag_bits = 12: non-uniform
+                  magnitudes with exponents spanning roughly
+                  +-2^12, including zero and pure-real/imaginary
+                  special values (the fixed-point path handles the
+                  wild exponents through its global scaling)
+
+   each in an exact variant (zero radii) and an inexact variant where
+   every component is perturbed by a relative error of 2^(4 - prec),
+   so that the propagated input radii and the arithmetic error are of
+   comparable size. */
+
+#include <stdio.h>
+#include "profiler.h"
+#include "ulong_extras.h"
+#include "arf.h"
+#include "acb.h"
+#include "gr.h"
+#include "gr_dft.h"
+
+static void
+max_rad_and_mid(mag_t maxrad, mag_t maxmid, acb_srcptr w, slong n)
+{
+    mag_t t;
+    slong j;
+
+    mag_init(t);
+    mag_zero(maxrad);
+    mag_zero(maxmid);
+
+    for (j = 0; j < n; j++)
+    {
+        mag_max(maxrad, maxrad, arb_radref(acb_realref(w + j)));
+        mag_max(maxrad, maxrad, arb_radref(acb_imagref(w + j)));
+
+        arf_get_mag(t, arb_midref(acb_realref(w + j)));
+        mag_max(maxmid, maxmid, t);
+        arf_get_mag(t, arb_midref(acb_imagref(w + j)));
+        mag_max(maxmid, maxmid, t);
+    }
+
+    mag_clear(t);
+}
+
+static void
+report(const char * mode, acb_srcptr w, slong n, slong prec, int status)
+{
+    mag_t maxrad, maxmid;
+
+    if (status != GR_SUCCESS)
+    {
+        flint_printf("  %-7s unable\n", mode);
+        return;
+    }
+
+    mag_init(maxrad);
+    mag_init(maxmid);
+    max_rad_and_mid(maxrad, maxmid, w, n);
+
+    if (mag_is_zero(maxrad))
+    {
+        flint_printf("  %-7s max rad = 0 (exact)\n", mode);
+    }
+    else
+    {
+        double lrad = mag_get_d_log2_approx(maxrad);
+        double lmid = mag_get_d_log2_approx(maxmid);
+        double loss = (double) prec - (lmid - lrad);
+
+        flint_printf("  %-7s max rad = 2^%.1f   loss = %.1f bits\n",
+                mode, lrad, loss);
+    }
+
+    mag_clear(maxrad);
+    mag_clear(maxmid);
+}
+
+int main(void)
+{
+    flint_rand_t state;
+    ulong n_tab[] = { 64, 256, 1024, 4096, 1000, 1009 };
+    slong prec_tab[] = { 53, 128, 512, 2048 };
+    slong ni, pi, style;
+
+    flint_rand_init(state);
+
+    for (ni = 0; ni < 6; ni++)
+    for (pi = 0; pi < 4; pi++)
+    {
+        ulong n = n_tab[ni];
+        slong prec = prec_tab[pi];
+
+        flint_printf("n = %wu, prec = %wd\n", n, prec);
+
+        for (style = 0; style < 4; style++)
+        {
+            int uniform = (style < 2);
+            int inexact = (style & 1);
+            acb_ptr v = _acb_vec_init(n);
+            acb_ptr w1 = _acb_vec_init(n);
+            acb_ptr w2 = _acb_vec_init(n);
+            slong j;
+            int status1, status2;
+
+            for (j = 0; j < (slong) n; j++)
+            {
+                if (uniform)
+                {
+                    acb_urandom(v + j, state, prec);
+                }
+                else
+                {
+                    acb_randtest(v + j, state, prec, 12);
+                    acb_get_mid(v + j, v + j);
+                }
+
+                if (inexact)
+                {
+                    /* relative perturbation 2^(4 - prec) per part */
+                    mag_t e;
+                    mag_init(e);
+                    arf_get_mag(e, arb_midref(acb_realref(v + j)));
+                    mag_mul_2exp_si(e, e, 4 - prec);
+                    mag_add(arb_radref(acb_realref(v + j)),
+                            arb_radref(acb_realref(v + j)), e);
+                    arf_get_mag(e, arb_midref(acb_imagref(v + j)));
+                    mag_mul_2exp_si(e, e, 4 - prec);
+                    mag_add(arb_radref(acb_imagref(v + j)),
+                            arb_radref(acb_imagref(v + j)), e);
+                    mag_clear(e);
+                }
+            }
+
+            flint_printf(" %s, %s:\n", uniform ? "uniform" : "randtest",
+                    inexact ? "inexact" : "exact");
+
+            status1 = _gr_dft_acb(w1, v, n, 0, 1, prec);
+            report("acb", w1, n, prec, status1);
+
+            status2 = _gr_dft_acb(w2, v, n, 0, 2, prec);
+            report("nfixed", w2, n, prec, status2);
+
+            _acb_vec_clear(v, n);
+            _acb_vec_clear(w1, n);
+            _acb_vec_clear(w2, n);
+        }
+
+        flint_printf("\n");
+    }
+
+    flint_rand_clear(state);
+    return 0;
+}

--- a/src/gr_dft/profile/p-gr_dft_nfixed.c
+++ b/src/gr_dft/profile/p-gr_dft_nfixed.c
@@ -1,0 +1,535 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <string.h>
+#include "profiler.h"
+#include "longlong.h"
+#include "ulong_extras.h"
+#include "mpn_extras.h"
+
+/* fallback for older FLINT versions (mirrors longlong.h) */
+#if !defined(sub_ddddmmmmssss)
+# define sub_ddddmmmmssss(s3, s2, s1, s0, a3, a2, a1, a0, b3, b2, b1, b0) \
+  do { \
+    ulong __t3, __t4; \
+    sub_dddmmmsss(__t3, s1, s0, (ulong) 0, a1, a0, (ulong) 0, b1, b0); \
+    sub_ddmmss(__t4, s2, (ulong) 0, a2, (ulong) 0, b2); \
+    sub_ddmmss(s3, s2, (a3) - (b3), s2, -__t4, -__t3); \
+  } while (0)
+#endif
+#include "gr.h"
+#include "gr_dft.h"
+
+/* Microbenchmarks of the fixed-point arithmetic primitives, for
+   machine tuning of the implementation choices in nfixed.c:
+
+   A. magnitude addition, 1-4 limbs: plain-C carry chains (as used by
+      the sized methods) against the inline-assembly chains of
+      longlong.h (as used by nfloat);
+   B. signed (sign-magnitude) subtraction: mpn_cmp followed by an
+      ordered mpn_sub_n (as in flint_mpn_signed_sub_n / nfloat)
+      against an unconditional mpn_sub_n followed by conditional
+      two's-complement negation, the latter both with a hand-written
+      loop (as currently in nfixed.c) and with mpn_neg; and the same
+      comparison for 1-4 limb specialized code;
+   C. the cost of the saturation checks: saturating against
+      non-saturating signed addition on random non-saturating inputs,
+      for the 1-4 limb specialized code and generic sizes;
+   D. classical against Karatsuba complex multiplication, for tuning
+      GR_DFT_NFIXED_KARATSUBA_CUTOFF.
+
+   Operands are random with magnitudes below 1/4, so the saturation
+   and sign branches are exercised but never taken pathologically;
+   per-operation times include the shared loop and store overhead. */
+
+#define VEC 1024
+#define MAXN 128
+
+static ulong buf_a[VEC][MAXN + 1];
+static ulong buf_b[VEC][MAXN + 1];
+static ulong buf_r[VEC][MAXN + 1];
+
+static void
+fill(flint_rand_t state, slong n, int signs)
+{
+    slong i, j;
+    for (i = 0; i < VEC; i++)
+    {
+        buf_a[i][0] = signs ? n_randint(state, 2) : 0;
+        buf_b[i][0] = signs ? n_randint(state, 2) : 0;
+        for (j = 1; j <= n; j++)
+        {
+            buf_a[i][j] = n_randlimb(state);
+            buf_b[i][j] = n_randlimb(state);
+        }
+        buf_a[i][n] >>= 2;      /* magnitudes below 1/4 */
+        buf_b[i][n] >>= 2;
+    }
+}
+
+typedef void (*op_fn)(nn_ptr, nn_srcptr, nn_srcptr, slong);
+
+static double
+time_op(op_fn f, slong n)
+{
+    timeit_t tm;
+    slong i, r, reps = 4;
+    double t;
+
+    for (i = 0; i < VEC; i++)
+        f(buf_r[i], buf_a[i], buf_b[i], n);
+
+    for (;;)
+    {
+        timeit_start(tm);
+        for (r = 0; r < reps; r++)
+            for (i = 0; i < VEC; i++)
+                f(buf_r[i], buf_a[i], buf_b[i], n);
+        timeit_stop(tm);
+        if (tm->wall >= 100)
+        {
+            t = 1e6 * tm->wall / ((double) reps * VEC);
+            break;
+        }
+        reps *= 4;
+    }
+    return t;
+}
+
+/* A. magnitude addition (no sign limb; a, b, r point at magnitudes) */
+
+static void addC_op(nn_ptr r, nn_srcptr a, nn_srcptr b, slong n)
+{
+    a++; b++; r++;
+    if (n == 1)
+    {
+        r[0] = a[0] + b[0];
+    }
+    else if (n == 2)
+    {
+        ulong c;
+        r[0] = a[0] + b[0]; c = r[0] < a[0];
+        r[1] = a[1] + b[1] + c;
+    }
+    else if (n == 3)
+    {
+        ulong c;
+        r[0] = a[0] + b[0]; c = r[0] < a[0];
+        r[1] = a[1] + b[1] + c; c = (r[1] < a[1]) | (c & (r[1] == a[1]));
+        r[2] = a[2] + b[2] + c;
+    }
+    else
+    {
+        ulong c;
+        r[0] = a[0] + b[0]; c = r[0] < a[0];
+        r[1] = a[1] + b[1] + c; c = (r[1] < a[1]) | (c & (r[1] == a[1]));
+        r[2] = a[2] + b[2] + c; c = (r[2] < a[2]) | (c & (r[2] == a[2]));
+        r[3] = a[3] + b[3] + c;
+    }
+}
+
+static void addA_op(nn_ptr r, nn_srcptr a, nn_srcptr b, slong n)
+{
+    a++; b++; r++;
+    if (n == 1)
+    {
+        r[0] = a[0] + b[0];
+    }
+    else if (n == 2)
+    {
+        add_ssaaaa(r[1], r[0], a[1], a[0], b[1], b[0]);
+    }
+    else if (n == 3)
+    {
+        add_sssaaaaaa(r[2], r[1], r[0], a[2], a[1], a[0], b[2], b[1], b[0]);
+    }
+    else
+    {
+        add_ssssaaaaaaaa(r[3], r[2], r[1], r[0],
+                a[3], a[2], a[1], a[0], b[3], b[2], b[1], b[0]);
+    }
+}
+
+/* B. signed subtraction of magnitudes: r = |a| - |b| with returned
+   sign; here the sign is stored in r[-1]... we use the leading slot */
+
+static void ssub_cmp_op(nn_ptr r, nn_srcptr a, nn_srcptr b, slong n)
+{
+    if (mpn_cmp(a + 1, b + 1, n) >= 0)
+    {
+        mpn_sub_n(r + 1, a + 1, b + 1, n);
+        r[0] = 0;
+    }
+    else
+    {
+        mpn_sub_n(r + 1, b + 1, a + 1, n);
+        r[0] = 1;
+    }
+}
+
+static void ssub_negloop_op(nn_ptr r, nn_srcptr a, nn_srcptr b, slong n)
+{
+    if (mpn_sub_n(r + 1, a + 1, b + 1, n))
+    {
+        slong i;
+        ulong cy = 1;
+        for (i = 1; i <= n; i++)
+        {
+            r[i] = ~r[i] + cy;
+            cy = cy & (r[i] == 0);
+        }
+        r[0] = 1;
+    }
+    else
+        r[0] = 0;
+}
+
+static void ssub_mpnneg_op(nn_ptr r, nn_srcptr a, nn_srcptr b, slong n)
+{
+    if (mpn_sub_n(r + 1, a + 1, b + 1, n))
+    {
+        mpn_neg(r + 1, r + 1, n);
+        r[0] = 1;
+    }
+    else
+        r[0] = 0;
+}
+
+/* sized: compare-first */
+static void ssub_cmp_sized_op(nn_ptr r, nn_srcptr a, nn_srcptr b, slong n)
+{
+    int swap;
+    nn_srcptr u, v;
+    slong i;
+
+    swap = 0;
+    for (i = n; i >= 1; i--)
+    {
+        if (a[i] != b[i])
+        {
+            swap = a[i] < b[i];
+            break;
+        }
+    }
+    u = swap ? b : a;
+    v = swap ? a : b;
+    r[0] = swap;
+
+    if (n == 1)
+    {
+        r[1] = u[1] - v[1];
+    }
+    else if (n == 2)
+    {
+        sub_ddmmss(r[2], r[1], u[2], u[1], v[2], v[1]);
+    }
+    else if (n == 3)
+    {
+        sub_dddmmmsss(r[3], r[2], r[1], u[3], u[2], u[1], v[3], v[2], v[1]);
+    }
+    else
+    {
+        sub_ddddmmmmssss(r[4], r[3], r[2], r[1],
+                u[4], u[3], u[2], u[1], v[4], v[3], v[2], v[1]);
+    }
+}
+
+/* sized: subtract, then conditional negation (plain C, mirroring the
+   MAG_SSUB macros of nfixed.c) */
+static void ssub_neg_sized_op(nn_ptr r, nn_srcptr a, nn_srcptr b, slong n)
+{
+    ulong bw;
+
+    if (n == 1)
+    {
+        r[1] = a[1] - b[1];
+        bw = a[1] < b[1];
+        if (bw)
+            r[1] = -r[1];
+    }
+    else if (n == 2)
+    {
+        ulong d0, d1, b0;
+        d0 = a[1] - b[1]; b0 = a[1] < b[1];
+        d1 = a[2] - b[2]; bw = a[2] < b[2];
+        bw |= (b0 & (d1 == 0)); d1 -= b0;
+        r[1] = d0; r[2] = d1;
+        if (bw)
+        {
+            ulong cy;
+            r[1] = -r[1]; cy = (r[1] == 0);
+            r[2] = ~r[2] + cy;
+        }
+    }
+    else if (n == 3)
+    {
+        sub_dddmmmsss(r[3], r[2], r[1], a[3], a[2], a[1], b[3], b[2], b[1]);
+        bw = (a[3] < b[3]) || (a[3] == b[3] &&
+                (a[2] < b[2] || (a[2] == b[2] && a[1] < b[1])));
+        if (bw)
+        {
+            ulong cy;
+            r[1] = -r[1]; cy = (r[1] == 0);
+            r[2] = ~r[2] + cy; cy = cy & (r[2] == 0);
+            r[3] = ~r[3] + cy;
+        }
+    }
+    else
+    {
+        sub_ddddmmmmssss(r[4], r[3], r[2], r[1],
+                a[4], a[3], a[2], a[1], b[4], b[3], b[2], b[1]);
+        bw = r[4] >> (FLINT_BITS - 1);
+        if (bw)
+        {
+            ulong cy;
+            r[1] = -r[1]; cy = (r[1] == 0);
+            r[2] = ~r[2] + cy; cy = cy & (r[2] == 0);
+            r[3] = ~r[3] + cy; cy = cy & (r[3] == 0);
+            r[4] = ~r[4] + cy;
+        }
+    }
+    r[0] = bw;
+}
+
+/* C. full signed addition, saturating vs not (generic via mpn) */
+
+static void sadd_sat_op(nn_ptr r, nn_srcptr a, nn_srcptr b, slong n)
+{
+    if (a[0] == b[0])
+    {
+        r[0] = a[0];
+        if (mpn_add_n(r + 1, a + 1, b + 1, n))
+        {
+            slong i;
+            for (i = 1; i <= n; i++)
+                r[i] = ~UWORD(0);
+        }
+    }
+    else
+    {
+        r[0] = a[0] ^ (ulong) (mpn_cmp(a + 1, b + 1, n) < 0);
+        if (mpn_cmp(a + 1, b + 1, n) >= 0)
+            mpn_sub_n(r + 1, a + 1, b + 1, n);
+        else
+            mpn_sub_n(r + 1, b + 1, a + 1, n);
+    }
+}
+
+static void sadd_nosat_op(nn_ptr r, nn_srcptr a, nn_srcptr b, slong n)
+{
+    if (a[0] == b[0])
+    {
+        r[0] = a[0];
+        mpn_add_n(r + 1, a + 1, b + 1, n);
+    }
+    else
+    {
+        r[0] = a[0] ^ (ulong) (mpn_cmp(a + 1, b + 1, n) < 0);
+        if (mpn_cmp(a + 1, b + 1, n) >= 0)
+            mpn_sub_n(r + 1, a + 1, b + 1, n);
+        else
+            mpn_sub_n(r + 1, b + 1, a + 1, n);
+    }
+}
+
+/* sized signed addition with/without saturation (2 limbs shown as the
+   representative case; dispatched below) */
+static void sadd_sat_sized_op(nn_ptr r, nn_srcptr a, nn_srcptr b, slong n)
+{
+    if (a[0] == b[0])
+    {
+        ulong cy;
+        r[0] = a[0];
+        if (n == 1)
+        {
+            r[1] = a[1] + b[1]; cy = r[1] < a[1];
+        }
+        else if (n == 2)
+        {
+            ulong t;
+            add_ssaaaa(t, r[1], a[2], a[1], b[2], b[1]);
+            cy = t < a[2]; r[2] = t;
+        }
+        else if (n == 3)
+        {
+            ulong t;
+            add_sssaaaaaa(t, r[2], r[1], a[3], a[2], a[1], b[3], b[2], b[1]);
+            cy = t < a[3]; r[3] = t;
+        }
+        else
+        {
+            ulong t;
+            add_ssssaaaaaaaa(t, r[3], r[2], r[1],
+                    a[4], a[3], a[2], a[1], b[4], b[3], b[2], b[1]);
+            cy = t < a[4]; r[4] = t;
+        }
+        if (cy)
+        {
+            slong i;
+            for (i = 1; i <= n; i++)
+                r[i] = ~UWORD(0);
+        }
+    }
+    else
+        ssub_neg_sized_op(r, a, b, n), r[0] ^= a[0];
+}
+
+static void sadd_nosat_sized_op(nn_ptr r, nn_srcptr a, nn_srcptr b, slong n)
+{
+    if (a[0] == b[0])
+    {
+        r[0] = a[0];
+        if (n == 1)
+            r[1] = a[1] + b[1];
+        else if (n == 2)
+            add_ssaaaa(r[2], r[1], a[2], a[1], b[2], b[1]);
+        else if (n == 3)
+            add_sssaaaaaa(r[3], r[2], r[1], a[3], a[2], a[1], b[3], b[2], b[1]);
+        else
+            add_ssssaaaaaaaa(r[4], r[3], r[2], r[1],
+                    a[4], a[3], a[2], a[1], b[4], b[3], b[2], b[1]);
+    }
+    else
+        ssub_neg_sized_op(r, a, b, n), r[0] ^= a[0];
+}
+
+int
+main(void)
+{
+    flint_rand_t state;
+    slong n, i;
+
+    flint_rand_init(state);
+
+    flint_printf("nfixed primitive microbenchmarks (ns per operation,\n");
+    flint_printf("including loop and store overhead)\n\n");
+
+    flint_printf("A. magnitude addition, plain-C carry chains vs "
+            "longlong chains\n");
+    flint_printf("%8s %10s %10s\n", "limbs", "plain C", "longlong");
+    for (n = 1; n <= 4; n++)
+    {
+        fill(state, n, 0);
+        flint_printf("%8wd %10.2f %10.2f\n", n,
+                time_op(addC_op, n), time_op(addA_op, n));
+    }
+
+    flint_printf("\nB. signed subtraction of magnitudes\n");
+    flint_printf("%8s %10s %10s %10s   (sized: cmp-first vs sub+neg)\n",
+            "limbs", "cmp+sub", "sub+neg", "");
+    for (n = 1; n <= 4; n++)
+    {
+        fill(state, n, 0);
+        flint_printf("%8wd %10.2f %10.2f\n", n,
+                time_op(ssub_cmp_sized_op, n),
+                time_op(ssub_neg_sized_op, n));
+    }
+    flint_printf("%8s %10s %10s %10s   (generic mpn)\n",
+            "limbs", "cmp+sub", "sub+loop", "sub+mpn_neg");
+    for (n = 4; n <= MAXN; n *= 2)
+    {
+        fill(state, n, 0);
+        flint_printf("%8wd %10.2f %10.2f %10.2f\n", n,
+                time_op(ssub_cmp_op, n),
+                time_op(ssub_negloop_op, n),
+                time_op(ssub_mpnneg_op, n));
+    }
+
+    flint_printf("\nC. signed addition, saturating vs non-saturating\n");
+    flint_printf("%8s %10s %10s   (sized)\n", "limbs", "sat", "no sat");
+    for (n = 1; n <= 4; n++)
+    {
+        fill(state, n, 1);
+        flint_printf("%8wd %10.2f %10.2f\n", n,
+                time_op(sadd_sat_sized_op, n),
+                time_op(sadd_nosat_sized_op, n));
+    }
+    flint_printf("%8s %10s %10s   (generic mpn)\n", "limbs", "sat", "no sat");
+    for (n = 4; n <= MAXN; n *= 2)
+    {
+        fill(state, n, 1);
+        flint_printf("%8wd %10.2f %10.2f\n", n,
+                time_op(sadd_sat_op, n), time_op(sadd_nosat_op, n));
+    }
+
+    flint_printf("\nD. complex multiplication, schoolbook vs Karatsuba\n");
+    flint_printf("%8s %12s %12s %8s\n", "limbs", "schoolbook", "karatsuba",
+            "ratio");
+    {
+        slong nls[] = { 2, 4, 8, 12, 16, 20, 24, 32, 48, 64, 96, 128, 0 };
+        slong t;
+
+        for (t = 0; nls[t] != 0; t++)
+        {
+            gr_ctx_t cctx;
+            gr_ptr x, y, r;
+            timeit_t tm;
+            slong reps, rr;
+            double ts, tk;
+            int status = GR_SUCCESS;
+
+            n = nls[t];
+            if (gr_dft_ctx_init_nfixed_complex(cctx, n) != GR_SUCCESS)
+                continue;
+
+            x = gr_heap_init(cctx);
+            y = gr_heap_init(cctx);
+            r = gr_heap_init(cctx);
+            status |= gr_randtest(x, state, cctx);
+            status |= gr_randtest(y, state, cctx);
+
+            status |= _gr_dft_nfixed_cmul_schoolbook(r, x, y, cctx);
+            for (reps = 4; ; reps *= 4)
+            {
+                timeit_start(tm);
+                for (rr = 0; rr < reps; rr++)
+                    status |= _gr_dft_nfixed_cmul_schoolbook(r, x, y, cctx);
+                timeit_stop(tm);
+                if (tm->wall >= 100)
+                    break;
+            }
+            ts = 1e6 * tm->wall / reps;
+
+            status |= _gr_dft_nfixed_cmul_karatsuba(r, x, y, cctx);
+            for (reps = 4; ; reps *= 4)
+            {
+                timeit_start(tm);
+                for (rr = 0; rr < reps; rr++)
+                    status |= _gr_dft_nfixed_cmul_karatsuba(r, x, y, cctx);
+                timeit_stop(tm);
+                if (tm->wall >= 100)
+                    break;
+            }
+            tk = 1e6 * tm->wall / reps;
+
+            flint_printf("%8wd %12.1f %12.1f %8.2f  (status %d)\n",
+                    n, ts, tk, ts / tk, status);
+
+            gr_heap_clear(x, cctx);
+            gr_heap_clear(y, cctx);
+            gr_heap_clear(r, cctx);
+            gr_ctx_clear(cctx);
+        }
+    }
+
+    /* keep the results alive */
+    {
+        ulong chk = 0;
+        for (i = 0; i < VEC; i++)
+            chk ^= buf_r[i][1];
+        if (chk == UWORD(0x123456789abcdef))
+            flint_printf("(unlikely)\n");
+    }
+
+    flint_rand_clear(state);
+    return 0;
+}

--- a/src/gr_dft/profile/p-gr_dft_threads.c
+++ b/src/gr_dft/profile/p-gr_dft_threads.c
@@ -1,0 +1,217 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdlib.h>
+#include <string.h>
+#include "profiler.h"
+#include "arb.h"
+#include "acb.h"
+#include "gr.h"
+#include "gr_vec.h"
+#include "gr_dft.h"
+
+/* Parallel speedup of the threaded transforms, per algorithm.
+
+   Usage: p-gr_dft_threads [acb|nfixed|nmod] [max_n] [prec] [max_threads] [-v]
+
+   The ring defaults to acb; prec (in bits, for acb and nfixed)
+   defaults to 128; max_n to 1048576; max_threads to 8. With -v, each
+   plan is printed (gr_dft_precomp_print) before its row. */
+
+static double
+time_dft(gr_dft_pre_t P, gr_ptr y, gr_srcptr x, gr_ctx_t ctx)
+{
+    timeit_t tm;
+    slong r, reps = 1;
+    int status = GR_SUCCESS;
+
+    status |= gr_dft_precomp(y, x, P, ctx);
+
+    for (;;)
+    {
+        timeit_start(tm);
+        for (r = 0; r < reps; r++)
+            status |= gr_dft_precomp(y, x, P, ctx);
+        timeit_stop(tm);
+        if (tm->wall >= 100 || reps >= 65536)
+            return (status == GR_SUCCESS) ? (double) tm->wall / reps : -1.0;
+        reps *= 4;
+    }
+}
+
+/* uniform random data of full working precision (randtest generates
+   special values and mixed magnitudes, which misrepresent the cost
+   over rings with data-dependent arithmetic) */
+static void
+rand_vec(gr_ptr x, ulong n, int ring, slong prec, flint_rand_t state,
+        gr_ctx_t ctx, gr_ctx_t rctx)
+{
+    ulong j;
+
+    if (ring == 0)          /* acb */
+    {
+        acb_ptr v = (acb_ptr) x;
+        for (j = 0; j < n; j++)
+            acb_urandom(v + j, state, prec);
+    }
+    else if (ring == 1)     /* nfixed: uniform components scaled below
+                               the transform magnitude bound */
+    {
+        slong rsz = rctx->sizeof_elem;
+        slong e = FLINT_BIT_COUNT(n) + 2;
+        arb_t u;
+        arb_init(u);
+        for (j = 0; j < 2 * n; j++)
+        {
+            gr_ptr comp = (gr_ptr) ((char *) x + j * rsz);
+            arb_urandom(u, state, prec + 64);
+            arf_mul_2exp_si(arb_midref(u), arb_midref(u), -e);
+            GR_IGNORE(gr_dft_nfixed_set_arf(comp, arb_midref(u), rctx));
+        }
+        arb_clear(u);
+    }
+    else                    /* nmod: arithmetic cost is data
+                               independent; randtest is uniform */
+    {
+        GR_IGNORE(_gr_vec_randtest(x, state, n, ctx));
+    }
+}
+
+int
+main(int argc, char * argv[])
+{
+    flint_rand_t state;
+    slong max_n = 1048576, prec = 128, max_threads = 8;
+    int verbose = 0, ring = 0;
+    const int algs[] = { GR_DFT_ALG_CT, GR_DFT_ALG_SPLIT,
+        GR_DFT_ALG_BAILEY, GR_DFT_ALG_AUTO };
+    const char * alg_names[] = { "ct", "split", "bailey", "auto" };
+    ulong n;
+    slong ai, nt, i;
+    slong nums[3];
+    slong num_count = 0;
+    gr_ctx_t ctx, rctx;
+    int have_rctx = 1;
+
+    for (i = 1; i < argc; i++)
+    {
+        if (strcmp(argv[i], "-v") == 0)
+            verbose = 1;
+        else if (strcmp(argv[i], "acb") == 0)
+            ring = 0;
+        else if (strcmp(argv[i], "nfixed") == 0)
+            ring = 1;
+        else if (strcmp(argv[i], "nmod") == 0)
+            ring = 2;
+        else if (atol(argv[i]) > 0 && num_count < 3)
+            nums[num_count++] = atol(argv[i]);
+    }
+
+    /* positional numbers: [max_n] [prec] [max_threads] for acb and
+       nfixed; [max_n] [max_threads] for nmod (no precision) */
+    if (num_count > 0) max_n = nums[0];
+    if (ring == 2)
+    {
+        if (num_count > 1) max_threads = nums[1];
+    }
+    else
+    {
+        if (num_count > 1) prec = nums[1];
+        if (num_count > 2) max_threads = nums[2];
+    }
+
+    flint_rand_init(state);
+
+    if (ring == 0)
+    {
+        gr_ctx_init_complex_acb(ctx, prec);
+        gr_ctx_init_real_arb(rctx, prec);
+        flint_printf("acb, prec = %wd", prec);
+    }
+    else if (ring == 1)
+    {
+        slong nl = (prec + FLINT_BITS - 1) / FLINT_BITS;
+        GR_MUST_SUCCEED(gr_dft_ctx_init_nfixed(rctx, nl));
+        GR_MUST_SUCCEED(gr_dft_ctx_init_nfixed_complex(ctx, nl));
+        flint_printf("nfixed, %wd limbs (%wd bits)", nl, nl * FLINT_BITS);
+    }
+    else
+    {
+        gr_ctx_init_nmod(ctx, UWORD(998244353));
+        have_rctx = 0;
+        flint_printf("nmod, q = 998244353");
+    }
+    flint_printf("; per-transform ms by thread count\n\n");
+
+    flint_printf("%8s %8s", "n", "alg");
+    for (nt = 1; nt <= max_threads; nt *= 2)
+        flint_printf("  %5wd thr", nt);
+    flint_printf("   speedup\n");
+
+    for (n = 64; n <= (ulong) max_n; n *= 4)
+    {
+        for (ai = 0; ai < 4; ai++)
+        {
+            gr_dft_pre_t P;
+            gr_ptr x, y;
+            double t1 = 0.0, t = 0.0;
+            int status;
+
+            if (ring == 2)
+            {
+                /* q - 1 = 119 * 2^23: use w = 3^((q-1)/n) */
+                gr_ptr w = gr_heap_init(ctx);
+                status = gr_set_ui(w, 3, ctx);
+                status |= gr_pow_ui(w, w, UWORD(998244352) / n, ctx);
+                status |= gr_dft_precomp_init_root(P, w, n, algs[ai], 0, ctx);
+                gr_heap_clear(w, ctx);
+            }
+            else
+            {
+                status = gr_dft_precomp_init_karatsuba(P, n, algs[ai], 0,
+                        rctx, ctx);
+            }
+            if (status != GR_SUCCESS)
+                continue;
+
+            if (verbose)
+                gr_dft_precomp_print(P);
+
+            x = gr_heap_init_vec(n, ctx);
+            y = gr_heap_init_vec(n, ctx);
+            rand_vec(x, n, ring, prec, state, ctx,
+                    have_rctx ? rctx : NULL);
+
+            flint_printf("%8wu %8s", n, alg_names[ai]);
+            for (nt = 1; nt <= max_threads; nt *= 2)
+            {
+                flint_set_num_threads(nt);
+                t = time_dft(P, y, x, ctx);
+                if (nt == 1)
+                    t1 = t;
+                flint_printf("  %9.3f", t);
+            }
+            flint_printf("  %7.2fx\n", (t > 0.0) ? t1 / t : 0.0);
+            flint_set_num_threads(1);
+
+            gr_heap_clear_vec(x, n, ctx);
+            gr_heap_clear_vec(y, n, ctx);
+            gr_dft_precomp_clear(P);
+        }
+    }
+
+    gr_ctx_clear(ctx);
+    if (have_rctx)
+        gr_ctx_clear(rctx);
+    flint_rand_clear(state);
+    return 0;
+}

--- a/src/gr_dft/split.c
+++ b/src/gr_dft/split.c
@@ -1,0 +1,592 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "thread_pool.h"
+#include "thread_support.h"
+#include "gr.h"
+#include "gr_dft.h"
+
+/* Split-radix decomposition, valid over any ring given w^(n/2) = -1.
+   For a transform of length m with root v = w^rstep (rstep = n/m),
+   splitting the input into the even entries, the entries 4j+1 and the
+   entries 4j+3 with transforms U (length m/2), Z, Z' (length m/4):
+
+       t   = v^k Z_k,   t' = v^(3k) Z'_k,
+       X_k          = U_k       + (t + t')
+       X_{k+m/2}    = U_k       - (t + t')
+       X_{k+m/4}    = U_{k+m/4} + v^(m/4) (t - t')
+       X_{k+3m/4}   = U_{k+m/4} - v^(m/4) (t - t')
+
+   for 0 <= k < m/4, where v^(m/4) = w^(n/4) plays the role of -i.
+   Per recursion step this costs 2 general root multiplications per k
+   plus one multiplication by w^(n/4); the latter is free in complex
+   mode, in which case the total number of multiplications by roots of
+   unity is about (n/3) log2(n) versus (n/2) log2(n) for radix-2,
+   and the number of real multiplications matches the minimal
+   (Winograd, WFTA) counts for n = 4, 8, 16.
+
+   Writes the natural-order transform of the strided input vec into the
+   contiguous output res; res must not alias vec. */
+/* rotation by +-i on complex-mode components (res may alias x) */
+static int
+_gr_dft_split_rot_i(gr_ptr res, gr_srcptr x, int plus_i, gr_ptr rtmp,
+        gr_ctx_struct * rctx, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    slong rsz = rctx->sizeof_elem;
+    gr_srcptr xr = x, xi = GR_ENTRY(x, 1, rsz);
+    gr_ptr rr = res, ri = GR_ENTRY(res, 1, rsz);
+
+    status |= gr_set(rtmp, xr, rctx);
+    if (plus_i)
+    {
+        /* i x = -xi + xr i */
+        status |= gr_neg(rr, xi, rctx);
+        status |= gr_set(ri, rtmp, rctx);
+    }
+    else
+    {
+        /* -i x = xi - xr i */
+        status |= gr_set(rr, xi, rctx);
+        status |= gr_neg(ri, rtmp, rctx);
+    }
+
+    return status;
+}
+
+/* The combine pass over k in [lo, hi) (the full pass is [0, q)),
+   shared by the serial and threaded transforms. When the complex
+   Karatsuba table is not in use, the twiddle multiplications run in a
+   tight loop with directly walked root-table indices (e1 = k rstep
+   and e2 = 3 k rstep stay below n over the whole pass since
+   q rstep = n/4, so a single conditional subtraction handles the
+   wraparound of the inverse walk) and plain gr_mul, avoiding the
+   per-multiplication dispatch of _gr_dft_mul_root; the rotation by
+   w^(n/4) keeps the dispatch, being a free special rotation in
+   complex mode. With the Karatsuba table active, the dispatched
+   3-multiplication path is used throughout. */
+static int
+_gr_dft_split_pass(gr_ptr res, ulong rstep, ulong q, ulong lo, ulong hi,
+        int inverse, gr_ptr t1, gr_ptr t2, gr_ptr t3, gr_ptr rtmp,
+        const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    slong sz = ctx->sizeof_elem;
+    ulong k;
+
+    if (P->stage_tab != NULL)
+    {
+        /* packed pair table for this size m = 4q: sequential entries
+           (w^(k rstep), w^(3 k rstep mod n)); the inverse walks the
+           pairs in reverse, using w^(-k r) = i w^((q-k) r) and
+           w^(-3k r) = -i w^(3 (q-k) r), the quarter rotations being
+           free in complex mode */
+        gr_ctx_struct * rctx = P->real_ctx;
+        gr_srcptr pairs = GR_ENTRY(P->stage_tab, P->n - 4 * q, sz);
+
+        for (k = lo; k < hi; k++)
+        {
+            gr_ptr u1 = GR_ENTRY(res, k, sz);
+            gr_ptr u2 = GR_ENTRY(res, q + k, sz);
+            gr_ptr zk = GR_ENTRY(res, 2 * q + k, sz);
+            gr_ptr zpk = GR_ENTRY(res, 3 * q + k, sz);
+
+            if (!inverse)
+            {
+                status |= gr_mul(t1, zk, GR_ENTRY(pairs, 2 * k, sz), ctx);
+                status |= gr_mul(t2, zpk, GR_ENTRY(pairs, 2 * k + 1, sz), ctx);
+            }
+            else if (k == 0)
+            {
+                status |= gr_set(t1, zk, ctx);
+                status |= gr_set(t2, zpk, ctx);
+            }
+            else
+            {
+                status |= gr_mul(t1, zk,
+                        GR_ENTRY(pairs, 2 * (q - k), sz), ctx);
+                status |= _gr_dft_split_rot_i(t1, t1, 1, rtmp, rctx, ctx);
+                status |= gr_mul(t2, zpk,
+                        GR_ENTRY(pairs, 2 * (q - k) + 1, sz), ctx);
+                status |= _gr_dft_split_rot_i(t2, t2, 0, rtmp, rctx, ctx);
+            }
+
+            status |= gr_add(t3, t1, t2, ctx);
+            status |= gr_sub(t1, t1, t2, ctx);
+            status |= _gr_dft_split_rot_i(t2, t1, inverse, rtmp, rctx, ctx);
+
+            status |= gr_sub(zk, u1, t3, ctx);
+            status |= gr_add(u1, u1, t3, ctx);
+            status |= gr_sub(zpk, u2, t2, ctx);
+            status |= gr_add(u2, u2, t2, ctx);
+        }
+
+        return status;
+    }
+
+    if (P->wtab == NULL)
+    {
+        ulong n = P->n;
+        ulong s1 = rstep, s3 = 3 * rstep;
+        ulong e1, e2;
+
+        if (s3 >= n)
+            s3 -= n;
+
+        if (!inverse)
+        {
+            e1 = lo * rstep;
+            e2 = 3 * lo * rstep;
+            if (e2 >= n)
+                e2 -= n;
+            if (e2 >= n)
+                e2 -= n;
+        }
+        else
+        {
+            /* multiply by w^(-e) = w^(n - e) */
+            e1 = (lo == 0) ? 0 : n - lo * rstep;
+            e2 = (3 * lo * rstep) % n;
+            e2 = (e2 == 0) ? 0 : n - e2;
+            s1 = n - s1;
+            s3 = (s3 == 0) ? 0 : n - s3;
+        }
+
+        for (k = lo; k < hi; k++)
+        {
+            gr_ptr u1 = GR_ENTRY(res, k, sz);
+            gr_ptr u2 = GR_ENTRY(res, q + k, sz);
+            gr_ptr zk = GR_ENTRY(res, 2 * q + k, sz);
+            gr_ptr zpk = GR_ENTRY(res, 3 * q + k, sz);
+
+            status |= gr_mul(t1, zk, GR_ENTRY(P->roots, e1, sz), ctx);
+            status |= gr_mul(t2, zpk, GR_ENTRY(P->roots, e2, sz), ctx);
+
+            status |= gr_add(t3, t1, t2, ctx);
+            status |= gr_sub(t1, t1, t2, ctx);
+            status |= _gr_dft_mul_root(t2, t1, P->n >> 2, inverse, rtmp, P);
+
+            status |= gr_sub(zk, u1, t3, ctx);
+            status |= gr_add(u1, u1, t3, ctx);
+            status |= gr_sub(zpk, u2, t2, ctx);
+            status |= gr_add(u2, u2, t2, ctx);
+
+            e1 += s1;
+            if (e1 >= n)
+                e1 -= n;
+            e2 += s3;
+            if (e2 >= n)
+                e2 -= n;
+        }
+    }
+    else
+    {
+        for (k = lo; k < hi; k++)
+        {
+            gr_ptr u1 = GR_ENTRY(res, k, sz);
+            gr_ptr u2 = GR_ENTRY(res, q + k, sz);
+            gr_ptr zk = GR_ENTRY(res, 2 * q + k, sz);
+            gr_ptr zpk = GR_ENTRY(res, 3 * q + k, sz);
+
+            status |= _gr_dft_mul_root(t1, zk, k * rstep, inverse, rtmp, P);
+            status |= _gr_dft_mul_root(t2, zpk, 3 * k * rstep, inverse, rtmp, P);
+
+            status |= gr_add(t3, t1, t2, ctx);
+            status |= gr_sub(t1, t1, t2, ctx);
+            status |= _gr_dft_mul_root(t2, t1, P->n >> 2, inverse, rtmp, P);
+
+            status |= gr_sub(zk, u1, t3, ctx);
+            status |= gr_add(u1, u1, t3, ctx);
+            status |= gr_sub(zpk, u2, t2, ctx);
+            status |= gr_add(u2, u2, t2, ctx);
+        }
+    }
+
+    return status;
+}
+
+static int
+_split(gr_ptr res, gr_srcptr vec, slong stride, ulong rstep, int depth,
+        int inverse, gr_ptr t1, gr_ptr t2, gr_ptr t3, gr_ptr rtmp,
+        const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    slong sz = ctx->sizeof_elem;
+    ulong m, q;
+
+    if (depth == 0)
+        return gr_set(res, vec, ctx);
+
+    if (depth == 1)
+    {
+        status |= gr_add(res, vec, GR_ENTRY(vec, stride, sz), ctx);
+        status |= gr_sub(GR_ENTRY(res, 1, sz), vec, GR_ENTRY(vec, stride, sz), ctx);
+        return status;
+    }
+
+    m = UWORD(1) << depth;
+    q = m >> 2;
+
+    /* U, Z, Z' into res[0, m/2), res[m/2, 3m/4), res[3m/4, m) */
+    status |= _split(res, vec, 2 * stride, 2 * rstep,
+            depth - 1, inverse, t1, t2, t3, rtmp, P, ctx);
+    status |= _split(GR_ENTRY(res, 2 * q, sz), GR_ENTRY(vec, stride, sz),
+            4 * stride, 4 * rstep, depth - 2, inverse, t1, t2, t3, rtmp, P, ctx);
+    status |= _split(GR_ENTRY(res, 3 * q, sz), GR_ENTRY(vec, 3 * stride, sz),
+            4 * stride, 4 * rstep, depth - 2, inverse, t1, t2, t3, rtmp, P, ctx);
+
+    status |= _gr_dft_split_pass(res, rstep, q, 0, q, inverse,
+            t1, t2, t3, rtmp, P, ctx);
+
+    return status;
+}
+
+int
+_gr_dft_split(gr_ptr res, gr_srcptr vec, int inverse,
+        const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    gr_ptr t1, t2, t3, rtmp = NULL;
+
+    GR_TMP_INIT3(t1, t2, t3, ctx);
+    if (P->real_ctx != NULL)
+        GR_TMP_INIT(rtmp, P->real_ctx);
+
+    status |= _split(res, vec, 1, 1, P->depth, inverse,
+            t1, t2, t3, rtmp, P, ctx);
+
+    GR_TMP_CLEAR3(t1, t2, t3, ctx);
+    if (P->real_ctx != NULL)
+        GR_TMP_CLEAR(rtmp, P->real_ctx);
+
+    return status;
+}
+
+/* Threaded execution: the three recursive sub-transforms write
+   disjoint regions of res and read disjoint strided cosets of vec, so
+   they can run concurrently (fork-join, partitioning the available
+   worker handles between the half-length sub-transform and the two
+   quarter-length ones), and the combine pass consists of q = m/4
+   independent iterations that are distributed across all workers.
+   Nodes without an allocation of workers, and nodes below the
+   granularity bound, run the serial code above. */
+
+typedef struct
+{
+    gr_ptr res;
+    gr_srcptr vec;
+    slong stride;
+    ulong rstep;
+    int depth;
+    int inverse;
+    thread_pool_handle * handles;
+    slong num_workers;
+    slong blk;
+    const gr_dft_pre_struct * P;
+    gr_ctx_struct * ctx;
+    int status;
+}
+_gr_dft_split_work_t;
+
+static int
+_split_mt(gr_ptr res, gr_srcptr vec, slong stride, ulong rstep, int depth,
+        int inverse, gr_ptr t1, gr_ptr t2, gr_ptr t3, gr_ptr rtmp,
+        thread_pool_handle * handles, slong num_workers, slong blk,
+        const gr_dft_pre_t P, gr_ctx_t ctx);
+
+static void _gr_dft_split_quarters_leaf(void * arg);
+
+/* task: the two quarter-length sub-transforms, run concurrently with
+   the half-length one; itself forks one quarter to a sub-worker when
+   it has any */
+static void
+_gr_dft_split_quarters_worker(void * arg)
+{
+    _gr_dft_split_work_t * w = arg;
+    gr_ctx_struct * ctx = w->ctx;
+    const gr_dft_pre_struct * P = w->P;
+    int status = GR_SUCCESS;
+    slong sz = ctx->sizeof_elem;
+    ulong q = (UWORD(1) << w->depth) >> 2;
+    gr_ptr t1, t2, t3, rtmp = NULL;
+
+    GR_TMP_INIT3(t1, t2, t3, ctx);
+    if (P->real_ctx != NULL)
+        GR_TMP_INIT(rtmp, P->real_ctx);
+
+    if (w->num_workers >= 1)
+    {
+        _gr_dft_split_work_t sub;
+        slong wz = (w->num_workers - 1) / 2;
+
+        sub.res = GR_ENTRY(w->res, 3 * q, sz);
+        sub.vec = GR_ENTRY(w->vec, 3 * w->stride, sz);
+        sub.stride = 4 * w->stride;
+        sub.rstep = 4 * w->rstep;
+        sub.depth = w->depth - 2;
+        sub.inverse = w->inverse;
+        sub.handles = w->handles + 1;
+        sub.num_workers = wz;
+        sub.blk = w->blk;
+        sub.P = P;
+        sub.ctx = ctx;
+        sub.status = GR_SUCCESS;
+
+        thread_pool_wake(global_thread_pool, w->handles[0], 0,
+                _gr_dft_split_quarters_leaf, &sub);
+
+        status |= _split_mt(GR_ENTRY(w->res, 2 * q, sz),
+                GR_ENTRY(w->vec, w->stride, sz), 4 * w->stride,
+                4 * w->rstep, w->depth - 2, w->inverse, t1, t2, t3, rtmp,
+                w->handles + 1 + wz, w->num_workers - 1 - wz, w->blk,
+                P, ctx);
+
+        thread_pool_wait(global_thread_pool, w->handles[0]);
+        status |= sub.status;
+    }
+    else
+    {
+        status |= _split_mt(GR_ENTRY(w->res, 2 * q, sz),
+                GR_ENTRY(w->vec, w->stride, sz), 4 * w->stride,
+                4 * w->rstep, w->depth - 2, w->inverse, t1, t2, t3, rtmp,
+                NULL, 0, w->blk, P, ctx);
+        status |= _split_mt(GR_ENTRY(w->res, 3 * q, sz),
+                GR_ENTRY(w->vec, 3 * w->stride, sz), 4 * w->stride,
+                4 * w->rstep, w->depth - 2, w->inverse, t1, t2, t3, rtmp,
+                NULL, 0, w->blk, P, ctx);
+    }
+
+    GR_TMP_CLEAR3(t1, t2, t3, ctx);
+    if (P->real_ctx != NULL)
+        GR_TMP_CLEAR(rtmp, P->real_ctx);
+
+    w->status = status;
+}
+
+static void
+_gr_dft_split_quarters_leaf(void * arg)
+{
+    _gr_dft_split_work_t * w = arg;
+    gr_ctx_struct * ctx = w->ctx;
+    const gr_dft_pre_struct * P = w->P;
+    gr_ptr t1, t2, t3, rtmp = NULL;
+
+    GR_TMP_INIT3(t1, t2, t3, ctx);
+    if (P->real_ctx != NULL)
+        GR_TMP_INIT(rtmp, P->real_ctx);
+
+    w->status = _split_mt(w->res, w->vec, w->stride, w->rstep, w->depth,
+            w->inverse, t1, t2, t3, rtmp, w->handles, w->num_workers,
+            w->blk, P, ctx);
+
+    GR_TMP_CLEAR3(t1, t2, t3, ctx);
+    if (P->real_ctx != NULL)
+        GR_TMP_CLEAR(rtmp, P->real_ctx);
+}
+
+/* one chunk of the combine pass over k in [lo, hi) */
+typedef struct
+{
+    gr_ptr res;
+    ulong rstep;
+    ulong q;
+    ulong lo;
+    ulong hi;
+    int inverse;
+    const gr_dft_pre_struct * P;
+    gr_ctx_struct * ctx;
+    int status;
+}
+_gr_dft_split_pass_work_t;
+
+static void
+_gr_dft_split_pass_worker(void * arg)
+{
+    _gr_dft_split_pass_work_t * w = arg;
+    gr_ctx_struct * ctx = w->ctx;
+    const gr_dft_pre_struct * P = w->P;
+    int status = GR_SUCCESS;
+    gr_ptr t1, t2, t3, rtmp = NULL;
+
+    GR_TMP_INIT3(t1, t2, t3, ctx);
+    if (P->real_ctx != NULL)
+        GR_TMP_INIT(rtmp, P->real_ctx);
+
+    status |= _gr_dft_split_pass(w->res, w->rstep, w->q, w->lo, w->hi,
+            w->inverse, t1, t2, t3, rtmp, P, ctx);
+
+    GR_TMP_CLEAR3(t1, t2, t3, ctx);
+    if (P->real_ctx != NULL)
+        GR_TMP_CLEAR(rtmp, P->real_ctx);
+
+    w->status = status;
+}
+
+static int
+_split_mt(gr_ptr res, gr_srcptr vec, slong stride, ulong rstep, int depth,
+        int inverse, gr_ptr t1, gr_ptr t2, gr_ptr t3, gr_ptr rtmp,
+        thread_pool_handle * handles, slong num_workers, slong blk,
+        const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    ulong m, q;
+    _gr_dft_split_work_t qt;
+    slong wq, i, nchunks;
+
+    if (num_workers < 1 || depth < 3 ||
+        ((UWORD(1) << depth) >> 2) < (ulong) blk)
+        return _split(res, vec, stride, rstep, depth, inverse,
+                t1, t2, t3, rtmp, P, ctx);
+
+    m = UWORD(1) << depth;
+    q = m >> 2;
+    (void) m;
+
+    /* fork the two quarter-length sub-transforms (about half the
+       recursive work) to a worker with about half of the execution
+       slots (rounding the quarters' share up: with W workers there
+       are W + 1 slots including this thread, and giving the quarters
+       fewer than 2 slots would leave both quarters serial on one
+       thread while the half side idles, which caps the speedup near
+       2 at W = 3); run the half-length transform here */
+    wq = (num_workers + 1) / 2;
+    wq = FLINT_MAX(wq, 1);
+
+    qt.res = res;
+    qt.vec = vec;
+    qt.stride = stride;
+    qt.rstep = rstep;
+    qt.depth = depth;
+    qt.inverse = inverse;
+    qt.handles = handles + 1;
+    qt.num_workers = wq - 1;
+    qt.blk = blk;
+    qt.P = P;
+    qt.ctx = ctx;
+    qt.status = GR_SUCCESS;
+
+    thread_pool_wake(global_thread_pool, handles[0], 0,
+            _gr_dft_split_quarters_worker, &qt);
+
+    status |= _split_mt(res, vec, 2 * stride, 2 * rstep, depth - 1,
+            inverse, t1, t2, t3, rtmp, handles + wq, num_workers - wq,
+            blk, P, ctx);
+
+    thread_pool_wait(global_thread_pool, handles[0]);
+    status |= qt.status;
+
+    /* combine pass, distributed over all workers */
+    nchunks = FLINT_MIN(num_workers + 1, (slong) (q / (ulong) blk));
+    nchunks = FLINT_MAX(nchunks, 1);
+
+    if (nchunks <= 1)
+    {
+        _gr_dft_split_pass_work_t pw;
+        pw.res = res; pw.rstep = rstep; pw.q = q;
+        pw.lo = 0; pw.hi = q;
+        pw.inverse = inverse; pw.P = P; pw.ctx = ctx;
+        pw.status = GR_SUCCESS;
+        _gr_dft_split_pass_worker(&pw);
+        status |= pw.status;
+    }
+    else
+    {
+        _gr_dft_split_pass_work_t * pw =
+            flint_malloc(nchunks * sizeof(_gr_dft_split_pass_work_t));
+
+        for (i = 0; i < nchunks; i++)
+        {
+            pw[i].res = res; pw[i].rstep = rstep; pw[i].q = q;
+            pw[i].lo = (q * (ulong) i) / (ulong) nchunks;
+            pw[i].hi = (q * (ulong) (i + 1)) / (ulong) nchunks;
+            pw[i].inverse = inverse; pw[i].P = P; pw[i].ctx = ctx;
+            pw[i].status = GR_SUCCESS;
+
+            if (i < nchunks - 1)
+                thread_pool_wake(global_thread_pool, handles[i], 0,
+                        _gr_dft_split_pass_worker, &pw[i]);
+        }
+
+        _gr_dft_split_pass_worker(&pw[nchunks - 1]);
+
+        for (i = 0; i < nchunks - 1; i++)
+            thread_pool_wait(global_thread_pool, handles[i]);
+
+        for (i = 0; i < nchunks; i++)
+            status |= pw[i].status;
+
+        flint_free(pw);
+    }
+
+    return status;
+}
+
+/* Top-level split-radix transform with threading when worker threads
+   are available (falling back to the serial transform otherwise). */
+int
+_gr_dft_split_threaded(gr_ptr res, gr_srcptr vec, int inverse,
+        const gr_dft_pre_t P, gr_ctx_t ctx)
+{
+    int status = GR_SUCCESS;
+    slong blk, max_chunks;
+    int threadsafe;
+    thread_pool_handle * handles = P->threads;
+    slong num_workers = P->num_threads;
+    thread_pool_handle * pool_handles = NULL;
+    slong pool_workers = 0;
+    gr_ptr t1, t2, t3, rtmp = NULL;
+
+    threadsafe = (gr_ctx_is_threadsafe(ctx) == T_TRUE) &&
+            (P->real_ctx == NULL ||
+             gr_ctx_is_threadsafe(P->real_ctx) == T_TRUE);
+
+    if (!threadsafe)
+    {
+        handles = NULL;
+        num_workers = 0;
+    }
+
+    blk = (P->serial_block > 0) ? P->serial_block : GR_DFT_SERIAL_BLOCK_DEFAULT;
+    max_chunks = (slong) (P->n / (ulong) blk);
+
+    if (threadsafe && handles == NULL && max_chunks >= 2 &&
+        flint_get_num_threads() > 1)
+    {
+        pool_workers = flint_request_threads(&pool_handles,
+                FLINT_MIN(max_chunks, (slong) (P->n / 2)));
+        handles = pool_handles;
+        num_workers = pool_workers;
+    }
+
+    if (handles == NULL || num_workers < 1 || max_chunks < 2)
+    {
+        if (pool_handles != NULL)
+            flint_give_back_threads(pool_handles, pool_workers);
+        return _gr_dft_split(res, vec, inverse, P, ctx);
+    }
+
+    GR_TMP_INIT3(t1, t2, t3, ctx);
+    if (P->real_ctx != NULL)
+        GR_TMP_INIT(rtmp, P->real_ctx);
+
+    status |= _split_mt(res, vec, 1, 1, P->depth, inverse,
+            t1, t2, t3, rtmp, handles, num_workers, blk, P, ctx);
+
+    GR_TMP_CLEAR3(t1, t2, t3, ctx);
+    if (P->real_ctx != NULL)
+        GR_TMP_CLEAR(rtmp, P->real_ctx);
+
+    if (pool_handles != NULL)
+        flint_give_back_threads(pool_handles, pool_workers);
+
+    return status;
+}

--- a/src/gr_dft/test/main.c
+++ b/src/gr_dft/test/main.c
@@ -1,0 +1,32 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+/* Include functions *********************************************************/
+
+#include "t-dft.c"
+#include "t-dft_inverse.c"
+#include "t-acb_dft.c"
+#include "t-nfixed.c"
+
+/* Array of test functions ***************************************************/
+
+test_struct tests[] =
+{
+    TEST_FUNCTION(gr_dft),
+    TEST_FUNCTION(gr_dft_inverse),
+    TEST_FUNCTION(gr_dft_acb),
+    TEST_FUNCTION(gr_dft_nfixed),
+};
+
+/* main function *************************************************************/
+
+TEST_MAIN(tests)

--- a/src/gr_dft/test/t-acb_dft.c
+++ b/src/gr_dft/test/t-acb_dft.c
@@ -1,0 +1,274 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "ulong_extras.h"
+#include "acb.h"
+#include "acb_dft.h"
+#include "gr.h"
+#include "gr_dft.h"
+
+TEST_FUNCTION_START(gr_dft_acb, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 30 * flint_test_multiplier(); iter++)
+    {
+        slong n = 1 + n_randint(state, 60);
+        slong prec = 53 + n_randint(state, 300);
+        slong refprec = prec + 128;
+        acb_ptr v, w1, w2, ref;
+        slong j;
+        int inverse = n_randint(state, 2);
+        int status;
+
+        if (n_randint(state, 4) == 0)
+            n = UWORD(1) << (1 + n_randint(state, 8));
+
+        v = _acb_vec_init(n);
+        w1 = _acb_vec_init(n);
+        w2 = _acb_vec_init(n);
+        ref = _acb_vec_init(n);
+
+        for (j = 0; j < n; j++)
+        {
+            acb_randtest(v + j, state, prec, 4);
+            if (n_randint(state, 2))
+                acb_get_mid(v + j, v + j);
+        }
+
+        /* reference: acb_dft at elevated precision on the midpoints */
+        for (j = 0; j < n; j++)
+            acb_get_mid(ref + j, v + j);
+        if (inverse)
+            acb_dft_inverse(ref, ref, n, refprec);
+        else
+            acb_dft(ref, ref, n, refprec);
+
+        /* both internal paths must contain the reference and agree */
+        status = _gr_dft_acb(w1, v, n, inverse, 2, prec);
+        if (status != GR_SUCCESS)
+            TEST_FUNCTION_FAIL("nfixed path failed, n = %wd, prec = %wd\n",
+                    n, prec);
+        status = _gr_dft_acb(w2, v, n, inverse, 1, prec);
+        if (status != GR_SUCCESS)
+            TEST_FUNCTION_FAIL("ball path failed, n = %wd, prec = %wd\n",
+                    n, prec);
+
+        for (j = 0; j < n; j++)
+        {
+            if (!acb_overlaps(w1 + j, ref + j))
+                TEST_FUNCTION_FAIL("nfixed path containment, n = %wd, "
+                        "prec = %wd, j = %wd\n", n, prec, j);
+            if (!acb_overlaps(w2 + j, ref + j))
+                TEST_FUNCTION_FAIL("ball path containment, n = %wd, "
+                        "prec = %wd, j = %wd\n", n, prec, j);
+            if (!acb_overlaps(w1 + j, w2 + j))
+                TEST_FUNCTION_FAIL("paths disagree, n = %wd, j = %wd\n",
+                        n, j);
+        }
+
+        /* public interface roundtrip */
+        gr_dft_acb(w1, v, n, prec);
+        gr_dft_acb_inverse(w2, w1, n, prec);
+        for (j = 0; j < n; j++)
+            if (!acb_overlaps(w2 + j, v + j))
+                TEST_FUNCTION_FAIL("roundtrip, n = %wd, j = %wd\n", n, j);
+
+        /* precomputed interface: agrees with the one-shot interface */
+        {
+            gr_dft_acb_pre_t Q;
+
+            if (gr_dft_acb_precomp_init(Q, n, prec) != GR_SUCCESS)
+                TEST_FUNCTION_FAIL("precomp init, n = %wd, prec = %wd\n",
+                        n, prec);
+
+            if (inverse)
+                gr_dft_acb_inverse_precomp(w2, v, Q, prec);
+            else
+                gr_dft_acb_precomp(w2, v, Q, prec);
+
+            for (j = 0; j < n; j++)
+                if (!acb_overlaps(w2 + j, ref + j))
+                    TEST_FUNCTION_FAIL("precomp containment, n = %wd, "
+                            "j = %wd\n", n, j);
+
+            gr_dft_acb_precomp_clear(Q);
+        }
+
+        _acb_vec_clear(v, n);
+        _acb_vec_clear(w1, n);
+        _acb_vec_clear(w2, n);
+        _acb_vec_clear(ref, n);
+    }
+
+
+    /* Edge cases of the drop-in interface: non-finite input, all-zero
+       midpoints with radii, exponents beyond the fixed-point range
+       (forcing the ball fallback), and a length large enough to
+       engage the threaded conversion loops. */
+    {
+        slong n = 64, j;
+        slong prec = 64;
+        acb_ptr v = _acb_vec_init(n), w = _acb_vec_init(n);
+        int status;
+
+        /* non-finite input: the fixed-point path must refuse */
+        for (j = 0; j < n; j++)
+            acb_one(v + j);
+        acb_indeterminate(v + 17);
+        status = _gr_dft_acb(w, v, n, 0, 2, prec);
+        if (status == GR_SUCCESS)
+            TEST_FUNCTION_FAIL("non-finite input accepted\n");
+        gr_dft_acb(w, v, n, prec);   /* public interface falls back */
+
+        /* all-zero midpoints: output midpoints are exactly zero and
+           the radii come from the perturbation bound */
+        for (j = 0; j < n; j++)
+        {
+            acb_zero(v + j);
+            mag_set_ui_2exp_si(arb_radref(acb_realref(v + j)), 1, -30);
+        }
+        status = _gr_dft_acb(w, v, n, 1, 2, prec);
+        if (status != GR_SUCCESS)
+            TEST_FUNCTION_FAIL("all-zero midpoints failed\n");
+        for (j = 0; j < n; j++)
+            if (!arf_is_zero(arb_midref(acb_realref(w + j))) ||
+                !arf_is_zero(arb_midref(acb_imagref(w + j))) ||
+                mag_is_zero(arb_radref(acb_realref(w + j))))
+                TEST_FUNCTION_FAIL("all-zero midpoints output, j = %wd\n", j);
+
+        /* bignum exponent out of the fixed-point range: fixed-point
+           path refuses, ball fallback still works */
+        {
+            fmpz_t big;
+            fmpz_init(big);
+            fmpz_one(big);
+            fmpz_mul_2exp(big, big, 100);
+
+            for (j = 0; j < n; j++)
+                acb_set_si(v + j, 1 + (j % 5));
+            acb_mul_2exp_fmpz(v + 0, v + 0, big);
+            status = _gr_dft_acb(w, v, n, 0, 2, prec);
+            if (status == GR_SUCCESS)
+                TEST_FUNCTION_FAIL("extreme exponent accepted\n");
+            status = _gr_dft_acb(w, v, n, 0, 1, prec);
+            if (status != GR_SUCCESS)
+                TEST_FUNCTION_FAIL("ball path on extreme exponent\n");
+
+            /* every midpoint hugely tiny: the magnitude bound
+               saturates negatively and the fixed-point path refuses */
+            fmpz_neg(big, big);
+            for (j = 0; j < n; j++)
+            {
+                acb_set_si(v + j, 1 + (j % 5));
+                acb_mul_2exp_fmpz(v + j, v + j, big);
+            }
+            status = _gr_dft_acb(w, v, n, 0, 2, prec);
+            if (status == GR_SUCCESS)
+                TEST_FUNCTION_FAIL("all-tiny bignum exponents accepted\n");
+            status = _gr_dft_acb(w, v, n, 0, 1, prec);
+            if (status != GR_SUCCESS)
+                TEST_FUNCTION_FAIL("ball path on tiny exponents\n");
+
+            fmpz_clear(big);
+        }
+
+        /* mixed magnitudes: a coefficient with a bignum-negative
+           exponent underflows to an exact zero inside the fixed-point
+           conversion (with the loss covered by the error bound), and
+           a large in-range slong exponent is handled through the
+           global scaling; both enclosures must overlap the ball
+           result */
+        {
+            acb_ptr w2 = _acb_vec_init(n);
+            fmpz_t big;
+            fmpz_init(big);
+            fmpz_one(big);
+            fmpz_mul_2exp(big, big, 100);
+            fmpz_neg(big, big);
+
+            for (j = 0; j < n; j++)
+                acb_set_si_si(v + j, (slong) j - 7, 3 - (slong) (j % 6));
+            acb_mul_2exp_fmpz(v + 1, v + 1, big);
+            acb_mul_2exp_si(v + 2, v + 2, WORD_MAX / 8);
+            acb_mul_2exp_si(v + 3, v + 3, -(WORD_MAX / 16));
+
+            status = _gr_dft_acb(w, v, n, 0, 2, prec);
+            if (status != GR_SUCCESS)
+                TEST_FUNCTION_FAIL("mixed magnitudes refused\n");
+            status = _gr_dft_acb(w2, v, n, 0, 1, prec);
+            if (status != GR_SUCCESS)
+                TEST_FUNCTION_FAIL("ball path on mixed magnitudes\n");
+            for (j = 0; j < n; j++)
+                if (!acb_overlaps(w + j, w2 + j))
+                    TEST_FUNCTION_FAIL("mixed magnitudes containment, "
+                            "j = %wd\n", j);
+
+            fmpz_clear(big);
+            _acb_vec_clear(w2, n);
+        }
+
+        _acb_vec_clear(v, n);
+        _acb_vec_clear(w, n);
+    }
+
+    /* very high precision exceeds the fixed-point limb cap, so the
+       precomputed interface falls back to ball arithmetic */
+    {
+        slong n = 8, j;
+        slong prec = 140000;
+        acb_ptr v = _acb_vec_init(n), w = _acb_vec_init(n);
+        gr_dft_acb_pre_t Q;
+
+        for (j = 0; j < n; j++)
+            acb_set_si(v + j, j - 3);
+
+        if (gr_dft_acb_precomp_init(Q, n, prec) != GR_SUCCESS)
+            TEST_FUNCTION_FAIL("ball-mode precomp init\n");
+        gr_dft_acb_precomp(w, v, Q, prec);
+        gr_dft_acb_inverse_precomp(w, w, Q, prec);
+        for (j = 0; j < n; j++)
+            if (!acb_contains(w + j, v + j))
+                TEST_FUNCTION_FAIL("ball-mode roundtrip, j = %wd\n", j);
+        gr_dft_acb_precomp_clear(Q);
+
+        _acb_vec_clear(v, n);
+        _acb_vec_clear(w, n);
+    }
+
+    {
+        slong n = 20000, j;
+        slong prec = 53;
+        acb_ptr v = _acb_vec_init(n), w1 = _acb_vec_init(n),
+                w2 = _acb_vec_init(n);
+
+        for (j = 0; j < n; j++)
+            acb_set_si_si(v + j, (slong) (j % 97) - 48,
+                    (slong) (j % 53) - 26);
+
+        flint_set_num_threads(3);
+        gr_dft_acb(w1, v, n, prec);
+        gr_dft_acb_inverse(w2, w1, n, prec);
+        flint_set_num_threads(1);
+
+        for (j = 0; j < n; j++)
+            if (!acb_contains(w2 + j, v + j))
+                TEST_FUNCTION_FAIL("threaded roundtrip, j = %wd\n", j);
+
+        _acb_vec_clear(v, n);
+        _acb_vec_clear(w1, n);
+        _acb_vec_clear(w2, n);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/gr_dft/test/t-dft.c
+++ b/src/gr_dft/test/t-dft.c
@@ -1,0 +1,409 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include "test_helpers.h"
+#include "thread_pool.h"
+#include "thread_support.h"
+#include "ulong_extras.h"
+#include "gr.h"
+#include "gr_vec.h"
+#include "gr_dft.h"
+
+/* which: 0 = Z/pZ with an NTT prime, 1 = CC (acb), 2 = CC (ca, exact) */
+
+TEST_FUNCTION_START(gr_dft, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 200 * flint_test_multiplier(); iter++)
+    {
+        gr_ctx_t ctx, rctx;
+        int which = n_randint(state, 3);
+        int have_real = 0, karatsuba = 0;
+        int status = GR_SUCCESS;
+        int alg, flags;
+        int use_threads, attach_threads;
+        thread_pool_handle * handles = NULL;
+        slong num_handles = 0;
+        ulong n, i, q = 0;
+        slong sz;
+        gr_ptr x, y1, y2, w;
+        ulong * perm;
+        gr_dft_pre_t P, Pref;
+
+        if (which == 0)
+        {
+            /* arbitrary n; pick a prime q = 1 mod n so that Z/qZ
+               contains n-th roots of unity */
+            ulong k;
+            n = 1 + n_randint(state, 300);
+            for (k = 1; ; k++)
+            {
+                q = k * n + 1;
+                if (q >= 3 && n_is_prime(q))
+                    break;
+            }
+            gr_ctx_init_nmod(ctx, q);
+        }
+        else if (which == 1)
+        {
+            slong prec = 64 + n_randint(state, 128);
+            gr_ctx_init_complex_acb(ctx, prec);
+            gr_ctx_init_real_arb(rctx, prec);
+            have_real = 1;
+
+            switch (n_randint(state, 4))
+            {
+                case 0:
+                    /* prime lengths exercising Bluestein */
+                    {
+                        static const ulong bl_primes[] =
+                            { 23, 29, 31, 37, 41, 101, 127 };
+                        n = bl_primes[n_randint(state, 7)];
+                    }
+                    break;
+                case 1:
+                    n = UWORD(1) << n_randint(state, 8);
+                    break;
+                default:
+                    n = 1 + n_randint(state, 200);
+                    break;
+            }
+        }
+        else
+        {
+            gr_ctx_init_complex_ca(ctx);
+            n = 1 + n_randint(state, 6);
+        }
+
+        sz = ctx->sizeof_elem;
+
+        /* pick an algorithm valid for this n and ring; Bluestein is
+           restricted to rings supporting gr_dft_default_root for the
+           power-of-two convolution length */
+        {
+            int algs[8];
+            int nalgs = 0, pow2 = ((n & (n - 1)) == 0), ncop;
+            ulong m, pp;
+
+            for (ncop = 0, m = n, pp = 2; m > 1; pp++)
+            {
+                if (m % pp == 0)
+                {
+                    ncop++;
+                    while (m % pp == 0)
+                        m /= pp;
+                }
+            }
+
+            algs[nalgs++] = GR_DFT_ALG_AUTO;
+            algs[nalgs++] = GR_DFT_ALG_NAIVE;
+            if (pow2)
+            {
+                algs[nalgs++] = GR_DFT_ALG_CT;
+                algs[nalgs++] = GR_DFT_ALG_BAILEY;
+                algs[nalgs++] = GR_DFT_ALG_SPLIT;
+            }
+            if (n >= 2)
+                algs[nalgs++] = GR_DFT_ALG_MIXED;
+            if (ncop >= 2)
+                algs[nalgs++] = GR_DFT_ALG_PFA;
+            if (n >= 3 && n % 2 == 1 && which == 1)
+                algs[nalgs++] = GR_DFT_ALG_BLUESTEIN;
+
+            alg = algs[n_randint(state, nalgs)];
+        }
+        flags = n_randint(state, 2) ? GR_DFT_SCRAMBLED : 0;
+        karatsuba = have_real && n_randint(state, 2);
+
+        /* thread settings are applied for all rings; the library only
+           actually uses threads when gr_ctx_is_threadsafe certifies the
+           ring (so e.g. ca plans run serially regardless) */
+        use_threads = n_randint(state, 2);
+        attach_threads = use_threads && n_randint(state, 2);
+        flint_set_num_threads(use_threads ? 2 + n_randint(state, 2) : 1);
+
+        w = gr_heap_init(ctx);
+
+        if (which == 0)
+        {
+            /* w = g^((q-1)/n) mod q for a primitive root g mod q */
+            status |= gr_set_ui(w, n_primitive_root_prime(q), ctx);
+            status |= gr_pow_ui(w, w, (q - 1) / n, ctx);
+        }
+        else
+        {
+            status |= gr_dft_default_root(w, n, ctx);
+        }
+
+        status |= gr_dft_precomp_init_root(Pref, w, n, GR_DFT_ALG_NAIVE, 0, ctx);
+
+        if (karatsuba)
+            status |= gr_dft_precomp_init_karatsuba(P, n, alg, flags, rctx, ctx);
+        else
+            status |= gr_dft_precomp_init_root(P, w, n, alg, flags, ctx);
+
+        if (status == GR_SUCCESS && use_threads)
+        {
+            /* force threaded code paths even at small n */
+            gr_dft_precomp_set_serial_block(P, 1 + (slong) n_randint(state, 16));
+
+            if (attach_threads)
+            {
+                num_handles = flint_request_threads(&handles, 3);
+                gr_dft_precomp_set_threads(P, handles, num_handles);
+            }
+        }
+
+        x = gr_heap_init_vec(n, ctx);
+        y1 = gr_heap_init_vec(n, ctx);
+        y2 = gr_heap_init_vec(n, ctx);
+        perm = flint_malloc(n * sizeof(ulong));
+
+        status |= _gr_vec_randtest(x, state, n, ctx);
+
+        status |= gr_dft_precomp(y1, x, Pref, ctx);
+
+        if (n_randint(state, 2))
+        {
+            status |= gr_dft_precomp(y2, x, P, ctx);
+        }
+        else
+        {
+            /* aliased input and output */
+            status |= _gr_vec_set(y2, x, n, ctx);
+            status |= gr_dft_precomp(y2, y2, P, ctx);
+        }
+
+        gr_dft_precomp_output_perm(perm, P);
+
+        if (status == GR_SUCCESS)
+        {
+            for (i = 0; i < n; i++)
+            {
+                truth_t eq = gr_equal(GR_ENTRY(y2, i, sz),
+                        GR_ENTRY(y1, perm[i], sz), ctx);
+
+                if (eq == T_FALSE || (which != 1 && eq != T_TRUE))
+                {
+                    flint_printf("FAIL\n\n");
+                    gr_ctx_println(ctx);
+                    flint_printf("n = %wu, alg = %d, flags = %d, karatsuba = %d, i = %wu\n",
+                            n, alg, flags, karatsuba, i);
+                    flint_printf("x = "); _gr_vec_print(x, n, ctx); flint_printf("\n");
+                    flint_printf("y1 = "); _gr_vec_print(y1, n, ctx); flint_printf("\n");
+                    flint_printf("y2 = "); _gr_vec_print(y2, n, ctx); flint_printf("\n");
+                    flint_abort();
+                }
+            }
+        }
+
+        gr_heap_clear_vec(x, n, ctx);
+        gr_heap_clear_vec(y1, n, ctx);
+        gr_heap_clear_vec(y2, n, ctx);
+        gr_heap_clear(w, ctx);
+        flint_free(perm);
+        gr_dft_precomp_clear(P);
+        gr_dft_precomp_clear(Pref);
+        if (handles != NULL)
+            flint_give_back_threads(handles, num_handles);
+        flint_set_num_threads(1);
+        gr_ctx_clear(ctx);
+        if (have_real)
+            gr_ctx_clear(rctx);
+    }
+
+
+    /* Deterministic algorithm sweep: every explicit algorithm at fixed
+       sizes, in natural and scrambled order where supported, serially
+       and with the threaded code paths forced, so that coverage of
+       each algorithm does not depend on the random draws above.  Also
+       exercises the plain gr_dft_precomp_init constructor, the
+       one-shot gr_dft / gr_dft_inverse interface, and the plan
+       printer. */
+    {
+        /* ring 0: acb; ring 1: acb at 2048 bits with the complex
+           Karatsuba tables (which only arise above the precision
+           cutoff and keep the serial twiddle layout with class
+           dispatch); ring 2: nmod, length 2 (the only depth-1 case,
+           covering the plain batch butterflies used when no class or
+           packed tables exist) */
+        static const struct { int alg; ulong n; int flags; int threads;
+                int ring; }
+        sweep[] = {
+            { GR_DFT_ALG_CT,        16, 0,                 1, 0 },
+            { GR_DFT_ALG_CT,        16, GR_DFT_SCRAMBLED,  1, 0 },
+            { GR_DFT_ALG_CT,        64, 0,                 3, 0 },
+            { GR_DFT_ALG_CT,        64, GR_DFT_SCRAMBLED,  3, 0 },
+            { GR_DFT_ALG_CT,        16, 0,                 1, 1 },
+            { GR_DFT_ALG_CT,        16, GR_DFT_SCRAMBLED,  1, 1 },
+            { GR_DFT_ALG_CT,         2, 0,                 1, 2 },
+            { GR_DFT_ALG_CT,         2, GR_DFT_SCRAMBLED,  1, 2 },
+            { GR_DFT_ALG_CT,     32768, 0,                 1, 2 },
+            { GR_DFT_ALG_BAILEY,    16, 0,                 1, 0 },
+            { GR_DFT_ALG_BAILEY,    16, GR_DFT_SCRAMBLED,  1, 0 },
+            { GR_DFT_ALG_BAILEY,    64, 0,                 3, 0 },
+            { GR_DFT_ALG_BAILEY,    64, GR_DFT_SCRAMBLED,  3, 0 },
+            { GR_DFT_ALG_SPLIT,     16, 0,                 1, 0 },
+            { GR_DFT_ALG_SPLIT,     64, 0,                 4, 0 },
+            { GR_DFT_ALG_SPLIT,     16, 0,                 1, 1 },
+            { GR_DFT_ALG_NAIVE,      7, GR_DFT_SCRAMBLED,  1, 0 },
+            { GR_DFT_ALG_MIXED,     48, 0,                 1, 0 },
+            { GR_DFT_ALG_PFA,       15, 0,                 1, 0 },
+            { GR_DFT_ALG_BLUESTEIN, 23, 0,                 1, 0 },
+            { GR_DFT_ALG_BLUESTEIN, 23, 0,                 1, 1 },
+        };
+        slong si;
+        gr_ctx_t actx, kctx, krctx, nctx;
+        FILE * devnull = tmpfile();
+        ulong q = 998244353;
+
+        gr_ctx_init_complex_acb(actx, 100);
+        gr_ctx_init_complex_acb(kctx, 2048);
+        gr_ctx_init_real_arb(krctx, 2048);
+        gr_ctx_init_nmod(nctx, q);
+
+        for (si = 0; si < (slong) (sizeof(sweep) / sizeof(sweep[0])); si++)
+        {
+            ulong n = sweep[si].n;
+            gr_ctx_struct * ctx = (sweep[si].ring == 2) ? nctx :
+                    (sweep[si].ring == 1) ? kctx : actx;
+            slong sz = ctx->sizeof_elem;
+            gr_dft_pre_t P, Pref;
+            gr_ptr x, y1, y2;
+            ulong * perm;
+            ulong i;
+            int status = GR_SUCCESS;
+            /* a naive reference costs n^2 multiplications, so large
+               lengths (which exercise the blocked recursion rather
+               than the arithmetic) are verified by an inverse
+               roundtrip instead */
+            int roundtrip = (n > 4096);
+
+            flint_set_num_threads(sweep[si].threads);
+
+            if (sweep[si].ring == 2)
+            {
+                /* explicit primitive root of unity mod q */
+                gr_ptr w = gr_heap_init(ctx);
+                status |= gr_set_ui(w, n_primitive_root_prime(q), ctx);
+                status |= gr_pow_ui(w, w, (q - 1) / n, ctx);
+                if (!roundtrip)
+                    status |= gr_dft_precomp_init_root(Pref, w, n,
+                            GR_DFT_ALG_NAIVE, 0, ctx);
+                status |= gr_dft_precomp_init_root(P, w, n,
+                        sweep[si].alg, sweep[si].flags, ctx);
+                gr_heap_clear(w, ctx);
+            }
+            else if (sweep[si].ring == 1)
+            {
+                status |= gr_dft_precomp_init(Pref, n, GR_DFT_ALG_NAIVE,
+                        0, ctx);
+                status |= gr_dft_precomp_init_karatsuba(P, n, sweep[si].alg,
+                        sweep[si].flags, krctx, ctx);
+            }
+            else
+            {
+                status |= gr_dft_precomp_init(Pref, n, GR_DFT_ALG_NAIVE,
+                        0, ctx);
+                status |= gr_dft_precomp_init(P, n, sweep[si].alg,
+                        sweep[si].flags, ctx);
+            }
+            if (sweep[si].threads > 1)
+                gr_dft_precomp_set_serial_block(P, 1);
+
+            if (devnull != NULL)
+                gr_dft_precomp_fprint(devnull, P);
+
+            x = gr_heap_init_vec(n, ctx);
+            y1 = gr_heap_init_vec(n, ctx);
+            y2 = gr_heap_init_vec(n, ctx);
+            perm = flint_malloc(n * sizeof(ulong));
+
+            status |= _gr_vec_randtest(x, state, n, ctx);
+            status |= gr_dft_precomp(y2, x, P, ctx);
+            if (roundtrip)
+                status |= gr_dft_inverse_precomp(y1, y2, P, ctx);
+            else
+                status |= gr_dft_precomp(y1, x, Pref, ctx);
+            gr_dft_precomp_output_perm(perm, P);
+
+            if (status != GR_SUCCESS)
+                TEST_FUNCTION_FAIL("sweep status, alg = %d, n = %wu, "
+                        "flags = %d\n", sweep[si].alg, n, sweep[si].flags);
+
+            for (i = 0; i < n; i++)
+            {
+                truth_t eq = roundtrip
+                    ? gr_equal(GR_ENTRY(y1, i, sz), GR_ENTRY(x, i, sz), ctx)
+                    : gr_equal(GR_ENTRY(y2, i, sz),
+                            GR_ENTRY(y1, perm[i], sz), ctx);
+                if (eq == T_FALSE || (sweep[si].ring == 2 && eq != T_TRUE))
+                    TEST_FUNCTION_FAIL("sweep mismatch, alg = %d, n = %wu, "
+                            "flags = %d, threads = %d, i = %wu\n",
+                            sweep[si].alg, n, sweep[si].flags,
+                            sweep[si].threads, i);
+            }
+
+            /* one-shot interface against the same reference */
+            if (sweep[si].flags == 0 && sweep[si].threads == 1 &&
+                sweep[si].ring == 0)
+            {
+                status = gr_dft(y2, x, n, ctx);
+                for (i = 0; i < n; i++)
+                    if (status != GR_SUCCESS ||
+                        gr_equal(GR_ENTRY(y2, i, sz),
+                            GR_ENTRY(y1, i, sz), ctx) == T_FALSE)
+                        TEST_FUNCTION_FAIL("one-shot dft, n = %wu\n", n);
+
+                status = gr_dft_inverse(y2, y1, n, ctx);
+                for (i = 0; i < n; i++)
+                    if (status != GR_SUCCESS ||
+                        gr_equal(GR_ENTRY(y2, i, sz),
+                            GR_ENTRY(x, i, sz), ctx) == T_FALSE)
+                        TEST_FUNCTION_FAIL("one-shot roundtrip, n = %wu\n", n);
+            }
+
+            gr_heap_clear_vec(x, n, ctx);
+            gr_heap_clear_vec(y1, n, ctx);
+            gr_heap_clear_vec(y2, n, ctx);
+            flint_free(perm);
+            gr_dft_precomp_clear(P);
+            if (!roundtrip)
+                gr_dft_precomp_clear(Pref);
+            flint_set_num_threads(1);
+        }
+
+        /* invalid algorithm/length combinations are rejected */
+        {
+            gr_dft_pre_t P;
+
+            if (gr_dft_precomp_init(P, 3, GR_DFT_ALG_CT, 0, actx)
+                    != GR_DOMAIN ||
+                gr_dft_precomp_init(P, 8, GR_DFT_ALG_PFA, 0, actx)
+                    != GR_DOMAIN ||
+                gr_dft_precomp_init(P, 8, GR_DFT_ALG_BLUESTEIN, 0, actx)
+                    != GR_DOMAIN)
+                TEST_FUNCTION_FAIL("invalid plan accepted\n");
+        }
+
+        if (devnull != NULL)
+            fclose(devnull);
+        gr_ctx_clear(actx);
+        gr_ctx_clear(kctx);
+        gr_ctx_clear(krctx);
+        gr_ctx_clear(nctx);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/gr_dft/test/t-dft_inverse.c
+++ b/src/gr_dft/test/t-dft_inverse.c
@@ -1,0 +1,316 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "thread_pool.h"
+#include "thread_support.h"
+#include "ulong_extras.h"
+#include "gr.h"
+#include "gr_vec.h"
+#include "gr_dft.h"
+
+TEST_FUNCTION_START(gr_dft_inverse, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 200 * flint_test_multiplier(); iter++)
+    {
+        gr_ctx_t ctx, rctx;
+        int which = n_randint(state, 3);
+        int have_real = 0, karatsuba = 0;
+        int status = GR_SUCCESS;
+        int alg, flags;
+        int use_threads, attach_threads;
+        thread_pool_handle * handles = NULL;
+        slong num_handles = 0;
+        ulong n, i, q = 0;
+        slong sz;
+        gr_ptr x, y, z, w;
+        gr_dft_pre_t P;
+
+        if (which == 0)
+        {
+            /* arbitrary n; pick a prime q = 1 mod n so that Z/qZ
+               contains n-th roots of unity */
+            ulong k;
+            n = 1 + n_randint(state, 300);
+            for (k = 1; ; k++)
+            {
+                q = k * n + 1;
+                if (q >= 3 && n_is_prime(q))
+                    break;
+            }
+            gr_ctx_init_nmod(ctx, q);
+        }
+        else if (which == 1)
+        {
+            slong prec = 64 + n_randint(state, 128);
+            gr_ctx_init_complex_acb(ctx, prec);
+            gr_ctx_init_real_arb(rctx, prec);
+            have_real = 1;
+
+            switch (n_randint(state, 4))
+            {
+                case 0:
+                    /* prime lengths exercising Bluestein */
+                    {
+                        static const ulong bl_primes[] =
+                            { 23, 29, 31, 37, 41, 101, 127 };
+                        n = bl_primes[n_randint(state, 7)];
+                    }
+                    break;
+                case 1:
+                    n = UWORD(1) << n_randint(state, 8);
+                    break;
+                default:
+                    n = 1 + n_randint(state, 200);
+                    break;
+            }
+        }
+        else
+        {
+            gr_ctx_init_complex_ca(ctx);
+            n = 1 + n_randint(state, 6);
+        }
+
+        sz = ctx->sizeof_elem;
+
+        /* pick an algorithm valid for this n and ring; Bluestein is
+           restricted to rings supporting gr_dft_default_root for the
+           power-of-two convolution length */
+        {
+            int algs[8];
+            int nalgs = 0, pow2 = ((n & (n - 1)) == 0), ncop;
+            ulong m, pp;
+
+            for (ncop = 0, m = n, pp = 2; m > 1; pp++)
+            {
+                if (m % pp == 0)
+                {
+                    ncop++;
+                    while (m % pp == 0)
+                        m /= pp;
+                }
+            }
+
+            algs[nalgs++] = GR_DFT_ALG_AUTO;
+            algs[nalgs++] = GR_DFT_ALG_NAIVE;
+            if (pow2)
+            {
+                algs[nalgs++] = GR_DFT_ALG_CT;
+                algs[nalgs++] = GR_DFT_ALG_BAILEY;
+                algs[nalgs++] = GR_DFT_ALG_SPLIT;
+            }
+            if (n >= 2)
+                algs[nalgs++] = GR_DFT_ALG_MIXED;
+            if (ncop >= 2)
+                algs[nalgs++] = GR_DFT_ALG_PFA;
+            if (n >= 3 && n % 2 == 1 && which == 1)
+                algs[nalgs++] = GR_DFT_ALG_BLUESTEIN;
+
+            alg = algs[n_randint(state, nalgs)];
+        }
+        flags = n_randint(state, 2) ? GR_DFT_SCRAMBLED : 0;
+        karatsuba = have_real && n_randint(state, 2);
+
+        /* thread settings are applied for all rings; the library only
+           actually uses threads when gr_ctx_is_threadsafe certifies the
+           ring (so e.g. ca plans run serially regardless) */
+        use_threads = n_randint(state, 2);
+        attach_threads = use_threads && n_randint(state, 2);
+        flint_set_num_threads(use_threads ? 2 + n_randint(state, 2) : 1);
+
+        w = gr_heap_init(ctx);
+
+        if (which == 0)
+        {
+            /* w = g^((q-1)/n) mod q for a primitive root g mod q */
+            status |= gr_set_ui(w, n_primitive_root_prime(q), ctx);
+            status |= gr_pow_ui(w, w, (q - 1) / n, ctx);
+        }
+        else
+        {
+            status |= gr_dft_default_root(w, n, ctx);
+        }
+
+        if (karatsuba)
+            status |= gr_dft_precomp_init_karatsuba(P, n, alg, flags, rctx, ctx);
+        else
+            status |= gr_dft_precomp_init_root(P, w, n, alg, flags, ctx);
+
+        if (status == GR_SUCCESS && use_threads)
+        {
+            /* force threaded code paths even at small n */
+            gr_dft_precomp_set_serial_block(P, 1 + (slong) n_randint(state, 16));
+
+            if (attach_threads)
+            {
+                num_handles = flint_request_threads(&handles, 3);
+                gr_dft_precomp_set_threads(P, handles, num_handles);
+            }
+        }
+
+        x = gr_heap_init_vec(n, ctx);
+        y = gr_heap_init_vec(n, ctx);
+        z = gr_heap_init_vec(n, ctx);
+
+        status |= _gr_vec_randtest(x, state, n, ctx);
+
+        status |= gr_dft_precomp(y, x, P, ctx);
+
+        if (n_randint(state, 2))
+        {
+            status |= gr_dft_inverse_precomp(z, y, P, ctx);
+        }
+        else
+        {
+            status |= _gr_vec_set(z, y, n, ctx);
+            status |= gr_dft_inverse_precomp(z, z, P, ctx);
+        }
+
+        if (status == GR_SUCCESS)
+        {
+            for (i = 0; i < n; i++)
+            {
+                truth_t eq = gr_equal(GR_ENTRY(z, i, sz),
+                        GR_ENTRY(x, i, sz), ctx);
+
+                if (eq == T_FALSE || (which != 1 && eq != T_TRUE))
+                {
+                    flint_printf("FAIL\n\n");
+                    gr_ctx_println(ctx);
+                    flint_printf("n = %wu, alg = %d, flags = %d, karatsuba = %d, i = %wu\n",
+                            n, alg, flags, karatsuba, i);
+                    flint_printf("x = "); _gr_vec_print(x, n, ctx); flint_printf("\n");
+                    flint_printf("y = "); _gr_vec_print(y, n, ctx); flint_printf("\n");
+                    flint_printf("z = "); _gr_vec_print(z, n, ctx); flint_printf("\n");
+                    flint_abort();
+                }
+            }
+        }
+
+        gr_heap_clear_vec(x, n, ctx);
+        gr_heap_clear_vec(y, n, ctx);
+        gr_heap_clear_vec(z, n, ctx);
+        gr_heap_clear(w, ctx);
+        gr_dft_precomp_clear(P);
+        if (handles != NULL)
+            flint_give_back_threads(handles, num_handles);
+        flint_set_num_threads(1);
+        gr_ctx_clear(ctx);
+        if (have_real)
+            gr_ctx_clear(rctx);
+    }
+
+
+    /* Deterministic inverse sweep over the explicit power-of-two
+       algorithms (including Bailey, which the random draws above can
+       miss), serially and with the threaded paths forced: forward
+       then inverse must reproduce the input. */
+    {
+        /* ring 0: acb; ring 1: acb at 2048 bits with the complex
+           Karatsuba tables (serial layout, DIT butterflies through the
+           class dispatch); ring 2: nmod (depth-1 and blocked-recursion
+           inverse paths) */
+        static const struct { int alg; ulong n; int threads; int ring; }
+        sweep[] = {
+            { GR_DFT_ALG_CT,        16, 1, 0 },
+            { GR_DFT_ALG_CT,        64, 3, 0 },
+            { GR_DFT_ALG_CT,        16, 1, 1 },
+            { GR_DFT_ALG_CT,         2, 1, 2 },
+            { GR_DFT_ALG_CT,     32768, 1, 2 },
+            { GR_DFT_ALG_BAILEY,    16, 1, 0 },
+            { GR_DFT_ALG_BAILEY,    64, 3, 0 },
+            { GR_DFT_ALG_SPLIT,     16, 1, 0 },
+            { GR_DFT_ALG_SPLIT,     64, 4, 0 },
+            { GR_DFT_ALG_SPLIT,     16, 1, 1 },
+        };
+        slong si;
+        gr_ctx_t actx, kctx, krctx, nctx;
+        ulong q = 998244353;
+
+        gr_ctx_init_complex_acb(actx, 100);
+        gr_ctx_init_complex_acb(kctx, 2048);
+        gr_ctx_init_real_arb(krctx, 2048);
+        gr_ctx_init_nmod(nctx, q);
+
+        for (si = 0; si < (slong) (sizeof(sweep) / sizeof(sweep[0])); si++)
+        {
+            ulong n = sweep[si].n;
+            gr_ctx_struct * ctx = (sweep[si].ring == 2) ? nctx :
+                    (sweep[si].ring == 1) ? kctx : actx;
+            slong sz = ctx->sizeof_elem;
+            gr_dft_pre_t P;
+            gr_ptr x, y, z;
+            ulong i;
+            int status = GR_SUCCESS;
+
+            flint_set_num_threads(sweep[si].threads);
+
+            if (sweep[si].ring == 2)
+            {
+                gr_ptr w = gr_heap_init(ctx);
+                status |= gr_set_ui(w, n_primitive_root_prime(q), ctx);
+                status |= gr_pow_ui(w, w, (q - 1) / n, ctx);
+                status |= gr_dft_precomp_init_root(P, w, n,
+                        sweep[si].alg, 0, ctx);
+                gr_heap_clear(w, ctx);
+            }
+            else if (sweep[si].ring == 1)
+            {
+                status |= gr_dft_precomp_init_karatsuba(P, n, sweep[si].alg,
+                        0, krctx, ctx);
+            }
+            else
+            {
+                status |= gr_dft_precomp_init(P, n, sweep[si].alg, 0, ctx);
+            }
+            if (sweep[si].threads > 1)
+                gr_dft_precomp_set_serial_block(P, 1);
+
+            x = gr_heap_init_vec(n, ctx);
+            y = gr_heap_init_vec(n, ctx);
+            z = gr_heap_init_vec(n, ctx);
+
+            status |= _gr_vec_randtest(x, state, n, ctx);
+            status |= gr_dft_precomp(y, x, P, ctx);
+            status |= gr_dft_inverse_precomp(z, y, P, ctx);
+
+            if (status != GR_SUCCESS)
+                TEST_FUNCTION_FAIL("inverse sweep status, alg = %d, "
+                        "n = %wu\n", sweep[si].alg, n);
+
+            for (i = 0; i < n; i++)
+            {
+                truth_t eq = gr_equal(GR_ENTRY(z, i, sz),
+                        GR_ENTRY(x, i, sz), ctx);
+                if (eq == T_FALSE || (sweep[si].ring == 2 && eq != T_TRUE))
+                    TEST_FUNCTION_FAIL("inverse sweep roundtrip, alg = %d, "
+                            "n = %wu, threads = %d, i = %wu\n",
+                            sweep[si].alg, n, sweep[si].threads, i);
+            }
+
+            gr_heap_clear_vec(x, n, ctx);
+            gr_heap_clear_vec(y, n, ctx);
+            gr_heap_clear_vec(z, n, ctx);
+            gr_dft_precomp_clear(P);
+            flint_set_num_threads(1);
+        }
+
+        gr_ctx_clear(actx);
+        gr_ctx_clear(kctx);
+        gr_ctx_clear(krctx);
+        gr_ctx_clear(nctx);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/gr_dft/test/t-nfixed.c
+++ b/src/gr_dft/test/t-nfixed.c
@@ -1,0 +1,480 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "ulong_extras.h"
+#include "arf.h"
+#include "arb.h"
+#include "acb.h"
+#include "gr.h"
+#include "gr_vec.h"
+#include "gr_dft.h"
+
+/* random arf in (-1, 1) */
+static void
+nfixed_randarf(arf_t x, flint_rand_t state, slong nlimbs)
+{
+    arf_randtest(x, state, nlimbs * FLINT_BITS, 0);
+    while (arf_cmpabs_2exp_si(x, 0) >= 0)
+        arf_mul_2exp_si(x, x, -1);
+}
+
+TEST_FUNCTION_START(gr_dft_nfixed, state)
+{
+    slong iter;
+
+    /* arithmetic against arf reference */
+    for (iter = 0; iter < 300 * flint_test_multiplier(); iter++)
+    {
+        slong nlimbs = 1 + n_randint(state, 24);
+        gr_ctx_t ctx;
+        gr_ptr a, b, c;
+        arf_t fa, fb, fc, ref, ulp;
+        int status = GR_SUCCESS;
+
+        if (gr_dft_ctx_init_nfixed(ctx, nlimbs) != GR_SUCCESS)
+            flint_abort();
+
+        a = gr_heap_init(ctx);
+        b = gr_heap_init(ctx);
+        c = gr_heap_init(ctx);
+        arf_init(fa); arf_init(fb); arf_init(fc);
+        arf_init(ref); arf_init(ulp);
+
+        nfixed_randarf(fa, state, nlimbs);
+        nfixed_randarf(fb, state, nlimbs);
+        status |= gr_dft_nfixed_set_arf(a, fa, ctx);
+        status |= gr_dft_nfixed_set_arf(b, fb, ctx);
+        gr_dft_nfixed_get_arf(fa, a, ctx);
+        gr_dft_nfixed_get_arf(fb, b, ctx);
+
+        /* multiplication: at most 2 ulp error */
+        status |= gr_mul(c, a, b, ctx);
+        gr_dft_nfixed_get_arf(fc, c, ctx);
+        arf_mul(ref, fa, fb, 2 * nlimbs * FLINT_BITS + 32, ARF_RND_NEAR);
+        arf_sub(ref, ref, fc, 2 * nlimbs * FLINT_BITS + 32, ARF_RND_NEAR);
+        arf_abs(ref, ref);
+        arf_one(ulp);
+        arf_mul_2exp_si(ulp, ulp, -nlimbs * FLINT_BITS + 1);
+        if (arf_cmp(ref, ulp) > 0)
+            TEST_FUNCTION_FAIL("mul error exceeds 2 ulp, nlimbs = %wd\n", nlimbs);
+
+        /* complex multiplication: at most cmul_err ulp per component,
+           covering the sized, schoolbook and Karatsuba paths */
+        {
+            gr_ctx_t cctx;
+            gr_ptr ca, cb, cc;
+            arf_t gr, gi, rr, ri;
+            slong prec = 2 * nlimbs * FLINT_BITS + 32;
+
+            if (gr_dft_ctx_init_nfixed_complex(cctx, nlimbs) != GR_SUCCESS)
+                flint_abort();
+
+            ca = gr_heap_init(cctx);
+            cb = gr_heap_init(cctx);
+            cc = gr_heap_init(cctx);
+            arf_init(gr); arf_init(gi); arf_init(rr); arf_init(ri);
+
+            /* local copies of fa, fb halved as the real parts (a, b,
+               fa, fb are reused by the checks below and must not be
+               clobbered); fresh imaginary parts, all halved so no
+               component of the product can reach 1 */
+            arf_t ha, hb;
+            arf_init(ha);
+            arf_init(hb);
+            arf_mul_2exp_si(ha, fa, -1);
+            arf_mul_2exp_si(hb, fb, -1);
+            nfixed_randarf(gr, state, nlimbs);
+            arf_mul_2exp_si(gr, gr, -1);
+            nfixed_randarf(gi, state, nlimbs);
+            arf_mul_2exp_si(gi, gi, -1);
+
+            status |= gr_dft_nfixed_set_arf(ca, ha, ctx);
+            status |= gr_dft_nfixed_set_arf(
+                    (gr_ptr)((char *) ca + ctx->sizeof_elem), gr, ctx);
+            status |= gr_dft_nfixed_set_arf(cb, hb, ctx);
+            status |= gr_dft_nfixed_set_arf(
+                    (gr_ptr)((char *) cb + ctx->sizeof_elem), gi, ctx);
+            gr_dft_nfixed_get_arf(ha, ca, ctx);
+            gr_dft_nfixed_get_arf(gr,
+                    (gr_srcptr)((const char *) ca + ctx->sizeof_elem), ctx);
+            gr_dft_nfixed_get_arf(hb, cb, ctx);
+            gr_dft_nfixed_get_arf(gi,
+                    (gr_srcptr)((const char *) cb + ctx->sizeof_elem), ctx);
+
+            status |= gr_mul(cc, ca, cb, cctx);
+
+            arf_mul(rr, ha, hb, prec, ARF_RND_NEAR);
+            arf_mul(ref, gr, gi, prec, ARF_RND_NEAR);
+            arf_sub(rr, rr, ref, prec, ARF_RND_NEAR);
+            arf_mul(ri, ha, gi, prec, ARF_RND_NEAR);
+            arf_mul(ref, gr, hb, prec, ARF_RND_NEAR);
+            arf_add(ri, ri, ref, prec, ARF_RND_NEAR);
+
+            arf_set_d(ulp, _gr_dft_nfixed_cmul_err_ulps(cctx));
+            arf_mul_2exp_si(ulp, ulp, -nlimbs * FLINT_BITS);
+
+            gr_dft_nfixed_get_arf(fc, cc, ctx);
+            arf_sub(ref, fc, rr, prec, ARF_RND_UP);
+            arf_abs(ref, ref);
+            if (arf_cmp(ref, ulp) > 0)
+                TEST_FUNCTION_FAIL("cmul re error, nlimbs = %wd\n", nlimbs);
+            gr_dft_nfixed_get_arf(fc,
+                    (gr_srcptr)((const char *) cc + ctx->sizeof_elem), ctx);
+            arf_sub(ref, fc, ri, prec, ARF_RND_UP);
+            arf_abs(ref, ref);
+            if (arf_cmp(ref, ulp) > 0)
+                TEST_FUNCTION_FAIL("cmul im error, nlimbs = %wd\n", nlimbs);
+
+            gr_heap_clear(ca, cctx);
+            gr_heap_clear(cb, cctx);
+            gr_heap_clear(cc, cctx);
+            arf_clear(ha); arf_clear(hb);
+            arf_clear(gr); arf_clear(gi); arf_clear(rr); arf_clear(ri);
+            gr_ctx_clear(cctx);
+        }
+
+        /* addition: exact and GR_SUCCESS when the result is in
+           range; GR_UNABLE exactly when the exact result has
+           magnitude at least 1 (a successful status certifies that
+           no overflow occurred) */
+        {
+            int st = gr_add(c, a, b, ctx);
+            arf_add(ref, fa, fb, 2 * nlimbs * FLINT_BITS + 32,
+                    ARF_RND_NEAR);
+            if (arf_cmpabs_2exp_si(ref, 0) < 0)
+            {
+                gr_dft_nfixed_get_arf(fc, c, ctx);
+                if (st != GR_SUCCESS || !arf_equal(ref, fc))
+                    TEST_FUNCTION_FAIL("add not exact, nlimbs = %wd\n",
+                            nlimbs);
+            }
+            else if (st != GR_UNABLE)
+                TEST_FUNCTION_FAIL("add overflow not flagged, "
+                        "nlimbs = %wd\n", nlimbs);
+        }
+
+        if (status != GR_SUCCESS)
+            TEST_FUNCTION_FAIL("unexpected status\n");
+
+        gr_heap_clear(a, ctx);
+        gr_heap_clear(b, ctx);
+        gr_heap_clear(c, ctx);
+        arf_clear(fa); arf_clear(fb); arf_clear(fc);
+        arf_clear(ref); arf_clear(ulp);
+        gr_ctx_clear(ctx);
+    }
+
+    /* DFT against a high-precision acb reference of the exact stored
+       inputs; the observed errors must respect the bound function */
+    for (iter = 0; iter < 30 * flint_test_multiplier(); iter++)
+    {
+        static const slong nl_tab[] = { 1, 2, 3, 4, 6, 16 };
+        slong nlimbs = nl_tab[n_randint(state, 6)];
+        ulong n = 1 + n_randint(state, 80);
+        gr_ctx_t rctx, cctx, actx;
+        gr_dft_pre_t P, PA;
+        gr_ptr x, y, xa, ya;
+        double peak1, err1, peak, err, scale;
+        slong prec = nlimbs * FLINT_BITS + 128;
+        slong asz;
+        ulong j;
+        arf_t t, s;
+        int status = GR_SUCCESS;
+
+        int alg = GR_DFT_ALG_AUTO;
+
+        if (n_randint(state, 2))
+            n = UWORD(1) << (1 + n_randint(state, 9));
+        else if (n % 2 == 1 && n >= 3 && n_randint(state, 2))
+            alg = GR_DFT_ALG_BLUESTEIN;
+
+        if (gr_dft_ctx_init_nfixed(rctx, nlimbs) != GR_SUCCESS)
+            flint_abort();
+        if (gr_dft_ctx_init_nfixed_complex(cctx, nlimbs) != GR_SUCCESS)
+            flint_abort();
+        gr_ctx_init_complex_acb(actx, prec);
+        asz = actx->sizeof_elem;
+
+        status |= gr_dft_precomp_init_karatsuba(P, n, alg, 0, rctx, cctx);
+        status |= gr_dft_precomp_init_karatsuba(PA, n, alg, 0, NULL, actx);
+        if (status != GR_SUCCESS)
+            TEST_FUNCTION_FAIL("plan init failed, n = %wu, nlimbs = %wd\n",
+                    n, nlimbs);
+
+        gr_dft_precomp_nfixed_bound(&peak1, &err1, 1.0, 0.0, P);
+        scale = 0.5 / peak1;
+
+        x = gr_heap_init_vec(n, cctx);
+        y = gr_heap_init_vec(n, cctx);
+        xa = gr_heap_init_vec(n, actx);
+        ya = gr_heap_init_vec(n, actx);
+        arf_init(t);
+        arf_init(s);
+
+        for (j = 0; j < 2 * n; j++)
+        {
+            gr_ptr comp = (gr_ptr) ((char *) x + j * rctx->sizeof_elem);
+            acb_ptr aj = (acb_ptr) GR_ENTRY(xa, j / 2, asz);
+            arb_ptr part = (j % 2) ? acb_imagref(aj) : acb_realref(aj);
+
+            nfixed_randarf(t, state, nlimbs);
+            arf_set_d(s, scale);
+            arf_mul(t, t, s, prec, ARF_RND_DOWN);
+            status |= gr_dft_nfixed_set_arf(comp, t, rctx);
+            gr_dft_nfixed_get_arf(arb_midref(part), comp, rctx);
+        }
+
+        status |= gr_dft_precomp(y, x, P, cctx);
+        status |= gr_dft_precomp(ya, xa, PA, actx);
+        if (status != GR_SUCCESS)
+            TEST_FUNCTION_FAIL("transform failed, n = %wu, nlimbs = %wd\n",
+                    n, nlimbs);
+
+        gr_dft_precomp_nfixed_bound(&peak, &err, scale, 0.0, P);
+        if (peak >= 1.0)
+            TEST_FUNCTION_FAIL("peak >= 1 despite scaling, n = %wu\n", n);
+
+        for (j = 0; j < 2 * n; j++)
+        {
+            gr_srcptr comp = (gr_srcptr)
+                ((const char *) y + j * rctx->sizeof_elem);
+            acb_srcptr aj = (acb_srcptr) GR_ENTRY(ya, j / 2, asz);
+            arb_srcptr part = (j % 2) ? acb_imagref(aj) : acb_realref(aj);
+            arf_t d, bnd;
+
+            arf_init(d);
+            arf_init(bnd);
+
+            gr_dft_nfixed_get_arf(t, comp, rctx);
+            arf_sub(d, t, arb_midref(part), prec, ARF_RND_UP);
+            arf_abs(d, d);
+            arf_set_mag(bnd, arb_radref(part));
+            arf_add(d, d, bnd, prec, ARF_RND_UP);
+
+            arf_set_d(bnd, err);
+            arf_mul_2exp_si(bnd, bnd, -nlimbs * FLINT_BITS);
+
+            if (arf_cmp(d, bnd) > 0)
+                TEST_FUNCTION_FAIL("error exceeds bound, n = %wu, "
+                        "nlimbs = %wd, component %wu\n", n, nlimbs, j);
+
+            arf_clear(d);
+            arf_clear(bnd);
+        }
+
+        arf_clear(t);
+        arf_clear(s);
+        gr_heap_clear_vec(x, n, cctx);
+        gr_heap_clear_vec(y, n, cctx);
+        gr_heap_clear_vec(xa, n, actx);
+        gr_heap_clear_vec(ya, n, actx);
+        gr_dft_precomp_clear(P);
+        gr_dft_precomp_clear(PA);
+        gr_ctx_clear(rctx);
+        gr_ctx_clear(cctx);
+        gr_ctx_clear(actx);
+    }
+
+
+    /* Method-table surface not reached through the transforms:
+       constants, integer setters, squaring, predicates, random
+       generation, the exported complex multiplication kernels, and
+       context printing. */
+    {
+        slong sizes[] = { 1, 2, 3, 4, 6, 24 };
+        slong si;
+
+        for (si = 0; si < 6; si++)
+        {
+            slong nlimbs = sizes[si];
+            gr_ctx_t ctx, cctx;
+            gr_ptr a, b, c, d;
+            arf_t fa, fb, ref;
+            char * str = NULL;
+
+            GR_MUST_SUCCEED(gr_dft_ctx_init_nfixed(ctx, nlimbs));
+            GR_MUST_SUCCEED(gr_dft_ctx_init_nfixed_complex(cctx, nlimbs));
+            a = gr_heap_init(ctx);
+            b = gr_heap_init(ctx);
+            arf_init(fa); arf_init(fb); arf_init(ref);
+
+            /* one and neg_one clamp to 1 - ulp and must cancel */
+            GR_MUST_SUCCEED(gr_one(a, ctx));
+            GR_MUST_SUCCEED(gr_neg_one(b, ctx));
+            gr_dft_nfixed_get_arf(fa, a, ctx);
+            gr_dft_nfixed_get_arf(fb, b, ctx);
+            arf_add(ref, fa, fb, nlimbs * FLINT_BITS + 8, ARF_RND_NEAR);
+            if (!arf_is_zero(ref) || gr_is_zero(a, ctx) != T_FALSE)
+                TEST_FUNCTION_FAIL("one/neg_one, nlimbs = %wd\n", nlimbs);
+
+            /* integer setters: 0 and +-1 in range, others GR_DOMAIN */
+            if (gr_set_si(a, 0, ctx) != GR_SUCCESS ||
+                gr_is_zero(a, ctx) != T_TRUE ||
+                gr_set_si(a, 1, ctx) != GR_SUCCESS ||
+                gr_set_si(a, -1, ctx) != GR_SUCCESS ||
+                gr_set_si(a, 2, ctx) != GR_DOMAIN ||
+                gr_set_ui(a, 1, ctx) != GR_SUCCESS ||
+                gr_set_ui(a, 7, ctx) != GR_DOMAIN)
+                TEST_FUNCTION_FAIL("set_si/set_ui, nlimbs = %wd\n", nlimbs);
+
+            /* squaring: within 2 ulp of the exact square, and equal
+               semantics on the operands */
+            GR_MUST_SUCCEED(gr_randtest(a, state, ctx));
+            GR_MUST_SUCCEED(gr_set(b, a, ctx));
+            if (gr_equal(a, b, ctx) != T_TRUE)
+                TEST_FUNCTION_FAIL("equal, nlimbs = %wd\n", nlimbs);
+            GR_MUST_SUCCEED(gr_sqr(b, a, ctx));
+            gr_dft_nfixed_get_arf(fa, a, ctx);
+            gr_dft_nfixed_get_arf(fb, b, ctx);
+            arf_mul(ref, fa, fa, 2 * nlimbs * FLINT_BITS + 8, ARF_RND_NEAR);
+            arf_sub(ref, ref, fb, 2 * nlimbs * FLINT_BITS + 8, ARF_RND_NEAR);
+            arf_abs(ref, ref);
+            arf_mul_2exp_si(ref, ref, nlimbs * FLINT_BITS - 1);
+            if (arf_cmp_si(ref, 1) > 0)
+                TEST_FUNCTION_FAIL("sqr error > 2 ulp, nlimbs = %wd\n",
+                        nlimbs);
+
+            /* aliased generic multiplication and squaring stage
+               through a temporary; swap for completeness */
+            GR_MUST_SUCCEED(gr_randtest(a, state, ctx));
+            GR_MUST_SUCCEED(gr_randtest(b, state, ctx));
+            GR_MUST_SUCCEED(gr_mul(a, a, b, ctx));
+            GR_MUST_SUCCEED(gr_sqr(a, a, ctx));
+            gr_swap(a, b, ctx);
+
+            /* randtest stays in range */
+            GR_MUST_SUCCEED(gr_randtest(a, state, ctx));
+            gr_dft_nfixed_get_arf(fa, a, ctx);
+            if (arf_cmpabs_2exp_si(fa, 0) >= 0)
+                TEST_FUNCTION_FAIL("randtest out of range, nlimbs = %wd\n",
+                        nlimbs);
+
+            /* exported complex multiplication kernels agree within
+               their documented error bound */
+            c = gr_heap_init(cctx);
+            d = gr_heap_init(cctx);
+            GR_MUST_SUCCEED(gr_randtest(c, state, cctx));
+            GR_MUST_SUCCEED(gr_randtest(d, state, cctx));
+            {
+                gr_ptr r1 = gr_heap_init(cctx), r2 = gr_heap_init(cctx);
+                arf_t g1, g2, dd;
+                double eb = _gr_dft_nfixed_cmul_err_ulps(cctx);
+                slong part;
+
+                GR_MUST_SUCCEED(_gr_dft_nfixed_cmul_schoolbook(r1, c, d, cctx));
+                GR_MUST_SUCCEED(_gr_dft_nfixed_cmul_karatsuba(r2, c, d, cctx));
+
+                arf_init(g1); arf_init(g2); arf_init(dd);
+                for (part = 0; part < 2; part++)
+                {
+                    gr_dft_nfixed_get_arf(g1, (gr_srcptr)
+                            ((const char *) r1 + part * (nlimbs + 1) *
+                             (slong) sizeof(ulong)), ctx);
+                    gr_dft_nfixed_get_arf(g2, (gr_srcptr)
+                            ((const char *) r2 + part * (nlimbs + 1) *
+                             (slong) sizeof(ulong)), ctx);
+                    arf_sub(dd, g1, g2, 2 * nlimbs * FLINT_BITS, ARF_RND_NEAR);
+                    arf_abs(dd, dd);
+                    arf_mul_2exp_si(dd, dd, nlimbs * FLINT_BITS);
+                    if (arf_cmp_d(dd, 2 * eb) > 0)
+                        TEST_FUNCTION_FAIL("cmul kernels disagree, "
+                                "nlimbs = %wd\n", nlimbs);
+                }
+                arf_clear(g1); arf_clear(g2); arf_clear(dd);
+                gr_heap_clear(r1, cctx);
+                gr_heap_clear(r2, cctx);
+            }
+            gr_heap_clear(c, cctx);
+            gr_heap_clear(d, cctx);
+
+            /* the same surface on the complex context */
+            c = gr_heap_init(cctx);
+            GR_MUST_SUCCEED(gr_one(c, cctx));
+            GR_MUST_SUCCEED(gr_neg(c, c, cctx));
+            d = gr_heap_init(cctx);
+            GR_MUST_SUCCEED(gr_neg_one(d, cctx));
+            if (gr_equal(c, d, cctx) != T_TRUE ||
+                gr_is_zero(c, cctx) != T_FALSE)
+                TEST_FUNCTION_FAIL("complex constants, nlimbs = %wd\n",
+                        nlimbs);
+            if (gr_set_si(c, 0, cctx) != GR_SUCCESS ||
+                gr_is_zero(c, cctx) != T_TRUE ||
+                gr_set_si(c, -1, cctx) != GR_SUCCESS ||
+                gr_set_si(c, 3, cctx) != GR_DOMAIN ||
+                gr_set_ui(c, 1, cctx) != GR_SUCCESS ||
+                gr_set_ui(c, 9, cctx) != GR_DOMAIN)
+                TEST_FUNCTION_FAIL("complex setters, nlimbs = %wd\n",
+                        nlimbs);
+            GR_MUST_SUCCEED(gr_randtest(c, state, cctx));
+            GR_MUST_SUCCEED(gr_set(d, c, cctx));
+            if (gr_equal(c, d, cctx) != T_TRUE)
+                TEST_FUNCTION_FAIL("complex equal, nlimbs = %wd\n", nlimbs);
+            GR_MUST_SUCCEED(gr_sqr(d, c, cctx));
+            gr_heap_clear(c, cctx);
+            gr_heap_clear(d, cctx);
+
+            /* printers: context and element strings */
+            GR_MUST_SUCCEED(gr_ctx_get_str(&str, ctx));
+            flint_free(str);
+            GR_MUST_SUCCEED(gr_ctx_get_str(&str, cctx));
+            flint_free(str);
+            GR_MUST_SUCCEED(gr_get_str(&str, a, ctx));
+            flint_free(str);
+            c = gr_heap_init(cctx);
+            GR_MUST_SUCCEED(gr_randtest(c, state, cctx));
+            GR_MUST_SUCCEED(gr_get_str(&str, c, cctx));
+            flint_free(str);
+            gr_heap_clear(c, cctx);
+
+            arf_clear(fa); arf_clear(fb); arf_clear(ref);
+            gr_heap_clear(a, ctx);
+            gr_heap_clear(b, ctx);
+            gr_ctx_clear(ctx);
+            gr_ctx_clear(cctx);
+        }
+    }
+
+    /* the a-priori bound machinery over every plan shape */
+    {
+        ulong n_tab[] = { 7, 12, 15, 16, 23 };
+        int alg_tab[] = { GR_DFT_ALG_NAIVE, GR_DFT_ALG_MIXED,
+                GR_DFT_ALG_PFA, GR_DFT_ALG_BAILEY, GR_DFT_ALG_BLUESTEIN };
+        slong bi;
+        gr_ctx_t rctx, cctx;
+
+        GR_MUST_SUCCEED(gr_dft_ctx_init_nfixed(rctx, 2));
+        GR_MUST_SUCCEED(gr_dft_ctx_init_nfixed_complex(cctx, 2));
+
+        for (bi = 0; bi < 5; bi++)
+        {
+            gr_dft_pre_t P;
+            double peak, err;
+
+            if (gr_dft_precomp_init_karatsuba(P, n_tab[bi], alg_tab[bi],
+                    0, rctx, cctx) != GR_SUCCESS)
+                TEST_FUNCTION_FAIL("bound plan init, n = %wu\n", n_tab[bi]);
+
+            gr_dft_precomp_nfixed_bound(&peak, &err, 0.001, 1.0, P);
+            if (!(peak >= 0.001) || !(err >= 1.0) || peak != peak ||
+                    err != err)
+                TEST_FUNCTION_FAIL("bound values, n = %wu\n", n_tab[bi]);
+
+            gr_dft_precomp_clear(P);
+        }
+
+        gr_ctx_clear(rctx);
+        gr_ctx_clear(cctx);
+    }
+
+    TEST_FUNCTION_END(state);
+}


### PR DESCRIPTION
Adds a new module `gr_dft` implementing DFT/IDFT of arbitrary-length vectors over generic rings (containing appropriate roots of unity). Developed using Claude Fable 5.

Not yet sure if it should be called `gr_fft` instead.

There are several algorithms:

* Naive O(n^2), used for small odd lengths and for testing
* Cooley-Tukey (single- and multithreaded; natural or scrambled order)
* Split-radix (single- and multithreaded)
* Good-Thomas
* Mixed-radix
* Bailey (single- and multithreaded)
* Bluestein, used for large prime lengths

As in `acb_dft`, there is a function that automatically constructs an optimal (hopefully) plan for the given length. Plans and tables of roots of unity can be precomputed to speed up doing multiple DFTs or IDFTs of the same length.

Note: Bailey is the theoretically optimal algorithm for huge transforms, but performs worse than Cooley-Tukey and split-radix in every case I've tested so it is not currently used by default. Perhaps this can be improved.

## Complex FFTs

The code has various optimizations for numerical DFTs over the complex numbers that make it significantly more efficient than `acb_dft` (at low precision, about 5-10 times faster):

* When working over the complex numbers, it uses split-radix instead of Cooley-Tukey for power-of-two lengths.
* It has several optimizations for cache efficiency (loop order, data layout for roots of unity).
* Rather than using `acb` arithmetic directly, it allows using fixed-point arithmetic internally (as in `nfloat/nfixed.c`). There is an ad-hoc GR ring for fixed-point arithmetic in the `gr_dft` module which should eventually be made public, and wrappers that emulate `acb_dft` by converting a given `acb` vector to `nfixed` format, doing the DFT in this internal representation, and converting back (with separate error bound calculations).

Once this is thoroughly tested, we should be able to make `acb_dft` a simple wrapper around `gr_dft`.

Single-threaded performance comparison of `acb_dft` vs `gr_dft` with `acb` input/output (`nfixed` internally):

```
$ build/gr_dft/profile/p-gr_dft_acb
wall-clock ms; precomputation and transform reported separately

prec = 128
       n      acb pre      acb dft       gr pre       gr dft  dft ratio
      64     0.002655      0.03979      0.00209     0.008301      4.79x
     100     0.003662       0.2051     0.001984      0.02979      6.89x
     101       0.3184       0.6367       0.0437       0.0708      8.99x
     256     0.009094        0.291      0.00528      0.03955      7.36x
     720     0.003601        1.875     0.003708       0.2578      7.27x
     729      0.08276        2.453      0.01178       0.2275     10.78x
    1000      0.01587          3.5     0.003754       0.6016      5.82x
    1009        3.656            7       0.4844         1.07      6.54x
    1024       0.0332        1.508      0.01843       0.1748      8.63x
    2310     0.004684        11.94     0.004303        2.594      4.60x
    3125        0.334        15.62      0.04517        2.703      5.78x
    4096       0.1289        7.312      0.06958        1.141      6.41x
    5040     0.004807        20.06      0.00473        3.844      5.22x
   10000      0.07031        46.25      0.01141            8      5.78x
   10007         75.5          150        16.88        27.75      5.41x
   16384       0.5234         34.5       0.2812        5.359      6.44x

prec = 256
       n      acb pre      acb dft       gr pre       gr dft  dft ratio
      64     0.004257      0.04614     0.003204      0.02417      1.91x
     100     0.004776       0.2842     0.003326       0.1055      2.69x
     101       0.3818       0.7383        0.126       0.2842      2.60x
     256      0.01514        0.333     0.009155       0.1299      2.56x
     720     0.005173        2.422      0.00528       0.8477      2.86x
     729       0.1104        3.203      0.04834       0.9727      3.29x
    1000      0.02148        4.609      0.01007        1.828      2.52x
    1009        4.484        8.562        1.641        3.547      2.41x
    1024      0.06128        1.766      0.03345       0.6875      2.57x
    2310      0.00647        16.31     0.006226        7.312      2.23x
    3125       0.4844        21.19       0.2031        8.875      2.39x
    4096       0.2461         8.75       0.1367        3.328      2.63x
    5040     0.007019           27     0.006836        10.94      2.47x
   10000       0.1006        63.25      0.04346           25      2.53x
   10007           97          196           43         81.5      2.40x
   16384       0.9414         40.5       0.5156        15.94      2.54x

prec = 1024
       n      acb pre      acb dft       gr pre       gr dft  dft ratio
      64     0.009888      0.09302     0.008911      0.05957      1.56x
     100      0.01227       0.6133     0.009094       0.2725      2.25x
     101         0.75        1.562        0.334       0.7148      2.19x
     256      0.02979       0.6445      0.02051       0.2988      2.16x
     720      0.01636        4.781      0.01733        1.891      2.53x
     729       0.2578        6.875       0.1182        2.312      2.97x
    1000      0.04858        9.812      0.02612        4.281      2.29x
    1009        8.812        18.06        3.969         8.75      2.06x
    1024       0.1104        3.469      0.07227        1.539      2.25x
    2310      0.01917        35.25      0.01965        17.12      2.06x
    3125        1.105        48.25       0.4922        21.12      2.28x
    4096       0.4375         17.5       0.2822        7.625      2.30x
    5040      0.02203         55.5      0.02325        23.88      2.32x
   10000       0.2295          137       0.1094         60.5      2.26x
   10007          224          452          116          215      2.10x
   16384         1.75           86        1.164         38.5      2.23x

prec = 4096
       n      acb pre      acb dft       gr pre       gr dft  dft ratio
      64       0.0376       0.5156      0.02856       0.3721      1.39x
     100      0.08569        3.938      0.06567        1.906      2.07x
     101        4.141        9.375        2.328        5.281      1.78x
     256       0.1562        3.578       0.1084        2.047      1.75x
     720      0.05225           29      0.04639        12.69      2.29x
     729         1.75        44.75       0.9805        16.31      2.74x
    1000       0.3252        62.25       0.1924           28      2.22x
    1009           46          104           28           60      1.73x
    1024       0.5703        18.56       0.3906        10.06      1.84x
    2310      0.08252          217        0.073          111      1.95x
    3125        6.875          306        3.844          142      2.15x
    4096        2.312        97.75        1.672         50.5      1.94x
    5040      0.07788          328      0.06836          151      2.17x
   10000        1.414          817       0.8086          397      2.06x
   10007         1205         2545          736         1433      1.78x
   16384        9.312          480        11.19          234      2.05x

prec = 65536
       n      acb pre      acb dft       gr pre       gr dft  dft ratio
      64        1.656        17.94        1.641        20.88      0.86x
     100        2.812          132        2.625          109      1.21x
     101          137          325          131          314      1.04x
     256        5.969          121            6          119      1.02x
     720        1.938          955        1.844          715      1.34x
     729        65.75         1529           62          938      1.63x
    1000        12.81         2259        12.06         1762      1.28x
    1009         1720         3943         1703         3803      1.04x
    1024        23.19          690           27          604      1.14x
    2310        2.734         8148        2.609         6881      1.18x
    3125          276    1.166e+04          272         8873      1.31x
    4096        92.25         3582          159         2959      1.21x
    5040         2.75    1.144e+04        2.578         8988      1.27x
```

Multithreaded comparison (8 threads):

```
wall-clock ms; precomputation and transform reported separately

prec = 128
       n      acb pre      acb dft       gr pre       gr dft  dft ratio
      64     0.002579      0.03833     0.001953     0.007996      4.79x
     100     0.003601       0.1973     0.001846      0.02881      6.85x
     101       0.3096       0.6133      0.04126      0.06812      9.00x
     256     0.008789       0.2812     0.004669       0.0376      7.48x
     720     0.003464        1.797     0.003525       0.2471      7.27x
     729       0.0813        2.359      0.01117       0.2305     10.24x
    1000      0.01562        3.359     0.003677       0.6016      5.58x
    1009        1.105        1.859       0.2168       0.4102      4.53x
    1024      0.03125       0.4492      0.01447       0.1299      3.46x
    2310     0.004395         11.5      0.00412        2.688      4.28x
    3125        0.333        14.75      0.04346        2.562      5.76x
    4096        0.125        1.766      0.06494       0.3984      4.43x
    5040     0.004532        18.94     0.004425        3.906      4.85x
   10000      0.06909        43.75      0.01111        8.188      5.34x
   10007        16.56           32         7.25        7.375      4.34x
   16384       0.5078         6.25       0.2871         1.02      6.13x

prec = 256
       n      acb pre      acb dft       gr pre       gr dft  dft ratio
      64     0.004227      0.04443     0.003021      0.02283      1.95x
     100     0.004623       0.2744     0.003067       0.1016      2.70x
     101       0.3691       0.7109       0.1182       0.2705      2.63x
     256       0.0155       0.3213     0.008301       0.1211      2.65x
     720     0.004944        2.328     0.004852       0.8086      2.88x
     729       0.1094        3.078      0.04492       0.9219      3.34x
    1000      0.02087        4.359     0.009705        1.766      2.47x
    1009        1.641        3.062       0.5352         1.27      2.41x
    1024      0.05933       0.4102      0.02979       0.4375      0.94x
    2310     0.006348        15.44     0.005951        7.125      2.17x
    3125       0.4688        19.88       0.1885        8.375      2.37x
    4096       0.2354        1.656       0.1279       0.9062      1.83x
    5040     0.006836        25.25      0.00647        9.938      2.54x
   10000      0.09766        58.25      0.04053        24.06      2.42x
   10007           22         42.5        14.19        23.31      1.82x
   16384        0.957        7.188       0.5117        2.766      2.60x

prec = 1024
       n      acb pre      acb dft       gr pre       gr dft  dft ratio
      64     0.009888      0.09131     0.008545      0.05322      1.72x
     100      0.01184       0.5938     0.008728       0.2607      2.28x
     101       0.7188        1.508       0.3184       0.6836      2.21x
     256      0.02905       0.6289      0.01953       0.2871      2.19x
     720      0.01569        4.609      0.01672        1.812      2.54x
     729         0.25        6.625       0.1123        2.172      3.05x
    1000      0.04639         9.25      0.02441        4.047      2.29x
    1009        2.547        5.266        1.172        2.906      1.81x
    1024       0.1094       0.6836      0.06616        0.957      0.71x
    2310       0.0188        33.75       0.0188        16.31      2.07x
    3125        1.082           46       0.4727        20.06      2.29x
    4096       0.4258        3.031       0.2715        1.922      1.58x
    5040      0.02155         52.5      0.02234         22.5      2.33x
   10000       0.2207          128       0.1035        55.75      2.30x
   10007        45.75          100         40.5        60.75      1.65x
   16384        1.719        14.44         1.09        6.875      2.10x

prec = 4096
       n      acb pre      acb dft       gr pre       gr dft  dft ratio
      64      0.03687          0.5      0.02783       0.3369      1.48x
     100      0.07764        3.547      0.05835        1.719      2.06x
     101        3.734        8.438        2.094        4.766      1.77x
     256       0.1445         3.25      0.09766        1.859      1.75x
     720      0.04736           26      0.04126        11.31      2.30x
     729        1.578           40       0.8828        14.62      2.74x
    1000        0.293           56       0.1758        26.75      2.09x
    1009        13.38         38.5            7        20.56      1.87x
    1024       0.5742        4.984        0.375        5.953      0.84x
    2310      0.07959          209      0.06958          107      1.95x
    3125        6.562          291        3.703          135      2.16x
    4096        2.188        18.25        1.504           15      1.22x
    5040      0.07397          312      0.06519          143      2.18x
   10000        1.359          785       0.7734          379      2.07x
   10007          269          643          237          418      1.54x
   16384        8.938           90        10.06         42.5      2.12x

prec = 65536
       n      acb pre      acb dft       gr pre       gr dft  dft ratio
      64        1.734        17.69        1.641        20.25      0.87x
     100        2.938          260        2.609          106      2.45x
     101          287          682          125          295      2.31x
     256        6.172          118            6          111      1.06x
     720        1.984         1121        1.828          685      1.64x
     729         68.5         1410        58.75          911      1.55x
    1000        13.12         3690        11.75         1656      2.23x
    1009          442         1550          496         1334      1.16x
    1024        26.44          115         26.5          381      0.30x
    2310        2.734     1.01e+04        2.641         6405      1.58x
    3125          280    1.584e+04          262         8380      1.89x
    4096          110          594          161          695      0.85x
    5040        2.828    1.794e+04        2.719         8728      2.05x
   10000          122    3.587e+04        49.25    2.328e+04      1.54x
   10007         9937    2.702e+04         9302    2.305e+04      1.17x
   16384          800         2932          556         2590      1.13x
```

There is a dip in the parallel performance for e.g. n = 1024 and n = 4096. This is due the serial/parallel cutoff currently having a fixed tuning value which becomes suboptimal here; the cutoff should eventually change with the ring.

## Non-complex rings

Non-complex rings use Cooley-Tukey for power of two lengths.

Just for fun, here is how `gr_dft` (using the option for scrambled-order coefficients) with `nmod` coefficients compares to `fft_small` (`sd_fft`):


```
p = 1095216660481, full in-place transforms, times in ms

         n   sd precomp       sd fft   gr precomp       gr fft    ratio
         2        0.002        0.000        0.000        0.000     4.2x
         4        0.002        0.000        0.000        0.000     3.4x
         8        0.002        0.000        0.000        0.000     5.5x
        16        0.002        0.000        0.000        0.000     8.5x
        32        0.002        0.000        0.000        0.000    15.0x
        64        0.002        0.000        0.000        0.001    15.7x
       128        0.002        0.000        0.000        0.002    19.0x
       256        0.002        0.000        0.000        0.005    18.1x
       512        0.002        0.001        0.001        0.012    20.0x
      1024        0.002        0.001        0.001        0.027    19.0x
      2048        0.002        0.003        0.003        0.061    18.9x
      4096        0.002        0.007        0.005        0.132    19.5x
      8192        0.002        0.015        0.010        0.289    19.9x
     16384        0.003        0.031        0.020        0.623    19.9x
     32768        0.005        0.066        0.039        1.332    20.1x
     65536        0.009        0.141        0.078        2.863    20.3x
    131072        0.018        0.302        0.158        6.078    20.1x
    262144        0.036        0.641        0.346       13.000    20.3x
    524288        0.067        1.352        0.688       27.375    20.3x
   1048576        0.137        2.961        1.355       57.750    19.5x
   2097152        0.261        6.891        2.723      121.000    17.6x
   4194304        0.832       15.625        5.422      253.000    16.2x
   8388608        2.965       32.750       26.688      537.000    16.4x
  16777216       21.312       67.000       53.000     1117.000    16.7x
  33554432       55.250      137.500      106.250     2315.000    16.8x
  67108864      121.500      300.000      210.000     5089.000    17.0x
 134217728      250.000      716.000      459.000    11075.000    15.5x
 268435456      513.000     1571.000      958.000    23646.000    15.1x
 536870912     1032.000     3518.000     1865.000    52954.000    15.1x
```

About 20x slower for medium sizes; 15x slower for huge, more memory-bound transforms.

This factor is unsurprising: each arithmetic operation in `gr_dft` is wrapped in a function call, and there is no vectorization and no delayed reduction. We could probably later on support ring-overridable basecases and vectorized butterflies, which should allow improving performance for `nmod`-like finite fields.

With 8 threads:

```

         n   sd precomp       sd fft   gr precomp       gr fft    ratio
       256        0.002        0.000        0.000        0.005    18.2x
       512        0.002        0.001        0.001        0.020    33.1x
      1024        0.002        0.001        0.001        0.035    24.6x
      2048        0.002        0.003        0.002        0.056    17.9x
      4096        0.002        0.007        0.005        0.087    13.3x
      8192        0.002        0.014        0.010        0.112     8.0x
     16384        0.003        0.030        0.019        0.138     4.6x
     32768        0.005        0.062        0.039        0.255     4.1x
     65536        0.009        0.133        0.077        0.501     3.8x
    131072        0.017        0.282        0.155        1.062     3.8x
    262144        0.033        0.602        0.340        2.141     3.6x
    524288        0.067        1.270        0.671        4.500     3.5x
   1048576        0.126        2.719        1.336        9.391     3.5x
   2097152        0.249        6.156        2.668       20.000     3.2x
   4194304        0.667       14.125        5.328       44.125     3.1x
   8388608        2.559       31.250       25.312       94.750     3.0x
  16777216       21.500       63.000       52.250      199.750     3.2x
  33554432       58.000      129.500      106.000      418.000     3.2x
  67108864      131.750      284.000      218.000      890.000     3.1x
 134217728      278.000      690.000      474.000     1899.000     2.8x
 268435456      560.000     1517.000      965.000     4219.000     2.8x
 536870912     1100.000     3360.000     1941.000     9239.000     2.7x
```

Less than a factor 3 -- clearly, it would be beneficial to add multithreading to `sd_fft` too.
