### PR TITLE
Radix square roots and some improvements

### DIFF
--- a/doc/source/radix.rst
+++ b/doc/source/radix.rst
@@ -306,7 +306,7 @@ Except where otherwise noted, the following rules apply:
 .. function:: int radix_rsqrtmod_bn(nn_ptr res, nn_srcptr x, slong xn, slong n, const radix_t radix)
 
     Computes the reciprocal of the square root computed by
-    :func:`radix_rsqrtmod_bn`, with the same meaning of the return flag.
+    :func:`radix_sqrtmod_bn`, with the same meaning of the return flag.
 
 .. function:: int radix_cmp_bn_half(nn_srcptr x, slong n, const radix_t radix)
 
@@ -319,6 +319,48 @@ Except where otherwise noted, the following rules apply:
     Sets `(res,n)` to the fractional limbs of an approximation of `1 / \sqrt{a}`.
     Assumes that `2 \le a < B`. The error is bounded by `2 B^{-n}`, i.e. by
     2 fixed-point ulps.
+
+.. function:: void radix_rsqrt_approx_basecase(nn_ptr q, nn_srcptr a, slong an, slong n, const radix_t radix)
+              void radix_rsqrt_approx(nn_ptr q, nn_srcptr a, slong an, slong n, const radix_t radix)
+
+    Given `(a, an)` representing a fixed-point number `a \in [B^{-2}, 1)`
+    with `an` fraction limbs (at least one of the two highest limbs must
+    be nonzero), sets `(q, n+2)` to an approximation of
+    `1/\sqrt{a} \in (1, B]` with `n` fraction limbs and two integral limbs
+    (the highest limb is nonzero only when `a` is close to `B^{-2}`).
+    The absolute error is bounded by `4 B^{-n} / \sqrt{a}`.
+    The input normalization is wider than that of :func:`radix_inv_approx`
+    (which requires `a \in [1/B, 1)`) so that :func:`radix_sqrtrem` can
+    handle inputs with an odd number of limbs, the square root scale
+    factor `B^{1/2}` not being a limb shift.
+
+.. function:: void radix_sqrt_approx_rsqrtmul(nn_ptr q, nn_srcptr a, slong an, slong n, const radix_t radix)
+              void radix_sqrt_approx(nn_ptr q, nn_srcptr a, slong an, slong n, const radix_t radix)
+
+    Given `(a, an)` representing a fixed-point number `a \in [B^{-2}, 1)`
+    as in :func:`radix_rsqrt_approx`, sets `(q, n+2)` to an approximation
+    of `\sqrt{a} \in [1/B, 1)` with `n` fraction limbs and two integral
+    limbs (normally zero, though the computed value can round up to 1).
+    The absolute error is bounded by `4 B^{-n} / \sqrt{a}`. Note that the
+    error is proportional to `1/\sqrt{a}` rather than to the output
+    `\sqrt{a}`: the corrections of the final iteration are multiplied by
+    an approximation of `1/\sqrt{a} \le B`, which amplifies their
+    `B^{-n}`-size rounding errors accordingly.
+
+.. function:: void radix_sqrtrem_via_mpn(nn_ptr s, nn_ptr r, nn_srcptr a, slong an, const radix_t radix)
+              void radix_sqrtrem_newton_karp_markstein(nn_ptr s, nn_ptr r, nn_srcptr a, slong an, const radix_t radix)
+              void radix_sqrtrem(nn_ptr s, nn_ptr r, nn_srcptr a, slong an, const radix_t radix)
+
+    Sets `(s, \lceil an/2 \rceil)` to the truncated square root of
+    `(a, an)` and `(r, \lceil an/2 \rceil + 1)` to the remainder
+    `a - s^2 \le 2s`. Requires `an \ge 1` and `a_{an-1} \ne 0`. The user
+    can pass ``NULL`` for `r` to compute only the square root.
+
+.. function:: int radix_sqrt(nn_ptr s, nn_srcptr a, slong an, const radix_t radix)
+
+    Sets `(s, \lceil an/2 \rceil)` to the truncated square root of
+    `(a, an)`, returning 1 if `a` is a perfect square and 0 otherwise.
+    Requires `an \ge 1` and `a_{an-1} \ne 0`.
 
 Radix conversion
 --------------------------------------------------------------------------------
@@ -522,6 +564,31 @@ Memory-managed integers
 
     Division with remainder: compute `a = qb + r` where `q` is the truncation,
     floor, and ceiling quotient respectively.
+
+.. function:: int radix_integer_sqrt(radix_integer_t s, const radix_integer_t x, const radix_t radix)
+
+    Sets `s` to the truncated square root of `x` and returns 1 if `x` is
+    a perfect square, otherwise returns 0. If `x` is negative, returns 0
+    without modifying `s`.
+
+.. function:: void radix_integer_sqrtrem(radix_integer_t s, radix_integer_t r, const radix_integer_t x, const radix_t radix)
+
+    Sets `s` to the truncated square root of `x` and `r` to the remainder
+    `x - s^2 \le 2s`. Raises an error if `x` is negative.
+
+.. function:: int radix_integer_is_square(const radix_integer_t x, const radix_t radix)
+
+    Returns 1 if `x` is a perfect square and 0 otherwise (in particular,
+    if `x` is negative).
+
+.. function:: int radix_integer_inv(radix_integer_t res, const radix_integer_t x, const radix_t radix)
+
+    If `x` is invertible, sets *res* to the inverse of `x` and returns 1,
+    otherwise returns 0 without modifying *res*.
+
+.. function:: int radix_integer_is_invertible(const radix_integer_t x, const radix_t radix)
+
+    Returns 1 if `x` is invertible, i.e. if `x = \pm 1`, and 0 otherwise.
 
 .. function:: int radix_integer_invmod_limbs(radix_integer_t res, const radix_integer_t x, slong n, const radix_t radix)
 

