### PR TITLE
Use `flint_mpn_mulmid` in `_fmpz_poly_mulmid_KS`, `_mpn_mod_poly_mulmid_KS`

### DIFF
--- a/src/fmpz_poly/mulmid_KS.c
+++ b/src/fmpz_poly/mulmid_KS.c
@@ -15,6 +15,31 @@
 #include "fmpz.h"
 #include "fmpz_vec.h"
 #include "fmpz_poly.h"
+#include "flint-mparam.h"
+
+#define GUARD_LIMBS 3
+
+#if FLINT_WANT_ASSERT
+
+/* the value of an fmpz modulo 2^FLINT_BITS, as an unsigned limb */
+static ulong
+_fmpz_low_limb(const fmpz * f)
+{
+    ulong u;
+    if (!COEFF_IS_MPZ(*f))
+        return (ulong) (slong) *f;
+    {
+        mpz_srcptr z = COEFF_TO_PTR(*f);
+        u = z->_mp_d[0];
+        if (z->_mp_size < 0)
+            u = -u;
+    }
+    return u;
+}
+
+#endif
+
+
 
 void
 _fmpz_poly_mulmid_KS(fmpz * res, const fmpz * poly1, slong len1,
@@ -26,6 +51,12 @@ _fmpz_poly_mulmid_KS(fmpz * res, const fmpz * poly1, slong len1,
     ulong *arr1, *arr2, *arr3;
     slong sign = 0;
     slong zero_high = 0;
+    int squaring = (poly1 == poly2) && (len1 == len2);
+
+#if FLINT_WANT_ASSERT
+    ulong m_ref = 0;
+    int check_m_ref = 0;
+#endif
 
     FLINT_ASSERT(len1 != 0);
     FLINT_ASSERT(len2 != 0);
@@ -126,20 +157,81 @@ _fmpz_poly_mulmid_KS(fmpz * res, const fmpz * poly1, slong len1,
         _fmpz_poly_bit_pack(arr2, poly2, len2, bits, neg2);
     }
 
-    arr3 = (nn_ptr) flint_malloc((limbs1 + limbs2) * sizeof(ulong));
+    {
+        slong flimbs = limbs1 + limbs2;
+        slong want_bit = nlo * bits;
+        slong exact_bit = FLINT_MAX(0, want_bit - (sign != 0));
+        slong elimb = exact_bit / FLINT_BITS;
+        slong zhi = FLINT_MIN(flimbs, (nhi * bits + FLINT_BITS - 1) / FLINT_BITS + 1);
+        slong zlo = FLINT_MAX(0, elimb - GUARD_LIMBS);
+        int windowed;
 
-    /* todo: mpn middle products */
-    if (arr1 == arr2 && limbs1 == limbs2)
-        flint_mpn_sqr(arr3, arr1, limbs1);
-    else if (limbs1 > limbs2)
-        flint_mpn_mul(arr3, arr1, limbs1, arr2, limbs2);
-    else
-        flint_mpn_mul(arr3, arr2, limbs2, arr1, limbs1);
+        windowed = (zlo > 0 || zhi < flimbs);
+
+        /* mulmid is currently missing good sub-fft sqrlow code */
+#if FLINT_HAVE_FFT_SMALL
+        windowed = windowed && !squaring;
+#else
+        windowed = windowed && (!squaring || FLINT_MIN(limbs1, limbs2) >= FLINT_FFT_SMALL_SQR_THRESHOLD);
+#endif
+
+        arr3 = (nn_ptr) flint_malloc((windowed ? zhi : flimbs) * sizeof(ulong));
+
+        if (windowed)
+        {
+            /* In general, flint_mpn_mulmid computes a window which may be 1 ulp
+               too small. However, all mulmid algorithms used in practice include
+               the contribution of all limbs in the middle window without
+               introducing any artificial borrows, so for unsigned coefficients
+               the result is actually guaranteed to be exact.
+
+               In the signed case, the result from flint_mpn_mulmid may be 1 ulp
+               too small, but the unpacked low coefficient will still be
+               correct for two nontrivial reasons. First, note that artificial borrows
+               are harmless, as _fmpz_poly_bit_unpack effectively self-corrects
+               (a real borrow and an artificial borrow get detected and corrected
+               all the same). Second, an artificial borrow cannot erase a genuinely
+               set sign bit due to slack in the KS packing: the slack in
+               min(len1,len2) < 2^loglen leaves plenty of room to absorb a
+               borrow with the number of guard limbs used. */
+            flint_mpn_mulmid(arr3 + zlo, arr1, limbs1, arr2, limbs2, zlo, zhi);
+
+            /* Do a sanity check mod 2^FLINT_BITS to verify that
+               flint_mpn_mulmid isn't doing anything weird. */
+#if FLINT_WANT_ASSERT
+            if (zlo > 0)
+            {
+                slong i;
+                check_m_ref = 1;
+                for (i = FLINT_MAX(0, nlo - (len2 - 1)); i <= FLINT_MIN(nlo, len1 - 1); i++)
+                    m_ref += _fmpz_low_limb(poly1 + i) * _fmpz_low_limb(poly2 + (nlo - i));
+            }
+#endif
+        }
+        else
+        {
+            if (arr1 == arr2 && limbs1 == limbs2)
+                flint_mpn_sqr(arr3, arr1, limbs1);
+            else if (limbs1 > limbs2)
+                flint_mpn_mul(arr3, arr1, limbs1, arr2, limbs2);
+            else
+                flint_mpn_mul(arr3, arr2, limbs2, arr1, limbs1);
+        }
+    }
 
     if (sign)
         _fmpz_poly_bit_unpack(res, nlo, nhi, arr3, bits, neg1 ^ neg2);
     else
         _fmpz_poly_bit_unpack_unsigned(res, nlo, nhi, arr3, bits);
+
+#if FLINT_WANT_ASSERT
+    if (check_m_ref)
+    {
+        if (m_ref != _fmpz_low_limb(res))
+            flint_abort();
+        FLINT_ASSERT(m_ref == _fmpz_low_limb(res));
+    }
+#endif
 
     if (zero_high != 0)
         _fmpz_vec_zero(res + nhi - nlo, zero_high);

--- a/src/mpn_extras/mulmid.c
+++ b/src/mpn_extras/mulmid.c
@@ -11,136 +11,75 @@
 
 #include "mpn_extras.h"
 #include "ulong_extras.h"
+#include "flint-mparam.h"
 
-#if FLINT_HAVE_NATIVE_mpn_mulmid_n && FLINT_HAVE_FFT_SMALL
-# define MULMID_KARATSUBA_CUTOFF 36
-#else
-# define MULMID_KARATSUBA_CUTOFF 20
-#endif
-
-#if FLINT_HAVE_FFT_SMALL
-# define MULMID_FFT_SMALL_CUTOFF 250
-#endif
-
-#if !FLINT_HAVE_NATIVE_mpn_mulmid_n && !FLINT_HAVE_FFT_SMALL
-/* bare build: above this a full product (GMP/FFT-backed flint_mpn_mul) plus a
-   slice beats schoolbook for a wide middle window */
-# define MULMID_BARE_MUL_CUTOFF 128
-#endif
-
-/* Zeros we are willing to append to a length-len operand, and the test for it
-   (also true when target <= len, i.e. when the operand is merely truncated). */
-#define MULMID_PAD_LIMIT(len) FLINT_MAX((mp_size_t) 4, (len) / 32)
-#define MULMID_PAD_OK(target, len) ((target) - (len) <= MULMID_PAD_LIMIT(len))
+#define APPROX_EQUAL(mm, nn) (FLINT_ABS((mm) - (nn)) <= FLINT_MAX((mm), (nn)) / 8)
 
 void
 flint_mpn_mulmid(mp_ptr z, mp_srcptr a, mp_size_t an, mp_srcptr b, mp_size_t bn,
                  mp_size_t zlo, mp_size_t zhi)
 {
-    mp_size_t ac, bc, m, M, zn, top, lim;
-#if FLINT_HAVE_NATIVE_mpn_mulmid_n
-    mp_size_t vac, vbc, vpa, vqb, La, Lb, zlo2, nb, vhalf;
-    int via_ok;
-#endif
-
     FLINT_ASSERT(an >= 1);
     FLINT_ASSERT(bn >= 1);
     FLINT_ASSERT(zlo >= 0);
     FLINT_ASSERT(zhi > zlo);
     FLINT_ASSERT(zhi <= an + bn);
 
-    ac = FLINT_MIN(an, zhi);
-    bc = FLINT_MIN(bn, zhi);
-    m = FLINT_MIN(ac, bc);
-    M = FLINT_MAX(ac, bc);
-    zn = zhi - zlo;
-    top = an + bn - zhi;            /* limbs above the window */
-    lim = MULMID_PAD_LIMIT(m);
+    if (zlo == 0 && zhi == an + bn)
+    {
+        if (a == b && an == bn)
+            flint_mpn_sqr(z, a, an);
+        else if (an >= bn)
+            flint_mpn_mul(z, a, an, b, bn);
+        else
+            flint_mpn_mul(z, b, bn, a, an);
+        return;
+    }
 
-    if (m < MULMID_KARATSUBA_CUTOFF || zn * zn <= m)
+    an = FLINT_MIN(an, zhi);
+    bn = FLINT_MIN(bn, zhi);
+
+    if (FLINT_MIN(FLINT_MIN(an, bn), zhi - zlo) < 48)
     {
         flint_mpn_mulmid_classical(z, a, an, b, bn, zlo, zhi);
         return;
     }
 
-    /* (A) full / nearly-full window */
-    if (zlo <= lim && top <= lim)
-    {
-        flint_mpn_mulmid_via_mul(z, a, an, b, bn, zlo, zhi);
-        return;
-    }
-
-    /* (B) low / nearly-low window */
-    if (zlo <= lim && MULMID_PAD_OK(zhi, an) && MULMID_PAD_OK(zhi, bn)
 #if FLINT_HAVE_FFT_SMALL
-            && (m < 2 * MULMID_FFT_SMALL_CUTOFF || zn < MULMID_FFT_SMALL_CUTOFF)
-#endif
-        )
-    {
-        flint_mpn_mulmid_via_mullow_n(z, a, an, b, bn, zlo, zhi);
-        return;
-    }
-
-    /* (C) high / nearly-high window */
-    if (top <= lim && zlo + lim >= M)
-    {
-        flint_mpn_mulmid_via_mulhigh_n(z, a, an, b, bn, zlo, zhi);
-        return;
-    }
-
-#if FLINT_HAVE_FFT_SMALL
-    /* large operands with a large (non-full, non-low, non-high) window: FFT */
-    if (m >= MULMID_FFT_SMALL_CUTOFF && zn >= MULMID_FFT_SMALL_CUTOFF)
+    if (FLINT_MIN(an, bn) >= ((a == b) ? FLINT_FFT_SMALL_SQR_THRESHOLD : FLINT_FFT_SMALL_MUL_THRESHOLD))
     {
         flint_mpn_mulmid_fft_small(z, a, an, b, bn, zlo, zhi);
         return;
     }
 #endif
 
-#if FLINT_HAVE_NATIVE_mpn_mulmid_n
-    /* Padding flint_mpn_mulmid_via_n_padded would incur: after clamping to zhi
-       and slicing the low non-contributing limbs, the longer sliced operand La
-       fills a 2n-1 slot and the shorter Lb an n slot. */
-    vac = FLINT_MIN(an, zhi);
-    vbc = FLINT_MIN(bn, zhi);
-    vpa = (zlo > vbc - 1) ? zlo - (vbc - 1) : 0;
-    vqb = (zlo > vac - 1) ? zlo - (vac - 1) : 0;
-    La = vac - vpa;
-    Lb = vbc - vqb;
-    via_ok = 0;
-    if (La > 0 && Lb > 0)
+    if (zlo <= (an + bn) / 8 && FLINT_MIN(an, bn) >= 7 * zhi / 8)
     {
-        zlo2 = zlo - vpa - vqb;
-        if (La < Lb) { mp_size_t t2 = La; La = Lb; Lb = t2; }
-        nb = zn;
-        if (Lb > nb) nb = Lb;
-        vhalf = (La + Lb - zlo2 + 1) / 2;
-        if (vhalf > nb) nb = vhalf;
-        /* via_n_padded reduces to a balanced middle product of size nb; even
-           with padding this is worth it whenever nb stays comfortably below the
-           M-sized problem the other reductions would build, so a generous
-           padding tolerance (max(8, len/8)) is used here. */
-        via_ok = (2 * nb - 1) - La <= FLINT_MAX((mp_size_t) 8, La / 8)
-              && nb - Lb <= FLINT_MAX((mp_size_t) 8, Lb / 8);
+        flint_mpn_mulmid_via_mullow_n(z, a, an, b, bn, zlo, zhi);
+        return;
     }
 
-    /* (D) balanced Karatsuba/Toom reduction, when its padding is economical */
-    if (via_ok)
+    if (zhi >= 7 * (an + bn) / 8 && FLINT_MIN(an, bn) >= 7 * (zhi - zlo) / 8)
+    {
+        flint_mpn_mulmid_via_mulhigh_n(z, a, an, b, bn, zlo, zhi);
+        return;
+    }
+
+#if FLINT_HAVE_NATIVE_mpn_mulmid_n
+    if (APPROX_EQUAL(an, 2 * bn) && APPROX_EQUAL(zlo, bn) && APPROX_EQUAL(zhi, an))
     {
         flint_mpn_mulmid_via_n_padded(z, a, an, b, bn, zlo, zhi);
         return;
     }
+
+    if (APPROX_EQUAL(bn, 2 * an) && APPROX_EQUAL(zlo, an) && APPROX_EQUAL(zhi, bn))
+    {
+        flint_mpn_mulmid_via_n_padded(z, b, bn, a, an, zlo, zhi);
+        return;
+    }
 #endif
 
-#if FLINT_HAVE_NATIVE_mpn_mulmid_n || FLINT_HAVE_FFT_SMALL
-    /* medium middle window: schoolbook (large wide windows already handled) */
-    flint_mpn_mulmid_classical(z, a, an, b, bn, zlo, zhi);
-#else
-    /* bare build: a wide middle window is cheaper as a full product plus a slice
-       (flint_mpn_mul is GMP/FFT-backed); a narrow one stays schoolbook */
-    if (m >= MULMID_BARE_MUL_CUTOFF && zn >= MULMID_BARE_MUL_CUTOFF)
-        flint_mpn_mulmid_via_mul(z, a, an, b, bn, zlo, zhi);
-    else
-        flint_mpn_mulmid_classical(z, a, an, b, bn, zlo, zhi);
-#endif
+    flint_mpn_mulmid_via_mul(z, a, an, b, bn, zlo, zhi);
+    return;
 }
+

--- a/src/mpn_extras/mulmid_via_mul.c
+++ b/src/mpn_extras/mulmid_via_mul.c
@@ -11,40 +11,27 @@
 
 #include "mpn_extras.h"
 
-/*
-    Windowed middle product via the full product.  Computes the whole product
-    a * b with the standard (unbalanced) flint_mpn_mul and copies out the limb
-    window [zlo, zhi).  Correct for any an >= 1, bn >= 1, 0 <= zlo < zhi <= an+bn;
-    the result is the *exact* window (every partial product and carry included),
-    which is a valid instance of the lower-approximation contract with zero
-    deficit.  Cheapest when the window is a large fraction of the product; for a
-    small window it wastes work on the discarded limbs.
-*/
 void
 flint_mpn_mulmid_via_mul(mp_ptr z, mp_srcptr a, mp_size_t an, mp_srcptr b, mp_size_t bn,
                          mp_size_t zlo, mp_size_t zhi)
 {
     mp_size_t zn = zhi - zlo;
-    mp_srcptr xp, yp;
-    mp_size_t xn, yn;
     mp_ptr t;
     TMP_INIT;
 
     FLINT_ASSERT(an >= 1 && bn >= 1);
     FLINT_ASSERT(0 <= zlo && zlo < zhi && zhi <= an + bn);
 
-    if (an >= bn) { xp = a; xn = an; yp = b; yn = bn; }
-    else          { xp = b; xn = bn; yp = a; yn = an; }
-
-    if (zlo == 0 && zhi == an + bn)     /* window is the entire product */
-    {
-        flint_mpn_mul(z, xp, xn, yp, yn);
-        return;
-    }
-
     TMP_START;
     t = TMP_ARRAY_ALLOC(an + bn, mp_limb_t);
-    flint_mpn_mul(t, xp, xn, yp, yn);
+
+    if (a == b && an == bn)
+        flint_mpn_sqr(t, a, an);
+    else if (an >= bn)
+        flint_mpn_mul(t, a, an, b, bn);
+    else
+        flint_mpn_mul(t, b, bn, a, an);
+
     flint_mpn_copyi(z, t + zlo, zn);
     TMP_END;
 }

--- a/src/mpn_extras/mulmid_via_mulhigh_n.c
+++ b/src/mpn_extras/mulmid_via_mulhigh_n.c
@@ -11,43 +11,6 @@
 
 #include "mpn_extras.h"
 
-/*
-    Windowed middle product via a balanced high product.  flint_mpn_mulhigh_n
-    returns (a lower approximation of) the top n limbs, i.e. limbs [n, 2n), of a
-    balanced n x n product.
-
-    Only the high ends of a and b reach the window: a limb a[p] can contribute to
-    limb >= zlo only if p + (bc - 1) >= zlo, and a limb at or above zhi never
-    reaches the window at all.  So we first clamp to zhi and slice off the low,
-    non-contributing limbs
-
-        ac = min(an, zhi),  bc = min(bn, zhi),
-        pa = max(0, zlo - (bc - 1)),  qb = max(0, zlo - (ac - 1)),
-        a' = a + pa  (La = ac - pa limbs),  b' = b + qb  (Lb = bc - qb limbs),
-        zlo2 = zlo - pa - qb,
-
-    which leaves a balanced-ish problem of size ~ zn rather than ~ max(an, bn).
-    The sliced product a'*b' still contains a few sub-zlo diagonals, but they lie
-    below limb zlo2 and are dropped by the high product just like the ones sliced
-    away -- so the net effect is the required "drop p + q < zlo".
-
-    The window [zlo2, zlo2 + zn) of a'*b' is then exposed as a top slice: pad both
-    operands to n limbs and, when the window starts below M = max(La, Lb), shift
-    them up by L = M - zlo2 low zero limbs so that limb zlo2 lands at limb n:
-
-        L   = max(0, M - zlo2),        n = M + L,        off = zlo2 - M + L (>= 0),
-        res = mulhigh_n(0^L,a',0.. , 0^L,b',0..)  ~=  limbs [n,2n) of a'*b'*B^{2L},
-        z   = res[off .. off + zn).
-
-    Correct for any input; the result is a lower approximation of the exact
-    window (mulhigh never exceeds the true high part).  Cheapest when the window
-    sits at the top of the product (zlo2 >= M, L = 0).
-
-    Copies are avoided where possible: when L = 0 an operand of length n is passed
-    verbatim and only a shorter one is padded; padded operands zero only their
-    genuine zero limbs; and when the window is exactly mulhigh_n's whole output
-    (off = 0, zn = n) it is written straight into z.
-*/
 void
 flint_mpn_mulmid_via_mulhigh_n(mp_ptr z, mp_srcptr a, mp_size_t an, mp_srcptr b, mp_size_t bn,
                                mp_size_t zlo, mp_size_t zhi)
@@ -56,6 +19,7 @@ flint_mpn_mulmid_via_mulhigh_n(mp_ptr z, mp_srcptr a, mp_size_t an, mp_srcptr b,
     mp_size_t ac, bc, pa, qb, La, Lb, zlo2, M, L, n, off;
     mp_srcptr xp, yp;
     mp_ptr res;
+    int squaring = (a == b) && (an == bn);
     TMP_INIT;
 
     FLINT_ASSERT(an >= 1 && bn >= 1);
@@ -70,8 +34,6 @@ flint_mpn_mulmid_via_mulhigh_n(mp_ptr z, mp_srcptr a, mp_size_t an, mp_srcptr b,
 
     if (La <= 0 || Lb <= 0)
     {
-        /* every partial product lands below zlo: the lower-approximation window
-           is all zero */
         flint_mpn_zero(z, zn);
         return;
     }
@@ -100,7 +62,12 @@ flint_mpn_mulmid_via_mulhigh_n(mp_ptr z, mp_srcptr a, mp_size_t an, mp_srcptr b,
             flint_mpn_zero(X + La, n - La);
             xp = X;
         }
-        if (Lb < n)
+
+        if (squaring)
+        {
+            yp = xp;
+        }
+        else if (Lb < n)
         {
             mp_ptr Y = TMP_ARRAY_ALLOC(n, mp_limb_t);
             flint_mpn_copyi(Y, b, Lb);
@@ -111,30 +78,44 @@ flint_mpn_mulmid_via_mulhigh_n(mp_ptr z, mp_srcptr a, mp_size_t an, mp_srcptr b,
     else
     {
         mp_ptr X = TMP_ARRAY_ALLOC(n, mp_limb_t);
-        mp_ptr Y = TMP_ARRAY_ALLOC(n, mp_limb_t);
-
         flint_mpn_zero(X, L);
         flint_mpn_copyi(X + L, a, La);
         flint_mpn_zero(X + L + La, n - L - La);
-
-        flint_mpn_zero(Y, L);
-        flint_mpn_copyi(Y + L, b, Lb);
-        flint_mpn_zero(Y + L + Lb, n - L - Lb);
-
         xp = X;
-        yp = Y;
+
+        if (squaring)
+        {
+            yp = xp;
+        }
+        else
+        {
+            mp_ptr Y = TMP_ARRAY_ALLOC(n, mp_limb_t);
+            flint_mpn_zero(Y, L);
+            flint_mpn_copyi(Y + L, b, Lb);
+            flint_mpn_zero(Y + L + Lb, n - L - Lb);
+            yp = Y;
+        }
     }
 
     if (off == 0 && zn == n)
     {
-        flint_mpn_mulhigh_n(z, xp, yp, n);
+        if (squaring)
+            flint_mpn_sqrhigh(z, xp, n);
+        else
+            flint_mpn_mulhigh_n(z, xp, yp, n);
     }
     else
     {
         res = TMP_ARRAY_ALLOC(n, mp_limb_t);
-        flint_mpn_mulhigh_n(res, xp, yp, n);
+
+        if (squaring)
+            flint_mpn_sqrhigh(res, xp, n);
+        else
+            flint_mpn_mulhigh_n(res, xp, yp, n);
+
         flint_mpn_copyi(z, res + off, zn);
     }
 
     TMP_END;
 }
+

--- a/src/mpn_extras/mulmid_via_mullow_n.c
+++ b/src/mpn_extras/mulmid_via_mullow_n.c
@@ -11,15 +11,6 @@
 
 #include "mpn_extras.h"
 
-/*
-    Windowed middle product via a balanced low product.  The low zhi limbs of
-    a * b are (a mod B^zhi) * (b mod B^zhi) mod B^zhi, computed exactly by
-    flint_mpn_mullow_n on operands zero-padded / truncated to n = zhi limbs; the
-    window [zlo, zhi) is then the top zn of those.  Correct for any input; the
-    result is the *exact* window (with carry-in from below zlo), a zero-deficit
-    instance of the contract.  Cheapest when zhi is small (a low or nearly-low
-    window); for large zhi it computes an almost full n x n product.
-*/
 void
 flint_mpn_mulmid_via_mullow_n(mp_ptr z, mp_srcptr a, mp_size_t an, mp_srcptr b, mp_size_t bn,
                               mp_size_t zlo, mp_size_t zhi)
@@ -63,3 +54,4 @@ flint_mpn_mulmid_via_mullow_n(mp_ptr z, mp_srcptr a, mp_size_t an, mp_srcptr b, 
     flint_mpn_copyi(z, rp + zlo, zn);
     TMP_END;
 }
+

--- a/src/mpn_extras/mulmid_via_n_padded.c
+++ b/src/mpn_extras/mulmid_via_n_padded.c
@@ -13,59 +13,6 @@
 
 #if FLINT_HAVE_NATIVE_mpn_mulmid_n
 
-/*
-    Set (z, zhi - zlo) to the limb window [zlo, zhi) of the integer product
-    a * b, as a lower approximation: partial products a[p] * b[q] whose low
-    limb lies below limb zlo (i.e. p + q < zlo) are dropped, so the carry they
-    would propagate into limb zlo is not recovered.  This matches the contract
-    of radix_mulmid_classical with radix B = 2^64 (and the schoolbook
-    flint_mpn_mulmid_classical).  Equivalently
-
-        z = ( sum_{p+q >= zlo} a[p]*b[q] * B^(p+q-zlo) ) mod B^(zhi-zlo).
-
-    Requires an >= 1, bn >= 1 and 0 <= zlo < zhi <= an + bn.
-
-    Implementation: reduce the window to a single *balanced* middle product and
-    hand it to flint_mpn_mulmid_n (Karatsuba/Toom-42).  flint_mpn_mulmid_n
-    computes, for inputs {A, 2n-1} and {B, n}, the band n-1 <= p'+q' < 2n-1 of
-    A*B shifted down by n-1, dropping all products with p'+q' < n-1 -- which is
-    exactly the same "drop everything below the floor" rule as our window's
-    lower-approximation, so the deficits coincide and the result is the *same*
-    value the schoolbook would produce (it is not merely another approximation).
-
-    To map the window onto that shape we:
-
-      (1) clamp an, bn to zhi (limbs at/above zhi cannot reach the window);
-
-      (2) slice off the low limbs that can never contribute: a[p] with
-          p + (bn-1) < zlo, and b[q] with q + (an-1) < zlo.  Every product
-          removed here has p+q < zlo (already dropped) or low limb >= zhi
-          (outside the window), so slicing changes nothing.  This also keeps
-          the balanced size from being tied to the full an;
-
-      (3) place the (longer) sliced operand of length La in the 2n-1 slot at
-          offset alpha and the shorter one of length Lb in the n slot at the
-          top (offset beta = n - Lb), with alpha + beta = n - 1 - zlo2 so that
-          output limb k lands exactly at product position zlo + k.  Here zlo2
-          is the window floor in sliced coordinates; one shows zlo2 <= Lb - 1,
-          hence alpha = (Lb-1) - zlo2 >= 0.
-
-    We choose the smallest n that fits both operands and covers the window:
-
-        n = max( zn, Lb, ceil((La + Lb - zlo2) / 2) ).
-
-    NOTE ON THE ALTERNATIVE.  This is the "generous n + zero-pad" route: one
-    balanced call, no fix-up.  It is a good fit when the window is wide (zn
-    comparable to Lb), i.e. exactly the regime where Karatsuba/Toom pays off.
-    It is *not* a good fit for a narrow window sitting in a tall, skewed region:
-    there n is forced up to ~Lb (B must hold all of b), so the balanced call
-    costs ~O(Lb^2) while the window only depends on ~zn diagonals and plain
-    schoolbook (flint_mpn_mulmid_classical) costs ~O(zn * Lb).  A
-    production dispatcher should therefore fall back to schoolbook for narrow
-    windows, or chunk the region the way the GMP-derived general middle product
-    (flint_mpn_mulmid_unbalanced, mulmid_gmp.c) does with MULMID_CHUNK, and only enter this
-    balanced reduction once a chunk is square enough to benefit.
-*/
 void
 flint_mpn_mulmid_via_n_padded(mp_ptr z, mp_srcptr a, mp_size_t an, mp_srcptr b, mp_size_t bn,
                  mp_size_t zlo, mp_size_t zhi)

--- a/src/mpn_extras/test/t-mulmid.c
+++ b/src/mpn_extras/test/t-mulmid.c
@@ -12,17 +12,6 @@
 #include "test_helpers.h"
 #include "mpn_extras.h"
 
-/*
-    flint_mpn_mulmid returns the window [zlo, zhi) of a*b as a lower
-    approximation: computed = exact - D, where the deficit D is a single carry
-    from the products dropped below zlo, bounded by min(an,bn,zlo)*2^64 (a couple
-    of backends, e.g. via_mulhigh, use a different but comparably small D).  Since
-    D is subtracted modulo 2^(64*zn), a narrow window can wrap so that the result
-    exceeds the exact window numerically -- that is allowed.  What we can check is
-    that the deficit d = (exact - computed) mod 2^(64*zn) is confined to the low
-    two limbs (it fits there whenever the window has room), and that with
-    zlo == 0, where nothing is dropped, the window is exact.
-*/
 TEST_FUNCTION_START(flint_mpn_mulmid, state)
 {
     slong ix;
@@ -52,7 +41,7 @@ TEST_FUNCTION_START(flint_mpn_mulmid, state)
 
         flint_mpn_rrandom(a, state, an);
         flint_mpn_rrandom(b, state, bn);
-        flint_mpn_rrandom(z, state, zn);        /* poison */
+        flint_mpn_rrandom(z, state, zn);
 
         flint_mpn_mulmid(z, a, an, b, bn, zlo, zhi);
 

--- a/src/mpn_extras/test/t-mulmid_n.c
+++ b/src/mpn_extras/test/t-mulmid_n.c
@@ -13,13 +13,6 @@
 #include "longlong.h"
 #include "mpn_extras.h"
 
-/*
-    flint_mpn_mulmid_n(rp, a, b, n) is the balanced exact middle product of
-    {a, 2n-1} and {b, n}, writing n + 2 limbs.  It is the sum of the diagonals
-    n-1 <= p+q < 2n-1 shifted down by n-1; the high n limbs (rp[2..n+2)) are
-    exact and the low two are guard limbs.  Reference: accumulate exactly that
-    band and compare the high n limbs.
-*/
 TEST_FUNCTION_START(flint_mpn_mulmid_n, state)
 {
     slong ix;

--- a/src/mpn_mod/poly_mullow_KS.c
+++ b/src/mpn_mod/poly_mullow_KS.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2024 Fredrik Johansson
+    Copyright (C) 2024, 2026 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -10,6 +10,9 @@
 */
 
 #include "mpn_mod.h"
+#include "flint-mparam.h"
+
+#define GUARD_LIMBS 3
 
 /* assumes res is initially zeroed */
 /* assumes that we can write one (zeroed) limb too much */
@@ -124,14 +127,62 @@ _mpn_mod_poly_mulmid_KS(nn_ptr res, nn_srcptr poly1, slong len1, nn_srcptr poly2
     if (!squaring)
         _mpn_mod_poly_bit_pack(arr2, poly2, len2, bits, nlimbs);
 
-    arr = flint_malloc((limbs1 + limbs2) * sizeof(ulong));
+    {
+        slong flimbs = limbs1 + limbs2;
+        slong f = nlo * bits;
+        slong elimb = f / FLINT_BITS;
+        slong zhi = FLINT_MIN(flimbs, (nhi * bits + FLINT_BITS - 1) / FLINT_BITS + 1);
+        slong zlo = FLINT_MAX(0, elimb - GUARD_LIMBS);
+        int windowed = (zlo > 0 || zhi < flimbs);
 
-    if (squaring)
-        flint_mpn_sqr(arr, arr1, limbs1);
-    else if (limbs1 >= limbs2)
-        flint_mpn_mul(arr, arr1, limbs1, arr2, limbs2);
-    else
-        flint_mpn_mul(arr, arr2, limbs2, arr1, limbs1);
+        /* mulmid is currently missing good sub-fft sqrlow code */
+#if FLINT_HAVE_FFT_SMALL
+        windowed = windowed && !squaring;
+#else
+        windowed = windowed && (!squaring || FLINT_MIN(limbs1, limbs2) >= FLINT_FFT_SMALL_SQR_THRESHOLD);
+#endif
+
+        arr = flint_malloc((windowed ? zhi : flimbs) * sizeof(ulong));
+
+        if (windowed)
+        {
+            /* In general, flint_mpn_mulmid computes a window which may be 1 ulp
+               too small. However, all mulmid algorithms used in practice include
+               the contribution of all limbs in the middle window without
+               introducing any artificial borrows, so the result is actually
+               guaranteed to be exact for KS integers. */
+            flint_mpn_mulmid(arr + zlo, arr1, limbs1, arr2, limbs2, zlo, zhi);
+
+            /* Do a sanity check mod 2^FLINT_BITS to verify that flint_mpn_mulmid
+               isn't doing anything weird. */
+#if FLINT_WANT_ASSERT
+            if (zlo > 0)
+            {
+                slong fl = (nlo * bits) / FLINT_BITS;
+                slong fb = (nlo * bits) % FLINT_BITS;
+                slong i;
+                ulong m = 0, Fobs;
+
+                for (i = FLINT_MAX(0, nlo - (len2 - 1)); i <= FLINT_MIN(nlo, len1 - 1); i++)
+                    m += poly1[i * nlimbs] * poly2[(nlo - i) * nlimbs];
+
+                Fobs = arr[fl] >> fb;
+                if (fb != 0)
+                    Fobs |= arr[fl + 1] << (FLINT_BITS - fb);
+                FLINT_ASSERT(Fobs == m);
+            }
+#endif
+        }
+        else
+        {
+            if (squaring)
+                flint_mpn_sqr(arr, arr1, limbs1);
+            else if (limbs1 >= limbs2)
+                flint_mpn_mul(arr, arr1, limbs1, arr2, limbs2);
+            else
+                flint_mpn_mul(arr, arr2, limbs2, arr1, limbs1);
+        }
+    }
 
     _mpn_mod_poly_bit_unpack(res, arr, nlo, nhi, bits, nlimbs, ctx);
 


### PR DESCRIPTION
Use `flint_mpn_mulmid` instead of a full `flint_mpn_mul` in `_fmpz_poly_mulmid_KS`, `_mpn_mod_poly_mulmid_KS` when computing truncated products. This is often a free 10-30% speedup.

Not done for `_nmod_poly_mulmid_KS` because `nmod_poly` multiplication would be better served by dedicated Karatsuba/SIMD code in affected ranges (FFT-size multiplication already goes directly to `fft_small`).

This PR also cleans up and simplifies `flint_mpn_mulmid` and improves its tuning for common inputs.

Timings for `fmpz_poly_mullow` for balanced length-n series products:

```
     bits         n       old       new  speedup

      300        10  2.52e-06  2.11e-06  1.194
      300       100  6.26e-05     5e-05  1.252
      300      1000  0.000709  0.000522  1.358
      300     10000   0.00891   0.00639  1.394
      300    100000     0.106    0.0803  1.320

     3000        10  5.78e-05  4.58e-05  1.262
     3000       100  0.000581  0.000464  1.252
     3000      1000   0.00708   0.00574  1.233
     3000     10000    0.0858    0.0745  1.152
     3000    100000     1.202     1.027  1.170

    30000        10  0.000577  0.000473  1.220
    30000       100   0.00711   0.00583  1.220
    30000      1000    0.0864    0.0755  1.144
    30000     10000     1.203     1.032  1.166
    30000    100000    16.905     14.85  1.138
```

Timings for `fmpz_poly_mulmid` for balanced middle products (2n x n -> [n, 2n)):

```
     bits    len1   len2        zlo     zhi        old       new  speedup

      300     20 x    10 -> [    10,     20)  5.17e-06  5.26e-06  0.983
      300    200 x   100 -> [   100,    200)  9.61e-05  7.66e-05  1.255
      300   2000 x  1000 -> [  1000,   2000)   0.00111   0.00084  1.321
      300  20000 x 10000 -> [ 10000,  20000)    0.0141   0.00997  1.414
      300 200000  100000 -> [100000, 200000)     0.171     0.131  1.305

     3000     20 x    10 -> [    10,     20)  8.76e-05  7.11e-05  1.232
     3000    200 x   100 -> [   100,    200)  0.000917  0.000698  1.314
     3000   2000 x  1000 -> [  1000,   2000)    0.0112    0.0088  1.273
     3000  20000 x 10000 -> [ 10000,  20000)     0.143      0.11  1.300
     3000 200000  100000 -> [100000, 200000)     1.983     1.681  1.180

    30000     20 x    10 -> [    10,     20)  0.000868  0.000675  1.286
    30000    200 x   100 -> [   100,    200)     0.011    0.0085  1.294
    30000   2000 x  1000 -> [  1000,   2000)     0.139     0.108  1.287
    30000  20000 x 10000 -> [ 10000,  20000)     1.976     1.667  1.185
    30000 200000  100000 -> [100000, 200000)    26.924      24.3  1.108
```

Timings for randomly chosen lengths and windows:

```
     bits    len1   len2        zlo     zhi        old       new  speedup

      300      2 x     6 -> [     1,      4)  1.43e-07  1.43e-07  1.000
      300      7 x     9 -> [     3,     12)  2.15e-06  2.14e-06  1.005
      300      9 x     3 -> [     9,     11)  7.84e-08   7.9e-08  0.992
      300     88 x    86 -> [   145,    157)   1.2e-05   1.2e-05  1.000
      300     42 x    54 -> [     5,     78)  2.72e-05  2.71e-05  1.004
      300     32 x    51 -> [    46,     47)  5.77e-07  5.77e-07  1.000
      300    560 x   336 -> [   429,    838)  0.000236  0.000199  1.186
      300      3 x   662 -> [    58,    410)  2.26e-05  2.24e-05  1.009
      300    472 x   309 -> [   128,    454)  0.000212  0.000175  1.211
      300   1253 x  3195 -> [  1112,   3128)   0.00171    0.0012  1.425
      300   3307 x  2990 -> [  1935,   3623)   0.00214   0.00164  1.305
      300   3965 x  2426 -> [  5584,   6326)  0.000505  0.000412  1.226
      300  65760 x 37450 -> [ 71246,  88268)    0.0315    0.0208  1.514
      300  44594 x 15403 -> [  6090,  53415)    0.0267    0.0249  1.072
      300  56926 x 27634 -> [  9219,  30548)    0.0237    0.0194  1.222

     3000      9 x     7 -> [     3,     15)  4.96e-05  5.01e-05  0.990
     3000      8 x     4 -> [     6,      7)  2.77e-06  2.76e-06  1.004
     3000      9 x     3 -> [     3,      9)  1.24e-05  1.25e-05  0.992
     3000     39 x    97 -> [    47,     81)   0.00031  0.000226  1.372
     3000     40 x    35 -> [     5,     50)  0.000194  0.000171  1.135
     3000     76 x    47 -> [    20,     91)  0.000358  0.000297  1.205
     3000    789 x   885 -> [    60,   1526)   0.00578   0.00555  1.041
     3000    227 x   774 -> [   529,    790)   0.00219   0.00169  1.296
     3000     78 x   379 -> [    62,    286)    0.0011  0.000945  1.164
     3000   9121 x   498 -> [  2177,   6837)    0.0216    0.0204  1.059
     3000   3258 x  2087 -> [  1667,   3510)    0.0206    0.0166  1.241
     3000   6609 x  2057 -> [  1828,   4189)    0.0253      0.02  1.265
     3000   5999 x 13300 -> [   981,  14576)    0.0813    0.0767  1.060
     3000  85653 x 61447 -> [ 69208, 115814)     0.833     0.697  1.195
     3000  30583 x 78509 -> [ 18182,  88224)     0.611     0.546  1.119

    30000      4 x     3 -> [     2,      4)  0.000143  0.000143  1.000
    30000     10 x     3 -> [     1,      4)  0.000191  0.000191  1.000
    30000      7 x     6 -> [     3,     11)  0.000379  0.000317  1.196
    30000      6 x    51 -> [     2,     55)   0.00175   0.00171  1.023
    30000     91 x    97 -> [   134,    138)   0.00337   0.00151  2.232
    30000     45 x    28 -> [    32,     50)   0.00214   0.00159  1.346
    30000    588 x    53 -> [   521,    537)   0.00381   0.00275  1.385
    30000    607 x   658 -> [   649,   1148)    0.0476    0.0395  1.205
    30000    112 x   458 -> [   293,    418)    0.0132    0.0102  1.294
    30000   2083 x  6558 -> [  6145,   7533)     0.243     0.193  1.259
    30000   6282 x  9507 -> [  2899,   5735)     0.668     0.506  1.320
    30000   9427 x  5117 -> [  8363,  12699)     0.662     0.532  1.244
    30000  43103 x 92211 -> [114202, 116542)     2.817     2.116  1.331
    30000  10419 x 52685 -> [ 52416,  56307)       1.2     0.901  1.332
    30000  39152 x 74203 -> [ 61991, 111896)     7.364     6.532  1.127
```

Fun fact: when I asked Claude Fable 5 to implement the mulmid optimization for mul_KS, it converged on a very complicated algorithm to correct for the possible approximation error in `flint_mpn_mulmid` which could lead to a low coefficient that is off by 1. Extensive testing suggested that the correction is never actually needed. When prompted further, Claude managed to prove that the correction is actually unnecessary, under realistic hypotheses about `flint_mpn_mulmid` (satisfied by all algorithms used currently). Instead of a correction algorithm, there is now just a `FLINT_ASSERT` for the bottom coefficient instead.

With unsigned coefficients, it is easy to see why: all mulmid algorithms contribute the full contribution from the limbs in the relevant window. It is also valid with signed coefficients, for less obvious reasons; although the approximated low coefficient may be off by 1 due to an artificial borrow, it turns out that this is always corrected for by the signed unpacking (and the sign bit of the coefficient just below can't be wrong due to slack in the KS packing bound).