### PR TITLE
Transform-reusing schoolbook polynomial multiplication

### DIFF
--- a/doc/source/fmpz_poly.rst
+++ b/doc/source/fmpz_poly.rst
@@ -692,6 +692,26 @@ Multiplication
     in the product of ``poly1`` and ``poly2``. Equivalently, compute
     `[(poly1 \cdot poly2) \bmod x^{nhi}] / x^{nlo}`.
 
+.. function:: int _fmpz_poly_mulmid_classical_fft_small(fmpz * res, const fmpz * poly1, slong len1, const fmpz * poly2, slong len2, slong nlo, slong nhi)
+
+    As :func:`_fmpz_poly_mulmid_classical`, computing the coefficients
+    `[\mathtt{nlo}, \mathtt{nhi})` of the product, but with the
+    coefficient arithmetic done pointwise on fft_small transforms: the
+    shorter operand's coefficients are transformed once and kept, the
+    longer operand rolls through a window of transform slots, and each
+    output coefficient is an accumulation of pointwise products
+    reconstructed once. When both operands are the same array, the
+    square shares transforms and pairs symmetric terms. The lengths may
+    be given in either order. Returns 1 on success and 0 when the
+    transformed representation is unavailable (small coefficients, or a
+    build without fft_small support), in which case nothing is written
+    and the caller should fall back to the classical routine.
+
+.. function:: int fmpz_poly_mulmid_classical_fft_small(fmpz_poly_t res, const fmpz_poly_t poly1, const fmpz_poly_t poly2, slong nlo, slong nhi)
+
+    Wrapper handling aliasing, zero operands and normalization, with
+    the same return convention.
+
 .. function:: void _fmpz_poly_mul_karatsuba(fmpz * res, const fmpz * poly1, slong len1, const fmpz * poly2, slong len2)
 
     Sets ``(res, len1 + len2 - 1)`` to the product of ``(poly1, len1)``

--- a/doc/source/fmpz_vec.rst
+++ b/doc/source/fmpz_vec.rst
@@ -90,6 +90,11 @@ Bit sizes and norms
     coefficient of ``vec``, then if any coefficient of ``vec`` is
     negative, `-b` is returned, else `b` is returned.
 
+.. function:: slong _fmpz_vec_weight_bits(const fmpz * vec, slong len)
+
+    Returns the sum of :func:`fmpz_bits` over the entries of
+    ``(vec, len)``.
+
 .. function:: slong _fmpz_vec_max_bits_ref(const fmpz * vec, slong len)
 
     If `b` is the maximum number of bits of the absolute value of any

--- a/doc/source/fmpzi.rst
+++ b/doc/source/fmpzi.rst
@@ -150,3 +150,20 @@ Primality testing
 .. function:: int fmpzi_is_probabprime(const fmpzi_t n)
 
     Check whether `n` is a probable Gaussian prime.
+
+.. function:: int _fmpzi_poly_mulmid_classical_fft_small(fmpzi_struct * res, const fmpzi_struct * poly1, slong len1, const fmpzi_struct * poly2, slong len2, slong nlo, slong nhi)
+
+    Computes the coefficients `[\mathtt{nlo}, \mathtt{nhi})` of the
+    product of the Gaussian integer polynomials ``(poly1, len1)`` and
+    ``(poly2, len2)``, with the coefficient arithmetic done pointwise
+    on fft_small transforms: two transforms per coefficient (real and
+    imaginary parts) and four pointwise operations per complex
+    product, the shorter operand's transforms kept and the longer
+    rolling as in :func:`_fmpz_poly_mulmid_classical_fft_small`.
+    Squaring shares transforms, pairs symmetric terms and computes
+    diagonal squares with three multiplications. The lengths may be
+    given in either order. Returns 1 on success and 0 when the
+    transformed representation is unavailable or unprofitable in which
+    case nothing is written and the caller should fall back to a
+    different routine.
+

--- a/src/fft_small/test/t-transformed_mpn.c
+++ b/src/fft_small/test/t-transformed_mpn.c
@@ -397,7 +397,8 @@ cleanup:
     {
         gr_ctx_t ctx;
         gr_ptr acc, x, y;
-        ulong a[1], b[1], z[8];
+        ulong a[1], b[1];
+        nn_ptr z;
         slong zn_out;
         int sign;
 
@@ -414,6 +415,9 @@ cleanup:
             GR_MUST_SUCCEED(gr_transformed_mpn_set(y, b, 1, 0, ctx));
             GR_MUST_SUCCEED(gr_mul(acc, x, x, ctx));
             GR_MUST_SUCCEED(gr_submul(acc, x, y, ctx));
+            z = flint_malloc(FLINT_MAX(
+                    gr_transformed_mpn_get_limbs(ctx, acc), 1)
+                    * sizeof(ulong));
             GR_MUST_SUCCEED(gr_transformed_mpn_get(z,
                     gr_transformed_mpn_get_limbs(ctx, acc),
                     &zn_out, &sign, acc, ctx));
@@ -421,6 +425,7 @@ cleanup:
             if (zn_out != 1 || sign != 1 || z[0] != 1)
                 TEST_FUNCTION_FAIL("1*1 - 1*2 != -1: "
                     "zn = %wd, sign = %d, z0 = %wu\n", zn_out, sign, z[0]);
+            flint_free(z);
 
             gr_heap_clear(acc, ctx);
             gr_heap_clear(x, ctx);
@@ -590,6 +595,137 @@ cleanup:
                 gr_ctx_clear(ctx);
             }
         }
+    }
+
+    /* trivial coefficients 0 and +-1: conversion keeps them in the
+       small side, products against them become additions or integer
+       bookkeeping, and the small side folds into reconstruction --
+       referee the whole algebra against fmpz over mixed chains */
+    {
+    slong iter2;
+    for (iter2 = 0; iter2 < 60 * flint_test_multiplier(); iter2++)
+    {
+        gr_ctx_t ctx;
+        gr_ptr acc, e[6];
+        fmpz_t facc, fe[6], t1;
+        slong bits = 700 + n_randint(state, 3000);
+        slong nterms = 1 + n_randint(state, 6), i, j;
+        int signed_ctx = n_randint(state, 4) != 0;
+        int status = GR_SUCCESS;
+
+        if (gr_ctx_init_transformed_mpn(ctx, 2*bits + 4, 16,
+                                        signed_ctx, 8) != GR_SUCCESS)
+            continue;
+
+        acc = flint_malloc(6 * ctx->sizeof_elem);
+        for (i = 0; i < 6; i++)
+        {
+            e[i] = GR_ENTRY(acc, i, ctx->sizeof_elem);
+            gr_init(e[i], ctx);
+            fmpz_init(fe[i]);
+        }
+        fmpz_init(facc);
+        fmpz_init(t1);
+
+        /* a mix of 0, +-1 and full-size values */
+        for (i = 0; i < 6; i++)
+        {
+            switch (n_randint(state, 5))
+            {
+                case 0: fmpz_zero(fe[i]); break;
+                case 1: fmpz_one(fe[i]); break;
+                case 2: fmpz_set_si(fe[i], signed_ctx ? -1 : 1); break;
+                default:
+                    fmpz_randtest_unsigned(fe[i], state, bits);
+                    if (signed_ctx && n_randint(state, 2))
+                        fmpz_neg(fe[i], fe[i]);
+            }
+            {
+                slong an = fmpz_size(fe[i]);
+                int sgn = fmpz_sgn(fe[i]) < 0;
+                {
+                    fmpz_t ab;
+                    fmpz_init(ab);
+                    fmpz_abs(ab, fe[i]);
+                    if (an == 0)
+                        status |= gr_transformed_mpn_set(e[i], NULL, 0,
+                                                         0, ctx);
+                    else
+                    {
+                        nn_ptr tmp = flint_malloc(an * sizeof(ulong));
+                        fmpz_get_ui_array(tmp, an, ab);
+                        status |= gr_transformed_mpn_set(e[i], tmp, an,
+                                                         sgn, ctx);
+                        flint_free(tmp);
+                    }
+                    fmpz_clear(ab);
+                }
+                (void) j;
+            }
+        }
+
+        /* accumulate: acc = sum of pairwise products with random
+           add/sub, refereed in fmpz */
+        {
+            gr_ptr a2 = e[0];
+            fmpz_zero(facc);
+            status |= gr_zero(a2, ctx);
+            for (j = 0; j < nterms && status == GR_SUCCESS; j++)
+            {
+                slong u = 1 + n_randint(state, 5);
+                slong v = 1 + n_randint(state, 5);
+                int sub = signed_ctx && n_randint(state, 2);
+                if (sub)
+                {
+                    status |= gr_submul(a2, e[u], e[v], ctx);
+                    fmpz_submul(facc, fe[u], fe[v]);
+                }
+                else
+                {
+                    status |= gr_addmul(a2, e[u], e[v], ctx);
+                    fmpz_addmul(facc, fe[u], fe[v]);
+                }
+            }
+            if (status == GR_SUCCESS)
+            {
+                {
+                    slong need = FLINT_MAX(
+                        gr_transformed_mpn_get_limbs(ctx, a2), 1);
+                    nn_ptr zz = flint_malloc(need * sizeof(ulong));
+                    slong zn2;
+                    int sg2;
+                    status |= gr_transformed_mpn_get(zz, need, &zn2,
+                                                     &sg2, a2, ctx);
+                    if (status == GR_SUCCESS)
+                    {
+                        if (zn2 == 0)
+                            fmpz_zero(t1);
+                        else
+                            fmpz_set_ui_array(t1, zz, zn2);
+                        if (sg2)
+                            fmpz_neg(t1, t1);
+                    }
+                    flint_free(zz);
+                }
+                if (status == GR_SUCCESS && !fmpz_equal(t1, facc))
+                    TEST_FUNCTION_FAIL("trivial-mix chain: bits = %wd, "
+                        "signed = %d, terms = %wd\n",
+                        bits, signed_ctx, nterms);
+            }
+            /* GR_UNABLE is acceptable (caps, unsigned-domain refusals);
+               wrong answers are not */
+        }
+
+        for (i = 0; i < 6; i++)
+        {
+            gr_clear(e[i], ctx);
+            fmpz_clear(fe[i]);
+        }
+        fmpz_clear(facc);
+        fmpz_clear(t1);
+        flint_free(acc);
+        gr_ctx_clear(ctx);
+    }
     }
 
     TEST_FUNCTION_END(state);

--- a/src/fmpz_mat/test/t-mul_fft_small.c
+++ b/src/fmpz_mat/test/t-mul_fft_small.c
@@ -154,5 +154,45 @@ TEST_FUNCTION_START(fmpz_mat_mul_fft_small, state)
         fmpz_mat_clear(B0);
     }
 
+        /* structured matrices: entries from {0, +1, -1, big} */
+    for (slong it2 = 0; it2 < 10 * flint_test_multiplier(); it2++)
+    {
+        slong r = 1 + n_randint(state, 6), c = 1 + n_randint(state, 6),
+              k = 1 + n_randint(state, 6);
+        slong bits = 11000 + n_randint(state, 6000);
+        fmpz_mat_t A, B, C, D;
+        fmpz_mat_init(A, r, k); fmpz_mat_init(B, k, c);
+        fmpz_mat_init(C, r, c); fmpz_mat_init(D, r, c);
+        for (slong i2 = 0; i2 < r; i2++)
+            for (slong j2 = 0; j2 < k; j2++)
+                switch (n_randint(state, 4))
+                {
+                    case 0: break;
+                    case 1: fmpz_set_si(fmpz_mat_entry(A, i2, j2),
+                                n_randint(state, 2) ? 1 : -1); break;
+                    default: fmpz_randtest(fmpz_mat_entry(A, i2, j2),
+                                           state, bits);
+                }
+        for (slong i2 = 0; i2 < k; i2++)
+            for (slong j2 = 0; j2 < c; j2++)
+                switch (n_randint(state, 4))
+                {
+                    case 0: break;
+                    case 1: fmpz_set_si(fmpz_mat_entry(B, i2, j2),
+                                n_randint(state, 2) ? 1 : -1); break;
+                    default: fmpz_randtest(fmpz_mat_entry(B, i2, j2),
+                                           state, bits);
+                }
+        if (fmpz_mat_mul_fft_small(C, A, B))
+        {
+            fmpz_mat_mul_classical(D, A, B);
+            if (!fmpz_mat_equal(C, D))
+                TEST_FUNCTION_FAIL("structured matrix mismatch: "
+                    "%wd x %wd x %wd, bits = %wd\n", r, k, c, bits);
+        }
+        fmpz_mat_clear(A); fmpz_mat_clear(B);
+        fmpz_mat_clear(C); fmpz_mat_clear(D);
+    }
+
     TEST_FUNCTION_END(state);
 }

