### PR TITLE
FFT space arithmetic

### DIFF
--- a/doc/source/fft_small.rst
+++ b/doc/source/fft_small.rst
@@ -89,3 +89,52 @@ Preconditioned polynomial arithmetic
 
     Polynomial multiplication given a precomputed transform ``M``.
     Returns 1 if successful, 0 if the precomputed transform is too short.
+
+
+Transform plans and operands
+--------------------------------------------------------------------------------
+
+.. type:: fft_small_plan_struct
+          fft_small_plan_t
+
+    Describes one convolution shape: the primes used, transform depth,
+    truncation lengths and coefficient windows. A plan is computed once
+    and reused for any number of transforms of that shape.
+
+.. type:: fft_small_op_struct
+          fft_small_op_t
+
+    One operand in transformed representation: a buffer of evaluations
+    for each prime, together with the plan parameters it was built for
+    and its current domain (primal data or pointwise products).
+
+.. function:: void fft_small_op_init(fft_small_op_t X, const fft_small_plan_t P)
+              void fft_small_op_init_borrowed(fft_small_op_t X, const fft_small_plan_t P, double * data)
+              ulong fft_small_op_sizeof_data(const fft_small_plan_t P)
+              void fft_small_op_clear(fft_small_op_t X)
+
+    Operand storage management. The *borrowed* variant places the
+    operand on caller-provided storage of ``fft_small_op_sizeof_data``
+    bytes, 4096-aligned, which must outlive the operand and is not freed
+    by *clear*.
+
+.. function:: void fft_small_export_mpn_signed(ulong * z, ulong zn, int * sign, const fft_small_op_t X, ulong nslots, const fft_small_plan_t P)
+              void fft_small_export_mpn_signed_trunc(ulong * z, ulong zn, int * sign, const fft_small_op_t X, ulong nslots, ulong lo_limbs, const fft_small_plan_t P)
+
+    Chinese-remainder reconstruction of a signed integer result: the
+    value is assembled in two's complement and the sign resolved from
+    the top limb, with the magnitude written to *z*. The *trunc* variant
+    writes the limbs of the value starting at limb *lo_limbs*, with an error against the
+    exact value within `(-1.5, +0.5)` ulp of the lowest returned limb --
+    equivalently, at most 1 from the floor-truncated value: every slot
+    whose coefficient span can reach the first returned limb is included
+    with carries propagated, so the error is the truncation itself
+    (one-sided, below 1 ulp) plus the total mass of the wholly dropped
+    slots, under half an ulp either way. With ``lo_limbs = 0`` the
+    export is exact.
+
+.. function:: void fft_small_export_nmod_range(ulong * z, const fft_small_op_t X, ulong zl, ulong zh, nmod_t mod, const fft_small_plan_t P)
+
+    Chinese remaindering restricted to the coefficient window
+    `[zl, zh)`, which must lie inside the plan's window; *z* receives
+    `zh - zl` reduced coefficients. Used for polynomial middle products.

--- a/doc/source/fft_small.rst
+++ b/doc/source/fft_small.rst
@@ -138,3 +138,17 @@ Transform plans and operands
     Chinese remaindering restricted to the coefficient window
     `[zl, zh)`, which must lie inside the plan's window; *z* receives
     `zh - zl` reduced coefficients. Used for polynomial middle products.
+
+.. macro:: FLINT_FFT_SMALL_ALIGNMENT
+
+    Alignment, in bytes, of transform data buffers.
+
+.. var:: ulong flint_fft_small_max_transformed_ring_size
+
+    Upper bound, in bytes, on the transform storage a single transformed
+    ring or context may plan for: its expected number of simultaneously
+    live elements times the per-element data size. Constructors decline
+    above the bound, so drivers fall back to slower algorithms rather
+    than exhaust memory; the matrix multiplication drivers respond by
+    multiplying in blocks instead. Mutable for tuning; the default is
+    4 GiB on 64-bit machines.

--- a/doc/source/fmpz_mat.rst
+++ b/doc/source/fmpz_mat.rst
@@ -1554,3 +1554,16 @@ Modified LLL
     See "Faster Algorithms for Integer Lattice Basis Reduction." Technical
     Report 249. Zurich, Switzerland: Department Informatik, ETH. July 30,
     1996.
+
+
+.. function:: int fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B)
+              int fmpz_mat_mul_fft_small_trunc(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B, slong lo)
+
+    Matrix multiplication with the entries in transformed (fft_small)
+    representation: each entry of the product is an accumulation of
+    pointwise products, converted out once. The *trunc* variant stores
+    in each entry of *C* the limbs of the exact entry starting at limb
+    *lo* (with its sign), with an error against the exact value within
+    `(-1.5, +0.5)` ulp of the lowest returned limb -- equivalently, at
+    most 1 from the floor-truncated value. Returns 0 without touching *C*
+    when the method is unavailable or unprofitable for the given shapes.

--- a/doc/source/fmpz_mat.rst
+++ b/doc/source/fmpz_mat.rst
@@ -1567,3 +1567,16 @@ Modified LLL
     `(-1.5, +0.5)` ulp of the lowest returned limb -- equivalently, at
     most 1 from the floor-truncated value. Returns 0 without touching *C*
     when the method is unavailable or unprofitable for the given shapes.
+
+    The driver budgets its transform storage against
+    ``flint_fft_small_max_transformed_ring_size``. When the whole
+    product does not fit, it multiplies in blocks -- one side resident
+    and the other streamed for rectangular shapes, both sides blocked,
+    or as a last resort the inner dimension split with the entries
+    accumulated across the pieces (the truncated variant refuses that
+    last regime, whose one-unit error contract does not survive summing
+    truncated pieces). Squaring, detected as ``B == A``, keeps a single
+    transform pool when everything is resident. Small inputs are
+    accepted; whether the transformed representation is worth using is
+    the caller's tuning decision.
+

--- a/doc/source/gr.rst
+++ b/doc/source/gr.rst
@@ -1064,3 +1064,10 @@ middle products) run substantially faster in such a representation.
     Element on caller-provided storage of
     ``gr_transformed_mpn_sizeof_data`` bytes, 4096-aligned, outliving
     the element; ``gr_clear`` will not free it.
+
+    The transformed-mpn context constructor takes a *num_live*
+    declaration of the elements expected alive simultaneously, and
+    declines when their combined transform storage would exceed
+    ``flint_fft_small_max_transformed_ring_size``; the transformed
+    polynomial workload structure carries the same declaration in its
+    ``num_live`` field (zero derives a conservative count).

--- a/doc/source/gr.rst
+++ b/doc/source/gr.rst
@@ -1008,7 +1008,7 @@ middle products) run substantially faster in such a representation.
     the implementation default). Implementations use it to judge whether
     switching representation is profitable and to size their tables.
 
-.. function:: int gr_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base, slong len_bound, slong terms_bound, const gr_transformed_poly_workload_struct * workload)
+.. function:: int gr_ctx_init_gr_poly_transformed_repr(gr_ctx_t ctx, gr_ctx_t base, slong len_bound, slong terms_bound, const gr_transformed_poly_workload_struct * workload)
 
     Constructs a ring of transformed polynomials over *base* admitting
     lengths up to *len_bound* and up to *terms_bound* accumulated

--- a/doc/source/gr.rst
+++ b/doc/source/gr.rst
@@ -1071,3 +1071,13 @@ middle products) run substantially faster in such a representation.
     ``flint_fft_small_max_transformed_ring_size``; the transformed
     polynomial workload structure carries the same declaration in its
     ``num_live`` field (zero derives a conservative count).
+
+    For the transformed-mpn context, *bits_bound* bounds the magnitude
+    of any single represented product; the representation provisions the
+    accumulation capacity from *terms_bound* and the sign headroom from
+    *is_signed* itself, so callers must not add either to the bound.
+    ``gr_transformed_mpn_get_limbs_bound(ctx)`` returns an upper bound,
+    over every element of the context, on what
+    ``gr_transformed_mpn_get_limbs`` can return -- conversion staging
+    should be sized from it rather than from a reconstruction of the
+    representation's limb requirements.

--- a/doc/source/gr.rst
+++ b/doc/source/gr.rst
@@ -1070,7 +1070,10 @@ middle products) run substantially faster in such a representation.
     declines when their combined transform storage would exceed
     ``flint_fft_small_max_transformed_ring_size``; the transformed
     polynomial workload structure carries the same declaration in its
-    ``num_live`` field (zero derives a conservative count).
+    ``num_live`` field (zero derives a conservative count). Its ``force``
+    field skips the profitability model and the storage budget entirely,
+    declining only on implementation bounds: for tests, where small
+    unprofitable sizes catch bugs most easily.
 
     For the transformed-mpn context, *bits_bound* bounds the magnitude
     of any single represented product; the representation provisions the

--- a/doc/source/gr.rst
+++ b/doc/source/gr.rst
@@ -1019,6 +1019,12 @@ middle products) run substantially faster in such a representation.
     ``GET_GR_POLY_WINDOW`` methods of the constructed context; the
     window variant writes the coefficients `[zl, zh)` of the represented
     polynomial, with zeros beyond its length.
+    ``_gr_get_gr_poly_destructive`` converts out through the
+    ``GET_GR_POLY_DESTRUCTIVE`` method where the representation provides
+    it: the inverse transforms run on the element's own storage, skipping
+    the transform-sized copy, and the element may only be cleared or
+    fully overwritten afterwards; representations without the method fall
+    back to the copying conversion.
 
 .. function:: int gr_ctx_init_transformed_mpn(gr_ctx_t ctx, slong bits_bound, slong terms_bound, int want_signed)
 

--- a/doc/source/gr.rst
+++ b/doc/source/gr.rst
@@ -986,3 +986,75 @@ Finite field methods
 .. raw:: latex
 
     \newpage
+
+
+Transformed representations
+--------------------------------------------------------------------------------
+
+A *transformed representation* holds ring elements in a form in which
+multiplications are cheap pointwise operations, at the price of
+conversions in and out -- e.g. polynomials as pointwise evaluations
+under a number-theoretic transform. Algorithms performing many
+multiplications between few conversions (matrix products, half-gcd,
+middle products) run substantially faster in such a representation.
+
+.. type:: gr_transformed_poly_workload_struct
+          gr_transformed_poly_workload_t
+
+    An advisory estimate of the intended workload: how many operands
+    will be converted in (*num_inputs*), how many pointwise
+    multiplications performed (*num_muls*), how many results converted
+    out (*num_outputs*), and a memory bound in bytes (*mem_limit*, 0 for
+    the implementation default). Implementations use it to judge whether
+    switching representation is profitable and to size their tables.
+
+.. function:: int gr_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base, slong len_bound, slong terms_bound, const gr_transformed_poly_workload_struct * workload)
+
+    Constructs a ring of transformed polynomials over *base* admitting
+    lengths up to *len_bound* and up to *terms_bound* accumulated
+    elementary products per element, for the estimated workload. Returns
+    ``GR_UNABLE`` if the base ring provides no transformed
+    representation or judges the switch unprofitable. Conversions are
+    performed by the ``SET_GR_POLY`` / ``GET_GR_POLY`` /
+    ``GET_GR_POLY_WINDOW`` methods of the constructed context; the
+    window variant writes the coefficients `[zl, zh)` of the represented
+    polynomial, with zeros beyond its length.
+
+.. function:: int gr_ctx_init_transformed_mpn(gr_ctx_t ctx, slong bits_bound, slong terms_bound, int want_signed)
+
+    Constructs the ring of transformed big integers: bilinear
+    expressions over `\mathbb{Z}` with results below ``2^bits_bound``
+    in absolute value, at most *terms_bound* accumulated elementary
+    products and multiplicative depth two. Elements carry a sign bit;
+    mixed-sign accumulations switch the pointwise additions and
+    subtractions, and the sign of a mixed result is resolved at
+    conversion out.
+
+.. function:: int gr_transformed_mpn_set(gr_ptr res, nn_srcptr a, slong an, int sign, gr_ctx_t ctx)
+              int gr_transformed_mpn_get(nn_ptr z, slong zn, slong * zn_out, int * sign, gr_srcptr x, gr_ctx_t ctx)
+              int gr_transformed_mpn_get_destructive(nn_ptr z, slong zn, slong * zn_out, int * sign, gr_ptr x, gr_ctx_t ctx)
+              slong gr_transformed_mpn_get_limbs(gr_ctx_t ctx, gr_srcptr x)
+
+    Conversions by limb arrays with an explicit sign. The *destructive*
+    get may consume the element, skipping a copy of the transform;
+    *get_limbs* returns the number of limbs the conversion needs.
+
+.. function:: int gr_transformed_mpn_get_trunc(nn_ptr z, slong zn, slong * zn_out, int * sign, slong lo, gr_srcptr x, gr_ctx_t ctx)
+              int gr_transformed_mpn_get_trunc_destructive(nn_ptr z, slong zn, slong * zn_out, int * sign, slong lo, gr_ptr x, gr_ctx_t ctx)
+              slong gr_transformed_mpn_get_limbs_trunc(gr_ctx_t ctx, gr_srcptr x, slong lo)
+
+    Truncated conversion out: the limbs of the value starting at limb
+    *lo*, with an error against the exact value within `(-1.5, +0.5)`
+    ulp of the lowest returned limb -- equivalently, at most 1 from the
+    floor-truncated value. The export includes every CRT slot whose
+    coefficient span can reach the first returned limb, with carries
+    propagated, so the error is the truncation itself (one-sided, below
+    1 ulp) plus the wholly dropped slots' total mass, under half an ulp
+    either way.
+
+.. function:: void gr_transformed_mpn_init_borrowed(gr_ptr x, double * data, gr_ctx_t ctx)
+              ulong gr_transformed_mpn_sizeof_data(gr_ctx_t ctx)
+
+    Element on caller-provided storage of
+    ``gr_transformed_mpn_sizeof_data`` bytes, 4096-aligned, outliving
+    the element; ``gr_clear`` will not free it.

--- a/doc/source/mpn_extras.rst
+++ b/doc/source/mpn_extras.rst
@@ -568,3 +568,52 @@ Random Number Generation
     it on ``rp``. The number it generates will tend to have
     long strings of zeros and ones in the binary representation.
 
+
+
+Complex multiplication
+--------------------------------------------------------------------------------
+
+Multiplication of Gaussian integers represented as pairs of limb arrays
+with separate sign bits (0 meaning nonnegative). No aliasing is permitted
+between output and input arrays.
+
+.. function:: void flint_mpn_mul_complex(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len, nn_srcptr ar, mp_size_t arn, int ar_sgn, nn_srcptr ai, mp_size_t ain, int ai_sgn, nn_srcptr br, mp_size_t brn, int br_sgn, nn_srcptr bi, mp_size_t bin, int bi_sgn)
+              void flint_mpn_sqr_complex(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len, nn_srcptr ar, mp_size_t arn, int ar_sgn, nn_srcptr ai, mp_size_t ain, int ai_sgn)
+
+    Sets `zr + zi i = (ar + ai i)(br + bi i)` (respectively the square of
+    `ar + ai i`). Each part takes an independent length, at least 1 limb
+    and not necessarily normalized. A *signed length* is written for each
+    output: the magnitude occupies ``|*zr_len|`` limbs and a negative
+    value means the result is negative; nothing above ``|*zr_len|`` limbs
+    is written. The outputs must have room for
+    ``max(arn, ain) + max(brn, bin) + 1`` limbs (``2 max(arn, ain) + 1``
+    for the square). The algorithm is selected from the shape: schoolbook
+    when a part is much shorter than its partner, Karatsuba when the
+    parts are internally balanced, and a transformed (fft_small) method
+    for large balanced operands.
+
+.. function:: void flint_mpn_mul_complex_classical(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len, nn_srcptr ar, mp_size_t arn, int ar_sgn, nn_srcptr ai, mp_size_t ain, int ai_sgn, nn_srcptr br, mp_size_t brn, int br_sgn, nn_srcptr bi, mp_size_t bin, int bi_sgn)
+              void flint_mpn_mul_complex_karatsuba(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len, nn_srcptr ar, mp_size_t arn, int ar_sgn, nn_srcptr ai, mp_size_t ain, int ai_sgn, nn_srcptr br, mp_size_t brn, int br_sgn, nn_srcptr bi, mp_size_t bin, int bi_sgn)
+              int flint_mpn_mul_complex_fft_small(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len, nn_srcptr ar, mp_size_t arn, int ar_sgn, nn_srcptr ai, mp_size_t ain, int ai_sgn, nn_srcptr br, mp_size_t brn, int br_sgn, nn_srcptr bi, mp_size_t bin, int bi_sgn)
+              void flint_mpn_sqr_complex_classical(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len, nn_srcptr ar, mp_size_t arn, int ar_sgn, nn_srcptr ai, mp_size_t ain, int ai_sgn)
+              void flint_mpn_sqr_complex_karatsuba(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len, nn_srcptr ar, mp_size_t arn, int ar_sgn, nn_srcptr ai, mp_size_t ain, int ai_sgn)
+              int flint_mpn_sqr_complex_fft_small(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len, nn_srcptr ar, mp_size_t arn, int ar_sgn, nn_srcptr ai, mp_size_t ain, int ai_sgn)
+
+    The individual algorithms behind the general functions, exposed for
+    comparison and tuning. All accept any shape. The *fft_small* variants
+    return 0, leaving the outputs untouched, when the method is
+    unavailable or refuses the operands.
+
+.. function:: void flint_mpn_mulhigh_n_complex(nn_ptr zr, int * zr_sgn, nn_ptr zi, int * zi_sgn, nn_srcptr ar, int ar_sgn, nn_srcptr ai, int ai_sgn, nn_srcptr br, int br_sgn, nn_srcptr bi, int bi_sgn, mp_size_t n)
+              void flint_mpn_sqrhigh_n_complex(nn_ptr zr, int * zr_sgn, nn_ptr zi, int * zi_sgn, nn_srcptr ar, int ar_sgn, nn_srcptr ai, int ai_sgn, mp_size_t n)
+
+    High products: all parts share the length `n`, and each output
+    receives exactly `n + 1` limbs, zero padded, plus a sign -- the limbs
+    `[n, 2n]` of the exact result, with an error of at most a few units
+    in the lowest returned limb.
+
+.. var:: slong flint_mpn_mul_complex_fft_cutoff
+         slong flint_mpn_sqr_complex_fft_cutoff
+
+    Sizes in limbs from which the general functions use the transformed
+    path. Machine dependent; writable for tuning.

--- a/doc/source/mpn_extras.rst
+++ b/doc/source/mpn_extras.rst
@@ -609,8 +609,14 @@ between output and input arrays.
 
     High products: all parts share the length `n`, and each output
     receives exactly `n + 1` limbs, zero padded, plus a sign -- the limbs
-    `[n, 2n]` of the exact result, with an error of at most a few units
-    in the lowest returned limb.
+    `[n, 2n]` of the exact result. Relative to the exact value the error
+    is below `2 + 3(n + 4)/2^{64}` ulp of the lowest returned limb for
+    the product and below `2 + 2(n + 4)/2^{64}` for the square -- each
+    underlying :func:`flint_mpn_mulhigh_n`, read as `n` limbs, errs by
+    `(-1 - \varepsilon, +\varepsilon)` ulp against the exact value with
+    `\varepsilon = (n + 4)/2^{64}`, and each output combines at most
+    three -- so below 3 ulp for any practical `n`. The transformed path
+    stays within `(-1.5, +0.5)` ulp.
 
 .. var:: slong flint_mpn_mul_complex_fft_cutoff
          slong flint_mpn_sqr_complex_fft_cutoff

--- a/doc/source/mpn_mod.rst
+++ b/doc/source/mpn_mod.rst
@@ -329,3 +329,10 @@ GCD
 
     Polynomial extended GCD with automatic selection between basecase
     and HGCD algorithms.
+
+
+.. function:: int _mpn_mod_poly_mullow_fft_small(nn_ptr res, nn_srcptr poly1, slong len1, nn_srcptr poly2, slong len2, slong len, gr_ctx_t ctx)
+
+    Truncated polynomial product over ``mpn_mod`` contexts via the
+    transformed representation. Returns ``GR_UNABLE`` when the modulus
+    or lengths are unsuitable.

--- a/doc/source/mpn_mod.rst
+++ b/doc/source/mpn_mod.rst
@@ -330,9 +330,3 @@ GCD
     Polynomial extended GCD with automatic selection between basecase
     and HGCD algorithms.
 
-
-.. function:: int _mpn_mod_poly_mullow_fft_small(nn_ptr res, nn_srcptr poly1, slong len1, nn_srcptr poly2, slong len2, slong len, gr_ctx_t ctx)
-
-    Truncated polynomial product over ``mpn_mod`` contexts via the
-    transformed representation. Returns ``GR_UNABLE`` when the modulus
-    or lengths are unsuitable.

--- a/doc/source/nmod_poly_mat.rst
+++ b/doc/source/nmod_poly_mat.rst
@@ -547,3 +547,11 @@ Solving
     The decomposition ``FFLU`` and permutation ``perm`` are assumed to come
     from :func:`nmod_poly_mat_fflu` applied to a nonsingular square matrix;
     this is not checked.
+
+
+.. function:: int nmod_poly_mat_mulmid_fft_small(nmod_poly_mat_t C, const nmod_poly_mat_t A, const nmod_poly_mat_t B, slong zl, slong zh)
+
+    Sets the entries of *C* to the coefficient windows `[zl, zh)` of the
+    entries of `A B`, computed with pointwise products on shared
+    fft_small transforms and windowed reconstruction. Returns 0 without
+    touching *C* if the method is unavailable for the modulus or shape.

--- a/doc/source/nmod_poly_mat.rst
+++ b/doc/source/nmod_poly_mat.rst
@@ -555,3 +555,11 @@ Solving
     entries of `A B`, computed with pointwise products on shared
     fft_small transforms and windowed reconstruction. Returns 0 without
     touching *C* if the method is unavailable for the modulus or shape.
+
+    When the full middle product exceeds the transform-storage budget
+    (``flint_fft_small_max_transformed_ring_size``),
+    ``nmod_poly_mat_mulmid_fft_small`` retries in row and column blocks
+    over matrix windows, halving the block size until it fits; the
+    window of a middle product is linear in the operands, so blocks
+    compose exactly. Squaring, detected as ``B == A``, keeps a single
+    transform pool.

--- a/src/crt_helpers.h
+++ b/src/crt_helpers.h
@@ -458,6 +458,99 @@ DEFINE_IT(6, 5)
 DEFINE_IT(7, 6)
 #undef DEFINE_IT
 
+/*
+    Template for the chinese remaindering stage of the fft_small
+    convolution engine. CRT_DEFINE(NP, N, M) defines a function with the
+    fft_small_crt_func signature reconstructing output coefficients from
+    NP prime images, where N is the coefficient length of the product of
+    the primes and M the length of the reduced cofactors (as in
+    crt_helpers.h).
+
+    Before instantiating, the including file defines:
+
+    CRT_FN(NP)             the function name, e.g. CAT3(_crt, NP, fn)
+    CRT_Z_TYPE             pointer type of the output
+    CRT_HEAD               declarations run once; may unpack `params` and
+                           `local` and use `min_an_bn`
+    CRT_EMIT(zi, r, NP, N, M)
+                           emit output coefficient `zi` (an index into
+                           `z`, `zl` already subtracted) from the
+                           reconstructed value `r` of N words; NP, N, M
+                           are compile-time constants usable for token
+                           pasting. The half product of the primes is
+                           available as `Mhalf` for signed emits.
+    CRT_TAIL               statements run once at the end; may write
+                           per-range outputs to `local`
+
+    and afterwards #undefs all of them and CRT_DEFINE.
+
+    The in-scope names np, n, m hold NP, N, M at runtime, and Rffts,
+    Rcrts, zl are the corresponding arguments.
+*/
+
+#define CRT_DEFINE(NP, N, M) \
+static void CRT_FN(NP)(void* zv, ulong zl, \
+    ulong zi_start, ulong zi_stop, \
+    sd_fft_ctx_struct* Rffts, double* d, ulong dstride, \
+    crt_data_struct* Rcrts, ulong min_an_bn, ulong* local, \
+    const void* params) \
+{ \
+    CRT_Z_TYPE z = (CRT_Z_TYPE) zv; \
+    ulong np = NP; \
+    ulong n = N; \
+    ulong m = M; \
+ \
+    CRT_HEAD \
+ \
+    FLINT_ASSERT(n == Rcrts[np-1].coeff_len); \
+    FLINT_ASSERT(1 <= N && N <= 7); \
+ \
+    if (n == m + 1) \
+    { \
+        for (ulong l = 0; l < np; l++) { \
+            FLINT_ASSERT(crt_data_co_prime(Rcrts + np - 1, l)[m] == 0); \
+        } \
+    } \
+    else \
+    { \
+        FLINT_ASSERT(n == m); \
+    } \
+ \
+    ulong Mhalf[N]; \
+    mpn_rshift(Mhalf, crt_data_prod_primes(Rcrts + np - 1), N, 1); \
+ \
+    ulong Xs[BLK_SZ*NP]; \
+ \
+    (void) min_an_bn; \
+    (void) local; \
+    (void) params; \
+    (void) Mhalf; \
+ \
+    for (ulong i = n_round_down(zi_start, BLK_SZ); i < zi_stop; i += BLK_SZ) \
+    { \
+        _convert_block(Xs, Rffts, d, dstride, np, i/BLK_SZ); \
+ \
+        ulong jstart = (i < zi_start) ? zi_start - i : 0; \
+        ulong jstop = FLINT_MIN(BLK_SZ, zi_stop - i); \
+        for (ulong j = jstart; j < jstop; j += 1) \
+        { \
+            ulong r[N]; \
+            ulong t[N]; \
+            ulong l = 0; \
+ \
+            CAT3(_big_mul, N, M)(r, t, _crt_data_co_prime(Rcrts + np - 1, l, n), Xs[l*BLK_SZ + j]); \
+            for (l++; l < np; l++) \
+                CAT3(_big_addmul, N, M)(r, t, _crt_data_co_prime(Rcrts + np - 1, l, n), Xs[l*BLK_SZ + j]); \
+ \
+            CAT(_reduce_big_sum, N)(r, t, crt_data_prod_primes(Rcrts + np - 1)); \
+ \
+            CRT_EMIT(i + j - zl, r, NP, N, M) \
+        } \
+    } \
+ \
+    CRT_TAIL \
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/fft_small.h
+++ b/src/fft_small.h
@@ -20,6 +20,17 @@
 # include <stdatomic.h>
 #endif
 
+/* alignment for transform data buffers */
+#define FLINT_FFT_SMALL_ALIGNMENT 4096
+
+/* Upper bound, in bytes, on the transform storage a single transformed
+   ring or context may plan for (its expected number of simultaneously
+   live elements times the per-element data size). Constructors decline
+   above the bound so drivers fall back to slower algorithms rather than
+   exhaust memory; mutable for tuning. A future FLINT-wide project may
+   replace this with allocation-failure interception. */
+FLINT_DLL extern ulong flint_fft_small_max_transformed_ring_size;
+
 #define LG_BLK_SZ 8
 #define BLK_SZ 256
 

--- a/src/fft_small.h
+++ b/src/fft_small.h
@@ -399,6 +399,267 @@ void* mpn_ctx_fit_buffer(mpn_ctx_t R, ulong n);
 void mpn_ctx_mpn_mul(mpn_ctx_t R, ulong* z, const ulong* a, ulong an, const ulong* b, ulong bn);
 void _mpn_ctx_mpn_mul_range(mpn_ctx_t R, ulong* z, ulong lo, ulong hi, const ulong* a, ulong an, const ulong* b, ulong bn);
 
+/* ------------------------------------------------------------------------ */
+/* FFT plans and transformed operands                                       */
+/* ------------------------------------------------------------------------ */
+
+/*
+    A plan fixes everything two operands must agree on in order to be
+    combined pointwise in transform space: the set of CRT primes
+    (np primes starting at index offset, or a direct single-prime FFT
+    modulo a user prime), the transform depth 2^depth, and the coefficient
+    bound the parameters were selected for. It also carries the output
+    window [zl, zh) of a length zn convolution for the operation currently
+    being performed, where ztrunc is the fft truncation length (equal to
+    2^depth when the wraparound trick computes a cyclic convolution).
+
+    The output coefficients (including any pointwise accumulation done in
+    transform space) must be bounded by bound_c * 2^bound_e; np is selected
+    such that the product of the primes exceeds this bound.
+
+    Forward transforms are unnormalized; the normalization factors
+    m[i] = (cop_i * 2^depth)^-1 mod p_i are folded in exactly once per
+    pointwise product, as sd_fft_ctx_point_mul does today.
+*/
+typedef struct
+{
+    mpn_ctx_struct * R;
+
+    /* CRT configuration */
+    ulong np;
+    ulong offset;
+    sd_fft_ctx_struct * ffts;   /* R->ffts, or direct_fft below */
+    crt_data_struct * crts;     /* R->crts */
+    sd_fft_ctx_struct direct_fft[1];
+    int use_direct_fft;
+
+    /* transform geometry */
+    ulong depth;
+    ulong stride;               /* n_round_up(2^depth, 128) */
+
+    /* window of the current operation */
+    ulong zl;
+    ulong zh;
+    ulong zn;
+    ulong ztrunc;
+
+    /* output coefficient bound bound_c * 2^bound_e */
+    ulong bound_c;
+    ulong bound_e;
+    ulong bits;     /* mpn plans: chunk size of the bit packing; 0 otherwise */
+    int sign;
+
+    /* normalization factors, indexed 0 <= i < np */
+    ulong m[MPN_CTX_NCRTS];
+} fft_small_plan_struct;
+
+typedef fft_small_plan_struct fft_small_plan_t[1];
+
+/* Select np and offset such that prod_primes(np) >= c * 2^e, considering
+   only the primes ffts[i] for i < np_max. Returns 0 on failure. */
+int _fft_small_plan_set_bound(fft_small_plan_t P, ulong c, ulong e, ulong np_max);
+
+/* Choose depth and ztrunc for the output window [zl, zh) of a length zn
+   convolution whose operand truncation lengths are at most xtrunc_max. */
+void _fft_small_plan_set_window(fft_small_plan_t P,
+                    ulong zl, ulong zh, ulong zn, ulong xtrunc_max);
+
+/* Same, but with the depth of P fixed. Returns 0 if the window needs a
+   transform longer than 2^depth. */
+int _fft_small_plan_fit_window(fft_small_plan_t P,
+                    ulong zl, ulong zh, ulong zn, ulong xtrunc_max);
+
+/* Compute stride and the normalization factors m[]. Requires the CRT
+   configuration and the depth to be set. */
+void _fft_small_plan_set_normalizers(fft_small_plan_t P);
+
+/*
+    Plan for computing the window [zl, zh) of a convolution of length zn
+    over Z/mod.n, where at most len_bound coefficient products, each of
+    absolute value less than 2^prod_bits, accumulate onto a single output
+    coefficient before reduction mod mod.n. For an ordinary multiplication
+    of lengths an and bn this means len_bound = min(an, bn) (any upper
+    bound such as bn works) and prod_bits = 2*modbits; a bilinear
+    accumulation of K products computed in transform space (e.g. matrix
+    multiplication with inner dimension K) passes len_bound = K*min(an, bn),
+    and unreduced inputs can be accounted for through prod_bits.
+
+    xtrunc_max is an upper bound for the operand truncation lengths
+    (n_round_up(max operand length, BLK_SZ)) and direct_len gates the
+    direct FFT branch (pass the length that should be compared against the
+    direct FFT cutoff, or 0 to disable the branch, e.g. when the plan will
+    be reused enough that the caller wants to force it with
+    fft_small_plan_force_direct_fft below).
+*/
+int fft_small_plan_init_nmod(fft_small_plan_t P, mpn_ctx_t R,
+                    ulong zl, ulong zh, ulong zn, ulong xtrunc_max,
+                    ulong len_bound, ulong prod_bits, nmod_t mod,
+                    ulong direct_len);
+
+/* Plan for cyclic convolutions modulo x^N - 1, N = 2^depth, writing the
+   output coefficients [0, zh). len_bound/prod_bits as above (a full
+   cyclic convolution accumulates up to N products, so an ordinary
+   multiplication passes len_bound = N). */
+/* Plan for transforms of nonnegative integers of at most an_max and
+   bn_max limbs, with prod_of_primes large enough for len_bound
+   accumulated products in transform space. Returns 0 if no admissible
+   prime count and chunk size exist. */
+int fft_small_plan_init_mpn(fft_small_plan_t P, mpn_ctx_t R,
+                    ulong an_max, ulong bn_max, ulong len_bound);
+
+int fft_small_plan_init_nmod_cyclic(fft_small_plan_t P, mpn_ctx_t R,
+                    ulong depth, ulong zh,
+                    ulong len_bound, ulong prod_bits, nmod_t mod);
+
+void fft_small_plan_clear(fft_small_plan_t P);
+
+/*
+    A transformed operand: the forward transforms of one operand modulo
+    each of the np primes of a plan, stored in the same layout as the
+    scratch buffers of the fused multiplication drivers (np per-prime
+    buffers of stride doubles each, in sd_fft block order).
+
+    An operand is only compatible with plans agreeing with the
+    np/offset/depth/stride fields it was created with, which is checked
+    with asserts. domain distinguishes unnormalized forward transforms
+    (PRIMAL) from pointwise products carrying one normalization factor
+    (PRODUCT); the two must not be mixed linearly.
+*/
+
+#define FFT_SMALL_OP_PRIMAL 0
+#define FFT_SMALL_OP_PRODUCT 1
+
+typedef struct
+{
+    double * data;
+    ulong stride;
+    ulong np;
+    ulong offset;
+    ulong depth;
+    ulong itrunc;
+    int domain;
+    int owns_data;
+} fft_small_op_struct;
+
+typedef fft_small_op_struct fft_small_op_t[1];
+
+void fft_small_op_init(fft_small_op_t X, const fft_small_plan_t P);
+void fft_small_op_clear(fft_small_op_t X);
+
+/* pointwise operations; Z may alias A (and B where it makes sense) */
+void fft_small_op_mul(fft_small_op_t Z, const fft_small_op_t A,
+                    const fft_small_op_t B, const fft_small_plan_t P);
+void fft_small_op_sqr(fft_small_op_t Z, const fft_small_op_t A,
+                    const fft_small_plan_t P);
+void fft_small_op_addmul(fft_small_op_t Z, const fft_small_op_t A,
+                    const fft_small_op_t B, const fft_small_plan_t P);
+void fft_small_op_submul(fft_small_op_t Z, const fft_small_op_t A,
+                    const fft_small_op_t B, const fft_small_plan_t P);
+void fft_small_op_add(fft_small_op_t Z, const fft_small_op_t A,
+                    const fft_small_op_t B, const fft_small_plan_t P);
+void fft_small_op_sub(fft_small_op_t Z, const fft_small_op_t A,
+                    const fft_small_op_t B, const fft_small_plan_t P);
+void fft_small_op_neg(fft_small_op_t Z, const fft_small_op_t A,
+                    const fft_small_plan_t P);
+
+/* inverse transform in place (normalization was already applied by the
+   pointwise stage) */
+void fft_small_ifft(fft_small_op_t X, const fft_small_plan_t P);
+
+/* forward transform of (a, an) reading it zero-padded to length itrunc,
+   with fft truncation P->ztrunc */
+void fft_small_fft_nmod(fft_small_op_t X, const ulong* a, ulong an,
+                    ulong itrunc, nmod_t mod, const fft_small_plan_t P);
+
+/* chinese remaindering of an inverse-transformed operand into the output
+   window [P->zl, P->zh) */
+void fft_small_fft_mpn(fft_small_op_t X, const ulong* a, ulong an,
+                    const fft_small_plan_t P);
+
+/* Write the low zn limbs of the accumulated integer to z. The true value
+   is reduced mod 2^(FLINT_BITS*zn) if it does not fit. */
+void fft_small_export_mpn(ulong* z, ulong zn, const fft_small_op_t X,
+                    const fft_small_plan_t P);
+
+void fft_small_export_nmod(ulong* z, const fft_small_op_t X, nmod_t mod,
+                    const fft_small_plan_t P);
+
+/* ------------------------------------------------------------------------ */
+/* Generic two-stage convolution engine                                     */
+/* ------------------------------------------------------------------------ */
+
+/*
+    The engine runs the fused per-prime pipeline shared by the fft_small
+    multiplication drivers: for each prime, convert and forward-transform
+    the operands, multiply pointwise with the normalization factor folded
+    in, and inverse-transform (stage 1, parallelized over the primes, with
+    an optional nested worker transforming b concurrently with a); then
+    chinese remainder blocks of output coefficients into the destination
+    (stage 2, parallelized over output ranges).
+
+    The coefficient-type specific parts enter through mod_fn (conversion
+    of an operand into a per-prime double buffer), crt_fn (chinese
+    remaindering of an output range, called once per range so that np can
+    be specialized at compile time by the callers), and a tuning table of
+    threshold predicates, so that each type keeps its separately tuned
+    thresholds.
+*/
+
+typedef void (*fft_small_mod_func)(double* xbuf, ulong xtrunc,
+    const void* x, ulong xn, slong xaux,
+    const sd_fft_ctx_struct* fft, const void* params);
+
+/* Per-range output slots for crt_fn (e.g. carries of a digit
+   representation), consumed by an optional serial pass after stage 2. */
+#define FFT_SMALL_CRT_LOCAL 4
+
+typedef struct
+{
+    ulong stop_zi;
+    ulong local[FFT_SMALL_CRT_LOCAL];
+} fft_small_crt_range_struct;
+
+typedef void (*fft_small_crt_func)(void* z, ulong zl,
+    ulong zi_start, ulong zi_stop,
+    sd_fft_ctx_struct* Rffts, double* d, ulong dstride,
+    crt_data_struct* Rcrts, ulong min_an_bn, ulong* local,
+    const void* params);
+
+typedef void (*fft_small_s2_finish_func)(void* z, ulong zl, ulong zh,
+    fft_small_crt_range_struct* ranges, ulong nranges, const void* params);
+
+typedef struct
+{
+    ulong (*s1_threads)(ulong np, ulong tune_n);
+    int (*s1_b_worker)(ulong np, ulong tune_n, int squaring);
+    int (*s2_rethread)(ulong np, ulong zn);   /* may be NULL */
+} fft_small_conv_tuning;
+
+typedef struct
+{
+    const void* a; ulong an; slong aaux; ulong atrunc;
+    const void* b; ulong bn; slong baux; ulong btrunc;
+    const double* bfft;         /* if != NULL, b is already transformed
+                                   (np buffers of stride bfft_stride) and
+                                   b/bn/baux/btrunc are ignored */
+    ulong bfft_stride;
+    int squaring;
+    ulong tune_n;               /* size fed to the tuning predicates */
+    ulong min_an_bn;            /* bound on the number of products
+                                   accumulating on one output coefficient */
+    fft_small_mod_func mod_fn;
+    fft_small_crt_func crt_fn;
+    fft_small_s2_finish_func s2_finish;   /* may be NULL; called serially
+                                             after stage 2 with the range
+                                             boundaries and crt_fn's
+                                             per-range local outputs */
+    const void* params;
+    const fft_small_conv_tuning* tuning;
+} fft_small_conv_arg_struct;
+
+void _fft_small_conv(void* z, const fft_small_plan_t P,
+                    const fft_small_conv_arg_struct* A);
+
 void _nmod_poly_mul_mid_mpn_ctx(
     ulong* z, ulong zl, ulong zh,
     const ulong* a, ulong an,
@@ -427,14 +688,10 @@ void _nmod_poly_mul_mid(
     nmod_t mod);
 
 typedef struct {
-    ulong depth;
-    ulong N;
-    ulong offset;
-    ulong np;
-    ulong stride;
+    fft_small_plan_struct P[1];
+    fft_small_op_struct bfft[1];
     ulong bn;
     ulong btrunc;
-    double* bbuf;
 } mul_precomp_struct;
 
 void _mul_precomp_init(
@@ -446,7 +703,8 @@ void _mul_precomp_init(
 
 FLINT_FORCE_INLINE void _mul_precomp_clear(mul_precomp_struct* M)
 {
-    flint_aligned_free(M->bbuf);
+    fft_small_op_clear(M->bfft);
+    fft_small_plan_clear(M->P);
 }
 
 int _nmod_poly_mul_mid_precomp(

--- a/src/fft_small.h
+++ b/src/fft_small.h
@@ -13,12 +13,6 @@
 #define FFT_SMALL_H
 
 #include "longlong.h"
-#include "machine_vectors.h"
-
-#if FLINT_USES_PTHREAD
-# include <pthread.h>
-# include <stdatomic.h>
-#endif
 
 /* alignment for transform data buffers */
 #define FLINT_FFT_SMALL_ALIGNMENT 4096
@@ -30,6 +24,15 @@
    exhaust memory; mutable for tuning. A future FLINT-wide project may
    replace this with allocation-failure interception. */
 FLINT_DLL extern ulong flint_fft_small_max_transformed_ring_size;
+
+#if FLINT_HAVE_FFT_SMALL
+
+#include "machine_vectors.h"
+
+#if FLINT_USES_PTHREAD
+# include <pthread.h>
+# include <stdatomic.h>
+#endif
 
 #define LG_BLK_SZ 8
 #define BLK_SZ 256
@@ -785,5 +788,7 @@ int _fmpz_poly_mul_mid_default_mpn_ctx(
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* FLINT_HAVE_FFT_SMALL */
 
 #endif

--- a/src/fft_small.h
+++ b/src/fft_small.h
@@ -575,6 +575,10 @@ void fft_small_fft_nmod(fft_small_op_t X, const ulong* a, ulong an,
    window [P->zl, P->zh) */
 void fft_small_fft_mpn(fft_small_op_t X, const ulong* a, ulong an,
                     const fft_small_plan_t P);
+/* chinese remaindering restricted to the window [zl, zh), which must lie
+   inside [P->zl, P->zh); z receives zh - zl coefficients */
+void fft_small_export_nmod_range(ulong* z, const fft_small_op_t X,
+                    ulong zl, ulong zh, nmod_t mod, const fft_small_plan_t P);
 
 /* Write the low zn limbs of the accumulated integer to z. The true value
    is reduced mod 2^(FLINT_BITS*zn) if it does not fit. */

--- a/src/fft_small.h
+++ b/src/fft_small.h
@@ -544,6 +544,9 @@ typedef struct
 typedef fft_small_op_struct fft_small_op_t[1];
 
 void fft_small_op_init(fft_small_op_t X, const fft_small_plan_t P);
+void fft_small_op_init_borrowed(fft_small_op_t X, const fft_small_plan_t P,
+                    double * data);
+ulong fft_small_op_sizeof_data(const fft_small_plan_t P);
 void fft_small_op_clear(fft_small_op_t X);
 
 /* pointwise operations; Z may alias A (and B where it makes sense) */
@@ -582,6 +585,12 @@ void fft_small_export_nmod_range(ulong* z, const fft_small_op_t X,
 
 /* Write the low zn limbs of the accumulated integer to z. The true value
    is reduced mod 2^(FLINT_BITS*zn) if it does not fit. */
+void fft_small_export_mpn_signed(ulong* z, ulong zn, int * sign,
+                    const fft_small_op_t X, ulong nslots,
+                    const fft_small_plan_t P);
+void fft_small_export_mpn_signed_trunc(ulong* z, ulong zn, int * sign,
+                    const fft_small_op_t X, ulong nslots, ulong lo_limbs,
+                    const fft_small_plan_t P);
 void fft_small_export_mpn(ulong* z, ulong zn, const fft_small_op_t X,
                     const fft_small_plan_t P);
 

--- a/src/fft_small/conv_engine.c
+++ b/src/fft_small/conv_engine.c
@@ -1,0 +1,237 @@
+/*
+    Copyright (C) 2022 Daniel Schultz
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "thread_pool.h"
+#include "thread_support.h"
+#include "nmod.h"
+#include "fft_small.h"
+
+/*
+    The two-stage convolution engine shared by the fused multiplication
+    drivers. Stage 1 computes, for each of the np primes of the plan, the
+    (possibly truncated) convolution of the images of the operands: convert
+    the operands into per-prime double buffers, forward transform, multiply
+    pointwise with the normalization factor P->m[i] folded in, and inverse
+    transform in place. Stage 2 chinese remainders BLK_SZ-aligned ranges of
+    output coefficients into the destination.
+
+    Both stages parallelize as the original per-type drivers did: stage 1
+    over the primes (with each worker optionally requesting one extra
+    thread to transform b concurrently with a), stage 2 over output
+    ranges, with an optional re-request of up to 8 threads in between.
+    The thresholds live in the caller-provided tuning table so that each
+    coefficient type keeps its own tuned values.
+*/
+
+#define MAX_CONV_THREADS 8
+
+typedef struct {
+    const fft_small_plan_struct* P;
+    const fft_small_conv_arg_struct* A;
+    ulong start_pi;
+    ulong stop_pi;
+    double* abuf;
+    double* bbuf;
+    ulong ioff;
+    int want_worker;
+} s1worker_struct;
+
+/* Convert `A->b` into `bbuf` and forward-transform it in place. Used as a
+   helper for `s1worker_func` in order to process `bbuf` and `abuf` in
+   parallel, assuming `!squaring`. */
+static void extra_func(void* varg)
+{
+    s1worker_struct* X = (s1worker_struct*) varg;
+    const fft_small_plan_struct* P = X->P;
+    const fft_small_conv_arg_struct* A = X->A;
+    sd_fft_ctx_struct* Q = P->ffts + X->ioff;
+
+    A->mod_fn(X->bbuf, A->btrunc, A->b, A->bn, A->baux, Q, A->params);
+    sd_fft_trunc(Q, X->bbuf, P->depth, A->btrunc, P->ztrunc);
+}
+
+/* Compute convolutions modulo the selected precomputed FFT primes.
+   Specifically, for each `start_pi <= i < stop_pi`, reduce the operands
+   modulo `P->ffts[i + P->offset].p` and convolve, writing the result
+   in-place to `abuf + stride*i`.
+   If `squaring` is true, the image of `a` is squared and `bbuf` is not
+   used. If `A->bfft` is not NULL, it holds forward transforms of the
+   second operand which are used directly.
+   If `flint_request_threads` returns the requested number of threads,
+   then each `s1worker_func` processes exactly one prime.  */
+static void s1worker_func(void* varg)
+{
+    s1worker_struct* X = (s1worker_struct*) varg;
+    const fft_small_plan_struct* P = X->P;
+    const fft_small_conv_arg_struct* A = X->A;
+    ulong i;
+    thread_pool_handle* handles = NULL;
+    slong nworkers = 0;
+
+    if (X->want_worker)
+        nworkers = flint_request_threads(&handles, 2);
+
+    for (i = X->start_pi; i < X->stop_pi; i++)
+    {
+        ulong ioff = i + P->offset;
+        double* abuf = X->abuf + P->stride*i;
+        double* bbuf = X->bbuf;
+        const double* bfft = NULL;
+        sd_fft_ctx_struct* Q = P->ffts + ioff;
+
+        if (A->bfft != NULL)
+        {
+            bfft = A->bfft + A->bfft_stride*i;
+        }
+        else if (!A->squaring)
+        {
+            if (nworkers > 0)
+            {
+                X->ioff = ioff; /* read by extra_func on the worker thread */
+                thread_pool_wake(global_thread_pool, handles[0], 0, extra_func, X);
+            }
+            else
+            {
+                A->mod_fn(bbuf, A->btrunc, A->b, A->bn, A->baux, Q, A->params);
+                sd_fft_trunc(Q, bbuf, P->depth, A->btrunc, P->ztrunc);
+            }
+
+            bfft = bbuf;
+        }
+
+        A->mod_fn(abuf, A->atrunc, A->a, A->an, A->aaux, Q, A->params);
+        sd_fft_trunc(Q, abuf, P->depth, A->atrunc, P->ztrunc);
+
+        if (A->bfft == NULL && !A->squaring && nworkers > 0)
+            thread_pool_wait(global_thread_pool, handles[0]);
+
+        if (A->squaring)
+            sd_fft_ctx_point_sqr(Q, abuf, P->m[i], P->depth);
+        else
+            sd_fft_ctx_point_mul(Q, abuf, bfft, P->m[i], P->depth);
+
+        sd_ifft_trunc(Q, abuf, P->depth, P->ztrunc);
+    }
+
+    flint_give_back_threads(handles, nworkers);
+}
+
+typedef struct {
+    const fft_small_plan_struct* P;
+    const fft_small_conv_arg_struct* A;
+    void* z;
+    ulong start_zi;
+    ulong stop_zi;
+    double* buf;
+    ulong* local;
+} s2worker_struct;
+
+/* Chinese remainder an output range, writing to `z[zi - zl]` for
+   `start_zi <= zi < stop_zi`.  */
+static void s2worker_func(void* varg)
+{
+    s2worker_struct* X = (s2worker_struct*) varg;
+    const fft_small_plan_struct* P = X->P;
+    const fft_small_conv_arg_struct* A = X->A;
+
+    A->crt_fn(X->z, P->zl, X->start_zi, X->stop_zi, P->ffts + P->offset,
+              X->buf, P->stride, P->crts + P->offset, A->min_an_bn,
+              X->local, A->params);
+}
+
+void _fft_small_conv(void* z, const fft_small_plan_t P,
+                    const fft_small_conv_arg_struct* A)
+{
+    ulong np = P->np;
+    ulong stride = P->stride;
+    ulong i, o, want_threads;
+    double* buf;
+    thread_pool_handle* handles;
+    slong nworkers;
+    ulong nthreads;
+
+    FLINT_ASSERT(P->zl < P->zh);
+    FLINT_ASSERT(P->zh <= P->zn);
+    FLINT_ASSERT(A->atrunc <= P->ztrunc);
+    FLINT_ASSERT(A->bfft != NULL || A->btrunc <= P->ztrunc);
+
+    want_threads = A->tuning->s1_threads(np, A->tune_n);
+
+    nworkers = flint_request_threads(&handles, want_threads);
+    nthreads = nworkers + 1;
+    FLINT_ASSERT(nthreads <= MAX_CONV_THREADS);
+
+    if (A->bfft != NULL)
+        buf = (double*) mpn_ctx_fit_buffer(P->R, np*stride*sizeof(double));
+    else
+        buf = (double*) mpn_ctx_fit_buffer(P->R,
+                                    (np + nthreads)*stride*sizeof(double));
+
+    s1worker_struct s1args[MAX_CONV_THREADS];
+    for (i = 0; i < nthreads; i++)
+    {
+        s1worker_struct* X = s1args + i;
+        X->P = P;
+        X->A = A;
+        X->start_pi = (i+0)*np/nthreads;
+        X->stop_pi  = (i+1)*np/nthreads;
+        X->abuf = buf;
+        X->bbuf = buf + (np+i)*stride;
+        X->want_worker = (A->bfft == NULL) &&
+                    A->tuning->s1_b_worker(np, A->tune_n, A->squaring);
+    }
+
+    for (i = nworkers; i > 0; i--)
+        thread_pool_wake(global_thread_pool, handles[i - 1], 0, s1worker_func, s1args + i);
+    s1worker_func(s1args + 0);
+    for (i = nworkers; i > 0; i--)
+        thread_pool_wait(global_thread_pool, handles[i - 1]);
+
+    if (A->tuning->s2_rethread != NULL &&
+        A->tuning->s2_rethread(np, P->zn))
+    {
+        flint_give_back_threads(handles, nworkers);
+        nworkers = flint_request_threads(&handles, MAX_CONV_THREADS);
+        nthreads = nworkers + 1;
+    }
+
+    s2worker_struct s2args[MAX_CONV_THREADS];
+    fft_small_crt_range_struct ranges[MAX_CONV_THREADS];
+    o = P->zl;
+    for (i = 0; i < nthreads; i++)
+    {
+        s2worker_struct* X = s2args + i;
+        X->P = P;
+        X->A = A;
+        X->z = z;
+        X->start_zi = o;
+        ulong newo = n_round_down(P->zl + (i+1)*(P->zh - P->zl)/nthreads, BLK_SZ);
+        o = i+1 < nthreads ? FLINT_MAX(o, newo) : P->zh;
+        X->stop_zi = o;
+        X->buf = buf;
+        ranges[i].stop_zi = o;
+        for (ulong k = 0; k < FFT_SMALL_CRT_LOCAL; k++)
+            ranges[i].local[k] = 0;
+        X->local = ranges[i].local;
+    }
+
+    for (i = nworkers; i > 0; i--)
+        thread_pool_wake(global_thread_pool, handles[i - 1], 0, s2worker_func, s2args + i);
+    s2worker_func(s2args + 0);
+    for (i = nworkers; i > 0; i--)
+        thread_pool_wait(global_thread_pool, handles[i - 1]);
+
+    flint_give_back_threads(handles, nworkers);
+
+    if (A->s2_finish != NULL)
+        A->s2_finish(z, P->zl, P->zh, ranges, nthreads, A->params);
+}

--- a/src/fft_small/export_signed.c
+++ b/src/fft_small/export_signed.c
@@ -252,7 +252,7 @@ _sig_segment(sig_seg_struct * S)
         if (klast + wlive > wlen)
         {
             ulong e = (W[wlen - 1] >> (FLINT_BITS - 1)) ? ~UWORD(0) : 0;
-            ulong L = A / FLINT_BITS, i2;
+            ulong i2;
             ulong s0 = (slot * bits) / FLINT_BITS - A;
 
 

--- a/src/fft_small/export_signed.c
+++ b/src/fft_small/export_signed.c
@@ -1,0 +1,488 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <string.h>
+#include <gmp.h>
+#include "mpn_extras.h"
+#include "fft_small.h"
+#include "machine_vectors.h"
+#include "crt_helpers.h"
+#include "thread_pool.h"
+#include "thread_support.h"
+
+/* defined in mpn_helpers.c */
+void _convert_block(ulong* Xs, sd_fft_ctx_struct* Rffts, double* d,
+                    ulong dstride, ulong np, ulong I);
+
+/*
+    One block of slots, reconstructed and glued into the window.
+
+    Everything in the inner loop is specialized on the geometry, exactly
+    as the unsigned reconstruction specializes its own: the Chinese
+    remainder dot product uses the same tuned even/odd-split kernels, and
+    the centered lift, the shift into place and the signed accumulation
+    into the window are unrolled at the coefficient length with carry
+    intrinsics rather than calls into mpn with runtime lengths. The
+    latter was what made this loop several times slower than the
+    templated unsigned one.
+
+    N is the coefficient length and M the number of significant cofactor
+    limbs; M is a function of np, not of N alone (np = 4 and np = 5 share
+    N = 4 but need M = 3 and M = 4), so the table is keyed on np.
+*/
+typedef void (* sig_block_func)(ulong * W, ulong wlen, ulong A, ulong bits,
+        const crt_data_struct * Cd, const ulong * Xs, nn_srcptr prod,
+        nn_srcptr prodh, ulong slot0, ulong jlo, ulong jhi);
+
+#define DEFINE_SIG_BLOCK(NP, N, M) \
+static void CAT(_sig_block, NP)(ulong * W, ulong wlen, ulong A, ulong bits, \
+        const crt_data_struct * Cd, const ulong * Xs, nn_srcptr prod, \
+        nn_srcptr prodh, ulong slot0, ulong jlo, ulong jhi) \
+{ \
+    for (ulong j = jlo; j < jhi; j++) \
+    { \
+        ulong r[N + 2], t[N + 2]; \
+        ulong slot = slot0 + j; \
+        ulong off = slot * bits; \
+        ulong k = off / FLINT_BITS - A; \
+        ulong sh = off % FLINT_BITS; \
+        ulong l = 0, acc = 0; \
+        slong q; \
+        unsigned char cf; \
+        int neg = 0; \
+ \
+        CAT3(_big_mul, N, M)(r, t, _crt_data_co_prime( \
+                (crt_data_struct *) Cd, l, N), Xs[l * BLK_SZ + j]); \
+        for (l++; l < NP; l++) \
+            CAT3(_big_addmul, N, M)(r, t, _crt_data_co_prime( \
+                    (crt_data_struct *) Cd, l, N), Xs[l * BLK_SZ + j]); \
+        CAT(_reduce_big_sum, N)(r, t, (ulong *) prod); \
+ \
+        for (q = 0; q < N; q++) \
+            acc |= r[q]; \
+        if (acc == 0) \
+            continue; \
+ \
+        /* centered lift */ \
+        for (q = N - 1; q >= 0; q--) \
+        { \
+            if (r[q] != prodh[q]) \
+            { \
+                neg = (r[q] > prodh[q]); \
+                break; \
+            } \
+        } \
+        if (neg) \
+        { \
+            cf = 0; \
+            for (q = 0; q < N; q++) \
+                cf = _subborrow_ulong(cf, prod[q], r[q], &r[q]); \
+        } \
+ \
+        /* shift into position within the limb */ \
+        if (sh != 0) \
+        { \
+            r[N] = r[N - 1] >> (FLINT_BITS - sh); \
+            for (q = N; q >= 2; q--) \
+                r[q - 1] = (r[q - 1] << sh) | (r[q - 2] >> (FLINT_BITS - sh)); \
+            r[0] = r[0] << sh; \
+        } \
+        else \
+            r[N] = 0; \
+ \
+        /* signed accumulation into the window */ \
+        if (!neg) \
+        { \
+            cf = 0; \
+            for (q = 0; q <= N; q++) \
+                cf = _addcarry_ulong(cf, W[k + q], r[q], &W[k + q]); \
+            for (q = k + N + 1; cf && q < (slong) wlen; q++) \
+                cf = _addcarry_ulong(0, W[q], UWORD(1), &W[q]); \
+        } \
+        else \
+        { \
+            cf = 0; \
+            for (q = 0; q <= N; q++) \
+                cf = _subborrow_ulong(cf, W[k + q], r[q], &W[k + q]); \
+            for (q = k + N + 1; cf && q < (slong) wlen; q++) \
+                cf = _subborrow_ulong(0, W[q], UWORD(1), &W[q]); \
+        } \
+    } \
+}
+
+DEFINE_SIG_BLOCK(4, 4, 3)
+DEFINE_SIG_BLOCK(5, 4, 4)
+DEFINE_SIG_BLOCK(6, 5, 4)
+DEFINE_SIG_BLOCK(7, 6, 5)
+DEFINE_SIG_BLOCK(8, 7, 6)
+
+#undef DEFINE_SIG_BLOCK
+
+static const sig_block_func _sig_block_tab[8 - 4 + 1] = {
+    _sig_block_4, _sig_block_5, _sig_block_6, _sig_block_7, _sig_block_8
+};
+
+/*
+    Signed counterpart of fft_small_export_mpn, for chunk values that may
+    be negative (bounded in magnitude by less than half the prime
+    product). The reconstruction is the composition
+
+        prod_p (Z/pZ)[x] -> (CRT) -> Z[x] -> (evaluate at 2^bits) -> Z
+
+    fused into a single pass: per slot, the Chinese remainder residue
+    r in [0, prod) is lifted to the centered remainder
+
+        r,          r <= prod/2
+        r - prod,   r >  prod/2
+
+    -- exactly the chunk's signed value, read where the wrap information
+    still exists -- and the evaluation glues the signed chunks with
+    borrow propagation. (Recovering the signs after an unsigned export is
+    impossible even in principle: overlapping slot contributions destroy
+    the wrap bits, and distinct in-range signed chunk vectors with
+    different values can produce the same unsigned output integer.)
+
+    The gluing uses a sliding two's-complement window: consecutive slots
+    overlap by 64 coeff_len - bits bits, and the running prefix sum
+    shifted past the current slot is bounded by twice the chunk magnitude
+    bound, so all carry and borrow propagation is confined to the window;
+    limbs below it are final and are flushed as they complete. The window
+    carries slack so the slide is amortized over many slots.
+
+    lo_limbs > 0 requests a truncated export of the limbs starting at
+    limb lo_limbs of the value: only slots that can influence the
+    requested window are processed, and the discarded low tail perturbs
+    the result by at most one unit in the lowest returned limb (the
+    standard mulhigh contract). With lo_limbs = 0 the export is exact.
+
+    Threading follows the multiplication driver's crt stage: the slot
+    range is split at BLK_SZ boundaries, each segment reconstructs into
+    its own window and writes its own band of output limbs, and the
+    signed spill each segment leaves above its band is added back in a
+    serial stitch afterwards. The sign is resolved once, from the top of
+    the assembled two's-complement result.
+
+    z receives zn limbs of |value| starting at limb lo_limbs, zero padded
+    at the top; *sign receives the sign. The first nslots chunk slots are
+    read; the caller must provide 64 (lo_limbs + zn) >=
+    nslots * bits + 64 coeff_len + 2.
+*/
+
+/* The window holds one whole block of slots plus a coefficient, so the
+   slide runs once per block: a block advances BLK_SZ * bits / 64 limbs,
+   which is a few thousand bytes -- comfortably L1-resident, and the
+   flush it produces is exactly the output rate. */
+
+/* one slot range: window reconstruction into the output band
+   [Lbase, Lstop), leaving the spill above Lstop in w->spill */
+typedef struct
+{
+    nn_ptr z;
+    ulong zn;
+    ulong lo_limbs;
+    const fft_small_op_struct * X;
+    const fft_small_plan_struct * P;
+    ulong slot_start;
+    ulong slot_stop;
+    ulong Lbase;
+    ulong Lstop;
+    int is_last;
+    nn_ptr spill;
+    ulong spill_alloc;
+    ulong spill_len;
+    ulong spill_base;
+}
+sig_seg_struct;
+
+static void
+_sig_segment(sig_seg_struct * S)
+{
+    const fft_small_plan_struct * P = S->P;
+    ulong bits = P->bits;
+    ulong np = P->np;
+    const crt_data_struct * Cd = P->crts + np - 1;
+    ulong n = Cd->coeff_len;
+    nn_srcptr prod = crt_data_prod_primes((crt_data_struct *) Cd);
+    ulong prodh[MPN_CTX_NCRTS + 2];
+    nn_ptr W;
+    ulong Xs[MPN_CTX_NCRTS * BLK_SZ];
+    ulong wlive = n + 3;
+    ulong wlen = wlive + n_cdiv((ulong) BLK_SZ * bits, FLINT_BITS) + 8;
+    ulong A = S->Lbase;
+    ulong slot, k, idx;
+    sig_block_func sig_block = _sig_block_tab[np - 4];
+
+    mpn_rshift(prodh, prod, n, 1);
+    W = flint_malloc(wlen * sizeof(ulong));
+    flint_mpn_zero(W, wlen);
+
+#define SIG_PUT(absidx, val) \
+    do { \
+        ulong _a = (absidx); \
+        if (_a >= S->lo_limbs && _a - S->lo_limbs < S->zn) \
+            S->z[_a - S->lo_limbs] = (val); \
+    } while (0)
+
+    /* one block at a time: the slide is checked per block (a block
+       advances BLK_SZ * bits / 64 limbs, well inside the slack), and the
+       block itself runs in the templated kernel */
+    for (slot = S->slot_start; slot < S->slot_stop; )
+    {
+        ulong blk = slot / BLK_SZ;
+        ulong bstart = blk * BLK_SZ;
+        ulong jlo = slot - bstart;
+        ulong jhi = n_min(BLK_SZ, S->slot_stop - bstart);
+        ulong klast;
+
+        _convert_block(Xs, P->ffts, S->X->data, P->stride, np, blk);
+
+        /* room for every slot of this block plus a coefficient; the
+           slide is by exactly this slot's offset, since only limbs
+           strictly below it are final -- a fixed stride could jump past
+           the first slot of the block and wrap its window index */
+        klast = ((bstart + jhi - 1) * bits) / FLINT_BITS - A;
+        if (klast + wlive > wlen)
+        {
+            ulong e = (W[wlen - 1] >> (FLINT_BITS - 1)) ? ~UWORD(0) : 0;
+            ulong L = A / FLINT_BITS, i2;
+            ulong s0 = (slot * bits) / FLINT_BITS - A;
+
+
+            FLINT_ASSERT(s0 <= wlen);
+            FLINT_ASSERT(klast - s0 + wlive <= wlen);
+            for (i2 = 0; i2 < s0; i2++)
+                SIG_PUT(A + i2, W[i2]);
+            memmove(W, W + s0, (wlen - s0) * sizeof(ulong));
+            for (i2 = wlen - s0; i2 < wlen; i2++)
+                W[i2] = e;
+            A += s0;
+        }
+
+        sig_block(W, wlen, A, bits, Cd, Xs, prod, prodh, bstart, jlo, jhi);
+        slot = bstart + jhi;
+    }
+
+    /* flush the part of the window below this segment's end, and hand
+       the rest on as a signed spill */
+    {
+        ulong e = (W[wlen - 1] >> (FLINT_BITS - 1)) ? ~UWORD(0) : 0;
+        ulong stop = S->is_last ? (S->lo_limbs + S->zn) : S->Lstop;
+
+        for (idx = 0; idx < wlen && A + idx < stop; idx++)
+            SIG_PUT(A + idx, W[idx]);
+
+        if (S->is_last)
+        {
+            /* sign extension fills the remainder of the output */
+            for (; A + idx < stop; idx++)
+                SIG_PUT(A + idx, e);
+            S->spill_len = 0;
+        }
+        else
+        {
+            ulong off = (S->Lstop > A) ? S->Lstop - A : 0;
+            ulong m = (off < wlen) ? wlen - off : 0;
+
+            S->spill = flint_malloc(wlen * sizeof(ulong));
+            S->spill_alloc = wlen;
+
+            for (k = 0; k < m; k++)
+                S->spill[k] = W[off + k];
+            for (; k < wlen; k++)
+                S->spill[k] = e;
+            S->spill_len = wlen;
+            S->spill_base = S->Lstop;
+        }
+    }
+
+    flint_free(W);
+#undef SIG_PUT
+}
+
+/* add a two's-complement spill (slen limbs, sign extended above) into
+   the output at absolute limb Labs */
+static void
+_sig_add_spill(nn_ptr z, ulong zn, ulong lo_limbs, ulong Labs,
+               nn_srcptr spill, ulong slen)
+{
+    int neg;
+    slong off;
+
+    if (slen == 0)
+        return;
+
+    neg = (spill[slen - 1] >> (FLINT_BITS - 1)) != 0;
+    off = (slong) Labs - (slong) lo_limbs;
+
+    if (off >= (slong) zn)
+        return;
+
+    if (off < 0)
+    {
+        ulong skip = (ulong) (-off);
+        if (skip >= slen)
+            return;
+        spill += skip;
+        slen -= skip;
+        off = 0;
+    }
+
+    if (slen > zn - (ulong) off)
+        slen = zn - (ulong) off;
+
+    mpn_add(z + off, z + off, zn - (ulong) off, spill, slen);
+
+    /* sign extension above the spill: all ones, i.e. a borrow one limb
+       past its top */
+    if (neg && (ulong) off + slen < zn)
+        mpn_sub_1(z + off + slen, z + off + slen,
+                  zn - (ulong) off - slen, 1);
+}
+
+typedef struct
+{
+    sig_seg_struct * S;
+}
+sig_worker_arg;
+
+static void
+_sig_worker(void * varg)
+{
+    _sig_segment(((sig_worker_arg *) varg)->S);
+}
+
+ulong _sig_max_threads_used = 0;   /* TEMPORARY */
+
+void
+fft_small_export_mpn_signed_trunc(ulong* z, ulong zn, int * sign,
+        const fft_small_op_t X, ulong nslots, ulong lo_limbs,
+        const fft_small_plan_t P)
+{
+    ulong bits = P->bits;
+    ulong n = (P->crts + P->np - 1)->coeff_len;
+    ulong j0;
+    thread_pool_handle * handles = NULL;
+    slong nworkers = 0;
+    ulong nthreads, l;
+
+    FLINT_ASSERT(4 <= P->np && P->np <= 8);
+    FLINT_ASSERT(P->offset == 0);
+    FLINT_ASSERT(X->domain == FFT_SMALL_OP_PRODUCT);
+    FLINT_ASSERT(FLINT_BITS * (lo_limbs + zn)
+                 >= nslots * bits + FLINT_BITS * n + 2);
+    {
+        static const ulong _clen_of_np[8 - 4 + 1] = {4, 4, 5, 6, 7};
+        FLINT_ASSERT(n == _clen_of_np[P->np - 4]);
+        (void) _clen_of_np;
+    }
+
+    /* first slot that can influence limbs >= lo_limbs */
+    j0 = 0;
+    if (FLINT_BITS * lo_limbs > FLINT_BITS * n + 1)
+        j0 = (FLINT_BITS * lo_limbs - FLINT_BITS * n - 1 + bits - 1) / bits;
+    j0 = n_min(j0, nslots);
+    j0 = (j0 / BLK_SZ) * BLK_SZ;
+
+    if (j0 >= nslots)
+    {
+        flint_mpn_zero(z, zn);
+        *sign = 0;
+        return;
+    }
+
+    /* the segments cover every limb from the first segment's base to the
+       top of the window, each written exactly once; only the prefix
+       below that base (truncated exports) needs clearing */
+    {
+        ulong Lfirst = (j0 * bits) / FLINT_BITS;
+        if (Lfirst > lo_limbs)
+            flint_mpn_zero(z, n_min(Lfirst - lo_limbs, zn));
+    }
+
+    /* the reconstruction is O(output); thread it from roughly the same
+       size the multiplication driver does */
+    if (nslots - j0 >= 4 * BLK_SZ &&
+            (nslots - j0) * bits >= 2048 * FLINT_BITS)
+        nworkers = flint_request_threads(&handles, 8);
+    nthreads = nworkers + 1;
+    if (nthreads > _sig_max_threads_used) _sig_max_threads_used = nthreads;
+
+    {
+        sig_seg_struct * segs = FLINT_ARRAY_ALLOC(nthreads, sig_seg_struct);
+        sig_worker_arg * args = FLINT_ARRAY_ALLOC(nthreads, sig_worker_arg);
+        ulong span = nslots - j0;
+
+        for (l = 0; l < nthreads; l++)
+        {
+            sig_seg_struct * S = segs + l;
+            ulong a = j0 + n_round_up((l + 0) * span / nthreads, BLK_SZ);
+            ulong b = j0 + n_round_up((l + 1) * span / nthreads, BLK_SZ);
+
+            a = n_min(a, nslots);
+            b = n_min(b, nslots);
+
+            S->z = z;
+            S->zn = zn;
+            S->lo_limbs = lo_limbs;
+            S->X = X;
+            S->P = P;
+            S->slot_start = a;
+            S->slot_stop = b;
+            S->Lbase = (a * bits) / FLINT_BITS;
+            S->Lstop = (b * bits) / FLINT_BITS;
+            S->is_last = (l + 1 == nthreads);
+            S->spill = NULL;
+            S->spill_alloc = 0;
+            S->spill_len = 0;
+            S->spill_base = S->Lstop;
+            args[l].S = S;
+        }
+
+        for (l = nworkers; l > 0; l--)
+            thread_pool_wake(global_thread_pool, handles[l - 1], 0,
+                             _sig_worker, args + l);
+        _sig_segment(segs + 0);
+        for (l = nworkers; l > 0; l--)
+            thread_pool_wait(global_thread_pool, handles[l - 1]);
+
+        /* serial stitch of the signed spills across segment boundaries */
+        for (l = 0; l + 1 < nthreads; l++)
+            _sig_add_spill(z, zn, lo_limbs, segs[l].spill_base,
+                           segs[l].spill, segs[l].spill_len);
+
+        for (l = 0; l < nthreads; l++)
+            flint_free(segs[l].spill);
+        flint_free(segs);
+        flint_free(args);
+    }
+
+    flint_give_back_threads(handles, nworkers);
+
+    /* one sign resolution for the assembled two's-complement result */
+    if (zn > 0 && (z[zn - 1] >> (FLINT_BITS - 1)))
+    {
+        *sign = 1;
+        mpn_com(z, z, zn);
+        mpn_add_1(z, z, zn, 1);
+    }
+    else
+        *sign = 0;
+
+    if (*sign && flint_mpn_zero_p(z, zn))
+        *sign = 0;
+}
+
+void
+fft_small_export_mpn_signed(ulong* z, ulong zn, int * sign,
+        const fft_small_op_t X, ulong nslots, const fft_small_plan_t P)
+{
+    fft_small_export_mpn_signed_trunc(z, zn, sign, X, nslots, 0, P);
+}

--- a/src/fft_small/fmpz_poly_mul.c
+++ b/src/fft_small/fmpz_poly_mul.c
@@ -206,72 +206,31 @@ static void fmpz_neg_ui_array(fmpz_t out, const ulong * in, slong in_len)
     }
 }
 
-#define DEFINE_IT(NP, N, M) \
-static void CAT(_crt, NP)( \
-    fmpz * z, ulong zl, ulong zi_start, ulong zi_stop, \
-    sd_fft_ctx_struct* Rffts, double* d, ulong dstride, \
-    crt_data_struct* Rcrts) \
-{ \
-    ulong np = NP; \
-    ulong n = N; \
-    ulong m = M; \
- \
-    FLINT_ASSERT(n == Rcrts[np-1].coeff_len); \
-    FLINT_ASSERT(1 <= N && N <= 7); \
- \
-    if (n == m + 1) \
+#define CRT_FN(NP) CAT3(_crt, NP, fn)
+#define CRT_Z_TYPE fmpz*
+#define CRT_HEAD
+#define CRT_EMIT(zi, r, NP, N, M) \
+    if (mpn_cmp(r, Mhalf, N) > 0) \
     { \
-        for (ulong l = 0; l < np; l++) { \
-            FLINT_ASSERT(crt_data_co_prime(Rcrts + np - 1, l)[m] == 0); \
-        } \
+        CAT(multi_rsub, N)(r, crt_data_prod_primes(Rcrts + np - 1)); \
+        fmpz_neg_ui_array(&z[zi], r, N); \
     } \
     else \
-    { \
-        FLINT_ASSERT(n == m); \
-    } \
- \
-    ulong Mhalf[N]; \
-    mpn_rshift(Mhalf, crt_data_prod_primes(Rcrts + np - 1), N, 1); \
- \
-    ulong Xs[BLK_SZ*NP]; \
- \
-    for (ulong i = n_round_down(zi_start, BLK_SZ); i < zi_stop; i += BLK_SZ) \
-    { \
-        _convert_block(Xs, Rffts, d, dstride, np, i/BLK_SZ); \
- \
-        ulong jstart = (i < zi_start) ? zi_start - i : 0; \
-        ulong jstop = FLINT_MIN(BLK_SZ, zi_stop - i); \
-        for (ulong j = jstart; j < jstop; j += 1) \
-        { \
-            ulong r[N]; \
-            ulong t[N]; \
-            ulong l = 0; \
- \
-            CAT3(_big_mul, N, M)(r, t, _crt_data_co_prime(Rcrts + np - 1, l, n), Xs[l*BLK_SZ + j]); \
-            for (l++; l < np; l++) \
-                CAT3(_big_addmul, N, M)(r, t, _crt_data_co_prime(Rcrts + np - 1, l, n), Xs[l*BLK_SZ + j]); \
- \
-            CAT(_reduce_big_sum, N)(r, t, crt_data_prod_primes(Rcrts + np - 1)); \
- \
-            if (mpn_cmp(r, Mhalf, N) > 0) \
-            { \
-                multi_rsub_ ## N(r, crt_data_prod_primes(Rcrts + np - 1)); \
-                fmpz_neg_ui_array(&z[i+j-zl], r, N); \
-            } \
-            else \
-                fmpz_set_ui_array(&z[i+j-zl], r, N); \
-        } \
-    } \
-}
-
-DEFINE_IT(2, 2, 1)  /* 100 bits */
-DEFINE_IT(3, 3, 2)  /* 150 bits */
-DEFINE_IT(4, 4, 3)  /* 200 bits */
-DEFINE_IT(5, 4, 4)  /* 250 bits */
-DEFINE_IT(6, 5, 4)  /* 300 bits */
-DEFINE_IT(7, 6, 5)  /* 350 bits */
-DEFINE_IT(8, 7, 6)  /* 400 bits */
-#undef DEFINE_IT
+        fmpz_set_ui_array(&z[zi], r, N);
+#define CRT_TAIL
+CRT_DEFINE(2, 2, 1)  /* 100 bits */
+CRT_DEFINE(3, 3, 2)  /* 150 bits */
+CRT_DEFINE(4, 4, 3)  /* 200 bits */
+CRT_DEFINE(5, 4, 4)  /* 250 bits */
+CRT_DEFINE(6, 5, 4)  /* 300 bits */
+CRT_DEFINE(7, 6, 5)  /* 350 bits */
+CRT_DEFINE(8, 7, 6)  /* 400 bits */
+#undef CRT_FN
+#undef CRT_Z_TYPE
+#undef CRT_HEAD
+#undef CRT_EMIT
+#undef CRT_TAIL
+#undef CRT_DEFINE
 
 /* 50 bits */
 static void _crt_1(
@@ -300,120 +259,62 @@ static void _crt_1(
     }
 }
 
-typedef struct {
-    ulong np;
-    ulong start_pi;
-    ulong stop_pi;
-    ulong offset;
-    double* abuf;
-    double* bbuf;
-    ulong depth;
-    ulong stride;
-    ulong atrunc;
-    ulong btrunc;
-    ulong ztrunc;
-    const fmpz * a;
-    ulong an;
-    slong abits;
-    const fmpz * b;
-    ulong bn;
-    slong bbits;
-    sd_fft_ctx_struct* ffts;
-    crt_data_struct* crts;
-    ulong ioff;
-    int squaring;
-    int want_worker;
-} s1worker_struct;
 
+/* ------------------------------------------------------------------------ */
+/* glue for the generic convolution engine                                  */
+/* ------------------------------------------------------------------------ */
 
-static void extra_func(void* varg)
+static void _mod_fn(double* xbuf, ulong xtrunc,
+    const void* x, ulong xn, slong xaux,
+    const sd_fft_ctx_struct* fft, const void* FLINT_UNUSED(params))
 {
-    s1worker_struct* X = (s1worker_struct*) varg;
-    sd_fft_ctx_struct* Q = X->ffts + X->ioff;
-
-    _mod(X->bbuf, X->btrunc, X->b, X->bn, X->bbits, Q);
-    sd_fft_trunc(Q, X->bbuf, X->depth, X->btrunc, X->ztrunc);
+    _mod(xbuf, xtrunc, (const fmpz *) x, xn, xaux, fft);
 }
 
-static void s1worker_func(void* varg)
+#define DEFINE_IT(NP) \
+static void CAT3(_crt, NP, fn)(void* z, ulong zl, \
+    ulong zi_start, ulong zi_stop, \
+    sd_fft_ctx_struct* Rffts, double* d, ulong dstride, \
+    crt_data_struct* Rcrts, ulong FLINT_UNUSED(min_an_bn), \
+    ulong* FLINT_UNUSED(local), const void* FLINT_UNUSED(params)) \
+{ \
+    CAT(_crt, NP)((fmpz *) z, zl, zi_start, zi_stop, Rffts, d, dstride, \
+                  Rcrts); \
+}
+DEFINE_IT(1)
+#undef DEFINE_IT
+
+static fft_small_crt_func _fmpz_crt_fn(ulong np)
 {
-    s1worker_struct* X = (s1worker_struct*) varg;
-    ulong i, m;
-    thread_pool_handle* handles = NULL;
-    slong nworkers = 0;
-
-    if (X->want_worker)
-        nworkers = flint_request_threads(&handles, 2);
-
-    for (i = X->start_pi; i < X->stop_pi; i++)
-    {
-        ulong ioff = i + X->offset;
-        double* abuf = X->abuf + X->stride*i;
-        double* bbuf = X->bbuf;
-        sd_fft_ctx_struct* Q = X->ffts + ioff;
-
-        if (!X->squaring)
-        {
-            if (nworkers > 0)
-            {
-                X->ioff = ioff;
-                thread_pool_wake(global_thread_pool, handles[0], 0, extra_func, X);
-            }
-            else
-            {
-                _mod(bbuf, X->btrunc, X->b, X->bn, X->bbits, Q);
-                sd_fft_trunc(Q, bbuf, X->depth, X->btrunc, X->ztrunc);
-            }
-        }
-
-        _mod(abuf, X->atrunc, X->a, X->an, X->abits, Q);
-        sd_fft_trunc(Q, abuf, X->depth, X->atrunc, X->ztrunc);
-
-        if (!X->squaring)
-        {
-            if (nworkers > 0)
-                thread_pool_wait(global_thread_pool, handles[0]);
-        }
-
-        ulong cop = X->np == 1 ? 1 : *crt_data_co_prime_red(X->crts + X->np - 1, ioff);
-        NMOD_RED2(m, cop >> (FLINT_BITS - X->depth), cop << X->depth, Q->mod);
-        m = nmod_inv(m, Q->mod);
-
-        if (X->squaring)
-            sd_fft_ctx_point_sqr(Q, abuf, m, X->depth);
-        else
-            sd_fft_ctx_point_mul(Q, abuf, bbuf, m, X->depth);
-
-        sd_ifft_trunc(Q, abuf, X->depth, X->ztrunc);
-    }
-
-    flint_give_back_threads(handles, nworkers);
+    return np == 1 ? _crt_1_fn :
+           np == 2 ? _crt_2_fn :
+           np == 3 ? _crt_3_fn :
+           np == 4 ? _crt_4_fn :
+           np == 5 ? _crt_5_fn :
+           np == 6 ? _crt_6_fn :
+           np == 7 ? _crt_7_fn :
+                     _crt_8_fn;
 }
 
-typedef struct {
-    fmpz * z;
-    ulong zl;
-    ulong start_zi;
-    ulong stop_zi;
-    double* buf;
-    ulong offset;
-    ulong stride;
-    sd_fft_ctx_struct* ffts;
-    crt_data_struct* crts;
-    nmod_t mod;
-    void (*f)(
-        fmpz * z, ulong zl, ulong zi_start, ulong zi_stop,
-        sd_fft_ctx_struct* Rffts, double* d, ulong dstride,
-        crt_data_struct* Rcrts);
-} s2worker_struct;
-
-static void s2worker_func(void* varg)
+static ulong _fmpz_conv_s1_threads(ulong np, ulong tune_n)
 {
-    s2worker_struct* X = (s2worker_struct*) varg;
-
-    X->f(X->z, X->zl, X->start_zi, X->stop_zi, X->ffts + X->offset, X->buf,
-         X->stride, X->crts + X->offset);
+    return ((np >= 2 && tune_n >= 1000) || (np >= 4 && tune_n >= 300)) ? np : 1;
 }
+
+static int _fmpz_conv_s1_b_worker(ulong np, ulong tune_n, int squaring)
+{
+    return !squaring && ((np == 1 && tune_n > 5000) ||
+                         (np >= 2 && tune_n >= 1000));
+}
+
+static int _fmpz_conv_s2_rethread(ulong np, ulong zn)
+{
+    return zn > 50000 || (np >= 2 && zn > 20000) || (np >= 4 && zn > 800);
+}
+
+static const fft_small_conv_tuning _fmpz_conv_tuning =
+    { _fmpz_conv_s1_threads, _fmpz_conv_s1_b_worker, _fmpz_conv_s2_rethread };
+
 
 int _fmpz_poly_mul_mid_mpn_ctx(
     fmpz * z, ulong zl, ulong zh,
@@ -422,14 +323,13 @@ int _fmpz_poly_mul_mid_mpn_ctx(
     mpn_ctx_t R)
 {
     ulong modbits;
-    ulong offset = 0;
     ulong zn = an + bn - 1;
-    ulong atrunc, btrunc, ztrunc;
-    ulong i, np, depth, stride;
-    double* buf;
+    ulong atrunc, btrunc;
     int squaring;
     slong bits1, bits2;
     int sign;
+    fft_small_plan_t P;
+    fft_small_conv_arg_struct A;
 
     FLINT_ASSERT(an > 0);
     FLINT_ASSERT(bn > 0);
@@ -458,7 +358,6 @@ int _fmpz_poly_mul_mid_mpn_ctx(
     else
         bits2 = _fmpz_vec_max_bits(b, bn);
     sign = (bits1 < 0) || (bits2 < 0);
-    (void) sign;
     /* should be +sign instead of +1, but currently the CRT code doesn't
        distinguish between the signed and unsigned cases */
     modbits = FLINT_ABS(bits1) + FLINT_ABS(bits2) + 1;
@@ -466,133 +365,36 @@ int _fmpz_poly_mul_mid_mpn_ctx(
     FLINT_ASSERT(zl < zh);
     FLINT_ASSERT(zh <= zn);
 
-    /* need prod_of_primes >= blen * 2^modbits */
-    for (np = 1; ; np++)
-    {
-        if (np > MPN_CTX_NCRTS)
-            return 0;
-
-        if (flint_mpn_cmp_ui_2exp(crt_data_prod_primes(R->crts + np - 1),
-              R->crts[np - 1].coeff_len, bn, modbits) >= 0)
-        {
-            break;
-        }
-    }
-
-    FLINT_ASSERT(0 <= flint_mpn_cmp_ui_2exp(
-                                  crt_data_prod_primes(R->crts + np - 1),
-                                  R->crts[np - 1].coeff_len, bn, modbits));
-
     atrunc = n_round_up(an, BLK_SZ);
     btrunc = n_round_up(bn, BLK_SZ);
-    ztrunc = n_round_up(zn, BLK_SZ);
-    /*
-        if there is a power of two 2^d between zh and zn with good wrap around
-            i.e. max(an, bn, zh) <= 2^d <= zn with zn - 2^d <= zl
-        then use d as the depth, otherwise the usual with no wrap around
-    */
-    depth = n_flog2(zn);
-    i = n_pow2(depth);
-    if (atrunc <= i && btrunc <= i && zh <= i && i <= zn && zn <= zl + i)
-    {
-        ztrunc = i;
-    }
-    else
-    {
-        depth = n_max(LG_BLK_SZ, n_clog2(ztrunc));
-    }
 
-    stride = n_round_up(sd_fft_ctx_data_size(depth), 128);
+    P->R = R;
+    P->sign = sign;
 
-    ulong want_threads;
+    _fft_small_plan_set_window(P, zl, zh, zn, n_max(atrunc, btrunc));
 
-    if ((np >= 2 && bn >= 1000) || (np >= 4 && bn >= 300))
-        want_threads = np;
-    else
-        want_threads = 1;
+    /* need prod_of_primes >= bn * 2^modbits */
+    if (!_fft_small_plan_set_bound(P, bn, modbits, MPN_CTX_NCRTS))
+        return 0;
 
-    thread_pool_handle* handles;
-    slong nworkers = flint_request_threads(&handles, want_threads);
-    ulong nthreads = nworkers + 1;
+    _fft_small_plan_set_normalizers(P);
 
-    buf = (double*) mpn_ctx_fit_buffer(R, (np+nthreads)*stride*sizeof(double));
+    A.a = a; A.an = an; A.aaux = bits1; A.atrunc = atrunc;
+    A.b = b; A.bn = bn; A.baux = bits2; A.btrunc = btrunc;
+    A.bfft = NULL;
+    A.bfft_stride = 0;
+    A.squaring = squaring;
+    A.tune_n = bn;
+    A.min_an_bn = FLINT_MIN(an, bn);
+    A.mod_fn = _mod_fn;
+    A.s2_finish = NULL;
+    A.crt_fn = _fmpz_crt_fn(P->np);
+    A.params = NULL;
+    A.tuning = &_fmpz_conv_tuning;
 
-    s1worker_struct s1args[8];
-    FLINT_ASSERT(nthreads <= 8);
-    for (i = 0; i < nthreads; i++)
-    {
-        s1worker_struct* X = s1args + i;
-        X->np = np;
-        X->start_pi = (i+0)*np/nthreads;
-        X->stop_pi  = (i+1)*np/nthreads;
-        X->offset = offset;
-        X->abuf = buf;
-        X->bbuf = buf + (np+i)*stride;
-        X->depth = depth;
-        X->stride = stride;
-        X->atrunc = atrunc;
-        X->btrunc = btrunc;
-        X->ztrunc = ztrunc;
-        X->a = a;
-        X->an = an;
-        X->abits = bits1;
-        X->b = b;
-        X->bn = bn;
-        X->bbits = bits2;
-        X->ffts = R->ffts;
-        X->crts = R->crts;
-        X->squaring = squaring;
-        X->want_worker = !squaring && ((np == 1 && bn > 5000) || (np >= 2 && bn >= 1000));
-    }
+    _fft_small_conv(z, P, &A);
 
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wake(global_thread_pool, handles[i - 1], 0, s1worker_func, s1args + i);
-    s1worker_func(s1args + 0);
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wait(global_thread_pool, handles[i - 1]);
-
-    if (zn > 50000 || (np >= 2 && zn > 20000) || (np >= 4 && zn > 800))
-    {
-        flint_give_back_threads(handles, nworkers);
-        nworkers = flint_request_threads(&handles, 8);
-        nthreads = nworkers + 1;
-    }
-
-    s2worker_struct s2args[8];
-    FLINT_ASSERT(nthreads <= 8);
-
-    ulong o = zl;
-    for (i = 0; i < nthreads; i++)
-    {
-        s2worker_struct* X = s2args + i;
-        X->z = z;
-        X->zl = zl;
-        X->start_zi = o;
-        ulong newo = n_round_down(zl + (i+1)*(zh-zl)/nthreads, BLK_SZ);
-        o = i+1 < nthreads ? FLINT_MAX(o, newo) : zh;
-        X->stop_zi = o;
-        X->buf = buf;
-        X->offset = offset;
-        X->stride = stride;
-        X->ffts = R->ffts;
-        X->crts = R->crts;
-        X->f =  np == 1 ? _crt_1 :
-                np == 2 ? _crt_2 :
-                np == 3 ? _crt_3 :
-                np == 4 ? _crt_4 :
-                np == 5 ? _crt_5 :
-                np == 6 ? _crt_6 :
-                np == 7 ? _crt_7 :
-                          _crt_8;
-    }
-
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wake(global_thread_pool, handles[i - 1], 0, s2worker_func, s2args + i);
-    s2worker_func(s2args + 0);
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wait(global_thread_pool, handles[i - 1]);
-
-    flint_give_back_threads(handles, nworkers);
+    fft_small_plan_clear(P);
 
     return 1;
 }

--- a/src/fft_small/mpn_mul.c
+++ b/src/fft_small/mpn_mul.c
@@ -1890,3 +1890,286 @@ void mpn_ctx_mpn_mul(mpn_ctx_t R, ulong* z, const ulong* a, ulong an, const ulon
 {
     _mpn_ctx_mpn_mul_range(R, z, 0, an + bn, a, an, b, bn);
 }
+
+/* ------------------------------------------------------------------------ */
+/* transforms of mpn operands for the plan/op interface                     */
+/* ------------------------------------------------------------------------ */
+
+typedef struct {
+    const fft_small_plan_struct* P;
+    fft_small_op_struct* X;
+    const ulong* a;
+    ulong an;
+    ulong atrunc;
+    to_ffts_func to_ffts;
+    ulong start_easy;
+    ulong stop_easy;
+    ulong start_hard;
+    ulong stop_hard;
+    ulong start_pi;      /* prime range for the fft (or fused slow) stage */
+    ulong stop_pi;
+} _op_mpn_fft_worker_struct;
+
+static void _op_mpn_pack_worker_func(void* varg)
+{
+    _op_mpn_fft_worker_struct* W = (_op_mpn_fft_worker_struct*) varg;
+    const fft_small_plan_struct* P = W->P;
+    mpn_ctx_struct* R = P->R;
+
+    W->to_ffts(R->ffts, W->X->data, P->stride, W->a, W->an, W->atrunc,
+               R->vec_two_pow_tab[n_cdiv(P->np, VEC_SZ) - 1],
+               W->start_easy, W->stop_easy, W->start_hard, W->stop_hard);
+}
+
+static void _op_mpn_fft_worker_func(void* varg)
+{
+    _op_mpn_fft_worker_struct* W = (_op_mpn_fft_worker_struct*) varg;
+    const fft_small_plan_struct* P = W->P;
+
+    for (ulong l = W->start_pi; l < W->stop_pi; l++)
+        sd_fft_trunc(P->R->ffts + l, W->X->data + l*P->stride, P->depth,
+                     W->atrunc, P->ztrunc);
+}
+
+static void _op_mpn_slow_worker_func(void* varg)
+{
+    _op_mpn_fft_worker_struct* W = (_op_mpn_fft_worker_struct*) varg;
+    const fft_small_plan_struct* P = W->P;
+    mpn_ctx_struct* R = P->R;
+
+    for (ulong l = W->start_pi; l < W->stop_pi; l++)
+    {
+        slow_mpn_to_fft(R->ffts + l, W->X->data + l*P->stride, W->atrunc,
+                        W->a, W->an, P->bits, R->slow_two_pow_tab[l]);
+        sd_fft_trunc(R->ffts + l, W->X->data + l*P->stride, P->depth,
+                     W->atrunc, P->ztrunc);
+    }
+}
+
+void fft_small_fft_mpn(fft_small_op_t X, const ulong* a, ulong an,
+                    const fft_small_plan_t P)
+{
+    mpn_ctx_struct* R = P->R;
+    ulong bits = P->bits;
+    ulong np = P->np;
+    ulong alen = n_cdiv(FLINT_BITS*an, bits);
+    ulong atrunc = n_round_up(alen, BLK_SZ);
+    to_ffts_func to_ffts = NULL;
+    ulong i;
+    thread_pool_handle* handles = NULL;
+    slong nworkers = 0;
+    ulong nthreads;
+    _op_mpn_fft_worker_struct args[MPN_CTX_NCRTS];
+
+    FLINT_ASSERT(an > 0);
+    FLINT_ASSERT(bits > 64);
+    FLINT_ASSERT(P->offset == 0);
+    FLINT_ASSERT(X->np == np && X->offset == P->offset &&
+                 X->depth == P->depth && X->stride == P->stride);
+    FLINT_ASSERT(atrunc <= P->ztrunc);
+
+    /* look for a vectorized packing profile matching (np, bits); the
+       profile's bn_bound concerns the multiplication drivers' product
+       bound and is irrelevant to the packing itself */
+    for (i = 0; i < R->profiles_size; i++)
+    {
+        if (R->profiles[i].np == np && R->profiles[i].bits == bits)
+        {
+            to_ffts = R->profiles[i].to_ffts;
+            break;
+        }
+    }
+
+    /* the threshold corresponds to the multiplication driver enabling
+       threads from a product of ~2048 limbs up */
+    if (an >= 1024)
+        nworkers = flint_request_threads(&handles, np);
+    nthreads = FLINT_MIN((ulong)(nworkers + 1), np);
+
+    if (to_ffts != NULL)
+    {
+        /* packing stage: split the easy coefficient range over the
+           threads, the last thread taking the hard tail, exactly as the
+           multiplication driver's mod workers do */
+        ulong a_stop_easy = n_min(atrunc, (FLINT_BITS*an - 33)/bits);
+        ulong a_stop_hard = n_min(atrunc, (FLINT_BITS*an + bits - 1)/bits);
+        ulong rounding = (bits%8 == 0) ? 4 : (bits%4 == 0) ? 8 : 16;
+
+        a_stop_easy &= -rounding;
+
+        for (i = 0; i < nthreads; i++)
+        {
+            _op_mpn_fft_worker_struct* W = args + i;
+            W->P = P;
+            W->X = X;
+            W->a = a;
+            W->an = an;
+            W->atrunc = atrunc;
+            W->to_ffts = to_ffts;
+            W->start_easy = n_round_up((i+0)*a_stop_easy/nthreads, rounding);
+            W->stop_easy  = n_round_up((i+1)*a_stop_easy/nthreads, rounding);
+            W->start_hard = (i + 1 == nthreads) ? a_stop_easy : atrunc;
+            W->stop_hard  = (i + 1 == nthreads) ? a_stop_hard : atrunc;
+        }
+
+        for (i = nthreads - 1; i > 0; i--)
+            thread_pool_wake(global_thread_pool, handles[i - 1], 0,
+                             _op_mpn_pack_worker_func, args + i);
+        _op_mpn_pack_worker_func(args + 0);
+        for (i = nthreads - 1; i > 0; i--)
+            thread_pool_wait(global_thread_pool, handles[i - 1]);
+
+        /* fft stage: split the primes */
+        for (i = 0; i < nthreads; i++)
+        {
+            args[i].start_pi = (i+0)*np/nthreads;
+            args[i].stop_pi  = (i+1)*np/nthreads;
+        }
+
+        for (i = nthreads - 1; i > 0; i--)
+            thread_pool_wake(global_thread_pool, handles[i - 1], 0,
+                             _op_mpn_fft_worker_func, args + i);
+        _op_mpn_fft_worker_func(args + 0);
+        for (i = nthreads - 1; i > 0; i--)
+            thread_pool_wait(global_thread_pool, handles[i - 1]);
+    }
+    else
+    {
+        /* slow packing is per prime anyway: fuse pack + fft per prime */
+        for (i = 0; i < nthreads; i++)
+        {
+            _op_mpn_fft_worker_struct* W = args + i;
+            W->P = P;
+            W->X = X;
+            W->a = a;
+            W->an = an;
+            W->atrunc = atrunc;
+            W->start_pi = (i+0)*np/nthreads;
+            W->stop_pi  = (i+1)*np/nthreads;
+        }
+
+        for (i = nthreads - 1; i > 0; i--)
+            thread_pool_wake(global_thread_pool, handles[i - 1], 0,
+                             _op_mpn_slow_worker_func, args + i);
+        _op_mpn_slow_worker_func(args + 0);
+        for (i = nthreads - 1; i > 0; i--)
+            thread_pool_wait(global_thread_pool, handles[i - 1]);
+    }
+
+    flint_give_back_threads(handles, nworkers);
+
+    X->itrunc = atrunc;
+    X->domain = FFT_SMALL_OP_PRIMAL;
+}
+
+void fft_small_export_mpn(ulong* z, ulong zn, const fft_small_op_t X,
+                    const fft_small_plan_t P)
+{
+    ulong bits = P->bits;
+    ulong c_hi = n_min(P->zn, n_cdiv(zn*FLINT_BITS, bits));
+    static from_ffts_func tab[8-4+1] = {_mpn_from_ffts_4,
+                                        _mpn_from_ffts_5,
+                                        _mpn_from_ffts_6,
+                                        _mpn_from_ffts_7,
+                                        _mpn_from_ffts_8};
+
+    ulong n = P->R->crts[P->np - 1].coeff_len;
+    ulong E1;
+    thread_pool_handle* handles = NULL;
+    slong nworkers = 0;
+    ulong nthreads;
+
+    FLINT_ASSERT(zn > 0);
+    FLINT_ASSERT(4 <= P->np && P->np <= 8);
+    FLINT_ASSERT(P->offset == 0);
+    FLINT_ASSERT(X->domain == FFT_SMALL_OP_PRODUCT);
+
+    /* BLK_SZ-aligned easy interval [0, E1) of coefficients whose whole
+       span lies inside [0, zn), as in the multiplication driver's crt
+       stage with lo = c_lo = 0 (so there is no bottom band) */
+    E1 = ((zn >= n + 1) ? zn - (n + 1) : UWORD(0))*FLINT_BITS/bits;
+    E1 &= -BLK_SZ;
+
+    /* the threshold corresponds to the multiplication driver enabling
+       threads from a product of ~2048 limbs up */
+    if (E1 > 0 && zn >= 2048)
+        nworkers = flint_request_threads(&handles, 8);
+    nthreads = nworkers + 1;
+
+    if (nthreads == 1)
+    {
+        /* serial reconstruction of limbs [0, zn), as the multiplication
+           driver's small-window branch */
+        tab[P->np - 4](z, 0, zn, 0, c_hi, P->R->ffts, X->data, X->stride,
+                       P->R->crts, bits, 0, 0, NULL, NULL);
+    }
+    else
+    {
+        /* the multiplication driver's threaded crt stage: per-range
+           reconstruction with overhang buffers, then a serial stitch of
+           the carries across the range boundaries */
+        crt_worker_struct w[8];
+        ulong span = E1;
+        ulong l;
+
+        for (l = 0; l < nthreads; l++)
+        {
+            crt_worker_struct* W = w + l;
+            W->from_ffts = tab[P->np - 4];
+            W->z = z;
+            W->lo = 0;
+            W->hi = zn;
+            W->c_lo = 0;
+            W->clen = c_hi;
+            W->fctxs = P->R->ffts;
+            W->abuf = X->data;
+            W->stride = X->stride;
+            W->crts = P->R->crts;
+            W->bits = bits;
+            W->start_easy = n_round_up((l+0)*span/nthreads, BLK_SZ);
+            W->stop_easy  = n_round_up((l+1)*span/nthreads, BLK_SZ);
+            W->overhang = (l + 1 == nthreads) ? NULL : W->overhang_buffer;
+            W->boundbuf = NULL;
+        }
+
+        for (slong i = nworkers; i > 0; i--)
+            thread_pool_wake(global_thread_pool, handles[i - 1], 0,
+                             crt_worker_func, w + i);
+        crt_worker_func(w + 0);
+        for (slong i = nworkers; i > 0; i--)
+            thread_pool_wait(global_thread_pool, handles[i - 1]);
+
+        /* stitch the per-segment overhangs (carries across boundaries) */
+        {
+            unsigned char cf = 0;
+            for (slong i = 1; i <= nworkers; i++)
+            {
+                ulong start = w[i].start_easy*bits/FLINT_BITS;
+                if (i == nworkers)
+                {
+                    cf = flint_mpn_add_inplace_c(z + start, zn - start,
+                                              w[i - 1].overhang_buffer, n, cf);
+                }
+                else
+                {
+                    ulong stop = w[i].stop_easy*bits/FLINT_BITS;
+                    if (stop > start)
+                    {
+                        cf = flint_mpn_add_inplace_c(z + start, stop - start,
+                                              w[i - 1].overhang_buffer, n, cf);
+                    }
+                    else
+                    {
+                        for (ulong k = 0; k < n; k++)
+                        {
+                            FLINT_ASSERT(w[i].overhang_buffer[k] == 0);
+                            w[i].overhang_buffer[k] = w[i - 1].overhang_buffer[k];
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    flint_give_back_threads(handles, nworkers);
+}

--- a/src/fft_small/mpn_mul.c
+++ b/src/fft_small/mpn_mul.c
@@ -2089,6 +2089,11 @@ void fft_small_export_mpn(ulong* z, ulong zn, const fft_small_op_t X,
        stage with lo = c_lo = 0 (so there is no bottom band) */
     E1 = ((zn >= n + 1) ? zn - (n + 1) : UWORD(0))*FLINT_BITS/bits;
     E1 &= -BLK_SZ;
+    /* never run the easy interval past the coefficients that were
+       actually produced: slots beyond c_hi were not computed by the
+       truncated inverse transform, and zn may be generous */
+    if (E1 > c_hi)
+        E1 = c_hi & -(ulong) BLK_SZ;
 
     /* the threshold corresponds to the multiplication driver enabling
        threads from a product of ~2048 limbs up */
@@ -2098,10 +2103,13 @@ void fft_small_export_mpn(ulong* z, ulong zn, const fft_small_op_t X,
 
     if (nthreads == 1)
     {
-        /* serial reconstruction of limbs [0, zn), as the multiplication
-           driver's small-window branch */
+        /* serial reconstruction of limbs [0, zn). The easy interval must
+           be passed here as well: with start_easy = stop_easy = 0 every
+           coefficient takes the hard tail, converting residues one at a
+           time with scalar reductions instead of block-converting them
+           with _convert_block -- measured about 3x slower overall. */
         tab[P->np - 4](z, 0, zn, 0, c_hi, P->R->ffts, X->data, X->stride,
-                       P->R->crts, bits, 0, 0, NULL, NULL);
+                       P->R->crts, bits, 0, E1, NULL, NULL);
     }
     else
     {

--- a/src/fft_small/nmod_poly_mul.c
+++ b/src/fft_small/nmod_poly_mul.c
@@ -221,75 +221,33 @@ FLINT_ASSERT(i+j < atrunc);
 
 
 
-#define DEFINE_IT(NP, N, M) \
-static void CAT(_crt, NP)( \
-    ulong* z, ulong zl, ulong zi_start, ulong zi_stop, \
-    sd_fft_ctx_struct* Rffts, double* d, ulong dstride, \
-    crt_data_struct* Rcrts, ulong min_an_bn,\
-    nmod_t mod) \
-{ \
-    ulong np = NP; \
-    ulong n = N; \
-    ulong m = M; \
- \
-    FLINT_ASSERT(n == Rcrts[np-1].coeff_len); \
-    FLINT_ASSERT(1 <= N && N <= 3); \
- \
-    if (n == m + 1) \
+/* _crt_1, _crt_2, _crt_3 are special-cased below; the generic template
+   handles four or more primes, with a fast path while the reconstructed
+   values stay below 2^192 */
+#define CRT_FN(NP) CAT3(_crt, NP, fn)
+#define CRT_Z_TYPE ulong*
+#define CRT_HEAD nmod_t mod = *(const nmod_t*) params;
+#define CRT_EMIT(zi, r, NP, N, M) \
+    if (N == 3 || (N == 4 && r[3] == 0)) \
     { \
-        for (ulong l = 0; l < np; l++) { \
-            FLINT_ASSERT(crt_data_co_prime(Rcrts + np - 1, l)[m] == 0); \
-        } \
+        NMOD_RED3(z[zi], r[2], r[1], r[0], mod); \
     } \
     else \
     { \
-        FLINT_ASSERT(n == m); \
-    } \
- \
-    ulong Xs[BLK_SZ*NP]; \
- \
-    (void) min_an_bn; \
- \
-    for (ulong i = n_round_down(zi_start, BLK_SZ); i < zi_stop; i += BLK_SZ) \
-    { \
-        _convert_block(Xs, Rffts, d, dstride, np, i/BLK_SZ); \
- \
-        ulong jstart = (i < zi_start) ? zi_start - i : 0; \
-        ulong jstop = FLINT_MIN(BLK_SZ, zi_stop - i); \
-        for (ulong j = jstart; j < jstop; j += 1) \
-        { \
-            ulong r[N]; \
-            ulong t[N]; \
-            ulong l = 0; \
- \
-            CAT3(_big_mul, N, M)(r, t, _crt_data_co_prime(Rcrts + np - 1, l, n), Xs[l*BLK_SZ + j]); \
-            for (l++; l < np; l++) \
-                CAT3(_big_addmul, N, M)(r, t, _crt_data_co_prime(Rcrts + np - 1, l, n), Xs[l*BLK_SZ + j]); \
- \
-            CAT(_reduce_big_sum, N)(r, t, crt_data_prod_primes(Rcrts + np - 1)); \
- \
-            if (N == 1) \
-            { \
-                NMOD_RED(z[i+j-zl], r[0], mod); \
-            } \
-            else if (N == 2) \
-            { \
-                NMOD2_RED2(z[i+j-zl], r[1], r[0], mod); \
-            } \
-            else \
-            { \
-                FLINT_ASSERT(N < 4 || r[3] == 0); \
-                NMOD_RED3(z[i+j-zl], r[2], r[1], r[0], mod); \
-            } \
-        } \
-    } \
-}
-
-// DEFINE_IT(1, 1, 1) -- special-cased below
-// DEFINE_IT(2, 2, 1) -- special-cased below
-// DEFINE_IT(3, 3, 2) -- special-cased below
-DEFINE_IT(4, 4, 3)
-#undef DEFINE_IT
+        z[zi] = mpn_mod_1(r, N, mod.n); \
+    }
+#define CRT_TAIL
+CRT_DEFINE(4, 4, 3)  /* 200 bits */
+CRT_DEFINE(5, 4, 4)  /* 250 bits */
+CRT_DEFINE(6, 5, 4)  /* 300 bits */
+CRT_DEFINE(7, 6, 5)  /* 350 bits */
+CRT_DEFINE(8, 7, 6)  /* 400 bits */
+#undef CRT_FN
+#undef CRT_Z_TYPE
+#undef CRT_HEAD
+#undef CRT_EMIT
+#undef CRT_TAIL
+#undef CRT_DEFINE
 
 
 FLINT_FORCE_INLINE
@@ -688,159 +646,204 @@ static void _crt_3(
 }
 
 
-typedef struct {
-    ulong np;
-    ulong start_pi;
-    ulong stop_pi;
-    ulong offset;
-    double* abuf;
-    double* bbuf;
-    ulong depth;
-    ulong stride;
-    ulong atrunc;
-    ulong btrunc;
-    ulong ztrunc;
-    const ulong* a;
-    ulong an;
-    const ulong* b;
-    ulong bn;
-    sd_fft_ctx_struct* ffts;
-    crt_data_struct* crts;
-    nmod_t mod;
-    ulong ioff;
-    int squaring;
-} s1worker_struct;
 
+/* ------------------------------------------------------------------------ */
+/* glue for the generic convolution engine                                  */
+/* ------------------------------------------------------------------------ */
 
-/* Reduce `const ulong* b` into `bbuf` and FFT-transform it in place.
-   Used as a helper for `s1worker_func` in order to process
-   `bbuf` and `abuf` in parallel, assuming `!squaring`.  */
-static void extra_func(void* varg)
+static void _mod_fn(double* xbuf, ulong xtrunc,
+    const void* x, ulong xn, slong FLINT_UNUSED(xaux),
+    const sd_fft_ctx_struct* fft, const void* params)
 {
-    s1worker_struct* X = (s1worker_struct*) varg;
-    sd_fft_ctx_struct* Q = X->ffts + X->ioff;
-
-    _mod(X->bbuf, X->btrunc, X->b, X->bn, Q, X->mod);
-    sd_fft_trunc(Q, X->bbuf, X->depth, X->btrunc, X->ztrunc);
+    _mod(xbuf, xtrunc, (const ulong*) x, xn, fft, *(const nmod_t*) params);
 }
 
-/* compute convolutions modulo the selected precomputed FFT primes.
-   Specifically, for each `start_pi <= i < stop_pi`, reduce
-   `a + stride*i` into `abuf + stride*i`, and multiply it by `b`,
-   modulo `ffts[i + X->offset].p`. The output is written in-place to
-   `abuf + stride*i`.
-   If `squaring` is true, `abuf` is squared, and `bbuf` is not used.
-   If `flint_request_threads` returns the requested number of threads,
-   then each `s1worker_func` processes exactly one prime.  */
-static void s1worker_func(void* varg)
+#define DEFINE_IT(NP) \
+static void CAT3(_crt, NP, fn)(void* z, ulong zl, \
+    ulong zi_start, ulong zi_stop, \
+    sd_fft_ctx_struct* Rffts, double* d, ulong dstride, \
+    crt_data_struct* Rcrts, ulong min_an_bn, ulong* FLINT_UNUSED(local), \
+    const void* params) \
+{ \
+    CAT(_crt, NP)((ulong*) z, zl, zi_start, zi_stop, Rffts, d, dstride, \
+                  Rcrts, min_an_bn, *(const nmod_t*) params); \
+}
+DEFINE_IT(1)
+DEFINE_IT(2)
+DEFINE_IT(3)
+#undef DEFINE_IT
+
+static fft_small_crt_func _nmod_crt_fn(ulong np)
 {
-    s1worker_struct* X = (s1worker_struct*) varg;
-    ulong i, m;
+    return np == 1 ? _crt_1_fn :
+           np == 2 ? _crt_2_fn :
+           np == 3 ? _crt_3_fn :
+           np == 4 ? _crt_4_fn :
+           np == 5 ? _crt_5_fn :
+           np == 6 ? _crt_6_fn :
+           np == 7 ? _crt_7_fn :
+                     _crt_8_fn;
+}
+
+/* todo: even with np == 1, we may want threads for the conversion to fft */
+static ulong _nmod_conv_s1_threads(ulong np, ulong tune_n)
+{
+    return tune_n < 1500 ? 1 : np;
+}
+
+static int _nmod_conv_s1_b_worker(ulong FLINT_UNUSED(np), ulong tune_n,
+                                  int squaring)
+{
+    return tune_n > 5000 && !squaring;
+}
+
+static int _nmod_conv_s2_rethread(ulong np, ulong zn)
+{
+    return np*zn > 10000;
+}
+
+static const fft_small_conv_tuning _nmod_conv_tuning =
+    { _nmod_conv_s1_threads, _nmod_conv_s1_b_worker, _nmod_conv_s2_rethread };
+
+/* the cyclic and precomputed-operand drivers historically do not
+   re-request threads for stage 2 */
+static const fft_small_conv_tuning _nmod_conv_tuning_no_rethread =
+    { _nmod_conv_s1_threads, _nmod_conv_s1_b_worker, NULL };
+
+typedef struct {
+    fft_small_op_struct* X;
+    const ulong* a;
+    ulong an;
+    ulong itrunc;
+    nmod_t mod;
+    const fft_small_plan_struct* P;
+    ulong start_pi;
+    ulong stop_pi;
+} _op_fft_worker_struct;
+
+static void _op_fft_worker_func(void* varg)
+{
+    _op_fft_worker_struct* W = (_op_fft_worker_struct*) varg;
+    const fft_small_plan_struct* P = W->P;
+
+    for (ulong i = W->start_pi; i < W->stop_pi; i++)
+    {
+        sd_fft_ctx_struct* Q = P->ffts + P->offset + i;
+        double* xbuf = W->X->data + P->stride*i;
+
+        _mod(xbuf, W->itrunc, W->a, W->an, Q, W->mod);
+        sd_fft_trunc(Q, xbuf, P->depth, W->itrunc, P->ztrunc);
+    }
+}
+
+void fft_small_fft_nmod(fft_small_op_t X, const ulong* a, ulong an,
+                    ulong itrunc, nmod_t mod, const fft_small_plan_t P)
+{
+    ulong i;
     thread_pool_handle* handles = NULL;
     slong nworkers = 0;
+    ulong nthreads;
+    _op_fft_worker_struct args[MPN_CTX_NCRTS];
 
-    if (X->bn > 5000 && !X->squaring)
-        nworkers = flint_request_threads(&handles, 2);
+    FLINT_ASSERT(X->np == P->np && X->offset == P->offset &&
+                 X->depth == P->depth && X->stride == P->stride);
+    FLINT_ASSERT(itrunc % BLK_SZ == 0);
+    FLINT_ASSERT(itrunc <= P->ztrunc);
 
-    for (i = X->start_pi; i < X->stop_pi; i++)
+    /* thread over the primes; the threshold mirrors the fused drivers'
+       stage 1 gate */
+    if (P->np >= 2 && an >= 1500)
+        nworkers = flint_request_threads(&handles, P->np);
+    nthreads = FLINT_MIN((ulong)(nworkers + 1), P->np);
+
+    for (i = 0; i < nthreads; i++)
     {
-        ulong ioff = i + X->offset;
-        double* abuf = X->abuf + X->stride*i;
-        double* bbuf = X->bbuf;
-        sd_fft_ctx_struct* Q = X->ffts + ioff;
-
-        if (nworkers > 0)
-        {
-            X->ioff = ioff; // read by extra_func on the worker thread
-            thread_pool_wake(global_thread_pool, handles[0], 0, extra_func, X);
-        }
-        else if (!X->squaring)
-        {
-            _mod(bbuf, X->btrunc, X->b, X->bn, Q, X->mod);
-            sd_fft_trunc(Q, bbuf, X->depth, X->btrunc, X->ztrunc);
-        }
-
-        _mod(abuf, X->atrunc, X->a, X->an, Q, X->mod);
-        sd_fft_trunc(Q, abuf, X->depth, X->atrunc, X->ztrunc);
-
-        if (nworkers > 0)
-            thread_pool_wait(global_thread_pool, handles[0]);
-
-        ulong cop = X->np == 1 ? 1 : *crt_data_co_prime_red(X->crts + X->np - 1, ioff);
-        NMOD_RED2(m, cop >> (FLINT_BITS - X->depth), cop << X->depth, Q->mod);
-        m = nmod_inv(m, Q->mod);
-
-        if (X->squaring)
-            sd_fft_ctx_point_sqr(Q, abuf, m, X->depth);
-        else
-            sd_fft_ctx_point_mul(Q, abuf, bbuf, m, X->depth);
-
-        sd_ifft_trunc(Q, abuf, X->depth, X->ztrunc);
+        _op_fft_worker_struct* W = args + i;
+        W->X = X;
+        W->a = a;
+        W->an = an;
+        W->itrunc = itrunc;
+        W->mod = mod;
+        W->P = P;
+        W->start_pi = (i+0)*P->np/nthreads;
+        W->stop_pi  = (i+1)*P->np/nthreads;
     }
 
+    for (i = nthreads - 1; i > 0; i--)
+        thread_pool_wake(global_thread_pool, handles[i - 1], 0,
+                         _op_fft_worker_func, args + i);
+    _op_fft_worker_func(args + 0);
+    for (i = nthreads - 1; i > 0; i--)
+        thread_pool_wait(global_thread_pool, handles[i - 1]);
+
     flint_give_back_threads(handles, nworkers);
+
+    X->itrunc = itrunc;
+    X->domain = FFT_SMALL_OP_PRIMAL;
 }
 
 typedef struct {
     ulong* z;
-    ulong zl;
+    const fft_small_op_struct* X;
+    nmod_t mod;
+    const fft_small_plan_struct* P;
+    fft_small_crt_func crt_fn;
     ulong start_zi;
     ulong stop_zi;
-    double* buf;
-    ulong offset;
-    ulong stride;
-    sd_fft_ctx_struct* ffts;
-    crt_data_struct* crts;
-    nmod_t mod;
-    ulong min_an_bn;  /* for precise output bounds */
-    void (*f)(
-        ulong* z, ulong zl, ulong zi_start, ulong zi_stop,
-        sd_fft_ctx_struct* Rffts, double* d, ulong dstride,
-        crt_data_struct* Rcrts, ulong min_an_bn,
-        nmod_t mod);  /* f = _crt_{np} for 1 <= np <= 4 */
-} s2worker_struct;
+} _op_export_worker_struct;
 
-/* Computes CRT for an output range, writing to `z[zi - zl]` for
-   `start_zi <= zi < stop_zi`.  */
-static void s2worker_func(void* varg)
+static void _op_export_worker_func(void* varg)
 {
-    s2worker_struct* X = (s2worker_struct*) varg;
+    _op_export_worker_struct* W = (_op_export_worker_struct*) varg;
+    const fft_small_plan_struct* P = W->P;
 
-    X->f(X->z, X->zl, X->start_zi, X->stop_zi, X->ffts + X->offset, X->buf,
-         X->stride, X->crts + X->offset, X->min_an_bn, X->mod);
+    W->crt_fn((void*) W->z, P->zl, W->start_zi, W->stop_zi,
+              P->ffts + P->offset, W->X->data, P->stride,
+              P->crts + P->offset, P->bound_c, NULL, &W->mod);
 }
 
-/* Return whether to compute the FFT directly modulo `mod`, rather than
-   modulo precomputed FFT primes followed by CRT reconstruction.
-   Direct computation requires `mod.n` to be prime and `mod.n - 1`
-   to have sufficiently high 2-valuation.
-   This is usually faster when CRT would need multiple primes, but it pays
-   the setup cost of initializing and clearing a temporary `sd_fft_ctx_t`.  */
-static int
-_nmod_poly_should_directly_fft(ulong bn, ulong depth, nmod_t mod)
+void fft_small_export_nmod(ulong* z, const fft_small_op_t X, nmod_t mod,
+                    const fft_small_plan_t P)
 {
-    if (bn < 1500)
-        return 0;
+    ulong i, o;
+    thread_pool_handle* handles = NULL;
+    slong nworkers = 0;
+    ulong nthreads;
+    _op_export_worker_struct args[8];
 
-    if (mod.n <= 2 || mod.n > (UWORD(1) << 50))
-        return 0;
+    /* the number of products accumulated onto one output coefficient is
+       bounded by the len_bound the plan was created with; thread over
+       BLK_SZ-aligned output ranges as the engine's stage 2 does, with
+       the same rethread heuristic */
+    if (P->np*(P->zh - P->zl) > 10000)
+        nworkers = flint_request_threads(&handles, 8);
+    nthreads = nworkers + 1;
 
-    if (NMOD_BITS(mod) < 20)
-        return 0;
+    o = P->zl;
+    for (i = 0; i < nthreads; i++)
+    {
+        _op_export_worker_struct* W = args + i;
+        W->z = z;
+        W->X = X;
+        W->mod = mod;
+        W->P = P;
+        W->crt_fn = _nmod_crt_fn(P->np);
+        W->start_zi = o;
+        ulong newo = n_round_down(P->zl + (i+1)*(P->zh - P->zl)/nthreads, BLK_SZ);
+        o = i+1 < nthreads ? FLINT_MAX(o, newo) : P->zh;
+        W->stop_zi = o;
+    }
 
-    if (!fft_small_mulmod_satisfies_bounds(mod.n))
-        /* should be implied by the 50-bit bound, but just in case */
-        return 0;
+    for (i = nworkers; i > 0; i--)
+        thread_pool_wake(global_thread_pool, handles[i - 1], 0,
+                         _op_export_worker_func, args + i);
+    _op_export_worker_func(args + 0);
+    for (i = nworkers; i > 0; i--)
+        thread_pool_wait(global_thread_pool, handles[i - 1]);
 
-    if (depth > SD_FFT_CTX_W2TAB_SIZE)
-        /* unlikely, the convolution length would have to be massive */
-        return 0;
-
-    if (n_trailing_zeros(mod.n - 1) < depth)
-        return 0;
-
-    return n_is_prime(mod.n); /* check the most expensive condition last */
+    flint_give_back_threads(handles, nworkers);
 }
+
 
 void _nmod_poly_mul_mid_mpn_ctx(
     ulong* z, ulong zl, ulong zh,
@@ -850,15 +853,11 @@ void _nmod_poly_mul_mid_mpn_ctx(
     mpn_ctx_t R)
 {
     ulong modbits = FLINT_BITS - mod.norm;
-    ulong offset = 0;
     ulong zn = an + bn - 1;
-    ulong atrunc, btrunc, ztrunc;
-    ulong i, np, depth, stride;
-    double* buf;
-    sd_fft_ctx_t direct_fft;  // initialized with mod.n in direct mode
-    int squaring;
-
-    direct_fft->w2tab[0] = NULL;  // use direct_fft branch iff this is not NULL
+    ulong atrunc, btrunc;
+    int squaring, success;
+    fft_small_plan_t P;
+    fft_small_conv_arg_struct A;
 
     FLINT_ASSERT(an > 0);
     FLINT_ASSERT(bn > 0);
@@ -878,154 +877,39 @@ void _nmod_poly_mul_mid_mpn_ctx(
         zh = zn;
     }
 
-    squaring = (a == b) && (an == bn);
-
     FLINT_ASSERT(zl < zh);
     FLINT_ASSERT(zh <= zn);
 
+    squaring = (a == b) && (an == bn);
+
     atrunc = n_round_up(an, BLK_SZ);
     btrunc = n_round_up(bn, BLK_SZ);
-    ztrunc = n_round_up(zn, BLK_SZ);
-    /*
-        if there is a power of two 2^d between zh and zn with good wrap around
-            i.e. max(an, bn, zh) <= 2^d <= zn with zn - 2^d <= zl
-        then use d as the depth, otherwise the usual with no wrap around
-    */
-    depth = n_flog2(zn);
-    i = n_pow2(depth);
-    if (atrunc <= i && btrunc <= i && zh <= i && i <= zn && zn <= zl + i)
-    {
-        ztrunc = i;
-    }
-    else
-    {
-        depth = n_max(LG_BLK_SZ, n_clog2(ztrunc));
-    }
 
-    /* first see if mod.n is one of R->ffts[i].mod.n */
-    if (modbits == 50)
-    {
-        for (i = 0; i < MPN_CTX_NCRTS; i++)
-        {
-            if (mod.n == R->ffts[i].mod.n)
-            {
-                offset = i;
-                np = 1;
-                goto got_np_and_offset;
-            }
-        }
-    }
+    /* at most min(an, bn) <= bn products, each < 2^(2*modbits), accumulate
+       onto one output coefficient */
+    success = fft_small_plan_init_nmod(P, R, zl, zh, zn,
+                        n_max(atrunc, btrunc), bn, 2*modbits, mod, bn);
+    FLINT_ASSERT(success);
+    (void) success;
 
-    if (_nmod_poly_should_directly_fft(bn, depth, mod))
-    {
-        sd_fft_ctx_init_prime(direct_fft, mod.n);
-        offset = 0;
-        np = 1;
-        goto got_np_and_offset;
-    }
+    A.a = a; A.an = an; A.aaux = 0; A.atrunc = atrunc;
+    A.b = b; A.bn = bn; A.baux = 0; A.btrunc = btrunc;
+    A.bfft = NULL;
+    A.bfft_stride = 0;
+    A.squaring = squaring;
+    A.tune_n = bn;
+    A.min_an_bn = FLINT_MIN(an, bn);
+    A.mod_fn = _mod_fn;
+    A.s2_finish = NULL;
+    A.crt_fn = _nmod_crt_fn(P->np);
+    A.params = &mod;
+    A.tuning = &_nmod_conv_tuning;
 
-    /* need prod_of_primes >= blen * 4^modbits */
-    for (np = 1; np < 4; np++)
-    {
-        if (flint_mpn_cmp_ui_2exp(crt_data_prod_primes(R->crts + np - 1),
-              R->crts[np - 1].coeff_len, bn, 2*modbits) >= 0)
-        {
-            break;
-        }
-    }
+    _fft_small_conv(z, P, &A);
 
-    FLINT_ASSERT(0 <= flint_mpn_cmp_ui_2exp(
-                                  crt_data_prod_primes(R->crts + np - 1),
-                                  R->crts[np - 1].coeff_len, bn, 2*modbits));
-
-
-got_np_and_offset:
-
-    stride = n_round_up(sd_fft_ctx_data_size(depth), 128);
-
-    ulong want_threads;
-
-    if (bn < 1500)
-        want_threads = 1;
-    else
-        want_threads = np;
-
-    thread_pool_handle* handles;
-    slong nworkers = flint_request_threads(&handles, want_threads);
-    ulong nthreads = nworkers + 1;
-
-    buf = (double*) mpn_ctx_fit_buffer(R, (np+nthreads)*stride*sizeof(double));
-
-    s1worker_struct s1args[4];
-    for (i = 0; i < nthreads; i++)
-    {
-        s1worker_struct* X = s1args + i;
-        X->np = np;
-        X->start_pi = (i+0)*np/nthreads;
-        X->stop_pi  = (i+1)*np/nthreads;
-        X->offset = offset;
-        X->abuf = buf;
-        X->bbuf = buf + (np+i)*stride;
-        X->depth = depth;
-        X->stride = stride;
-        X->atrunc = atrunc;
-        X->btrunc = btrunc;
-        X->ztrunc = ztrunc;
-        X->a = a;
-        X->an = an;
-        X->b = b;
-        X->bn = bn;
-        X->ffts = direct_fft->w2tab[0] != NULL ? direct_fft : R->ffts;
-        X->crts = R->crts;
-        X->mod = mod;
-        X->squaring = squaring;
-    }
-
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wake(global_thread_pool, handles[i - 1], 0, s1worker_func, s1args + i);
-    s1worker_func(s1args + 0);
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wait(global_thread_pool, handles[i - 1]);
-
-    if (np*zn > 10000)
-    {
-        flint_give_back_threads(handles, nworkers);
-        nworkers = flint_request_threads(&handles, 8);
-        nthreads = nworkers + 1;
-    }
-
-    s2worker_struct s2args[8];
-    ulong o = zl;
-    for (i = 0; i < nthreads; i++)
-    {
-        s2worker_struct* X = s2args + i;
-        X->z = z;
-        X->zl = zl;
-        X->start_zi = o;
-        ulong newo = n_round_down(zl + (i+1)*(zh-zl)/nthreads, BLK_SZ);
-        o = i+1 < nthreads ? FLINT_MAX(o, newo) : zh;
-        X->stop_zi = o;
-        X->buf = buf;
-        X->offset = offset;
-        X->stride = stride;
-        X->ffts = direct_fft->w2tab[0] != NULL ? direct_fft : R->ffts;
-        X->crts = R->crts;
-        X->mod = mod;
-        X->min_an_bn = FLINT_MIN(an, bn);
-        X->f = np == 1 ? _crt_1 : np == 2 ? _crt_2 : np == 3 ? _crt_3 : _crt_4;
-    }
-
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wake(global_thread_pool, handles[i - 1], 0, s2worker_func, s2args + i);
-    s2worker_func(s2args + 0);
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wait(global_thread_pool, handles[i - 1]);
-
-    flint_give_back_threads(handles, nworkers);
-
-    if (direct_fft->w2tab[0] != NULL)
-        sd_fft_ctx_clear(direct_fft);
+    fft_small_plan_clear(P);
 }
+
 
 #if 0
 static void _nmod_poly_mul_mod_xpnm1_naive(
@@ -1072,167 +956,39 @@ static void _nmod_poly_mul_mod_xpnm1(
 {
     ulong N = n_pow2(depth);
     ulong modbits = FLINT_BITS - mod.norm;
-    ulong offset = 0;
-    ulong i, np, stride;
-    double* buf;
+    fft_small_plan_t P;
+    fft_small_conv_arg_struct A;
+    int success;
 
     FLINT_ASSERT(an > 0);
     FLINT_ASSERT(bn > 0);
     FLINT_ASSERT(ztrunc <= N);
 
-    /* first see if mod.n is one of R->ffts[i].mod.n */
-    if (modbits == 50)
-    {
-        for (i = 0; i < MPN_CTX_NCRTS; i++)
-        {
-            if (mod.n == R->ffts[i].mod.n)
-            {
-                offset = i;
-                np = 1;
-                goto got_np_and_offset;
-            }
-        }
-    }
+    /* a cyclic convolution accumulates up to N products onto one output
+       coefficient */
+    success = fft_small_plan_init_nmod_cyclic(P, R, depth, ztrunc, N,
+                                              2*modbits, mod);
+    FLINT_ASSERT(success);
+    (void) success;
 
-    /* need prod_of_primes >= N * 4^modbits */
-    for (np = 1; np < 4; np++)
-    {
-        if (flint_mpn_cmp_ui_2exp(crt_data_prod_primes(R->crts + np - 1),
-              R->crts[np - 1].coeff_len, N, 2*modbits) >= 0)
-        {
-            break;
-        }
-    }
+    A.a = a; A.an = an; A.aaux = 0; A.atrunc = N;
+    A.b = b; A.bn = bn; A.baux = 0; A.btrunc = N;
+    A.bfft = NULL;
+    A.bfft_stride = 0;
+    A.squaring = 0;
+    A.tune_n = bn;
+    A.min_an_bn = FLINT_MIN(an, bn);
+    A.mod_fn = _mod_fn;
+    A.s2_finish = NULL;
+    A.crt_fn = _nmod_crt_fn(P->np);
+    A.params = &mod;
+    A.tuning = &_nmod_conv_tuning_no_rethread;
 
-    FLINT_ASSERT(0 <= flint_mpn_cmp_ui_2exp(
-                                  crt_data_prod_primes(R->crts + np - 1),
-                                  R->crts[np - 1].coeff_len, N, 2*modbits));
+    _fft_small_conv(z, P, &A);
 
-
-got_np_and_offset:
-
-    stride = n_round_up(sd_fft_ctx_data_size(depth), 128);
-
-    ulong want_threads;
-
-    if (bn < 1500)
-        want_threads = 1;
-    else
-        want_threads = np;
-
-    thread_pool_handle* handles;
-    slong nworkers = flint_request_threads(&handles, want_threads);
-    ulong nthreads = nworkers + 1;
-
-    buf = (double*) mpn_ctx_fit_buffer(R, (np+nthreads)*stride*sizeof(double));
-
-    s1worker_struct s1args[4];
-    for (i = 0; i < nthreads; i++)
-    {
-        s1worker_struct* X = s1args + i;
-        X->np = np;
-        X->start_pi = (i+0)*np/nthreads;
-        X->stop_pi  = (i+1)*np/nthreads;
-        X->offset = offset;
-        X->abuf = buf;
-        X->bbuf = buf + (np+i)*stride;
-        X->depth = depth;
-        X->stride = stride;
-        X->atrunc = N;
-        X->btrunc = N;
-        X->ztrunc = N;
-        X->a = a;
-        X->an = an;
-        X->b = b;
-        X->bn = bn;
-        X->ffts = R->ffts;
-        X->crts = R->crts;
-        X->mod = mod;
-        X->squaring = 0;
-    }
-
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wake(global_thread_pool, handles[i - 1], 0, s1worker_func, s1args + i);
-    s1worker_func(s1args + 0);
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wait(global_thread_pool, handles[i - 1]);
-
-    s2worker_struct s2args[8];
-    ulong zl = 0;
-    ulong zh = ztrunc;
-    ulong o = zl;
-    for (i = 0; i < nthreads; i++)
-    {
-        s2worker_struct* X = s2args + i;
-        X->z = z;
-        X->zl = zl;
-        X->start_zi = o;
-        ulong newo = n_round_down(zl + (i+1)*(zh-zl)/nthreads, BLK_SZ);
-        o = i+1 < nthreads ? FLINT_MAX(o, newo) : zh;
-        X->stop_zi = o;
-        X->buf = buf;
-        X->offset = offset;
-        X->stride = stride;
-        X->ffts = R->ffts;
-        X->crts = R->crts;
-        X->mod = mod;
-        X->min_an_bn = FLINT_MIN(an, bn);
-        X->f = np == 1 ? _crt_1 : np == 2 ? _crt_2 : np == 3 ? _crt_3 : _crt_4;
-    }
-
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wake(global_thread_pool, handles[i - 1], 0, s2worker_func, s2args + i);
-    s2worker_func(s2args + 0);
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wait(global_thread_pool, handles[i - 1]);
-
-    flint_give_back_threads(handles, nworkers);
+    fft_small_plan_clear(P);
 }
 
-
-typedef struct {
-    ulong np;
-    ulong start_pi;
-    ulong stop_pi;
-    ulong offset;
-    double* abuf;
-    double* bbuf;
-    ulong depth;
-    ulong stride;
-    ulong atrunc;
-    ulong ztrunc;
-    const ulong* a;
-    ulong an;
-    sd_fft_ctx_struct* ffts;
-    crt_data_struct* crts;
-    nmod_t mod;
-} s1pworker_struct;
-
-/* similar to `s1worker_func`, but assume `bbuf` is already FFT-transformed.
-   If `flint_request_threads` returns the requested number of threads,
-   then each `s1pworker_func` processes exactly one prime.  */
-static void s1pworker_func(void* varg)
-{
-    s1pworker_struct* X = (s1pworker_struct*) varg;
-    ulong i, m;
-
-    for (i = X->start_pi; i < X->stop_pi; i++)
-    {
-        ulong ioff = i + X->offset;
-        double* abuf = X->abuf + X->stride*i;
-        sd_fft_ctx_struct* Q = X->ffts + ioff;
-
-        _mod(abuf, X->atrunc, X->a, X->an, Q, X->mod);
-        sd_fft_trunc(Q, abuf, X->depth, X->atrunc, X->ztrunc);
-
-        ulong cop = X->np == 1 ? 1 : *crt_data_co_prime_red(X->crts + X->np - 1, ioff);
-        NMOD_RED2(m, cop >> (FLINT_BITS - X->depth), cop << X->depth, Q->mod);
-        m = nmod_inv(m, Q->mod);
-        sd_fft_ctx_point_mul(Q, abuf, X->bbuf + X->stride*i, m, X->depth);
-
-        sd_ifft_trunc(Q, abuf, X->depth, X->ztrunc);
-    }
-}
 
 void _mul_precomp_init(
     mul_precomp_struct* M,
@@ -1241,65 +997,24 @@ void _mul_precomp_init(
     nmod_t mod,
     mpn_ctx_t R)
 {
-    ulong N = n_pow2(depth);
     ulong modbits = FLINT_BITS - mod.norm;
-    ulong offset = 0;
-    ulong i, np, stride;
+    ulong N = n_pow2(depth);
+    int success;
 
     btrunc = n_round_up(btrunc, BLK_SZ);
 
-    FLINT_ASSERT(bn > 0);
+    /* the transform may be used for cyclic convolutions, which accumulate
+       up to N products onto one output coefficient */
+    success = fft_small_plan_init_nmod_cyclic(M->P, R, depth, N, N,
+                                              2*modbits, mod);
+    FLINT_ASSERT(success);
+    (void) success;
 
-    /* first see if mod.n is one of R->ffts[i].mod.n */
-    if (modbits == 50)
-    {
-        for (i = 0; i < MPN_CTX_NCRTS; i++)
-        {
-            if (mod.n == R->ffts[i].mod.n)
-            {
-                offset = i;
-                np = 1;
-                goto got_np_and_offset;
-            }
-        }
-    }
-
-    /* need prod_of_primes >= N * 4^modbits */
-    for (np = 1; np < 4; np++)
-    {
-        if (flint_mpn_cmp_ui_2exp(crt_data_prod_primes(R->crts + np - 1),
-              R->crts[np - 1].coeff_len, N, 2*modbits) >= 0)
-        {
-            break;
-        }
-    }
-
-    FLINT_ASSERT(0 <= flint_mpn_cmp_ui_2exp(
-                                  crt_data_prod_primes(R->crts + np - 1),
-                                  R->crts[np - 1].coeff_len, N, 2*modbits));
-
-got_np_and_offset:
-
-    stride = n_round_up(sd_fft_ctx_data_size(depth), 128);
-
-    M->depth = depth;
-    M->N = N;
-    M->offset = offset;
-    M->np = np;
-    M->stride = stride;
     M->bn = bn;
     M->btrunc = btrunc;
-    M->bbuf = flint_aligned_alloc(4096, n_round_up(np*stride*sizeof(double), 4096));
 
-    for (i = 0; i < np; i++)
-    {
-        ulong ioff = i + offset;
-        double* bbuf = M->bbuf + stride*i;
-        sd_fft_ctx_struct* Q = R->ffts + ioff;
-
-        _mod(bbuf, N, b, bn, Q, mod);
-        sd_fft_trunc(Q, bbuf, depth, N, N);
-    }
+    fft_small_op_init(M->bfft, M->P);
+    fft_small_fft_nmod(M->bfft, b, bn, N, mod, M->P);
 }
 
 
@@ -1312,15 +1027,13 @@ int _nmod_poly_mul_mid_precomp(
 {
     ulong bn = M->bn;
     ulong zn = an + bn - 1;
-    ulong atrunc, ztrunc;
-    ulong depth = M->depth;
-    ulong N = n_pow2(depth);
-    ulong i, np = M->np;
-    double* buf;
+    ulong atrunc;
+    fft_small_conv_arg_struct A;
 
     FLINT_ASSERT(an > 0);
     FLINT_ASSERT(bn > 0);
-    FLINT_ASSERT(M->btrunc <= N);
+    FLINT_ASSERT(M->btrunc <= n_pow2(M->P->depth));
+    FLINT_ASSERT(R == M->P->R);
 
     if (zl >= zh)
         return 1;
@@ -1341,91 +1054,30 @@ int _nmod_poly_mul_mid_precomp(
     FLINT_ASSERT(zh <= zn);
 
     atrunc = n_round_up(an, BLK_SZ);
-    ztrunc = n_round_up(zn, BLK_SZ);
 
-    if (atrunc <= N && zh <= N && N <= zn && zn <= zl + N)
-    {
-        ztrunc = N;
-    }
-    else if (ztrunc <= N)
-    {
-    }
-    else
-    {
+    /* note: adjusting the window in M means concurrent calls on the same M
+       race, but they already race on the scratch buffer in R */
+    if (!_fft_small_plan_fit_window(M->P, zl, zh, zn, atrunc))
         return 0;
-    }
 
-    ulong want_threads;
+    A.a = a; A.an = an; A.aaux = 0; A.atrunc = atrunc;
+    A.b = NULL; A.bn = bn; A.baux = 0; A.btrunc = 0;
+    A.bfft = M->bfft->data;
+    A.bfft_stride = M->bfft->stride;
+    A.squaring = 0;
+    A.tune_n = bn;
+    A.min_an_bn = FLINT_MIN(an, bn);
+    A.mod_fn = _mod_fn;
+    A.s2_finish = NULL;
+    A.crt_fn = _nmod_crt_fn(M->P->np);
+    A.params = &mod;
+    A.tuning = &_nmod_conv_tuning_no_rethread;
 
-    /* todo: even with np == 1, we may want threads for the conversion to fft */
-    if (bn < 1500)
-        want_threads = 1;
-    else
-        want_threads = np;
+    _fft_small_conv(z, M->P, &A);
 
-    thread_pool_handle* handles;
-    slong nworkers = flint_request_threads(&handles, want_threads);
-    ulong nthreads = nworkers + 1;
-
-    buf = (double*) mpn_ctx_fit_buffer(R, np*M->stride*sizeof(double));
-
-    s1pworker_struct s1pargs[4];
-    for (i = 0; i < nthreads; i++)
-    {
-        s1pworker_struct* X = s1pargs + i;
-        X->np = np;
-        X->start_pi = (i+0)*np/nthreads;
-        X->stop_pi  = (i+1)*np/nthreads;
-        X->offset = M->offset;
-        X->abuf = buf;
-        X->bbuf = M->bbuf;
-        X->depth = depth;
-        X->stride = M->stride;
-        X->atrunc = atrunc;
-        X->ztrunc = ztrunc;
-        X->a = a;
-        X->an = an;
-        X->ffts = R->ffts;
-        X->crts = R->crts;
-        X->mod = mod;
-    }
-
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wake(global_thread_pool, handles[i - 1], 0, s1pworker_func, s1pargs + i);
-    s1pworker_func(s1pargs + 0);
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wait(global_thread_pool, handles[i - 1]);
-
-    s2worker_struct s2args[8];
-    ulong o = zl;
-    for (i = 0; i < nthreads; i++)
-    {
-        s2worker_struct* X = s2args + i;
-        X->z = z;
-        X->zl = zl;
-        X->start_zi = o;
-        ulong newo = n_round_down(zl + (i+1)*(zh-zl)/nthreads, BLK_SZ);
-        o = i+1 < nthreads ? FLINT_MAX(o, newo) : zh;
-        X->stop_zi = o;
-        X->buf = buf;
-        X->offset = M->offset;
-        X->stride = M->stride;
-        X->ffts = R->ffts;
-        X->crts = R->crts;
-        X->mod = mod;
-        X->min_an_bn = FLINT_MIN(an, bn);
-        X->f = np == 1 ? _crt_1 : np == 2 ? _crt_2 : np == 3 ? _crt_3 : _crt_4;
-    }
-
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wake(global_thread_pool, handles[i - 1], 0, s2worker_func, s2args + i);
-    s2worker_func(s2args + 0);
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wait(global_thread_pool, handles[i - 1]);
-
-    flint_give_back_threads(handles, nworkers);
     return 1;
 }
+
 
 static void _nmod_poly_mul_mod_xpnm1_precomp(
     ulong* z, ulong ztrunc,
@@ -1434,84 +1086,36 @@ static void _nmod_poly_mul_mod_xpnm1_precomp(
     nmod_t mod,
     mpn_ctx_t R)
 {
-    ulong depth = M->depth;
-    ulong i, np = M->np;
-    double* buf;
+    fft_small_conv_arg_struct A;
 
     FLINT_ASSERT(an > 0);
+    FLINT_ASSERT(R == M->P->R);
+    FLINT_ASSERT(ztrunc <= M->btrunc);
 
-    ulong want_threads;
+    /* output window [0, ztrunc) of a cyclic convolution, with the ffts
+       truncated at M->btrunc as the precomputed transform was */
+    M->P->zl = 0;
+    M->P->zh = ztrunc;
+    M->P->zn = n_pow2(M->P->depth);
+    M->P->ztrunc = M->btrunc;
 
-    if (an < 1500)
-        want_threads = 1;
-    else
-        want_threads = np;
+    A.a = a; A.an = an; A.aaux = 0; A.atrunc = M->btrunc;
+    A.b = NULL; A.bn = 0; A.baux = 0; A.btrunc = 0;
+    A.bfft = M->bfft->data;
+    A.bfft_stride = M->bfft->stride;
+    A.squaring = 0;
+    A.tune_n = an;
+    A.min_an_bn = an;  /* Todo: we might want to store bn and min by this here,
+                          in case this is much smaller than an. */
+    A.mod_fn = _mod_fn;
+    A.s2_finish = NULL;
+    A.crt_fn = _nmod_crt_fn(M->P->np);
+    A.params = &mod;
+    A.tuning = &_nmod_conv_tuning_no_rethread;
 
-    thread_pool_handle* handles;
-    slong nworkers = flint_request_threads(&handles, want_threads);
-    ulong nthreads = nworkers + 1;
-
-    buf = (double*) mpn_ctx_fit_buffer(R, np*M->stride*sizeof(double));
-
-    s1pworker_struct s1pargs[4];
-    for (i = 0; i < nthreads; i++)
-    {
-        s1pworker_struct* X = s1pargs + i;
-        X->np = np;
-        X->start_pi = (i+0)*np/nthreads;
-        X->stop_pi  = (i+1)*np/nthreads;
-        X->offset = M->offset;
-        X->abuf = buf;
-        X->bbuf = M->bbuf;
-        X->depth = depth;
-        X->stride = M->stride;
-        X->atrunc = M->btrunc;
-        X->ztrunc = M->btrunc;
-        X->a = a;
-        X->an = an;
-        X->ffts = R->ffts;
-        X->crts = R->crts;
-        X->mod = mod;
-    }
-
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wake(global_thread_pool, handles[i - 1], 0, s1pworker_func, s1pargs + i);
-    s1pworker_func(s1pargs + 0);
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wait(global_thread_pool, handles[i - 1]);
-
-    s2worker_struct s2args[8];
-    ulong zl = 0;
-    ulong zh = ztrunc;
-    ulong o = zl;
-    for (i = 0; i < nthreads; i++)
-    {
-        s2worker_struct* X = s2args + i;
-        X->z = z;
-        X->zl = zl;
-        X->start_zi = o;
-        ulong newo = n_round_down(zl + (i+1)*(zh-zl)/nthreads, BLK_SZ);
-        o = i+1 < nthreads ? FLINT_MAX(o, newo) : zh;
-        X->stop_zi = o;
-        X->buf = buf;
-        X->offset = M->offset;
-        X->stride = M->stride;
-        X->ffts = R->ffts;
-        X->crts = R->crts;
-        X->mod = mod;
-        X->min_an_bn = an;  /* Todo: we might want to store bn and min by this here,
-                               in case this is much smaller than an. */
-        X->f = np == 1 ? _crt_1 : np == 2 ? _crt_2 : np == 3 ? _crt_3 : _crt_4;
-    }
-
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wake(global_thread_pool, handles[i - 1], 0, s2worker_func, s2args + i);
-    s2worker_func(s2args + 0);
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wait(global_thread_pool, handles[i - 1]);
-
-    flint_give_back_threads(handles, nworkers);
+    _fft_small_conv(z, M->P, &A);
 }
+
 
 
 /* z -= a mod x^N-1, write coeffs [0,ztrunc) */
@@ -1645,7 +1249,7 @@ int _nmod_poly_divrem_precomp(
     if (!_nmod_poly_mul_mid_precomp(q, Bn-1, Bn-1+qn, a+an-qn, qn, M->quo_maker, mod, R))
         return 0;
     _nmod_poly_mul_mod_xpnm1_precomp(r, bn-1, q, qn, M->rem_maker, mod, R);
-    _nmod_poly_sub_mod_xpNm1(r, bn-1, a, an, M->rem_maker->N, mod);
+    _nmod_poly_sub_mod_xpNm1(r, bn-1, a, an, n_pow2(M->rem_maker->P->depth), mod);
     return 1;
 }
 

--- a/src/fft_small/nmod_poly_mul.c
+++ b/src/fft_small/nmod_poly_mul.c
@@ -962,7 +962,7 @@ static void _nmod_poly_mul_mod_xpnm1_naive(
     const ulong* b, ulong bn,
     ulong lgN,
     nmod_t mod,
-    mpn_ctx_t FLINT_UNUSED(R))
+    mpn_ctx_t R)
 {
     ulong N = n_pow2(lgN);
     FLINT_ASSERT(zn <= N);
@@ -1067,7 +1067,7 @@ int _nmod_poly_mul_mid_precomp(
     const ulong* a, ulong an,
     mul_precomp_struct* M,
     nmod_t mod,
-    mpn_ctx_t R)
+    mpn_ctx_t FLINT_UNUSED(R))
 {
     ulong bn = M->bn;
     ulong zn = an + bn - 1;
@@ -1128,7 +1128,7 @@ static void _nmod_poly_mul_mod_xpnm1_precomp(
     const ulong* a, ulong an,
     mul_precomp_struct* M,
     nmod_t mod,
-    mpn_ctx_t R)
+    mpn_ctx_t FLINT_UNUSED(R))
 {
     fft_small_conv_arg_struct A;
 

--- a/src/fft_small/nmod_poly_mul.c
+++ b/src/fft_small/nmod_poly_mul.c
@@ -802,6 +802,49 @@ static void _op_export_worker_func(void* varg)
               P->crts + P->offset, P->bound_c, NULL, &W->mod);
 }
 
+void fft_small_export_nmod_range(ulong* z, const fft_small_op_t X,
+                    ulong zl, ulong zh, nmod_t mod, const fft_small_plan_t P)
+{
+    ulong i, o;
+    thread_pool_handle* handles = NULL;
+    slong nworkers = 0;
+    ulong nthreads;
+    _op_export_worker_struct args[8];
+
+    FLINT_ASSERT(P->zl <= zl && zh <= P->zh);
+
+    if (zl >= zh)
+        return;
+
+    if (P->np*(zh - zl) > 10000)
+        nworkers = flint_request_threads(&handles, 8);
+    nthreads = nworkers + 1;
+
+    o = zl;
+    for (i = 0; i < nthreads; i++)
+    {
+        _op_export_worker_struct* W = args + i;
+        W->z = z - (zl - P->zl);   /* worker offsets by P->zl */
+        W->X = X;
+        W->mod = mod;
+        W->P = P;
+        W->crt_fn = _nmod_crt_fn(P->np);
+        W->start_zi = o;
+        ulong newo = n_round_down(zl + (i+1)*(zh - zl)/nthreads, BLK_SZ);
+        o = i+1 < nthreads ? FLINT_MAX(o, newo) : zh;
+        W->stop_zi = o;
+    }
+
+    for (i = nworkers; i > 0; i--)
+        thread_pool_wake(global_thread_pool, handles[i - 1], 0,
+                         _op_export_worker_func, args + i);
+    _op_export_worker_func(args + 0);
+    for (i = nworkers; i > 0; i--)
+        thread_pool_wait(global_thread_pool, handles[i - 1]);
+
+    flint_give_back_threads(handles, nworkers);
+}
+
 void fft_small_export_nmod(ulong* z, const fft_small_op_t X, nmod_t mod,
                     const fft_small_plan_t P)
 {

--- a/src/fft_small/nmod_poly_mul.c
+++ b/src/fft_small/nmod_poly_mul.c
@@ -547,6 +547,7 @@ static void _crt_3(
     /* Bound coefficients before modular reduction. */
     umul_ppmm(hi, lo, mod.n - 1, mod.n - 1);
     FLINT_MPN_MUL_2X1(u2, u1, u0, hi, lo, min_an_bn);
+    (void) u0;
     two_limbs = (u2 == 0);
 
     /* For moduli close to 2^63, we can avoid the high word reduction

--- a/src/fft_small/op.c
+++ b/src/fft_small/op.c
@@ -14,12 +14,6 @@
 #include "fft_small.h"
 #include "machine_vectors.h"
 
-#if FLINT_BITS == 64
-ulong flint_fft_small_max_transformed_ring_size = UWORD(4) << 30;
-#else
-ulong flint_fft_small_max_transformed_ring_size = UWORD(1) << 30;
-#endif
-
 void fft_small_op_init(fft_small_op_t X, const fft_small_plan_t P)
 {
     X->stride = P->stride;

--- a/src/fft_small/op.c
+++ b/src/fft_small/op.c
@@ -73,9 +73,14 @@ FLINT_FORCE_INLINE int _op_compatible(const fft_small_op_struct* X,
     further pointwise operations and to sd_ifft_trunc.
 */
 
-/* z = a*b*m */
-static void _point_mul(const sd_fft_ctx_struct* Q,
-    double* z, const double* a, const double* b, ulong m_, ulong depth)
+/* z = a*b*m; the containment step (see the range comment above) is a
+   mulmod by the reduced m, or a plain reduction when the normalizer is
+   deferred (m == 1). The worker takes the choice as a constant so every
+   optimization level emits branch-free loops -- GCC only unswitches
+   such loops at -O3, and only for some of these kernels. */
+FLINT_FORCE_INLINE void _point_mul_impl(const sd_fft_ctx_struct* Q,
+    double* z, const double* a, const double* b, ulong m_, ulong depth,
+    int m_is_one)
 {
     vec8d m = vec8d_set_d(vec1d_reduce_0n_to_pmhn((slong)m_, Q->p));
     vec8d n    = vec8d_set_d(Q->p);
@@ -92,8 +97,16 @@ static void _point_mul(const sd_fft_ctx_struct* Q,
             x1 = vec8d_load(ax+j+8);
             b0 = vec8d_load(bx+j+0);
             b1 = vec8d_load(bx+j+8);
-            x0 = vec8d_mulmod(x0, m, n, ninv);
-            x1 = vec8d_mulmod(x1, m, n, ninv);
+            if (m_is_one)
+            {
+                x0 = vec8d_reduce_to_pm1n(x0, n, ninv);
+                x1 = vec8d_reduce_to_pm1n(x1, n, ninv);
+            }
+            else
+            {
+                x0 = vec8d_mulmod(x0, m, n, ninv);
+                x1 = vec8d_mulmod(x1, m, n, ninv);
+            }
             x0 = vec8d_mulmod(x0, b0, n, ninv);
             x1 = vec8d_mulmod(x1, b1, n, ninv);
             vec8d_store(zx+j+0, x0);
@@ -102,9 +115,20 @@ static void _point_mul(const sd_fft_ctx_struct* Q,
     }
 }
 
-/* z = a*a*m */
-static void _point_sqr(const sd_fft_ctx_struct* Q,
-    double* z, const double* a, ulong m_, ulong depth)
+static void _point_mul(const sd_fft_ctx_struct* Q,
+    double* z, const double* a, const double* b, ulong m_, ulong depth)
+{
+    if (m_ == 1)
+        _point_mul_impl(Q, z, a, b, m_, depth, 1);
+    else
+        _point_mul_impl(Q, z, a, b, m_, depth, 0);
+}
+
+/* z = a*a*m; by-m-first (or reduce-first with the normalizer deferred)
+   exactly as _point_mul, for the same range containment; constant
+   specialization for the same branch-free loops. */
+FLINT_FORCE_INLINE void _point_sqr_impl(const sd_fft_ctx_struct* Q,
+    double* z, const double* a, ulong m_, ulong depth, int m_is_one)
 {
     vec8d m = vec8d_set_d(vec1d_reduce_0n_to_pmhn((slong)m_, Q->p));
     vec8d n    = vec8d_set_d(Q->p);
@@ -115,15 +139,19 @@ static void _point_sqr(const sd_fft_ctx_struct* Q,
         double* zx = z + sd_fft_ctx_blk_offset(I);
         const double* ax = a + sd_fft_ctx_blk_offset(I);
         ulong j = 0; do {
-            vec8d x0, x1;
+            vec8d x0, x1, t0, t1;
             x0 = vec8d_load(ax+j+0);
             x1 = vec8d_load(ax+j+8);
-            vec8d t0, t1;
-            /* by m first, exactly as _point_mul: squaring two raw
-               transform entries (each in (-4n, 4n)) first would exceed
-               the chained mulmod input bound */
-            t0 = vec8d_mulmod(x0, m, n, ninv);
-            t1 = vec8d_mulmod(x1, m, n, ninv);
+            if (m_is_one)
+            {
+                t0 = vec8d_reduce_to_pm1n(x0, n, ninv);
+                t1 = vec8d_reduce_to_pm1n(x1, n, ninv);
+            }
+            else
+            {
+                t0 = vec8d_mulmod(x0, m, n, ninv);
+                t1 = vec8d_mulmod(x1, m, n, ninv);
+            }
             x0 = vec8d_mulmod(t0, x0, n, ninv);
             x1 = vec8d_mulmod(t1, x1, n, ninv);
             vec8d_store(zx+j+0, x0);
@@ -132,10 +160,19 @@ static void _point_sqr(const sd_fft_ctx_struct* Q,
     }
 }
 
+static void _point_sqr(const sd_fft_ctx_struct* Q,
+    double* z, const double* a, ulong m_, ulong depth)
+{
+    if (m_ == 1)
+        _point_sqr_impl(Q, z, a, m_, depth, 1);
+    else
+        _point_sqr_impl(Q, z, a, m_, depth, 0);
+}
+
 /* z = z +/- a*b*m */
-static void _point_addmul(const sd_fft_ctx_struct* Q,
+FLINT_FORCE_INLINE void _point_addmul_impl(const sd_fft_ctx_struct* Q,
     double* z, const double* a, const double* b, ulong m_, int subtract,
-    ulong depth)
+    ulong depth, int m_is_one)
 {
     vec8d m = vec8d_set_d(vec1d_reduce_0n_to_pmhn((slong)m_, Q->p));
     vec8d n    = vec8d_set_d(Q->p);
@@ -154,8 +191,16 @@ static void _point_addmul(const sd_fft_ctx_struct* Q,
             b1 = vec8d_load(bx+j+8);
             z0 = vec8d_load(zx+j+0);
             z1 = vec8d_load(zx+j+8);
-            x0 = vec8d_mulmod(x0, m, n, ninv);
-            x1 = vec8d_mulmod(x1, m, n, ninv);
+            if (m_is_one)
+            {
+                x0 = vec8d_reduce_to_pm1n(x0, n, ninv);
+                x1 = vec8d_reduce_to_pm1n(x1, n, ninv);
+            }
+            else
+            {
+                x0 = vec8d_mulmod(x0, m, n, ninv);
+                x1 = vec8d_mulmod(x1, m, n, ninv);
+            }
             x0 = vec8d_mulmod(x0, b0, n, ninv);
             x1 = vec8d_mulmod(x1, b1, n, ninv);
             if (subtract)
@@ -174,6 +219,16 @@ static void _point_addmul(const sd_fft_ctx_struct* Q,
             vec8d_store(zx+j+8, z1);
         } while (j += 16, j < BLK_SZ);
     }
+}
+
+static void _point_addmul(const sd_fft_ctx_struct* Q,
+    double* z, const double* a, const double* b, ulong m_, int subtract,
+    ulong depth)
+{
+    if (m_ == 1)
+        _point_addmul_impl(Q, z, a, b, m_, subtract, depth, 1);
+    else
+        _point_addmul_impl(Q, z, a, b, m_, subtract, depth, 0);
 }
 
 /* z = a +/- b, or z = -a for b == NULL */

--- a/src/fft_small/op.c
+++ b/src/fft_small/op.c
@@ -1,0 +1,358 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "thread_pool.h"
+#include "thread_support.h"
+#include "fft_small.h"
+#include "machine_vectors.h"
+
+void fft_small_op_init(fft_small_op_t X, const fft_small_plan_t P)
+{
+    X->stride = P->stride;
+    X->np = P->np;
+    X->offset = P->offset;
+    X->depth = P->depth;
+    X->itrunc = 0;
+    X->domain = FFT_SMALL_OP_PRIMAL;
+    X->owns_data = 1;
+    X->data = flint_aligned_alloc(4096,
+                 n_round_up(P->np*P->stride*sizeof(double), 4096));
+}
+
+void fft_small_op_clear(fft_small_op_t X)
+{
+    if (X->owns_data)
+        flint_aligned_free(X->data);
+}
+
+FLINT_FORCE_INLINE int _op_compatible(const fft_small_op_struct* X,
+                                      const fft_small_plan_struct* P)
+{
+    return X->np == P->np && X->offset == P->offset &&
+           X->depth == P->depth && X->stride == P->stride;
+}
+
+/*
+    Pointwise kernels. Forward transforms leave entries in (-4n, 4n) and
+    sd_ifft_trunc accepts entries in that range; sd_fft_ctx_point_mul
+    keeps its two chained mulmods within the (-4n^2, 4n^2) input bound by
+    first multiplying by m reduced to (-n/2, n/2], producing entries in
+    (-3n/2, 3n/2) (see the range documentation of mulmod in
+    machine_vectors.h). The kernels below do the same, and after additive
+    steps reduce back into [-n, n] with reduce_to_pm1n, so that the result
+    of any sequence of pointwise operations stays a valid input both to
+    further pointwise operations and to sd_ifft_trunc.
+*/
+
+/* z = a*b*m */
+static void _point_mul(const sd_fft_ctx_struct* Q,
+    double* z, const double* a, const double* b, ulong m_, ulong depth)
+{
+    vec8d m = vec8d_set_d(vec1d_reduce_0n_to_pmhn((slong)m_, Q->p));
+    vec8d n    = vec8d_set_d(Q->p);
+    vec8d ninv = vec8d_set_d(Q->pinv);
+    FLINT_ASSERT(depth >= LG_BLK_SZ);
+    for (ulong I = 0; I < n_pow2(depth - LG_BLK_SZ); I++)
+    {
+        double* zx = z + sd_fft_ctx_blk_offset(I);
+        const double* ax = a + sd_fft_ctx_blk_offset(I);
+        const double* bx = b + sd_fft_ctx_blk_offset(I);
+        ulong j = 0; do {
+            vec8d x0, x1, b0, b1;
+            x0 = vec8d_load(ax+j+0);
+            x1 = vec8d_load(ax+j+8);
+            b0 = vec8d_load(bx+j+0);
+            b1 = vec8d_load(bx+j+8);
+            x0 = vec8d_mulmod(x0, m, n, ninv);
+            x1 = vec8d_mulmod(x1, m, n, ninv);
+            x0 = vec8d_mulmod(x0, b0, n, ninv);
+            x1 = vec8d_mulmod(x1, b1, n, ninv);
+            vec8d_store(zx+j+0, x0);
+            vec8d_store(zx+j+8, x1);
+        } while (j += 16, j < BLK_SZ);
+    }
+}
+
+/* z = a*a*m */
+static void _point_sqr(const sd_fft_ctx_struct* Q,
+    double* z, const double* a, ulong m_, ulong depth)
+{
+    vec8d m = vec8d_set_d(vec1d_reduce_0n_to_pmhn((slong)m_, Q->p));
+    vec8d n    = vec8d_set_d(Q->p);
+    vec8d ninv = vec8d_set_d(Q->pinv);
+    FLINT_ASSERT(depth >= LG_BLK_SZ);
+    for (ulong I = 0; I < n_pow2(depth - LG_BLK_SZ); I++)
+    {
+        double* zx = z + sd_fft_ctx_blk_offset(I);
+        const double* ax = a + sd_fft_ctx_blk_offset(I);
+        ulong j = 0; do {
+            vec8d x0, x1;
+            x0 = vec8d_load(ax+j+0);
+            x1 = vec8d_load(ax+j+8);
+            x0 = vec8d_mulmod(x0, x0, n, ninv);
+            x1 = vec8d_mulmod(x1, x1, n, ninv);
+            x0 = vec8d_mulmod(x0, m, n, ninv);
+            x1 = vec8d_mulmod(x1, m, n, ninv);
+            vec8d_store(zx+j+0, x0);
+            vec8d_store(zx+j+8, x1);
+        } while (j += 16, j < BLK_SZ);
+    }
+}
+
+/* z = z +/- a*b*m */
+static void _point_addmul(const sd_fft_ctx_struct* Q,
+    double* z, const double* a, const double* b, ulong m_, int subtract,
+    ulong depth)
+{
+    vec8d m = vec8d_set_d(vec1d_reduce_0n_to_pmhn((slong)m_, Q->p));
+    vec8d n    = vec8d_set_d(Q->p);
+    vec8d ninv = vec8d_set_d(Q->pinv);
+    FLINT_ASSERT(depth >= LG_BLK_SZ);
+    for (ulong I = 0; I < n_pow2(depth - LG_BLK_SZ); I++)
+    {
+        double* zx = z + sd_fft_ctx_blk_offset(I);
+        const double* ax = a + sd_fft_ctx_blk_offset(I);
+        const double* bx = b + sd_fft_ctx_blk_offset(I);
+        ulong j = 0; do {
+            vec8d x0, x1, b0, b1, z0, z1;
+            x0 = vec8d_load(ax+j+0);
+            x1 = vec8d_load(ax+j+8);
+            b0 = vec8d_load(bx+j+0);
+            b1 = vec8d_load(bx+j+8);
+            z0 = vec8d_load(zx+j+0);
+            z1 = vec8d_load(zx+j+8);
+            x0 = vec8d_mulmod(x0, m, n, ninv);
+            x1 = vec8d_mulmod(x1, m, n, ninv);
+            x0 = vec8d_mulmod(x0, b0, n, ninv);
+            x1 = vec8d_mulmod(x1, b1, n, ninv);
+            if (subtract)
+            {
+                z0 = vec8d_sub(z0, x0);
+                z1 = vec8d_sub(z1, x1);
+            }
+            else
+            {
+                z0 = vec8d_add(z0, x0);
+                z1 = vec8d_add(z1, x1);
+            }
+            z0 = vec8d_reduce_to_pm1n(z0, n, ninv);
+            z1 = vec8d_reduce_to_pm1n(z1, n, ninv);
+            vec8d_store(zx+j+0, z0);
+            vec8d_store(zx+j+8, z1);
+        } while (j += 16, j < BLK_SZ);
+    }
+}
+
+/* z = a +/- b, or z = -a for b == NULL */
+static void _point_add(const sd_fft_ctx_struct* Q,
+    double* z, const double* a, const double* b, int subtract, ulong depth)
+{
+    vec8d n    = vec8d_set_d(Q->p);
+    vec8d ninv = vec8d_set_d(Q->pinv);
+    FLINT_ASSERT(depth >= LG_BLK_SZ);
+    for (ulong I = 0; I < n_pow2(depth - LG_BLK_SZ); I++)
+    {
+        double* zx = z + sd_fft_ctx_blk_offset(I);
+        const double* ax = a + sd_fft_ctx_blk_offset(I);
+        const double* bx = (b == NULL) ? NULL : b + sd_fft_ctx_blk_offset(I);
+        ulong j = 0; do {
+            vec8d x0, x1;
+            x0 = vec8d_load(ax+j+0);
+            x1 = vec8d_load(ax+j+8);
+            if (bx == NULL)
+            {
+                x0 = vec8d_neg(x0);
+                x1 = vec8d_neg(x1);
+            }
+            else if (subtract)
+            {
+                x0 = vec8d_sub(x0, vec8d_load(bx+j+0));
+                x1 = vec8d_sub(x1, vec8d_load(bx+j+8));
+                x0 = vec8d_reduce_to_pm1n(x0, n, ninv);
+                x1 = vec8d_reduce_to_pm1n(x1, n, ninv);
+            }
+            else
+            {
+                x0 = vec8d_add(x0, vec8d_load(bx+j+0));
+                x1 = vec8d_add(x1, vec8d_load(bx+j+8));
+                x0 = vec8d_reduce_to_pm1n(x0, n, ninv);
+                x1 = vec8d_reduce_to_pm1n(x1, n, ninv);
+            }
+            vec8d_store(zx+j+0, x0);
+            vec8d_store(zx+j+8, x1);
+        } while (j += 16, j < BLK_SZ);
+    }
+}
+
+void fft_small_op_mul(fft_small_op_t Z, const fft_small_op_t A,
+                    const fft_small_op_t B, const fft_small_plan_t P)
+{
+    ulong i;
+
+    FLINT_ASSERT(_op_compatible(A, P) && _op_compatible(B, P) &&
+                 _op_compatible(Z, P));
+    FLINT_ASSERT(A->domain == FFT_SMALL_OP_PRIMAL);
+    FLINT_ASSERT(B->domain == FFT_SMALL_OP_PRIMAL);
+
+    for (i = 0; i < P->np; i++)
+        _point_mul(P->ffts + P->offset + i, Z->data + P->stride*i,
+                A->data + P->stride*i, B->data + P->stride*i,
+                P->m[i], P->depth);
+
+    Z->domain = FFT_SMALL_OP_PRODUCT;
+}
+
+void fft_small_op_sqr(fft_small_op_t Z, const fft_small_op_t A,
+                    const fft_small_plan_t P)
+{
+    ulong i;
+
+    FLINT_ASSERT(_op_compatible(A, P) && _op_compatible(Z, P));
+    FLINT_ASSERT(A->domain == FFT_SMALL_OP_PRIMAL);
+
+    for (i = 0; i < P->np; i++)
+        _point_sqr(P->ffts + P->offset + i, Z->data + P->stride*i,
+                A->data + P->stride*i, P->m[i], P->depth);
+
+    Z->domain = FFT_SMALL_OP_PRODUCT;
+}
+
+void fft_small_op_addmul(fft_small_op_t Z, const fft_small_op_t A,
+                    const fft_small_op_t B, const fft_small_plan_t P)
+{
+    ulong i;
+
+    FLINT_ASSERT(_op_compatible(A, P) && _op_compatible(B, P) &&
+                 _op_compatible(Z, P));
+    FLINT_ASSERT(A->domain == FFT_SMALL_OP_PRIMAL);
+    FLINT_ASSERT(B->domain == FFT_SMALL_OP_PRIMAL);
+    FLINT_ASSERT(Z->domain == FFT_SMALL_OP_PRODUCT);
+
+    for (i = 0; i < P->np; i++)
+        _point_addmul(P->ffts + P->offset + i, Z->data + P->stride*i,
+                A->data + P->stride*i, B->data + P->stride*i,
+                P->m[i], 0, P->depth);
+}
+
+void fft_small_op_submul(fft_small_op_t Z, const fft_small_op_t A,
+                    const fft_small_op_t B, const fft_small_plan_t P)
+{
+    ulong i;
+
+    FLINT_ASSERT(_op_compatible(A, P) && _op_compatible(B, P) &&
+                 _op_compatible(Z, P));
+    FLINT_ASSERT(A->domain == FFT_SMALL_OP_PRIMAL);
+    FLINT_ASSERT(B->domain == FFT_SMALL_OP_PRIMAL);
+    FLINT_ASSERT(Z->domain == FFT_SMALL_OP_PRODUCT);
+
+    for (i = 0; i < P->np; i++)
+        _point_addmul(P->ffts + P->offset + i, Z->data + P->stride*i,
+                A->data + P->stride*i, B->data + P->stride*i,
+                P->m[i], 1, P->depth);
+}
+
+void fft_small_op_add(fft_small_op_t Z, const fft_small_op_t A,
+                    const fft_small_op_t B, const fft_small_plan_t P)
+{
+    ulong i;
+
+    FLINT_ASSERT(_op_compatible(A, P) && _op_compatible(B, P) &&
+                 _op_compatible(Z, P));
+    FLINT_ASSERT(A->domain == B->domain);
+
+    for (i = 0; i < P->np; i++)
+        _point_add(P->ffts + P->offset + i, Z->data + P->stride*i,
+                A->data + P->stride*i, B->data + P->stride*i, 0, P->depth);
+
+    Z->domain = A->domain;
+}
+
+void fft_small_op_sub(fft_small_op_t Z, const fft_small_op_t A,
+                    const fft_small_op_t B, const fft_small_plan_t P)
+{
+    ulong i;
+
+    FLINT_ASSERT(_op_compatible(A, P) && _op_compatible(B, P) &&
+                 _op_compatible(Z, P));
+    FLINT_ASSERT(A->domain == B->domain);
+
+    for (i = 0; i < P->np; i++)
+        _point_add(P->ffts + P->offset + i, Z->data + P->stride*i,
+                A->data + P->stride*i, B->data + P->stride*i, 1, P->depth);
+
+    Z->domain = A->domain;
+}
+
+void fft_small_op_neg(fft_small_op_t Z, const fft_small_op_t A,
+                    const fft_small_plan_t P)
+{
+    ulong i;
+
+    FLINT_ASSERT(_op_compatible(A, P) && _op_compatible(Z, P));
+
+    for (i = 0; i < P->np; i++)
+        _point_add(P->ffts + P->offset + i, Z->data + P->stride*i,
+                A->data + P->stride*i, NULL, 0, P->depth);
+
+    Z->domain = A->domain;
+}
+
+typedef struct {
+    fft_small_op_struct* X;
+    const fft_small_plan_struct* P;
+    ulong start_pi;
+    ulong stop_pi;
+} _ifft_worker_struct;
+
+static void _ifft_worker_func(void* varg)
+{
+    _ifft_worker_struct* W = (_ifft_worker_struct*) varg;
+    const fft_small_plan_struct* P = W->P;
+
+    for (ulong i = W->start_pi; i < W->stop_pi; i++)
+        sd_ifft_trunc(P->ffts + P->offset + i, W->X->data + P->stride*i,
+                P->depth, P->ztrunc);
+}
+
+void fft_small_ifft(fft_small_op_t X, const fft_small_plan_t P)
+{
+    ulong i;
+    thread_pool_handle* handles = NULL;
+    slong nworkers = 0;
+    ulong nthreads;
+    _ifft_worker_struct args[MPN_CTX_NCRTS];
+
+    FLINT_ASSERT(_op_compatible(X, P));
+    FLINT_ASSERT(X->domain == FFT_SMALL_OP_PRODUCT);
+
+    /* thread over the primes; ztrunc ~ an + bn, so this corresponds to
+       the fused drivers threading from operand length ~1500 up */
+    if (P->np >= 2 && P->ztrunc >= 3072)
+        nworkers = flint_request_threads(&handles, P->np);
+    nthreads = FLINT_MIN((ulong)(nworkers + 1), P->np);
+
+    for (i = 0; i < nthreads; i++)
+    {
+        args[i].X = X;
+        args[i].P = P;
+        args[i].start_pi = (i+0)*P->np/nthreads;
+        args[i].stop_pi  = (i+1)*P->np/nthreads;
+    }
+
+    for (i = nthreads - 1; i > 0; i--)
+        thread_pool_wake(global_thread_pool, handles[i - 1], 0,
+                         _ifft_worker_func, args + i);
+    _ifft_worker_func(args + 0);
+    for (i = nthreads - 1; i > 0; i--)
+        thread_pool_wait(global_thread_pool, handles[i - 1]);
+
+    flint_give_back_threads(handles, nworkers);
+}

--- a/src/fft_small/op.c
+++ b/src/fft_small/op.c
@@ -118,10 +118,14 @@ static void _point_sqr(const sd_fft_ctx_struct* Q,
             vec8d x0, x1;
             x0 = vec8d_load(ax+j+0);
             x1 = vec8d_load(ax+j+8);
-            x0 = vec8d_mulmod(x0, x0, n, ninv);
-            x1 = vec8d_mulmod(x1, x1, n, ninv);
-            x0 = vec8d_mulmod(x0, m, n, ninv);
-            x1 = vec8d_mulmod(x1, m, n, ninv);
+            vec8d t0, t1;
+            /* by m first, exactly as _point_mul: squaring two raw
+               transform entries (each in (-4n, 4n)) first would exceed
+               the chained mulmod input bound */
+            t0 = vec8d_mulmod(x0, m, n, ninv);
+            t1 = vec8d_mulmod(x1, m, n, ninv);
+            x0 = vec8d_mulmod(t0, x0, n, ninv);
+            x1 = vec8d_mulmod(t1, x1, n, ninv);
             vec8d_store(zx+j+0, x0);
             vec8d_store(zx+j+8, x1);
         } while (j += 16, j < BLK_SZ);

--- a/src/fft_small/op.c
+++ b/src/fft_small/op.c
@@ -14,6 +14,12 @@
 #include "fft_small.h"
 #include "machine_vectors.h"
 
+#if FLINT_BITS == 64
+ulong flint_fft_small_max_transformed_ring_size = UWORD(4) << 30;
+#else
+ulong flint_fft_small_max_transformed_ring_size = UWORD(1) << 30;
+#endif
+
 void fft_small_op_init(fft_small_op_t X, const fft_small_plan_t P)
 {
     X->stride = P->stride;
@@ -23,8 +29,8 @@ void fft_small_op_init(fft_small_op_t X, const fft_small_plan_t P)
     X->itrunc = 0;
     X->domain = FFT_SMALL_OP_PRIMAL;
     X->owns_data = 1;
-    X->data = flint_aligned_alloc(4096,
-                 n_round_up(P->np*P->stride*sizeof(double), 4096));
+    X->data = flint_aligned_alloc(FLINT_FFT_SMALL_ALIGNMENT,
+                 n_round_up(P->np*P->stride*sizeof(double), FLINT_FFT_SMALL_ALIGNMENT));
 }
 
 /* as fft_small_op_init, with caller-provided storage: 'data' must hold
@@ -45,7 +51,7 @@ void fft_small_op_init_borrowed(fft_small_op_t X, const fft_small_plan_t P,
 
 ulong fft_small_op_sizeof_data(const fft_small_plan_t P)
 {
-    return n_round_up(P->np * P->stride * sizeof(double), 4096);
+    return n_round_up(P->np * P->stride * sizeof(double), FLINT_FFT_SMALL_ALIGNMENT);
 }
 
 void fft_small_op_clear(fft_small_op_t X)

--- a/src/fft_small/op.c
+++ b/src/fft_small/op.c
@@ -27,6 +27,27 @@ void fft_small_op_init(fft_small_op_t X, const fft_small_plan_t P)
                  n_round_up(P->np*P->stride*sizeof(double), 4096));
 }
 
+/* as fft_small_op_init, with caller-provided storage: 'data' must hold
+   fft_small_op_sizeof_data(P) bytes, 4096-aligned, and outlive the op;
+   clear will not free it */
+void fft_small_op_init_borrowed(fft_small_op_t X, const fft_small_plan_t P,
+                                double * data)
+{
+    X->stride = P->stride;
+    X->np = P->np;
+    X->offset = P->offset;
+    X->depth = P->depth;
+    X->itrunc = 0;
+    X->domain = FFT_SMALL_OP_PRIMAL;
+    X->owns_data = 0;
+    X->data = data;
+}
+
+ulong fft_small_op_sizeof_data(const fft_small_plan_t P)
+{
+    return n_round_up(P->np * P->stride * sizeof(double), 4096);
+}
+
 void fft_small_op_clear(fft_small_op_t X)
 {
     if (X->owns_data)

--- a/src/fft_small/plan.c
+++ b/src/fft_small/plan.c
@@ -1,0 +1,361 @@
+/*
+    Copyright (C) 2022 Daniel Schultz
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "mpn_extras.h"
+#include "ulong_extras.h"
+#include "nmod.h"
+#include "fft_small.h"
+
+int _fft_small_plan_set_bound(fft_small_plan_t P, ulong c, ulong e, ulong np_max)
+{
+    mpn_ctx_struct * R = P->R;
+    ulong np;
+
+    P->bound_c = c;
+    P->bound_e = e;
+
+    for (np = 1; ; np++)
+    {
+        if (np > np_max)
+            return 0;
+
+        if (flint_mpn_cmp_ui_2exp(crt_data_prod_primes(R->crts + np - 1),
+              R->crts[np - 1].coeff_len, c, e) >= 0)
+        {
+            break;
+        }
+    }
+
+    P->np = np;
+    P->offset = 0;
+    P->ffts = R->ffts;
+    P->crts = R->crts;
+    P->use_direct_fft = 0;
+
+    return 1;
+}
+
+void _fft_small_plan_set_window(fft_small_plan_t P,
+                    ulong zl, ulong zh, ulong zn, ulong xtrunc_max)
+{
+    ulong ztrunc, depth, i;
+
+    FLINT_ASSERT(zl < zh);
+    FLINT_ASSERT(zh <= zn);
+
+    ztrunc = n_round_up(zn, BLK_SZ);
+    /*
+        if there is a power of two 2^d between zh and zn with good wrap around
+            i.e. max(operand lengths, zh) <= 2^d <= zn with zn - 2^d <= zl
+        then use d as the depth, otherwise the usual with no wrap around
+    */
+    depth = n_flog2(zn);
+    i = n_pow2(depth);
+    if (xtrunc_max <= i && zh <= i && i <= zn && zn <= zl + i)
+    {
+        ztrunc = i;
+    }
+    else
+    {
+        depth = n_max(LG_BLK_SZ, n_clog2(ztrunc));
+    }
+
+    P->zl = zl;
+    P->zh = zh;
+    P->zn = zn;
+    P->ztrunc = ztrunc;
+    P->depth = depth;
+    P->bits = 0;
+}
+
+int _fft_small_plan_fit_window(fft_small_plan_t P,
+                    ulong zl, ulong zh, ulong zn, ulong xtrunc_max)
+{
+    ulong N = n_pow2(P->depth);
+    ulong ztrunc;
+
+    FLINT_ASSERT(zl < zh);
+    FLINT_ASSERT(zh <= zn);
+
+    ztrunc = n_round_up(zn, BLK_SZ);
+
+    if (xtrunc_max <= N && zh <= N && N <= zn && zn <= zl + N)
+    {
+        ztrunc = N;
+    }
+    else if (ztrunc <= N)
+    {
+    }
+    else
+    {
+        return 0;
+    }
+
+    P->zl = zl;
+    P->zh = zh;
+    P->zn = zn;
+    P->ztrunc = ztrunc;
+
+    return 1;
+}
+
+void _fft_small_plan_set_normalizers(fft_small_plan_t P)
+{
+    ulong i, m, cop;
+    ulong np = P->np;
+    ulong depth = P->depth;
+
+    P->stride = n_round_up(sd_fft_ctx_data_size(depth), 128);
+
+    for (i = 0; i < np; i++)
+    {
+        ulong ioff = i + P->offset;
+        sd_fft_ctx_struct* Q = P->ffts + ioff;
+
+        cop = np == 1 ? 1 : *crt_data_co_prime_red(P->crts + np - 1, ioff);
+        NMOD_RED2(m, cop >> (FLINT_BITS - depth), cop << depth, Q->mod);
+        m = nmod_inv(m, Q->mod);
+
+        P->m[i] = m;
+    }
+}
+
+/*
+    Plan for mpn (integer) operands: choose a prime count np in [4, 8]
+    (the range the mpn chinese remaindering implements) and an even chunk
+    size `bits` with
+
+        len_bound * ceil(FLINT_BITS*min(an_max, bn_max)/bits) * 2^(2*bits)
+            <= prod_of_primes(np),
+
+    i.e. enough room for len_bound products accumulated in transform
+    space, maximizing bits for each np and choosing np by the same
+    transform-cost heuristic np*depth*ztrunc the multiplication driver
+    scores profiles with. The geometry is the full product of the
+    maximal operand lengths; zl/zh/zn are in coefficient units and are
+    not consulted by fft_small_export_mpn, which windows in limbs.
+*/
+int fft_small_plan_init_mpn(fft_small_plan_t P, mpn_ctx_t R,
+                    ulong an_max, ulong bn_max, ulong len_bound)
+{
+    ulong np, best_np = 0, best_bits = 0;
+    ulong min_bn = FLINT_MIN(an_max, bn_max);
+    double best_score = 0.0;
+
+    FLINT_ASSERT(an_max > 0);
+    FLINT_ASSERT(bn_max > 0);
+    FLINT_ASSERT(len_bound > 0);
+
+    for (np = 4; np <= MPN_CTX_NCRTS; np++)
+    {
+        const crt_data_struct* C = R->crts + np - 1;
+        ulong bits, alen, blen, zlen, ztrunc, depth;
+        double score;
+
+        /* the slow packing reads two_pow up to index bits - 32, and the
+           reconstruction requires whole limbs to fit in a chunk */
+        for (bits = (MPN_CTX_TWO_POWER_TAB_SIZE + 31) & ~UWORD(1);
+             bits > 64;
+             bits -= 2)
+        {
+            ulong t, thi;
+
+            umul_ppmm(thi, t, len_bound, n_cdiv(FLINT_BITS*min_bn, bits));
+            if (thi != 0)
+                continue;
+
+            if (flint_mpn_cmp_ui_2exp(crt_data_prod_primes(C),
+                                      C->coeff_len, t, 2*bits) >= 0)
+            {
+                break;
+            }
+        }
+
+        if (bits <= 64)
+            continue;
+
+        alen = n_cdiv(FLINT_BITS*an_max, bits);
+        blen = n_cdiv(FLINT_BITS*bn_max, bits);
+        zlen = alen + blen - 1;
+        ztrunc = n_round_up(zlen, BLK_SZ);
+        depth = n_max(LG_BLK_SZ, n_clog2(ztrunc));
+
+        {
+            double ratio = (double) ztrunc / (double) n_pow2(depth);
+            score = (1 - 0.25*ratio) * (double) np * (double) depth
+                                     * (double) ztrunc;
+        }
+        if (best_np == 0 || score < best_score)
+        {
+            best_np = np;
+            best_bits = bits;
+            best_score = score;
+        }
+    }
+
+    if (best_np == 0)
+        return 0;
+
+    {
+        ulong bits = best_bits;
+        ulong alen = n_cdiv(FLINT_BITS*an_max, bits);
+        ulong blen = n_cdiv(FLINT_BITS*bn_max, bits);
+        ulong zlen = alen + blen - 1;
+
+        P->R = R;
+        P->sign = 0;
+
+        _fft_small_plan_set_window(P, 0, zlen, zlen,
+                    n_max(n_round_up(alen, BLK_SZ), n_round_up(blen, BLK_SZ)));
+
+        P->bits = bits;
+        P->bound_c = len_bound;
+        P->bound_e = 2*bits;
+        P->np = best_np;
+        P->offset = 0;
+        P->ffts = R->ffts;
+        P->crts = R->crts;
+        P->use_direct_fft = 0;
+
+        _fft_small_plan_set_normalizers(P);
+    }
+
+    return 1;
+}
+
+/* Return whether to compute the FFT directly modulo `mod`, rather than
+   modulo precomputed FFT primes followed by CRT reconstruction.
+   Direct computation requires `mod.n` to be prime and `mod.n - 1`
+   to have sufficiently high 2-valuation.
+   This is usually faster when CRT would need multiple primes, but it pays
+   the setup cost of initializing and clearing a temporary `sd_fft_ctx_t`.  */
+static int
+_nmod_poly_should_directly_fft(ulong bn, ulong depth, nmod_t mod)
+{
+    if (bn < 1500)
+        return 0;
+
+    if (mod.n <= 2 || mod.n > (UWORD(1) << 50))
+        return 0;
+
+    if (NMOD_BITS(mod) < 20)
+        return 0;
+
+    if (!fft_small_mulmod_satisfies_bounds(mod.n))
+        /* should be implied by the 50-bit bound, but just in case */
+        return 0;
+
+    if (depth > SD_FFT_CTX_W2TAB_SIZE)
+        /* unlikely, the convolution length would have to be massive */
+        return 0;
+
+    if (n_trailing_zeros(mod.n - 1) < depth)
+        return 0;
+
+    return n_is_prime(mod.n); /* check the most expensive condition last */
+}
+
+/* np/offset selection shared by the nmod plans. len_bound * 2^prod_bits
+   is guaranteed to fit four primes for prod_bits <= 2*modbits and any
+   realistic len_bound; larger accumulation bounds passed in by bilinear
+   applications can use up to MPN_CTX_NCRTS primes, beyond which we
+   return 0. */
+static int _fft_small_plan_set_bound_nmod(fft_small_plan_t P,
+                    ulong len_bound, ulong prod_bits, nmod_t mod,
+                    ulong direct_len)
+{
+    mpn_ctx_struct * R = P->R;
+    ulong modbits = FLINT_BITS - mod.norm;
+    ulong i;
+
+    P->bound_c = len_bound;
+    P->bound_e = prod_bits;
+
+    /* first see if mod.n is one of R->ffts[i].mod.n */
+    if (modbits == 50)
+    {
+        for (i = 0; i < MPN_CTX_NCRTS; i++)
+        {
+            if (mod.n == R->ffts[i].mod.n)
+            {
+                P->np = 1;
+                P->offset = i;
+                P->ffts = R->ffts;
+                P->crts = R->crts;
+                P->use_direct_fft = 0;
+                return 1;
+            }
+        }
+    }
+
+    if (direct_len != 0 &&
+        _nmod_poly_should_directly_fft(direct_len, P->depth, mod))
+    {
+        sd_fft_ctx_init_prime(P->direct_fft, mod.n);
+        P->np = 1;
+        P->offset = 0;
+        P->ffts = P->direct_fft;
+        P->crts = R->crts;
+        P->use_direct_fft = 1;
+        return 1;
+    }
+
+    /* need prod_of_primes >= len_bound * 2^prod_bits */
+    return _fft_small_plan_set_bound(P, len_bound, prod_bits, MPN_CTX_NCRTS);
+}
+
+int fft_small_plan_init_nmod(fft_small_plan_t P, mpn_ctx_t R,
+                    ulong zl, ulong zh, ulong zn, ulong xtrunc_max,
+                    ulong len_bound, ulong prod_bits, nmod_t mod,
+                    ulong direct_len)
+{
+    P->R = R;
+    P->sign = 0;
+
+    _fft_small_plan_set_window(P, zl, zh, zn, xtrunc_max);
+
+    if (!_fft_small_plan_set_bound_nmod(P, len_bound, prod_bits, mod, direct_len))
+        return 0;
+
+    _fft_small_plan_set_normalizers(P);
+    return 1;
+}
+
+int fft_small_plan_init_nmod_cyclic(fft_small_plan_t P, mpn_ctx_t R,
+                    ulong depth, ulong zh,
+                    ulong len_bound, ulong prod_bits, nmod_t mod)
+{
+    ulong N = n_pow2(depth);
+
+    FLINT_ASSERT(depth >= LG_BLK_SZ);
+    FLINT_ASSERT(zh <= N);
+
+    P->R = R;
+    P->sign = 0;
+    P->depth = depth;
+    P->zl = 0;
+    P->zh = zh;
+    P->zn = N;
+    P->ztrunc = N;
+
+    if (!_fft_small_plan_set_bound_nmod(P, len_bound, prod_bits, mod, 0))
+        return 0;
+
+    _fft_small_plan_set_normalizers(P);
+    return 1;
+}
+
+void fft_small_plan_clear(fft_small_plan_t P)
+{
+    if (P->use_direct_fft)
+        sd_fft_ctx_clear(P->direct_fft);
+}

--- a/src/fft_small/plan.c
+++ b/src/fft_small/plan.c
@@ -155,6 +155,51 @@ int fft_small_plan_init_mpn(fft_small_plan_t P, mpn_ctx_t R,
     FLINT_ASSERT(bn_max > 0);
     FLINT_ASSERT(len_bound > 0);
 
+    /* prefer (np, bits) pairs with a vectorized packing profile: the
+       operand conversions otherwise fall back to the scalar packing
+       path, which costs more than the transforms it feeds */
+    {
+        ulong i;
+        for (i = 0; i < R->profiles_size; i++)
+        {
+            ulong bits = R->profiles[i].bits;
+            ulong pnp = R->profiles[i].np;
+            const crt_data_struct* C = R->crts + pnp - 1;
+            ulong t, thi, alen, blen, zlen, ztrunc, depth;
+            double score;
+
+            if (pnp < 4)
+                continue;
+
+            umul_ppmm(thi, t, len_bound, n_cdiv(FLINT_BITS*min_bn, bits));
+            if (thi != 0 ||
+                flint_mpn_cmp_ui_2exp(crt_data_prod_primes(C),
+                                      C->coeff_len, t, 2*bits) < 0)
+                continue;
+
+            alen = n_cdiv(FLINT_BITS*an_max, bits);
+            blen = n_cdiv(FLINT_BITS*bn_max, bits);
+            zlen = alen + blen - 1;
+            ztrunc = n_round_up(zlen, BLK_SZ);
+            depth = n_max(LG_BLK_SZ, n_clog2(ztrunc));
+
+            {
+                double ratio = (double) ztrunc / (double) n_pow2(depth);
+                score = (1 - 0.25*ratio) * (double) pnp * (double) depth
+                                         * (double) ztrunc;
+            }
+            if (best_np == 0 || score < best_score)
+            {
+                best_np = pnp;
+                best_bits = bits;
+                best_score = score;
+            }
+        }
+
+        if (best_np != 0)
+            goto have_choice;
+    }
+
     for (np = 4; np <= MPN_CTX_NCRTS; np++)
     {
         const crt_data_struct* C = R->crts + np - 1;
@@ -205,6 +250,7 @@ int fft_small_plan_init_mpn(fft_small_plan_t P, mpn_ctx_t R,
     if (best_np == 0)
         return 0;
 
+have_choice:
     {
         ulong bits = best_bits;
         ulong alen = n_cdiv(FLINT_BITS*an_max, bits);

--- a/src/fft_small/test/main.c
+++ b/src/fft_small/test/main.c
@@ -20,6 +20,7 @@
 #include "t-op_mpn.c"
 #include "t-op_nmod.c"
 #include "t-sd_fft.c"
+#include "t-transformed_mpn.c"
 
 /* Array of test functions ***************************************************/
 
@@ -33,7 +34,8 @@ test_struct tests[] =
     TEST_FUNCTION(_nmod_poly_mul_mid_mpn_ctx),
     TEST_FUNCTION(fft_small_op_mpn),
     TEST_FUNCTION(fft_small_op_nmod),
-    TEST_FUNCTION(sd_fft)
+    TEST_FUNCTION(sd_fft),
+    TEST_FUNCTION(gr_transformed_mpn)
 };
 
 /* main function *************************************************************/

--- a/src/fft_small/test/main.c
+++ b/src/fft_small/test/main.c
@@ -17,6 +17,8 @@
 #include "t-mul.c"
 #include "t-nmod_poly_divrem.c"
 #include "t-nmod_poly_mul.c"
+#include "t-op_mpn.c"
+#include "t-op_nmod.c"
 #include "t-sd_fft.c"
 
 /* Array of test functions ***************************************************/
@@ -29,6 +31,8 @@ test_struct tests[] =
     TEST_FUNCTION(mpn_ctx_mpn_mul),
     TEST_FUNCTION(_nmod_poly_divrem_mpn_ctx),
     TEST_FUNCTION(_nmod_poly_mul_mid_mpn_ctx),
+    TEST_FUNCTION(fft_small_op_mpn),
+    TEST_FUNCTION(fft_small_op_nmod),
     TEST_FUNCTION(sd_fft)
 };
 

--- a/src/fft_small/test/t-op_mpn.c
+++ b/src/fft_small/test/t-op_mpn.c
@@ -1,0 +1,175 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "mpn_extras.h"
+#include "fft_small.h"
+
+/* Accumulate K integer products in transform space and compare the
+   exported limbs against mpn_mul. Inflating len_bound drives the plan
+   across np = 4..8 and onto varying chunk sizes. */
+TEST_FUNCTION_START(fft_small_op_mpn, state)
+{
+    mpn_ctx_t R;
+
+    mpn_ctx_init(R, UWORD(0x0003f00000000001));
+
+    for (slong iter = 0; iter < 100 * flint_test_multiplier(); iter++)
+    {
+        int large = n_randint(state, 8) == 0;
+        ulong K = 1 + n_randint(state, large ? 2 : 4);
+        /* the occasional large iterations cross the internal threading
+           thresholds of fft_small_fft_mpn and fft_small_export_mpn,
+           including the overhang stitching between crt ranges */
+        ulong an = large ? 1100 + n_randint(state, 2000)
+                         : 1 + n_randint(state, 150);
+        ulong bn = large ? 1100 + n_randint(state, 2000)
+                         : 1 + n_randint(state, 150);
+        ulong zn = an + bn;
+        /* weighted toward large inflations, where the transform-cost
+           score starts preferring more primes with larger chunks */
+        ulong inflate = n_randint(state, 2) ? n_randint(state, 60)
+                                            : 45 + n_randint(state, 15);
+        ulong len_bound;
+        ulong i, k;
+        int use_sqr, use_sub;
+        fft_small_plan_t P;
+        fft_small_op_t A, B, Z, T;
+        ulong *a, *b, *z, *ref, *t;
+
+        flint_set_num_threads(1 + n_randint(state, 8));
+
+        /* inflate the accumulation bound to sweep prime counts and
+           chunk sizes */
+        if (inflate >= FLINT_BITS - FLINT_BIT_COUNT(K))
+            len_bound = UWORD_MAX;   /* certainly fails: tests the 0 return */
+        else
+            len_bound = K << inflate;
+
+        if (!fft_small_plan_init_mpn(P, R, an, bn, len_bound))
+        {
+            continue;
+        }
+
+        a = FLINT_ARRAY_ALLOC(K*an, ulong);
+        b = FLINT_ARRAY_ALLOC(K*bn, ulong);
+        z = FLINT_ARRAY_ALLOC(zn, ulong);
+        ref = FLINT_ARRAY_ALLOC(zn, ulong);
+        t = FLINT_ARRAY_ALLOC(zn, ulong);
+
+        use_sqr = (an == bn) && n_randint(state, 4) == 0;
+        use_sub = (K >= 2) && n_randint(state, 3) == 0;
+
+        for (k = 0; k < K; k++)
+        {
+            flint_mpn_rrandom(a + k*an, state, an);
+            /* keep the K-fold sum below 2^(FLINT_BITS*zn) so that the
+               reference accumulation cannot carry out of zn limbs,
+               except in the untruncated K = 1 case */
+            if (K > 1)
+                a[k*an + an - 1] = 0;
+
+            if (use_sqr)
+                flint_mpn_copyi(b + k*bn, a + k*an, bn);
+            else
+                flint_mpn_rrandom(b + k*bn, state, bn);
+        }
+
+        fft_small_op_init(A, P);
+        fft_small_op_init(B, P);
+        fft_small_op_init(Z, P);
+        fft_small_op_init(T, P);
+
+        for (k = 0; k < K; k++)
+        {
+            fft_small_fft_mpn(A, a + k*an, an, P);
+
+            if (use_sqr)
+            {
+                if (k == 0)
+                    fft_small_op_sqr(Z, A, P);
+                else
+                {
+                    fft_small_op_sqr(T, A, P);
+                    fft_small_op_add(Z, Z, T, P);
+                }
+            }
+            else
+            {
+                fft_small_fft_mpn(B, b + k*bn, bn, P);
+
+                if (k == 0)
+                    fft_small_op_mul(Z, A, B, P);
+                else
+                    fft_small_op_addmul(Z, A, B, P);
+            }
+        }
+
+        if (use_sub)
+        {
+            /* add and subtract the same product: the true value stays
+               nonnegative as the unsigned reconstruction requires */
+            fft_small_fft_mpn(A, a + (K-1)*an, an, P);
+            fft_small_fft_mpn(B, b + (K-1)*bn, bn, P);
+            fft_small_op_addmul(Z, A, B, P);
+            fft_small_op_submul(Z, A, B, P);
+        }
+
+        fft_small_ifft(Z, P);
+        fft_small_export_mpn(z, zn, Z, P);
+
+        /* reference */
+        flint_mpn_zero(ref, zn);
+        for (k = 0; k < K; k++)
+        {
+            if (an >= bn)
+                flint_mpn_mul(t, a + k*an, an, b + k*bn, bn);
+            else
+                flint_mpn_mul(t, b + k*bn, bn, a + k*an, an);
+
+            i = mpn_add_n(ref, ref, t, zn);
+            FLINT_ASSERT(i == 0);
+        }
+
+        for (i = 0; i < zn; i++)
+        {
+            if (z[i] != ref[i])
+            {
+                TEST_FUNCTION_FAIL(
+                        "limb i = %wu, zn = %wu, an = %wu, bn = %wu\n"
+                        "K = %wu, inflate = %wu\n"
+                        "np = %wu, bits = %wu, depth = %wu, ztrunc = %wu\n"
+                        "use_sqr = %d, use_sub = %d\n"
+                        "got %wx, expected %wx\n",
+                        i, zn, an, bn, K, inflate,
+                        P->np, P->bits, P->depth, P->ztrunc,
+                        use_sqr, use_sub,
+                        z[i], ref[i]);
+            }
+        }
+
+        fft_small_op_clear(A);
+        fft_small_op_clear(B);
+        fft_small_op_clear(Z);
+        fft_small_op_clear(T);
+        fft_small_plan_clear(P);
+
+        flint_free(a);
+        flint_free(b);
+        flint_free(z);
+        flint_free(ref);
+        flint_free(t);
+    }
+
+    mpn_ctx_clear(R);
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/fft_small/test/t-op_mpn.c
+++ b/src/fft_small/test/t-op_mpn.c
@@ -33,7 +33,14 @@ TEST_FUNCTION_START(fft_small_op_mpn, state)
                          : 1 + n_randint(state, 150);
         ulong bn = large ? 1100 + n_randint(state, 2000)
                          : 1 + n_randint(state, 150);
-        ulong zn = an + bn;
+        ulong zn;
+
+        /* equal lengths every few iterations so the square op actually
+           runs (independent draws almost never coincide); this must
+           precede every use of bn: the sizes, the plan and the buffers */
+        if (iter % 3 == 0)
+            bn = an;
+        zn = an + bn;
         /* weighted toward large inflations, where the transform-cost
            score starts preferring more primes with larger chunks */
         ulong inflate = n_randint(state, 2) ? n_randint(state, 60)
@@ -65,7 +72,7 @@ TEST_FUNCTION_START(fft_small_op_mpn, state)
         ref = FLINT_ARRAY_ALLOC(zn, ulong);
         t = FLINT_ARRAY_ALLOC(zn, ulong);
 
-        use_sqr = (an == bn) && n_randint(state, 4) == 0;
+        use_sqr = (an == bn) && n_randint(state, 2) == 0;
         use_sub = (K >= 2) && n_randint(state, 3) == 0;
 
         for (k = 0; k < K; k++)

--- a/src/fft_small/test/t-op_nmod.c
+++ b/src/fft_small/test/t-op_nmod.c
@@ -1,0 +1,210 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "nmod.h"
+#include "nmod_vec.h"
+#include "nmod_poly.h"
+#include "fft_small.h"
+
+/* Accumulate K products in transform space (as a bilinear application
+   like matrix multiplication would) and compare the exported window
+   against classical multiplications. Inflating prod_bits beyond the
+   2*modbits an ordinary multiplication needs also drives the plan onto
+   5 to 8 primes, exercising the template-generated nmod chinese
+   remaindering. */
+TEST_FUNCTION_START(fft_small_op_nmod, state)
+{
+    mpn_ctx_t R;
+
+    mpn_ctx_init(R, UWORD(0x0003f00000000001));
+
+    for (slong iter = 0; iter < 300 * flint_test_multiplier(); iter++)
+    {
+        nmod_t mod;
+        int large = n_randint(state, 8) == 0;
+        ulong K = 1 + n_randint(state, large ? 2 : 5);
+        /* the occasional large iterations cross the internal threading
+           thresholds of fft_small_fft_nmod, fft_small_ifft and
+           fft_small_export_nmod */
+        ulong an = large ? 1500 + n_randint(state, 3500)
+                         : 1 + n_randint(state, 700);
+        ulong bn = large ? 1500 + n_randint(state, 3500)
+                         : 1 + n_randint(state, 700);
+        ulong zn = an + bn - 1;
+        ulong zl = n_randint(state, zn);
+        ulong zh = zl + 1 + n_randint(state, zn - zl);
+        ulong atrunc = n_round_up(an, BLK_SZ);
+        ulong btrunc = n_round_up(bn, BLK_SZ);
+        ulong extra_bits = n_randint(state, 300);
+        ulong modbits = 2 + n_randint(state, 49);
+        ulong i, k;
+        int use_sqr, use_sub, use_add;
+        fft_small_plan_t P;
+        fft_small_op_t A, B, Z, T;
+        ulong *a, *b, *z, *ref, *t, *ta;
+
+        flint_set_num_threads(1 + n_randint(state, 8));
+
+        nmod_init(&mod, n_randbits(state, modbits));
+
+        /* z = sum_k a_k * b_k needs len_bound = K*min(an, bn); inflate
+           prod_bits to force more primes than 2*modbits would need */
+        if (!fft_small_plan_init_nmod(P, R, zl, zh, zn,
+                        FLINT_MAX(atrunc, btrunc), K*FLINT_MIN(an, bn),
+                        2*modbits + extra_bits, mod, 0))
+        {
+            continue;   /* bound needs more than MPN_CTX_NCRTS primes */
+        }
+
+        a = FLINT_ARRAY_ALLOC(K*an, ulong);
+        b = FLINT_ARRAY_ALLOC(K*bn, ulong);
+        z = FLINT_ARRAY_ALLOC(zh - zl, ulong);
+        ref = FLINT_ARRAY_ALLOC(zn, ulong);
+        t = FLINT_ARRAY_ALLOC(zn, ulong);
+        ta = FLINT_ARRAY_ALLOC(an, ulong);
+
+        use_sqr = (an == bn) && n_randint(state, 4) == 0;
+        /* an extra pair with subtracted product keeps the true
+           coefficients nonnegative, which the unsigned nmod export
+           requires */
+        use_sub = (K >= 2) && n_randint(state, 3) == 0;
+        /* sometimes fold a_1 into a_0 with a pointwise add instead of a
+           separate product; the sums are unreduced, so this needs a bit
+           of bound headroom */
+        use_add = !use_sqr && !use_sub && (K >= 2) && extra_bits >= 2 &&
+                  n_randint(state, 3) == 0;
+
+        for (k = 0; k < K; k++)
+        {
+            _nmod_vec_randtest(a + k*an, state, an, mod);
+            if (use_sqr)
+                flint_mpn_copyi(b + k*bn, a + k*an, bn);
+            else
+                _nmod_vec_randtest(b + k*bn, state, bn, mod);
+        }
+
+        fft_small_op_init(A, P);
+        fft_small_op_init(B, P);
+        fft_small_op_init(Z, P);
+        fft_small_op_init(T, P);
+
+        /* transform space: Z = sum_k A_k B_k (with the use_* variations) */
+        for (k = 0; k < K; k++)
+        {
+            fft_small_fft_nmod(A, a + k*an, an, atrunc, mod, P);
+
+            if (use_add && k == 0)
+            {
+                /* A = A_0 + A_1 pointwise, then skip k == 1 */
+                fft_small_fft_nmod(T, a + 1*an, an, atrunc, mod, P);
+                fft_small_op_add(A, A, T, P);
+            }
+
+            if (use_sqr)
+            {
+                if (k == 0)
+                    fft_small_op_sqr(Z, A, P);
+                else
+                {
+                    fft_small_op_sqr(T, A, P);
+                    fft_small_op_add(Z, Z, T, P);
+                }
+            }
+            else
+            {
+                fft_small_fft_nmod(B, b + k*bn, bn, btrunc, mod, P);
+
+                if (k == 0)
+                    fft_small_op_mul(Z, A, B, P);
+                else
+                    fft_small_op_addmul(Z, A, B, P);
+            }
+
+            if (use_add && k == 0)
+                k++;   /* a_1 was already folded in */
+        }
+
+        if (use_sub)
+        {
+            /* subtract the last product again: Z += A_{K-1} B_{K-1}
+               was done above, now Z -= A_{K-1} B_{K-1} */
+            fft_small_fft_nmod(A, a + (K-1)*an, an, atrunc, mod, P);
+            fft_small_fft_nmod(B, b + (K-1)*bn, bn, btrunc, mod, P);
+            fft_small_op_submul(Z, A, B, P);
+        }
+
+        fft_small_ifft(Z, P);
+        fft_small_export_nmod(z, Z, mod, P);
+
+        /* reference via classical multiplication */
+        _nmod_vec_zero(ref, zn);
+        for (k = 0; k < K; k++)
+        {
+            if (use_sub && k == K - 1)
+                continue;
+
+            if (use_add && k == 0)
+            {
+                _nmod_vec_add(ta, a + 0*an, a + 1*an, an, mod);
+                if (an >= bn)
+                    _nmod_poly_mul(t, ta, an, b + 0*bn, bn, mod);
+                else
+                    _nmod_poly_mul(t, b + 0*bn, bn, ta, an, mod);
+            }
+            else if (an >= bn)
+                _nmod_poly_mul(t, a + k*an, an, b + k*bn, bn, mod);
+            else
+                _nmod_poly_mul(t, b + k*bn, bn, a + k*an, an, mod);
+
+            _nmod_vec_add(ref, ref, t, zn, mod);
+
+            if (use_add && k == 0)
+                k++;
+        }
+
+        for (i = zl; i < zh; i++)
+        {
+            if (z[i - zl] != ref[i])
+            {
+                TEST_FUNCTION_FAIL(
+                        "i = %wu, zl = %wu, zh = %wu, zn = %wu\n"
+                        "an = %wu, bn = %wu, K = %wu\n"
+                        "np = %wu, depth = %wu, ztrunc = %wu\n"
+                        "modulus = %wu, extra_bits = %wu\n"
+                        "use_sqr = %d, use_sub = %d, use_add = %d\n"
+                        "got %wu, expected %wu\n",
+                        i, zl, zh, zn, an, bn, K,
+                        P->np, P->depth, P->ztrunc,
+                        mod.n, extra_bits,
+                        use_sqr, use_sub, use_add,
+                        z[i - zl], ref[i]);
+            }
+        }
+
+        fft_small_op_clear(A);
+        fft_small_op_clear(B);
+        fft_small_op_clear(Z);
+        fft_small_op_clear(T);
+        fft_small_plan_clear(P);
+
+        flint_free(a);
+        flint_free(b);
+        flint_free(z);
+        flint_free(ref);
+        flint_free(t);
+        flint_free(ta);
+    }
+
+    mpn_ctx_clear(R);
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/fft_small/test/t-op_nmod.c
+++ b/src/fft_small/test/t-op_nmod.c
@@ -39,7 +39,12 @@ TEST_FUNCTION_START(fft_small_op_nmod, state)
                          : 1 + n_randint(state, 700);
         ulong bn = large ? 1500 + n_randint(state, 3500)
                          : 1 + n_randint(state, 700);
-        ulong zn = an + bn - 1;
+        ulong zn;
+        /* equal lengths every few iterations so the square op actually
+           runs; this must precede every use of bn */
+        if (iter % 3 == 0)
+            bn = an;
+        zn = an + bn - 1;
         ulong zl = n_randint(state, zn);
         ulong zh = zl + 1 + n_randint(state, zn - zl);
         ulong atrunc = n_round_up(an, BLK_SZ);
@@ -72,7 +77,7 @@ TEST_FUNCTION_START(fft_small_op_nmod, state)
         t = FLINT_ARRAY_ALLOC(zn, ulong);
         ta = FLINT_ARRAY_ALLOC(an, ulong);
 
-        use_sqr = (an == bn) && n_randint(state, 4) == 0;
+        use_sqr = (an == bn) && n_randint(state, 2) == 0;
         /* an extra pair with subtracted product keeps the true
            coefficients nonnegative, which the unsigned nmod export
            requires */

--- a/src/fft_small/test/t-transformed_mpn.c
+++ b/src/fft_small/test/t-transformed_mpn.c
@@ -108,7 +108,7 @@ TEST_FUNCTION_START(gr_transformed_mpn, state)
         int as, bs, sign, status;
 
         if (gr_ctx_init_transformed_mpn(ctx, bits_bound, terms_bound,
-                                        is_signed) != GR_SUCCESS)
+                                        is_signed, 16) != GR_SUCCESS)
             continue;
 
         acc = gr_heap_init(ctx);
@@ -303,7 +303,7 @@ cleanup:
         slong j, need, zn_out;
         int sign;
 
-        if (gr_ctx_init_transformed_mpn(ctx, bits_bound, terms_bound, 1)
+        if (gr_ctx_init_transformed_mpn(ctx, bits_bound, terms_bound, 1, 16)
                 != GR_SUCCESS)
             continue;
 
@@ -401,7 +401,7 @@ cleanup:
         slong zn_out;
         int sign;
 
-        if (gr_ctx_init_transformed_mpn(ctx, 4096, 4, 1) == GR_SUCCESS)
+        if (gr_ctx_init_transformed_mpn(ctx, 4096, 4, 1, 16) == GR_SUCCESS)
         {
             acc = gr_heap_init(ctx);
             x = gr_heap_init(ctx);
@@ -428,7 +428,7 @@ cleanup:
             gr_ctx_clear(ctx);
         }
 
-        if (gr_ctx_init_transformed_mpn(ctx, 4096, 4, 0) == GR_SUCCESS)
+        if (gr_ctx_init_transformed_mpn(ctx, 4096, 4, 0, 16) == GR_SUCCESS)
         {
             acc = gr_heap_init(ctx);
             x = gr_heap_init(ctx);
@@ -476,7 +476,7 @@ cleanup:
             slong lo, zn, zl, j, e;
             int sg, sb, adv = iter2 % 3;
 
-            if (gr_ctx_init_transformed_mpn(tctx, 128 * n + 8, 2, 1)
+            if (gr_ctx_init_transformed_mpn(tctx, 128 * n + 8, 2, 1, 16)
                     != GR_SUCCESS)
                 continue;
 

--- a/src/fft_small/test/t-transformed_mpn.c
+++ b/src/fft_small/test/t-transformed_mpn.c
@@ -556,5 +556,41 @@ cleanup:
         }
     }
 
+        /* randomized ring-compliance testing: operations outside the
+       representation's provisioning (depth, accumulated terms, chunk
+       capacity) answer GR_UNABLE, which the framework accepts */
+    {
+        gr_ctx_t ctx;
+        slong it;
+        for (it = 0; it < 6; it++)
+        {
+            slong bits = 128 << n_randint(state, 6);
+            slong terms = 1 + n_randint(state, 6);
+            int sgn = (int) n_randint(state, 2);
+            if (gr_ctx_init_transformed_mpn(ctx, bits, terms, sgn, 8)
+                    == GR_SUCCESS)
+            {
+                {
+                    /* aliased accumulation through the internal
+                       temporary */
+                    gr_ptr u, v;
+                    ulong lu = 7, lv = 9;
+                    u = gr_heap_init(ctx); v = gr_heap_init(ctx);
+                    if (gr_transformed_mpn_set(u, &lu, 1, 0, ctx)
+                            == GR_SUCCESS &&
+                        gr_transformed_mpn_set(v, &lv, 1, sgn, ctx)
+                            == GR_SUCCESS)
+                    {
+                        (void) gr_addmul(u, u, v, ctx);
+                        (void) gr_submul(u, v, u, ctx);
+                    }
+                    gr_heap_clear(u, ctx); gr_heap_clear(v, ctx);
+                }
+                gr_test_ring(ctx, 25, 0);
+                gr_ctx_clear(ctx);
+            }
+        }
+    }
+
     TEST_FUNCTION_END(state);
 }

--- a/src/fft_small/test/t-transformed_mpn.c
+++ b/src/fft_small/test/t-transformed_mpn.c
@@ -174,7 +174,7 @@ TEST_FUNCTION_START(gr_transformed_mpn, state)
         {
             slong small = n_randint(state, need);
             if (gr_transformed_mpn_get(z, small, &zn_out, &sign, acc, ctx)
-                    != GR_DOMAIN && fmpz_size(ref) > (ulong) small)
+                    != GR_DOMAIN && fmpz_size(ref) > small)
                 TEST_FUNCTION_FAIL("undersized buffer not refused\n"
                     "need = %wd, given = %wd\n", need, small);
         }

--- a/src/fft_small/test/t-transformed_mpn.c
+++ b/src/fft_small/test/t-transformed_mpn.c
@@ -1,0 +1,463 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "fmpz.h"
+#include "mpn_extras.h"
+#include "gr.h"
+#include "fft_small.h"
+
+/* (z, zn, sign) as produced by the conversions, as an fmpz */
+static void
+_get_fmpz(fmpz_t res, nn_srcptr z, slong zn, int sign)
+{
+    if (zn <= 0)
+        fmpz_zero(res);
+    else
+    {
+        fmpz_set_ui_array(res, z, zn);
+        if (sign)
+            fmpz_neg(res, res);
+    }
+}
+
+static void
+_rand_operand(fmpz_t f, nn_ptr a, slong * an, int * as, slong maxn,
+              int allow_sign, flint_rand_t state)
+{
+    slong j;
+
+    *an = 1 + n_randint(state, maxn);
+
+    switch (n_randint(state, 8))
+    {
+        case 0:     /* one limb */
+            *an = 1;
+            a[0] = 1 + n_randint(state, 4);
+            break;
+        case 1:     /* zero */
+            *an = 0;
+            break;
+        case 2:     /* all bits set */
+            for (j = 0; j < *an; j++)
+                a[j] = ~UWORD(0);
+            break;
+        case 3:     /* sparse: a single high bit */
+            for (j = 0; j < *an; j++)
+                a[j] = 0;
+            a[*an - 1] = UWORD(1) << n_randint(state, FLINT_BITS);
+            break;
+        default:
+            for (j = 0; j < *an; j++)
+                a[j] = n_randlimb(state);
+            break;
+    }
+
+    while (*an > 0 && a[*an - 1] == 0)
+        (*an)--;
+
+    *as = (allow_sign && *an > 0) ? (int) n_randint(state, 2) : 0;
+
+    if (*an == 0)
+        fmpz_zero(f);
+    else
+    {
+        fmpz_set_ui_array(f, a, *an);
+        if (*as)
+            fmpz_neg(f, f);
+    }
+}
+
+/*
+    Exercises the transformed-integer ring against fmpz: random bilinear
+    expressions of depth <= 2 with mixed signs and unbalanced operands,
+    the exact and truncated conversions, and the refusal contract
+    (GR_UNABLE on sign or capacity violations, GR_DOMAIN on undersized
+    output buffers). Geometries are drawn to cross np = 4..8, several
+    chunk sizes, and the threading thresholds of the transforms.
+*/
+TEST_FUNCTION_START(gr_transformed_mpn, state)
+{
+    for (slong iter = 0; iter < 200 * flint_test_multiplier(); iter++)
+    {
+        int large = (n_randint(state, 25) == 0);
+
+        /* the signed reconstruction splits into per-segment windows with
+           a serial stitch of the signed spills; vary the worker count so
+           the boundaries land in different places */
+        flint_set_num_threads(1 + n_randint(state, 4));
+        int is_signed = n_randint(state, 2);
+        slong terms_bound = 1 + n_randint(state, 5);
+        slong opbits = large ? 20000 + n_randint(state, 200000)
+                             : 64 + n_randint(state, 4000);
+        slong bits_bound = 2 * opbits + 64 + FLINT_BIT_COUNT(terms_bound);
+        slong maxn = opbits / FLINT_BITS;
+        gr_ctx_t ctx;
+        gr_ptr acc, x, y;
+        fmpz_t fx, fy, ref, got;
+        nn_ptr a, b, z;
+        slong an, bn, zn_out, need, k, nterms;
+        int as, bs, sign, status;
+
+        if (gr_ctx_init_transformed_mpn(ctx, bits_bound, terms_bound,
+                                        is_signed) != GR_SUCCESS)
+            continue;
+
+        acc = gr_heap_init(ctx);
+        x = gr_heap_init(ctx);
+        y = gr_heap_init(ctx);
+        fmpz_init(fx);
+        fmpz_init(fy);
+        fmpz_init(ref);
+        fmpz_init(got);
+        a = flint_malloc((maxn + 1) * sizeof(ulong));
+        b = flint_malloc((maxn + 1) * sizeof(ulong));
+
+        nterms = 1 + n_randint(state, terms_bound);
+        fmpz_zero(ref);
+        status = GR_SUCCESS;
+
+        for (k = 0; k < nterms && status == GR_SUCCESS; k++)
+        {
+            int sub = is_signed && n_randint(state, 2);
+
+            _rand_operand(fx, a, &an, &as, maxn, is_signed, state);
+            _rand_operand(fy, b, &bn, &bs, maxn, is_signed, state);
+
+            status |= gr_transformed_mpn_set(x, a, an, as, ctx);
+            status |= gr_transformed_mpn_set(y, b, bn, bs, ctx);
+            if (status != GR_SUCCESS)
+                break;
+
+            if (k == 0)
+            {
+                status |= gr_mul(acc, x, y, ctx);
+                fmpz_mul(ref, fx, fy);
+            }
+            else if (sub)
+            {
+                status |= gr_submul(acc, x, y, ctx);
+                fmpz_submul(ref, fx, fy);
+            }
+            else
+            {
+                status |= gr_addmul(acc, x, y, ctx);
+                fmpz_addmul(ref, fx, fy);
+            }
+        }
+
+        /* an unsigned context must refuse everything that could produce a
+           negative value rather than return a wrong one */
+        if (status != GR_SUCCESS)
+        {
+            if (status != GR_UNABLE && status != GR_DOMAIN)
+                TEST_FUNCTION_FAIL(
+                    "unexpected status %d\n"
+                    "is_signed = %d, terms_bound = %wd, bits_bound = %wd\n",
+                    status, is_signed, terms_bound, bits_bound);
+            goto cleanup;
+        }
+
+        need = gr_transformed_mpn_get_limbs(ctx, acc);
+        z = flint_malloc(FLINT_MAX(need, 1) * sizeof(ulong));
+
+        /* undersized output buffers must be refused, not truncated */
+        if (need > 1)
+        {
+            slong small = n_randint(state, need);
+            if (gr_transformed_mpn_get(z, small, &zn_out, &sign, acc, ctx)
+                    != GR_DOMAIN && fmpz_size(ref) > (ulong) small)
+                TEST_FUNCTION_FAIL("undersized buffer not refused\n"
+                    "need = %wd, given = %wd\n", need, small);
+        }
+
+        if (gr_transformed_mpn_get(z, need, &zn_out, &sign, acc, ctx)
+                != GR_SUCCESS)
+            TEST_FUNCTION_FAIL("exact conversion failed\n"
+                "is_signed = %d, terms_bound = %wd, bits_bound = %wd\n",
+                is_signed, terms_bound, bits_bound);
+
+        _get_fmpz(got, z, zn_out, sign);
+
+        if (!fmpz_equal(got, ref))
+            TEST_FUNCTION_FAIL(
+                "exact conversion wrong\n"
+                "is_signed = %d, terms_bound = %wd, bits_bound = %wd\n"
+                "ref bits = %wd, got bits = %wd\n"
+                "ref sign = %d, got sign = %d\n",
+                is_signed, terms_bound, bits_bound,
+                (slong) fmpz_bits(ref), (slong) fmpz_bits(got),
+                fmpz_sgn(ref), sign ? -1 : 1);
+
+        /* zero must be canonical */
+        if (fmpz_is_zero(ref) && (zn_out != 0 || sign != 0))
+            TEST_FUNCTION_FAIL("zero not canonical: zn_out = %wd, sign = %d\n",
+                zn_out, sign);
+
+        /* exact cancellation: acc - acc = 0 */
+        if (is_signed)
+        {
+            gr_ptr c = gr_heap_init(ctx);
+            slong zn2;
+            int sg2, st2;
+
+            st2 = gr_sub(c, acc, acc, ctx);
+            if (st2 == GR_SUCCESS)
+            {
+                slong nd2 = gr_transformed_mpn_get_limbs(ctx, c);
+                nn_ptr z2 = flint_malloc(FLINT_MAX(nd2, 1) * sizeof(ulong));
+
+                if (gr_transformed_mpn_get(z2, nd2, &zn2, &sg2, c, ctx)
+                        == GR_SUCCESS && (zn2 != 0 || sg2 != 0))
+                    TEST_FUNCTION_FAIL("cancellation not zero: "
+                        "zn = %wd, sign = %d\n", zn2, sg2);
+                flint_free(z2);
+            }
+            gr_heap_clear(c, ctx);
+        }
+
+        /* truncated conversion: at most one unit of error in the lowest
+           returned limb, and exact for lo = 0 */
+        {
+            slong lo = n_randint(state, need + 2);
+            slong needt = gr_transformed_mpn_get_limbs_trunc(ctx, acc, lo);
+            nn_ptr zt = flint_malloc(FLINT_MAX(needt, 1) * sizeof(ulong));
+            slong znt;
+            int sgt;
+
+            if (gr_transformed_mpn_get_trunc(zt, needt, &znt, &sgt, lo,
+                                             acc, ctx) == GR_SUCCESS)
+            {
+                fmpz_t want, diff;
+
+                fmpz_init(want);
+                fmpz_init(diff);
+                fmpz_abs(want, ref);
+                fmpz_fdiv_q_2exp(want, want, FLINT_BITS * lo);
+
+                _get_fmpz(got, zt, znt, 0);
+                fmpz_sub(diff, got, want);
+                fmpz_abs(diff, diff);
+
+                if (fmpz_cmp_ui(diff, 1) > 0)
+                    TEST_FUNCTION_FAIL(
+                        "truncated conversion off by more than one unit\n"
+                        "lo = %wd, need = %wd, want bits = %wd, "
+                        "got bits = %wd\n",
+                        lo, need, (slong) fmpz_bits(want),
+                        (slong) fmpz_bits(got));
+
+                if (lo == 0 && !fmpz_equal(got, want))
+                    TEST_FUNCTION_FAIL("lo = 0 truncation not exact\n");
+
+                if (!fmpz_is_zero(want) && !fmpz_is_zero(got) &&
+                        sgt != (fmpz_sgn(ref) < 0))
+                    TEST_FUNCTION_FAIL("truncated sign wrong: "
+                        "got %d, ref sgn %d\n", sgt, fmpz_sgn(ref));
+
+                fmpz_clear(want);
+                fmpz_clear(diff);
+            }
+            flint_free(zt);
+        }
+
+        flint_free(z);
+
+cleanup:
+        gr_heap_clear(acc, ctx);
+        gr_heap_clear(x, ctx);
+        gr_heap_clear(y, ctx);
+        fmpz_clear(fx);
+        fmpz_clear(fy);
+        fmpz_clear(ref);
+        fmpz_clear(got);
+        flint_free(a);
+        flint_free(b);
+        gr_ctx_clear(ctx);
+    }
+
+    /* Directed geometry sweep: walk the planner across chunk sizes and
+       prime counts (np = 4..8) deterministically, since the per-slot
+       reconstruction kernels of the signed export are selected by np and
+       a wrong (np, N, M) pairing silently drops a cofactor limb at some
+       geometries only. Each geometry is checked with a signed
+       expression whose result is negative. */
+    for (slong k = 9; k <= 21; k++)
+    {
+        slong opbits = WORD(1) << k;
+        slong terms_bound = 4;
+        slong bits_bound = 2 * opbits + 64 + FLINT_BIT_COUNT(terms_bound);
+        slong maxn = opbits / FLINT_BITS;
+        gr_ctx_t ctx;
+        gr_ptr acc, x, y;
+        fmpz_t fx, fy, ref, got;
+        nn_ptr a, b, z;
+        slong j, need, zn_out;
+        int sign;
+
+        if (gr_ctx_init_transformed_mpn(ctx, bits_bound, terms_bound, 1)
+                != GR_SUCCESS)
+            continue;
+
+        acc = gr_heap_init(ctx);
+        x = gr_heap_init(ctx);
+        y = gr_heap_init(ctx);
+        fmpz_init(fx);
+        fmpz_init(fy);
+        fmpz_init(ref);
+        fmpz_init(got);
+        a = flint_malloc(FLINT_MAX(maxn, 1) * sizeof(ulong));
+        b = flint_malloc(FLINT_MAX(maxn, 1) * sizeof(ulong));
+
+        for (j = 0; j < maxn; j++)
+        {
+            a[j] = n_randlimb(state);
+            b[j] = n_randlimb(state);
+        }
+        a[maxn - 1] |= UWORD(1) << (FLINT_BITS - 1);
+        b[maxn - 1] |= UWORD(1) << (FLINT_BITS - 1);
+        fmpz_set_ui_array(fx, a, maxn);
+        fmpz_set_ui_array(fy, b, maxn);
+
+        /* x*x - y*y with |y| > |x| forces a negative result and a
+           full-width cancellation through the centered lifts */
+        GR_MUST_SUCCEED(gr_transformed_mpn_set(x, a, maxn, 0, ctx));
+        GR_MUST_SUCCEED(gr_transformed_mpn_set(y, b, maxn, 0, ctx));
+        GR_MUST_SUCCEED(gr_mul(acc, x, x, ctx));
+        GR_MUST_SUCCEED(gr_submul(acc, y, y, ctx));
+        fmpz_mul(ref, fx, fx);
+        fmpz_submul(ref, fy, fy);
+
+        need = gr_transformed_mpn_get_limbs(ctx, acc);
+        z = flint_malloc(FLINT_MAX(need, 1) * sizeof(ulong));
+        GR_MUST_SUCCEED(gr_transformed_mpn_get(z, need, &zn_out, &sign,
+                                               acc, ctx));
+        _get_fmpz(got, z, zn_out, sign);
+
+        if (!fmpz_equal(got, ref))
+            TEST_FUNCTION_FAIL(
+                "geometry sweep failed at opbits = %wd\n"
+                "bits_bound = %wd, ref bits = %wd, got bits = %wd\n",
+                opbits, bits_bound, (slong) fmpz_bits(ref),
+                (slong) fmpz_bits(got));
+
+        /* the same geometry through the truncated conversion */
+        {
+            slong lo = need / 3;
+            slong needt = gr_transformed_mpn_get_limbs_trunc(ctx, acc, lo);
+            nn_ptr zt = flint_malloc(FLINT_MAX(needt, 1) * sizeof(ulong));
+            slong znt;
+            int sgt;
+            fmpz_t want, diff;
+
+            GR_MUST_SUCCEED(gr_transformed_mpn_get_trunc(zt, needt, &znt,
+                                                    &sgt, lo, acc, ctx));
+            fmpz_init(want);
+            fmpz_init(diff);
+            fmpz_abs(want, ref);
+            fmpz_fdiv_q_2exp(want, want, FLINT_BITS * lo);
+            _get_fmpz(got, zt, znt, 0);
+            fmpz_sub(diff, got, want);
+            fmpz_abs(diff, diff);
+
+            if (fmpz_cmp_ui(diff, 1) > 0 || sgt != (fmpz_sgn(ref) < 0))
+                TEST_FUNCTION_FAIL(
+                    "truncated geometry sweep failed at opbits = %wd\n"
+                    "lo = %wd, sign got %d want %d\n",
+                    opbits, lo, sgt, fmpz_sgn(ref) < 0);
+
+            fmpz_clear(want);
+            fmpz_clear(diff);
+            flint_free(zt);
+        }
+
+        flint_free(z);
+        flint_free(a);
+        flint_free(b);
+        gr_heap_clear(acc, ctx);
+        gr_heap_clear(x, ctx);
+        gr_heap_clear(y, ctx);
+        fmpz_clear(fx);
+        fmpz_clear(fy);
+        fmpz_clear(ref);
+        fmpz_clear(got);
+        gr_ctx_clear(ctx);
+    }
+
+    /* directed cases: exact small values, sign of the difference, and
+       the refusal contract of unsigned contexts */
+    {
+        gr_ctx_t ctx;
+        gr_ptr acc, x, y;
+        ulong a[1], b[1], z[8];
+        slong zn_out;
+        int sign;
+
+        if (gr_ctx_init_transformed_mpn(ctx, 4096, 4, 1) == GR_SUCCESS)
+        {
+            acc = gr_heap_init(ctx);
+            x = gr_heap_init(ctx);
+            y = gr_heap_init(ctx);
+
+            /* 1 * 1 - 1 * 2 = -1 */
+            a[0] = 1;
+            b[0] = 2;
+            GR_MUST_SUCCEED(gr_transformed_mpn_set(x, a, 1, 0, ctx));
+            GR_MUST_SUCCEED(gr_transformed_mpn_set(y, b, 1, 0, ctx));
+            GR_MUST_SUCCEED(gr_mul(acc, x, x, ctx));
+            GR_MUST_SUCCEED(gr_submul(acc, x, y, ctx));
+            GR_MUST_SUCCEED(gr_transformed_mpn_get(z,
+                    gr_transformed_mpn_get_limbs(ctx, acc),
+                    &zn_out, &sign, acc, ctx));
+
+            if (zn_out != 1 || sign != 1 || z[0] != 1)
+                TEST_FUNCTION_FAIL("1*1 - 1*2 != -1: "
+                    "zn = %wd, sign = %d, z0 = %wu\n", zn_out, sign, z[0]);
+
+            gr_heap_clear(acc, ctx);
+            gr_heap_clear(x, ctx);
+            gr_heap_clear(y, ctx);
+            gr_ctx_clear(ctx);
+        }
+
+        if (gr_ctx_init_transformed_mpn(ctx, 4096, 4, 0) == GR_SUCCESS)
+        {
+            acc = gr_heap_init(ctx);
+            x = gr_heap_init(ctx);
+            y = gr_heap_init(ctx);
+
+            a[0] = 1;
+            b[0] = 2;
+            GR_MUST_SUCCEED(gr_transformed_mpn_set(x, a, 1, 0, ctx));
+            GR_MUST_SUCCEED(gr_transformed_mpn_set(y, b, 1, 0, ctx));
+
+            /* negative inputs and sign-producing operations must be
+               refused on an unsigned context */
+            if (gr_transformed_mpn_set(x, a, 1, 1, ctx) != GR_DOMAIN)
+                TEST_FUNCTION_FAIL("negative input accepted by an "
+                    "unsigned context\n");
+
+            GR_MUST_SUCCEED(gr_mul(acc, x, y, ctx));
+            if (gr_submul(acc, y, y, ctx) != GR_UNABLE)
+                TEST_FUNCTION_FAIL("submul accepted by an unsigned "
+                    "context\n");
+
+            gr_heap_clear(acc, ctx);
+            gr_heap_clear(x, ctx);
+            gr_heap_clear(y, ctx);
+            gr_ctx_clear(ctx);
+        }
+    }
+
+    flint_set_num_threads(1);
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/fft_small/test/t-transformed_mpn.c
+++ b/src/fft_small/test/t-transformed_mpn.c
@@ -459,5 +459,102 @@ cleanup:
 
     flint_set_num_threads(1);
 
+    /* the truncated get is documented to differ from the floor-truncated
+       value by at most 1 in the lowest returned limb; drive it with
+       carry-adversarial operands (all-ones, near-cancellation) as well
+       as random ones */
+    {
+        slong iter2;
+
+        for (iter2 = 0; iter2 < 60 * flint_test_multiplier(); iter2++)
+        {
+            slong n = 32 + n_randint(state, 300);
+            gr_ctx_t tctx;
+            gr_ptr E;
+            nn_ptr a, b, c, d, z;
+            fmpz_t fa, fb, fc, fd, X, Q, G;
+            slong lo, zn, zl, j, e;
+            int sg, sb, adv = iter2 % 3;
+
+            if (gr_ctx_init_transformed_mpn(tctx, 128 * n + 8, 2, 1)
+                    != GR_SUCCESS)
+                continue;
+
+            E = flint_malloc(5 * tctx->sizeof_elem);
+#define E2_(i) GR_ENTRY(E, i, tctx->sizeof_elem)
+            for (j = 0; j < 5; j++)
+                gr_init(E2_(j), tctx);
+
+            a = flint_malloc(n * sizeof(ulong));
+            b = flint_malloc(n * sizeof(ulong));
+            c = flint_malloc(n * sizeof(ulong));
+            d = flint_malloc(n * sizeof(ulong));
+            for (j = 0; j < n; j++)
+            {
+                a[j] = n_randlimb(state);
+                b[j] = n_randlimb(state);
+                c[j] = n_randlimb(state);
+                d[j] = n_randlimb(state);
+            }
+            if (adv == 1)
+                for (j = 0; j < n; j++)
+                    a[j] = c[j] = ~UWORD(0);
+            if (adv == 2)
+            {
+                flint_mpn_copyi(b, a, n);
+                flint_mpn_copyi(d, c, n);
+                d[0] ^= 1;
+            }
+
+            GR_MUST_SUCCEED(gr_transformed_mpn_set(E2_(0), a, n, 0, tctx));
+            sb = (int) n_randint(state, 2);
+            GR_MUST_SUCCEED(gr_transformed_mpn_set(E2_(1), b, n, sb, tctx));
+            GR_MUST_SUCCEED(gr_transformed_mpn_set(E2_(2), c, n, 0, tctx));
+            GR_MUST_SUCCEED(gr_transformed_mpn_set(E2_(3), d, n, 1, tctx));
+            GR_MUST_SUCCEED(gr_mul(E2_(4), E2_(0), E2_(2), tctx));
+            GR_MUST_SUCCEED(gr_addmul(E2_(4), E2_(1), E2_(3), tctx));
+
+            lo = n / 2 + n_randint(state, n);
+            zn = gr_transformed_mpn_get_limbs_trunc(tctx, E2_(4), lo);
+            z = flint_malloc(FLINT_MAX(zn, 1) * sizeof(ulong));
+            GR_MUST_SUCCEED(gr_transformed_mpn_get_trunc(z, zn, &zl, &sg,
+                    lo, E2_(4), tctx));
+
+            fmpz_init(fa); fmpz_init(fb); fmpz_init(fc); fmpz_init(fd);
+            fmpz_init(X); fmpz_init(Q); fmpz_init(G);
+            fmpz_set_ui_array(fa, a, n);
+            fmpz_set_ui_array(fb, b, n);
+            if (sb)
+                fmpz_neg(fb, fb);
+            fmpz_set_ui_array(fc, c, n);
+            fmpz_set_ui_array(fd, d, n);
+            fmpz_mul(X, fa, fc);
+            fmpz_submul(X, fb, fd);
+            fmpz_fdiv_q_2exp(Q, X, FLINT_BITS * lo);
+
+            if (zl == 0)
+                fmpz_zero(G);
+            else
+                fmpz_set_ui_array(G, z, FLINT_ABS(zl));
+            if (sg)
+                fmpz_neg(G, G);
+            fmpz_sub(G, G, Q);
+            e = fmpz_get_si(G);
+            if (FLINT_ABS(e) > 1)
+                TEST_FUNCTION_FAIL("get_trunc: error %wd exceeds the "
+                        "documented 1 ulp (n = %wd, lo = %wd, adv = %d)\n",
+                        e, n, lo, adv);
+
+            flint_free(a); flint_free(b); flint_free(c); flint_free(d);
+            flint_free(z);
+            fmpz_clear(fa); fmpz_clear(fb); fmpz_clear(fc); fmpz_clear(fd);
+            fmpz_clear(X); fmpz_clear(Q); fmpz_clear(G);
+            for (j = 0; j < 5; j++)
+                gr_clear(E2_(j), tctx);
+            flint_free(E);
+            gr_ctx_clear(tctx);
+        }
+    }
+
     TEST_FUNCTION_END(state);
 }

--- a/src/fmpz_mat.h
+++ b/src/fmpz_mat.h
@@ -478,6 +478,16 @@ int fmpz_mat_col_partition(slong * part, fmpz_mat_t M, int short_circuit);
 
 int fmpz_mat_next_col_van_hoeij(fmpz_mat_t M, fmpz_t P, fmpz_mat_t col, slong exp, slong U_exp);
 
+/* transformed-integer matrix product (fft_small); returns 0 without
+   touching C when unavailable or unprofitable, so callers can fall back */
+int fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A,
+                           const fmpz_mat_t B);
+/* each entry receives the limbs of its magnitude above limb lo_limbs,
+   with the entry's sign; at most one unit of error in the lowest
+   returned limb of each entry (lo_limbs = 0 is exact) */
+int fmpz_mat_mul_fft_small_trunc(fmpz_mat_t C, const fmpz_mat_t A,
+                           const fmpz_mat_t B, slong lo_limbs);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/fmpz_mat/mul.c
+++ b/src/fmpz_mat/mul.c
@@ -184,6 +184,14 @@ fmpz_mat_mul(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B)
 
     cbits = abits + bbits + FLINT_BIT_COUNT(br);
 
+    /* FFT deals efficiently with huge entries. Todo: retune for squaring,
+       and possibly for BLAS. */
+    if (FLINT_MIN(abits, bbits) >= ((dim <= 5) ? 10000 : 7000 + 0.15 * dim * dim))
+    {
+        if (fmpz_mat_mul_fft_small(C, A, B))
+            return;
+    }
+
 #if FLINT_USES_BLAS && FLINT_BITS == 64
     if (dim > 50)
     {

--- a/src/fmpz_mat/mul_fft_small.c
+++ b/src/fmpz_mat/mul_fft_small.c
@@ -154,27 +154,23 @@ _fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B,
     if (C == A || C == B)
         return 0;
 
-    abits = FLINT_ABS(fmpz_mat_max_bits(A));
-    bbits = FLINT_ABS(fmpz_mat_max_bits(B));
+    /* fmpz_mat_max_bits encodes "any negative entry" in its sign, so
+       the nonnegativity scan comes free with the bounds (and the calls
+       are made once: FLINT_ABS would evaluate its argument twice) */
+    {
+        slong amax = fmpz_mat_max_bits(A);
+        slong bmax = fmpz_mat_max_bits(B);
+
+        abits = FLINT_ABS(amax);
+        bbits = FLINT_ABS(bmax);
+        signed_needed = (amax < 0 || bmax < 0);
+    }
     if (abits == 0 || bbits == 0)
         return 0;
 
     share = (A == B);
 
     bits_bound = abits + bbits + FLINT_BIT_COUNT((ulong) k) + 2;
-
-    signed_needed = 0;
-    {
-        slong ii, jj;
-        for (ii = 0; ii < ar && !signed_needed; ii++)
-            for (jj = 0; jj < k; jj++)
-                if (fmpz_sgn(fmpz_mat_entry(A, ii, jj)) < 0)
-                { signed_needed = 1; break; }
-        for (ii = 0; ii < k && !share && !signed_needed; ii++)
-            for (jj = 0; jj < bc; jj++)
-                if (fmpz_sgn(fmpz_mat_entry(B, ii, jj)) < 0)
-                { signed_needed = 1; break; }
-    }
 
     /* the driver manages its own storage budget through the blocking
        below, so the context is created with a minimal live count; the

--- a/src/fmpz_mat/mul_fft_small.c
+++ b/src/fmpz_mat/mul_fft_small.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "gmpcompat.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
 #include "gr.h"
@@ -64,18 +65,23 @@
 */
 
 static int
-_set_entry(gr_ptr elem, const fmpz * e, nn_ptr t, gr_ctx_t tctx)
+_set_entry(gr_ptr elem, const fmpz * e, gr_ctx_t tctx)
 {
-    slong en = fmpz_size(e);
-    int ok;
-    fmpz_t ea;
-    fmpz_init(ea);
-    fmpz_abs(ea, e);
-    fmpz_get_ui_array(t, FLINT_MAX(en, 1), ea);
-    ok = gr_transformed_mpn_set(elem, t, en, fmpz_sgn(e) < 0, tctx)
-            == GR_SUCCESS;
-    fmpz_clear(ea);
-    return ok;
+    fmpz c = *e;
+
+    if (!COEFF_IS_MPZ(c))
+    {
+        ulong v = FLINT_ABS(c);
+        return gr_transformed_mpn_set(elem, &v, c != 0, c < 0, tctx)
+                == GR_SUCCESS;
+    }
+    else
+    {
+        mpz_srcptr m = COEFF_TO_PTR(c);
+        return gr_transformed_mpn_set(elem, m->_mp_d,
+                FLINT_ABS(m->_mp_size), m->_mp_size < 0, tctx)
+                == GR_SUCCESS;
+    }
 }
 
 /* convert the accumulator out into e (add_into: accumulate); consumes
@@ -170,7 +176,12 @@ _fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B,
 
     share = (A == B);
 
-    bits_bound = abits + bbits + FLINT_BIT_COUNT((ulong) k) + 2;
+    /* the bound describes one product's magnitude: the context
+       provisions the k-fold accumulation from terms_bound and the sign
+       from is_signed itself (an earlier revision added
+       FLINT_BIT_COUNT(k) + 2 here, duplicating headroom the
+       representation owns) */
+    bits_bound = abits + bbits;
 
     /* the driver manages its own storage budget through the blocking
        below, so the context is created with a minimal live count; the
@@ -254,7 +265,9 @@ _fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B,
     acc = flint_malloc(tctx->sizeof_elem);
     gr_transformed_mpn_init_borrowed(acc, acc_data, tctx);
 
-    tn_max = (abits + bbits + 128) / FLINT_BITS + 4 + k;
+    /* conversion staging sized by the ring's own bound rather than a
+       reconstruction of its limb requirements here */
+    tn_max = gr_transformed_mpn_get_limbs_bound(tctx);
     t = flint_malloc(tn_max * sizeof(ulong));
 
     for (L = 0; ok && L < k; L += kb)
@@ -269,7 +282,7 @@ _fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B,
             for (i = 0; ok && i < ml; i++)
                 for (l = 0; ok && l < kl; l++)
                     ok = _set_entry(EA_(i * kb + l),
-                            fmpz_mat_entry(A, I + i, L + l), t, tctx);
+                            fmpz_mat_entry(A, I + i, L + l), tctx);
 
             for (J = 0; ok && J < bc; J += nb)
             {
@@ -285,7 +298,7 @@ _fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B,
                     for (l = 0; ok && l < kl; l++)
                         for (j = 0; ok && j < nl; j++)
                             ok = _set_entry(EB_(l * nb + j),
-                                    fmpz_mat_entry(B, L + l, J + j), t, tctx);
+                                    fmpz_mat_entry(B, L + l, J + j), tctx);
 
                 for (i = 0; ok && i < ml; i++)
                     for (j = 0; ok && j < nl; j++)

--- a/src/fmpz_mat/mul_fft_small.c
+++ b/src/fmpz_mat/mul_fft_small.c
@@ -31,15 +31,104 @@
     stages already thread over large entries).
 */
 
-#define FMPZ_MAT_MUL_FFT_SMALL_MIN_BITS 16384
-
 /*
     Shared driver: lo_limbs = 0 gives the exact product; lo_limbs > 0
     returns, for each entry, the limbs of the magnitude above limb
     lo_limbs (with the entry's sign), which is what a working-precision
     matrix product such as arb_mat_mul needs -- the discarded low tail
     perturbs each entry by at most one unit in its lowest returned limb.
+
+    Memory strategy. The driver budgets its transform storage against
+    flint_fft_small_max_transformed_ring_size and picks the cheapest
+    blocking that fits:
+
+    - everything resident (the classical amortization: every entry
+      transformed once, every output converted once); squaring (B == A)
+      keeps a single transform pool here, halving the transforms and the
+      memory;
+    - one side resident, the other streamed in row (column) blocks --
+      the windowed strategy for rectangular products: still no entry is
+      transformed twice;
+    - both sides blocked: the streamed inner side is re-transformed once
+      per outer block, trading forward transforms (the cheap phase) for
+      fitting in memory;
+    - as a last resort the inner dimension itself is blocked and the
+      output entries accumulated across the pieces on the fmpz side;
+      this multiplies the conversions out and is unavailable for the
+      truncated variant, whose one-ulp contract does not survive summing
+      truncated pieces.
+
+    Whether the transformed representation is worth using at all (entry
+    sizes, dimensions) is the caller's tuning decision; the driver
+    accepts any input it can compute.
 */
+
+static int
+_set_entry(gr_ptr elem, const fmpz * e, nn_ptr t, gr_ctx_t tctx)
+{
+    slong en = fmpz_size(e);
+    int ok;
+    fmpz_t ea;
+    fmpz_init(ea);
+    fmpz_abs(ea, e);
+    fmpz_get_ui_array(t, FLINT_MAX(en, 1), ea);
+    ok = gr_transformed_mpn_set(elem, t, en, fmpz_sgn(e) < 0, tctx)
+            == GR_SUCCESS;
+    fmpz_clear(ea);
+    return ok;
+}
+
+/* convert the accumulator out into e (add_into: accumulate); consumes
+   acc, which the caller re-initializes */
+static int
+_export_entry(fmpz * e, gr_ptr acc, slong lo_limbs, int add_into,
+              nn_ptr * t, slong * tn_max, gr_ctx_t tctx)
+{
+    slong need, zn;
+    int sg, ok;
+
+    need = (lo_limbs == 0)
+            ? gr_transformed_mpn_get_limbs(tctx, acc)
+            : gr_transformed_mpn_get_limbs_trunc(tctx, acc, lo_limbs);
+    if (need > *tn_max)
+    {
+        *t = flint_realloc(*t, need * sizeof(ulong));
+        *tn_max = need;
+    }
+    if (lo_limbs == 0)
+        ok = gr_transformed_mpn_get_destructive(*t, need, &zn, &sg, acc,
+                tctx) == GR_SUCCESS;
+    else
+        ok = gr_transformed_mpn_get_trunc_destructive(*t, need, &zn, &sg,
+                lo_limbs, acc, tctx) == GR_SUCCESS;
+    if (!ok)
+        return 0;
+
+    if (!add_into)
+    {
+        if (zn == 0)
+            fmpz_zero(e);
+        else
+        {
+            fmpz_set_ui_array(e, *t, zn);
+            if (sg)
+                fmpz_neg(e, e);
+        }
+    }
+    else if (zn != 0)
+    {
+        fmpz_t p;
+        fmpz_init(p);
+        fmpz_set_ui_array(p, *t, zn);
+        if (sg)
+            fmpz_sub(e, e, p);
+        else
+            fmpz_add(e, e, p);
+        fmpz_clear(p);
+    }
+    return 1;
+}
+
 static int
 _fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B,
                         slong lo_limbs)
@@ -49,14 +138,16 @@ _fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B,
     slong k = fmpz_mat_ncols(A);
     slong bc = fmpz_mat_ncols(B);
     slong abits, bbits, bits_bound;
-    slong i, j, l;
+    int signed_needed, share;
+    slong i, j, l, I, J, L;
     gr_ctx_t tctx;
-    gr_ptr E, acc;
+    gr_ptr EA, EB, acc;
     double * acc_data;
     nn_ptr t;
-    slong tn_max;
+    slong tn_max, budget, mb, nb, kb;
     int ok = 1;
-#define E_(i) GR_ENTRY(E, i, tctx->sizeof_elem)
+#define EA_(i) GR_ENTRY(EA, i, tctx->sizeof_elem)
+#define EB_(i) GR_ENTRY(EB, i, tctx->sizeof_elem)
 
     if (ar == 0 || bc == 0 || k == 0)
         return 0;
@@ -68,108 +159,186 @@ _fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B,
     if (abits == 0 || bbits == 0)
         return 0;
 
-    if (abits + bbits < FMPZ_MAT_MUL_FFT_SMALL_MIN_BITS)
-        return 0;
+    share = (A == B);
 
     bits_bound = abits + bbits + FLINT_BIT_COUNT((ulong) k) + 2;
 
-    if (gr_ctx_init_transformed_mpn(tctx, bits_bound, k, 1) != GR_SUCCESS)
+    signed_needed = 0;
+    {
+        slong ii, jj;
+        for (ii = 0; ii < ar && !signed_needed; ii++)
+            for (jj = 0; jj < k; jj++)
+                if (fmpz_sgn(fmpz_mat_entry(A, ii, jj)) < 0)
+                { signed_needed = 1; break; }
+        for (ii = 0; ii < k && !share && !signed_needed; ii++)
+            for (jj = 0; jj < bc; jj++)
+                if (fmpz_sgn(fmpz_mat_entry(B, ii, jj)) < 0)
+                { signed_needed = 1; break; }
+    }
+
+    /* the driver manages its own storage budget through the blocking
+       below, so the context is created with a minimal live count; the
+       context-level gate protects callers without such a strategy */
+    if (gr_ctx_init_transformed_mpn(tctx, bits_bound, k, signed_needed, 4)
+            != GR_SUCCESS)
         return 0;
 
-    E = flint_malloc((ar * k + k * bc) * tctx->sizeof_elem);
-    for (i = 0; i < ar * k + k * bc; i++)
-        gr_init(E_(i), tctx);
-    /* the accumulator is converted out destructively -- skipping the
-       multi-megabyte transform copy per entry -- and re-initialized in
-       place, which borrowed storage makes free */
-    acc_data = flint_aligned_alloc(4096, n_round_up(
-            gr_transformed_mpn_sizeof_data(tctx), 4096));
+    /* elements of transform storage the budget admits */
+    {
+        ulong per = n_round_up(gr_transformed_mpn_sizeof_data(tctx),
+                               FLINT_FFT_SMALL_ALIGNMENT);
+        ulong nb_ = flint_fft_small_max_transformed_ring_size / per;
+        budget = (nb_ > (ulong) WORD_MAX) ? WORD_MAX : (slong) nb_;
+    }
+    if (budget < 3)
+    {
+        gr_ctx_clear(tctx);
+        return 0;
+    }
+
+    /* blocking decision: mb rows of A and nb columns of B resident at a
+       time, over the full inner dimension (kb = k) when possible */
+    kb = k;
+    if (share && ar * k + 1 <= budget)
+    {
+        mb = ar; nb = bc;               /* single resident pool */
+    }
+    else if (!share && ar * k + k * bc + 1 <= budget)
+    {
+        mb = ar; nb = bc;               /* everything resident */
+    }
+    else if (k * bc + k + 1 <= budget)
+    {
+        nb = bc;                        /* B resident, stream A rows */
+        mb = FLINT_MIN(ar, (budget - 1 - k * bc) / k);
+        share = 0;
+    }
+    else if (ar * k + k + 1 <= budget)
+    {
+        mb = ar;                        /* A resident, stream B columns */
+        nb = FLINT_MIN(bc, (budget - 1 - ar * k) / k);
+        share = 0;
+    }
+    else if (2 * k + 1 <= budget)
+    {
+        /* both sides blocked; the inner (B) side is re-transformed once
+           per outer block */
+        mb = FLINT_MIN(ar, (budget - 1) / (2 * k));
+        nb = FLINT_MIN(bc, (budget - 1) / (2 * k));
+        share = 0;
+    }
+    else
+    {
+        /* the inner dimension itself must be blocked; entries accumulate
+           across the pieces, which multiplies the conversions out and
+           breaks the truncated contract */
+        if (lo_limbs > 0)
+        {
+            gr_ctx_clear(tctx);
+            return 0;
+        }
+        mb = 1; nb = 1;
+        kb = (budget - 1) / 2;
+        share = 0;
+    }
+
+    EA = flint_malloc((mb * kb) * tctx->sizeof_elem);
+    for (i = 0; i < mb * kb; i++)
+        gr_init(EA_(i), tctx);
+    if (share)
+        EB = EA;
+    else
+    {
+        EB = flint_malloc((kb * nb) * tctx->sizeof_elem);
+        for (i = 0; i < kb * nb; i++)
+            gr_init(EB_(i), tctx);
+    }
+    acc_data = flint_aligned_alloc(FLINT_FFT_SMALL_ALIGNMENT, n_round_up(
+            gr_transformed_mpn_sizeof_data(tctx), FLINT_FFT_SMALL_ALIGNMENT));
     acc = flint_malloc(tctx->sizeof_elem);
     gr_transformed_mpn_init_borrowed(acc, acc_data, tctx);
 
     tn_max = (abits + bbits + 128) / FLINT_BITS + 4 + k;
     t = flint_malloc(tn_max * sizeof(ulong));
 
-    /* conversions in */
-    for (i = 0; ok && i < ar; i++)
-        for (l = 0; ok && l < k; l++)
-        {
-            const fmpz * e = fmpz_mat_entry(A, i, l);
-            slong en = fmpz_size(e);
-            fmpz_t ea; fmpz_init(ea); fmpz_abs(ea, e);
-            fmpz_get_ui_array(t, FLINT_MAX(en, 1), ea);
-            ok = gr_transformed_mpn_set(E_(i * k + l), t, en,
-                    fmpz_sgn(e) < 0, tctx) == GR_SUCCESS;
-            fmpz_clear(ea);
-        }
-    for (l = 0; ok && l < k; l++)
-        for (j = 0; ok && j < bc; j++)
-        {
-            const fmpz * e = fmpz_mat_entry(B, l, j);
-            slong en = fmpz_size(e);
-            fmpz_t ea; fmpz_init(ea); fmpz_abs(ea, e);
-            fmpz_get_ui_array(t, FLINT_MAX(en, 1), ea);
-            ok = gr_transformed_mpn_set(E_(ar * k + l * bc + j), t, en,
-                    fmpz_sgn(e) < 0, tctx) == GR_SUCCESS;
-            fmpz_clear(ea);
-        }
+    for (L = 0; ok && L < k; L += kb)
+    {
+        slong kl = FLINT_MIN(kb, k - L);
 
-    /* accumulate and convert out */
-    for (i = 0; ok && i < ar; i++)
-        for (j = 0; ok && j < bc; j++)
+        for (I = 0; ok && I < ar; I += mb)
         {
-            slong need, zn; int sg;
+            slong ml = FLINT_MIN(mb, ar - I);
 
-            ok = gr_mul(acc, E_(i * k), E_(ar * k + j), tctx) == GR_SUCCESS;
-            for (l = 1; ok && l < k; l++)
-                ok = gr_addmul(acc, E_(i * k + l),
-                        E_(ar * k + l * bc + j), tctx) == GR_SUCCESS;
+            /* the A block, transformed once per (L, I) */
+            for (i = 0; ok && i < ml; i++)
+                for (l = 0; ok && l < kl; l++)
+                    ok = _set_entry(EA_(i * kb + l),
+                            fmpz_mat_entry(A, I + i, L + l), t, tctx);
 
-            need = (lo_limbs == 0)
-                    ? gr_transformed_mpn_get_limbs(tctx, acc)
-                    : gr_transformed_mpn_get_limbs_trunc(tctx, acc, lo_limbs);
-            if (need > tn_max)
+            for (J = 0; ok && J < bc; J += nb)
             {
-                t = flint_realloc(t, need * sizeof(ulong));
-                tn_max = need;
-            }
-            if (lo_limbs == 0)
-                ok = ok && gr_transformed_mpn_get_destructive(t, need,
-                        &zn, &sg, acc, tctx) == GR_SUCCESS;
-            else
-                ok = ok && gr_transformed_mpn_get_trunc_destructive(t,
-                        need, &zn, &sg, lo_limbs, acc, tctx) == GR_SUCCESS;
+                slong nl = FLINT_MIN(nb, bc - J);
 
-            /* the destructive get consumed acc: bring it back for the
-               next entry, free on borrowed storage */
-            gr_clear(acc, tctx);
-            gr_transformed_mpn_init_borrowed(acc, acc_data, tctx);
+                /* the B block; when both sides fit this runs once,
+                   when only A is blocked it runs once per J, and in the
+                   doubly blocked regime once per (I, J) */
+                /* EB already holds block (L, J) whenever B is fully
+                   resident in the column direction and I has advanced;
+                   otherwise the J (or J and I) traversal overwrote it */
+                if (!share && (I == 0 || nb < bc))
+                    for (l = 0; ok && l < kl; l++)
+                        for (j = 0; ok && j < nl; j++)
+                            ok = _set_entry(EB_(l * nb + j),
+                                    fmpz_mat_entry(B, L + l, J + j), t, tctx);
 
-            if (ok)
-            {
-                fmpz * e = fmpz_mat_entry(C, i, j);
-                if (zn == 0)
-                    fmpz_zero(e);
-                else
-                {
-                    fmpz_set_ui_array(e, t, zn);
-                    if (sg)
-                        fmpz_neg(e, e);
-                }
+                for (i = 0; ok && i < ml; i++)
+                    for (j = 0; ok && j < nl; j++)
+                    {
+                        gr_srcptr b0 = share
+                            ? EA_((L + 0) * kb + (J + j))
+                            : EB_(0 * nb + j);
+
+                        ok = gr_mul(acc, EA_(i * kb + 0), b0, tctx)
+                                == GR_SUCCESS;
+                        for (l = 1; ok && l < kl; l++)
+                        {
+                            gr_srcptr bl = share
+                                ? EA_((L + l) * kb + (J + j))
+                                : EB_(l * nb + j);
+                            ok = gr_addmul(acc, EA_(i * kb + l), bl, tctx)
+                                    == GR_SUCCESS;
+                        }
+
+                        if (ok)
+                            ok = _export_entry(fmpz_mat_entry(C, I + i, J + j),
+                                    acc, lo_limbs, L > 0, &t, &tn_max, tctx);
+
+                        gr_clear(acc, tctx);
+                        gr_transformed_mpn_init_borrowed(acc, acc_data, tctx);
+                    }
             }
         }
+    }
 
-    for (i = 0; i < ar * k + k * bc; i++)
-        gr_clear(E_(i), tctx);
-    flint_free(E);
+    for (i = 0; i < mb * kb; i++)
+        gr_clear(EA_(i), tctx);
+    flint_free(EA);
+    if (!share)
+    {
+        for (i = 0; i < kb * nb; i++)
+            gr_clear(EB_(i), tctx);
+        flint_free(EB);
+    }
     gr_clear(acc, tctx);
     flint_free(acc);
     flint_aligned_free(acc_data);
     flint_free(t);
     gr_ctx_clear(tctx);
-#undef E_
+#undef EA_
+#undef EB_
     return ok;
 #else
+    (void) C; (void) A; (void) B; (void) lo_limbs;
     return 0;
 #endif
 }

--- a/src/fmpz_mat/mul_fft_small.c
+++ b/src/fmpz_mat/mul_fft_small.c
@@ -52,6 +52,7 @@ _fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B,
     slong i, j, l;
     gr_ctx_t tctx;
     gr_ptr E, acc;
+    double * acc_data;
     nn_ptr t;
     slong tn_max;
     int ok = 1;
@@ -78,7 +79,13 @@ _fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B,
     E = flint_malloc((ar * k + k * bc) * tctx->sizeof_elem);
     for (i = 0; i < ar * k + k * bc; i++)
         gr_init(E_(i), tctx);
-    acc = gr_heap_init(tctx);
+    /* the accumulator is converted out destructively -- skipping the
+       multi-megabyte transform copy per entry -- and re-initialized in
+       place, which borrowed storage makes free */
+    acc_data = flint_aligned_alloc(4096, n_round_up(
+            gr_transformed_mpn_sizeof_data(tctx), 4096));
+    acc = flint_malloc(tctx->sizeof_elem);
+    gr_transformed_mpn_init_borrowed(acc, acc_data, tctx);
 
     tn_max = (abits + bbits + 128) / FLINT_BITS + 4 + k;
     t = flint_malloc(tn_max * sizeof(ulong));
@@ -127,11 +134,17 @@ _fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B,
                 tn_max = need;
             }
             if (lo_limbs == 0)
-                ok = ok && gr_transformed_mpn_get(t, need, &zn, &sg, acc,
-                        tctx) == GR_SUCCESS;
+                ok = ok && gr_transformed_mpn_get_destructive(t, need,
+                        &zn, &sg, acc, tctx) == GR_SUCCESS;
             else
-                ok = ok && gr_transformed_mpn_get_trunc(t, need, &zn, &sg,
-                        lo_limbs, acc, tctx) == GR_SUCCESS;
+                ok = ok && gr_transformed_mpn_get_trunc_destructive(t,
+                        need, &zn, &sg, lo_limbs, acc, tctx) == GR_SUCCESS;
+
+            /* the destructive get consumed acc: bring it back for the
+               next entry, free on borrowed storage */
+            gr_clear(acc, tctx);
+            gr_transformed_mpn_init_borrowed(acc, acc_data, tctx);
+
             if (ok)
             {
                 fmpz * e = fmpz_mat_entry(C, i, j);
@@ -149,7 +162,9 @@ _fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B,
     for (i = 0; i < ar * k + k * bc; i++)
         gr_clear(E_(i), tctx);
     flint_free(E);
-    gr_heap_clear(acc, tctx);
+    gr_clear(acc, tctx);
+    flint_free(acc);
+    flint_aligned_free(acc_data);
     flint_free(t);
     gr_ctx_clear(tctx);
 #undef E_

--- a/src/fmpz_mat/mul_fft_small.c
+++ b/src/fmpz_mat/mul_fft_small.c
@@ -1,0 +1,175 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz.h"
+#include "fmpz_mat.h"
+#include "gr.h"
+#if FLINT_HAVE_FFT_SMALL
+# include "fft_small.h"
+#endif
+
+/*
+    Integer matrix product over a transformed-integer context: each of the
+    ar*k + k*bc entries is transformed once and reused across the ar*bc*k
+    pointwise products, with entry signs handled by the context's sign
+    machinery (pointwise addmul/submul switching, signed conversion out).
+    Returns 0 when the transformed representation is unavailable or
+    judged unprofitable (small entries); C may then be partially written,
+    but A and B are untouched, so a caller falls back to fmpz_mat_mul.
+
+    Currently single-threaded at the entry level (the context itself is
+    thread safe, so the two-phase pool pattern of the polynomial matrix
+    drivers transfers directly; the internal transform and reconstruction
+    stages already thread over large entries).
+*/
+
+#define FMPZ_MAT_MUL_FFT_SMALL_MIN_BITS 16384
+
+/*
+    Shared driver: lo_limbs = 0 gives the exact product; lo_limbs > 0
+    returns, for each entry, the limbs of the magnitude above limb
+    lo_limbs (with the entry's sign), which is what a working-precision
+    matrix product such as arb_mat_mul needs -- the discarded low tail
+    perturbs each entry by at most one unit in its lowest returned limb.
+*/
+static int
+_fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B,
+                        slong lo_limbs)
+{
+#if FLINT_HAVE_FFT_SMALL
+    slong ar = fmpz_mat_nrows(A);
+    slong k = fmpz_mat_ncols(A);
+    slong bc = fmpz_mat_ncols(B);
+    slong abits, bbits, bits_bound;
+    slong i, j, l;
+    gr_ctx_t tctx;
+    gr_ptr E, acc;
+    nn_ptr t;
+    slong tn_max;
+    int ok = 1;
+#define E_(i) GR_ENTRY(E, i, tctx->sizeof_elem)
+
+    if (ar == 0 || bc == 0 || k == 0)
+        return 0;
+    if (C == A || C == B)
+        return 0;
+
+    abits = FLINT_ABS(fmpz_mat_max_bits(A));
+    bbits = FLINT_ABS(fmpz_mat_max_bits(B));
+    if (abits == 0 || bbits == 0)
+        return 0;
+
+    if (abits + bbits < FMPZ_MAT_MUL_FFT_SMALL_MIN_BITS)
+        return 0;
+
+    bits_bound = abits + bbits + FLINT_BIT_COUNT((ulong) k) + 2;
+
+    if (gr_ctx_init_transformed_mpn(tctx, bits_bound, k, 1) != GR_SUCCESS)
+        return 0;
+
+    E = flint_malloc((ar * k + k * bc) * tctx->sizeof_elem);
+    for (i = 0; i < ar * k + k * bc; i++)
+        gr_init(E_(i), tctx);
+    acc = gr_heap_init(tctx);
+
+    tn_max = (abits + bbits + 128) / FLINT_BITS + 4 + k;
+    t = flint_malloc(tn_max * sizeof(ulong));
+
+    /* conversions in */
+    for (i = 0; ok && i < ar; i++)
+        for (l = 0; ok && l < k; l++)
+        {
+            const fmpz * e = fmpz_mat_entry(A, i, l);
+            slong en = fmpz_size(e);
+            fmpz_t ea; fmpz_init(ea); fmpz_abs(ea, e);
+            fmpz_get_ui_array(t, FLINT_MAX(en, 1), ea);
+            ok = gr_transformed_mpn_set(E_(i * k + l), t, en,
+                    fmpz_sgn(e) < 0, tctx) == GR_SUCCESS;
+            fmpz_clear(ea);
+        }
+    for (l = 0; ok && l < k; l++)
+        for (j = 0; ok && j < bc; j++)
+        {
+            const fmpz * e = fmpz_mat_entry(B, l, j);
+            slong en = fmpz_size(e);
+            fmpz_t ea; fmpz_init(ea); fmpz_abs(ea, e);
+            fmpz_get_ui_array(t, FLINT_MAX(en, 1), ea);
+            ok = gr_transformed_mpn_set(E_(ar * k + l * bc + j), t, en,
+                    fmpz_sgn(e) < 0, tctx) == GR_SUCCESS;
+            fmpz_clear(ea);
+        }
+
+    /* accumulate and convert out */
+    for (i = 0; ok && i < ar; i++)
+        for (j = 0; ok && j < bc; j++)
+        {
+            slong need, zn; int sg;
+
+            ok = gr_mul(acc, E_(i * k), E_(ar * k + j), tctx) == GR_SUCCESS;
+            for (l = 1; ok && l < k; l++)
+                ok = gr_addmul(acc, E_(i * k + l),
+                        E_(ar * k + l * bc + j), tctx) == GR_SUCCESS;
+
+            need = (lo_limbs == 0)
+                    ? gr_transformed_mpn_get_limbs(tctx, acc)
+                    : gr_transformed_mpn_get_limbs_trunc(tctx, acc, lo_limbs);
+            if (need > tn_max)
+            {
+                t = flint_realloc(t, need * sizeof(ulong));
+                tn_max = need;
+            }
+            if (lo_limbs == 0)
+                ok = ok && gr_transformed_mpn_get(t, need, &zn, &sg, acc,
+                        tctx) == GR_SUCCESS;
+            else
+                ok = ok && gr_transformed_mpn_get_trunc(t, need, &zn, &sg,
+                        lo_limbs, acc, tctx) == GR_SUCCESS;
+            if (ok)
+            {
+                fmpz * e = fmpz_mat_entry(C, i, j);
+                if (zn == 0)
+                    fmpz_zero(e);
+                else
+                {
+                    fmpz_set_ui_array(e, t, zn);
+                    if (sg)
+                        fmpz_neg(e, e);
+                }
+            }
+        }
+
+    for (i = 0; i < ar * k + k * bc; i++)
+        gr_clear(E_(i), tctx);
+    flint_free(E);
+    gr_heap_clear(acc, tctx);
+    flint_free(t);
+    gr_ctx_clear(tctx);
+#undef E_
+    return ok;
+#else
+    return 0;
+#endif
+}
+
+int
+fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B)
+{
+    return _fmpz_mat_mul_fft_small(C, A, B, 0);
+}
+
+int
+fmpz_mat_mul_fft_small_trunc(fmpz_mat_t C, const fmpz_mat_t A,
+                             const fmpz_mat_t B, slong lo_limbs)
+{
+    if (lo_limbs < 0)
+        return 0;
+    return _fmpz_mat_mul_fft_small(C, A, B, lo_limbs);
+}

--- a/src/fmpz_mat/mul_fft_small.c
+++ b/src/fmpz_mat/mul_fft_small.c
@@ -88,7 +88,7 @@ _set_entry(gr_ptr elem, const fmpz * e, gr_ctx_t tctx)
    acc, which the caller re-initializes */
 static int
 _export_entry(fmpz * e, gr_ptr acc, slong lo_limbs, int add_into,
-              nn_ptr * t, slong * tn_max, gr_ctx_t tctx)
+              nn_ptr t, slong tn_max, gr_ctx_t tctx)
 {
     slong need, zn;
     int sg, ok;
@@ -96,16 +96,15 @@ _export_entry(fmpz * e, gr_ptr acc, slong lo_limbs, int add_into,
     need = (lo_limbs == 0)
             ? gr_transformed_mpn_get_limbs(tctx, acc)
             : gr_transformed_mpn_get_limbs_trunc(tctx, acc, lo_limbs);
-    if (need > *tn_max)
-    {
-        *t = flint_realloc(*t, need * sizeof(ulong));
-        *tn_max = need;
-    }
+    /* the buffer was sized from gr_transformed_mpn_get_limbs_bound, of
+       which need is a per-element instance */
+    FLINT_ASSERT(need <= tn_max);
+    (void) tn_max;
     if (lo_limbs == 0)
-        ok = gr_transformed_mpn_get_destructive(*t, need, &zn, &sg, acc,
+        ok = gr_transformed_mpn_get_destructive(t, need, &zn, &sg, acc,
                 tctx) == GR_SUCCESS;
     else
-        ok = gr_transformed_mpn_get_trunc_destructive(*t, need, &zn, &sg,
+        ok = gr_transformed_mpn_get_trunc_destructive(t, need, &zn, &sg,
                 lo_limbs, acc, tctx) == GR_SUCCESS;
     if (!ok)
         return 0;
@@ -116,7 +115,7 @@ _export_entry(fmpz * e, gr_ptr acc, slong lo_limbs, int add_into,
             fmpz_zero(e);
         else
         {
-            fmpz_set_ui_array(e, *t, zn);
+            fmpz_set_ui_array(e, t, zn);
             if (sg)
                 fmpz_neg(e, e);
         }
@@ -125,7 +124,7 @@ _export_entry(fmpz * e, gr_ptr acc, slong lo_limbs, int add_into,
     {
         fmpz_t p;
         fmpz_init(p);
-        fmpz_set_ui_array(p, *t, zn);
+        fmpz_set_ui_array(p, t, zn);
         if (sg)
             fmpz_sub(e, e, p);
         else
@@ -320,7 +319,7 @@ _fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B,
 
                         if (ok)
                             ok = _export_entry(fmpz_mat_entry(C, I + i, J + j),
-                                    acc, lo_limbs, L > 0, &t, &tn_max, tctx);
+                                    acc, lo_limbs, L > 0, t, tn_max, tctx);
 
                         gr_clear(acc, tctx);
                         gr_transformed_mpn_init_borrowed(acc, acc_data, tctx);

--- a/src/fmpz_mat/sqr.c
+++ b/src/fmpz_mat/sqr.c
@@ -28,14 +28,14 @@ fmpz_mat_sqr(fmpz_mat_t B, const fmpz_mat_t A)
         return;
     }
 
-    if (n <= 3)
+    ab = fmpz_mat_max_bits(A);
+    ab = FLINT_ABS(ab);
+
+    if ((n <= 3 || (n == 4 && ab >= 1024)) && ab <= 12000)
     {
         fmpz_mat_sqr_bodrato(B, A);
         return;
     }
-
-    ab = fmpz_mat_max_bits(A);
-    ab = FLINT_ABS(ab);
 
     if (n == 4 && ab >= 1024)
         fmpz_mat_sqr_bodrato(B, A);

--- a/src/fmpz_mat/test/main.c
+++ b/src/fmpz_mat/test/main.c
@@ -78,6 +78,7 @@
 #include "t-mul_blas.c"
 #include "t-mul.c"
 #include "t-mul_classical.c"
+#include "t-mul_fft_small.c"
 #include "t-mul_double_word.c"
 #include "t-mul_fft.c"
 #include "t-mul_fmpz_vec.c"
@@ -184,6 +185,7 @@ test_struct tests[] =
     TEST_FUNCTION(fmpz_mat_mul_blas),
     TEST_FUNCTION(fmpz_mat_mul),
     TEST_FUNCTION(fmpz_mat_mul_classical),
+    TEST_FUNCTION(fmpz_mat_mul_fft_small),
     TEST_FUNCTION(fmpz_mat_mul_double_word),
     TEST_FUNCTION(fmpz_mat_mul_fft),
     TEST_FUNCTION(fmpz_mat_mul_fmpz_vec),

--- a/src/fmpz_mat/test/t-mul_fft_small.c
+++ b/src/fmpz_mat/test/t-mul_fft_small.c
@@ -27,6 +27,16 @@ TEST_FUNCTION_START(fmpz_mat_mul_fft_small, state)
         slong r = 1 + n_randint(state, 4);
         slong k = 1 + n_randint(state, 4);
         slong c = 1 + n_randint(state, 4);
+
+        /* asymmetric shapes reach the one-side-resident streaming tiers
+           in both orientations, and a large inner dimension with a
+           starved budget reaches the inner-blocked accumulation tier */
+        if (iter % 8 == 5)
+        { r = 1 + n_randint(state, 2); c = 5 + n_randint(state, 4); }
+        else if (iter % 8 == 6)
+        { r = 5 + n_randint(state, 4); c = 1 + n_randint(state, 2); }
+        else if (iter % 8 == 7)
+        { r = 1; c = 1; k = 8 + n_randint(state, 5); }
         ulong save_limit = flint_fft_small_max_transformed_ring_size;
         int square = (iter % 4 == 1);
 
@@ -37,7 +47,8 @@ TEST_FUNCTION_START(fmpz_mat_mul_fft_small, state)
         if (iter % 4 == 2)
             flint_fft_small_max_transformed_ring_size = UWORD(1) << 20;
         else if (iter % 4 == 3)
-            flint_fft_small_max_transformed_ring_size = UWORD(1) << 18;
+            flint_fft_small_max_transformed_ring_size =
+                UWORD(1) << (13 + n_randint(state, 8));
         slong bits = 8192 + n_randint(state, 8192);
         fmpz_mat_t A, B, C, D, A0, B0;
         slong i, j;

--- a/src/fmpz_mat/test/t-mul_fft_small.c
+++ b/src/fmpz_mat/test/t-mul_fft_small.c
@@ -1,0 +1,123 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "fmpz.h"
+#include "fmpz_mat.h"
+
+/* Transformed-integer matrix product against the default algorithm. The
+   function returns 0 when the representation is unavailable or judged
+   unprofitable; entries are drawn dense (fmpz_mat_randtest is sparse
+   enough to fall below the gate) with both signs. */
+TEST_FUNCTION_START(fmpz_mat_mul_fft_small, state)
+{
+    for (slong iter = 0; iter < 10 * flint_test_multiplier(); iter++)
+    {
+        slong r = 1 + n_randint(state, 4);
+        slong k = 1 + n_randint(state, 4);
+        slong c = 1 + n_randint(state, 4);
+        slong bits = 8192 + n_randint(state, 8192);
+        fmpz_mat_t A, B, C, D, A0, B0;
+        slong i, j;
+
+        fmpz_mat_init(A, r, k);
+        fmpz_mat_init(B, k, c);
+        fmpz_mat_init(C, r, c);
+        fmpz_mat_init(D, r, c);
+
+        for (i = 0; i < r; i++)
+            for (j = 0; j < k; j++)
+            {
+                fmpz_randbits(fmpz_mat_entry(A, i, j), state, bits);
+                if (n_randint(state, 8) == 0)
+                    fmpz_zero(fmpz_mat_entry(A, i, j));
+            }
+        for (i = 0; i < k; i++)
+            for (j = 0; j < c; j++)
+            {
+                fmpz_randbits(fmpz_mat_entry(B, i, j), state, bits);
+                if (n_randint(state, 8) == 0)
+                    fmpz_zero(fmpz_mat_entry(B, i, j));
+            }
+
+        fmpz_mat_init_set(A0, A);
+        fmpz_mat_init_set(B0, B);
+
+        fmpz_mat_mul(D, A, B);
+
+        if (fmpz_mat_mul_fft_small(C, A, B))
+        {
+            if (!fmpz_mat_equal(C, D))
+                TEST_FUNCTION_FAIL(
+                    "wrong product\n"
+                    "dims %wd x %wd x %wd, entry bits %wd\n",
+                    r, k, c, bits);
+        }
+
+        /* the inputs must be untouched whether or not the product ran */
+        if (!fmpz_mat_equal(A, A0) || !fmpz_mat_equal(B, B0))
+            TEST_FUNCTION_FAIL("input matrices modified\n");
+
+        /* truncated product: each entry's magnitude above limb lo, with
+           the entry's sign and at most one unit of error in the lowest
+           returned limb */
+        {
+            slong lo = n_randint(state, 2 + bits / (2 * FLINT_BITS));
+            fmpz_mat_t E;
+
+            fmpz_mat_init(E, r, c);
+            if (fmpz_mat_mul_fft_small_trunc(E, A, B, lo))
+            {
+                for (i = 0; i < r; i++)
+                    for (j = 0; j < c; j++)
+                    {
+                        fmpz_t want, got, diff;
+
+                        fmpz_init(want);
+                        fmpz_init(got);
+                        fmpz_init(diff);
+                        fmpz_abs(want, fmpz_mat_entry(D, i, j));
+                        fmpz_fdiv_q_2exp(want, want, FLINT_BITS * lo);
+                        fmpz_abs(got, fmpz_mat_entry(E, i, j));
+                        fmpz_sub(diff, got, want);
+                        fmpz_abs(diff, diff);
+
+                        if (fmpz_cmp_ui(diff, 1) > 0)
+                            TEST_FUNCTION_FAIL(
+                                "truncated entry (%wd, %wd) off by more "
+                                "than one unit\nlo = %wd, bits = %wd\n",
+                                i, j, lo, bits);
+
+                        if (!fmpz_is_zero(got) && !fmpz_is_zero(want) &&
+                                fmpz_sgn(fmpz_mat_entry(E, i, j)) !=
+                                fmpz_sgn(fmpz_mat_entry(D, i, j)))
+                            TEST_FUNCTION_FAIL(
+                                "truncated entry (%wd, %wd) sign wrong\n",
+                                i, j);
+
+                        fmpz_clear(want);
+                        fmpz_clear(got);
+                        fmpz_clear(diff);
+                    }
+            }
+            fmpz_mat_clear(E);
+        }
+
+        fmpz_mat_clear(A);
+        fmpz_mat_clear(B);
+        fmpz_mat_clear(C);
+        fmpz_mat_clear(D);
+        fmpz_mat_clear(A0);
+        fmpz_mat_clear(B0);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/fmpz_mat/test/t-mul_fft_small.c
+++ b/src/fmpz_mat/test/t-mul_fft_small.c
@@ -11,12 +11,15 @@
 
 #include "test_helpers.h"
 #include "fmpz.h"
+#include "fft_small.h"
 #include "fmpz_mat.h"
 
 /* Transformed-integer matrix product against the default algorithm. The
    function returns 0 when the representation is unavailable or judged
-   unprofitable; entries are drawn dense (fmpz_mat_randtest is sparse
-   enough to fall below the gate) with both signs. */
+   unprofitable; entries are drawn dense (fmpz_mat_randtest's sparse
+   entries make degenerate shapes) with both signs; every fourth
+   iteration squares (B aliased to A), and a rotating storage budget
+   forces each blocking tier of the driver. */
 TEST_FUNCTION_START(fmpz_mat_mul_fft_small, state)
 {
     for (slong iter = 0; iter < 10 * flint_test_multiplier(); iter++)
@@ -24,6 +27,17 @@ TEST_FUNCTION_START(fmpz_mat_mul_fft_small, state)
         slong r = 1 + n_randint(state, 4);
         slong k = 1 + n_randint(state, 4);
         slong c = 1 + n_randint(state, 4);
+        ulong save_limit = flint_fft_small_max_transformed_ring_size;
+        int square = (iter % 4 == 1);
+
+        if (square)
+        { k = r; c = r; }
+        /* rotate the budget to force the resident, streamed, doubly
+           blocked and inner-blocked strategies in turn */
+        if (iter % 4 == 2)
+            flint_fft_small_max_transformed_ring_size = UWORD(1) << 20;
+        else if (iter % 4 == 3)
+            flint_fft_small_max_transformed_ring_size = UWORD(1) << 18;
         slong bits = 8192 + n_randint(state, 8192);
         fmpz_mat_t A, B, C, D, A0, B0;
         slong i, j;
@@ -37,6 +51,12 @@ TEST_FUNCTION_START(fmpz_mat_mul_fft_small, state)
             for (j = 0; j < k; j++)
             {
                 fmpz_randbits(fmpz_mat_entry(A, i, j), state, bits);
+                /* every third iteration keeps everything nonnegative to
+                   exercise the unsigned-context fast path, which signed
+                   entries almost never select by chance */
+                if (iter % 3 == 0)
+                    fmpz_abs(fmpz_mat_entry(A, i, j),
+                             fmpz_mat_entry(A, i, j));
                 if (n_randint(state, 8) == 0)
                     fmpz_zero(fmpz_mat_entry(A, i, j));
             }
@@ -44,6 +64,9 @@ TEST_FUNCTION_START(fmpz_mat_mul_fft_small, state)
             for (j = 0; j < c; j++)
             {
                 fmpz_randbits(fmpz_mat_entry(B, i, j), state, bits);
+                if (iter % 3 == 0)
+                    fmpz_abs(fmpz_mat_entry(B, i, j),
+                             fmpz_mat_entry(B, i, j));
                 if (n_randint(state, 8) == 0)
                     fmpz_zero(fmpz_mat_entry(B, i, j));
             }
@@ -51,9 +74,9 @@ TEST_FUNCTION_START(fmpz_mat_mul_fft_small, state)
         fmpz_mat_init_set(A0, A);
         fmpz_mat_init_set(B0, B);
 
-        fmpz_mat_mul(D, A, B);
+        fmpz_mat_mul(D, A, square ? A : B);
 
-        if (fmpz_mat_mul_fft_small(C, A, B))
+        if (fmpz_mat_mul_fft_small(C, A, square ? A : B))
         {
             if (!fmpz_mat_equal(C, D))
                 TEST_FUNCTION_FAIL(
@@ -74,7 +97,7 @@ TEST_FUNCTION_START(fmpz_mat_mul_fft_small, state)
             fmpz_mat_t E;
 
             fmpz_mat_init(E, r, c);
-            if (fmpz_mat_mul_fft_small_trunc(E, A, B, lo))
+            if (fmpz_mat_mul_fft_small_trunc(E, A, square ? A : B, lo))
             {
                 for (i = 0; i < r; i++)
                     for (j = 0; j < c; j++)
@@ -111,6 +134,7 @@ TEST_FUNCTION_START(fmpz_mat_mul_fft_small, state)
             fmpz_mat_clear(E);
         }
 
+        flint_fft_small_max_transformed_ring_size = save_limit;
         fmpz_mat_clear(A);
         fmpz_mat_clear(B);
         fmpz_mat_clear(C);

--- a/src/fmpzi/mul.c
+++ b/src/fmpzi/mul.c
@@ -10,12 +10,12 @@
 */
 
 #include "longlong.h"
+#include "mpn_extras.h"
 #include "fmpzi.h"
 
 void
 fmpzi_mul(fmpzi_t res, const fmpzi_t x, const fmpzi_t y)
 {
-    slong asize, bsize, csize, dsize;
     fmpzi_struct * rp;
     fmpzi_t tmp;
     fmpz * t;
@@ -73,34 +73,32 @@ fmpzi_mul(fmpzi_t res, const fmpzi_t x, const fmpzi_t y)
     t = fmpzi_realref(rp);
     u = fmpzi_imagref(rp);
 
-    if (!xsmall && !ysmall)
+    if (COEFF_IS_MPZ(ca) && COEFF_IS_MPZ(cb) &&
+        COEFF_IS_MPZ(cc) && COEFF_IS_MPZ(cd))
     {
-        asize = fmpz_size(a);
+        mpz_srcptr ma = COEFF_TO_PTR(ca), mb = COEFF_TO_PTR(cb);
+        mpz_srcptr mc = COEFF_TO_PTR(cc), md = COEFF_TO_PTR(cd);
+        slong an = FLINT_ABS(ma->_mp_size), bn = FLINT_ABS(mb->_mp_size);
+        slong cn = FLINT_ABS(mc->_mp_size), dn = FLINT_ABS(md->_mp_size);
+        slong w = FLINT_MAX(an, bn) + FLINT_MAX(cn, dn) + 1;
+        slong lzr, lzi;
+        mpz_ptr mt, mu;
 
-        if (asize >= 13)
-        {
-            bsize = fmpz_size(b);
-            csize = fmpz_size(c);
-            dsize = fmpz_size(d);
+        mt = _fmpz_promote(t);
+        mu = _fmpz_promote(u);
 
-            if (csize >= 13 && FLINT_ABS(asize - bsize) <= 2 && FLINT_ABS(csize - dsize) <= 2)
-            {
-                fmpz_t v;
+        flint_mpn_mul_complex(FLINT_MPZ_REALLOC(mt, w), &lzr,
+                              FLINT_MPZ_REALLOC(mu, w), &lzi,
+                              ma->_mp_d, an, ma->_mp_size < 0,
+                              mb->_mp_d, bn, mb->_mp_size < 0,
+                              mc->_mp_d, cn, mc->_mp_size < 0,
+                              md->_mp_d, dn, md->_mp_size < 0);
 
-                fmpz_init(v);
-                fmpz_add(t, a, b);
-                fmpz_add(v, c, d);
-                fmpz_mul(u, t, v);
-                fmpz_mul(t, a, c);
-                fmpz_mul(v, b, d);
-                fmpz_sub(u, u, t);
-                fmpz_sub(u, u, v);
-                fmpz_sub(t, t, v);
-                fmpz_clear(v);
-
-                goto cleanup;
-            }
-        }
+        mt->_mp_size = lzr;
+        mu->_mp_size = lzi;
+        _fmpz_demote_val(t);
+        _fmpz_demote_val(u);
+        goto cleanup;
     }
 
     fmpz_mul(t, a, c);

--- a/src/fmpzi/sqr.c
+++ b/src/fmpzi/sqr.c
@@ -11,12 +11,12 @@
 
 #include <gmp.h>
 #include "longlong.h"
+#include "mpn_extras.h"
 #include "fmpzi.h"
 
 void
 fmpzi_sqr(fmpzi_t res, const fmpzi_t x)
 {
-    slong asize, bsize;
     fmpzi_struct * rp;
     fmpzi_t tmp;
     fmpz * t;
@@ -73,33 +73,25 @@ fmpzi_sqr(fmpzi_t res, const fmpzi_t x)
 
     if (COEFF_IS_MPZ(ca) && COEFF_IS_MPZ(cb))
     {
-        asize = COEFF_TO_PTR(ca)->_mp_size;
-        asize = FLINT_ABS(asize);
+        mpz_srcptr ma = COEFF_TO_PTR(ca), mb = COEFF_TO_PTR(cb);
+        slong an = FLINT_ABS(ma->_mp_size), bn = FLINT_ABS(mb->_mp_size);
+        slong w = 2 * FLINT_MAX(an, bn) + 1;
+        slong lzr, lzi;
+        mpz_ptr mt, mu;
 
-        if (asize >= 16)
-        {
-            bsize = COEFF_TO_PTR(cb)->_mp_size;
-            bsize = FLINT_ABS(bsize);
+        mt = _fmpz_promote(t);
+        mu = _fmpz_promote(u);
 
-            if (FLINT_ABS(asize - bsize) <= 2)
-            {
-                fmpz_t v;
-                fmpz_init(v);
+        flint_mpn_sqr_complex(FLINT_MPZ_REALLOC(mt, w), &lzr,
+                              FLINT_MPZ_REALLOC(mu, w), &lzi,
+                              ma->_mp_d, an, ma->_mp_size < 0,
+                              mb->_mp_d, bn, mb->_mp_size < 0);
 
-                /* a^2-b^2, (a+b)^2-a^2-b^2 */
-                fmpz_add(v, a, b);
-                fmpz_mul(u, v, v);
-                fmpz_mul(t, a, a);
-                fmpz_sub(u, u, t);
-                fmpz_mul(v, b, b);
-                fmpz_sub(t, t, v);
-                fmpz_sub(u, u, v);
-
-                fmpz_clear(v);
-
-                goto cleanup;
-            }
-        }
+        mt->_mp_size = lzr;
+        mu->_mp_size = lzi;
+        _fmpz_demote_val(t);
+        _fmpz_demote_val(u);
+        goto cleanup;
     }
 
     fmpz_mul(t, a, a);

--- a/src/gr.h
+++ b/src/gr.h
@@ -879,6 +879,8 @@ typedef struct gr_transformed_poly_workload_struct
     slong num_inputs;
     slong num_muls;
     slong num_outputs;
+    slong num_live;     /* expected simultaneously live elements;
+                           0 derives num_inputs + num_outputs + 2 */
     slong mem_limit;
 }
 gr_transformed_poly_workload_struct;
@@ -1489,7 +1491,7 @@ void _gr_ctx_init_fmpz_mod_from_ref(gr_ctx_t ctx, const void * fmod_ctx);
    (one-sided, below 1) plus the wholly dropped slots' total mass
    (under half an ulp either way). */
 int gr_ctx_init_transformed_mpn(gr_ctx_t ctx, slong bits_bound,
-                    slong terms_bound, int is_signed);
+                    slong terms_bound, int is_signed, slong num_live);
 int gr_transformed_mpn_set(gr_ptr res, nn_srcptr a, slong an, int sign,
                     gr_ctx_t ctx);
 int gr_transformed_mpn_get(nn_ptr z, slong zn, slong * zn_out, int * sign,

--- a/src/gr.h
+++ b/src/gr.h
@@ -1504,6 +1504,7 @@ int gr_transformed_mpn_get_trunc_destructive(nn_ptr z, slong zn,
 void gr_transformed_mpn_init_borrowed(gr_ptr x, double * data, gr_ctx_t ctx);
 ulong gr_transformed_mpn_sizeof_data(gr_ctx_t ctx);
 slong gr_transformed_mpn_get_limbs(gr_ctx_t ctx, gr_srcptr x);
+slong gr_transformed_mpn_get_limbs_bound(gr_ctx_t ctx);
 slong gr_transformed_mpn_get_limbs_trunc(gr_ctx_t ctx, gr_srcptr x,
                     slong lo);
 int gr_transformed_mpn_get_trunc(nn_ptr z, slong zn, slong * zn_out,

--- a/src/gr.h
+++ b/src/gr.h
@@ -1466,8 +1466,14 @@ void _gr_ctx_init_fmpz_mod_from_ref(gr_ctx_t ctx, const void * fmod_ctx);
    sign bit; mixed-sign accumulations switch the pointwise additions and
    subtractions, and the sign of a mixed result is resolved at conversion
    out. Conversions in and out are by limb arrays with an explicit sign;
-   gr_transformed_mpn_get_trunc returns the limbs above a given position,
-   with at most one unit of error in the lowest returned limb. */
+   gr_transformed_mpn_get_trunc returns the limbs of the value starting
+   at a given position, with an error against the exact value within
+   (-1.5, +0.5) ulp of the lowest returned limb -- equivalently, at most
+   1 from the floor-truncated value: the export includes every CRT slot
+   whose coefficient span can reach the first returned limb and
+   propagates their carries, so the error is the truncation itself
+   (one-sided, below 1) plus the wholly dropped slots' total mass
+   (under half an ulp either way). */
 int gr_ctx_init_transformed_mpn(gr_ctx_t ctx, slong bits_bound,
                     slong terms_bound, int is_signed);
 int gr_transformed_mpn_set(gr_ptr res, nn_srcptr a, slong an, int sign,

--- a/src/gr.h
+++ b/src/gr.h
@@ -884,6 +884,12 @@ gr_transformed_poly_workload_struct;
 
 typedef gr_transformed_poly_workload_struct gr_transformed_poly_workload_t[1];
 
+/* implementation of the transformed-polynomial constructor for nmod base
+   rings, installed in their method table */
+int _gr_nmod_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base,
+                    slong len_bound, slong terms_bound,
+                    const gr_transformed_poly_workload_struct * workload);
+
 /* construct a ring of transformed polynomials over a base ring, with the
    given length and accumulated-terms capacities, for the estimated
    workload (may be NULL, though implementations will then usually judge

--- a/src/gr.h
+++ b/src/gr.h
@@ -668,6 +668,7 @@ typedef enum
     GR_METHOD_CTX_INIT_TRANSFORMED_POLY_REPR,
     GR_METHOD_SET_GR_POLY,
     GR_METHOD_GET_GR_POLY,
+    GR_METHOD_GET_GR_POLY_DESTRUCTIVE,
     GR_METHOD_GET_GR_POLY_WINDOW,
     GR_METHOD_POLY_DIV,
     GR_METHOD_POLY_DIVREM,
@@ -889,6 +890,11 @@ typedef gr_transformed_poly_workload_struct gr_transformed_poly_workload_t[1];
 int _gr_nmod_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base,
                     slong len_bound, slong terms_bound,
                     const gr_transformed_poly_workload_struct * workload);
+/* windowed conversion out that consumes the element in place of copying
+   its transform; the element may only be cleared or fully overwritten
+   afterwards */
+int _gr_nmod_tpoly_get_gr_poly_window_destructive(nn_ptr cc, gr_ptr x,
+                    slong zl, slong zh, gr_ctx_t ctx);
 
 /* construct a ring of transformed polynomials over a base ring, with the
    given length and accumulated-terms capacities, for the estimated
@@ -899,6 +905,7 @@ typedef int ((*gr_method_ctx_init_transformed_poly_repr_op)(gr_ctx_ptr, gr_ctx_p
    of a transformed polynomial ring */
 typedef int ((*gr_method_set_gr_poly_op)(gr_ptr, gr_srcptr, slong, gr_ctx_ptr, gr_ctx_ptr));
 typedef int ((*gr_method_get_gr_poly_op)(gr_ptr, slong *, gr_srcptr, gr_ctx_ptr, gr_ctx_ptr));
+typedef int ((*gr_method_get_gr_poly_destructive_op)(gr_ptr, slong *, gr_ptr, gr_ctx_ptr, gr_ctx_ptr));
 /* windowed conversion out: writes the coefficients [zl, zh) of the
    represented polynomial (zeros beyond its length) */
 typedef int ((*gr_method_get_gr_poly_window_op)(gr_ptr, gr_srcptr, slong, slong, gr_ctx_ptr, gr_ctx_ptr));
@@ -1010,6 +1017,7 @@ typedef int ((*gr_method_set_fexpr_op)(gr_ptr, fexpr_vec_t, gr_vec_t, const fexp
 #define GR_CTX_INIT_TRANSFORMED_POLY_REPR_OP(ctx, NAME) (((gr_method_ctx_init_transformed_poly_repr_op *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_SET_GR_POLY_OP(ctx, NAME) (((gr_method_set_gr_poly_op *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_GET_GR_POLY_OP(ctx, NAME) (((gr_method_get_gr_poly_op *) ctx->methods)[GR_METHOD_ ## NAME])
+#define GR_GET_GR_POLY_DESTRUCTIVE_OP(ctx, NAME) (((gr_method_get_gr_poly_destructive_op *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_GET_GR_POLY_WINDOW_OP(ctx, NAME) (((gr_method_get_gr_poly_window_op *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_POLY_BINARY_TRUNC2_OP(ctx, NAME) (((gr_method_poly_binary_trunc2_op *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_POLY_GCD_OP(ctx, NAME) (((gr_method_poly_gcd_op *) ctx->methods)[GR_METHOD_ ## NAME])

--- a/src/gr.h
+++ b/src/gr.h
@@ -882,6 +882,10 @@ typedef struct gr_transformed_poly_workload_struct
     slong num_live;     /* expected simultaneously live elements;
                            0 derives num_inputs + num_outputs + 2 */
     slong mem_limit;
+    int force;          /* skip the profitability model and the storage
+                           budget, declining only on implementation
+                           bounds: for tests, where small unprofitable
+                           sizes catch bugs most easily */
 }
 gr_transformed_poly_workload_struct;
 

--- a/src/gr.h
+++ b/src/gr.h
@@ -739,6 +739,7 @@ typedef enum
     GR_CTX_MPF,
     GR_CTX_FMPZ_POLY, GR_CTX_FMPQ_POLY, GR_CTX_GR_POLY,
     GR_CTX_GR_TRANSFORMED_POLY,
+    GR_CTX_GR_TRANSFORMED_MPN,
     GR_CTX_FMPZ_MPOLY, GR_CTX_FMPQ_MPOLY, GR_CTX_GR_MPOLY,
     GR_CTX_FMPZ_MPOLY_Q,
     GR_CTX_FMPZ_MOD_MPOLY_Q,
@@ -1458,6 +1459,33 @@ void gr_ctx_init_fmpzi(gr_ctx_t ctx);
 
 void gr_ctx_init_fmpz_mod(gr_ctx_t ctx, const fmpz_t n);
 void _gr_ctx_init_fmpz_mod_from_ref(gr_ctx_t ctx, const void * fmod_ctx);
+
+/* Transformed big integers: bilinear expressions over Z with results
+   below 2^bits_bound in absolute value, at most terms_bound accumulated
+   elementary products and multiplicative depth two. Elements carry a
+   sign bit; mixed-sign accumulations switch the pointwise additions and
+   subtractions, and the sign of a mixed result is resolved at conversion
+   out. Conversions in and out are by limb arrays with an explicit sign;
+   gr_transformed_mpn_get_trunc returns the limbs above a given position,
+   with at most one unit of error in the lowest returned limb. */
+int gr_ctx_init_transformed_mpn(gr_ctx_t ctx, slong bits_bound,
+                    slong terms_bound, int is_signed);
+int gr_transformed_mpn_set(gr_ptr res, nn_srcptr a, slong an, int sign,
+                    gr_ctx_t ctx);
+int gr_transformed_mpn_get(nn_ptr z, slong zn, slong * zn_out, int * sign,
+                    gr_srcptr x, gr_ctx_t ctx);
+int gr_transformed_mpn_get_destructive(nn_ptr z, slong zn, slong * zn_out,
+                    int * sign, gr_ptr x, gr_ctx_t ctx);
+int gr_transformed_mpn_get_trunc_destructive(nn_ptr z, slong zn,
+                    slong * zn_out, int * sign, slong lo, gr_ptr x,
+                    gr_ctx_t ctx);
+void gr_transformed_mpn_init_borrowed(gr_ptr x, double * data, gr_ctx_t ctx);
+ulong gr_transformed_mpn_sizeof_data(gr_ctx_t ctx);
+slong gr_transformed_mpn_get_limbs(gr_ctx_t ctx, gr_srcptr x);
+slong gr_transformed_mpn_get_limbs_trunc(gr_ctx_t ctx, gr_srcptr x,
+                    slong lo);
+int gr_transformed_mpn_get_trunc(nn_ptr z, slong zn, slong * zn_out,
+                    int * sign, slong lo, gr_srcptr x, gr_ctx_t ctx);
 
 int gr_ctx_init_nmod(gr_ctx_t ctx, ulong n);
 void _gr_ctx_init_nmod(gr_ctx_t ctx, void * nmod_t_ref);

--- a/src/gr.h
+++ b/src/gr.h
@@ -664,6 +664,7 @@ typedef enum
     /* Polynomial methods (todo: rename -> GR_POLY) */
     GR_METHOD_POLY_MULLOW,
     GR_METHOD_POLY_MULMID,
+    GR_METHOD_POLY_HGCD_MAT_MUL,
     GR_METHOD_POLY_DIV,
     GR_METHOD_POLY_DIVREM,
     GR_METHOD_POLY_DIVEXACT,
@@ -857,6 +858,9 @@ typedef int ((*gr_method_poly_unary_trunc_op)(gr_ptr, gr_srcptr, slong, slong, g
 typedef int ((*gr_method_poly_binary_op)(gr_ptr, gr_srcptr, slong, gr_srcptr, slong, gr_ctx_ptr));
 typedef int ((*gr_method_poly_binary_binary_op)(gr_ptr, gr_ptr, gr_srcptr, slong, gr_srcptr, slong, gr_ctx_ptr));
 typedef int ((*gr_method_poly_binary_trunc_op)(gr_ptr, gr_srcptr, slong, gr_srcptr, slong, slong, gr_ctx_ptr));
+/* 2x2 polynomial matrix product for hgcd: C, A, B are arrays of 4 entries
+   with lengths lenC, lenA, lenB; T0, T1 are scratch for any single product */
+typedef int ((*gr_method_poly_hgcd_mat_mul_op)(gr_ptr *, slong *, gr_ptr *, slong *, gr_ptr *, slong *, gr_ptr, gr_ptr, gr_ctx_ptr));
 typedef int ((*gr_method_poly_binary_trunc2_op)(gr_ptr, gr_srcptr, slong, gr_srcptr, slong, slong, slong, gr_ctx_ptr));
 typedef int ((*gr_method_poly_gcd_op)(gr_ptr, slong *, gr_srcptr, slong, gr_srcptr, slong, gr_ctx_ptr));
 typedef int ((*gr_method_poly_xgcd_op)(slong *, gr_ptr, gr_ptr, gr_ptr, gr_srcptr, slong, gr_srcptr, slong, gr_ctx_ptr));
@@ -961,6 +965,7 @@ typedef int ((*gr_method_set_fexpr_op)(gr_ptr, fexpr_vec_t, gr_vec_t, const fexp
 #define GR_POLY_UNARY_TRUNC_OP(ctx, NAME) (((gr_method_poly_unary_trunc_op *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_POLY_BINARY_BINARY_OP(ctx, NAME) (((gr_method_poly_binary_binary_op *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_POLY_BINARY_TRUNC_OP(ctx, NAME) (((gr_method_poly_binary_trunc_op *) ctx->methods)[GR_METHOD_ ## NAME])
+#define GR_POLY_HGCD_MAT_MUL_OP(ctx, NAME) (((gr_method_poly_hgcd_mat_mul_op *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_POLY_BINARY_TRUNC2_OP(ctx, NAME) (((gr_method_poly_binary_trunc2_op *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_POLY_GCD_OP(ctx, NAME) (((gr_method_poly_gcd_op *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_POLY_XGCD_OP(ctx, NAME) (((gr_method_poly_xgcd_op *) ctx->methods)[GR_METHOD_ ## NAME])

--- a/src/gr.h
+++ b/src/gr.h
@@ -665,6 +665,10 @@ typedef enum
     GR_METHOD_POLY_MULLOW,
     GR_METHOD_POLY_MULMID,
     GR_METHOD_POLY_HGCD_MAT_MUL,
+    GR_METHOD_CTX_INIT_TRANSFORMED_POLY_REPR,
+    GR_METHOD_SET_GR_POLY,
+    GR_METHOD_GET_GR_POLY,
+    GR_METHOD_GET_GR_POLY_WINDOW,
     GR_METHOD_POLY_DIV,
     GR_METHOD_POLY_DIVREM,
     GR_METHOD_POLY_DIVEXACT,
@@ -734,6 +738,7 @@ typedef enum
     GR_CTX_NFLOAT, GR_CTX_NFLOAT_COMPLEX,
     GR_CTX_MPF,
     GR_CTX_FMPZ_POLY, GR_CTX_FMPQ_POLY, GR_CTX_GR_POLY,
+    GR_CTX_GR_TRANSFORMED_POLY,
     GR_CTX_FMPZ_MPOLY, GR_CTX_FMPQ_MPOLY, GR_CTX_GR_MPOLY,
     GR_CTX_FMPZ_MPOLY_Q,
     GR_CTX_FMPZ_MOD_MPOLY_Q,
@@ -861,6 +866,35 @@ typedef int ((*gr_method_poly_binary_trunc_op)(gr_ptr, gr_srcptr, slong, gr_srcp
 /* 2x2 polynomial matrix product for hgcd: C, A, B are arrays of 4 entries
    with lengths lenC, lenA, lenB; T0, T1 are scratch for any single product */
 typedef int ((*gr_method_poly_hgcd_mat_mul_op)(gr_ptr *, slong *, gr_ptr *, slong *, gr_ptr *, slong *, gr_ptr, gr_ptr, gr_ctx_ptr));
+/* estimated workload for a transformed polynomial ring: how many operands
+   will be converted in (forward transforms), how many pointwise
+   multiplications performed, and how many results converted out (inverse
+   transforms). Advisory: used to decide whether the representation is
+   worth switching to and to bound its memory use (mem_limit in bytes,
+   0 for the implementation default). */
+typedef struct gr_transformed_poly_workload_struct
+{
+    slong num_inputs;
+    slong num_muls;
+    slong num_outputs;
+    slong mem_limit;
+}
+gr_transformed_poly_workload_struct;
+
+typedef gr_transformed_poly_workload_struct gr_transformed_poly_workload_t[1];
+
+/* construct a ring of transformed polynomials over a base ring, with the
+   given length and accumulated-terms capacities, for the estimated
+   workload (may be NULL, though implementations will then usually judge
+   the switch unprofitable) */
+typedef int ((*gr_method_ctx_init_transformed_poly_repr_op)(gr_ctx_ptr, gr_ctx_ptr, slong, slong, const gr_transformed_poly_workload_struct *));
+/* conversions between coefficient vectors over the base ring and elements
+   of a transformed polynomial ring */
+typedef int ((*gr_method_set_gr_poly_op)(gr_ptr, gr_srcptr, slong, gr_ctx_ptr, gr_ctx_ptr));
+typedef int ((*gr_method_get_gr_poly_op)(gr_ptr, slong *, gr_srcptr, gr_ctx_ptr, gr_ctx_ptr));
+/* windowed conversion out: writes the coefficients [zl, zh) of the
+   represented polynomial (zeros beyond its length) */
+typedef int ((*gr_method_get_gr_poly_window_op)(gr_ptr, gr_srcptr, slong, slong, gr_ctx_ptr, gr_ctx_ptr));
 typedef int ((*gr_method_poly_binary_trunc2_op)(gr_ptr, gr_srcptr, slong, gr_srcptr, slong, slong, slong, gr_ctx_ptr));
 typedef int ((*gr_method_poly_gcd_op)(gr_ptr, slong *, gr_srcptr, slong, gr_srcptr, slong, gr_ctx_ptr));
 typedef int ((*gr_method_poly_xgcd_op)(slong *, gr_ptr, gr_ptr, gr_ptr, gr_srcptr, slong, gr_srcptr, slong, gr_ctx_ptr));
@@ -966,6 +1000,10 @@ typedef int ((*gr_method_set_fexpr_op)(gr_ptr, fexpr_vec_t, gr_vec_t, const fexp
 #define GR_POLY_BINARY_BINARY_OP(ctx, NAME) (((gr_method_poly_binary_binary_op *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_POLY_BINARY_TRUNC_OP(ctx, NAME) (((gr_method_poly_binary_trunc_op *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_POLY_HGCD_MAT_MUL_OP(ctx, NAME) (((gr_method_poly_hgcd_mat_mul_op *) ctx->methods)[GR_METHOD_ ## NAME])
+#define GR_CTX_INIT_TRANSFORMED_POLY_REPR_OP(ctx, NAME) (((gr_method_ctx_init_transformed_poly_repr_op *) ctx->methods)[GR_METHOD_ ## NAME])
+#define GR_SET_GR_POLY_OP(ctx, NAME) (((gr_method_set_gr_poly_op *) ctx->methods)[GR_METHOD_ ## NAME])
+#define GR_GET_GR_POLY_OP(ctx, NAME) (((gr_method_get_gr_poly_op *) ctx->methods)[GR_METHOD_ ## NAME])
+#define GR_GET_GR_POLY_WINDOW_OP(ctx, NAME) (((gr_method_get_gr_poly_window_op *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_POLY_BINARY_TRUNC2_OP(ctx, NAME) (((gr_method_poly_binary_trunc2_op *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_POLY_GCD_OP(ctx, NAME) (((gr_method_poly_gcd_op *) ctx->methods)[GR_METHOD_ ## NAME])
 #define GR_POLY_XGCD_OP(ctx, NAME) (((gr_method_poly_xgcd_op *) ctx->methods)[GR_METHOD_ ## NAME])

--- a/src/gr/nmod.c
+++ b/src/gr/nmod.c
@@ -1510,7 +1510,7 @@ gr_method_tab_input __gr_nmod_methods_input[] =
     {GR_METHOD_VEC_RECIPROCALS, (gr_funcptr) _gr_nmod_vec_reciprocals},
     {GR_METHOD_POLY_MULLOW,     (gr_funcptr) _gr_nmod_poly_mullow},
     {GR_METHOD_CTX_INIT_TRANSFORMED_POLY_REPR,
-                                (gr_funcptr) _gr_nmod_ctx_init_transformed_poly_repr},
+                                (gr_funcptr) (void (*)(void)) _gr_nmod_ctx_init_transformed_poly_repr},
     {GR_METHOD_POLY_MULMID,     (gr_funcptr) _gr_nmod_poly_mulmid},
     {GR_METHOD_POLY_DIVREM,     (gr_funcptr) _gr_nmod_poly_divrem},
     {GR_METHOD_POLY_DIVEXACT,   (gr_funcptr) _gr_nmod_poly_divexact},

--- a/src/gr/nmod.c
+++ b/src/gr/nmod.c
@@ -957,7 +957,7 @@ _gr_nmod_vec_reciprocals(ulong * res, slong len, gr_ctx_t ctx)
         return GR_SUCCESS;
     }
 
-    if (mod.n <= len || mod.n % 2 == 0)
+    if (mod.n <= (ulong) len || mod.n % 2 == 0)
         return GR_DOMAIN;
 
     res[0] = 1;
@@ -977,10 +977,6 @@ _gr_nmod_vec_reciprocals(ulong * res, slong len, gr_ctx_t ctx)
 
 
 /* implemented in gr/nmod_transformed_poly.c */
-int _gr_nmod_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base,
-                                        slong len_bound, slong terms_bound,
-                                        const gr_transformed_poly_workload_struct * workload);
-
 /* 2x2 matrix products inside hgcd: from this entry length on, reusing the
    fft_small transforms of the 8 inputs beats Strassen (single-threaded
    tuning; the transform and export stages also thread internally when

--- a/src/gr/nmod.c
+++ b/src/gr/nmod.c
@@ -15,6 +15,8 @@
 #include "nmod_poly.h"
 #include "nmod_poly/impl.h"
 #include "nmod_mat.h"
+#include "mpn_extras.h"
+#include "nmod_poly_mat.h"
 #include "gr.h"
 #include "gr_vec.h"
 #include "gr_mat.h"
@@ -972,6 +974,74 @@ _gr_nmod_vec_reciprocals(ulong * res, slong len, gr_ctx_t ctx)
     return GR_SUCCESS;
 }
 
+
+/* 2x2 matrix products inside hgcd: from this entry length on, reusing the
+   fft_small transforms of the 8 inputs beats Strassen (single-threaded
+   tuning; the transform and export stages also thread internally when
+   the pool has workers) */
+#define NMOD_POLY_HGCD_MAT_MUL_FFT_CUTOFF 128
+
+static int
+_gr_nmod_poly_hgcd_mat_mul(gr_ptr * C, slong * lenC,
+        gr_ptr * A, slong * lenA, gr_ptr * B, slong * lenB,
+        gr_ptr T0, gr_ptr T1, gr_ctx_t ctx)
+{
+#if FLINT_HAVE_FFT_SMALL
+    slong i;
+    slong minlen = lenA[0];
+    slong amax = 0, bmax = 0;
+
+    for (i = 0; i < 4; i++)
+    {
+        minlen = FLINT_MIN(minlen, FLINT_MIN(lenA[i], lenB[i]));
+        amax = FLINT_MAX(amax, lenA[i]);
+        bmax = FLINT_MAX(bmax, lenB[i]);
+    }
+
+    if (minlen >= NMOD_POLY_HGCD_MAT_MUL_FFT_CUTOFF)
+    {
+        /* wrap the raw vectors in borrowed-coefficient polynomial
+           matrices; the outputs go through freshly allocated buffers of
+           the full window length zn, since the caller's C buffers are
+           only guaranteed to hold each entry's own products */
+        nmod_poly_struct Ae[4], Be[4], Ce[4];
+        nmod_poly_mat_struct Am, Bm, Cm;
+        nmod_t mod = NMOD_CTX(ctx);
+        slong zn = amax + bmax - 1;
+        nn_ptr tmp = flint_malloc(4 * zn * sizeof(ulong));
+
+        for (i = 0; i < 4; i++)
+        {
+            Ae[i].coeffs = A[i]; Ae[i].length = lenA[i];
+            Ae[i].alloc = lenA[i]; Ae[i].mod = mod;
+            Be[i].coeffs = B[i]; Be[i].length = lenB[i];
+            Be[i].alloc = lenB[i]; Be[i].mod = mod;
+            Ce[i].coeffs = tmp + i * zn; Ce[i].length = 0;
+            Ce[i].alloc = zn; Ce[i].mod = mod;
+        }
+        Am.entries = Ae; Am.r = 2; Am.c = 2; Am.stride = 2; Am.modulus = mod.n;
+        Bm.entries = Be; Bm.r = 2; Bm.c = 2; Bm.stride = 2; Bm.modulus = mod.n;
+        Cm.entries = Ce; Cm.r = 2; Cm.c = 2; Cm.stride = 2; Cm.modulus = mod.n;
+
+        if (nmod_poly_mat_mulmid_fft_small(&Cm, &Am, &Bm, 0, zn))
+        {
+            for (i = 0; i < 4; i++)
+            {
+                FLINT_ASSERT(Ce[i].coeffs == tmp + i * zn);
+                lenC[i] = Ce[i].length;
+                flint_mpn_copyi(C[i], Ce[i].coeffs, lenC[i]);
+            }
+            flint_free(tmp);
+            return GR_SUCCESS;
+        }
+
+        flint_free(tmp);
+    }
+#endif
+
+    return _gr_poly_hgcd_mat_mul_generic(C, lenC, A, lenA, B, lenB, T0, T1, ctx);
+}
+
 static int
 _gr_nmod_poly_mullow(ulong * res,
     const ulong * poly1, slong len1,
@@ -1499,6 +1569,7 @@ gr_method_tab_input __gr_nmod_methods_input[] =
     {GR_METHOD_VEC_DOT_STRIDED, (gr_funcptr) __gr_nmod_vec_dot_strided},
     {GR_METHOD_VEC_RECIPROCALS, (gr_funcptr) _gr_nmod_vec_reciprocals},
     {GR_METHOD_POLY_MULLOW,     (gr_funcptr) _gr_nmod_poly_mullow},
+    {GR_METHOD_POLY_HGCD_MAT_MUL, (gr_funcptr) _gr_nmod_poly_hgcd_mat_mul},
     {GR_METHOD_POLY_MULMID,     (gr_funcptr) _gr_nmod_poly_mulmid},
     {GR_METHOD_POLY_DIVREM,     (gr_funcptr) _gr_nmod_poly_divrem},
     {GR_METHOD_POLY_DIVEXACT,   (gr_funcptr) _gr_nmod_poly_divexact},

--- a/src/gr/nmod.c
+++ b/src/gr/nmod.c
@@ -20,6 +20,7 @@
 #include "gr.h"
 #include "gr_vec.h"
 #include "gr_mat.h"
+#include "thread_pool.h"
 #include "gr_poly.h"
 #include "gr_generic.h"
 
@@ -975,72 +976,15 @@ _gr_nmod_vec_reciprocals(ulong * res, slong len, gr_ctx_t ctx)
 }
 
 
+/* implemented in gr/nmod_transformed_poly.c */
+int _gr_nmod_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base,
+                                        slong len_bound, slong terms_bound,
+                                        const gr_transformed_poly_workload_struct * workload);
+
 /* 2x2 matrix products inside hgcd: from this entry length on, reusing the
    fft_small transforms of the 8 inputs beats Strassen (single-threaded
    tuning; the transform and export stages also thread internally when
    the pool has workers) */
-#define NMOD_POLY_HGCD_MAT_MUL_FFT_CUTOFF 128
-
-static int
-_gr_nmod_poly_hgcd_mat_mul(gr_ptr * C, slong * lenC,
-        gr_ptr * A, slong * lenA, gr_ptr * B, slong * lenB,
-        gr_ptr T0, gr_ptr T1, gr_ctx_t ctx)
-{
-#if FLINT_HAVE_FFT_SMALL
-    slong i;
-    slong minlen = lenA[0];
-    slong amax = 0, bmax = 0;
-
-    for (i = 0; i < 4; i++)
-    {
-        minlen = FLINT_MIN(minlen, FLINT_MIN(lenA[i], lenB[i]));
-        amax = FLINT_MAX(amax, lenA[i]);
-        bmax = FLINT_MAX(bmax, lenB[i]);
-    }
-
-    if (minlen >= NMOD_POLY_HGCD_MAT_MUL_FFT_CUTOFF)
-    {
-        /* wrap the raw vectors in borrowed-coefficient polynomial
-           matrices; the outputs go through freshly allocated buffers of
-           the full window length zn, since the caller's C buffers are
-           only guaranteed to hold each entry's own products */
-        nmod_poly_struct Ae[4], Be[4], Ce[4];
-        nmod_poly_mat_struct Am, Bm, Cm;
-        nmod_t mod = NMOD_CTX(ctx);
-        slong zn = amax + bmax - 1;
-        nn_ptr tmp = flint_malloc(4 * zn * sizeof(ulong));
-
-        for (i = 0; i < 4; i++)
-        {
-            Ae[i].coeffs = A[i]; Ae[i].length = lenA[i];
-            Ae[i].alloc = lenA[i]; Ae[i].mod = mod;
-            Be[i].coeffs = B[i]; Be[i].length = lenB[i];
-            Be[i].alloc = lenB[i]; Be[i].mod = mod;
-            Ce[i].coeffs = tmp + i * zn; Ce[i].length = 0;
-            Ce[i].alloc = zn; Ce[i].mod = mod;
-        }
-        Am.entries = Ae; Am.r = 2; Am.c = 2; Am.stride = 2; Am.modulus = mod.n;
-        Bm.entries = Be; Bm.r = 2; Bm.c = 2; Bm.stride = 2; Bm.modulus = mod.n;
-        Cm.entries = Ce; Cm.r = 2; Cm.c = 2; Cm.stride = 2; Cm.modulus = mod.n;
-
-        if (nmod_poly_mat_mulmid_fft_small(&Cm, &Am, &Bm, 0, zn))
-        {
-            for (i = 0; i < 4; i++)
-            {
-                FLINT_ASSERT(Ce[i].coeffs == tmp + i * zn);
-                lenC[i] = Ce[i].length;
-                flint_mpn_copyi(C[i], Ce[i].coeffs, lenC[i]);
-            }
-            flint_free(tmp);
-            return GR_SUCCESS;
-        }
-
-        flint_free(tmp);
-    }
-#endif
-
-    return _gr_poly_hgcd_mat_mul_generic(C, lenC, A, lenA, B, lenB, T0, T1, ctx);
-}
 
 static int
 _gr_nmod_poly_mullow(ulong * res,
@@ -1569,7 +1513,8 @@ gr_method_tab_input __gr_nmod_methods_input[] =
     {GR_METHOD_VEC_DOT_STRIDED, (gr_funcptr) __gr_nmod_vec_dot_strided},
     {GR_METHOD_VEC_RECIPROCALS, (gr_funcptr) _gr_nmod_vec_reciprocals},
     {GR_METHOD_POLY_MULLOW,     (gr_funcptr) _gr_nmod_poly_mullow},
-    {GR_METHOD_POLY_HGCD_MAT_MUL, (gr_funcptr) _gr_nmod_poly_hgcd_mat_mul},
+    {GR_METHOD_CTX_INIT_TRANSFORMED_POLY_REPR,
+                                (gr_funcptr) _gr_nmod_ctx_init_transformed_poly_repr},
     {GR_METHOD_POLY_MULMID,     (gr_funcptr) _gr_nmod_poly_mulmid},
     {GR_METHOD_POLY_DIVREM,     (gr_funcptr) _gr_nmod_poly_divrem},
     {GR_METHOD_POLY_DIVEXACT,   (gr_funcptr) _gr_nmod_poly_divexact},

--- a/src/gr/nmod_transformed_poly.c
+++ b/src/gr/nmod_transformed_poly.c
@@ -590,6 +590,22 @@ tpoly_addsubmul(gr_ptr res, gr_srcptr x, gr_srcptr y, int sub, gr_ctx_t ctx)
     if (TPOLY(x)->len == 0 || TPOLY(y)->len == 0)
         return GR_SUCCESS;
 
+    /* with res aliasing an operand, the per-call domain bookkeeping
+       below cannot mark the same struct as both input and accumulator;
+       route through the ring's own guarded multiply and add */
+    if (res == x || res == y)
+    {
+        gr_ptr t;
+        int status;
+        GR_TMP_INIT(t, ctx);
+        status = tpoly_mul(t, x, y, ctx);
+        if (status == GR_SUCCESS)
+            status = sub ? tpoly_sub(res, res, t, ctx)
+                         : tpoly_add(res, res, t, ctx);
+        GR_TMP_CLEAR(t, ctx);
+        return status;
+    }
+
     if (TPOLY(res)->len == 0)
     {
         int status = tpoly_mul(res, x, y, ctx);
@@ -638,6 +654,62 @@ tpoly_submul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
 static gr_funcptr __tpoly_methods[GR_METHOD_TAB_SIZE];
 static int __tpoly_methods_initialized = 0;
 
+/* random depth-1 elements within the length capacity, and a value
+   writer via the nondestructive conversion out: what gr_test_ring and
+   diagnostics need, at conversion cost only they pay */
+static int
+tpoly_randtest(gr_ptr res, flint_rand_t state, gr_ctx_t ctx)
+{
+    tpoly_ctx_struct * T = TPOLY_CTX(ctx);
+    gr_ctx_t base;
+    slong i, len = n_randint(state, T->N + 1);
+    nn_ptr c;
+    int status;
+
+    if (len == 0 || n_randint(state, 8) == 0)
+        return gr_zero(res, ctx);
+
+    gr_ctx_init_nmod(base, T->mod.n);
+    c = flint_malloc(len * sizeof(ulong));
+    for (i = 0; i < len; i++)
+        c[i] = n_randint(state, T->mod.n);
+    c[len - 1] += (c[len - 1] == 0 && T->mod.n > 1);
+    status = tpoly_set_gr_poly(res, c, len, base, ctx);
+    flint_free(c);
+    gr_ctx_clear(base);
+    return status;
+}
+
+static int
+tpoly_write(gr_stream_t out, gr_srcptr x, gr_ctx_t ctx)
+{
+    tpoly_ctx_struct * T = TPOLY_CTX(ctx);
+    gr_ctx_t base;
+    nn_ptr c;
+    slong i, len = 0;
+    int status;
+
+    gr_ctx_init_nmod(base, T->mod.n);
+    /* every element's polynomial length is bounded by the ring's N
+       (products beyond it are declined at the operation) */
+    c = flint_malloc(FLINT_MAX(T->N, 1) * sizeof(ulong));
+    status = tpoly_get_gr_poly(c, &len, x, base, ctx);
+    if (status == GR_SUCCESS)
+    {
+        status |= gr_stream_write(out, "[");
+        for (i = 0; i < len; i++)
+        {
+            if (i > 0)
+                status |= gr_stream_write(out, ", ");
+            status |= gr_stream_write_ui(out, c[i]);
+        }
+        status |= gr_stream_write(out, "]");
+    }
+    flint_free(c);
+    gr_ctx_clear(base);
+    return status;
+}
+
 static gr_method_tab_input __tpoly_methods_input[] =
 {
     {GR_METHOD_CTX_WRITE,       (gr_funcptr) (void (*)(void)) tpoly_ctx_write},
@@ -648,6 +720,8 @@ static gr_method_tab_input __tpoly_methods_input[] =
     {GR_METHOD_SET,             (gr_funcptr) (void (*)(void)) tpoly_set},
     {GR_METHOD_ZERO,            (gr_funcptr) (void (*)(void)) tpoly_zero},
     {GR_METHOD_ONE,             (gr_funcptr) (void (*)(void)) tpoly_one},
+    {GR_METHOD_WRITE,           (gr_funcptr) (void (*)(void)) tpoly_write},
+    {GR_METHOD_RANDTEST,        (gr_funcptr) (void (*)(void)) tpoly_randtest},
     {GR_METHOD_IS_ZERO,         (gr_funcptr) (void (*)(void)) tpoly_is_zero},
     {GR_METHOD_EQUAL,           (gr_funcptr) (void (*)(void)) tpoly_equal},
     {GR_METHOD_NEG,             (gr_funcptr) (void (*)(void)) tpoly_neg},
@@ -718,67 +792,74 @@ _gr_nmod_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base,
        Constants are calibrated against gcd measurements on this class of
        hardware; the model errs conservative. */
     {
-        const gr_transformed_poly_workload_struct def = { 2, 1, 1, 0, 0 };
+        const gr_transformed_poly_workload_struct def = { 2, 1, 1, 0, 0, 0 };
         const gr_transformed_poly_workload_struct * wl =
             workload ? workload : &def;
-        double L = (double) n_round_up(N, BLK_SZ);
-        double lg = (double) FLINT_BIT_COUNT((ulong) L);
-        double np = (double) T->P->np;
-        double ni = (double) wl->num_inputs;
-        double nm = (double) wl->num_muls;
-        double no = (double) wl->num_outputs;
-        double npf, Lf, lgf, rep, fuse, margin, bytes, limit;
 
-        rep = np * L * ((ni + no) * (lg + 2.0) + nm * 2.0)
-                + no * np * L * 3.0 + 5e4;
+    /* forced initialization (tests): only implementation
+       bounds below decline; the profitability model and the
+       storage budget are policy and are skipped */
+    if (!wl->force)
+    {
+            double L = (double) n_round_up(N, BLK_SZ);
+            double lg = (double) FLINT_BIT_COUNT((ulong) L);
+            double np = (double) T->P->np;
+            double ni = (double) wl->num_inputs;
+            double nm = (double) wl->num_muls;
+            double no = (double) wl->num_outputs;
+            double npf, Lf, lgf, rep, fuse, margin, bytes, limit;
 
-        if (mod.n <= TPOLY_MAX_REPACK)
-        {
-            npf = 1.0;
-            Lf = L / 2;
-        }
-        else
-        {
-            npf = (double) ((2 * modbits + FLINT_BIT_COUNT((ulong) L) + 49)
-                            / 50);
-            npf = FLINT_MAX(npf, 1.0);
-            Lf = L;
-        }
-        lgf = (double) FLINT_BIT_COUNT((ulong) Lf);
-        /* homogeneous workloads (batched operands of comparable length,
-           as in matrix products) face fused alternatives at the same
-           transform sizes; heterogeneous whole-algorithm batching proved
-           unprofitable (operands transformed at the shared upper-bound
-           length lose the reuse advantage) and is not attempted */
-        fuse = nm * (npf * Lf * (3.0 * lgf + 6.0) + npf * Lf * 3.0);
+            rep = np * L * ((ni + no) * (lg + 2.0) + nm * 2.0)
+                    + no * np * L * 3.0 + 5e4;
 
-        /* single-prime transforms leave little to deduplicate relative to
-           the surrounding fixed and conversion costs (measured), so
-           require a decisive advantage there */
-        margin = (T->P->np == 1) ? 0.6 : 0.865;
+            if (mod.n <= TPOLY_MAX_REPACK)
+            {
+                npf = 1.0;
+                Lf = L / 2;
+            }
+            else
+            {
+                npf = (double) ((2 * modbits + FLINT_BIT_COUNT((ulong) L) + 49)
+                                / 50);
+                npf = FLINT_MAX(npf, 1.0);
+                Lf = L;
+            }
+            lgf = (double) FLINT_BIT_COUNT((ulong) Lf);
+            /* homogeneous workloads (batched operands of comparable length,
+               as in matrix products) face fused alternatives at the same
+               transform sizes; heterogeneous whole-algorithm batching proved
+               unprofitable (operands transformed at the shared upper-bound
+               length lose the reuse advantage) and is not attempted */
+            fuse = nm * (npf * Lf * (3.0 * lgf + 6.0) + npf * Lf * 3.0);
 
-        /* low-reuse workloads whose live elements far exceed cache go
-           memory bound at one or two primes (measured); high-reuse
-           workloads amortize the streaming */
-        /* live elements as declared by the driver; a zero declaration
-           derives a conservative count from the workload shape */
-        {
-            double nlive = wl->num_live > 0 ? (double) wl->num_live
-                                            : (ni + no + 2.0);
-            bytes = nlive * np *
-                    (double) sd_fft_ctx_data_size(T->P->depth) * 8.0;
-        }
-        limit = wl->mem_limit > 0 ? (double) wl->mem_limit
-                    : (double) flint_fft_small_max_transformed_ring_size;
+            /* single-prime transforms leave little to deduplicate relative to
+               the surrounding fixed and conversion costs (measured), so
+               require a decisive advantage there */
+            margin = (T->P->np == 1) ? 0.6 : 0.865;
 
-        if (rep >= margin * fuse
-            || (T->P->np <= 2 && nm < 4.0 * ni && bytes > 32.0 * 1048576.0)
-            || bytes > limit)
-        {
-            fft_small_plan_clear(T->P);
-            flint_free(T);
-            return GR_UNABLE;
-        }
+            /* low-reuse workloads whose live elements far exceed cache go
+               memory bound at one or two primes (measured); high-reuse
+               workloads amortize the streaming */
+            /* live elements as declared by the driver; a zero declaration
+               derives a conservative count from the workload shape */
+            {
+                double nlive = wl->num_live > 0 ? (double) wl->num_live
+                                                : (ni + no + 2.0);
+                bytes = nlive * np *
+                        (double) sd_fft_ctx_data_size(T->P->depth) * 8.0;
+            }
+            limit = wl->mem_limit > 0 ? (double) wl->mem_limit
+                        : (double) flint_fft_small_max_transformed_ring_size;
+
+            if (rep >= margin * fuse
+                || (T->P->np <= 2 && nm < 4.0 * ni && bytes > 32.0 * 1048576.0)
+                || bytes > limit)
+            {
+                fft_small_plan_clear(T->P);
+                flint_free(T);
+                return GR_UNABLE;
+            }
+    }
     }
 
     if (exact)

--- a/src/gr/nmod_transformed_poly.c
+++ b/src/gr/nmod_transformed_poly.c
@@ -172,19 +172,19 @@ tpoly_init(gr_ptr x, gr_ctx_t ctx)
 }
 
 static void
-tpoly_clear(gr_ptr x, gr_ctx_t ctx)
+tpoly_clear(gr_ptr x, gr_ctx_t FLINT_UNUSED(ctx))
 {
     fft_small_op_clear(&TPOLY(x)->op);
 }
 
 static void
-tpoly_swap(gr_ptr x, gr_ptr y, gr_ctx_t ctx)
+tpoly_swap(gr_ptr x, gr_ptr y, gr_ctx_t FLINT_UNUSED(ctx))
 {
     FLINT_SWAP(tpoly_struct, *TPOLY(x), *TPOLY(y));
 }
 
 static int
-tpoly_zero(gr_ptr x, gr_ctx_t ctx)
+tpoly_zero(gr_ptr x, gr_ctx_t FLINT_UNUSED(ctx))
 {
     TPOLY(x)->len = 0;
     TPOLY(x)->terms = 0;
@@ -214,13 +214,13 @@ tpoly_set(gr_ptr res, gr_srcptr x, gr_ctx_t ctx)
 }
 
 static truth_t
-tpoly_is_zero(gr_srcptr x, gr_ctx_t ctx)
+tpoly_is_zero(gr_srcptr x, gr_ctx_t FLINT_UNUSED(ctx))
 {
     return (TPOLY(x)->len == 0) ? T_TRUE : T_UNKNOWN;
 }
 
 static truth_t
-tpoly_equal(gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+tpoly_equal(gr_srcptr x, gr_srcptr y, gr_ctx_t FLINT_UNUSED(ctx))
 {
     if (TPOLY(x)->len == 0 && TPOLY(y)->len == 0)
         return T_TRUE;
@@ -549,26 +549,26 @@ static int __tpoly_methods_initialized = 0;
 
 static gr_method_tab_input __tpoly_methods_input[] =
 {
-    {GR_METHOD_CTX_WRITE,       (gr_funcptr) tpoly_ctx_write},
-    {GR_METHOD_CTX_CLEAR,       (gr_funcptr) tpoly_ctx_clear},
-    {GR_METHOD_INIT,            (gr_funcptr) tpoly_init},
-    {GR_METHOD_CLEAR,           (gr_funcptr) tpoly_clear},
-    {GR_METHOD_SWAP,            (gr_funcptr) tpoly_swap},
-    {GR_METHOD_SET,             (gr_funcptr) tpoly_set},
-    {GR_METHOD_ZERO,            (gr_funcptr) tpoly_zero},
-    {GR_METHOD_ONE,             (gr_funcptr) tpoly_one},
-    {GR_METHOD_IS_ZERO,         (gr_funcptr) tpoly_is_zero},
-    {GR_METHOD_EQUAL,           (gr_funcptr) tpoly_equal},
-    {GR_METHOD_NEG,             (gr_funcptr) tpoly_neg},
-    {GR_METHOD_ADD,             (gr_funcptr) tpoly_add},
-    {GR_METHOD_SUB,             (gr_funcptr) tpoly_sub},
-    {GR_METHOD_MUL,             (gr_funcptr) tpoly_mul},
-    {GR_METHOD_ADDMUL,          (gr_funcptr) tpoly_addmul},
-    {GR_METHOD_SUBMUL,          (gr_funcptr) tpoly_submul},
-    {GR_METHOD_SET_GR_POLY,     (gr_funcptr) tpoly_set_gr_poly},
-    {GR_METHOD_GET_GR_POLY,     (gr_funcptr) tpoly_get_gr_poly},
-    {GR_METHOD_GET_GR_POLY_WINDOW, (gr_funcptr) tpoly_get_gr_poly_window},
-    {0,                         (gr_funcptr) NULL},
+    {GR_METHOD_CTX_WRITE,       (gr_funcptr) (void (*)(void)) tpoly_ctx_write},
+    {GR_METHOD_CTX_CLEAR,       (gr_funcptr) (void (*)(void)) tpoly_ctx_clear},
+    {GR_METHOD_INIT,            (gr_funcptr) (void (*)(void)) tpoly_init},
+    {GR_METHOD_CLEAR,           (gr_funcptr) (void (*)(void)) tpoly_clear},
+    {GR_METHOD_SWAP,            (gr_funcptr) (void (*)(void)) tpoly_swap},
+    {GR_METHOD_SET,             (gr_funcptr) (void (*)(void)) tpoly_set},
+    {GR_METHOD_ZERO,            (gr_funcptr) (void (*)(void)) tpoly_zero},
+    {GR_METHOD_ONE,             (gr_funcptr) (void (*)(void)) tpoly_one},
+    {GR_METHOD_IS_ZERO,         (gr_funcptr) (void (*)(void)) tpoly_is_zero},
+    {GR_METHOD_EQUAL,           (gr_funcptr) (void (*)(void)) tpoly_equal},
+    {GR_METHOD_NEG,             (gr_funcptr) (void (*)(void)) tpoly_neg},
+    {GR_METHOD_ADD,             (gr_funcptr) (void (*)(void)) tpoly_add},
+    {GR_METHOD_SUB,             (gr_funcptr) (void (*)(void)) tpoly_sub},
+    {GR_METHOD_MUL,             (gr_funcptr) (void (*)(void)) tpoly_mul},
+    {GR_METHOD_ADDMUL,          (gr_funcptr) (void (*)(void)) tpoly_addmul},
+    {GR_METHOD_SUBMUL,          (gr_funcptr) (void (*)(void)) tpoly_submul},
+    {GR_METHOD_SET_GR_POLY,     (gr_funcptr) (void (*)(void)) tpoly_set_gr_poly},
+    {GR_METHOD_GET_GR_POLY,     (gr_funcptr) (void (*)(void)) tpoly_get_gr_poly},
+    {GR_METHOD_GET_GR_POLY_WINDOW, (gr_funcptr) (void (*)(void)) tpoly_get_gr_poly_window},
+    {0,                         (gr_funcptr) (void (*)(void)) NULL},
 };
 
 /* the nmod overload of gr_ctx_init_gr_poly_transformed_repr */
@@ -750,8 +750,10 @@ _gr_nmod_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base,
 #else /* FLINT_HAVE_FFT_SMALL */
 
 int
-_gr_nmod_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base,
-                                        slong len_bound, slong terms_bound)
+_gr_nmod_ctx_init_transformed_poly_repr(gr_ctx_t FLINT_UNUSED(ctx),
+        gr_ctx_t FLINT_UNUSED(base), slong FLINT_UNUSED(len_bound),
+        slong FLINT_UNUSED(terms_bound),
+        const gr_transformed_poly_workload_struct * FLINT_UNUSED(workload))
 {
     return GR_UNABLE;
 }

--- a/src/gr/nmod_transformed_poly.c
+++ b/src/gr/nmod_transformed_poly.c
@@ -295,6 +295,97 @@ _tpoly_export(tpoly_ctx_struct * T, gr_srcptr x, slong zl, slong ub,
             z[i] = nmod_sub(z[i], T->bias_mod_n, T->mod);
 }
 
+/* Destructive counterpart of the windowed conversion: the inverse
+   transforms, scaling and bias run directly on the element's own
+   evaluations, so no scratch is allocated and no transform-sized copy is
+   made. The element is consumed -- afterwards it may only be cleared or
+   fully overwritten as the destination of a set or a multiplication.
+   Safe under the drivers' threading, since each thread owns the
+   accumulator it converts. */
+/* invert, scale and bias the element's own evaluations in place */
+static void
+_tpoly_invert_in_place(tpoly_ctx_struct * T, gr_ptr x)
+{
+    const fft_small_plan_struct * P = T->P;
+    ulong itr = n_round_up((ulong) TPOLY(x)->len, BLK_SZ);
+    slong i;
+
+    for (i = 0; i < (slong) P->np; i++)
+    {
+        sd_fft_ctx_struct * Q = P->ffts + P->offset + i;
+        double * d = TPOLY(x)->op.data + P->stride * i;
+        double b = TPOLY(x)->negs ? (double) T->bias_res[i] : 0.0;
+
+        sd_ifft_trunc(Q, d, P->depth, itr);
+        _tpoly_scale_bias(Q, d, T->m_orig[i], b, itr / BLK_SZ);
+    }
+}
+
+int
+_gr_nmod_tpoly_get_gr_poly_window_destructive(nn_ptr cc, gr_ptr x,
+        slong zl, slong zh, gr_ctx_t ctx)
+{
+    tpoly_ctx_struct * T = TPOLY_CTX(ctx);
+    slong xlen = TPOLY(x)->len;
+    slong ub, i;
+
+    if (zl < 0 || zh < zl || zh > T->N)
+        return GR_DOMAIN;
+
+    ub = FLINT_MIN(zh, xlen);
+    if (ub > zl)
+    {
+        _tpoly_invert_in_place(T, x);
+        fft_small_export_nmod_range(cc, &TPOLY(x)->op, (ulong) zl,
+                                    (ulong) ub, T->mod, T->P);
+
+        if (TPOLY(x)->negs)
+            for (i = 0; i < ub - zl; i++)
+                cc[i] = nmod_sub(cc[i], T->bias_mod_n, T->mod);
+    }
+    else
+        ub = zl;
+    memset(cc + (ub - zl), 0, (zh - ub) * sizeof(ulong));
+
+    TPOLY(x)->len = 0;
+    return GR_SUCCESS;
+}
+
+/* the GET_GR_POLY_DESTRUCTIVE method: full-length conversion out on the
+   element's own storage */
+static int
+tpoly_get_gr_poly_destructive(gr_ptr c, slong * len, gr_ptr x,
+                              gr_ctx_t base_ctx, gr_ctx_t ctx)
+{
+    tpoly_ctx_struct * T = TPOLY_CTX(ctx);
+    nn_ptr cc = (nn_ptr) c;
+    slong xlen = TPOLY(x)->len;
+    slong i;
+
+    if (base_ctx->which_ring != GR_CTX_NMOD ||
+            NMOD_CTX(base_ctx).n != T->mod.n)
+        return GR_DOMAIN;
+
+    if (xlen == 0)
+    {
+        *len = 0;
+        return GR_SUCCESS;
+    }
+
+    _tpoly_invert_in_place(T, x);
+    fft_small_export_nmod_range(cc, &TPOLY(x)->op, 0, (ulong) xlen,
+                                T->mod, T->P);
+    if (TPOLY(x)->negs)
+        for (i = 0; i < xlen; i++)
+            cc[i] = nmod_sub(cc[i], T->bias_mod_n, T->mod);
+    TPOLY(x)->len = 0;
+
+    while (xlen > 0 && cc[xlen - 1] == 0)
+        xlen--;
+    *len = xlen;
+    return GR_SUCCESS;
+}
+
 /* per-call temporary for the inverse-transform copy */
 static double *
 _tpoly_scratch_alloc(const tpoly_ctx_struct * T)
@@ -567,6 +658,8 @@ static gr_method_tab_input __tpoly_methods_input[] =
     {GR_METHOD_SUBMUL,          (gr_funcptr) (void (*)(void)) tpoly_submul},
     {GR_METHOD_SET_GR_POLY,     (gr_funcptr) (void (*)(void)) tpoly_set_gr_poly},
     {GR_METHOD_GET_GR_POLY,     (gr_funcptr) (void (*)(void)) tpoly_get_gr_poly},
+    {GR_METHOD_GET_GR_POLY_DESTRUCTIVE,
+                                (gr_funcptr) (void (*)(void)) tpoly_get_gr_poly_destructive},
     {GR_METHOD_GET_GR_POLY_WINDOW, (gr_funcptr) (void (*)(void)) tpoly_get_gr_poly_window},
     {0,                         (gr_funcptr) (void (*)(void)) NULL},
 };

--- a/src/gr/nmod_transformed_poly.c
+++ b/src/gr/nmod_transformed_poly.c
@@ -390,8 +390,8 @@ tpoly_get_gr_poly_destructive(gr_ptr c, slong * len, gr_ptr x,
 static double *
 _tpoly_scratch_alloc(const tpoly_ctx_struct * T)
 {
-    return flint_aligned_alloc(4096,
-            n_round_up(T->P->np * T->P->stride * sizeof(double), 4096));
+    return flint_aligned_alloc(FLINT_FFT_SMALL_ALIGNMENT,
+            n_round_up(T->P->np * T->P->stride * sizeof(double), FLINT_FFT_SMALL_ALIGNMENT));
 }
 
 /* conversion to coefficients: the GET_GR_POLY method; c must have room
@@ -718,7 +718,7 @@ _gr_nmod_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base,
        Constants are calibrated against gcd measurements on this class of
        hardware; the model errs conservative. */
     {
-        const gr_transformed_poly_workload_struct def = { 2, 1, 1, 0 };
+        const gr_transformed_poly_workload_struct def = { 2, 1, 1, 0, 0 };
         const gr_transformed_poly_workload_struct * wl =
             workload ? workload : &def;
         double L = (double) n_round_up(N, BLK_SZ);
@@ -760,9 +760,16 @@ _gr_nmod_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base,
         /* low-reuse workloads whose live elements far exceed cache go
            memory bound at one or two primes (measured); high-reuse
            workloads amortize the streaming */
-        bytes = (ni + 3.0) * np *
-                (double) sd_fft_ctx_data_size(T->P->depth) * 8.0;
-        limit = wl->mem_limit > 0 ? (double) wl->mem_limit : 4.0 * 1073741824.0;
+        /* live elements as declared by the driver; a zero declaration
+           derives a conservative count from the workload shape */
+        {
+            double nlive = wl->num_live > 0 ? (double) wl->num_live
+                                            : (ni + no + 2.0);
+            bytes = nlive * np *
+                    (double) sd_fft_ctx_data_size(T->P->depth) * 8.0;
+        }
+        limit = wl->mem_limit > 0 ? (double) wl->mem_limit
+                    : (double) flint_fft_small_max_transformed_ring_size;
 
         if (rep >= margin * fuse
             || (T->P->np <= 2 && nm < 4.0 * ni && bytes > 32.0 * 1048576.0)

--- a/src/gr/nmod_transformed_poly.c
+++ b/src/gr/nmod_transformed_poly.c
@@ -1,0 +1,759 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <string.h>
+#include "fmpz.h"
+#include "mpn_extras.h"
+#include "ulong_extras.h"
+#include "nmod.h"
+#include "nmod_vec.h"
+#include "gr.h"
+#include "gr_poly.h"
+
+#if FLINT_HAVE_FFT_SMALL
+
+#include "machine_vectors.h"
+#include "fft_small.h"
+
+/*
+    Ring of nmod polynomials of bounded length in fft_small transformed
+    representation (prototype).
+
+    A context wraps an fft_small plan of capacity (len_bound, terms_bound):
+    elements represent polynomials of length at most len_bound = N over the
+    base nmod ring, and the integer coefficients of any represented value,
+    viewed as an expression in freshly converted inputs, accumulate at most
+    terms_bound elementary products of base elements per coefficient.
+
+    Elements store, per plan prime, the plain pointwise evaluations of the
+    represented polynomial on the transform domain: the plan's normalizers
+    are overridden to 1 so that the op-layer pointwise kernels compute
+    plain products and sums, which makes the representation closed under
+    +, -, * (a graded primal/product distinction would otherwise prevent
+    multiplying previously multiplied elements). The saved normalizers
+    m_i = inv(cop_i * 2^depth) mod p_i are applied once at conversion back
+    to coefficients, which is exactly the scaling the chinese remaindering
+    expects after an unnormalized inverse transform.
+
+    The chinese remaindering's final reduction handles reconstructed
+    integers of at most three limbs, so representable expressions are
+    restricted to multiplicative depth two in base elements (products of
+    previously multiplied elements return GR_UNABLE beyond that; callers
+    renormalize through a conversion roundtrip where deeper products are
+    needed). Single-prime plans computing directly mod n are exact and
+    carry no depth restriction.
+
+    Values represented by expressions involving subtraction can have
+    negative true integer coefficients, while the chinese remaindering
+    reconstructs representatives in [0, prod of primes). Conversion back
+    to coefficients therefore adds a fixed bias C = terms_bound * (n-1)^2,
+    at least as large as any representable coefficient magnitude, to each
+    inverse-transformed coefficient (as the per-prime residue of C in the
+    convention the chinese remaindering expects), and subtracts C mod n
+    from each reconstructed coefficient. The plan is
+    provisioned with an accumulation bound of 2 * terms_bound so that the
+    chinese remaindering's declared coefficient bound is exactly 2C, which
+    both selects enough primes and calibrates the reduction branch
+    preconditions for the biased values.
+
+    Each element carries a virtual length and a terms counter; operations
+    return GR_UNABLE when a result would exceed the context capacity
+    (wraparound past the transform size, or coefficients past the prime
+    product), which composes safely through arbitrary expressions.
+
+    Limitations of the prototype, by design:
+    - equal / is_zero return T_UNKNOWN for nonzero-length operands (the
+      redundant floating point residues are not canonicalized);
+    - a context may be shared by any number of threads: conversions use
+      plain per-call temporary space, and the context itself is read-only
+      after construction (distinct elements may be operated on
+      concurrently; a single element still belongs to one thread at a
+      time, as usual);
+    - the exported window is always [0, N).
+*/
+
+typedef struct
+{
+    fft_small_plan_t P;
+    nmod_t mod;
+    slong N;                        /* length capacity */
+    ulong terms_bound;              /* accumulation capacity */
+    ulong max_depth;                /* multiplicative depth capacity */
+    ulong m_orig[MPN_CTX_NCRTS];    /* saved export normalizers */
+    ulong bias_res[MPN_CTX_NCRTS];  /* C * inv(cop_i) mod p_i */
+    ulong bias_mod_n;               /* C mod n */
+} tpoly_ctx_struct;
+
+typedef struct
+{
+    fft_small_op_struct op;
+    slong len;                      /* virtual length; 0 = zero element */
+    ulong terms;                    /* elementary product count bound */
+    ulong depth;                    /* multiplicative depth in base elements */
+    int negs;                       /* true integer coeffs may be negative */
+} tpoly_struct;
+
+/* must match FFT_SMALL_MAX_REPACK in nmod_poly/mullow_fft_small.c: below
+   this, the fused drivers pack two coefficients per transform slot */
+#define TPOLY_MAX_REPACK 23
+
+#define TPOLY_CTX(ctx) ((tpoly_ctx_struct *) GR_CTX_DATA_AS_PTR(ctx))
+#define TPOLY(x) ((tpoly_struct *) (x))
+
+/* d = m*d + b over the first nblk blocks: applies the saved normalizer
+   (and, for values that may be negative, the reconstruction bias) to the
+   inverse-transformed coefficients; scaling commutes with the linear
+   inverse transform, and applying it afterwards touches only the
+   element's virtual length instead of the full transform */
+static void
+_tpoly_scale_bias(const sd_fft_ctx_struct * Q, double * d,
+                  ulong m_, double b, ulong nblk)
+{
+    vec8d m = vec8d_set_d(vec1d_reduce_0n_to_pmhn((slong) m_, Q->p));
+    vec8d bb = vec8d_set_d(b);
+    vec8d n = vec8d_set_d(Q->p);
+    vec8d ninv = vec8d_set_d(Q->pinv);
+    ulong I;
+
+    for (I = 0; I < nblk; I++)
+    {
+        double * dx = d + sd_fft_ctx_blk_offset(I);
+        ulong j = 0; do {
+            vec8d x0, x1;
+            x0 = vec8d_load(dx + j + 0);
+            x1 = vec8d_load(dx + j + 8);
+            x0 = vec8d_add(vec8d_mulmod(x0, m, n, ninv), bb);
+            x1 = vec8d_add(vec8d_mulmod(x1, m, n, ninv), bb);
+            vec8d_store(dx + j + 0, x0);
+            vec8d_store(dx + j + 8, x1);
+        } while (j += 16, j < BLK_SZ);
+    }
+}
+
+static int
+tpoly_ctx_write(gr_stream_t out, gr_ctx_t ctx)
+{
+    tpoly_ctx_struct * T = TPOLY_CTX(ctx);
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, "Transformed polynomials (fft_small) over integers mod ");
+    status |= gr_stream_write_ui(out, T->mod.n);
+    status |= gr_stream_write(out, " (len_bound ");
+    status |= gr_stream_write_si(out, T->N);
+    status |= gr_stream_write(out, ", terms_bound ");
+    status |= gr_stream_write_ui(out, T->terms_bound);
+    status |= gr_stream_write(out, ")");
+    return status;
+}
+
+static void
+tpoly_ctx_clear(gr_ctx_t ctx)
+{
+    tpoly_ctx_struct * T = TPOLY_CTX(ctx);
+    fft_small_plan_clear(T->P);
+    flint_free(T);
+}
+
+static void
+tpoly_init(gr_ptr x, gr_ctx_t ctx)
+{
+    fft_small_op_init(&TPOLY(x)->op, TPOLY_CTX(ctx)->P);
+    TPOLY(x)->len = 0;
+    TPOLY(x)->terms = 0;
+    TPOLY(x)->depth = 0;
+    TPOLY(x)->negs = 0;
+}
+
+static void
+tpoly_clear(gr_ptr x, gr_ctx_t ctx)
+{
+    fft_small_op_clear(&TPOLY(x)->op);
+}
+
+static void
+tpoly_swap(gr_ptr x, gr_ptr y, gr_ctx_t ctx)
+{
+    FLINT_SWAP(tpoly_struct, *TPOLY(x), *TPOLY(y));
+}
+
+static int
+tpoly_zero(gr_ptr x, gr_ctx_t ctx)
+{
+    TPOLY(x)->len = 0;
+    TPOLY(x)->terms = 0;
+    TPOLY(x)->depth = 0;
+    TPOLY(x)->negs = 0;
+    return GR_SUCCESS;
+}
+
+static int
+tpoly_set(gr_ptr res, gr_srcptr x, gr_ctx_t ctx)
+{
+    tpoly_ctx_struct * T = TPOLY_CTX(ctx);
+
+    if (res == x)
+        return GR_SUCCESS;
+
+    if (TPOLY(x)->len > 0)
+        memcpy(TPOLY(res)->op.data, TPOLY(x)->op.data,
+                     T->P->np * T->P->stride * sizeof(double));
+    TPOLY(res)->op.domain = TPOLY(x)->op.domain;
+    TPOLY(res)->op.itrunc = TPOLY(x)->op.itrunc;
+    TPOLY(res)->len = TPOLY(x)->len;
+    TPOLY(res)->terms = TPOLY(x)->terms;
+    TPOLY(res)->depth = TPOLY(x)->depth;
+    TPOLY(res)->negs = TPOLY(x)->negs;
+    return GR_SUCCESS;
+}
+
+static truth_t
+tpoly_is_zero(gr_srcptr x, gr_ctx_t ctx)
+{
+    return (TPOLY(x)->len == 0) ? T_TRUE : T_UNKNOWN;
+}
+
+static truth_t
+tpoly_equal(gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    if (TPOLY(x)->len == 0 && TPOLY(y)->len == 0)
+        return T_TRUE;
+    return T_UNKNOWN;
+}
+
+/* conversion from coefficients: the SET_GR_POLY method */
+static int
+tpoly_set_gr_poly(gr_ptr res, gr_srcptr a, slong len,
+                  gr_ctx_t base_ctx, gr_ctx_t ctx)
+{
+    tpoly_ctx_struct * T = TPOLY_CTX(ctx);
+    nn_srcptr ac = (nn_srcptr) a;
+
+    if (base_ctx->which_ring != GR_CTX_NMOD ||
+            NMOD_CTX(base_ctx).n != T->mod.n)
+        return GR_DOMAIN;
+
+    while (len > 0 && ac[len - 1] == 0)
+        len--;
+
+    if (len > T->N)
+        return GR_DOMAIN;
+
+    if (len == 0)
+        return tpoly_zero(res, ctx);
+
+    fft_small_fft_nmod(&TPOLY(res)->op, ac, len,
+                       n_round_up(len, BLK_SZ), T->mod, T->P);
+    TPOLY(res)->len = len;
+    TPOLY(res)->terms = 1;
+    TPOLY(res)->depth = 1;
+    TPOLY(res)->negs = 0;
+    return GR_SUCCESS;
+}
+
+/* shared conversion-out core: reconstruct coefficients [zl, ub) of x,
+   ub <= xlen, directly into z (z receives ub - zl values, bias already
+   removed); sdata is per-call temporary space of np * stride doubles */
+static void
+_tpoly_export(tpoly_ctx_struct * T, gr_srcptr x, slong zl, slong ub,
+              double * sdata, nn_ptr z)
+{
+    const fft_small_plan_struct * P = T->P;
+    slong xlen = TPOLY(x)->len;
+    fft_small_op_struct tmp;
+    ulong itr = n_round_up((ulong) xlen, BLK_SZ);
+    slong i;
+
+    tmp = TPOLY(x)->op;
+    tmp.data = sdata;
+
+    /* invert up to the element's virtual length (truncating below it
+       would violate the inverse transform's zero-tail assumption even
+       for a smaller window), apply the saved normalizers and, if the
+       values may be negative, the reconstruction bias, then remainder
+       the window */
+    memcpy(sdata, TPOLY(x)->op.data, P->np * P->stride * sizeof(double));
+    for (i = 0; i < (slong) P->np; i++)
+    {
+        sd_fft_ctx_struct * Q = P->ffts + P->offset + i;
+        double * d = sdata + P->stride * i;
+        double b = TPOLY(x)->negs ? (double) T->bias_res[i] : 0.0;
+
+        sd_ifft_trunc(Q, d, P->depth, itr);
+        _tpoly_scale_bias(Q, d, T->m_orig[i], b, itr / BLK_SZ);
+    }
+    fft_small_export_nmod_range(z, &tmp, (ulong) zl, (ulong) ub, T->mod, P);
+
+    if (TPOLY(x)->negs)
+        for (i = 0; i < ub - zl; i++)
+            z[i] = nmod_sub(z[i], T->bias_mod_n, T->mod);
+}
+
+/* per-call temporary for the inverse-transform copy */
+static double *
+_tpoly_scratch_alloc(const tpoly_ctx_struct * T)
+{
+    return flint_aligned_alloc(4096,
+            n_round_up(T->P->np * T->P->stride * sizeof(double), 4096));
+}
+
+/* conversion to coefficients: the GET_GR_POLY method; c must have room
+   for the element's virtual length; the returned length is normalized */
+static int
+tpoly_get_gr_poly(gr_ptr c, slong * len, gr_srcptr x,
+                  gr_ctx_t base_ctx, gr_ctx_t ctx)
+{
+    tpoly_ctx_struct * T = TPOLY_CTX(ctx);
+    nn_ptr cc = (nn_ptr) c;
+    slong xlen = TPOLY(x)->len;
+
+    if (base_ctx->which_ring != GR_CTX_NMOD ||
+            NMOD_CTX(base_ctx).n != T->mod.n)
+        return GR_DOMAIN;
+
+    if (xlen == 0)
+    {
+        *len = 0;
+        return GR_SUCCESS;
+    }
+
+    {
+        double * sdata = _tpoly_scratch_alloc(T);
+        _tpoly_export(T, x, 0, xlen, sdata, cc);
+        flint_aligned_free(sdata);
+    }
+
+    while (xlen > 0 && cc[xlen - 1] == 0)
+        xlen--;
+    *len = xlen;
+    return GR_SUCCESS;
+}
+
+/* windowed conversion: writes the coefficients [zl, zh) of the
+   represented polynomial into c (zeros beyond its virtual length) */
+static int
+tpoly_get_gr_poly_window(gr_ptr c, gr_srcptr x, slong zl, slong zh,
+                         gr_ctx_t base_ctx, gr_ctx_t ctx)
+{
+    tpoly_ctx_struct * T = TPOLY_CTX(ctx);
+    nn_ptr cc = (nn_ptr) c;
+    slong xlen = TPOLY(x)->len;
+    slong ub;
+
+    if (base_ctx->which_ring != GR_CTX_NMOD ||
+            NMOD_CTX(base_ctx).n != T->mod.n)
+        return GR_DOMAIN;
+    if (zl < 0 || zh < zl || zh > T->N)
+        return GR_DOMAIN;
+
+    ub = FLINT_MIN(zh, xlen);
+    if (ub > zl)
+    {
+        double * sdata = _tpoly_scratch_alloc(T);
+        _tpoly_export(T, x, zl, ub, sdata, cc);
+        flint_aligned_free(sdata);
+    }
+    else
+        ub = zl;
+    memset(cc + (ub - zl), 0, (zh - ub) * sizeof(ulong));
+    return GR_SUCCESS;
+}
+
+static int
+tpoly_one(gr_ptr x, gr_ctx_t ctx)
+{
+    tpoly_ctx_struct * T = TPOLY_CTX(ctx);
+    ulong c = 1;
+
+    fft_small_fft_nmod(&TPOLY(x)->op, &c, 1, BLK_SZ, T->mod, T->P);
+    TPOLY(x)->len = 1;
+    TPOLY(x)->terms = 1;
+    TPOLY(x)->depth = 1;
+    TPOLY(x)->negs = 0;
+    return GR_SUCCESS;
+}
+
+static int
+tpoly_neg(gr_ptr res, gr_srcptr x, gr_ctx_t ctx)
+{
+    tpoly_ctx_struct * T = TPOLY_CTX(ctx);
+
+    if (TPOLY(x)->len == 0)
+        return tpoly_zero(res, ctx);
+
+    fft_small_op_neg(&TPOLY(res)->op, &TPOLY(x)->op, T->P);
+    TPOLY(res)->op.domain = FFT_SMALL_OP_PRIMAL;
+    TPOLY(res)->len = TPOLY(x)->len;
+    TPOLY(res)->terms = TPOLY(x)->terms;
+    TPOLY(res)->depth = TPOLY(x)->depth;
+    TPOLY(res)->negs = 1;
+    return GR_SUCCESS;
+}
+
+static int
+tpoly_add(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    tpoly_ctx_struct * T = TPOLY_CTX(ctx);
+    ulong terms;
+
+    if (TPOLY(x)->len == 0)
+        return tpoly_set(res, y, ctx);
+    if (TPOLY(y)->len == 0)
+        return tpoly_set(res, x, ctx);
+
+    terms = TPOLY(x)->terms + TPOLY(y)->terms;
+    if (terms < TPOLY(x)->terms || terms > T->terms_bound)
+        return GR_UNABLE;
+
+    TPOLY(x)->op.domain = TPOLY(y)->op.domain = FFT_SMALL_OP_PRIMAL;
+    fft_small_op_add(&TPOLY(res)->op, &TPOLY(x)->op, &TPOLY(y)->op, T->P);
+    TPOLY(res)->op.domain = FFT_SMALL_OP_PRIMAL;
+    TPOLY(res)->len = FLINT_MAX(TPOLY(x)->len, TPOLY(y)->len);
+    TPOLY(res)->terms = terms;
+    TPOLY(res)->depth = FLINT_MAX(TPOLY(x)->depth, TPOLY(y)->depth);
+    TPOLY(res)->negs = TPOLY(x)->negs | TPOLY(y)->negs;
+    return GR_SUCCESS;
+}
+
+static int
+tpoly_sub(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    tpoly_ctx_struct * T = TPOLY_CTX(ctx);
+    ulong terms;
+
+    if (TPOLY(y)->len == 0)
+        return tpoly_set(res, x, ctx);
+    if (TPOLY(x)->len == 0)
+        return tpoly_neg(res, y, ctx);
+
+    terms = TPOLY(x)->terms + TPOLY(y)->terms;
+    if (terms < TPOLY(x)->terms || terms > T->terms_bound)
+        return GR_UNABLE;
+
+    TPOLY(x)->op.domain = TPOLY(y)->op.domain = FFT_SMALL_OP_PRIMAL;
+    fft_small_op_sub(&TPOLY(res)->op, &TPOLY(x)->op, &TPOLY(y)->op, T->P);
+    TPOLY(res)->op.domain = FFT_SMALL_OP_PRIMAL;
+    TPOLY(res)->len = FLINT_MAX(TPOLY(x)->len, TPOLY(y)->len);
+    TPOLY(res)->terms = terms;
+    TPOLY(res)->depth = FLINT_MAX(TPOLY(x)->depth, TPOLY(y)->depth);
+    TPOLY(res)->negs = 1;
+    return GR_SUCCESS;
+}
+
+/* terms bound of a product: tx * ty * min(lenx, leny), saturating */
+static int
+_mul_terms(ulong * terms, const tpoly_struct * x, const tpoly_struct * y,
+           ulong terms_bound)
+{
+    ulong hi, t;
+
+    umul_ppmm(hi, t, x->terms, y->terms);
+    if (hi != 0)
+        return 0;
+    umul_ppmm(hi, t, t, (ulong) FLINT_MIN(x->len, y->len));
+    if (hi != 0 || t > terms_bound)
+        return 0;
+    *terms = t;
+    return 1;
+}
+
+static int
+tpoly_mul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    tpoly_ctx_struct * T = TPOLY_CTX(ctx);
+    slong len;
+    ulong terms;
+
+    if (TPOLY(x)->len == 0 || TPOLY(y)->len == 0)
+        return tpoly_zero(res, ctx);
+
+    len = TPOLY(x)->len + TPOLY(y)->len - 1;
+    if (len > T->N || !_mul_terms(&terms, TPOLY(x), TPOLY(y), T->terms_bound))
+        return GR_UNABLE;
+    if (TPOLY(x)->depth + TPOLY(y)->depth > T->max_depth)
+        return GR_UNABLE;
+
+    TPOLY(x)->op.domain = TPOLY(y)->op.domain = FFT_SMALL_OP_PRIMAL;
+    fft_small_op_mul(&TPOLY(res)->op, &TPOLY(x)->op, &TPOLY(y)->op, T->P);
+    TPOLY(res)->op.domain = FFT_SMALL_OP_PRIMAL;
+    TPOLY(res)->len = len;
+    TPOLY(res)->terms = terms;
+    TPOLY(res)->depth = TPOLY(x)->depth + TPOLY(y)->depth;
+    TPOLY(res)->negs = TPOLY(x)->negs | TPOLY(y)->negs;
+    return GR_SUCCESS;
+}
+
+static int
+tpoly_addsubmul(gr_ptr res, gr_srcptr x, gr_srcptr y, int sub, gr_ctx_t ctx)
+{
+    tpoly_ctx_struct * T = TPOLY_CTX(ctx);
+    slong len;
+    ulong terms, t2;
+
+    if (TPOLY(x)->len == 0 || TPOLY(y)->len == 0)
+        return GR_SUCCESS;
+
+    if (TPOLY(res)->len == 0)
+    {
+        int status = tpoly_mul(res, x, y, ctx);
+        if (status == GR_SUCCESS && sub)
+            status = tpoly_neg(res, res, ctx);
+        return status;
+    }
+
+    len = TPOLY(x)->len + TPOLY(y)->len - 1;
+    if (len > T->N || !_mul_terms(&t2, TPOLY(x), TPOLY(y), T->terms_bound))
+        return GR_UNABLE;
+    terms = TPOLY(res)->terms + t2;
+    if (terms < t2 || terms > T->terms_bound)
+        return GR_UNABLE;
+    if (TPOLY(x)->depth + TPOLY(y)->depth > T->max_depth)
+        return GR_UNABLE;
+
+    TPOLY(x)->op.domain = TPOLY(y)->op.domain = FFT_SMALL_OP_PRIMAL;
+    TPOLY(res)->op.domain = FFT_SMALL_OP_PRODUCT;
+    if (sub)
+        fft_small_op_submul(&TPOLY(res)->op, &TPOLY(x)->op, &TPOLY(y)->op, T->P);
+    else
+        fft_small_op_addmul(&TPOLY(res)->op, &TPOLY(x)->op, &TPOLY(y)->op, T->P);
+    TPOLY(res)->op.domain = FFT_SMALL_OP_PRIMAL;
+    TPOLY(res)->len = FLINT_MAX(TPOLY(res)->len, len);
+    TPOLY(res)->terms = terms;
+    TPOLY(res)->depth = FLINT_MAX(TPOLY(res)->depth,
+                            TPOLY(x)->depth + TPOLY(y)->depth);
+    TPOLY(res)->negs = sub ? 1 :
+        (TPOLY(res)->negs | TPOLY(x)->negs | TPOLY(y)->negs);
+    return GR_SUCCESS;
+}
+
+static int
+tpoly_addmul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    return tpoly_addsubmul(res, x, y, 0, ctx);
+}
+
+static int
+tpoly_submul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    return tpoly_addsubmul(res, x, y, 1, ctx);
+}
+
+static gr_funcptr __tpoly_methods[GR_METHOD_TAB_SIZE];
+static int __tpoly_methods_initialized = 0;
+
+static gr_method_tab_input __tpoly_methods_input[] =
+{
+    {GR_METHOD_CTX_WRITE,       (gr_funcptr) tpoly_ctx_write},
+    {GR_METHOD_CTX_CLEAR,       (gr_funcptr) tpoly_ctx_clear},
+    {GR_METHOD_INIT,            (gr_funcptr) tpoly_init},
+    {GR_METHOD_CLEAR,           (gr_funcptr) tpoly_clear},
+    {GR_METHOD_SWAP,            (gr_funcptr) tpoly_swap},
+    {GR_METHOD_SET,             (gr_funcptr) tpoly_set},
+    {GR_METHOD_ZERO,            (gr_funcptr) tpoly_zero},
+    {GR_METHOD_ONE,             (gr_funcptr) tpoly_one},
+    {GR_METHOD_IS_ZERO,         (gr_funcptr) tpoly_is_zero},
+    {GR_METHOD_EQUAL,           (gr_funcptr) tpoly_equal},
+    {GR_METHOD_NEG,             (gr_funcptr) tpoly_neg},
+    {GR_METHOD_ADD,             (gr_funcptr) tpoly_add},
+    {GR_METHOD_SUB,             (gr_funcptr) tpoly_sub},
+    {GR_METHOD_MUL,             (gr_funcptr) tpoly_mul},
+    {GR_METHOD_ADDMUL,          (gr_funcptr) tpoly_addmul},
+    {GR_METHOD_SUBMUL,          (gr_funcptr) tpoly_submul},
+    {GR_METHOD_SET_GR_POLY,     (gr_funcptr) tpoly_set_gr_poly},
+    {GR_METHOD_GET_GR_POLY,     (gr_funcptr) tpoly_get_gr_poly},
+    {GR_METHOD_GET_GR_POLY_WINDOW, (gr_funcptr) tpoly_get_gr_poly_window},
+    {0,                         (gr_funcptr) NULL},
+};
+
+/* the nmod overload of gr_ctx_init_gr_poly_transformed_repr */
+int
+_gr_nmod_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base,
+                                        slong len_bound, slong terms_bound,
+                                        const gr_transformed_poly_workload_struct * workload)
+{
+    tpoly_ctx_struct * T;
+    nmod_t mod;
+    slong N = len_bound;
+    ulong modbits, i;
+
+    if (base->which_ring != GR_CTX_NMOD || N < 1 || terms_bound < 1 ||
+            (ulong) terms_bound > UWORD_MAX / 4)
+        return GR_UNABLE;
+
+    mod = NMOD_CTX(base);
+    modbits = FLINT_BITS - mod.norm;
+
+    T = FLINT_ARRAY_ALLOC(1, tpoly_ctx_struct);
+    T->mod = mod;
+    T->N = N;
+    T->terms_bound = (ulong) terms_bound;
+
+    /* provision the chinese remaindering for products of multiplicative
+       depth up to 2 in base elements with up to terms_bound elementary
+       products, doubled to cover the signed-value bias; the crt's final
+       reduction handles three limbs, which bounds the total */
+    if (2 * modbits + 1 + FLINT_BIT_COUNT((ulong) terms_bound) > 3 * FLINT_BITS
+        || !fft_small_plan_init_nmod(T->P, get_default_mpn_ctx(),
+            0, N, N, n_round_up(N, BLK_SZ), 2 * (ulong) terms_bound,
+            2 * modbits, mod, N))
+    {
+        flint_free(T);
+        return GR_UNABLE;
+    }
+
+    /* single-prime plans that compute directly mod n (an fft prime as
+       the modulus, or a direct transform) are exact for any expression:
+       no depth or accumulation restriction applies, and no signed-value
+       bias is needed */
+    int exact = T->P->use_direct_fft || (T->P->np == 1 &&
+            T->P->ffts[T->P->offset].mod.n == mod.n);
+
+    /* Profitability and memory model. Estimate the cost of performing
+       the declared workload in this representation against fused
+       multiplications, in double-ops per coefficient: a transform costs
+       ~lg(L) per coefficient per prime, a conversion pass ~2, a pointwise
+       multiplication ~2, and chinese remaindering ~3. Fused products use
+       tighter operand lengths in typical algorithmic callers (factor
+       ~0.6), often need fewer primes than the level-wide bound here
+       requires, and repack two coefficients per slot for tiny moduli.
+       Constants are calibrated against gcd measurements on this class of
+       hardware; the model errs conservative. */
+    {
+        const gr_transformed_poly_workload_struct def = { 2, 1, 1, 0 };
+        const gr_transformed_poly_workload_struct * wl =
+            workload ? workload : &def;
+        double L = (double) n_round_up(N, BLK_SZ);
+        double lg = (double) FLINT_BIT_COUNT((ulong) L);
+        double np = (double) T->P->np;
+        double ni = (double) wl->num_inputs;
+        double nm = (double) wl->num_muls;
+        double no = (double) wl->num_outputs;
+        double npf, Lf, lgf, rep, fuse, margin, bytes, limit;
+
+        rep = np * L * ((ni + no) * (lg + 2.0) + nm * 2.0)
+                + no * np * L * 3.0 + 5e4;
+
+        if (mod.n <= TPOLY_MAX_REPACK)
+        {
+            npf = 1.0;
+            Lf = L / 2;
+        }
+        else
+        {
+            npf = (double) ((2 * modbits + FLINT_BIT_COUNT((ulong) L) + 49)
+                            / 50);
+            npf = FLINT_MAX(npf, 1.0);
+            Lf = L;
+        }
+        lgf = (double) FLINT_BIT_COUNT((ulong) Lf);
+        /* homogeneous workloads (batched operands of comparable length,
+           as in matrix products) face fused alternatives at the same
+           transform sizes; heterogeneous whole-algorithm batching proved
+           unprofitable (operands transformed at the shared upper-bound
+           length lose the reuse advantage) and is not attempted */
+        fuse = nm * (npf * Lf * (3.0 * lgf + 6.0) + npf * Lf * 3.0);
+
+        /* single-prime transforms leave little to deduplicate relative to
+           the surrounding fixed and conversion costs (measured), so
+           require a decisive advantage there */
+        margin = (T->P->np == 1) ? 0.6 : 0.865;
+
+        /* low-reuse workloads whose live elements far exceed cache go
+           memory bound at one or two primes (measured); high-reuse
+           workloads amortize the streaming */
+        bytes = (ni + 3.0) * np *
+                (double) sd_fft_ctx_data_size(T->P->depth) * 8.0;
+        limit = wl->mem_limit > 0 ? (double) wl->mem_limit : 4.0 * 1073741824.0;
+
+        if (rep >= margin * fuse
+            || (T->P->np <= 2 && nm < 4.0 * ni && bytes > 32.0 * 1048576.0)
+            || bytes > limit)
+        {
+            fft_small_plan_clear(T->P);
+            flint_free(T);
+            return GR_UNABLE;
+        }
+    }
+
+    if (exact)
+    {
+        T->max_depth = UWORD_MAX / 4;
+        T->terms_bound = UWORD_MAX / 4;
+    }
+    else
+        T->max_depth = 2;
+
+    /* elements hold plain evaluations: make the pointwise kernels
+       apply no scaling, and save the true normalizers for conversion
+       back to coefficients */
+    for (i = 0; i < T->P->np; i++)
+    {
+        T->m_orig[i] = T->P->m[i];
+        T->P->m[i] = 1;
+    }
+
+
+    /* per-prime residues of the bias C = terms_bound * (n-1)^2, in the
+       convention of inverse-transformed coefficients (divided by the crt
+       cofactor), to be added to each coefficient before reconstruction;
+       exact plans need no bias since all arithmetic is mod n */
+    if (exact)
+    {
+        for (i = 0; i < T->P->np; i++)
+            T->bias_res[i] = 0;
+        T->bias_mod_n = 0;
+    }
+    else
+    {
+        fmpz_t C;
+
+        fmpz_init_set_ui(C, mod.n - 1);
+        fmpz_mul(C, C, C);
+        fmpz_mul_ui(C, C, (ulong) terms_bound);
+        for (i = 0; i < T->P->np; i++)
+        {
+            sd_fft_ctx_struct * Q = T->P->ffts + T->P->offset + i;
+            ulong cop = T->P->np == 1 ? 1 :
+                *crt_data_co_prime_red(T->P->crts + T->P->np - 1,
+                                       T->P->offset + i);
+            ulong Ci = fmpz_fdiv_ui(C, Q->mod.n);
+            T->bias_res[i] = nmod_mul(Ci, nmod_inv(cop % Q->mod.n, Q->mod),
+                                      Q->mod);
+        }
+        T->bias_mod_n = fmpz_fdiv_ui(C, mod.n);
+        fmpz_clear(C);
+    }
+
+    ctx->which_ring = GR_CTX_GR_TRANSFORMED_POLY;
+    ctx->sizeof_elem = sizeof(tpoly_struct);
+    ctx->size_limit = WORD_MAX;
+    GR_CTX_DATA_AS_PTR(ctx) = T;
+    ctx->methods = __tpoly_methods;
+
+    /* concurrent initializations write identical data, which is the
+       accepted pattern for gr method tables */
+    if (!__tpoly_methods_initialized)
+    {
+        gr_method_tab_init(__tpoly_methods, __tpoly_methods_input);
+        __tpoly_methods_initialized = 1;
+    }
+
+    return GR_SUCCESS;
+}
+
+#else /* FLINT_HAVE_FFT_SMALL */
+
+int
+_gr_nmod_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base,
+                                        slong len_bound, slong terms_bound)
+{
+    return GR_UNABLE;
+}
+
+#endif

--- a/src/gr/transformed_mpn.c
+++ b/src/gr/transformed_mpn.c
@@ -744,36 +744,6 @@ gr_ctx_init_transformed_mpn(gr_ctx_t ctx, slong bits_bound,
     return GR_SUCCESS;
 }
 
-#else /* FLINT_HAVE_FFT_SMALL */
-
-int
-gr_ctx_init_transformed_mpn(gr_ctx_t ctx, slong bits_bound,
-                            slong terms_bound, int is_signed)
-{
-    return GR_UNABLE;
-}
-
-int
-gr_transformed_mpn_set(gr_ptr res, nn_srcptr a, slong an, int sign,
-                       gr_ctx_t ctx)
-{
-    return GR_UNABLE;
-}
-
-int
-gr_transformed_mpn_get(nn_ptr z, slong zn, slong * zn_out, int * sign,
-                       gr_srcptr x, gr_ctx_t ctx)
-{
-    return GR_UNABLE;
-}
-
-slong
-gr_transformed_mpn_get_limbs(gr_ctx_t ctx, gr_srcptr x)
-{
-    return 0;
-}
-
-#endif
 
 int
 gr_transformed_mpn_get(nn_ptr z, slong zn, slong * zn_out, int * sign,
@@ -804,3 +774,79 @@ gr_transformed_mpn_get_trunc_destructive(nn_ptr z, slong zn, slong * zn_out,
 {
     return _tmpn_get_trunc(z, zn, zn_out, sign, lo, x, 1, ctx);
 }
+
+#else /* FLINT_HAVE_FFT_SMALL */
+
+/* Without fft_small the transformed representation does not exist: the
+   constructor reports GR_UNABLE and callers fall through to their plain
+   code paths. The remaining functions are unreachable then, but the
+   full public surface is defined so the library links; each returns the
+   neutral answer for its type. */
+
+int
+gr_ctx_init_transformed_mpn(gr_ctx_t ctx, slong bits_bound,
+                            slong terms_bound, int is_signed)
+{
+    return GR_UNABLE;
+}
+
+int
+gr_transformed_mpn_set(gr_ptr res, nn_srcptr a, slong an, int sign,
+                       gr_ctx_t ctx)
+{
+    return GR_UNABLE;
+}
+
+int
+gr_transformed_mpn_get(nn_ptr z, slong zn, slong * zn_out, int * sign,
+                       gr_srcptr x, gr_ctx_t ctx)
+{
+    return GR_UNABLE;
+}
+
+int
+gr_transformed_mpn_get_destructive(nn_ptr z, slong zn, slong * zn_out,
+                                   int * sign, gr_ptr x, gr_ctx_t ctx)
+{
+    return GR_UNABLE;
+}
+
+int
+gr_transformed_mpn_get_trunc(nn_ptr z, slong zn, slong * zn_out, int * sign,
+                             slong lo, gr_srcptr x, gr_ctx_t ctx)
+{
+    return GR_UNABLE;
+}
+
+int
+gr_transformed_mpn_get_trunc_destructive(nn_ptr z, slong zn, slong * zn_out,
+                                         int * sign, slong lo, gr_ptr x,
+                                         gr_ctx_t ctx)
+{
+    return GR_UNABLE;
+}
+
+slong
+gr_transformed_mpn_get_limbs(gr_ctx_t ctx, gr_srcptr x)
+{
+    return 0;
+}
+
+slong
+gr_transformed_mpn_get_limbs_trunc(gr_ctx_t ctx, gr_srcptr x, slong lo)
+{
+    return 0;
+}
+
+void
+gr_transformed_mpn_init_borrowed(gr_ptr x, double * data, gr_ctx_t ctx)
+{
+}
+
+ulong
+gr_transformed_mpn_sizeof_data(gr_ctx_t ctx)
+{
+    return 0;
+}
+
+#endif

--- a/src/gr/transformed_mpn.c
+++ b/src/gr/transformed_mpn.c
@@ -391,6 +391,16 @@ gr_transformed_mpn_get_limbs(gr_ctx_t ctx, gr_srcptr x)
                               TMPN(x)->negs);
 }
 
+/* an upper bound over every element of the ring: what
+   gr_transformed_mpn_get_limbs can return at the context's full chunk
+   capacity -- callers size conversion staging from this instead of
+   reconstructing the representation's limb requirements themselves */
+slong
+gr_transformed_mpn_get_limbs_bound(gr_ctx_t ctx)
+{
+    return _tmpn_export_limbs(TMPN_CTX(ctx), TMPN_CTX(ctx)->zcap, 1);
+}
+
 /* limbs required for a truncated conversion returning the limbs of the
    value starting at limb lo */
 slong
@@ -845,6 +855,12 @@ gr_transformed_mpn_get_trunc_destructive(nn_ptr FLINT_UNUSED(z), slong FLINT_UNU
 
 slong
 gr_transformed_mpn_get_limbs(gr_ctx_t FLINT_UNUSED(ctx), gr_srcptr FLINT_UNUSED(x))
+{
+    return 0;
+}
+
+slong
+gr_transformed_mpn_get_limbs_bound(gr_ctx_t FLINT_UNUSED(ctx))
 {
     return 0;
 }

--- a/src/gr/transformed_mpn.c
+++ b/src/gr/transformed_mpn.c
@@ -167,6 +167,74 @@ tmpn_swap(gr_ptr x, gr_ptr y, gr_ctx_t FLINT_UNUSED(ctx))
     FLINT_SWAP(tmpn_struct, *TMPN(x), *TMPN(y));
 }
 
+/* writes the represented value (reconstructed nondestructively);
+   costs an inverse transform, which only diagnostics and the test
+   framework pay */
+static int
+tmpn_write(gr_stream_t out, gr_srcptr x, gr_ctx_t ctx)
+{
+    slong need = gr_transformed_mpn_get_limbs(ctx, x);
+    nn_ptr t;
+    slong zn;
+    int sgn, status;
+    fmpz_t v;
+
+    if (need <= 0)
+    {
+        return gr_stream_write(out, "0");
+    }
+    t = flint_malloc(need * sizeof(ulong));
+    status = gr_transformed_mpn_get(t, need, &zn, &sgn, x, ctx);
+    if (status == GR_SUCCESS)
+    {
+        fmpz_init(v);
+        if (zn == 0)
+            fmpz_zero(v);
+        else
+        {
+            fmpz_set_ui_array(v, t, zn);
+            if (sgn)
+                fmpz_neg(v, v);
+        }
+        status |= gr_stream_write_fmpz(out, v);
+        fmpz_clear(v);
+    }
+    flint_free(t);
+    return status;
+}
+
+static int
+tmpn_one(gr_ptr res, gr_ctx_t ctx)
+{
+    ulong v = 1;
+    return gr_transformed_mpn_set(res, &v, 1, 0, ctx);
+}
+
+/* random depth-1 elements within the context's operand capacity;
+   gr_test_ring drives the ring through these */
+static int
+tmpn_randtest(gr_ptr res, flint_rand_t state, gr_ctx_t ctx)
+{
+    tmpn_ctx_struct * T = TMPN_CTX(ctx);
+    slong maxn = FLINT_MAX(1, (slong) (T->bits_bound / (2 * FLINT_BITS)));
+    slong n = n_randint(state, maxn + 1);
+    int sgn = T->is_signed ? (int) n_randint(state, 2) : 0;
+    nn_ptr t;
+    slong i;
+    int status;
+
+    if (n == 0 || n_randint(state, 8) == 0)
+        return gr_zero(res, ctx);
+
+    t = flint_malloc(n * sizeof(ulong));
+    for (i = 0; i < n; i++)
+        t[i] = n_randtest(state);
+    t[n - 1] += (t[n - 1] == 0);
+    status = gr_transformed_mpn_set(res, t, n, sgn, ctx);
+    flint_free(t);
+    return status;
+}
+
 static int
 tmpn_zero(gr_ptr x, gr_ctx_t FLINT_UNUSED(ctx))
 {
@@ -604,6 +672,22 @@ _tmpn_addsubmul(gr_ptr res, gr_srcptr x, gr_srcptr y, int subflip,
     if (TMPN(x)->nchunks == 0 || TMPN(y)->nchunks == 0)
         return GR_SUCCESS;
 
+    /* with res aliasing an operand, the per-call domain bookkeeping
+       below cannot mark the same struct as both input and accumulator;
+       route through the ring's own guarded multiply and add */
+    if (res == x || res == y)
+    {
+        gr_ptr t;
+        int status;
+        GR_TMP_INIT(t, ctx);
+        status = tmpn_mul(t, x, y, ctx);
+        if (status == GR_SUCCESS)
+            status = subflip ? tmpn_sub(res, res, t, ctx)
+                             : tmpn_add(res, res, t, ctx);
+        GR_TMP_CLEAR(t, ctx);
+        return status;
+    }
+
     if (TMPN(res)->nchunks == 0)
     {
         int status = tmpn_mul(res, x, y, ctx);
@@ -678,6 +762,9 @@ static gr_method_tab_input __tmpn_methods_input[] =
     {GR_METHOD_SWAP,            (gr_funcptr) (void (*)(void)) tmpn_swap},
     {GR_METHOD_SET,             (gr_funcptr) (void (*)(void)) tmpn_set},
     {GR_METHOD_ZERO,            (gr_funcptr) (void (*)(void)) tmpn_zero},
+    {GR_METHOD_WRITE,           (gr_funcptr) (void (*)(void)) tmpn_write},
+    {GR_METHOD_ONE,             (gr_funcptr) (void (*)(void)) tmpn_one},
+    {GR_METHOD_RANDTEST,        (gr_funcptr) (void (*)(void)) tmpn_randtest},
     {GR_METHOD_IS_ZERO,         (gr_funcptr) (void (*)(void)) tmpn_is_zero},
     {GR_METHOD_EQUAL,           (gr_funcptr) (void (*)(void)) tmpn_equal},
     {GR_METHOD_NEG,             (gr_funcptr) (void (*)(void)) tmpn_neg},

--- a/src/gr/transformed_mpn.c
+++ b/src/gr/transformed_mpn.c
@@ -323,8 +323,8 @@ _tmpn_get(nn_ptr z, slong zn, slong * zn_out, int * sign,
     }
     else
     {
-        sdata = flint_aligned_alloc(4096,
-                n_round_up(P->np * P->stride * sizeof(double), 4096));
+        sdata = flint_aligned_alloc(FLINT_FFT_SMALL_ALIGNMENT,
+                n_round_up(P->np * P->stride * sizeof(double), FLINT_FFT_SMALL_ALIGNMENT));
         tmp = TMPN(x)->op;
         tmp.data = sdata;
         memcpy(sdata, TMPN(x)->op.data,
@@ -439,8 +439,8 @@ _tmpn_get_trunc(nn_ptr z, slong zn, slong * zn_out, int * sign,
     }
     else
     {
-        sdata = flint_aligned_alloc(4096,
-                n_round_up(P->np * P->stride * sizeof(double), 4096));
+        sdata = flint_aligned_alloc(FLINT_FFT_SMALL_ALIGNMENT,
+                n_round_up(P->np * P->stride * sizeof(double), FLINT_FFT_SMALL_ALIGNMENT));
         tmp = TMPN(x)->op;
         tmp.data = sdata;
         memcpy(sdata, TMPN(x)->op.data,
@@ -681,10 +681,13 @@ static gr_method_tab_input __tmpn_methods_input[] =
 
 int
 gr_ctx_init_transformed_mpn(gr_ctx_t ctx, slong bits_bound,
-                            slong terms_bound, int is_signed)
+                            slong terms_bound, int is_signed, slong num_live)
 {
     tmpn_ctx_struct * T;
     ulong opn;
+
+    if (num_live < 1)
+        num_live = 4;
 
     if (bits_bound < FLINT_BITS || terms_bound < 1 ||
             (ulong) terms_bound > UWORD_MAX / 8)
@@ -708,6 +711,20 @@ gr_ctx_init_transformed_mpn(gr_ctx_t ctx, slong bits_bound,
     {
         flint_free(T);
         return GR_UNABLE;
+    }
+
+    /* decline when the declared number of simultaneously live elements
+       would exceed the transform-storage budget, so callers fall back to
+       slower algorithms instead of exhausting memory */
+    {
+        ulong per = n_round_up(T->P->np * T->P->stride * sizeof(double),
+                               FLINT_FFT_SMALL_ALIGNMENT);
+        if (per > flint_fft_small_max_transformed_ring_size / (ulong) num_live)
+        {
+            fft_small_plan_clear(T->P);
+            flint_free(T);
+            return GR_UNABLE;
+        }
     }
 
     T->zcap = (slong) T->P->zn;
@@ -785,7 +802,7 @@ gr_transformed_mpn_get_trunc_destructive(nn_ptr z, slong zn, slong * zn_out,
 
 int
 gr_ctx_init_transformed_mpn(gr_ctx_t FLINT_UNUSED(ctx), slong FLINT_UNUSED(bits_bound),
-                            slong FLINT_UNUSED(terms_bound), int FLINT_UNUSED(is_signed))
+                            slong FLINT_UNUSED(terms_bound), int FLINT_UNUSED(is_signed), slong FLINT_UNUSED(num_live))
 {
     return GR_UNABLE;
 }

--- a/src/gr/transformed_mpn.c
+++ b/src/gr/transformed_mpn.c
@@ -1,0 +1,806 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <string.h>
+#include "fmpz.h"
+#include "mpn_extras.h"
+#include "ulong_extras.h"
+#include "gr.h"
+
+#if FLINT_HAVE_FFT_SMALL
+
+#include "machine_vectors.h"
+#include "fft_small.h"
+
+/*
+    Transformed big integers (fft_small), for bilinear expressions such as
+    complex multiplications and matrix products over Z.
+
+    A context has a capacity: results of expressions must have absolute
+    value below 2^bits_bound, accumulate at most terms_bound elementary
+    products per bit-chunk, and have multiplicative depth at most 2 in
+    converted-in operands. Elements store the fft_small transform of the
+    operand's bit-chunk sequence (the existing packing code, untouched)
+    together with a virtual chunk length, an accumulation counter, a depth
+    counter, a sign bit and a chunks-possibly-signed flag: an element
+    represents (-1)^sign * (sum of chunks * 2^(j*bits)).
+
+    Signs: conversion in takes a magnitude and a sign bit, so the packing
+    never sees signed data. Multiplication multiplies sign bits and keeps
+    chunks nonnegative. Additive operations compare sign bits and switch
+    the roles of the pointwise additions and subtractions (add <-> sub,
+    addmul <-> submul); when a subtraction actually occurs, the chunk
+    values may become signed and the element is flagged. Conversion out of
+    a flagged element biases every chunk by C = terms_bound * (2^bits-1)^2
+    in the pointwise domain -- so the existing unsigned reconstruction and
+    carry propagation run untouched -- which adds the known integer
+    C * (1 + 2^bits + ... + 2^((m-1) bits)) to the result; one comparison
+    against that bias integer determines the result's sign and one
+    subtraction recovers its magnitude. Unsigned contexts and provably
+    nonnegative elements skip the bias entirely.
+
+    A context is read-only after construction and may be shared by any
+    number of threads; a single element belongs to one thread at a time.
+*/
+
+typedef struct
+{
+    fft_small_plan_t P;
+    slong bits_bound;               /* result magnitude < 2^bits_bound */
+    slong zcap;                     /* usable product chunks (plan chunk
+                                       range minus bias-digit headroom) */
+    ulong terms_bound;
+    ulong max_depth;
+    int is_signed;
+    ulong m_orig[MPN_CTX_NCRTS];    /* saved export normalizers */
+} tmpn_ctx_struct;
+
+typedef struct
+{
+    fft_small_op_struct op;
+    slong nchunks;                  /* virtual chunk length; 0 = zero */
+    ulong terms;
+    ulong depth;
+    int sign;                       /* 0 or 1: (-1)^sign */
+    int negs;                       /* chunk values may be signed */
+} tmpn_struct;
+
+#define TMPN_CTX(ctx) ((tmpn_ctx_struct *) GR_CTX_DATA_AS_PTR(ctx))
+#define TMPN(x) ((tmpn_struct *) (x))
+
+/* d = m*d + b over the first nblk blocks (see the polynomial rings) */
+static void
+_tmpn_scale(const sd_fft_ctx_struct * Q, double * d, ulong m_, ulong nblk)
+{
+    vec8d m = vec8d_set_d(vec1d_reduce_0n_to_pmhn((slong) m_, Q->p));
+    vec8d n = vec8d_set_d(Q->p);
+    vec8d ninv = vec8d_set_d(Q->pinv);
+    ulong I;
+
+    for (I = 0; I < nblk; I++)
+    {
+        double * dx = d + sd_fft_ctx_blk_offset(I);
+        ulong j = 0; do {
+            vec8d x0, x1;
+            x0 = vec8d_load(dx + j + 0);
+            x1 = vec8d_load(dx + j + 8);
+            x0 = vec8d_mulmod(x0, m, n, ninv);
+            x1 = vec8d_mulmod(x1, m, n, ninv);
+            vec8d_store(dx + j + 0, x0);
+            vec8d_store(dx + j + 8, x1);
+        } while (j += 16, j < BLK_SZ);
+    }
+}
+
+static int
+tmpn_ctx_write(gr_stream_t out, gr_ctx_t ctx)
+{
+    tmpn_ctx_struct * T = TMPN_CTX(ctx);
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out, T->is_signed ?
+        "Transformed signed integers (fft_small, bits_bound " :
+        "Transformed unsigned integers (fft_small, bits_bound ");
+    status |= gr_stream_write_si(out, T->bits_bound);
+    status |= gr_stream_write(out, ", terms_bound ");
+    status |= gr_stream_write_ui(out, T->terms_bound);
+    status |= gr_stream_write(out, ")");
+    return status;
+}
+
+static void
+tmpn_ctx_clear(gr_ctx_t ctx)
+{
+    tmpn_ctx_struct * T = TMPN_CTX(ctx);
+    fft_small_plan_clear(T->P);
+    flint_free(T);
+}
+
+static void
+tmpn_init(gr_ptr x, gr_ctx_t ctx)
+{
+    fft_small_op_init(&TMPN(x)->op, TMPN_CTX(ctx)->P);
+    TMPN(x)->nchunks = 0;
+    TMPN(x)->terms = 0;
+    TMPN(x)->depth = 0;
+    TMPN(x)->sign = 0;
+    TMPN(x)->negs = 0;
+}
+
+/* element on caller-provided storage: 'data' must hold
+   fft_small_op_sizeof_data of the context's plan, 4096-aligned, and
+   outlive the element; gr_clear will not free it */
+void
+gr_transformed_mpn_init_borrowed(gr_ptr x, double * data, gr_ctx_t ctx)
+{
+    fft_small_op_init_borrowed(&TMPN(x)->op, TMPN_CTX(ctx)->P, data);
+    TMPN(x)->nchunks = 0;
+    TMPN(x)->terms = 0;
+    TMPN(x)->depth = 0;
+    TMPN(x)->sign = 0;
+    TMPN(x)->negs = 0;
+}
+
+/* bytes of storage one element of this context needs */
+ulong
+gr_transformed_mpn_sizeof_data(gr_ctx_t ctx)
+{
+    return fft_small_op_sizeof_data(TMPN_CTX(ctx)->P);
+}
+
+static void
+tmpn_clear(gr_ptr x, gr_ctx_t ctx)
+{
+    fft_small_op_clear(&TMPN(x)->op);
+}
+
+static void
+tmpn_swap(gr_ptr x, gr_ptr y, gr_ctx_t ctx)
+{
+    FLINT_SWAP(tmpn_struct, *TMPN(x), *TMPN(y));
+}
+
+static int
+tmpn_zero(gr_ptr x, gr_ctx_t ctx)
+{
+    TMPN(x)->nchunks = 0;
+    TMPN(x)->terms = 0;
+    TMPN(x)->depth = 0;
+    TMPN(x)->sign = 0;
+    TMPN(x)->negs = 0;
+    return GR_SUCCESS;
+}
+
+static int
+tmpn_set(gr_ptr res, gr_srcptr x, gr_ctx_t ctx)
+{
+    tmpn_ctx_struct * T = TMPN_CTX(ctx);
+
+    if (res == x)
+        return GR_SUCCESS;
+
+    if (TMPN(x)->nchunks > 0)
+        memcpy(TMPN(res)->op.data, TMPN(x)->op.data,
+               T->P->np * T->P->stride * sizeof(double));
+    TMPN(res)->op.domain = TMPN(x)->op.domain;
+    TMPN(res)->op.itrunc = TMPN(x)->op.itrunc;
+    TMPN(res)->nchunks = TMPN(x)->nchunks;
+    TMPN(res)->terms = TMPN(x)->terms;
+    TMPN(res)->depth = TMPN(x)->depth;
+    TMPN(res)->sign = TMPN(x)->sign;
+    TMPN(res)->negs = TMPN(x)->negs;
+    return GR_SUCCESS;
+}
+
+static truth_t
+tmpn_is_zero(gr_srcptr x, gr_ctx_t ctx)
+{
+    return (TMPN(x)->nchunks == 0) ? T_TRUE : T_UNKNOWN;
+}
+
+static truth_t
+tmpn_equal(gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    if (TMPN(x)->nchunks == 0 && TMPN(y)->nchunks == 0)
+        return T_TRUE;
+    return T_UNKNOWN;
+}
+
+static int
+tmpn_neg(gr_ptr res, gr_srcptr x, gr_ctx_t ctx)
+{
+    int status = tmpn_set(res, x, ctx);
+    if (status == GR_SUCCESS && TMPN(res)->nchunks > 0)
+    {
+        if (!TMPN_CTX(ctx)->is_signed)
+            return GR_UNABLE;
+        TMPN(res)->sign ^= 1;
+    }
+    return status;
+}
+
+/* conversion in: the packing never sees signs */
+int
+gr_transformed_mpn_set(gr_ptr res, nn_srcptr a, slong an, int sign,
+                       gr_ctx_t ctx)
+{
+    tmpn_ctx_struct * T = TMPN_CTX(ctx);
+
+    while (an > 0 && a[an - 1] == 0)
+        an--;
+
+    if (an == 0)
+        return tmpn_zero(res, ctx);
+
+    if (sign && !T->is_signed)
+        return GR_DOMAIN;
+    if ((ulong) an * FLINT_BITS > (ulong) T->zcap * T->P->bits)
+        return GR_DOMAIN;
+
+    fft_small_fft_mpn(&TMPN(res)->op, a, (ulong) an, T->P);
+    TMPN(res)->nchunks = (slong) n_cdiv((ulong) an * FLINT_BITS, T->P->bits);
+    TMPN(res)->terms = 1;
+    TMPN(res)->depth = 1;
+    TMPN(res)->sign = sign ? 1 : 0;
+    TMPN(res)->negs = 0;
+    return GR_SUCCESS;
+}
+
+/* number of limbs certainly sufficient for the biased reconstruction of
+   an element with m chunks */
+static slong
+_tmpn_export_limbs_raw(const fft_small_plan_struct * P, ulong terms_bound,
+                       ulong mchunks)
+{
+    return (slong) n_cdiv(mchunks * P->bits + 2 * P->bits
+            + FLINT_BIT_COUNT(terms_bound)
+            + FLINT_BIT_COUNT((ulong) P->zn) + 4,
+            FLINT_BITS);
+}
+
+static slong
+_tmpn_export_limbs(const tmpn_ctx_struct * T, slong m, int negs)
+{
+    if (negs)
+    {
+        /* the signed export reads round_up(m) slots and requires
+           64 zn >= nslots bits + 64 coeff_len + 2 */
+        ulong clen = (T->P->crts + T->P->np - 1)->coeff_len;
+        return (slong) n_cdiv((ulong) m * T->P->bits
+                + FLINT_BITS * clen + 2 + (FLINT_BITS - 1), FLINT_BITS);
+    }
+    return _tmpn_export_limbs_raw(T->P, T->terms_bound,
+            n_min(n_round_up((ulong) m, BLK_SZ), T->P->zn));
+}
+
+/* conversion out: z receives the magnitude (zn limbs allocated by the
+   caller, at least gr_transformed_mpn_get_limbs(ctx, x)); *zn_out is the
+   normalized limb count and *sign the sign bit */
+/*
+    Conversion out. With 'destroy' the element's own transform buffer is
+    consumed in place rather than copied. Both the inverse transform and
+    the reconstruction need a writable copy of the evaluations, and
+    copying one is a full pass over np * 2^depth doubles -- 3 MB for a
+    megabyte-size operand, a substantial share of the conversion cost.
+    Callers finished with the element should use the destructive form;
+    the element is then unusable and must only be cleared.
+*/
+static int
+_tmpn_get(nn_ptr z, slong zn, slong * zn_out, int * sign,
+          gr_srcptr x, int destroy, gr_ctx_t ctx)
+{
+    tmpn_ctx_struct * T = TMPN_CTX(ctx);
+    const fft_small_plan_struct * P = T->P;
+    slong m = TMPN(x)->nchunks;
+    int negs = TMPN(x)->negs;
+    slong need = _tmpn_export_limbs(T, m, negs);
+    fft_small_op_struct tmp;
+    double * sdata;
+    ulong itr;
+    slong i;
+
+    if (m == 0)
+    {
+        *zn_out = 0;
+        *sign = 0;
+        return GR_SUCCESS;
+    }
+
+    if (zn < need)
+        return GR_DOMAIN;
+
+    if (destroy)
+    {
+        sdata = NULL;
+        tmp = TMPN(x)->op;
+    }
+    else
+    {
+        sdata = flint_aligned_alloc(4096,
+                n_round_up(P->np * P->stride * sizeof(double), 4096));
+        tmp = TMPN(x)->op;
+        tmp.data = sdata;
+        memcpy(sdata, TMPN(x)->op.data,
+               P->np * P->stride * sizeof(double));
+    }
+    itr = n_round_up((ulong) m, BLK_SZ);
+
+    for (i = 0; i < (slong) P->np; i++)
+    {
+        sd_fft_ctx_struct * Q = P->ffts + P->offset + i;
+        double * d = tmp.data + P->stride * i;
+
+        sd_ifft_trunc(Q, d, P->depth, itr);
+        _tmpn_scale(Q, d, T->m_orig[i], itr / BLK_SZ);
+
+        /* the unsigned reconstruction reads whole chunks up to the
+           requested limb count; slots beyond the inverse transform's
+           range are garbage and represent true zero chunks, so clear
+           them (the signed export reads exactly itr slots instead) */
+        if (!negs)
+        {
+            ulong chi = n_min(n_pow2(P->depth),
+                              n_round_up(n_cdiv((ulong) need * FLINT_BITS,
+                                                P->bits), BLK_SZ));
+            ulong I;
+            for (I = itr / BLK_SZ; I < chi / BLK_SZ; I++)
+                memset(d + sd_fft_ctx_blk_offset(I), 0,
+                       BLK_SZ * sizeof(double));
+        }
+    }
+    tmp.domain = FFT_SMALL_OP_PRODUCT;
+    if (negs)
+    {
+        /* per-slot centered lifts: signed chunk values convert directly,
+           with no bias operand and no precomputation */
+        int esign;
+        fft_small_export_mpn_signed(z, (ulong) need, &esign, &tmp,
+                                    (ulong) m, P);
+        *sign = TMPN(x)->sign ^ esign;
+    }
+    else
+    {
+        fft_small_export_mpn(z, (ulong) need, &tmp, P);
+        *sign = TMPN(x)->sign;
+    }
+    if (sdata != NULL)
+        flint_aligned_free(sdata);
+
+    if (need < zn)
+        flint_mpn_zero(z + need, zn - need);
+
+    i = need;
+    while (i > 0 && z[i - 1] == 0)
+        i--;
+    *zn_out = i;
+    if (i == 0)
+        *sign = 0;
+    return GR_SUCCESS;
+}
+slong
+gr_transformed_mpn_get_limbs(gr_ctx_t ctx, gr_srcptr x)
+{
+    return _tmpn_export_limbs(TMPN_CTX(ctx), TMPN(x)->nchunks,
+                              TMPN(x)->negs);
+}
+
+/* limbs required for a truncated conversion returning the limbs of the
+   value starting at limb lo */
+slong
+gr_transformed_mpn_get_limbs_trunc(gr_ctx_t ctx, gr_srcptr x, slong lo)
+{
+    slong needf = _tmpn_export_limbs(TMPN_CTX(ctx), TMPN(x)->nchunks, 1);
+    return FLINT_MAX(needf - lo, 0);
+}
+
+/* Truncated conversion: z receives zn limbs of |value| starting at limb
+   lo (zero padded at the top), *sign the sign, *zn_out the significant
+   limb count within the window. The discarded low tail perturbs the
+   lowest returned limb by at most one unit (the mulhigh contract); with
+   lo = 0 the conversion is exact. */
+static int
+_tmpn_get_trunc(nn_ptr z, slong zn, slong * zn_out, int * sign,
+                slong lo, gr_srcptr x, int destroy, gr_ctx_t ctx)
+{
+    tmpn_ctx_struct * T = TMPN_CTX(ctx);
+    const fft_small_plan_struct * P = T->P;
+    slong m = TMPN(x)->nchunks;
+    slong needf = _tmpn_export_limbs(T, m, 1);
+    fft_small_op_struct tmp;
+    double * sdata;
+    ulong itr;
+    slong i;
+    int esign;
+
+    if (m == 0 || lo >= needf)
+    {
+        flint_mpn_zero(z, zn);
+        *zn_out = 0;
+        *sign = 0;
+        return GR_SUCCESS;
+    }
+
+    if (lo + zn < needf)
+        return GR_DOMAIN;
+
+    itr = n_round_up((ulong) m, BLK_SZ);
+
+    if (destroy)
+    {
+        sdata = NULL;
+        tmp = TMPN(x)->op;
+    }
+    else
+    {
+        sdata = flint_aligned_alloc(4096,
+                n_round_up(P->np * P->stride * sizeof(double), 4096));
+        tmp = TMPN(x)->op;
+        tmp.data = sdata;
+        memcpy(sdata, TMPN(x)->op.data,
+               P->np * P->stride * sizeof(double));
+    }
+
+    for (i = 0; i < (slong) P->np; i++)
+    {
+        sd_fft_ctx_struct * Q = P->ffts + P->offset + i;
+        double * d = tmp.data + P->stride * i;
+
+        sd_ifft_trunc(Q, d, P->depth, itr);
+        _tmpn_scale(Q, d, T->m_orig[i], itr / BLK_SZ);
+    }
+    tmp.domain = FFT_SMALL_OP_PRODUCT;
+    fft_small_export_mpn_signed_trunc(z, (ulong) zn, &esign, &tmp,
+                                      (ulong) m, (ulong) lo, P);
+    if (sdata != NULL)
+        flint_aligned_free(sdata);
+
+    *sign = TMPN(x)->sign ^ esign;
+
+    i = zn;
+    while (i > 0 && z[i - 1] == 0)
+        i--;
+    *zn_out = i;
+    if (i == 0)
+        *sign = 0;
+    return GR_SUCCESS;
+}
+
+static int
+tmpn_add(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx);
+
+static int
+_tmpn_addsub(gr_ptr res, gr_srcptr x, gr_srcptr y, int ysign_flip,
+             gr_ctx_t ctx)
+{
+    tmpn_ctx_struct * T = TMPN_CTX(ctx);
+    int sy = TMPN(y)->sign ^ ysign_flip;
+    ulong terms;
+
+    if (TMPN(y)->nchunks == 0)
+        return tmpn_set(res, x, ctx);
+    if (TMPN(x)->nchunks == 0)
+    {
+        int status = tmpn_set(res, y, ctx);
+        if (status == GR_SUCCESS && (TMPN(res)->sign ^ ysign_flip) !=
+                TMPN(res)->sign)
+        {
+            if (!T->is_signed)
+                return GR_UNABLE;
+            TMPN(res)->sign ^= ysign_flip;
+        }
+        return status;
+    }
+
+    terms = TMPN(x)->terms + TMPN(y)->terms;
+    if (terms < TMPN(x)->terms || terms > T->terms_bound)
+        return GR_UNABLE;
+
+    TMPN(x)->op.domain = TMPN(y)->op.domain = FFT_SMALL_OP_PRIMAL;
+    if (TMPN(x)->sign == sy)
+    {
+        /* same signs: pointwise addition, sign preserved */
+        fft_small_op_add(&TMPN(res)->op, &TMPN(x)->op, &TMPN(y)->op, T->P);
+        TMPN(res)->negs = TMPN(x)->negs | TMPN(y)->negs;
+    }
+    else
+    {
+        /* opposite signs: pointwise subtraction; the chunk values may go
+           negative and the sign is resolved at conversion out */
+        if (!T->is_signed)
+            return GR_UNABLE;
+        fft_small_op_sub(&TMPN(res)->op, &TMPN(x)->op, &TMPN(y)->op, T->P);
+        TMPN(res)->negs = 1;
+    }
+    TMPN(res)->op.domain = FFT_SMALL_OP_PRIMAL;
+    TMPN(res)->sign = TMPN(x)->sign;
+    TMPN(res)->nchunks = FLINT_MAX(TMPN(x)->nchunks, TMPN(y)->nchunks);
+    TMPN(res)->terms = terms;
+    TMPN(res)->depth = FLINT_MAX(TMPN(x)->depth, TMPN(y)->depth);
+    return GR_SUCCESS;
+}
+
+static int
+tmpn_add(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    return _tmpn_addsub(res, x, y, 0, ctx);
+}
+
+static int
+tmpn_sub(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    return _tmpn_addsub(res, x, y, 1, ctx);
+}
+
+/* the per-product chunk-count factor is provisioned inside the plan (its
+   bound criterion multiplies by the operand chunk count); element terms
+   count accumulated products only */
+static int
+_tmpn_mul_terms(ulong * terms, const tmpn_struct * x, const tmpn_struct * y,
+                ulong terms_bound)
+{
+    ulong hi, t;
+
+    umul_ppmm(hi, t, x->terms, y->terms);
+    if (hi != 0 || t > terms_bound)
+        return 0;
+    *terms = t;
+    return 1;
+}
+
+static int
+tmpn_mul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    tmpn_ctx_struct * T = TMPN_CTX(ctx);
+    slong m;
+    ulong terms;
+
+    if (TMPN(x)->nchunks == 0 || TMPN(y)->nchunks == 0)
+        return tmpn_zero(res, ctx);
+
+    m = TMPN(x)->nchunks + TMPN(y)->nchunks - 1;
+    if (m > T->zcap ||
+        !_tmpn_mul_terms(&terms, TMPN(x), TMPN(y), T->terms_bound))
+        return GR_UNABLE;
+    if (TMPN(x)->depth + TMPN(y)->depth > T->max_depth)
+        return GR_UNABLE;
+
+    TMPN(x)->op.domain = TMPN(y)->op.domain = FFT_SMALL_OP_PRIMAL;
+    fft_small_op_mul(&TMPN(res)->op, &TMPN(x)->op, &TMPN(y)->op, T->P);
+    TMPN(res)->op.domain = FFT_SMALL_OP_PRIMAL;
+    TMPN(res)->nchunks = m;
+    TMPN(res)->terms = terms;
+    TMPN(res)->depth = TMPN(x)->depth + TMPN(y)->depth;
+    TMPN(res)->sign = TMPN(x)->sign ^ TMPN(y)->sign;
+    TMPN(res)->negs = TMPN(x)->negs | TMPN(y)->negs;
+    return GR_SUCCESS;
+}
+
+static int
+_tmpn_addsubmul(gr_ptr res, gr_srcptr x, gr_srcptr y, int subflip,
+                gr_ctx_t ctx)
+{
+    tmpn_ctx_struct * T = TMPN_CTX(ctx);
+    int psign;
+    slong m;
+    ulong terms, t2;
+
+    if (TMPN(x)->nchunks == 0 || TMPN(y)->nchunks == 0)
+        return GR_SUCCESS;
+
+    if (TMPN(res)->nchunks == 0)
+    {
+        int status = tmpn_mul(res, x, y, ctx);
+        if (status == GR_SUCCESS && subflip && TMPN(res)->nchunks > 0)
+        {
+            if (!T->is_signed)
+                return GR_UNABLE;
+            TMPN(res)->sign ^= 1;
+        }
+        return status;
+    }
+
+    m = TMPN(x)->nchunks + TMPN(y)->nchunks - 1;
+    if (m > T->zcap ||
+        !_tmpn_mul_terms(&t2, TMPN(x), TMPN(y), T->terms_bound))
+        return GR_UNABLE;
+    terms = TMPN(res)->terms + t2;
+    if (terms < t2 || terms > T->terms_bound)
+        return GR_UNABLE;
+    if (TMPN(x)->depth + TMPN(y)->depth > T->max_depth)
+        return GR_UNABLE;
+
+    psign = TMPN(x)->sign ^ TMPN(y)->sign ^ subflip;
+
+    TMPN(x)->op.domain = TMPN(y)->op.domain = FFT_SMALL_OP_PRIMAL;
+    TMPN(res)->op.domain = FFT_SMALL_OP_PRODUCT;
+    if (psign == TMPN(res)->sign)
+    {
+        /* accumulated product has the accumulator's sign: pointwise
+           addmul */
+        fft_small_op_addmul(&TMPN(res)->op, &TMPN(x)->op, &TMPN(y)->op, T->P);
+        TMPN(res)->negs |= TMPN(x)->negs | TMPN(y)->negs;
+    }
+    else
+    {
+        /* opposite sign: the roles switch to a pointwise submul and the
+           chunk values may go negative */
+        if (!T->is_signed)
+            return GR_UNABLE;
+        fft_small_op_submul(&TMPN(res)->op, &TMPN(x)->op, &TMPN(y)->op, T->P);
+        TMPN(res)->negs = 1;
+    }
+    TMPN(res)->op.domain = FFT_SMALL_OP_PRIMAL;
+    TMPN(res)->nchunks = FLINT_MAX(TMPN(res)->nchunks, m);
+    TMPN(res)->terms = terms;
+    TMPN(res)->depth = FLINT_MAX(TMPN(res)->depth,
+                                 TMPN(x)->depth + TMPN(y)->depth);
+    return GR_SUCCESS;
+}
+
+static int
+tmpn_addmul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    return _tmpn_addsubmul(res, x, y, 0, ctx);
+}
+
+static int
+tmpn_submul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    return _tmpn_addsubmul(res, x, y, 1, ctx);
+}
+
+static gr_funcptr __tmpn_methods[GR_METHOD_TAB_SIZE];
+static int __tmpn_methods_initialized = 0;
+
+static gr_method_tab_input __tmpn_methods_input[] =
+{
+    {GR_METHOD_CTX_WRITE,       (gr_funcptr) tmpn_ctx_write},
+    {GR_METHOD_CTX_CLEAR,       (gr_funcptr) tmpn_ctx_clear},
+    {GR_METHOD_INIT,            (gr_funcptr) tmpn_init},
+    {GR_METHOD_CLEAR,           (gr_funcptr) tmpn_clear},
+    {GR_METHOD_SWAP,            (gr_funcptr) tmpn_swap},
+    {GR_METHOD_SET,             (gr_funcptr) tmpn_set},
+    {GR_METHOD_ZERO,            (gr_funcptr) tmpn_zero},
+    {GR_METHOD_IS_ZERO,         (gr_funcptr) tmpn_is_zero},
+    {GR_METHOD_EQUAL,           (gr_funcptr) tmpn_equal},
+    {GR_METHOD_NEG,             (gr_funcptr) tmpn_neg},
+    {GR_METHOD_ADD,             (gr_funcptr) tmpn_add},
+    {GR_METHOD_SUB,             (gr_funcptr) tmpn_sub},
+    {GR_METHOD_MUL,             (gr_funcptr) tmpn_mul},
+    {GR_METHOD_ADDMUL,          (gr_funcptr) tmpn_addmul},
+    {GR_METHOD_SUBMUL,          (gr_funcptr) tmpn_submul},
+    {0,                         (gr_funcptr) NULL},
+};
+
+int
+gr_ctx_init_transformed_mpn(gr_ctx_t ctx, slong bits_bound,
+                            slong terms_bound, int is_signed)
+{
+    tmpn_ctx_struct * T;
+    ulong opn;
+
+    if (bits_bound < FLINT_BITS || terms_bound < 1 ||
+            (ulong) terms_bound > UWORD_MAX / 8)
+        return GR_UNABLE;
+
+    T = FLINT_ARRAY_ALLOC(1, tmpn_ctx_struct);
+    T->bits_bound = bits_bound;
+    T->terms_bound = (ulong) terms_bound;
+    T->max_depth = 2;
+    T->is_signed = is_signed != 0;
+
+    /* operands of up to bits_bound/2 bits each on either side (unbalanced
+       operands simply occupy fewer chunks); provision the accumulation
+       bound times two in the signed case for the bias headroom (biased
+       chunk values reach twice the magnitude bound). The extra limbs
+       give the plan chunk headroom for the top digits of the bias
+       integer, whose per-chunk constant spans several chunks */
+    opn = n_cdiv((ulong) bits_bound, 2 * FLINT_BITS) + 1;
+    if (!fft_small_plan_init_mpn(T->P, get_default_mpn_ctx(), opn, opn,
+            (is_signed ? 2 : 1) * (ulong) terms_bound))
+    {
+        flint_free(T);
+        return GR_UNABLE;
+    }
+
+    T->zcap = (slong) T->P->zn;
+
+    {
+        ulong i;
+        for (i = 0; i < T->P->np; i++)
+        {
+            T->m_orig[i] = T->P->m[i];
+            T->P->m[i] = 1;
+        }
+    }
+
+    /* Signed output conversion needs no per-context state: the signed
+       export interprets each chunk slot's reconstruction as a centered
+       residue, which is valid whenever chunk magnitudes stay below half
+       the prime product -- guaranteed by the times-four provisioning of
+       the accumulation bound above. */
+
+    ctx->which_ring = GR_CTX_GR_TRANSFORMED_MPN;
+    ctx->sizeof_elem = sizeof(tmpn_struct);
+    ctx->size_limit = WORD_MAX;
+    GR_CTX_DATA_AS_PTR(ctx) = T;
+    ctx->methods = __tmpn_methods;
+
+    /* concurrent initializations write identical data, which is the
+       accepted pattern for gr method tables */
+    if (!__tmpn_methods_initialized)
+    {
+        gr_method_tab_init(__tmpn_methods, __tmpn_methods_input);
+        __tmpn_methods_initialized = 1;
+    }
+
+    return GR_SUCCESS;
+}
+
+#else /* FLINT_HAVE_FFT_SMALL */
+
+int
+gr_ctx_init_transformed_mpn(gr_ctx_t ctx, slong bits_bound,
+                            slong terms_bound, int is_signed)
+{
+    return GR_UNABLE;
+}
+
+int
+gr_transformed_mpn_set(gr_ptr res, nn_srcptr a, slong an, int sign,
+                       gr_ctx_t ctx)
+{
+    return GR_UNABLE;
+}
+
+int
+gr_transformed_mpn_get(nn_ptr z, slong zn, slong * zn_out, int * sign,
+                       gr_srcptr x, gr_ctx_t ctx)
+{
+    return GR_UNABLE;
+}
+
+slong
+gr_transformed_mpn_get_limbs(gr_ctx_t ctx, gr_srcptr x)
+{
+    return 0;
+}
+
+#endif
+
+int
+gr_transformed_mpn_get(nn_ptr z, slong zn, slong * zn_out, int * sign,
+                       gr_srcptr x, gr_ctx_t ctx)
+{
+    return _tmpn_get(z, zn, zn_out, sign, x, 0, ctx);
+}
+
+/* as above but consumes x: only gr_clear may follow */
+int
+gr_transformed_mpn_get_destructive(nn_ptr z, slong zn, slong * zn_out,
+                                   int * sign, gr_ptr x, gr_ctx_t ctx)
+{
+    return _tmpn_get(z, zn, zn_out, sign, x, 1, ctx);
+}
+
+int
+gr_transformed_mpn_get_trunc(nn_ptr z, slong zn, slong * zn_out, int * sign,
+                             slong lo, gr_srcptr x, gr_ctx_t ctx)
+{
+    return _tmpn_get_trunc(z, zn, zn_out, sign, lo, x, 0, ctx);
+}
+
+int
+gr_transformed_mpn_get_trunc_destructive(nn_ptr z, slong zn, slong * zn_out,
+                                         int * sign, slong lo, gr_ptr x,
+                                         gr_ctx_t ctx)
+{
+    return _tmpn_get_trunc(z, zn, zn_out, sign, lo, x, 1, ctx);
+}

--- a/src/gr/transformed_mpn.c
+++ b/src/gr/transformed_mpn.c
@@ -156,19 +156,19 @@ gr_transformed_mpn_sizeof_data(gr_ctx_t ctx)
 }
 
 static void
-tmpn_clear(gr_ptr x, gr_ctx_t ctx)
+tmpn_clear(gr_ptr x, gr_ctx_t FLINT_UNUSED(ctx))
 {
     fft_small_op_clear(&TMPN(x)->op);
 }
 
 static void
-tmpn_swap(gr_ptr x, gr_ptr y, gr_ctx_t ctx)
+tmpn_swap(gr_ptr x, gr_ptr y, gr_ctx_t FLINT_UNUSED(ctx))
 {
     FLINT_SWAP(tmpn_struct, *TMPN(x), *TMPN(y));
 }
 
 static int
-tmpn_zero(gr_ptr x, gr_ctx_t ctx)
+tmpn_zero(gr_ptr x, gr_ctx_t FLINT_UNUSED(ctx))
 {
     TMPN(x)->nchunks = 0;
     TMPN(x)->terms = 0;
@@ -200,13 +200,13 @@ tmpn_set(gr_ptr res, gr_srcptr x, gr_ctx_t ctx)
 }
 
 static truth_t
-tmpn_is_zero(gr_srcptr x, gr_ctx_t ctx)
+tmpn_is_zero(gr_srcptr x, gr_ctx_t FLINT_UNUSED(ctx))
 {
     return (TMPN(x)->nchunks == 0) ? T_TRUE : T_UNKNOWN;
 }
 
 static truth_t
-tmpn_equal(gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+tmpn_equal(gr_srcptr x, gr_srcptr y, gr_ctx_t FLINT_UNUSED(ctx))
 {
     if (TMPN(x)->nchunks == 0 && TMPN(y)->nchunks == 0)
         return T_TRUE;
@@ -661,22 +661,22 @@ static int __tmpn_methods_initialized = 0;
 
 static gr_method_tab_input __tmpn_methods_input[] =
 {
-    {GR_METHOD_CTX_WRITE,       (gr_funcptr) tmpn_ctx_write},
-    {GR_METHOD_CTX_CLEAR,       (gr_funcptr) tmpn_ctx_clear},
-    {GR_METHOD_INIT,            (gr_funcptr) tmpn_init},
-    {GR_METHOD_CLEAR,           (gr_funcptr) tmpn_clear},
-    {GR_METHOD_SWAP,            (gr_funcptr) tmpn_swap},
-    {GR_METHOD_SET,             (gr_funcptr) tmpn_set},
-    {GR_METHOD_ZERO,            (gr_funcptr) tmpn_zero},
-    {GR_METHOD_IS_ZERO,         (gr_funcptr) tmpn_is_zero},
-    {GR_METHOD_EQUAL,           (gr_funcptr) tmpn_equal},
-    {GR_METHOD_NEG,             (gr_funcptr) tmpn_neg},
-    {GR_METHOD_ADD,             (gr_funcptr) tmpn_add},
-    {GR_METHOD_SUB,             (gr_funcptr) tmpn_sub},
-    {GR_METHOD_MUL,             (gr_funcptr) tmpn_mul},
-    {GR_METHOD_ADDMUL,          (gr_funcptr) tmpn_addmul},
-    {GR_METHOD_SUBMUL,          (gr_funcptr) tmpn_submul},
-    {0,                         (gr_funcptr) NULL},
+    {GR_METHOD_CTX_WRITE,       (gr_funcptr) (void (*)(void)) tmpn_ctx_write},
+    {GR_METHOD_CTX_CLEAR,       (gr_funcptr) (void (*)(void)) tmpn_ctx_clear},
+    {GR_METHOD_INIT,            (gr_funcptr) (void (*)(void)) tmpn_init},
+    {GR_METHOD_CLEAR,           (gr_funcptr) (void (*)(void)) tmpn_clear},
+    {GR_METHOD_SWAP,            (gr_funcptr) (void (*)(void)) tmpn_swap},
+    {GR_METHOD_SET,             (gr_funcptr) (void (*)(void)) tmpn_set},
+    {GR_METHOD_ZERO,            (gr_funcptr) (void (*)(void)) tmpn_zero},
+    {GR_METHOD_IS_ZERO,         (gr_funcptr) (void (*)(void)) tmpn_is_zero},
+    {GR_METHOD_EQUAL,           (gr_funcptr) (void (*)(void)) tmpn_equal},
+    {GR_METHOD_NEG,             (gr_funcptr) (void (*)(void)) tmpn_neg},
+    {GR_METHOD_ADD,             (gr_funcptr) (void (*)(void)) tmpn_add},
+    {GR_METHOD_SUB,             (gr_funcptr) (void (*)(void)) tmpn_sub},
+    {GR_METHOD_MUL,             (gr_funcptr) (void (*)(void)) tmpn_mul},
+    {GR_METHOD_ADDMUL,          (gr_funcptr) (void (*)(void)) tmpn_addmul},
+    {GR_METHOD_SUBMUL,          (gr_funcptr) (void (*)(void)) tmpn_submul},
+    {0,                         (gr_funcptr) (void (*)(void)) NULL},
 };
 
 int
@@ -784,67 +784,67 @@ gr_transformed_mpn_get_trunc_destructive(nn_ptr z, slong zn, slong * zn_out,
    neutral answer for its type. */
 
 int
-gr_ctx_init_transformed_mpn(gr_ctx_t ctx, slong bits_bound,
-                            slong terms_bound, int is_signed)
+gr_ctx_init_transformed_mpn(gr_ctx_t FLINT_UNUSED(ctx), slong FLINT_UNUSED(bits_bound),
+                            slong FLINT_UNUSED(terms_bound), int FLINT_UNUSED(is_signed))
 {
     return GR_UNABLE;
 }
 
 int
-gr_transformed_mpn_set(gr_ptr res, nn_srcptr a, slong an, int sign,
-                       gr_ctx_t ctx)
+gr_transformed_mpn_set(gr_ptr FLINT_UNUSED(res), nn_srcptr FLINT_UNUSED(a), slong FLINT_UNUSED(an), int FLINT_UNUSED(sign),
+                       gr_ctx_t FLINT_UNUSED(ctx))
 {
     return GR_UNABLE;
 }
 
 int
-gr_transformed_mpn_get(nn_ptr z, slong zn, slong * zn_out, int * sign,
-                       gr_srcptr x, gr_ctx_t ctx)
+gr_transformed_mpn_get(nn_ptr FLINT_UNUSED(z), slong FLINT_UNUSED(zn), slong * FLINT_UNUSED(zn_out), int * FLINT_UNUSED(sign),
+                       gr_srcptr FLINT_UNUSED(x), gr_ctx_t FLINT_UNUSED(ctx))
 {
     return GR_UNABLE;
 }
 
 int
-gr_transformed_mpn_get_destructive(nn_ptr z, slong zn, slong * zn_out,
-                                   int * sign, gr_ptr x, gr_ctx_t ctx)
+gr_transformed_mpn_get_destructive(nn_ptr FLINT_UNUSED(z), slong FLINT_UNUSED(zn), slong * FLINT_UNUSED(zn_out),
+                                   int * FLINT_UNUSED(sign), gr_ptr FLINT_UNUSED(x), gr_ctx_t FLINT_UNUSED(ctx))
 {
     return GR_UNABLE;
 }
 
 int
-gr_transformed_mpn_get_trunc(nn_ptr z, slong zn, slong * zn_out, int * sign,
-                             slong lo, gr_srcptr x, gr_ctx_t ctx)
+gr_transformed_mpn_get_trunc(nn_ptr FLINT_UNUSED(z), slong FLINT_UNUSED(zn), slong * FLINT_UNUSED(zn_out), int * FLINT_UNUSED(sign),
+                             slong FLINT_UNUSED(lo), gr_srcptr FLINT_UNUSED(x), gr_ctx_t FLINT_UNUSED(ctx))
 {
     return GR_UNABLE;
 }
 
 int
-gr_transformed_mpn_get_trunc_destructive(nn_ptr z, slong zn, slong * zn_out,
-                                         int * sign, slong lo, gr_ptr x,
-                                         gr_ctx_t ctx)
+gr_transformed_mpn_get_trunc_destructive(nn_ptr FLINT_UNUSED(z), slong FLINT_UNUSED(zn), slong * FLINT_UNUSED(zn_out),
+                                         int * FLINT_UNUSED(sign), slong FLINT_UNUSED(lo), gr_ptr FLINT_UNUSED(x),
+                                         gr_ctx_t FLINT_UNUSED(ctx))
 {
     return GR_UNABLE;
 }
 
 slong
-gr_transformed_mpn_get_limbs(gr_ctx_t ctx, gr_srcptr x)
+gr_transformed_mpn_get_limbs(gr_ctx_t FLINT_UNUSED(ctx), gr_srcptr FLINT_UNUSED(x))
 {
     return 0;
 }
 
 slong
-gr_transformed_mpn_get_limbs_trunc(gr_ctx_t ctx, gr_srcptr x, slong lo)
+gr_transformed_mpn_get_limbs_trunc(gr_ctx_t FLINT_UNUSED(ctx), gr_srcptr FLINT_UNUSED(x), slong FLINT_UNUSED(lo))
 {
     return 0;
 }
 
 void
-gr_transformed_mpn_init_borrowed(gr_ptr x, double * data, gr_ctx_t ctx)
+gr_transformed_mpn_init_borrowed(gr_ptr FLINT_UNUSED(x), double * FLINT_UNUSED(data), gr_ctx_t FLINT_UNUSED(ctx))
 {
 }
 
 ulong
-gr_transformed_mpn_sizeof_data(gr_ctx_t ctx)
+gr_transformed_mpn_sizeof_data(gr_ctx_t FLINT_UNUSED(ctx))
 {
     return 0;
 }

--- a/src/gr_generic/generic.c
+++ b/src/gr_generic/generic.c
@@ -3143,6 +3143,7 @@ const gr_method_tab_input _gr_generic_methods[] =
     {GR_METHOD_VEC_SET_POWERS,          (gr_funcptr) gr_generic_vec_set_powers},
 
     {GR_METHOD_POLY_MULLOW,             (gr_funcptr) _gr_poly_mullow_generic},
+    {GR_METHOD_POLY_HGCD_MAT_MUL,       (gr_funcptr) _gr_poly_hgcd_mat_mul_generic},
     {GR_METHOD_POLY_MULMID,             (gr_funcptr) _gr_poly_mulmid_generic},
     {GR_METHOD_POLY_DIV,                (gr_funcptr) _gr_poly_div_generic},
     {GR_METHOD_POLY_DIVREM,             (gr_funcptr) _gr_poly_divrem_generic},

--- a/src/gr_poly.h
+++ b/src/gr_poly.h
@@ -180,6 +180,31 @@ GR_POLY_INLINE WARN_UNUSED_RESULT int _gr_poly_hgcd_mat_mul(gr_ptr * C, slong * 
     return GR_POLY_HGCD_MAT_MUL_OP(ctx, POLY_HGCD_MAT_MUL)(C, lenC, A, lenA, B, lenB, T0, T1, ctx);
 }
 
+/* Construct a ring of transformed polynomials of length at most len_bound
+   over the base ring ctx, supporting expressions accumulating at most
+   terms_bound elementary coefficient products, or return GR_UNABLE if no
+   such representation is available. Elements support the standard ring
+   operations; conversions go through _gr_set_gr_poly / _gr_get_gr_poly. */
+GR_POLY_INLINE WARN_UNUSED_RESULT int gr_ctx_init_gr_poly_transformed_repr(gr_ctx_t out, gr_ctx_t base_ctx, slong len_bound, slong terms_bound, const gr_transformed_poly_workload_struct * workload)
+{
+    return GR_CTX_INIT_TRANSFORMED_POLY_REPR_OP(base_ctx, CTX_INIT_TRANSFORMED_POLY_REPR)(out, base_ctx, len_bound, terms_bound, workload);
+}
+
+GR_POLY_INLINE WARN_UNUSED_RESULT int _gr_set_gr_poly(gr_ptr res, gr_srcptr a, slong len, gr_ctx_t base_ctx, gr_ctx_t tctx)
+{
+    return GR_SET_GR_POLY_OP(tctx, SET_GR_POLY)(res, a, len, base_ctx, tctx);
+}
+
+GR_POLY_INLINE WARN_UNUSED_RESULT int _gr_get_gr_poly(gr_ptr c, slong * len, gr_srcptr x, gr_ctx_t base_ctx, gr_ctx_t tctx)
+{
+    return GR_GET_GR_POLY_OP(tctx, GET_GR_POLY)(c, len, x, base_ctx, tctx);
+}
+
+GR_POLY_INLINE WARN_UNUSED_RESULT int _gr_get_gr_poly_window(gr_ptr c, gr_srcptr x, slong zl, slong zh, gr_ctx_t base_ctx, gr_ctx_t tctx)
+{
+    return GR_GET_GR_POLY_WINDOW_OP(tctx, GET_GR_POLY_WINDOW)(c, x, zl, zh, base_ctx, tctx);
+}
+
 WARN_UNUSED_RESULT int _gr_poly_mullow_generic(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, slong n, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_mullow(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, slong n, gr_ctx_t ctx);
 

--- a/src/gr_poly.h
+++ b/src/gr_poly.h
@@ -200,6 +200,19 @@ GR_POLY_INLINE WARN_UNUSED_RESULT int _gr_get_gr_poly(gr_ptr c, slong * len, gr_
     return GR_GET_GR_POLY_OP(tctx, GET_GR_POLY)(c, len, x, base_ctx, tctx);
 }
 
+/* Conversion out that may consume the element -- implementations run the
+   inverse transforms on its own storage, skipping the transform copy;
+   afterwards the element may only be cleared or fully overwritten as the
+   destination of a set or a multiplication. Falls back to the copying
+   conversion where the representation does not provide it. */
+GR_POLY_INLINE WARN_UNUSED_RESULT int _gr_get_gr_poly_destructive(gr_ptr c, slong * len, gr_ptr x, gr_ctx_t base_ctx, gr_ctx_t tctx)
+{
+    int status = GR_GET_GR_POLY_DESTRUCTIVE_OP(tctx, GET_GR_POLY_DESTRUCTIVE)(c, len, x, base_ctx, tctx);
+    if (status == GR_UNABLE)
+        status = GR_GET_GR_POLY_OP(tctx, GET_GR_POLY)(c, len, x, base_ctx, tctx);
+    return status;
+}
+
 GR_POLY_INLINE WARN_UNUSED_RESULT int _gr_get_gr_poly_window(gr_ptr c, gr_srcptr x, slong zl, slong zh, gr_ctx_t base_ctx, gr_ctx_t tctx)
 {
     return GR_GET_GR_POLY_WINDOW_OP(tctx, GET_GR_POLY_WINDOW)(c, x, zl, zh, base_ctx, tctx);

--- a/src/gr_poly.h
+++ b/src/gr_poly.h
@@ -168,6 +168,18 @@ GR_POLY_INLINE WARN_UNUSED_RESULT int _gr_poly_mullow(gr_ptr res, gr_srcptr poly
     return GR_POLY_BINARY_TRUNC_OP(ctx, POLY_MULLOW)(res, poly1, len1, poly2, len2, len, ctx);
 }
 
+/* 2x2 polynomial matrix product C = A*B used by hgcd. C, A, B point to 4
+   entries each (row-major), with lengths in lenC, lenA, lenB; the output
+   lengths are normalized. Aliasing is not supported. T0 and T1 must have
+   room for any single polynomial product of an entry of A by an entry
+   of B. */
+WARN_UNUSED_RESULT int _gr_poly_hgcd_mat_mul_generic(gr_ptr * C, slong * lenC, gr_ptr * A, slong * lenA, gr_ptr * B, slong * lenB, gr_ptr T0, gr_ptr T1, gr_ctx_t ctx);
+
+GR_POLY_INLINE WARN_UNUSED_RESULT int _gr_poly_hgcd_mat_mul(gr_ptr * C, slong * lenC, gr_ptr * A, slong * lenA, gr_ptr * B, slong * lenB, gr_ptr T0, gr_ptr T1, gr_ctx_t ctx)
+{
+    return GR_POLY_HGCD_MAT_MUL_OP(ctx, POLY_HGCD_MAT_MUL)(C, lenC, A, lenA, B, lenB, T0, T1, ctx);
+}
+
 WARN_UNUSED_RESULT int _gr_poly_mullow_generic(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, slong n, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_mullow(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, slong n, gr_ctx_t ctx);
 

--- a/src/gr_poly/hgcd.c
+++ b/src/gr_poly/hgcd.c
@@ -229,8 +229,8 @@ __mat_mul_strassen(gr_ptr * C, slong * lenC,
     polynomial products involved.
  */
 
-static int
-__mat_mul(gr_ptr * C, slong * lenC,
+int
+_gr_poly_hgcd_mat_mul_generic(gr_ptr * C, slong * lenC,
           gr_ptr * A, slong * lenA,
           gr_ptr * B, slong * lenB,
           gr_ptr T0, gr_ptr T1,
@@ -642,7 +642,7 @@ static int _gr_poly_hgcd_recursive(
                 __mul(T0, lenT0, S[3], lenS[3], q, lenq);
                 __add(S[1], lenS[1], S[1], lenS[1], T0, lenT0);
 
-                __mat_mul(M, lenM, R, lenR, S, lenS, a2, b2, ctx);
+                status |= _gr_poly_hgcd_mat_mul(M, lenM, R, lenR, S, lenS, a2, b2, ctx);
             }
 
             *ans_sgn = -(sgnR * sgnS);

--- a/src/gr_poly/hgcd.c
+++ b/src/gr_poly/hgcd.c
@@ -296,7 +296,7 @@ static void _hgcd_mm_phase2(void * varg)
 static int
 _gr_poly_hgcd_mat_mul_transformed(gr_ptr * C, slong * lenC,
         gr_ptr * A, slong * lenA, gr_ptr * B, slong * lenB,
-        gr_ptr T0, gr_ptr T1, gr_ctx_t ctx)
+        gr_ptr FLINT_UNUSED(T0), gr_ptr FLINT_UNUSED(T1), gr_ctx_t ctx)
 {
 #if FLINT_HAVE_FFT_SMALL
     slong i;

--- a/src/gr_poly/hgcd.c
+++ b/src/gr_poly/hgcd.c
@@ -318,7 +318,7 @@ _gr_poly_hgcd_mat_mul_transformed(gr_ptr * C, slong * lenC,
     {
         gr_ctx_t tctx;
         gr_transformed_poly_workload_t wl =
-            {{ 8, 8, 4, 8 + 4, 0 }};   /* 8 inputs live + up to 4
+            {{ 8, 8, 4, 8 + 4, 0, 0 }};   /* 8 inputs live + up to 4
                                           per-thread accumulators */
 
         if (gr_ctx_init_gr_poly_transformed_repr(tctx, ctx,

--- a/src/gr_poly/hgcd.c
+++ b/src/gr_poly/hgcd.c
@@ -11,7 +11,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "thread_support.h"
 #include "longlong.h"
+#include "thread_pool.h"
 #include "gr_poly.h"
 #include "gr_vec.h"
 
@@ -229,6 +231,150 @@ __mat_mul_strassen(gr_ptr * C, slong * lenC,
     polynomial products involved.
  */
 
+#define HGCD_MAT_MUL_TRANSFORMED_CUTOFF 128
+#define HGCD_MAT_MUL_TRANSFORMED_THREAD_CUTOFF 1024
+
+#if FLINT_HAVE_FFT_SMALL
+
+/* 2x2 polynomial matrix product in a transformed polynomial ring: each of
+   the eight entries is transformed once and reused across the four
+   accumulated products (8 forward + 4 inverse transforms instead of 16 + 8
+   for fused multiplications). The batch is homogeneous -- all entries have
+   comparable lengths -- so the shared transform size is tight. Works for
+   any base ring whose transformed-representation constructor engages (it
+   returns GR_UNABLE otherwise, falling through to the plain code below).
+   The ring is thread safe, so for large entries the eight conversions in
+   and the four output entries are distributed over the global thread
+   pool. */
+
+typedef struct
+{
+    gr_ctx_struct * ctx;
+    gr_ctx_struct * tctx;
+    gr_ptr TE;
+    gr_ptr * A; slong * lenA;
+    gr_ptr * B; slong * lenB;
+    gr_ptr * C; slong * lenC;
+    slong tid, nthreads;
+    int status;
+}
+_hgcd_mm_arg;
+
+#define _HGCD_TE(a, i) GR_ENTRY((a)->TE, i, (a)->tctx->sizeof_elem)
+
+static void _hgcd_mm_phase1(void * varg)
+{
+    _hgcd_mm_arg * a = (_hgcd_mm_arg *) varg;
+    slong i;
+    for (i = a->tid; i < 8; i += a->nthreads)
+    {
+        if (i < 4)
+            a->status |= _gr_set_gr_poly(_HGCD_TE(a, i),
+                    a->A[i], a->lenA[i], a->ctx, a->tctx);
+        else
+            a->status |= _gr_set_gr_poly(_HGCD_TE(a, i),
+                    a->B[i - 4], a->lenB[i - 4], a->ctx, a->tctx);
+    }
+}
+
+static void _hgcd_mm_phase2(void * varg)
+{
+    _hgcd_mm_arg * a = (_hgcd_mm_arg *) varg;
+    gr_ptr acc = _HGCD_TE(a, 8 + a->tid);
+    slong i;
+    for (i = a->tid; i < 4; i += a->nthreads)
+    {
+        slong r = 2 * (i / 2), c = i % 2;
+        a->status |= gr_mul(acc, _HGCD_TE(a, r), _HGCD_TE(a, 4 + c), a->tctx);
+        a->status |= gr_addmul(acc, _HGCD_TE(a, r + 1), _HGCD_TE(a, 6 + c), a->tctx);
+        a->status |= _gr_get_gr_poly(a->C[i], &a->lenC[i], acc, a->ctx, a->tctx);
+    }
+}
+
+#endif
+
+static int
+_gr_poly_hgcd_mat_mul_transformed(gr_ptr * C, slong * lenC,
+        gr_ptr * A, slong * lenA, gr_ptr * B, slong * lenB,
+        gr_ptr T0, gr_ptr T1, gr_ctx_t ctx)
+{
+#if FLINT_HAVE_FFT_SMALL
+    slong i;
+    slong minlen = lenA[0];
+    slong amax = 0, bmax = 0;
+
+    for (i = 0; i < 4; i++)
+    {
+        minlen = FLINT_MIN(minlen, FLINT_MIN(lenA[i], lenB[i]));
+        amax = FLINT_MAX(amax, lenA[i]);
+        bmax = FLINT_MAX(bmax, lenB[i]);
+    }
+
+    if (minlen >= HGCD_MAT_MUL_TRANSFORMED_CUTOFF)
+    {
+        gr_ctx_t tctx;
+        gr_transformed_poly_workload_t wl = {{ 8, 8, 4, 0 }};
+
+        if (gr_ctx_init_gr_poly_transformed_repr(tctx, ctx,
+                amax + bmax - 1, 2 * FLINT_MIN(amax, bmax) + 2,
+                wl) == GR_SUCCESS)
+        {
+            gr_ptr TE;
+            thread_pool_handle * handles = NULL;
+            slong nworkers = 0, nthreads;
+            _hgcd_mm_arg args[4];
+            int status = GR_SUCCESS;
+
+            if (FLINT_MIN(amax, bmax) >= HGCD_MAT_MUL_TRANSFORMED_THREAD_CUTOFF)
+                nworkers = flint_request_threads(&handles, 4);
+            nthreads = nworkers + 1;
+
+            GR_TMP_INIT_VEC(TE, 8 + nthreads, tctx);
+
+            for (i = 0; i < nthreads; i++)
+            {
+                args[i].ctx = ctx; args[i].tctx = tctx; args[i].TE = TE;
+                args[i].A = A; args[i].lenA = lenA;
+                args[i].B = B; args[i].lenB = lenB;
+                args[i].C = C; args[i].lenC = lenC;
+                args[i].tid = i; args[i].nthreads = nthreads;
+                args[i].status = GR_SUCCESS;
+            }
+
+            for (i = nworkers; i > 0; i--)
+                thread_pool_wake(global_thread_pool, handles[i - 1], 0,
+                                 _hgcd_mm_phase1, args + i);
+            _hgcd_mm_phase1(args + 0);
+            for (i = nworkers; i > 0; i--)
+                thread_pool_wait(global_thread_pool, handles[i - 1]);
+
+            for (i = nworkers; i > 0; i--)
+                thread_pool_wake(global_thread_pool, handles[i - 1], 0,
+                                 _hgcd_mm_phase2, args + i);
+            _hgcd_mm_phase2(args + 0);
+            for (i = nworkers; i > 0; i--)
+                thread_pool_wait(global_thread_pool, handles[i - 1]);
+
+            flint_give_back_threads(handles, nworkers);
+
+            for (i = 0; i < nthreads; i++)
+                status |= args[i].status;
+
+            GR_TMP_CLEAR_VEC(TE, 8 + nthreads, tctx);
+            gr_ctx_clear(tctx);
+
+            if (status == GR_SUCCESS)
+                return GR_SUCCESS;
+            /* A and B are untouched; fall through and recompute */
+        }
+    }
+
+#endif
+
+    return -1;   /* not handled; the caller runs the plain code */
+}
+
+
 int
 _gr_poly_hgcd_mat_mul_generic(gr_ptr * C, slong * lenC,
           gr_ptr * A, slong * lenA,
@@ -236,6 +382,13 @@ _gr_poly_hgcd_mat_mul_generic(gr_ptr * C, slong * lenC,
           gr_ptr T0, gr_ptr T1,
           gr_ctx_t ctx)
 {
+    {
+        int tstatus = _gr_poly_hgcd_mat_mul_transformed(C, lenC, A, lenA,
+                                                        B, lenB, T0, T1, ctx);
+        if (tstatus != -1)
+            return tstatus;
+    }
+
     slong min = lenA[0];
 
     min = FLINT_MIN(min, lenA[1]);

--- a/src/gr_poly/hgcd.c
+++ b/src/gr_poly/hgcd.c
@@ -287,7 +287,11 @@ static void _hgcd_mm_phase2(void * varg)
         slong r = 2 * (i / 2), c = i % 2;
         a->status |= gr_mul(acc, _HGCD_TE(a, r), _HGCD_TE(a, 4 + c), a->tctx);
         a->status |= gr_addmul(acc, _HGCD_TE(a, r + 1), _HGCD_TE(a, 6 + c), a->tctx);
-        a->status |= _gr_get_gr_poly(a->C[i], &a->lenC[i], acc, a->ctx, a->tctx);
+        /* acc is this thread's own and dead after the entry: convert it
+           out on its own storage, skipping the transform copy; the next
+           entry's gr_mul rebuilds it as a full-write destination */
+        a->status |= _gr_get_gr_poly_destructive(a->C[i], &a->lenC[i], acc,
+                                                 a->ctx, a->tctx);
     }
 }
 

--- a/src/gr_poly/hgcd.c
+++ b/src/gr_poly/hgcd.c
@@ -317,7 +317,9 @@ _gr_poly_hgcd_mat_mul_transformed(gr_ptr * C, slong * lenC,
     if (minlen >= HGCD_MAT_MUL_TRANSFORMED_CUTOFF)
     {
         gr_ctx_t tctx;
-        gr_transformed_poly_workload_t wl = {{ 8, 8, 4, 0 }};
+        gr_transformed_poly_workload_t wl =
+            {{ 8, 8, 4, 8 + 4, 0 }};   /* 8 inputs live + up to 4
+                                          per-thread accumulators */
 
         if (gr_ctx_init_gr_poly_transformed_repr(tctx, ctx,
                 amax + bmax - 1, 2 * FLINT_MIN(amax, bmax) + 2,

--- a/src/mpn_extras.h
+++ b/src/mpn_extras.h
@@ -1089,6 +1089,85 @@ t##quotient_found:                                                          \
 } while (0)
 
 
+/* Sizes in limbs from which the complex functions below use the
+   transformed (fft_small) path (products and squares separately). See
+   the comment in mpn_extras/mul_complex.c for measured defaults. */
+FLINT_DLL extern slong flint_mpn_mul_complex_fft_cutoff;
+FLINT_DLL extern slong flint_mpn_sqr_complex_fft_cutoff;
+
+/* Complex multiplication with separate sign bits (0 = nonnegative):
+   zr + i zi = (ar + i ai) (br + i bi), outputs being exact magnitudes
+   and signs.
+
+   The full products take an independent length (>= 1 limb) for every
+   part, which need not be normalized, and report a *signed length* for
+   each output: the magnitude occupies |len| limbs and len < 0 means
+   negative. Nothing above |len| is written, so an fmpz caller can use
+   the value as an mpz size directly. zr and zi must each have room for
+   max(arn, ain) + max(brn, bin) + 1 limbs (2 max(arn, ain) + 1 for the
+   square) -- one bound for both, covering either product plus the carry
+   of the sum. The algorithm is chosen per shape: schoolbook when any
+   part is much shorter than its partner, Karatsuba when the parts are
+   internally balanced within each operand, and the transformed
+   fft_small path when they are balanced and large. The two operands
+   need not resemble each other in size.
+
+   The high variants take a single length n for all four parts and
+   receive exactly n + 1 limbs, zero padded, with a sign: they are the
+   limbs [n, 2n] of the exact result, with at most a few units of error
+   in the lowest returned limb. */
+void flint_mpn_mul_complex(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len,
+    nn_srcptr ar, mp_size_t arn, int ar_sgn,
+    nn_srcptr ai, mp_size_t ain, int ai_sgn,
+    nn_srcptr br, mp_size_t brn, int br_sgn,
+    nn_srcptr bi, mp_size_t bin, int bi_sgn);
+void flint_mpn_sqr_complex(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len,
+    nn_srcptr ar, mp_size_t arn, int ar_sgn,
+    nn_srcptr ai, mp_size_t ain, int ai_sgn);
+
+/* the individual algorithms behind the two functions above, exposed for
+   comparison and tuning: classical (schoolbook), Karatsuba (three
+   products for a multiplication, one for the real part of a square) and
+   the transformed fft_small path, which returns 0 without touching the
+   outputs when it is unavailable or the plan is inadmissible. All accept
+   any shape; the dispatchers choose between them by shape and size. */
+void flint_mpn_mul_complex_classical(nn_ptr zr, slong * zr_len,
+    nn_ptr zi, slong * zi_len,
+    nn_srcptr ar, mp_size_t arn, int ar_sgn,
+    nn_srcptr ai, mp_size_t ain, int ai_sgn,
+    nn_srcptr br, mp_size_t brn, int br_sgn,
+    nn_srcptr bi, mp_size_t bin, int bi_sgn);
+void flint_mpn_mul_complex_karatsuba(nn_ptr zr, slong * zr_len,
+    nn_ptr zi, slong * zi_len,
+    nn_srcptr ar, mp_size_t arn, int ar_sgn,
+    nn_srcptr ai, mp_size_t ain, int ai_sgn,
+    nn_srcptr br, mp_size_t brn, int br_sgn,
+    nn_srcptr bi, mp_size_t bin, int bi_sgn);
+int flint_mpn_mul_complex_fft_small(nn_ptr zr, slong * zr_len,
+    nn_ptr zi, slong * zi_len,
+    nn_srcptr ar, mp_size_t arn, int ar_sgn,
+    nn_srcptr ai, mp_size_t ain, int ai_sgn,
+    nn_srcptr br, mp_size_t brn, int br_sgn,
+    nn_srcptr bi, mp_size_t bin, int bi_sgn);
+void flint_mpn_sqr_complex_classical(nn_ptr zr, slong * zr_len,
+    nn_ptr zi, slong * zi_len,
+    nn_srcptr ar, mp_size_t arn, int ar_sgn,
+    nn_srcptr ai, mp_size_t ain, int ai_sgn);
+void flint_mpn_sqr_complex_karatsuba(nn_ptr zr, slong * zr_len,
+    nn_ptr zi, slong * zi_len,
+    nn_srcptr ar, mp_size_t arn, int ar_sgn,
+    nn_srcptr ai, mp_size_t ain, int ai_sgn);
+int flint_mpn_sqr_complex_fft_small(nn_ptr zr, slong * zr_len,
+    nn_ptr zi, slong * zi_len,
+    nn_srcptr ar, mp_size_t arn, int ar_sgn,
+    nn_srcptr ai, mp_size_t ain, int ai_sgn);
+void flint_mpn_mulhigh_n_complex(nn_ptr zr, int * zr_sgn, nn_ptr zi,
+    int * zi_sgn, nn_srcptr ar, int ar_sgn, nn_srcptr ai, int ai_sgn,
+    nn_srcptr br, int br_sgn, nn_srcptr bi, int bi_sgn, mp_size_t n);
+void flint_mpn_sqrhigh_n_complex(nn_ptr zr, int * zr_sgn, nn_ptr zi,
+    int * zi_sgn, nn_srcptr ar, int ar_sgn, nn_srcptr ai, int ai_sgn,
+    mp_size_t n);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/mpn_extras.h
+++ b/src/mpn_extras.h
@@ -1114,8 +1114,12 @@ FLINT_DLL extern slong flint_mpn_sqr_complex_fft_cutoff;
 
    The high variants take a single length n for all four parts and
    receive exactly n + 1 limbs, zero padded, with a sign: they are the
-   limbs [n, 2n] of the exact result, with at most a few units of error
-   in the lowest returned limb. */
+   limbs [n, 2n] of the exact result. Relative to the exact value the
+   error is below 2 + 3 (n + 4)/2^64 ulp of the lowest returned limb
+   (below 2 + 2 (n + 4)/2^64 for the square) -- each underlying high
+   product errs by (-1 - eps, +eps) ulp against the exact value, and
+   each output combines at most three -- so below 3 ulp for any
+   practical n; the transformed path stays within (-1.5, +0.5). */
 void flint_mpn_mul_complex(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len,
     nn_srcptr ar, mp_size_t arn, int ar_sgn,
     nn_srcptr ai, mp_size_t ain, int ai_sgn,

--- a/src/mpn_extras/mul_complex.c
+++ b/src/mpn_extras/mul_complex.c
@@ -328,12 +328,119 @@ _cmp_trim(nn_srcptr x, mp_size_t * xn, nn_srcptr y, mp_size_t * yn)
     return (*xn == 0) ? 0 : mpn_cmp(x, y, *xn);
 }
 
+/* z == x permitted (y must be distinct). The manual's blanket rule for
+   the mpn layer allows in-place operation "where source and destination
+   are the same" and forbids partial overlap; for a source shorter than
+   the destination but sharing its starting address -- which is what the
+   swap branches of the general routine would pass as the second source
+   of mpn_add/mpn_sub -- the text does not say which case applies. All
+   implementations process low to high, so it is safe in practice; this
+   variant expresses the aliasing through the equal-length primitives,
+   whose in-place behavior is unambiguous, rather than relying on a
+   reading of the rule. */
+static slong
+_signed_add_normalise_zx(nn_ptr z, mp_size_t xn, int xs,
+                         nn_srcptr y, mp_size_t yn, int ys)
+{
+    mp_size_t rn;
+    int rs;
+    nn_srcptr x = z;
+
+    /* the lengths are bounds: trim before treating an operand as
+       absent, and never hand a zero length to the mpn primitives */
+    while (xn > 0 && z[xn - 1] == 0)
+        xn--;
+    while (yn > 0 && y[yn - 1] == 0)
+        yn--;
+    if (xn == 0)
+    {
+        if (yn > 0)
+            flint_mpn_copyi(z, y, yn);
+        return ys ? -yn : yn;
+    }
+    if (yn == 0)
+        return xs ? -xn : xn;
+
+    if (xs == ys)
+    {
+        ulong cy;
+
+        if (xn >= yn)
+            cy = mpn_add(z, x, xn, y, yn);
+        else
+        {
+            cy = mpn_add_n(z, x, y, xn);
+            cy = mpn_add_1(z + xn, y + xn, yn - xn, cy);
+        }
+        rn = FLINT_MAX(xn, yn);
+        if (cy != 0)
+        {
+            z[rn] = cy;
+            rn++;
+        }
+        else
+        {
+            while (rn > 0 && z[rn - 1] == 0)
+                rn--;
+        }
+        rs = xs;
+    }
+    else
+    {
+        int c = _cmp_trim(x, &xn, y, &yn);
+
+        if (c == 0)
+            return 0;
+
+        if (c > 0)
+        {
+            mpn_sub(z, x, xn, y, yn);
+            rn = xn;
+            rs = xs;
+        }
+        else
+        {
+            ulong bw;
+
+            bw = mpn_sub_n(z, y, x, xn);
+            if (yn > xn)
+                mpn_sub_1(z + xn, y + xn, yn - xn, bw);
+            rn = yn;
+            rs = ys;
+        }
+
+        while (rn > 0 && z[rn - 1] == 0)
+            rn--;
+        if (rn == 0)
+            return 0;
+    }
+
+    return rs ? -rn : rn;
+}
+
 static slong
 _signed_add_normalise(nn_ptr z, nn_srcptr x, mp_size_t xn, int xs,
                       nn_srcptr y, mp_size_t yn, int ys)
 {
     mp_size_t rn;
     int rs;
+
+    while (xn > 0 && x[xn - 1] == 0)
+        xn--;
+    while (yn > 0 && y[yn - 1] == 0)
+        yn--;
+    if (xn == 0)
+    {
+        if (yn > 0)
+            flint_mpn_copyi(z, y, yn);
+        return ys ? -yn : yn;
+    }
+    if (yn == 0)
+    {
+        if (z != x)
+            flint_mpn_copyi(z, x, xn);
+        return xs ? -xn : xn;
+    }
 
     if (xs == ys)
     {
@@ -350,8 +457,20 @@ _signed_add_normalise(nn_ptr z, nn_srcptr x, mp_size_t xn, int xs,
             rn = yn;
         }
 
-        z[rn] = cy;
-        rn += (cy != 0);
+        if (cy != 0)
+        {
+            z[rn] = cy;
+            rn++;
+        }
+        else
+        {
+            /* the input lengths are bounds, not normalized: a product
+               of trimmed operands may still carry a zero top limb, and
+               the returned length must not include it (callers install
+               it directly as an mpz size) */
+            while (rn > 0 && z[rn - 1] == 0)
+                rn--;
+        }
         rs = xs;
     }
     else
@@ -439,13 +558,13 @@ flint_mpn_mul_complex_classical(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi
 
     _mul_any_order(zr, ar, arn, br, brn);
     _mul_any_order(t, ai, ain, bi, bin);
-    *zr_len = _signed_add_normalise(zr, zr, arn + brn, ar_sgn ^ br_sgn,
-                                    t, ain + bin, ai_sgn ^ bi_sgn ^ 1);
+    *zr_len = _signed_add_normalise_zx(zr, arn + brn, ar_sgn ^ br_sgn,
+                                       t, ain + bin, ai_sgn ^ bi_sgn ^ 1);
 
     _mul_any_order(zi, ar, arn, bi, bin);
     _mul_any_order(t, ai, ain, br, brn);
-    *zi_len = _signed_add_normalise(zi, zi, arn + bin, ar_sgn ^ bi_sgn,
-                                    t, ain + brn, ai_sgn ^ br_sgn);
+    *zi_len = _signed_add_normalise_zx(zi, arn + bin, ar_sgn ^ bi_sgn,
+                                       t, ain + brn, ai_sgn ^ br_sgn);
 
     TMP_END;
 }
@@ -467,10 +586,10 @@ flint_mpn_mul_complex_karatsuba(nn_ptr zr, slong * zr_len,
     nn_srcptr bi, mp_size_t bin, int bi_sgn)
 {
     mp_size_t maxa = FLINT_MAX(arn, ain), maxb = FLINT_MAX(brn, bin);
-    nn_ptr t1, t2, t3, p, u, v, zt;
-    mp_size_t un0 = maxa + 1, vn0 = maxb + 1, pw = maxa + maxb + 2;
-    slong ul, vl, pl, il;
-    int s1, s2;
+    nn_ptr t2, t3, u, v;
+    mp_size_t un0 = maxa + 1, vn0 = maxb + 1;
+    slong ul, vl, il;
+    int s1, s2, s3;
     TMP_INIT;
 
     arn = _norm(ar, arn);
@@ -478,37 +597,44 @@ flint_mpn_mul_complex_karatsuba(nn_ptr zr, slong * zr_len,
     brn = _norm(br, brn);
     bin = _norm(bi, bin);
 
+    /*
+        The layout matters at large sizes, where fresh pages are a
+        dominant linear cost: ar br is written straight into the
+        caller's zr and both outputs are combined in place with the
+        aliasing-tolerant variant above, so the scratch holds one
+        product (ai bi), the product of the two operand sums, and the
+        sums themselves -- about half the previous footprint -- and
+        nothing is copied at the end. All combination values fit the
+        caller's maxa + maxb + 1 window: the products are below
+        2^(64(maxa+maxb)), the sum product below 2^(64(maxa+maxb)+2),
+        and every intermediate below 2^(64(maxa+maxb)+3).
+    */
     TMP_START;
-    t1 = TMP_ALLOC(((arn + brn) + (ain + bin) + (un0 + vn0) + pw
-                    + un0 + vn0 + (pw + 2)) * sizeof(ulong));
-    t2 = t1 + arn + brn;
+    t2 = TMP_ALLOC((ain + bin + un0 + vn0 + un0 + vn0) * sizeof(ulong));
     t3 = t2 + ain + bin;
-    p = t3 + un0 + vn0;
-    u = p + pw;
+    u = t3 + un0 + vn0;
     v = u + un0;
-    zt = v + vn0;
 
-    _mul_any_order(t1, ar, arn, br, brn);
-    _mul_any_order(t2, ai, ain, bi, bin);
     s1 = ar_sgn ^ br_sgn;
     s2 = ai_sgn ^ bi_sgn;
 
     ul = _signed_add_normalise(u, ar, arn, ar_sgn, ai, ain, ai_sgn);
     vl = _signed_add_normalise(v, br, brn, br_sgn, bi, bin, bi_sgn);
     _mul_any_order(t3, u, FLINT_ABS(ul), v, FLINT_ABS(vl));
+    s3 = (ul < 0) ^ (vl < 0);
 
-    *zr_len = _signed_add_normalise(zr, t1, arn + brn, s1,
-                                    t2, ain + bin, s2 ^ 1);
+    _mul_any_order(t2, ai, ain, bi, bin);
+    _mul_any_order(zr, ar, arn, br, brn);       /* t1, in place */
 
-    pl = _signed_add_normalise(p, t1, arn + brn, s1, t2, ain + bin, s2);
+    /* zi = (t3 - t1) - t2; the first combination reads t1 from zr and
+       aliases nothing, the second and the zr combination run in place */
+    il = _signed_add_normalise(zi, t3, FLINT_ABS(ul) + FLINT_ABS(vl), s3,
+                               zr, arn + brn, s1 ^ 1);
+    *zi_len = _signed_add_normalise_zx(zi, FLINT_ABS(il), il < 0,
+                                       t2, ain + bin, s2 ^ 1);
 
-    /* t3 can reach maxa + maxb + 2 limbs, one past the caller's window,
-       so this one combination is formed in scratch */
-    il = _signed_add_normalise(zt, t3, FLINT_ABS(ul) + FLINT_ABS(vl),
-                               (ul < 0) ^ (vl < 0),
-                               p, FLINT_ABS(pl), (pl < 0) ^ 1);
-    flint_mpn_copyi(zi, zt, FLINT_ABS(il));
-    *zi_len = il;
+    *zr_len = _signed_add_normalise_zx(zr, arn + brn, s1,
+                                       t2, ain + bin, s2 ^ 1);
 
     TMP_END;
 }
@@ -608,7 +734,7 @@ flint_mpn_sqr_complex_classical(nn_ptr zr, slong * zr_len,
 
     flint_mpn_sqr(zr, ar, arn);
     flint_mpn_sqr(t1, ai, ain);
-    *zr_len = _signed_add_normalise(zr, zr, 2 * arn, 0, t1, 2 * ain, 1);
+    *zr_len = _signed_add_normalise_zx(zr, 2 * arn, 0, t1, 2 * ain, 1);
 
     *zi_len = _sqr_zi_double(zi, ar, arn, ar_sgn, ai, ain, ai_sgn);
 
@@ -625,20 +751,23 @@ flint_mpn_sqr_complex_karatsuba(nn_ptr zr, slong * zr_len,
        form uses two squarings, so the inputs are normalized first */
     mp_size_t maxa = FLINT_MAX(arn, ain), rn;
     mp_size_t an = _norm(ar, arn), bn = _norm(ai, ain);
-    nn_ptr u, v, t1;
+    nn_ptr u, v;
     slong ul, vl;
     TMP_INIT;
 
     TMP_START;
-    u = TMP_ALLOC((2 * (maxa + 1) + 2 * (maxa + 2)) * sizeof(ulong));
+    u = TMP_ALLOC(2 * (maxa + 1) * sizeof(ulong));
     v = u + maxa + 1;
-    t1 = v + maxa + 1;
 
+    /* exactly one of the two combinations is a magnitude sum (at most
+       maxa + 1 limbs) and the other a magnitude difference (at most
+       maxa), so their product spans at most 2 maxa + 1 limbs and is
+       written straight into the caller's window; the scratch holds only
+       the sums, and nothing is copied */
     ul = _signed_add_normalise(u, ar, an, ar_sgn, ai, bn, ai_sgn);
     vl = _signed_add_normalise(v, ar, an, ar_sgn, ai, bn, ai_sgn ^ 1);
-    _mul_any_order(t1, u, FLINT_ABS(ul), v, FLINT_ABS(vl));
-    rn = _norm(t1, FLINT_ABS(ul) + FLINT_ABS(vl));
-    flint_mpn_copyi(zr, t1, rn);
+    _mul_any_order(zr, u, FLINT_ABS(ul), v, FLINT_ABS(vl));
+    rn = _norm(zr, FLINT_ABS(ul) + FLINT_ABS(vl));
     *zr_len = (rn == 0 || !((ul < 0) ^ (vl < 0))) ? rn : -rn;
 
     *zi_len = _sqr_zi_double(zi, ar, arn, ar_sgn, ai, ain, ai_sgn);
@@ -732,17 +861,17 @@ _mul_complex_high(nn_ptr zr, int * zr_sgn, nn_ptr zi, int * zi_sgn,
 
     if (n < MULHIGH_COMPLEX_KARATSUBA_CUTOFF)
     {
-        nn_ptr h1 = TMP_ALLOC(4 * n * sizeof(ulong));
-        nn_ptr h2 = h1 + n, h3 = h2 + n, h4 = h3 + n;
+        nn_ptr h2 = TMP_ALLOC(2 * n * sizeof(ulong));
+        nn_ptr h4 = h2 + n;
 
-        flint_mpn_mulhigh_n(h1, ar, br, n);
+        flint_mpn_mulhigh_n(zr, ar, br, n);
         flint_mpn_mulhigh_n(h2, ai, bi, n);
-        flint_mpn_mulhigh_n(h3, ar, bi, n);
+        flint_mpn_mulhigh_n(zi, ar, bi, n);
         flint_mpn_mulhigh_n(h4, ai, br, n);
 
-        _high_combine(zr, zr_sgn, h1, ar_sgn ^ br_sgn,
+        _high_combine(zr, zr_sgn, zr, ar_sgn ^ br_sgn,
                       h2, ai_sgn ^ bi_sgn ^ 1, n);
-        _high_combine(zi, zi_sgn, h3, ar_sgn ^ bi_sgn,
+        _high_combine(zi, zi_sgn, zi, ar_sgn ^ bi_sgn,
                       h4, ai_sgn ^ br_sgn, n);
     }
     else
@@ -820,11 +949,11 @@ _sqr_complex_high(nn_ptr zr, int * zr_sgn, nn_ptr zi, int * zi_sgn,
         su = _signed_add_n1(U + 1, ar, ar_sgn, ai, ai_sgn, n);
         sv = _signed_add_n1(V + 1, ar, ar_sgn, ai, ai_sgn ^ 1, n);
         flint_mpn_mulhigh_n(h1, U, V, n + 2);
-        flint_mpn_mulhigh_n(h2, ar, ai, n);
+        flint_mpn_mulhigh_n(zi, ar, ai, n);
 
         flint_mpn_copyi(zr, h1, n + 1);
         *zr_sgn = su ^ sv;
-        zi[n] = mpn_lshift(zi, h2, n, 1);
+        zi[n] = mpn_lshift(zi, zi, n, 1);
         *zi_sgn = ar_sgn ^ ai_sgn;
     }
 

--- a/src/mpn_extras/mul_complex.c
+++ b/src/mpn_extras/mul_complex.c
@@ -138,9 +138,11 @@ _mul_complex_fft(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len,
     int ok = 1;
 #define E_(i) GR_ENTRY(E, i, tctx->sizeof_elem)
 
+    /* the bound is one product's magnitude; the two-term accumulation
+       and the sign are the context's own provisioning */
     if (gr_ctx_init_transformed_mpn(tctx,
-            FLINT_BITS * (slong) (FLINT_MAX(arn, ain) + FLINT_MAX(brn, bin))
-            + 8, 2, 1, 6) != GR_SUCCESS)
+            FLINT_BITS * (slong) (FLINT_MAX(arn, ain) + FLINT_MAX(brn, bin)),
+            2, 1, 6) != GR_SUCCESS)
         return 0;
 
     {
@@ -209,7 +211,7 @@ _sqr_complex_fft(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len,
         ar * ar - ai * ai keeps the same geometry as the complex product.
     */
     if (gr_ctx_init_transformed_mpn(tctx,
-            FLINT_BITS * (slong) (2 * FLINT_MAX(arn, ain)) + 8, 2, 1, 4)
+            FLINT_BITS * (slong) (2 * FLINT_MAX(arn, ain)), 2, 1, 4)
             != GR_SUCCESS)
         return 0;
 

--- a/src/mpn_extras/mul_complex.c
+++ b/src/mpn_extras/mul_complex.c
@@ -179,7 +179,7 @@ _mul_complex_fft(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len,
 
     if (gr_ctx_init_transformed_mpn(tctx,
             FLINT_BITS * (slong) (FLINT_MAX(arn, ain) + FLINT_MAX(brn, bin))
-            + 8, 2, 1) != GR_SUCCESS)
+            + 8, 2, 1, 6) != GR_SUCCESS)
         return 0;
 
     {
@@ -248,7 +248,7 @@ _sqr_complex_fft(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len,
         ar * ar - ai * ai keeps the same geometry as the complex product.
     */
     if (gr_ctx_init_transformed_mpn(tctx,
-            FLINT_BITS * (slong) (2 * FLINT_MAX(arn, ain)) + 8, 2, 1)
+            FLINT_BITS * (slong) (2 * FLINT_MAX(arn, ain)) + 8, 2, 1, 4)
             != GR_SUCCESS)
         return 0;
 

--- a/src/mpn_extras/mul_complex.c
+++ b/src/mpn_extras/mul_complex.c
@@ -112,43 +112,6 @@ slong flint_mpn_sqr_complex_fft_cutoff = 4096;
 #define MULHIGH_COMPLEX_KARATSUBA_CUTOFF 12
 #define SQRHIGH_COMPLEX_KARATSUBA_CUTOFF 20
 
-/* z (m+1 limbs), *zs: (-1)^xs x + (-1)^ys y with x, y of m limbs */
-static void
-_signed_add(nn_ptr z, int * zs, nn_srcptr x, int xs, nn_srcptr y, int ys,
-            mp_size_t m)
-{
-    if (xs == ys)
-    {
-        z[m] = mpn_add_n(z, x, y, m);
-        *zs = xs;
-    }
-    else
-    {
-        int c = mpn_cmp(x, y, m);
-        z[m] = 0;
-        if (c >= 0)
-        {
-            mpn_sub_n(z, x, y, m);
-            *zs = (c == 0) ? 0 : xs;
-        }
-        else
-        {
-            mpn_sub_n(z, y, x, m);
-            *zs = ys;
-        }
-    }
-}
-
-static int
-_mpn_is_zero(nn_srcptr x, mp_size_t n)
-{
-    mp_size_t i;
-    for (i = 0; i < n; i++)
-        if (x[i] != 0)
-            return 0;
-    return 1;
-}
-
 #if FLINT_HAVE_FFT_SMALL
 
 /* convert an accumulated element out into (z, zlimbs) starting at limb
@@ -316,6 +279,18 @@ _sqr_complex_fft(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len,
     gr_ctx_clear(tctx);
 #undef E_
     return ok;
+}
+
+/* the high variants promise exactly zlimbs limbs, zero padded, plus a
+   sign; the shared fft path hands back a signed length */
+static void
+_high_pad(nn_ptr z, int * zsgn, slong len, mp_size_t zlimbs)
+{
+    mp_size_t rn = FLINT_ABS(len);
+
+    if (rn < zlimbs)
+        flint_mpn_zero(z + rn, zlimbs - rn);
+    *zsgn = (len < 0);
 }
 
 #endif /* FLINT_HAVE_FFT_SMALL */
@@ -707,18 +682,6 @@ _sqr_complex_general(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len,
     else
         flint_mpn_sqr_complex_classical(zr, zr_len, zi, zi_len,
                 ar, arn, ar_sgn, ai, ain, ai_sgn);
-}
-
-/* the high variants promise exactly zlimbs limbs, zero padded, plus a
-   sign; the shared fft path hands back a signed length */
-static void
-_high_pad(nn_ptr z, int * zsgn, slong len, mp_size_t zlimbs)
-{
-    mp_size_t rn = FLINT_ABS(len);
-
-    if (rn < zlimbs)
-        flint_mpn_zero(z + rn, zlimbs - rn);
-    *zsgn = (len < 0);
 }
 
 /* z (n + 1 limbs) = (-1)^xs |x| + (-1)^ys |y| for n-limb magnitudes;

--- a/src/mpn_extras/mul_complex.c
+++ b/src/mpn_extras/mul_complex.c
@@ -1,0 +1,953 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <string.h>
+#include "mpn_extras.h"
+#include "gr.h"
+#if FLINT_HAVE_FFT_SMALL
+# include "fft_small.h"
+#endif
+
+/*
+    Complex multiplication of n-limb components with separate sign bits
+    (0 = nonnegative), for numerical applications:
+
+        zr + i zi = (ar + i ai) * (br + i bi)
+
+    with all values given as (magnitude, sign bit).
+
+    The full products are exact: zr and zi receive 2n + 1 limbs (the
+    extra limb holds the carry of the additive combination). Below the
+    fft threshold they use a Karatsuba-style scheme -- three real
+    multiplications for a product, via t3 = (ar + ai)(br + bi), and two
+    for a square, via zr = (ar + ai)(ar - ai) -- with the terms
+    accumulated in a two's-complement accumulator so that the mixed signs
+    need no case analysis. Above the threshold the operands are converted
+    once into a transformed-integer context and reused across the
+    pointwise products: 4 forward + 2 inverse transforms replace the
+    8 + 4 of four fused multiplications (2 + 2 replace 6 + 3 for
+    squaring).
+
+    The high variants receive n + 1 limbs, the limbs [n, 2n] of the exact
+    result. They are approximate, as usual for high products: each real
+    product is a mulhigh (or sqrhigh), whose window is exact or one unit
+    low, and the discarded low halves can carry; above the fft threshold
+    the truncated reconstruction perturbs its lowest limb by at most one
+    unit. Summing the terms leaves an error of at most four units in the
+    lowest returned limb (the worst observed over wide random testing is
+    two) -- the caller is expected to track it, as ball arithmetic does.
+
+    Karatsuba applies on the high path too. Its auxiliary product
+    (ar + ai)(br + bi) has (n+1)-limb operands, so a plain mulhigh would
+    start one limb above the window the other terms supply; giving each
+    operand a low zero limb scales the product by 2^128, and the high
+    n + 2 limbs of the scaled product are exactly the limbs [n, 2n+1] of
+    the unscaled one -- the wanted window with a guard limb. That costs
+    one mulhigh of size n + 2 in place of two of size n.
+
+    */
+
+/* Measured crossover on an AVX2 machine at -O1: the transformed path
+   wins from ~896 limbs (1.3x at 896, 1.4x at 1280), and the two are
+   within noise between 640 and 768. Re-tune per platform. */
+/* Measured crossover on an AVX2 machine at -O1: the transformed path
+   wins from ~896 limbs (1.3x at 896, 1.4x at 1280), and the two are
+   within noise between 640 and 768. Re-tune per platform; the Karatsuba
+   and mulhigh classical paths moved this point, so it was re-swept. */
+/*
+    Sizes (in limbs) from which the complex functions use the
+    transformed path; separate for products and squares because their
+    classical competitors differ (a squaring's high path is two cheap
+    high products, so its crossover sits higher).
+
+    Measured on one AVX2 machine at -O1 with assembly disabled, after
+    the reconstruction fix and with the per-thread element scratch
+    below: products and high products cross at ~1024 limbs (1.1-1.3x
+    from there through 65536). Squares, full and high alike, are a wash
+    at 2048 and win 1.1-1.2x from 4096 -- their classical competitors
+    are only two real (high) multiplications, so the transform saving
+    is thinner. On a build with the mulhigh assembly enabled the
+    classical side speeds up and these crossovers move upward; re-tune
+    per platform. The variables stay writable so the tests can drive
+    both paths and callers can adjust.
+*/
+slong flint_mpn_mul_complex_fft_cutoff = 1024;
+slong flint_mpn_sqr_complex_fft_cutoff = 4096;
+
+/*
+    The elements live in the multiplication context's cached per-thread
+    buffer (mpn_ctx_fit_buffer) -- the same storage the standard
+    multiplication amortizes its setup with; allocating fresh element
+    buffers per call was dominated by first-touch page faults.
+
+    Safety invariant: nothing between the conversions in and out may
+    touch that buffer. Its only other users are _mpn_ctx_mpn_mul_range
+    and the nmod conv engine, and the element set / pointwise / get
+    paths reach neither. If they ever start multiplying integers, the
+    buffer would be reallocated under live elements and this must revert
+    to a private cache.
+*/
+
+
+
+/* Measured with the split entry points on the streamlined (v24) code --
+   the old value of 32 was tuned against the accumulator version, which
+   taxed Karatsuba's extra additions. Products: a tie at 8 limbs and
+   1.1-1.3x from 10 up. Squares: a clear loss at 4-6 limbs, ties through
+   14, small gains above -- their classical form is two cheap squarings,
+   so the crossover sits higher. The high thresholds are taken from the
+   nfloat complex code (12 for products, 20 for squares); mulhigh has no
+   small basecases in this assembly-less build, so they cannot be
+   re-measured here and await tuning on a normal build. */
+#define MUL_COMPLEX_KARATSUBA_CUTOFF 8
+#define SQR_COMPLEX_KARATSUBA_CUTOFF 16
+#define MULHIGH_COMPLEX_KARATSUBA_CUTOFF 12
+#define SQRHIGH_COMPLEX_KARATSUBA_CUTOFF 20
+
+/* z (m+1 limbs), *zs: (-1)^xs x + (-1)^ys y with x, y of m limbs */
+static void
+_signed_add(nn_ptr z, int * zs, nn_srcptr x, int xs, nn_srcptr y, int ys,
+            mp_size_t m)
+{
+    if (xs == ys)
+    {
+        z[m] = mpn_add_n(z, x, y, m);
+        *zs = xs;
+    }
+    else
+    {
+        int c = mpn_cmp(x, y, m);
+        z[m] = 0;
+        if (c >= 0)
+        {
+            mpn_sub_n(z, x, y, m);
+            *zs = (c == 0) ? 0 : xs;
+        }
+        else
+        {
+            mpn_sub_n(z, y, x, m);
+            *zs = ys;
+        }
+    }
+}
+
+static int
+_mpn_is_zero(nn_srcptr x, mp_size_t n)
+{
+    mp_size_t i;
+    for (i = 0; i < n; i++)
+        if (x[i] != 0)
+            return 0;
+    return 1;
+}
+
+#if FLINT_HAVE_FFT_SMALL
+
+/* convert an accumulated element out into (z, zlimbs) starting at limb
+   offset 'shift' of the magnitude; returns 0 on any refusal. shift > 0
+   uses the truncated conversion (at most one unit of error in the
+   lowest returned limb, the mulhigh contract); shift = 0 is exact. */
+static int
+_tmpn_out(nn_ptr z, mp_size_t zlimbs, slong * zlen, gr_ptr acc,
+          mp_size_t shift, nn_ptr t, ulong tmax, gr_ctx_t tctx)
+{
+    slong need, tn;
+    int sg, status;
+
+    /* the accumulators are dead after this, so the conversion may
+       consume them and skip copying the transform; t is a slice of a
+       dead operand's storage, large enough by construction (an element
+       holds np * stride doubles against need ~ zlimbs + a few limbs) */
+    if (shift > 0)
+    {
+        need = gr_transformed_mpn_get_limbs_trunc(tctx, acc, shift);
+        if ((ulong) need > tmax)
+            return 0;
+        status = gr_transformed_mpn_get_trunc_destructive(t, need, &tn, &sg,
+                                                          shift, acc, tctx);
+    }
+    else
+    {
+        need = gr_transformed_mpn_get_limbs(tctx, acc);
+        if ((ulong) need > tmax)
+            return 0;
+        status = gr_transformed_mpn_get_destructive(t, need, &tn, &sg, acc,
+                                                    tctx);
+    }
+
+    if (status == GR_SUCCESS)
+    {
+        /* the true value must fit the caller's window */
+        if (tn > zlimbs)
+            status = GR_UNABLE;
+        else
+        {
+            if (tn > 0)
+                flint_mpn_copyi(z, t, tn);
+            *zlen = (tn == 0 || !sg) ? tn : -(slong) tn;
+        }
+    }
+    return status == GR_SUCCESS;
+}
+
+/* fft path shared by mul and mulhigh: shift = 0 writes 2n+1 limbs,
+   shift = n writes n+1 limbs */
+static int
+_mul_complex_fft(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len,
+    nn_srcptr ar, mp_size_t arn, int ar_sgn,
+    nn_srcptr ai, mp_size_t ain, int ai_sgn,
+    nn_srcptr br, mp_size_t brn, int br_sgn,
+    nn_srcptr bi, mp_size_t bin, int bi_sgn,
+    mp_size_t shift, mp_size_t zlimbs)
+{
+    gr_ctx_t tctx;
+    gr_ptr E;
+    double * base;
+    int ok = 1;
+#define E_(i) GR_ENTRY(E, i, tctx->sizeof_elem)
+
+    if (gr_ctx_init_transformed_mpn(tctx,
+            FLINT_BITS * (slong) (FLINT_MAX(arn, ain) + FLINT_MAX(brn, bin))
+            + 8, 2, 1) != GR_SUCCESS)
+        return 0;
+
+    {
+        ulong esz = gr_transformed_mpn_sizeof_data(tctx);
+
+        base = (double *) mpn_ctx_fit_buffer(get_default_mpn_ctx(),
+                    6 * esz + 6 * tctx->sizeof_elem);
+        E = (gr_ptr) (base + 6 * (esz / sizeof(double)));
+        { slong i; for (i = 0; i < 6; i++)
+            gr_transformed_mpn_init_borrowed(E_(i),
+                    base + i * (esz / sizeof(double)), tctx); }
+    }
+
+    ok = ok && gr_transformed_mpn_set(E_(0), ar, arn, ar_sgn, tctx) == GR_SUCCESS;
+    ok = ok && gr_transformed_mpn_set(E_(1), ai, ain, ai_sgn, tctx) == GR_SUCCESS;
+    ok = ok && gr_transformed_mpn_set(E_(2), br, brn, br_sgn, tctx) == GR_SUCCESS;
+    ok = ok && gr_transformed_mpn_set(E_(3), bi, bin, bi_sgn, tctx) == GR_SUCCESS;
+
+    /* zr = ar br - ai bi, zi = ar bi + ai br */
+    ok = ok && gr_mul(E_(4), E_(0), E_(2), tctx) == GR_SUCCESS;
+    ok = ok && gr_submul(E_(4), E_(1), E_(3), tctx) == GR_SUCCESS;
+    ok = ok && gr_mul(E_(5), E_(0), E_(3), tctx) == GR_SUCCESS;
+    ok = ok && gr_addmul(E_(5), E_(1), E_(2), tctx) == GR_SUCCESS;
+
+    /* the operands are dead once the pointwise stage is done: their
+       storage (the first two scratch slices) doubles as the export
+       staging buffers */
+    {
+        ulong esz = gr_transformed_mpn_sizeof_data(tctx);
+        ulong tmax = esz / sizeof(ulong);
+
+        ok = ok && _tmpn_out(zr, zlimbs, zr_len, E_(4), shift,
+                             (nn_ptr) base, tmax, tctx);
+        ok = ok && _tmpn_out(zi, zlimbs, zi_len, E_(5), shift,
+                             (nn_ptr) (base + esz / sizeof(double)), tmax,
+                             tctx);
+    }
+
+    { slong i; for (i = 0; i < 6; i++) gr_clear(E_(i), tctx); }
+    gr_ctx_clear(tctx);
+#undef E_
+    return ok;
+}
+
+static int
+_sqr_complex_fft(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len,
+    nn_srcptr ar, mp_size_t arn, int ar_sgn,
+    nn_srcptr ai, mp_size_t ain, int ai_sgn,
+    mp_size_t shift, mp_size_t zlimbs)
+{
+    gr_ctx_t tctx;
+    gr_ptr E;
+    double * base;
+    int ok = 1;
+#define E_(i) GR_ENTRY(E, i, tctx->sizeof_elem)
+
+    if (gr_ctx_init_transformed_mpn(tctx,
+            FLINT_BITS * (slong) (2 * FLINT_MAX(arn, ain)) + 8, 4, 1)
+            != GR_SUCCESS)
+        return 0;
+
+    {
+        ulong esz = gr_transformed_mpn_sizeof_data(tctx);
+
+        base = (double *) mpn_ctx_fit_buffer(get_default_mpn_ctx(),
+                    6 * esz + 6 * tctx->sizeof_elem);
+        E = (gr_ptr) (base + 6 * (esz / sizeof(double)));
+        { slong i; for (i = 0; i < 6; i++)
+            gr_transformed_mpn_init_borrowed(E_(i),
+                    base + i * (esz / sizeof(double)), tctx); }
+    }
+
+    ok = ok && gr_transformed_mpn_set(E_(0), ar, arn, ar_sgn, tctx) == GR_SUCCESS;
+    ok = ok && gr_transformed_mpn_set(E_(1), ai, ain, ai_sgn, tctx) == GR_SUCCESS;
+
+    /* zr = (ar + ai)(ar - ai), zi = 2 ar ai */
+    ok = ok && gr_add(E_(2), E_(0), E_(1), tctx) == GR_SUCCESS;
+    ok = ok && gr_sub(E_(3), E_(0), E_(1), tctx) == GR_SUCCESS;
+    ok = ok && gr_mul(E_(4), E_(2), E_(3), tctx) == GR_SUCCESS;
+    ok = ok && gr_mul(E_(5), E_(0), E_(1), tctx) == GR_SUCCESS;
+    ok = ok && gr_addmul(E_(5), E_(0), E_(1), tctx) == GR_SUCCESS;
+
+    /* operands dead after the pointwise stage; their slices stage the
+       exports */
+    {
+        ulong esz = gr_transformed_mpn_sizeof_data(tctx);
+        ulong tmax = esz / sizeof(ulong);
+
+        ok = ok && _tmpn_out(zr, zlimbs, zr_len, E_(4), shift,
+                             (nn_ptr) base, tmax, tctx);
+        ok = ok && _tmpn_out(zi, zlimbs, zi_len, E_(5), shift,
+                             (nn_ptr) (base + esz / sizeof(double)), tmax,
+                             tctx);
+    }
+
+    { slong i; for (i = 0; i < 6; i++) gr_clear(E_(i), tctx); }
+    gr_ctx_clear(tctx);
+#undef E_
+    return ok;
+}
+
+#endif /* FLINT_HAVE_FFT_SMALL */
+
+/* significant limbs of x, 0 if x is zero */
+static mp_size_t
+_norm(nn_srcptr x, mp_size_t n)
+{
+    while (n > 0 && x[n - 1] == 0)
+        n--;
+    return n;
+}
+
+static void
+_mul_any_order(nn_ptr r, nn_srcptr a, mp_size_t an, nn_srcptr b, mp_size_t bn)
+{
+    if (an == 0 || bn == 0)
+    {
+        flint_mpn_zero(r, an + bn);
+        return;
+    }
+
+    if (an >= bn)
+        flint_mpn_mul(r, a, an, b, bn);
+    else
+        flint_mpn_mul(r, b, bn, a, an);
+}
+
+/*
+    z receives (-1)^xs {x,xn} + (-1)^ys {y,yn} and the signed length is
+    returned. The operand lengths are upper bounds, not normalized
+    lengths: carrying an insignificant high limb through an addition
+    costs a cycle, while normalizing every input costs a scan, and only
+    the result needs to be canonical. z may be x or y exactly, and needs
+    room for max(xn, yn) + 1 limbs.
+*/
+/* compare magnitudes given as upper-bound lengths, trimming both to
+   their significant lengths; only the excess limbs are scanned, which is
+   what makes it cheap enough to skip normalizing the inputs */
+static int
+_cmp_trim(nn_srcptr x, mp_size_t * xn, nn_srcptr y, mp_size_t * yn)
+{
+    while (*xn > *yn && x[*xn - 1] == 0)
+        (*xn)--;
+    while (*yn > *xn && y[*yn - 1] == 0)
+        (*yn)--;
+
+    if (*xn != *yn)
+        return (*xn > *yn) ? 1 : -1;
+
+    return (*xn == 0) ? 0 : mpn_cmp(x, y, *xn);
+}
+
+static slong
+_signed_add_normalise(nn_ptr z, nn_srcptr x, mp_size_t xn, int xs,
+                      nn_srcptr y, mp_size_t yn, int ys)
+{
+    mp_size_t rn;
+    int rs;
+
+    if (xs == ys)
+    {
+        ulong cy;
+
+        if (xn >= yn)
+        {
+            cy = mpn_add(z, x, xn, y, yn);
+            rn = xn;
+        }
+        else
+        {
+            cy = mpn_add(z, y, yn, x, xn);
+            rn = yn;
+        }
+
+        z[rn] = cy;
+        rn += (cy != 0);
+        rs = xs;
+    }
+    else
+    {
+        int c = _cmp_trim(x, &xn, y, &yn);
+
+        if (c == 0)
+            return 0;
+
+        if (c > 0)
+        {
+            mpn_sub(z, x, xn, y, yn);
+            rn = xn;
+            rs = xs;
+        }
+        else
+        {
+            mpn_sub(z, y, yn, x, xn);
+            rn = yn;
+            rs = ys;
+        }
+    }
+
+    while (rn > 0 && z[rn - 1] == 0)
+        rn--;
+
+    return rs ? -rn : rn;
+}
+
+/*
+    Is the Karatsuba scheme worth it for these shapes?
+
+    It replaces the two cross products ar bi and ai br with the single
+    auxiliary product (ar + ai)(br + bi), whose operands have
+    max(arn, ain) + 1 and max(brn, bin) + 1 limbs. Comparing limb-product
+    counts, that is a gain exactly when the auxiliary product is smaller
+    than the two it removes -- true when the real and imaginary parts are
+    internally balanced within each operand, false when any part is much
+    shorter than its partner, without needing a ratio threshold. The two
+    operands need not resemble each other.
+
+    Verified directly on twelve unbalanced shapes (see the PR notes):
+    eleven predictions correct, the miss on the exact boundary at a 4%
+    cost -- a wrong call can only occur where the two algorithms are
+    near-equal, since the counts being compared are what define the
+    boundary.
+*/
+static int
+_kara_worth_it(mp_size_t arn, mp_size_t ain, mp_size_t brn, mp_size_t bin,
+               mp_size_t cutoff)
+{
+    mp_size_t maxa = FLINT_MAX(arn, ain);
+    mp_size_t maxb = FLINT_MAX(brn, bin);
+
+    if (maxa < cutoff || maxb < cutoff)
+        return 0;
+
+    /* the products below would overflow for parts of 2^31 limbs and
+       more; every scheme is asymptotically better than schoolbook long
+       before that */
+    if ((maxa | maxb) >> (FLINT_BITS / 2 - 1) != 0)
+        return 1;
+
+    return (maxa + 1) * (maxb + 1) < arn * bin + ain * brn;
+}
+
+/*
+    Schoolbook: four products, each output taking one of them directly
+    and having the other combined into it in place. Nothing is normalized
+    on the way in -- the products are formed at the lengths given and the
+    additions run at those upper bounds.
+*/
+void
+flint_mpn_mul_complex_classical(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len,
+    nn_srcptr ar, mp_size_t arn, int ar_sgn,
+    nn_srcptr ai, mp_size_t ain, int ai_sgn,
+    nn_srcptr br, mp_size_t brn, int br_sgn,
+    nn_srcptr bi, mp_size_t bin, int bi_sgn)
+{
+    nn_ptr t;
+    TMP_INIT;
+
+    TMP_START;
+    t = TMP_ALLOC(FLINT_MAX(ain + bin, ain + brn) * sizeof(ulong));
+
+    _mul_any_order(zr, ar, arn, br, brn);
+    _mul_any_order(t, ai, ain, bi, bin);
+    *zr_len = _signed_add_normalise(zr, zr, arn + brn, ar_sgn ^ br_sgn,
+                                    t, ain + bin, ai_sgn ^ bi_sgn ^ 1);
+
+    _mul_any_order(zi, ar, arn, bi, bin);
+    _mul_any_order(t, ai, ain, br, brn);
+    *zi_len = _signed_add_normalise(zi, zi, arn + bin, ar_sgn ^ bi_sgn,
+                                    t, ain + brn, ai_sgn ^ br_sgn);
+
+    TMP_END;
+}
+
+/*
+    Karatsuba: t1 = ar br, t2 = ai bi, t3 = (ar + ai)(br + bi);
+    zr = t1 - t2 and zi = t3 - (t1 + t2).
+
+    Here the inputs *are* normalized first: an insignificant high limb
+    costs a cycle in an addition but a whole extra row in a
+    multiplication, and this path performs three of them.
+*/
+void
+flint_mpn_mul_complex_karatsuba(nn_ptr zr, slong * zr_len,
+    nn_ptr zi, slong * zi_len,
+    nn_srcptr ar, mp_size_t arn, int ar_sgn,
+    nn_srcptr ai, mp_size_t ain, int ai_sgn,
+    nn_srcptr br, mp_size_t brn, int br_sgn,
+    nn_srcptr bi, mp_size_t bin, int bi_sgn)
+{
+    mp_size_t maxa = FLINT_MAX(arn, ain), maxb = FLINT_MAX(brn, bin);
+    nn_ptr t1, t2, t3, p, u, v, zt;
+    mp_size_t un0 = maxa + 1, vn0 = maxb + 1, pw = maxa + maxb + 2;
+    slong ul, vl, pl, il;
+    int s1, s2;
+    TMP_INIT;
+
+    arn = _norm(ar, arn);
+    ain = _norm(ai, ain);
+    brn = _norm(br, brn);
+    bin = _norm(bi, bin);
+
+    TMP_START;
+    t1 = TMP_ALLOC(((arn + brn) + (ain + bin) + (un0 + vn0) + pw
+                    + un0 + vn0 + (pw + 2)) * sizeof(ulong));
+    t2 = t1 + arn + brn;
+    t3 = t2 + ain + bin;
+    p = t3 + un0 + vn0;
+    u = p + pw;
+    v = u + un0;
+    zt = v + vn0;
+
+    _mul_any_order(t1, ar, arn, br, brn);
+    _mul_any_order(t2, ai, ain, bi, bin);
+    s1 = ar_sgn ^ br_sgn;
+    s2 = ai_sgn ^ bi_sgn;
+
+    ul = _signed_add_normalise(u, ar, arn, ar_sgn, ai, ain, ai_sgn);
+    vl = _signed_add_normalise(v, br, brn, br_sgn, bi, bin, bi_sgn);
+    _mul_any_order(t3, u, FLINT_ABS(ul), v, FLINT_ABS(vl));
+
+    *zr_len = _signed_add_normalise(zr, t1, arn + brn, s1,
+                                    t2, ain + bin, s2 ^ 1);
+
+    pl = _signed_add_normalise(p, t1, arn + brn, s1, t2, ain + bin, s2);
+
+    /* t3 can reach maxa + maxb + 2 limbs, one past the caller's window,
+       so this one combination is formed in scratch */
+    il = _signed_add_normalise(zt, t3, FLINT_ABS(ul) + FLINT_ABS(vl),
+                               (ul < 0) ^ (vl < 0),
+                               p, FLINT_ABS(pl), (pl < 0) ^ 1);
+    flint_mpn_copyi(zi, zt, FLINT_ABS(il));
+    *zi_len = il;
+
+    TMP_END;
+}
+
+/* the transformed path; returns 0 (leaving the outputs untouched) if
+   fft_small is not built in or the plan is inadmissible */
+int
+flint_mpn_mul_complex_fft_small(nn_ptr zr, slong * zr_len,
+    nn_ptr zi, slong * zi_len,
+    nn_srcptr ar, mp_size_t arn, int ar_sgn,
+    nn_srcptr ai, mp_size_t ain, int ai_sgn,
+    nn_srcptr br, mp_size_t brn, int br_sgn,
+    nn_srcptr bi, mp_size_t bin, int bi_sgn)
+{
+#if FLINT_HAVE_FFT_SMALL
+    mp_size_t maxa = FLINT_MAX(arn, ain), maxb = FLINT_MAX(brn, bin);
+
+    return _mul_complex_fft(zr, zr_len, zi, zi_len, ar, arn, ar_sgn,
+                            ai, ain, ai_sgn, br, brn, br_sgn, bi, bin,
+                            bi_sgn, 0, maxa + maxb + 1);
+#else
+    return 0;
+#endif
+}
+
+int
+flint_mpn_sqr_complex_fft_small(nn_ptr zr, slong * zr_len,
+    nn_ptr zi, slong * zi_len,
+    nn_srcptr ar, mp_size_t arn, int ar_sgn,
+    nn_srcptr ai, mp_size_t ain, int ai_sgn)
+{
+#if FLINT_HAVE_FFT_SMALL
+    mp_size_t maxa = FLINT_MAX(arn, ain);
+
+    return _sqr_complex_fft(zr, zr_len, zi, zi_len, ar, arn, ar_sgn,
+                            ai, ain, ai_sgn, 0, 2 * maxa + 1);
+#else
+    return 0;
+#endif
+}
+
+static void
+_mul_complex_general(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len,
+    nn_srcptr ar, mp_size_t arn, int ar_sgn,
+    nn_srcptr ai, mp_size_t ain, int ai_sgn,
+    nn_srcptr br, mp_size_t brn, int br_sgn,
+    nn_srcptr bi, mp_size_t bin, int bi_sgn)
+{
+    mp_size_t maxa = FLINT_MAX(arn, ain), maxb = FLINT_MAX(brn, bin);
+
+    if (_kara_worth_it(arn, ain, brn, bin, MUL_COMPLEX_KARATSUBA_CUTOFF))
+    {
+        if (FLINT_MIN(maxa, maxb) >= flint_mpn_mul_complex_fft_cutoff &&
+            flint_mpn_mul_complex_fft_small(zr, zr_len, zi, zi_len,
+                    ar, arn, ar_sgn, ai, ain, ai_sgn,
+                    br, brn, br_sgn, bi, bin, bi_sgn))
+            return;
+
+        flint_mpn_mul_complex_karatsuba(zr, zr_len, zi, zi_len, ar, arn,
+                ar_sgn, ai, ain, ai_sgn, br, brn, br_sgn, bi, bin, bi_sgn);
+    }
+    else
+        flint_mpn_mul_complex_classical(zr, zr_len, zi, zi_len, ar, arn,
+                ar_sgn, ai, ain, ai_sgn, br, brn, br_sgn, bi, bin, bi_sgn);
+}
+
+/* zi = 2 ar ai for both squaring algorithms: the product written into
+   zi and doubled in place */
+static slong
+_sqr_zi_double(nn_ptr zi, nn_srcptr ar, mp_size_t arn, int ar_sgn,
+               nn_srcptr ai, mp_size_t ain, int ai_sgn)
+{
+    mp_size_t rn = arn + ain;
+    ulong cy;
+
+    _mul_any_order(zi, ar, arn, ai, ain);
+    cy = mpn_lshift(zi, zi, rn, 1);
+    zi[rn] = cy;
+    rn += (cy != 0);
+    while (rn > 0 && zi[rn - 1] == 0)
+        rn--;
+
+    return (rn == 0 || !(ar_sgn ^ ai_sgn)) ? rn : -rn;
+}
+
+void
+flint_mpn_sqr_complex_classical(nn_ptr zr, slong * zr_len,
+    nn_ptr zi, slong * zi_len,
+    nn_srcptr ar, mp_size_t arn, int ar_sgn,
+    nn_srcptr ai, mp_size_t ain, int ai_sgn)
+{
+    nn_ptr t1;
+    TMP_INIT;
+
+    TMP_START;
+    t1 = TMP_ALLOC(2 * ain * sizeof(ulong));
+
+    flint_mpn_sqr(zr, ar, arn);
+    flint_mpn_sqr(t1, ai, ain);
+    *zr_len = _signed_add_normalise(zr, zr, 2 * arn, 0, t1, 2 * ain, 1);
+
+    *zi_len = _sqr_zi_double(zi, ar, arn, ar_sgn, ai, ain, ai_sgn);
+
+    TMP_END;
+}
+
+void
+flint_mpn_sqr_complex_karatsuba(nn_ptr zr, slong * zr_len,
+    nn_ptr zi, slong * zi_len,
+    nn_srcptr ar, mp_size_t arn, int ar_sgn,
+    nn_srcptr ai, mp_size_t ain, int ai_sgn)
+{
+    /* zr = (ar + ai)(ar - ai): one multiplication where the classical
+       form uses two squarings, so the inputs are normalized first */
+    mp_size_t maxa = FLINT_MAX(arn, ain), rn;
+    mp_size_t an = _norm(ar, arn), bn = _norm(ai, ain);
+    nn_ptr u, v, t1;
+    slong ul, vl;
+    TMP_INIT;
+
+    TMP_START;
+    u = TMP_ALLOC((2 * (maxa + 1) + 2 * (maxa + 2)) * sizeof(ulong));
+    v = u + maxa + 1;
+    t1 = v + maxa + 1;
+
+    ul = _signed_add_normalise(u, ar, an, ar_sgn, ai, bn, ai_sgn);
+    vl = _signed_add_normalise(v, ar, an, ar_sgn, ai, bn, ai_sgn ^ 1);
+    _mul_any_order(t1, u, FLINT_ABS(ul), v, FLINT_ABS(vl));
+    rn = _norm(t1, FLINT_ABS(ul) + FLINT_ABS(vl));
+    flint_mpn_copyi(zr, t1, rn);
+    *zr_len = (rn == 0 || !((ul < 0) ^ (vl < 0))) ? rn : -rn;
+
+    *zi_len = _sqr_zi_double(zi, ar, arn, ar_sgn, ai, ain, ai_sgn);
+
+    TMP_END;
+}
+
+static void
+_sqr_complex_general(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len,
+    nn_srcptr ar, mp_size_t arn, int ar_sgn,
+    nn_srcptr ai, mp_size_t ain, int ai_sgn)
+{
+    mp_size_t maxa = FLINT_MAX(arn, ain);
+
+    if (_kara_worth_it(arn, ain, arn, ain, SQR_COMPLEX_KARATSUBA_CUTOFF))
+    {
+        if (maxa >= flint_mpn_sqr_complex_fft_cutoff &&
+            flint_mpn_sqr_complex_fft_small(zr, zr_len, zi, zi_len,
+                    ar, arn, ar_sgn, ai, ain, ai_sgn))
+            return;
+
+        flint_mpn_sqr_complex_karatsuba(zr, zr_len, zi, zi_len,
+                ar, arn, ar_sgn, ai, ain, ai_sgn);
+    }
+    else
+        flint_mpn_sqr_complex_classical(zr, zr_len, zi, zi_len,
+                ar, arn, ar_sgn, ai, ain, ai_sgn);
+}
+
+/* the high variants promise exactly zlimbs limbs, zero padded, plus a
+   sign; the shared fft path hands back a signed length */
+static void
+_high_pad(nn_ptr z, int * zsgn, slong len, mp_size_t zlimbs)
+{
+    mp_size_t rn = FLINT_ABS(len);
+
+    if (rn < zlimbs)
+        flint_mpn_zero(z + rn, zlimbs - rn);
+    *zsgn = (len < 0);
+}
+
+/* z (n + 1 limbs) = (-1)^xs |x| + (-1)^ys |y| for n-limb magnitudes;
+   returns the sign of the result */
+static int
+_signed_add_n1(nn_ptr z, nn_srcptr x, int xs, nn_srcptr y, int ys,
+               mp_size_t n)
+{
+    if (xs == ys)
+    {
+        z[n] = mpn_add_n(z, x, y, n);
+        return xs;
+    }
+
+    if (mpn_cmp(x, y, n) >= 0)
+    {
+        mpn_sub_n(z, x, y, n);
+        z[n] = 0;
+        return xs;
+    }
+
+    mpn_sub_n(z, y, x, n);
+    z[n] = 0;
+    return ys;
+}
+
+/*
+    High variants: every product shares the length n, so the combinations
+    are fixed-length signed adds -- one mpn_add_n, or one mpn_cmp plus
+    mpn_sub_n -- in the style of nfloat's complex multiplication, with the
+    carry limb completing the promised n + 1 and no accumulator to clear
+    or copy out of.
+*/
+static void
+_high_combine(nn_ptr z, int * zsgn, nn_srcptr x, int xs,
+              nn_srcptr y, int ys, mp_size_t n)
+{
+    if (xs == ys)
+    {
+        z[n] = mpn_add_n(z, x, y, n);
+        *zsgn = xs;
+    }
+    else if (mpn_cmp(x, y, n) >= 0)
+    {
+        mpn_sub_n(z, x, y, n);
+        z[n] = 0;
+        *zsgn = xs;
+    }
+    else
+    {
+        mpn_sub_n(z, y, x, n);
+        z[n] = 0;
+        *zsgn = ys;
+    }
+}
+
+static void
+_mul_complex_high(nn_ptr zr, int * zr_sgn, nn_ptr zi, int * zi_sgn,
+    nn_srcptr ar, int ar_sgn, nn_srcptr ai, int ai_sgn,
+    nn_srcptr br, int br_sgn, nn_srcptr bi, int bi_sgn, mp_size_t n)
+{
+    TMP_INIT;
+    TMP_START;
+
+    if (n < MULHIGH_COMPLEX_KARATSUBA_CUTOFF)
+    {
+        nn_ptr h1 = TMP_ALLOC(4 * n * sizeof(ulong));
+        nn_ptr h2 = h1 + n, h3 = h2 + n, h4 = h3 + n;
+
+        flint_mpn_mulhigh_n(h1, ar, br, n);
+        flint_mpn_mulhigh_n(h2, ai, bi, n);
+        flint_mpn_mulhigh_n(h3, ar, bi, n);
+        flint_mpn_mulhigh_n(h4, ai, br, n);
+
+        _high_combine(zr, zr_sgn, h1, ar_sgn ^ br_sgn,
+                      h2, ai_sgn ^ bi_sgn ^ 1, n);
+        _high_combine(zi, zi_sgn, h3, ar_sgn ^ bi_sgn,
+                      h4, ai_sgn ^ br_sgn, n);
+    }
+    else
+    {
+        /* three high products, the auxiliary one padded with a low zero
+           limb so its window lines up with the others */
+        /* zt holds h1 + h2 (n + 1 limbs) followed by the h3 - that
+           combination (n + 3 limbs) */
+        nn_ptr h1 = TMP_ALLOC((2 * n + (n + 2) + 2 * (n + 2)
+                               + (2 * n + 4)) * sizeof(ulong));
+        nn_ptr h2 = h1 + n, h3 = h2 + n;
+        nn_ptr U = h3 + n + 2, V = U + n + 2, zt = V + n + 2;
+        slong pl, il;
+        int su, sv;
+
+        flint_mpn_mulhigh_n(h1, ar, br, n);
+        flint_mpn_mulhigh_n(h2, ai, bi, n);
+
+        U[0] = 0;
+        V[0] = 0;
+        su = _signed_add_n1(U + 1, ar, ar_sgn, ai, ai_sgn, n);
+        sv = _signed_add_n1(V + 1, br, br_sgn, bi, bi_sgn, n);
+        flint_mpn_mulhigh_n(h3, U, V, n + 2);
+
+        _high_combine(zr, zr_sgn, h1, ar_sgn ^ br_sgn,
+                      h2, ai_sgn ^ bi_sgn ^ 1, n);
+
+        /* zi = h3 - (h1 + h2), the sum in scratch since h3 spans n + 2 */
+        pl = _signed_add_normalise(zt, h1, n, ar_sgn ^ br_sgn,
+                                   h2, n, ai_sgn ^ bi_sgn);
+        il = _signed_add_normalise(zt + n + 1, h3, n + 2, su ^ sv,
+                                   zt, FLINT_ABS(pl), (pl < 0) ^ 1);
+        {
+            mp_size_t k = FLINT_MIN(FLINT_ABS(il), n + 1);
+
+            flint_mpn_copyi(zi, zt + n + 1, k);
+            if (k < n + 1)
+                flint_mpn_zero(zi + k, n + 1 - k);
+            *zi_sgn = (il < 0);
+        }
+    }
+
+    TMP_END;
+}
+
+static void
+_sqr_complex_high(nn_ptr zr, int * zr_sgn, nn_ptr zi, int * zi_sgn,
+    nn_srcptr ar, int ar_sgn, nn_srcptr ai, int ai_sgn, mp_size_t n)
+{
+    TMP_INIT;
+    TMP_START;
+
+    if (n < SQRHIGH_COMPLEX_KARATSUBA_CUTOFF)
+    {
+        nn_ptr h1 = TMP_ALLOC(3 * n * sizeof(ulong));
+        nn_ptr h2 = h1 + n, h3 = h2 + n;
+
+        flint_mpn_sqrhigh(h1, ar, n);
+        flint_mpn_sqrhigh(h2, ai, n);
+        flint_mpn_mulhigh_n(h3, ar, ai, n);
+
+        _high_combine(zr, zr_sgn, h1, 0, h2, 1, n);
+        zi[n] = mpn_lshift(zi, h3, n, 1);
+        *zi_sgn = ar_sgn ^ ai_sgn;
+    }
+    else
+    {
+        nn_ptr h1 = TMP_ALLOC(((n + 2) + n + 2 * (n + 2)) * sizeof(ulong));
+        nn_ptr h2 = h1 + n + 2;
+        nn_ptr U = h2 + n, V = U + n + 2;
+        int su, sv;
+
+        U[0] = 0;
+        V[0] = 0;
+        su = _signed_add_n1(U + 1, ar, ar_sgn, ai, ai_sgn, n);
+        sv = _signed_add_n1(V + 1, ar, ar_sgn, ai, ai_sgn ^ 1, n);
+        flint_mpn_mulhigh_n(h1, U, V, n + 2);
+        flint_mpn_mulhigh_n(h2, ar, ai, n);
+
+        flint_mpn_copyi(zr, h1, n + 1);
+        *zr_sgn = su ^ sv;
+        zi[n] = mpn_lshift(zi, h2, n, 1);
+        *zi_sgn = ar_sgn ^ ai_sgn;
+    }
+
+    TMP_END;
+}
+
+void
+flint_mpn_mul_complex(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len,
+    nn_srcptr ar, mp_size_t arn, int ar_sgn,
+    nn_srcptr ai, mp_size_t ain, int ai_sgn,
+    nn_srcptr br, mp_size_t brn, int br_sgn,
+    nn_srcptr bi, mp_size_t bin, int bi_sgn)
+{
+    FLINT_ASSERT(arn >= 1 && ain >= 1 && brn >= 1 && bin >= 1);
+
+    _mul_complex_general(zr, zr_len, zi, zi_len, ar, arn, ar_sgn,
+                         ai, ain, ai_sgn, br, brn, br_sgn, bi, bin, bi_sgn);
+}
+
+void
+flint_mpn_sqr_complex(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len,
+    nn_srcptr ar, mp_size_t arn, int ar_sgn,
+    nn_srcptr ai, mp_size_t ain, int ai_sgn)
+{
+    FLINT_ASSERT(arn >= 1 && ain >= 1);
+
+    _sqr_complex_general(zr, zr_len, zi, zi_len, ar, arn, ar_sgn,
+                         ai, ain, ai_sgn);
+}
+
+void
+flint_mpn_mulhigh_n_complex(nn_ptr zr, int * zr_sgn, nn_ptr zi, int * zi_sgn,
+    nn_srcptr ar, int ar_sgn, nn_srcptr ai, int ai_sgn,
+    nn_srcptr br, int br_sgn, nn_srcptr bi, int bi_sgn, mp_size_t n)
+{
+#if FLINT_HAVE_FFT_SMALL
+    {
+        slong lr, li;
+
+        if (n >= flint_mpn_mul_complex_fft_cutoff &&
+            _mul_complex_fft(zr, &lr, zi, &li, ar, n, ar_sgn, ai, n, ai_sgn,
+                             br, n, br_sgn, bi, n, bi_sgn, n, n + 1))
+        {
+            _high_pad(zr, zr_sgn, lr, n + 1);
+            _high_pad(zi, zi_sgn, li, n + 1);
+            return;
+        }
+    }
+#endif
+    _mul_complex_high(zr, zr_sgn, zi, zi_sgn, ar, ar_sgn, ai, ai_sgn,
+                      br, br_sgn, bi, bi_sgn, n);
+}
+
+void
+flint_mpn_sqrhigh_n_complex(nn_ptr zr, int * zr_sgn, nn_ptr zi, int * zi_sgn,
+    nn_srcptr ar, int ar_sgn, nn_srcptr ai, int ai_sgn, mp_size_t n)
+{
+#if FLINT_HAVE_FFT_SMALL
+    {
+        slong lr, li;
+
+        if (n >= flint_mpn_sqr_complex_fft_cutoff &&
+            _sqr_complex_fft(zr, &lr, zi, &li, ar, n, ar_sgn, ai, n, ai_sgn,
+                             n, n + 1))
+        {
+            _high_pad(zr, zr_sgn, lr, n + 1);
+            _high_pad(zi, zi_sgn, li, n + 1);
+            return;
+        }
+    }
+#endif
+    _sqr_complex_high(zr, zr_sgn, zi, zi_sgn, ar, ar_sgn, ai, ai_sgn, n);
+}

--- a/src/mpn_extras/mul_complex.c
+++ b/src/mpn_extras/mul_complex.c
@@ -55,58 +55,19 @@
 
     */
 
-/* Measured crossover on an AVX2 machine at -O1: the transformed path
-   wins from ~896 limbs (1.3x at 896, 1.4x at 1280), and the two are
-   within noise between 640 and 768. Re-tune per platform. */
-/* Measured crossover on an AVX2 machine at -O1: the transformed path
-   wins from ~896 limbs (1.3x at 896, 1.4x at 1280), and the two are
-   within noise between 640 and 768. Re-tune per platform; the Karatsuba
-   and mulhigh classical paths moved this point, so it was re-swept. */
-/*
-    Sizes (in limbs) from which the complex functions use the
-    transformed path; separate for products and squares because their
-    classical competitors differ (a squaring's high path is two cheap
-    high products, so its crossover sits higher).
-
-    Measured on one AVX2 machine at -O1 with assembly disabled, after
-    the reconstruction fix and with the per-thread element scratch
-    below: products and high products cross at ~1024 limbs (1.1-1.3x
-    from there through 65536). Squares, full and high alike, are a wash
-    at 2048 and win 1.1-1.2x from 4096 -- their classical competitors
-    are only two real (high) multiplications, so the transform saving
-    is thinner. On a build with the mulhigh assembly enabled the
-    classical side speeds up and these crossovers move upward; re-tune
-    per platform. The variables stay writable so the tests can drive
-    both paths and callers can adjust.
-*/
 slong flint_mpn_mul_complex_fft_cutoff = 700;
 slong flint_mpn_sqr_complex_fft_cutoff = 3000000;
 
-/*
-    The elements live in the multiplication context's cached per-thread
-    buffer (mpn_ctx_fit_buffer) -- the same storage the standard
-    multiplication amortizes its setup with; allocating fresh element
-    buffers per call was dominated by first-touch page faults.
+/* Defined here rather than in the fft_small module, which unsupported
+   platforms exclude from the build entirely: the budget must be
+   settable everywhere, since the drivers' fallback logic references it
+   unconditionally. */
+#if FLINT_BITS == 64
+ulong flint_fft_small_max_transformed_ring_size = UWORD(4) << 30;
+#else
+ulong flint_fft_small_max_transformed_ring_size = UWORD(1) << 30;
+#endif
 
-    Safety invariant: nothing between the conversions in and out may
-    touch that buffer. Its only other users are _mpn_ctx_mpn_mul_range
-    and the nmod conv engine, and the element set / pointwise / get
-    paths reach neither. If they ever start multiplying integers, the
-    buffer would be reallocated under live elements and this must revert
-    to a private cache.
-*/
-
-
-
-/* Measured with the split entry points on the streamlined (v24) code --
-   the old value of 32 was tuned against the accumulator version, which
-   taxed Karatsuba's extra additions. Products: a tie at 8 limbs and
-   1.1-1.3x from 10 up. Squares: a clear loss at 4-6 limbs, ties through
-   14, small gains above -- their classical form is two cheap squarings,
-   so the crossover sits higher. The high thresholds are taken from the
-   nfloat complex code (12 for products, 20 for squares); mulhigh has no
-   small basecases in this assembly-less build, so they cannot be
-   re-measured here and await tuning on a normal build. */
 #define MUL_COMPLEX_KARATSUBA_CUTOFF 8
 #define SQR_COMPLEX_KARATSUBA_CUTOFF 16
 #define MULHIGH_COMPLEX_KARATSUBA_CUTOFF 12

--- a/src/mpn_extras/mul_complex.c
+++ b/src/mpn_extras/mul_complex.c
@@ -79,8 +79,8 @@
     per platform. The variables stay writable so the tests can drive
     both paths and callers can adjust.
 */
-slong flint_mpn_mul_complex_fft_cutoff = 1024;
-slong flint_mpn_sqr_complex_fft_cutoff = 4096;
+slong flint_mpn_mul_complex_fft_cutoff = 700;
+slong flint_mpn_sqr_complex_fft_cutoff = 3000000;
 
 /*
     The elements live in the multiplication context's cached per-thread
@@ -236,8 +236,19 @@ _sqr_complex_fft(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len,
     int ok = 1;
 #define E_(i) GR_ENTRY(E, i, tctx->sizeof_elem)
 
+    /*
+        terms_bound is 2, not 4: an earlier version formed
+        (ar + ai)(ar - ai) on sums of transforms, whose slot values need
+        four products' capacity -- the profile then packs fewer bits per
+        slot, and since the conversions dominate (their cost is
+        proportional to the slot count), both directions inflated by more
+        than the two forward transforms the method saves over the
+        two-multiplication Karatsuba square. The identity buys nothing
+        where multiplications are pointwise; the direct
+        ar * ar - ai * ai keeps the same geometry as the complex product.
+    */
     if (gr_ctx_init_transformed_mpn(tctx,
-            FLINT_BITS * (slong) (2 * FLINT_MAX(arn, ain)) + 8, 4, 1)
+            FLINT_BITS * (slong) (2 * FLINT_MAX(arn, ain)) + 8, 2, 1)
             != GR_SUCCESS)
         return 0;
 
@@ -245,22 +256,30 @@ _sqr_complex_fft(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len,
         ulong esz = gr_transformed_mpn_sizeof_data(tctx);
 
         base = (double *) mpn_ctx_fit_buffer(get_default_mpn_ctx(),
-                    6 * esz + 6 * tctx->sizeof_elem);
-        E = (gr_ptr) (base + 6 * (esz / sizeof(double)));
-        { slong i; for (i = 0; i < 6; i++)
+                    4 * esz + 4 * tctx->sizeof_elem);
+        E = (gr_ptr) (base + 4 * (esz / sizeof(double)));
+        { slong i; for (i = 0; i < 4; i++)
             gr_transformed_mpn_init_borrowed(E_(i),
                     base + i * (esz / sizeof(double)), tctx); }
     }
 
-    ok = ok && gr_transformed_mpn_set(E_(0), ar, arn, ar_sgn, tctx) == GR_SUCCESS;
-    ok = ok && gr_transformed_mpn_set(E_(1), ai, ain, ai_sgn, tctx) == GR_SUCCESS;
+    /* the operands enter as magnitudes: the squares are sign free and
+       2 ar ai has the known sign ar_sgn ^ ai_sgn, applied below -- so
+       the imaginary part keeps a nonnegative element and takes the
+       cheaper unsigned reconstruction, which lacks the bias and
+       two's-complement sign-resolution passes of the signed one; only
+       the real part, whose sign genuinely depends on the values, pays
+       for the signed export */
+    ok = ok && gr_transformed_mpn_set(E_(0), ar, arn, 0, tctx) == GR_SUCCESS;
+    ok = ok && gr_transformed_mpn_set(E_(1), ai, ain, 0, tctx) == GR_SUCCESS;
 
-    /* zr = (ar + ai)(ar - ai), zi = 2 ar ai */
-    ok = ok && gr_add(E_(2), E_(0), E_(1), tctx) == GR_SUCCESS;
-    ok = ok && gr_sub(E_(3), E_(0), E_(1), tctx) == GR_SUCCESS;
-    ok = ok && gr_mul(E_(4), E_(2), E_(3), tctx) == GR_SUCCESS;
-    ok = ok && gr_mul(E_(5), E_(0), E_(1), tctx) == GR_SUCCESS;
-    ok = ok && gr_addmul(E_(5), E_(0), E_(1), tctx) == GR_SUCCESS;
+    /* zr = ar ar - ai ai; zi = ar ai doubled by a pointwise addition,
+       which costs a pass over the evaluations against a full pointwise
+       multiplication */
+    ok = ok && gr_mul(E_(2), E_(0), E_(0), tctx) == GR_SUCCESS;
+    ok = ok && gr_submul(E_(2), E_(1), E_(1), tctx) == GR_SUCCESS;
+    ok = ok && gr_mul(E_(3), E_(0), E_(1), tctx) == GR_SUCCESS;
+    ok = ok && gr_add(E_(3), E_(3), E_(3), tctx) == GR_SUCCESS;
 
     /* operands dead after the pointwise stage; their slices stage the
        exports */
@@ -268,14 +287,18 @@ _sqr_complex_fft(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len,
         ulong esz = gr_transformed_mpn_sizeof_data(tctx);
         ulong tmax = esz / sizeof(ulong);
 
-        ok = ok && _tmpn_out(zr, zlimbs, zr_len, E_(4), shift,
+        ok = ok && _tmpn_out(zr, zlimbs, zr_len, E_(2), shift,
                              (nn_ptr) base, tmax, tctx);
-        ok = ok && _tmpn_out(zi, zlimbs, zi_len, E_(5), shift,
+        ok = ok && _tmpn_out(zi, zlimbs, zi_len, E_(3), shift,
                              (nn_ptr) (base + esz / sizeof(double)), tmax,
                              tctx);
+
+        /* attach the known sign of 2 ar ai */
+        if (ok && (ar_sgn ^ ai_sgn))
+            *zi_len = -*zi_len;
     }
 
-    { slong i; for (i = 0; i < 6; i++) gr_clear(E_(i), tctx); }
+    { slong i; for (i = 0; i < 4; i++) gr_clear(E_(i), tctx); }
     gr_ctx_clear(tctx);
 #undef E_
     return ok;

--- a/src/mpn_extras/test/main.c
+++ b/src/mpn_extras/test/main.c
@@ -23,6 +23,7 @@
 #include "t-mod_preinvn.c"
 #include "t-mul.c"
 #include "t-mul_n.c"
+#include "t-mul_complex.c"
 #include "t-mul_toom22.c"
 #include "t-mullow_n.c"
 #include "t-mulhigh_n.c"
@@ -58,6 +59,7 @@ test_struct tests[] =
     TEST_FUNCTION(flint_mpn_mod_preinvn),
     TEST_FUNCTION(flint_mpn_mul),
     TEST_FUNCTION(flint_mpn_mul_n),
+    TEST_FUNCTION(flint_mpn_mul_complex),
     TEST_FUNCTION(flint_mpn_mul_toom22),
     TEST_FUNCTION(flint_mpn_mullow_n),
     TEST_FUNCTION(flint_mpn_mulhigh_n_tab),

--- a/src/mpn_extras/test/t-mul_complex.c
+++ b/src/mpn_extras/test/t-mul_complex.c
@@ -76,8 +76,56 @@ _check_high(const fmpz_t ref, nn_srcptr z, slong n, int sgn, slong nn,
    the internal cutoff, and zero components exercise the canonical zero. */
 TEST_FUNCTION_START(flint_mpn_mul_complex, state)
 {
+    /* some iterations force the transformed paths regardless of size,
+       covering the square pointwise ops and the signed exports */
+    slong save_mul_cutoff = flint_mpn_mul_complex_fft_cutoff;
+    slong save_sqr_cutoff = flint_mpn_sqr_complex_fft_cutoff;
+
     for (slong iter = 0; iter < 40 * flint_test_multiplier(); iter++)
     {
+        if (iter % 3 == 1)
+        {
+            flint_mpn_mul_complex_fft_cutoff = 1;
+            flint_mpn_sqr_complex_fft_cutoff = 1;
+        }
+        else
+        {
+            flint_mpn_mul_complex_fft_cutoff = save_mul_cutoff;
+            flint_mpn_sqr_complex_fft_cutoff = save_sqr_cutoff;
+        }
+
+        /* the square path: under the forced cutoff this reaches the
+           transformed square ops and their signed exports; the
+           Karatsuba square is the reference */
+        if (iter % 3 == 1)
+        {
+            slong sn = 1 + n_randint(state, 300);
+            nn_ptr sa = flint_malloc(sn * sizeof(ulong));
+            nn_ptr sb = flint_malloc(sn * sizeof(ulong));
+            nn_ptr z1 = flint_malloc((2 * sn + 2) * sizeof(ulong));
+            nn_ptr z2 = flint_malloc((2 * sn + 2) * sizeof(ulong));
+            nn_ptr z3 = flint_malloc((2 * sn + 2) * sizeof(ulong));
+            nn_ptr z4 = flint_malloc((2 * sn + 2) * sizeof(ulong));
+            slong l1, l2, l3, l4, q;
+            int s1 = (int) n_randint(state, 2), s2 = (int) n_randint(state, 2);
+            for (q = 0; q < sn; q++)
+            { sa[q] = n_randtest(state); sb[q] = n_randtest(state); }
+            if (flint_mpn_sqr_complex_fft_small(z1, &l1, z2, &l2,
+                    sa, sn, s1, sb, sn, s2))
+            {
+                flint_mpn_sqr_complex_karatsuba(z3, &l3, z4, &l4,
+                        sa, sn, s1, sb, sn, s2);
+                if (l1 != l3 || l2 != l4
+                    || (l1 != 0 && mpn_cmp(z1, z3, FLINT_ABS(l1)) != 0)
+                    || (l2 != 0 && mpn_cmp(z2, z4, FLINT_ABS(l2)) != 0))
+                    TEST_FUNCTION_FAIL("transformed square vs karatsuba: "
+                            "sn=%wd s=%d%d\n", sn, s1, s2);
+            }
+            flint_free(sa); flint_free(sb);
+            flint_free(z1); flint_free(z2); flint_free(z3); flint_free(z4);
+        }
+
+
         /* the transformed path is off by default, so drive it explicitly
            on some iterations; sizes straddle the Karatsuba threshold */
         int fftpath = (iter % 4 == 0);
@@ -291,5 +339,7 @@ TEST_FUNCTION_START(flint_mpn_mul_complex, state)
     flint_mpn_mul_complex_fft_cutoff = 1024;
     flint_mpn_sqr_complex_fft_cutoff = 4096;
 
+    flint_mpn_mul_complex_fft_cutoff = save_mul_cutoff;
+    flint_mpn_sqr_complex_fft_cutoff = save_sqr_cutoff;
     TEST_FUNCTION_END(state);
 }

--- a/src/mpn_extras/test/t-mul_complex.c
+++ b/src/mpn_extras/test/t-mul_complex.c
@@ -1,0 +1,287 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "fmpz.h"
+#include "mpn_extras.h"
+
+static void
+_set_signed(fmpz_t f, nn_srcptr a, slong n, int s)
+{
+    /* a returned length may legitimately be zero: ar = ai with equal
+       signs makes the real part of a square vanish */
+    if (n <= 0)
+    {
+        fmpz_zero(f);
+        return;
+    }
+
+    fmpz_set_ui_array(f, a, n);
+    if (s)
+        fmpz_neg(f, f);
+}
+
+/* the high variants return limbs [n, 2n] of the exact result, with at
+   most four units of error in the lowest returned limb (each high
+   product is exact or one unit low, and the discarded low halves can
+   carry); returns 0 on success, 1 if the magnitude is off, 2 if the
+   sign is wrong */
+static int
+_check_high(const fmpz_t ref, nn_srcptr z, slong n, int sgn, slong nn)
+{
+    fmpz_t want, got, diff;
+    int res = 0;
+
+    fmpz_init(want);
+    fmpz_init(got);
+    fmpz_init(diff);
+
+    fmpz_abs(want, ref);
+    fmpz_fdiv_q_2exp(want, want, FLINT_BITS * nn);
+    fmpz_set_ui_array(got, z, n);
+    fmpz_sub(diff, got, want);
+    fmpz_abs(diff, diff);
+
+    if (fmpz_cmp_ui(diff, 4) > 0)
+        res = 1;
+    else if (!fmpz_is_zero(want) && !fmpz_is_zero(got) &&
+                sgn != (fmpz_sgn(ref) < 0))
+        res = 2;
+
+    fmpz_clear(want);
+    fmpz_clear(got);
+    fmpz_clear(diff);
+
+    return res;
+}
+
+/* Complex multiplication of limb arrays with separate sign bits, on both
+   the classical and the transformed (fft_small) paths: sizes straddle
+   the internal cutoff, and zero components exercise the canonical zero. */
+TEST_FUNCTION_START(flint_mpn_mul_complex, state)
+{
+    for (slong iter = 0; iter < 40 * flint_test_multiplier(); iter++)
+    {
+        /* the transformed path is off by default, so drive it explicitly
+           on some iterations; sizes straddle the Karatsuba threshold */
+        int fftpath = (iter % 4 == 0);
+        slong n = fftpath ? 1024 + n_randint(state, 300)
+                          : 1 + n_randint(state, 200);
+        slong arn, ain, brn, bin, wfull, wsqr;
+        int cancel_a, cancel_b;
+
+        flint_mpn_mul_complex_fft_cutoff = fftpath ? 1 : WORD_MAX;
+        flint_mpn_sqr_complex_fft_cutoff = fftpath ? 1 : WORD_MAX;
+
+        /* the transformed conversions thread from a size threshold */
+        flint_set_num_threads(1 + n_randint(state, 4));
+
+        /* independent part lengths; every third iteration is
+           deliberately lopsided so the schoolbook selection is covered
+           alongside the Karatsuba and transformed ones */
+        arn = n; ain = n; brn = n; bin = n;
+        if (iter % 3 == 0)
+        {
+            arn = 1 + n_randint(state, n);
+            ain = 1 + n_randint(state, n);
+            brn = 1 + n_randint(state, n);
+            bin = 1 + n_randint(state, n);
+        }
+
+        /* sometimes make the Karatsuba auxiliary sums cancel: with
+           ai = ar and opposite signs, ar + ai collapses, which shrinks
+           the intermediate lengths -- where a width taken from the wrong
+           buffer shows up. Decided here, before the output widths are
+           computed from the lengths. */
+        cancel_a = (n_randint(state, 5) == 0);
+        cancel_b = (n_randint(state, 5) == 0);
+        if (cancel_a)
+            arn = ain = n;
+        if (cancel_b)
+            brn = bin = n;
+        nn_ptr ar, ai, br, bi, zr, zi, hr, hi;
+        fmpz_t fa, fb, fc, fd, refr, refi, got;
+        int sar, sai, sbr, sbi, shr, shi;
+        slong lzr, lzi;
+        slong j;
+
+        ar = flint_malloc(n * sizeof(ulong));
+        ai = flint_malloc(n * sizeof(ulong));
+        br = flint_malloc(n * sizeof(ulong));
+        bi = flint_malloc(n * sizeof(ulong));
+        wfull = FLINT_MAX(arn, ain) + FLINT_MAX(brn, bin) + 1;
+        wsqr = 2 * FLINT_MAX(arn, ain) + 1;
+        zr = flint_malloc(FLINT_MAX(wfull, wsqr) * sizeof(ulong));
+        zi = flint_malloc(FLINT_MAX(wfull, wsqr) * sizeof(ulong));
+        hr = flint_malloc((n + 1) * sizeof(ulong));
+        hi = flint_malloc((n + 1) * sizeof(ulong));
+
+        for (j = 0; j < n; j++)
+        {
+            ar[j] = n_randlimb(state);
+            ai[j] = n_randlimb(state);
+            br[j] = n_randlimb(state);
+            bi[j] = n_randlimb(state);
+        }
+
+        if (cancel_a)
+            flint_mpn_copyi(ai, ar, n);
+        if (cancel_b)
+            flint_mpn_copyi(bi, br, n);
+
+        /* zero components must not disturb the signs */
+        if (n_randint(state, 6) == 0)
+            flint_mpn_zero(ai, n);
+        if (n_randint(state, 6) == 0)
+            flint_mpn_zero(br, n);
+
+        sar = n_randint(state, 2);
+        sai = n_randint(state, 2);
+        sbr = n_randint(state, 2);
+        sbi = n_randint(state, 2);
+
+        fmpz_init(fa);
+        fmpz_init(fb);
+        fmpz_init(fc);
+        fmpz_init(fd);
+        fmpz_init(refr);
+        fmpz_init(refi);
+        fmpz_init(got);
+
+        _set_signed(fa, ar, arn, sar);
+        _set_signed(fb, ai, ain, sai);
+        _set_signed(fc, br, brn, sbr);
+        _set_signed(fd, bi, bin, sbi);
+
+        /* (ar + i ai)(br + i bi) */
+        fmpz_mul(refr, fa, fc);
+        fmpz_submul(refr, fb, fd);
+        fmpz_mul(refi, fa, fd);
+        fmpz_addmul(refi, fb, fc);
+
+        /* exercise the three public methods directly as well as the
+           dispatcher, whatever the shape */
+        if (iter % 4 == 1)
+            flint_mpn_mul_complex_classical(zr, &lzr, zi, &lzi, ar, arn, sar,
+                    ai, ain, sai, br, brn, sbr, bi, bin, sbi);
+        else if (iter % 4 == 2)
+            flint_mpn_mul_complex_karatsuba(zr, &lzr, zi, &lzi, ar, arn, sar,
+                    ai, ain, sai, br, brn, sbr, bi, bin, sbi);
+        else if (iter % 4 == 3 &&
+                 flint_mpn_mul_complex_fft_small(zr, &lzr, zi, &lzi, ar, arn,
+                     sar, ai, ain, sai, br, brn, sbr, bi, bin, sbi))
+            ;
+        else
+            flint_mpn_mul_complex(zr, &lzr, zi, &lzi, ar, arn, sar, ai, ain,
+                                  sai, br, brn, sbr, bi, bin, sbi);
+
+        if (FLINT_ABS(lzr) > wfull || FLINT_ABS(lzi) > wfull)
+            TEST_FUNCTION_FAIL("mul: returned length exceeds the documented "
+                               "capacity (%wd, %wd against %wd)\n",
+                               lzr, lzi, wfull);
+        if ((lzr != 0 && zr[FLINT_ABS(lzr) - 1] == 0) ||
+            (lzi != 0 && zi[FLINT_ABS(lzi) - 1] == 0))
+            TEST_FUNCTION_FAIL("mul: returned length not normalized\n");
+
+        _set_signed(got, zr, FLINT_ABS(lzr), lzr < 0);
+        if (!fmpz_equal(got, refr))
+            TEST_FUNCTION_FAIL("mul: real part wrong (arn = %wd, ain = %wd, "
+                               "brn = %wd, bin = %wd)\n", arn, ain, brn, bin);
+        _set_signed(got, zi, FLINT_ABS(lzi), lzi < 0);
+        if (!fmpz_equal(got, refi))
+            TEST_FUNCTION_FAIL("mul: imaginary part wrong (arn = %wd, "
+                               "ain = %wd, brn = %wd, bin = %wd)\n",
+                               arn, ain, brn, bin);
+
+        /* the high variants take one length for all four parts */
+        _set_signed(fa, ar, n, sar);
+        _set_signed(fb, ai, n, sai);
+        _set_signed(fc, br, n, sbr);
+        _set_signed(fd, bi, n, sbi);
+        fmpz_mul(refr, fa, fc);
+        fmpz_submul(refr, fb, fd);
+        fmpz_mul(refi, fa, fd);
+        fmpz_addmul(refi, fb, fc);
+
+        flint_mpn_mulhigh_n_complex(hr, &shr, hi, &shi, ar, sar, ai, sai,
+                                    br, sbr, bi, sbi, n);
+        if (_check_high(refr, hr, n + 1, shr, n))
+            TEST_FUNCTION_FAIL("mulhigh: real part wrong (n = %wd)\n", n);
+        if (_check_high(refi, hi, n + 1, shi, n))
+            TEST_FUNCTION_FAIL("mulhigh: imaginary part wrong (n = %wd)\n", n);
+
+        /* (ar + i ai)^2, per-part lengths */
+        _set_signed(fa, ar, arn, sar);
+        _set_signed(fb, ai, ain, sai);
+        fmpz_mul(refr, fa, fa);
+        fmpz_submul(refr, fb, fb);
+        fmpz_mul(refi, fa, fb);
+        fmpz_mul_2exp(refi, refi, 1);
+
+        if (iter % 4 == 1)
+            flint_mpn_sqr_complex_classical(zr, &lzr, zi, &lzi,
+                    ar, arn, sar, ai, ain, sai);
+        else if (iter % 4 == 2)
+            flint_mpn_sqr_complex_karatsuba(zr, &lzr, zi, &lzi,
+                    ar, arn, sar, ai, ain, sai);
+        else if (iter % 4 == 3 &&
+                 flint_mpn_sqr_complex_fft_small(zr, &lzr, zi, &lzi,
+                     ar, arn, sar, ai, ain, sai))
+            ;
+        else
+            flint_mpn_sqr_complex(zr, &lzr, zi, &lzi, ar, arn, sar,
+                                  ai, ain, sai);
+
+        _set_signed(got, zr, FLINT_ABS(lzr), lzr < 0);
+        if (!fmpz_equal(got, refr))
+            TEST_FUNCTION_FAIL("sqr: real part wrong (arn = %wd, ain = %wd)\n",
+                               arn, ain);
+        _set_signed(got, zi, FLINT_ABS(lzi), lzi < 0);
+        if (!fmpz_equal(got, refi))
+            TEST_FUNCTION_FAIL("sqr: imaginary part wrong (arn = %wd, "
+                               "ain = %wd)\n", arn, ain);
+
+        /* the high square again takes one length */
+        _set_signed(fa, ar, n, sar);
+        _set_signed(fb, ai, n, sai);
+        fmpz_mul(refr, fa, fa);
+        fmpz_submul(refr, fb, fb);
+        fmpz_mul(refi, fa, fb);
+        fmpz_mul_2exp(refi, refi, 1);
+
+        flint_mpn_sqrhigh_n_complex(hr, &shr, hi, &shi, ar, sar, ai, sai, n);
+        if (_check_high(refr, hr, n + 1, shr, n))
+            TEST_FUNCTION_FAIL("sqrhigh: real part wrong (n = %wd)\n", n);
+        if (_check_high(refi, hi, n + 1, shi, n))
+            TEST_FUNCTION_FAIL("sqrhigh: imaginary part wrong (n = %wd)\n", n);
+
+        flint_free(ar);
+        flint_free(ai);
+        flint_free(br);
+        flint_free(bi);
+        flint_free(zr);
+        flint_free(zi);
+        flint_free(hr);
+        flint_free(hi);
+        fmpz_clear(fa);
+        fmpz_clear(fb);
+        fmpz_clear(fc);
+        fmpz_clear(fd);
+        fmpz_clear(refr);
+        fmpz_clear(refi);
+        fmpz_clear(got);
+    }
+
+    flint_mpn_mul_complex_fft_cutoff = 1024;
+    flint_mpn_sqr_complex_fft_cutoff = 4096;
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/mpn_extras/test/t-mul_complex.c
+++ b/src/mpn_extras/test/t-mul_complex.c
@@ -29,13 +29,21 @@ _set_signed(fmpz_t f, nn_srcptr a, slong n, int s)
         fmpz_neg(f, f);
 }
 
-/* the high variants return limbs [n, 2n] of the exact result, with at
-   most four units of error in the lowest returned limb (each high
-   product is exact or one unit low, and the discarded low halves can
-   carry); returns 0 on success, 1 if the magnitude is off, 2 if the
-   sign is wrong */
+/* Error bound of the high variants, measured against the exact value:
+   one flint_mpn_mulhigh_n read as n limbs errs by (-1 - eps, +eps) ulp
+   of its lowest limb, eps = (n + 4)/2^64 -- the floor drop of its
+   returned limb is one-sided in [0, 1) and the documented n + 2 ulp of
+   that limb contributes eps either way. Composing: two products per
+   output classically gives |error| < 2 + 2 eps; the Karatsuba mulhigh
+   combination c3 - (c1 + c2) gives < 2 + 3 eps; the transformed path
+   errs within (-1.5, +0.5). Since the outputs are integers they differ
+   from the floor of the exact value by at most 3 in the lowest returned
+   limb, which is what is asserted here (observed worst case: 2).
+   Returns 0 on success, 1 if the magnitude is off by more than tol,
+   2 if the sign is wrong. */
 static int
-_check_high(const fmpz_t ref, nn_srcptr z, slong n, int sgn, slong nn)
+_check_high(const fmpz_t ref, nn_srcptr z, slong n, int sgn, slong nn,
+            slong tol)
 {
     fmpz_t want, got, diff;
     int res = 0;
@@ -50,7 +58,7 @@ _check_high(const fmpz_t ref, nn_srcptr z, slong n, int sgn, slong nn)
     fmpz_sub(diff, got, want);
     fmpz_abs(diff, diff);
 
-    if (fmpz_cmp_ui(diff, 4) > 0)
+    if (fmpz_cmp_ui(diff, tol) > 0)
         res = 1;
     else if (!fmpz_is_zero(want) && !fmpz_is_zero(got) &&
                 sgn != (fmpz_sgn(ref) < 0))
@@ -213,9 +221,9 @@ TEST_FUNCTION_START(flint_mpn_mul_complex, state)
 
         flint_mpn_mulhigh_n_complex(hr, &shr, hi, &shi, ar, sar, ai, sai,
                                     br, sbr, bi, sbi, n);
-        if (_check_high(refr, hr, n + 1, shr, n))
+        if (_check_high(refr, hr, n + 1, shr, n, 3))
             TEST_FUNCTION_FAIL("mulhigh: real part wrong (n = %wd)\n", n);
-        if (_check_high(refi, hi, n + 1, shi, n))
+        if (_check_high(refi, hi, n + 1, shi, n, 3))
             TEST_FUNCTION_FAIL("mulhigh: imaginary part wrong (n = %wd)\n", n);
 
         /* (ar + i ai)^2, per-part lengths */
@@ -258,9 +266,9 @@ TEST_FUNCTION_START(flint_mpn_mul_complex, state)
         fmpz_mul_2exp(refi, refi, 1);
 
         flint_mpn_sqrhigh_n_complex(hr, &shr, hi, &shi, ar, sar, ai, sai, n);
-        if (_check_high(refr, hr, n + 1, shr, n))
+        if (_check_high(refr, hr, n + 1, shr, n, 3))
             TEST_FUNCTION_FAIL("sqrhigh: real part wrong (n = %wd)\n", n);
-        if (_check_high(refi, hi, n + 1, shi, n))
+        if (_check_high(refi, hi, n + 1, shi, n, 3))
             TEST_FUNCTION_FAIL("sqrhigh: imaginary part wrong (n = %wd)\n", n);
 
         flint_free(ar);

--- a/src/mpn_mod.h
+++ b/src/mpn_mod.h
@@ -251,6 +251,19 @@ int _mpn_mod_poly_div(nn_ptr Q, nn_srcptr A, slong lenA, nn_srcptr B, slong lenB
 int _mpn_mod_poly_gcd(nn_ptr G, slong * lenG, nn_srcptr A, slong lenA, nn_srcptr B, slong lenB, gr_ctx_t ctx);
 int _mpn_mod_poly_xgcd(slong * lenG, nn_ptr G, nn_ptr S, nn_ptr T, nn_srcptr A, slong lenA, nn_srcptr B, slong lenB, gr_ctx_t ctx);
 
+#if FLINT_HAVE_FFT_SMALL
+#include "fft_small.h"
+/* transformed polynomial representation support */
+void fft_small_fft_mpn_mod(fft_small_op_t X, nn_srcptr a,
+        ulong an, ulong itrunc, gr_ctx_t ctx, const fft_small_plan_t P);
+void fft_small_export_mpn_mod_range(nn_ptr z, const fft_small_op_t X,
+        ulong zl, ulong zh, gr_ctx_t ctx, const fft_small_plan_t P);
+#endif
+
+int _gr_mpn_mod_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base,
+        slong len_bound, slong terms_bound,
+        const struct gr_transformed_poly_workload_struct * workload);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/mpn_mod.h
+++ b/src/mpn_mod.h
@@ -260,6 +260,7 @@ void fft_small_export_mpn_mod_range(nn_ptr z, const fft_small_op_t X,
         ulong zl, ulong zh, gr_ctx_t ctx, const fft_small_plan_t P);
 #endif
 
+struct gr_transformed_poly_workload_struct;
 int _gr_mpn_mod_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base,
         slong len_bound, slong terms_bound,
         const struct gr_transformed_poly_workload_struct * workload);

--- a/src/mpn_mod/ctx.c
+++ b/src/mpn_mod/ctx.c
@@ -130,7 +130,7 @@ gr_method_tab_input _mpn_mod_methods_input[] =
 
     {GR_METHOD_POLY_MULLOW,     (gr_funcptr) _mpn_mod_poly_mullow},
     {GR_METHOD_CTX_INIT_TRANSFORMED_POLY_REPR,
-                                (gr_funcptr) _gr_mpn_mod_ctx_init_transformed_poly_repr},
+                                (gr_funcptr) (void (*)(void)) _gr_mpn_mod_ctx_init_transformed_poly_repr},
     {GR_METHOD_POLY_MULMID,     (gr_funcptr) _mpn_mod_poly_mulmid},
     {GR_METHOD_POLY_INV_SERIES, (gr_funcptr) _mpn_mod_poly_inv_series},
     {GR_METHOD_POLY_DIV_SERIES, (gr_funcptr) _mpn_mod_poly_div_series},

--- a/src/mpn_mod/ctx.c
+++ b/src/mpn_mod/ctx.c
@@ -129,6 +129,8 @@ gr_method_tab_input _mpn_mod_methods_input[] =
     {GR_METHOD_VEC_DOT_STRIDED, (gr_funcptr) _mpn_mod_vec_dot_strided},
 
     {GR_METHOD_POLY_MULLOW,     (gr_funcptr) _mpn_mod_poly_mullow},
+    {GR_METHOD_CTX_INIT_TRANSFORMED_POLY_REPR,
+                                (gr_funcptr) _gr_mpn_mod_ctx_init_transformed_poly_repr},
     {GR_METHOD_POLY_MULMID,     (gr_funcptr) _mpn_mod_poly_mulmid},
     {GR_METHOD_POLY_INV_SERIES, (gr_funcptr) _mpn_mod_poly_inv_series},
     {GR_METHOD_POLY_DIV_SERIES, (gr_funcptr) _mpn_mod_poly_div_series},

--- a/src/mpn_mod/poly_mullow_fft_small.c
+++ b/src/mpn_mod/poly_mullow_fft_small.c
@@ -163,6 +163,103 @@ static void _crt_1(
 }
 
 
+/* standalone forward transform of a coefficient vector into an operand,
+   for the transformed polynomial representation */
+void fft_small_fft_mpn_mod(fft_small_op_t X, nn_srcptr a, ulong an,
+                    ulong itrunc, gr_ctx_t ctx, const fft_small_plan_t P)
+{
+    slong nlimbs = MPN_MOD_CTX_NLIMBS(ctx);
+    ulong i;
+
+    FLINT_ASSERT(itrunc <= P->ztrunc);
+
+    for (i = 0; i < P->np; i++)
+    {
+        sd_fft_ctx_struct * Q = P->ffts + P->offset + i;
+        double * d = X->data + P->stride * i;
+
+        _mod(d, itrunc, a, an, nlimbs, Q);
+        sd_fft_trunc(Q, d, P->depth, itrunc, P->ztrunc);
+    }
+
+    X->itrunc = itrunc;
+    X->domain = FFT_SMALL_OP_PRIMAL;
+}
+
+/* chinese remaindering of an inverse-transformed operand restricted to the
+   window [zl, zh) inside [P->zl, P->zh); z receives zh - zl coefficients */
+
+static fft_small_crt_func _mpn_mod_crt_fn(ulong np);
+
+typedef struct {
+    nn_ptr z;
+    const fft_small_op_struct * X;
+    _conv_params_struct * par;
+    const fft_small_plan_struct * P;
+    fft_small_crt_func crt_fn;
+    ulong start_zi;
+    ulong stop_zi;
+} _op_export_mpn_mod_worker_struct;
+
+static void _op_export_mpn_mod_worker_func(void * varg)
+{
+    _op_export_mpn_mod_worker_struct * W =
+        (_op_export_mpn_mod_worker_struct *) varg;
+    const fft_small_plan_struct * P = W->P;
+
+    W->crt_fn((void *) W->z, P->zl, W->start_zi, W->stop_zi,
+              P->ffts + P->offset, W->X->data, P->stride,
+              P->crts + P->offset, P->bound_c, NULL, W->par);
+}
+
+void fft_small_export_mpn_mod_range(nn_ptr z, const fft_small_op_t X,
+                    ulong zl, ulong zh, gr_ctx_t ctx, const fft_small_plan_t P)
+{
+    slong nlimbs = MPN_MOD_CTX_NLIMBS(ctx);
+    ulong i, o;
+    thread_pool_handle * handles = NULL;
+    slong nworkers = 0;
+    ulong nthreads;
+    _conv_params_struct par;
+    _op_export_mpn_mod_worker_struct args[8];
+
+    FLINT_ASSERT(P->zl <= zl && zh <= P->zh);
+
+    if (zl >= zh)
+        return;
+
+    par.nlimbs = nlimbs;
+    par.ctx = ctx;
+
+    if (P->np * (zh - zl) > 10000)
+        nworkers = flint_request_threads(&handles, 8);
+    nthreads = nworkers + 1;
+
+    o = zl;
+    for (i = 0; i < nthreads; i++)
+    {
+        _op_export_mpn_mod_worker_struct * W = args + i;
+        W->z = z - (zl - P->zl) * nlimbs;   /* worker offsets by P->zl */
+        W->X = X;
+        W->par = &par;
+        W->P = P;
+        W->crt_fn = _mpn_mod_crt_fn(P->np);
+        W->start_zi = o;
+        ulong newo = n_round_down(zl + (i + 1) * (zh - zl) / nthreads, BLK_SZ);
+        o = i + 1 < nthreads ? FLINT_MAX(o, newo) : zh;
+        W->stop_zi = o;
+    }
+
+    for (i = nworkers; i > 0; i--)
+        thread_pool_wake(global_thread_pool, handles[i - 1], 0,
+                         _op_export_mpn_mod_worker_func, args + i);
+    _op_export_mpn_mod_worker_func(args + 0);
+    for (i = nworkers; i > 0; i--)
+        thread_pool_wait(global_thread_pool, handles[i - 1]);
+
+    flint_give_back_threads(handles, nworkers);
+}
+
 /* ------------------------------------------------------------------------ */
 /* glue for the generic convolution engine                                  */
 /* ------------------------------------------------------------------------ */

--- a/src/mpn_mod/poly_mullow_fft_small.c
+++ b/src/mpn_mod/poly_mullow_fft_small.c
@@ -120,70 +120,38 @@ static void _mod(
         abuf[i] = 0;
 }
 
-#define DEFINE_IT(NP, N, M) \
-static void CAT(_crt, NP)( \
-    nn_ptr z, ulong zl, ulong zi_start, ulong zi_stop, \
-    sd_fft_ctx_struct* Rffts, double* d, ulong dstride, \
-    crt_data_struct* Rcrts, slong nlimbs, gr_ctx_t ctx) \
-{ \
-    ulong np = NP; \
-    ulong n = N; \
-    ulong m = M; \
- \
-    FLINT_ASSERT(n == Rcrts[np-1].coeff_len); \
-    FLINT_ASSERT(1 <= N && N <= 7); \
- \
-    if (n == m + 1) \
-    { \
-        for (ulong l = 0; l < np; l++) { \
-            FLINT_ASSERT(crt_data_co_prime(Rcrts + np - 1, l)[m] == 0); \
-        } \
-    } \
-    else \
-    { \
-        FLINT_ASSERT(n == m); \
-    } \
- \
-    ulong Mhalf[N]; \
-    mpn_rshift(Mhalf, crt_data_prod_primes(Rcrts + np - 1), N, 1); \
- \
-    ulong Xs[BLK_SZ*NP]; \
- \
-    for (ulong i = n_round_down(zi_start, BLK_SZ); i < zi_stop; i += BLK_SZ) \
-    { \
-        _convert_block(Xs, Rffts, d, dstride, np, i/BLK_SZ); \
- \
-        ulong jstart = (i < zi_start) ? zi_start - i : 0; \
-        ulong jstop = FLINT_MIN(BLK_SZ, zi_stop - i); \
-        for (ulong j = jstart; j < jstop; j += 1) \
-        { \
-            ulong r[N]; \
-            ulong t[N]; \
-            ulong l = 0; \
-            ulong nn; \
- \
-            CAT3(_big_mul, N, M)(r, t, _crt_data_co_prime(Rcrts + np - 1, l, n), Xs[l*BLK_SZ + j]); \
-            for (l++; l < np; l++) \
-                CAT3(_big_addmul, N, M)(r, t, _crt_data_co_prime(Rcrts + np - 1, l, n), Xs[l*BLK_SZ + j]); \
- \
-            CAT(_reduce_big_sum, N)(r, t, crt_data_prod_primes(Rcrts + np - 1)); \
- \
-            FLINT_ASSERT(mpn_cmp(r, Mhalf, N) <= 0); /* coefficients must be unsigned */ \
-            nn = N; \
-            MPN_NORM(r, nn); \
-            mpn_mod_set_mpn(z + (i + j - zl) * nlimbs, r, nn, ctx); \
-        } \
-    } \
-}
+typedef struct {
+    slong nlimbs;
+    gr_ctx_struct * ctx;
+} _conv_params_struct;
 
-DEFINE_IT(2, 2, 1)  /* 100 bits (unused) */
-DEFINE_IT(3, 3, 2)  /* 150 bits */
-DEFINE_IT(4, 4, 3)  /* 200 bits */
-DEFINE_IT(5, 4, 4)  /* 250 bits */
-DEFINE_IT(6, 5, 4)  /* 300 bits */
-DEFINE_IT(7, 6, 5)  /* 350 bits */
-DEFINE_IT(8, 7, 6)  /* 400 bits */
-#undef DEFINE_IT
+#define CRT_FN(NP) CAT3(_crt, NP, fn)
+#define CRT_Z_TYPE nn_ptr
+#define CRT_HEAD \
+    const _conv_params_struct* par = (const _conv_params_struct*) params; \
+    slong nlimbs = par->nlimbs;
+#define CRT_EMIT(zi, r, NP, N, M) \
+    { \
+        ulong nn; \
+        FLINT_ASSERT(mpn_cmp(r, Mhalf, N) <= 0); /* coefficients must be unsigned */ \
+        nn = N; \
+        MPN_NORM(r, nn); \
+        mpn_mod_set_mpn(z + (zi) * nlimbs, r, nn, par->ctx); \
+    }
+#define CRT_TAIL
+CRT_DEFINE(2, 2, 1)  /* 100 bits (unused) */
+CRT_DEFINE(3, 3, 2)  /* 150 bits */
+CRT_DEFINE(4, 4, 3)  /* 200 bits */
+CRT_DEFINE(5, 4, 4)  /* 250 bits */
+CRT_DEFINE(6, 5, 4)  /* 300 bits */
+CRT_DEFINE(7, 6, 5)  /* 350 bits */
+CRT_DEFINE(8, 7, 6)  /* 400 bits */
+#undef CRT_FN
+#undef CRT_Z_TYPE
+#undef CRT_HEAD
+#undef CRT_EMIT
+#undef CRT_TAIL
+#undef CRT_DEFINE
 
 /* 50 bits (unused) */
 static void _crt_1(
@@ -194,122 +162,69 @@ static void _crt_1(
     flint_abort();
 }
 
-typedef struct {
-    ulong np;
-    ulong start_pi;
-    ulong stop_pi;
-    ulong offset;
-    double* abuf;
-    double* bbuf;
-    ulong depth;
-    ulong stride;
-    ulong atrunc;
-    ulong btrunc;
-    ulong ztrunc;
-    nn_srcptr a;
-    ulong an;
-    nn_srcptr b;
-    ulong bn;
-    slong nlimbs;
-    gr_ctx_struct * mpn_mod_ctx;
-    sd_fft_ctx_struct* ffts;
-    crt_data_struct* crts;
-    ulong ioff;
-    int squaring;
-    int want_worker;
-} s1worker_struct;
 
+/* ------------------------------------------------------------------------ */
+/* glue for the generic convolution engine                                  */
+/* ------------------------------------------------------------------------ */
 
-static void extra_func(void* varg)
+static void _mod_fn(double* xbuf, ulong xtrunc,
+    const void* x, ulong xn, slong FLINT_UNUSED(xaux),
+    const sd_fft_ctx_struct* fft, const void* params)
 {
-    s1worker_struct* X = (s1worker_struct*) varg;
-    sd_fft_ctx_struct* Q = X->ffts + X->ioff;
+    const _conv_params_struct* par = (const _conv_params_struct*) params;
 
-    _mod(X->bbuf, X->btrunc, X->b, X->bn, X->nlimbs, X->ffts + X->ioff);
-    sd_fft_trunc(Q, X->bbuf, X->depth, X->btrunc, X->ztrunc);
+    _mod(xbuf, xtrunc, (nn_srcptr) x, xn, par->nlimbs, fft);
 }
 
-static void s1worker_func(void* varg)
+#define DEFINE_IT(NP) \
+static void CAT3(_crt, NP, fn)(void* z, ulong zl, \
+    ulong zi_start, ulong zi_stop, \
+    sd_fft_ctx_struct* Rffts, double* d, ulong dstride, \
+    crt_data_struct* Rcrts, ulong FLINT_UNUSED(min_an_bn), \
+    ulong* FLINT_UNUSED(local), const void* params) \
+{ \
+    const _conv_params_struct* par = (const _conv_params_struct*) params; \
+ \
+    CAT(_crt, NP)((nn_ptr) z, zl, zi_start, zi_stop, Rffts, d, dstride, \
+                  Rcrts, par->nlimbs, par->ctx); \
+}
+DEFINE_IT(1)
+#undef DEFINE_IT
+
+static fft_small_crt_func _mpn_mod_crt_fn(ulong np)
 {
-    s1worker_struct* X = (s1worker_struct*) varg;
-    ulong i, m;
-    thread_pool_handle* handles = NULL;
-    slong nworkers = 0;
-
-    if (X->want_worker)
-        nworkers = flint_request_threads(&handles, 2);
-
-    for (i = X->start_pi; i < X->stop_pi; i++)
-    {
-        ulong ioff = i + X->offset;
-        double* abuf = X->abuf + X->stride*i;
-        double* bbuf = X->bbuf;
-        sd_fft_ctx_struct* Q = X->ffts + ioff;
-
-        if (!X->squaring)
-        {
-            if (nworkers > 0)
-            {
-                X->ioff = ioff;
-                thread_pool_wake(global_thread_pool, handles[0], 0, extra_func, X);
-            }
-            else
-            {
-                _mod(bbuf, X->btrunc, X->b, X->bn, X->nlimbs, Q);
-                sd_fft_trunc(Q, bbuf, X->depth, X->btrunc, X->ztrunc);
-            }
-        }
-
-        _mod(abuf, X->atrunc, X->a, X->an, X->nlimbs, Q);
-        sd_fft_trunc(Q, abuf, X->depth, X->atrunc, X->ztrunc);
-
-        if (!X->squaring)
-        {
-            if (nworkers > 0)
-                thread_pool_wait(global_thread_pool, handles[0]);
-        }
-
-        ulong cop = X->np == 1 ? 1 : *crt_data_co_prime_red(X->crts + X->np - 1, ioff);
-        NMOD_RED2(m, cop >> (FLINT_BITS - X->depth), cop << X->depth, Q->mod);
-        m = nmod_inv(m, Q->mod);
-
-        if (X->squaring)
-            sd_fft_ctx_point_sqr(Q, abuf, m, X->depth);
-        else
-            sd_fft_ctx_point_mul(Q, abuf, bbuf, m, X->depth);
-
-        sd_ifft_trunc(Q, abuf, X->depth, X->ztrunc);
-    }
-
-    flint_give_back_threads(handles, nworkers);
+    return np == 1 ? _crt_1_fn :
+           np == 2 ? _crt_2_fn :
+           np == 3 ? _crt_3_fn :
+           np == 4 ? _crt_4_fn :
+           np == 5 ? _crt_5_fn :
+           np == 6 ? _crt_6_fn :
+           np == 7 ? _crt_7_fn :
+                     _crt_8_fn;
 }
 
-typedef struct {
-    nn_ptr z;
-    ulong zl;
-    ulong start_zi;
-    ulong stop_zi;
-    double* buf;
-    ulong offset;
-    ulong stride;
-    sd_fft_ctx_struct* ffts;
-    crt_data_struct* crts;
-    nmod_t mod;
-    slong nlimbs;
-    gr_ctx_struct * mpn_mod_ctx;
-    void (*f)(
-        nn_ptr z, ulong zl, ulong zi_start, ulong zi_stop,
-        sd_fft_ctx_struct* Rffts, double* d, ulong dstride,
-        crt_data_struct* Rcrts, slong nlimbs, gr_ctx_t ctx);
-} s2worker_struct;
-
-static void s2worker_func(void* varg)
+/* currently the same thresholds as the fmpz driver, but kept separate so
+   that they can be tuned independently (the per-coefficient conversions
+   here are more expensive) */
+static ulong _mpn_mod_conv_s1_threads(ulong np, ulong tune_n)
 {
-    s2worker_struct* X = (s2worker_struct*) varg;
-
-    X->f(X->z, X->zl, X->start_zi, X->stop_zi, X->ffts + X->offset, X->buf,
-         X->stride, X->crts + X->offset, X->nlimbs, X->mpn_mod_ctx);
+    return ((np >= 2 && tune_n >= 1000) || (np >= 4 && tune_n >= 300)) ? np : 1;
 }
+
+static int _mpn_mod_conv_s1_b_worker(ulong np, ulong tune_n, int squaring)
+{
+    return !squaring && ((np == 1 && tune_n > 5000) ||
+                         (np >= 2 && tune_n >= 1000));
+}
+
+static int _mpn_mod_conv_s2_rethread(ulong np, ulong zn)
+{
+    return zn > 50000 || (np >= 2 && zn > 20000) || (np >= 4 && zn > 800);
+}
+
+static const fft_small_conv_tuning _mpn_mod_conv_tuning =
+    { _mpn_mod_conv_s1_threads, _mpn_mod_conv_s1_b_worker,
+      _mpn_mod_conv_s2_rethread };
 
 static int _mpn_mod_poly_mulmid_fft_small_internal(nn_ptr z, ulong zl, ulong zh,
     nn_srcptr a, ulong an,
@@ -317,16 +232,15 @@ static int _mpn_mod_poly_mulmid_fft_small_internal(nn_ptr z, ulong zl, ulong zh,
     mpn_ctx_t R, gr_ctx_t ctx)
 {
     ulong modbits;
-    ulong offset = 0;
     ulong zn = an + bn - 1;
-    ulong atrunc, btrunc, ztrunc;
-    ulong i, np, depth, stride;
-    double* buf;
+    ulong atrunc, btrunc;
     int squaring;
     slong bits1, bits2;
-    int sign = 0;
     slong nlimbs = MPN_MOD_CTX_NLIMBS(ctx);
     flint_bitcnt_t nbits = MPN_MOD_CTX_MODULUS_BITS(ctx);
+    fft_small_plan_t P;
+    fft_small_conv_arg_struct A;
+    _conv_params_struct par;
 
     FLINT_ASSERT(an > 0);
     FLINT_ASSERT(bn > 0);
@@ -351,7 +265,6 @@ static int _mpn_mod_poly_mulmid_fft_small_internal(nn_ptr z, ulong zl, ulong zh,
     /* TODO: consider counting bits, in case the inputs are small */
     bits1 = bits2 = nbits;
 
-    (void) sign;
     /* should be +sign instead of +1, but currently the CRT code doesn't
        distinguish between the signed and unsigned cases */
     modbits = FLINT_ABS(bits1) + FLINT_ABS(bits2) + 1;
@@ -359,138 +272,43 @@ static int _mpn_mod_poly_mulmid_fft_small_internal(nn_ptr z, ulong zl, ulong zh,
     FLINT_ASSERT(zl < zh);
     FLINT_ASSERT(zh <= zn);
 
-    /* need prod_of_primes >= blen * 2^modbits */
-    for (np = 1; ; np++)
-    {
-        if (np > MPN_CTX_NCRTS)
-            return GR_UNABLE;
-
-        if (flint_mpn_cmp_ui_2exp(crt_data_prod_primes(R->crts + np - 1),
-              R->crts[np - 1].coeff_len, bn, modbits) >= 0)
-        {
-            break;
-        }
-    }
-
-    FLINT_ASSERT(0 <= flint_mpn_cmp_ui_2exp(
-                                  crt_data_prod_primes(R->crts + np - 1),
-                                  R->crts[np - 1].coeff_len, bn, modbits));
-
     atrunc = n_round_up(an, BLK_SZ);
     btrunc = n_round_up(bn, BLK_SZ);
-    ztrunc = n_round_up(zn, BLK_SZ);
-    /*
-        if there is a power of two 2^d between zh and zn with good wrap around
-            i.e. max(an, bn, zh) <= 2^d <= zn with zn - 2^d <= zl
-        then use d as the depth, otherwise the usual with no wrap around
-    */
-    depth = n_flog2(zn);
-    i = n_pow2(depth);
-    if (atrunc <= i && btrunc <= i && zh <= i && i <= zn && zn <= zl + i)
-    {
-        ztrunc = i;
-    }
-    else
-    {
-        depth = n_max(LG_BLK_SZ, n_clog2(ztrunc));
-    }
 
-    stride = n_round_up(sd_fft_ctx_data_size(depth), 128);
+    P->R = R;
+    P->sign = 0;
 
-    ulong want_threads;
+    _fft_small_plan_set_window(P, zl, zh, zn, n_max(atrunc, btrunc));
 
-    if ((np >= 2 && bn >= 1000) || (np >= 4 && bn >= 300))
-        want_threads = np;
-    else
-        want_threads = 1;
+    /* need prod_of_primes >= bn * 2^modbits */
+    if (!_fft_small_plan_set_bound(P, bn, modbits, MPN_CTX_NCRTS))
+        return GR_UNABLE;
 
-    thread_pool_handle* handles;
-    slong nworkers = flint_request_threads(&handles, want_threads);
-    ulong nthreads = nworkers + 1;
+    _fft_small_plan_set_normalizers(P);
 
-    buf = (double*) mpn_ctx_fit_buffer(R, (np+nthreads)*stride*sizeof(double));
+    par.nlimbs = nlimbs;
+    par.ctx = ctx;
 
-    s1worker_struct s1args[8];
-    FLINT_ASSERT(nthreads <= 8);
-    for (i = 0; i < nthreads; i++)
-    {
-        s1worker_struct* X = s1args + i;
-        X->np = np;
-        X->start_pi = (i+0)*np/nthreads;
-        X->stop_pi  = (i+1)*np/nthreads;
-        X->offset = offset;
-        X->abuf = buf;
-        X->bbuf = buf + (np+i)*stride;
-        X->depth = depth;
-        X->stride = stride;
-        X->atrunc = atrunc;
-        X->btrunc = btrunc;
-        X->ztrunc = ztrunc;
-        X->a = a;
-        X->an = an;
-        X->b = b;
-        X->bn = bn;
-        X->nlimbs = nlimbs;
-        X->mpn_mod_ctx = ctx;
-        X->ffts = R->ffts;
-        X->crts = R->crts;
-        X->squaring = squaring;
-        X->want_worker = !squaring && ((np == 1 && bn > 5000) || (np >= 2 && bn >= 1000));
-    }
+    A.a = a; A.an = an; A.aaux = 0; A.atrunc = atrunc;
+    A.b = b; A.bn = bn; A.baux = 0; A.btrunc = btrunc;
+    A.bfft = NULL;
+    A.bfft_stride = 0;
+    A.squaring = squaring;
+    A.tune_n = bn;
+    A.min_an_bn = FLINT_MIN(an, bn);
+    A.mod_fn = _mod_fn;
+    A.s2_finish = NULL;
+    A.crt_fn = _mpn_mod_crt_fn(P->np);
+    A.params = &par;
+    A.tuning = &_mpn_mod_conv_tuning;
 
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wake(global_thread_pool, handles[i - 1], 0, s1worker_func, s1args + i);
-    s1worker_func(s1args + 0);
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wait(global_thread_pool, handles[i - 1]);
+    _fft_small_conv(z, P, &A);
 
-    if (zn > 50000 || (np >= 2 && zn > 20000) || (np >= 4 && zn > 800))
-    {
-        flint_give_back_threads(handles, nworkers);
-        nworkers = flint_request_threads(&handles, 8);
-        nthreads = nworkers + 1;
-    }
-
-    s2worker_struct s2args[8];
-    FLINT_ASSERT(nthreads <= 8);
-
-    ulong o = zl;
-    for (i = 0; i < nthreads; i++)
-    {
-        s2worker_struct* X = s2args + i;
-        X->z = z;
-        X->zl = zl;
-        X->start_zi = o;
-        ulong newo = n_round_down(zl + (i+1)*(zh-zl)/nthreads, BLK_SZ);
-        o = i+1 < nthreads ? FLINT_MAX(o, newo) : zh;
-        X->stop_zi = o;
-        X->buf = buf;
-        X->offset = offset;
-        X->stride = stride;
-        X->ffts = R->ffts;
-        X->crts = R->crts;
-        X->nlimbs = nlimbs;
-        X->mpn_mod_ctx = ctx;
-        X->f =  np == 1 ? _crt_1 :
-                np == 2 ? _crt_2 :
-                np == 3 ? _crt_3 :
-                np == 4 ? _crt_4 :
-                np == 5 ? _crt_5 :
-                np == 6 ? _crt_6 :
-                np == 7 ? _crt_7 :
-                          _crt_8;
-    }
-
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wake(global_thread_pool, handles[i - 1], 0, s2worker_func, s2args + i);
-    s2worker_func(s2args + 0);
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wait(global_thread_pool, handles[i - 1]);
-
-    flint_give_back_threads(handles, nworkers);
+    fft_small_plan_clear(P);
 
     return GR_SUCCESS;
 }
+
 
 int
 _mpn_mod_poly_mullow_fft_small(nn_ptr res, nn_srcptr poly1, slong len1, nn_srcptr poly2, slong len2, slong len, gr_ctx_t ctx)

--- a/src/mpn_mod/test/t-poly_mullow_fft_small.c
+++ b/src/mpn_mod/test/t-poly_mullow_fft_small.c
@@ -56,5 +56,161 @@ TEST_FUNCTION_START(mpn_mod_poly_mullow_fft_small, state)
         gr_ctx_clear(ctx);
     }
 
+    #if FLINT_HAVE_FFT_SMALL
+    /* ring compliance for the transformed mpn_mod polynomial contexts:
+       forced initialization so small unprofitable sizes -- where bugs
+       are easiest to catch -- are testable */
+    {
+        slong it, n_engaged = 0;
+        for (it = 0; it < 4; it++)
+        {
+            gr_ctx_t base, tctx;
+            fmpz_t m;
+            gr_transformed_poly_workload_t wl = {{ 0, 0, 0, 0, 0, 1 }};
+            slong nb, Nc;
+
+            /* the first attempt is deterministic and within the crt
+               capacity on any fft_small platform, so the engagement
+               assertion below cannot fail on unlucky draws: moduli
+               whose coefficient products exceed the prime set refuse
+               even when forced (a genuine implementation bound); the
+               last attempt deliberately reaches beyond it to keep the
+               refusal path exercised, without asserting refusal, since
+               a larger prime table may admit it */
+            if (it == 0)
+            { nb = 2 * FLINT_BITS - 3; Nc = 6; }
+            else if (it == 3)
+            { nb = 5 * FLINT_BITS; Nc = 4; }
+            else
+            { nb = FLINT_BITS * (2 + (slong) n_randint(state, 2));
+              Nc = 2 + (slong) n_randint(state, 24); }
+
+            fmpz_init(m);
+            fmpz_randprime(m, state, nb, 0);
+            if (gr_ctx_init_mpn_mod(base, m) == GR_SUCCESS)
+            {
+                if (_gr_mpn_mod_ctx_init_transformed_poly_repr(tctx, base,
+                        Nc, Nc, wl) == GR_SUCCESS)
+                {
+                    gr_test_ring(tctx, 15, 0);
+                    gr_ctx_clear(tctx);
+                    n_engaged++;
+                }
+                gr_ctx_clear(base);
+            }
+            fmpz_clear(m);
+        }
+        if (n_engaged == 0)
+            TEST_FUNCTION_FAIL("forced tpoly context never engaged\n");
+    }
+
+    /* the unforced constructor exercises the profitability model in
+       both directions: a heavy declared workload accepts, the default
+       declines at unprofitable sizes */
+    {
+        gr_ctx_t base, tctx;
+        fmpz_t m;
+        gr_transformed_poly_workload_t heavy =
+            {{ 64, 100000, 64, 0, 0, 0 }};
+        fmpz_init(m);
+        fmpz_randprime(m, state, 3 * FLINT_BITS, 0);
+        if (gr_ctx_init_mpn_mod(base, m) == GR_SUCCESS)
+        {
+            if (_gr_mpn_mod_ctx_init_transformed_poly_repr(tctx, base,
+                    64, 64, heavy) == GR_SUCCESS)
+                gr_ctx_clear(tctx);
+            if (_gr_mpn_mod_ctx_init_transformed_poly_repr(tctx, base,
+                    4, 2, NULL) == GR_SUCCESS)
+                gr_ctx_clear(tctx);
+            gr_ctx_clear(base);
+        }
+        fmpz_clear(m);
+    }
+
+    /* directed exercise: negated accumulation and the destructive
+       conversion out, against a gr_poly reference over the base */
+    {
+        slong it;
+        for (it = 0; it < 6; it++)
+        {
+            gr_ctx_t base, tctx;
+            fmpz_t m;
+            gr_transformed_poly_workload_t wl = {{ 0, 0, 0, 0, 0, 1 }};
+            slong N = 4 + (slong) n_randint(state, 20);
+            slong half = FLINT_MAX(1, N / 2);
+            fmpz_init(m);
+            fmpz_randprime(m, state,
+                    FLINT_BITS * (2 + (slong) n_randint(state, 3)), 0);
+            if (gr_ctx_init_mpn_mod(base, m) != GR_SUCCESS)
+            { fmpz_clear(m); continue; }
+            if (_gr_mpn_mod_ctx_init_transformed_poly_repr(tctx, base, N,
+                    N, wl) != GR_SUCCESS)
+            { gr_ctx_clear(base); fmpz_clear(m); continue; }
+            {
+                gr_poly_t a, b, c, d, ref, t2, got;
+                gr_ptr xa, xb, xc, xd, acc;
+                slong len = 0;
+                gr_poly_init(a, base); gr_poly_init(b, base);
+                gr_poly_init(c, base); gr_poly_init(d, base);
+                gr_poly_init(ref, base); gr_poly_init(t2, base);
+                gr_poly_init(got, base);
+                GR_MUST_SUCCEED(gr_poly_randtest(a, state, half, base));
+                GR_MUST_SUCCEED(gr_poly_randtest(b, state, half, base));
+                GR_MUST_SUCCEED(gr_poly_randtest(c, state, half, base));
+                GR_MUST_SUCCEED(gr_poly_randtest(d, state, half, base));
+                GR_MUST_SUCCEED(gr_poly_set_coeff_si(a, 0, 1, base));
+                GR_MUST_SUCCEED(gr_poly_set_coeff_si(b, 0, 1, base));
+                GR_MUST_SUCCEED(gr_poly_set_coeff_si(c, 0, 1, base));
+                GR_MUST_SUCCEED(gr_poly_set_coeff_si(d, 0, 1, base));
+                xa = gr_heap_init(tctx); xb = gr_heap_init(tctx);
+                xc = gr_heap_init(tctx); xd = gr_heap_init(tctx);
+                acc = gr_heap_init(tctx);
+                GR_MUST_SUCCEED(_gr_set_gr_poly(xa, a->coeffs, a->length,
+                        base, tctx));
+                GR_MUST_SUCCEED(_gr_set_gr_poly(xb, b->coeffs, b->length,
+                        base, tctx));
+                GR_MUST_SUCCEED(_gr_set_gr_poly(xc, c->coeffs, c->length,
+                        base, tctx));
+                GR_MUST_SUCCEED(_gr_set_gr_poly(xd, d->coeffs, d->length,
+                        base, tctx));
+                GR_MUST_SUCCEED(gr_mul(acc, xa, xb, tctx));
+                GR_MUST_SUCCEED(gr_submul(acc, xc, xd, tctx));
+                /* aliased accumulation must route through a temporary
+                   internally; UNABLE is a legitimate answer at tight
+                   provisioning, a crash or GR_DOMAIN is not */
+                {
+                    int st1 = gr_addmul(acc, acc, xb, tctx);
+                    (void) st1;
+                }
+                gr_heap_clear(acc, tctx);
+                acc = gr_heap_init(tctx);
+                GR_MUST_SUCCEED(gr_mul(acc, xa, xb, tctx));
+                GR_MUST_SUCCEED(gr_submul(acc, xc, xd, tctx));
+                GR_MUST_SUCCEED(gr_poly_mul(ref, a, b, base));
+                GR_MUST_SUCCEED(gr_poly_mul(t2, c, d, base));
+                GR_MUST_SUCCEED(gr_poly_sub(ref, ref, t2, base));
+                gr_poly_fit_length(got, N, base);
+                GR_MUST_SUCCEED(_gr_get_gr_poly_destructive(got->coeffs,
+                        &len, acc, base, tctx));
+                _gr_poly_set_length(got, len, base);
+                _gr_poly_normalise(got, base);
+                if (gr_poly_equal(got, ref, base) != T_TRUE)
+                    TEST_FUNCTION_FAIL("mpn_mod negs destructive get: "
+                            "N=%wd\n", N);
+                gr_heap_clear(xa, tctx); gr_heap_clear(xb, tctx);
+                gr_heap_clear(xc, tctx); gr_heap_clear(xd, tctx);
+                gr_heap_clear(acc, tctx);
+                gr_poly_clear(a, base); gr_poly_clear(b, base);
+                gr_poly_clear(c, base); gr_poly_clear(d, base);
+                gr_poly_clear(ref, base); gr_poly_clear(t2, base);
+                gr_poly_clear(got, base);
+            }
+            gr_ctx_clear(tctx);
+            gr_ctx_clear(base);
+            fmpz_clear(m);
+        }
+    }
+#endif
+
     TEST_FUNCTION_END(state);
 }

--- a/src/mpn_mod/transformed_poly.c
+++ b/src/mpn_mod/transformed_poly.c
@@ -136,19 +136,19 @@ mtpoly_init(gr_ptr x, gr_ctx_t ctx)
 }
 
 static void
-mtpoly_clear(gr_ptr x, gr_ctx_t ctx)
+mtpoly_clear(gr_ptr x, gr_ctx_t FLINT_UNUSED(ctx))
 {
     fft_small_op_clear(&MTPOLY(x)->op);
 }
 
 static void
-mtpoly_swap(gr_ptr x, gr_ptr y, gr_ctx_t ctx)
+mtpoly_swap(gr_ptr x, gr_ptr y, gr_ctx_t FLINT_UNUSED(ctx))
 {
     FLINT_SWAP(mtpoly_struct, *MTPOLY(x), *MTPOLY(y));
 }
 
 static int
-mtpoly_zero(gr_ptr x, gr_ctx_t ctx)
+mtpoly_zero(gr_ptr x, gr_ctx_t FLINT_UNUSED(ctx))
 {
     MTPOLY(x)->len = 0;
     MTPOLY(x)->terms = 0;
@@ -178,13 +178,13 @@ mtpoly_set(gr_ptr res, gr_srcptr x, gr_ctx_t ctx)
 }
 
 static truth_t
-mtpoly_is_zero(gr_srcptr x, gr_ctx_t ctx)
+mtpoly_is_zero(gr_srcptr x, gr_ctx_t FLINT_UNUSED(ctx))
 {
     return (MTPOLY(x)->len == 0) ? T_TRUE : T_UNKNOWN;
 }
 
 static truth_t
-mtpoly_equal(gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+mtpoly_equal(gr_srcptr x, gr_srcptr y, gr_ctx_t FLINT_UNUSED(ctx))
 {
     if (MTPOLY(x)->len == 0 && MTPOLY(y)->len == 0)
         return T_TRUE;
@@ -515,26 +515,26 @@ static int __mtpoly_methods_initialized = 0;
 
 static gr_method_tab_input __mtpoly_methods_input[] =
 {
-    {GR_METHOD_CTX_WRITE,       (gr_funcptr) mtpoly_ctx_write},
-    {GR_METHOD_CTX_CLEAR,       (gr_funcptr) mtpoly_ctx_clear},
-    {GR_METHOD_INIT,            (gr_funcptr) mtpoly_init},
-    {GR_METHOD_CLEAR,           (gr_funcptr) mtpoly_clear},
-    {GR_METHOD_SWAP,            (gr_funcptr) mtpoly_swap},
-    {GR_METHOD_SET,             (gr_funcptr) mtpoly_set},
-    {GR_METHOD_ZERO,            (gr_funcptr) mtpoly_zero},
-    {GR_METHOD_ONE,             (gr_funcptr) mtpoly_one},
-    {GR_METHOD_IS_ZERO,         (gr_funcptr) mtpoly_is_zero},
-    {GR_METHOD_EQUAL,           (gr_funcptr) mtpoly_equal},
-    {GR_METHOD_NEG,             (gr_funcptr) mtpoly_neg},
-    {GR_METHOD_ADD,             (gr_funcptr) mtpoly_add},
-    {GR_METHOD_SUB,             (gr_funcptr) mtpoly_sub},
-    {GR_METHOD_MUL,             (gr_funcptr) mtpoly_mul},
-    {GR_METHOD_ADDMUL,          (gr_funcptr) mtpoly_addmul},
-    {GR_METHOD_SUBMUL,          (gr_funcptr) mtpoly_submul},
-    {GR_METHOD_SET_GR_POLY,     (gr_funcptr) mtpoly_set_gr_poly},
-    {GR_METHOD_GET_GR_POLY,     (gr_funcptr) mtpoly_get_gr_poly},
-    {GR_METHOD_GET_GR_POLY_WINDOW, (gr_funcptr) mtpoly_get_gr_poly_window},
-    {0,                         (gr_funcptr) NULL},
+    {GR_METHOD_CTX_WRITE,       (gr_funcptr) (void (*)(void)) mtpoly_ctx_write},
+    {GR_METHOD_CTX_CLEAR,       (gr_funcptr) (void (*)(void)) mtpoly_ctx_clear},
+    {GR_METHOD_INIT,            (gr_funcptr) (void (*)(void)) mtpoly_init},
+    {GR_METHOD_CLEAR,           (gr_funcptr) (void (*)(void)) mtpoly_clear},
+    {GR_METHOD_SWAP,            (gr_funcptr) (void (*)(void)) mtpoly_swap},
+    {GR_METHOD_SET,             (gr_funcptr) (void (*)(void)) mtpoly_set},
+    {GR_METHOD_ZERO,            (gr_funcptr) (void (*)(void)) mtpoly_zero},
+    {GR_METHOD_ONE,             (gr_funcptr) (void (*)(void)) mtpoly_one},
+    {GR_METHOD_IS_ZERO,         (gr_funcptr) (void (*)(void)) mtpoly_is_zero},
+    {GR_METHOD_EQUAL,           (gr_funcptr) (void (*)(void)) mtpoly_equal},
+    {GR_METHOD_NEG,             (gr_funcptr) (void (*)(void)) mtpoly_neg},
+    {GR_METHOD_ADD,             (gr_funcptr) (void (*)(void)) mtpoly_add},
+    {GR_METHOD_SUB,             (gr_funcptr) (void (*)(void)) mtpoly_sub},
+    {GR_METHOD_MUL,             (gr_funcptr) (void (*)(void)) mtpoly_mul},
+    {GR_METHOD_ADDMUL,          (gr_funcptr) (void (*)(void)) mtpoly_addmul},
+    {GR_METHOD_SUBMUL,          (gr_funcptr) (void (*)(void)) mtpoly_submul},
+    {GR_METHOD_SET_GR_POLY,     (gr_funcptr) (void (*)(void)) mtpoly_set_gr_poly},
+    {GR_METHOD_GET_GR_POLY,     (gr_funcptr) (void (*)(void)) mtpoly_get_gr_poly},
+    {GR_METHOD_GET_GR_POLY_WINDOW, (gr_funcptr) (void (*)(void)) mtpoly_get_gr_poly_window},
+    {0,                         (gr_funcptr) (void (*)(void)) NULL},
 };
 
 int
@@ -666,9 +666,9 @@ _gr_mpn_mod_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base,
 #else /* FLINT_HAVE_FFT_SMALL */
 
 int
-_gr_mpn_mod_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base,
-        slong len_bound, slong terms_bound,
-        const struct gr_transformed_poly_workload_struct * workload)
+_gr_mpn_mod_ctx_init_transformed_poly_repr(gr_ctx_t FLINT_UNUSED(ctx), gr_ctx_t FLINT_UNUSED(base),
+        slong FLINT_UNUSED(len_bound), slong FLINT_UNUSED(terms_bound),
+        const struct gr_transformed_poly_workload_struct * FLINT_UNUSED(workload))
 {
     return GR_UNABLE;
 }

--- a/src/mpn_mod/transformed_poly.c
+++ b/src/mpn_mod/transformed_poly.c
@@ -266,8 +266,8 @@ _mtpoly_export(mtpoly_ctx_struct * T, gr_srcptr x, slong zl, slong ub,
 static double *
 _mtpoly_scratch_alloc(const mtpoly_ctx_struct * T)
 {
-    return flint_aligned_alloc(4096,
-            n_round_up(T->P->np * T->P->stride * sizeof(double), 4096));
+    return flint_aligned_alloc(FLINT_FFT_SMALL_ALIGNMENT,
+            n_round_up(T->P->np * T->P->stride * sizeof(double), FLINT_FFT_SMALL_ALIGNMENT));
 }
 
 /* the GET_GR_POLY_DESTRUCTIVE method: the inverse transforms, scaling
@@ -632,7 +632,7 @@ _gr_mpn_mod_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base,
        side always uses the same transform sizes with its own (usually
        equal) prime count */
     {
-        const gr_transformed_poly_workload_struct def = { 2, 1, 1, 0 };
+        const gr_transformed_poly_workload_struct def = { 2, 1, 1, 0, 0 };
         const gr_transformed_poly_workload_struct * wl =
             workload ? workload : &def;
         double L = (double) n_round_up((ulong) N, BLK_SZ);
@@ -651,9 +651,16 @@ _gr_mpn_mod_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base,
         fuse = nm * (npf * L * (3.0 * lg + 4.0 * nlimbs + 2.0)
                      + npf * L * 3.0);
 
-        bytes = (ni + 3.0) * np *
-                (double) sd_fft_ctx_data_size(T->P->depth) * 8.0;
-        limit = wl->mem_limit > 0 ? (double) wl->mem_limit : 4.0 * 1073741824.0;
+        /* live elements as declared by the driver; a zero declaration
+           derives a conservative count from the workload shape */
+        {
+            double nlive = wl->num_live > 0 ? (double) wl->num_live
+                                            : (ni + no + 2.0);
+            bytes = nlive * np *
+                    (double) sd_fft_ctx_data_size(T->P->depth) * 8.0;
+        }
+        limit = wl->mem_limit > 0 ? (double) wl->mem_limit
+                    : (double) flint_fft_small_max_transformed_ring_size;
 
         if (rep >= 0.865 * fuse || bytes > limit)
         {

--- a/src/mpn_mod/transformed_poly.c
+++ b/src/mpn_mod/transformed_poly.c
@@ -270,6 +270,54 @@ _mtpoly_scratch_alloc(const mtpoly_ctx_struct * T)
             n_round_up(T->P->np * T->P->stride * sizeof(double), 4096));
 }
 
+/* the GET_GR_POLY_DESTRUCTIVE method: the inverse transforms, scaling
+   and bias run on the element's own evaluations, so no scratch is
+   allocated and no transform copy is made; the element may only be
+   cleared or fully overwritten afterwards */
+static int
+mtpoly_get_gr_poly_destructive(gr_ptr c, slong * len, gr_ptr x,
+                               gr_ctx_t base_ctx, gr_ctx_t ctx)
+{
+    mtpoly_ctx_struct * T = MTPOLY_CTX(ctx);
+    const fft_small_plan_struct * P = T->P;
+    nn_ptr cc = (nn_ptr) c;
+    slong xlen = MTPOLY(x)->len;
+    ulong itr = n_round_up((ulong) xlen, BLK_SZ);
+    slong i;
+
+    if (!_mtpoly_base_ok(base_ctx, T))
+        return GR_DOMAIN;
+
+    if (xlen == 0)
+    {
+        *len = 0;
+        return GR_SUCCESS;
+    }
+
+    for (i = 0; i < (slong) P->np; i++)
+    {
+        sd_fft_ctx_struct * Q = P->ffts + P->offset + i;
+        double * d = MTPOLY(x)->op.data + P->stride * i;
+        double b = MTPOLY(x)->negs ? (double) T->bias_res[i] : 0.0;
+
+        sd_ifft_trunc(Q, d, P->depth, itr);
+        _mtpoly_scale_bias(Q, d, T->m_orig[i], b, itr / BLK_SZ);
+    }
+    fft_small_export_mpn_mod_range(cc, &MTPOLY(x)->op, 0, (ulong) xlen,
+                                   T->base, P);
+    if (MTPOLY(x)->negs)
+        for (i = 0; i < xlen; i++)
+            mpn_mod_sub(cc + i * T->nlimbs, cc + i * T->nlimbs,
+                        T->bias_mod_n, T->base);
+    MTPOLY(x)->len = 0;
+
+    while (xlen > 0 &&
+           flint_mpn_zero_p(cc + (xlen - 1) * T->nlimbs, T->nlimbs))
+        xlen--;
+    *len = xlen;
+    return GR_SUCCESS;
+}
+
 static int
 mtpoly_get_gr_poly(gr_ptr c, slong * len, gr_srcptr x,
                    gr_ctx_t base_ctx, gr_ctx_t ctx)
@@ -533,6 +581,8 @@ static gr_method_tab_input __mtpoly_methods_input[] =
     {GR_METHOD_SUBMUL,          (gr_funcptr) (void (*)(void)) mtpoly_submul},
     {GR_METHOD_SET_GR_POLY,     (gr_funcptr) (void (*)(void)) mtpoly_set_gr_poly},
     {GR_METHOD_GET_GR_POLY,     (gr_funcptr) (void (*)(void)) mtpoly_get_gr_poly},
+    {GR_METHOD_GET_GR_POLY_DESTRUCTIVE,
+                                (gr_funcptr) (void (*)(void)) mtpoly_get_gr_poly_destructive},
     {GR_METHOD_GET_GR_POLY_WINDOW, (gr_funcptr) (void (*)(void)) mtpoly_get_gr_poly_window},
     {0,                         (gr_funcptr) (void (*)(void)) NULL},
 };

--- a/src/mpn_mod/transformed_poly.c
+++ b/src/mpn_mod/transformed_poly.c
@@ -510,6 +510,22 @@ mtpoly_addsubmul(gr_ptr res, gr_srcptr x, gr_srcptr y, int sub, gr_ctx_t ctx)
     if (MTPOLY(x)->len == 0 || MTPOLY(y)->len == 0)
         return GR_SUCCESS;
 
+    /* with res aliasing an operand, the per-call domain bookkeeping
+       below cannot mark the same struct as both input and accumulator;
+       route through the ring's own guarded multiply and add */
+    if (res == x || res == y)
+    {
+        gr_ptr t;
+        int status;
+        GR_TMP_INIT(t, ctx);
+        status = mtpoly_mul(t, x, y, ctx);
+        if (status == GR_SUCCESS)
+            status = sub ? mtpoly_sub(res, res, t, ctx)
+                         : mtpoly_add(res, res, t, ctx);
+        GR_TMP_CLEAR(t, ctx);
+        return status;
+    }
+
     if (MTPOLY(res)->len == 0)
     {
         int status = mtpoly_mul(res, x, y, ctx);
@@ -561,6 +577,68 @@ mtpoly_submul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
 static gr_funcptr __mtpoly_methods[GR_METHOD_TAB_SIZE];
 static int __mtpoly_methods_initialized = 0;
 
+/* random depth-1 elements and a value writer, via the stored base
+   context: gr_test_ring compliance at conversion cost only */
+static int
+mtpoly_randtest(gr_ptr res, flint_rand_t state, gr_ctx_t ctx)
+{
+    mtpoly_ctx_struct * T = MTPOLY_CTX(ctx);
+    slong nl = T->nlimbs;
+    slong i, j, len = n_randint(state, T->N + 1);
+    nn_ptr c;
+    nn_srcptr m = MPN_MOD_CTX_MODULUS(T->base);
+    int status;
+
+    if (len == 0 || n_randint(state, 8) == 0)
+        return gr_zero(res, ctx);
+
+    c = flint_malloc(len * nl * sizeof(ulong));
+    for (i = 0; i < len; i++)
+    {
+        nn_ptr ci = c + i * nl;
+        for (j = 0; j < nl; j++)
+            ci[j] = n_randtest(state);
+        /* keep the value below the modulus: top limb strictly below
+           the modulus's top limb */
+        ci[nl - 1] = (m[nl - 1] > 0) ? n_randint(state, m[nl - 1]) : 0;
+    }
+    status = mtpoly_set_gr_poly(res, c, len, T->base, ctx);
+    flint_free(c);
+    return status;
+}
+
+static int
+mtpoly_write(gr_stream_t out, gr_srcptr x, gr_ctx_t ctx)
+{
+    mtpoly_ctx_struct * T = MTPOLY_CTX(ctx);
+    slong nl = T->nlimbs;
+    nn_ptr c;
+    slong i, len = 0;
+    int status;
+    fmpz_t v;
+
+    /* every element's polynomial length is bounded by the ring's N
+       (products beyond it are declined at the operation) */
+    c = flint_malloc(FLINT_MAX(T->N, 1) * nl * sizeof(ulong));
+    status = mtpoly_get_gr_poly(c, &len, x, T->base, ctx);
+    if (status == GR_SUCCESS)
+    {
+        fmpz_init(v);
+        status |= gr_stream_write(out, "[");
+        for (i = 0; i < len; i++)
+        {
+            if (i > 0)
+                status |= gr_stream_write(out, ", ");
+            fmpz_set_ui_array(v, c + i * nl, nl);
+            status |= gr_stream_write_fmpz(out, v);
+        }
+        status |= gr_stream_write(out, "]");
+        fmpz_clear(v);
+    }
+    flint_free(c);
+    return status;
+}
+
 static gr_method_tab_input __mtpoly_methods_input[] =
 {
     {GR_METHOD_CTX_WRITE,       (gr_funcptr) (void (*)(void)) mtpoly_ctx_write},
@@ -571,6 +649,8 @@ static gr_method_tab_input __mtpoly_methods_input[] =
     {GR_METHOD_SET,             (gr_funcptr) (void (*)(void)) mtpoly_set},
     {GR_METHOD_ZERO,            (gr_funcptr) (void (*)(void)) mtpoly_zero},
     {GR_METHOD_ONE,             (gr_funcptr) (void (*)(void)) mtpoly_one},
+    {GR_METHOD_WRITE,           (gr_funcptr) (void (*)(void)) mtpoly_write},
+    {GR_METHOD_RANDTEST,        (gr_funcptr) (void (*)(void)) mtpoly_randtest},
     {GR_METHOD_IS_ZERO,         (gr_funcptr) (void (*)(void)) mtpoly_is_zero},
     {GR_METHOD_EQUAL,           (gr_funcptr) (void (*)(void)) mtpoly_equal},
     {GR_METHOD_NEG,             (gr_funcptr) (void (*)(void)) mtpoly_neg},
@@ -632,42 +712,49 @@ _gr_mpn_mod_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base,
        side always uses the same transform sizes with its own (usually
        equal) prime count */
     {
-        const gr_transformed_poly_workload_struct def = { 2, 1, 1, 0, 0 };
+        const gr_transformed_poly_workload_struct def = { 2, 1, 1, 0, 0, 0 };
         const gr_transformed_poly_workload_struct * wl =
             workload ? workload : &def;
-        double L = (double) n_round_up((ulong) N, BLK_SZ);
-        double lg = (double) FLINT_BIT_COUNT((ulong) L);
-        double np = (double) T->P->np;
-        double ni = (double) wl->num_inputs;
-        double nm = (double) wl->num_muls;
-        double no = (double) wl->num_outputs;
-        double npf, rep, fuse, bytes, limit;
 
-        /* per-coefficient conversions cost ~nlimbs here */
-        rep = np * L * ((ni + no) * (lg + 2.0 * nlimbs) + nm * 2.0)
-                + no * np * L * 3.0 + 5e4;
-        npf = (double) ((2 * nbits + FLINT_BIT_COUNT((ulong) L) + 49) / 50);
-        npf = FLINT_MAX(npf, 1.0);
-        fuse = nm * (npf * L * (3.0 * lg + 4.0 * nlimbs + 2.0)
-                     + npf * L * 3.0);
+    /* forced initialization (tests): only implementation
+       bounds below decline; the profitability model and the
+       storage budget are policy and are skipped */
+    if (!wl->force)
+    {
+            double L = (double) n_round_up((ulong) N, BLK_SZ);
+            double lg = (double) FLINT_BIT_COUNT((ulong) L);
+            double np = (double) T->P->np;
+            double ni = (double) wl->num_inputs;
+            double nm = (double) wl->num_muls;
+            double no = (double) wl->num_outputs;
+            double npf, rep, fuse, bytes, limit;
 
-        /* live elements as declared by the driver; a zero declaration
-           derives a conservative count from the workload shape */
-        {
-            double nlive = wl->num_live > 0 ? (double) wl->num_live
-                                            : (ni + no + 2.0);
-            bytes = nlive * np *
-                    (double) sd_fft_ctx_data_size(T->P->depth) * 8.0;
-        }
-        limit = wl->mem_limit > 0 ? (double) wl->mem_limit
-                    : (double) flint_fft_small_max_transformed_ring_size;
+            /* per-coefficient conversions cost ~nlimbs here */
+            rep = np * L * ((ni + no) * (lg + 2.0 * nlimbs) + nm * 2.0)
+                    + no * np * L * 3.0 + 5e4;
+            npf = (double) ((2 * nbits + FLINT_BIT_COUNT((ulong) L) + 49) / 50);
+            npf = FLINT_MAX(npf, 1.0);
+            fuse = nm * (npf * L * (3.0 * lg + 4.0 * nlimbs + 2.0)
+                         + npf * L * 3.0);
 
-        if (rep >= 0.865 * fuse || bytes > limit)
-        {
-            fft_small_plan_clear(T->P);
-            flint_free(T);
-            return GR_UNABLE;
-        }
+            /* live elements as declared by the driver; a zero declaration
+               derives a conservative count from the workload shape */
+            {
+                double nlive = wl->num_live > 0 ? (double) wl->num_live
+                                                : (ni + no + 2.0);
+                bytes = nlive * np *
+                        (double) sd_fft_ctx_data_size(T->P->depth) * 8.0;
+            }
+            limit = wl->mem_limit > 0 ? (double) wl->mem_limit
+                        : (double) flint_fft_small_max_transformed_ring_size;
+
+            if (rep >= 0.865 * fuse || bytes > limit)
+            {
+                fft_small_plan_clear(T->P);
+                flint_free(T);
+                return GR_UNABLE;
+            }
+    }
     }
 
     for (i = 0; i < T->P->np; i++)

--- a/src/mpn_mod/transformed_poly.c
+++ b/src/mpn_mod/transformed_poly.c
@@ -1,0 +1,676 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <string.h>
+#include "fmpz.h"
+#include "mpn_extras.h"
+#include "ulong_extras.h"
+#include "gr.h"
+#include "gr_poly.h"
+#include "nmod.h"
+#include "mpn_mod.h"
+
+#if FLINT_HAVE_FFT_SMALL
+
+#include "machine_vectors.h"
+#include "fft_small.h"
+
+/*
+    Ring of mpn_mod polynomials of bounded length in fft_small transformed
+    representation, following gr/nmod_transformed_poly.c: elements are
+    plain per-prime evaluations (the plan's pointwise normalizers are
+    overridden to 1 and the saved originals applied once at conversion
+    out), carrying a virtual length, an elementary product counter, a
+    multiplicative depth and a negativity flag. Conversions in and out go
+    through the per-coefficient reductions and chinese remaindering of the
+    mpn_mod fused driver (fft_small_fft_mpn_mod /
+    fft_small_export_mpn_mod_range).
+
+    Differences from the nmod ring:
+    - the chinese remaindering reconstructs full-width integers and asserts
+      them below half the prime product, so the plan is provisioned with an
+      accumulation bound of 4 * terms_bound (one bit for the signed-value
+      bias, one for the unsigned-half constraint);
+    - there is no exact single-prime path (the modulus never matches an
+      fft prime), so the multiplicative depth is always capped at 2 and
+      the bias always provisioned;
+    - the base context is retained by pointer for the modular reductions
+      at conversion out, so it must outlive this context.
+
+    A context is read-only after construction and may be shared by any
+    number of threads (a single element still belongs to one thread at a
+    time).
+*/
+
+typedef struct
+{
+    fft_small_plan_t P;
+    gr_ctx_struct * base;           /* must outlive this context */
+    slong nlimbs;
+    slong N;                        /* length capacity */
+    ulong terms_bound;              /* accumulation capacity */
+    ulong max_depth;                /* multiplicative depth capacity */
+    ulong m_orig[MPN_CTX_NCRTS];    /* saved export normalizers */
+    ulong bias_res[MPN_CTX_NCRTS];  /* C * inv(cop_i) mod p_i */
+    nn_ptr bias_mod_n;              /* C mod n, nlimbs */
+} mtpoly_ctx_struct;
+
+typedef struct
+{
+    fft_small_op_struct op;
+    slong len;                      /* virtual length; 0 = zero element */
+    ulong terms;                    /* elementary product count bound */
+    ulong depth;                    /* multiplicative depth in base elements */
+    int negs;                       /* true integer coeffs may be negative */
+} mtpoly_struct;
+
+#define MTPOLY_CTX(ctx) ((mtpoly_ctx_struct *) GR_CTX_DATA_AS_PTR(ctx))
+#define MTPOLY(x) ((mtpoly_struct *) (x))
+
+/* d = m*d + b over the first nblk blocks (see the nmod ring) */
+static void
+_mtpoly_scale_bias(const sd_fft_ctx_struct * Q, double * d,
+                   ulong m_, double b, ulong nblk)
+{
+    vec8d m = vec8d_set_d(vec1d_reduce_0n_to_pmhn((slong) m_, Q->p));
+    vec8d bb = vec8d_set_d(b);
+    vec8d n = vec8d_set_d(Q->p);
+    vec8d ninv = vec8d_set_d(Q->pinv);
+    ulong I;
+
+    for (I = 0; I < nblk; I++)
+    {
+        double * dx = d + sd_fft_ctx_blk_offset(I);
+        ulong j = 0; do {
+            vec8d x0, x1;
+            x0 = vec8d_load(dx + j + 0);
+            x1 = vec8d_load(dx + j + 8);
+            x0 = vec8d_add(vec8d_mulmod(x0, m, n, ninv), bb);
+            x1 = vec8d_add(vec8d_mulmod(x1, m, n, ninv), bb);
+            vec8d_store(dx + j + 0, x0);
+            vec8d_store(dx + j + 8, x1);
+        } while (j += 16, j < BLK_SZ);
+    }
+}
+
+static int
+mtpoly_ctx_write(gr_stream_t out, gr_ctx_t ctx)
+{
+    mtpoly_ctx_struct * T = MTPOLY_CTX(ctx);
+    int status = GR_SUCCESS;
+    status |= gr_stream_write(out,
+        "Transformed polynomials (fft_small) over multi-word integers mod n"
+        " (len_bound ");
+    status |= gr_stream_write_si(out, T->N);
+    status |= gr_stream_write(out, ", terms_bound ");
+    status |= gr_stream_write_ui(out, T->terms_bound);
+    status |= gr_stream_write(out, ")");
+    return status;
+}
+
+static void
+mtpoly_ctx_clear(gr_ctx_t ctx)
+{
+    mtpoly_ctx_struct * T = MTPOLY_CTX(ctx);
+    fft_small_plan_clear(T->P);
+    flint_free(T->bias_mod_n);
+    flint_free(T);
+}
+
+static void
+mtpoly_init(gr_ptr x, gr_ctx_t ctx)
+{
+    fft_small_op_init(&MTPOLY(x)->op, MTPOLY_CTX(ctx)->P);
+    MTPOLY(x)->len = 0;
+    MTPOLY(x)->terms = 0;
+    MTPOLY(x)->depth = 0;
+    MTPOLY(x)->negs = 0;
+}
+
+static void
+mtpoly_clear(gr_ptr x, gr_ctx_t ctx)
+{
+    fft_small_op_clear(&MTPOLY(x)->op);
+}
+
+static void
+mtpoly_swap(gr_ptr x, gr_ptr y, gr_ctx_t ctx)
+{
+    FLINT_SWAP(mtpoly_struct, *MTPOLY(x), *MTPOLY(y));
+}
+
+static int
+mtpoly_zero(gr_ptr x, gr_ctx_t ctx)
+{
+    MTPOLY(x)->len = 0;
+    MTPOLY(x)->terms = 0;
+    MTPOLY(x)->depth = 0;
+    MTPOLY(x)->negs = 0;
+    return GR_SUCCESS;
+}
+
+static int
+mtpoly_set(gr_ptr res, gr_srcptr x, gr_ctx_t ctx)
+{
+    mtpoly_ctx_struct * T = MTPOLY_CTX(ctx);
+
+    if (res == x)
+        return GR_SUCCESS;
+
+    if (MTPOLY(x)->len > 0)
+        memcpy(MTPOLY(res)->op.data, MTPOLY(x)->op.data,
+               T->P->np * T->P->stride * sizeof(double));
+    MTPOLY(res)->op.domain = MTPOLY(x)->op.domain;
+    MTPOLY(res)->op.itrunc = MTPOLY(x)->op.itrunc;
+    MTPOLY(res)->len = MTPOLY(x)->len;
+    MTPOLY(res)->terms = MTPOLY(x)->terms;
+    MTPOLY(res)->depth = MTPOLY(x)->depth;
+    MTPOLY(res)->negs = MTPOLY(x)->negs;
+    return GR_SUCCESS;
+}
+
+static truth_t
+mtpoly_is_zero(gr_srcptr x, gr_ctx_t ctx)
+{
+    return (MTPOLY(x)->len == 0) ? T_TRUE : T_UNKNOWN;
+}
+
+static truth_t
+mtpoly_equal(gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    if (MTPOLY(x)->len == 0 && MTPOLY(y)->len == 0)
+        return T_TRUE;
+    return T_UNKNOWN;
+}
+
+static int
+_mtpoly_base_ok(gr_ctx_t base_ctx, const mtpoly_ctx_struct * T)
+{
+    return base_ctx->which_ring == GR_CTX_MPN_MOD &&
+           MPN_MOD_CTX_NLIMBS(base_ctx) == T->nlimbs &&
+           mpn_cmp(MPN_MOD_CTX_MODULUS(base_ctx),
+                   MPN_MOD_CTX_MODULUS(T->base), T->nlimbs) == 0;
+}
+
+static int
+mtpoly_set_gr_poly(gr_ptr res, gr_srcptr a, slong len,
+                   gr_ctx_t base_ctx, gr_ctx_t ctx)
+{
+    mtpoly_ctx_struct * T = MTPOLY_CTX(ctx);
+    nn_srcptr ac = (nn_srcptr) a;
+
+    if (!_mtpoly_base_ok(base_ctx, T))
+        return GR_DOMAIN;
+
+    while (len > 0 && flint_mpn_zero_p(ac + (len - 1) * T->nlimbs, T->nlimbs))
+        len--;
+
+    if (len > T->N)
+        return GR_DOMAIN;
+
+    if (len == 0)
+        return mtpoly_zero(res, ctx);
+
+    fft_small_fft_mpn_mod(&MTPOLY(res)->op, ac, len,
+                          n_round_up(len, BLK_SZ), T->base, T->P);
+    MTPOLY(res)->len = len;
+    MTPOLY(res)->terms = 1;
+    MTPOLY(res)->depth = 1;
+    MTPOLY(res)->negs = 0;
+    return GR_SUCCESS;
+}
+
+/* shared conversion-out core: reconstruct coefficients [zl, ub) of x,
+   ub <= xlen, directly into z (ub - zl coefficients of nlimbs words,
+   bias already removed); sdata is per-call temporary space */
+static void
+_mtpoly_export(mtpoly_ctx_struct * T, gr_srcptr x, slong zl, slong ub,
+               double * sdata, nn_ptr z)
+{
+    const fft_small_plan_struct * P = T->P;
+    slong xlen = MTPOLY(x)->len;
+    fft_small_op_struct tmp;
+    ulong itr = n_round_up((ulong) xlen, BLK_SZ);
+    slong i;
+
+    tmp = MTPOLY(x)->op;
+    tmp.data = sdata;
+
+    memcpy(sdata, MTPOLY(x)->op.data, P->np * P->stride * sizeof(double));
+    for (i = 0; i < (slong) P->np; i++)
+    {
+        sd_fft_ctx_struct * Q = P->ffts + P->offset + i;
+        double * d = sdata + P->stride * i;
+        double b = MTPOLY(x)->negs ? (double) T->bias_res[i] : 0.0;
+
+        sd_ifft_trunc(Q, d, P->depth, itr);
+        _mtpoly_scale_bias(Q, d, T->m_orig[i], b, itr / BLK_SZ);
+    }
+    fft_small_export_mpn_mod_range(z, &tmp, (ulong) zl, (ulong) ub,
+                                   T->base, P);
+
+    if (MTPOLY(x)->negs)
+        for (i = 0; i < ub - zl; i++)
+            mpn_mod_sub(z + i * T->nlimbs, z + i * T->nlimbs,
+                        T->bias_mod_n, T->base);
+}
+
+static double *
+_mtpoly_scratch_alloc(const mtpoly_ctx_struct * T)
+{
+    return flint_aligned_alloc(4096,
+            n_round_up(T->P->np * T->P->stride * sizeof(double), 4096));
+}
+
+static int
+mtpoly_get_gr_poly(gr_ptr c, slong * len, gr_srcptr x,
+                   gr_ctx_t base_ctx, gr_ctx_t ctx)
+{
+    mtpoly_ctx_struct * T = MTPOLY_CTX(ctx);
+    nn_ptr cc = (nn_ptr) c;
+    slong xlen = MTPOLY(x)->len;
+
+    if (!_mtpoly_base_ok(base_ctx, T))
+        return GR_DOMAIN;
+
+    if (xlen == 0)
+    {
+        *len = 0;
+        return GR_SUCCESS;
+    }
+
+    {
+        double * sdata = _mtpoly_scratch_alloc(T);
+        _mtpoly_export(T, x, 0, xlen, sdata, cc);
+        flint_aligned_free(sdata);
+    }
+
+    while (xlen > 0 && flint_mpn_zero_p(cc + (xlen - 1) * T->nlimbs, T->nlimbs))
+        xlen--;
+    *len = xlen;
+    return GR_SUCCESS;
+}
+
+static int
+mtpoly_get_gr_poly_window(gr_ptr c, gr_srcptr x, slong zl, slong zh,
+                          gr_ctx_t base_ctx, gr_ctx_t ctx)
+{
+    mtpoly_ctx_struct * T = MTPOLY_CTX(ctx);
+    nn_ptr cc = (nn_ptr) c;
+    slong xlen = MTPOLY(x)->len;
+    slong ub;
+
+    if (!_mtpoly_base_ok(base_ctx, T))
+        return GR_DOMAIN;
+    if (zl < 0 || zh < zl || zh > T->N)
+        return GR_DOMAIN;
+
+    ub = FLINT_MIN(zh, xlen);
+    if (ub > zl)
+    {
+        double * sdata = _mtpoly_scratch_alloc(T);
+        _mtpoly_export(T, x, zl, ub, sdata, cc);
+        flint_aligned_free(sdata);
+    }
+    else
+        ub = zl;
+    flint_mpn_zero(cc + (ub - zl) * T->nlimbs, (zh - ub) * T->nlimbs);
+    return GR_SUCCESS;
+}
+
+static int
+mtpoly_one(gr_ptr x, gr_ctx_t ctx)
+{
+    mtpoly_ctx_struct * T = MTPOLY_CTX(ctx);
+    nn_ptr c = flint_calloc(T->nlimbs, sizeof(ulong));
+    c[0] = 1;
+
+    fft_small_fft_mpn_mod(&MTPOLY(x)->op, c, 1, BLK_SZ, T->base, T->P);
+    flint_free(c);
+    MTPOLY(x)->len = 1;
+    MTPOLY(x)->terms = 1;
+    MTPOLY(x)->depth = 1;
+    MTPOLY(x)->negs = 0;
+    return GR_SUCCESS;
+}
+
+static int
+mtpoly_neg(gr_ptr res, gr_srcptr x, gr_ctx_t ctx)
+{
+    mtpoly_ctx_struct * T = MTPOLY_CTX(ctx);
+
+    if (MTPOLY(x)->len == 0)
+        return mtpoly_zero(res, ctx);
+
+    fft_small_op_neg(&MTPOLY(res)->op, &MTPOLY(x)->op, T->P);
+    MTPOLY(res)->op.domain = FFT_SMALL_OP_PRIMAL;
+    MTPOLY(res)->len = MTPOLY(x)->len;
+    MTPOLY(res)->terms = MTPOLY(x)->terms;
+    MTPOLY(res)->depth = MTPOLY(x)->depth;
+    MTPOLY(res)->negs = 1;
+    return GR_SUCCESS;
+}
+
+static int
+mtpoly_add(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    mtpoly_ctx_struct * T = MTPOLY_CTX(ctx);
+    ulong terms;
+
+    if (MTPOLY(x)->len == 0)
+        return mtpoly_set(res, y, ctx);
+    if (MTPOLY(y)->len == 0)
+        return mtpoly_set(res, x, ctx);
+
+    terms = MTPOLY(x)->terms + MTPOLY(y)->terms;
+    if (terms < MTPOLY(x)->terms || terms > T->terms_bound)
+        return GR_UNABLE;
+
+    MTPOLY(x)->op.domain = MTPOLY(y)->op.domain = FFT_SMALL_OP_PRIMAL;
+    fft_small_op_add(&MTPOLY(res)->op, &MTPOLY(x)->op, &MTPOLY(y)->op, T->P);
+    MTPOLY(res)->op.domain = FFT_SMALL_OP_PRIMAL;
+    MTPOLY(res)->len = FLINT_MAX(MTPOLY(x)->len, MTPOLY(y)->len);
+    MTPOLY(res)->terms = terms;
+    MTPOLY(res)->depth = FLINT_MAX(MTPOLY(x)->depth, MTPOLY(y)->depth);
+    MTPOLY(res)->negs = MTPOLY(x)->negs | MTPOLY(y)->negs;
+    return GR_SUCCESS;
+}
+
+static int
+mtpoly_sub(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    mtpoly_ctx_struct * T = MTPOLY_CTX(ctx);
+    ulong terms;
+
+    if (MTPOLY(y)->len == 0)
+        return mtpoly_set(res, x, ctx);
+    if (MTPOLY(x)->len == 0)
+        return mtpoly_neg(res, y, ctx);
+
+    terms = MTPOLY(x)->terms + MTPOLY(y)->terms;
+    if (terms < MTPOLY(x)->terms || terms > T->terms_bound)
+        return GR_UNABLE;
+
+    MTPOLY(x)->op.domain = MTPOLY(y)->op.domain = FFT_SMALL_OP_PRIMAL;
+    fft_small_op_sub(&MTPOLY(res)->op, &MTPOLY(x)->op, &MTPOLY(y)->op, T->P);
+    MTPOLY(res)->op.domain = FFT_SMALL_OP_PRIMAL;
+    MTPOLY(res)->len = FLINT_MAX(MTPOLY(x)->len, MTPOLY(y)->len);
+    MTPOLY(res)->terms = terms;
+    MTPOLY(res)->depth = FLINT_MAX(MTPOLY(x)->depth, MTPOLY(y)->depth);
+    MTPOLY(res)->negs = 1;
+    return GR_SUCCESS;
+}
+
+static int
+_mtpoly_mul_terms(ulong * terms, const mtpoly_struct * x,
+                  const mtpoly_struct * y, ulong terms_bound)
+{
+    ulong hi, t;
+
+    umul_ppmm(hi, t, x->terms, y->terms);
+    if (hi != 0)
+        return 0;
+    umul_ppmm(hi, t, t, (ulong) FLINT_MIN(x->len, y->len));
+    if (hi != 0 || t > terms_bound)
+        return 0;
+    *terms = t;
+    return 1;
+}
+
+static int
+mtpoly_mul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    mtpoly_ctx_struct * T = MTPOLY_CTX(ctx);
+    slong len;
+    ulong terms;
+
+    if (MTPOLY(x)->len == 0 || MTPOLY(y)->len == 0)
+        return mtpoly_zero(res, ctx);
+
+    len = MTPOLY(x)->len + MTPOLY(y)->len - 1;
+    if (len > T->N ||
+        !_mtpoly_mul_terms(&terms, MTPOLY(x), MTPOLY(y), T->terms_bound))
+        return GR_UNABLE;
+    if (MTPOLY(x)->depth + MTPOLY(y)->depth > T->max_depth)
+        return GR_UNABLE;
+
+    MTPOLY(x)->op.domain = MTPOLY(y)->op.domain = FFT_SMALL_OP_PRIMAL;
+    fft_small_op_mul(&MTPOLY(res)->op, &MTPOLY(x)->op, &MTPOLY(y)->op, T->P);
+    MTPOLY(res)->op.domain = FFT_SMALL_OP_PRIMAL;
+    MTPOLY(res)->len = len;
+    MTPOLY(res)->terms = terms;
+    MTPOLY(res)->depth = MTPOLY(x)->depth + MTPOLY(y)->depth;
+    MTPOLY(res)->negs = MTPOLY(x)->negs | MTPOLY(y)->negs;
+    return GR_SUCCESS;
+}
+
+static int
+mtpoly_addsubmul(gr_ptr res, gr_srcptr x, gr_srcptr y, int sub, gr_ctx_t ctx)
+{
+    mtpoly_ctx_struct * T = MTPOLY_CTX(ctx);
+    slong len;
+    ulong terms, t2;
+
+    if (MTPOLY(x)->len == 0 || MTPOLY(y)->len == 0)
+        return GR_SUCCESS;
+
+    if (MTPOLY(res)->len == 0)
+    {
+        int status = mtpoly_mul(res, x, y, ctx);
+        if (status == GR_SUCCESS && sub)
+            status = mtpoly_neg(res, res, ctx);
+        return status;
+    }
+
+    len = MTPOLY(x)->len + MTPOLY(y)->len - 1;
+    if (len > T->N ||
+        !_mtpoly_mul_terms(&t2, MTPOLY(x), MTPOLY(y), T->terms_bound))
+        return GR_UNABLE;
+    terms = MTPOLY(res)->terms + t2;
+    if (terms < t2 || terms > T->terms_bound)
+        return GR_UNABLE;
+    if (MTPOLY(x)->depth + MTPOLY(y)->depth > T->max_depth)
+        return GR_UNABLE;
+
+    MTPOLY(x)->op.domain = MTPOLY(y)->op.domain = FFT_SMALL_OP_PRIMAL;
+    MTPOLY(res)->op.domain = FFT_SMALL_OP_PRODUCT;
+    if (sub)
+        fft_small_op_submul(&MTPOLY(res)->op, &MTPOLY(x)->op,
+                            &MTPOLY(y)->op, T->P);
+    else
+        fft_small_op_addmul(&MTPOLY(res)->op, &MTPOLY(x)->op,
+                            &MTPOLY(y)->op, T->P);
+    MTPOLY(res)->op.domain = FFT_SMALL_OP_PRIMAL;
+    MTPOLY(res)->len = FLINT_MAX(MTPOLY(res)->len, len);
+    MTPOLY(res)->terms = terms;
+    MTPOLY(res)->depth = FLINT_MAX(MTPOLY(res)->depth,
+                            MTPOLY(x)->depth + MTPOLY(y)->depth);
+    MTPOLY(res)->negs = sub ? 1 :
+        (MTPOLY(res)->negs | MTPOLY(x)->negs | MTPOLY(y)->negs);
+    return GR_SUCCESS;
+}
+
+static int
+mtpoly_addmul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    return mtpoly_addsubmul(res, x, y, 0, ctx);
+}
+
+static int
+mtpoly_submul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
+{
+    return mtpoly_addsubmul(res, x, y, 1, ctx);
+}
+
+static gr_funcptr __mtpoly_methods[GR_METHOD_TAB_SIZE];
+static int __mtpoly_methods_initialized = 0;
+
+static gr_method_tab_input __mtpoly_methods_input[] =
+{
+    {GR_METHOD_CTX_WRITE,       (gr_funcptr) mtpoly_ctx_write},
+    {GR_METHOD_CTX_CLEAR,       (gr_funcptr) mtpoly_ctx_clear},
+    {GR_METHOD_INIT,            (gr_funcptr) mtpoly_init},
+    {GR_METHOD_CLEAR,           (gr_funcptr) mtpoly_clear},
+    {GR_METHOD_SWAP,            (gr_funcptr) mtpoly_swap},
+    {GR_METHOD_SET,             (gr_funcptr) mtpoly_set},
+    {GR_METHOD_ZERO,            (gr_funcptr) mtpoly_zero},
+    {GR_METHOD_ONE,             (gr_funcptr) mtpoly_one},
+    {GR_METHOD_IS_ZERO,         (gr_funcptr) mtpoly_is_zero},
+    {GR_METHOD_EQUAL,           (gr_funcptr) mtpoly_equal},
+    {GR_METHOD_NEG,             (gr_funcptr) mtpoly_neg},
+    {GR_METHOD_ADD,             (gr_funcptr) mtpoly_add},
+    {GR_METHOD_SUB,             (gr_funcptr) mtpoly_sub},
+    {GR_METHOD_MUL,             (gr_funcptr) mtpoly_mul},
+    {GR_METHOD_ADDMUL,          (gr_funcptr) mtpoly_addmul},
+    {GR_METHOD_SUBMUL,          (gr_funcptr) mtpoly_submul},
+    {GR_METHOD_SET_GR_POLY,     (gr_funcptr) mtpoly_set_gr_poly},
+    {GR_METHOD_GET_GR_POLY,     (gr_funcptr) mtpoly_get_gr_poly},
+    {GR_METHOD_GET_GR_POLY_WINDOW, (gr_funcptr) mtpoly_get_gr_poly_window},
+    {0,                         (gr_funcptr) NULL},
+};
+
+int
+_gr_mpn_mod_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base,
+        slong len_bound, slong terms_bound,
+        const struct gr_transformed_poly_workload_struct * workload)
+{
+    mtpoly_ctx_struct * T;
+    slong N = len_bound;
+    slong nlimbs;
+    ulong nbits, i;
+
+    if (base->which_ring != GR_CTX_MPN_MOD || N < 1 || terms_bound < 1 ||
+            (ulong) terms_bound > UWORD_MAX / 8)
+        return GR_UNABLE;
+
+    nlimbs = MPN_MOD_CTX_NLIMBS(base);
+    nbits = MPN_MOD_CTX_MODULUS_BITS(base);
+
+    T = FLINT_ARRAY_ALLOC(1, mtpoly_ctx_struct);
+    T->base = base;
+    T->nlimbs = nlimbs;
+    T->N = N;
+    T->terms_bound = (ulong) terms_bound;
+    T->max_depth = 2;
+
+    /* provision the chinese remaindering for products of multiplicative
+       depth up to 2 with up to terms_bound elementary products, times
+       four: one bit for the signed-value bias and one because the
+       reconstruction requires values below half the prime product */
+    T->P->R = get_default_mpn_ctx();
+    T->P->sign = 0;
+    _fft_small_plan_set_window(T->P, 0, (ulong) N, (ulong) N,
+                               n_round_up((ulong) N, BLK_SZ));
+    if (!_fft_small_plan_set_bound(T->P, 4 * (ulong) terms_bound,
+                                   2 * nbits, MPN_CTX_NCRTS))
+    {
+        flint_free(T);
+        return GR_UNABLE;
+    }
+    _fft_small_plan_set_normalizers(T->P);
+
+    /* workload cost model, as in the nmod ring; there is no repacked or
+       single-prime fused alternative for multi-word moduli, so the fused
+       side always uses the same transform sizes with its own (usually
+       equal) prime count */
+    {
+        const gr_transformed_poly_workload_struct def = { 2, 1, 1, 0 };
+        const gr_transformed_poly_workload_struct * wl =
+            workload ? workload : &def;
+        double L = (double) n_round_up((ulong) N, BLK_SZ);
+        double lg = (double) FLINT_BIT_COUNT((ulong) L);
+        double np = (double) T->P->np;
+        double ni = (double) wl->num_inputs;
+        double nm = (double) wl->num_muls;
+        double no = (double) wl->num_outputs;
+        double npf, rep, fuse, bytes, limit;
+
+        /* per-coefficient conversions cost ~nlimbs here */
+        rep = np * L * ((ni + no) * (lg + 2.0 * nlimbs) + nm * 2.0)
+                + no * np * L * 3.0 + 5e4;
+        npf = (double) ((2 * nbits + FLINT_BIT_COUNT((ulong) L) + 49) / 50);
+        npf = FLINT_MAX(npf, 1.0);
+        fuse = nm * (npf * L * (3.0 * lg + 4.0 * nlimbs + 2.0)
+                     + npf * L * 3.0);
+
+        bytes = (ni + 3.0) * np *
+                (double) sd_fft_ctx_data_size(T->P->depth) * 8.0;
+        limit = wl->mem_limit > 0 ? (double) wl->mem_limit : 4.0 * 1073741824.0;
+
+        if (rep >= 0.865 * fuse || bytes > limit)
+        {
+            fft_small_plan_clear(T->P);
+            flint_free(T);
+            return GR_UNABLE;
+        }
+    }
+
+    for (i = 0; i < T->P->np; i++)
+    {
+        T->m_orig[i] = T->P->m[i];
+        T->P->m[i] = 1;
+    }
+
+    /* bias C = terms_bound * (n-1)^2 (see the nmod ring) */
+    {
+        fmpz_t C, nz;
+        T->bias_mod_n = FLINT_ARRAY_ALLOC(nlimbs, ulong);
+
+        fmpz_init(nz);
+        fmpz_set_ui_array(nz, MPN_MOD_CTX_MODULUS(base), nlimbs);
+        fmpz_init(C);
+        fmpz_sub_ui(C, nz, 1);
+        fmpz_mul(C, C, C);
+        fmpz_mul_ui(C, C, (ulong) terms_bound);
+        for (i = 0; i < T->P->np; i++)
+        {
+            sd_fft_ctx_struct * Q = T->P->ffts + T->P->offset + i;
+            ulong cop = T->P->np == 1 ? 1 :
+                *crt_data_co_prime_red(T->P->crts + T->P->np - 1,
+                                       T->P->offset + i);
+            ulong Ci = fmpz_fdiv_ui(C, Q->mod.n);
+            T->bias_res[i] = nmod_mul(Ci, nmod_inv(cop % Q->mod.n, Q->mod),
+                                      Q->mod);
+        }
+        fmpz_mod(C, C, nz);
+        fmpz_get_ui_array(T->bias_mod_n, nlimbs, C);
+        fmpz_clear(C);
+        fmpz_clear(nz);
+    }
+
+    ctx->which_ring = GR_CTX_GR_TRANSFORMED_POLY;
+    ctx->sizeof_elem = sizeof(mtpoly_struct);
+    ctx->size_limit = WORD_MAX;
+    GR_CTX_DATA_AS_PTR(ctx) = T;
+    ctx->methods = __mtpoly_methods;
+
+    /* concurrent initializations write identical data, which is the
+       accepted pattern for gr method tables */
+    if (!__mtpoly_methods_initialized)
+    {
+        gr_method_tab_init(__mtpoly_methods, __mtpoly_methods_input);
+        __mtpoly_methods_initialized = 1;
+    }
+
+    return GR_SUCCESS;
+}
+
+#else /* FLINT_HAVE_FFT_SMALL */
+
+int
+_gr_mpn_mod_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base,
+        slong len_bound, slong terms_bound,
+        const struct gr_transformed_poly_workload_struct * workload)
+{
+    return GR_UNABLE;
+}
+
+#endif

--- a/src/nmod_poly_mat.h
+++ b/src/nmod_poly_mat.h
@@ -196,6 +196,12 @@ void nmod_poly_mat_neg(nmod_poly_mat_t B, const nmod_poly_mat_t A);
 void nmod_poly_mat_mul(nmod_poly_mat_t C, const nmod_poly_mat_t A,
                                             const nmod_poly_mat_t B);
 
+/* Window [zl, zh) of each entry of A*B through the small-prime FFT with
+   transform reuse; returns 0 if the accumulation bound admits no plan. */
+int nmod_poly_mat_mulmid_fft_small(nmod_poly_mat_t C,
+                    const nmod_poly_mat_t A, const nmod_poly_mat_t B,
+                    slong zl, slong zh);
+
 void nmod_poly_mat_mul_interpolate(nmod_poly_mat_t C, const nmod_poly_mat_t A,
     const nmod_poly_mat_t B);
 

--- a/src/nmod_poly_mat/mul.c
+++ b/src/nmod_poly_mat/mul.c
@@ -17,6 +17,12 @@
 #define INTERPOLATE_MIN_DIM 60
 #define KS_MAX_LENGTH 128
 
+/* transform-reuse fft matmul pays off from these operand lengths on;
+   the lower cutoff needs the larger per-product cost of multi-prime
+   moduli to amortize the transform padding (single-threaded tuning) */
+#define FFT_MIN_LENGTH 128
+#define FFT_MIN_LENGTH_BIG_MOD 64
+
 void
 nmod_poly_mat_mul(nmod_poly_mat_t C, const nmod_poly_mat_t A,
     const nmod_poly_mat_t B)
@@ -29,6 +35,22 @@ nmod_poly_mat_mul(nmod_poly_mat_t C, const nmod_poly_mat_t A,
     bc = B->c;
 
     dim = FLINT_MIN(FLINT_MIN(ar, br), bc);
+
+    if (dim >= 2)
+    {
+        slong Alen = nmod_poly_mat_max_length(A);
+        slong Blen = nmod_poly_mat_max_length(B);
+        slong minlen = FLINT_MIN(Alen, Blen);
+        slong cutoff = (dim >= 3 &&
+                FLINT_BIT_COUNT(nmod_poly_mat_modulus(A)) > 40)
+                        ? FFT_MIN_LENGTH_BIG_MOD : FFT_MIN_LENGTH;
+
+        /* returns 0 when fft_small is unavailable or no plan exists, in
+           which case we fall through to the other algorithms */
+        if (minlen >= cutoff &&
+                nmod_poly_mat_mulmid_fft_small(C, A, B, 0, Alen + Blen - 1))
+            return;
+    }
 
     if (dim < KS_MIN_DIM)
     {

--- a/src/nmod_poly_mat/mul.c
+++ b/src/nmod_poly_mat/mul.c
@@ -17,9 +17,6 @@
 #define INTERPOLATE_MIN_DIM 60
 #define KS_MAX_LENGTH 128
 
-/* transform-reuse fft matmul pays off from these operand lengths on;
-   the lower cutoff needs the larger per-product cost of multi-prime
-   moduli to amortize the transform padding (single-threaded tuning) */
 #define FFT_MIN_LENGTH 128
 #define FFT_MIN_LENGTH_BIG_MOD 64
 
@@ -41,13 +38,13 @@ nmod_poly_mat_mul(nmod_poly_mat_t C, const nmod_poly_mat_t A,
         slong Alen = nmod_poly_mat_max_length(A);
         slong Blen = nmod_poly_mat_max_length(B);
         slong minlen = FLINT_MIN(Alen, Blen);
-        slong cutoff = (dim >= 3 &&
-                FLINT_BIT_COUNT(nmod_poly_mat_modulus(A)) > 40)
+
+        slong cutoff = (FLINT_BIT_COUNT(nmod_poly_mat_modulus(A)) > 40)
                         ? FFT_MIN_LENGTH_BIG_MOD : FFT_MIN_LENGTH;
 
         /* returns 0 when fft_small is unavailable or no plan exists, in
            which case we fall through to the other algorithms */
-        if (minlen >= cutoff &&
+        if (minlen >= cutoff && minlen >= 2 * (slong) dim &&
                 nmod_poly_mat_mulmid_fft_small(C, A, B, 0, Alen + Blen - 1))
             return;
     }

--- a/src/nmod_poly_mat/mulmid_fft_small.c
+++ b/src/nmod_poly_mat/mulmid_fft_small.c
@@ -42,9 +42,10 @@ typedef struct
     const nmod_poly_mat_struct * A;
     const nmod_poly_mat_struct * B;
     nmod_poly_mat_struct * C;
-    slong ar, k, bc, nA;
+    slong ar, k, bc, nA, nB;
     slong zl, hi, wlen;
     slong tid, nthreads;
+    int share;
     int status;
 }
 _mm_arg;
@@ -54,7 +55,7 @@ _mm_arg;
 static void _mm_phase1(void * varg)
 {
     _mm_arg * a = (_mm_arg *) varg;
-    slong t, ntot = a->nA + a->k * a->bc;
+    slong t, ntot = a->nA + a->nB;
 
     for (t = a->tid; t < ntot; t += a->nthreads)
     {
@@ -74,7 +75,7 @@ static void _mm_phase1(void * varg)
 static void _mm_phase2(void * varg)
 {
     _mm_arg * a = (_mm_arg *) varg;
-    slong nin = a->nA + a->k * a->bc;
+    slong nin = a->nA + a->nB;
     gr_ptr acc = _MM_TE(a, nin + a->tid);
     slong t, l;
 
@@ -84,10 +85,13 @@ static void _mm_phase2(void * varg)
         nmod_poly_struct * entry = nmod_poly_mat_entry(a->C, i, j);
 
         a->status |= gr_mul(acc, _MM_TE(a, i * a->k),
-                            _MM_TE(a, a->nA + j), a->tctx);
+                            a->share ? _MM_TE(a, j)
+                                     : _MM_TE(a, a->nA + j), a->tctx);
         for (l = 1; l < a->k; l++)
             a->status |= gr_addmul(acc, _MM_TE(a, i * a->k + l),
-                                   _MM_TE(a, a->nA + l * a->bc + j), a->tctx);
+                                   a->share ? _MM_TE(a, l * a->k + j)
+                                            : _MM_TE(a, a->nA + l * a->bc + j),
+                                   a->tctx);
 
         nmod_poly_fit_length(entry, a->wlen);
         /* the accumulator is this thread's own and dead after the
@@ -104,13 +108,15 @@ static void _mm_phase2(void * varg)
     }
 }
 
-int nmod_poly_mat_mulmid_fft_small(nmod_poly_mat_t C,
+static int _mulmid_fft_small_direct(nmod_poly_mat_t C,
                     const nmod_poly_mat_t A, const nmod_poly_mat_t B,
                     slong zl, slong zh)
 {
     slong ar = A->r;
     slong k = A->c;
     slong bc = B->c;
+    int share = (A == B);
+    slong nB;
     slong i, j, l;
     ulong amax, bmax, zn, terms, hi_prod, lo_prod;
     nmod_t mod;
@@ -140,7 +146,7 @@ int nmod_poly_mat_mulmid_fft_small(nmod_poly_mat_t C,
     {
         nmod_poly_mat_t T;
         nmod_poly_mat_init(T, ar, bc, nmod_poly_mat_modulus(A));
-        success = nmod_poly_mat_mulmid_fft_small(T, A, B, zl, zh);
+        success = _mulmid_fft_small_direct(T, A, B, zl, zh);
         if (success)
             nmod_poly_mat_swap_entrywise(C, T);
         nmod_poly_mat_clear(T);
@@ -174,9 +180,13 @@ int nmod_poly_mat_mulmid_fft_small(nmod_poly_mat_t C,
     terms = lo_prod + 2;
 
     gr_ctx_init_nmod(ctx, mod.n);
-    wl->num_inputs = ar * k + k * bc;
+    nB = share ? 0 : k * bc;
+    wl->num_inputs = ar * k + nB;
     wl->num_muls = ar * bc * k;
     wl->num_outputs = ar * bc;
+    /* the input transforms stay live throughout (a squaring keeps a
+       single pool), plus one accumulator per thread */
+    wl->num_live = ar * k + nB + flint_get_num_available_threads();
     wl->mem_limit = 0;
 
     if (gr_ctx_init_gr_poly_transformed_repr(tctx, ctx, (slong) zn,
@@ -189,7 +199,7 @@ int nmod_poly_mat_mulmid_fft_small(nmod_poly_mat_t C,
     nworkers = flint_request_threads(&handles, 8);
     nthreads = nworkers + 1;
 
-    GR_TMP_INIT_VEC(TE, ar * k + k * bc + nthreads, tctx);
+    GR_TMP_INIT_VEC(TE, ar * k + nB + nthreads, tctx);
 
     for (i = 0; i < nthreads; i++)
     {
@@ -197,6 +207,8 @@ int nmod_poly_mat_mulmid_fft_small(nmod_poly_mat_t C,
         args[i].A = A; args[i].B = B; args[i].C = C;
         args[i].ar = ar; args[i].k = k; args[i].bc = bc;
         args[i].nA = ar * k;
+        args[i].nB = nB;
+        args[i].share = share;
         args[i].zl = zl;
         args[i].hi = FLINT_MIN(zh, (slong) zn);
         args[i].wlen = zh - zl;
@@ -223,11 +235,65 @@ int nmod_poly_mat_mulmid_fft_small(nmod_poly_mat_t C,
     for (i = 0; i < nthreads; i++)
         status |= args[i].status;
 
-    GR_TMP_CLEAR_VEC(TE, ar * k + k * bc + nthreads, tctx);
+    GR_TMP_CLEAR_VEC(TE, ar * k + nB + nthreads, tctx);
     gr_ctx_clear(tctx);
     gr_ctx_clear(ctx);
 
     return status == GR_SUCCESS;
+}
+
+int nmod_poly_mat_mulmid_fft_small(nmod_poly_mat_t C,
+                    const nmod_poly_mat_t A, const nmod_poly_mat_t B,
+                    slong zl, slong zh)
+{
+    slong ar = A->r, bc = B->c, bs, I, J;
+
+    if (_mulmid_fft_small_direct(C, A, B, zl, zh))
+        return 1;
+
+    /* the full product exceeded the transform-storage budget: retry in
+       row and column blocks over the full inner dimension (the window
+       [zl, zh) of a middle product is linear in the operands, so blocks
+       compose exactly), halving the block size until it fits; the inner
+       dimension itself is never split */
+    if (C == A || C == B)
+    {
+        nmod_poly_mat_t T;
+        int success;
+        nmod_poly_mat_init(T, ar, bc, nmod_poly_mat_modulus(A));
+        success = nmod_poly_mat_mulmid_fft_small(T, A, B, zl, zh);
+        if (success)
+            nmod_poly_mat_swap(C, T);
+        nmod_poly_mat_clear(T);
+        return success;
+    }
+
+    for (bs = (FLINT_MAX(ar, bc) + 1) / 2; bs >= 1; bs /= 2)
+    {
+        int feasible = 1;
+
+        for (I = 0; feasible && I < ar; I += bs)
+            for (J = 0; feasible && J < bc; J += bs)
+            {
+                nmod_poly_mat_t Aw, Bw, Cw;
+                slong ml = FLINT_MIN(bs, ar - I);
+                slong nl = FLINT_MIN(bs, bc - J);
+
+                nmod_poly_mat_window_init(Aw, A, I, 0, I + ml, A->c);
+                nmod_poly_mat_window_init(Bw, B, 0, J, B->r, J + nl);
+                nmod_poly_mat_window_init(Cw, C, I, J, I + ml, J + nl);
+                feasible = _mulmid_fft_small_direct(Cw, Aw, Bw, zl, zh);
+                nmod_poly_mat_window_clear(Aw);
+                nmod_poly_mat_window_clear(Bw);
+                nmod_poly_mat_window_clear(Cw);
+            }
+
+        if (feasible)
+            return 1;
+        if (bs == 1)
+            break;
+    }
+    return 0;
 }
 
 #else

--- a/src/nmod_poly_mat/mulmid_fft_small.c
+++ b/src/nmod_poly_mat/mulmid_fft_small.c
@@ -188,6 +188,7 @@ static int _mulmid_fft_small_direct(nmod_poly_mat_t C,
        single pool), plus one accumulator per thread */
     wl->num_live = ar * k + nB + flint_get_num_available_threads();
     wl->mem_limit = 0;
+    wl->force = 0;
 
     if (gr_ctx_init_gr_poly_transformed_repr(tctx, ctx, (slong) zn,
                 (slong) terms, wl) != GR_SUCCESS)

--- a/src/nmod_poly_mat/mulmid_fft_small.c
+++ b/src/nmod_poly_mat/mulmid_fft_small.c
@@ -9,126 +9,93 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "thread_pool.h"
 #include "thread_support.h"
-#include "mpn_extras.h"
-#include "ulong_extras.h"
+#include "thread_pool.h"
+
+#include <string.h>
+#include "thread_pool.h"
 #include "nmod.h"
 #include "nmod_vec.h"
 #include "nmod_poly.h"
 #include "nmod_poly_mat.h"
+#include "gr.h"
+#include "gr_poly.h"
 
 #if FLINT_HAVE_FFT_SMALL
 
-#include "fft_small.h"
-
 /*
-    Set each entry of C to the coefficient window [zl, zh) of the
-    corresponding entry of the matrix product A*B, computed with a single
-    fft_small plan: every input polynomial is transformed once, the k
-    products of each output entry are accumulated pointwise in transform
-    space, and one inverse transform plus chinese remaindering per output
-    entry recovers the window.
-
-    Work is distributed over the available threads at the task level:
-    input transforms in one pass, then (accumulate, ifft, export) per
-    output entry in a second pass. When there are fewer tasks than
-    threads, the transform and export functions pick up the spare pool
-    threads internally through their own flint_request_threads calls, so
-    both small matrices of huge polynomials and large matrices of small
-    polynomials parallelize.
-
-    Returns 1 on success and 0 (leaving C undefined) if no plan exists,
-    which requires the accumulation bound k*min(amax, bmax)*2^(2*modbits)
-    to exceed the available primes and is unreachable for practical
-    dimensions.
+    Windowed matrix product over a ring of transformed polynomials: the
+    ar*k + k*bc input entries are each transformed once and reused across
+    the ar*bc*k pointwise products, and only the ar*bc output entries are
+    inverse-transformed, with chinese remaindering restricted to the
+    window [zl, zh). The batch is homogeneous, so the ring's shared
+    transform size is tight. The ring is thread safe: the conversions in
+    and the output entries are distributed over the global thread pool,
+    with one accumulator element per thread.
 */
 
-typedef struct {
-    fft_small_op_struct* ops;
-    const nmod_poly_struct** tasks;
-    ulong ntasks;
-    nmod_t mod;
-    const fft_small_plan_struct* P;
-    ulong start;
-    ulong stop;
-} _transform_worker_struct;
-
-static void _transform_worker_func(void* varg)
+typedef struct
 {
-    _transform_worker_struct* W = (_transform_worker_struct*) varg;
+    gr_ctx_struct * ctx;
+    gr_ctx_struct * tctx;
+    gr_ptr TE;
+    const nmod_poly_mat_struct * A;
+    const nmod_poly_mat_struct * B;
+    nmod_poly_mat_struct * C;
+    slong ar, k, bc, nA;
+    slong zl, hi, wlen;
+    slong tid, nthreads;
+    int status;
+}
+_mm_arg;
 
-    for (ulong t = W->start; t < W->stop; t++)
+#define _MM_TE(a, i) GR_ENTRY((a)->TE, i, (a)->tctx->sizeof_elem)
+
+static void _mm_phase1(void * varg)
+{
+    _mm_arg * a = (_mm_arg *) varg;
+    slong t, ntot = a->nA + a->k * a->bc;
+
+    for (t = a->tid; t < ntot; t += a->nthreads)
     {
-        const nmod_poly_struct* p = W->tasks[t];
-
-        if (p->length > 0)
-            fft_small_fft_nmod(W->ops + t, p->coeffs, p->length,
-                    n_round_up(p->length, BLK_SZ), W->mod, W->P);
+        const nmod_poly_struct * e;
+        if (t < a->nA)
+            e = nmod_poly_mat_entry(a->A, t / a->k, t % a->k);
+        else
+        {
+            slong u = t - a->nA;
+            e = nmod_poly_mat_entry(a->B, u / a->bc, u % a->bc);
+        }
+        a->status |= _gr_set_gr_poly(_MM_TE(a, t), e->coeffs, e->length,
+                                     a->ctx, a->tctx);
     }
 }
 
-typedef struct {
-    nmod_poly_mat_struct* C;
-    const fft_small_op_struct* Aops;    /* entry (i, l) at index i*k + l */
-    const fft_small_op_struct* Bops;    /* entry (l, j) at index l*bc + j */
-    slong k;
-    slong bc;
-    ulong wlen;                         /* zh - zl of the original window */
-    nmod_t mod;
-    const fft_small_plan_struct* P;
-    fft_small_op_struct Z[1];           /* per-worker accumulator */
-    ulong* tmp;                         /* per-worker export buffer */
-    ulong start_ij;
-    ulong stop_ij;
-} _entry_worker_struct;
-
-static void _entry_worker_func(void* varg)
+static void _mm_phase2(void * varg)
 {
-    _entry_worker_struct* W = (_entry_worker_struct*) varg;
-    const fft_small_plan_struct* P = W->P;
-    ulong elen = P->zh - P->zl;         /* exported length (window clamped
-                                           to the maximal product length) */
+    _mm_arg * a = (_mm_arg *) varg;
+    slong nin = a->nA + a->k * a->bc;
+    gr_ptr acc = _MM_TE(a, nin + a->tid);
+    slong t, l;
 
-    for (ulong idx = W->start_ij; idx < W->stop_ij; idx++)
+    for (t = a->tid; t < a->ar * a->bc; t += a->nthreads)
     {
-        slong i = idx / W->bc;
-        slong j = idx % W->bc;
-        nmod_poly_struct* entry = nmod_poly_mat_entry(W->C, i, j);
-        ulong cnt = 0;
+        slong i = t / a->bc, j = t % a->bc;
+        nmod_poly_struct * entry = nmod_poly_mat_entry(a->C, i, j);
 
-        for (slong l = 0; l < W->k; l++)
-        {
-            const fft_small_op_struct* Ail = W->Aops + i*W->k + l;
-            const fft_small_op_struct* Blj = W->Bops + l*W->bc + j;
+        a->status |= gr_mul(acc, _MM_TE(a, i * a->k),
+                            _MM_TE(a, a->nA + j), a->tctx);
+        for (l = 1; l < a->k; l++)
+            a->status |= gr_addmul(acc, _MM_TE(a, i * a->k + l),
+                                   _MM_TE(a, a->nA + l * a->bc + j), a->tctx);
 
-            /* zero factors were never transformed and contribute nothing */
-            if (Ail->itrunc == 0 || Blj->itrunc == 0)
-                continue;
-
-            if (cnt == 0)
-                fft_small_op_mul(W->Z, Ail, Blj, P);
-            else
-                fft_small_op_addmul(W->Z, Ail, Blj, P);
-            cnt++;
-        }
-
-        nmod_poly_fit_length(entry, W->wlen);
-
-        if (cnt == 0)
-        {
-            _nmod_vec_zero(entry->coeffs, W->wlen);
-        }
-        else
-        {
-            fft_small_ifft(W->Z, P);
-            fft_small_export_nmod(W->tmp, W->Z, W->mod, P);
-            flint_mpn_copyi(entry->coeffs, W->tmp, elen);
-            if (W->wlen > elen)
-                _nmod_vec_zero(entry->coeffs + elen, W->wlen - elen);
-        }
-
-        _nmod_poly_set_length(entry, W->wlen);
+        nmod_poly_fit_length(entry, a->wlen);
+        a->status |= _gr_get_gr_poly_window(entry->coeffs, acc,
+                                            a->zl, a->hi, a->ctx, a->tctx);
+        if (a->wlen > a->hi - a->zl)
+            _nmod_vec_zero(entry->coeffs + (a->hi - a->zl),
+                           a->wlen - (a->hi - a->zl));
+        _nmod_poly_set_length(entry, a->wlen);
         _nmod_poly_normalise(entry);
     }
 }
@@ -141,18 +108,15 @@ int nmod_poly_mat_mulmid_fft_small(nmod_poly_mat_t C,
     slong k = A->c;
     slong bc = B->c;
     slong i, j, l;
-    ulong amax, bmax, zn, wlen, modbits, len_bound, hi;
-    ulong nA, nB, nC, ntasks, t;
+    ulong amax, bmax, zn, terms, hi_prod, lo_prod;
     nmod_t mod;
-    fft_small_plan_t P;
-    fft_small_op_struct* ops;
-    const nmod_poly_struct** tasks;
-    _transform_worker_struct* targs;
-    _entry_worker_struct* eargs;
-    thread_pool_handle* handles;
-    slong nworkers;
-    ulong nthreads;
-    int success;
+    gr_ctx_t ctx, tctx;
+    gr_transformed_poly_workload_t wl;
+    gr_ptr TE;
+    thread_pool_handle * handles = NULL;
+    slong nworkers, nthreads;
+    _mm_arg args[9];
+    int status = GR_SUCCESS, success;
 
     FLINT_ASSERT(k == B->r);
     FLINT_ASSERT(C->r == ar && C->c == bc);
@@ -180,7 +144,6 @@ int nmod_poly_mat_mulmid_fft_small(nmod_poly_mat_t C,
     }
 
     nmod_init(&mod, nmod_poly_mat_modulus(A));
-    wlen = (ulong) (zh - zl);
 
     amax = 0;
     for (i = 0; i < ar; i++)
@@ -199,123 +162,71 @@ int nmod_poly_mat_mulmid_fft_small(nmod_poly_mat_t C,
     }
 
     zn = amax + bmax - 1;
-    hi = FLINT_MIN((ulong) zh, zn);
 
-    modbits = FLINT_BITS - mod.norm;
-
-    /* at most k*min(amax, bmax) products, each < 2^(2*modbits), accumulate
-       onto one output coefficient */
-    {
-        ulong lo_prod, hi_prod;
-        umul_ppmm(hi_prod, lo_prod, (ulong) k, FLINT_MIN(amax, bmax));
-        if (hi_prod != 0)
-            return 0;
-        len_bound = lo_prod;
-    }
-
-    success = fft_small_plan_init_nmod(P, get_default_mpn_ctx(),
-                    (ulong) zl, hi, zn,
-                    n_max(n_round_up(amax, BLK_SZ), n_round_up(bmax, BLK_SZ)),
-                    len_bound, 2*modbits, mod, FLINT_MIN(amax, bmax));
-    if (!success)
+    /* at most k*min(amax, bmax) products accumulate per coefficient */
+    umul_ppmm(hi_prod, lo_prod, (ulong) k, FLINT_MIN(amax, bmax));
+    if (hi_prod != 0 || lo_prod > UWORD_MAX / 8)
         return 0;
+    terms = lo_prod + 2;
 
-    nA = (ulong) ar * k;
-    nB = (ulong) k * bc;
-    nC = (ulong) ar * bc;
+    gr_ctx_init_nmod(ctx, mod.n);
+    wl->num_inputs = ar * k + k * bc;
+    wl->num_muls = ar * bc * k;
+    wl->num_outputs = ar * bc;
+    wl->mem_limit = 0;
 
-    ops = FLINT_ARRAY_ALLOC(nA + nB, fft_small_op_struct);
-    tasks = FLINT_ARRAY_ALLOC(nA + nB, const nmod_poly_struct*);
-
-    for (i = 0; i < ar; i++)
-        for (l = 0; l < k; l++)
-            tasks[i*k + l] = nmod_poly_mat_entry(A, i, l);
-    for (l = 0; l < k; l++)
-        for (j = 0; j < bc; j++)
-            tasks[nA + l*bc + j] = nmod_poly_mat_entry(B, l, j);
-
-    /* itrunc == 0 marks an untransformed (zero) operand for the
-       accumulation pass */
-    for (t = 0; t < nA + nB; t++)
+    if (gr_ctx_init_gr_poly_transformed_repr(tctx, ctx, (slong) zn,
+                (slong) terms, wl) != GR_SUCCESS)
     {
-        fft_small_op_init(ops + t, P);
-        ops[t].itrunc = 0;
+        gr_ctx_clear(ctx);
+        return 0;
     }
 
-    ntasks = FLINT_MAX(nA + nB, nC);
-    nworkers = flint_request_threads(&handles, ntasks);
+    nworkers = flint_request_threads(&handles, 8);
     nthreads = nworkers + 1;
 
-    /* stage 1: all input transforms, distributed over the threads; when
-       tasks are fewer than threads, fft_small_fft_nmod itself picks up
-       the spare pool threads */
-    targs = FLINT_ARRAY_ALLOC(nthreads, _transform_worker_struct);
-    for (t = 0; t < nthreads; t++)
+    GR_TMP_INIT_VEC(TE, ar * k + k * bc + nthreads, tctx);
+
+    for (i = 0; i < nthreads; i++)
     {
-        _transform_worker_struct* W = targs + t;
-        W->ops = ops;
-        W->tasks = tasks;
-        W->ntasks = nA + nB;
-        W->mod = mod;
-        W->P = P;
-        W->start = (t+0)*(nA + nB)/nthreads;
-        W->stop  = (t+1)*(nA + nB)/nthreads;
+        args[i].ctx = ctx; args[i].tctx = tctx; args[i].TE = TE;
+        args[i].A = A; args[i].B = B; args[i].C = C;
+        args[i].ar = ar; args[i].k = k; args[i].bc = bc;
+        args[i].nA = ar * k;
+        args[i].zl = zl;
+        args[i].hi = FLINT_MIN(zh, (slong) zn);
+        args[i].wlen = zh - zl;
+        args[i].tid = i; args[i].nthreads = nthreads;
+        args[i].status = GR_SUCCESS;
     }
 
-    for (t = nthreads - 1; t > 0; t--)
-        thread_pool_wake(global_thread_pool, handles[t - 1], 0,
-                         _transform_worker_func, targs + t);
-    _transform_worker_func(targs + 0);
-    for (t = nthreads - 1; t > 0; t--)
-        thread_pool_wait(global_thread_pool, handles[t - 1]);
+    for (i = nworkers; i > 0; i--)
+        thread_pool_wake(global_thread_pool, handles[i - 1], 0,
+                         _mm_phase1, args + i);
+    _mm_phase1(args + 0);
+    for (i = nworkers; i > 0; i--)
+        thread_pool_wait(global_thread_pool, handles[i - 1]);
 
-    /* stage 2: accumulate, invert and export each output entry,
-       distributed over the threads */
-    eargs = FLINT_ARRAY_ALLOC(nthreads, _entry_worker_struct);
-    for (t = 0; t < nthreads; t++)
-    {
-        _entry_worker_struct* W = eargs + t;
-        W->C = C;
-        W->Aops = ops;
-        W->Bops = ops + nA;
-        W->k = k;
-        W->bc = bc;
-        W->wlen = wlen;
-        W->mod = mod;
-        W->P = P;
-        fft_small_op_init(W->Z, P);
-        W->tmp = FLINT_ARRAY_ALLOC(P->zh - P->zl, ulong);
-        W->start_ij = (t+0)*nC/nthreads;
-        W->stop_ij  = (t+1)*nC/nthreads;
-    }
-
-    for (t = nthreads - 1; t > 0; t--)
-        thread_pool_wake(global_thread_pool, handles[t - 1], 0,
-                         _entry_worker_func, eargs + t);
-    _entry_worker_func(eargs + 0);
-    for (t = nthreads - 1; t > 0; t--)
-        thread_pool_wait(global_thread_pool, handles[t - 1]);
+    for (i = nworkers; i > 0; i--)
+        thread_pool_wake(global_thread_pool, handles[i - 1], 0,
+                         _mm_phase2, args + i);
+    _mm_phase2(args + 0);
+    for (i = nworkers; i > 0; i--)
+        thread_pool_wait(global_thread_pool, handles[i - 1]);
 
     flint_give_back_threads(handles, nworkers);
 
-    for (t = 0; t < nthreads; t++)
-    {
-        fft_small_op_clear(eargs[t].Z);
-        flint_free(eargs[t].tmp);
-    }
-    for (t = 0; t < nA + nB; t++)
-        fft_small_op_clear(ops + t);
+    for (i = 0; i < nthreads; i++)
+        status |= args[i].status;
 
-    flint_free(eargs);
-    flint_free(targs);
-    flint_free(tasks);
-    flint_free(ops);
-    fft_small_plan_clear(P);
+    GR_TMP_CLEAR_VEC(TE, ar * k + k * bc + nthreads, tctx);
+    gr_ctx_clear(tctx);
+    gr_ctx_clear(ctx);
 
-    return 1;
+    return status == GR_SUCCESS;
 }
 
-#else /* FLINT_HAVE_FFT_SMALL */
+#else
 
 int nmod_poly_mat_mulmid_fft_small(nmod_poly_mat_t C,
                     const nmod_poly_mat_t A, const nmod_poly_mat_t B,

--- a/src/nmod_poly_mat/mulmid_fft_small.c
+++ b/src/nmod_poly_mat/mulmid_fft_small.c
@@ -1,0 +1,327 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "thread_pool.h"
+#include "thread_support.h"
+#include "mpn_extras.h"
+#include "ulong_extras.h"
+#include "nmod.h"
+#include "nmod_vec.h"
+#include "nmod_poly.h"
+#include "nmod_poly_mat.h"
+
+#if FLINT_HAVE_FFT_SMALL
+
+#include "fft_small.h"
+
+/*
+    Set each entry of C to the coefficient window [zl, zh) of the
+    corresponding entry of the matrix product A*B, computed with a single
+    fft_small plan: every input polynomial is transformed once, the k
+    products of each output entry are accumulated pointwise in transform
+    space, and one inverse transform plus chinese remaindering per output
+    entry recovers the window.
+
+    Work is distributed over the available threads at the task level:
+    input transforms in one pass, then (accumulate, ifft, export) per
+    output entry in a second pass. When there are fewer tasks than
+    threads, the transform and export functions pick up the spare pool
+    threads internally through their own flint_request_threads calls, so
+    both small matrices of huge polynomials and large matrices of small
+    polynomials parallelize.
+
+    Returns 1 on success and 0 (leaving C undefined) if no plan exists,
+    which requires the accumulation bound k*min(amax, bmax)*2^(2*modbits)
+    to exceed the available primes and is unreachable for practical
+    dimensions.
+*/
+
+typedef struct {
+    fft_small_op_struct* ops;
+    const nmod_poly_struct** tasks;
+    ulong ntasks;
+    nmod_t mod;
+    const fft_small_plan_struct* P;
+    ulong start;
+    ulong stop;
+} _transform_worker_struct;
+
+static void _transform_worker_func(void* varg)
+{
+    _transform_worker_struct* W = (_transform_worker_struct*) varg;
+
+    for (ulong t = W->start; t < W->stop; t++)
+    {
+        const nmod_poly_struct* p = W->tasks[t];
+
+        if (p->length > 0)
+            fft_small_fft_nmod(W->ops + t, p->coeffs, p->length,
+                    n_round_up(p->length, BLK_SZ), W->mod, W->P);
+    }
+}
+
+typedef struct {
+    nmod_poly_mat_struct* C;
+    const fft_small_op_struct* Aops;    /* entry (i, l) at index i*k + l */
+    const fft_small_op_struct* Bops;    /* entry (l, j) at index l*bc + j */
+    slong k;
+    slong bc;
+    ulong wlen;                         /* zh - zl of the original window */
+    nmod_t mod;
+    const fft_small_plan_struct* P;
+    fft_small_op_struct Z[1];           /* per-worker accumulator */
+    ulong* tmp;                         /* per-worker export buffer */
+    ulong start_ij;
+    ulong stop_ij;
+} _entry_worker_struct;
+
+static void _entry_worker_func(void* varg)
+{
+    _entry_worker_struct* W = (_entry_worker_struct*) varg;
+    const fft_small_plan_struct* P = W->P;
+    ulong elen = P->zh - P->zl;         /* exported length (window clamped
+                                           to the maximal product length) */
+
+    for (ulong idx = W->start_ij; idx < W->stop_ij; idx++)
+    {
+        slong i = idx / W->bc;
+        slong j = idx % W->bc;
+        nmod_poly_struct* entry = nmod_poly_mat_entry(W->C, i, j);
+        ulong cnt = 0;
+
+        for (slong l = 0; l < W->k; l++)
+        {
+            const fft_small_op_struct* Ail = W->Aops + i*W->k + l;
+            const fft_small_op_struct* Blj = W->Bops + l*W->bc + j;
+
+            /* zero factors were never transformed and contribute nothing */
+            if (Ail->itrunc == 0 || Blj->itrunc == 0)
+                continue;
+
+            if (cnt == 0)
+                fft_small_op_mul(W->Z, Ail, Blj, P);
+            else
+                fft_small_op_addmul(W->Z, Ail, Blj, P);
+            cnt++;
+        }
+
+        nmod_poly_fit_length(entry, W->wlen);
+
+        if (cnt == 0)
+        {
+            _nmod_vec_zero(entry->coeffs, W->wlen);
+        }
+        else
+        {
+            fft_small_ifft(W->Z, P);
+            fft_small_export_nmod(W->tmp, W->Z, W->mod, P);
+            flint_mpn_copyi(entry->coeffs, W->tmp, elen);
+            if (W->wlen > elen)
+                _nmod_vec_zero(entry->coeffs + elen, W->wlen - elen);
+        }
+
+        _nmod_poly_set_length(entry, W->wlen);
+        _nmod_poly_normalise(entry);
+    }
+}
+
+int nmod_poly_mat_mulmid_fft_small(nmod_poly_mat_t C,
+                    const nmod_poly_mat_t A, const nmod_poly_mat_t B,
+                    slong zl, slong zh)
+{
+    slong ar = A->r;
+    slong k = A->c;
+    slong bc = B->c;
+    slong i, j, l;
+    ulong amax, bmax, zn, wlen, modbits, len_bound, hi;
+    ulong nA, nB, nC, ntasks, t;
+    nmod_t mod;
+    fft_small_plan_t P;
+    fft_small_op_struct* ops;
+    const nmod_poly_struct** tasks;
+    _transform_worker_struct* targs;
+    _entry_worker_struct* eargs;
+    thread_pool_handle* handles;
+    slong nworkers;
+    ulong nthreads;
+    int success;
+
+    FLINT_ASSERT(k == B->r);
+    FLINT_ASSERT(C->r == ar && C->c == bc);
+    FLINT_ASSERT(zl >= 0);
+    FLINT_ASSERT(zh >= 0);
+
+    if (ar == 0 || bc == 0)
+        return 1;
+
+    if (zl >= zh)
+    {
+        nmod_poly_mat_zero(C);
+        return 1;
+    }
+
+    if (C == A || C == B)
+    {
+        nmod_poly_mat_t T;
+        nmod_poly_mat_init(T, ar, bc, nmod_poly_mat_modulus(A));
+        success = nmod_poly_mat_mulmid_fft_small(T, A, B, zl, zh);
+        if (success)
+            nmod_poly_mat_swap_entrywise(C, T);
+        nmod_poly_mat_clear(T);
+        return success;
+    }
+
+    nmod_init(&mod, nmod_poly_mat_modulus(A));
+    wlen = (ulong) (zh - zl);
+
+    amax = 0;
+    for (i = 0; i < ar; i++)
+        for (l = 0; l < k; l++)
+            amax = FLINT_MAX(amax, (ulong) nmod_poly_length(nmod_poly_mat_entry(A, i, l)));
+    bmax = 0;
+    for (l = 0; l < k; l++)
+        for (j = 0; j < bc; j++)
+            bmax = FLINT_MAX(bmax, (ulong) nmod_poly_length(nmod_poly_mat_entry(B, l, j)));
+
+    /* every product lies beyond the window, or there are no products */
+    if (amax == 0 || bmax == 0 || (ulong) zl >= amax + bmax - 1)
+    {
+        nmod_poly_mat_zero(C);
+        return 1;
+    }
+
+    zn = amax + bmax - 1;
+    hi = FLINT_MIN((ulong) zh, zn);
+
+    modbits = FLINT_BITS - mod.norm;
+
+    /* at most k*min(amax, bmax) products, each < 2^(2*modbits), accumulate
+       onto one output coefficient */
+    {
+        ulong lo_prod, hi_prod;
+        umul_ppmm(hi_prod, lo_prod, (ulong) k, FLINT_MIN(amax, bmax));
+        if (hi_prod != 0)
+            return 0;
+        len_bound = lo_prod;
+    }
+
+    success = fft_small_plan_init_nmod(P, get_default_mpn_ctx(),
+                    (ulong) zl, hi, zn,
+                    n_max(n_round_up(amax, BLK_SZ), n_round_up(bmax, BLK_SZ)),
+                    len_bound, 2*modbits, mod, FLINT_MIN(amax, bmax));
+    if (!success)
+        return 0;
+
+    nA = (ulong) ar * k;
+    nB = (ulong) k * bc;
+    nC = (ulong) ar * bc;
+
+    ops = FLINT_ARRAY_ALLOC(nA + nB, fft_small_op_struct);
+    tasks = FLINT_ARRAY_ALLOC(nA + nB, const nmod_poly_struct*);
+
+    for (i = 0; i < ar; i++)
+        for (l = 0; l < k; l++)
+            tasks[i*k + l] = nmod_poly_mat_entry(A, i, l);
+    for (l = 0; l < k; l++)
+        for (j = 0; j < bc; j++)
+            tasks[nA + l*bc + j] = nmod_poly_mat_entry(B, l, j);
+
+    /* itrunc == 0 marks an untransformed (zero) operand for the
+       accumulation pass */
+    for (t = 0; t < nA + nB; t++)
+    {
+        fft_small_op_init(ops + t, P);
+        ops[t].itrunc = 0;
+    }
+
+    ntasks = FLINT_MAX(nA + nB, nC);
+    nworkers = flint_request_threads(&handles, ntasks);
+    nthreads = nworkers + 1;
+
+    /* stage 1: all input transforms, distributed over the threads; when
+       tasks are fewer than threads, fft_small_fft_nmod itself picks up
+       the spare pool threads */
+    targs = FLINT_ARRAY_ALLOC(nthreads, _transform_worker_struct);
+    for (t = 0; t < nthreads; t++)
+    {
+        _transform_worker_struct* W = targs + t;
+        W->ops = ops;
+        W->tasks = tasks;
+        W->ntasks = nA + nB;
+        W->mod = mod;
+        W->P = P;
+        W->start = (t+0)*(nA + nB)/nthreads;
+        W->stop  = (t+1)*(nA + nB)/nthreads;
+    }
+
+    for (t = nthreads - 1; t > 0; t--)
+        thread_pool_wake(global_thread_pool, handles[t - 1], 0,
+                         _transform_worker_func, targs + t);
+    _transform_worker_func(targs + 0);
+    for (t = nthreads - 1; t > 0; t--)
+        thread_pool_wait(global_thread_pool, handles[t - 1]);
+
+    /* stage 2: accumulate, invert and export each output entry,
+       distributed over the threads */
+    eargs = FLINT_ARRAY_ALLOC(nthreads, _entry_worker_struct);
+    for (t = 0; t < nthreads; t++)
+    {
+        _entry_worker_struct* W = eargs + t;
+        W->C = C;
+        W->Aops = ops;
+        W->Bops = ops + nA;
+        W->k = k;
+        W->bc = bc;
+        W->wlen = wlen;
+        W->mod = mod;
+        W->P = P;
+        fft_small_op_init(W->Z, P);
+        W->tmp = FLINT_ARRAY_ALLOC(P->zh - P->zl, ulong);
+        W->start_ij = (t+0)*nC/nthreads;
+        W->stop_ij  = (t+1)*nC/nthreads;
+    }
+
+    for (t = nthreads - 1; t > 0; t--)
+        thread_pool_wake(global_thread_pool, handles[t - 1], 0,
+                         _entry_worker_func, eargs + t);
+    _entry_worker_func(eargs + 0);
+    for (t = nthreads - 1; t > 0; t--)
+        thread_pool_wait(global_thread_pool, handles[t - 1]);
+
+    flint_give_back_threads(handles, nworkers);
+
+    for (t = 0; t < nthreads; t++)
+    {
+        fft_small_op_clear(eargs[t].Z);
+        flint_free(eargs[t].tmp);
+    }
+    for (t = 0; t < nA + nB; t++)
+        fft_small_op_clear(ops + t);
+
+    flint_free(eargs);
+    flint_free(targs);
+    flint_free(tasks);
+    flint_free(ops);
+    fft_small_plan_clear(P);
+
+    return 1;
+}
+
+#else /* FLINT_HAVE_FFT_SMALL */
+
+int nmod_poly_mat_mulmid_fft_small(nmod_poly_mat_t C,
+                    const nmod_poly_mat_t A, const nmod_poly_mat_t B,
+                    slong zl, slong zh)
+{
+    return 0;
+}
+
+#endif

--- a/src/nmod_poly_mat/mulmid_fft_small.c
+++ b/src/nmod_poly_mat/mulmid_fft_small.c
@@ -90,8 +90,12 @@ static void _mm_phase2(void * varg)
                                    _MM_TE(a, a->nA + l * a->bc + j), a->tctx);
 
         nmod_poly_fit_length(entry, a->wlen);
-        a->status |= _gr_get_gr_poly_window(entry->coeffs, acc,
-                                            a->zl, a->hi, a->ctx, a->tctx);
+        /* the accumulator is this thread's own and dead after the
+           entry: convert it out in place, skipping the transform copy
+           and the scratch allocation; the next entry's gr_mul rebuilds
+           it as a full-write destination */
+        a->status |= _gr_nmod_tpoly_get_gr_poly_window_destructive(
+                entry->coeffs, acc, a->zl, a->hi, a->tctx);
         if (a->wlen > a->hi - a->zl)
             _nmod_vec_zero(entry->coeffs + (a->hi - a->zl),
                            a->wlen - (a->hi - a->zl));

--- a/src/nmod_poly_mat/test/main.c
+++ b/src/nmod_poly_mat/test/main.c
@@ -22,6 +22,7 @@
 #include "t-mul.c"
 #include "t-mul_interpolate.c"
 #include "t-mul_KS.c"
+#include "t-mulmid_fft_small.c"
 #include "t-neg.c"
 #include "t-nullspace.c"
 #include "t-one.c"
@@ -56,6 +57,7 @@ test_struct tests[] =
     TEST_FUNCTION(nmod_poly_mat_mul),
     TEST_FUNCTION(nmod_poly_mat_mul_interpolate),
     TEST_FUNCTION(nmod_poly_mat_mul_KS),
+    TEST_FUNCTION(nmod_poly_mat_mulmid_fft_small),
     TEST_FUNCTION(nmod_poly_mat_neg),
     TEST_FUNCTION(nmod_poly_mat_nullspace),
     TEST_FUNCTION(nmod_poly_mat_one),

--- a/src/nmod_poly_mat/test/t-mul.c
+++ b/src/nmod_poly_mat/test/t-mul.c
@@ -27,10 +27,21 @@ TEST_FUNCTION_START(nmod_poly_mat_mul, state)
         slong m, n, k, deg;
 
         mod = n_randtest_prime(state, 0);
-        m = n_randint(state, 20);
-        n = n_randint(state, 20);
-        k = n_randint(state, 20);
-        deg = 1 + n_randint(state, 10);
+        if (n_randint(state, 4) == 0)
+        {
+            /* degrees crossing the fft dispatch cutoffs */
+            m = n_randint(state, 6);
+            n = n_randint(state, 6);
+            k = n_randint(state, 6);
+            deg = 64 + n_randint(state, 400);
+        }
+        else
+        {
+            m = n_randint(state, 20);
+            n = n_randint(state, 20);
+            k = n_randint(state, 20);
+            deg = 1 + n_randint(state, 10);
+        }
 
         nmod_poly_mat_init(A, m, n, mod);
         nmod_poly_mat_init(B, n, k, mod);

--- a/src/nmod_poly_mat/test/t-mulmid_fft_small.c
+++ b/src/nmod_poly_mat/test/t-mulmid_fft_small.c
@@ -118,11 +118,11 @@ TEST_FUNCTION_START(nmod_poly_mat_mulmid_fft_small, state)
         nmod_poly_mat_clear(D);
         nmod_poly_clear(t);
     }
-#endif
-
-    /* the mixed sizes and moduli must exercise the engaged path */
+    /* the mixed sizes and moduli must exercise the engaged path; without
+       fft_small the driver never runs and there is nothing to require */
     if (n_engaged == 0)
         TEST_FUNCTION_FAIL("driver never engaged (%wd refusals)\n", n_refused);
+#endif
 
     TEST_FUNCTION_END(state);
 }

--- a/src/nmod_poly_mat/test/t-mulmid_fft_small.c
+++ b/src/nmod_poly_mat/test/t-mulmid_fft_small.c
@@ -1,0 +1,111 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "nmod_poly.h"
+#include "nmod_poly_mat.h"
+
+TEST_FUNCTION_START(nmod_poly_mat_mulmid_fft_small, state)
+{
+#if FLINT_HAVE_FFT_SMALL
+    for (slong iter = 0; iter < 100 * flint_test_multiplier(); iter++)
+    {
+        nmod_poly_mat_t A, B, C, D;
+        nmod_poly_t t;
+        ulong n;
+        slong ar, k, bc, i, j;
+        ulong maxlen, zn_max;
+        slong zl, zh;
+        int large = n_randint(state, 10) == 0;
+        int alias, success;
+
+        flint_set_num_threads(1 + n_randint(state, 8));
+
+        /* the occasional large iterations cross the internal threading
+           thresholds of the transform and export paths, so that both
+           entry-level and intra-transform threading run */
+        ar = n_randint(state, large ? 3 : 5);
+        k  = n_randint(state, large ? 3 : 5);
+        bc = n_randint(state, large ? 3 : 5);
+        maxlen = large ? 1500 + n_randint(state, 3000)
+                       : 1 + n_randint(state, 300);
+
+        /* random moduli, sometimes an fft prime for the matching-prime
+           plan, sometimes an fft-friendly prime for the direct branch */
+        switch (n_randint(state, 4))
+        {
+            case 0:  n = UWORD(0x0003f00000000001); break;
+            case 1:  n = UWORD(1) + (UWORD(3) << 29); break;
+            default: n = n_randtest_not_zero(state);
+                     n += (n == 1);
+                     break;
+        }
+
+        nmod_poly_mat_init(A, ar, k, n);
+        nmod_poly_mat_init(B, k, bc, n);
+        nmod_poly_mat_init(C, ar, bc, n);
+        nmod_poly_mat_init(D, ar, bc, n);
+        nmod_poly_init(t, n);
+
+        nmod_poly_mat_randtest(A, state, maxlen);
+        nmod_poly_mat_randtest(B, state, maxlen);
+
+        /* window, occasionally reaching past the product length */
+        zn_max = 2*maxlen + 2;
+        zl = (slong) n_randint(state, zn_max);
+        zh = zl + 1 + (slong) n_randint(state, zn_max - (ulong) zl);
+
+        /* aliasing C with A requires matching dimensions, so k == bc;
+           the reference must be computed before the operand is clobbered */
+        alias = (k == bc) && n_randint(state, 8) == 0;
+
+        nmod_poly_mat_mul(D, A, B);
+
+        if (alias)
+            success = nmod_poly_mat_mulmid_fft_small(A, A, B, zl, zh);
+        else
+            success = nmod_poly_mat_mulmid_fft_small(C, A, B, zl, zh);
+
+        if (!success)
+            TEST_FUNCTION_FAIL("plan init failed unexpectedly\n"
+                    "modulus = %wu, k = %wd, maxlen = %wu\n", n, k, maxlen);
+
+        for (i = 0; i < ar; i++)
+        for (j = 0; j < bc; j++)
+        {
+            nmod_poly_struct* got = alias ? nmod_poly_mat_entry(A, i, j)
+                                          : nmod_poly_mat_entry(C, i, j);
+
+            nmod_poly_shift_right(t, nmod_poly_mat_entry(D, i, j), zl);
+            nmod_poly_truncate(t, zh - zl);
+
+            if (!nmod_poly_equal(t, got))
+            {
+                TEST_FUNCTION_FAIL(
+                        "entry (%wd, %wd) of %wd x %wd x %wd\n"
+                        "modulus = %wu, maxlen = %wu\n"
+                        "zl = %wd, zh = %wd, alias = %d\n"
+                        "got %{nmod_poly}\nexpected %{nmod_poly}\n",
+                        i, j, ar, k, bc, n, maxlen, zl, zh, alias,
+                        got, t);
+            }
+        }
+
+        nmod_poly_mat_clear(A);
+        nmod_poly_mat_clear(B);
+        nmod_poly_mat_clear(C);
+        nmod_poly_mat_clear(D);
+        nmod_poly_clear(t);
+    }
+#endif
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/nmod_poly_mat/test/t-mulmid_fft_small.c
+++ b/src/nmod_poly_mat/test/t-mulmid_fft_small.c
@@ -14,6 +14,8 @@
 #include "nmod_poly_mat.h"
 
 TEST_FUNCTION_START(nmod_poly_mat_mulmid_fft_small, state)
+
+    slong n_engaged = 0, n_refused = 0;
 {
 #if FLINT_HAVE_FFT_SMALL
     for (slong iter = 0; iter < 100 * flint_test_multiplier(); iter++)
@@ -75,8 +77,19 @@ TEST_FUNCTION_START(nmod_poly_mat_mulmid_fft_small, state)
             success = nmod_poly_mat_mulmid_fft_small(C, A, B, zl, zh);
 
         if (!success)
-            TEST_FUNCTION_FAIL("plan init failed unexpectedly\n"
-                    "modulus = %wu, k = %wd, maxlen = %wu\n", n, k, maxlen);
+        {
+            /* the driver may decline when its profitability or memory
+               model judges the transformed representation not worth it
+               (small workloads, single-prime or tiny moduli); the
+               dispatcher falls back to other algorithms then, so a
+               refusal leaves nothing to verify here */
+            n_refused++;
+            nmod_poly_mat_clear(A); nmod_poly_mat_clear(B);
+            nmod_poly_mat_clear(C); nmod_poly_mat_clear(D);
+            nmod_poly_clear(t);
+            continue;
+        }
+        n_engaged++;
 
         for (i = 0; i < ar; i++)
         for (j = 0; j < bc; j++)
@@ -106,6 +119,10 @@ TEST_FUNCTION_START(nmod_poly_mat_mulmid_fft_small, state)
         nmod_poly_clear(t);
     }
 #endif
+
+    /* the mixed sizes and moduli must exercise the engaged path */
+    if (n_engaged == 0)
+        TEST_FUNCTION_FAIL("driver never engaged (%wd refusals)\n", n_refused);
 
     TEST_FUNCTION_END(state);
 }

--- a/src/nmod_poly_mat/test/t-mulmid_fft_small.c
+++ b/src/nmod_poly_mat/test/t-mulmid_fft_small.c
@@ -10,6 +10,7 @@
 */
 
 #include "test_helpers.h"
+#include "fft_small.h"
 #include "nmod_poly.h"
 #include "nmod_poly_mat.h"
 
@@ -27,7 +28,8 @@ TEST_FUNCTION_START(nmod_poly_mat_mulmid_fft_small, state)
         ulong maxlen, zn_max;
         slong zl, zh;
         int large = n_randint(state, 10) == 0;
-        int alias, success;
+        int square, alias, success;
+        ulong save_limit = flint_fft_small_max_transformed_ring_size;
 
         flint_set_num_threads(1 + n_randint(state, 8));
 
@@ -37,6 +39,12 @@ TEST_FUNCTION_START(nmod_poly_mat_mulmid_fft_small, state)
         ar = n_randint(state, large ? 3 : 5);
         k  = n_randint(state, large ? 3 : 5);
         bc = n_randint(state, large ? 3 : 5);
+        square = (iter % 5 == 0);
+        if (square)
+        { k = ar; bc = ar; }
+        /* a starved storage budget forces the blocked wrapper */
+        if (iter % 4 == 3)
+            flint_fft_small_max_transformed_ring_size = UWORD(1) << 18;
         maxlen = large ? 1500 + n_randint(state, 3000)
                        : 1 + n_randint(state, 300);
 
@@ -69,12 +77,14 @@ TEST_FUNCTION_START(nmod_poly_mat_mulmid_fft_small, state)
            the reference must be computed before the operand is clobbered */
         alias = (k == bc) && n_randint(state, 8) == 0;
 
-        nmod_poly_mat_mul(D, A, B);
+        nmod_poly_mat_mul(D, A, square ? A : B);
 
         if (alias)
-            success = nmod_poly_mat_mulmid_fft_small(A, A, B, zl, zh);
+            success = nmod_poly_mat_mulmid_fft_small(A, A,
+                    square ? A : B, zl, zh);
         else
-            success = nmod_poly_mat_mulmid_fft_small(C, A, B, zl, zh);
+            success = nmod_poly_mat_mulmid_fft_small(C, A,
+                    square ? A : B, zl, zh);
 
         if (!success)
         {
@@ -84,6 +94,7 @@ TEST_FUNCTION_START(nmod_poly_mat_mulmid_fft_small, state)
                dispatcher falls back to other algorithms then, so a
                refusal leaves nothing to verify here */
             n_refused++;
+            flint_fft_small_max_transformed_ring_size = save_limit;
             nmod_poly_mat_clear(A); nmod_poly_mat_clear(B);
             nmod_poly_mat_clear(C); nmod_poly_mat_clear(D);
             nmod_poly_clear(t);
@@ -112,6 +123,7 @@ TEST_FUNCTION_START(nmod_poly_mat_mulmid_fft_small, state)
             }
         }
 
+        flint_fft_small_max_transformed_ring_size = save_limit;
         nmod_poly_mat_clear(A);
         nmod_poly_mat_clear(B);
         nmod_poly_mat_clear(C);

--- a/src/nmod_poly_mat/test/t-mulmid_fft_small.c
+++ b/src/nmod_poly_mat/test/t-mulmid_fft_small.c
@@ -11,6 +11,8 @@
 
 #include "test_helpers.h"
 #include "fft_small.h"
+#include "gr.h"
+#include "gr_poly.h"
 #include "nmod_poly.h"
 #include "nmod_poly_mat.h"
 
@@ -134,6 +136,149 @@ TEST_FUNCTION_START(nmod_poly_mat_mulmid_fft_small, state)
        fft_small the driver never runs and there is nothing to require */
     if (n_engaged == 0)
         TEST_FUNCTION_FAIL("driver never engaged (%wd refusals)\n", n_refused);
+#endif
+
+    #if FLINT_HAVE_FFT_SMALL
+    /* ring compliance for the transformed nmod polynomial contexts:
+       operations beyond the provisioning answer GR_UNABLE, which the
+       framework accepts */
+    {
+        slong it, n_engaged = 0;
+        for (it = 0; it < 4; it++)
+        {
+            gr_ctx_t base, tctx;
+            /* the first modulus and size are deterministic so the
+               engagement assertion cannot fail on unlucky draws */
+            ulong n = (it % 2) ? UWORD(0x0003f00000000001)
+                               : n_randtest_prime(state, 0);
+            /* forced: only implementation bounds decline, so small
+               unprofitable sizes -- where bugs are easiest to catch --
+               are testable */
+            gr_transformed_poly_workload_t wl = {{ 0, 0, 0, 0, 0, 1 }};
+            gr_ctx_init_nmod(base, n);
+            /* the terms bound must cover the convolution accumulation
+               of a full product (min operand length per coefficient) */
+            slong Nc = (it == 0) ? 8
+                                 : 2 + (slong) n_randint(state, 40);
+            if (_gr_nmod_ctx_init_transformed_poly_repr(tctx, base,
+                    Nc, Nc, wl) == GR_SUCCESS)
+            {
+                gr_test_ring(tctx, 20, 0);
+                gr_ctx_clear(tctx);
+                n_engaged++;
+            }
+            gr_ctx_clear(base);
+        }
+        if (n_engaged == 0)
+            TEST_FUNCTION_FAIL("forced tpoly context never engaged\n");
+    }
+
+    /* directed exercise of the conversion-out family: negated
+       accumulations (the biased path), the destructive get, and the
+       windowed destructive get, against nmod_poly reference */
+    {
+        slong it;
+        for (it = 0; it < 8; it++)
+        {
+            gr_ctx_t base, tctx;
+            gr_transformed_poly_workload_t wl = {{ 0, 0, 0, 0, 0, 1 }};
+            ulong n = n_randtest_prime(state, 0);
+            slong N = 2 + n_randint(state, 50);
+            /* products must fit the element bound N */
+            slong half = FLINT_MAX(1, N / 2);
+            slong la = 1 + n_randint(state, half), lb = 1 + n_randint(state, half);
+            slong zl, zh;
+
+            gr_ctx_init_nmod(base, n);
+            if (_gr_nmod_ctx_init_transformed_poly_repr(tctx, base, N,
+                    N, wl) != GR_SUCCESS)
+            { gr_ctx_clear(base); continue; }
+            {
+                nmod_poly_t a, b, c, d, ref, got;
+                gr_ptr xa, xb, xc, xd, acc;
+                slong len = 0;
+                nmod_poly_init(a, n); nmod_poly_init(b, n);
+                nmod_poly_init(c, n); nmod_poly_init(d, n);
+                nmod_poly_init(ref, n); nmod_poly_init(got, n);
+                nmod_poly_randtest(a, state, la);
+                nmod_poly_randtest(b, state, lb);
+                nmod_poly_randtest(c, state, 1 + n_randint(state, half));
+                nmod_poly_randtest(d, state, 1 + n_randint(state, half));
+                /* nonzero operands: the conversions accept length 0,
+                   but the reference bookkeeping below is simpler
+                   without it */
+                nmod_poly_set_coeff_ui(a, 0, 1);
+                nmod_poly_set_coeff_ui(b, 0, 1);
+                nmod_poly_set_coeff_ui(c, 0, 1);
+                nmod_poly_set_coeff_ui(d, 0, 1);
+                xa = gr_heap_init(tctx); xb = gr_heap_init(tctx);
+                xc = gr_heap_init(tctx); xd = gr_heap_init(tctx);
+                acc = gr_heap_init(tctx);
+                GR_MUST_SUCCEED(_gr_set_gr_poly(xa, a->coeffs, a->length, base, tctx));
+                GR_MUST_SUCCEED(_gr_set_gr_poly(xb, b->coeffs, b->length, base, tctx));
+                GR_MUST_SUCCEED(_gr_set_gr_poly(xc, c->coeffs, c->length, base, tctx));
+                GR_MUST_SUCCEED(_gr_set_gr_poly(xd, d->coeffs, d->length, base, tctx));
+                /* acc = a b - c d: submul drives the negated path */
+                GR_MUST_SUCCEED(gr_mul(acc, xa, xb, tctx));
+                GR_MUST_SUCCEED(gr_submul(acc, xc, xd, tctx));
+                nmod_poly_mul(ref, a, b);
+                nmod_poly_mul(got, c, d);
+                nmod_poly_sub(ref, ref, got);
+                /* windowed destructive get of [zl, zh) */
+                zh = N;
+                zl = n_randint(state, zh);
+                nmod_poly_fit_length(got, zh - zl);
+                GR_MUST_SUCCEED(_gr_nmod_tpoly_get_gr_poly_window_destructive(
+                        got->coeffs, acc, zl, zh, tctx));
+                _nmod_poly_set_length(got, zh - zl);
+                _nmod_poly_normalise(got);
+                nmod_poly_shift_right(ref, ref, zl);
+                nmod_poly_truncate(ref, zh - zl);
+                if (!nmod_poly_equal(got, ref))
+                    TEST_FUNCTION_FAIL("windowed negs get: N=%wd n=%wu "
+                            "zl=%wd zh=%wd\n", N, n, zl, zh);
+                /* aliased accumulation, which the domain bookkeeping
+                   must route through a temporary: acc += acc * xb and
+                   acc -= xa * acc */
+                GR_MUST_SUCCEED(gr_mul(acc, xa, xb, tctx));
+                {
+                    int st1 = gr_addmul(acc, acc, xb, tctx);
+                    int st2 = gr_submul(acc, xa, acc, tctx);
+                    if (st1 == GR_DOMAIN || st2 == GR_DOMAIN)
+                        TEST_FUNCTION_FAIL("aliased addmul/submul "
+                                "returned GR_DOMAIN\n");
+                }
+                gr_heap_clear(acc, tctx);
+                acc = gr_heap_init(tctx);
+
+                /* full destructive get on a fresh negated accumulation;
+                   the windowed destructive get consumed acc, whose
+                   contract allows only clearing afterwards */
+                gr_heap_clear(acc, tctx);
+                acc = gr_heap_init(tctx);
+                GR_MUST_SUCCEED(gr_mul(acc, xa, xb, tctx));
+                GR_MUST_SUCCEED(gr_submul(acc, xc, xd, tctx));
+                nmod_poly_mul(ref, a, b);
+                nmod_poly_mul(got, c, d);
+                nmod_poly_sub(ref, ref, got);
+                nmod_poly_fit_length(got, N);
+                GR_MUST_SUCCEED(_gr_get_gr_poly_destructive(got->coeffs, &len, acc, base, tctx));
+                _nmod_poly_set_length(got, len);
+                _nmod_poly_normalise(got);
+                if (!nmod_poly_equal(got, ref))
+                    TEST_FUNCTION_FAIL("destructive negs get: N=%wd n=%wu\n",
+                            N, n);
+                gr_heap_clear(xa, tctx); gr_heap_clear(xb, tctx);
+                gr_heap_clear(xc, tctx); gr_heap_clear(xd, tctx);
+                gr_heap_clear(acc, tctx);
+                nmod_poly_clear(a); nmod_poly_clear(b);
+                nmod_poly_clear(c); nmod_poly_clear(d);
+                nmod_poly_clear(ref); nmod_poly_clear(got);
+            }
+            gr_ctx_clear(tctx);
+            gr_ctx_clear(base);
+        }
+    }
 #endif
 
     TEST_FUNCTION_END(state);

--- a/src/radix/mulmid_fft_small.c
+++ b/src/radix/mulmid_fft_small.c
@@ -151,80 +151,50 @@ FLINT_ASSERT(i+j < atrunc);
         abuf[i] = 0;
 }
 
-#define DEFINE_IT(NP, N, M) \
-static void CAT(_crt, NP)( \
-    ulong* z, ulong zl, ulong zi_start, ulong zi_stop, \
-    sd_fft_ctx_struct* Rffts, double* d, ulong dstride, \
-    crt_data_struct* Rcrts, ulong * carry_out, \
-    nmod_t mod) \
-{ \
-    ulong np = NP; \
-    ulong n = N; \
-    ulong m = M; \
-    ulong cy[3] = { 0, 0, 0 }; \
- \
-    FLINT_ASSERT(n == Rcrts[np-1].coeff_len); \
-    FLINT_ASSERT(1 <= N && N <= 4); \
- \
-    if (n == m + 1) \
+typedef struct {
+    nmod_t mod;
+    int write_carry_out;
+} _conv_params_struct;
+
+/* the reconstructed coefficients are digits in a chain: each range keeps
+   a running carry that is divided out coefficient by coefficient, with
+   the final carry exported through `local` for the serial fixup pass */
+#define CRT_FN(NP) CAT3(_crt, NP, fn)
+#define CRT_Z_TYPE ulong*
+#define CRT_HEAD \
+    nmod_t mod = ((const _conv_params_struct*) params)->mod; \
+    ulong cy[3] = { 0, 0, 0 };
+#define CRT_EMIT(zi, r, NP, N, M) \
+    if (N == 2) \
     { \
-        for (ulong l = 0; l < np; l++) { \
-            FLINT_ASSERT(crt_data_co_prime(Rcrts + np - 1, l)[m] == 0); \
-        } \
+        add_ssaaaa(r[1], r[0], r[1], r[0], cy[1], cy[0]); \
+        if (mod.norm == 0) \
+            z[zi] = flint_mpn_divrem_2_1_preinv_norm(cy, r, mod.n, mod.ninv); \
+        else \
+            z[zi] = flint_mpn_divrem_2_1_preinv_unnorm(cy, r, mod.n, mod.ninv, mod.norm); \
     } \
     else \
     { \
-        FLINT_ASSERT(n == m); \
-    } \
- \
-    ulong Xs[BLK_SZ*NP]; \
- \
-    for (ulong i = n_round_down(zi_start, BLK_SZ); i < zi_stop; i += BLK_SZ) \
-    { \
-        _convert_block(Xs, Rffts, d, dstride, np, i/BLK_SZ); \
- \
-        ulong jstart = (i < zi_start) ? zi_start - i : 0; \
-        ulong jstop = FLINT_MIN(BLK_SZ, zi_stop - i); \
-        for (ulong j = jstart; j < jstop; j += 1) \
-        { \
-            ulong r[N]; \
-            ulong t[N]; \
-            ulong l = 0; \
- \
-            CAT3(_big_mul, N, M)(r, t, _crt_data_co_prime(Rcrts + np - 1, l, n), Xs[l*BLK_SZ + j]); \
-            for (l++; l < np; l++) \
-                CAT3(_big_addmul, N, M)(r, t, _crt_data_co_prime(Rcrts + np - 1, l, n), Xs[l*BLK_SZ + j]); \
- \
-            CAT(_reduce_big_sum, N)(r, t, crt_data_prod_primes(Rcrts + np - 1)); \
- \
-            if (N == 2) \
-            { \
-                add_ssaaaa(r[1], r[0], r[1], r[0], cy[1], cy[0]); \
-                if (mod.norm == 0) \
-                    z[i+j-zl] = flint_mpn_divrem_2_1_preinv_norm(cy, r, mod.n, mod.ninv); \
-                else \
-                    z[i+j-zl] = flint_mpn_divrem_2_1_preinv_unnorm(cy, r, mod.n, mod.ninv, mod.norm); \
-            } \
-            else \
-            { \
-                FLINT_ASSERT(N < 4 || r[3] == 0); \
-                add_sssaaaaaa(r[2], r[1], r[0], r[2], r[1], r[0], cy[2], cy[1], cy[0]); \
-                if (mod.norm == 0) \
-                    z[i+j-zl] = flint_mpn_divrem_3_1_preinv_norm(cy, r, mod.n, mod.ninv); \
-                else \
-                    z[i+j-zl] = flint_mpn_divrem_3_1_preinv_unnorm(cy, r, mod.n, mod.ninv, mod.norm); \
-            } \
-        } \
-    } \
-    carry_out[0] = cy[0]; \
-    carry_out[1] = cy[1]; \
-    carry_out[2] = cy[2]; \
-}
-
-DEFINE_IT(2, 2, 1)
-DEFINE_IT(3, 3, 2)
-DEFINE_IT(4, 4, 3)
-#undef DEFINE_IT
+        FLINT_ASSERT(N < 4 || r[3] == 0); \
+        add_sssaaaaaa(r[2], r[1], r[0], r[2], r[1], r[0], cy[2], cy[1], cy[0]); \
+        if (mod.norm == 0) \
+            z[zi] = flint_mpn_divrem_3_1_preinv_norm(cy, r, mod.n, mod.ninv); \
+        else \
+            z[zi] = flint_mpn_divrem_3_1_preinv_unnorm(cy, r, mod.n, mod.ninv, mod.norm); \
+    }
+#define CRT_TAIL \
+    local[0] = cy[0]; \
+    local[1] = cy[1]; \
+    local[2] = cy[2];
+CRT_DEFINE(2, 2, 1)
+CRT_DEFINE(3, 3, 2)
+CRT_DEFINE(4, 4, 3)
+#undef CRT_FN
+#undef CRT_Z_TYPE
+#undef CRT_HEAD
+#undef CRT_EMIT
+#undef CRT_TAIL
+#undef CRT_DEFINE
 
 static void _crt_1(
     ulong* z, ulong zl, ulong zi_start, ulong zi_stop,
@@ -257,119 +227,120 @@ static void _crt_1(
     carry_out[2] = 0;
 }
 
-typedef struct {
-    ulong np;
-    ulong start_pi;
-    ulong stop_pi;
-    ulong offset;
-    double* abuf;
-    double* bbuf;
-    ulong depth;
-    ulong stride;
-    ulong atrunc;
-    ulong btrunc;
-    ulong ztrunc;
-    const ulong* a;
-    ulong an;
-    const ulong* b;
-    ulong bn;
-    sd_fft_ctx_struct* ffts;
-    crt_data_struct* crts;
-    nmod_t mod;
-    ulong ioff;
-    int squaring;
-} s1worker_struct;
 
+/* ------------------------------------------------------------------------ */
+/* glue for the generic convolution engine                                  */
+/* ------------------------------------------------------------------------ */
 
-static void extra_func(void* varg)
+static void _mod_fn(double* xbuf, ulong xtrunc,
+    const void* x, ulong xn, slong FLINT_UNUSED(xaux),
+    const sd_fft_ctx_struct* fft, const void* params)
 {
-    s1worker_struct* X = (s1worker_struct*) varg;
-    sd_fft_ctx_struct* Q = X->ffts + X->ioff;
+    const _conv_params_struct* par = (const _conv_params_struct*) params;
 
-    _mod(X->bbuf, X->btrunc, X->b, X->bn, Q, X->mod);
-    sd_fft_trunc(Q, X->bbuf, X->depth, X->btrunc, X->ztrunc);
+    _mod(xbuf, xtrunc, (const ulong*) x, xn, fft, par->mod);
 }
 
-static void s1worker_func(void* varg)
+#define DEFINE_IT(NP) \
+static void CAT3(_crt, NP, fn)(void* z, ulong zl, \
+    ulong zi_start, ulong zi_stop, \
+    sd_fft_ctx_struct* Rffts, double* d, ulong dstride, \
+    crt_data_struct* Rcrts, ulong FLINT_UNUSED(min_an_bn), \
+    ulong* local, const void* params) \
+{ \
+    const _conv_params_struct* par = (const _conv_params_struct*) params; \
+ \
+    CAT(_crt, NP)((ulong*) z, zl, zi_start, zi_stop, Rffts, d, dstride, \
+                  Rcrts, local, par->mod); \
+}
+DEFINE_IT(1)
+#undef DEFINE_IT
+
+static fft_small_crt_func _radix_crt_fn(ulong np)
 {
-    s1worker_struct* X = (s1worker_struct*) varg;
-    ulong i, m;
-    thread_pool_handle* handles = NULL;
-    slong nworkers = 0;
+    return np == 1 ? _crt_1_fn :
+           np == 2 ? _crt_2_fn :
+           np == 3 ? _crt_3_fn : _crt_4_fn;
+}
 
-    if (X->bn > 5000 && !X->squaring)
-        nworkers = flint_request_threads(&handles, 2);
+static ulong _radix_conv_s1_threads(ulong np, ulong tune_n)
+{
+    return (tune_n < 1500 || radix_mulmid_force_threading) ? 1 : np;
+}
 
-    for (i = X->start_pi; i < X->stop_pi; i++)
+static int _radix_conv_s1_b_worker(ulong FLINT_UNUSED(np), ulong tune_n,
+                                   int squaring)
+{
+    return tune_n > 5000 && !squaring;
+}
+
+static int _radix_conv_s2_rethread(ulong np, ulong zn)
+{
+    return np*zn > 10000 || radix_mulmid_force_threading;
+}
+
+static const fft_small_conv_tuning _radix_conv_tuning =
+    { _radix_conv_s1_threads, _radix_conv_s1_b_worker,
+      _radix_conv_s2_rethread };
+
+/* Serial pass over the stage 2 ranges: reduce each range's carries into
+   the following coefficients and write the top carry of the full product
+   if requested. */
+static void _radix_s2_finish(void* zv, ulong zl, ulong FLINT_UNUSED(zh),
+    fft_small_crt_range_struct* ranges, ulong nranges, const void* params)
+{
+    ulong* z = (ulong*) zv;
+    const _conv_params_struct* par = (const _conv_params_struct*) params;
+    nmod_t mod = par->mod;
+    ulong i;
+
+    for (i = 0; i < nranges; i++)
     {
-        ulong ioff = i + X->offset;
-        double* abuf = X->abuf + X->stride*i;
-        double* bbuf = X->bbuf;
-        sd_fft_ctx_struct* Q = X->ffts + ioff;
+        slong stop = ranges[i].stop_zi;
 
-        if (!X->squaring)
+        /* Final segment */
+        if (i == nranges - 1)
         {
-            if (nworkers > 0)
+            /* Write carry to the top limb of the full product. */
+            if (par->write_carry_out)
             {
-                X->ioff = ioff;
-                thread_pool_wake(global_thread_pool, handles[0], 0, extra_func, X);
+                z[stop - zl] = ranges[i].local[0];
+
+                FLINT_ASSERT(ranges[i].local[1] == 0 && ranges[i].local[2] == 0);
             }
-            else
-            {
-                _mod(bbuf, X->btrunc, X->b, X->bn, Q, X->mod);
-                sd_fft_trunc(Q, bbuf, X->depth, X->btrunc, X->ztrunc);
-            }
+            /* Otherwise, the product was truncated. */
         }
-
-        _mod(abuf, X->atrunc, X->a, X->an, Q, X->mod);
-        sd_fft_trunc(Q, abuf, X->depth, X->atrunc, X->ztrunc);
-
-        if (!X->squaring)
-        {
-            if (nworkers > 0)
-                thread_pool_wait(global_thread_pool, handles[0]);
-        }
-
-        ulong cop = X->np == 1 ? 1 : *crt_data_co_prime_red(X->crts + X->np - 1, ioff);
-        NMOD_RED2(m, cop >> (FLINT_BITS - X->depth), cop << X->depth, Q->mod);
-        m = nmod_inv(m, Q->mod);
-
-        if (X->squaring)
-            sd_fft_ctx_point_sqr(Q, abuf, m, X->depth);
         else
-            sd_fft_ctx_point_mul(Q, abuf, bbuf, m, X->depth);
+        {
+            /* Propagate carries from the previous segment */
+            slong stop2 = ranges[i + 1].stop_zi;
 
-        sd_ifft_trunc(Q, abuf, X->depth, X->ztrunc);
+            ulong cy[3];
+            slong j;
+
+            cy[0] = ranges[i].local[0];
+            cy[1] = ranges[i].local[1];
+            cy[2] = ranges[i].local[2];
+
+            for (j = stop; j < stop2; j++)
+            {
+                add_sssaaaaaa(cy[2], cy[1], cy[0], cy[2], cy[1], cy[0], 0, 0, z[j - zl]);
+
+                if (mod.norm == 0)
+                    z[j - zl] = flint_mpn_divrem_3_1_preinv_norm(cy, cy, mod.n, mod.ninv);
+                else
+                    z[j - zl] = flint_mpn_divrem_3_1_preinv_unnorm(cy, cy, mod.n, mod.ninv, mod.norm);
+
+                if (cy[0] == 0 && cy[1] == 0 && cy[2] == 0)
+                    break;
+            }
+
+            /* Propagate carry to next segment */
+            add_sssaaaaaa(ranges[i + 1].local[2], ranges[i + 1].local[1], ranges[i + 1].local[0],
+                          ranges[i + 1].local[2], ranges[i + 1].local[1], ranges[i + 1].local[0],
+                          cy[2], cy[1], cy[0]);
+        }
     }
-
-    flint_give_back_threads(handles, nworkers);
-}
-
-typedef struct {
-    ulong* z;
-    ulong zl;
-    ulong start_zi;
-    ulong stop_zi;
-    double* buf;
-    ulong offset;
-    ulong stride;
-    sd_fft_ctx_struct* ffts;
-    crt_data_struct* crts;
-    nmod_t mod;
-    void (*f)(
-        ulong* z, ulong zl, ulong zi_start, ulong zi_stop,
-        sd_fft_ctx_struct* Rffts, double* d, ulong dstride,
-        crt_data_struct* Rcrts, ulong * carry_out,
-        nmod_t mod);
-    ulong carry_out[3];
-} s2worker_struct;
-
-static void s2worker_func(void* varg)
-{
-    s2worker_struct* X = (s2worker_struct*) varg;
-
-    X->f(X->z, X->zl, X->start_zi, X->stop_zi, X->ffts + X->offset, X->buf,
-         X->stride, X->crts + X->offset, X->carry_out, X->mod);
 }
 
 static void _radix_mul_mpn_ctx(
@@ -380,18 +351,16 @@ static void _radix_mul_mpn_ctx(
     mpn_ctx_t R)
 {
     ulong modbits = FLINT_BITS - mod.norm;
-    ulong offset = 0;
     ulong zn = an + bn - 1;
-    ulong atrunc, btrunc, ztrunc;
-    ulong i, np, depth, stride;
-    double* buf;
-    int squaring;
+    ulong atrunc, btrunc;
+    int squaring, success;
     int write_carry_out = 0;
+    fft_small_plan_t P;
+    fft_small_conv_arg_struct A;
+    _conv_params_struct par;
 
     an = FLINT_MIN(an, zh);
     bn = FLINT_MIN(bn, zh);
-
-//    flint_printf("have a = %{ulong*} b = %{ulong*} mod %wu\n", a, an, b, bn, mod.n);
 
     FLINT_ASSERT(an > 0);
     FLINT_ASSERT(bn > 0);
@@ -419,173 +388,43 @@ static void _radix_mul_mpn_ctx(
     FLINT_ASSERT(zl < zh);
     FLINT_ASSERT(zh <= zn);
 
-    /* need prod_of_primes >= blen * 4^modbits */
-    for (np = 1; np < 4; np++)
-    {
-        if (flint_mpn_cmp_ui_2exp(crt_data_prod_primes(R->crts + np - 1),
-              R->crts[np - 1].coeff_len, bn, 2*modbits) >= 0)
-        {
-            break;
-        }
-    }
-
-    FLINT_ASSERT(0 <= flint_mpn_cmp_ui_2exp(
-                                  crt_data_prod_primes(R->crts + np - 1),
-                                  R->crts[np - 1].coeff_len, bn, 2*modbits));
-
-
     atrunc = n_round_up(an, BLK_SZ);
     btrunc = n_round_up(bn, BLK_SZ);
-    ztrunc = n_round_up(zn, BLK_SZ);
-    /*
-        if there is a power of two 2^d between zh and zn with good wrap around
-            i.e. max(an, bn, zh) <= 2^d <= zn with zn - 2^d <= zl
-        then use d as the depth, otherwise the usual with no wrap around
-    */
-    depth = n_flog2(zn);
-    i = n_pow2(depth);
-    if (atrunc <= i && btrunc <= i && zh <= i && i <= zn && zn <= zl + i)
-    {
-        ztrunc = i;
-    }
-    else
-    {
-        depth = n_max(LG_BLK_SZ, n_clog2(ztrunc));
-    }
 
-    stride = n_round_up(sd_fft_ctx_data_size(depth), 128);
+    P->R = R;
+    P->sign = 0;
 
-    ulong want_threads;
+    _fft_small_plan_set_window(P, zl, zh, zn, n_max(atrunc, btrunc));
 
-    if (bn < 1500 || radix_mulmid_force_threading)
-        want_threads = 1;
-    else
-        want_threads = np;
+    /* need prod_of_primes >= bn * 4^modbits; the radix chinese
+       remaindering handles at most 4 primes */
+    success = _fft_small_plan_set_bound(P, bn, 2*modbits, 4);
+    FLINT_ASSERT(success);
+    (void) success;
 
-    thread_pool_handle* handles;
-    slong nworkers = flint_request_threads(&handles, want_threads);
-    ulong nthreads = nworkers + 1;
+    _fft_small_plan_set_normalizers(P);
 
-    buf = (double*) mpn_ctx_fit_buffer(R, (np+nthreads)*stride*sizeof(double));
+    par.mod = mod;
+    par.write_carry_out = write_carry_out;
 
-    s1worker_struct s1args[4];
-    for (i = 0; i < nthreads; i++)
-    {
-        s1worker_struct* X = s1args + i;
-        X->np = np;
-        X->start_pi = (i+0)*np/nthreads;
-        X->stop_pi  = (i+1)*np/nthreads;
-        X->offset = offset;
-        X->abuf = buf;
-        X->bbuf = buf + (np+i)*stride;
-        X->depth = depth;
-        X->stride = stride;
-        X->atrunc = atrunc;
-        X->btrunc = btrunc;
-        X->ztrunc = ztrunc;
-        X->a = a;
-        X->an = an;
-        X->b = b;
-        X->bn = bn;
-        X->ffts = R->ffts;
-        X->crts = R->crts;
-        X->mod = mod;
-        X->squaring = squaring;
-    }
+    A.a = a; A.an = an; A.aaux = 0; A.atrunc = atrunc;
+    A.b = b; A.bn = bn; A.baux = 0; A.btrunc = btrunc;
+    A.bfft = NULL;
+    A.bfft_stride = 0;
+    A.squaring = squaring;
+    A.tune_n = bn;
+    A.min_an_bn = FLINT_MIN(an, bn);
+    A.mod_fn = _mod_fn;
+    A.s2_finish = _radix_s2_finish;
+    A.crt_fn = _radix_crt_fn(P->np);
+    A.params = &par;
+    A.tuning = &_radix_conv_tuning;
 
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wake(global_thread_pool, handles[i - 1], 0, s1worker_func, s1args + i);
-    s1worker_func(s1args + 0);
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wait(global_thread_pool, handles[i - 1]);
+    _fft_small_conv(z, P, &A);
 
-    if (np*zn > 10000 || radix_mulmid_force_threading)
-    {
-        flint_give_back_threads(handles, nworkers);
-        nworkers = flint_request_threads(&handles, 8);
-        nthreads = nworkers + 1;
-    }
-
-    s2worker_struct s2args[8];
-    ulong o = zl;
-    for (i = 0; i < nthreads; i++)
-    {
-        s2worker_struct* X = s2args + i;
-        X->z = z;
-        X->zl = zl;
-        X->start_zi = o;
-        ulong newo = n_round_down(zl + (i+1)*(zh-zl)/nthreads, BLK_SZ);
-        o = i+1 < nthreads ? FLINT_MAX(o, newo) : zh;
-        X->stop_zi = o;
-        X->buf = buf;
-        X->offset = offset;
-        X->stride = stride;
-        X->ffts = R->ffts;
-        X->crts = R->crts;
-        X->mod = mod;
-        X->f = np == 1 ? _crt_1 : np == 2 ? _crt_2 : np == 3 ? _crt_3 : _crt_4;
-    }
-
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wake(global_thread_pool, handles[i - 1], 0, s2worker_func, s2args + i);
-    s2worker_func(s2args + 0);
-    for (i = nworkers; i > 0; i--)
-        thread_pool_wait(global_thread_pool, handles[i - 1]);
-
-    flint_give_back_threads(handles, nworkers);
-
-    for (i = 0; i < nthreads; i++)
-    {
-        slong stop = s2args[i].stop_zi;
-
-        /* Final segment */
-        if (i == nthreads - 1)
-        {
-            /* Write carry to the top limb of the full product. */
-            if (write_carry_out)
-            {
-                z[stop - zl] = s2args[i].carry_out[0];
-
-                FLINT_ASSERT(s2args[i].carry_out[1] == 0 && s2args[i].carry_out[2] == 0);
-            }
-            /* Otherwise, the product was truncated. */
-        }
-        else
-        {
-            /* Propagate carries from the previous segment */
-            slong stop2 = s2args[i + 1].stop_zi;
-
-            // flint_printf("overhang %wd / %wd: stop = %wd  stop2 = %wd,  zh = %wd\n", i, nthreads, stop, stop2, zh);
-
-            ulong cy[3];
-            slong j;
-
-            cy[0] = s2args[i].carry_out[0];
-            cy[1] = s2args[i].carry_out[1];
-            cy[2] = s2args[i].carry_out[2];
-
-            for (j = stop; j < stop2; j++)
-            {
-                add_sssaaaaaa(cy[2], cy[1], cy[0], cy[2], cy[1], cy[0], 0, 0, z[j - zl]);
-
-                if (mod.norm == 0)
-                    z[j - zl] = flint_mpn_divrem_3_1_preinv_norm(cy, cy, mod.n, mod.ninv);
-                else
-                    z[j - zl] = flint_mpn_divrem_3_1_preinv_unnorm(cy, cy, mod.n, mod.ninv, mod.norm);
-
-                if (cy[0] == 0 && cy[1] == 0 && cy[2] == 0)
-                    break;
-            }
-
-            /* Propagate carry to next segment */
-            add_sssaaaaaa(s2args[i + 1].carry_out[2], s2args[i + 1].carry_out[1], s2args[i + 1].carry_out[0],
-                          s2args[i + 1].carry_out[2], s2args[i + 1].carry_out[1], s2args[i + 1].carry_out[0],
-                          cy[2], cy[1], cy[0]);
-
-            // flint_printf("next: %wu %wu %wu\n", s2args[i + 1].carry_out[2], s2args[i + 1].carry_out[1], s2args[i + 1].carry_out[0]);
-        }
-    }
+    fft_small_plan_clear(P);
 }
+
 
 void
 radix_mulmid_fft_small(nn_ptr res, nn_srcptr a, slong an, nn_srcptr b, slong bn, slong zlo, slong zhi, const radix_t radix)


### PR DESCRIPTION
This PR refactors `fft_small` for more easily working with transformed operands, and uses this in various places. This enables huge speedups for algorithms that can reuse the same operand for many multiplications, e.g. matrix multiplication -- the largest speedup I've measured so far is 15x for 64x64 `fmpz_mat_mul` with 100,000-digit entries.

* The previously monolithic `fft_small` multiplication routines simplify into function calls for creating a plan object, creating operands, transforming operands, doing pointwise operations, and transforming back
* We add `gr` rings for transformed `nmod_poly`, `mpn_mod_poly` and (signed) `mpn` integers. Others can easily be added in the future.
* Applications (so far): FFT based `fmpz_mat_mul`, `nmod_poly_mat_mul`, complex multiplication (`fmpzi_mul`), 2x2 matrix multiplication in `gr_poly_gcd_hgcd`. There is also truncating complex multiplication and matrix multiplication useful for `acb_mul`, `arb_mat_mul`, etc., but this is not yet tuned and integrated.

This was developed mainly using Claude Fable 5 over a couple of weeks; the code still needs some cleanup.

# Important remarks

* Signed output conversions was missing and had to be implemented. The signed conversions are slower than than the unsigned ones.
* It is extremely important for performance that transforms are done fully in-place without allocating scratch space. The design consequence is that `gr` transform rings either need to maintain an internal scratch pool or use destructive output conversions instead of standard conversions. I opted for destructive conversions.
* The standard cost model assuming 1 input transform ~= 1 output transform is inaccurate: output conversion with CRT is generally much more expensive than input conversion, especially in the signed case. This means that the achievable speedups are often smaller than theory predict. For example, for 2x2 `fmpz_mat` multiplication transformed multiplication barely beats Strassen with unsigned coefficients and not at all with signed coefficients (currently FFT multiplication is only used by default here for n >= 3).
* Since FFT:ed operands consume a lot of memory, the generic transform rings decline when the expected memory usage for all operands exceeds the limit `flint_fft_small_max_transformed_ring_size` which currently defaults to 4 GB. Matrix multiplication still benefits for matrices much larger than this: the multiplication algorithm simply selects a smaller block size than the full matrix.
* Multithreading is not yet fully tuned. Hopefully existing code shouldn't slow down, but this may need checking.

# Speedup for `fmpz_mat_mul`

Timings for integer matrices with uniform (`fmpz_randbits`) entries. FFT multiplication kicks in from around 7000-10000 bits for small n, the tuned cutoff increasing with larger n.

```
  n         bits       old        new   speedup

  3         8192   8.47e-05  8.46e-05   1.001
  3        16384   0.000258  0.000144   1.792
  3        32768    0.00073   0.00029   2.517
  3        65536    0.00133  0.000607   2.191
  3       131072    0.00262    0.0012   2.183
  3       262144    0.00552   0.00246   2.244
  3       524288     0.0112   0.00676   1.657
  3      1048576     0.0234    0.0122   1.918
  3      2097152     0.0482    0.0318   1.516

  4         8192   0.000175  0.000176   0.994
  4        16384   0.000527  0.000286   1.843
  4        32768    0.00155  0.000623   2.488
  4        65536    0.00275   0.00131   2.099
  4       131072    0.00532   0.00269   1.978
  4       262144     0.0112   0.00563   1.989
  4       524288     0.0226    0.0105   2.152
  4      1048576     0.0474    0.0274   1.730
  4      2097152     0.0983    0.0646   1.522

  8         8192    0.00126  0.000849   1.484
  8        16384    0.00363   0.00145   2.503
  8        32768     0.0109    0.0028   3.893
  8        65536     0.0191   0.00576   3.316
  8       131072     0.0369    0.0123   3.000
  8       262144      0.077    0.0282   2.730
  8       524288      0.157    0.0562   2.794
  8      1048576      0.331     0.112   2.955
  8      2097152      0.676     0.288   2.347

 16         8192    0.00912   0.00444   2.054
 16        16384     0.0264   0.00718   3.677
 16        32768     0.0792    0.0147   5.388
 16        65536       0.14    0.0318   4.403
 16       131072      0.272    0.0668   4.072
 16       262144      0.566     0.133   4.256
 16       524288      1.146     0.271   4.229
 16      1048576      2.403     0.563   4.268
 16      2097152      4.944     1.357   3.643

 32         8192     0.0652    0.0288   2.264
 32        16384      0.191    0.0488   3.914
 32        32768      0.573    0.0975   5.877
 32        65536      0.994     0.191   5.204
 32       131072      1.923     0.378   5.087
 32       262144      4.015     0.761   5.276
 32       524288      8.112     1.565   5.183
 32      1048576     16.972     3.238   5.242
 32      2097152     34.915     7.483   4.666

 64         8192       0.42     0.243   1.728
 64        16384      1.191     0.351   3.393
 64        32768      3.396     0.639   5.315
 64        65536      9.608     1.216   7.901
 64       131072     26.475     2.405   11.008
 64       262144     71.051     4.869   14.593
 64       524288    178.076    11.586   15.370
 64      1048576     118.14     21.37   5.528
 64      2097152    242.875    50.687   4.792

128         8192      1.812     1.815   0.998
128        16384      5.072     2.614   1.940
128        32768     14.157     4.591   3.084
128        65536     38.849     8.739   4.445
128       131072    108.001    17.541   6.157
128       262144     288.81    35.733   8.082
128       524288    719.603    92.443   7.784
128      1048576    1740.92   178.814   9.736

256         8192      8.073     8.067   1.001
256        16384     21.536    21.533   1.000
256        32768     59.463     34.65   1.716
256        65536    163.358    68.146   2.397

512         8192     38.683    38.687   1.000
512        16384      98.91    98.926   1.000
512        32768    262.065     261.9   1.001
512        65536    712.764   600.961   1.186
```

Note: matrix mulhigh is implemented but not yet used/profiled.

# Speedup for `nmod_poly_mat_mul`

Example timings modulo p = nextprime(2^63), uniform entries.

```
  n          len        old        new  speedup

  2           64   2.39e-05  2.06e-05   1.160
  2          256   7.81e-05  4.32e-05   1.808
  2         1024   0.000401  0.000323   1.241
  2         4096    0.00178   0.00155   1.148
  2        16384    0.00779   0.00678   1.149
  2        65536     0.0342    0.0313   1.093
  2       262144       0.16     0.135   1.185

  3           64    8.5e-05  5.16e-05   1.647
  3          256   0.000311  0.000108   2.880
  3         1024    0.00141  0.000533   2.645
  3         4096    0.00616    0.0023   2.678
  3        16384     0.0268    0.0107   2.505
  3        65536      0.117    0.0695   1.683
  3       262144       0.54     0.311   1.736

  4           64   0.000202  9.71e-05   2.080
  4          256   0.000758  0.000218   3.477
  4         1024    0.00335     0.001   3.350
  4         4096     0.0145   0.00429   3.380
  4        16384     0.0635    0.0206   3.083
  4        65536      0.278     0.124   2.242
  4       262144      1.295     0.563   2.300

  8           64    0.00167  0.000516   3.236
  8          256    0.00621   0.00115   5.400
  8         1024     0.0272   0.00492   5.528
  8         4096      0.119     0.023   5.174
  8        16384      0.516     0.133   3.880
  8        65536      2.238     0.561   3.989
  8       262144      10.51      3.69   2.848

 16           64     0.0108   0.00297   3.636
 16          256     0.0511   0.00644   7.935
 16         1024      0.223    0.0294   7.585
 16         4096      0.963     0.145   6.641
 16        16384      4.181     0.664   6.297
 16        65536     18.082     2.811   6.433

 32           64     0.0766    0.0204   3.755
 32          256      0.414    0.0458   9.039
 32         1024      1.796     0.211   8.512
 32         4096       7.69     0.873   8.809
 32        16384     33.537     3.739   8.970

 64           64       0.51     0.512   0.996
 64          256      3.378     0.389   8.684
 64         1024     14.382     1.368   10.513

128           64      1.038     1.033   1.005
128          256       7.64     2.772   2.756
128         1024     52.733     9.307   5.666
```

Note: matrix mulmid is implemented but not yet used/profiled.

# Polynomial HGCD

The generic `gr_poly_gcd_hgcd` gets an overload for its 2x2 matrix multiplication to allow using FFT instead of Strassen. The speedup for the GCD as a whole is small but measurable. Timings for `nmod_poly`, p being a 50-bit FFT prime:

```
     len        old       new   speedup

     100   1.38e-05  1.38e-05   1.000
     300   9.07e-05  9.08e-05   0.999
     900   0.000821  0.000822   0.999
    2700    0.00293   0.00289   1.014
    8100      0.012    0.0117   1.026
   24300     0.0379    0.0365   1.038
   72900      0.144     0.128   1.125
  218700      0.463     0.439   1.055
  656100      1.713     1.537   1.115
 1968300      5.511     5.197   1.060
 5904900     18.686    17.705   1.055
```

Timings for p = nextprime(2^63):

```
     len        old       new   speedup

     100   1.57e-05  1.56e-05   1.006
     300   0.000107  0.000108   0.991
     900   0.000967  0.000968   0.999
    2700    0.00582   0.00561   1.037
    8100     0.0237    0.0225   1.053
   24300     0.0978    0.0907   1.078
   72900      0.346     0.312   1.109
  218700      1.256     1.144   1.098
  656100      4.406     3.975   1.108
 1968300     15.085      13.7   1.101
 5904900     55.245    51.534   1.072
```

Timings for `mpn_mod`, p = nextprime(2^127):

```
     len        old       new   speedup

     100   9.06e-05  9.14e-05   0.991
     300    0.00107   0.00107   1.000
     900    0.00559   0.00559   1.000
    2700     0.0247    0.0236   1.047
    8100     0.0963    0.0911   1.057
   24300      0.366     0.334   1.096
   72900      1.346     1.204   1.118
  218700      4.719      4.23   1.116
  656100     16.905    15.366   1.100
```

# Complex multiplication

Timings for `fmpzi_mul` and `fmpzi_sqr`, which become wrappers around the new `flint_mpn_mul_complex` and `flint_mpn_sqr_complex`:

```
      bits        old       new   speedup         old       new   speedup

        50   9.77e-09  9.37e-09   1.043      8.84e-09  8.19e-09   1.079
       150   5.31e-08  5.05e-08   1.051      4.62e-08  3.69e-08   1.252
       450   1.24e-07   1.3e-07   0.954         1e-07  9.02e-08   1.109
      1350   6.32e-07  6.08e-07   1.039      4.66e-07  3.91e-07   1.192
      4050   3.29e-06  3.28e-06   1.003      2.38e-06   2.1e-06   1.133
     12150   1.92e-05  1.91e-05   1.005      1.29e-05  1.25e-05   1.032
     36450   8.02e-05     8e-05   1.002      6.53e-05  5.31e-05   1.230
    109350   0.000249  0.000238   1.046      0.000189  0.000164   1.152
    328050   0.000884  0.000817   1.082      0.000681  0.000576   1.182
    984150    0.00275   0.00246   1.118       0.00209   0.00181   1.155
   2952450    0.00942   0.00773   1.219       0.00727   0.00625   1.163
   8857350     0.0283    0.0258   1.097        0.0205    0.0186   1.102
  26572050      0.099    0.0967   1.024        0.0725    0.0654   1.109
  79716150      0.342     0.303   1.129         0.251     0.218   1.151
 239148450      1.117      0.97   1.152         0.816     0.746   1.094
 717445350      3.857     3.232   1.193         2.815     2.584   1.089
2152336050     15.717    16.154   0.973        10.283    10.477   0.981
6457008150     51.441    52.725   0.976        34.021    34.203   0.995
```

Some nice 10-20% speedups. It should be noted that the speedup for squaring over most of the range just comes from a better Karatsuba variant (see #2781); FFT squaring is only used from 190M bits (vs 44K bits for multiplication).

At 2152336050 bits the 4 GB transform limit kicks in and we fall back to Strassen as before (the new code is 2% slower due to differences in memory allocation).

If I bump the 4 GB limit I get:

```
2152336050     16.275    12.275   1.326        10.335     8.045   1.285
```

but at 6457008150 bits my machine runs out of memory.

Complex mulhigh implemented but not yet used/profiled.