### PR TITLE
Optimize for sub-block transform lengths in fft_small transformed rings

### DIFF
--- a/src/fft_small.h
+++ b/src/fft_small.h
@@ -475,13 +475,16 @@ int _fft_small_plan_set_bound(fft_small_plan_t P, ulong c, ulong e, ulong np_max
 
 /* Choose depth and ztrunc for the output window [zl, zh) of a length zn
    convolution whose operand truncation lengths are at most xtrunc_max. */
+/* min_depth: LG_BLK_SZ for plans whose conversions are block
+   structured (the chunked mpn import and export), 4 where the
+   conversions handle short transforms (the nmod paths) */
 void _fft_small_plan_set_window(fft_small_plan_t P,
-                    ulong zl, ulong zh, ulong zn, ulong xtrunc_max);
+                    ulong zl, ulong zh, ulong zn, ulong xtrunc_max, ulong min_depth);
 
 /* Same, but with the depth of P fixed. Returns 0 if the window needs a
    transform longer than 2^depth. */
 int _fft_small_plan_fit_window(fft_small_plan_t P,
-                    ulong zl, ulong zh, ulong zn, ulong xtrunc_max);
+                    ulong zl, ulong zh, ulong zn, ulong xtrunc_max, ulong min_depth);
 
 /* Compute stride and the normalization factors m[]. Requires the CRT
    configuration and the depth to be set. */

--- a/src/fft_small/export_signed.c
+++ b/src/fft_small/export_signed.c
@@ -118,6 +118,7 @@ static void CAT(_sig_block, NP)(ulong * W, ulong wlen, ulong A, ulong bits, \
     } \
 }
 
+DEFINE_SIG_BLOCK(3, 3, 2)
 DEFINE_SIG_BLOCK(4, 4, 3)
 DEFINE_SIG_BLOCK(5, 4, 4)
 DEFINE_SIG_BLOCK(6, 5, 4)
@@ -126,8 +127,9 @@ DEFINE_SIG_BLOCK(8, 7, 6)
 
 #undef DEFINE_SIG_BLOCK
 
-static const sig_block_func _sig_block_tab[8 - 4 + 1] = {
-    _sig_block_4, _sig_block_5, _sig_block_6, _sig_block_7, _sig_block_8
+static const sig_block_func _sig_block_tab[8 - 3 + 1] = {
+    _sig_block_3, _sig_block_4, _sig_block_5, _sig_block_6, _sig_block_7,
+    _sig_block_8
 };
 
 /*
@@ -218,7 +220,7 @@ _sig_segment(sig_seg_struct * S)
     ulong wlen = wlive + n_cdiv((ulong) BLK_SZ * bits, FLINT_BITS) + 8;
     ulong A = S->Lbase;
     ulong slot, k, idx;
-    sig_block_func sig_block = _sig_block_tab[np - 4];
+    sig_block_func sig_block = _sig_block_tab[np - 3];
 
     mpn_rshift(prodh, prod, n, 1);
     W = flint_malloc(wlen * sizeof(ulong));
@@ -373,14 +375,14 @@ fft_small_export_mpn_signed_trunc(ulong* z, ulong zn, int * sign,
     slong nworkers = 0;
     ulong nthreads, l;
 
-    FLINT_ASSERT(4 <= P->np && P->np <= 8);
+    FLINT_ASSERT(3 <= P->np && P->np <= 8);
     FLINT_ASSERT(P->offset == 0);
     FLINT_ASSERT(X->domain == FFT_SMALL_OP_PRODUCT);
     FLINT_ASSERT(FLINT_BITS * (lo_limbs + zn)
                  >= nslots * bits + FLINT_BITS * n + 2);
     {
-        static const ulong _clen_of_np[8 - 4 + 1] = {4, 4, 5, 6, 7};
-        FLINT_ASSERT(n == _clen_of_np[P->np - 4]);
+        static const ulong _clen_of_np[8 - 3 + 1] = {3, 4, 4, 5, 6, 7};
+        FLINT_ASSERT(n == _clen_of_np[P->np - 3]);
         (void) _clen_of_np;
     }
 

--- a/src/fft_small/fmpz_poly_mul.c
+++ b/src/fft_small/fmpz_poly_mul.c
@@ -371,7 +371,8 @@ int _fmpz_poly_mul_mid_mpn_ctx(
     P->R = R;
     P->sign = sign;
 
-    _fft_small_plan_set_window(P, zl, zh, zn, n_max(atrunc, btrunc));
+    _fft_small_plan_set_window(P, zl, zh, zn, n_max(atrunc, btrunc),
+                               LG_BLK_SZ);
 
     /* need prod_of_primes >= bn * 2^modbits */
     if (!_fft_small_plan_set_bound(P, bn, modbits, MPN_CTX_NCRTS))

--- a/src/fft_small/mpn_mul.c
+++ b/src/fft_small/mpn_mul.c
@@ -722,6 +722,7 @@ FLINT_FORCE_INLINE void CAT(_add_to_answer_hard, n)(ulong z[], ulong r[], ulong 
     mpn_add_n(z + toff, z + toff, r, zn - toff); \
 }
 
+DEFINE_IT(3, 4)
 DEFINE_IT(4, 5)
 DEFINE_IT(5, 6)
 DEFINE_IT(6, 7)
@@ -967,6 +968,7 @@ static void CAT(_mpn_from_ffts, NP)( \
     } \
 }
 
+DEFINE_IT(3, 3, 2)
 DEFINE_IT(4, 4, 3)
 DEFINE_IT(5, 4, 4)
 DEFINE_IT(6, 5, 4)