--- a/src/fmpz_poly.h
+++ b/src/fmpz_poly.h
@@ -365,6 +365,9 @@ void fmpz_poly_mulhigh_classical(fmpz_poly_t res,
 
 void _fmpz_poly_mulmid_classical(fmpz * res, const fmpz * poly1, slong len1, const fmpz * poly2, slong len2, slong nlo, slong nhi);
 void fmpz_poly_mulmid_classical(fmpz_poly_t res, const fmpz_poly_t poly1, const fmpz_poly_t poly2, slong nlo, slong nhi);
+
+int _fmpz_poly_mulmid_classical_fft_small(fmpz * res, const fmpz * poly1, slong len1, const fmpz * poly2, slong len2, slong nlo, slong nhi);
+int fmpz_poly_mulmid_classical_fft_small(fmpz_poly_t res, const fmpz_poly_t poly1, const fmpz_poly_t poly2, slong nlo, slong nhi);
 void _fmpz_poly_mulmid_SS(fmpz * res, const fmpz * poly1, slong len1, const fmpz * poly2, slong len2, slong nlo, slong nhi);
 void fmpz_poly_mulmid_SS(fmpz_poly_t res, const fmpz_poly_t poly1, const fmpz_poly_t poly2, slong nlo, slong nhi);
 void _fmpz_poly_mulmid_KS(fmpz * res, const fmpz * poly1, slong len1, const fmpz * poly2, slong len2, slong nlo, slong nhi);

--- a/src/fmpz_poly/mulmid_classical_fft_small.c
+++ b/src/fmpz_poly/mulmid_classical_fft_small.c
@@ -205,7 +205,6 @@ _fmpz_poly_mulmid_classical_fft_small(fmpz * res,
     {
         slong jlo = FLINT_MAX(0, i - len1 + 1);
         slong jhi = FLINT_MIN(i, k - 1);
-        int acc_used = 0, acc2_used = 0;
         gr_ptr ea, eb;
 
         if (!share)
@@ -216,9 +215,7 @@ _fmpz_poly_mulmid_classical_fft_small(fmpz * res,
                 eb = GR_ENTRY(B, j, sz);
                 if (status != GR_SUCCESS)
                     break;
-                status |= acc_used ? gr_addmul(acc, ea, eb, ctx)
-                                   : gr_mul(acc, ea, eb, ctx);
-                acc_used = 1;
+                status |= gr_addmul(acc, ea, eb, ctx);
             }
         }
         else
@@ -242,47 +239,31 @@ _fmpz_poly_mulmid_classical_fft_small(fmpz * res,
 
                 if (paired && j < jp)
                 {
-                    status |= acc2_used ? gr_addmul(acc2, ea, eb, ctx)
-                                        : gr_mul(acc2, ea, eb, ctx);
-                    acc2_used = 1;
+                    status |= gr_addmul(acc2, ea, eb, ctx);
                 }
                 else
                 {
-                    status |= acc_used ? gr_addmul(acc, ea, eb, ctx)
-                                       : gr_mul(acc, ea, eb, ctx);
-                    acc_used = 1;
+                    status |= gr_addmul(acc, ea, eb, ctx);
                 }
             }
 
-            if (status == GR_SUCCESS && acc2_used)
-            {
-                if (!acc_used)
-                {
-                    status |= gr_set(acc, acc2, ctx);
-                    status |= gr_add(acc, acc, acc2, ctx);
-                }
-                else
-                {
-                    status |= gr_add(acc, acc, acc2, ctx);
-                    status |= gr_add(acc, acc, acc2, ctx);
-                }
-                acc_used = 1;
-            }
+            /* fold the paired sum in twice; when nothing paired,
+            acc2 is the ring's zero and the additions are
+            short-circuited bookkeeping */
+            status |= gr_add(acc, acc, acc2, ctx);
+            status |= gr_add(acc, acc, acc2, ctx);
         }
 
         if (status != GR_SUCCESS)
             break;
 
-        if (!acc_used)
-            fmpz_zero(res + (i - nlo));
-        else
-        {
-            status |= _get_coeff(res + (i - nlo), acc, ctx);
+        status |= _get_coeff(res + (i - nlo), acc, ctx);
             /* the destructive get consumed acc: bring it back for the
                next output; on borrowed storage this costs nothing */
-            gr_clear(acc, ctx);
-            gr_transformed_mpn_init_borrowed(acc, acc_data, ctx);
-        }
+        gr_clear(acc, ctx);
+        gr_transformed_mpn_init_borrowed(acc, acc_data, ctx);
+        gr_clear(acc2, ctx);
+        gr_transformed_mpn_init_borrowed(acc2, acc2_data, ctx);
     }
 
 #undef A_ELEM

--- a/src/fmpz_poly/mulmid_classical_fft_small.c
+++ b/src/fmpz_poly/mulmid_classical_fft_small.c
@@ -1,0 +1,337 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "gmpcompat.h"
+#include "flint.h"
+#include "fmpz.h"
+#include "fmpz_vec.h"
+#include "fmpz_poly.h"
+#include "fft_small.h"
+#include "gr.h"
+
+static nn_srcptr
+_coeff_limbs(const fmpz * f, ulong * scratch, slong * n, int * sgn)
+{
+    fmpz c = *f;
+
+    if (!COEFF_IS_MPZ(c))
+    {
+        *scratch = FLINT_ABS(c);
+        *n = 1;
+        *sgn = c < 0;
+        return scratch;
+    }
+    else
+    {
+        mpz_srcptr m = COEFF_TO_PTR(c);
+
+        *n = FLINT_ABS(m->_mp_size);
+        *sgn = m->_mp_size < 0;
+        return m->_mp_d;
+    }
+}
+
+static int
+_set_coeff(gr_ptr elem, const fmpz * f, gr_ctx_t ctx)
+{
+    ulong scratch;
+    slong n;
+    int sgn;
+    nn_srcptr p = _coeff_limbs(f, &scratch, &n, &sgn);
+
+    return gr_transformed_mpn_set(elem, p, n, sgn, ctx);
+}
+
+/* the accumulated element, converted out directly into an fmpz */
+/* converts the accumulator out destructively -- the caller re-initializes
+   it (borrowed storage, so that is free) before the next output */
+static int
+_get_coeff(fmpz * f, gr_ptr elem, gr_ctx_t ctx)
+{
+    slong w = gr_transformed_mpn_get_limbs(ctx, elem);
+    slong zl;
+    int sg, status;
+    mpz_ptr m;
+
+    if (w <= 0)
+        w = 1;
+
+    m = _fmpz_promote(f);
+    status = gr_transformed_mpn_get_destructive(FLINT_MPZ_REALLOC(m, w), w,
+                                                &zl, &sg, elem, ctx);
+    if (status != GR_SUCCESS)
+    {
+        _fmpz_demote(f);
+        fmpz_zero(f);
+        return status;
+    }
+
+    m->_mp_size = sg ? -zl : zl;
+    _fmpz_demote_val(f);
+    return GR_SUCCESS;
+}
+
+int
+_fmpz_poly_mulmid_classical_fft_small(fmpz * res,
+    const fmpz * poly1, slong len1, const fmpz * poly2, slong len2,
+    slong nlo, slong nhi)
+{
+#if !FLINT_HAVE_FFT_SMALL
+    return 0;
+#else
+    gr_ctx_t ctx;
+    gr_ptr B, X, acc, acc2, E;
+    double * acc_data, * acc2_data;
+    slong * xidx;                 /* which poly1 index each X slot holds */
+    slong k = len2, i, j, abits = 0, bbits = 0, sz;
+    int share = (poly1 == poly2);
+    int signed_needed;
+    int status = GR_SUCCESS;
+
+    if (len2 < 1 || len1 < 1 || nlo >= nhi)
+        return 0;
+
+    /* the product window is symmetric in the operands; keep the
+       shorter operand as the transformed-and-kept side */
+    if (len1 < len2)
+    {
+        const fmpz * tp = poly1;
+        slong tl = len1;
+        poly1 = poly2;
+        len1 = len2;
+        poly2 = tp;
+        len2 = tl;
+        k = len2;
+    }
+
+    /* _fmpz_vec_max_bits encodes "any negative coefficient" in its
+       sign, so the bounds and the signedness scan are one pass; an
+       all-nonnegative product takes the cheaper unsigned representation
+       (as in the fmpz_mat driver) */
+    {
+        slong amax = _fmpz_vec_max_bits(poly1, len1);
+        slong bmax = share ? amax : _fmpz_vec_max_bits(poly2, len2);
+        abits = FLINT_ABS(amax);
+        bbits = FLINT_ABS(bmax);
+        signed_needed = (amax < 0 || bmax < 0);
+    }
+
+    if (abits == 0 || bbits == 0)
+    {
+        /* a zero operand: the window of the product is zero */
+        _fmpz_vec_zero(res, nhi - nlo);
+        return 1;
+    }
+
+    /* Decline if too sparse; to be moved to the algorithm selection in
+       _fmpz_poly_mulmid when this  function has been integrated.
+    {
+        slong wa = _fmpz_vec_weight_bits(poly1, len1);
+        slong wb = share ? wa : _fmpz_vec_weight_bits(poly2, len2);
+        double density = (double) (wa + wb) / ((double) len1 * abits + (double) len2 * bbits);
+        double need = (k <= 2) ? 0.90
+                    : (k <= 4) ? 0.62
+                    : (k <= 8) ? 0.50
+                    : 0.30;
+        if (density < need)
+            return 0;
+    } */
+
+    /* one product's magnitude; the k-term accumulation and the sign
+       are the context's own provisioning */
+    if (gr_ctx_init_transformed_mpn(ctx,
+            abits + bbits, k, signed_needed, 2 * k + 2) != GR_SUCCESS)
+        return 0;
+
+    sz = ctx->sizeof_elem;
+
+    /* k kept transforms of poly2, k rolling slots for poly1 indices >= the
+       kept range (all indices when not sharing); the accumulators live on
+       borrowed slabs so they can be converted out destructively and
+       re-initialized for free */
+    E = flint_malloc((2 * k + 2) * sz);
+    B = E;
+    X = GR_ENTRY(E, k, sz);
+    acc = GR_ENTRY(E, 2 * k, sz);
+    acc2 = GR_ENTRY(E, 2 * k + 1, sz);
+
+    for (i = 0; i < 2 * k; i++)
+        gr_init(GR_ENTRY(E, i, sz), ctx);
+    {
+        ulong slab = n_round_up(gr_transformed_mpn_sizeof_data(ctx),
+                                FLINT_FFT_SMALL_ALIGNMENT);
+        acc_data = flint_aligned_alloc(FLINT_FFT_SMALL_ALIGNMENT, slab);
+        acc2_data = flint_aligned_alloc(FLINT_FFT_SMALL_ALIGNMENT, slab);
+        gr_transformed_mpn_init_borrowed(acc, acc_data, ctx);
+        gr_transformed_mpn_init_borrowed(acc2, acc2_data, ctx);
+    }
+
+    xidx = flint_malloc(k * sizeof(slong));
+    for (i = 0; i < k; i++)
+        xidx[i] = -1;
+
+    /* the kept transforms; when sharing they serve both roles */
+    for (j = 0; j < k && status == GR_SUCCESS; j++)
+        status |= _set_coeff(GR_ENTRY(B, j, sz),
+                             (share ? poly1 : poly2) + j, ctx);
+
+#define A_ELEM(t, out) \
+    do { \
+        if (share && (t) < k) \
+            (out) = GR_ENTRY(B, (t), sz); \
+        else \
+        { \
+            slong _s = share ? ((t) - k) % k : (t) % k; \
+            gr_ptr _e = GR_ENTRY(X, _s, sz); \
+            if (xidx[_s] != (t)) \
+            { \
+                status |= _set_coeff(_e, poly1 + (t), ctx); \
+                xidx[_s] = (t); \
+            } \
+            (out) = _e; \
+        } \
+    } while (0)
+
+    for (i = nlo; i < nhi && status == GR_SUCCESS; i++)
+    {
+        slong jlo = FLINT_MAX(0, i - len1 + 1);
+        slong jhi = FLINT_MIN(i, k - 1);
+        int acc_used = 0, acc2_used = 0;
+        gr_ptr ea, eb;
+
+        if (!share)
+        {
+            for (j = jlo; j <= jhi; j++)
+            {
+                A_ELEM(i - j, ea);
+                eb = GR_ENTRY(B, j, sz);
+                if (status != GR_SUCCESS)
+                    break;
+                status |= acc_used ? gr_addmul(acc, ea, eb, ctx)
+                                   : gr_mul(acc, ea, eb, ctx);
+                acc_used = 1;
+            }
+        }
+        else
+        {
+            /* pair j with i - j: within [jlo, jhi] both orders of each
+               product appear, so multiply once and add the pair sum in
+               twice; the diagonal term (i even) is a plain square, and
+               terms whose partner falls outside the range stay single */
+            for (j = jlo; j <= jhi; j++)
+            {
+                slong jp = i - j;         /* the partner index */
+                int paired = (jp >= jlo && jp <= jhi);
+
+                if (paired && j > jp)
+                    continue;             /* counted at the partner */
+
+                A_ELEM(i - j, ea);
+                A_ELEM(j, eb);
+                if (status != GR_SUCCESS)
+                    break;
+
+                if (paired && j < jp)
+                {
+                    status |= acc2_used ? gr_addmul(acc2, ea, eb, ctx)
+                                        : gr_mul(acc2, ea, eb, ctx);
+                    acc2_used = 1;
+                }
+                else
+                {
+                    status |= acc_used ? gr_addmul(acc, ea, eb, ctx)
+                                       : gr_mul(acc, ea, eb, ctx);
+                    acc_used = 1;
+                }
+            }
+
+            if (status == GR_SUCCESS && acc2_used)
+            {
+                if (!acc_used)
+                {
+                    status |= gr_set(acc, acc2, ctx);
+                    status |= gr_add(acc, acc, acc2, ctx);
+                }
+                else
+                {
+                    status |= gr_add(acc, acc, acc2, ctx);
+                    status |= gr_add(acc, acc, acc2, ctx);
+                }
+                acc_used = 1;
+            }
+        }
+
+        if (status != GR_SUCCESS)
+            break;
+
+        if (!acc_used)
+            fmpz_zero(res + (i - nlo));
+        else
+        {
+            status |= _get_coeff(res + (i - nlo), acc, ctx);
+            /* the destructive get consumed acc: bring it back for the
+               next output; on borrowed storage this costs nothing */
+            gr_clear(acc, ctx);
+            gr_transformed_mpn_init_borrowed(acc, acc_data, ctx);
+        }
+    }
+
+#undef A_ELEM
+
+    for (i = 0; i < 2 * k + 2; i++)
+        gr_clear(GR_ENTRY(E, i, sz), ctx);
+    flint_free(E);
+    flint_aligned_free(acc_data);
+    flint_aligned_free(acc2_data);
+    flint_free(xidx);
+    gr_ctx_clear(ctx);
+
+    return status == GR_SUCCESS;
+#endif
+}
+
+int
+fmpz_poly_mulmid_classical_fft_small(fmpz_poly_t res,
+    const fmpz_poly_t poly1, const fmpz_poly_t poly2, slong nlo,
+    slong nhi)
+{
+    slong len1 = poly1->length, len2 = poly2->length;
+    int ok;
+
+    if (len1 == 0 || len2 == 0 || nlo >= nhi)
+    {
+        fmpz_poly_zero(res);
+        return 1;
+    }
+
+    if (res == poly1 || res == poly2)
+    {
+        fmpz_poly_t t;
+        fmpz_poly_init2(t, nhi - nlo);
+        ok = fmpz_poly_mulmid_classical_fft_small(t, poly1, poly2,
+                                                  nlo, nhi);
+        if (ok)
+            fmpz_poly_swap(res, t);
+        fmpz_poly_clear(t);
+        return ok;
+    }
+
+    fmpz_poly_fit_length(res, nhi - nlo);
+    ok = _fmpz_poly_mulmid_classical_fft_small(res->coeffs,
+            poly1->coeffs, len1, poly2->coeffs, len2, nlo, nhi);
+    if (ok)
+    {
+        _fmpz_poly_set_length(res, nhi - nlo);
+        _fmpz_poly_normalise(res);
+    }
+    return ok;
+}

