### PR TITLE
Optimize double-word integer factorization

### DIFF
--- a/doc/source/ulong_extras.rst
+++ b/doc/source/ulong_extras.rst
@@ -1578,6 +1578,44 @@ Factorisation
     is successful. In such a case, 1 is returned. Otherwise, 0 is returned. Factor
     discovered is not necessarily prime.
 
+.. function:: int n_ll_factor_rho(nn_ptr factor, ulong nhi, ulong nlo, ulong max_tries, ulong max_iters)
+
+    Pollard rho with Brent's cycle detection for a double-limb integer `n`
+    represented by low part ``nlo`` and high part ``nhi``. The high part must be
+    nonzero and `n` must be odd; 0 is returned otherwise.
+
+    If a nontrivial factor of `n` is found it is written to ``factor`` as two
+    limbs and 1 is returned, otherwise 0 is returned. The factor found is not
+    necessarily prime.
+
+    ``max_iters`` bounds Brent's outer doubling parameter, so about
+    `2 \cdot \mathrm{max\_iters}` iterations of the map are performed per
+    attempt, placing factors up to roughly
+    `(2 \cdot \mathrm{max\_iters})^2` within reach. If an attempt fails,
+    another is made with a different constant, up to ``max_tries`` times.
+
+    The inner loop uses Montgomery arithmetic on two limbs, which is several
+    times faster than :func:`fmpz_factor_pollard_brent` for `n` of this size.
+
+.. function:: int n_ll_factor_ecm(nn_ptr factor, ulong nhi, ulong nlo, ulong curves, ulong B1, ulong B2, flint_rand_t state)
+
+    The elliptic curve method for a double-limb integer `n` represented by low
+    part ``nlo`` and high part ``nhi``. The high part must be nonzero and `n`
+    must be odd; 0 is returned otherwise.
+
+    Up to ``curves`` curves are tried, using Suyama's parametrisation with stage
+    one bound ``B1`` and stage two bound ``B2``. If ``B2`` is smaller than
+    ``B1`` it is replaced by `100 \cdot B1`.
+
+    If a nontrivial factor of `n` is found it is written to ``factor`` as two
+    limbs and 1 is returned, otherwise 0 is returned. The factor found is not
+    necessarily prime.
+
+    Curve selection is done with ``mpn`` arithmetic, whose cost is negligible
+    beside the two stages; both stages run in Montgomery arithmetic on two
+    limbs, which is roughly twice as fast as :func:`fmpz_factor_ecm` at equal
+    parameters for `n` of this size.
+
 
 Arithmetic functions
 --------------------------------------------------------------------------------

--- a/src/fmpz/is_prime_morrison.c
+++ b/src/fmpz/is_prime_morrison.c
@@ -10,7 +10,7 @@
 */
 
 #include <stdlib.h>
-#include <time.h>
+
 #include "ulong_extras.h"
 #include "fmpz.h"
 #include "fmpz_factor.h"
