### PR TITLE
Fix hang in `nmod_mpoly_gcd`

### DIFF
--- a/src/fq_nmod_mpoly/mpolyu_gcdp_zippel.c
+++ b/src/fq_nmod_mpoly/mpolyu_gcdp_zippel.c
@@ -384,6 +384,7 @@ nmod_gcds_ret_t fq_nmod_mpolyu_gcds_zippel(
 {
     slong d = fq_nmod_ctx_degree(ctx->fqctx);
     int eval_points_tried;
+    slong l_growths = 0;
     nmod_gcds_ret_t success;
     fq_nmod_mpolyu_t Aevalsk1, Bevalsk1, fevalsk1, Aevalski, Bevalski, fevalski;
     fq_nmod_poly_t Aeval, Beval, Geval;
@@ -504,10 +505,21 @@ nmod_gcds_ret_t fq_nmod_mpolyu_gcds_zippel(
     for (i = 0; i < (f->coeffs + tlen[f->length - 1])->length; i++)
         fq_nmod_init(b + i, ctx->fqctx);
 
-    fq_nmod_mat_init(MF, 0, l, ctx->fqctx);
+    /* compute how many masks are needed */
+    entries = f->bits * var;
+    offs = (slong *) TMP_ALLOC(entries*sizeof(slong));
+    masks = (ulong *) TMP_ALLOC(entries*sizeof(slong));
+    powers = (fq_nmod_struct *) TMP_ALLOC(entries*sizeof(fq_nmod_struct));
+    for (i = 0; i < entries; i++)
+        fq_nmod_init(powers + i, ctx->fqctx);
 
     M = (fq_nmod_mat_struct *) TMP_ALLOC(f->length*sizeof(fq_nmod_mat_struct));
     ML_is_initialized = (int *) TMP_ALLOC(f->length*sizeof(int));
+
+alloc_images:
+
+    fq_nmod_mat_init(MF, 0, l, ctx->fqctx);
+
     for (i = 0; i < f->length; i++)
     {
         fq_nmod_mat_init(M + i, l, (f->coeffs + i)->length, ctx->fqctx);
@@ -520,14 +532,6 @@ nmod_gcds_ret_t fq_nmod_mpolyu_gcds_zippel(
 
 
     fq_nmod_mat_init(Msol, l, 1, ctx->fqctx);
-
-    /* compute how many masks are needed */
-    entries = f->bits * var;
-    offs = (slong *) TMP_ALLOC(entries*sizeof(slong));
-    masks = (ulong *) TMP_ALLOC(entries*sizeof(slong));
-    powers = (fq_nmod_struct *) TMP_ALLOC(entries*sizeof(fq_nmod_struct));
-    for (i = 0; i < entries; i++)
-        fq_nmod_init(powers + i, ctx->fqctx);
 
 
     /***** evaluation loop head *******/
@@ -739,6 +743,25 @@ pick_evaluation_point:
         ++underdeterminedcount;
         if (underdeterminedcount < 2)
             goto pick_evaluation_point;
+
+        /* see nmod version: structural underdetermination, use more images */
+        if (++l_growths <= 4)
+        {
+            for (i = 0; i < l*f->length; i++)
+                fq_nmod_clear(W + i, ctx->fqctx);
+            flint_free(W);
+            fq_nmod_mat_clear(MF, ctx->fqctx);
+            fq_nmod_mat_clear(Msol, ctx->fqctx);
+            for (i = 0; i < f->length; i++)
+            {
+                fq_nmod_mat_clear(M + i, ctx->fqctx);
+                if (ML_is_initialized[i])
+                    fq_nmod_mat_clear(ML + i, ctx->fqctx);
+            }
+            l += 1 + l/2;
+            underdeterminedcount = 0;
+            goto alloc_images;
+        }
 
         success = nmod_gcds_scales_not_found;
         goto finished;

--- a/src/fq_nmod_mpoly/test/t-gcd_zippel.c
+++ b/src/fq_nmod_mpoly/test/t-gcd_zippel.c
@@ -107,6 +107,35 @@ TEST_FUNCTION_START(fq_nmod_mpoly_gcd_zippel, state)
 {
     slong i, j;
 
+    /* issue #2581: the LINZIP scale system in gcds_zippel was generically
+       underdetermined for these inputs and the evaluation-point retry loop
+       effectively never terminated */
+    {
+        fq_nmod_mpoly_ctx_t ctx;
+        fq_nmod_mpoly_t g, a, b, t;
+
+        fq_nmod_mpoly_ctx_init_deg(ctx, 12, ORD_LEX, UWORD(2147483647), 1);
+        fq_nmod_mpoly_init(g, ctx);
+        fq_nmod_mpoly_init(a, ctx);
+        fq_nmod_mpoly_init(b, ctx);
+        fq_nmod_mpoly_init(t, ctx);
+
+        fq_nmod_mpoly_set_str_pretty(t, "x4*x7^2*x11^3*x12 + x4*x7^2*x11*x12^3 + 2*x4*x7*x8*x10*x11^2*x12 + 2*x4*x7*x8*x10*x12^3 + 2*x4*x7*x9*x10*x11^3 + 2*x4*x7*x9*x10*x11*x12^2 + x4*x8^2*x10^2*x11*x12 + x4*x8^2*x11*x12^3 + x4*x8*x9*x10^2*x11^2 + x4*x8*x9*x10^2*x12^2 + 2*x4*x8*x9*x11^2*x12^2 + x4*x9^2*x10^2*x11*x12 + x4*x9^2*x11^3*x12 - x5*x7^2*x11*x12^3 - 2*x5*x7*x8*x10*x12^3 - 2*x5*x7*x9*x10*x11*x12^2 - x5*x8^2*x11*x12^3 + x5*x8*x9*x10^2*x11^2 - 2*x5*x8*x9*x10^2*x12^2 - x5*x8*x9*x11^2*x12^2 - x5*x9^2*x10^2*x11*x12 - x6*x7^2*x11^3*x12 - 2*x6*x7*x8*x10*x11^2*x12 - 2*x6*x7*x9*x10*x11^3 - x6*x8^2*x10^2*x11*x12 - 2*x6*x8*x9*x10^2*x11^2 + x6*x8*x9*x10^2*x12^2 - x6*x8*x9*x11^2*x12^2 - x6*x9^2*x11^3*x12", NULL, ctx);
+        fq_nmod_mpoly_set_str_pretty(a, "x3*(x5-x4)", NULL, ctx);
+        fq_nmod_mpoly_set_str_pretty(b, "x2*(x4-x6)", NULL, ctx);
+        fq_nmod_mpoly_mul(a, a, t, ctx);
+        fq_nmod_mpoly_mul(b, b, t, ctx);
+
+        gcd_check(g, a, b, t, ctx, 0, 0, "issue 2581");
+
+        fq_nmod_mpoly_clear(g, ctx);
+        fq_nmod_mpoly_clear(a, ctx);
+        fq_nmod_mpoly_clear(b, ctx);
+        fq_nmod_mpoly_clear(t, ctx);
+        fq_nmod_mpoly_ctx_clear(ctx);
+    }
+
+
     for (i = 0; i < 20*flint_test_multiplier(); i++)
     {
         fq_nmod_mpoly_ctx_t ctx;

--- a/src/nmod_mpoly/mpolyu_gcdp_zippel.c
+++ b/src/nmod_mpoly/mpolyu_gcdp_zippel.c
@@ -194,6 +194,7 @@ nmod_gcds_ret_t nmod_mpolyu_gcds_zippel(nmod_mpolyu_t G,
           const nmod_mpoly_ctx_t ctx, flint_rand_t randstate, slong * degbound)
 {
     int eval_points_tried;
+    slong l_growths = 0;
     nmod_gcds_ret_t success;
     nmod_mpolyu_t Aevalsk1, Bevalsk1, fevalsk1, Aevalski, Bevalski, fevalski;
     nmod_poly_t Aeval, Beval, Geval;
@@ -303,10 +304,19 @@ nmod_gcds_ret_t nmod_mpolyu_gcds_zippel(nmod_mpolyu_t G,
     b = (ulong *) TMP_ALLOC((f->coeffs + d[f->length - 1])->length
                                                            *sizeof(ulong));
 
-    nmod_mat_init(MF, 0, l, ctx->mod.n);
+    /* compute how many masks are needed */
+    entries = f->bits * var;
+    offs = (slong *) TMP_ALLOC(entries*sizeof(slong));
+    masks = (ulong *) TMP_ALLOC(entries*sizeof(slong));
+    powers = (ulong *) TMP_ALLOC(entries*sizeof(ulong));
 
     M = (nmod_mat_struct *) TMP_ALLOC(f->length*sizeof(nmod_mat_struct));
     ML_is_initialized = (int *) TMP_ALLOC(f->length*sizeof(int));
+
+alloc_images:
+
+    nmod_mat_init(MF, 0, l, ctx->mod.n);
+
     for (i = 0; i < f->length; i++)
     {
         nmod_mat_init(M + i, l, (f->coeffs + i)->length, ctx->mod.n);
@@ -316,12 +326,6 @@ nmod_gcds_ret_t nmod_mpolyu_gcds_zippel(nmod_mpolyu_t G,
     W = (ulong *) flint_malloc(l*f->length*sizeof(ulong));
 
     nmod_mat_init(Msol, l, 1, ctx->mod.n);
-
-    /* compute how many masks are needed */
-    entries = f->bits * var;
-    offs = (slong *) TMP_ALLOC(entries*sizeof(slong));
-    masks = (ulong *) TMP_ALLOC(entries*sizeof(slong));
-    powers = (ulong *) TMP_ALLOC(entries*sizeof(ulong));
 
 
     /***** evaluation loop head *******/
@@ -526,6 +530,29 @@ pick_evaluation_point:
         ++underdeterminedcount;
         if (underdeterminedcount < 2)
             goto pick_evaluation_point;
+
+        /*
+            The failure is likely structural: with this form the scale
+            system is generically underdetermined for this number of
+            images. Retry with more images instead of giving up, which
+            would otherwise send the caller into a near-infinite loop
+            of new evaluation points that can never succeed.
+        */
+        if (++l_growths <= 4)
+        {
+            flint_free(W);
+            nmod_mat_clear(MF);
+            nmod_mat_clear(Msol);
+            for (i = 0; i < f->length; i++)
+            {
+                nmod_mat_clear(M + i);
+                if (ML_is_initialized[i])
+                    nmod_mat_clear(ML + i);
+            }
+            l += 1 + l/2;
+            underdeterminedcount = 0;
+            goto alloc_images;
+        }
 
         success = nmod_gcds_scales_not_found;
         goto finished;

--- a/src/nmod_mpoly/test/t-gcd.c
+++ b/src/nmod_mpoly/test/t-gcd.c
@@ -138,6 +138,38 @@ TEST_FUNCTION_START(nmod_mpoly_gcd, state)
     const slong max_threads = 5;
     slong i, j, k, tmul = 5;
 
+    /* issue #2581: the LINZIP scale system in gcds_zippel was generically
+       underdetermined for these inputs and the evaluation-point retry loop
+       effectively never terminated */
+    {
+        nmod_mpoly_ctx_t ctx;
+        nmod_mpoly_t g, a, b, t;
+        const char * vars[] = {"l1", "l2", "l3", "a1", "a2", "a3",
+                               "b1", "b2", "b3", "g1", "g2", "g3"};
+
+        nmod_mpoly_ctx_init(ctx, 12, ORD_LEX, UWORD(2147483647));
+        nmod_mpoly_init(g, ctx);
+        nmod_mpoly_init(a, ctx);
+        nmod_mpoly_init(b, ctx);
+        nmod_mpoly_init(t, ctx);
+
+        nmod_mpoly_set_str_pretty(t, "l1*a2-l1*a3-l2*a1+l2*a3+l3*a1-l3*a2", vars, ctx);
+        nmod_mpoly_set_str_pretty(a, "(b1*g2*g3+b2*g1*g3+b3*g1*g2)^2", vars, ctx);
+        nmod_mpoly_set_str_pretty(b, "a1*b1^2*g2^3*g3 + a1*b1^2*g2*g3^3 + 2*a1*b1*b2*g1*g2^2*g3 + 2*a1*b1*b2*g1*g3^3 + 2*a1*b1*b3*g1*g2^3 + 2*a1*b1*b3*g1*g2*g3^2 + a1*b2^2*g1^2*g2*g3 + a1*b2^2*g2*g3^3 + a1*b2*b3*g1^2*g2^2 + a1*b2*b3*g1^2*g3^2 + 2*a1*b2*b3*g2^2*g3^2 + a1*b3^2*g1^2*g2*g3 + a1*b3^2*g2^3*g3 - a2*b1^2*g2*g3^3 - 2*a2*b1*b2*g1*g3^3 - 2*a2*b1*b3*g1*g2*g3^2 - a2*b2^2*g2*g3^3 + a2*b2*b3*g1^2*g2^2 - 2*a2*b2*b3*g1^2*g3^2 - a2*b2*b3*g2^2*g3^2 - a2*b3^2*g1^2*g2*g3 - a3*b1^2*g2^3*g3 - 2*a3*b1*b2*g1*g2^2*g3 - 2*a3*b1*b3*g1*g2^3 - a3*b2^2*g1^2*g2*g3 - 2*a3*b2*b3*g1^2*g2^2 + a3*b2*b3*g1^2*g3^2 - a3*b2*b3*g2^2*g3^2 - a3*b3^2*g2^3*g3", vars, ctx);
+        nmod_mpoly_mul(a, a, t, ctx);
+        nmod_mpoly_mul(a, a, t, ctx);
+        nmod_mpoly_mul(b, b, t, ctx);
+
+        gcd_check(g, a, b, ctx, 0, 0, "issue 2581");
+
+        nmod_mpoly_clear(g, ctx);
+        nmod_mpoly_clear(a, ctx);
+        nmod_mpoly_clear(b, ctx);
+        nmod_mpoly_clear(t, ctx);
+        nmod_mpoly_ctx_clear(ctx);
+    }
+
+
     {
         nmod_mpoly_ctx_t ctx;
         nmod_mpoly_t g, a, b;

--- a/src/nmod_mpoly/test/t-gcd_cofactors.c
+++ b/src/nmod_mpoly/test/t-gcd_cofactors.c
@@ -268,6 +268,43 @@ TEST_FUNCTION_START(nmod_mpoly_gcd_cofactors, state)
     const slong max_threads = 5;
     slong i, j, k, tmul = 3;
 
+    /* issue #2581: the LINZIP scale system in gcds_zippel was generically
+       underdetermined for these inputs and the evaluation-point retry loop
+       effectively never terminated */
+    {
+        nmod_mpoly_ctx_t ctx;
+        nmod_mpoly_t g, a, b, t;
+        nmod_mpoly_t abar, bbar;
+        const char * vars[] = {"l1", "l2", "l3", "a1", "a2", "a3",
+                               "b1", "b2", "b3", "g1", "g2", "g3"};
+
+        nmod_mpoly_ctx_init(ctx, 12, ORD_LEX, UWORD(2147483647));
+        nmod_mpoly_init(g, ctx);
+        nmod_mpoly_init(a, ctx);
+        nmod_mpoly_init(b, ctx);
+        nmod_mpoly_init(t, ctx);
+        nmod_mpoly_init(abar, ctx);
+        nmod_mpoly_init(bbar, ctx);
+
+        nmod_mpoly_set_str_pretty(t, "l1*a2-l1*a3-l2*a1+l2*a3+l3*a1-l3*a2", vars, ctx);
+        nmod_mpoly_set_str_pretty(a, "(b1*g2*g3+b2*g1*g3+b3*g1*g2)^2", vars, ctx);
+        nmod_mpoly_set_str_pretty(b, "a1*b1^2*g2^3*g3 + a1*b1^2*g2*g3^3 + 2*a1*b1*b2*g1*g2^2*g3 + 2*a1*b1*b2*g1*g3^3 + 2*a1*b1*b3*g1*g2^3 + 2*a1*b1*b3*g1*g2*g3^2 + a1*b2^2*g1^2*g2*g3 + a1*b2^2*g2*g3^3 + a1*b2*b3*g1^2*g2^2 + a1*b2*b3*g1^2*g3^2 + 2*a1*b2*b3*g2^2*g3^2 + a1*b3^2*g1^2*g2*g3 + a1*b3^2*g2^3*g3 - a2*b1^2*g2*g3^3 - 2*a2*b1*b2*g1*g3^3 - 2*a2*b1*b3*g1*g2*g3^2 - a2*b2^2*g2*g3^3 + a2*b2*b3*g1^2*g2^2 - 2*a2*b2*b3*g1^2*g3^2 - a2*b2*b3*g2^2*g3^2 - a2*b3^2*g1^2*g2*g3 - a3*b1^2*g2^3*g3 - 2*a3*b1*b2*g1*g2^2*g3 - 2*a3*b1*b3*g1*g2^3 - a3*b2^2*g1^2*g2*g3 - 2*a3*b2*b3*g1^2*g2^2 + a3*b2*b3*g1^2*g3^2 - a3*b2*b3*g2^2*g3^2 - a3*b3^2*g2^3*g3", vars, ctx);
+        nmod_mpoly_mul(a, a, t, ctx);
+        nmod_mpoly_mul(a, a, t, ctx);
+        nmod_mpoly_mul(b, b, t, ctx);
+
+        gcd_check(g, abar, bbar, a, b, t, ctx, 0, 0, "issue 2581");
+
+        nmod_mpoly_clear(g, ctx);
+        nmod_mpoly_clear(a, ctx);
+        nmod_mpoly_clear(b, ctx);
+        nmod_mpoly_clear(t, ctx);
+        nmod_mpoly_clear(abar, ctx);
+        nmod_mpoly_clear(bbar, ctx);
+        nmod_mpoly_ctx_clear(ctx);
+    }
+
+
     {
         nmod_mpoly_ctx_t ctx;
         nmod_mpoly_t g, abar, bbar, a, b, t;

--- a/src/nmod_mpoly/test/t-gcd_hensel.c
+++ b/src/nmod_mpoly/test/t-gcd_hensel.c
@@ -107,6 +107,38 @@ TEST_FUNCTION_START(nmod_mpoly_gcd_hensel, state)
 {
     slong i, j;
 
+    /* issue #2581: the LINZIP scale system in gcds_zippel was generically
+       underdetermined for these inputs and the evaluation-point retry loop
+       effectively never terminated */
+    {
+        nmod_mpoly_ctx_t ctx;
+        nmod_mpoly_t g, a, b, t;
+        const char * vars[] = {"l1", "l2", "l3", "a1", "a2", "a3",
+                               "b1", "b2", "b3", "g1", "g2", "g3"};
+
+        nmod_mpoly_ctx_init(ctx, 12, ORD_LEX, UWORD(2147483647));
+        nmod_mpoly_init(g, ctx);
+        nmod_mpoly_init(a, ctx);
+        nmod_mpoly_init(b, ctx);
+        nmod_mpoly_init(t, ctx);
+
+        nmod_mpoly_set_str_pretty(t, "l1*a2-l1*a3-l2*a1+l2*a3+l3*a1-l3*a2", vars, ctx);
+        nmod_mpoly_set_str_pretty(a, "(b1*g2*g3+b2*g1*g3+b3*g1*g2)^2", vars, ctx);
+        nmod_mpoly_set_str_pretty(b, "a1*b1^2*g2^3*g3 + a1*b1^2*g2*g3^3 + 2*a1*b1*b2*g1*g2^2*g3 + 2*a1*b1*b2*g1*g3^3 + 2*a1*b1*b3*g1*g2^3 + 2*a1*b1*b3*g1*g2*g3^2 + a1*b2^2*g1^2*g2*g3 + a1*b2^2*g2*g3^3 + a1*b2*b3*g1^2*g2^2 + a1*b2*b3*g1^2*g3^2 + 2*a1*b2*b3*g2^2*g3^2 + a1*b3^2*g1^2*g2*g3 + a1*b3^2*g2^3*g3 - a2*b1^2*g2*g3^3 - 2*a2*b1*b2*g1*g3^3 - 2*a2*b1*b3*g1*g2*g3^2 - a2*b2^2*g2*g3^3 + a2*b2*b3*g1^2*g2^2 - 2*a2*b2*b3*g1^2*g3^2 - a2*b2*b3*g2^2*g3^2 - a2*b3^2*g1^2*g2*g3 - a3*b1^2*g2^3*g3 - 2*a3*b1*b2*g1*g2^2*g3 - 2*a3*b1*b3*g1*g2^3 - a3*b2^2*g1^2*g2*g3 - 2*a3*b2*b3*g1^2*g2^2 + a3*b2*b3*g1^2*g3^2 - a3*b2*b3*g2^2*g3^2 - a3*b3^2*g2^3*g3", vars, ctx);
+        nmod_mpoly_mul(a, a, t, ctx);
+        nmod_mpoly_mul(a, a, t, ctx);
+        nmod_mpoly_mul(b, b, t, ctx);
+
+        gcd_check(g, a, b, t, ctx, 0, 0, "issue 2581");
+
+        nmod_mpoly_clear(g, ctx);
+        nmod_mpoly_clear(a, ctx);
+        nmod_mpoly_clear(b, ctx);
+        nmod_mpoly_clear(t, ctx);
+        nmod_mpoly_ctx_clear(ctx);
+    }
+
+
     for (i = 0; i < 10 * flint_test_multiplier(); i++)
     {
         nmod_mpoly_ctx_t ctx;

--- a/src/nmod_mpoly/test/t-gcd_zippel.c
+++ b/src/nmod_mpoly/test/t-gcd_zippel.c
@@ -107,6 +107,35 @@ TEST_FUNCTION_START(nmod_mpoly_gcd_zippel, state)
 {
     slong i, j;
 
+    /* issue #2581: the LINZIP scale system in gcds_zippel was generically
+       underdetermined for these inputs and the evaluation-point retry loop
+       effectively never terminated */
+    {
+        nmod_mpoly_ctx_t ctx;
+        nmod_mpoly_t g, a, b, t;
+
+        nmod_mpoly_ctx_init(ctx, 12, ORD_LEX, UWORD(2147483647));
+        nmod_mpoly_init(g, ctx);
+        nmod_mpoly_init(a, ctx);
+        nmod_mpoly_init(b, ctx);
+        nmod_mpoly_init(t, ctx);
+
+        nmod_mpoly_set_str_pretty(t, "x4*x7^2*x11^3*x12 + x4*x7^2*x11*x12^3 + 2*x4*x7*x8*x10*x11^2*x12 + 2*x4*x7*x8*x10*x12^3 + 2*x4*x7*x9*x10*x11^3 + 2*x4*x7*x9*x10*x11*x12^2 + x4*x8^2*x10^2*x11*x12 + x4*x8^2*x11*x12^3 + x4*x8*x9*x10^2*x11^2 + x4*x8*x9*x10^2*x12^2 + 2*x4*x8*x9*x11^2*x12^2 + x4*x9^2*x10^2*x11*x12 + x4*x9^2*x11^3*x12 - x5*x7^2*x11*x12^3 - 2*x5*x7*x8*x10*x12^3 - 2*x5*x7*x9*x10*x11*x12^2 - x5*x8^2*x11*x12^3 + x5*x8*x9*x10^2*x11^2 - 2*x5*x8*x9*x10^2*x12^2 - x5*x8*x9*x11^2*x12^2 - x5*x9^2*x10^2*x11*x12 - x6*x7^2*x11^3*x12 - 2*x6*x7*x8*x10*x11^2*x12 - 2*x6*x7*x9*x10*x11^3 - x6*x8^2*x10^2*x11*x12 - 2*x6*x8*x9*x10^2*x11^2 + x6*x8*x9*x10^2*x12^2 - x6*x8*x9*x11^2*x12^2 - x6*x9^2*x11^3*x12", NULL, ctx);
+        nmod_mpoly_set_str_pretty(a, "x3*(x5-x4)", NULL, ctx);
+        nmod_mpoly_set_str_pretty(b, "x2*(x4-x6)", NULL, ctx);
+        nmod_mpoly_mul(a, a, t, ctx);
+        nmod_mpoly_mul(b, b, t, ctx);
+
+        gcd_check(g, a, b, t, ctx, 0, 0, "issue 2581");
+
+        nmod_mpoly_clear(g, ctx);
+        nmod_mpoly_clear(a, ctx);
+        nmod_mpoly_clear(b, ctx);
+        nmod_mpoly_clear(t, ctx);
+        nmod_mpoly_ctx_clear(ctx);
+    }
+
+
     for (i = 0; i < 30 * flint_test_multiplier(); i++)
     {
         nmod_mpoly_ctx_t ctx;

--- a/src/nmod_mpoly/test/t-gcd_zippel2.c
+++ b/src/nmod_mpoly/test/t-gcd_zippel2.c
@@ -107,6 +107,38 @@ TEST_FUNCTION_START(nmod_mpoly_gcd_zippel2, state)
 {
     slong i, j;
 
+    /* issue #2581: the LINZIP scale system in gcds_zippel was generically
+       underdetermined for these inputs and the evaluation-point retry loop
+       effectively never terminated */
+    {
+        nmod_mpoly_ctx_t ctx;
+        nmod_mpoly_t g, a, b, t;
+        const char * vars[] = {"l1", "l2", "l3", "a1", "a2", "a3",
+                               "b1", "b2", "b3", "g1", "g2", "g3"};
+
+        nmod_mpoly_ctx_init(ctx, 12, ORD_LEX, UWORD(2147483647));
+        nmod_mpoly_init(g, ctx);
+        nmod_mpoly_init(a, ctx);
+        nmod_mpoly_init(b, ctx);
+        nmod_mpoly_init(t, ctx);
+
+        nmod_mpoly_set_str_pretty(t, "l1*a2-l1*a3-l2*a1+l2*a3+l3*a1-l3*a2", vars, ctx);
+        nmod_mpoly_set_str_pretty(a, "(b1*g2*g3+b2*g1*g3+b3*g1*g2)^2", vars, ctx);
+        nmod_mpoly_set_str_pretty(b, "a1*b1^2*g2^3*g3 + a1*b1^2*g2*g3^3 + 2*a1*b1*b2*g1*g2^2*g3 + 2*a1*b1*b2*g1*g3^3 + 2*a1*b1*b3*g1*g2^3 + 2*a1*b1*b3*g1*g2*g3^2 + a1*b2^2*g1^2*g2*g3 + a1*b2^2*g2*g3^3 + a1*b2*b3*g1^2*g2^2 + a1*b2*b3*g1^2*g3^2 + 2*a1*b2*b3*g2^2*g3^2 + a1*b3^2*g1^2*g2*g3 + a1*b3^2*g2^3*g3 - a2*b1^2*g2*g3^3 - 2*a2*b1*b2*g1*g3^3 - 2*a2*b1*b3*g1*g2*g3^2 - a2*b2^2*g2*g3^3 + a2*b2*b3*g1^2*g2^2 - 2*a2*b2*b3*g1^2*g3^2 - a2*b2*b3*g2^2*g3^2 - a2*b3^2*g1^2*g2*g3 - a3*b1^2*g2^3*g3 - 2*a3*b1*b2*g1*g2^2*g3 - 2*a3*b1*b3*g1*g2^3 - a3*b2^2*g1^2*g2*g3 - 2*a3*b2*b3*g1^2*g2^2 + a3*b2*b3*g1^2*g3^2 - a3*b2*b3*g2^2*g3^2 - a3*b3^2*g2^3*g3", vars, ctx);
+        nmod_mpoly_mul(a, a, t, ctx);
+        nmod_mpoly_mul(a, a, t, ctx);
+        nmod_mpoly_mul(b, b, t, ctx);
+
+        gcd_check(g, a, b, t, ctx, 0, 0, "issue 2581");
+
+        nmod_mpoly_clear(g, ctx);
+        nmod_mpoly_clear(a, ctx);
+        nmod_mpoly_clear(b, ctx);
+        nmod_mpoly_clear(t, ctx);
+        nmod_mpoly_ctx_clear(ctx);
+    }
+
+
     for (i = 0; i < 20 * flint_test_multiplier(); i++)
     {
         nmod_mpoly_ctx_t ctx;


### PR DESCRIPTION
I asked Fable 5 to fix #2581.

Its report is below. I did not ask it to follow up on its suggestion

```
A production fix should probably also bound the scales_not_found /
eval_point_not_found / eval_gcd_deg_too_high retries in both
gcdp_zippel inner loops (defense in depth — any other systematic failure
mode currently loops ~2^31 times for a 31-bit modulus), and could grow l
more carefully (e.g. +flen per round). The fmpz_mpoly Zippel path reduces to
these nmod/fq_nmod kernels, so both benefit.
```

since we currently have no other hanging examples, but someone else may want to investigate that.

# Investigation of flintlib/flint#2581 — `nmod_mpoly_gcd` hangs

Reproduced on current master (`474f55e`), p = 2^31 − 1, 12 variables. Baseline behavior:

| call | original (g, h) | deflated pair (sg2, sh2) |
|---|---|---|
| `nmod_mpoly_gcd` | hang | — |
| `nmod_mpoly_gcd_zippel` | 0.9 ms ✓ | hang |
| `nmod_mpoly_gcd_zippel2` | hang | 0.9 ms ✓ |
| `nmod_mpoly_gcd_hensel` | hang | — |
| `nmod_mpoly_gcd_brown` | 5.8 s ✓ | — |

## Where the hang is

All of the hanging entry points funnel into the **same loop**. Stack sample of `nmod_mpoly_gcd`:

```
nmod_mpoly_gcd → _try_zippel2 → nmod_mpolyl_content (num_vars=2)
  → _nmod_mpoly_vec_content_mpoly → nmod_mpoly_gcd (recursive, on coefficients)
    → _try_zippel → nmod_mpolyu_gcdm_zippel
      → nmod_mpolyu_gcdp_zippel (var 7 → 6 → 5 → 4 → 3)
        → nmod_mpolyu_gcds_zippel → nmod_mat_rref   ← spinning here
```

`_try_zippel2` (and `_try_hensel`) begin by removing content in the two main
variables; that content computation is a recursive `nmod_mpoly_gcd`, which
selects classic Zippel — so `gcd`, `gcd_zippel2` and `gcd_hensel` all hang in
the same place. The "deflated polynomials" in the earlier comment are exactly
that inner content subproblem.

## What the loop is doing

Instrumenting `nmod_mpolyu_gcds_zippel` (the LINZIP sparse-interpolation step)
shows that at recursion level `var = 3` it returns
`nmod_gcds_scales_not_found` on **every single call**:

```
gcds call 7:     var=3 flen=3 ret=scales_not_found
gcds call 8:     var=3 flen=3 ret=scales_not_found
...
gcds call 20000: var=3 flen=3 ret=scales_not_found   (totals: 19994 × scales_not_found)
```

The caller `nmod_mpolyu_gcdp_zippel` treats `scales_not_found` as an unlucky
evaluation point and retries with a new α (`goto inner_continue`). Its loop
only terminates when α wraps all the way around the field — with p ≈ 2^31 and
an rref per iteration, that is an effective hang (months of CPU).

## Root cause: `l` (number of images) is too small; the failure is structural, not bad luck

Dumping the failing subproblem (4 remaining variables; main variable X of
degree 2; coefficient supports of sizes 4, 8, 12) shows:

* the true gcd there is **equal to B** (B divides A),
* the assumed form `f` matches the gcd's support exactly,
* the gcd is primitive (content 1 in the non-main variables).

So neither the form nor content is the problem. Re-implementing the LINZIP
multiple-scaling linear system independently (same Kronecker-power evaluation
scheme, same per-block rref + stacked constraint matrix) shows that for this
support structure the system is **generically rank-deficient** at the image
count FLINT chooses:

```
l = 13 (FLINT's choice)  →  nullity = 3     (every random α; tested many)
l = 14                   →  nullity = 2
l = 15                   →  nullity = 1     (unique solution, as required)
```

FLINT computes `l = (Σ len_j + flen − 3)/(flen − 1)`, max'd with the largest
block, plus one test image — a naive equation count that assumes the stacked
constraint rows are generically independent. For this input they are not: two
images' worth of equations are dependent, so the system stays underdetermined
no matter which evaluation point is chosen. Retrying with new points can
therefore **never** succeed, but nothing in the code path ever increases `l`
or gives up:

* `nmod_mpolyu_gcds_zippel` retries up to 10 fresh points internally, then
  returns `scales_not_found`;
* `nmod_mpolyu_gcdp_zippel` responds by picking yet another α and calling
  `gcds` again with the same form → the same `l` → the same nullity — for up
  to p − 2 iterations.

## Two independent defects

1. **No escalation on underdetermination.** LINZIP's prescription for an
   underdetermined scale system is to add more images/equations. FLINT
   restarts with a fresh point but an identical system size.

2. **Unbounded retry of a non-transient failure.** The inner loop in
   `gcdp_zippel` bounds nothing except α wrapping the whole field. Capping the
   retries alone is *not* sufficient here: with only a retry cap, the failure
   propagates to `nmod_mpolyu_gcdm_zippel`'s extension-field fallback, and the
   identical LINZIP code in `fq_nmod_mpolyu_gcds_zippel` hangs the same way
   (verified by stack sampling). The same duplicated logic lives in
   `src/nmod_mpoly/mpolyu_gcdp_zippel.c` and
   `src/fq_nmod_mpoly/mpolyu_gcdp_zippel.c`.

## Proof-of-concept fix

`flint-issue2581-poc-fix.patch` modifies both copies of `gcds_zippel`: when
the system is still underdetermined after the existing two-point retry, free
the l-sized objects, grow `l` by ~50% (up to 4 times), and re-run — instead of
returning `scales_not_found`.

With the patch (nothing else changed), every previously hanging case
completes, all with the correct answer `l1*a2 − l1*a3 − l2*a1 + l2*a3 + l3*a1 − l3*a2`:

| call | original (g, h) | deflated pair |
|---|---|---|
| `nmod_mpoly_gcd` | **4.7 ms** | — |
| `gcd_zippel` | 1.0 ms | **3.8 ms** |
| `gcd_zippel2` | **4.7 ms** | 1.2 ms |
| `gcd_hensel` | **4.3 ms** | — |

Regression tests all pass: `nmod_mpoly_gcd`, `gcd_zippel`, `gcd_zippel2`,
`gcd_hensel`, `gcd_cofactors`, `gcd_brown`, and `fq_nmod_mpoly_gcd`,
`fq_nmod_mpoly_gcd_zippel`, `fq_nmod_mpoly_gcd_cofactors`.

A production fix should probably also bound the `scales_not_found` /
`eval_point_not_found` / `eval_gcd_deg_too_high` retries in both
`gcdp_zippel` inner loops (defense in depth — any other systematic failure
mode currently loops ~2^31 times for a 31-bit modulus), and could grow `l`
more carefully (e.g. `+flen` per round). The fmpz_mpoly Zippel path reduces to
these nmod/fq_nmod kernels, so both benefit.


## Regression tests

`flint-issue2581-fix-and-tests.patch` supersedes the earlier PoC patch: it
contains the fix for both LINZIP copies plus regression tests in all six
affected test files. The test inputs are built compactly from the factored
forms (the deflated pair's 29-term common factor turns out to be exactly the
large cofactor of `h`, up to variable renaming):

| test file | input | exercises |
|---|---|---|
| `nmod_mpoly/test/t-gcd.c` | original (g, h) | default algorithm cascade (zippel2 → content → zippel) |
| `nmod_mpoly/test/t-gcd_cofactors.c` | original (g, h) | cofactor variant of the cascade |
| `nmod_mpoly/test/t-gcd_zippel2.c` | original (g, h) | zippel2's content preprocessing |
| `nmod_mpoly/test/t-gcd_hensel.c` | original (g, h) | hensel's content preprocessing |
| `nmod_mpoly/test/t-gcd_zippel.c` | deflated pair | classic Zippel / `nmod_mpolyu_gcds_zippel` directly |
| `fq_nmod_mpoly/test/t-gcd_zippel.c` | deflated pair over F_p (deg-1 ctx) | the fq_nmod twin `fq_nmod_mpolyu_gcds_zippel` directly |

Validation performed both ways:

* **Unpatched library**: all six tests hang (killed by a 12 s timeout) — they
  reliably catch the bug, including the fq_nmod branch that a fix to only the
  nmod copy would miss.
* **Patched library**: all six pass in normal test time (0.2–1.1 s per test
  function), along with `nmod_mpoly_gcd_brown` and `fq_nmod_mpoly_gcd` as
  broader regression checks.