--- a/src/fmpz_poly/test/main.c
+++ b/src/fmpz_poly/test/main.c
@@ -125,6 +125,7 @@
 #include "t-mullow_SS_precache.c"
 #include "t-mulmid.c"
 #include "t-mulmid_classical.c"
+#include "t-mulmid_classical_fft_small.c"
 #include "t-mulmid_KS.c"
 #include "t-mulmid_SS.c"
 #include "t-mul_SS.c"
@@ -316,6 +317,7 @@ test_struct tests[] =
     TEST_FUNCTION(fmpz_poly_mullow_SS_precache),
     TEST_FUNCTION(fmpz_poly_mulmid),
     TEST_FUNCTION(fmpz_poly_mulmid_classical),
+    TEST_FUNCTION(fmpz_poly_mulmid_classical_fft_small),
     TEST_FUNCTION(fmpz_poly_mulmid_KS),
     TEST_FUNCTION(fmpz_poly_mulmid_SS),
     TEST_FUNCTION(fmpz_poly_mul_SS),

--- a/src/fmpz_poly/test/t-mulmid_classical_fft_small.c
+++ b/src/fmpz_poly/test/t-mulmid_classical_fft_small.c
@@ -214,5 +214,27 @@ sparse_next:
         fmpz_poly_clear(d);
     }
 
+    /* a zero operand yields a zero window and succeeds (deterministic
+       coverage of the zero-operand branch) */
+#if FLINT_HAVE_FFT_SMALL
+    {
+        fmpz * a = _fmpz_vec_init(5);
+        fmpz * b = _fmpz_vec_init(3);
+        fmpz * r = _fmpz_vec_init(4);
+        slong i;
+        int ok;
+        for (i = 0; i < 5; i++)
+            fmpz_randbits(a + i, state, 15000);
+        fmpz_one(r + 0);   /* stale content must be overwritten */
+        ok = _fmpz_poly_mulmid_classical_fft_small(r, a, 5, b, 3,
+                                                   2, 6);
+        if (!ok || !_fmpz_vec_is_zero(r, 4))
+            TEST_FUNCTION_FAIL("zero operand window\n");
+        _fmpz_vec_clear(a, 5);
+        _fmpz_vec_clear(b, 3);
+        _fmpz_vec_clear(r, 4);
+    }
+#endif
+
     TEST_FUNCTION_END(state);
 }

