### PR TITLE
Capelli irreducibility certificate

### DIFF
--- a/doc/source/fmpz_poly_factor.rst
+++ b/doc/source/fmpz_poly_factor.rst
@@ -149,3 +149,41 @@ Factoring algorithms
     A wrapper of the Zassenhaus and van Hoeij factoring algorithms, which takes
     as input any polynomial `F`, and stores a factorization in
     ``final_fac``.
+
+.. function:: int _fmpz_poly_factor_inflation_is_irreducible_capelli(const fmpz_poly_t T, ulong p)
+
+    Given `T` irreducible over `\mathbb{Q}` of degree at least 1 and a prime
+    `p`, attempts to certify that the inflation `T(x^p)` is irreducible over
+    `\mathbb{Q}`.  Returns 1 if a certificate was found, in which case
+    `T(x^p)` is provably irreducible, and 0 if the search was inconclusive,
+    in which case nothing is claimed (in particular, `T(x^p)` may still be
+    irreducible).  The behaviour is undefined if `T` is reducible.  `T` need
+    not be primitive and may have negative leading coefficient.
+
+    By Capelli's theorem, for prime `p` the polynomial `T(x^p)` is
+    irreducible over `\mathbb{Q}` if and only if `\theta`, the image of `x`
+    in `K = \mathbb{Q}[x]/(T)`, is not a `p`-th power in `K`.  For
+    `\deg T = 1`, and for `\deg T = 2` with `p = 2`, this condition is
+    decided exactly (so the return value is 1 precisely when `T(x^p)` is
+    irreducible).  Otherwise the function searches for a rational prime `q`,
+    with `T` squarefree modulo `q` and `q` dividing neither the leading nor
+    the constant coefficient of `T`, such that `\theta` reduces to a
+    non-`p`-th power in some residue field of `K` above `q`; any such
+    witness proves `\theta \notin K^p`.  The search is heuristically tuned:
+    its budget is linear in `\deg T` (for inputs with abelian splitting
+    fields of exponent `p`, such as the deflations of Swinnerton-Dyer
+    polynomials, witnesses have density only `1/(p \deg T)` among rational
+    primes and occur only in degree-1 residue fields), and it terminates
+    early when accumulated local evidence makes irreducibility unlikely.
+
+.. function:: int fmpz_poly_factor_inflation_is_irreducible_capelli(const fmpz_poly_t T, ulong d)
+
+    Given `T` irreducible over `\mathbb{Q}` of degree at least 1 and
+    `d \geq 1`, returns 1 if the inflation `T(x^d)` is certified irreducible
+    over `\mathbb{Q}`, and 0 if the certification was inconclusive, in which
+    case nothing is claimed.  Chains the prime-step certificate over the
+    prime factorisation of `d`, via `T(x^d) = U(x^{d/p})` with
+    `U = T(x^p)`.  The behaviour is undefined if `T` is reducible.
+    This certificate is used by :func:`fmpz_poly_factor` to avoid
+    refactoring inflations of irreducible deflation factors.
+

