### PR TITLE
Fix two `fmpz_poly` bugs

### DIFF
--- a/src/fmpz_mat/mul_fft.c
+++ b/src/fmpz_mat/mul_fft.c
@@ -54,7 +54,10 @@ static ulong fft_combine_bits_signed(
         ulong s;
         ulong halflimb = UWORD(1) << (FLINT_BITS - 1);
 
-        if (a[i][limbs] | (a[i][limbs - 1] > halflimb))
+        /* negative iff the ring value strictly exceeds 2^(N-1) */
+        if (a[i][limbs] || (a[i][limbs - 1] > halflimb)
+            || (a[i][limbs - 1] == halflimb
+                && !flint_mpn_zero_p(a[i], limbs - 1)))
         {
             mpn_sub_1(t, a[i], limbs, UWORD(1));
             s = 1;

--- a/src/fmpz_poly/remove.c
+++ b/src/fmpz_poly/remove.c
@@ -60,7 +60,18 @@ fmpz_poly_remove(fmpz_poly_t res, const fmpz_poly_t poly1,
         } else
             i = (poly1->length - 1)/(poly2->length - 1);
     } else if (fmpz_is_zero(p1sum) || fmpz_is_one(p2sum))
-        i = (poly1->length - 1)/(poly2->length - 1);
+    {
+        if (poly2->length == 1)
+        {
+            fmpz_t cont;
+            fmpz_init(cont);
+            _fmpz_poly_content(cont, poly1->coeffs, poly1->length);
+            i = fmpz_remove(qsum, cont, p2sum);
+            fmpz_clear(cont);
+        }
+        else
+            i = (poly1->length - 1)/(poly2->length - 1);
+    }
     else
         i = fmpz_remove(qsum, p1sum, p2sum);
 

--- a/src/fmpz_vec/set_fft.c
+++ b/src/fmpz_vec/set_fft.c
@@ -28,11 +28,14 @@ static void _fmpz_vec_set_fft_coeff(fmpz * coeffs_m, slong i,
     {
         ulong halflimb = UWORD(1) << (FLINT_BITS - 1);
 
+
         {
             mcoeffs_m = _fmpz_promote(coeffs_m);
             data = FLINT_MPZ_REALLOC(mcoeffs_m, limbs);
 
-			if ((coeffs_f[i][limbs - 1] > halflimb) || coeffs_f[i][limbs])
+            if (coeffs_f[i][limbs] || (coeffs_f[i][limbs - 1] > halflimb)
+                || (coeffs_f[i][limbs - 1] == halflimb
+                    && !flint_mpn_zero_p(coeffs_f[i], limbs - 1)))
             {
                 mpn_neg(data, coeffs_f[i], limbs);
                 mpn_add_1(data, data, limbs, WORD(1));

--- a/src/fmpz_vec/test/t-get_set_fft.c
+++ b/src/fmpz_vec/test/t-get_set_fft.c
@@ -65,6 +65,61 @@ TEST_FUNCTION_START(fmpz_vec_get_set_fft, state)
         _fmpz_vec_clear(b, len);
     }
 
+    /* directed boundary cases: values within a limb of +-2^(N-1),
+       whose ring representatives have top limb exactly halflimb --
+       the band a formerly strict sign test misclassified */
+    for (i = 0; i < 200 * flint_test_multiplier(); i++)
+    {
+        fmpz * a, * b;
+        slong limbs = 1 + n_randint(state, 8);
+        ulong * ii[1], * ptr;
+        slong bt;
+        int result2;
+
+        ptr = flint_malloc((limbs + 1) * sizeof(ulong));
+        ii[0] = ptr;
+
+        a = _fmpz_vec_init(1);
+        b = _fmpz_vec_init(1);
+
+        fmpz_one(a + 0);
+        fmpz_mul_2exp(a + 0, a + 0, FLINT_BITS * limbs - 1);
+        switch (n_randint(state, 4))
+        {
+            case 0: break;                        /* +2^(N-1) */
+            case 1:                               /* +2^(N-1) - small */
+                fmpz_sub_ui(a + 0, a + 0,
+                            1 + n_randint(state, 1000));
+                break;
+            case 2:                               /* -2^(N-1) */
+                fmpz_neg(a + 0, a + 0);
+                break;
+            default:                              /* -(2^(N-1) - small) */
+                fmpz_sub_ui(a + 0, a + 0,
+                            1 + n_randint(state, 1000));
+                fmpz_neg(a + 0, a + 0);
+        }
+
+        _fmpz_vec_get_fft(ii, a, limbs, 1);
+        bt = _fmpz_vec_max_bits(a, 1);
+        mpn_normmod_2expp1(ii[0], limbs);
+        _fmpz_vec_set_fft(b, 1, (const nn_ptr *) ii, limbs, bt < 0);
+
+        result2 = _fmpz_vec_equal(a, b, 1);
+        if (!result2)
+        {
+            flint_printf("FAIL (boundary):\n");
+            _fmpz_vec_print(a, 1), flint_printf("\n");
+            _fmpz_vec_print(b, 1), flint_printf("\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        flint_free(ptr);
+        _fmpz_vec_clear(a, 1);
+        _fmpz_vec_clear(b, 1);
+    }
+
      /* convert back and forth unsigned and compare */
     for (i = 0; i < 1000 * flint_test_multiplier(); i++)
     {


### PR DESCRIPTION
Fix two bugs:

* `fmpz_poly_remove` could divide by zero
* `_fmpz_vec_set_fft_coeff` used an incorrect twos complement sign test, checking only the top two limbs. In rare cases `fmpz_poly_mul_SS` could return a wrong result.

Both triggered test failures when running the `fmpz_poly` tests with `FLINT_TEST_MULTIPLIER=100`; the FFT bug gets dedicated test coverage.