### PR TITLE
Fix slow sparse bivariate factorization

### DIFF
--- a/src/fmpz_mpoly_factor/factor.c
+++ b/src/fmpz_mpoly_factor/factor.c
@@ -174,8 +174,18 @@ static int _factor_irred_compressed(
 
         success = 1;
     }
-    else if (ctx->minfo->nvars == 2)
+    else if (ctx->minfo->nvars == 2 &&
+             ((Adegs[0] + 1.0)*(Adegs[1] + 1.0) <= 400 ||
+              A->length >= 0.2*(Adegs[0] + 1.0)*(Adegs[1] + 1.0)))
     {
+        /*
+            The dense bivariate factoring code is only competitive for
+            dense-ish inputs: its lifting and recombination work with dense
+            representations of size about deg_x*deg_y. For sparse inputs with
+            large degrees (issue #2408) it can be several orders of magnitude
+            slower than the generic sparse machinery below, which also
+            handles nvars == 2.
+        */
         fmpz_bpoly_t b;
         fmpz_tpoly_t bf;
 

--- a/src/fmpz_mpoly_factor/irred_wang.c
+++ b/src/fmpz_mpoly_factor/irred_wang.c
@@ -42,7 +42,7 @@ int fmpz_mpoly_factor_irred_wang(
     fmpz_mpolyv_t new_lcs, lc_divs;
     fmpz_t q;
 
-    FLINT_ASSERT(n > 1);
+    FLINT_ASSERT(n > 0);
     FLINT_ASSERT(ctx->minfo->ord == ORD_LEX);
     FLINT_ASSERT(A->bits <= FLINT_BITS);
     FLINT_ASSERT(fmpz_mpoly_factor_matches(lcA, lcAfac, ctx));

--- a/src/fmpz_mpoly_factor/irred_zassenhaus.c
+++ b/src/fmpz_mpoly_factor/irred_zassenhaus.c
@@ -144,7 +144,7 @@ int fmpz_mpoly_factor_irred_zassenhaus(
     fmpz_bpoly_t B;
     fmpz_tpoly_t F;
 
-    FLINT_ASSERT(n > 1);
+    FLINT_ASSERT(n > 0);
     FLINT_ASSERT(A->length > 0);
     FLINT_ASSERT(fmpz_sgn(A->coeffs + 0) > 0);
     FLINT_ASSERT(A->bits <= FLINT_BITS);
@@ -221,7 +221,8 @@ got_alpha:
         fmpz_mpoly_repack_bits_inplace(Aevals + i, A->bits, ctx);
     }
 
-    fmpz_mpoly_get_bpoly(B, Aevals + 1, 0, 1, ctx);
+    /* for nvars = 2 (n = 1) the bivariate image is A itself */
+    fmpz_mpoly_get_bpoly(B, n > 1 ? Aevals + 1 : A, 0, 1, ctx);
     fmpz_bpoly_factor(c, F, B);
     FLINT_ASSERT(c->length == 1 && fmpz_is_pm1(c->coeffs + 0));
 

--- a/src/fmpz_mpoly_factor/irred_zippel.c
+++ b/src/fmpz_mpoly_factor/irred_zippel.c
@@ -691,7 +691,7 @@ int fmpz_mpoly_factor_irred_zippel(
     ulong * alphap;
     slong r, L;
 
-    FLINT_ASSERT(n > 1);
+    FLINT_ASSERT(n > 0);
     FLINT_ASSERT(ctx->minfo->ord == ORD_LEX);
     FLINT_ASSERT(A->bits <= FLINT_BITS);
     FLINT_ASSERT(fmpz_mpoly_factor_matches(lcA, lcAfac, ctx));

--- a/src/fmpz_mpoly_factor/test/t-factor.c
+++ b/src/fmpz_mpoly_factor/test/t-factor.c
@@ -117,6 +117,33 @@ TEST_FUNCTION_START(fmpz_mpoly_factor, state)
 {
     slong i, j, tmul = 25;
 
+    /* issue #2408: sparse bivariates with large degrees were sent to the
+       dense fmpz_bpoly_factor code and took tens of seconds each */
+    {
+        fmpz_mpoly_ctx_t ctx;
+        fmpz_mpoly_t f;
+        const char * vars[] = {"x", "y"};
+
+        fmpz_mpoly_ctx_init(ctx, 2, ORD_LEX);
+        fmpz_mpoly_init(f, ctx);
+
+        fmpz_mpoly_set_str_pretty(f, "x^103+x^2*y^3+x^101*y^103+y^106", vars, ctx);
+        check_omega(2, 2, f, ctx, fmpz_mpoly_factor);
+
+        fmpz_mpoly_set_str_pretty(f, "x^162*y^127+x^156*y^13+x^6*y^114+1", vars, ctx);
+        check_omega(4, 4, f, ctx, fmpz_mpoly_factor);
+
+        fmpz_mpoly_set_str_pretty(f, "x^174+y^16+x^240*y^168+x^66*y^184", vars, ctx);
+        check_omega(3, 3, f, ctx, fmpz_mpoly_factor);
+
+        fmpz_mpoly_set_str_pretty(f, "453192*x^128*y^27-652695*x^170*y^89-61824*x^130*y^115+89040*x^172*y^177", vars, ctx);
+        check_omega(157, 157, f, ctx, fmpz_mpoly_factor);
+
+        fmpz_mpoly_clear(f, ctx);
+        fmpz_mpoly_ctx_clear(ctx);
+    }
+
+
     {
         fmpz_mpoly_ctx_t ctx;
         fmpz_mpoly_t f;

--- a/src/fmpz_mpoly_factor/test/t-factor_zassenhaus.c
+++ b/src/fmpz_mpoly_factor/test/t-factor_zassenhaus.c
@@ -116,6 +116,24 @@ TEST_FUNCTION_START(fmpz_mpoly_factor_zassenhaus, state)
 {
     slong i, j, tmul = 20;
 
+    /* issue #2408: with sparse bivariates routed to the generic code,
+       irred_zassenhaus used to read out of bounds for nvars = 2 */
+    {
+        fmpz_mpoly_ctx_t ctx;
+        fmpz_mpoly_t a;
+        const char * vars[] = {"x", "y"};
+
+        fmpz_mpoly_ctx_init(ctx, 2, ORD_LEX);
+        fmpz_mpoly_init(a, ctx);
+
+        fmpz_mpoly_set_str_pretty(a, "(x^30+y+1)*(x+y^30+1)", vars, ctx);
+        check_omega(2, 2, a, ctx, fmpz_mpoly_factor_zassenhaus);
+
+        fmpz_mpoly_clear(a, ctx);
+        fmpz_mpoly_ctx_clear(ctx);
+    }
+
+
     {
         fmpz_mpoly_ctx_t ctx;
         fmpz_mpoly_t a;


### PR DESCRIPTION
I asked Fable 5 to fix #2408.

With the patch, which is exactly what I'd expect the fix to look like without introducing an entirely new handler for special cases, I get:

```
$ time build/examples/factor_polynomial "x^103 + x^2*y^3 + x^101*y^103 + y^106"
x^103+x^101*y^103+x^2*y^3+y^106 =
1*(x^2+y^103)^1*(x^101+y^3)^1

real	0m0,013s
user	0m0,009s
sys	0m0,005s
```

Fable's report attached below.

# Investigation of flintlib/flint#2408 — slow bivariate factoring over Z

Reproduced on current master. Timings of `fmpz_mpoly_factor` on the four
examples from the issue, before and after the fix (single core):

| example | before | after |
|---|---|---|
| `x^103 + x^2 y^3 + x^101 y^103 + y^106` | 44.7 s | 0.015 s |
| `x^162 y^127 + x^156 y^13 + x^6 y^114 + 1` | 19.2 s | 0.18 s |
| `x^174 + y^16 + x^240 y^168 + x^66 y^184` | 15.7 s | 0.064 s |
| `453192 x^128 y^27 − …` | 0.038 s | 0.012 s |

## Where the time goes

Stack sampling confirms the discussion on the issue: example 1 is dominated
by `_recombine_naive → fmpz_bpoly_divides` (trial division of factor
combinations with FFT-sized multiplications), examples 2–3 by
`_bivar_lift_quartic` (dense Hensel lifting via `fmpz_mod_poly_mul` /
`fmpz_poly_mulmid`).

The underlying problem is representational: `fmpz_bpoly_factor` is a *dense*
bivariate algorithm — everything it does (lifting, division, recombination)
works with ~deg_x·deg_y coefficients. These inputs have 4 terms but degrees
in the hundreds, so the dense size is ~10⁴–10⁵ large integers and the
asymptotics are hopeless, while the generic sparse multivariate machinery
(Wang/Zippel/Zassenhaus) factors them in milliseconds. This is inherent to
the dense approach — "fixing `fmpz_bpoly_factor`" would mean writing a sparse
bivariate factoring algorithm, i.e. exactly what the generic code already is.

## The crash blocking the simple fix

As noted in the issue, just removing the `nvars == 2` branch from
`_factor_irred_compressed` crashes the test suite. I isolated it:
`fmpz_mpoly_factor_zassenhaus` dies with SIGFPE (or SIGSEGV, depending on
heap contents) in `fmpz_mpoly_factor_irred_zassenhaus`. With `n = nvars − 1`,
the function allocates and initializes `Aevals[0..n-1]`, and everywhere uses
the convention "index n means A itself" — except one line:

```c
fmpz_mpoly_get_bpoly(B, Aevals + 1, 0, 1, ctx);
```

For `nvars == 2` (n = 1), `Aevals + 1` is one past the end of the array: an
uninitialized `fmpz_mpoly_struct` whose `bits` field is garbage, producing a
division by zero (or worse) inside `mpoly_gen_offset_shift_sp`. There is even
a `FLINT_ASSERT(n > 1)` at the top of the function, so plain-release builds
read out of bounds silently. The rest of the function is n = 1 clean: the
`m = 2..n` recombination loop is skipped and the bivariate factors are
returned directly.

## Fix

Two changes (`flint-issue2408-fix-and-tests.patch`):

1. **`irred_zassenhaus.c`**: relax the assert to `n > 0` and use
   `n > 1 ? Aevals + 1 : A` at the bpoly conversion, matching the convention
   used everywhere else in the file. This makes the whole generic branch
   (Wang, Zippel, Zassenhaus) safe for bivariates — the Wang and Zippel paths
   already were, as running the suite with the branch disabled shows.

2. **`factor.c`**: route bivariates to `fmpz_bpoly_factor` only when the
   input is dense-ish:

   ```c
   nvars == 2 && (dense_size <= 400 || A->length >= 0.2 * dense_size)
   ```

   where `dense_size = (deg_x + 1)(deg_y + 1)`; otherwise fall through to the
   generic sparse code.

The thresholds come from benchmarking both paths on products of two random
bivariate factors (3-rep averages, 20-bit coefficients):

| deg | factor terms | dense bpoly | generic |
|---|---|---|---|
| 24 | dense | 0.11 s | 0.11 s |
| 40 | dense | 0.79 s | 0.89 s |
| 60 | dense | 3.6 s | 8.1 s |
| 40 | 15 | 0.21 s | 0.016 s |
| 60 | 15 | 0.85 s | 0.039 s |
| 60 | 30 | 1.5 s | 1.6 s |
| 100 | 10 | 4.8 s | 0.10 s |
| 100 | 30 | 11.4 s | 0.18 s |

The dense path wins by up to ~2.2× on genuinely dense inputs (kept: density
≥ 0.2 routes there, and everything with dense size ≤ 400 where both paths
are < 20 ms), while the generic path wins by 10–60× and more as density
drops — unboundedly so for inputs like the issue's. After the fix the dense
benchmarks are unchanged (0.10/0.80/3.7 s) and the sparse ones match the
generic column.

## Regression tests

* `t-factor.c`: all four issue examples with exact factor counts (ω = 2, 4,
  3, 157). On unfixed code the test exceeds 30 s (killed by timeout); with
  the fix it adds ~0.3 s.
* `t-factor_zassenhaus.c`: a sparse bivariate `(x^30 + y + 1)(x + y^30 + 1)`
  that the new heuristic routes to the generic code. With the heuristic but
  without the `irred_zassenhaus` fix this crashes (observed SIGSEGV/SIGFPE),
  so it pins the out-of-bounds fix independently.

Validated in all three configurations: unfixed (t-factor > 30 s, timeout),
heuristic-only (zassenhaus test crashes, exit 139), full fix (entire
`fmpz_mpoly_factor` suite passes: factor, zassenhaus, wang, zippel, content,
squarefree, the four gcd tests, lcc_kaltofen, poly_pfrac).

## Notes for further work

* With `algo = ZAS` forced on a sparse bivariate, `irred_zassenhaus` now
  works but still reduces to the dense `fmpz_bpoly_factor` on A itself, so it
  remains slow for issue-style inputs; the default algorithm and
  Wang/Zippel-first cascade avoid this. A sparse bivariate lifting path would
  be needed to fix that corner too.
* The suggestion in the issue of a dedicated 4-term binomial-pair special
  case becomes unnecessary: the generic code already handles those inputs in
  milliseconds once they are allowed to reach it.