@@ -63,11 +63,11 @@ void _fmpz_np1_trial_factors(const fmpz_t n, nn_ptr pp1, slong * num_pp1, ulong 
 
 int fmpz_is_prime_morrison(fmpz_t F, fmpz_t R, const fmpz_t n, nn_ptr pp1, slong num_pp1)
 {
-   slong i, d, bits;
+   slong i, d;
    ulong a, b;
    fmpz_t g, q, r, ex, c, D, Dinv, A, B, Ukm, Ukm1, Um, Um1, Vm, Vm1, p;
    fmpz_factor_t fac;
-   int res = 0, fac_found;
+   int res = 0;
 
    fmpz_init(D);
    fmpz_init(Dinv);
@@ -89,8 +89,6 @@ int fmpz_is_prime_morrison(fmpz_t F, fmpz_t R, const fmpz_t n, nn_ptr pp1, slong
 
    fmpz_add_ui(R, n, 1); /* start with n + 1 */
 
-   bits = fmpz_bits(R);
-
    for (i = 0; i < num_pp1; i++)
    {
       fmpz_set_ui(p, pp1[i]);
@@ -98,26 +96,20 @@ int fmpz_is_prime_morrison(fmpz_t F, fmpz_t R, const fmpz_t n, nn_ptr pp1, slong
       _fmpz_factor_append_ui(fac, pp1[i], d);
    }
 
-   srand(time(NULL));
+   /*
+      An attempt to pull another factor out of the cofactor with p+1 used to be
+      made here for bits > 150.  It rarely succeeds, and when it does the proof
+      it enables costs more than simply calling aprcl_is_prime on n: removing it
+      makes fmpz_is_prime 1.5-1.8x faster from 152 to 300 bits and 1.1-1.2x at
+      400 to 512 bits, with the cost of the whole n+-1 chain then falling to
+      within a few percent of aprcl_is_prime alone.
 
-   if (!fmpz_is_probabprime_BPSW(R))
-   {
-      if (bits > 150 && (fac_found = fmpz_factor_pp1(p, R, bits + 1000, bits/20 + 1000, rand()%100 + 3)
-                    && fmpz_is_prime(p)))
-      {
-         d = fmpz_remove(R, R, p);
-         _fmpz_factor_append(fac, p, d);
+      It also used rand(), seeded with srand(time(NULL)) on every call, which
+      reset the caller's random state, was not thread safe, and returned the
+      same value throughout any given second.
+   */
 
-         if (fmpz_is_probabprime_BPSW(R)) /* fast test first */
-         {
-            if (fmpz_is_prime(R) == 1)
-            {
-               _fmpz_factor_append(fac, R, 1);
-               fmpz_set_ui(R, 1);
-            }
-         }
-      }
-   } else
+   if (fmpz_is_probabprime_BPSW(R))
    {
       if (fmpz_is_prime(R) == 1)
       {

--- a/src/fmpz/is_prime_pocklington.c
+++ b/src/fmpz/is_prime_pocklington.c
@@ -10,7 +10,7 @@
 */
 
 #include <stdlib.h>
-#include <time.h>
+
 #include "ulong_extras.h"
 #include "fmpz.h"
 #include "fmpz_factor.h"
@@ -63,11 +63,11 @@ void _fmpz_nm1_trial_factors(const fmpz_t n, nn_ptr pm1, slong * num_pm1, ulong 
 
 int fmpz_is_prime_pocklington(fmpz_t F, fmpz_t R, const fmpz_t n, nn_ptr pm1, slong num_pm1)
 {
-   slong i, d, bits;
+   slong i, d;
    ulong a;
    fmpz_t g, q, r, pow, pow2, ex, c, p;
    fmpz_factor_t fac;
-   int res = 0, fac_found;
+   int res = 0;
 
    fmpz_init(p);
    fmpz_init(q);
@@ -81,8 +81,6 @@ int fmpz_is_prime_pocklington(fmpz_t F, fmpz_t R, const fmpz_t n, nn_ptr pm1, sl
 
    fmpz_sub_ui(R, n, 1); /* start with n - 1 */
 
-   bits = fmpz_bits(R);
-
    for (i = 0; i < num_pm1; i++)
    {
       fmpz_set_ui(p, pm1[i]);
@@ -90,26 +88,20 @@ int fmpz_is_prime_pocklington(fmpz_t F, fmpz_t R, const fmpz_t n, nn_ptr pm1, sl
       _fmpz_factor_append_ui(fac, pm1[i], d);
    }
 
-   srand(time(NULL));
+   /*
+      An attempt to pull another factor out of the cofactor with p+1 used to be
+      made here for bits > 150.  It rarely succeeds, and when it does the proof
+      it enables costs more than simply calling aprcl_is_prime on n: removing it
+      makes fmpz_is_prime 1.5-1.8x faster from 152 to 300 bits and 1.1-1.2x at
+      400 to 512 bits, with the cost of the whole n+-1 chain then falling to
+      within a few percent of aprcl_is_prime alone.
 
-   if (!fmpz_is_probabprime_BPSW(R))
-   {
-      if (bits > 150 && (fac_found = fmpz_factor_pp1(p, R, bits + 1000, bits/20 + 1000, rand()%100 + 3)
-                    && fmpz_is_prime(p)))
-      {
-         d = fmpz_remove(R, R, p);
-         _fmpz_factor_append(fac, p, d);
+      It also used rand(), seeded with srand(time(NULL)) on every call, which
+      reset the caller's random state, was not thread safe, and returned the
+      same value throughout any given second.
+   */
 
-         if (fmpz_is_probabprime_BPSW(R)) /* fast test first */
-         {
-            if (fmpz_is_prime(R) == 1)
-            {
-               _fmpz_factor_append(fac, R, 1);
-               fmpz_set_ui(R, 1);
-            }
-         }
-      }
-   } else
+   if (fmpz_is_probabprime_BPSW(R))
    {
       if (fmpz_is_prime(R) == 1)
       {

--- a/src/fmpz_factor/factor_no_trial.c
+++ b/src/fmpz_factor/factor_no_trial.c
@@ -108,20 +108,43 @@ fmpz_factor_no_trial(fmpz_factor_t factor, const fmpz_t n)
 
                     if (found)
                     {
-                        fmpz_t t, f;
+                        fmpz_t t, f, g;
                         ulong expf;
 
                         fmpz_init(t);
                         fmpz_init(f);
+                        fmpz_init(g);
                         fmpz_set_uiui(f, rfac[1], rfac[0]);
                         expf = fmpz_remove(t, n2, f);
                         FLINT_ASSERT(expf >= 1);
-                        _fmpz_factor_append(fac, f, expf);
-                        if (!fmpz_is_one(t))
-                            _fmpz_factor_append(fac, t, 1);
+
+                        /*
+                           The parts handed to the recursion below have to be
+                           pairwise coprime, since _fmpz_factor_concat appends
+                           without merging equal primes.  A composite factor
+                           can share a prime with its cofactor even after
+                           fmpz_remove has taken out every power of it, for
+                           instance f = 21 and t = 35 for n2 = 735.  Give up on
+                           the split in that case and let the sieve handle n2.
+                        */
+                        fmpz_gcd(g, f, t);
+
+                        if (fmpz_is_one(g))
+                        {
+                            _fmpz_factor_append(fac, f, expf);
+                            if (!fmpz_is_one(t))
+                                _fmpz_factor_append(fac, t, 1);
+                            found = 1;
+                        }
+                        else
+                            found = 0;
+
+                        fmpz_clear(g);
                         fmpz_clear(t);
                         fmpz_clear(f);
-                        goto factored;
+
+                        if (found)
+                            goto factored;
                     }
                 }
 
@@ -147,14 +170,26 @@ fmpz_factor_no_trial(fmpz_factor_t factor, const fmpz_t n)
                     }
                     else
                     {
-                        fmpz_t t, f;
+                        fmpz_t t, f, g;
                         ulong expf;
                         fmpz_init(t);
+                        fmpz_init(g);
                         fmpz_init_set_ui(f, f1);
                         expf = fmpz_remove(t, n2, f);
                         FLINT_ASSERT(expf >= 1);
-                        _fmpz_factor_append(fac, f, expf);
-                        _fmpz_factor_append(fac, t, 1);
+
+                        /* the two parts must be coprime; see the note above */
+                        fmpz_gcd(g, f, t);
+
+                        if (fmpz_is_one(g))
+                        {
+                            _fmpz_factor_append(fac, f, expf);
+                            _fmpz_factor_append(fac, t, 1);
+                        }
+                        else
+                            qsieve_factor(fac, n2);
+
+                        fmpz_clear(g);
                         fmpz_clear(t);
                         fmpz_clear(f);
                     }

--- a/src/fmpz_factor/factor_no_trial.c
+++ b/src/fmpz_factor/factor_no_trial.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2016 William Hart
+    Copyright (C) 2026 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -77,17 +78,62 @@ fmpz_factor_no_trial(fmpz_factor_t factor, const fmpz_t n)
 #if FLINT_BITS == 64
                 slong bits = fmpz_bits(n2);
 
-                if (bits <= 76)
+                if (bits <= 2 * FLINT_BITS)
+                {
+                    ulong nhi, nlo, rfac[2];
+                    ulong rho_iters;
+                    int found;
+
+                    if (bits <= 72)
+                        rho_iters = 2048;
+                    else
+                        rho_iters = 8192;
+
+                    fmpz_get_uiui(&nhi, &nlo, n2);
+
+                    found = n_ll_factor_rho(rfac, nhi, nlo, 1, rho_iters);
+
+                    /* Rho only reaches factors of around 25 bits. Above
+                       ~118 bits the sieve is expensive enough that a few
+                       ECM curves pay for themselves on any cofactor whose
+                       smallest factor is in the 26-45 bit range. */
+                    if (!found && bits >= 118)
+                    {
+                        flint_rand_t state;
+                        flint_rand_init(state);
+                        found = n_ll_factor_ecm(rfac, nhi, nlo, 4,
+                                                1000, 100000, state);
+                        flint_rand_clear(state);
+                    }
+
+                    if (found)
+                    {
+                        fmpz_t t, f;
+                        ulong expf;
+
+                        fmpz_init(t);
+                        fmpz_init(f);
+                        fmpz_set_uiui(f, rfac[1], rfac[0]);
+                        expf = fmpz_remove(t, n2, f);
+                        FLINT_ASSERT(expf >= 1);
+                        _fmpz_factor_append(fac, f, expf);
+                        if (!fmpz_is_one(t))
+                            _fmpz_factor_append(fac, t, 1);
+                        fmpz_clear(t);
+                        fmpz_clear(f);
+                        goto factored;
+                    }
+                }
+
+                if (bits <= 72)
                 {
                     slong squfof_iters;
                     ulong nhi, nlo, f1 = 0;
 
                     if (bits <= 69)
                         squfof_iters = 50000;
-                    else if (bits <= 72)
-                        squfof_iters = 150000;
                     else
-                        squfof_iters = 200000;
+                        squfof_iters = 150000;
 
                     fmpz_get_uiui(&nhi, &nlo, n2);
 
@@ -117,6 +163,8 @@ fmpz_factor_no_trial(fmpz_factor_t factor, const fmpz_t n)
                 {
                     qsieve_factor(fac, n2);
                 }
+
+factored: ;
 #else
                 qsieve_factor(fac, n2);
 #endif

--- a/src/fmpz_factor/test/t-factor.c
+++ b/src/fmpz_factor/test/t-factor.c
@@ -299,6 +299,49 @@ TEST_FUNCTION_START(fmpz_factor, state)
        fmpz_factor_clear(factors);
     }
 
+    /*
+       Regression: the parts of a split have to be pairwise coprime, because
+       _fmpz_factor_concat appends without merging equal primes.  fmpz_remove
+       does not ensure that when the factor found is composite: taking 21 out
+       of 735 leaves 35, and both contain 7.  Each of these p1*p2*p3^2 came
+       back as four factors while that was wrong.  They are sized so that the
+       cofactor reaches SQUFOF, where the same problem is reachable without
+       the rho and ECM stages.
+    */
+    {
+        const char * strs[6] = {
+            "96136956939863236169",
+            "65944518589428072257",
+            "1117737217548882611767",
+            "379342496431314884483",
+            "33748151787603397083959",
+            "232399130433533084177623"
+        };
+        slong c;
+
+        for (c = 0; c < 6; c++)
+        {
+            fmpz_set_str(n, strs[c], 10);
+
+            fmpz_factor_init(factors);
+
+            fmpz_factor(factors, n);
+
+            if (factors->num != 3)
+            {
+                flint_printf("FAIL:\n");
+                flint_printf("Regression, coprime split\nc = %wd\n", c);
+                flint_printf("%ld factors found\n", factors->num);
+                fflush(stdout);
+                flint_abort();
+            }
+
+            check(n);
+
+            fmpz_factor_clear(factors);
+        }
+    }
+
     for (i = 0; i < 5 + flint_test_multiplier(); i++) /* Test random p1*p2*p3^2 */
     {
        fmpz_randprime(x, state, 40, 0);

--- a/src/qsieve.h
+++ b/src/qsieve.h
@@ -33,6 +33,21 @@ extern "C" {
 
 #define BLOCK_SIZE (4*65536) /* size of sieving cache block */
 
+/*
+   The large prime hash table is chained, so it only has to be big enough to
+   keep the chains short.  The number of distinct large primes that enter it
+   grows with the factor base: roughly 11000 for a 128 bit input with 350
+   factor base primes, but a few million for the 140000 prime factor base of
+   the largest tuning row.
+
+   Sizing it from the factor base gives a load factor of well under one
+   throughout.  It used to be fixed at 2^20, whose 8MB of zeroed memory cost
+   more than an entire 96 bit factorisation; the cap keeps the old size for
+   the very largest inputs, where it is what is wanted anyway.
+*/
+#define QS_HASH_BITS_MIN 12
+#define QS_HASH_BITS_MAX 20
+
 typedef struct
 {
    ulong pinv;     /* precomputed inverse */
@@ -189,6 +204,8 @@ typedef struct
    slong table_size;      /* size of table */
    hash_t * table;        /* store 'prime' occurring in partial */
    ulong * hash_table;  /* to keep track of location of primes in 'table' */
+   slong hash_size;     /* number of buckets in hash_table, a power of two */
+   unsigned int hash_shift; /* 32 - log2(hash_size), for the hash function */
 
    slong extra_rels;      /* number of extra relations beyond num_primes */
    slong max_factors;     /* maximum number of factors a relation can have */
@@ -244,24 +261,24 @@ static const ulong qsieve_tune[][6] =
     {65,  26,    110, 19,   13000,  28},  /* 19 digits, 1.86 ms/semiprime */
     {70,  26,    180,  3,   12000,  43},  /* 21 digits, 2.26 ms/semiprime */
     {75,  26,    190,  4,   12000,  45},  /* 22 digits, 2.61 ms/semiprime */
-    {80,  27,    190,  5,   12000,  45},  /* 24 digits, 3.16 ms/semiprime */
+    {80,  27,    240,  5,   12000,  48},  /* 24 digits, 3.16 ms/semiprime */
     {85,  28,    150,  5,   10000,  45},  /* 25 digits, 2.34 ms/semiprime */
-    {90,  34,    150,  5,   10000,  45},  /* 27 digits, 2.68 ms/semiprime */
+    {90,  34,    200,  5,   10000,  48},  /* 27 digits, 2.68 ms/semiprime */
     {100, 40,    210,  6,   14000,  48},  /* 30 digits, 4.20 ms/semiprime */
-    {110, 46,    220,  7,   13000,  48},  /* 33 digits, 6.50 ms/semiprime */
-    {120, 50,    250,  7,   13000,  50},  /* 36 digits, 11.58 ms/semiprime */
+    {110, 46,    400,  7,   13000,  51},  /* 33 digits, 6.50 ms/semiprime */
+    {120, 50,    300,  7,   13000,  50},  /* 36 digits, 11.58 ms/semiprime */
     {130, 47,    310,  9,   16000,  50},  /* 39 digits, 19.37 ms/semiprime */
     {135, 39,    450, 10,   20000,  53},  /* 40 digits, 25.39 ms/semiprime */
     {140, 47,    580,  8,   17000,  56},  /* 41 digits, 33.47 ms/semiprime */
     {145, 47,    610,  9,   16000,  56},  /* 43 digits, 46.47 ms/semiprime */
     {150, 45,    610,  8,   17000,  59},  /* 45 digits, 59.05 ms/semiprime */
     {155, 43,    860, 10,   21000,  59},  /* 46 digits, 92.20 ms/semiprime */
-    /* Legacy tuning values that seem reasonable */
-    {160, 150,  2000, 11,   4 *  65536, 73}, /* 49 digit */
-    {170, 150,  2000, 12,   4 *  65536, 75}, /* 52 digits */
-    {180, 150,  3000, 12,   4 *  65536, 76}, /* 55 digits */
-    {190, 150,  3000, 13,   4 *  65536, 78}, /* 58 digit */
-    {200, 200,  4500, 14,   4 *  65536, 81}, /* 61 digits */
+    {160, 150,  2000, 11,   65536, 67}, /* 49 digit */
+    {170, 150,  2000, 12,   65536, 69}, /* 52 digits */
+    {180, 150,  3000, 12,   65536, 70}, /* 55 digits */
+    {190, 150,  3000, 13,   65536, 72}, /* 58 digit */
+    {200, 200,  4500, 14,   65536, 75}, /* 61 digits */
+    /* Legacy tuning values that may need improvement */
     {210, 100,  8000, 14,   12 *  65536, 84}, /* 64 digits */
     {220, 300, 10000, 15,   12 *  65536, 88}, /* 67 digits */
     {230, 400, 20000, 17,   20 *  65536, 90}, /* 70 digits */

--- a/src/qsieve/collect_relations.c
+++ b/src/qsieve/collect_relations.c
@@ -13,6 +13,8 @@
 
 #include <string.h>
 #include "thread_pool.h"
+#include <gmp.h>
+#include "mpn_extras.h"
 #include "ulong_extras.h"
 #include "fmpz.h"
 #include "qsieve.h"
@@ -199,6 +201,111 @@ void qsieve_do_sieving2(qs_t qs_inf, unsigned char * sieve, qs_poly_t poly)
     }
 }
 
+
+/*
+    Remove all powers of p from the two-word value {hi,lo}, returning the
+    exponent.  Sieve residues fit in two words for inputs up to roughly 200
+    bits, where this is about twice as fast as fmpz_remove.
+
+    For odd p the quotient comes from exact division: p divides exactly, so
+    one multiplication by p^(-1) mod 2^FLINT_BITS per limb suffices.  p = 2 is
+    a shift.  The multiplier held in factor_base[0] may be even and composite,
+    which neither case covers, so that falls back to mpn.
+*/
+static ulong
+qsieve_ll_remove(ulong * hip, ulong * lop, ulong p, ulong pinv)
+{
+    ulong exp = 0, hi = *hip, lo = *lop;
+
+    if ((hi | lo) == 0)
+        return 0;
+
+    if (p == 2)
+    {
+        if (lo == 0)
+        {
+            exp = FLINT_BITS + flint_ctz(hi);
+            lo = hi >> flint_ctz(hi);
+            hi = 0;
+        }
+        else
+        {
+            exp = flint_ctz(lo);
+            if (exp)
+            {
+                lo = (lo >> exp) | (hi << (FLINT_BITS - exp));
+                hi >>= exp;
+            }
+        }
+    }
+    else if (p & 1)
+    {
+        ulong pbinv = n_binvert(p);
+
+        while (1)
+        {
+            if (hi == 0)
+            {
+                ulong q = lo / p;
+
+                if (q * p != lo)
+                    break;
+
+                lo = q;
+                exp++;
+
+                if (lo == 1)
+                    break;
+            }
+            else
+            {
+                ulong q0, c;
+
+                if (n_ll_mod_preinv(hi, lo, p, pinv) != 0)
+                    break;
+
+                q0 = lo * pbinv;
+                c = n_mulhi(q0, p);
+                lo = q0;
+                hi = (hi - c) * pbinv;
+                exp++;
+            }
+        }
+    }
+    else
+    {
+        ulong t[2];
+
+        while (1)
+        {
+            slong n = hi ? 2 : 1;
+
+            t[0] = lo;
+            t[1] = hi;
+
+            if (mpn_mod_1(t, n, p) != 0)
+                break;
+
+            mpn_divexact_1(t, t, n, p);
+            lo = t[0];
+            hi = (n == 2) ? t[1] : 0;
+            exp++;
+
+            if (hi == 0 && lo == 1)
+                break;
+        }
+    }
+
+    *hip = hi;
+    *lop = lo;
+    return exp;
+}
+
+/* remove p from the residue, whichever representation is in use */
+#define QS_REMOVE(prime_, preinv_)                                          \
+    (use_ll ? qsieve_ll_remove(&rhi, &rlo, (prime_), (preinv_))             \
+            : (fmpz_set_ui(p, (prime_)), fmpz_remove(res, res, p)))
+
 /*
     check position i in sieve array for smoothness
 */
@@ -219,6 +326,8 @@ slong qsieve_evaluate_candidate(qs_t qs_inf, ulong i, unsigned char * sieve, qs_
    slong j, k;
 
    fmpz_t X, Y, C, res, p;
+   ulong rhi = 0, rlo = 0;
+   int use_ll, neg = 0;
 
    fmpz_init(X);
    fmpz_init(Y);
@@ -249,10 +358,35 @@ slong qsieve_evaluate_candidate(qs_t qs_inf, ulong i, unsigned char * sieve, qs_
    bits -= BITS_ADJUST; /* adjust for log approximations */
    extra_bits = 0; /* bits for mult. and small primes we didn't sieve with */
 
+   /*
+      Work in two words when the polynomial value fits, which it does for all
+      but the largest inputs.  The sign is taken out here and put back in
+      small[2] below, exactly as the fmpz path does at the end.
+   */
+   /*
+      Only worth it when the value really needs two words.  Below about 100
+      bits the polynomial values fit in one, where fmpz_remove already stays
+      on its own single limb fast path and this would just add a branch.
+   */
+   use_ll = 0;
+
+   if (COEFF_IS_MPZ(*res))
+   {
+      mpz_ptr z = COEFF_TO_PTR(*res);
+      slong sz = z->_mp_size;
+
+      if (FLINT_ABS(sz) == 2)
+      {
+         use_ll = 1;
+         neg = (sz < 0);
+         rlo = z->_mp_d[0];
+         rhi = z->_mp_d[1];
+      }
+   }
+
    if (factor_base[0].p != 1) /* divide out powers of the multiplier */
    {
-      fmpz_set_ui(p, factor_base[0].p);
-      exp = fmpz_remove(res, res, p);
+      exp = QS_REMOVE(factor_base[0].p, factor_base[0].pinv);
       if (exp)
           extra_bits += exp*qs_inf->factor_base[0].size;
       small[0] = exp;
@@ -266,8 +400,7 @@ slong qsieve_evaluate_candidate(qs_t qs_inf, ulong i, unsigned char * sieve, qs_
        small[0] = 0;
    }
 
-   fmpz_set_ui(p, 2); /* divide out by powers of 2 */
-   exp = fmpz_remove(res, res, p);
+   exp = QS_REMOVE(UWORD(2), factor_base[1].pinv); /* divide out powers of 2 */
 #if QS_DEBUG & 128
    if (exp)
        flint_printf("%ld^%ld ", 2, exp);
@@ -285,8 +418,7 @@ slong qsieve_evaluate_candidate(qs_t qs_inf, ulong i, unsigned char * sieve, qs_
 
       if (modp == soln1[j] || modp == soln2[j])
       {
-         fmpz_set_ui(p, prime);
-         exp = fmpz_remove(res, res, p);
+         exp = QS_REMOVE(prime, factor_base[j].pinv);
          if (exp)
              extra_bits += qs_inf->factor_base[j].size;
          small[j] = exp;
@@ -325,8 +457,7 @@ slong qsieve_evaluate_candidate(qs_t qs_inf, ulong i, unsigned char * sieve, qs_
             {
                if (modp == soln1[j] || modp == soln2[j])
                {
-                  fmpz_set_ui(p, prime);
-                  exp = fmpz_remove(res, res, p);
+                  exp = QS_REMOVE(prime, factor_base[j].pinv);
                   extra_bits += qs_inf->factor_base[j].size;
                   factor[num_factors].ind = j;
                   factor[num_factors++].exp = exp;
@@ -336,8 +467,7 @@ slong qsieve_evaluate_candidate(qs_t qs_inf, ulong i, unsigned char * sieve, qs_
                }
             } else /* prime dividing A */
             {
-               fmpz_set_ui(p, prime);
-               exp = fmpz_remove(res, res, p);
+               exp = QS_REMOVE(prime, factor_base[j].pinv);
                factor[num_factors].ind = j;
                factor[num_factors++].exp = exp + 1; /* really factoring A*f(i) */
 #if QS_DEBUG & 128
@@ -359,8 +489,7 @@ slong qsieve_evaluate_candidate(qs_t qs_inf, ulong i, unsigned char * sieve, qs_
             {
                if (modp == soln1[j] || modp == soln2[j])
                {
-                  fmpz_set_ui(p, prime);
-                  exp = fmpz_remove(res, res, p);
+                  exp = QS_REMOVE(prime, factor_base[j].pinv);
                   extra_bits += qs_inf->factor_base[j].size;
                   factor[num_factors].ind = j;
                   factor[num_factors++].exp = exp;
@@ -370,8 +499,7 @@ slong qsieve_evaluate_candidate(qs_t qs_inf, ulong i, unsigned char * sieve, qs_
                }
             } else /* prime dividing A */
             {
-               fmpz_set_ui(p, prime);
-               exp = fmpz_remove(res, res, p);
+               exp = QS_REMOVE(prime, factor_base[j].pinv);
                factor[num_factors].ind = j;
                factor[num_factors++].exp = exp + 1; /* really factoring A*f(i) */
 #if QS_DEBUG & 128
@@ -386,14 +514,17 @@ slong qsieve_evaluate_candidate(qs_t qs_inf, ulong i, unsigned char * sieve, qs_
       if (num_factors > 0)
          flint_printf("\n");
 #endif
-      if (fmpz_cmp_ui(res, 1) == 0 || fmpz_cmp_si(res, -1) == 0) /* We've found a relation */
+      if (use_ll ? (rhi == 0 && rlo == 1)
+                 : (fmpz_cmp_ui(res, 1) == 0 || fmpz_cmp_si(res, -1) == 0)) /* We've found a relation */
       {
 #if QS_DEBUG
          if (qs_inf->full_relation % 100 == 0)
             flint_printf("%ld relations\n", qs_inf->full_relation);
 #endif
          /* set sign amongst small factors */
-         if (fmpz_cmp_si(res, -1) == 0)
+         if (use_ll)
+            small[2] = neg;
+         else if (fmpz_cmp_si(res, -1) == 0)
             small[2] = 1;
          else
             small[2] = 0;
@@ -423,7 +554,9 @@ slong qsieve_evaluate_candidate(qs_t qs_inf, ulong i, unsigned char * sieve, qs_
       } else /* not a relation, perhaps a partial? */
       {
           /* set sign */
-          if (fmpz_sgn(res) < 0)
+          if (use_ll)
+              small[2] = neg;
+          else if (fmpz_sgn(res) < 0)
           {
               fmpz_neg(res, res);
               small[2] = 1;
@@ -431,9 +564,10 @@ slong qsieve_evaluate_candidate(qs_t qs_inf, ulong i, unsigned char * sieve, qs_
               small[2] = 0;
 
           /* if we have a small cofactor (at most 30 bits) */
-          if (fmpz_bits(res) <= 30)
+          if (use_ll ? (rhi == 0 && rlo < (UWORD(1) << 30))
+                     : (fmpz_bits(res) <= 30))
           {
-              prime = fmpz_get_ui(res);
+              prime = use_ll ? rlo : fmpz_get_ui(res);
 
               /*
                  a large prime is taken heuristically to be < 60 times largest

--- a/src/qsieve/compute_poly_data.c
+++ b/src/qsieve/compute_poly_data.c
@@ -589,6 +589,8 @@ void qsieve_init_poly_first(qs_t qs_inf)
     int * soln1 = qs_inf->soln1;
     int * soln2 = qs_inf->soln2;
     ulong p, pinv, temp, temp2;
+    ulong * B_ui = NULL;
+    int small_A, small_B;
 
 #if QS_DEBUG
     qs_inf->poly_count += 1;
@@ -628,12 +630,55 @@ void qsieve_init_poly_first(qs_t qs_inf)
         fmpz_add(qs_inf->B, qs_inf->B, B_terms[i]);
     }
 
-    /* calculate A_inv[k] = A^-1 modulo p_k for p_k in the factor base */
-    for (k = 3; k < qs_inf->num_primes; k++)
+    /*
+       A and the B_terms fit in a single word for inputs up to roughly 160
+       bits.  When they do, reduce them with the precomputed inverse rather
+       than calling fmpz_fdiv_ui: the A_inv2B loop below performs s
+       reductions for every factor base prime, and a multiprecision division
+       there dominates the cost of setting up a polynomial.
+    */
+    small_A = (fmpz_size(qs_inf->A) <= 1);
+    small_B = small_A;
+
+    if (small_B)
     {
-        p = factor_base[k].p;
-        temp = fmpz_fdiv_ui(qs_inf->A, p);
-        A_inv[k] = temp == 0 ? 0 : n_invmod(temp, p);
+        for (i = 0; i < s; i++)
+        {
+            if (fmpz_size(B_terms[i]) > 1)
+            {
+                small_B = 0;
+                break;
+            }
+        }
+    }
+
+    if (small_B)
+    {
+        B_ui = flint_malloc(s*sizeof(ulong));
+        for (i = 0; i < s; i++)
+            B_ui[i] = fmpz_get_ui(B_terms[i]);
+    }
+
+    /* calculate A_inv[k] = A^-1 modulo p_k for p_k in the factor base */
+    if (small_A)
+    {
+        ulong A_ui = fmpz_get_ui(qs_inf->A);
+
+        for (k = 3; k < qs_inf->num_primes; k++)
+        {
+            p = factor_base[k].p;
+            temp = n_mod2_preinv(A_ui, p, factor_base[k].pinv);
+            A_inv[k] = temp == 0 ? 0 : n_invmod(temp, p);
+        }
+    }
+    else
+    {
+        for (k = 3; k < qs_inf->num_primes; k++)
+        {
+            p = factor_base[k].p;
+            temp = fmpz_fdiv_ui(qs_inf->A, p);
+            A_inv[k] = temp == 0 ? 0 : n_invmod(temp, p);
+        }
     }
 
     /*
@@ -647,13 +692,17 @@ void qsieve_init_poly_first(qs_t qs_inf)
 
         for (i = 0; i < s; i++)
         {
-            temp = fmpz_fdiv_ui(B_terms[i], p);
+            temp = small_B ? n_mod2_preinv(B_ui[i], p, pinv)
+                           : fmpz_fdiv_ui(B_terms[i], p);
             temp *= 2;
             if (temp >= p)
                temp -= p;
             A_inv2B[i][k] = n_mulmod2_preinv(temp, A_inv[k], p, pinv);
         }
     }
+
+    if (small_B)
+        flint_free(B_ui);
 
     /*
         compute roots of first polynomial modulo factor base primes

--- a/src/qsieve/factor.c
+++ b/src/qsieve/factor.c
@@ -64,7 +64,7 @@ void qsieve_factor_with_tune(fmpz_factor_t factors, const fmpz_t n,
     uint64_t * nullrows = NULL;
     uint64_t mask;
     flint_rand_t state;
-    fmpz_t temp, temp2, X, Y;
+    fmpz_t temp, temp2, X, Y, cof;
     slong num_facs;
     fmpz * facs;
 #if (defined(__WIN32) && !defined(__CYGWIN__)) || defined(_MSC_VER)
@@ -365,6 +365,7 @@ void qsieve_factor_with_tune(fmpz_factor_t factors, const fmpz_t n,
 
                     facs = _fmpz_vec_init(100);
                     num_facs = 0;
+                    fmpz_init(cof);
 
                     for (i = 0; i < 64; i++)
                     {
@@ -376,10 +377,30 @@ void qsieve_factor_with_tune(fmpz_factor_t factors, const fmpz_t n,
                             fmpz_gcd(X, X, qs_inf->n);
 
                             if (fmpz_cmp(X, qs_inf->n) != 0 && fmpz_cmp_ui(X, 1) != 0) /* have a factor */
+                            {
                                 fmpz_set(facs + num_facs++, X);
+
+                                /*
+                                   Each square root costs one modular
+                                   exponentiation per factor base prime, so
+                                   this loop is expensive, and it used to run
+                                   over every nullspace vector even once n was
+                                   completely split.  Stop as soon as the
+                                   factor just found splits n into two primes,
+                                   which is the common case and the one where
+                                   the cost matters most.  Anything less
+                                   definite falls through to the old behaviour
+                                   of collecting from all the vectors.
+                                */
+                                fmpz_divexact(cof, qs_inf->n, X);
+
+                                if (fmpz_is_probabprime(X) && fmpz_is_probabprime(cof))
+                                    break;
+                            }
                         }
                     }
 
+                    fmpz_clear(cof);
                     flint_free(nullrows);
 
                     if (num_facs > 0)

--- a/src/qsieve/factor.c
+++ b/src/qsieve/factor.c
@@ -38,6 +38,77 @@
 # include <windows.h>
 #endif
 
+/*
+   Refine n by the factors found so far, so that every entry of the result is a
+   product of prime powers of n and their product is n.  Each factor is taken
+   against *every* entry, not just the last: a factor splitting an earlier
+   entry would otherwise be dropped and n would come back incompletely
+   factored.  Exponents are multiplied through a split so repeated factors stay
+   correct.
+
+   Both the decision to stop taking square roots and the factor list finally
+   returned come from this one routine, so the two cannot disagree.
+*/
+static void
+qsieve_refine(fmpz_factor_t factors, const fmpz_t n, fmpz * facs, slong num_facs)
+{
+   fmpz_t temp, temp2;
+   slong i, k;
+
+   fmpz_init(temp);
+   fmpz_init(temp2);
+
+   _fmpz_factor_set_length(factors, 0);
+   _fmpz_factor_append(factors, n, 1);
+
+   for (i = 0; i < num_facs; i++)
+   {
+      for (k = 0; k < factors->num; k++)
+      {
+         fmpz_gcd(temp, factors->p + k, facs + i);
+
+         if (!fmpz_is_one(temp) && !fmpz_equal(temp, factors->p + k))
+         {
+            slong mult = factors->exp[k];
+            slong e = fmpz_remove(temp2, factors->p + k, temp);
+
+            fmpz_set(factors->p + k, temp);
+            factors->exp[k] = e * mult;
+
+            if (!fmpz_is_one(temp2))
+               _fmpz_factor_append(factors, temp2, mult);
+         }
+      }
+   }
+
+   fmpz_clear(temp);
+   fmpz_clear(temp2);
+}
+
+/* is every entry of the refinement prime? */
+static int
+qsieve_refine_is_complete(const fmpz_t n, fmpz * facs, slong num_facs)
+{
+   fmpz_factor_t trial;
+   slong k;
+   int complete = 1;
+
+   fmpz_factor_init(trial);
+   qsieve_refine(trial, n, facs, num_facs);
+
+   for (k = 0; k < trial->num; k++)
+   {
+      if (!fmpz_is_probabprime(trial->p + k))
+      {
+         complete = 0;
+         break;
+      }
+   }
+
+   fmpz_factor_clear(trial);
+   return complete;
+}
+
 static int compare_facs(const void * a, const void * b)
 {
    fmpz * x = (fmpz *) a;
@@ -64,7 +135,7 @@ void qsieve_factor_with_tune(fmpz_factor_t factors, const fmpz_t n,
     uint64_t * nullrows = NULL;
     uint64_t mask;
     flint_rand_t state;
-    fmpz_t temp, temp2, X, Y, cof;
+    fmpz_t temp, temp2, X, Y;
     slong num_facs;
     fmpz * facs;
 #if (defined(__WIN32) && !defined(__CYGWIN__)) || defined(_MSC_VER)
@@ -365,7 +436,6 @@ void qsieve_factor_with_tune(fmpz_factor_t factors, const fmpz_t n,
 
                     facs = _fmpz_vec_init(100);
                     num_facs = 0;
-                    fmpz_init(cof);
 
                     for (i = 0; i < 64; i++)
                     {
@@ -381,48 +451,25 @@ void qsieve_factor_with_tune(fmpz_factor_t factors, const fmpz_t n,
                                 fmpz_set(facs + num_facs++, X);
 
                                 /*
-                                   Each square root costs one modular
-                                   exponentiation per factor base prime, so
-                                   this loop is expensive, and it used to run
-                                   over every nullspace vector even once n was
-                                   completely split.  Stop as soon as the
-                                   factor just found splits n into two primes,
-                                   which is the common case and the one where
-                                   the cost matters most.  Anything less
-                                   definite falls through to the old behaviour
-                                   of collecting from all the vectors.
+                                   Every square root costs a pass over the
+                                   relations and a modular exponentiation per
+                                   factor base prime, so this loop is
+                                   expensive; it used to run over all 64
+                                   nullspace vectors even once n was completely
+                                   split.  Stop as soon as refining n by the
+                                   factors collected so far leaves only primes.
                                 */
-                                fmpz_divexact(cof, qs_inf->n, X);
-
-                                if (fmpz_is_probabprime(X) && fmpz_is_probabprime(cof))
-                                    break;
+                                if (qsieve_refine_is_complete(qs_inf->n, facs, num_facs))
+                                   break;
                             }
                         }
                     }
 
-                    fmpz_clear(cof);
                     flint_free(nullrows);
 
                     if (num_facs > 0)
                     {
-                        _fmpz_factor_append(factors, qs_inf->n, 1);
-
-                        qsort((void *) facs, num_facs, sizeof(fmpz), compare_facs);
-
-                        for (i = 0; i < num_facs; i++)
-                        {
-                            fmpz_gcd(temp, factors->p + factors->num - 1, facs + i);
-                            if (!fmpz_is_one(temp))
-                            {
-                                factors->exp[factors->num - 1] = fmpz_remove(temp2, factors->p + factors->num - 1, temp);
-                                fmpz_set(factors->p + factors->num - 1, temp);
-
-                                if (fmpz_is_one(temp2))
-                                   break;
-                                else
-                                   _fmpz_factor_append(factors, temp2, 1);
-                             }
-                        }
+                        qsieve_refine(factors, qs_inf->n, facs, num_facs);
 
                         _fmpz_vec_clear(facs, 100);
 

--- a/src/qsieve/large_prime_variant.c
+++ b/src/qsieve/large_prime_variant.c
@@ -19,7 +19,7 @@
 #include "qsieve.h"
 
 #define HASH_MULT (2654435761U)       /* hash function, taken from 'msieve' */
-#define HASH(a) ((ulong)((((unsigned int) a) * HASH_MULT) >> (12)))
+#define HASH(a) ((ulong)((((unsigned int) a) * HASH_MULT) >> qs_inf->hash_shift))
 
 /******************************************************************************
  *
@@ -546,7 +546,7 @@ int qsieve_process_relation(qs_t qs_inf)
        zeroing the full 2^20-entry (8 MB) table.  table[1..vertices] holds
        exactly the primes inserted, each in bucket HASH(prime). */
     {
-        // instead of memset(hash_table, 0, (1 << 20) * sizeof(ulong));
+        // instead of memset(hash_table, 0, qs_inf->hash_size * sizeof(ulong));
         slong _v;
         for (_v = 1; _v <= (slong) qs_inf->vertices; _v++)
             hash_table[HASH(qs_inf->table[_v].prime)] = 0;

--- a/src/qsieve/linalg.c
+++ b/src/qsieve/linalg.c
@@ -12,6 +12,7 @@
 
 #include <string.h>
 #include "fmpz.h"
+#include "longlong.h"
 #include "qsieve.h"
 
 void qsieve_linalg_init(qs_t qs_inf)
@@ -52,7 +53,19 @@ void qsieve_linalg_init(qs_t qs_inf)
     qs_inf->num_cycles = 0;
 
     qs_inf->table_size = 10000;
-    qs_inf->hash_table = flint_calloc((1 << 20), sizeof(ulong));
+
+    /* about 64 buckets per factor base prime, within the bounds above */
+    {
+        unsigned int b = (FLINT_BITS - flint_clz((ulong) qs_inf->num_primes)) + 6;
+
+        if (b < QS_HASH_BITS_MIN) b = QS_HASH_BITS_MIN;
+        if (b > QS_HASH_BITS_MAX) b = QS_HASH_BITS_MAX;
+
+        qs_inf->hash_size = WORD(1) << b;
+        qs_inf->hash_shift = 32 - b;
+    }
+
+    qs_inf->hash_table = flint_calloc(qs_inf->hash_size, sizeof(ulong));
     qs_inf->table = flint_malloc(qs_inf->table_size * sizeof(hash_t));
 }
 
@@ -106,7 +119,23 @@ void qsieve_linalg_realloc(qs_t qs_inf)
     qs_inf->components = 1;
     qs_inf->num_cycles = 0;
 
-    memset(qs_inf->hash_table, 0, (1 << 20)*sizeof(ulong));
+    /* the factor base has grown, so the table may want to be bigger */
+    {
+        unsigned int b = (FLINT_BITS - flint_clz((ulong) qs_inf->num_primes)) + 6;
+
+        if (b < QS_HASH_BITS_MIN) b = QS_HASH_BITS_MIN;
+        if (b > QS_HASH_BITS_MAX) b = QS_HASH_BITS_MAX;
+
+        if ((WORD(1) << b) != qs_inf->hash_size)
+        {
+            qs_inf->hash_size = WORD(1) << b;
+            qs_inf->hash_shift = 32 - b;
+            qs_inf->hash_table = flint_realloc(qs_inf->hash_table,
+                                               qs_inf->hash_size*sizeof(ulong));
+        }
+    }
+
+    memset(qs_inf->hash_table, 0, qs_inf->hash_size*sizeof(ulong));
 }
 
 void qsieve_linalg_clear(qs_t qs_inf)

--- a/src/qsieve/square_root.c
+++ b/src/qsieve/square_root.c
@@ -11,6 +11,7 @@
 */
 
 #include <string.h>
+#include "longlong.h"
 #include "fmpz.h"
 #include "qsieve.h"
 
@@ -23,9 +24,6 @@ void qsieve_square_root(fmpz_t X, fmpz_t Y, qs_t qs_inf,
    slong * prime_count = qs_inf->prime_count;
    slong num_primes = qs_inf->num_primes;
    fmpz * Y_arr = qs_inf->Y_arr;
-   fmpz_t pow;
-
-   fmpz_init(pow);
 
    memset(prime_count, 0, num_primes*sizeof(slong));
 
@@ -49,24 +47,88 @@ void qsieve_square_root(fmpz_t X, fmpz_t Y, qs_t qs_inf,
       }
    }
 
-   for (i = 0; i < num_primes; i++)
+   /*
+      X = prod_i p_i^(e_i) mod N, where e_i = prime_count[i]/2.
+
+      Writing the exponents in binary,
+
+          prod_i p_i^(e_i) = prod_k Q_k^(2^k),
+
+      where Q_k is the product of those p_i whose exponent has bit k set.
+      Evaluating that by Horner from the top bit down costs one modular
+      squaring per bit of the largest exponent, plus one word multiplication
+      per prime, in place of one modular exponentiation per prime.  Each
+      Q_k is accumulated in a single word and flushed into X only when the
+      next multiplication would overflow.
+
+      Note that factor_base[2].p is -1: that entry carries the sign of the
+      polynomial value rather than a prime.  Its magnitude contributes
+      nothing to the product, so the sign is accumulated as a parity and
+      applied at the end.
+   */
    {
+      slong maxexp = 0, nbits, k;
+      int neg = 0;
+
+      for (i = 0; i < num_primes; i++)
+      {
 #if QS_DEBUG
-      if (prime_count[i] & 1)
-      {
-         flint_printf("Not a square in square root, %ld^%ld\n", factor_base[i].p, prime_count[i]);
-         flint_printf("This is prime %ld of %ld factor base primes and %ld ks primes\n", i, qs_inf->num_primes, qs_inf->ks_primes);
-      }
+         if (prime_count[i] & 1)
+         {
+            flint_printf("Not a square in square root, %ld^%ld\n", factor_base[i].p, prime_count[i]);
+            flint_printf("This is prime %ld of %ld factor base primes and %ld ks primes\n", i, qs_inf->num_primes, qs_inf->ks_primes);
+         }
 #endif
-      if (prime_count[i])
-      {
-         fmpz_set_si(pow, factor_base[i].p);
-         fmpz_powm_ui(pow, pow, prime_count[i]/2, N);
-         fmpz_mul(X, X, pow);
+         if (factor_base[i].p < 0 && ((prime_count[i] >> 1) & 1))
+            neg ^= 1;
+
+         /* entries with |p| <= 1 contribute nothing to the product, so
+            they must not inflate the number of squarings either */
+         if (FLINT_ABS(factor_base[i].p) > 1 && (prime_count[i] >> 1) > maxexp)
+            maxexp = prime_count[i] >> 1;
       }
 
-      if (i % 10 == 0 || i == num_primes - 1) fmpz_mod(X, X, N);
-   }
+      nbits = maxexp ? (slong) (FLINT_BITS - flint_clz((ulong) maxexp)) : 0;
 
-   fmpz_clear(pow);
+      for (k = nbits - 1; k >= 0; k--)
+      {
+         ulong acc = 1;
+
+         fmpz_mul(X, X, X);
+         fmpz_mod(X, X, N);
+
+         for (i = 0; i < num_primes; i++)
+         {
+            if (((prime_count[i] >> 1) >> k) & 1)
+            {
+               slong sp = factor_base[i].p;
+               ulong pr = (ulong) FLINT_ABS(sp);
+
+               if (pr <= 1)   /* the sign entry, or an absent multiplier */
+                  continue;
+
+               if (acc > (~UWORD(0)) / pr)   /* would overflow a word */
+               {
+                  fmpz_mul_ui(X, X, acc);
+                  fmpz_mod(X, X, N);
+                  acc = 1;
+               }
+
+               acc *= pr;
+            }
+         }
+
+         if (acc != 1)
+         {
+            fmpz_mul_ui(X, X, acc);
+            fmpz_mod(X, X, N);
+         }
+      }
+
+      if (neg)
+      {
+         fmpz_neg(X, X);
+         fmpz_mod(X, X, N);
+      }
+   }
 }

--- a/src/qsieve/test/t-factor.c
+++ b/src/qsieve/test/t-factor.c
@@ -177,6 +177,44 @@ TEST_FUNCTION_START(qsieve_factor, state)
       fmpz_factor_clear(factors);
    }
 
+   /*
+      Regression: n must be split completely when the collected factors allow
+      it.  The refinement of n by those factors has to be applied to every
+      entry of the output rather than only the last, or a factor splitting an
+      earlier entry is dropped.  These three products of three 40-bit primes
+      each came back as two factors while that was wrong.
+   */
+   {
+      const char * strs[3] = {
+         "510351044738189044795649562843011021",
+         "364780511359625600767798259905079621",
+         "938825737845414913824362581154338591"
+      };
+      slong c;
+
+      for (c = 0; c < 3; c++)
+      {
+         fmpz_set_str(n, strs[c], 10);
+
+         fmpz_factor_init(factors);
+
+         flint_set_num_threads(1);
+
+         qsieve_factor(factors, n);
+
+         if (factors->num < 3)
+         {
+            flint_printf("FAIL:\n");
+            flint_printf("Regression, three factors expected\nc = %wd\n", c);
+            flint_printf("%wd factors found\n", factors->num);
+            fflush(stdout);
+            flint_abort();
+         }
+
+         fmpz_factor_clear(factors);
+      }
+   }
+
    /* Test random n, three factors */
    for (i = 0; i < tmul*flint_test_multiplier(); i++)
    {

--- a/src/qsieve/test/t-factor.c
+++ b/src/qsieve/test/t-factor.c
@@ -247,6 +247,55 @@ TEST_FUNCTION_START(qsieve_factor, state)
       fmpz_factor_clear(factors);
    }
 
+   /*
+      Cover the path that grows the factor base.  A sieve threshold above the
+      tuned value means no sieve entry is ever accepted as a candidate, so the
+      polynomials run out with too few relations and qsieve has to increase the
+      factor base and redo the linear algebra setup.  qsieve_linalg_realloc,
+      and with it the resizing of the large prime hash table, is reached only
+      this way, and nothing else in the suite takes that path.
+   */
+   for (i = 0; i < 3 * flint_test_multiplier(); i++)
+   {
+      fmpz_t prod, pw;
+      slong k;
+
+      randprime(x, state, 45);
+      do {
+         randprime(y, state, 45);
+      } while (fmpz_equal(x, y));
+
+      fmpz_mul(n, x, y);
+
+      fmpz_factor_init(factors);
+
+      flint_set_num_threads(1);
+
+      qsieve_factor_with_tune(factors, n, 30, 200, 5, 8000, 60);
+
+      fmpz_init_set_ui(prod, 1);
+      fmpz_init(pw);
+
+      for (k = 0; k < factors->num; k++)
+      {
+         fmpz_pow_ui(pw, factors->p + k, factors->exp[k]);
+         fmpz_mul(prod, prod, pw);
+      }
+
+      if (factors->num < 2 || !fmpz_equal(prod, n))
+      {
+         flint_printf("FAIL:\n");
+         flint_printf("Factor base growth\ni = %wd\n", i);
+         flint_printf("%wd factors found\n", factors->num);
+         fflush(stdout);
+         flint_abort();
+      }
+
+      fmpz_clear(prod);
+      fmpz_clear(pw);
+      fmpz_factor_clear(factors);
+   }
+
    /* Test random n, small factors */
    for (i = 0; i < tmul*flint_test_multiplier(); i++)
    {

--- a/src/ulong_extras.h
+++ b/src/ulong_extras.h
@@ -595,6 +595,8 @@ ulong n_factor_one_line(ulong n, ulong iters);
 ulong n_factor_lehman(ulong n);
 
 ulong n_ll_factor_SQUFOF(ulong nhi, ulong nlo, ulong iters);
+int n_ll_factor_rho(nn_ptr factor, ulong nhi, ulong nlo, ulong max_tries, ulong max_iters);
+int n_ll_factor_ecm(nn_ptr factor, ulong nhi, ulong nlo, ulong curves, ulong B1, ulong B2, flint_rand_t state);
 ulong n_factor_SQUFOF(ulong n, ulong iters);
 
 ulong n_factor_pp1(ulong n, ulong B1, ulong c);

--- a/src/ulong_extras/ll_factor_ecm.c
+++ b/src/ulong_extras/ll_factor_ecm.c
@@ -1,0 +1,454 @@
+/*
+    Copyright (C) 2015 Kushagra Singh
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Opus 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+/*
+   The elliptic curve method specialised to two-word moduli.
+
+   Curve selection (Suyama parametrisation) is done once per curve with
+   mpn arithmetic, which is negligible against the cost of the stages and
+   keeps the modular inversion simple.  Stage 1 and stage 2 run entirely
+   in two-word Montgomery arithmetic; this is where essentially all the
+   time goes.
+
+   The algorithm mirrors fmpz_factor_ecm: Montgomery curve XZ-only
+   arithmetic, a binary ladder for stage 1, and the standard continuation
+   with a primorial step P for stage 2.
+*/
+
+#include "longlong.h"
+#include "mpn_extras.h"
+#include "ulong_extras.h"
+
+#include "ll_mont2.h"
+
+#if FLINT_BITS == 64
+
+typedef struct
+{
+    ulong n0, n1, np;
+    ulong one[2];    /* R mod n */
+    ulong R2[2];     /* R^2 mod n */
+}
+ll_mont_s;
+
+typedef ll_mont_s ll_mont_t[1];
+
+#define MMUL(r, a, b) \
+    LL_MULMOD((r)[1], (r)[0], (a)[1], (a)[0], (b)[1], (b)[0], M->n1, M->n0, M->np)
+#define MADD(r, a, b) \
+    LL_ADDMOD((r)[1], (r)[0], (a)[1], (a)[0], (b)[1], (b)[0], M->n1, M->n0)
+#define MSUB(r, a, b) \
+    LL_SUBMOD((r)[1], (r)[0], (a)[1], (a)[0], (b)[1], (b)[0], M->n1, M->n0)
+#define MSQR(r, a) \
+    LL_SQRMOD((r)[1], (r)[0], (a)[1], (a)[0], M->n1, M->n0, M->np)
+
+static void
+ll_mont_init(ll_mont_t M, ulong n1, ulong n0)
+{
+    ulong num[5], quot[4], nvec[2];
+
+    M->n0 = n0;
+    M->n1 = n1;
+    M->np = LL_NEG_NINV(n0);
+
+    nvec[0] = n0;
+    nvec[1] = n1;
+
+    /* R^2 mod n, where R = 2^(2*FLINT_BITS) */
+    num[0] = num[1] = num[2] = num[3] = 0;
+    num[4] = 1;
+    mpn_tdiv_qr(quot, M->R2, 0, num, 5, nvec, 2);
+
+    /* R mod n = R^2 / R */
+    LL_MULMOD(M->one[1], M->one[0], M->R2[1], M->R2[0], 0, 1, n1, n0, M->np);
+}
+
+/* convert the two-word value {a1,a0} in [0,n) into Montgomery form */
+static void
+ll_to_mont(nn_ptr r, ulong a1, ulong a0, const ll_mont_t M)
+{
+    LL_MULMOD(r[1], r[0], a1, a0, M->R2[1], M->R2[0], M->n1, M->n0, M->np);
+}
+
+/*
+   Montgomery curve arithmetic on (X : Z) coordinates.  In both routines
+   every input is consumed before any output is written, so the
+   destination may alias the inputs other than the difference point.
+*/
+
+static void
+ll_xz_double(nn_ptr X2, nn_ptr Z2, nn_srcptr X, nn_srcptr Z,
+             nn_srcptr a24, const ll_mont_t M)
+{
+    ulong u[2], v[2], w[2];
+
+    MADD(u, X, Z);  MSQR(u, u);      /* u = (X+Z)^2 */
+    MSUB(v, X, Z);  MSQR(v, v);      /* v = (X-Z)^2 */
+    MMUL(X2, u, v);                     /* X2 = u*v */
+    MSUB(w, u, v);                      /* w = 4*X*Z */
+    MMUL(u, w, a24);
+    MADD(u, u, v);
+    MMUL(Z2, w, u);
+}
+
+/* (X3:Z3) = (X1:Z1) + (X2:Z2) where (X0:Z0) is their difference */
+static void
+ll_xz_add(nn_ptr X3, nn_ptr Z3, nn_srcptr X1, nn_srcptr Z1,
+          nn_srcptr X2, nn_srcptr Z2, nn_srcptr X0, nn_srcptr Z0,
+          const ll_mont_t M)
+{
+    ulong u[2], v[2], w[2];
+
+    MSUB(u, X2, Z2);
+    MADD(v, X1, Z1);
+    MMUL(u, u, v);
+    MSUB(v, X1, Z1);
+    MADD(w, X2, Z2);
+    MMUL(v, v, w);
+    MADD(w, u, v);
+    MSUB(v, v, u);
+    MSQR(w, w);
+    MSQR(v, v);
+    MMUL(X3, Z0, w);
+    MMUL(Z3, X0, v);
+}
+
+/* (RX:RZ) = k*(X:Z) by the Montgomery ladder */
+static void
+ll_xz_mul(nn_ptr RX, nn_ptr RZ, nn_srcptr X, nn_srcptr Z, ulong k,
+          nn_srcptr a24, const ll_mont_t M)
+{
+    ulong x1[2], z1[2], x2[2], z2[2];
+    slong i;
+
+    if (k == 0)
+    {
+        RX[0] = RX[1] = 0;
+        RZ[0] = RZ[1] = 0;
+        return;
+    }
+
+    x1[0] = X[0]; x1[1] = X[1];
+    z1[0] = Z[0]; z1[1] = Z[1];
+
+    if (k == 1)
+    {
+        RX[0] = x1[0]; RX[1] = x1[1];
+        RZ[0] = z1[0]; RZ[1] = z1[1];
+        return;
+    }
+
+    ll_xz_double(x2, z2, X, Z, a24, M);
+
+    /* invariant: (x2:z2) - (x1:z1) = (X:Z) */
+    for (i = (slong) FLINT_BIT_COUNT(k) - 2; i >= 0; i--)
+    {
+        if ((k >> i) & 1)
+        {
+            ll_xz_add(x1, z1, x1, z1, x2, z2, X, Z, M);
+            ll_xz_double(x2, z2, x2, z2, a24, M);
+        }
+        else
+        {
+            ll_xz_add(x2, z2, x1, z1, x2, z2, X, Z, M);
+            ll_xz_double(x1, z1, x1, z1, a24, M);
+        }
+    }
+
+    RX[0] = x1[0]; RX[1] = x1[1];
+    RZ[0] = z1[0]; RZ[1] = z1[1];
+}
+
+/* gcd(v, n); returns 1 and writes a proper divisor to factor */
+static int
+ll_gcd_factor(nn_ptr factor, nn_srcptr v, ulong n1, ulong n0)
+{
+    ulong nvec[2], vvec[2], g[2];
+    mp_size_t gs;
+
+    if ((v[0] | v[1]) == 0)
+        return 0;
+
+    nvec[0] = n0; nvec[1] = n1;
+    vvec[0] = v[0]; vvec[1] = v[1];
+
+    gs = flint_mpn_gcd_full(g, nvec, 2, vvec, v[1] ? 2 : 1);
+
+    if (gs == 1)
+    {
+        if (g[0] == 1)
+            return 0;
+        factor[0] = g[0];
+        factor[1] = 0;
+        return 1;
+    }
+
+    if (g[0] == n0 && g[1] == n1)
+        return 0;
+
+    factor[0] = g[0];
+    factor[1] = g[1];
+    return 1;
+}
+
+/* stage 2 step; P is a primorial, tab[(i-mmin)*(maxj+1) + j] flags a prime hit */
+#define LL_ECM_P 210
+
+static int
+ll_ecm_curve(nn_ptr factor, ulong n1, ulong n0, ulong sigma, ulong B1,
+             const ll_mont_t M, const unsigned char * tab, ulong mmin, ulong mmax)
+{
+    ulong X[2], Z[2], a24[2];
+    ulong sig[2], u[2], v[2], t[2], num[2], den[2], c5[2], c3[2], c16[2];
+    int ret = 0;
+
+    /*
+       Suyama's parametrisation, in Montgomery form throughout:
+           u = sigma^2 - 5,  v = 4*sigma,
+           x0 = u^3,  z0 = v^3,
+           a24 = (A+2)/4 = (v-u)^3 * (3u+v) / (16 * u^3 * v).
+       Only the final division needs an inversion.
+    */
+    ll_to_mont(sig, 0, sigma, M);
+    ll_to_mont(c5, 0, 5, M);
+    ll_to_mont(c3, 0, 3, M);
+    ll_to_mont(c16, 0, 16, M);
+
+    MSQR(u, sig);
+    MSUB(u, u, c5);                       /* u = sigma^2 - 5 */
+
+    MADD(v, sig, sig);
+    MADD(v, v, v);                        /* v = 4*sigma */
+
+    MSQR(X, u);  MMUL(X, X, u);           /* x0 = u^3 */
+    MSQR(Z, v);  MMUL(Z, Z, v);           /* z0 = v^3 */
+
+    MSUB(t, v, u);
+    MSQR(num, t);  MMUL(num, num, t);     /* (v-u)^3 */
+    MMUL(t, u, c3);
+    MADD(t, t, v);                        /* 3u + v */
+    MMUL(num, num, t);
+
+    MMUL(den, c16, X);
+    MMUL(den, den, v);                    /* 16 * u^3 * v */
+
+    /*
+       Invert den.  mpn_gcdext wants both operands given as exactly
+       n limbs with the modulus normalised, as in mpn_mod_inv; the gcd it
+       returns is the factor of n when the inverse does not exist.
+    */
+    {
+        ulong dord[2], nvec[2], tmp[2], one_ord[2], g[4], sv[4];
+        mp_size_t gsize, ssize;
+
+        /* leave Montgomery form: den * 1 / R gives the ordinary residue */
+        one_ord[0] = 1; one_ord[1] = 0;
+        MMUL(dord, den, one_ord);
+
+        if ((dord[0] | dord[1]) == 0)
+            goto cleanup;                 /* degenerate curve, skip it */
+
+        nvec[0] = M->n0; nvec[1] = M->n1;
+        tmp[0] = dord[0]; tmp[1] = dord[1];
+
+        gsize = mpn_gcdext(g, sv, &ssize, tmp, 2, nvec, 2);
+
+        if (!(gsize == 1 && g[0] == 1))
+        {
+            /* den shares a factor with n */
+            if (!(gsize == 2 && g[0] == M->n0 && g[1] == M->n1))
+            {
+                factor[0] = g[0];
+                factor[1] = (gsize > 1) ? g[1] : 0;
+                ret = 1;
+            }
+            goto cleanup;
+        }
+
+        flint_mpn_zero(sv + FLINT_ABS(ssize), 2 - FLINT_ABS(ssize));
+        if (ssize < 0)
+            flint_mpn_negmod_n(sv, sv, nvec, 2);
+
+        /* back into Montgomery form and combine */
+        ll_to_mont(t, sv[1], sv[0], M);
+        MMUL(a24, num, t);
+    }
+
+    /* ---------------- stage 1 ---------------- */
+    {
+        n_primes_t iter;
+        ulong p;
+
+        n_primes_init(iter);
+        while ((p = n_primes_next(iter)) <= B1)
+        {
+            ulong q = p;
+            while (q <= B1 / p)
+                q *= p;
+            ll_xz_mul(X, Z, X, Z, q, a24, M);
+        }
+        n_primes_clear(iter);
+    }
+
+    if (ll_gcd_factor(factor, Z, n1, n0))
+    {
+        ret = 1;
+        goto cleanup;
+    }
+
+    if ((Z[0] | Z[1]) == 0)     /* point at infinity, nothing more to learn */
+        goto cleanup;
+
+    /* ---------------- stage 2 ---------------- */
+    {
+        const ulong P = LL_ECM_P;
+        ulong maxj = (P + 1) / 2;
+        ulong nj = (maxj >> 1) + 1;
+        ulong row = maxj + 1;
+        nn_ptr arrx, arrz;
+        ulong Q0x2[2], Q0z2[2];
+        ulong Qx[2], Qz[2], Rx[2], Rz[2], Qdx[2], Qdz[2];
+        ulong g[4][2], a[2], b[2], sx[2], sz[2];
+        ulong i, j;
+        int gi = 0;
+
+        arrx = flint_malloc(2 * nj * sizeof(ulong));
+        arrz = flint_malloc(2 * nj * sizeof(ulong));
+
+        /* arr[j>>1] = j*Q0 for odd j */
+        arrx[0] = X[0]; arrx[1] = X[1];
+        arrz[0] = Z[0]; arrz[1] = Z[1];
+        ll_xz_double(Q0x2, Q0z2, X, Z, a24, M);
+        ll_xz_add(arrx + 2, arrz + 2, Q0x2, Q0z2, arrx, arrz, arrx, arrz, M);
+        for (j = 2; j < nj; j++)
+            ll_xz_add(arrx + 2*j, arrz + 2*j, arrx + 2*(j-1), arrz + 2*(j-1),
+                      Q0x2, Q0z2, arrx + 2*(j-2), arrz + 2*(j-2), M);
+
+        ll_xz_mul(Qx, Qz, X, Z, P, a24, M);
+        ll_xz_mul(Rx, Rz, Qx, Qz, mmin, a24, M);
+        ll_xz_mul(Qdx, Qdz, Qx, Qz, mmin - 1, a24, M);
+
+        for (j = 0; j < 4; j++)
+        {
+            g[j][0] = M->one[0];
+            g[j][1] = M->one[1];
+        }
+
+        for (i = mmin; i <= mmax; i++)
+        {
+            const unsigned char * trow = tab + (i - mmin) * row;
+
+            for (j = 1; j <= maxj; j += 2)
+            {
+                if (!trow[j])
+                    continue;
+
+                MMUL(a, Rx, arrz + 2*(j >> 1));
+                MMUL(b, Rz, arrx + 2*(j >> 1));
+                MSUB(a, a, b);
+                MMUL(g[gi], g[gi], a);
+                gi = (gi + 1) & 3;
+            }
+
+            sx[0] = Rx[0]; sx[1] = Rx[1];
+            sz[0] = Rz[0]; sz[1] = Rz[1];
+            ll_xz_add(Rx, Rz, Rx, Rz, Qx, Qz, Qdx, Qdz, M);
+            Qdx[0] = sx[0]; Qdx[1] = sx[1];
+            Qdz[0] = sz[0]; Qdz[1] = sz[1];
+        }
+
+        MMUL(g[0], g[0], g[1]);
+        MMUL(g[2], g[2], g[3]);
+        MMUL(g[0], g[0], g[2]);
+
+        if (ll_gcd_factor(factor, g[0], n1, n0))
+            ret = 1;
+
+        flint_free(arrx);
+        flint_free(arrz);
+    }
+
+cleanup:
+    return ret;
+}
+
+int
+n_ll_factor_ecm(nn_ptr factor, ulong nhi, ulong nlo, ulong curves,
+                ulong B1, ulong B2, flint_rand_t state)
+{
+    ll_mont_t M;
+    unsigned char * tab;
+    ulong mmin, mmax, maxj, row, c;
+    int ret = 0;
+
+    if (nhi == 0 || (nlo & 1) == 0 || B1 < 2)
+        return 0;
+
+    if (B2 < B1)
+        B2 = 100 * B1;
+
+    mmin = (B1 + LL_ECM_P / 2) / LL_ECM_P;
+    if (mmin == 0)
+        mmin = 1;
+    mmax = ((B2 - LL_ECM_P / 2) + LL_ECM_P - 1) / LL_ECM_P;
+    if (mmax < mmin)
+        mmax = mmin;
+    maxj = (LL_ECM_P + 1) / 2;
+    row = maxj + 1;
+
+    /*
+       Mark the (i,j) pairs for which i*P-j or i*P+j is a prime in (B1,B2].
+       Walking the primes is cheaper than sieving to B2, and the table is
+       built once for all curves.
+    */
+    tab = flint_calloc((mmax - mmin + 1) * row, sizeof(unsigned char));
+    {
+        n_primes_t iter;
+        ulong p;
+
+        n_primes_init(iter);
+        while ((p = n_primes_next(iter)) <= B2)
+        {
+            ulong i, j;
+
+            if (p <= B1)
+                continue;
+
+            i = (p + LL_ECM_P / 2) / LL_ECM_P;   /* nearest multiple of P */
+            if (i < mmin || i > mmax)
+                continue;
+            j = (p > i * LL_ECM_P) ? (p - i * LL_ECM_P) : (i * LL_ECM_P - p);
+            if (j <= maxj && (j & 1))
+                tab[(i - mmin) * row + j] = 1;
+        }
+        n_primes_clear(iter);
+    }
+
+    ll_mont_init(M, nhi, nlo);
+
+    for (c = 0; c < curves; c++)
+    {
+        ulong sigma = 6 + n_randint(state, UWORD(1) << 30);
+
+        if (ll_ecm_curve(factor, nhi, nlo, sigma, B1, M, tab, mmin, mmax))
+        {
+            ret = 1;
+            break;
+        }
+    }
+
+    flint_free(tab);
+    return ret;
+}
+
+#endif

--- a/src/ulong_extras/ll_factor_rho.c
+++ b/src/ulong_extras/ll_factor_rho.c
@@ -1,0 +1,150 @@
+/*
+    Copyright (C) 2015 Kushagra Singh
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Opus 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+/*
+   Pollard rho with Brent's cycle detection, specialised to two-word
+   moduli.  The inner loop uses Montgomery arithmetic with a fully
+   unrolled two-limb REDC, which avoids the generic mpn call overhead
+   and the normalisation/shift bookkeeping of
+   flint_mpn_factor_pollard_brent_single.
+
+   The iteration is y <- y^2 + c (mod n).  Montgomery representation is
+   compatible with this: if yh = y*R then REDC(yh*yh) = y^2*R, and adding
+   ch = c*R gives (y^2+c)*R.  The accumulated product of differences is
+   scaled by a power of R, which is a unit mod n, so the gcd is unaffected.
+*/
+
+#include "longlong.h"
+#include "mpn_extras.h"
+#include "ulong_extras.h"
+
+#include "ll_mont2.h"
+
+#if FLINT_BITS == 64
+
+/*
+   Find a nontrivial factor of the two-word odd composite n = {nhi,nlo}.
+   Returns 1 and writes the (one or two word) factor to factor[0..1] on
+   success, 0 on failure.  max_iters bounds Brent's outer doubling
+   parameter, so roughly 2*max_iters iterations of the map are performed
+   per try.
+*/
+int
+n_ll_factor_rho(nn_ptr factor, ulong nhi, ulong nlo, ulong max_tries,
+                ulong max_iters)
+{
+    ulong n0 = nlo, n1 = nhi, np;
+    ulong r2[2], nvec[2], gvec[2], qvec[2];
+    ulong one1, one0;
+    ulong try_i;
+    mp_size_t gsize;
+
+    if (n1 == 0 || (n0 & 1) == 0)
+        return 0;
+
+    np = LL_NEG_NINV(n0);
+    nvec[0] = n0;
+    nvec[1] = n1;
+
+    /* R^2 mod n, where R = 2^128 */
+    {
+        ulong tmp[5], q[4];
+        tmp[0] = tmp[1] = tmp[2] = tmp[3] = 0;
+        tmp[4] = 1;                       /* 2^256 */
+        mpn_tdiv_qr(q, r2, 0, tmp, 5, nvec, 2);
+    }
+
+    /* 1 in Montgomery form = R mod n */
+    LL_MULMOD(one1, one0, 0, 1, r2[1], r2[0], n1, n0, np);
+
+    for (try_i = 0; try_i < max_tries; try_i++)
+    {
+        ulong x1, x0, y1, y0, q1, q0, c1, c0;
+        ulong r, k, i;
+
+        /* c = try_i + 1, in Montgomery form */
+        LL_MULMOD(c1, c0, 0, try_i + 1, r2[1], r2[0], n1, n0, np);
+
+        y1 = one1; y0 = one0;
+        q1 = one1; q0 = one0;
+        x1 = y1;   x0 = y0;
+
+        for (r = 1; r <= max_iters; r *= 2)
+        {
+            x1 = y1; x0 = y0;
+
+            for (i = 0; i < r; i++)
+            {
+                LL_SQRMOD(y1, y0, y1, y0, n1, n0, np);
+                LL_ADDMOD(y1, y0, y1, y0, c1, c0, n1, n0);
+            }
+
+            for (k = 0; k < r; k += 128)
+            {
+                ulong lim = FLINT_MIN(128, r - k);
+
+                for (i = 0; i < lim; i++)
+                {
+                    ulong d1, d0;
+
+                    LL_SQRMOD(y1, y0, y1, y0, n1, n0, np);
+                    LL_ADDMOD(y1, y0, y1, y0, c1, c0, n1, n0);
+
+                    if (x1 > y1 || (x1 == y1 && x0 >= y0))
+                        sub_ddmmss(d1, d0, x1, x0, y1, y0);
+                    else
+                        sub_ddmmss(d1, d0, y1, y0, x1, x0);
+
+                    /* d == 0 means the cycle closed with no factor split */
+                    if ((d1 | d0) == 0)
+                        goto next_try;
+
+                    LL_MULMOD(q1, q0, q1, q0, d1, d0, n1, n0, np);
+                }
+
+                if ((q1 | q0) == 0)
+                    goto next_try;
+
+                qvec[0] = q0;
+                qvec[1] = q1;
+                gsize = flint_mpn_gcd_full(gvec, nvec, 2, qvec, q1 ? 2 : 1);
+
+                if (gsize == 1)
+                {
+                    if (gvec[0] != 1)
+                    {
+                        factor[0] = gvec[0];
+                        factor[1] = 0;
+                        return 1;
+                    }
+                }
+                else
+                {
+                    if (!(gvec[0] == n0 && gvec[1] == n1))
+                    {
+                        factor[0] = gvec[0];
+                        factor[1] = gvec[1];
+                        return 1;
+                    }
+                    /* gcd == n: the batch swallowed all factors, retry */
+                    goto next_try;
+                }
+            }
+        }
+next_try: ;
+    }
+
+    return 0;
+}
+
+#endif

--- a/src/ulong_extras/ll_factor_rho.c
+++ b/src/ulong_extras/ll_factor_rho.c
@@ -130,14 +130,15 @@ n_ll_factor_rho(nn_ptr factor, ulong nhi, ulong nlo, ulong max_tries,
                 }
                 else
                 {
-                    if (!(gvec[0] == n0 && gvec[1] == n1))
-                    {
-                        factor[0] = gvec[0];
-                        factor[1] = gvec[1];
-                        return 1;
-                    }
-                    /* gcd == n: the batch swallowed all factors, retry */
-                    goto next_try;
+                    /*
+                       q is a nonzero residue modulo n here, the zero case
+                       having been taken above, so the gcd divides q and is
+                       strictly smaller than n.  It is therefore a proper
+                       factor and there is no need to test for gcd == n.
+                    */
+                    factor[0] = gvec[0];
+                    factor[1] = gvec[1];
+                    return 1;
                 }
             }
         }

--- a/src/ulong_extras/ll_mont2.h
+++ b/src/ulong_extras/ll_mont2.h
@@ -1,0 +1,121 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Opus 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+/*
+   Two-word Montgomery arithmetic, shared by the double-word factoring
+   routines (ll_factor_rho.c, ll_factor_ecm.c).
+
+   The modulus n = {n1,n0} must be odd with n1 != 0, and np = -n^(-1) mod
+   2^FLINT_BITS.  Values are held as ordinary two-word residues in [0,n);
+   "Montgomery form" of a is a*R mod n with R = 2^(2*FLINT_BITS).
+
+   Note that gcd(a*R mod n, n) = gcd(a, n) because R is a unit mod n, so
+   factor detection needs no conversion out of Montgomery form.
+*/
+
+#ifndef LL_MONT2_H
+#define LL_MONT2_H
+
+#include "longlong.h"
+#include "mpn_extras.h"
+#include "ulong_extras.h"
+
+#if FLINT_BITS == 64
+
+/*
+   Products are computed with the existing mpn_extras macros:
+   FLINT_MPN_MUL_2X2 for a general 2x2 product and FLINT_MPN_SQR_2X2 for a
+   square, which saves one multiplication.
+*/
+
+/*
+   Montgomery reduction of {p3,p2,p1,p0} modulo {n1,n0}.  A fifth
+   accumulator word is carried because the intermediate sum can exceed
+   four words.  The result is reduced to [0, n).
+*/
+#define LL_REDC_2(r1, r0, p3, p2, p1, p0, n1, n0, np)                       \
+    do {                                                                    \
+        ulong __T4 = 0, __T3 = (p3), __T2 = (p2), __T1 = (p1), __T0 = (p0); \
+        ulong __m, __h, __l, __cy;                                          \
+                                                                            \
+        __m = __T0 * (np);                                                  \
+        umul_ppmm(__h, __l, __m, (n0));                                     \
+        add_ssaaaa(__cy, __T0, 0, __T0, __h, __l);   /* __T0 becomes 0 */   \
+        umul_ppmm(__h, __l, __m, (n1));                                     \
+        add_ssaaaa(__h, __l, __h, __l, 0, __cy);                            \
+        add_ssssaaaaaaaa(__T4, __T3, __T2, __T1,                            \
+                         __T4, __T3, __T2, __T1, 0, 0, __h, __l);           \
+                                                                            \
+        __m = __T1 * (np);                                                  \
+        umul_ppmm(__h, __l, __m, (n0));                                     \
+        add_ssaaaa(__cy, __T1, 0, __T1, __h, __l);   /* __T1 becomes 0 */   \
+        umul_ppmm(__h, __l, __m, (n1));                                     \
+        add_ssaaaa(__h, __l, __h, __l, 0, __cy);                            \
+        add_sssaaaaaa(__T4, __T3, __T2, __T4, __T3, __T2, 0, __h, __l);     \
+                                                                            \
+        if (__T4 || __T3 > (n1) || (__T3 == (n1) && __T2 >= (n0)))          \
+            sub_ddmmss(__T3, __T2, __T3, __T2, (n1), (n0));                 \
+                                                                            \
+        (r1) = __T3;                                                        \
+        (r0) = __T2;                                                        \
+    } while (0)
+
+#define LL_MULMOD(r1, r0, a1, a0, b1, b0, n1, n0, np)                       \
+    do {                                                                    \
+        ulong __q3, __q2, __q1, __q0;                                       \
+        FLINT_MPN_MUL_2X2(__q3, __q2, __q1, __q0, a1, a0, b1, b0);          \
+        LL_REDC_2(r1, r0, __q3, __q2, __q1, __q0, n1, n0, np);              \
+    } while (0)
+
+/* as LL_MULMOD, but squaring {a1,a0} */
+#define LL_SQRMOD(r1, r0, a1, a0, n1, n0, np)                               \
+    do {                                                                    \
+        ulong __q3, __q2, __q1, __q0;                                       \
+        FLINT_MPN_SQR_2X2(__q3, __q2, __q1, __q0, a1, a0);                  \
+        LL_REDC_2(r1, r0, __q3, __q2, __q1, __q0, n1, n0, np);              \
+    } while (0)
+
+/* add {b1,b0} to {a1,a0} modulo {n1,n0}; inputs must be reduced */
+#define LL_ADDMOD(r1, r0, a1, a0, b1, b0, n1, n0)                           \
+    do {                                                                    \
+        ulong __s2 = 0, __s1, __s0;                                         \
+        add_sssaaaaaa(__s2, __s1, __s0, 0, a1, a0, 0, b1, b0);              \
+        if (__s2 || __s1 > (n1) || (__s1 == (n1) && __s0 >= (n0)))          \
+            sub_ddmmss(__s1, __s0, __s1, __s0, (n1), (n0));                 \
+        (r1) = __s1;                                                        \
+        (r0) = __s0;                                                        \
+    } while (0)
+
+/* subtract {b1,b0} from {a1,a0} modulo {n1,n0}; inputs must be reduced */
+#define LL_SUBMOD(r1, r0, a1, a0, b1, b0, n1, n0)                           \
+    do {                                                                    \
+        ulong __d1, __d0;                                                   \
+        if ((a1) > (b1) || ((a1) == (b1) && (a0) >= (b0)))                  \
+            sub_ddmmss(__d1, __d0, a1, a0, b1, b0);                         \
+        else                                                                \
+        {                                                                   \
+            sub_ddmmss(__d1, __d0, (n1), (n0), b1, b0);                     \
+            add_ssaaaa(__d1, __d0, __d1, __d0, a1, a0);                     \
+        }                                                                   \
+        (r1) = __d1;                                                        \
+        (r0) = __d0;                                                        \
+    } while (0)
+
+/*
+   The Montgomery constant is -n^(-1) mod 2^FLINT_BITS; n_binvert gives
+   n^(-1) mod 2^FLINT_BITS (Hurchalla's algorithm with a lookup table).
+*/
+#define LL_NEG_NINV(n0) (-n_binvert(n0))
+
+#endif
+
+#endif

--- a/src/ulong_extras/test/main.c
+++ b/src/ulong_extras/test/main.c
@@ -63,6 +63,8 @@
 #include "t-jacobi.c"
 #include "t-ll_is_prime.c"
 #include "t-lll_mod_preinv.c"
+#include "t-ll_factor_ecm.c"
+#include "t-ll_factor_rho.c"
 #include "t-ll_mod_preinv.c"
 #include "t-ll_small_powmod.c"
 #include "t-mod2_precomp.c"
@@ -165,6 +167,8 @@ test_struct tests[] =
     TEST_FUNCTION(n_jacobi),
     TEST_FUNCTION(n_ll_is_prime),
     TEST_FUNCTION(n_lll_mod_preinv),
+    TEST_FUNCTION(n_ll_factor_ecm),
+    TEST_FUNCTION(n_ll_factor_rho),
     TEST_FUNCTION(n_ll_mod_preinv),
     TEST_FUNCTION(n_ll_small_powmod),
     TEST_FUNCTION(n_mod2_precomp),

--- a/src/ulong_extras/test/t-ll_factor_ecm.c
+++ b/src/ulong_extras/test/t-ll_factor_ecm.c
@@ -71,6 +71,60 @@ TEST_FUNCTION_START(n_ll_factor_ecm, state)
         fmpz_clear(t);
     }
 
+    /* arguments outside the supported range are rejected */
+    {
+        ulong fac[2];
+
+        if (n_ll_factor_ecm(fac, 0, UWORD(101), 4, 1000, 100000, state))
+            TEST_FUNCTION_FAIL("accepted a one limb argument\n");
+
+        if (n_ll_factor_ecm(fac, 1, UWORD(0), 4, 1000, 100000, state))
+            TEST_FUNCTION_FAIL("accepted an even argument\n");
+
+        if (n_ll_factor_ecm(fac, 1, UWORD(101), 4, 1, 100000, state))
+            TEST_FUNCTION_FAIL("accepted a stage one bound below two\n");
+    }
+
+    /*
+       A stage two bound below the stage one bound is replaced by a default,
+       and a modulus sharing a factor with Suyama's denominator makes the
+       curve degenerate, which yields a factor during setup.
+    */
+    for (i = 0; i < 10 * flint_test_multiplier(); i++)
+    {
+        fmpz_t p, n, f, t;
+        ulong nhi, nlo, fac[2];
+
+        fmpz_init(p);
+        fmpz_init(n);
+        fmpz_init(f);
+        fmpz_init(t);
+
+        fmpz_randprime(p, state, 66, 0);
+        fmpz_mul_ui(n, p, 15);          /* small factors force degenerate curves */
+
+        if (fmpz_bits(n) <= 128 && fmpz_is_odd(n))
+        {
+            fmpz_get_uiui(&nhi, &nlo, n);
+
+            /* B2 smaller than B1 asks for the default */
+            if (n_ll_factor_ecm(fac, nhi, nlo, 4, 1000, 0, state))
+            {
+                fmpz_set_uiui(f, fac[1], fac[0]);
+                fmpz_mod(t, n, f);
+
+                if (!fmpz_is_zero(t) || fmpz_is_one(f) || fmpz_equal(f, n))
+                    TEST_FUNCTION_FAIL("bad factor with a defaulted B2\n"
+                                       "n = %{fmpz}\nf = %{fmpz}\n", n, f);
+            }
+        }
+
+        fmpz_clear(p);
+        fmpz_clear(n);
+        fmpz_clear(f);
+        fmpz_clear(t);
+    }
+
     if (trials > 20 && count < trials / 5)
         TEST_FUNCTION_FAIL("only %wu of %wu numbers factored\n", count, trials);
 

--- a/src/ulong_extras/test/t-ll_factor_ecm.c
+++ b/src/ulong_extras/test/t-ll_factor_ecm.c
@@ -1,0 +1,87 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Opus 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "fmpz.h"
+#include "ulong_extras.h"
+
+#if FLINT_BITS == 64
+
+TEST_FUNCTION_START(n_ll_factor_ecm, state)
+{
+    slong i;
+    ulong count = 0, trials = 0;
+
+    for (i = 0; i < 30 * flint_test_multiplier(); i++)
+    {
+        fmpz_t p, q, n, f, t;
+        ulong nhi, nlo, fac[2];
+        flint_bitcnt_t pbits, qbits;
+
+        fmpz_init(p);
+        fmpz_init(q);
+        fmpz_init(n);
+        fmpz_init(f);
+        fmpz_init(t);
+
+        /* a factor ECM has a fair chance of finding, and a large cofactor */
+        pbits = 20 + n_randint(state, 18);
+        qbits = 128 - pbits - n_randint(state, 20);
+        if (pbits + qbits < 65)
+            qbits = 65 - pbits;
+
+        fmpz_randprime(p, state, pbits, 0);
+        fmpz_randprime(q, state, qbits, 0);
+        fmpz_mul(n, p, q);
+
+        if (fmpz_bits(n) > 64 && fmpz_bits(n) <= 128 && fmpz_is_odd(n))
+        {
+            trials++;
+            fmpz_get_uiui(&nhi, &nlo, n);
+
+            if (n_ll_factor_ecm(fac, nhi, nlo, 4, 1000, 100000, state))
+            {
+                fmpz_set_uiui(f, fac[1], fac[0]);
+
+                if (fmpz_is_one(f) || fmpz_equal(f, n))
+                    TEST_FUNCTION_FAIL("trivial factor returned\n"
+                                       "n = %{fmpz}\nf = %{fmpz}\n", n, f);
+
+                fmpz_mod(t, n, f);
+                if (!fmpz_is_zero(t))
+                    TEST_FUNCTION_FAIL("factor does not divide n\n"
+                                       "n = %{fmpz}\nf = %{fmpz}\n", n, f);
+                count++;
+            }
+        }
+
+        fmpz_clear(p);
+        fmpz_clear(q);
+        fmpz_clear(n);
+        fmpz_clear(f);
+        fmpz_clear(t);
+    }
+
+    if (trials > 20 && count < trials / 5)
+        TEST_FUNCTION_FAIL("only %wu of %wu numbers factored\n", count, trials);
+
+    TEST_FUNCTION_END(state);
+}
+
+#else
+
+TEST_FUNCTION_START(n_ll_factor_ecm, state)
+{
+    TEST_FUNCTION_END_SKIPPED(state);
+}
+
+#endif

--- a/src/ulong_extras/test/t-ll_factor_rho.c
+++ b/src/ulong_extras/test/t-ll_factor_rho.c
@@ -71,6 +71,104 @@ TEST_FUNCTION_START(n_ll_factor_rho, state)
         fmpz_clear(t);
     }
 
+    /* arguments outside the supported range are rejected */
+    {
+        ulong fac[2];
+
+        if (n_ll_factor_rho(fac, 0, UWORD(101), 1, 1024))
+            TEST_FUNCTION_FAIL("accepted a one limb argument\n");
+
+        if (n_ll_factor_rho(fac, 1, UWORD(0), 1, 1024))
+            TEST_FUNCTION_FAIL("accepted an even argument\n");
+    }
+
+    /*
+       A small modulus with a large budget makes the batched product run into
+       every factor at once, so the gcd comes back equal to n and the attempt
+       has to be restarted with a different constant.
+    */
+    for (i = 0; i < 5 * flint_test_multiplier(); i++)
+    {
+        fmpz_t p, q, n, f, t;
+        ulong nhi, nlo, fac[2];
+
+        fmpz_init(p);
+        fmpz_init(q);
+        fmpz_init(n);
+        fmpz_init(f);
+        fmpz_init(t);
+
+        fmpz_randprime(p, state, 33, 0);
+        fmpz_randprime(q, state, 33, 0);
+        fmpz_mul(n, p, q);
+
+        if (fmpz_bits(n) > 64 && fmpz_is_odd(n))
+        {
+            fmpz_get_uiui(&nhi, &nlo, n);
+
+            if (n_ll_factor_rho(fac, nhi, nlo, 4, 65536))
+            {
+                fmpz_set_uiui(f, fac[1], fac[0]);
+                fmpz_mod(t, n, f);
+
+                if (!fmpz_is_zero(t) || fmpz_is_one(f) || fmpz_equal(f, n))
+                    TEST_FUNCTION_FAIL("bad factor with a large budget\n"
+                                       "n = %{fmpz}\nf = %{fmpz}\n", n, f);
+            }
+        }
+
+        fmpz_clear(p);
+        fmpz_clear(q);
+        fmpz_clear(n);
+        fmpz_clear(f);
+        fmpz_clear(t);
+    }
+
+    /*
+       Three factors, two of which multiply to more than one limb, so the
+       batched gcd can return a factor that needs both limbs.
+    */
+    for (i = 0; i < 10 * flint_test_multiplier(); i++)
+    {
+        fmpz_t p, q, r, n, f, t;
+        ulong nhi, nlo, fac[2];
+
+        fmpz_init(p);
+        fmpz_init(q);
+        fmpz_init(r);
+        fmpz_init(n);
+        fmpz_init(f);
+        fmpz_init(t);
+
+        fmpz_randprime(p, state, 34, 0);
+        fmpz_randprime(q, state, 34, 0);
+        fmpz_randprime(r, state, 20, 0);
+        fmpz_mul(n, p, q);
+        fmpz_mul(n, n, r);
+
+        if (fmpz_bits(n) > 64 && fmpz_bits(n) <= 128 && fmpz_is_odd(n))
+        {
+            fmpz_get_uiui(&nhi, &nlo, n);
+
+            if (n_ll_factor_rho(fac, nhi, nlo, 3, 8192))
+            {
+                fmpz_set_uiui(f, fac[1], fac[0]);
+                fmpz_mod(t, n, f);
+
+                if (!fmpz_is_zero(t) || fmpz_is_one(f) || fmpz_equal(f, n))
+                    TEST_FUNCTION_FAIL("bad factor for a three factor input\n"
+                                       "n = %{fmpz}\nf = %{fmpz}\n", n, f);
+            }
+        }
+
+        fmpz_clear(p);
+        fmpz_clear(q);
+        fmpz_clear(r);
+        fmpz_clear(n);
+        fmpz_clear(f);
+        fmpz_clear(t);
+    }
+
     /* the map should succeed on a decent fraction of these */
     if (trials > 100 && count < trials / 4)
         TEST_FUNCTION_FAIL("only %wu of %wu numbers factored\n", count, trials);

--- a/src/ulong_extras/test/t-ll_factor_rho.c
+++ b/src/ulong_extras/test/t-ll_factor_rho.c
@@ -1,0 +1,88 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Opus 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "fmpz.h"
+#include "ulong_extras.h"
+
+#if FLINT_BITS == 64
+
+TEST_FUNCTION_START(n_ll_factor_rho, state)
+{
+    slong i;
+    ulong count = 0, trials = 0;
+
+    for (i = 0; i < 400 * flint_test_multiplier(); i++)
+    {
+        fmpz_t p, q, n, f, t;
+        ulong nhi, nlo, fac[2];
+        flint_bitcnt_t pbits, qbits;
+
+        fmpz_init(p);
+        fmpz_init(q);
+        fmpz_init(n);
+        fmpz_init(f);
+        fmpz_init(t);
+
+        /* p small enough that rho has a fair chance, q making n two words */
+        pbits = 10 + n_randint(state, 22);
+        qbits = 65 - pbits + n_randint(state, 128 - 65);
+        if (pbits + qbits > 128)
+            qbits = 128 - pbits;
+
+        fmpz_randprime(p, state, pbits, 0);
+        fmpz_randprime(q, state, qbits, 0);
+        fmpz_mul(n, p, q);
+
+        if (fmpz_bits(n) > 64 && fmpz_bits(n) <= 128 && fmpz_is_odd(n))
+        {
+            trials++;
+            fmpz_get_uiui(&nhi, &nlo, n);
+
+            if (n_ll_factor_rho(fac, nhi, nlo, 3, 4096))
+            {
+                fmpz_set_uiui(f, fac[1], fac[0]);
+
+                if (fmpz_is_one(f) || fmpz_equal(f, n))
+                    TEST_FUNCTION_FAIL("trivial factor returned\n"
+                                       "n = %{fmpz}\nf = %{fmpz}\n", n, f);
+
+                fmpz_mod(t, n, f);
+                if (!fmpz_is_zero(t))
+                    TEST_FUNCTION_FAIL("factor does not divide n\n"
+                                       "n = %{fmpz}\nf = %{fmpz}\n", n, f);
+                count++;
+            }
+        }
+
+        fmpz_clear(p);
+        fmpz_clear(q);
+        fmpz_clear(n);
+        fmpz_clear(f);
+        fmpz_clear(t);
+    }
+
+    /* the map should succeed on a decent fraction of these */
+    if (trials > 100 && count < trials / 4)
+        TEST_FUNCTION_FAIL("only %wu of %wu numbers factored\n", count, trials);
+
+    TEST_FUNCTION_END(state);
+}
+
+#else
+
+TEST_FUNCTION_START(n_ll_factor_rho, state)
+{
+    TEST_FUNCTION_END_SKIPPED(state);
+}
+
+#endif


### PR DESCRIPTION
This fixes most of the slowness of `fmpz_factor` in the 65-160 bit range observed in #2625. The speedup is largest around 80 bits where we gain nearly 6x on average for random integers. Performance is also slightly improved for 3-4 word integers.

Several changes:

* Lower SQUFOF threshold to 72 bits
* Optimize Pollard-Brent rho and ECM for double-word arithmetic and use these in appropriate ranges
* Reduce initialization costs for qsieve
* Optimize removal for double-word values in qsieve
* Tweak tuning values for qsieve
* Optimize modular square root in qsieve

Average time per factorization to factor 100 random integers of the given bit size:

```
          uniformly random                 semiprimes
bits        old        new  speedup         old        new  speedup
  72  2.740e-04  1.187e-04  2.310x    2.102e-03  2.218e-03  0.948x
  80  8.527e-04  1.431e-04  5.959x    3.445e-03  2.625e-03  1.312x
  88  1.559e-03  3.535e-04  4.411x    2.697e-03  1.923e-03  1.402x
  96  2.387e-03  6.841e-04  3.489x    3.678e-03  2.745e-03  1.340x
 104  2.642e-03  1.053e-03  2.509x    5.304e-03  4.094e-03  1.296x
 112  3.377e-03  1.354e-03  2.495x    8.032e-03  6.359e-03  1.263x
 120  4.202e-03  2.161e-03  1.945x    1.308e-02  1.163e-02  1.125x
 128  6.392e-03  3.862e-03  1.655x    2.366e-02  1.741e-02  1.359x
 136  9.211e-03  6.904e-03  1.334x    3.489e-02  2.818e-02  1.238x
 144  1.471e-02  1.190e-02  1.236x    6.179e-02  5.237e-02  1.180x
 152  1.703e-02  1.479e-02  1.152x    9.785e-02  8.795e-02  1.113x
 160  2.768e-02  2.527e-02  1.095x    2.010e-01  1.511e-01  1.330x
 168  4.596e-02  4.154e-02  1.106x    3.128e-01  2.504e-01  1.249x
 176  5.872e-02  5.031e-02  1.167x    5.764e-01  4.122e-01  1.398x
 184  9.741e-02  7.924e-02  1.229x    9.098e-01  6.880e-01  1.323x
 192  1.359e-01  1.170e-01  1.162x    1.504e+00  1.356e+00  1.109x
```

Worst-case time for the same 100 inputs:

```
          uniformly random                 semiprimes
bits        old        new  speedup         old        new  speedup
  72  5.800e-03  4.600e-03  1.261x    1.900e-02  1.900e-02  1.000x
  80  6.700e-03  2.100e-03  3.190x    6.300e-03  5.000e-03  1.260x
  88  1.000e-02  4.100e-03  2.439x    4.000e-03  3.400e-03  1.176x
  96  7.200e-03  3.700e-03  1.946x    4.400e-03  3.500e-03  1.257x
 104  7.200e-03  5.300e-03  1.358x    7.800e-03  6.500e-03  1.200x
 112  1.000e-02  8.100e-03  1.235x    1.100e-02  8.900e-03  1.236x
 120  1.500e-02  1.400e-02  1.071x    2.400e-02  2.100e-02  1.143x
 128  2.400e-02  2.100e-02  1.143x    4.000e-02  3.100e-02  1.290x
 136  4.100e-02  3.700e-02  1.108x    6.400e-02  5.500e-02  1.164x
 144  6.000e-02  5.400e-02  1.111x    2.160e-01  1.980e-01  1.091x
 152  1.020e-01  9.700e-02  1.052x    1.670e-01  1.560e-01  1.071x
 160  1.900e-01  1.820e-01  1.044x    3.770e-01  2.590e-01  1.456x
 168  3.140e-01  2.550e-01  1.231x    5.810e-01  4.990e-01  1.164x
 176  6.070e-01  4.480e-01  1.355x    1.020e+00  7.500e-01  1.360x
 184  1.248e+00  8.900e-01  1.402x    1.398e+00  2.649e+00  0.528x
 192  1.730e+00  1.576e+00  1.098x    3.318e+00  3.079e+00  1.078x
```

Tried before to get Opus 4.8 to do this, but it persistently failed to identify the real bottlenecks/solutions; Fable refused to touch this problem (work on integer factorization apparently triggers its safety guardrails); finally Opus 5 got the job done in a few hours.