--- a/src/fmpz_poly/test/t-mulmid_classical_fft_small.c
+++ b/src/fmpz_poly/test/t-mulmid_classical_fft_small.c
@@ -1,0 +1,218 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "fmpz.h"
+#include "fmpz_vec.h"
+#include "fmpz_poly.h"
+
+TEST_FUNCTION_START(fmpz_poly_mulmid_classical_fft_small, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 30 * flint_test_multiplier(); iter++)
+    {
+        slong len1 = 1 + n_randint(state, 12);
+        slong len2 = 1 + n_randint(state, 12);
+        slong big = FLINT_MAX(len1, len2);
+        slong bits = 12000 + n_randint(state, 12000);
+        slong nlo, nhi, i;
+        int sq = (n_randint(state, 4) == 0);
+        int ok;
+        fmpz * a, * b, * r1, * r2;
+
+        if (sq)
+            len2 = len1;
+
+        nlo = n_randint(state, len1 + len2 - 1);
+        nhi = nlo + 1 + n_randint(state, len1 + len2 - 1 - nlo);
+
+        a = _fmpz_vec_init(len1);
+        b = sq ? a : _fmpz_vec_init(len2);
+        r1 = _fmpz_vec_init(nhi - nlo);
+        r2 = _fmpz_vec_init(nhi - nlo);
+
+        for (i = 0; i < len1; i++)
+        {
+            fmpz_randbits(a + i, state, bits);
+            if (n_randint(state, 2))
+                fmpz_neg(a + i, a + i);
+        }
+        if (!sq)
+            for (i = 0; i < len2; i++)
+            {
+                fmpz_randbits(b + i, state, bits);
+                if (n_randint(state, 2))
+                    fmpz_neg(b + i, b + i);
+            }
+        if (n_randint(state, 3) == 0)
+            fmpz_zero(a + n_randint(state, len1));
+
+        if (n_randint(state, 2))
+            ok = _fmpz_poly_mulmid_classical_fft_small(r1, a, len1,
+                                                       b, len2, nlo, nhi);
+        else
+            ok = _fmpz_poly_mulmid_classical_fft_small(r1, b, len2,
+                                                       a, len1, nlo, nhi);
+
+        if (!ok)
+        {
+            /* the density gate may refuse (e.g. a planted zero at
+               small k): the fallback contract, not a failure */
+            _fmpz_vec_clear(a, len1);
+            if (!sq)
+                _fmpz_vec_clear(b, len2);
+            _fmpz_vec_clear(r1, nhi - nlo);
+            _fmpz_vec_clear(r2, nhi - nlo);
+            continue;
+        }
+
+        /* classical requires the longer operand first */
+        if (len1 >= len2)
+            _fmpz_poly_mulmid_classical(r2, a, len1, b, len2, nlo, nhi);
+        else
+            _fmpz_poly_mulmid_classical(r2, b, len2, a, len1, nlo, nhi);
+
+        if (!_fmpz_vec_equal(r1, r2, nhi - nlo))
+            TEST_FUNCTION_FAIL("len1 = %wd, len2 = %wd, bits = %wd, "
+                "window [%wd, %wd), sq = %d\n",
+                len1, len2, bits, nlo, nhi, sq);
+
+        _fmpz_vec_clear(a, len1);
+        if (!sq)
+            _fmpz_vec_clear(b, len2);
+        _fmpz_vec_clear(r1, nhi - nlo);
+        _fmpz_vec_clear(r2, nhi - nlo);
+        (void) big;
+    }
+
+    /* sparse and structured operands: coefficients drawn from
+       {0, +1, -1, big} exercise the trivial-coefficient fast paths
+       of the transformed ring (free conversion, pointwise ops
+       degenerating to additions or integer bookkeeping) */
+    for (iter = 0; iter < 20 * flint_test_multiplier(); iter++)
+    {
+        slong len1 = 2 + n_randint(state, 10);
+        slong len2 = 2 + n_randint(state, 10);
+        slong bits = 12000 + n_randint(state, 8000);
+        slong nlo, nhi, i;
+        int ok;
+        fmpz * a, * b, * r1, * r2;
+
+        nlo = n_randint(state, len1 + len2 - 1);
+        nhi = nlo + 1 + n_randint(state, len1 + len2 - 1 - nlo);
+
+        a = _fmpz_vec_init(len1);
+        b = _fmpz_vec_init(len2);
+        r1 = _fmpz_vec_init(nhi - nlo);
+        r2 = _fmpz_vec_init(nhi - nlo);
+
+        for (i = 0; i < len1; i++)
+            switch (n_randint(state, 4))
+            {
+                case 0: break;
+                case 1: fmpz_set_si(a + i,
+                            n_randint(state, 2) ? 1 : -1); break;
+                default: fmpz_randtest(a + i, state, bits);
+            }
+        for (i = 0; i < len2; i++)
+            switch (n_randint(state, 4))
+            {
+                case 0: break;
+                case 1: fmpz_set_si(b + i,
+                            n_randint(state, 2) ? 1 : -1); break;
+                default: fmpz_randtest(b + i, state, bits);
+            }
+        /* one genuinely large coefficient per operand, so the
+           transformed representation stays engaged (an all-trivial
+           operand may legitimately refuse and fall back) */
+        fmpz_randbits(a + n_randint(state, len1), state, bits);
+        fmpz_randbits(b + n_randint(state, len2), state, bits);
+
+        ok = _fmpz_poly_mulmid_classical_fft_small(r1, a, len1,
+                                                   b, len2, nlo, nhi);
+        if (!ok)
+            goto sparse_next;   /* the density gate may refuse
+                                   trivial-heavy inputs: the fallback
+                                   contract, not a failure */
+        if (len1 >= len2)
+            _fmpz_poly_mulmid_classical(r2, a, len1, b, len2, nlo, nhi);
+        else
+            _fmpz_poly_mulmid_classical(r2, b, len2, a, len1, nlo, nhi);
+        if (!_fmpz_vec_equal(r1, r2, nhi - nlo))
+            TEST_FUNCTION_FAIL("sparse mismatch: len1 = %wd, "
+                "len2 = %wd, bits = %wd, window [%wd, %wd)\n",
+                len1, len2, bits, nlo, nhi);
+
+sparse_next:
+        _fmpz_vec_clear(a, len1);
+        _fmpz_vec_clear(b, len2);
+        _fmpz_vec_clear(r1, nhi - nlo);
+        _fmpz_vec_clear(r2, nhi - nlo);
+    }
+
+    /* wrapper: aliasing, zero operands, empty windows; small
+       coefficients exercise the refusal-and-fallback contract */
+    for (iter = 0; iter < 20 * flint_test_multiplier(); iter++)
+    {
+        fmpz_poly_t a, b, c, d;
+        slong bits = n_randint(state, 2) ? 20000 : 100;
+        slong len1, len2, nlo, nhi;
+        int ok;
+
+        fmpz_poly_init(a);
+        fmpz_poly_init(b);
+        fmpz_poly_init(c);
+        fmpz_poly_init(d);
+        fmpz_poly_randtest(a, state, 1 + n_randint(state, 10), bits);
+        fmpz_poly_randtest(b, state, 1 + n_randint(state, 10), bits);
+        len1 = a->length;
+        len2 = b->length;
+
+        if (len1 == 0 || len2 == 0)
+        {
+            nlo = 0;
+            nhi = 1;
+        }
+        else
+        {
+            nlo = n_randint(state, len1 + len2 - 1);
+            nhi = nlo + 1 + n_randint(state, len1 + len2 - 1 - nlo);
+        }
+
+        ok = fmpz_poly_mulmid_classical_fft_small(c, a, b, nlo, nhi);
+        if (ok)
+        {
+            fmpz_poly_mulmid_classical(d,
+                len1 >= len2 ? a : b, len1 >= len2 ? b : a, nlo, nhi);
+            if (!fmpz_poly_equal(c, d))
+                TEST_FUNCTION_FAIL("wrapper: bits = %wd, window "
+                    "[%wd, %wd)\n", bits, nlo, nhi);
+
+            /* aliased call must agree with the unaliased result */
+            fmpz_poly_set(d, a);
+            ok = fmpz_poly_mulmid_classical_fft_small(d, d, b, nlo, nhi);
+            if (!ok || !fmpz_poly_equal(c, d))
+                TEST_FUNCTION_FAIL("wrapper aliasing: bits = %wd\n",
+                                   bits);
+        }
+        /* wrapper refusals fall back by contract (small bits or the
+           density gate); nothing further to check */
+
+        fmpz_poly_clear(a);
+        fmpz_poly_clear(b);
+        fmpz_poly_clear(c);
+        fmpz_poly_clear(d);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/fmpz_vec.h
+++ b/src/fmpz_vec.h
@@ -100,6 +100,7 @@ void _fmpz_vec_randtest_unsigned(fmpz * f, flint_rand_t state, slong len, flint_
 /*  Norms  *******************************************************************/
 
 slong _fmpz_vec_max_bits(const fmpz * vec, slong len);
+slong _fmpz_vec_weight_bits(const fmpz * vec, slong len);
 slong _fmpz_vec_max_bits_ref(const fmpz * vec, slong len);
 
 void _fmpz_vec_sum_max_bits(slong * sumabs, slong * maxabs, const fmpz * coeffs, slong length);

--- a/src/fmpz_vec/weight_bits.c
+++ b/src/fmpz_vec/weight_bits.c
@@ -1,0 +1,25 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz.h"
+#include "fmpz_vec.h"
+
+slong
+_fmpz_vec_weight_bits(const fmpz * vec, slong len)
+{
+    slong i;
+    ulong w = 0;
+
+    for (i = 0; i < len; i++)
+        w += fmpz_bits(vec + i);
+
+    return w;
+}

--- a/src/fmpzi.h
+++ b/src/fmpzi.h
@@ -188,6 +188,8 @@ void fmpzi_gcd(fmpzi_t g, const fmpzi_t x, const fmpzi_t y);
 int fmpzi_is_prime(const fmpzi_t n);
 int fmpzi_is_probabprime(const fmpzi_t n);
 
+int _fmpzi_poly_mulmid_classical_fft_small(fmpzi_struct * res, const fmpzi_struct * poly1, slong len1, const fmpzi_struct * poly2, slong len2, slong nlo, slong nhi);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/fmpzi/mulmid_classical_fft_small.c
+++ b/src/fmpzi/mulmid_classical_fft_small.c
@@ -247,15 +247,13 @@ _fmpzi_poly_mulmid_classical_fft_small(fmpzi_struct * res,
     } while (0)
 
     /* one complex product accumulated into the (re, im) target pair */
-#define CPROD(tr, ti, trused, tiused, ar, ai, br, bi) \
+/* the freshly re-initialized accumulators are the ring's zero and
+   the ring's addmul handles empty accumulators itself */
+#define CPROD(tr, ti, ar, ai, br, bi) \
     do { \
-        status |= (trused) ? gr_addmul(tr, ar, br, ctx) \
-                           : gr_mul(tr, ar, br, ctx); \
-        (trused) = 1; \
+        status |= gr_addmul(tr, ar, br, ctx); \
         status |= gr_submul(tr, ai, bi, ctx); \
-        status |= (tiused) ? gr_addmul(ti, ar, bi, ctx) \
-                           : gr_mul(ti, ar, bi, ctx); \
-        (tiused) = 1; \
+        status |= gr_addmul(ti, ar, bi, ctx); \
         status |= gr_addmul(ti, ai, br, ctx); \
     } while (0)
 
@@ -263,7 +261,6 @@ _fmpzi_poly_mulmid_classical_fft_small(fmpzi_struct * res,
     {
         slong jlo = FLINT_MAX(0, i - len1 + 1);
         slong jhi = FLINT_MIN(i, k - 1);
-        int r1u = 0, i1u = 0, r2u = 0, i2u = 0;
         gr_ptr ar, ai, br, bi;
 
         if (!share)
@@ -275,7 +272,7 @@ _fmpzi_poly_mulmid_classical_fft_small(fmpzi_struct * res,
                 bi = GR_ENTRY(B, 2 * j + 1, sz);
                 if (status != GR_SUCCESS)
                     break;
-                CPROD(accR, accI, r1u, i1u, ar, ai, br, bi);
+                CPROD(accR, accI, ar, ai, br, bi);
             }
         }
         else
@@ -294,65 +291,36 @@ _fmpzi_poly_mulmid_classical_fft_small(fmpzi_struct * res,
                     break;
 
                 if (paired && j < jp)
-                    CPROD(accR2, accI2, r2u, i2u, ar, ai, br, bi);
+                    CPROD(accR2, accI2, ar, ai, br, bi);
                 else if (paired)
                 {
                     /* the diagonal square: r^2 - i^2 into the single
                        accumulator, r i into the doubled one */
-                    status |= r1u ? gr_addmul(accR, ar, ar, ctx)
-                                  : gr_mul(accR, ar, ar, ctx);
-                    r1u = 1;
+                    status |= gr_addmul(accR, ar, ar, ctx);
                     status |= gr_submul(accR, ai, ai, ctx);
-                    status |= i2u ? gr_addmul(accI2, ar, ai, ctx)
-                                  : gr_mul(accI2, ar, ai, ctx);
-                    i2u = 1;
+                    status |= gr_addmul(accI2, ar, ai, ctx);
                 }
                 else
-                    CPROD(accR, accI, r1u, i1u, ar, ai, br, bi);
+                    CPROD(accR, accI, ar, ai, br, bi);
             }
         }
 
-        if (status == GR_SUCCESS && r2u)
+        /* fold the paired sums in twice; zero paired accumulators
+           reduce to short-circuited bookkeeping */
+        if (status == GR_SUCCESS)
         {
-            if (!r1u)
-            {
-                status |= gr_set(accR, accR2, ctx);
-                status |= gr_add(accR, accR, accR2, ctx);
-            }
-            else
-            {
-                status |= gr_add(accR, accR, accR2, ctx);
-                status |= gr_add(accR, accR, accR2, ctx);
-            }
-            r1u = 1;
-        }
-        if (status == GR_SUCCESS && i2u)
-        {
-            if (!i1u)
-            {
-                status |= gr_set(accI, accI2, ctx);
-                status |= gr_add(accI, accI, accI2, ctx);
-            }
-            else
-            {
-                status |= gr_add(accI, accI, accI2, ctx);
-                status |= gr_add(accI, accI, accI2, ctx);
-            }
-            i1u = 1;
+            status |= gr_add(accR, accR, accR2, ctx);
+            status |= gr_add(accR, accR, accR2, ctx);
+            status |= gr_add(accI, accI, accI2, ctx);
+            status |= gr_add(accI, accI, accI2, ctx);
         }
 
         if (status == GR_SUCCESS)
         {
-            if (r1u)
-                status |= _get_coeff(fmpzi_realref(res + i - nlo),
-                                     accR, ctx);
-            else
-                fmpz_zero(fmpzi_realref(res + i - nlo));
-            if (i1u)
-                status |= _get_coeff(fmpzi_imagref(res + i - nlo),
-                                     accI, ctx);
-            else
-                fmpz_zero(fmpzi_imagref(res + i - nlo));
+            status |= _get_coeff(fmpzi_realref(res + i - nlo),
+                                 accR, ctx);
+            status |= _get_coeff(fmpzi_imagref(res + i - nlo),
+                                 accI, ctx);
             /* borrowed storage: re-initialization is free */
             gr_transformed_mpn_init_borrowed(accR, accd[0], ctx);
             gr_transformed_mpn_init_borrowed(accI, accd[1], ctx);

--- a/src/fmpzi/mulmid_classical_fft_small.c
+++ b/src/fmpzi/mulmid_classical_fft_small.c
@@ -1,0 +1,389 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <gmp.h>
+#include "flint.h"
+#include "fmpz.h"
+#include "fmpz_vec.h"
+#include "fmpzi.h"
+#include "gr.h"
+#include "fft_small.h"
+#include "ulong_extras.h"
+
+/* Middle products of Gaussian integer polynomials with the coefficient
+   arithmetic done pointwise on fft_small transforms: the same rolling
+   schoolbook as _fmpz_poly_mulmid_classical_fft_small, with two
+   transforms per coefficient (real and imaginary parts) and four
+   pointwise operations per complex product,
+       re += ra rb,  re -= ia ib,  im += ra ib,  im += ia rb.
+   Squaring shares transforms, pairs symmetric terms through doubled
+   accumulators, and computes diagonal squares with three
+   multiplications ((r + ii)^2 = r^2 - i^2 + 2ri i, the cross term
+   riding the doubled accumulator). Returns 1 on success, 0 when the
+   transformed representation is unavailable or unprofitable. */
+
+#if FLINT_HAVE_FFT_SMALL
+
+static nn_srcptr
+_coeff_limbs(const fmpz * f, ulong * scratch, slong * n, int * sgn)
+{
+    fmpz c = *f;
+
+    if (!COEFF_IS_MPZ(c))
+    {
+        *scratch = FLINT_ABS(c);
+        *n = 1;
+        *sgn = c < 0;
+        return scratch;
+    }
+    else
+    {
+        mpz_srcptr m = COEFF_TO_PTR(c);
+
+        *n = FLINT_ABS(m->_mp_size);
+        *sgn = m->_mp_size < 0;
+        return m->_mp_d;
+    }
+}
+
+static int
+_set_coeff(gr_ptr elem, const fmpz * f, gr_ctx_t ctx)
+{
+    ulong scratch;
+    slong n;
+    int sgn;
+    nn_srcptr p = _coeff_limbs(f, &scratch, &n, &sgn);
+
+    return gr_transformed_mpn_set(elem, p, n, sgn, ctx);
+}
+
+/* the accumulated element, converted out directly into an fmpz */
+/* converts the accumulator out destructively -- the caller re-initializes
+   it (borrowed storage, so that is free) before the next output */
+static int
+_get_coeff(fmpz * f, gr_ptr elem, gr_ctx_t ctx)
+{
+    slong w = gr_transformed_mpn_get_limbs(ctx, elem);
+    slong zl;
+    int sg, status;
+    mpz_ptr m;
+
+    if (w <= 0)
+        w = 1;
+
+    m = _fmpz_promote(f);
+    status = gr_transformed_mpn_get_destructive(FLINT_MPZ_REALLOC(m, w), w,
+                                                &zl, &sg, elem, ctx);
+    if (status != GR_SUCCESS)
+    {
+        _fmpz_demote(f);
+        fmpz_zero(f);
+        return status;
+    }
+
+    m->_mp_size = sg ? -zl : zl;
+    _fmpz_demote_val(f);
+    return GR_SUCCESS;
+}
+
+
+int
+_fmpzi_poly_mulmid_classical_fft_small(fmpzi_struct * res,
+    const fmpzi_struct * poly1, slong len1,
+    const fmpzi_struct * poly2, slong len2,
+    slong nlo, slong nhi)
+{
+    gr_ctx_t ctx;
+    gr_ptr E, B, X, accR, accI, accR2, accI2;
+    double * accd[4];
+    slong i, j, k, sz, abits, bbits;
+    slong * xidx;
+    int share = (poly1 == poly2);
+    int status = GR_SUCCESS;
+    int ok;
+
+    if (len2 < 1 || len1 < 1 || nlo >= nhi)
+        return 0;
+
+    if (len1 < len2)
+    {
+        const fmpzi_struct * tp = poly1;
+        slong tl = len1;
+        poly1 = poly2;
+        len1 = len2;
+        poly2 = tp;
+        len2 = tl;
+    }
+    k = len2;
+
+    /* bounds over both components; the subtraction in the real part
+       makes the representation signed regardless of input signs */
+    {
+        slong m, t;
+        abits = 0;
+        for (i = 0; i < len1; i++)
+        {
+            t = fmpz_bits(fmpzi_realref(poly1 + i));
+            m = fmpz_bits(fmpzi_imagref(poly1 + i));
+            abits = FLINT_MAX(abits, FLINT_MAX(t, m));
+        }
+        if (share)
+            bbits = abits;
+        else
+        {
+            bbits = 0;
+            for (i = 0; i < len2; i++)
+            {
+                t = fmpz_bits(fmpzi_realref(poly2 + i));
+                m = fmpz_bits(fmpzi_imagref(poly2 + i));
+                bbits = FLINT_MAX(bbits, FLINT_MAX(t, m));
+            }
+        }
+    }
+    if (abits == 0 || bbits == 0)
+    {
+        for (i = 0; i < nhi - nlo; i++)
+            fmpzi_zero(res + i);
+        return 1;
+    }
+
+    /* Decline if too sparse; to be moved to the algorithm selection in
+       a future _fmpzi_poly_mulmid when this  function has been integrated.
+    {
+        slong wa = 0, wb = 0;
+        double density, need;
+        for (i = 0; i < len1; i++)
+            wa += fmpz_bits(fmpzi_realref(poly1 + i))
+                + fmpz_bits(fmpzi_imagref(poly1 + i));
+        if (share)
+            wb = wa;
+        else
+            for (i = 0; i < len2; i++)
+                wb += fmpz_bits(fmpzi_realref(poly2 + i))
+                    + fmpz_bits(fmpzi_imagref(poly2 + i));
+        density = (double) (wa + wb)
+                  / (2.0 * ((double) len1 * abits
+                            + (double) len2 * bbits));
+        need = (k <= 2) ? 0.90 : (k <= 4) ? 0.62
+             : (k <= 8) ? 0.50 : 0.30;
+        if (density < need)
+            return 0;
+    } */
+
+    /* each output component accumulates at most 2 k product
+       magnitudes of one product's size */
+    if (gr_ctx_init_transformed_mpn(ctx,
+            abits + bbits, 2 * k, 1, 4 * k + 4) != GR_SUCCESS)
+        return 0;
+
+    sz = ctx->sizeof_elem;
+    /* 2k kept transforms (re, im interleaved), 2k rolling slots, and
+       four accumulators on borrowed slabs */
+    E = flint_malloc((4 * k + 4) * sz);
+    B = E;
+    X = GR_ENTRY(E, 2 * k, sz);
+    accR = GR_ENTRY(E, 4 * k, sz);
+    accI = GR_ENTRY(E, 4 * k + 1, sz);
+    accR2 = GR_ENTRY(E, 4 * k + 2, sz);
+    accI2 = GR_ENTRY(E, 4 * k + 3, sz);
+    for (i = 0; i < 4 * k; i++)
+        gr_init(GR_ENTRY(E, i, sz), ctx);
+    {
+        ulong slab = n_round_up(gr_transformed_mpn_sizeof_data(ctx),
+                                FLINT_FFT_SMALL_ALIGNMENT);
+        for (i = 0; i < 4; i++)
+            accd[i] = flint_aligned_alloc(FLINT_FFT_SMALL_ALIGNMENT,
+                                          slab);
+        gr_transformed_mpn_init_borrowed(accR, accd[0], ctx);
+        gr_transformed_mpn_init_borrowed(accI, accd[1], ctx);
+        gr_transformed_mpn_init_borrowed(accR2, accd[2], ctx);
+        gr_transformed_mpn_init_borrowed(accI2, accd[3], ctx);
+    }
+    xidx = flint_malloc(k * sizeof(slong));
+    for (i = 0; i < k; i++)
+        xidx[i] = -1;
+
+    for (j = 0; j < k && status == GR_SUCCESS; j++)
+    {
+        const fmpzi_struct * c = (share ? poly1 : poly2) + j;
+        status |= _set_coeff(GR_ENTRY(B, 2 * j, sz),
+                             fmpzi_realref(c), ctx);
+        status |= _set_coeff(GR_ENTRY(B, 2 * j + 1, sz),
+                             fmpzi_imagref(c), ctx);
+    }
+
+#define A_PAIR(t, outr, outi) \
+    do { \
+        if (share && (t) < k) \
+        { \
+            (outr) = GR_ENTRY(B, 2 * (t), sz); \
+            (outi) = GR_ENTRY(B, 2 * (t) + 1, sz); \
+        } \
+        else \
+        { \
+            slong _s = share ? ((t) - k) % k : (t) % k; \
+            gr_ptr _er = GR_ENTRY(X, 2 * _s, sz); \
+            gr_ptr _ei = GR_ENTRY(X, 2 * _s + 1, sz); \
+            if (xidx[_s] != (t)) \
+            { \
+                status |= _set_coeff(_er, \
+                    fmpzi_realref(poly1 + (t)), ctx); \
+                status |= _set_coeff(_ei, \
+                    fmpzi_imagref(poly1 + (t)), ctx); \
+                xidx[_s] = (t); \
+            } \
+            (outr) = _er; \
+            (outi) = _ei; \
+        } \
+    } while (0)
+
+    /* one complex product accumulated into the (re, im) target pair */
+#define CPROD(tr, ti, trused, tiused, ar, ai, br, bi) \
+    do { \
+        status |= (trused) ? gr_addmul(tr, ar, br, ctx) \
+                           : gr_mul(tr, ar, br, ctx); \
+        (trused) = 1; \
+        status |= gr_submul(tr, ai, bi, ctx); \
+        status |= (tiused) ? gr_addmul(ti, ar, bi, ctx) \
+                           : gr_mul(ti, ar, bi, ctx); \
+        (tiused) = 1; \
+        status |= gr_addmul(ti, ai, br, ctx); \
+    } while (0)
+
+    for (i = nlo; i < nhi && status == GR_SUCCESS; i++)
+    {
+        slong jlo = FLINT_MAX(0, i - len1 + 1);
+        slong jhi = FLINT_MIN(i, k - 1);
+        int r1u = 0, i1u = 0, r2u = 0, i2u = 0;
+        gr_ptr ar, ai, br, bi;
+
+        if (!share)
+        {
+            for (j = jlo; j <= jhi; j++)
+            {
+                A_PAIR(i - j, ar, ai);
+                br = GR_ENTRY(B, 2 * j, sz);
+                bi = GR_ENTRY(B, 2 * j + 1, sz);
+                if (status != GR_SUCCESS)
+                    break;
+                CPROD(accR, accI, r1u, i1u, ar, ai, br, bi);
+            }
+        }
+        else
+        {
+            for (j = jlo; j <= jhi; j++)
+            {
+                slong jp = i - j;
+                int paired = (jp >= jlo && jp <= jhi);
+
+                if (paired && j > jp)
+                    continue;
+
+                A_PAIR(i - j, ar, ai);
+                A_PAIR(j, br, bi);
+                if (status != GR_SUCCESS)
+                    break;
+
+                if (paired && j < jp)
+                    CPROD(accR2, accI2, r2u, i2u, ar, ai, br, bi);
+                else if (paired)
+                {
+                    /* the diagonal square: r^2 - i^2 into the single
+                       accumulator, r i into the doubled one */
+                    status |= r1u ? gr_addmul(accR, ar, ar, ctx)
+                                  : gr_mul(accR, ar, ar, ctx);
+                    r1u = 1;
+                    status |= gr_submul(accR, ai, ai, ctx);
+                    status |= i2u ? gr_addmul(accI2, ar, ai, ctx)
+                                  : gr_mul(accI2, ar, ai, ctx);
+                    i2u = 1;
+                }
+                else
+                    CPROD(accR, accI, r1u, i1u, ar, ai, br, bi);
+            }
+        }
+
+        if (status == GR_SUCCESS && r2u)
+        {
+            if (!r1u)
+            {
+                status |= gr_set(accR, accR2, ctx);
+                status |= gr_add(accR, accR, accR2, ctx);
+            }
+            else
+            {
+                status |= gr_add(accR, accR, accR2, ctx);
+                status |= gr_add(accR, accR, accR2, ctx);
+            }
+            r1u = 1;
+        }
+        if (status == GR_SUCCESS && i2u)
+        {
+            if (!i1u)
+            {
+                status |= gr_set(accI, accI2, ctx);
+                status |= gr_add(accI, accI, accI2, ctx);
+            }
+            else
+            {
+                status |= gr_add(accI, accI, accI2, ctx);
+                status |= gr_add(accI, accI, accI2, ctx);
+            }
+            i1u = 1;
+        }
+
+        if (status == GR_SUCCESS)
+        {
+            if (r1u)
+                status |= _get_coeff(fmpzi_realref(res + i - nlo),
+                                     accR, ctx);
+            else
+                fmpz_zero(fmpzi_realref(res + i - nlo));
+            if (i1u)
+                status |= _get_coeff(fmpzi_imagref(res + i - nlo),
+                                     accI, ctx);
+            else
+                fmpz_zero(fmpzi_imagref(res + i - nlo));
+            /* borrowed storage: re-initialization is free */
+            gr_transformed_mpn_init_borrowed(accR, accd[0], ctx);
+            gr_transformed_mpn_init_borrowed(accI, accd[1], ctx);
+            gr_transformed_mpn_init_borrowed(accR2, accd[2], ctx);
+            gr_transformed_mpn_init_borrowed(accI2, accd[3], ctx);
+        }
+    }
+
+#undef A_PAIR
+#undef CPROD
+
+    ok = (status == GR_SUCCESS);
+    for (i = 0; i < 4 * k; i++)
+        gr_clear(GR_ENTRY(E, i, sz), ctx);
+    flint_free(E);
+    for (i = 0; i < 4; i++)
+        flint_free(accd[i]);
+    flint_free(xidx);
+    gr_ctx_clear(ctx);
+    return ok;
+}
+
+#else
+
+int
+_fmpzi_poly_mulmid_classical_fft_small(fmpzi_struct * res,
+    const fmpzi_struct * poly1, slong len1,
+    const fmpzi_struct * poly2, slong len2,
+    slong nlo, slong nhi)
+{
+    return 0;
+}
+
+#endif

--- a/src/fmpzi/test/main.c
+++ b/src/fmpzi/test/main.c
@@ -12,6 +12,7 @@
 /* Include functions *********************************************************/
 
 #include "t-add_sub.c"
+#include "t-mulmid_classical_fft_small.c"
 #include "t-divexact.c"
 #include "t-divrem_approx.c"
 #include "t-divrem.c"
@@ -31,6 +32,7 @@
 test_struct tests[] =
 {
     TEST_FUNCTION(fmpzi_add_sub),
+    TEST_FUNCTION(fmpzi_poly_mulmid_classical_fft_small),
     TEST_FUNCTION(fmpzi_divexact),
     TEST_FUNCTION(fmpzi_divrem_approx),
     TEST_FUNCTION(fmpzi_divrem),

--- a/src/fmpzi/test/t-mulmid_classical_fft_small.c
+++ b/src/fmpzi/test/t-mulmid_classical_fft_small.c
@@ -1,0 +1,130 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "fmpz.h"
+#include "fmpzi.h"
+
+TEST_FUNCTION_START(fmpzi_poly_mulmid_classical_fft_small, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 30 * flint_test_multiplier(); iter++)
+    {
+        slong len1 = 1 + n_randint(state, 10);
+        slong len2 = 1 + n_randint(state, 10);
+        slong bits = 9000 + n_randint(state, 9000);
+        slong nlo, nhi, i, j;
+        int sq = (n_randint(state, 4) == 0);
+        int ok;
+        fmpzi_struct * a, * b, * r1, * r2;
+        fmpzi_t t, u;
+
+        if (sq)
+            len2 = len1;
+
+        nlo = n_randint(state, len1 + len2 - 1);
+        nhi = nlo + 1 + n_randint(state, len1 + len2 - 1 - nlo);
+
+        a = flint_malloc(len1 * sizeof(fmpzi_struct));
+        b = sq ? a : flint_malloc(len2 * sizeof(fmpzi_struct));
+        r1 = flint_malloc((nhi - nlo) * sizeof(fmpzi_struct));
+        r2 = flint_malloc((nhi - nlo) * sizeof(fmpzi_struct));
+        for (i = 0; i < len1; i++)
+            fmpzi_init(a + i);
+        if (!sq)
+            for (i = 0; i < len2; i++)
+                fmpzi_init(b + i);
+        for (i = 0; i < nhi - nlo; i++)
+        {
+            fmpzi_init(r1 + i);
+            fmpzi_init(r2 + i);
+        }
+        fmpzi_init(t);
+        fmpzi_init(u);
+
+        for (i = 0; i < len1; i++)
+        {
+            fmpz_randbits(fmpzi_realref(a + i), state, bits);
+            fmpz_randbits(fmpzi_imagref(a + i), state, bits);
+            if (n_randint(state, 2))
+                fmpz_neg(fmpzi_realref(a + i), fmpzi_realref(a + i));
+            if (n_randint(state, 2))
+                fmpz_neg(fmpzi_imagref(a + i), fmpzi_imagref(a + i));
+            if (n_randint(state, 8) == 0)
+                fmpz_zero(fmpzi_imagref(a + i));
+        }
+        if (!sq)
+            for (i = 0; i < len2; i++)
+            {
+                fmpz_randbits(fmpzi_realref(b + i), state, bits);
+                fmpz_randbits(fmpzi_imagref(b + i), state, bits);
+                if (n_randint(state, 2))
+                    fmpz_neg(fmpzi_realref(b + i),
+                             fmpzi_realref(b + i));
+                if (n_randint(state, 2))
+                    fmpz_neg(fmpzi_imagref(b + i),
+                             fmpzi_imagref(b + i));
+            }
+
+        /* either length order */
+        if (n_randint(state, 2))
+            ok = _fmpzi_poly_mulmid_classical_fft_small(r1, a, len1,
+                                                        b, len2,
+                                                        nlo, nhi);
+        else
+            ok = _fmpzi_poly_mulmid_classical_fft_small(r1, b, len2,
+                                                        a, len1,
+                                                        nlo, nhi);
+        if (!ok)
+            goto next;   /* gate or representation refusal: fallback */
+
+        /* schoolbook referee */
+        for (i = nlo; i < nhi; i++)
+        {
+            fmpzi_zero(r2 + i - nlo);
+            for (j = FLINT_MAX(0, i - len1 + 1);
+                 j <= FLINT_MIN(i, len2 - 1); j++)
+            {
+                fmpzi_mul(t, a + (i - j), b + j);
+                fmpzi_add(r2 + i - nlo, r2 + i - nlo, t);
+            }
+        }
+
+        for (i = 0; i < nhi - nlo; i++)
+            if (!fmpzi_equal(r1 + i, r2 + i))
+                TEST_FUNCTION_FAIL("len1 = %wd, len2 = %wd, "
+                    "bits = %wd, window [%wd, %wd), sq = %d, "
+                    "coeff %wd\n", len1, len2, bits, nlo, nhi, sq, i);
+
+next:
+        for (i = 0; i < len1; i++)
+            fmpzi_clear(a + i);
+        if (!sq)
+            for (i = 0; i < len2; i++)
+                fmpzi_clear(b + i);
+        for (i = 0; i < nhi - nlo; i++)
+        {
+            fmpzi_clear(r1 + i);
+            fmpzi_clear(r2 + i);
+        }
+        fmpzi_clear(t);
+        fmpzi_clear(u);
+        flint_free(a);
+        if (!sq)
+            flint_free(b);
+        flint_free(r1);
+        flint_free(r2);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/fmpzi/test/t-mulmid_classical_fft_small.c
+++ b/src/fmpzi/test/t-mulmid_classical_fft_small.c
@@ -126,5 +126,71 @@ next:
         flint_free(r2);
     }
 
+    /* deterministic coverage: a zero operand yields a zero window;
+       and a shared-pointer call with DIFFERENT lengths exercises the
+       squaring loop's unpaired terms (partners falling outside the
+       kept range) */
+#if FLINT_HAVE_FFT_SMALL
+    {
+        fmpzi_struct a[6], r[5];
+        slong i, j;
+        int ok;
+
+        for (i = 0; i < 6; i++)
+            fmpzi_init(a + i);
+        for (i = 0; i < 5; i++)
+            fmpzi_init(r + i);
+
+        for (i = 0; i < 6; i++)
+        {
+            fmpz_randbits(fmpzi_realref(a + i), state, 12000);
+            fmpz_randbits(fmpzi_imagref(a + i), state, 12000);
+        }
+
+        {
+            fmpzi_struct zb[2];
+            fmpzi_init(zb + 0);
+            fmpzi_init(zb + 1);
+            fmpz_one(fmpzi_realref(r + 0));
+            ok = _fmpzi_poly_mulmid_classical_fft_small(r, a, 6,
+                                                        zb, 2, 1, 4);
+            if (!ok || !fmpzi_is_zero(r + 0) || !fmpzi_is_zero(r + 1)
+                || !fmpzi_is_zero(r + 2))
+                TEST_FUNCTION_FAIL("fmpzi zero operand window\n");
+            fmpzi_clear(zb + 0);
+            fmpzi_clear(zb + 1);
+        }
+
+        ok = _fmpzi_poly_mulmid_classical_fft_small(r, a, 6, a, 3,
+                                                    2, 7);
+        if (ok)
+        {
+            fmpzi_t t, s;
+            fmpzi_init(t);
+            fmpzi_init(s);
+            for (i = 2; i < 7; i++)
+            {
+                fmpzi_zero(s);
+                for (j = FLINT_MAX(0, i - 5); j <= FLINT_MIN(i, 2);
+                     j++)
+                {
+                    fmpzi_mul(t, a + (i - j), a + j);
+                    fmpzi_add(s, s, t);
+                }
+                if (!fmpzi_equal(r + i - 2, s))
+                    TEST_FUNCTION_FAIL("shared unequal lengths: "
+                        "coeff %wd\n", i);
+            }
+            fmpzi_clear(t);
+            fmpzi_clear(s);
+        }
+
+        for (i = 0; i < 6; i++)
+            fmpzi_clear(a + i);
+        for (i = 0; i < 5; i++)
+            fmpzi_clear(r + i);
+    }
+#endif
+
     TEST_FUNCTION_END(state);
 }

--- a/src/gr/transformed_mpn.c
+++ b/src/gr/transformed_mpn.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
 
     This file is part of FLINT.
 
@@ -77,6 +78,16 @@ typedef struct
     ulong depth;
     int sign;                       /* 0 or 1: (-1)^sign */
     int negs;                       /* chunk values may be signed */
+    slong small;                    /* small side value: the element
+                                       represents (-1)^sign * T + small,
+                                       with T = 0 when nchunks == 0.
+                                       Coefficients 0 and +-1 are held
+                                       here without any transform, and
+                                       products of such coefficients
+                                       accumulate here as integer
+                                       additions, folded into the
+                                       reconstruction at conversion
+                                       out. */
 } tmpn_struct;
 
 #define TMPN_CTX(ctx) ((tmpn_ctx_struct *) GR_CTX_DATA_AS_PTR(ctx))
@@ -132,6 +143,7 @@ tmpn_init(gr_ptr x, gr_ctx_t ctx)
 {
     fft_small_op_init(&TMPN(x)->op, TMPN_CTX(ctx)->P);
     TMPN(x)->nchunks = 0;
+    TMPN(x)->small = 0;
     TMPN(x)->terms = 0;
     TMPN(x)->depth = 0;
     TMPN(x)->sign = 0;
@@ -146,6 +158,7 @@ gr_transformed_mpn_init_borrowed(gr_ptr x, double * data, gr_ctx_t ctx)
 {
     fft_small_op_init_borrowed(&TMPN(x)->op, TMPN_CTX(ctx)->P, data);
     TMPN(x)->nchunks = 0;
+    TMPN(x)->small = 0;
     TMPN(x)->terms = 0;
     TMPN(x)->depth = 0;
     TMPN(x)->sign = 0;
@@ -247,6 +260,7 @@ tmpn_zero(gr_ptr x, gr_ctx_t FLINT_UNUSED(ctx))
     TMPN(x)->depth = 0;
     TMPN(x)->sign = 0;
     TMPN(x)->negs = 0;
+    TMPN(x)->small = 0;
     return GR_SUCCESS;
 }
 
@@ -268,20 +282,23 @@ tmpn_set(gr_ptr res, gr_srcptr x, gr_ctx_t ctx)
     TMPN(res)->depth = TMPN(x)->depth;
     TMPN(res)->sign = TMPN(x)->sign;
     TMPN(res)->negs = TMPN(x)->negs;
+    TMPN(res)->small = TMPN(x)->small;
     return GR_SUCCESS;
 }
 
 static truth_t
 tmpn_is_zero(gr_srcptr x, gr_ctx_t FLINT_UNUSED(ctx))
 {
-    return (TMPN(x)->nchunks == 0) ? T_TRUE : T_UNKNOWN;
+    if (TMPN(x)->nchunks == 0)
+        return (TMPN(x)->small == 0) ? T_TRUE : T_FALSE;
+    return T_UNKNOWN;
 }
 
 static truth_t
 tmpn_equal(gr_srcptr x, gr_srcptr y, gr_ctx_t FLINT_UNUSED(ctx))
 {
     if (TMPN(x)->nchunks == 0 && TMPN(y)->nchunks == 0)
-        return T_TRUE;
+        return (TMPN(x)->small == TMPN(y)->small) ? T_TRUE : T_FALSE;
     return T_UNKNOWN;
 }
 
@@ -289,12 +306,14 @@ static int
 tmpn_neg(gr_ptr res, gr_srcptr x, gr_ctx_t ctx)
 {
     int status = tmpn_set(res, x, ctx);
-    if (status == GR_SUCCESS && TMPN(res)->nchunks > 0)
-    {
-        if (!TMPN_CTX(ctx)->is_signed)
-            return GR_UNABLE;
+    if (status != GR_SUCCESS)
+        return status;
+    if (!TMPN_CTX(ctx)->is_signed
+        && (TMPN(res)->nchunks > 0 || TMPN(res)->small > 0))
+        return GR_UNABLE;
+    if (TMPN(res)->nchunks > 0)
         TMPN(res)->sign ^= 1;
-    }
+    TMPN(res)->small = -TMPN(res)->small;
     return status;
 }
 
@@ -313,6 +332,17 @@ gr_transformed_mpn_set(gr_ptr res, nn_srcptr a, slong an, int sign,
 
     if (sign && !T->is_signed)
         return GR_DOMAIN;
+
+    if (an == 1 && a[0] == 1)
+    {
+        /* the coefficient stays in the small side: conversion costs
+           nothing, and pointwise operations against it degenerate to
+           additions or integer bookkeeping */
+        tmpn_zero(res, ctx);
+        TMPN(res)->small = sign ? -1 : 1;
+        TMPN(res)->terms = 1;
+        return GR_SUCCESS;
+    }
     if ((ulong) an * FLINT_BITS > (ulong) T->zcap * T->P->bits)
         return GR_DOMAIN;
 
@@ -322,6 +352,7 @@ gr_transformed_mpn_set(gr_ptr res, nn_srcptr a, slong an, int sign,
     TMPN(res)->depth = 1;
     TMPN(res)->sign = sign ? 1 : 0;
     TMPN(res)->negs = 0;
+    TMPN(res)->small = 0;
     return GR_SUCCESS;
 }
 
@@ -380,8 +411,18 @@ _tmpn_get(nn_ptr z, slong zn, slong * zn_out, int * sign,
 
     if (m == 0)
     {
-        *zn_out = 0;
-        *sign = 0;
+        slong sv = TMPN(x)->small;
+        if (sv == 0)
+        {
+            *zn_out = 0;
+            *sign = 0;
+            return GR_SUCCESS;
+        }
+        if (zn < 1)
+            return GR_DOMAIN;
+        z[0] = (ulong) FLINT_ABS(sv);
+        *zn_out = 1;
+        *sign = sv < 0;
         return GR_SUCCESS;
     }
 
@@ -448,6 +489,47 @@ _tmpn_get(nn_ptr z, slong zn, slong * zn_out, int * sign,
     i = need;
     while (i > 0 && z[i - 1] == 0)
         i--;
+
+    /* fold the small side value in: the element represents
+       (-1)^sign * T + small, and the export just produced T */
+    if (TMPN(x)->small != 0)
+    {
+        slong sv = TMPN(x)->small;
+        ulong av = (ulong) FLINT_ABS(sv);
+        int ssign = sv < 0;
+
+        if (i == 0)
+        {
+            z[0] = av;
+            i = 1;
+            *sign = ssign;
+        }
+        else if (*sign == ssign)
+        {
+            /* the export bound's terms headroom guarantees room:
+               |T| + terms_bound < 2^(64 need) */
+            ulong cy = mpn_add_1(z, z, i, av);
+            if (cy != 0)
+            {
+                FLINT_ASSERT(i < need);
+                z[i++] = cy;
+            }
+        }
+        else if (i > 1 || z[0] > av)
+        {
+            mpn_sub_1(z, z, i, av);
+            while (i > 0 && z[i - 1] == 0)
+                i--;
+        }
+        else
+        {
+            /* |T| <= |small|: the sign crosses */
+            z[0] = av - z[0];
+            i = (z[0] != 0);
+            *sign = ssign;
+        }
+    }
+
     *zn_out = i;
     if (i == 0)
         *sign = 0;
@@ -563,18 +645,43 @@ _tmpn_addsub(gr_ptr res, gr_srcptr x, gr_srcptr y, int ysign_flip,
     ulong terms;
 
     if (TMPN(y)->nchunks == 0)
-        return tmpn_set(res, x, ctx);
+    {
+        /* y is a pure small value */
+        slong sy_small = ysign_flip ? -TMPN(y)->small : TMPN(y)->small;
+        ulong t = TMPN(x)->terms + TMPN(y)->terms;
+        int status;
+        if (t < TMPN(x)->terms || t > T->terms_bound)
+            return GR_UNABLE;
+        status = tmpn_set(res, x, ctx);
+        if (status != GR_SUCCESS)
+            return status;
+        TMPN(res)->small += sy_small;
+        TMPN(res)->terms = t;
+        if (!T->is_signed && TMPN(res)->nchunks == 0
+            && TMPN(res)->small < 0)
+            return GR_UNABLE;
+        return GR_SUCCESS;
+    }
     if (TMPN(x)->nchunks == 0)
     {
-        int status = tmpn_set(res, y, ctx);
-        if (status == GR_SUCCESS && (TMPN(res)->sign ^ ysign_flip) !=
-                TMPN(res)->sign)
+        ulong t = TMPN(x)->terms + TMPN(y)->terms;
+        int status;
+        slong sx_small = TMPN(x)->small;
+        if (t < TMPN(x)->terms || t > T->terms_bound)
+            return GR_UNABLE;
+        status = tmpn_set(res, y, ctx);
+        if (status != GR_SUCCESS)
+            return status;
+        if (ysign_flip)
         {
             if (!T->is_signed)
                 return GR_UNABLE;
-            TMPN(res)->sign ^= ysign_flip;
+            TMPN(res)->sign ^= 1;
+            TMPN(res)->small = -TMPN(res)->small;
         }
-        return status;
+        TMPN(res)->small += sx_small;
+        TMPN(res)->terms = t;
+        return GR_SUCCESS;
     }
 
     terms = TMPN(x)->terms + TMPN(y)->terms;
@@ -602,6 +709,8 @@ _tmpn_addsub(gr_ptr res, gr_srcptr x, gr_srcptr y, int ysign_flip,
     TMPN(res)->nchunks = FLINT_MAX(TMPN(x)->nchunks, TMPN(y)->nchunks);
     TMPN(res)->terms = terms;
     TMPN(res)->depth = FLINT_MAX(TMPN(x)->depth, TMPN(y)->depth);
+    TMPN(res)->small = TMPN(x)->small
+        + (ysign_flip ? -TMPN(y)->small : TMPN(y)->small);
     return GR_SUCCESS;
 }
 
@@ -641,7 +750,41 @@ tmpn_mul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
     ulong terms;
 
     if (TMPN(x)->nchunks == 0 || TMPN(y)->nchunks == 0)
-        return tmpn_zero(res, ctx);
+    {
+        /* a pure small factor: zero annihilates; +-1 copies the other
+           operand with a sign adjustment; larger smalls (sums of
+           trivial coefficients) are left to the caller */
+        gr_srcptr sm = (TMPN(x)->nchunks == 0) ? x : y;
+        gr_srcptr ot = (sm == x) ? y : x;
+        slong sv = TMPN(sm)->small;
+        int status;
+
+        if (sv == 0)
+            return tmpn_zero(res, ctx);
+        if (sv != 1 && sv != -1)
+            return GR_UNABLE;
+        if (!_tmpn_mul_terms(&terms, TMPN(x), TMPN(y), T->terms_bound))
+            return GR_UNABLE;
+        status = tmpn_set(res, ot, ctx);
+        if (status != GR_SUCCESS)
+            return status;
+        if (sv == -1)
+        {
+            if (!T->is_signed)
+                return GR_UNABLE;
+            if (TMPN(res)->nchunks > 0)
+                TMPN(res)->sign ^= 1;
+            TMPN(res)->small = -TMPN(res)->small;
+        }
+        TMPN(res)->terms = terms;
+        return GR_SUCCESS;
+    }
+
+    /* a transformed operand carrying a small side value cannot enter a
+       pointwise product without materializing it; the drivers only
+       multiply freshly converted operands, whose small side is zero */
+    if (TMPN(x)->small != 0 || TMPN(y)->small != 0)
+        return GR_UNABLE;
 
     m = TMPN(x)->nchunks + TMPN(y)->nchunks - 1;
     if (m > T->zcap ||
@@ -658,6 +801,7 @@ tmpn_mul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
     TMPN(res)->depth = TMPN(x)->depth + TMPN(y)->depth;
     TMPN(res)->sign = TMPN(x)->sign ^ TMPN(y)->sign;
     TMPN(res)->negs = TMPN(x)->negs | TMPN(y)->negs;
+    TMPN(res)->small = 0;
     return GR_SUCCESS;
 }
 
@@ -670,8 +814,43 @@ _tmpn_addsubmul(gr_ptr res, gr_srcptr x, gr_srcptr y, int subflip,
     slong m;
     ulong terms, t2;
 
+    if ((TMPN(x)->nchunks == 0 && TMPN(x)->small == 0)
+        || (TMPN(y)->nchunks == 0 && TMPN(y)->small == 0))
+        return GR_SUCCESS;   /* a zero factor: nothing to accumulate */
+
     if (TMPN(x)->nchunks == 0 || TMPN(y)->nchunks == 0)
-        return GR_SUCCESS;
+    {
+        /* a pure small +-1 factor: the accumulated product is the
+           other operand up to sign, so the pointwise multiplication
+           becomes an addition or subtraction (or pure integer
+           bookkeeping when the other operand is small too) */
+        gr_srcptr sm = (TMPN(x)->nchunks == 0) ? x : y;
+        gr_srcptr ot = (sm == x) ? y : x;
+        slong sv = TMPN(sm)->small;
+        int psub;
+
+        if (sv != 1 && sv != -1)
+            return GR_UNABLE;
+        psub = subflip ^ (sv < 0);
+        if (TMPN(ot)->nchunks == 0)
+        {
+            ulong t = TMPN(res)->terms + TMPN(ot)->terms;
+            if (t < TMPN(res)->terms || t > T->terms_bound)
+                return GR_UNABLE;
+            TMPN(res)->small += psub ? -TMPN(ot)->small
+                                     : TMPN(ot)->small;
+            TMPN(res)->terms = t;
+            if (!T->is_signed && TMPN(res)->nchunks == 0
+                && TMPN(res)->small < 0)
+                return GR_UNABLE;
+            return GR_SUCCESS;
+        }
+        return psub ? tmpn_sub(res, res, ot, ctx)
+                    : tmpn_add(res, res, ot, ctx);
+    }
+
+    if (TMPN(x)->small != 0 || TMPN(y)->small != 0)
+        return GR_UNABLE;
 
     /* with res aliasing an operand, the per-call domain bookkeeping
        below cannot mark the same struct as both input and accumulator;
@@ -691,12 +870,32 @@ _tmpn_addsubmul(gr_ptr res, gr_srcptr x, gr_srcptr y, int subflip,
 
     if (TMPN(res)->nchunks == 0)
     {
+        /* the accumulator has no transform data, but it may hold an
+           accumulated small side value, which must survive the
+           product being written over it */
+        slong rs = TMPN(res)->small;
+        ulong rt = TMPN(res)->terms;
         int status = tmpn_mul(res, x, y, ctx);
-        if (status == GR_SUCCESS && subflip && TMPN(res)->nchunks > 0)
+        if (status != GR_SUCCESS)
+            return status;
+        if (subflip)
         {
             if (!T->is_signed)
                 return GR_UNABLE;
-            TMPN(res)->sign ^= 1;
+            if (TMPN(res)->nchunks > 0)
+                TMPN(res)->sign ^= 1;
+            TMPN(res)->small = -TMPN(res)->small;
+        }
+        if (rs != 0)
+        {
+            ulong t = rt + TMPN(res)->terms;
+            if (t < rt || t > T->terms_bound)
+                return GR_UNABLE;
+            TMPN(res)->small += rs;
+            TMPN(res)->terms = t;
+            if (!T->is_signed && TMPN(res)->nchunks == 0
+                && TMPN(res)->small < 0)
+                return GR_UNABLE;
         }
         return status;
     }


### PR DESCRIPTION
Adds `_fmpz_poly_mulmid_classical_fft_small` and `_fmpzi_poly_mulmid_classical_fft_small` for short products with huge entries: inputs are transformed, schoolbook multiplication is done in the transformed representation, and the output is transformed back. This can yield up to a ~2x speedup over currently used algorithms, and more than this if the current algorithm selection is poor.

Also optimizes the transformed mpn representation to special-case coefficients +/-1 and 0 so that this isn't unnecessarily inefficient for short even/odd polynomials, monic polynomials, etc.

Done with Claude Fable 5.

Not yet integrated by default in `fmpz_poly_mul`/`fmpz_poly_mulmid` and the `fmpzi` polynomial multiplication wrapper; I'll probably delay that until there is competing Toom-Cook code to compare with too.

Timings vs `fmpz_poly_mul`/`fmpz_poly_mullow`/`fmpz_poly_mulmid` ("default"); "full" means full n x n -> 2n-1 product, "mullow" means n x n -> n, and "mulmid" means standard 2n x n -> 2n mulmid window.

```
                    full                        mullow                         mulmid

     bits n    default  fft      speedup    default    fft    speedup    default    fft    speedup

   10000  2 | 1.47e-05 2.02e-05  0.728x  | 1.48e-05 2.02e-05  0.733x  | 2.01e-05  3.3e-05  0.609x
   10000  3 |  3.1e-05 2.92e-05  1.062x  |  3.1e-05  2.9e-05  1.069x  |  4.5e-05  3.3e-05  1.364x
   10000  4 |    5e-05  4.7e-05  1.064x  |    5e-05  5.1e-05  0.980x  |  8.1e-05  5.8e-05  1.397x
   10000  6 | 0.000107  6.2e-05  1.726x  | 0.000106  6.2e-05  1.710x  | 0.000116    9e-05  1.289x
   10000  9 | 0.000143 0.000112  1.277x  | 0.000144 0.000112  1.286x  | 0.000185 0.000127  1.457x
   10000 13 | 0.000194 0.000165  1.176x  | 0.000195 0.000167  1.168x  |  0.00027 0.000205  1.317x
   10000 19 |  0.00029 0.000271  1.070x  | 0.000292 0.000272  1.074x  |   0.0004  0.00036  1.111x
   10000 28 |  0.00044  0.00045  0.978x  |  0.00043  0.00045  0.956x  |  0.00063  0.00067  0.940x
   10000 42 |   0.0007  0.00079  0.886x  |   0.0007   0.0008  0.875x  |    0.001  0.00126  0.794x
   10000 63 |  0.00111  0.00148  0.750x  |  0.00111  0.00149  0.745x  |   0.0015  0.00241  0.622x
   10000 94 |  0.00161  0.00287  0.561x  |  0.00162  0.00288  0.562x  |  0.00235   0.0049  0.480x

  100000  2 | 0.000257 0.000185  1.389x  | 0.000255 0.000181  1.409x  |  0.00034  0.00029  1.172x
  100000  3 |  0.00055 0.000273  2.015x  |  0.00054 0.000271  1.993x  |  0.00083  0.00034  2.441x
  100000  4 |  0.00093  0.00038  2.447x  |  0.00093  0.00038  2.447x  |  0.00152  0.00058  2.621x
  100000  6 |  0.00198  0.00066  3.000x  |  0.00199  0.00067  2.970x  |  0.00138  0.00086  1.605x
  100000  9 |  0.00155  0.00103  1.505x  |  0.00155  0.00103  1.505x  |  0.00219  0.00131  1.672x
  100000 13 |  0.00237  0.00164  1.445x  |  0.00233  0.00162  1.438x  |   0.0032  0.00209  1.531x
  100000 19 |   0.0034  0.00255  1.333x  |   0.0034  0.00255  1.333x  |   0.0053   0.0036  1.472x
  100000 28 |   0.0057   0.0042  1.357x  |   0.0056   0.0043  1.302x  |   0.0079   0.0066  1.197x
  100000 42 |   0.0085   0.0079  1.076x  |   0.0085   0.0077  1.104x  |    0.013   0.0116  1.121x
  100000 63 |    0.014   0.0138  1.014x  |   0.0139   0.0141  0.986x  |    0.031   0.0252  1.230x
  100000 94 |   0.0213     0.03  0.710x  |   0.0212   0.0302  0.702x  |    0.047    0.059  0.797x

 1000000  2 |    0.003  0.00197  1.523x  |  0.00292    0.002  1.460x  |   0.0039  0.00248  1.573x
 1000000  3 |    0.006   0.0032  1.875x  |   0.0059   0.0032  1.844x  |   0.0088   0.0038  2.316x
 1000000  4 |     0.01   0.0049  2.041x  |   0.0099   0.0049  2.020x  |   0.0157   0.0059  2.661x
 1000000  6 |   0.0207   0.0073  2.836x  |   0.0206   0.0078  2.641x  |   0.0176   0.0092  1.913x
 1000000  9 |   0.0193   0.0125  1.544x  |   0.0192   0.0125  1.536x  |     0.03   0.0159  1.887x
 1000000 13 |    0.031   0.0197  1.574x  |     0.03   0.0197  1.523x  |    0.064   0.0294  2.177x
 1000000 19 |    0.049    0.038  1.289x  |    0.046    0.035  1.314x  |    0.101    0.051  1.980x
 1000000 28 |    0.073     0.06  1.217x  |    0.073    0.058  1.259x  |    0.141    0.089  1.584x
 1000000 42 |    0.111     0.11  1.009x  |    0.114    0.111  1.027x  |    0.258    0.182  1.418x
 1000000 63 |    0.176    0.205  0.859x  |    0.187    0.215  0.870x  |    0.361    0.357  1.011x
 1000000 94 |    0.291    0.441  0.660x  |    0.293    0.434  0.675x  |     0.56    0.752  0.745x

10000000  2 |    0.039    0.035  1.114x  |    0.037    0.029  1.276x  |     0.05    0.043  1.163x
10000000  3 |    0.076    0.048  1.583x  |    0.075    0.042  1.786x  |    0.112    0.056  2.000x
10000000  4 |    0.129    0.071  1.817x  |    0.128    0.073  1.753x  |    0.198     0.08  2.475x
10000000  6 |    0.263    0.123  2.138x  |    0.261    0.124  2.105x  |    0.243    0.154  1.578x
10000000  9 |    0.288    0.205  1.405x  |    0.284     0.21  1.352x  |      0.4    0.236  1.695x
10000000 13 |     0.42    0.318  1.321x  |    0.413    0.326  1.267x  |    0.748    0.398  1.879x
10000000 19 |    0.618    0.498  1.241x  |    0.625    0.511  1.223x  |    1.167    0.667  1.750x
10000000 28 |    0.933    0.838  1.113x  |    0.938    0.808  1.161x  |    1.912    1.223  1.563x
10000000 42 |    1.669    1.478  1.129x  |     1.68    1.499  1.121x  |    2.898    2.124  1.364x
10000000 63 |    2.554    2.603  0.981x  |    2.534    2.651  0.956x  |    5.228    3.918  1.334x
10000000 94 |    4.892     5.09  0.961x  |     4.86    5.051  0.962x  |    8.482    7.879  1.077x
```

Timings for `fmpzi` polynomial multiplication vs the current `gr_poly_mulmid`:

```
                    full                        mullow                         mulmid

     bits n    default  fft      speedup    default    fft    speedup    default    fft    speedup

   10000  2 |  4.3e-05  4.7e-05  0.915x  |  4.3e-05  4.7e-05  0.915x  |  5.8e-05  6.1e-05  0.951x
   10000  3 |  8.7e-05  6.5e-05  1.338x  |  8.8e-05  6.5e-05  1.354x  | 0.000132  9.4e-05  1.404x
   10000  4 | 0.000149 0.000103  1.447x  |  0.00015 0.000104  1.442x  | 0.000245 0.000103  2.379x
   10000  6 |  0.00032 0.000171  1.871x  |  0.00033 0.000173  1.908x  |  0.00055 0.000196  2.806x
   10000  9 |  0.00068 0.000286  2.378x  |  0.00069 0.000285  2.421x  |  0.00124  0.00038  3.263x
   10000 13 |  0.00141  0.00047  3.000x  |   0.0014  0.00046  3.043x  |  0.00259  0.00061  4.246x
   10000 19 |   0.0031  0.00085  3.647x  |    0.003  0.00081  3.704x  |   0.0056  0.00115  4.870x
   10000 28 |   0.0063  0.00138  4.565x  |   0.0063  0.00137  4.599x  |    0.012  0.00205  5.854x
   10000 42 |  0.00286  0.00264  1.083x  |  0.00286  0.00268  1.067x  |   0.0043   0.0039  1.103x
   10000 63 |   0.0046   0.0046  1.000x  |   0.0045   0.0045  1.000x  |   0.0062   0.0079  0.785x
   10000 94 |   0.0065   0.0092  0.707x  |   0.0064   0.0092  0.696x  |   0.0095   0.0167  0.569x

  100000  2 |  0.00064   0.0004  1.600x  |  0.00064   0.0004  1.600x  |  0.00092  0.00053  1.736x
  100000  3 |  0.00139  0.00075  1.853x  |  0.00151  0.00075  2.013x  |  0.00232  0.00079  2.937x
  100000  4 |  0.00238  0.00096  2.479x  |  0.00238    0.001  2.380x  |   0.0041  0.00113  3.628x
  100000  6 |   0.0052  0.00164  3.171x  |   0.0051  0.00164  3.110x  |   0.0092  0.00198  4.646x
  100000  9 |   0.0111   0.0025  4.440x  |   0.0111  0.00251  4.422x  |   0.0208   0.0034  6.118x
  100000 13 |   0.0228   0.0042  5.429x  |    0.023   0.0042  5.476x  |    0.043   0.0058  7.414x
  100000 19 |    0.048   0.0069  6.957x  |    0.048   0.0069  6.957x  |    0.092   0.0102  9.020x
  100000 28 |    0.101   0.0119  8.487x  |    0.102   0.0128  7.969x  |    0.206   0.0201  10.249x
  100000 42 |    0.043   0.0247  1.741x  |    0.037   0.0242  1.529x  |    0.064    0.044  1.455x
  100000 63 |    0.057    0.054  1.056x  |    0.059    0.051  1.157x  |    0.092    0.102  0.902x
  100000 94 |    0.089    0.114  0.781x  |    0.088    0.108  0.815x  |    0.141    0.218  0.647x

 1000000  2 |   0.0076    0.005  1.520x  |   0.0087   0.0049  1.776x  |     0.01   0.0059  1.695x
 1000000  3 |   0.0154   0.0082  1.878x  |   0.0152   0.0082  1.854x  |   0.0237   0.0099  2.394x
 1000000  4 |   0.0262   0.0126  2.079x  |    0.026   0.0126  2.063x  |     0.04   0.0134  2.985x
 1000000  6 |    0.056   0.0186  3.011x  |    0.056   0.0183  3.060x  |    0.094   0.0257  3.658x
 1000000  9 |    0.115     0.03  3.833x  |    0.112    0.031  3.613x  |    0.211    0.045  4.689x
 1000000 13 |    0.237    0.058  4.086x  |    0.235    0.052  4.519x  |    0.439    0.078  5.628x
 1000000 19 |    0.488    0.097  5.031x  |    0.495    0.106  4.670x  |    0.936     0.15  6.240x
 1000000 28 |    1.073    0.181  5.928x  |    1.075    0.187  5.749x  |    2.024    0.276  7.333x
 1000000 42 |    0.493    0.323  1.526x  |    0.448    0.316  1.418x  |      0.8    0.545  1.468x
 1000000 63 |    0.759    0.659  1.152x  |    0.734    0.669  1.097x  |    1.198     1.13  1.060x
 1000000 94 |    1.165    1.331  0.875x  |    1.153    1.313  0.878x  |    1.836    2.397  0.766x

10000000  2 |     0.11     0.08  1.375x  |    0.104    0.069  1.507x  |    0.139    0.086  1.616x
10000000  3 |    0.213    0.124  1.718x  |    0.208    0.133  1.564x  |    0.318    0.166  1.916x
10000000  4 |    0.351    0.179  1.961x  |    0.347    0.183  1.896x  |    0.564    0.231  2.442x
10000000  6 |    0.753    0.304  2.477x  |     0.75    0.303  2.475x  |    1.267    0.407  3.113x
10000000  9 |    1.597    0.531  3.008x  |    1.613    0.535  3.015x  |    2.779    0.715  3.887x
10000000 13 |    3.219    0.869  3.704x  |     3.22    0.873  3.688x  |    5.932    1.254  4.730x
10000000 19 |    6.572    1.457  4.511x  |    6.616    1.497  4.420x  |    12.58    2.272  5.537x
10000000 28 |   14.322    2.512  5.701x  |   13.944    2.544  5.481x  |   26.671    3.967  6.723x
10000000 42 |    6.997    4.782  1.463x  |    6.553    4.789  1.368x  |   10.007    7.973  1.255x
10000000 63 |   10.356    9.826  1.054x  |    10.14   10.232  0.991x  |   19.332   17.256  1.120x
10000000 94 |   19.635   19.426  1.011x  |   19.409   19.412  1.000x  |   33.474   36.634  0.914x
```