@@ -1321,12 +1323,14 @@ void sd_fft_ctx_point_mul(
     vec8d m = vec8d_set_d(vec1d_reduce_0n_to_pmhn((slong)m_, Q->p));
     vec8d n    = vec8d_set_d(Q->p);
     vec8d ninv = vec8d_set_d(Q->pinv);
-    FLINT_ASSERT(depth >= LG_BLK_SZ);
-    for (ulong I = 0; I < n_pow2(depth - LG_BLK_SZ); I++)
+    /* flat over the whole transform: below one block the data is
+       simply shorter, the addressing is unchanged */
+    FLINT_ASSERT(depth >= 4);
     {
-        double* ax = a + sd_fft_ctx_blk_offset(I);
-        const double* bx = b + sd_fft_ctx_blk_offset(I);
-        ulong j = 0; do {
+    double* ax = a;
+    const double* bx = b;
+    ulong npts = n_pow2(depth);
+    ulong j = 0; do {
             vec8d x0, x1, b0, b1;
             x0 = vec8d_load(ax+j+0);
             x1 = vec8d_load(ax+j+8);
@@ -1338,7 +1342,7 @@ void sd_fft_ctx_point_mul(
             x1 = vec8d_mulmod(x1, b1, n, ninv);
             vec8d_store(ax+j+0, x0);
             vec8d_store(ax+j+8, x1);
-        } while (j += 16, j < BLK_SZ);
+        } while (j += 16, j < npts);
     }
 }
 
@@ -1351,12 +1355,13 @@ void sd_fft_ctx_point_sqr(
     vec8d m = vec8d_set_d(vec1d_reduce_0n_to_pmhn((slong)m_, Q->p));
     vec8d n    = vec8d_set_d(Q->p);
     vec8d ninv = vec8d_set_d(Q->pinv);
-    FLINT_ASSERT(depth >= LG_BLK_SZ);
+    /* flat, as above */
+    FLINT_ASSERT(depth >= 4);
 
-    for (ulong I = 0; I < n_pow2(depth - LG_BLK_SZ); I++)
     {
-        double* ax = a + sd_fft_ctx_blk_offset(I);
-        ulong j = 0; do {
+    double* ax = a;
+    ulong npts = n_pow2(depth);
+    ulong j = 0; do {
             vec8d x0, x1;
             x0 = vec8d_load(ax+j+0);
             x1 = vec8d_load(ax+j+8);
@@ -1366,7 +1371,7 @@ void sd_fft_ctx_point_sqr(
             x1 = vec8d_mulmod(x1, m, n, ninv);
             vec8d_store(ax+j+0, x0);
             vec8d_store(ax+j+8, x1);
-        } while (j += 16, j < BLK_SZ);
+        } while (j += 16, j < npts);
     }
 }
 
@@ -1777,7 +1782,8 @@ void _mpn_ctx_mpn_mul_range(mpn_ctx_t R, ulong* z, ulong lo, ulong hi,
         /* this is how much space was statically allocated in each struct */
         FLINT_ASSERT(n <= MPN_CTX_NCRTS);
         FLINT_ASSERT(4 <= P.np && P.np <= 8);
-        static from_ffts_func tab[8-4+1] = {_mpn_from_ffts_4,
+        static from_ffts_func tab[8-3+1] = {_mpn_from_ffts_3,
+                                            _mpn_from_ffts_4,
                                             _mpn_from_ffts_5,
                                             _mpn_from_ffts_6,
                                             _mpn_from_ffts_7,
@@ -1795,7 +1801,7 @@ void _mpn_ctx_mpn_mul_range(mpn_ctx_t R, ulong* z, ulong lo, ulong hi,
             ulong tlen = hi - L0;
             ulong* tmp = FLINT_ARRAY_ALLOC(tlen, ulong);
 
-            tab[P.np - 4](tmp, L0, hi, c_lo, c_hi, R->ffts, abuf, stride,
+            tab[P.np - 3](tmp, L0, hi, c_lo, c_hi, R->ffts, abuf, stride,
                           R->crts, bits, c_lo, c_lo, NULL, NULL);
 
             flint_mpn_copyi(z, tmp + (lo - L0), hi - lo);
@@ -1815,7 +1821,7 @@ void _mpn_ctx_mpn_mul_range(mpn_ctx_t R, ulong* z, ulong lo, ulong hi,
             for (ulong l = 0; l < nthreads; l++)
             {
                 crt_worker_struct* X = w + l;
-                X->from_ffts = tab[P.np - 4];
+                X->from_ffts = tab[P.np - 3];
                 X->z = z;
                 X->lo = lo;
                 X->hi = hi;
@@ -1928,7 +1934,7 @@ static void _op_mpn_fft_worker_func(void* varg)
 
     for (ulong l = W->start_pi; l < W->stop_pi; l++)
         sd_fft_trunc(P->R->ffts + l, W->X->data + l*P->stride, P->depth,
-                     W->atrunc, P->ztrunc);
+                     n_min(W->atrunc, P->ztrunc), P->ztrunc);
 }
 
 static void _op_mpn_slow_worker_func(void* varg)
@@ -1942,7 +1948,7 @@ static void _op_mpn_slow_worker_func(void* varg)
         slow_mpn_to_fft(R->ffts + l, W->X->data + l*P->stride, W->atrunc,
                         W->a, W->an, P->bits, R->slow_two_pow_tab[l]);
         sd_fft_trunc(R->ffts + l, W->X->data + l*P->stride, P->depth,
-                     W->atrunc, P->ztrunc);
+                     n_min(W->atrunc, P->ztrunc), P->ztrunc);
     }
 }
 
@@ -1953,6 +1959,9 @@ void fft_small_fft_mpn(fft_small_op_t X, const ulong* a, ulong an,
     ulong bits = P->bits;
     ulong np = P->np;
     ulong alen = n_cdiv(FLINT_BITS*an, bits);
+    /* the packing passes work in whole blocks; for sub-block
+       transforms the excess lands in the zeroed slab padding and the
+       transform itself runs at the plan's truncation */
     ulong atrunc = n_round_up(alen, BLK_SZ);
     to_ffts_func to_ffts = NULL;
     ulong i;
@@ -1966,7 +1975,10 @@ void fft_small_fft_mpn(fft_small_op_t X, const ulong* a, ulong an,
     FLINT_ASSERT(P->offset == 0);
     FLINT_ASSERT(X->np == np && X->offset == P->offset &&
                  X->depth == P->depth && X->stride == P->stride);
-    FLINT_ASSERT(atrunc <= P->ztrunc);
+    /* atrunc is the packing extent: whole blocks, whose excess over a
+       sub-block transform lands in the zeroed slab padding; the
+       transforms themselves run capped at the plan's truncation */
+    FLINT_ASSERT(atrunc <= P->stride);
 
     /* look for a vectorized packing profile matching (np, bits); the
        profile's bn_bound concerns the multiplication drivers' product
@@ -2067,7 +2079,8 @@ void fft_small_export_mpn(ulong* z, ulong zn, const fft_small_op_t X,
 {
     ulong bits = P->bits;
     ulong c_hi = n_min(P->zn, n_cdiv(zn*FLINT_BITS, bits));
-    static from_ffts_func tab[8-4+1] = {_mpn_from_ffts_4,
+    static from_ffts_func tab[8-3+1] = {_mpn_from_ffts_3,
+                                        _mpn_from_ffts_4,
                                         _mpn_from_ffts_5,
                                         _mpn_from_ffts_6,
                                         _mpn_from_ffts_7,
@@ -2080,7 +2093,7 @@ void fft_small_export_mpn(ulong* z, ulong zn, const fft_small_op_t X,
     ulong nthreads;
 
     FLINT_ASSERT(zn > 0);
-    FLINT_ASSERT(4 <= P->np && P->np <= 8);
+    FLINT_ASSERT(3 <= P->np && P->np <= 8);
     FLINT_ASSERT(P->offset == 0);
     FLINT_ASSERT(X->domain == FFT_SMALL_OP_PRODUCT);
 
@@ -2108,7 +2121,7 @@ void fft_small_export_mpn(ulong* z, ulong zn, const fft_small_op_t X,
            coefficient takes the hard tail, converting residues one at a
            time with scalar reductions instead of block-converting them
            with _convert_block -- measured about 3x slower overall. */
-        tab[P->np - 4](z, 0, zn, 0, c_hi, P->R->ffts, X->data, X->stride,
+        tab[P->np - 3](z, 0, zn, 0, c_hi, P->R->ffts, X->data, X->stride,
                        P->R->crts, bits, 0, E1, NULL, NULL);
     }
     else
@@ -2123,7 +2136,7 @@ void fft_small_export_mpn(ulong* z, ulong zn, const fft_small_op_t X,
         for (l = 0; l < nthreads; l++)
         {
             crt_worker_struct* W = w + l;
-            W->from_ffts = tab[P->np - 4];
+            W->from_ffts = tab[P->np - 3];
             W->z = z;
             W->lo = 0;
             W->hi = zn;

--- a/src/fft_small/nmod_poly_mul.c
+++ b/src/fft_small/nmod_poly_mul.c
@@ -19,6 +19,17 @@
 #include "crt_helpers.h"
 #include "fft_small.h"
 
+/* truncation granularity follows the plan's depth: whole blocks at
+   block depths, the full (short) transform length below one block */
+
+/* the anticipated granularity for a length before any plan exists */
+#define _len_trunc(x) \
+    ((n_clog2(x) < LG_BLK_SZ) ? n_pow2(n_max((ulong) 4, n_clog2(x))) \
+                              : n_round_up((x), BLK_SZ))
+#define _op_trunc(x, Pln) \
+    (((Pln)->depth < LG_BLK_SZ) ? n_pow2((Pln)->depth) \
+                                : n_round_up((x), BLK_SZ))
+
 static void _mod_red(
     double* abuf, ulong atrunc,
     const ulong* a, ulong an,
@@ -26,10 +37,12 @@ static void _mod_red(
     nmod_t mod)
 {
     double* aI;
-    ulong i, j;
+    ulong j;
 
     FLINT_ASSERT(atrunc < an);
-    FLINT_ASSERT(atrunc%BLK_SZ == 0);
+    /* flat over the transform: short lengths are simply fewer
+       iterations, the addressing is unchanged */
+    FLINT_ASSERT(atrunc % 8 == 0);
 
 #if 1
 
@@ -37,19 +50,18 @@ static void _mod_red(
 
 #define UNROLL 8
 
-    for (i = 0; i < atrunc; i += BLK_SZ)
     {
-        aI = sd_fft_ctx_blk_index(abuf, i/BLK_SZ);
+        aI = abuf;
 
         vec8n nn = vec8n_set_n(mod.n);
         vec8d n = vec8d_set_d(fft->p);
         vec8d ninv = vec8d_set_d(fft->pinv);
 
-        for (j = 0; j < BLK_SZ; j += UNROLL)
+        for (j = 0; j < atrunc; j += UNROLL)
         {
-            if (i+j+UNROLL <= tt || i+j >= tt)
+            if (j+UNROLL <= tt || j >= tt)
             {
-                ulong k = i+j;
+                ulong k = j;
                 FLINT_ASSERT(k+UNROLL-1 < an);
                 vec8n t = vec8n_load_unaligned(a + k);
 
@@ -69,7 +81,7 @@ static void _mod_red(
             {
                 for (ulong l = 0; l < UNROLL; l++)
                 {
-                    ulong k = i+j+l;
+                    ulong k = j+l;
                     ulong c = a[k];
                     for (k += atrunc; k < an; k += atrunc)
                         c = nmod_add(c, a[k], mod);
@@ -748,7 +760,7 @@ void fft_small_fft_nmod(fft_small_op_t X, const ulong* a, ulong an,
 
     FLINT_ASSERT(X->np == P->np && X->offset == P->offset &&
                  X->depth == P->depth && X->stride == P->stride);
-    FLINT_ASSERT(itrunc % BLK_SZ == 0);
+    FLINT_ASSERT(itrunc % 8 == 0);
     FLINT_ASSERT(itrunc <= P->ztrunc);
 
     /* thread over the primes; the threshold mirrors the fused drivers'
@@ -926,8 +938,8 @@ void _nmod_poly_mul_mid_mpn_ctx(
 
     squaring = (a == b) && (an == bn);
 
-    atrunc = n_round_up(an, BLK_SZ);
-    btrunc = n_round_up(bn, BLK_SZ);
+    atrunc = _len_trunc(an);
+    btrunc = _len_trunc(bn);
 
     /* at most min(an, bn) <= bn products, each < 2^(2*modbits), accumulate
        onto one output coefficient */
@@ -935,6 +947,11 @@ void _nmod_poly_mul_mid_mpn_ctx(
                         n_max(atrunc, btrunc), bn, 2*modbits, mod, bn);
     FLINT_ASSERT(success);
     (void) success;
+
+    /* operand truncations are capped by the plan's transform: the
+       wraparound importer folds any excess length */
+    atrunc = n_min(atrunc, P->ztrunc);
+    btrunc = n_min(btrunc, P->ztrunc);
 
     A.a = a; A.an = an; A.aaux = 0; A.atrunc = atrunc;
     A.b = b; A.bn = bn; A.baux = 0; A.btrunc = btrunc;
@@ -1045,7 +1062,7 @@ void _mul_precomp_init(
     ulong N = n_pow2(depth);
     int success;
 
-    btrunc = n_round_up(btrunc, BLK_SZ);
+    btrunc = _len_trunc(btrunc);
 
     /* the transform may be used for cyclic convolutions, which accumulate
        up to N products onto one output coefficient */
@@ -1097,12 +1114,17 @@ int _nmod_poly_mul_mid_precomp(
     FLINT_ASSERT(zl < zh);
     FLINT_ASSERT(zh <= zn);
 
-    atrunc = n_round_up(an, BLK_SZ);
+    atrunc = n_min(_len_trunc(an), n_pow2(M->P->depth));
 
     /* note: adjusting the window in M means concurrent calls on the same M
        race, but they already race on the scratch buffer in R */
-    if (!_fft_small_plan_fit_window(M->P, zl, zh, zn, atrunc))
+    if (!_fft_small_plan_fit_window(M->P, zl, zh, zn, atrunc, (ulong) 4))
         return 0;
+
+    /* cap AFTER the window is fitted: fitting recomputes ztrunc, which
+       can shrink on a reused plan, and coefficients past it cannot
+       reach a linear window */
+    atrunc = n_min(atrunc, M->P->ztrunc);
 
     A.a = a; A.an = an; A.aaux = 0; A.atrunc = atrunc;
     A.b = NULL; A.bn = bn; A.baux = 0; A.btrunc = 0;

--- a/src/fft_small/op.c
+++ b/src/fft_small/op.c
@@ -11,6 +11,7 @@
 
 #include "thread_pool.h"
 #include "thread_support.h"
+#include <string.h>
 #include "fft_small.h"
 #include "machine_vectors.h"
 
@@ -25,6 +26,17 @@ void fft_small_op_init(fft_small_op_t X, const fft_small_plan_t P)
     X->owns_data = 1;
     X->data = flint_aligned_alloc(FLINT_FFT_SMALL_ALIGNMENT,
                  n_round_up(P->np*P->stride*sizeof(double), FLINT_FFT_SMALL_ALIGNMENT));
+    /* zero the block padding of sub-block transforms (see plan.c) */
+    if (P->stride > sd_fft_ctx_data_size(P->depth))
+    {
+        ulong pi;
+        for (pi = 0; pi < P->np; pi++)
+            memset(X->data + pi * P->stride
+                       + sd_fft_ctx_data_size(P->depth), 0,
+                   (P->stride - sd_fft_ctx_data_size(P->depth))
+                       * sizeof(double));
+    }
+
 }
 
 /* as fft_small_op_init, with caller-provided storage: 'data' must hold
@@ -85,13 +97,15 @@ FLINT_FORCE_INLINE void _point_mul_impl(const sd_fft_ctx_struct* Q,
     vec8d m = vec8d_set_d(vec1d_reduce_0n_to_pmhn((slong)m_, Q->p));
     vec8d n    = vec8d_set_d(Q->p);
     vec8d ninv = vec8d_set_d(Q->pinv);
-    FLINT_ASSERT(depth >= LG_BLK_SZ);
-    for (ulong I = 0; I < n_pow2(depth - LG_BLK_SZ); I++)
+    /* flat over the whole transform: below one block the
+       data is simply shorter, the addressing is unchanged */
+    FLINT_ASSERT(depth >= 4);
     {
-        double* zx = z + sd_fft_ctx_blk_offset(I);
-        const double* ax = a + sd_fft_ctx_blk_offset(I);
-        const double* bx = b + sd_fft_ctx_blk_offset(I);
-        ulong j = 0; do {
+    double* zx = z;
+    const double* ax = a;
+    const double* bx = b;
+    ulong npts = n_pow2(depth);
+    ulong j = 0; do {
             vec8d x0, x1, b0, b1;
             x0 = vec8d_load(ax+j+0);
             x1 = vec8d_load(ax+j+8);
@@ -111,7 +125,7 @@ FLINT_FORCE_INLINE void _point_mul_impl(const sd_fft_ctx_struct* Q,
             x1 = vec8d_mulmod(x1, b1, n, ninv);
             vec8d_store(zx+j+0, x0);
             vec8d_store(zx+j+8, x1);
-        } while (j += 16, j < BLK_SZ);
+        } while (j += 16, j < npts);
     }
 }
 
@@ -133,12 +147,14 @@ FLINT_FORCE_INLINE void _point_sqr_impl(const sd_fft_ctx_struct* Q,
     vec8d m = vec8d_set_d(vec1d_reduce_0n_to_pmhn((slong)m_, Q->p));
     vec8d n    = vec8d_set_d(Q->p);
     vec8d ninv = vec8d_set_d(Q->pinv);
-    FLINT_ASSERT(depth >= LG_BLK_SZ);
-    for (ulong I = 0; I < n_pow2(depth - LG_BLK_SZ); I++)
+    /* flat over the whole transform: below one block the
+       data is simply shorter, the addressing is unchanged */
+    FLINT_ASSERT(depth >= 4);
     {
-        double* zx = z + sd_fft_ctx_blk_offset(I);
-        const double* ax = a + sd_fft_ctx_blk_offset(I);
-        ulong j = 0; do {
+    double* zx = z;
+    const double* ax = a;
+    ulong npts = n_pow2(depth);
+    ulong j = 0; do {
             vec8d x0, x1, t0, t1;
             x0 = vec8d_load(ax+j+0);
             x1 = vec8d_load(ax+j+8);
@@ -156,7 +172,7 @@ FLINT_FORCE_INLINE void _point_sqr_impl(const sd_fft_ctx_struct* Q,
             x1 = vec8d_mulmod(t1, x1, n, ninv);
             vec8d_store(zx+j+0, x0);
             vec8d_store(zx+j+8, x1);
-        } while (j += 16, j < BLK_SZ);
+        } while (j += 16, j < npts);
     }
 }
 
@@ -177,13 +193,15 @@ FLINT_FORCE_INLINE void _point_addmul_impl(const sd_fft_ctx_struct* Q,
     vec8d m = vec8d_set_d(vec1d_reduce_0n_to_pmhn((slong)m_, Q->p));
     vec8d n    = vec8d_set_d(Q->p);
     vec8d ninv = vec8d_set_d(Q->pinv);
-    FLINT_ASSERT(depth >= LG_BLK_SZ);
-    for (ulong I = 0; I < n_pow2(depth - LG_BLK_SZ); I++)
+    /* flat over the whole transform: below one block the
+       data is simply shorter, the addressing is unchanged */
+    FLINT_ASSERT(depth >= 4);
     {
-        double* zx = z + sd_fft_ctx_blk_offset(I);
-        const double* ax = a + sd_fft_ctx_blk_offset(I);
-        const double* bx = b + sd_fft_ctx_blk_offset(I);
-        ulong j = 0; do {
+    double* zx = z;
+    const double* ax = a;
+    const double* bx = b;
+    ulong npts = n_pow2(depth);
+    ulong j = 0; do {
             vec8d x0, x1, b0, b1, z0, z1;
             x0 = vec8d_load(ax+j+0);
             x1 = vec8d_load(ax+j+8);
@@ -217,7 +235,7 @@ FLINT_FORCE_INLINE void _point_addmul_impl(const sd_fft_ctx_struct* Q,
             z1 = vec8d_reduce_to_pm1n(z1, n, ninv);
             vec8d_store(zx+j+0, z0);
             vec8d_store(zx+j+8, z1);
-        } while (j += 16, j < BLK_SZ);
+        } while (j += 16, j < npts);
     }
 }
 
@@ -237,13 +255,15 @@ static void _point_add(const sd_fft_ctx_struct* Q,
 {
     vec8d n    = vec8d_set_d(Q->p);
     vec8d ninv = vec8d_set_d(Q->pinv);
-    FLINT_ASSERT(depth >= LG_BLK_SZ);
-    for (ulong I = 0; I < n_pow2(depth - LG_BLK_SZ); I++)
+/* flat over the whole transform: below one block the
+       data is simply shorter, the addressing is unchanged */
+    FLINT_ASSERT(depth >= 4);
     {
-        double* zx = z + sd_fft_ctx_blk_offset(I);
-        const double* ax = a + sd_fft_ctx_blk_offset(I);
-        const double* bx = (b == NULL) ? NULL : b + sd_fft_ctx_blk_offset(I);
-        ulong j = 0; do {
+    double* zx = z;
+    const double* ax = a;
+    const double* bx = b;
+    ulong npts = n_pow2(depth);
+    ulong j = 0; do {
             vec8d x0, x1;
             x0 = vec8d_load(ax+j+0);
             x1 = vec8d_load(ax+j+8);
@@ -268,7 +288,7 @@ static void _point_add(const sd_fft_ctx_struct* Q,
             }
             vec8d_store(zx+j+0, x0);
             vec8d_store(zx+j+8, x1);
-        } while (j += 16, j < BLK_SZ);
+        } while (j += 16, j < npts);
     }
 }
 

--- a/src/fft_small/plan.c
+++ b/src/fft_small/plan.c
@@ -45,28 +45,39 @@ int _fft_small_plan_set_bound(fft_small_plan_t P, ulong c, ulong e, ulong np_max
 }
 
 void _fft_small_plan_set_window(fft_small_plan_t P,
-                    ulong zl, ulong zh, ulong zn, ulong xtrunc_max)
+                    ulong zl, ulong zh, ulong zn, ulong xtrunc_max,
+                    ulong min_depth)
 {
     ulong ztrunc, depth, i;
 
     FLINT_ASSERT(zl < zh);
     FLINT_ASSERT(zh <= zn);
 
-    ztrunc = n_round_up(zn, BLK_SZ);
     /*
         if there is a power of two 2^d between zh and zn with good wrap around
             i.e. max(operand lengths, zh) <= 2^d <= zn with zn - 2^d <= zl
-        then use d as the depth, otherwise the usual with no wrap around
-    */
+        then use d as the depth, otherwise the usual with no wrap around.
+        Truncation granularity is one block at block depths and the
+        transform length itself below one block, where sd_fft_trunc
+        dispatches to the register basecases. */
     depth = n_flog2(zn);
     i = n_pow2(depth);
     if (xtrunc_max <= i && zh <= i && i <= zn && zn <= zl + i)
     {
-        ztrunc = i;
+        depth = n_max(depth, min_depth);
+        /* if the floor raised the depth, the transform length grows
+           with it; the wraparound conditions are monotone in i, so
+           they continue to hold */
+        ztrunc = n_pow2(depth);
     }
     else
     {
-        depth = n_max(LG_BLK_SZ, n_clog2(ztrunc));
+        /* the small headroom above zn covers the signed
+           representation's bias digits, which span a few chunks past
+           the product and were absorbed by block rounding before */
+        depth = n_max(min_depth, n_clog2(zn + 4));
+        ztrunc = (depth < LG_BLK_SZ) ? n_pow2(depth)
+                                     : n_round_up(zn, BLK_SZ);
     }
 
     P->zl = zl;
@@ -78,7 +89,8 @@ void _fft_small_plan_set_window(fft_small_plan_t P,
 }
 
 int _fft_small_plan_fit_window(fft_small_plan_t P,
-                    ulong zl, ulong zh, ulong zn, ulong xtrunc_max)
+                    ulong zl, ulong zh, ulong zn, ulong xtrunc_max,
+                    ulong min_depth)
 {
     ulong N = n_pow2(P->depth);
     ulong ztrunc;
@@ -86,7 +98,11 @@ int _fft_small_plan_fit_window(fft_small_plan_t P,
     FLINT_ASSERT(zl < zh);
     FLINT_ASSERT(zh <= zn);
 
-    ztrunc = n_round_up(zn, BLK_SZ);
+    /* a fixed depth below the conversions' floor cannot serve */
+    if (P->depth < min_depth)
+        return 0;
+
+    ztrunc = (P->depth < LG_BLK_SZ) ? N : n_round_up(zn, BLK_SZ);
 
     if (xtrunc_max <= N && zh <= N && N <= zn && zn <= zl + N)
     {
@@ -114,7 +130,10 @@ void _fft_small_plan_set_normalizers(fft_small_plan_t P)
     ulong np = P->np;
     ulong depth = P->depth;
 
-    P->stride = n_round_up(sd_fft_ctx_data_size(depth), 128);
+    /* slabs padded to whole blocks: block-granular readers read a
+       full block and discard beyond the emitted range; op init zeroes
+       the pad. No cost at block depths. */
+    P->stride = n_round_up(sd_fft_ctx_data_size(depth), BLK_SZ);
 
     for (i = 0; i < np; i++)
     {
@@ -180,6 +199,14 @@ int fft_small_plan_init_mpn(fft_small_plan_t P, mpn_ctx_t R,
             alen = n_cdiv(FLINT_BITS*an_max, bits);
             blen = n_cdiv(FLINT_BITS*bn_max, bits);
             zlen = alen + blen - 1;
+            /* the (np, bits) selection deliberately scores at block
+               granularity even though set_window will shorten the
+               chosen plan: scoring short-aware makes the model trade
+               prime count for depth (e.g. np 7 at depth 5 over np 4
+               at depth 6), which measures slower -- the crt and
+               conversion costs it underweights dominate at these
+               sizes. Block scoring keeps the minimal-np narrow-chunk
+               choices that measure best. */
             ztrunc = n_round_up(zlen, BLK_SZ);
             depth = n_max(LG_BLK_SZ, n_clog2(ztrunc));
 
@@ -200,7 +227,10 @@ int fft_small_plan_init_mpn(fft_small_plan_t P, mpn_ctx_t R,
             goto have_choice;
     }
 
-    for (np = 4; np <= MPN_CTX_NCRTS; np++)
+    /* np = 3 has no vectorized packing profile: its imports take the
+       slow per-coefficient path, which the narrow chunks (65..69 bits
+       against the 3-prime product) keep affordable at small sizes */
+    for (np = 3; np <= MPN_CTX_NCRTS; np++)
     {
         const crt_data_struct* C = R->crts + np - 1;
         ulong bits, alen, blen, zlen, ztrunc, depth;
@@ -231,7 +261,7 @@ int fft_small_plan_init_mpn(fft_small_plan_t P, mpn_ctx_t R,
         alen = n_cdiv(FLINT_BITS*an_max, bits);
         blen = n_cdiv(FLINT_BITS*bn_max, bits);
         zlen = alen + blen - 1;
-        ztrunc = n_round_up(zlen, BLK_SZ);
+        ztrunc = n_round_up(zlen, BLK_SZ);   /* scored at block, as above */
         depth = n_max(LG_BLK_SZ, n_clog2(ztrunc));
 
         {
@@ -260,8 +290,12 @@ have_choice:
         P->R = R;
         P->sign = 0;
 
+        /* the block-rounded operand bound keeps the wraparound branch
+           off for mpn plans, whose chunked conversions assume linear
+           transforms; short depths come from the non-wrap branch */
         _fft_small_plan_set_window(P, 0, zlen, zlen,
-                    n_max(n_round_up(alen, BLK_SZ), n_round_up(blen, BLK_SZ)));
+                    n_max(n_round_up(alen, BLK_SZ), n_round_up(blen, BLK_SZ)),
+                    (ulong) 4);
 
         P->bits = bits;
         P->bound_c = len_bound;
@@ -367,7 +401,9 @@ int fft_small_plan_init_nmod(fft_small_plan_t P, mpn_ctx_t R,
     P->R = R;
     P->sign = 0;
 
-    _fft_small_plan_set_window(P, zl, zh, zn, xtrunc_max);
+    /* the nmod conversions are per-coefficient and handle short
+       transforms; the register basecases serve depths from 4 */
+    _fft_small_plan_set_window(P, zl, zh, zn, xtrunc_max, (ulong) 4);
 
     if (!_fft_small_plan_set_bound_nmod(P, len_bound, prod_bits, mod, direct_len))
         return 0;
@@ -382,7 +418,7 @@ int fft_small_plan_init_nmod_cyclic(fft_small_plan_t P, mpn_ctx_t R,
 {
     ulong N = n_pow2(depth);
 
-    FLINT_ASSERT(depth >= LG_BLK_SZ);
+    FLINT_ASSERT(depth >= 4);
     FLINT_ASSERT(zh <= N);
 
     P->R = R;

--- a/src/fft_small/test/main.c
+++ b/src/fft_small/test/main.c
@@ -12,6 +12,7 @@
 /* Include functions *********************************************************/
 
 #include "t-fmpz_poly_mul.c"
+#include "t-gr_transformed_nmod_poly.c"
 #include "t-mpn_add_inplace_c.c"
 #include "t-mpn_mulmid.c"
 #include "t-mul.c"
@@ -27,6 +28,7 @@
 test_struct tests[] =
 {
     TEST_FUNCTION(_fmpz_poly_mul_mid_mpn_ctx),
+    TEST_FUNCTION(gr_transformed_nmod_poly),
     TEST_FUNCTION(flint_mpn_add_inplace_c),
     TEST_FUNCTION(_mpn_ctx_mpn_mul_range),
     TEST_FUNCTION(mpn_ctx_mpn_mul),

--- a/src/fft_small/test/t-gr_transformed_nmod_poly.c
+++ b/src/fft_small/test/t-gr_transformed_nmod_poly.c
@@ -1,0 +1,147 @@
+/*
+    Copyright (C) 2025 The FLINT team
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "nmod.h"
+#include "nmod_vec.h"
+#include "gr.h"
+#include "gr_poly.h"
+#include "fft_small.h"
+
+/* Direct test of the transformed nmod polynomial ring: accumulate
+   K products in transform space against an nmod_vec reference, with
+   the workload forced so that small, unprofitable shapes -- in
+   particular sub-block transform lengths, which reach the ring only
+   through production gates otherwise -- are exercised, along with
+   moduli beyond 50 bits and windowed exports (the export applies the
+   deferred normalizer, so every comparison checks it). */
+TEST_FUNCTION_START(gr_transformed_nmod_poly, state)
+{
+    for (slong iter = 0; iter < 200 * flint_test_multiplier(); iter++)
+    {
+        nmod_t mod;
+        ulong modbits = 2 + n_randint(state, 61);
+        int large = n_randint(state, 6) == 0;
+        slong K = 1 + n_randint(state, 3);
+        slong an = 1 + n_randint(state, large ? 600 : 90);
+        slong bn = 1 + n_randint(state, large ? 600 : 90);
+        slong zn = an + bn - 1;
+        slong zl = n_randint(state, zn);
+        slong zh = zl + 1 + n_randint(state, zn - zl);
+        ulong terms;
+        gr_ctx_t ctx, tctx;
+        gr_transformed_poly_workload_t wl;
+        nn_ptr a, b, t, ref, got;
+        gr_ptr A, B, T, Z;
+        slong k, glen;
+        int status = GR_SUCCESS;
+
+        nmod_init(&mod, n_randbits(state, modbits));
+
+        terms = (ulong) K * (ulong) FLINT_MIN(an, bn) + 2;
+
+        wl->num_inputs = 2 * K;
+        wl->num_muls = K;
+        wl->num_outputs = 1;
+        wl->num_live = 0;
+        wl->mem_limit = 0;
+        wl->force = 1;
+
+        gr_ctx_init_nmod(ctx, mod.n);
+
+        if (gr_ctx_init_gr_poly_transformed_repr(tctx, ctx, zn,
+                        (slong) terms, wl) != GR_SUCCESS)
+        {
+            /* implementation bounds (e.g. the prime product cannot
+               cover the declared capacity) */
+            gr_ctx_clear(ctx);
+            continue;
+        }
+
+        a = _nmod_vec_init(K * an);
+        b = _nmod_vec_init(K * bn);
+        t = _nmod_vec_init(zn);
+        ref = _nmod_vec_init(zn);
+        got = _nmod_vec_init(zn);
+
+        for (k = 0; k < K * an; k++) a[k] = n_randint(state, mod.n);
+        for (k = 0; k < K * bn; k++) b[k] = n_randint(state, mod.n);
+
+        /* reference: ref = sum_k a_k * b_k as plain convolutions */
+        _nmod_vec_zero(ref, zn);
+        for (k = 0; k < K; k++)
+        {
+            slong i, j;
+            _nmod_vec_zero(t, zn);
+            for (i = 0; i < an; i++)
+                for (j = 0; j < bn; j++)
+                    t[i + j] = nmod_add(t[i + j],
+                        nmod_mul(a[k*an + i], b[k*bn + j], mod), mod);
+            _nmod_vec_add(ref, ref, t, zn, mod);
+        }
+
+        A = gr_heap_init(tctx);
+        B = gr_heap_init(tctx);
+        T = gr_heap_init(tctx);
+        Z = gr_heap_init(tctx);
+
+        status |= gr_zero(Z, tctx);
+        for (k = 0; k < K; k++)
+        {
+            status |= _gr_set_gr_poly(A, GR_ENTRY(a, k*an, sizeof(ulong)),
+                                      an, ctx, tctx);
+            status |= _gr_set_gr_poly(B, GR_ENTRY(b, k*bn, sizeof(ulong)),
+                                      bn, ctx, tctx);
+            status |= gr_mul(T, A, B, tctx);
+            status |= gr_add(Z, Z, T, tctx);
+        }
+
+        if (status != GR_SUCCESS)
+            TEST_FUNCTION_FAIL("ring ops declined: modbits %wu an %wd "
+                "bn %wd K %wd\n", modbits, an, bn, K);
+
+        /* full export */
+        glen = 0;
+        status |= _gr_get_gr_poly(got, &glen, Z, ctx, tctx);
+        if (status != GR_SUCCESS || glen > zn)
+            TEST_FUNCTION_FAIL("export declined: modbits %wu an %wd "
+                "bn %wd K %wd\n", modbits, an, bn, K);
+        for (k = glen; k < zn; k++) got[k] = 0;
+        if (!_nmod_vec_equal(got, ref, zn))
+            TEST_FUNCTION_FAIL("full export mismatch: modbits %wu an %wd "
+                "bn %wd K %wd zn %wd\n", modbits, an, bn, K, zn);
+
+        /* windowed export */
+        _nmod_vec_zero(got, zn);
+        status |= _gr_get_gr_poly_window(got, Z, zl, zh, ctx, tctx);
+        if (status != GR_SUCCESS)
+            TEST_FUNCTION_FAIL("window declined: modbits %wu an %wd "
+                "bn %wd zl %wd zh %wd\n", modbits, an, bn, zl, zh);
+        if (!_nmod_vec_equal(got, ref + zl, zh - zl))
+            TEST_FUNCTION_FAIL("window mismatch: modbits %wu an %wd "
+                "bn %wd K %wd zl %wd zh %wd\n",
+                modbits, an, bn, K, zl, zh);
+
+        gr_heap_clear(A, tctx);
+        gr_heap_clear(B, tctx);
+        gr_heap_clear(T, tctx);
+        gr_heap_clear(Z, tctx);
+        _nmod_vec_clear(a);
+        _nmod_vec_clear(b);
+        _nmod_vec_clear(t);
+        _nmod_vec_clear(ref);
+        _nmod_vec_clear(got);
+        gr_ctx_clear(tctx);
+        gr_ctx_clear(ctx);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/fft_small/test/t-op_nmod.c
+++ b/src/fft_small/test/t-op_nmod.c
@@ -15,6 +15,11 @@
 #include "nmod_poly.h"
 #include "fft_small.h"
 
+/* truncation granularity follows the plan's depth */
+#define _op_trunc(x, Pln) \
+    (((Pln)->depth < LG_BLK_SZ) ? n_pow2((Pln)->depth) \
+                                : n_round_up((x), BLK_SZ))
+
 /* Accumulate K products in transform space (as a bilinear application
    like matrix multiplication would) and compare the exported window
    against classical multiplications. Inflating prod_bits beyond the
@@ -47,6 +52,9 @@ TEST_FUNCTION_START(fft_small_op_nmod, state)
         zn = an + bn - 1;
         ulong zl = n_randint(state, zn);
         ulong zh = zl + 1 + n_randint(state, zn - zl);
+        /* the block-rounded lengths serve as conservative pre-plan
+           bounds; the operative truncations are re-derived from the
+           plan's granularity right after init */
         ulong atrunc = n_round_up(an, BLK_SZ);
         ulong btrunc = n_round_up(bn, BLK_SZ);
         ulong extra_bits = n_randint(state, 300);
@@ -69,6 +77,9 @@ TEST_FUNCTION_START(fft_small_op_nmod, state)
         {
             continue;   /* bound needs more than MPN_CTX_NCRTS primes */
         }
+
+        atrunc = _op_trunc(an, P);
+        btrunc = _op_trunc(bn, P);
 
         a = FLINT_ARRAY_ALLOC(K*an, ulong);
         b = FLINT_ARRAY_ALLOC(K*bn, ulong);

--- a/src/gr/nmod_transformed_poly.c
+++ b/src/gr/nmod_transformed_poly.c
@@ -23,6 +23,17 @@
 #include "machine_vectors.h"
 #include "fft_small.h"
 
+/* truncation granularity follows the plan's depth: whole blocks at
+   block depths, the full (short) transform length below one block */
+
+/* the anticipated granularity for a length before any plan exists */
+#define _len_trunc(x) \
+    ((n_clog2(x) < LG_BLK_SZ) ? n_pow2(n_max((ulong) 4, n_clog2(x))) \
+                              : n_round_up((x), BLK_SZ))
+#define _op_trunc(x, Pln) \
+    (((Pln)->depth < LG_BLK_SZ) ? n_pow2((Pln)->depth) \
+                                : n_round_up((x), BLK_SZ))
+
 /*
     Ring of nmod polynomials of bounded length in fft_small transformed
     representation (prototype).
@@ -108,34 +119,33 @@ typedef struct
 #define TPOLY_CTX(ctx) ((tpoly_ctx_struct *) GR_CTX_DATA_AS_PTR(ctx))
 #define TPOLY(x) ((tpoly_struct *) (x))
 
-/* d = m*d + b over the first nblk blocks: applies the saved normalizer
+/* d = m*d + b over the element's truncation: applies the saved normalizer
    (and, for values that may be negative, the reconstruction bias) to the
    inverse-transformed coefficients; scaling commutes with the linear
    inverse transform, and applying it afterwards touches only the
    element's virtual length instead of the full transform */
 static void
 _tpoly_scale_bias(const sd_fft_ctx_struct * Q, double * d,
-                  ulong m_, double b, ulong nblk)
+                  ulong m_, double b, ulong npts)
 {
     vec8d m = vec8d_set_d(vec1d_reduce_0n_to_pmhn((slong) m_, Q->p));
     vec8d bb = vec8d_set_d(b);
     vec8d n = vec8d_set_d(Q->p);
     vec8d ninv = vec8d_set_d(Q->pinv);
-    ulong I;
 
-    for (I = 0; I < nblk; I++)
-    {
-        double * dx = d + sd_fft_ctx_blk_offset(I);
-        ulong j = 0; do {
-            vec8d x0, x1;
-            x0 = vec8d_load(dx + j + 0);
-            x1 = vec8d_load(dx + j + 8);
-            x0 = vec8d_add(vec8d_mulmod(x0, m, n, ninv), bb);
-            x1 = vec8d_add(vec8d_mulmod(x1, m, n, ninv), bb);
-            vec8d_store(dx + j + 0, x0);
-            vec8d_store(dx + j + 8, x1);
-        } while (j += 16, j < BLK_SZ);
-    }
+    /* flat over the element's truncation: sub-block transforms are
+       simply fewer iterations (a block-count parameter here rounded a
+       sub-block truncation down to zero passes, silently skipping the
+       normalizer) */
+    ulong j = 0; do {
+        vec8d x0, x1;
+        x0 = vec8d_load(d + j + 0);
+        x1 = vec8d_load(d + j + 8);
+        x0 = vec8d_add(vec8d_mulmod(x0, m, n, ninv), bb);
+        x1 = vec8d_add(vec8d_mulmod(x1, m, n, ninv), bb);
+        vec8d_store(d + j + 0, x0);
+        vec8d_store(d + j + 8, x1);
+    } while (j += 16, j < npts);
 }
 
 static int
@@ -249,7 +259,7 @@ tpoly_set_gr_poly(gr_ptr res, gr_srcptr a, slong len,
         return tpoly_zero(res, ctx);
 
     fft_small_fft_nmod(&TPOLY(res)->op, ac, len,
-                       n_round_up(len, BLK_SZ), T->mod, T->P);
+                       _op_trunc(len, T->P), T->mod, T->P);
     TPOLY(res)->len = len;
     TPOLY(res)->terms = 1;
     TPOLY(res)->depth = 1;
@@ -267,7 +277,7 @@ _tpoly_export(tpoly_ctx_struct * T, gr_srcptr x, slong zl, slong ub,
     const fft_small_plan_struct * P = T->P;
     slong xlen = TPOLY(x)->len;
     fft_small_op_struct tmp;
-    ulong itr = n_round_up((ulong) xlen, BLK_SZ);
+    ulong itr = _op_trunc((ulong) xlen, P);
     slong i;
 
     tmp = TPOLY(x)->op;
@@ -286,7 +296,7 @@ _tpoly_export(tpoly_ctx_struct * T, gr_srcptr x, slong zl, slong ub,
         double b = TPOLY(x)->negs ? (double) T->bias_res[i] : 0.0;
 
         sd_ifft_trunc(Q, d, P->depth, itr);
-        _tpoly_scale_bias(Q, d, T->m_orig[i], b, itr / BLK_SZ);
+        _tpoly_scale_bias(Q, d, T->m_orig[i], b, itr);
     }
     fft_small_export_nmod_range(z, &tmp, (ulong) zl, (ulong) ub, T->mod, P);
 
@@ -307,7 +317,7 @@ static void
 _tpoly_invert_in_place(tpoly_ctx_struct * T, gr_ptr x)
 {
     const fft_small_plan_struct * P = T->P;
-    ulong itr = n_round_up((ulong) TPOLY(x)->len, BLK_SZ);
+    ulong itr = _op_trunc((ulong) TPOLY(x)->len, P);
     slong i;
 
     for (i = 0; i < (slong) P->np; i++)
@@ -317,7 +327,7 @@ _tpoly_invert_in_place(tpoly_ctx_struct * T, gr_ptr x)
         double b = TPOLY(x)->negs ? (double) T->bias_res[i] : 0.0;
 
         sd_ifft_trunc(Q, d, P->depth, itr);
-        _tpoly_scale_bias(Q, d, T->m_orig[i], b, itr / BLK_SZ);
+        _tpoly_scale_bias(Q, d, T->m_orig[i], b, itr);
     }
 }
 
@@ -462,7 +472,7 @@ tpoly_one(gr_ptr x, gr_ctx_t ctx)
     tpoly_ctx_struct * T = TPOLY_CTX(ctx);
     ulong c = 1;
 
-    fft_small_fft_nmod(&TPOLY(x)->op, &c, 1, BLK_SZ, T->mod, T->P);
+    fft_small_fft_nmod(&TPOLY(x)->op, &c, 1, _op_trunc(1, T->P), T->mod, T->P);
     TPOLY(x)->len = 1;
     TPOLY(x)->terms = 1;
     TPOLY(x)->depth = 1;
@@ -767,7 +777,7 @@ _gr_nmod_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base,
        reduction handles three limbs, which bounds the total */
     if (2 * modbits + 1 + FLINT_BIT_COUNT((ulong) terms_bound) > 3 * FLINT_BITS
         || !fft_small_plan_init_nmod(T->P, get_default_mpn_ctx(),
-            0, N, N, n_round_up(N, BLK_SZ), 2 * (ulong) terms_bound,
+            0, N, N, _len_trunc(N), 2 * (ulong) terms_bound,
             2 * modbits, mod, N))
     {
         flint_free(T);
@@ -801,7 +811,7 @@ _gr_nmod_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base,
        storage budget are policy and are skipped */
     if (!wl->force)
     {
-            double L = (double) n_round_up(N, BLK_SZ);
+            double L = (double) _len_trunc(N);
             double lg = (double) FLINT_BIT_COUNT((ulong) L);
             double np = (double) T->P->np;
             double ni = (double) wl->num_inputs;

--- a/src/gr/transformed_mpn.c
+++ b/src/gr/transformed_mpn.c
@@ -20,6 +20,12 @@
 #include "machine_vectors.h"
 #include "fft_small.h"
 
+/* truncation granularity follows the plan's depth: whole blocks at
+   block depths, the full (short) transform length below one block */
+#define _op_trunc(x, Pln) \
+    (((Pln)->depth < LG_BLK_SZ) ? n_pow2((Pln)->depth) \
+                                : n_round_up((x), BLK_SZ))
+
 /*
     Transformed big integers (fft_small), for bilinear expressions such as
     complex multiplications and matrix products over Z.
@@ -76,18 +82,16 @@ typedef struct
 #define TMPN_CTX(ctx) ((tmpn_ctx_struct *) GR_CTX_DATA_AS_PTR(ctx))
 #define TMPN(x) ((tmpn_struct *) (x))
 
-/* d = m*d + b over the first nblk blocks (see the polynomial rings) */
+/* d = m*d over the element's truncation (see the polynomial rings);
+   flat so that sub-block transforms are simply fewer iterations */
 static void
-_tmpn_scale(const sd_fft_ctx_struct * Q, double * d, ulong m_, ulong nblk)
+_tmpn_scale(const sd_fft_ctx_struct * Q, double * d, ulong m_, ulong npts)
 {
     vec8d m = vec8d_set_d(vec1d_reduce_0n_to_pmhn((slong) m_, Q->p));
     vec8d n = vec8d_set_d(Q->p);
     vec8d ninv = vec8d_set_d(Q->pinv);
-    ulong I;
-
-    for (I = 0; I < nblk; I++)
     {
-        double * dx = d + sd_fft_ctx_blk_offset(I);
+        double * dx = d;
         ulong j = 0; do {
             vec8d x0, x1;
             x0 = vec8d_load(dx + j + 0);
@@ -96,7 +100,7 @@ _tmpn_scale(const sd_fft_ctx_struct * Q, double * d, ulong m_, ulong nblk)
             x1 = vec8d_mulmod(x1, m, n, ninv);
             vec8d_store(dx + j + 0, x0);
             vec8d_store(dx + j + 8, x1);
-        } while (j += 16, j < BLK_SZ);
+        } while (j += 16, j < npts);
     }
 }
 
@@ -345,7 +349,7 @@ _tmpn_export_limbs(const tmpn_ctx_struct * T, slong m, int negs)
                 + FLINT_BITS * clen + 2 + (FLINT_BITS - 1), FLINT_BITS);
     }
     return _tmpn_export_limbs_raw(T->P, T->terms_bound,
-            n_min(n_round_up((ulong) m, BLK_SZ), T->P->zn));
+            n_min(_op_trunc((ulong) m, T->P), T->P->zn));
 }
 
 /* conversion out: z receives the magnitude (zn limbs allocated by the
@@ -398,7 +402,7 @@ _tmpn_get(nn_ptr z, slong zn, slong * zn_out, int * sign,
         memcpy(sdata, TMPN(x)->op.data,
                P->np * P->stride * sizeof(double));
     }
-    itr = n_round_up((ulong) m, BLK_SZ);
+    itr = _op_trunc((ulong) m, P);
 
     for (i = 0; i < (slong) P->np; i++)
     {
@@ -406,7 +410,7 @@ _tmpn_get(nn_ptr z, slong zn, slong * zn_out, int * sign,
         double * d = tmp.data + P->stride * i;
 
         sd_ifft_trunc(Q, d, P->depth, itr);
-        _tmpn_scale(Q, d, T->m_orig[i], itr / BLK_SZ);
+        _tmpn_scale(Q, d, T->m_orig[i], itr);
 
         /* the unsigned reconstruction reads whole chunks up to the
            requested limb count; slots beyond the inverse transform's
@@ -415,12 +419,9 @@ _tmpn_get(nn_ptr z, slong zn, slong * zn_out, int * sign,
         if (!negs)
         {
             ulong chi = n_min(n_pow2(P->depth),
-                              n_round_up(n_cdiv((ulong) need * FLINT_BITS,
-                                                P->bits), BLK_SZ));
-            ulong I;
-            for (I = itr / BLK_SZ; I < chi / BLK_SZ; I++)
-                memset(d + sd_fft_ctx_blk_offset(I), 0,
-                       BLK_SZ * sizeof(double));
+                              n_cdiv((ulong) need * FLINT_BITS, P->bits));
+            if (chi > itr)
+                memset(d + itr, 0, (chi - itr) * sizeof(double));
         }
     }
     tmp.domain = FFT_SMALL_OP_PRODUCT;
@@ -508,7 +509,7 @@ _tmpn_get_trunc(nn_ptr z, slong zn, slong * zn_out, int * sign,
     if (lo + zn < needf)
         return GR_DOMAIN;
 
-    itr = n_round_up((ulong) m, BLK_SZ);
+    itr = _op_trunc((ulong) m, P);
 
     if (destroy)
     {
@@ -531,7 +532,7 @@ _tmpn_get_trunc(nn_ptr z, slong zn, slong * zn_out, int * sign,
         double * d = tmp.data + P->stride * i;
 
         sd_ifft_trunc(Q, d, P->depth, itr);
-        _tmpn_scale(Q, d, T->m_orig[i], itr / BLK_SZ);
+        _tmpn_scale(Q, d, T->m_orig[i], itr);
     }
     tmp.domain = FFT_SMALL_OP_PRODUCT;
     fft_small_export_mpn_signed_trunc(z, (ulong) zn, &esign, &tmp,

--- a/src/mpn_mod/poly_mullow_fft_small.c
+++ b/src/mpn_mod/poly_mullow_fft_small.c
@@ -375,7 +375,8 @@ static int _mpn_mod_poly_mulmid_fft_small_internal(nn_ptr z, ulong zl, ulong zh,
     P->R = R;
     P->sign = 0;
 
-    _fft_small_plan_set_window(P, zl, zh, zn, n_max(atrunc, btrunc));
+    _fft_small_plan_set_window(P, zl, zh, zn, n_max(atrunc, btrunc),
+                               LG_BLK_SZ);
 
     /* need prod_of_primes >= bn * 2^modbits */
     if (!_fft_small_plan_set_bound(P, bn, modbits, MPN_CTX_NCRTS))

--- a/src/mpn_mod/transformed_poly.c
+++ b/src/mpn_mod/transformed_poly.c
@@ -23,6 +23,17 @@
 #include "machine_vectors.h"
 #include "fft_small.h"
 
+/* truncation granularity follows the plan's depth: whole blocks at
+   block depths, the full (short) transform length below one block */
+
+/* the anticipated granularity for a length before any plan exists */
+#define _len_trunc(x) \
+    ((n_clog2(x) < LG_BLK_SZ) ? n_pow2(n_max((ulong) 4, n_clog2(x))) \
+                              : n_round_up((x), BLK_SZ))
+#define _op_trunc(x, Pln) \
+    (((Pln)->depth < LG_BLK_SZ) ? n_pow2((Pln)->depth) \
+                                : n_round_up((x), BLK_SZ))
+
 /*
     Ring of mpn_mod polynomials of bounded length in fft_small transformed
     representation, following gr/nmod_transformed_poly.c: elements are
@@ -75,30 +86,26 @@ typedef struct
 #define MTPOLY_CTX(ctx) ((mtpoly_ctx_struct *) GR_CTX_DATA_AS_PTR(ctx))
 #define MTPOLY(x) ((mtpoly_struct *) (x))
 
-/* d = m*d + b over the first nblk blocks (see the nmod ring) */
+/* d = m*d + b over the element's truncation (see the nmod ring);
+   flat so that sub-block transforms are simply fewer iterations */
 static void
 _mtpoly_scale_bias(const sd_fft_ctx_struct * Q, double * d,
-                   ulong m_, double b, ulong nblk)
+                   ulong m_, double b, ulong npts)
 {
     vec8d m = vec8d_set_d(vec1d_reduce_0n_to_pmhn((slong) m_, Q->p));
     vec8d bb = vec8d_set_d(b);
     vec8d n = vec8d_set_d(Q->p);
     vec8d ninv = vec8d_set_d(Q->pinv);
-    ulong I;
 
-    for (I = 0; I < nblk; I++)
-    {
-        double * dx = d + sd_fft_ctx_blk_offset(I);
-        ulong j = 0; do {
-            vec8d x0, x1;
-            x0 = vec8d_load(dx + j + 0);
-            x1 = vec8d_load(dx + j + 8);
-            x0 = vec8d_add(vec8d_mulmod(x0, m, n, ninv), bb);
-            x1 = vec8d_add(vec8d_mulmod(x1, m, n, ninv), bb);
-            vec8d_store(dx + j + 0, x0);
-            vec8d_store(dx + j + 8, x1);
-        } while (j += 16, j < BLK_SZ);
-    }
+    ulong j = 0; do {
+        vec8d x0, x1;
+        x0 = vec8d_load(d + j + 0);
+        x1 = vec8d_load(d + j + 8);
+        x0 = vec8d_add(vec8d_mulmod(x0, m, n, ninv), bb);
+        x1 = vec8d_add(vec8d_mulmod(x1, m, n, ninv), bb);
+        vec8d_store(d + j + 0, x0);
+        vec8d_store(d + j + 8, x1);
+    } while (j += 16, j < npts);
 }
 
 static int
@@ -220,7 +227,7 @@ mtpoly_set_gr_poly(gr_ptr res, gr_srcptr a, slong len,
         return mtpoly_zero(res, ctx);
 
     fft_small_fft_mpn_mod(&MTPOLY(res)->op, ac, len,
-                          n_round_up(len, BLK_SZ), T->base, T->P);
+                          _op_trunc(len, T->P), T->base, T->P);
     MTPOLY(res)->len = len;
     MTPOLY(res)->terms = 1;
     MTPOLY(res)->depth = 1;
@@ -238,7 +245,7 @@ _mtpoly_export(mtpoly_ctx_struct * T, gr_srcptr x, slong zl, slong ub,
     const fft_small_plan_struct * P = T->P;
     slong xlen = MTPOLY(x)->len;
     fft_small_op_struct tmp;
-    ulong itr = n_round_up((ulong) xlen, BLK_SZ);
+    ulong itr = _op_trunc((ulong) xlen, P);
     slong i;
 
     tmp = MTPOLY(x)->op;
@@ -252,7 +259,7 @@ _mtpoly_export(mtpoly_ctx_struct * T, gr_srcptr x, slong zl, slong ub,
         double b = MTPOLY(x)->negs ? (double) T->bias_res[i] : 0.0;
 
         sd_ifft_trunc(Q, d, P->depth, itr);
-        _mtpoly_scale_bias(Q, d, T->m_orig[i], b, itr / BLK_SZ);
+        _mtpoly_scale_bias(Q, d, T->m_orig[i], b, itr);
     }
     fft_small_export_mpn_mod_range(z, &tmp, (ulong) zl, (ulong) ub,
                                    T->base, P);
@@ -282,7 +289,7 @@ mtpoly_get_gr_poly_destructive(gr_ptr c, slong * len, gr_ptr x,
     const fft_small_plan_struct * P = T->P;
     nn_ptr cc = (nn_ptr) c;
     slong xlen = MTPOLY(x)->len;
-    ulong itr = n_round_up((ulong) xlen, BLK_SZ);
+    ulong itr = _op_trunc((ulong) xlen, P);
     slong i;
 
     if (!_mtpoly_base_ok(base_ctx, T))
@@ -301,7 +308,7 @@ mtpoly_get_gr_poly_destructive(gr_ptr c, slong * len, gr_ptr x,
         double b = MTPOLY(x)->negs ? (double) T->bias_res[i] : 0.0;
 
         sd_ifft_trunc(Q, d, P->depth, itr);
-        _mtpoly_scale_bias(Q, d, T->m_orig[i], b, itr / BLK_SZ);
+        _mtpoly_scale_bias(Q, d, T->m_orig[i], b, itr);
     }
     fft_small_export_mpn_mod_range(cc, &MTPOLY(x)->op, 0, (ulong) xlen,
                                    T->base, P);
@@ -381,7 +388,7 @@ mtpoly_one(gr_ptr x, gr_ctx_t ctx)
     nn_ptr c = flint_calloc(T->nlimbs, sizeof(ulong));
     c[0] = 1;
 
-    fft_small_fft_mpn_mod(&MTPOLY(x)->op, c, 1, BLK_SZ, T->base, T->P);
+    fft_small_fft_mpn_mod(&MTPOLY(x)->op, c, 1, _op_trunc(1, T->P), T->base, T->P);
     flint_free(c);
     MTPOLY(x)->len = 1;
     MTPOLY(x)->terms = 1;
@@ -698,7 +705,7 @@ _gr_mpn_mod_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base,
     T->P->R = get_default_mpn_ctx();
     T->P->sign = 0;
     _fft_small_plan_set_window(T->P, 0, (ulong) N, (ulong) N,
-                               n_round_up((ulong) N, BLK_SZ));
+                               n_round_up((ulong) N, BLK_SZ), LG_BLK_SZ);
     if (!_fft_small_plan_set_bound(T->P, 4 * (ulong) terms_bound,
                                    2 * nbits, MPN_CTX_NCRTS))
     {
@@ -721,7 +728,7 @@ _gr_mpn_mod_ctx_init_transformed_poly_repr(gr_ctx_t ctx, gr_ctx_t base,
        storage budget are policy and are skipped */
     if (!wl->force)
     {
-            double L = (double) n_round_up((ulong) N, BLK_SZ);
+            double L = (double) _len_trunc((ulong) N);
             double lg = (double) FLINT_BIT_COUNT((ulong) L);
             double np = (double) T->P->np;
             double ni = (double) wl->num_inputs;

--- a/src/nmod_poly_mat/mul.c
+++ b/src/nmod_poly_mat/mul.c
@@ -17,8 +17,13 @@
 #define INTERPOLATE_MIN_DIM 60
 #define KS_MAX_LENGTH 128
 
-#define FFT_MIN_LENGTH 128
-#define FFT_MIN_LENGTH_BIG_MOD 64
+/* with short transforms active in the fft path's plans, the
+   crossovers against the classical route drop substantially; tuned
+   with assembly enabled. The smallest dimension pays proportionally
+   more per-entry conversion overhead against fewer shared transforms,
+   so dim = 2 doubles the cutoff. */
+#define FFT_MIN_LENGTH 64
+#define FFT_MIN_LENGTH_BIG_MOD 32
 
 void
 nmod_poly_mat_mul(nmod_poly_mat_t C, const nmod_poly_mat_t A,
@@ -41,6 +46,9 @@ nmod_poly_mat_mul(nmod_poly_mat_t C, const nmod_poly_mat_t A,
 
         slong cutoff = (FLINT_BIT_COUNT(nmod_poly_mat_modulus(A)) > 40)
                         ? FFT_MIN_LENGTH_BIG_MOD : FFT_MIN_LENGTH;
+
+        if (dim == 2)
+            cutoff *= 2;
 
         /* returns 0 when fft_small is unavailable or no plan exists, in
            which case we fall through to the other algorithms */

--- a/src/nmod_poly_mat/mulmid_fft_small.c
+++ b/src/nmod_poly_mat/mulmid_fft_small.c
@@ -13,6 +13,7 @@
 #include "thread_pool.h"
 
 #include <string.h>
+#include <stdio.h>
 #include "thread_pool.h"
 #include "nmod.h"
 #include "nmod_vec.h"

--- a/src/radix/mulmid_fft_small.c
+++ b/src/radix/mulmid_fft_small.c
@@ -394,7 +394,8 @@ static void _radix_mul_mpn_ctx(
     P->R = R;
     P->sign = 0;
 
-    _fft_small_plan_set_window(P, zl, zh, zn, n_max(atrunc, btrunc));
+    _fft_small_plan_set_window(P, zl, zh, zn, n_max(atrunc, btrunc),
+                               (ulong) 4);
 
     /* need prod_of_primes >= bn * 4^modbits; the radix chinese
        remaindering handles at most 4 primes */
@@ -403,6 +404,12 @@ static void _radix_mul_mpn_ctx(
     (void) success;
 
     _fft_small_plan_set_normalizers(P);
+
+    /* the block rounding above can exceed a short plan's capacity;
+       cap at the transform actually chosen (a no-op at block depths,
+       where ztrunc dominates both roundings) */
+    atrunc = n_min(atrunc, P->ztrunc);
+    btrunc = n_min(btrunc, P->ztrunc);
 
     par.mod = mod;
     par.write_carry_out = write_carry_out;


### PR DESCRIPTION
Transformed representations were previously limited to the `fft_small` block size granularity 256, but can now go down to length 32, 64 or 128.

As a result the input length crossover where FFT wins in `nmod_poly_mat_mul` roughly halves to ~32 and the cutoff is adjusted accordingly.

For `fmpz_mat_mul_fft_small`, the crossovers drop ~1000 bits, but I left the existing algorithm cutoffs for now since the effect isn't huge.

Done using Claude Fable 5.

I also tried to smoothen out the jumps at small sizes by adding transforms of length $3 \cdot 2^k$. This does speed up lengths 33-48 for `nmod_poly_mat_mul` by 5-20% but  gives inconsistent speedups at lengths 65-96 or 129-192 with a ~10% slowdown for large matrix dimensions. Omitted from this PR to keep things simple, but may be worth resurrecting with better optimized transform kernels; see the attached patch

[0003-composed-lengths.patch](https://github.com/user-attachments/files/30696577/0003-composed-lengths.patch)
