### PR TITLE
Resolve symlinks when checking for out-of-tree builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1219,7 +1219,7 @@ if test "$enable_lto" = "yes";
 then AC_SUBST(WANT_LTO,1)
 else AC_SUBST(WANT_LTO,0) fi
 
-if test "$ac_abs_confdir" = "`pwd`";
+if test "`cd "$ac_abs_confdir" && pwd -P`" = "`pwd -P`";
 then AC_SUBST(IS_OUT_OF_TREE,0)
 else AC_SUBST(IS_OUT_OF_TREE,1) fi
 


### PR DESCRIPTION
Otherwise, we might think it's an out-of-tree build when it's really an in-tree build.  Then later, we get multiple definition errors w/ fmpz.c because we try to link it twice since it's in both the source and build directories (which look different but are really the same).

Closes: #2799