--- a/src/fmpz_poly_factor.h
+++ b/src/fmpz_poly_factor.h
@@ -81,6 +81,11 @@ void fmpz_poly_factor_van_hoeij(fmpz_poly_factor_t final_fac,
 
 void fmpz_poly_factor(fmpz_poly_factor_t fac, const fmpz_poly_t G);
 
+/* Irreducibility certificate ************************************************/
+
+int _fmpz_poly_factor_inflation_is_irreducible_capelli(const fmpz_poly_t T, ulong p);
+int fmpz_poly_factor_inflation_is_irreducible_capelli(const fmpz_poly_t T, ulong d);
+
 /* Inlines *******************************************************************/
 
 void fmpz_poly_factor_get_fmpz_poly(fmpz_poly_t z, const fmpz_poly_factor_t F, slong i);

--- a/src/fmpz_poly_factor/factor.c
+++ b/src/fmpz_poly_factor/factor.c
@@ -14,6 +14,82 @@
 #include "fmpz_poly.h"
 #include "fmpz_poly_factor.h"
 
+static void fmpz_poly_factor_deflation(fmpz_poly_factor_t fac,
+                                       const fmpz_poly_t G, int deflation);
+
+static void _fmpz_poly_factor_inflation(fmpz_poly_factor_t fac,
+                                        const fmpz_poly_t T, ulong d,
+                                        slong exp);
+
+static ulong
+_smallest_prime_factor(ulong d)
+{
+    ulong t;
+    if (d % 2 == 0)
+        return 2;
+    for (t = 3; t * t <= d; t += 2)
+        if (d % t == 0)
+            return t;
+    return d;
+}
+
+/*
+    Append the factorisation of T(x^d), with outer multiplicity exp, to fac,
+    where T is irreducible over Q, primitive with positive leading
+    coefficient.  Chains over the prime factors p of d via
+    T(x^d) = U(x^(d/p)) with U = T(x^p): each prime step is either certified
+    irreducible by _fmpz_poly_factor_inflation_is_irreducible_capelli
+    (in which case no factorisation
+    is performed at all) or handled by the generic machinery at degree
+    p*deg(T), which is never larger, and usually much smaller, than the
+    single call at degree d*deg(T) it replaces.
+*/
+static void
+_fmpz_poly_factor_inflation(fmpz_poly_factor_t fac, const fmpz_poly_t T,
+                            ulong d, slong exp)
+{
+    ulong p;
+    fmpz_poly_t U;
+
+    if (d == 1)
+    {
+        fmpz_poly_factor_insert(fac, T, exp);
+        return;
+    }
+
+    /* T(0) != 0 is guaranteed: fmpz_poly_factor_deflation strips powers
+       of x before deflating, and factors of U = T(x^p) with U(0) != 0
+       again have nonzero constant term, so the invariant persists through
+       the recursion below. */
+
+    p = _smallest_prime_factor(d);
+
+    fmpz_poly_init(U);
+    fmpz_poly_inflate(U, T, p);
+
+    if (_fmpz_poly_factor_inflation_is_irreducible_capelli(T, p))
+    {
+        /* U = T(x^p) is certified irreducible */
+        _fmpz_poly_factor_inflation(fac, U, d / p, exp);
+    }
+    else
+    {
+        slong i;
+        fmpz_poly_factor_t ufac;
+
+        fmpz_poly_factor_init(ufac);
+        fmpz_poly_factor_deflation(ufac, U, 0);
+
+        for (i = 0; i < ufac->num; i++)
+            _fmpz_poly_factor_inflation(fac, ufac->p + i, d / p,
+                                        exp * ufac->exp[i]);
+
+        fmpz_poly_factor_clear(ufac);
+    }
+
+    fmpz_poly_clear(U);
+}
+
 static void fmpz_poly_factor_deflation(fmpz_poly_factor_t fac, const fmpz_poly_t G, int deflation)
 {
     const slong lenG = G->length;
@@ -75,18 +151,12 @@ static void fmpz_poly_factor_deflation(fmpz_poly_factor_t fac, const fmpz_poly_t
             fmpz_poly_factor(gfac, g);
             fmpz_set(&fac->c, &gfac->c);
 
+            /* Each gfac->p + i is irreducible; factor its inflation by
+               chained Capelli certification instead of refactoring
+               (gfac->p + i)(x^d) from scratch. */
             for (i = 0; i < gfac->num; i++)
-            {
-                fmpz_poly_factor_t hfac;
-                fmpz_poly_factor_init(hfac);
-                fmpz_poly_inflate(gfac->p + i, gfac->p + i, d);
-                fmpz_poly_factor_deflation(hfac, gfac->p + i, 0);
-
-                for (j = 0; j < hfac->num; j++)
-                    fmpz_poly_factor_insert(fac, hfac->p + j, gfac->exp[i] * hfac->exp[j]);
-
-                fmpz_poly_factor_clear(hfac);
-            }
+                _fmpz_poly_factor_inflation(fac, gfac->p + i, (ulong) d,
+                                            gfac->exp[i]);
 
             fmpz_poly_factor_clear(gfac);
         }

--- a/src/fmpz_poly_factor/inflation_is_irreducible_capelli.c
+++ b/src/fmpz_poly_factor/inflation_is_irreducible_capelli.c
@@ -1,0 +1,490 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "nmod_poly.h"
+#include "ulong_extras.h"
+#include "fmpz.h"
+#include "fmpz_poly.h"
+#include "fmpz_poly_factor.h"
+
+static ulong
+_capelli_smallest_prime_factor(ulong d)
+{
+    ulong t;
+    if (d % 2 == 0)
+        return 2;
+    for (t = 3; t * t <= d; t += 2)
+        if (d % t == 0)
+            return t;
+    return d;
+}
+
+/*
+    Given E = theta^((q^f - 1)/p) reduced modulo Pf, a squarefree product of
+    degree-f irreducibles mod q in whose residue fields theta is a unit,
+    return 1 iff some component certifies theta a non-p-th power there.
+    For p = 2 the component values are +-1, so a witness is a component
+    where E = -1, detected by gcd(E + 1, Pf); for odd p any component value
+    different from 1 is a witness, i.e. E - 1 nonzero modulo Pf.
+*/
+static int
+_capelli_euler_witness(const nmod_poly_t E, const nmod_poly_t Pf, ulong p,
+                       nmod_poly_t tmp)
+{
+    nmod_poly_zero(tmp);
+    nmod_poly_set_coeff_ui(tmp, 0, 1);
+
+    if (p == 2)
+    {
+        nmod_poly_add(tmp, E, tmp);
+        if (nmod_poly_is_zero(tmp))
+            return 1;
+        nmod_poly_gcd(tmp, tmp, Pf);
+        return nmod_poly_degree(tmp) >= 1;
+    }
+    else
+    {
+        nmod_poly_sub(tmp, E, tmp);
+        return !nmod_poly_is_zero(tmp);
+    }
+}
+
+static void
+_capelli_preinv(nmod_poly_t finv, const nmod_poly_t f)
+{
+    nmod_poly_reverse(finv, f, f->length);
+    nmod_poly_inv_series(finv, finv, f->length);
+}
+
+/*
+    Given T irreducible over Q and p prime, attempt to certify that T(x^p)
+    is irreducible over Q.  T is assumed primitive with positive leading
+    coefficient (as produced by fmpz_poly_factor); the degree-1 exact test
+    relies on this to read theta = -T(0)/T(1) in lowest terms, and the
+    assumption spares callers with low degree and huge coefficients a
+    redundant integer gcd.  The non-underscore chaining version normalises
+    arbitrary input first.
+
+    TODO (sqrt(theta) reconstruction): make the p = 2 certificate two-sided
+    for deg T >= 3.  When the witness search only ever sees "theta is a
+    square" evidence, attempt to construct gamma in K = Q[y]/(T) with
+    gamma^2 = theta: at a prime q minimising the number r of local factors,
+    compute componentwise square roots in the residue fields, Hensel-lift
+    to q^k with k from a Mignotte bound on the factor g in
+    T(x^2) = +- g(x) g(-x), resolve the 2^(r-1) componentwise sign
+    ambiguity (cheap pruning by rational reconstruction of a single
+    coefficient for moderate r; fields with abelian splitting behaviour
+    have no low-r primes and would need recursive multiquadratic descent),
+    then verify gamma^2 = theta exactly.  Success yields the factorisation
+    with both halves irreducible by construction, so certification would
+    terminate with an answer in both directions instead of falling back
+    after an exhausted budget.
+
+    By Capelli's theorem (prime exponent case), T(x^p) is irreducible over Q
+    iff x^p - theta is irreducible over K = Q[y]/(T(y)) iff theta (the image
+    of y) is not a p-th power in K.
+
+    We search for a rational prime q with q not dividing lc(T)*T(0) and
+    T squarefree mod q.  Then K (x) Q_q is an unramified etale algebra whose
+    components have residue fields F_q[y]/(T_i(y)) for the irreducible
+    factors T_i of T mod q, and theta is a unit in every component.  A global
+    p-th power theta = gamma^p forces gamma to be a unit as well, so theta
+    reduces to a p-th power in every residue field.  Hence a single component
+    F_{q^f} with p | q^f - 1 and theta-bar^((q^f-1)/p) != 1 proves that theta
+    is not a p-th power in K, certifying irreducibility of T(x^p).
+
+    The search performs the cheap distinct-degree phase of factorisation
+    mod q and one Euler-criterion power per degree class (no equal-degree
+    splitting is needed: for p = 2 the witness condition on the product P_f
+    of all degree-f components is deg gcd(E + 1, P_f) > 0, and for odd p it
+    is (E - 1) != 0 mod P_f, where E = theta-bar^((q^f-1)/p) mod P_f).
+
+    Returns 1 if a certificate was found (T(x^p) is then provably
+    irreducible), and 0 if the search budget was exhausted, in which case
+    nothing is claimed.
+
+    Note on the budget: for typical Galois groups a witness prime has
+    positive density (often ~ 1/2) among primes with a small-degree
+    component, so the first few candidates succeed.  The hard case is a
+    multiquadratic-type (elementary abelian) splitting field, e.g. the
+    Swinnerton-Dyer polynomials, where the witness density is 2^-n =
+    1/(2 deg T): there, all Frobenius elements are exposed only through
+    rational primes, so roughly 2 deg T candidates are required.  The budget
+    is chosen linear in deg T to cover this case; the per-candidate cost is
+    a handful of modular power/gcd operations, so even an exhausted search
+    (which happens when T(x^p) is in fact reducible) costs a small fraction
+    of the factorisation it precedes.
+*/
+int
+_fmpz_poly_factor_inflation_is_irreducible_capelli(const fmpz_poly_t T, ulong p)
+{
+    slong m = fmpz_poly_degree(T);
+    slong candA = 0, rawB = 0, budgetB, powbits = 0;
+    int found = 0, phaseB_ok;
+    n_primes_t piter;
+
+    if (m < 1)
+        return 0;
+
+    if (m == 1)
+    {
+        /* K = Q and theta = -T(0)/T(1) in lowest terms (T is primitive).
+           By Capelli (p prime), x^p - theta is irreducible over Q iff theta
+           is not a p-th power in Q; for p = 2 a negative theta is never a
+           square.  This exact O(size) test replaces the prime scan, and is
+           effectively two-sided: on a p-th power the caller's fallback
+           performs the (genuine) split at trivial cost. */
+        fmpz_t u, r, w;
+        int upow, vpow;
+
+        if (fmpz_is_zero(T->coeffs + 0))
+            return 0;
+
+        fmpz_init(u);
+        fmpz_init(r);
+        fmpz_init(w);
+
+        /* theta = u / v with u = -T(0), v = T(1) > 0; primitivity of T
+           makes this lowest terms, which the p-th power criterion below
+           requires (u and v must be separately p-th powers) */
+        fmpz_neg(u, T->coeffs + 0);
+
+        if (p == 2 && fmpz_sgn(u) < 0)
+            found = 1;                      /* theta < 0: nonsquare */
+        else
+        {
+            fmpz_abs(w, u);
+            upow = fmpz_root(r, w, (slong) p);
+            vpow = 1;
+            if (!fmpz_is_one(T->coeffs + 1))
+                vpow = fmpz_root(r, T->coeffs + 1, (slong) p);
+            found = !(upow && vpow);
+        }
+
+        fmpz_clear(u);
+        fmpz_clear(r);
+        fmpz_clear(w);
+
+        return found;
+    }
+
+    if (m == 2 && p == 2)
+    {
+        /* K is a quadratic field, where theta in K^2 has an exact integer
+           criterion: with T = a y^2 + b y + c irreducible (a > 0), theta
+           is a square in K iff a c is a perfect square, say s^2 with
+           s >= 0, and a (2 e s - b) is a perfect square for one of
+           e = +-1; equivalently T(x^2) admits the norm-form factorisation
+           a (x^2 + beta x + nu)(x^2 - beta x + nu), which is the only way
+           it can factor when T is irreducible.  Like the degree-1 case
+           this is O(size) and two-sided.  (Degree-2 T is always Galois,
+           so the mixed-degree evidence bail below can never fire for it;
+           this test removes the scan for the ubiquitous quadratic-field
+           inputs altogether.) */
+        fmpz_t s2, w;
+        int e;
+
+        fmpz_init(s2);
+        fmpz_init(w);
+
+        fmpz_mul(w, T->coeffs + 2, T->coeffs + 0);
+        if (fmpz_sgn(w) < 0 || !fmpz_is_square(w))
+            found = 1;
+        else
+        {
+            found = 1;
+            fmpz_sqrt(s2, w);
+            for (e = 0; e < 2; e++)
+            {
+                fmpz_mul_2exp(w, s2, 1);
+                if (e)
+                    fmpz_neg(w, w);
+                fmpz_sub(w, w, T->coeffs + 1);
+                fmpz_mul(w, w, T->coeffs + 2);
+                if (fmpz_sgn(w) >= 0 && fmpz_is_square(w))
+                    found = 0;              /* theta = gamma^2: reducible */
+            }
+        }
+
+        fmpz_clear(s2);
+        fmpz_clear(w);
+
+        return found;
+    }
+
+    /* Phase A is cheap at every scale and, on inputs arising in practice
+       (e.g. qqbar arithmetic), succeeds often enough that it is worth
+       attempting unconditionally.  Phase B, in contrast, is only worth its
+       possible exhaustion when the fallback would be genuinely expensive:
+       below (inflated) degree ~64 even the hard abelian-type inputs
+       factor in a few milliseconds, which is what an exhausted phase-B
+       scan would itself cost. */
+    phaseB_ok = (p * (ulong) m > 64);
+
+    /* Phase B (see below) can succeed only for inputs whose splitting field
+       is an abelian group of exponent p; a reducible T(x^p) with such local
+       behaviour makes phase B pure waste.  The common source of that trap
+       is cyclotomic-type inputs, which are self-reciprocal with constant
+       term of absolute value 1, whereas the hard Swinnerton-Dyer-type
+       inputs have huge constant terms (norms of sums of radicals); so we
+       exclude plausibly-cyclotomic inputs from phase B up front.  Search
+       policy only; certificates are unaffected. */
+    if (fmpz_is_pm1(T->coeffs + 0))
+    {
+        fmpz_poly_t rev;
+        fmpz_poly_init(rev);
+        fmpz_poly_reverse(rev, T, T->length);
+        if (fmpz_poly_equal(rev, T))
+            phaseB_ok = 0;
+        else
+        {
+            fmpz_poly_neg(rev, rev);
+            if (fmpz_poly_equal(rev, T))
+                phaseB_ok = 0;
+        }
+        fmpz_poly_clear(rev);
+    }
+
+    /* Phase B budget: the hard irreducible inputs (elementary-abelian-type
+       splitting fields, e.g. Swinnerton-Dyer) have witness density
+       1/(p * deg T) among rational primes, so the budget must be a small
+       multiple of deg T.  Exhausting it (which happens when T(x^p) is in
+       fact reducible) costs one Frobenius power and one gcd mod q per
+       prime, a small fraction of the factorisation that follows. */
+    budgetB = FLINT_MIN(512 + 32 * m, WORD(24576));
+
+    n_primes_init(piter);
+
+    while (!found && rawB <= budgetB && (candA < 16 || phaseB_ok))
+    {
+        ulong q = n_primes_next(piter);
+        nmod_poly_t Tq, dT, sf, R, X, xp, Pf, E, tmp, Fi;
+        slong f, fmax;
+
+        if (q == 2)
+            continue;
+        if (fmpz_fdiv_ui(T->coeffs + m, q) == 0)
+            continue;
+        if (fmpz_fdiv_ui(T->coeffs + 0, q) == 0)
+            continue;
+        if (candA >= 16 && p != 2 && (q - 1) % p != 0)
+            continue;   /* phase B tests degree-1 residue fields: need p | q - 1 */
+
+        nmod_poly_init(Tq, q);
+        nmod_poly_init(dT, q);
+        nmod_poly_init(sf, q);
+        nmod_poly_init(R, q);
+        nmod_poly_init(X, q);
+        nmod_poly_init(xp, q);
+        nmod_poly_init(Pf, q);
+        nmod_poly_init(E, q);
+        nmod_poly_init(tmp, q);
+        nmod_poly_init(Fi, q);
+
+        fmpz_poly_get_nmod_poly(Tq, T);
+        nmod_poly_set_coeff_ui(xp, 1, 1);            /* xp = x */
+
+        if (candA < 16)
+        {
+            /* Phase A (generic inputs): distinct-degree scan with an Euler
+               test per degree class.  When T(x^p) is irreducible and the
+               Galois group of its splitting field is not an abelian
+               p-group, a witness has positive density (typically about
+               1/2) among these candidates, so a handful suffice. */
+            nmod_poly_derivative(dT, Tq);
+            nmod_poly_gcd(sf, Tq, dT);
+
+            if (nmod_poly_degree(sf) == 0)
+            {
+                slong mleqp = 0, dfseen = 0, ctested = 0;
+
+                candA++;
+                fmax = FLINT_MAX(WORD(6), FLINT_MIN(m, (slong) p));
+
+                nmod_poly_set(R, Tq);
+                nmod_poly_rem(X, xp, R);
+                _capelli_preinv(Fi, R);
+
+                for (f = 1; f <= fmax && nmod_poly_degree(R) >= 1 && !found; f++)
+                {
+                    nmod_poly_powmod_ui_binexp_preinv(X, X, q, R, Fi);
+                    nmod_poly_sub(tmp, X, xp);
+                    nmod_poly_gcd(Pf, tmp, R);
+
+                    if (nmod_poly_degree(Pf) >= 1)
+                    {
+                        fmpz_t e;
+
+                        dfseen++;
+                        if (f <= (slong) p)
+                            mleqp += nmod_poly_degree(Pf);
+
+                        fmpz_init_set_ui(e, q);
+                        fmpz_pow_ui(e, e, (ulong) f);
+                        fmpz_sub_ui(e, e, 1);
+
+                        if (fmpz_fdiv_ui(e, p) == 0)
+                        {
+                            fmpz_divexact_ui(e, e, p);
+                            ctested += nmod_poly_degree(Pf) / f;
+                            nmod_poly_rem(tmp, xp, Pf);
+                            _capelli_preinv(Fi, Pf);   /* recomputed below if R shrinks */
+                            nmod_poly_powmod_fmpz_binexp_preinv(E, tmp, e, Pf, Fi);
+
+                            found = _capelli_euler_witness(E, Pf, p, tmp);
+                        }
+
+                        fmpz_clear(e);
+
+                        if (!found && f < fmax)
+                        {
+                            nmod_poly_divrem(R, tmp, R, Pf);   /* exact */
+                            nmod_poly_rem(X, X, R);
+                            _capelli_preinv(Fi, R);
+                        }
+                    }
+                }
+
+                /* Phase B assumes every Frobenius element has order <= p
+                   (abelian exponent-p splitting field); any mass in local
+                   degrees > p at any good prime disproves that. */
+                if (!found && mleqp != m)
+                    phaseB_ok = 0;
+
+                /* Sequential evidence bail: at a prime whose factor degrees
+                   are mixed, T is provably not Galois and the residue
+                   components behave nearly independently, so under
+                   irreducibility of T(x^p) each tested component is a
+                   non-p-th-power with probability about 1 - 1/p.  Some 12
+                   consecutive p-th-power components with no witness make
+                   irreducibility very unlikely; stop scanning and let the
+                   fallback do the (probable) real factorisation.  Primes
+                   with all component degrees equal are Galois-consistent
+                   and carry essentially no such evidence -- for abelian
+                   inputs (e.g. Swinnerton-Dyer) "all components are powers"
+                   has probability close to 1 under irreducibility -- so
+                   they are deliberately not counted; this keeps the hard
+                   abelian certificates unaffected. */
+                if (!found && dfseen >= 2)
+                {
+                    powbits += ctested;
+                    if (powbits >= 12)
+                    {
+                        candA = 16;
+                        phaseB_ok = 0;
+                    }
+                }
+            }
+        }
+        else
+        {
+            /* Phase B (specialist): essentially only inputs whose splitting
+               field has an abelian p-group Galois group survive phase A
+               with T(x^p) irreducible.  For those, every completion of the
+               splitting field has residue degree <= p over F_q, so a
+               witness can only sit in a degree-1 residue field (a prime of
+               K of residue degree p splits, rather than staying inert, in
+               K(theta^(1/p))).  Hence: one Frobenius power, the product of
+               the linear factors, and an Euler test only when that product
+               is nonempty, which for the hard inputs is rare -- e.g. for
+               Swinnerton-Dyer inputs a fraction 2^(1-n) of primes.  The
+               squarefreeness check (needed for the soundness of the
+               certificate, not for the search) is deferred until a
+               potential witness is on the table. */
+            rawB++;
+
+            nmod_poly_rem(X, xp, Tq);   /* deg(T) = 1 edge case */
+            _capelli_preinv(Fi, Tq);
+            nmod_poly_powmod_ui_binexp_preinv(X, X, q, Tq, Fi);
+            nmod_poly_sub(tmp, X, xp);
+            nmod_poly_gcd(Pf, tmp, Tq);
+
+            if (nmod_poly_degree(Pf) >= 1)
+            {
+                nmod_poly_derivative(dT, Tq);
+                nmod_poly_gcd(sf, Tq, dT);
+
+                if (nmod_poly_degree(sf) == 0)
+                {
+                    nmod_poly_rem(tmp, xp, Pf);
+                    _capelli_preinv(Fi, Pf);
+                    nmod_poly_powmod_ui_binexp_preinv(E, tmp, (q - 1) / p, Pf, Fi);
+
+                    found = _capelli_euler_witness(E, Pf, p, tmp);
+                }
+            }
+        }
+
+        nmod_poly_clear(Tq);
+        nmod_poly_clear(dT);
+        nmod_poly_clear(sf);
+        nmod_poly_clear(R);
+        nmod_poly_clear(X);
+        nmod_poly_clear(xp);
+        nmod_poly_clear(Pf);
+        nmod_poly_clear(E);
+        nmod_poly_clear(tmp);
+        nmod_poly_clear(Fi);
+    }
+
+    n_primes_clear(piter);
+
+    return found;
+}
+
+
+/*
+    Given T irreducible over Q and d >= 1, return 1 if T(x^d) is certified
+    irreducible over Q, and 0 if no certificate was found (in which case
+    nothing is claimed: T(x^d) may or may not be irreducible).  Chains the
+    prime-step certificate over the prime factorisation of d, via
+    T(x^d) = U(x^(d/p)) with U = T(x^p).
+*/
+int
+fmpz_poly_factor_inflation_is_irreducible_capelli(const fmpz_poly_t T, ulong d)
+{
+    fmpz_poly_t U;
+    int res = 1;
+
+    if (d == 0 || fmpz_poly_degree(T) < 1)
+        return 0;
+
+    fmpz_poly_init(U);
+
+    /* the underscore prime-step assumes primitive input with positive
+       leading coefficient; normalise once (inflation preserves both) */
+    {
+        fmpz_t cont;
+        fmpz_init(cont);
+        fmpz_poly_content(cont, T);
+        if (fmpz_sgn(fmpz_poly_lead(T)) < 0)
+            fmpz_neg(cont, cont);
+        fmpz_poly_scalar_divexact_fmpz(U, T, cont);
+        fmpz_clear(cont);
+    }
+
+    while (d > 1 && res)
+    {
+        ulong p = _capelli_smallest_prime_factor(d);
+
+        if (_fmpz_poly_factor_inflation_is_irreducible_capelli(U, p))
+        {
+            fmpz_poly_inflate(U, U, p);
+            d /= p;
+        }
+        else
+            res = 0;
+    }
+
+    fmpz_poly_clear(U);
+    return res;
+}

--- a/src/fmpz_poly_factor/test/main.c
+++ b/src/fmpz_poly_factor/test/main.c
@@ -13,7 +13,9 @@
 
 #include "t-factor.c"
 #include "t-factor_cubic.c"
+#include "t-factor_deflation_capelli.c"
 #include "t-factor_squarefree.c"
+#include "t-inflation_is_irreducible_capelli.c"
 #include "t-factor_zassenhaus.c"
 #include "t-zassenhaus_subset.c"
 
@@ -23,7 +25,9 @@ test_struct tests[] =
 {
     TEST_FUNCTION(fmpz_poly_factor),
     TEST_FUNCTION(fmpz_poly_factor_cubic),
+    TEST_FUNCTION(fmpz_poly_factor_deflation_capelli),
     TEST_FUNCTION(fmpz_poly_factor_squarefree),
+    TEST_FUNCTION(fmpz_poly_factor_inflation_is_irreducible_capelli),
     TEST_FUNCTION(fmpz_poly_factor_zassenhaus),
     TEST_FUNCTION(fmpz_poly_factor_zassenhaus_subset)
 };

--- a/src/fmpz_poly_factor/test/t-factor_deflation_capelli.c
+++ b/src/fmpz_poly_factor/test/t-factor_deflation_capelli.c
@@ -1,0 +1,255 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "fmpz.h"
+#include "fmpz_poly.h"
+#include "fmpz_poly_factor.h"
+#include "ulong_extras.h"
+
+/*
+    Targeted test of the deflation branch of fmpz_poly_factor and the
+    Capelli-certification pathways inside it, comparing against
+    fmpz_poly_factor_zassenhaus, which never takes the deflation branch
+    and therefore serves as an independent oracle.
+
+    The generators below are engineered to hit, in particular:
+    - certified irreducible inflations, both via the exact rational p-th
+      power test (linear deflation factors) and via witness search
+      (p = 2 and odd p, including multiquadratic-type inputs whose
+      witnesses have density 1/(p deg T));
+    - reducible inflations with no witness (perfect-power theta, norm-form
+      products g(x) g(-x)), exercising budget/evidence bails and fallback;
+    - self-reciprocal (cyclotomic-guard) inputs;
+    - chained composite deflations d = 4, 6, 8, 9, 12;
+    - powers of x, contents, signs and multiplicities on top of deflation.
+*/
+
+static int
+factor_matches(const fmpz_poly_factor_t a, const fmpz_poly_factor_t b)
+{
+    slong i, j;
+    int * used;
+    int ok = 1;
+
+    if (a->num != b->num || !fmpz_equal(&a->c, &b->c))
+        return 0;
+
+    used = flint_calloc(b->num, sizeof(int));
+    for (i = 0; i < a->num && ok; i++)
+    {
+        for (j = 0; j < b->num; j++)
+        {
+            if (!used[j] && a->exp[i] == b->exp[j]
+                         && fmpz_poly_equal(a->p + i, b->p + j))
+            {
+                used[j] = 1;
+                break;
+            }
+        }
+        if (j == b->num)
+            ok = 0;
+    }
+    flint_free(used);
+    return ok;
+}
+
+static void
+check_product(const fmpz_poly_factor_t fac, const fmpz_poly_t G,
+              const char * which)
+{
+    slong i, j;
+    fmpz_poly_t prod;
+
+    fmpz_poly_init(prod);
+    fmpz_poly_set_fmpz(prod, &fac->c);
+    for (i = 0; i < fac->num; i++)
+        for (j = 0; j < fac->exp[i]; j++)
+            fmpz_poly_mul(prod, prod, fac->p + i);
+
+    if (!fmpz_poly_equal(prod, G))
+    {
+        flint_printf("FAIL (%s: product)\n", which);
+        flint_printf("G = "); fmpz_poly_print(G); flint_printf("\n");
+        fflush(stdout);
+        flint_abort();
+    }
+    fmpz_poly_clear(prod);
+}
+
+TEST_FUNCTION_START(fmpz_poly_factor_deflation_capelli, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 150 * flint_test_multiplier(); iter++)
+    {
+        fmpz_poly_t G, T, t, u;
+        fmpz_poly_factor_t fac, zfac;
+        fmpz_t a;
+        slong mode = n_randint(state, 6);
+        ulong d;
+
+        fmpz_poly_init(G); fmpz_poly_init(T);
+        fmpz_poly_init(t); fmpz_poly_init(u);
+        fmpz_init(a);
+
+        switch (mode)
+        {
+        case 0:
+            /* x^d - a and x^d + a, a sometimes a perfect power:
+               exercises the exact rational p-th power test and odd-p
+               witness search through chained deflation */
+            {
+                ulong ds[] = {4, 6, 8, 9, 12};
+                d = ds[n_randint(state, 5)];
+                fmpz_randtest_not_zero(a, state, 24);
+                if (n_randint(state, 2))
+                {
+                    slong e = 2 + n_randint(state, 3);
+                    fmpz_pow_ui(a, a, (ulong) e);   /* perfect power */
+                }
+                fmpz_poly_set_coeff_ui(G, (slong) d, 1);
+                fmpz_neg(a, a);
+                fmpz_poly_set_coeff_fmpz(G, 0, a);
+            }
+            break;
+
+        case 1:
+            /* +- g(x) g(-x): even, inflation of an irreducible piece is
+               reducible with theta a square in K; no witness exists,
+               exercising the evidence bail and fallback */
+            do {
+                fmpz_poly_randtest(t, state, 2 + n_randint(state, 4), 30);
+            } while (fmpz_poly_degree(t) < 1 ||
+                     fmpz_is_zero(t->coeffs + 0));
+            {
+                slong i;
+                fmpz_poly_set(u, t);
+                for (i = 1; i <= fmpz_poly_degree(u); i += 2)
+                {
+                    fmpz_poly_get_coeff_fmpz(a, u, i);
+                    fmpz_neg(a, a);
+                    fmpz_poly_set_coeff_fmpz(u, i, a);
+                }
+                fmpz_poly_mul(G, t, u);
+            }
+            break;
+
+        case 2:
+            /* minimal polynomial of sqrt(b) + sqrt(c):
+               x^4 - 2(b+c) x^2 + (b-c)^2, multiquadratic-type input with
+               rare witnesses; sometimes inflated once more */
+            {
+                slong b = 2 + n_randint(state, 30);
+                slong c = 2 + n_randint(state, 30);
+                fmpz_poly_set_coeff_ui(G, 4, 1);
+                fmpz_set_si(a, -2 * (b + c));
+                fmpz_poly_set_coeff_fmpz(G, 2, a);
+                fmpz_set_si(a, (b - c) * (b - c));
+                fmpz_poly_set_coeff_fmpz(G, 0, a);
+                if (n_randint(state, 2))
+                {
+                    fmpz_poly_inflate(G, G, 2 + n_randint(state, 2));
+                    if (fmpz_poly_degree(G) > 16)
+                        fmpz_poly_deflate(G, G, 2);
+                }
+            }
+            break;
+
+        case 3:
+            /* self-reciprocal, constant term 1: cyclotomic-guard path,
+               e.g. x^(4k) + x^(2k) + 1 and x^(2k) + 1 */
+            {
+                slong k = 1 + n_randint(state, 4);
+                if (n_randint(state, 2))
+                {
+                    fmpz_poly_set_coeff_ui(G, 4 * k, 1);
+                    fmpz_poly_set_coeff_ui(G, 2 * k, 1);
+                    fmpz_poly_set_coeff_ui(G, 0, 1);
+                }
+                else
+                {
+                    fmpz_poly_set_coeff_ui(G, 2 * k, 1);
+                    fmpz_poly_set_coeff_ui(G, 0, 1);
+                }
+            }
+            break;
+
+        case 4:
+            /* random polynomial in x^2 or x^3, occasionally sparse,
+               coefficients up to ~60 bits: generic deflation exercise */
+            do {
+                fmpz_poly_randtest(t, state, 3 + n_randint(state, 6), 60);
+            } while (fmpz_poly_degree(t) < 1);
+            fmpz_poly_inflate(G, t, 2 + n_randint(state, 2));
+            break;
+
+        case 5:
+            /* small multiquadratic norm form times an x^d - a piece:
+               mixes certified and fallback levels in one chain */
+            fmpz_poly_set_coeff_ui(t, 4, 1);
+            fmpz_poly_set_coeff_si(t, 2, -10);
+            fmpz_poly_set_coeff_ui(t, 0, 1);       /* min poly sqrt2+sqrt3 */
+            fmpz_poly_set_coeff_ui(u, 4, 1);
+            fmpz_randtest_not_zero(a, state, 16);
+            fmpz_poly_set_coeff_fmpz(u, 0, a);
+            fmpz_poly_mul(G, t, u);
+            break;
+        }
+
+        if (fmpz_poly_degree(G) < 1)
+            goto cleanup;
+
+        /* dress the input: powers of x, content, sign, multiplicity */
+        if (n_randint(state, 3) == 0)
+            fmpz_poly_shift_left(G, G, 1 + n_randint(state, 3));
+        if (n_randint(state, 3) == 0)
+        {
+            fmpz_randtest_not_zero(a, state, 10);
+            fmpz_poly_scalar_mul_fmpz(G, G, a);
+        }
+        if (n_randint(state, 4) == 0 && fmpz_poly_degree(G) <= 12)
+            fmpz_poly_mul(G, G, G);
+
+        if (fmpz_poly_degree(G) > 40)
+            goto cleanup;
+
+        fmpz_poly_factor_init(fac);
+        fmpz_poly_factor_init(zfac);
+
+        fmpz_poly_factor(fac, G);
+        fmpz_poly_factor_zassenhaus(zfac, G);
+
+        check_product(fac, G, "factor");
+        check_product(zfac, G, "zassenhaus");
+
+        if (!factor_matches(fac, zfac))
+        {
+            flint_printf("FAIL (mismatch vs zassenhaus, mode %wd)\n", mode);
+            flint_printf("G = "); fmpz_poly_print(G); flint_printf("\n");
+            flint_printf("factor num = %wd, zassenhaus num = %wd\n",
+                         fac->num, zfac->num);
+            fflush(stdout);
+            flint_abort();
+        }
+
+        fmpz_poly_factor_clear(fac);
+        fmpz_poly_factor_clear(zfac);
+
+cleanup:
+        fmpz_poly_clear(G); fmpz_poly_clear(T);
+        fmpz_poly_clear(t); fmpz_poly_clear(u);
+        fmpz_clear(a);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/fmpz_poly_factor/test/t-inflation_is_irreducible_capelli.c
+++ b/src/fmpz_poly_factor/test/t-inflation_is_irreducible_capelli.c
@@ -1,0 +1,279 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "fmpz.h"
+#include "fmpz_poly.h"
+#include "fmpz_poly_factor.h"
+#include "ulong_extras.h"
+
+/* is G irreducible, decided by zassenhaus (never uses deflation) */
+static int
+zassenhaus_irreducible(const fmpz_poly_t G)
+{
+    fmpz_poly_factor_t fac;
+    int res;
+    fmpz_poly_factor_init(fac);
+    fmpz_poly_factor_zassenhaus(fac, G);
+    res = (fac->num == 1 && fac->exp[0] == 1
+                         && fmpz_poly_degree(fac->p + 0)
+                            == fmpz_poly_degree(G));
+    fmpz_poly_factor_clear(fac);
+    return res;
+}
+
+TEST_FUNCTION_START(fmpz_poly_factor_inflation_is_irreducible_capelli, state)
+{
+    slong iter;
+
+    /* trivial and edge inputs */
+    {
+        fmpz_poly_t T;
+        fmpz_poly_init(T);
+
+        fmpz_poly_set_ui(T, 5);                       /* deg < 1 */
+        FLINT_TEST(!_fmpz_poly_factor_inflation_is_irreducible_capelli(T, 2));
+        FLINT_TEST(!fmpz_poly_factor_inflation_is_irreducible_capelli(T, 2));
+
+        fmpz_poly_set_coeff_ui(T, 1, 1);
+        fmpz_poly_set_coeff_ui(T, 0, 0);              /* T = x: theta = 0 */
+        FLINT_TEST(!_fmpz_poly_factor_inflation_is_irreducible_capelli(T, 2));
+
+        fmpz_poly_set_coeff_si(T, 0, 1);              /* T = x + 1, d = 0, 1 */
+        FLINT_TEST(!fmpz_poly_factor_inflation_is_irreducible_capelli(T, 0));
+        FLINT_TEST(fmpz_poly_factor_inflation_is_irreducible_capelli(T, 1));
+
+        fmpz_poly_clear(T);
+    }
+
+    /* degree 1: the exact rational p-th power test, all branches,
+       including non-primitive input and negative leading coefficient */
+    for (iter = 0; iter < 100 * flint_test_multiplier(); iter++)
+    {
+        fmpz_poly_t T, G;
+        fmpz_t a, b, g;
+        ulong ps[] = {2, 3, 5};
+        ulong p = ps[n_randint(state, 3)];
+        int certified;
+
+        fmpz_poly_init(T); fmpz_poly_init(G);
+        fmpz_init(a); fmpz_init(b); fmpz_init(g);
+
+        fmpz_randtest_not_zero(a, state, 40);
+        if (n_randint(state, 2))
+            fmpz_pow_ui(a, a, p);                     /* perfect power */
+        do {
+            fmpz_randtest_not_zero(b, state, 8);
+        } while (fmpz_is_zero(b));
+        if (n_randint(state, 2))
+            fmpz_one(b);
+        if (n_randint(state, 3) == 0)                 /* force common factor */
+        {
+            fmpz_mul(a, a, b);
+        }
+
+        /* T = b x - a, theta = a / b; sometimes negate the whole thing */
+        fmpz_poly_set_coeff_fmpz(T, 1, b);
+        fmpz_neg(a, a);
+        fmpz_poly_set_coeff_fmpz(T, 0, a);
+        if (n_randint(state, 2))
+            fmpz_poly_neg(T, T);
+
+        /* skip if T is not irreducible, i.e. degenerate */
+        if (fmpz_poly_degree(T) != 1)
+            goto cleanup1;
+
+        /* the public function normalises content and sign; also exercise
+           the underscore version on the normalised polynomial */
+        certified = fmpz_poly_factor_inflation_is_irreducible_capelli(T, p);
+        {
+            fmpz_t cont;
+            fmpz_init(cont);
+            fmpz_poly_content(cont, T);
+            if (fmpz_sgn(fmpz_poly_lead(T)) < 0)
+                fmpz_neg(cont, cont);
+            fmpz_poly_scalar_divexact_fmpz(G, T, cont);
+            fmpz_clear(cont);
+            if (certified !=
+                _fmpz_poly_factor_inflation_is_irreducible_capelli(G, p))
+            {
+                flint_printf("FAIL (deg 1 normalisation, p = %wu)\n", p);
+                flint_abort();
+            }
+        }
+        fmpz_poly_inflate(G, T, p);
+
+        /* the linear case is decided exactly: certified iff irreducible */
+        if (certified != zassenhaus_irreducible(G))
+        {
+            flint_printf("FAIL (deg 1, p = %wu)\nT = ", p);
+            fmpz_poly_print(T); flint_printf("\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+cleanup1:
+        fmpz_poly_clear(T); fmpz_poly_clear(G);
+        fmpz_clear(a); fmpz_clear(b); fmpz_clear(g);
+    }
+
+    /* degree 2 with p = 2: the exact quadratic-field square test.
+       Generate both random irreducible quadratics and engineered
+       norm-form reducible inflations a(x^2+bx+c)(x^2-bx+c). */
+    for (iter = 0; iter < 100 * flint_test_multiplier(); iter++)
+    {
+        fmpz_poly_t T, G, u, v;
+        int certified;
+
+        fmpz_poly_init(T); fmpz_poly_init(G);
+        fmpz_poly_init(u); fmpz_poly_init(v);
+
+        if (n_randint(state, 2))
+        {
+            fmpz_poly_randtest(T, state, 3, 12);
+        }
+        else
+        {
+            /* T = deflation of (x^2+bx+c)(x^2-bx+c): theta is a square */
+            slong b = 1 + (slong) n_randint(state, 20);
+            slong c = (slong) n_randint(state, 40) - 20;
+            fmpz_poly_set_coeff_ui(u, 2, 1);
+            fmpz_poly_set_coeff_si(u, 1, b);
+            fmpz_poly_set_coeff_si(u, 0, c);
+            fmpz_poly_set_coeff_ui(v, 2, 1);
+            fmpz_poly_set_coeff_si(v, 1, -b);
+            fmpz_poly_set_coeff_si(v, 0, c);
+            fmpz_poly_mul(G, u, v);
+            fmpz_poly_deflate(T, G, 2);
+        }
+
+        if (fmpz_poly_degree(T) != 2 || !zassenhaus_irreducible(T))
+            goto cleanup2;
+
+        certified = _fmpz_poly_factor_inflation_is_irreducible_capelli(T, 2);
+        fmpz_poly_inflate(G, T, 2);
+
+        /* the quadratic case with p = 2 is decided exactly */
+        if (certified != zassenhaus_irreducible(G))
+        {
+            flint_printf("FAIL (deg 2, p = 2)\nT = ");
+            fmpz_poly_print(T); flint_printf("\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+cleanup2:
+        fmpz_poly_clear(T); fmpz_poly_clear(G);
+        fmpz_poly_clear(u); fmpz_poly_clear(v);
+    }
+
+    /* general degrees: soundness (certified implies irreducible) for the
+       witness search, over irreducible factors of random and structured
+       polynomials, prime and composite d */
+    for (iter = 0; iter < 40 * flint_test_multiplier(); iter++)
+    {
+        fmpz_poly_t t, T, G;
+        fmpz_poly_factor_t fac;
+        ulong ds[] = {2, 3, 4, 5, 6, 9};
+        ulong d = ds[n_randint(state, 6)];
+        int certified;
+
+        fmpz_poly_init(t); fmpz_poly_init(T); fmpz_poly_init(G);
+        fmpz_poly_factor_init(fac);
+
+        switch (n_randint(state, 3))
+        {
+        case 0:                                   /* random */
+            fmpz_poly_randtest(t, state, 3 + n_randint(state, 5), 20);
+            break;
+        case 1:                                   /* multiquadratic-type */
+            {
+                slong b = 2 + (slong) n_randint(state, 20);
+                slong c = 2 + (slong) n_randint(state, 20);
+                fmpz_poly_set_coeff_ui(t, 4, 1);
+                fmpz_poly_set_coeff_si(t, 2, -2 * (b + c));
+                fmpz_poly_set_coeff_si(t, 0, (b - c) * (b - c));
+            }
+            break;
+        case 2:                                   /* self-reciprocal */
+            fmpz_poly_set_coeff_ui(t, 4, 1);
+            fmpz_poly_set_coeff_si(t, 3, -1);
+            fmpz_poly_set_coeff_ui(t, 2, 1);
+            fmpz_poly_set_coeff_si(t, 1, -1);
+            fmpz_poly_set_coeff_ui(t, 0, 1);
+            break;
+        }
+
+        if (fmpz_poly_degree(t) < 1)
+            goto cleanup3;
+
+        fmpz_poly_factor(fac, t);
+        if (fac->num < 1 || fmpz_poly_degree(fac->p + 0) < 1)
+            goto cleanup3;
+        fmpz_poly_set(T, fac->p + 0);
+
+        if ((ulong) fmpz_poly_degree(T) * d > 24)
+            goto cleanup3;                        /* keep the zassenhaus cheap */
+
+        certified = fmpz_poly_factor_inflation_is_irreducible_capelli(T, d);
+        fmpz_poly_inflate(G, T, d);
+
+        if (certified && !zassenhaus_irreducible(G))
+        {
+            flint_printf("FAIL (soundness, d = %wu)\nT = ", d);
+            fmpz_poly_print(T); flint_printf("\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+cleanup3:
+        fmpz_poly_factor_clear(fac);
+        fmpz_poly_clear(t); fmpz_poly_clear(T); fmpz_poly_clear(G);
+    }
+
+    /* deterministic large abelian case: the degree-64 deflation T of the
+       Swinnerton-Dyer polynomial S_7 (minimal polynomial of
+       sqrt2+...+sqrt17).  This reaches the phase-B specialist search:
+       witnesses exist only at the density-2^-7 primes where all seven
+       p_i are quadratic nonresidues, in degree-1 residue fields.  The
+       prime scan is deterministic, so the certificate is reproducible. */
+    {
+        fmpz_poly_t g, T;
+
+        fmpz_poly_init(g);
+        fmpz_poly_init(T);
+
+        fmpz_poly_swinnerton_dyer(g, 7);
+        fmpz_poly_deflate(T, g, 2);
+
+        FLINT_TEST(_fmpz_poly_factor_inflation_is_irreducible_capelli(T, 2));
+
+        fmpz_poly_clear(g);
+        fmpz_poly_clear(T);
+    }
+
+    /* odd-p phase B: with p = 61 and T = y^2 - 2 the inflated degree
+       exceeds the phase-B threshold, phase A carries no Euler information
+       (61 rarely divides q^f - 1 there), and phase B decides via primes
+       q = 1 mod 61.  sqrt(2) has norm -2, not a 61st power, so x^61 -
+       sqrt(2) is irreducible over Q(sqrt 2); the scan is deterministic. */
+    {
+        fmpz_poly_t T;
+        fmpz_poly_init(T);
+        fmpz_poly_set_coeff_ui(T, 2, 1);
+        fmpz_poly_set_coeff_si(T, 0, -2);
+        FLINT_TEST(_fmpz_poly_factor_inflation_is_irreducible_capelli(T, 61));
+        fmpz_poly_clear(T);
+    }
+
+    TEST_FUNCTION_END(state);
+}


### PR DESCRIPTION
In `fmpz_poly_factor`, we use the power hack for polynomials of the form $f = g(x^n)$, first attempting to factor $g$. However, this was only used to find factors; when $g$ is irreducible, we would always call Zassenhaus/van Hoeij again on $f$.

Improvement: use Capelli's theorem to certify that $f$ is irreducible knowing that $g$ is irreducible. This is implemented as a partial certificate (returns irreducible/inconclusive); there is a TODO about extending it.

Suggested by and implemented using Claude Fable 5.

Speedups on `build/fmpz_poly_factor/profile/p-factor_hard -hard`:

| Test | Factors | Old (s) | New (s) | Speedup |
|---|---:|---:|---:|---:|
| P1 | 36 | 0.005 | 0.005 | 1.00× |
| P2 | 12 | 0.011 | 0.011 | 1.00× |
| P3 | 16 | 0.023 | 0.022 | 1.05× |
| P4 | 2 | 0.141 | 0.130 | 1.08× |
| P5 | 1 | 0.006 | 0.006 | 1.00× |
| P6 | 6 | 0.010 | 0.010 | 1.00× |
| P7 | 1 | 0.155 | 0.016 | **9.69×** |
| P8 | 1 | 0.092 | 0.013 | **7.08×** |
| M12_5 | 1 | 0.416 | 0.386 | 1.08× |
| M12_6 | 2 | 2.870 | 2.765 | 1.04× |
| T1 | 2 | 0.085 | 0.081 | 1.05× |
| T2 | 2 | 0.091 | 0.087 | 1.05× |
| T3 | 4 | 1.607 | 1.527 | 1.05× |
| H1 | 28 | 1.018 | 0.958 | 1.06× |
| S7 | 1 | 0.049 | 0.018 | **2.72×** |
| S8 | 1 | 0.945 | 0.171 | **5.53×** |
| C1 | 32 | 0.134 | 0.078 | **1.72×** |
| S9 | 1 | 26.425 | 1.738 | **15.20×** |
| H2 | 6 | 16.282 | 0.359 | **45.35×** |
| P7*M12_5 | 2 | 26.040 | 25.699 | 1.01× |
| P7*M12_6 | 3 | 44.787 | 42.611 | 1.05× |
| S10 | 1 | 1085.359 | 59.832 | **18.14×** |

This also helps `qqbar` arithmetic in many cases. For example `build/examples/huge_expr` improves from 2.543 to 2.505 seconds and `build/examples/huge_expr -ca` improves from 1.576 to 1.486 seconds (best of three).