--- a/src/gr_poly/rsqrt_series_newton.c
+++ b/src/gr_poly/rsqrt_series_newton.c
@@ -26,6 +26,14 @@ _gr_poly_rsqrt_series_newton(gr_ptr g,
     if (len == 0)
         return GR_SUCCESS;
 
+    if (hlen == 1)
+    {
+        status = _gr_poly_rsqrt_series_basecase(g, h, 1, 1, ctx);
+        if (len > 1)
+            status |= _gr_vec_zero(GR_ENTRY(g, 1, sz), len - 1, ctx);
+        return status;
+    }
+
     cutoff = FLINT_MAX(cutoff, 2);
     a[i = 0] = n = len;
     while (n >= cutoff)
@@ -51,13 +59,14 @@ _gr_poly_rsqrt_series_newton(gr_ptr g,
     if (len > n)
     {
         gr_ptr t, u;
-        slong tlen, ulen;
+        slong tlen, ualloc;
 
         /* Hack: until all rings have a good mulmid, implement both with and without. */
-        /* Todo: tighten allocations when we have mulmid */
         int have_mulmid = (ctx->methods[GR_METHOD_POLY_MULMID] != (gr_funcptr) _gr_poly_mulmid_generic);
 
-        GR_TMP_INIT_VEC(t, 2 * len, ctx);
+        ualloc = have_mulmid ? (len / 2) : len;
+
+        GR_TMP_INIT_VEC(t, len + ualloc, ctx);
         u = GR_ENTRY(t, len, sz);
 
         for (i--; i >= 0; i--)
@@ -66,26 +75,24 @@ _gr_poly_rsqrt_series_newton(gr_ptr g,
             n = a[i];
 
             tlen = FLINT_MIN(2 * m - 1, n);
-            ulen = FLINT_MIN(n, m + tlen - 1);
-
             status |= _gr_poly_mullow(t, g, m, g, m, tlen, ctx);
-            status |= _gr_poly_mullow(u, g, m, t, tlen, ulen, ctx);
 
             if (have_mulmid)
             {
-                status |= _gr_poly_mulmid(GR_ENTRY(g, m, sz), u, ulen, h, FLINT_MIN(hlen, n), m, n, ctx);
-                status |= _gr_vec_mul_scalar_2exp_si(GR_ENTRY(g, m, sz), GR_ENTRY(g, m, sz), n - m, -1, ctx);
+                status |= _gr_poly_mulmid(u, t, tlen, h, FLINT_MIN(hlen, n), m, n, ctx);
+                status |= _gr_poly_mullow(GR_ENTRY(g, m, sz), g, n - m, u, n - m, n - m, ctx);
             }
             else
             {
-                status |= _gr_poly_mullow(t, u, ulen, h, FLINT_MIN(hlen, n), n, ctx);
-                status |= _gr_vec_mul_scalar_2exp_si(GR_ENTRY(g, m, sz), GR_ENTRY(t, m, sz), n - m, -1, ctx);
+                status |= _gr_poly_mullow(u, t, tlen, h, FLINT_MIN(hlen, n), n, ctx);
+                status |= _gr_poly_mullow(GR_ENTRY(g, m, sz), g, n - m, GR_ENTRY(u, m, sz), n - m, n - m, ctx);
             }
 
+            status |= _gr_vec_mul_scalar_2exp_si(GR_ENTRY(g, m, sz), GR_ENTRY(g, m, sz), n - m, -1, ctx);
             status |= _gr_vec_neg(GR_ENTRY(g, m, sz), GR_ENTRY(g, m, sz), n - m, ctx);
         }
 
-        GR_TMP_CLEAR_VEC(t, 2 * len, ctx);
+        GR_TMP_CLEAR_VEC(t, len + ualloc, ctx);
     }
 
     return status;

--- a/src/gr_poly/sqrt_series_newton.c
+++ b/src/gr_poly/sqrt_series_newton.c
@@ -21,7 +21,7 @@ _gr_poly_sqrt_series_newton(gr_ptr g,
     slong a[FLINT_BITS];
     slong i, m, n, alloc;
     gr_ptr t, u, v;
-    slong tlen, ulen;
+    slong tlen, r1, r2, rlen;
 
     hlen = FLINT_MIN(hlen, len);
 
@@ -30,6 +30,13 @@ _gr_poly_sqrt_series_newton(gr_ptr g,
 
     if (len < cutoff || len == 1)
         return _gr_poly_sqrt_series_basecase(g, h, hlen, len, ctx);
+
+    if (hlen == 1)
+    {
+        status = _gr_poly_sqrt_series_basecase(g, h, 1, 1, ctx);
+        status |= _gr_vec_zero(GR_ENTRY(g, 1, sz), len - 1, ctx);
+        return status;
+    }
 
     cutoff = FLINT_MAX(cutoff, 2);
     a[i = 0] = n = len;
@@ -42,14 +49,13 @@ _gr_poly_sqrt_series_newton(gr_ptr g,
         return status;
 
     /* Hack: until all rings have a good mulmid, implement both with and without. */
-    /* Todo: tighten allocations when we have mulmid */
     int have_mulmid = (ctx->methods[GR_METHOD_POLY_MULMID] != (gr_funcptr) _gr_poly_mulmid_generic);
 
-    alloc = 2 * len + (len + 1) / 2;
+    alloc = (have_mulmid ? (len + 1) / 2 : len) + 2 * ((len + 1) / 2);
 
     GR_TMP_INIT_VEC(t, alloc, ctx);
-    u = GR_ENTRY(t, len, sz);
-    v = GR_ENTRY(u, len, sz);
+    u = GR_ENTRY(t, have_mulmid ? (len + 1) / 2 : len, sz);
+    v = GR_ENTRY(u, (len + 1) / 2, sz);
 
     for (i--; i >= 1; i--)
     {
@@ -57,22 +63,21 @@ _gr_poly_sqrt_series_newton(gr_ptr g,
         n = a[i];
 
         tlen = FLINT_MIN(2 * m - 1, n);
-        ulen = FLINT_MIN(n, m + tlen - 1);
 
         status |= _gr_poly_mullow(t, g, m, g, m, tlen, ctx);
-        status |= _gr_poly_mullow(u, g, m, t, tlen, ulen, ctx);
 
         if (have_mulmid)
         {
-            status |= _gr_poly_mulmid(GR_ENTRY(g, m, sz), u, ulen, h, FLINT_MIN(hlen, n), m, n, ctx);
-            status |= _gr_vec_mul_scalar_2exp_si(GR_ENTRY(g, m, sz), GR_ENTRY(g, m, sz), n - m, -1, ctx);
+            status |= _gr_poly_mulmid(u, t, tlen, h, FLINT_MIN(hlen, n), m, n, ctx);
+            status |= _gr_poly_mullow(GR_ENTRY(g, m, sz), g, n - m, u, n - m, n - m, ctx);
         }
         else
         {
-            status |= _gr_poly_mullow(t, u, ulen, h, FLINT_MIN(hlen, n), n, ctx);
-            status |= _gr_vec_mul_scalar_2exp_si(GR_ENTRY(g, m, sz), GR_ENTRY(t, m, sz), n - m, -1, ctx);
+            status |= _gr_poly_mullow(u, t, tlen, h, FLINT_MIN(hlen, n), n, ctx);
+            status |= _gr_poly_mullow(GR_ENTRY(g, m, sz), g, n - m, GR_ENTRY(u, m, sz), n - m, n - m, ctx);
         }
 
+        status |= _gr_vec_mul_scalar_2exp_si(GR_ENTRY(g, m, sz), GR_ENTRY(g, m, sz), n - m, -1, ctx);
         status |= _gr_vec_neg(GR_ENTRY(g, m, sz), GR_ENTRY(g, m, sz), n - m, ctx);
     }
 
@@ -80,25 +85,27 @@ _gr_poly_sqrt_series_newton(gr_ptr g,
     n = len;
 
     /* Karp-Markstein */
-    /* todo: cleanup; improve allocations? */
     tlen = FLINT_MIN(2 * m - 1, n);
-    status |= _gr_poly_mullow(v, g, m, h, hlen, m, ctx);
+
+    status |= _gr_poly_mullow(v, g, m, h, FLINT_MIN(hlen, m), m, ctx);
+
+    r1 = FLINT_MAX(0, FLINT_MIN(hlen - m, n - m));
+    r2 = FLINT_MAX(0, FLINT_MIN(tlen - m, n - m));
+    rlen = FLINT_MAX(r1, r2);
 
     if (have_mulmid)
     {
         if (m < tlen)
             status |= _gr_poly_mulmid(t, v, m, v, m, m, tlen, ctx);
-        status |= _gr_poly_sub(GR_ENTRY(u, m, sz), GR_ENTRY(h, m, sz),
-            FLINT_MAX(0, FLINT_MIN(hlen - m, n - m)), t, FLINT_MAX(0, FLINT_MIN(tlen - m, n - m)), ctx);
+        status |= _gr_poly_sub(u, GR_ENTRY(h, m, sz), r1, t, r2, ctx);
     }
     else
     {
         status |= _gr_poly_mullow(t, v, m, v, m, tlen, ctx);
-        status |= _gr_poly_sub(GR_ENTRY(u, m, sz), GR_ENTRY(h, m, sz),
-            FLINT_MAX(0, FLINT_MIN(hlen - m, n - m)), GR_ENTRY(t, m, sz), FLINT_MAX(0, FLINT_MIN(tlen - m, n - m)), ctx);
+        status |= _gr_poly_sub(u, GR_ENTRY(h, m, sz), r1, GR_ENTRY(t, m, sz), r2, ctx);
     }
 
-    status |= _gr_poly_mullow(GR_ENTRY(g, m, sz), g, m, GR_ENTRY(u, m, sz), n - m, n - m, ctx);
+    status |= _gr_poly_mullow(GR_ENTRY(g, m, sz), g, n - m, u, rlen, n - m, ctx);
     status |= _gr_vec_mul_scalar_2exp_si(GR_ENTRY(g, m, sz), GR_ENTRY(g, m, sz), n - m, -1, ctx);
     _gr_vec_swap(g, v, m, ctx);
 

--- a/src/radix.h
+++ b/src/radix.h
@@ -250,6 +250,15 @@ radix_cmp_bn_half(nn_srcptr x, slong n, const radix_t radix)
 void radix_rsqrt_1_approx_basecase(nn_ptr res, ulong a, slong n, const radix_t radix);
 void radix_rsqrt_1_approx(nn_ptr res, ulong a, slong n, const radix_t radix);
 
+void radix_sqrtrem_via_mpn(nn_ptr s, nn_ptr r, nn_srcptr a, slong an, const radix_t radix);
+void radix_rsqrt_approx_basecase(nn_ptr q, nn_srcptr a, slong an, slong n, const radix_t radix);
+void radix_rsqrt_approx(nn_ptr q, nn_srcptr a, slong an, slong n, const radix_t radix);
+void radix_sqrt_approx_rsqrtmul(nn_ptr q, nn_srcptr a, slong an, slong n, const radix_t radix);
+void radix_sqrt_approx(nn_ptr q, nn_srcptr a, slong an, slong n, const radix_t radix);
+void radix_sqrtrem_newton_karp_markstein(nn_ptr s, nn_ptr r, nn_srcptr a, slong an, const radix_t radix);
+void radix_sqrtrem(nn_ptr s, nn_ptr r, nn_srcptr a, slong an, const radix_t radix);
+int radix_sqrt(nn_ptr s, nn_srcptr a, slong an, const radix_t radix);
+
 /* Modular (Hensel) division */
 
 int radix_invmod_bn(nn_ptr res, nn_srcptr x, slong xn, slong n, const radix_t radix);
@@ -434,6 +443,12 @@ void radix_integer_tdiv_r(radix_integer_t r, const radix_integer_t a, const radi
 void radix_integer_fdiv_r(radix_integer_t r, const radix_integer_t a, const radix_integer_t b, const radix_t radix);
 void radix_integer_cdiv_r(radix_integer_t r, const radix_integer_t a, const radix_integer_t b, const radix_t radix);
 
+int radix_integer_inv(radix_integer_t res, const radix_integer_t x, const radix_t radix);
+int radix_integer_is_invertible(const radix_integer_t x, const radix_t radix);
+
+int radix_integer_sqrt(radix_integer_t s, const radix_integer_t x, const radix_t radix);
+void radix_integer_sqrtrem(radix_integer_t s, radix_integer_t r, const radix_integer_t x, const radix_t radix);
+int radix_integer_is_square(const radix_integer_t x, const radix_t radix);
 
 /* Utilities */
 

--- a/src/radix/integer.c
+++ b/src/radix/integer.c
@@ -1759,6 +1759,110 @@ radix_integer_cdiv_r(radix_integer_t r,
     radix_integer_clear(q, radix);
 }
 
+
+int
+radix_integer_sqrt(radix_integer_t s, const radix_integer_t x, const radix_t radix)
+{
+    slong xn, sn;
+    nn_srcptr xd;
+    nn_ptr sd;
+    int exact;
+
+    xn = x->size;
+
+    if (xn < 0)
+        return 0;
+
+    if (xn == 0)
+    {
+        radix_integer_zero(s, radix);
+        return 1;
+    }
+
+    sn = (xn + 1) / 2;
+    sd = radix_integer_fit_limbs(s, sn, radix);
+    /* read after fit_limbs in case of possible aliasing */
+    xd = x->d;
+
+    exact = radix_sqrt(sd, xd, xn, radix);
+
+    MPN_NORM(sd, sn);
+    s->size = sn;
+
+    return exact;
+}
+
+void
+radix_integer_sqrtrem(radix_integer_t s, radix_integer_t r, const radix_integer_t x, const radix_t radix)
+{
+    slong xn, sn, rn;
+    nn_srcptr xd;
+    nn_ptr sd, rd;
+
+    xn = x->size;
+
+    if (xn < 0)
+        flint_throw(FLINT_ERROR, "radix_integer_sqrtrem: negative input");
+
+    if (xn == 0)
+    {
+        radix_integer_zero(s, radix);
+        radix_integer_zero(r, radix);
+        return;
+    }
+
+    sn = (xn + 1) / 2;
+    rn = sn + 1;
+    sd = radix_integer_fit_limbs(s, sn, radix);
+    rd = radix_integer_fit_limbs(r, rn, radix);
+    /* read after fit_limbs in case of possible aliasing */
+    xd = x->d;
+
+    radix_sqrtrem(sd, rd, xd, xn, radix);
+
+    MPN_NORM(sd, sn);
+    MPN_NORM(rd, rn);
+
+    s->size = sn;
+    r->size = rn;
+}
+
+/* todo: fast nonresidue tests to detect most non-squares cheaply */
+int
+radix_integer_is_square(const radix_integer_t x, const radix_t radix)
+{
+    radix_integer_t s;
+    int exact;
+
+    if (x->size < 0)
+        return 0;
+
+    if (x->size == 0)
+        return 1;
+
+    radix_integer_init(s, radix);
+    exact = radix_integer_sqrt(s, x, radix);
+    radix_integer_clear(s, radix);
+
+    return exact;
+}
+
+int
+radix_integer_is_invertible(const radix_integer_t x, const radix_t radix)
+{
+    return radix_integer_is_one(x, radix) || radix_integer_is_neg_one(x, radix);
+}
+
+int
+radix_integer_inv(radix_integer_t res, const radix_integer_t x, const radix_t radix)
+{
+    if (!radix_integer_is_invertible(x, radix))
+        return 0;
+
+    radix_integer_set(res, x, radix);
+    return 1;
+}
+
 /* ------------------------------------------------------------------------- */
 /*    GR wrapper                                                             */
 /* ------------------------------------------------------------------------- */
@@ -2039,6 +2143,26 @@ static int _gr_radix_integer_fdiv_qr(radix_integer_t res1, radix_integer_t res2,
     return GR_SUCCESS;
 }
 
+static int _gr_radix_integer_sqrt(radix_integer_t res, const radix_integer_t x, gr_ctx_t ctx)
+{
+    return radix_integer_sqrt(res, x, GR_RADIX_CTX(ctx)) ? GR_SUCCESS : GR_DOMAIN;
+}
+
+static truth_t _gr_radix_integer_is_square(const radix_integer_t x, gr_ctx_t ctx)
+{
+    return radix_integer_is_square(x, GR_RADIX_CTX(ctx)) ? T_TRUE : T_FALSE;
+}
+
+static int _gr_radix_integer_inv(radix_integer_t res, const radix_integer_t x, gr_ctx_t ctx)
+{
+    return radix_integer_inv(res, x, GR_RADIX_CTX(ctx)) ? GR_SUCCESS : GR_DOMAIN;
+}
+
+static truth_t _gr_radix_integer_is_invertible(const radix_integer_t x, gr_ctx_t ctx)
+{
+    return radix_integer_is_invertible(x, GR_RADIX_CTX(ctx)) ? T_TRUE : T_FALSE;
+}
+
 static int _gr_radix_integer_cmp(int * res, const radix_integer_t x, const radix_integer_t y, gr_ctx_t ctx)
 {
     *res = radix_integer_cmp(x, y, GR_RADIX_CTX(ctx));
@@ -2104,6 +2228,10 @@ gr_method_tab_input _gr_radix_integer_methods_input[] =
     {GR_METHOD_EUCLIDEAN_DIV,   (gr_funcptr) _gr_radix_integer_fdiv_q},
     {GR_METHOD_EUCLIDEAN_REM,   (gr_funcptr) _gr_radix_integer_fdiv_r},
     {GR_METHOD_EUCLIDEAN_DIVREM,   (gr_funcptr) _gr_radix_integer_fdiv_qr},
+    {GR_METHOD_IS_INVERTIBLE,   (gr_funcptr) _gr_radix_integer_is_invertible},
+    {GR_METHOD_INV,             (gr_funcptr) _gr_radix_integer_inv},
+    {GR_METHOD_IS_SQUARE,       (gr_funcptr) _gr_radix_integer_is_square},
+    {GR_METHOD_SQRT,            (gr_funcptr) _gr_radix_integer_sqrt},
     {GR_METHOD_CMP,             (gr_funcptr) _gr_radix_integer_cmp},
     {GR_METHOD_CMPABS,          (gr_funcptr) _gr_radix_integer_cmpabs},
     {GR_METHOD_SGN,             (gr_funcptr) _gr_radix_integer_sgn},

--- a/src/radix/profile/p-sqrt.c
+++ b/src/radix/profile/p-sqrt.c
@@ -1,0 +1,86 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <math.h>
+#include "profiler.h"
+#include "radix.h"
+
+#include "fmpz.h"
+#include "arb.h"
+
+/* s = floor(sqrt(a)) and perfect-square detection via mpn, mirroring
+   what int radix_sqrt computes */
+int
+flint_mpn_sqrt(nn_ptr s, nn_srcptr a, slong an, nn_ptr scratch)
+{
+    return mpn_sqrtrem(s, scratch, a, an) == 0;
+}
+
+int main()
+{
+    radix_t radix;
+    slong digits, nd, n1, n2;
+    nn_ptr a, c, d;
+    int FLINT_SET_BUT_UNUSED(exact);
+    double tmpn, tradix, FLINT_SET_BUT_UNUSED(tt);
+
+    flint_rand_t state;
+    flint_rand_init(state);
+
+    flint_printf("   decimal      mpn  decimal        time        time    relative\n");
+    flint_printf("    digits    limbs    limbs    mpn_sqrtrem radix_sqrt  time\n\n");
+
+    for (nd = 1; nd <= 100000000; nd = FLINT_MAX(nd + 1, nd * 1.5))
+    {
+        radix_init(radix, 10, 0);
+
+        digits = nd * 19;
+
+        /* Number of full-word limbs */
+        n1 = (slong) (digits * (log(10) / (FLINT_BITS * log(2))) + 1.0);
+        /* Number of radix 10^e limbs */
+        n2 = (digits + radix->exp - 1) / radix->exp;
+
+        a = flint_malloc(2 * n2 * sizeof(ulong));
+        c = flint_malloc(n2 * sizeof(ulong));
+        d = flint_malloc(2 * n2 * sizeof(ulong));   /* mpn_sqrtrem needs n limbs of remainder space */
+
+        flint_mpn_urandomb(a, state, 2 * n1 * FLINT_BITS);
+        a[2 * n1 - 1] |= (UWORD(1) << (FLINT_BITS - 1));
+
+        exact = flint_mpn_sqrt(c, a, 2 * n1, d);
+        TIMEIT_START;
+        exact = flint_mpn_sqrt(c, a, 2 * n1, d);
+        TIMEIT_STOP_VALUES(tt, tmpn);
+
+        radix_rand_limbs(a, state, 2 * n2, radix);
+        if (a[2 * n2 - 1] == 0)
+            a[2 * n2 - 1] = 1;
+
+        exact = radix_sqrt(c, a, 2 * n2, radix);
+        TIMEIT_START;
+        exact = radix_sqrt(c, a, 2 * n2, radix);
+        TIMEIT_STOP_VALUES(tt, tradix);
+
+        flint_printf("%10wd %8wd %8wd    %8g    %8g    %.3fx\n",
+            digits, n1, n2, tmpn, tradix, tradix / tmpn);
+
+        flint_free(a);
+        flint_free(c);
+        flint_free(d);
+
+        radix_clear(radix);
+    }
+
+    flint_rand_clear(state);
+    flint_cleanup_master();
+    return 0;
+}

--- a/src/radix/profile/p-sqrt_approx.c
+++ b/src/radix/profile/p-sqrt_approx.c
@@ -1,0 +1,86 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <math.h>
+#include "profiler.h"
+#include "radix.h"
+
+#include "fmpz.h"
+#include "arb.h"
+
+/* s = floor(sqrt(a)) and perfect-square detection via mpn, mirroring
+   what int radix_sqrt computes */
+int
+flint_mpn_sqrt(nn_ptr s, nn_srcptr a, slong an, nn_ptr scratch)
+{
+    return mpn_sqrtrem(s, scratch, a, an) == 0;
+}
+
+int main()
+{
+    radix_t radix;
+    slong digits, nd, n1, n2;
+    nn_ptr a, c, d;
+    int FLINT_SET_BUT_UNUSED(exact);
+    double tmpn, tradix, FLINT_SET_BUT_UNUSED(tt);
+
+    flint_rand_t state;
+    flint_rand_init(state);
+
+    flint_printf("   decimal      mpn  decimal        time        time      relative\n");
+    flint_printf("    digits    limbs    limbs  mpn_sqrtrem radix_sqrt_approx  time\n\n");
+
+    for (nd = 1; nd <= 100000000; nd = FLINT_MAX(nd + 1, nd * 1.5))
+    {
+        radix_init(radix, 10, 0);
+
+        digits = nd * 19;
+
+        /* Number of full-word limbs */
+        n1 = (slong) (digits * (log(10) / (FLINT_BITS * log(2))) + 1.0);
+        /* Number of radix 10^e limbs */
+        n2 = (digits + radix->exp - 1) / radix->exp;
+
+        a = flint_malloc(2 * n2 * sizeof(ulong));
+        c = flint_malloc((n2 + 2) * sizeof(ulong));
+        d = flint_malloc(2 * n2 * sizeof(ulong));   /* mpn_sqrtrem needs n limbs of remainder space */
+
+        flint_mpn_urandomb(a, state, 2 * n1 * FLINT_BITS);
+        a[2 * n1 - 1] |= (UWORD(1) << (FLINT_BITS - 1));
+
+        exact = flint_mpn_sqrt(c, a, 2 * n1, d);
+        TIMEIT_START;
+        exact = flint_mpn_sqrt(c, a, 2 * n1, d);
+        TIMEIT_STOP_VALUES(tt, tmpn);
+
+        radix_rand_limbs(a, state, 2 * n2, radix);
+        if (a[2 * n2 - 1] == 0)
+            a[2 * n2 - 1] = 1;
+
+        radix_sqrt_approx(c, a, n2, n2, radix);
+        TIMEIT_START;
+        radix_sqrt_approx(c, a, n2, n2, radix);
+        TIMEIT_STOP_VALUES(tt, tradix);
+
+        flint_printf("%10wd %8wd %8wd    %8g    %8g    %.3fx\n",
+            digits, n1, n2, tmpn, tradix, tradix / tmpn);
+
+        flint_free(a);
+        flint_free(c);
+        flint_free(d);
+
+        radix_clear(radix);
+    }
+
+    flint_rand_clear(state);
+    flint_cleanup_master();
+    return 0;
+}

--- a/src/radix/profile/p-sqrtrem.c
+++ b/src/radix/profile/p-sqrtrem.c
@@ -1,0 +1,74 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <math.h>
+#include "profiler.h"
+#include "radix.h"
+
+int main()
+{
+    radix_t radix;
+    slong digits, nd, n1, n2;
+    nn_ptr a, c, d;
+    double tmpn, tradix, FLINT_SET_BUT_UNUSED(tt);
+
+    flint_rand_t state;
+    flint_rand_init(state);
+
+    flint_printf("   decimal      mpn  decimal        time        time    relative\n");
+    flint_printf("    digits    limbs    limbs mpn_sqrtrem radix_sqrtrem  time\n\n");
+
+    for (nd = 1; nd <= 100000000; nd = FLINT_MAX(nd + 1, nd * 1.5))
+    {
+        radix_init(radix, 10, 0);
+
+        digits = nd * 19;
+
+        /* Number of full-word limbs */
+        n1 = (slong) (digits * (log(10) / (FLINT_BITS * log(2))) + 1.0);
+        /* Number of radix 10^e limbs */
+        n2 = (digits + radix->exp - 1) / radix->exp;
+
+        a = flint_malloc(2 * n2 * sizeof(ulong));
+        c = flint_malloc(n2 * sizeof(ulong));
+        d = flint_malloc(2 * n2 * sizeof(ulong));   /* mpn_sqrtrem needs n limbs of remainder space */
+
+        flint_mpn_urandomb(a, state, 2 * n1 * FLINT_BITS);
+        a[2 * n1 - 1] |= (UWORD(1) << (FLINT_BITS - 1));
+
+        mpn_sqrtrem(c, d, a, 2 * n1);
+        TIMEIT_START;
+        mpn_sqrtrem(c, d, a, 2 * n1);
+        TIMEIT_STOP_VALUES(tt, tmpn);
+
+        radix_rand_limbs(a, state, 2 * n2, radix);
+        if (a[2 * n2 - 1] == 0)
+            a[2 * n2 - 1] = 1;
+
+        radix_sqrtrem(c, d, a, 2 * n2, radix);
+        TIMEIT_START;
+        radix_sqrtrem(c, d, a, 2 * n2, radix);
+        TIMEIT_STOP_VALUES(tt, tradix);
+
+        flint_printf("%10wd %8wd %8wd    %8g    %8g    %.3fx\n",
+            digits, n1, n2, tmpn, tradix, tradix / tmpn);
+
+        flint_free(a);
+        flint_free(c);
+        flint_free(d);
+
+        radix_clear(radix);
+    }
+
+    flint_rand_clear(state);
+    flint_cleanup_master();
+    return 0;
+}

--- a/src/radix/rsqrtmod_bn.c
+++ b/src/radix/rsqrtmod_bn.c
@@ -40,8 +40,22 @@
 
     For odd p the high part H = (x y^2)[m, n) is obtained from a guarded middle
     product (its low m limbs are the identity 0..01), via the shared
-    _radix_mulhigh_known_low, exactly as radix_invmod_bn forms (x y)[m, n). The
-    p = 2 path still uses plain low products.
+    _radix_mulhigh_known_low, exactly as radix_invmod_bn forms (x y)[m, n).
+
+    The full-recompute structure for p = 2 does not force full-width products:
+    entering a step with c bits of equation precision (x y^2 == 1 (mod 2^c)),
+    the low zl = (c - 1)/e limbs of x y^2 are 00..01, so its high limbs also
+    come from _radix_mulhigh_known_low; the subtraction of 1 lives entirely
+    below that window, the halving shifts in a zero bit from below, and the
+    halved residual is divisible by B^zl, so the final product and subtraction
+    act only on limbs [zl, nl). (One cannot take zl = c/e: the schedule only
+    guarantees equation precision c, not root precision, so merely
+    zl e + 1 <= c low bits of x y^2 - 1 may be assumed zero; with e | c and
+    zl = c/e the bit shifted out by the halving could be lost.) In addition,
+    the squaring passes y with its actual support of ceil(c/e) limbs. Note
+    that _radix_mulhigh_known_low falls back to a plain low product for small
+    limb radix; the fast path applies in the regime B >> n of practical
+    interest.
 
     Returns 1 on success, 0 if x is not a square modulo B (in which case nothing
     is written). y receives n limbs (caller provides room); y may alias x only
@@ -176,7 +190,7 @@ _radix2_rsqrtmod_bn(nn_ptr res, nn_srcptr x, slong xn, slong n, const radix_t ra
     slong ed[2 * FLINT_BITS];
     slong L, k;
     ulong one = 1;
-    nn_ptr y2, w, t;
+    nn_ptr y2, w, t, scr;
     TMP_INIT;
 
     FLINT_ASSERT(e >= 3);
@@ -195,32 +209,61 @@ _radix2_rsqrtmod_bn(nn_ptr res, nn_srcptr x, slong xn, slong n, const radix_t ra
     }
 
     TMP_START;
-    y2 = TMP_ALLOC((n + 1) * sizeof(ulong));
-    w  = TMP_ALLOC((n + 1) * sizeof(ulong));
-    t  = TMP_ALLOC((n + 1) * sizeof(ulong));
+    y2  = TMP_ALLOC((n + 1) * sizeof(ulong));
+    w   = TMP_ALLOC((n + 1) * sizeof(ulong));
+    t   = TMP_ALLOC((n + 1) * sizeof(ulong));
+    scr = TMP_ALLOC((n + 1) * sizeof(ulong));
 
     for (k = L - 1; k >= 0; k--)
     {
+        slong cd = ed[k + 1];             /* x y^2 == 1 (mod 2^cd) on entry */
         slong nd = ed[k];                 /* target bits this step */
         slong hd = nd + 1;                /* one guard bit kept before the shift */
         slong nl = (nd + e - 1) / e;
         slong hl = (hd + e - 1) / e;
+        slong pl = (cd + e - 1) / e;      /* support of res (masked to cd bits) */
+        slong zl = (cd - 1) / e;          /* zero limbs of the halved residual */
 
-        /* w = (x y^2 - 1) mod 2^hd  (divisible by 2) */
-        radix_mulmid(y2, res, hl, res, hl, 0, hl, radix);
+        /* y^2 mod 2^hd: res has pl nonzero limbs, and hl <= 2 pl since
+           nd <= 2 cd - 2. */
+        radix_mulmid(y2, res, pl, res, pl, 0, hl, radix);
         _radix2_mask(y2, hd, hl, e);
-        radix_mulmid(w, x, FLINT_MIN(xn, hl), y2, hl, 0, hl, radix);
-        _radix2_mask(w, hd, hl, e);
-        radix_sub(w, w, hl, &one, 1, radix);
-        _radix2_mask(w, hd, hl, e);
 
-        /* w /= 2  ->  (x y^2 - 1)/2 mod 2^nd */
-        radix_rshift_digits(w, w, hl, 1, radix);
+        if (zl >= 1)
+        {
+            /* x y^2 - 1 == 0 (mod 2^cd) with zl e + 1 <= cd, so the low zl
+               limbs of x y^2 are 00..01: limbs [zl, hl) come from a known-low
+               high product, the subtraction of 1 lives below the window (no
+               borrow), and the halving is an exact bit shift with a zero bit
+               entering from below. The halved residual is divisible by B^zl,
+               so the correction touches only limbs [zl, nl) of res. */
+            _radix_mulhigh_known_low(w, x, FLINT_MIN(xn, hl), y2, hl,
+                &one, 1, zl, hl, scr, radix);
+            _radix2_mask(w, hd - zl * e, hl - zl, e);
+            radix_rshift_digits(w, w, hl - zl, 1, radix);
 
-        /* res = y - y w mod 2^nd */
-        radix_mulmid(t, res, nl, w, nl, 0, nl, radix);
-        _radix2_mask(t, nd, nl, e);
-        radix_sub(res, res, nl, t, nl, radix);
+            /* res[zl, nl) -= (y w)[0, nl - zl) mod 2^(nd - zl e) */
+            radix_mulmid(t, res, FLINT_MIN(pl, nl - zl), w, nl - zl, 0, nl - zl, radix);
+            _radix2_mask(t, nd - zl * e, nl - zl, e);
+            radix_sub(res + zl, res + zl, nl - zl, t, nl - zl, radix);
+        }
+        else
+        {
+            /* w = (x y^2 - 1) mod 2^hd  (divisible by 2) */
+            radix_mulmid(w, x, FLINT_MIN(xn, hl), y2, hl, 0, hl, radix);
+            _radix2_mask(w, hd, hl, e);
+            radix_sub(w, w, hl, &one, 1, radix);
+            _radix2_mask(w, hd, hl, e);
+
+            /* w /= 2  ->  (x y^2 - 1)/2 mod 2^nd */
+            radix_rshift_digits(w, w, hl, 1, radix);
+
+            /* res = y - y w mod 2^nd */
+            radix_mulmid(t, res, FLINT_MIN(pl, nl), w, nl, 0, nl, radix);
+            _radix2_mask(t, nd, nl, e);
+            radix_sub(res, res, nl, t, nl, radix);
+        }
+
         _radix2_mask(res, nd, nl, e);
     }
 
@@ -288,8 +331,9 @@ radix_rsqrtmod_bn(nn_ptr res, nn_srcptr x, slong xn, slong n, const radix_t radi
         _radix_mulhigh_known_low(hbuf, x, FLINT_MIN(xn, nn), t, nn,
             &one, 1, m, nn, scr, radix);
 
-        /* y'[m, nn) = -((y H)/2)[0, nm) */
-        radix_mulmid(t, res, m, hbuf, nm, 0, nm, radix);     /* y H, low nm */
+        /* y'[m, nn) = -((y H)/2)[0, nm); only the low nm <= m limbs of y
+           enter. */
+        radix_mulmid(t, res, nm, hbuf, nm, 0, nm, radix);    /* y H, low nm */
         _radix_halve_odd(t, t, nm, radix);                   /* (y H) 2^{-1} */
         radix_neg(res + m, t, nm, radix);
     }

--- a/src/radix/sqrt.c
+++ b/src/radix/sqrt.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "ulong_extras.h"
 #include "radix.h"
 
 void radix_rsqrt_1_approx_basecase(nn_ptr Y, ulong a, slong n, const radix_t radix)
@@ -40,7 +41,6 @@ void radix_rsqrt_1_approx_basecase(nn_ptr Y, ulong a, slong n, const radix_t rad
 }
 
 // todo: allocs
-// todo: fast mul_1
 // todo: fast divrem_two
 
 /*
@@ -94,7 +94,7 @@ void radix_rsqrt_1_approx(nn_ptr Y, ulong a, slong n, const radix_t radix)
 
         /* T = Yhi^2 with 2m fraction limbs */
         radix_mulmid(T, Yhi, m, Yhi, m, 0, m + 2, radix);
-        radix_mulmid(U, T, m + 2, &a, 1, 0, m + 2, radix);
+        radix_mul_1(U, T, m + 2, a, radix);   /* mod B^(m+2): carry discarded */
         cy = (U[m + 1] == 0);
         /* a*y^2-1 or 1-a*y^2 */
         if (!cy)
@@ -127,3 +127,699 @@ cleanup:
     }
 }
 
+
+/* Integer square root with remainder via binary (machine) radix
+   conversion; mirrors radix_divrem_via_mpn. */
+void
+radix_sqrtrem_via_mpn(nn_ptr s, nn_ptr r, nn_srcptr a, slong an, const radix_t radix)
+{
+    nn_ptr ba, br, bs, tmp;
+    slong ban, brn, bsn, sn;
+    TMP_INIT;
+
+    FLINT_ASSERT(an >= 1);
+    FLINT_ASSERT(a[an - 1] != 0);
+
+    sn = (an + 1) / 2;
+
+    TMP_START;
+    tmp = TMP_ALLOC((2 * an + (an + 3) / 2) * sizeof(ulong));
+    ba = tmp;
+    br = ba + an;
+    bs = br + an;
+
+    ban = radix_get_mpn(ba, a, an, radix);
+    bsn = (ban + 1) / 2;
+
+    brn = mpn_sqrtrem(bs, (r == NULL) ? NULL : br, ba, ban);
+
+    /* Need to do radix conversion in temporary space as radix conversion may
+       need an extra output scratch limb. */
+    slong qn, rn, qn2, rn2;
+    nn_ptr tmp2, s2, r2;
+
+    qn2 = radix_set_mpn_need_alloc(bsn, radix);
+    tmp2 = TMP_ALLOC(qn2 * sizeof(ulong));
+    s2 = tmp2;
+    qn = radix_set_mpn(s2, bs, bsn, radix);
+    FLINT_ASSERT(qn <= sn);
+    flint_mpn_copyi(s, s2, qn);
+    flint_mpn_zero(s + qn, sn - qn);
+
+    if (r != NULL)
+    {
+        if (brn == 0)
+        {
+            flint_mpn_zero(r, sn + 1);
+        }
+        else
+        {
+            rn2 = radix_set_mpn_need_alloc(brn, radix);
+            tmp2 = TMP_ALLOC(rn2 * sizeof(ulong));
+            r2 = tmp2;
+            rn = radix_set_mpn(r2, br, brn, radix);
+            FLINT_ASSERT(rn <= sn + 1);
+            flint_mpn_copyi(r, r2, rn);
+            flint_mpn_zero(r + rn, (sn + 1) - rn);
+        }
+    }
+
+    TMP_END;
+}
+
+/*
+Input: A is a fixed-point number with An fraction limbs representing
+a value alpha in [B^-2, 1), i.e. at least one of the top two limbs of A
+is nonzero. (The wider normalization, compared to [B^-1, 1) for
+radix_inv_approx, is what radix_sqrtrem needs to handle inputs with an
+odd number of limbs, since the square-root scaling B^(1/2) is not a limb
+shift.)
+
+Output: n + 2 limbs approximating 1/sqrt(alpha) in (1, B] with n fraction
+limbs and 2 integral limbs. The second integral limb is nonzero only when
+alpha is close to B^-2.
+
+Q = floor(B^(n+Vn+g) / floor(sqrt(V * B^(Vn+2g)))) where V is the top
+Vn = min(An, n+2) limbs of A and g = max(0, n + 2 - Vn) supplies working
+precision when A is short: the relative error of floor(sqrt(W)) is up to
+1/sqrt(W), so W must have ~2(n+2) limbs regardless of An. Two guard limbs
+(rather than inv_approx's one) are needed because the relative effect of
+truncating A is e/(2*alpha) <= B^2*e/2 under the wider normalization.
+*/
+void
+radix_rsqrt_approx_basecase(nn_ptr Q, nn_srcptr A, slong An, slong n, const radix_t radix)
+{
+    nn_ptr W, U, bW, bU, bs, bq, br, q2;
+    nn_srcptr V;
+    slong Vn, g, Wn, Un, bWn, bUn, bsn, bqn, qn, qn2;
+    slong guard_limbs = 2;
+    TMP_INIT;
+
+    Vn = FLINT_MIN(An, n + guard_limbs);
+    g = FLINT_MAX(0, n + guard_limbs - Vn);
+    V = A + An - Vn;
+
+    Wn = 2 * (Vn + g);
+    Un = n + Vn + g + 1;
+
+    TMP_START;
+    /* Radix scratch for W = V * B^(Vn + 2g) and U = B^(n + Vn + g).
+       The square root and the reciprocal are both computed in the binary
+       (machine) radix, avoiding radix conversion roundtrips for the
+       intermediate square root. */
+    W = TMP_ALLOC((Wn + Un) * sizeof(ulong));
+    U = W + Wn;
+
+    flint_mpn_zero(W, Vn + 2 * g);
+    flint_mpn_copyi(W + Vn + 2 * g, V, Vn);
+
+    /* The top limb of A (hence of W) may be zero when alpha < B^-1. */
+    while (Wn > 0 && W[Wn - 1] == 0)
+        Wn--;
+    FLINT_ASSERT(Wn >= 2 * (Vn + g) - 1);
+
+    flint_mpn_zero(U, Un - 1);
+    U[Un - 1] = 1;
+
+    /* bs = floor(sqrt(W)) */
+    bW = TMP_ALLOC((Wn + Un + (Wn + 3) / 2 + Un + (Wn + 3) / 2) * sizeof(ulong));
+    bU = bW + Wn;
+    bs = bU + Un;
+    bq = bs + (Wn + 3) / 2;
+    br = bq + Un;
+
+    bWn = radix_get_mpn(bW, W, Wn, radix);
+    bsn = (bWn + 1) / 2;
+    mpn_sqrtrem(bs, NULL, bW, bWn);
+
+    /* bq = floor(U / bs); the quotient is < B^(n+2) since
+       bs >= B^(Vn+g-1) */
+    bUn = radix_get_mpn(bU, U, Un, radix);
+    bqn = bUn - bsn + 1;
+    FLINT_ASSERT(bUn >= bsn);
+    mpn_tdiv_qr(bq, br, 0, bU, bUn, bs, bsn);
+
+    /* Need to do radix conversion in temporary space as radix conversion may
+       need an extra output scratch limb. */
+    qn2 = radix_set_mpn_need_alloc(bqn, radix);
+    q2 = TMP_ALLOC(qn2 * sizeof(ulong));
+    qn = radix_set_mpn(q2, bq, bqn, radix);
+    FLINT_ASSERT(qn <= n + 2);
+    flint_mpn_copyi(Q, q2, qn);
+    flint_mpn_zero(Q + qn, (n + 2) - qn);
+
+    TMP_END;
+}
+
+/* Must be large enough that m - 2 >= 2 and 2m - n - 2 >= 0 hold in the
+   recursive cases of radix_rsqrt_approx and radix_sqrt_approx.
+   Empirically 8 is close to optimal for word-size limb radices; for
+   small-digit radices (where the basecase's binary operands are much
+   smaller than the radix limb count) a larger cutoff would be slightly
+   better at small n. */
+#define RADIX_RSQRT_NEWTON_CUTOFF 8
+
+/*
+Claim: the absolute error is bounded by 4*B^(-n)/sqrt(A). This is not tight.
+
+Proof sketch: let m = (n+1)/2 + 1 + [B <= 3], so that B^(-2m) <= B^(-n-2)
+(<= B^(-n-4) for B = 3).
+
+The initial approximation is assumed to satisfy
+
+    Y = (1/sqrt(A)) * (1 + e1)  where  |e1| <= C*B^(-m)  with C = 4.
+
+We compute Y' = Y + Y * (1 - (A + e2) * Y^2 + e3) / 2 + e4 where
+
+    e2 = B^(-n-2) is the error from truncating A (two guard limbs are
+    needed since the fixed point of the iteration moves by
+    e2/(2*A) <= B^2*e2/2 relative),
+
+    e3 = B^(-n) + B^(-n)/2 + {(2m+4)*B^(-n-1)}
+    e4 = B^(-n) + {(m+2)*B^(-n-1)}
+
+are the errors from the truncated products, the halving of the residual,
+and the final multiplication by Y; the terms in curly brackets appear only
+when mulhigh is used, which requires B > 2*(m+2). All contributions to the
+relative error of Y' are
+
+    (3/2)*e1^2 + (1/2)*|e1|^3 + (1 + e1)*(Y^2*e2 + e3)/2 + e4*sqrt(A)
+
+and since Y^2*e2 <= B^(-n)/2 * (1+e1)^2 and B^(-2m) <= B^(-n-2), verifying
+that this is below 4*B^(-n) for all B >= 3 is straightforward numerics.
+(The basecase satisfies the bound with C < 2.)
+*/
+void
+radix_rsqrt_approx(nn_ptr Q, nn_srcptr A, slong An, slong n, const radix_t radix)
+{
+    if (n <= RADIX_RSQRT_NEWTON_CUTOFF)
+    {
+        radix_rsqrt_approx_basecase(Q, A, An, n, radix);
+    }
+    else
+    {
+        nn_ptr U, V, W, T, Vhigh, Uhigh;
+        nn_srcptr Ahigh;
+        slong m, Uhighn, Tn, Wn, Ahighn, Vhighn;
+        int Unegative;
+        TMP_INIT;
+
+        /*
+        Compute T ~= 1 / sqrt(A) as a fixed-point number with m fraction
+        limbs, 2 integral limbs and store in the high part of Q.
+        */
+        m = (n + 1) / 2 + 1 + (LIMB_RADIX(radix) <= 3);
+        radix_rsqrt_approx(Q + n - m, A, An, m, radix);
+
+        TMP_START;
+
+        T = Q + n - m;
+        Tn = m + 1 + (T[m + 1] != 0);
+
+        flint_mpn_zero(Q, n - m);
+
+        /* W = T^2 with 2m fraction limbs (full product; all but O(1) of its
+           low limbs are needed below, so truncation is not worthwhile). */
+        Wn = 2 * Tn;
+        W = TMP_ALLOC(Wn * sizeof(ulong));
+        radix_mul(W, T, Tn, T, Tn, radix);
+
+        /*
+        Let A' be the high n+2 limbs of A. We compute U ~= 1 - A'*T^2 as a
+        fixed-point number with n fraction limbs, using the same middle
+        product + control limb construction as radix_inv_approx: the low
+        limbs of the product can be truncated because we only need n
+        fraction limbs, and the high limbs are known a priori to be all
+        0 or B-1 since A'*T^2 approximates 1.
+        */
+        slong control_limb = n / 2 + 2;
+
+        /* If An < n + 2, zero-extend A. */
+        slong A_low_zeroes = 0;
+
+        if (An >= n + 2)
+        {
+            Ahighn = n + 2;
+            Ahigh = A + An - Ahighn;
+        }
+        else
+        {
+            Ahighn = An;
+            Ahigh = A;
+            A_low_zeroes = n + 2 - An;
+        }
+
+        // The full product has n+2+2m fraction limbs; remove 2m+2 fraction
+        // limbs to get n fraction limbs.
+        slong low_trunc_without_mulhigh = 2 * m + 2;
+        // When using mulhigh, include 2 guard limbs to get an accurate high
+        // product.
+        slong low_trunc_with_mulhigh = 2 * m;
+
+        /* A_low_zeroes <= n <= 2m - 2, so unlike in radix_inv_approx no
+           third case for very short A is needed. */
+        FLINT_ASSERT(A_low_zeroes <= low_trunc_with_mulhigh - 2);
+
+        if (LIMB_RADIX(radix) > 2 * (m + 2))
+        {
+            U = TMP_ALLOC((2 + (control_limb + 1)) * sizeof(ulong));
+            radix_mulmid(U, Ahigh, Ahighn, W, Wn,
+                low_trunc_with_mulhigh - A_low_zeroes,
+                low_trunc_with_mulhigh - A_low_zeroes + 2 + (control_limb + 1),
+                radix);
+            Uhigh = U + 2;
+        }
+        else
+        {
+            // Emulate high product by computing the full product and
+            // throwing away excess fraction limbs
+            U = TMP_ALLOC((low_trunc_without_mulhigh - A_low_zeroes + (control_limb) + 1) * sizeof(ulong));
+            radix_mulmid(U, Ahigh, Ahighn, W, Wn, 0,
+                low_trunc_without_mulhigh - A_low_zeroes + (control_limb) + 1,
+                radix);
+            Uhigh = U + low_trunc_without_mulhigh - A_low_zeroes;
+        }
+
+        Unegative = (Uhigh[control_limb] != 0);
+        if (Unegative)
+            radix_neg(Uhigh, Uhigh, control_limb, radix);
+
+        /* There may be additional cancellation. */
+        Uhighn = control_limb;
+        while (Uhighn > 0 && Uhigh[Uhighn - 1] == 0)
+            Uhighn--;
+
+        if (Uhighn != 0)
+        {
+            /* The correction is T * (1 - A*T^2) / 2. */
+            radix_divrem_two(Uhigh, Uhigh, Uhighn, radix);
+            while (Uhighn > 0 && Uhigh[Uhighn - 1] == 0)
+                Uhighn--;
+        }
+
+        if (Uhighn != 0)
+        {
+            /* Compute V = T * U with n fraction limbs. */
+            if (LIMB_RADIX(radix) > 2 * (m + 2))
+            {
+                // V = T * |1 - A' * T^2| / 2 with n+2 fraction limbs
+                V = TMP_ALLOC((Tn + Uhighn - (m - 2)) * sizeof(ulong));
+                radix_mulmid(V, T, Tn, Uhigh, Uhighn, m - 2, Tn + Uhighn, radix);
+                Vhigh = V + 2;
+                Vhighn = Tn + Uhighn - (m - 2) - 2;
+            }
+            else
+            {
+                // V = T * |1 - A' * T^2| / 2 with n+m fraction limbs
+                V = TMP_ALLOC((Tn + Uhighn) * sizeof(ulong));
+                radix_mul(V, T, Tn, Uhigh, Uhighn, radix);
+                Vhigh = V + m;
+                Vhighn = Tn + Uhighn - m;
+            }
+
+            /* Finally, compute T + T * (1 - A'T^2)/2 or T - T * (A'T^2 - 1)/2
+            depending on the sign of U. */
+            if (Unegative)
+                radix_add(Q, Q, n + 2, Vhigh, Vhighn, radix);
+            else
+                radix_sub(Q, Q, n + 2, Vhigh, Vhighn, radix);
+        }
+
+        TMP_END;
+    }
+}
+
+void
+radix_sqrt_approx_rsqrtmul(nn_ptr Q, nn_srcptr A, slong An, slong n, const radix_t radix)
+{
+    nn_ptr T;
+    nn_srcptr A2;
+    slong A2n;
+    TMP_INIT;
+    TMP_START;
+
+    A2n = FLINT_MIN(An, n + 2);
+    A2 = A + An - A2n;
+
+    T = TMP_ALLOC((A2n + n + 2) * sizeof(ulong));
+
+    radix_rsqrt_approx(Q, A, An, n, radix);
+    /* Should be a high multiplication. */
+    radix_mul(T, Q, n + 2, A2, A2n, radix);
+    flint_mpn_copyi(Q, T + A2n, n + 2);
+
+    TMP_END;
+}
+
+/* Karp-Markstein square root: analogous to radix_div_approx
+   but evaluates S + T * (A - S^2) / 2 with S = T * A instead of
+   TB + T * (B - A * TB).
+
+   Input as for radix_rsqrt_approx: A has An fraction limbs with value
+   alpha in [B^-2, 1). Output: n + 2 limbs approximating sqrt(alpha) in
+   [B^-1, 1) with n fraction limbs; the integral limbs are normally zero
+   but the value can round to 1.000... when alpha is close to 1.
+
+   Claim: the absolute error is bounded by 4*B^(-n)/sqrt(A). Note that,
+   as for radix_rsqrt_approx, the error is proportional to 1/sqrt(A)
+   rather than to the output sqrt(A): the corrections of the last
+   iteration are multiplied by T ~= 1/sqrt(A) <= B, which amplifies
+   their B^(-n)-size rounding errors accordingly. */
+void
+radix_sqrt_approx(nn_ptr Q, nn_srcptr A, slong An, slong n, const radix_t radix)
+{
+    nn_ptr U, V, T, TS, Vhigh, Uhigh, TShigh;
+    slong m, Un, Uhighn, Tn, Vhighn;
+    int Unegative;
+    TMP_INIT;
+
+    if (n <= 4)
+    {
+        radix_sqrt_approx_rsqrtmul(Q, A, An, n, radix);
+        return;
+    }
+
+    m = (n + 1) / 2 + 1 + (LIMB_RADIX(radix) <= 3);
+
+    radix_rsqrt_approx(Q + n - m, A, An, m, radix);
+
+    TMP_START;
+    T = Q + n - m;
+    Tn = m + 1 + (T[m + 1] != 0);
+
+    flint_mpn_zero(Q, n - m);
+
+    // Compute S = T * A2 ~= sqrt(A) as a fixed-point number with m fraction
+    // limbs. Unlike in radix_div_approx, two extra limbs of the truncated
+    // operand are needed: the truncation error is multiplied by T <= B.
+    slong A2n = FLINT_MIN(m + 2, An);
+    nn_srcptr A2 = A + An - A2n;
+
+    if (LIMB_RADIX(radix) > 2 * (m + 2) && A2n > 2)
+    {
+        TS = TMP_ALLOC((Tn + 2) * sizeof(ulong));
+        radix_mulmid(TS, T, Tn, A2, A2n, A2n - 2, A2n + Tn, radix);
+        TShigh = TS + 2;
+    }
+    else
+    {
+        TS = TMP_ALLOC((A2n + Tn) * sizeof(ulong));
+        radix_mul(TS, T, Tn, A2, A2n, radix);
+        TShigh = TS + A2n;
+    }
+
+    slong control_limb = n / 2 + 2;
+
+    Un = control_limb + 1;
+
+    /* U = band of S^2 at weights B^(-n) .. B^(control_limb - n), plus
+       2 guard limbs in the mulhigh case. The full square has 2m fraction
+       limbs, so the band starts 2m - n limbs up. */
+    if (LIMB_RADIX(radix) > 2 * (m + 2) && 2 * m - n - 2 >= 0)
+    {
+        U = TMP_ALLOC((2 + Un) * sizeof(ulong));
+        radix_mulmid(U, TShigh, Tn, TShigh, Tn, 2 * m - n - 2, 2 * m - n + Un, radix);
+        Uhigh = U + 2;
+    }
+    else
+    {
+        U = TMP_ALLOC((2 * m - n + Un) * sizeof(ulong));
+        radix_mulmid(U, TShigh, Tn, TShigh, Tn, 0, 2 * m - n + Un, radix);
+        Uhigh = U + 2 * m - n;
+    }
+
+    // Compute (A - S^2) with n fraction limbs, with sign
+    if (An > n - Un)
+    {
+        if (An >= n)
+        {
+            nn_srcptr Ahigh = A + An - n;
+            radix_sub(Uhigh, Ahigh, Un, Uhigh, Un, radix);
+        }
+        else
+        {
+            slong nz = n - An;
+            ulong cy = radix_neg(Uhigh, Uhigh, nz, radix);
+            radix_sub(Uhigh + nz, A, Un - nz, Uhigh + nz, Un - nz, radix);
+            radix_sub(Uhigh + nz, Uhigh + nz, Un - nz, &cy, 1, radix);
+        }
+
+        Unegative = 1;
+        if (radix_cmp_bn_half(Uhigh, Un, radix) > 0)
+        {
+            radix_neg(Uhigh, Uhigh, Un, radix);
+            Unegative = 0;
+        }
+    }
+    else
+    {
+        Unegative = 0;
+        if (radix_cmp_bn_half(Uhigh, Un, radix) > 0)
+        {
+            radix_neg(Uhigh, Uhigh, Un, radix);
+            Unegative = 1;
+        }
+    }
+
+    Uhighn = Un;
+    while (Uhighn > 0 && Uhigh[Uhighn - 1] == 0)
+        Uhighn--;
+
+    if (Uhighn != 0)
+    {
+        /* The correction is T * (A - S^2) / 2. */
+        radix_divrem_two(Uhigh, Uhigh, Uhighn, radix);
+        while (Uhighn > 0 && Uhigh[Uhighn - 1] == 0)
+            Uhighn--;
+    }
+
+    if (Uhighn != 0)
+    {
+        if (LIMB_RADIX(radix) > 2 * (m + 2))
+        {
+            V = TMP_ALLOC((Tn + Uhighn - (m - 2)) * sizeof(ulong));
+            radix_mulmid(V, T, Tn, Uhigh, Uhighn, m - 2, Tn + Uhighn, radix);
+            Vhigh = V + 2;
+            Vhighn = Tn + Uhighn - (m - 2) - 2;
+        }
+        else
+        {
+            V = TMP_ALLOC((Tn + Uhighn) * sizeof(ulong));
+            radix_mul(V, T, Tn, Uhigh, Uhighn, radix);
+            Vhigh = V + m;
+            Vhighn = Tn + Uhighn - m;
+        }
+
+        // Overwrite T with S
+        Q[n + 1] = 0;
+        flint_mpn_copyi(Q + n - m, TShigh, Tn);
+
+        if (Unegative)
+            radix_add(Q, Q, n + 2, Vhigh, Vhighn, radix);
+        else
+            radix_sub(Q, Q, n + 2, Vhigh, Vhighn, radix);
+    }
+    else
+    {
+        // Overwrite T with S
+        Q[n + 1] = 0;
+        flint_mpn_copyi(Q + n - m, TShigh, Tn);
+    }
+
+    TMP_END;
+}
+
+/* Instead of computing sqrt(A) with ~1 ulp error and doing a full
+   multiplication to check the remainder, compute a few fraction limbs.
+   If the first fraction limb is not too close to the limb boundary, we
+   have the correct root and the remainder can be determined by a low
+   multiplication (or omitted if we only want the root).
+
+   Three extra fraction limbs are used (one more than division's
+   PREINV2_EXTRA_LIMBS): the sqrt_approx error is C*B^(-n2)/sqrt(alpha)
+   with alpha as small as B^-2 when an is odd, i.e. up to C*B^(-n2+1),
+   so n2 = sn + 3 leaves error <= C*B^(-2) at the integer scale.
+
+   The fast acceptance is gated on LIMB_RADIX > 8: with the error bound
+   C*B^(-2), C = 4, the check q[-1] in [2, B-2] certifies the integer
+   part only when C < B. For smaller radices we always run the (always
+   correct) verification loops. */
+void
+radix_sqrtrem_newton_karp_markstein(nn_ptr s, nn_ptr r, nn_srcptr a, slong an, const radix_t radix)
+{
+    nn_ptr S, P, t, q, Apad;
+    nn_srcptr Aview;
+    slong sn, n2, viewn;
+    ulong one = 1;
+    TMP_INIT;
+
+    FLINT_ASSERT(an >= 1);
+    FLINT_ASSERT(a[an - 1] != 0);
+
+    sn = (an + 1) / 2;
+
+    TMP_START;
+
+    /* View a as a fixed-point number with 2*sn fraction limbs (zero-padded
+       on top when an is odd), representing alpha = a * B^(-2sn) in
+       [B^-2, 1). Then sqrt(a) = sqrt(alpha) * B^sn. */
+    viewn = 2 * sn;
+    if (an == viewn)
+    {
+        Aview = a;
+    }
+    else
+    {
+        Apad = TMP_ALLOC(viewn * sizeof(ulong));
+        flint_mpn_copyi(Apad, a, an);
+        Apad[viewn - 1] = 0;
+        Aview = Apad;
+    }
+
+    n2 = sn + 3;
+
+    S = TMP_ALLOC((n2 + 2) * sizeof(ulong));
+    radix_sqrt_approx(S, Aview, viewn, n2, radix);
+
+    FLINT_ASSERT(S[n2 + 1] == 0);
+    /* q[0], ..., q[sn-1] are the candidate digits of floor(sqrt(a));
+       q[-1] is the first fraction digit; q[sn] the integral overflow. */
+    q = S + n2 - sn;
+
+    if (LIMB_RADIX(radix) > 8 && q[sn] == 0
+        && q[-1] > 1 && q[-1] < LIMB_RADIX(radix) - 1)
+    {
+        /* Certified: q = floor(sqrt(a)). */
+        if (r != NULL)
+        {
+            P = TMP_ALLOC(FLINT_MAX(an, sn + 1) * sizeof(ulong));
+            radix_mulmid(P, q, sn, q, sn, 0, an, radix);
+            radix_sub(P, a, an, P, an, radix);
+            FLINT_ASSERT(an <= sn + 1 || flint_mpn_zero_p(P + sn + 1, an - (sn + 1)));
+            if (an < sn + 1)
+                flint_mpn_zero(P + an, (sn + 1) - an);
+            flint_mpn_copyi(r, P, sn + 1);
+        }
+        flint_mpn_copyi(s, q, sn);
+        TMP_END;
+        return;
+    }
+
+    if (q[sn] != 0)
+        radix_sub(q, q, sn + 1, &one, 1, radix);
+
+    /* Verification: adjust q by O(1) steps. P holds q^2, later a - q^2,
+       over an an+1 limb window; t holds 2q+1 over sn+1 limbs. */
+    P = TMP_ALLOC((an + 1) * sizeof(ulong));
+    t = TMP_ALLOC((sn + 1) * sizeof(ulong));
+
+    flint_mpn_zero(P, an + 1);
+    radix_mulmid(P, q, sn, q, sn, 0, FLINT_MIN(2 * sn, an + 1), radix);
+
+    while (P[an] != 0 || mpn_cmp(P, a, an) > 0)
+    {
+        radix_sub(q, q, sn, &one, 1, radix);
+        /* t = 2q + 1 for the new q; q_old^2 - (2q+1) = q^2 */
+        t[sn] = radix_add(t, q, sn, q, sn, radix);
+        radix_add(t, t, sn + 1, &one, 1, radix);
+        radix_sub(P, P, an + 1, t, sn + 1, radix);
+    }
+
+    /* P = a - q^2 (nonnegative; P[an] is zero at this point) */
+    radix_sub(P, a, an, P, an, radix);
+
+    for (;;)
+    {
+        /* t = 2q + 1 */
+        t[sn] = radix_add(t, q, sn, q, sn, radix);
+        radix_add(t, t, sn + 1, &one, 1, radix);
+
+        /* stop when a - q^2 < 2q + 1, i.e. (q+1)^2 > a */
+        if (flint_mpn_zero_p(P + sn + 1, (an + 1) - (sn + 1))
+            && mpn_cmp(P, t, sn + 1) < 0)
+            break;
+
+        radix_add(q, q, sn, &one, 1, radix);
+        radix_sub(P, P, an + 1, t, sn + 1, radix);
+    }
+
+    if (r != NULL)
+        flint_mpn_copyi(r, P, sn + 1);
+    flint_mpn_copyi(s, q, sn);
+
+    TMP_END;
+}
+
+/* Below this size, converting to binary and using mpn_sqrtrem wins;
+   above it, Newton-Karp-Markstein is faster on average. The crossover
+   grows as the limbs get narrower, since the binary operands shrink
+   proportionally: with b bits per limb, an an-limb input is only about
+   an*b/64 binary limbs. The formula below approximates measured
+   crossovers of ~40 limbs at b = 63, ~100 at b = 30, ~450 at b = 10.
+   (As for radix_divrem, the crossover is not monotone: with B = 2^63
+   the mpn path is competitive again in a window around an ~ 256..1024
+   before the radix multiplication switches to fft_small, so a
+   dual-range dispatch in the style of radix_divrem could be used.) */
+RADIX_INLINE slong
+_radix_sqrtrem_km_cutoff(const radix_t radix)
+{
+    slong b = FLINT_BIT_COUNT(LIMB_RADIX(radix));
+    return 2500 / b + 20000 / (b * b);
+}
+
+/* s = floor(sqrt(a)), sn = (an+1)/2 limbs. If r is not NULL, it is set
+   to a - s^2 (at most 2s), zero-padded to sn + 1 limbs. */
+void
+radix_sqrtrem(nn_ptr s, nn_ptr r, nn_srcptr a, slong an, const radix_t radix)
+{
+    FLINT_ASSERT(an >= 1);
+    FLINT_ASSERT(a[an - 1] != 0);
+
+    if (an == 1)
+    {
+        ulong s0 = n_sqrt(a[0]);
+        s[0] = s0;
+        if (r != NULL)
+        {
+            r[0] = a[0] - s0 * s0;
+            r[1] = 0;
+        }
+        return;
+    }
+
+    if (an < _radix_sqrtrem_km_cutoff(radix))
+        radix_sqrtrem_via_mpn(s, r, a, an, radix);
+    else
+        radix_sqrtrem_newton_karp_markstein(s, r, a, an, radix);
+}
+
+/* s = floor(sqrt(a)), sn = (an+1)/2 limbs. Returns 1 iff a is a
+   perfect square. */
+int
+radix_sqrt(nn_ptr s, nn_srcptr a, slong an, const radix_t radix)
+{
+    slong sn;
+    int exact;
+    nn_ptr r;
+    TMP_INIT;
+
+    FLINT_ASSERT(an >= 1);
+    FLINT_ASSERT(a[an - 1] != 0);
+
+    if (an == 1)
+    {
+        ulong s0 = n_sqrt(a[0]);
+        s[0] = s0;
+        return s0 * s0 == a[0];
+    }
+
+    sn = (an + 1) / 2;
+
+    TMP_START;
+    r = TMP_ALLOC((sn + 1) * sizeof(ulong));
+    radix_sqrtrem(s, r, a, an, radix);
+    exact = flint_mpn_zero_p(r, sn + 1);
+    TMP_END;
+
+    return exact;
+}

--- a/src/radix/sqrt.c
+++ b/src/radix/sqrt.c
@@ -376,9 +376,10 @@ radix_rsqrt_approx(nn_ptr Q, nn_srcptr A, slong An, slong n, const radix_t radix
         // product.
         slong low_trunc_with_mulhigh = 2 * m;
 
-        /* A_low_zeroes <= n <= 2m - 2, so unlike in radix_inv_approx no
-           third case for very short A is needed. */
-        FLINT_ASSERT(A_low_zeroes <= low_trunc_with_mulhigh - 2);
+        /* A_low_zeroes <= n + 1 <= 2m - 1 (the extreme being An = 1 with
+           n even), so unlike in radix_inv_approx no third case for very
+           short A is needed: the band always starts at limb >= 1. */
+        FLINT_ASSERT(A_low_zeroes <= low_trunc_with_mulhigh - 1);
 
         if (LIMB_RADIX(radix) > 2 * (m + 2))
         {

--- a/src/radix/sqrtmod_bn.c
+++ b/src/radix/sqrtmod_bn.c
@@ -35,42 +35,36 @@
     Since x - b^2 == 0 (mod B^m), the correction y(x - b^2)/2 vanishes modulo
     B^m, so s shares its low m limbs with b and only its high n-m limbs are new.
 
+    In both cases b is written straight into the low limbs of the root, the
+    high part (b^2)[m', n') comes from a guarded middle product (its low m'
+    limbs are x mod B^m') via the shared _radix_mulhigh_known_low, and only
+    the high difference limbs are formed, so no full-width square, x copy or
+    root copy is needed.
+
     Division by 2:
       - p odd: modular half of y*(x-b^2)[m, n) (the same short division by two as
         in radix_rsqrtmod_bn); the high limbs are limb-aligned.
-      - p = 2: 1/2 does not exist, but x - b^2 == 0 (mod 2^{e m}) is even, so the
-        whole correction y(x - b^2) is shifted right by one bit exactly. The
-        single bit dropped at the top is absorbed by computing one guard limb
-        and then reducing to n limbs.
+      - p = 2: 1/2 does not exist, but x - b^2 == 0 (mod 2^{e m'}) is even
+        (with m' = m + 1, see below), so the correction y (x - b^2) / 2 is an
+        exact halving. Since only x - b^2 == 0 (mod 2^{e m'}) is guaranteed
+        -- not (mod 2^{e m' + 1}) -- the halved correction is aligned at bit
+        e m' - 1 rather than at limb m': it equals
 
-    For odd p, b is written straight into the low m limbs of the root, the high
-    part (b^2)[m, n) comes from a guarded middle product (its low m limbs are
-    x mod B^m) via the shared _radix_mulhigh_known_low, and only the n-m high
-    difference limbs are formed, so no full-width square, x copy or root copy is
-    needed. The p = 2 path still uses low products.
+            B^{m'-1} * ((y * dh) * 2^{e-1}  mod B^{n-m'+1}),
+
+        dh = (x - b^2)[m', n+1), and is added over limbs [m'-1, n) of the
+        root, straddling the limb boundary by one bit. The multiplication by
+        2^{e-1} is a left shift by e-1 p-adic digits; the bits it pushes out
+        at the top, like the original guard-limb formulation, fall above
+        limb n and are discarded.
+
+        The reciprocal root is taken one limb beyond ceil(n/2) (m' = m + 1)
+        so that the few bits lost to the 2-adic squaring still leave all n
+        limbs correct.
 
     s receives n limbs (caller provides room). Returns 1 on success, 0 if x is
     not a square modulo B (nothing written in that case). s must not alias x.
 */
-
-/* keep only the low d bits of a (limbs hold e bits each, p = 2) */
-static void
-_radix2_mask_bits(nn_ptr a, slong d, slong alimbs, slong e)
-{
-    slong full = d / e, r = d % e, i;
-
-    if (r)
-    {
-        a[full] &= (UWORD(1) << r) - 1;
-        for (i = full + 1; i < alimbs; i++)
-            a[i] = 0;
-    }
-    else
-    {
-        for (i = full; i < alimbs; i++)
-            a[i] = 0;
-    }
-}
 
 /* W[0,k) = V[0,k) / 2 mod B^k for ODD radix; overflow-safe short division by 2,
    adding the (odd) modulus once when V is odd. W may alias V. */
@@ -121,16 +115,12 @@ radix_sqrtmod_bn(nn_ptr res, nn_srcptr x, slong xn, slong n, const radix_t radix
 
     if (DIGIT_RADIX(radix) == 2)
     {
-        /* p = 2: form the full correction y(x - b^2) and shift it right one bit.
-           One guard limb absorbs the bit dropped by that shift. The half-
-           precision root is taken one limb beyond ceil(n/2) so that the few bits
-           lost to the 2-adic squaring still leave all n limbs correct. */
+        /* p = 2: limb-aligned products, bit-straddling correction (see above) */
         slong e = radix->exp;
         slong mm = m + 1;            /* reciprocal-root precision (limbs) */
-        slong w = n + 1;             /* working limbs (1 guard limb) */
-        slong xc;
+        slong ah;
         ulong bo;
-        nn_ptr b, b2, c, yc;
+        nn_ptr b;
 
         y = TMP_ALLOC(mm * sizeof(ulong));
         if (!radix_rsqrtmod_bn(y, x, xn, mm, radix))
@@ -139,40 +129,57 @@ radix_sqrtmod_bn(nn_ptr res, nn_srcptr x, slong xn, slong n, const radix_t radix
             return 0;
         }
 
-        b  = TMP_ALLOC(w * sizeof(ulong));
-        b2 = TMP_ALLOC(w * sizeof(ulong));
-        c  = TMP_ALLOC(w * sizeof(ulong));
-        yc = TMP_ALLOC(w * sizeof(ulong));
+        b = TMP_ALLOC(mm * sizeof(ulong));
 
         /* b = x y mod B^mm */
         radix_mulmid(b, x, FLINT_MIN(xn, mm), y, mm, 0, mm, radix);
-        flint_mpn_zero(b + mm, w - mm);
+        flint_mpn_copyi(res, b, FLINT_MIN(mm, n));
 
-        /* b2 = b^2 mod B^w */
-        radix_mulmid(b2, b, mm, b, mm, 0, w, radix);
-
-        /* c = x - b^2 mod B^w  (== 0 mod B^mm, hence even). Built without a
-           zero-padded x: subtract where x has limbs, negate the rest, fold in
-           the low borrow. */
-        xc = FLINT_MIN(xn, w);
-        bo = 0;
-        if (xc > 0)
-            bo = radix_sub(c, x, xc, b2, xc, radix);
-        if (xc < w)
+        /* nm = n - m = (n + 1) - mm is both the number of limbs of
+           (x - b^2)[mm, n+1) and the size n - (mm - 1) of the correction
+           window [mm-1, n) in the root. */
+        if (nm > 0)
         {
-            radix_neg(c + xc, b2 + xc, w - xc, radix);
-            if (bo)
-                radix_sub(c + xc, c + xc, w - xc, &bo, 1, radix);
+            slong w = n + 1;
+            nn_ptr b2h, dh, scr;
+
+            b2h = TMP_ALLOC(nm * sizeof(ulong));
+            dh  = TMP_ALLOC(nm * sizeof(ulong));
+            scr = TMP_ALLOC(w * sizeof(ulong));
+
+            /* (b^2)[mm, n+1): the low mm limbs of b^2 are x mod B^mm (known),
+               so this is a guarded middle product rather than a full square. */
+            _radix_mulhigh_known_low(b2h, b, mm, b, mm, x, FLINT_MIN(xn, mm),
+                mm, w, scr, radix);
+
+            /* dh = (x - b^2)[mm, n+1), where x is zero above limb xn. Rather
+               than materialise the zero-padded operand, subtract over the
+               limbs where x is present and negate over the zero limbs, then
+               fold in the borrow out of the low subtraction (radix_neg takes
+               no borrow-in). No incoming borrow at limb mm:
+               x - b^2 == 0 (mod B^mm). */
+            ah = (xn > mm) ? FLINT_MIN(xn - mm, nm) : 0;
+            bo = 0;
+            if (ah > 0)
+                bo = radix_sub(dh, x + mm, ah, b2h, ah, radix);
+            if (ah < nm)
+            {
+                radix_neg(dh + ah, b2h + ah, nm - ah, radix);
+                if (bo)
+                    radix_sub(dh + ah, dh + ah, nm - ah, &bo, 1, radix);
+            }
+
+            /* s[mm-1, n) += (y dh 2^{e-1})[0, nm); only the low nm <= mm
+               limbs of y enter, digits shifted past the window top fall
+               above limb n and are discarded, and the carry out of the
+               addition is the reduction mod B^n. */
+            radix_mulmid(scr, y, FLINT_MIN(mm, nm), dh, nm, 0, nm, radix);
+            radix_lshift_digits(scr, scr, nm, e - 1, radix);
+
+            if (n > mm)
+                flint_mpn_zero(res + mm, n - mm);
+            radix_add(res + (mm - 1), res + (mm - 1), nm, scr, nm, radix);
         }
-
-        /* yc = y c mod B^w, then yc /= 2 (exact bit shift) */
-        radix_mulmid(yc, y, mm, c, w, 0, w, radix);
-        radix_rshift_digits(yc, yc, w, 1, radix);
-
-        /* s = b + yc/2 mod B^w; keep the low n limbs */
-        radix_add(b, b, w, yc, w, radix);
-        _radix2_mask_bits(b, e * n, w, e);
-        flint_mpn_copyi(res, b, n);
 
         TMP_END;
         return 1;
@@ -221,8 +228,9 @@ radix_sqrtmod_bn(nn_ptr res, nn_srcptr x, slong xn, slong n, const radix_t radix
                     radix_sub(dh + ah, dh + ah, nm - ah, &bo, 1, radix);
             }
 
-            /* s[m, n) = (y * dh / 2)[0, nm) -> straight into the high limbs. */
-            radix_mulmid(res + m, y, m, dh, nm, 0, nm, radix);
+            /* s[m, n) = (y * dh / 2)[0, nm) -> straight into the high limbs;
+               only the low nm <= m limbs of y enter. */
+            radix_mulmid(res + m, y, nm, dh, nm, 0, nm, radix);
             _radix_halve_odd(res + m, res + m, nm, radix);
         }
 

--- a/src/radix/test/main.c
+++ b/src/radix/test/main.c
@@ -33,9 +33,13 @@
 #include "t-neg.c"
 #include "t-rshift.c"
 #include "t-rsqrt_1_approx.c"
+#include "t-rsqrt_approx.c"
 #include "t-rsqrtmod_bn.c"
 #include "t-set_mpn.c"
+#include "t-sqrt.c"
+#include "t-sqrt_approx.c"
 #include "t-sqrtmod_bn.c"
+#include "t-sqrtrem.c"
 #include "t-sub.c"
 
 /* Array of test functions ***************************************************/
@@ -64,9 +68,12 @@ test_struct tests[] =
     TEST_FUNCTION(radix_neg),
     TEST_FUNCTION(radix_rshift),
     TEST_FUNCTION(radix_rsqrt_1_approx),
+    TEST_FUNCTION(radix_rsqrt_approx),
     TEST_FUNCTION(radix_rsqrtmod_bn),
     TEST_FUNCTION(radix_set_mpn),
+    TEST_FUNCTION(radix_sqrt),
     TEST_FUNCTION(radix_sqrtmod_bn),
+    TEST_FUNCTION(radix_sqrtrem),
     TEST_FUNCTION(radix_sub),
 };
 

--- a/src/radix/test/t-rsqrt_approx.c
+++ b/src/radix/test/t-rsqrt_approx.c
@@ -1,0 +1,116 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <math.h>
+#include "test_helpers.h"
+#include "radix.h"
+
+TEST_FUNCTION_START(radix_rsqrt_approx, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 10000 * flint_test_multiplier(); iter++)
+    {
+        nn_ptr A, B, C, err;
+        slong errn, err_limbs = 10;
+        double dbl_err, dbl_a, dbl_powB;
+        slong j;
+
+        radix_t radix;
+        radix_init_randtest(radix, state);
+
+        slong n, an;
+
+        if (n_randint(state, 100))
+        {
+            n = 1 + n_randint(state, 100);
+            an = 1 + n_randint(state, 100);
+        }
+        else
+        {
+            n = 1 + n_randint(state, 1000);
+            an = 1 + n_randint(state, 1000);
+        }
+
+        A = flint_malloc(sizeof(ulong) * an);
+        B = flint_malloc(sizeof(ulong) * (n + 2 + err_limbs));
+        C = flint_malloc(sizeof(ulong) * (n + 2 + err_limbs));
+        err = flint_malloc(sizeof(ulong) * (n + 2 + err_limbs));
+
+        radix_randtest_limbs(A, state, an, radix);
+
+        /* A represents a value in [B^-2, 1): the top limb may be zero
+           as long as the next one is nonzero. */
+        if (an >= 2 && n_randint(state, 2))
+        {
+            A[an - 1] = 0;
+            if (A[an - 2] == 0)
+                A[an - 2] = 1 + n_randint(state, LIMB_RADIX(radix) - 1);
+        }
+        else
+        {
+            if (A[an - 1] == 0)
+                A[an - 1] = 1 + n_randint(state, LIMB_RADIX(radix) - 1);
+        }
+
+        radix_rsqrt_approx_basecase(B, A, an, n + err_limbs, radix);
+        flint_mpn_zero(C, err_limbs);
+
+        radix_rsqrt_approx(C + err_limbs, A, an, n, radix);
+
+        if (mpn_cmp(B, C, n + 2 + err_limbs) >= 0)
+            radix_sub(err, B, n + 2 + err_limbs, C, n + 2 + err_limbs, radix);
+        else
+            radix_sub(err, C, n + 2 + err_limbs, B, n + 2 + err_limbs, radix);
+
+        errn = n + 2 + err_limbs;
+        MPN_NORM(err, errn);
+
+        dbl_err = 0.0;
+        dbl_powB = pow(LIMB_RADIX(radix), -err_limbs);
+        for (j = 0; j < errn; j++)
+        {
+            dbl_err += dbl_powB * err[j];
+            dbl_powB *= LIMB_RADIX(radix);
+        }
+
+        dbl_a = 0.0;
+        dbl_powB = 1.0 / LIMB_RADIX(radix);
+        for (j = 0; j < an; j++)
+        {
+            dbl_a += dbl_powB * A[an - 1 - j];
+            dbl_powB /= LIMB_RADIX(radix);
+        }
+
+        /* |computed - 1/sqrt(A)| * sqrt(A) should be a few ulps */
+        dbl_err *= sqrt(dbl_a);
+
+        if (dbl_err > 3.0)
+        {
+            flint_printf("FAIL: too large error: radix %wu^%wd, n = %wd, an = %wd\n", DIGIT_RADIX(radix), radix->exp, n, an);
+            flint_printf("A = %{ulong*}\n", A, an);
+            flint_printf("B = %{ulong*}\n", B, n + err_limbs + 2);
+            flint_printf("C = %{ulong*}\n", C, n + err_limbs + 2);
+            flint_printf("err = %{ulong*}\n", err, n + err_limbs + 2);
+            flint_printf("dbl_err: %f\n", dbl_err);
+            flint_abort();
+        }
+
+        flint_free(A);
+        flint_free(B);
+        flint_free(C);
+        flint_free(err);
+
+        radix_clear(radix);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/radix/test/t-sqrt.c
+++ b/src/radix/test/t-sqrt.c
@@ -1,0 +1,95 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "radix.h"
+
+TEST_FUNCTION_START(radix_sqrt, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 10000 * flint_test_multiplier(); iter++)
+    {
+        nn_ptr a, s, s0;
+        slong an, sn, sn0;
+        int exact, want_exact;
+
+        radix_t radix;
+        radix_init_randtest(radix, state);
+
+        sn0 = 1 + n_randint(state, n_randint(state, 100) ? 20 : 150);
+
+        a = flint_malloc(sizeof(ulong) * (2 * sn0 + 1));
+        s0 = flint_malloc(sizeof(ulong) * sn0);
+
+        radix_randtest_limbs(s0, state, sn0, radix);
+        if (s0[sn0 - 1] == 0)
+            s0[sn0 - 1] = 1 + n_randint(state, LIMB_RADIX(radix) - 1);
+
+        /* a = s0^2 + d with 0 <= d <= 2*s0, so floor(sqrt(a)) = s0 */
+        radix_mul(a, s0, sn0, s0, sn0, radix);
+        an = 2 * sn0;
+        MPN_NORM(a, an);
+
+        want_exact = n_randint(state, 2);
+        if (!want_exact)
+        {
+            /* add d in [1, 2*s0]: either a small d or 2*s0 itself */
+            a[an] = 0;
+            if (n_randint(state, 2))
+            {
+                ulong dmax = LIMB_RADIX(radix) - 1;
+                if (sn0 == 1 && 2 * s0[0] < dmax)
+                    dmax = 2 * s0[0];
+                ulong d = 1 + n_randint(state, dmax);
+                radix_add(a, a, an + 1, &d, 1, radix);
+            }
+            else
+            {
+                nn_ptr t = flint_malloc(sizeof(ulong) * (sn0 + 1));
+                t[sn0] = radix_add(t, s0, sn0, s0, sn0, radix);
+                radix_add(a, a, an + 1, t, sn0 + 1, radix);
+                flint_free(t);
+            }
+            an = an + 1;
+            MPN_NORM(a, an);
+        }
+
+        sn = (an + 1) / 2;
+        s = flint_malloc(sizeof(ulong) * sn);
+
+        exact = radix_sqrt(s, a, an, radix);
+
+        if (exact != want_exact)
+        {
+            flint_printf("FAIL: wrong exactness flag: radix %wu^%wd, an = %wd, exact = %d\n", DIGIT_RADIX(radix), radix->exp, an, exact);
+            flint_printf("a = %{ulong*}\n", a, an);
+            flint_abort();
+        }
+
+        if (sn != sn0 || mpn_cmp(s, s0, sn0) != 0)
+        {
+            flint_printf("FAIL: wrong root: radix %wu^%wd, an = %wd\n", DIGIT_RADIX(radix), radix->exp, an);
+            flint_printf("a = %{ulong*}\n", a, an);
+            flint_printf("s  = %{ulong*}\n", s, sn);
+            flint_printf("s0 = %{ulong*}\n", s0, sn0);
+            flint_abort();
+        }
+
+        flint_free(a);
+        flint_free(s);
+        flint_free(s0);
+
+        radix_clear(radix);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/radix/test/t-sqrt_approx.c
+++ b/src/radix/test/t-sqrt_approx.c
@@ -1,0 +1,126 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <math.h>
+#include "test_helpers.h"
+#include "radix.h"
+
+TEST_FUNCTION_START(radix_sqrt_approx, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 10000 * flint_test_multiplier(); iter++)
+    {
+        nn_ptr A, B, C, T, err;
+        slong errn, err_limbs = 10;
+        double dbl_err, dbl_a, dbl_powB;
+        slong j, N;
+
+        radix_t radix;
+        radix_init_randtest(radix, state);
+
+        slong n, an;
+
+        if (n_randint(state, 100))
+        {
+            n = 1 + n_randint(state, 100);
+            an = 1 + n_randint(state, 100);
+        }
+        else
+        {
+            n = 1 + n_randint(state, 700);
+            an = 1 + n_randint(state, 700);
+        }
+
+        N = n + err_limbs;
+
+        A = flint_malloc(sizeof(ulong) * an);
+        B = flint_malloc(sizeof(ulong) * (N + 2));
+        C = flint_malloc(sizeof(ulong) * (N + 2));
+        T = flint_malloc(sizeof(ulong) * (2 * N + 6));
+        err = flint_malloc(sizeof(ulong) * (N + 2));
+
+        radix_randtest_limbs(A, state, an, radix);
+
+        if (an >= 2 && n_randint(state, 2))
+        {
+            A[an - 1] = 0;
+            if (A[an - 2] == 0)
+                A[an - 2] = 1 + n_randint(state, LIMB_RADIX(radix) - 1);
+        }
+        else
+        {
+            if (A[an - 1] == 0)
+                A[an - 1] = 1 + n_randint(state, LIMB_RADIX(radix) - 1);
+        }
+
+        /* Reference: multiply a basecase reciprocal square root at higher
+           precision by A, mirroring radix_sqrt_approx_rsqrtmul. */
+        {
+            slong A2n = FLINT_MIN(an, N + 2);
+            nn_srcptr A2 = A + an - A2n;
+            radix_rsqrt_approx_basecase(B, A, an, N, radix);
+            radix_mul(T, B, N + 2, A2, A2n, radix);
+            flint_mpn_copyi(B, T + A2n, N + 2);
+        }
+
+        flint_mpn_zero(C, err_limbs);
+        radix_sqrt_approx(C + err_limbs, A, an, n, radix);
+
+        if (mpn_cmp(B, C, N + 2) >= 0)
+            radix_sub(err, B, N + 2, C, N + 2, radix);
+        else
+            radix_sub(err, C, N + 2, B, N + 2, radix);
+
+        errn = N + 2;
+        MPN_NORM(err, errn);
+
+        dbl_err = 0.0;
+        dbl_powB = pow(LIMB_RADIX(radix), -err_limbs);
+        for (j = 0; j < errn; j++)
+        {
+            dbl_err += dbl_powB * err[j];
+            dbl_powB *= LIMB_RADIX(radix);
+        }
+
+        dbl_a = 0.0;
+        dbl_powB = 1.0 / LIMB_RADIX(radix);
+        for (j = 0; j < an; j++)
+        {
+            dbl_a += dbl_powB * A[an - 1 - j];
+            dbl_powB /= LIMB_RADIX(radix);
+        }
+
+        /* |computed - sqrt(A)| * sqrt(A) should be a few ulps */
+        dbl_err *= sqrt(dbl_a);
+
+        if (dbl_err > 3.0)
+        {
+            flint_printf("FAIL: too large error: radix %wu^%wd, n = %wd, an = %wd\n", DIGIT_RADIX(radix), radix->exp, n, an);
+            flint_printf("A = %{ulong*}\n", A, an);
+            flint_printf("B = %{ulong*}\n", B, N + 2);
+            flint_printf("C = %{ulong*}\n", C, N + 2);
+            flint_printf("err = %{ulong*}\n", err, N + 2);
+            flint_printf("dbl_err: %f\n", dbl_err);
+            flint_abort();
+        }
+
+        flint_free(A);
+        flint_free(B);
+        flint_free(C);
+        flint_free(T);
+        flint_free(err);
+
+        radix_clear(radix);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/radix/test/t-sqrtrem.c
+++ b/src/radix/test/t-sqrtrem.c
@@ -1,0 +1,136 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "radix.h"
+
+TEST_FUNCTION_START(radix_sqrtrem, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 10000 * flint_test_multiplier(); iter++)
+    {
+        nn_ptr a, s, r, s2, r2, P, t;
+        slong an, sn;
+        ulong one = 1;
+
+        radix_t radix;
+        radix_init_randtest(radix, state);
+
+        if (n_randint(state, 100))
+            an = 1 + n_randint(state, 30);
+        else
+            an = 1 + n_randint(state, 300);
+
+        a = flint_malloc(sizeof(ulong) * (an + 2));
+
+        radix_randtest_limbs(a, state, an, radix);
+        if (a[an - 1] == 0)
+            a[an - 1] = 1 + n_randint(state, LIMB_RADIX(radix) - 1);
+
+        sn = (an + 1) / 2;
+
+        /* Bias towards perfect squares and near-squares to exercise the
+           boundary digits. */
+        if (n_randint(state, 4) == 0)
+        {
+            nn_ptr s0 = flint_malloc(sizeof(ulong) * sn);
+            radix_randtest_limbs(s0, state, sn, radix);
+            if (s0[sn - 1] == 0)
+                s0[sn - 1] = 1 + n_randint(state, LIMB_RADIX(radix) - 1);
+            radix_mul(a, s0, sn, s0, sn, radix);
+            an = 2 * sn;
+            MPN_NORM(a, an);
+            if (n_randint(state, 2))
+            {
+                ulong d = 1 + n_randint(state, LIMB_RADIX(radix) - 1);
+                a[an] = 0;
+                radix_add(a, a, an + 1, &d, 1, radix);
+                an = an + 1;
+            }
+            MPN_NORM(a, an);
+            sn = (an + 1) / 2;
+            flint_free(s0);
+        }
+
+        s = flint_malloc(sizeof(ulong) * sn);
+        r = flint_malloc(sizeof(ulong) * (sn + 1));
+        s2 = flint_malloc(sizeof(ulong) * sn);
+        r2 = flint_malloc(sizeof(ulong) * (sn + 1));
+        P = flint_malloc(sizeof(ulong) * (an + 2));
+        t = flint_malloc(sizeof(ulong) * (sn + 2));
+
+        radix_sqrtrem(s, r, a, an, radix);
+
+        /* Check s^2 + r == a */
+        flint_mpn_zero(P, an + 1);
+        radix_mul(P, s, sn, s, sn, radix);
+        if (2 * sn < an + 1)
+            flint_mpn_zero(P + 2 * sn, an + 1 - 2 * sn);
+        radix_add(P, P, an + 1, r, sn + 1, radix);
+
+        if (P[an] != 0 || mpn_cmp(P, a, an) != 0)
+        {
+            flint_printf("FAIL: s^2 + r != a: radix %wu^%wd, an = %wd\n", DIGIT_RADIX(radix), radix->exp, an);
+            flint_printf("a = %{ulong*}\n", a, an);
+            flint_printf("s = %{ulong*}\n", s, sn);
+            flint_printf("r = %{ulong*}\n", r, sn + 1);
+            flint_abort();
+        }
+
+        /* Check r < 2s + 1 */
+        t[sn] = radix_add(t, s, sn, s, sn, radix);
+        radix_add(t, t, sn + 1, &one, 1, radix);
+
+        if (mpn_cmp(r, t, sn + 1) >= 0)
+        {
+            flint_printf("FAIL: r >= 2s + 1: radix %wu^%wd, an = %wd\n", DIGIT_RADIX(radix), radix->exp, an);
+            flint_printf("a = %{ulong*}\n", a, an);
+            flint_printf("s = %{ulong*}\n", s, sn);
+            flint_printf("r = %{ulong*}\n", r, sn + 1);
+            flint_abort();
+        }
+
+        /* Cross-check the Newton-Karp-Markstein path against the dispatch
+           (which uses mpn conversion for small an), and the r == NULL
+           variant. */
+        radix_sqrtrem_newton_karp_markstein(s2, r2, a, an, radix);
+
+        if (mpn_cmp(s, s2, sn) != 0 || mpn_cmp(r, r2, sn + 1) != 0)
+        {
+            flint_printf("FAIL: newton_karp_markstein mismatch: radix %wu^%wd, an = %wd\n", DIGIT_RADIX(radix), radix->exp, an);
+            flint_printf("a = %{ulong*}\n", a, an);
+            flint_printf("s = %{ulong*}\n", s, sn);
+            flint_printf("s2 = %{ulong*}\n", s2, sn);
+            flint_abort();
+        }
+
+        radix_sqrtrem_newton_karp_markstein(s2, NULL, a, an, radix);
+
+        if (mpn_cmp(s, s2, sn) != 0)
+        {
+            flint_printf("FAIL: r == NULL mismatch: radix %wu^%wd, an = %wd\n", DIGIT_RADIX(radix), radix->exp, an);
+            flint_abort();
+        }
+
+        flint_free(a);
+        flint_free(s);
+        flint_free(r);
+        flint_free(s2);
+        flint_free(r2);
+        flint_free(P);
+        flint_free(t);
+
+        radix_clear(radix);
+    }
+
+    TEST_FUNCTION_END(state);
+}


### PR DESCRIPTION
New functions generated with Claude Fable 5 asked to follow the strategy used in the division functions:

* `radix_rsqrt_approx`
* `radix_sqrt_approx`
* `radix_sqrtrem`
* `radix_sqrt`
* `radix_integer_sqrt`
* `radix_integer_sqrtrem`
* `radix_integer_is_square`
* (Also `radix_integer_inv`, `radix_integer_is_invertible` which were missing)

The PR also tightens up the Hensel square root code and optimizes the operation sequence in the `gr_poly` power series square root code which should make these functions a few percent faster.

Radix square roots are about 2x faster than `mpn_sqrtrem` asymptotically and approximate square roots are up to 3x faster. This should make them a bit faster than the current Newton-based `arb` square root code as well.

```
$ build/radix/profile/p-sqrt
   decimal      mpn  decimal        time        time    relative
    digits    limbs    limbs    mpn_sqrtrem radix_sqrt  time

        19        1        1    8.28e-09    4.05e-08    4.891x
        38        2        2    3.69e-08    1.09e-07    2.954x
        57        3        3     6.3e-08    1.56e-07    2.476x
        76        4        4    7.78e-08    1.81e-07    2.326x
       114        6        6    1.16e-07    2.96e-07    2.552x
       171        9        9    1.88e-07     5.1e-07    2.713x
       247       13       13    2.48e-07    8.25e-07    3.327x
       361       19       19    3.54e-07    1.59e-06    4.492x
       532       28       28    4.76e-07    2.57e-06    5.399x
       798       42       42    8.57e-07    3.83e-06    4.469x
      1197       63       63    1.43e-06    6.07e-06    4.245x
      1786       93       94     2.7e-06    1.15e-05    4.259x
      2679      140      141    5.18e-06    1.96e-05    3.784x
      4009      209      211    9.72e-06    3.56e-05    3.663x
      6004      312      316    1.87e-05    6.54e-05    3.497x
      9006      468      474    3.57e-05    8.76e-05    2.454x
     13509      702      711    6.93e-05     0.00014    2.020x
     20254     1052     1066    0.000129    0.000224    1.736x
     30381     1577     1599    0.000244    0.000324    1.328x
     45562     2365     2398    0.000432    0.000505    1.169x
     68343     3548     3597    0.000769     0.00074    0.962x
    102505     5321     5395     0.00138     0.00116    0.841x
    153748     7981     8092     0.00229     0.00163    0.712x
    230622    11971    12138     0.00394     0.00265    0.673x
    345933    17956    18207     0.00629     0.00411    0.653x
    518890    26934    27310      0.0104     0.00605    0.582x
    778335    40400    40965      0.0166     0.00956    0.576x
   1167493    60599    61447       0.025       0.014    0.560x
   1751230    90898    92170      0.0381      0.0218    0.572x
   2626845   136347   138255      0.0674      0.0358    0.531x
   3940258   204520   207382       0.111      0.0527    0.475x
   5910387   306780   311073       0.168      0.0868    0.517x
   8865571   460169   466609       0.266       0.126    0.474x
  13298347   690253   699913       0.463       0.214    0.462x
  19947511  1035379  1049869        0.77       0.376    0.488x
  29921257  1553067  1574803       1.054       0.536    0.509x
  44881876  2329600  2362204       1.886       1.001    0.531x
  67322814  3494400  3543306       3.022       1.352    0.447x
 100984221  5241599  5314959       5.145       2.614    0.508x
 151476322  7862398  7972438       7.301       3.682    0.504x
 227214483 11793597 11958657      12.097       6.097    0.504x
 340821715 17690395 17937985      20.302      10.518    0.518x
```

```
$ build/radix/profile/p-sqrt_approx 
   decimal      mpn  decimal        time        time      relative
    digits    limbs    limbs  mpn_sqrtrem radix_sqrt_approx  time

        19        1        1    8.45e-09    2.21e-07    26.154x
        38        2        2    3.81e-08     2.9e-07    7.612x
        57        3        3    6.59e-08     3.7e-07    5.615x
        76        4        4    8.08e-08    4.38e-07    5.421x
       114        6        6    1.19e-07     5.5e-07    4.622x
       171        9        9    1.97e-07    7.25e-07    3.680x
       247       13       13    2.55e-07    9.21e-07    3.612x
       361       19       19    3.66e-07    1.29e-06    3.525x
       532       28       28     4.9e-07    1.78e-06    3.633x
       798       42       42    8.79e-07    2.47e-06    2.810x
      1197       63       63    1.49e-06    3.88e-06    2.604x
      1786       93       94    2.78e-06    6.19e-06    2.227x
      2679      140      141     5.3e-06    1.08e-05    2.038x
      4009      209      211       1e-05    2.48e-05    2.480x
      6004      312      316     1.9e-05    4.93e-05    2.595x
      9006      468      474    3.63e-05    6.49e-05    1.788x
     13509      702      711    7.06e-05    0.000107    1.516x
     20254     1052     1066    0.000131     0.00017    1.298x
     30381     1577     1599    0.000248    0.000246    0.992x
     45562     2365     2398    0.000438    0.000379    0.865x
     68343     3548     3597    0.000778    0.000551    0.708x
    102505     5321     5395     0.00141    0.000878    0.623x
    153748     7981     8092     0.00236     0.00124    0.525x
    230622    11971    12138     0.00403     0.00196    0.486x
    345933    17956    18207     0.00651     0.00312    0.479x
    518890    26934    27310      0.0105      0.0046    0.438x
    778335    40400    40965      0.0172     0.00773    0.449x
   1167493    60599    61447      0.0274      0.0112    0.409x
   1751230    90898    92170      0.0415      0.0176    0.424x
   2626845   136347   138255      0.0739      0.0287    0.388x
   3940258   204520   207382       0.116      0.0419    0.361x
   5910387   306780   311073       0.184      0.0688    0.374x
   8865571   460169   466609       0.293         0.1    0.341x
  13298347   690253   699913       0.499       0.167    0.335x
  19947511  1035379  1049869       0.817       0.291    0.356x
  29921257  1553067  1574803       1.113       0.412    0.370x
  44881876  2329600  2362204       2.009       0.702    0.349x
  67322814  3494400  3543306       3.192       0.983    0.308x
 100984221  5241599  5314959       5.397       1.986    0.368x
 151476322  7862398  7972438       7.642       2.813    0.368x
 227214483 11793597 11958657      12.429       4.643    0.374x
 340821715 17690395 17937985      19.766       7.839    0.397x
```