### PR TITLE
Faster modular exponentiation of integers

### DIFF
--- a/doc/source/mpn_extras.rst
+++ b/doc/source/mpn_extras.rst
@@ -486,7 +486,9 @@ Montgomery reduction and modular exponentiation
     from :func:`flint_mpn_mulhigh_n`, whose rounding is resolved in
     constant time by comparing the returned guard limb against the top
     limb of the exactly known low half `B^n - X_{lo}`; see the source
-    for the argument and [KimZim2024]_ for sharper error bounds.
+    for the argument, [Mul2000]_ and [HanZim2004b]_ for the analysis
+    of short products, and [DEGR2024]_ for truncated multiplication
+    in the Montgomery setting.
 
 .. function:: void flint_mpn_powm_preinvn(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en, nn_srcptr m, mp_size_t mn, nn_srcptr dinv, flint_bitcnt_t norm)
 

--- a/doc/source/mpn_extras.rst
+++ b/doc/source/mpn_extras.rst
@@ -449,6 +449,95 @@ Division and modular arithmetic with precomputed inverses
     provided by ``flint_mpn_preinvn``, computes `a_1 b_1 + a_2 b_2 \pmod{d}`. We require
     all operands to be reduced modulo `d`.
 
+Montgomery reduction and modular exponentiation
+--------------------------------------------------------------------------------
+
+.. function:: mp_size_t flint_mpn_mulmod_bnm1_next_size(mp_size_t n)
+              mp_size_t flint_mpn_mulmod_bnm1_itch(mp_size_t rn)
+              void flint_mpn_mulmod_bnm1(nn_ptr rp, mp_size_t rn, nn_srcptr ap, mp_size_t an, nn_srcptr bp, mp_size_t bn, nn_ptr tp)
+
+    Sets `r` to a representative below `B^{rn}` of `a b \bmod
+    (B^{rn} - 1)`, for ``rn`` obtained from ``next_size`` and operands
+    of at most ``rn`` limbs, using ``itch(rn)`` limbs of scratch space.
+    No aliasing is permitted.
+
+    For even ``rn`` the computation splits by CRT into products modulo
+    `B^{h} - 1` (recursively) and `B^{h} + 1`
+    (:func:`flint_mpn_mulmod_2expp1_basecase`) with `h = rn/2`,
+    stopping at odd or small sizes with a plain multiplication; the
+    cost is about `0.6` multiplications of size ``rn``.
+
+
+.. function:: void _flint_mpn_binvert(nn_ptr v, nn_srcptr m, mp_size_t n)
+
+    Sets `v = m^{-1} \bmod B^n` for odd `m` of `n` limbs, by Hensel
+    lifting. No aliasing is permitted.
+
+.. function:: void _flint_mpn_redc_n(nn_ptr t, nn_srcptr X, nn_srcptr m, nn_srcptr minv, mp_size_t n, nn_ptr scratch)
+
+    Montgomery reduction: sets `t = X B^{-n} \bmod m`, canonical in
+    `[0, m)`, for odd `m` of `n` limbs and `0 \le X < m B^n` (`2n` limbs),
+    where ``minv`` is `-m^{-1} \bmod B^n` (the negation of the output of
+    :func:`_flint_mpn_binvert`). Requires `2n` limbs of scratch space.
+    `t` must not alias `X`, `m` or ``minv``; `X` is preserved.
+
+    With `q = X_{lo} \cdot minv \bmod B^n` one has `X + q m = t B^n`
+    exactly. The high product `\lfloor q m / B^n \rfloor` is obtained
+    from :func:`flint_mpn_mulhigh_n`, whose rounding is resolved in
+    constant time by comparing the returned guard limb against the top
+    limb of the exactly known low half `B^n - X_{lo}`; see the source
+    for the argument and [KimZim2024]_ for sharper error bounds.
+
+.. function:: void flint_mpn_powm_preinvn(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en, nn_srcptr m, mp_size_t mn, nn_srcptr dinv, flint_bitcnt_t norm)
+
+    As :func:`flint_mpn_powm`, taking the precomputed inverse ``dinv``
+    of `m 2^{norm}` from :func:`flint_mpn_preinvn` with
+    ``norm = clz(m[mn-1])``, as stored for instance in an
+    ``fmpz_preinvn_t``. Exponents of at most a few dozen bits are
+    computed on the supplied inverse with no per-call precomputation,
+    which is several times faster than ``mpz_powm`` for exponents like
+    `2` or `3`; larger exponents fall through to the Montgomery
+    machinery of :func:`flint_mpn_powm`, whose setup then amortizes.
+
+.. function:: void flint_mpn_powm(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en, nn_srcptr m, mp_size_t mn)
+
+    Sets `r = b^e \bmod m`. The modulus `m` has ``mn`` limbs and must be
+    normalised (nonzero top limb); `b` must be reduced modulo `m` and
+    occupies ``mn`` limbs; the exponent `e` has ``en`` limbs (``en`` may
+    be zero, denoting `e = 0`, in which case `r = 1 \bmod m`). No
+    aliasing of `r` with the inputs is permitted.
+
+    Even moduli are handled by CRT between the odd part and the power
+    of two; the odd part is computed by the *redc* stage below. Single-limb moduli
+    use plain ``nmod`` arithmetic.
+
+.. function:: void _flint_mpn_powm_basecase(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en, nn_srcptr m, mp_size_t mn)
+              void _flint_mpn_powm_redc(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en, nn_srcptr m, mp_size_t mn)
+
+    Stage implementations of :func:`flint_mpn_powm`, requiring `m > 1`
+    normalised, `b < m` and `e` nonzero with nonzero top limb. Both use
+    sliding window exponentiation with single-limb bases handled by
+    scalar window multipliers and `O(n)` reductions.
+
+    The *basecase* version works on residues shifted left by the norm
+    of `m` via :func:`flint_mpn_mulmod_preinvn` and accepts any `m > 1`.
+
+    The *redc* version requires `m` odd and uses Montgomery
+    multiplication. Below a threshold the reduction is
+    :func:`_flint_mpn_redc_n`. Above it (with ``FLINT_HAVE_FFT_SMALL``),
+    the reduction follows the structure of GMP's ``redc_n``: since the
+    low half of `q m` is exactly `B^{mn} - X_{lo}`, the high half
+    `H < m` is recovered from the wraparound product
+    `q m \bmod (B^{nnc} - 1)`, computed as a cyclic convolution against
+    a cached transform of `m` (see
+    :func:`fft_small_plan_init_mpn_cyclic`) followed by a limb
+    rotation. At still larger sizes the quotient
+    `q = X_{lo} \cdot (-m^{-1}) \bmod B^{mn}` also runs in the
+    transform domain against a cached transform of the inverse. The
+    Montgomery radix stays `B^{mn}` throughout, so the multiplications
+    themselves are unpadded calls to ``flint_mpn_sqr``,
+    ``flint_mpn_mul_n`` and ``flint_mpn_mullow_n``.
+
 Preconditioned modular multiplication
 --------------------------------------------------------------------------------
 

--- a/doc/source/mpn_extras.rst
+++ b/doc/source/mpn_extras.rst
@@ -467,7 +467,6 @@ Montgomery reduction and modular exponentiation
     stopping at odd or small sizes with a plain multiplication; the
     cost is about `0.6` multiplications of size ``rn``.
 
-
 .. function:: void _flint_mpn_binvert(nn_ptr v, nn_srcptr m, mp_size_t n)
 
     Sets `v = m^{-1} \bmod B^n` for odd `m` of `n` limbs, by Hensel
@@ -495,11 +494,15 @@ Montgomery reduction and modular exponentiation
     As :func:`flint_mpn_powm`, taking the precomputed inverse ``dinv``
     of `m 2^{norm}` from :func:`flint_mpn_preinvn` with
     ``norm = clz(m[mn-1])``, as stored for instance in an
-    ``fmpz_preinvn_t``. Exponents of at most a few dozen bits are
-    computed on the supplied inverse with no per-call precomputation,
-    which is several times faster than ``mpz_powm`` for exponents like
-    `2` or `3`; larger exponents fall through to the Montgomery
-    machinery of :func:`flint_mpn_powm`, whose setup then amortizes.
+    ``fmpz_preinvn_t``. Both entry points share a single dispatcher, so
+    this one differs only in having an inverse to hand: exponents small
+    enough that the division-based basecase wins are run on the supplied
+    inverse with no per-call precomputation, and `2`, `3` and `4` skip
+    the sliding-window bookkeeping entirely. The cutoff tracks the point
+    where :func:`flint_mpn_powm` hands a small modulus to ``mpz_powm``,
+    since past that there is nothing for the inverse to save. Larger
+    exponents fall through to the Montgomery machinery, whose setup then
+    amortizes.
 
 .. function:: void flint_mpn_powm(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en, nn_srcptr m, mp_size_t mn)
 
@@ -510,8 +513,9 @@ Montgomery reduction and modular exponentiation
     aliasing of `r` with the inputs is permitted.
 
     Even moduli are handled by CRT between the odd part and the power
-    of two; the odd part is computed by the *redc* stage below. Single-limb moduli
-    use plain ``nmod`` arithmetic.
+    of two; the odd part is computed by the *redc* stage below.
+    Single-limb moduli with a single-limb exponent use plain ``nmod``
+    arithmetic.
 
 .. function:: void _flint_mpn_powm_basecase(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en, nn_srcptr m, mp_size_t mn)
               void _flint_mpn_powm_redc(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en, nn_srcptr m, mp_size_t mn)

--- a/doc/source/references.rst
+++ b/doc/source/references.rst
@@ -101,6 +101,8 @@ References
 
 .. [DYF1999] \A. Dzieciol, S. Yngve and P. O. Fröman, "Coulomb wave functions with complex values of the variable and the parameters", J. Math. Phys. 40, 6145 (1999), https://doi.org/10.1063/1.533083
 
+.. [DEGR2024] \L.-S. Didier, N. El Mrabet, L. Glandus and J.-M. Robert, "Truncated multiplication and batch software SIMD AVX512 implementation for faster Montgomery multiplications and modular exponentiation". IACR Communications in Cryptology, Vol. 1, No. 3 (2024). https://doi.org/10.62056/a3txl86bm
+
 .. [DelegliseNicolasZimmermann2009] \Deleglise, Marc and Niclas, Jean-Louis and Zimmermann, Paul : Landau's function for one million billions, J. Théor. Nombres Bordeaux 20:3 (2009) 625--671
 
 .. [DomKanTro1987] \Domich, P. D. and Kannan, R. and Trotter, L. E. Jr. : Hermite Normal Form Computation Using Modulo Determinant Arithmetic, Math. Operations Res. (12) 1987 50-59
@@ -158,6 +160,8 @@ References
 .. [HZ2004] \G. Hanrot and P. Zimmermann, "Newton Iteration Revisited" (2004), http://www.loria.fr/~zimmerma/papers/fastnewton.ps.gz
 
 .. [HanZim2004] \Guillaume Hanrot and Paul Zimmermann : Newton Iteration Revisited (2004) https://www.loria.fr/~zimmerma/papers/fastnewton.ps.gz
+
+.. [HanZim2004b] \G. Hanrot and P. Zimmermann, "A long note on Mulders' short product". Journal of Symbolic Computation, Vol. 37, No. 3 (2004), pp. 391-401. https://doi.org/10.1016/j.jsc.2003.03.001 (corrigendum: Vol. 66 (2015), pp. 111-112)
 
 .. [Har2010] \D. Harvey,  "A multimodular algorithm for computing Bernoulli numbers" (2010), Mathematics of Computation 79.272: 2361-2370
 
@@ -369,14 +373,14 @@ References
 
 .. [vdH2006] \J. van der Hoeven, "Computations with effective real numbers". Theoretical Computer Science, Volume 351, Issue 1, 14 February 2006, Pages 52-60. https://doi.org/10.1016/j.tcs.2005.09.060
 
-All referenced works: [AbbottBronsteinMulders1999]_, [Apostol1997]_, [Ari2011]_, [Ari2012]_, [Arn2010]_, [Arn2012]_, [ArnoldMonagan2011]_,
+All referenced works: [DEGR2024]_, [HanZim2004b]_, [AbbottBronsteinMulders1999]_, [Apostol1997]_, [Ari2011]_, [Ari2012]_, [Arn2010]_, [Arn2012]_, [ArnoldMonagan2011]_,
 [BBC1997]_, [BBC2000]_, [BBK2014]_, [BD1992]_, [BF2020]_, [BCOSSS2007]_, [BFSS2006]_, [BJ2013]_, [BM1980]_, [BZ1992]_, [BZ2011]_, [BaiWag1980]_, [BerTas2010]_,
 [Bin1996]_, [Blo2009]_, [Bodrato2010]_, [Boe2020]_, [Bog2012]_, [Bol1887]_, [Bor1987]_, [Bor2000]_, [Bre1978]_, [Bre1979]_, [Bre2010]_,
 [BrentKung1978]_, [BuhlerCrandallSompolski1992]_, [CFG2017]_, [CFG2019]_, [CGHJK1996]_, [CP2005]_, [Car1995]_, [Car2004]_, [Chen2003]_,
 [Cho1999]_, [Coh1996]_, [Coh2000]_, [Col1971]_, [CraPom2005]_, [DHBHS2004]_, [DYF1999]_, [DelegliseNicolasZimmermann2009]_,
 [DomKanTro1987]_, [Dup2006]_, [Dus1999]_, [EHJ2016]_, [EM2004]_, [EK2025]_, [Fie2007]_, [FieHof2014]_, [Fil1992]_, [GCL1992]_,
 [GG2003]_, [GS2003]_, [GVL1996]_, [Gas2018]_, [Gly2010]_, [Gos1974]_, [GowWag2008]_, [GraMol2010]_, [HM2017]_, [HS1967]_, [HZ2004]_,
-[HanZim2004]_, [Har2010]_, [HZ2011]_, [Har2012]_, [Har2015]_, [Har2018]_, [Hart2010]_, [Hen1956]_, [Hoe2001]_, [Hoe2009]_,
+[HanZim2004]_, [HanZim2004b]_, [Har2010]_, [HZ2011]_, [Har2012]_, [Har2015]_, [Har2018]_, [Hart2010]_, [Hen1956]_, [Hoe2001]_, [Hoe2009]_,
 [Hor1972]_, [Iliopoulos1989]_, [Igu1972]_, [Igu1979]_, [JB2018]_, [JM2018]_, [JR1999]_, [Joh2012]_, [Joh2013]_, [Joh2014a]_,
 [Joh2014b]_, [Joh2014c]_, [Joh2015]_, [Joh2015b]_, [Joh2016]_, [Joh2017]_, [Joh2017a]_, [Joh2017b]_, [Joh2018a]_, [Joh2018b]_,
 [JvdP2002]_, [Kahan1991]_, [KanBac1979]_, [Kar1998]_, [Knu1997]_, [Kob2010]_, [Kri2013]_, [LT2016]_, [Leh1970]_, [LukPatWil1996]_,

--- a/doc/source/references.rst
+++ b/doc/source/references.rst
@@ -373,11 +373,11 @@ References
 
 .. [vdH2006] \J. van der Hoeven, "Computations with effective real numbers". Theoretical Computer Science, Volume 351, Issue 1, 14 February 2006, Pages 52-60. https://doi.org/10.1016/j.tcs.2005.09.060
 
-All referenced works: [DEGR2024]_, [HanZim2004b]_, [AbbottBronsteinMulders1999]_, [Apostol1997]_, [Ari2011]_, [Ari2012]_, [Arn2010]_, [Arn2012]_, [ArnoldMonagan2011]_,
+All referenced works: [AbbottBronsteinMulders1999]_, [Apostol1997]_, [Ari2011]_, [Ari2012]_, [Arn2010]_, [Arn2012]_, [ArnoldMonagan2011]_,
 [BBC1997]_, [BBC2000]_, [BBK2014]_, [BD1992]_, [BF2020]_, [BCOSSS2007]_, [BFSS2006]_, [BJ2013]_, [BM1980]_, [BZ1992]_, [BZ2011]_, [BaiWag1980]_, [BerTas2010]_,
 [Bin1996]_, [Blo2009]_, [Bodrato2010]_, [Boe2020]_, [Bog2012]_, [Bol1887]_, [Bor1987]_, [Bor2000]_, [Bre1978]_, [Bre1979]_, [Bre2010]_,
 [BrentKung1978]_, [BuhlerCrandallSompolski1992]_, [CFG2017]_, [CFG2019]_, [CGHJK1996]_, [CP2005]_, [Car1995]_, [Car2004]_, [Chen2003]_,
-[Cho1999]_, [Coh1996]_, [Coh2000]_, [Col1971]_, [CraPom2005]_, [DHBHS2004]_, [DYF1999]_, [DelegliseNicolasZimmermann2009]_,
+[Cho1999]_, [Coh1996]_, [Coh2000]_, [Col1971]_, [CraPom2005]_, [DHBHS2004]_, [DYF1999]_, [DEGR2024]_, [DelegliseNicolasZimmermann2009]_,
 [DomKanTro1987]_, [Dup2006]_, [Dus1999]_, [EHJ2016]_, [EM2004]_, [EK2025]_, [Fie2007]_, [FieHof2014]_, [Fil1992]_, [GCL1992]_,
 [GG2003]_, [GS2003]_, [GVL1996]_, [Gas2018]_, [Gly2010]_, [Gos1974]_, [GowWag2008]_, [GraMol2010]_, [HM2017]_, [HS1967]_, [HZ2004]_,
 [HanZim2004]_, [HanZim2004b]_, [Har2010]_, [HZ2011]_, [Har2012]_, [Har2015]_, [Har2018]_, [Hart2010]_, [Hen1956]_, [Hoe2001]_, [Hoe2009]_,

--- a/src/fmpz/powm.c
+++ b/src/fmpz/powm.c
@@ -14,8 +14,46 @@
 #include "gmpcompat.h"
 #include "ulong_extras.h"
 #include "fmpz.h"
-#include "gr.h"
-#include "gr_generic.h"
+#include "mpn_extras.h"
+
+/* res = x^e mod m for positive multiprecision m and a positive
+   exponent given by (ep, en); alias-safe via temporaries */
+static void
+_fmpz_powm_mpn(fmpz_t res, const fmpz_t x, nn_srcptr ep, mp_size_t en,
+               const fmpz_t m)
+{
+    mpz_ptr zm = COEFF_TO_PTR(*m);
+    mp_size_t mn = zm->_mp_size, c;
+    fmpz_t xr;
+    nn_ptr bp, rp;
+    TMP_INIT;
+
+    fmpz_init(xr);
+    fmpz_fdiv_r(xr, x, m);
+
+    TMP_START;
+    bp = TMP_ALLOC(2 * mn * sizeof(ulong));
+    rp = bp + mn;
+
+    if (!COEFF_IS_MPZ(*xr))
+    {
+        bp[0] = *xr;
+        flint_mpn_zero(bp + 1, mn - 1);
+    }
+    else
+    {
+        mpz_ptr zx = COEFF_TO_PTR(*xr);
+        c = zx->_mp_size;
+        flint_mpn_copyi(bp, zx->_mp_d, c);
+        flint_mpn_zero(bp + c, mn - c);
+    }
+
+    flint_mpn_powm(rp, bp, ep, en, zm->_mp_d, mn);
+    fmpz_set_ui_array(res, rp, mn);
+
+    fmpz_clear(xr);
+    TMP_END;
+}
 
 /* assumes e is large */
 static void
@@ -47,27 +85,12 @@ _fmpz_powm(fmpz_t res, const fmpz_t x, const fmpz_t e, const fmpz_t m)
     {
         fmpz_set(res, x);
     }
-#if FLINT_HAVE_FFT_SMALL
-    else if (fmpz_bits(m) >= 70000)
+    else if (COEFF_TO_PTR(*e)->_mp_size > 0)
     {
-        gr_ctx_t gctx;
-        fmpz_t t;
-
-        gr_ctx_init_fmpz_mod(gctx, m);
-        fmpz_init(t);
-
-        /* fmpz_mod input must be reduced */
-        GR_MUST_SUCCEED(gr_set_fmpz(t, x, gctx));
-
-        if (!COEFF_IS_MPZ(*x))
-            GR_MUST_SUCCEED(gr_generic_pow_fmpz_binexp(res, t, e, gctx));
-        else
-            GR_MUST_SUCCEED(gr_generic_pow_fmpz_sliding(res, t, e, gctx));
-
-        fmpz_clear(t);
-        gr_ctx_clear(gctx);
+        mpz_ptr ze = COEFF_TO_PTR(*e);
+        _fmpz_powm_mpn(res, x, ze->_mp_d, ze->_mp_size, m);
     }
-#endif
+    /* negative multiprecision exponent: mpz_powm inverts */
     else
     {
         if (!COEFF_IS_MPZ(*x))  /* x is small */
@@ -176,53 +199,12 @@ _fmpz_powm_ui(fmpz_t res, const fmpz_t x, ulong e, const fmpz_t m)
     {
         fmpz_set(res, x);
     }
-#if FLINT_HAVE_FFT_SMALL
-    else if (fmpz_bits(m) >= 70000)
-    {
-        gr_ctx_t gctx;
-        fmpz_t t;
-
-        gr_ctx_init_fmpz_mod(gctx, m);
-        fmpz_init(t);
-
-        /* fmpz_mod input must be reduced */
-        GR_MUST_SUCCEED(gr_set_fmpz(t, x, gctx));
-
-        if (!COEFF_IS_MPZ(*x) || FLINT_BIT_COUNT(e) < 20)
-            GR_MUST_SUCCEED(gr_generic_pow_ui_binexp(res, t, e, gctx));
-        else
-            GR_MUST_SUCCEED(gr_generic_pow_ui_sliding(res, t, e, gctx));
-
-        fmpz_clear(t);
-        gr_ctx_clear(gctx);
-    }
-#endif
     else
     {
-        if (!COEFF_IS_MPZ(*x))  /* x is small */
-        {
-            mpz_t zx;
-            mpz_ptr zres;
-            ulong c1;
-
-            c1 = FLINT_ABS(*x);
-
-            zx->_mp_d = &c1;
-            zx->_mp_size = (*x == 0) ? 0 : ((*x > 0) ? 1 : -1);
-            zx->_mp_alloc = 1;
-
-            zres = _fmpz_promote(res);
-            flint_mpz_powm_ui(zres, zx, e, COEFF_TO_PTR(*m));
-            _fmpz_demote_val(res);
-        }
-        else  /* x is large */
-        {
-            mpz_ptr zres = _fmpz_promote(res);
-            flint_mpz_powm_ui(zres, COEFF_TO_PTR(*x), e, COEFF_TO_PTR(*m));
-            _fmpz_demote_val(res);
-        }
+        _fmpz_powm_mpn(res, x, &e, 1, m);
     }
 }
+
 
 void fmpz_powm_ui(fmpz_t f, const fmpz_t g, ulong e, const fmpz_t m)
 {

--- a/src/fmpz/powm.c
+++ b/src/fmpz/powm.c
@@ -17,6 +17,10 @@
 #include "mpn_extras.h"
 #include "nmod.h"
 
+/* flint_mpn_powm just wraps mpz_powm at some sizes; don't bother
+   with the setup and just call mpz_powm directly */
+#define USE_MPN_CUTOFF 128
+
 /* res = x^e mod m for positive multiprecision m and a positive
    exponent given by (ep, en); alias-safe via temporaries */
 static void
@@ -56,7 +60,7 @@ _fmpz_powm_mpn(fmpz_t res, const fmpz_t x, nn_srcptr ep, mp_size_t en,
     TMP_END;
 }
 
-/* assumes e is large */
+/* assumes e > 0 is large */
 static void
 _fmpz_powm(fmpz_t res, const fmpz_t x, const fmpz_t e, const fmpz_t m)
 {
@@ -86,13 +90,7 @@ _fmpz_powm(fmpz_t res, const fmpz_t x, const fmpz_t e, const fmpz_t m)
     {
         fmpz_set(res, x);
     }
-    else if (COEFF_TO_PTR(*e)->_mp_size > 0)
-    {
-        mpz_ptr ze = COEFF_TO_PTR(*e);
-        _fmpz_powm_mpn(res, x, ze->_mp_d, ze->_mp_size, m);
-    }
-    /* negative multiprecision exponent: mpz_powm inverts */
-    else
+    else if (fmpz_size(m) <= USE_MPN_CUTOFF)
     {
         if (!COEFF_IS_MPZ(*x))  /* x is small */
         {
@@ -116,6 +114,11 @@ _fmpz_powm(fmpz_t res, const fmpz_t x, const fmpz_t e, const fmpz_t m)
             mpz_powm(zres, COEFF_TO_PTR(*x), COEFF_TO_PTR(*e), COEFF_TO_PTR(*m));
             _fmpz_demote_val(res);
         }
+    }
+    else
+    {
+        mpz_ptr ze = COEFF_TO_PTR(*e);
+        _fmpz_powm_mpn(res, x, ze->_mp_d, ze->_mp_size, m);
     }
 }
 
@@ -207,6 +210,37 @@ _fmpz_powm_ui(fmpz_t res, const fmpz_t x, ulong e, const fmpz_t m)
     else if (fmpz_is_zero(x) || fmpz_is_one(x))
     {
         fmpz_set(res, x);
+    }
+    else if (fmpz_size(m) <= USE_MPN_CUTOFF)
+    {
+        if (!COEFF_IS_MPZ(*x))  /* x is small */
+        {
+            mpz_t zx;
+            mpz_ptr zres;
+            ulong c1;
+
+            c1 = FLINT_ABS(*x);
+
+            zx->_mp_d = &c1;
+            zx->_mp_size = (*x == 0) ? 0 : ((*x > 0) ? 1 : -1);
+            zx->_mp_alloc = 1;
+
+            zres = _fmpz_promote(res);
+            flint_mpz_powm_ui(zres, zx, e, COEFF_TO_PTR(*m));
+            _fmpz_demote_val(res);
+        }
+        else  /* x is large */
+        {
+            mpz_ptr zres = _fmpz_promote(res);
+            flint_mpz_powm_ui(zres, COEFF_TO_PTR(*x), e, COEFF_TO_PTR(*m));
+            _fmpz_demote_val(res);
+        }
+    }
+    else if (res != m && e <= (fmpz_bits(m) - 1) / fmpz_bits(x))
+    {
+        fmpz_pow_ui(res, x, e);
+        if (fmpz_sgn(res) < 0)
+            fmpz_add(res, res, m);
     }
     else
     {

--- a/src/fmpz/powm.c
+++ b/src/fmpz/powm.c
@@ -1,7 +1,7 @@
 /*
     Copyright (C) 2009 William Hart
     Copyright (C) 2011 Sebastian Pancratz
-    Copyright (C) 2023 Fredrik Johansson
+    Copyright (C) 2023, 2026 Fredrik Johansson
 
     This file is part of FLINT.
 
@@ -15,6 +15,7 @@
 #include "ulong_extras.h"
 #include "fmpz.h"
 #include "mpn_extras.h"
+#include "nmod.h"
 
 /* res = x^e mod m for positive multiprecision m and a positive
    exponent given by (ep, en); alias-safe via temporaries */
@@ -125,28 +126,36 @@ void fmpz_powm(fmpz_t f, const fmpz_t g, const fmpz_t e, const fmpz_t m)
         flint_throw(FLINT_ERROR, "Exception in fmpz_powm: "
                                                   "Modulus is less than 1.\n");
     }
-    else if (!COEFF_IS_MPZ(*e))  /* e is small */
+    else if (fmpz_sgn(e) < 0)
     {
-        if (*e >= 0)
+        fmpz_t g_inv;
+        fmpz_init(g_inv);
+
+        if (!fmpz_invmod(g_inv, g, m))
         {
-            fmpz_powm_ui(f, g, *e, m);
+            fmpz_clear(g_inv);
+            flint_throw(FLINT_ERROR, "Exception in fmpz_powm: "
+                                             "Base is not invertible.\n");
+        }
+
+        if (!COEFF_IS_MPZ(*e))
+        {
+            fmpz_powm_ui(f, g_inv, -*e, m);
         }
         else
         {
-            fmpz_t g_inv;
-            fmpz_init(g_inv);
-            if (!fmpz_invmod(g_inv, g, m))
-            {
-                fmpz_clear(g_inv);
-                flint_throw(FLINT_ERROR, "Exception in fmpz_powm: "
-                                                 "Base is not invertible.\n");
-            }
-            else
-            {
-                fmpz_powm_ui(f, g_inv, -*e, m);
-                fmpz_clear(g_inv);
-            }
+            fmpz_t t;
+            fmpz_init(t);
+            fmpz_neg(t, e);
+            _fmpz_powm(f, g_inv, t, m);
+            fmpz_clear(t);
         }
+
+        fmpz_clear(g_inv);
+    }
+    else if (!COEFF_IS_MPZ(*e))  /* e is small */
+    {
+        fmpz_powm_ui(f, g, *e, m);
     }
     else  /* e is large */
     {
@@ -230,19 +239,18 @@ void fmpz_powm_ui(fmpz_t f, const fmpz_t g, ulong e, const fmpz_t m)
         {
             if (!COEFF_IS_MPZ(g2))  /* g is small */
             {
-                ulong minv = n_preinvert_limb(m2);
+                nmod_t mod;
+                nmod_init(&mod, m2);
 
                 _fmpz_demote(f);
 
                 if (g2 >= 0)
                 {
-                    g2 = n_mod2_preinv(g2, m2, minv);
-                    *f = n_powmod2_ui_preinv(g2, e, m2, minv);
+                    *f = nmod_pow_ui(nmod_set_ui(g2, mod), e, mod);
                 }
                 else
                 {
-                    g2 = n_mod2_preinv(-g2, m2, minv);
-                    *f = n_powmod2_ui_preinv(g2, e, m2, minv);
+                    *f = nmod_pow_ui(nmod_set_ui(-g2, mod), e, mod);
                     if ((e & UWORD(1)))
                         *f = n_negmod(*f, m2);
                 }

--- a/src/fmpz/powm.c
+++ b/src/fmpz/powm.c
@@ -248,7 +248,6 @@ _fmpz_powm_ui(fmpz_t res, const fmpz_t x, ulong e, const fmpz_t m)
     }
 }
 
-
 void fmpz_powm_ui(fmpz_t f, const fmpz_t g, ulong e, const fmpz_t m)
 {
     if (fmpz_sgn(m) <= 0)

--- a/src/fmpz/test/t-powm.c
+++ b/src/fmpz/test/t-powm.c
@@ -25,6 +25,7 @@ TEST_FUNCTION_START(fmpz_powm, state)
         mpz_t d, e, f, m;
         fmpz_t x;
         mpz_t y;
+        slong mbits, ebits;
         int aliasing;
 
         fmpz_init(a);
@@ -38,13 +39,16 @@ TEST_FUNCTION_START(fmpz_powm, state)
         mpz_init(m);
         mpz_init(y);
 
-        fmpz_randtest(a, state, 200);
-        fmpz_randtest_not_zero(c, state, 200);
+        mbits = n_randint(state, 1000) ? 200 : 20000;
+        ebits = n_randint(state, 10) ? 20 : 200;
+
+        fmpz_randtest(a, state, mbits);
+        fmpz_randtest_not_zero(c, state, mbits);
         fmpz_abs(c, c);
 
         fmpz_get_mpz(d, a);
         fmpz_get_mpz(m, c);
-        fmpz_randtest_unsigned(x, state, 20);
+        fmpz_randtest_unsigned(x, state, ebits);
         fmpz_get_mpz(y, x);
 
         aliasing = n_randint(state, 5);

--- a/src/fmpz_mod/pow.c
+++ b/src/fmpz_mod/pow.c
@@ -13,10 +13,47 @@
 #include "longlong.h"
 #include "fmpz.h"
 #include "fmpz_mod.h"
-#include "gr.h"
-#include "gr_generic.h"
 
-#if FLINT_HAVE_FFT_SMALL
+#include "mpn_extras.h"
+
+/* canonical x in [0, n) as mn limbs */
+static void
+_fmpz_mod_to_mpn(nn_ptr bp, const fmpz_t x, mp_size_t mn)
+{
+    if (!COEFF_IS_MPZ(*x))
+    {
+        bp[0] = *x;
+        flint_mpn_zero(bp + 1, mn - 1);
+    }
+    else
+    {
+        mpz_ptr zx = COEFF_TO_PTR(*x);
+        mp_size_t c = zx->_mp_size;
+        flint_mpn_copyi(bp, zx->_mp_d, c);
+        flint_mpn_zero(bp + c, mn - c);
+    }
+}
+
+/* x canonical, exponent (ep, en) positive; uses the context's
+   precomputed inverse so that small exponents need no setup at all */
+static void
+_fmpz_mod_pow_mpn(fmpz_t res, const fmpz_t x, nn_srcptr ep, mp_size_t en,
+                  const fmpz_mod_ctx_t ctx)
+{
+    mpz_ptr zn = COEFF_TO_PTR(*ctx->n);
+    mp_size_t mn = zn->_mp_size;
+    nn_ptr bp, rp;
+    TMP_INIT;
+
+    TMP_START;
+    bp = TMP_ALLOC(2 * mn * sizeof(ulong));
+    rp = bp + mn;
+    _fmpz_mod_to_mpn(bp, x, mn);
+    flint_mpn_powm_preinvn(rp, bp, ep, en, zn->_mp_d, mn,
+                           ctx->ninv_huge->dinv, ctx->ninv_huge->norm);
+    fmpz_set_ui_array(res, rp, mn);
+    TMP_END;
+}
 
 static void
 _fmpz_mod_pow_fmpz(fmpz_t res, const fmpz_t x, const fmpz_t e, const fmpz_mod_ctx_t ctx)
@@ -34,31 +71,50 @@ _fmpz_mod_pow_fmpz(fmpz_t res, const fmpz_t x, const fmpz_t e, const fmpz_mod_ct
     {
         fmpz_set(res, x);
     }
-    else if (fmpz_bits(ctx->n) < 70000)
+    else if (COEFF_IS_MPZ(*ctx->n) && ctx->ninv_huge != NULL)
     {
-        fmpz_powm(res, x, e, ctx->n);
+        if (!COEFF_IS_MPZ(*e))
+        {
+            ulong ee = *e;
+            _fmpz_mod_pow_mpn(res, x, &ee, 1, ctx);
+        }
+        else
+        {
+            mpz_ptr ze = COEFF_TO_PTR(*e);
+            _fmpz_mod_pow_mpn(res, x, ze->_mp_d, ze->_mp_size, ctx);
+        }
     }
     else
     {
-        gr_ctx_t gctx;
-        _gr_ctx_init_fmpz_mod_from_ref(gctx, ctx);
-
-        if (!COEFF_IS_MPZ(*x) || fmpz_bits(e) < 20)
-            GR_MUST_SUCCEED(gr_generic_pow_fmpz_binexp(res, x, e, gctx));
-        else
-            GR_MUST_SUCCEED(gr_generic_pow_fmpz_sliding(res, x, e, gctx));
+        fmpz_powm(res, x, e, ctx->n);
     }
 }
 
-#else
-
 static void
-_fmpz_mod_pow_fmpz(fmpz_t res, const fmpz_t x, const fmpz_t e, const fmpz_mod_ctx_t ctx)
+_fmpz_mod_pow_ui(fmpz_t res, const fmpz_t x, ulong e, const fmpz_mod_ctx_t ctx)
 {
-    fmpz_powm(res, x, e, ctx->n);
+    if (e <= 2)
+    {
+        if (e == 0)
+            fmpz_mod_set_ui(res, 1, ctx);
+        else if (e == 1)
+            fmpz_set(res, x);
+        else
+            fmpz_mod_mul(res, x, x, ctx);
+    }
+    else if (fmpz_is_zero(x) || fmpz_is_one(x))
+    {
+        fmpz_set(res, x);
+    }
+    else if (COEFF_IS_MPZ(*ctx->n) && ctx->ninv_huge != NULL)
+    {
+        _fmpz_mod_pow_mpn(res, x, &e, 1, ctx);
+    }
+    else
+    {
+        fmpz_powm_ui(res, x, e, ctx->n);
+    }
 }
-
-#endif
 
 int fmpz_mod_pow_fmpz(fmpz_t a, const fmpz_t b, const fmpz_t pow,
                                                       const fmpz_mod_ctx_t ctx)
@@ -91,50 +147,6 @@ int fmpz_mod_pow_fmpz(fmpz_t a, const fmpz_t b, const fmpz_t pow,
     return success;
 }
 
-#if FLINT_HAVE_FFT_SMALL
-
-static void
-_fmpz_mod_pow_ui(fmpz_t res, const fmpz_t x, ulong e, const fmpz_mod_ctx_t ctx)
-{
-    if (e <= 2)
-    {
-        if (e == 0)
-            fmpz_mod_set_ui(res, 1, ctx);
-        else if (e == 1)
-            fmpz_set(res, x);
-        else
-            fmpz_mod_mul(res, x, x, ctx);
-    }
-    else if (fmpz_is_zero(x) || fmpz_is_one(x))
-    {
-        fmpz_set(res, x);
-    }
-    else if (fmpz_bits(ctx->n) < 70000)
-    {
-        fmpz_powm_ui(res, x, e, ctx->n);
-    }
-    else
-    {
-        gr_ctx_t gctx;
-        _gr_ctx_init_fmpz_mod_from_ref(gctx, ctx);
-
-        if (!COEFF_IS_MPZ(*x) || FLINT_BIT_COUNT(e) < 20)
-            GR_MUST_SUCCEED(gr_generic_pow_ui_binexp(res, x, e, gctx));
-        else
-            GR_MUST_SUCCEED(gr_generic_pow_ui_sliding(res, x, e, gctx));
-    }
-}
-
-#else
-
-static void
-_fmpz_mod_pow_ui(fmpz_t res, const fmpz_t x, ulong e, const fmpz_mod_ctx_t ctx)
-{
-    fmpz_powm_ui(res, x, e, ctx->n);
-}
-
-#endif
-
 void fmpz_mod_pow_ui(fmpz_t a, const fmpz_t b, ulong pow,
                                                      const fmpz_mod_ctx_t ctx)
 {
@@ -142,3 +154,4 @@ void fmpz_mod_pow_ui(fmpz_t a, const fmpz_t b, ulong pow,
     _fmpz_mod_pow_ui(a, b, pow, ctx);
     FLINT_ASSERT(fmpz_mod_is_canonical(a, ctx));
 }
+

--- a/src/mpn_extras.h
+++ b/src/mpn_extras.h
@@ -879,6 +879,36 @@ mp_limb_t mpn_invert_limb(mp_limb_t);
 mp_limb_t flint_mpn_preinv1(mp_limb_t d, mp_limb_t d2);
 void flint_mpn_preinvn(mp_ptr dinv, mp_srcptr d, mp_size_t n);
 
+/* r = a*b mod (B^rn - 1) as a representative < B^rn, for rn from
+   next_size and an, bn <= rn; tp: itch(rn) limbs; no aliasing */
+mp_size_t flint_mpn_mulmod_bnm1_next_size(mp_size_t n);
+mp_size_t flint_mpn_mulmod_bnm1_itch(mp_size_t rn);
+void flint_mpn_mulmod_bnm1(nn_ptr rp, mp_size_t rn, nn_srcptr ap,
+                    mp_size_t an, nn_srcptr bp, mp_size_t bn, nn_ptr tp);
+
+/* Hensel inverse mod B^n: v = m^(-1) mod B^n for odd m, no aliasing */
+void _flint_mpn_binvert(nn_ptr v, nn_srcptr m, mp_size_t n);
+
+/* Montgomery reduction t = X * B^(-n) mod m in [0, m) for odd m,
+   0 <= X < m * B^n, minv = -m^(-1) mod B^n; scratch: 2n limbs;
+   t must not alias X, m, minv; X is preserved */
+void _flint_mpn_redc_n(nn_ptr t, nn_srcptr X, nn_srcptr m, nn_srcptr minv,
+                    mp_size_t n, nn_ptr scratch);
+
+/* r = b^e mod m; r, b, m: mn limbs, m normalized, b < m; e: en limbs;
+   r must not alias b, e or m */
+void flint_mpn_powm(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en,
+                    nn_srcptr m, mp_size_t mn);
+/* as flint_mpn_powm, with dinv = flint_mpn_preinvn of m << norm,
+   norm = clz(m[mn-1]); no per-call setup for small exponents */
+void flint_mpn_powm_preinvn(nn_ptr r, nn_srcptr b, nn_srcptr e,
+                    mp_size_t en, nn_srcptr m, mp_size_t mn,
+                    nn_srcptr dinv, flint_bitcnt_t norm);
+void _flint_mpn_powm_basecase(nn_ptr r, nn_srcptr b, nn_srcptr e,
+                    mp_size_t en, nn_srcptr m, mp_size_t mn);
+void _flint_mpn_powm_redc(nn_ptr r, nn_srcptr b, nn_srcptr e,
+                    mp_size_t en, nn_srcptr m, mp_size_t mn);
+
 #if defined(mpn_modexact_1_odd)
 MPN_EXTRAS_INLINE
 int flint_mpn_divisible_1_odd(mp_srcptr x, mp_size_t xsize, mp_limb_t d)

--- a/src/mpn_extras/binvert.c
+++ b/src/mpn_extras/binvert.c
@@ -1,0 +1,55 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "mpn_extras.h"
+#include "ulong_extras.h"
+
+/* v = m^(-1) mod B^n for odd m, by Hensel lifting v <- v*(2 - m*v).
+   No aliasing. About 2/3 the cost of two full-size mullows. */
+void
+_flint_mpn_binvert(nn_ptr v, nn_srcptr m, mp_size_t n)
+{
+    mp_size_t k, k2;
+    nn_ptr u, w;
+    TMP_INIT;
+
+    FLINT_ASSERT(n >= 1);
+    FLINT_ASSERT(m[0] & 1);
+
+    v[0] = n_binvert(m[0]);
+
+    if (n == 1)
+        return;
+
+    TMP_START;
+    u = TMP_ALLOC(2 * n * sizeof(ulong));
+    w = u + n;
+
+    for (k = 1; k < n; k = k2)
+    {
+        k2 = FLINT_MIN(2 * k, n);
+
+        /* v has k valid limbs; the lift reads it zero-padded to k2 */
+        flint_mpn_zero(v + k, k2 - k);
+
+        /* u = 2 - m*v mod B^k2 */
+        flint_mpn_mullow_n(u, m, v, k2);
+        mpn_neg(u, u, k2);
+        mpn_add_1(u, u, k2, 2);
+
+        /* v = v*u mod B^k2; low k limbs are unchanged by construction,
+           but recomputing them costs nothing extra with mullow */
+        flint_mpn_mullow_n(w, v, u, k2);
+        flint_mpn_copyi(v, w, k2);
+    }
+
+    TMP_END;
+}

--- a/src/mpn_extras/binvert.c
+++ b/src/mpn_extras/binvert.c
@@ -12,8 +12,7 @@
 #include "mpn_extras.h"
 #include "ulong_extras.h"
 
-/* v = m^(-1) mod B^n for odd m, by Hensel lifting v <- v*(2 - m*v).
-   No aliasing. About 2/3 the cost of two full-size mullows. */
+/* v = m^(-1) mod B^n for odd m, no aliasing. Not optimized. */
 void
 _flint_mpn_binvert(nn_ptr v, nn_srcptr m, mp_size_t n)
 {
@@ -45,8 +44,7 @@ _flint_mpn_binvert(nn_ptr v, nn_srcptr m, mp_size_t n)
         mpn_neg(u, u, k2);
         mpn_add_1(u, u, k2, 2);
 
-        /* v = v*u mod B^k2; low k limbs are unchanged by construction,
-           but recomputing them costs nothing extra with mullow */
+        /* v = v*u mod B^k2 */
         flint_mpn_mullow_n(w, v, u, k2);
         flint_mpn_copyi(v, w, k2);
     }

--- a/src/mpn_extras/mulmod_bnm1.c
+++ b/src/mpn_extras/mulmod_bnm1.c
@@ -1,0 +1,185 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "mpn_extras.h"
+
+/*
+    r = a * b mod (B^rn - 1), as a representative < B^rn, following the
+    splitting used by GMP's mulmod_bnm1: for even rn = 2h,
+
+        u = a b mod (B^h - 1)      (recursively)
+        v = a b mod (B^h + 1)      (flint_mpn_mulmod_2expp1_basecase)
+
+    and, writing the product as p0 + p1 B^h, the reconstruction solves
+    r ≡ u (mod B^h - 1), r ≡ v (mod B^h + 1) as
+
+        r = u + (B^h - 1) s,   s = (u - v)/2 mod (B^h + 1),
+
+    where the division by two adds B^h + 1 to odd values. Everything is
+    a representative rather than canonical, which the recursion and the
+    callers tolerate.
+*/
+
+/* even sizes at or below this use one plain multiplication: further
+   splitting loses to the linear-pass overheads (residues, CRT, the
+   2expp1 fold), which is also why the recursion stops at any odd
+   size and why the rounding below never exceeds multiples of 8 */
+#define MULMOD_BNM1_MUL_THRESHOLD 32
+
+mp_size_t
+flint_mpn_mulmod_bnm1_next_size(mp_size_t n)
+{
+    if (n <= MULMOD_BNM1_MUL_THRESHOLD)
+        return n;
+    if (n <= 96)
+        return (n + 1) & ~(mp_size_t) 1;
+    if (n <= 192)
+        return (n + 3) & ~(mp_size_t) 3;
+    return (n + 7) & ~(mp_size_t) 7;
+}
+
+mp_size_t
+flint_mpn_mulmod_bnm1_itch(mp_size_t rn)
+{
+    return 8 * rn + 64;
+}
+
+/* rp (rn limbs) = value of (vp, vn) mod B^rn - 1, representative */
+static void
+bnm1_fold(nn_ptr rp, nn_srcptr vp, mp_size_t vn, mp_size_t rn)
+{
+    mp_size_t c = FLINT_MIN(vn, rn);
+    ulong cy;
+
+    flint_mpn_copyi(rp, vp, c);
+    flint_mpn_zero(rp + c, rn - c);
+    vp += c;
+    vn -= c;
+
+    while (vn > 0)
+    {
+        c = FLINT_MIN(vn, rn);
+        cy = mpn_add(rp, rp, rn, vp, c);
+        while (cy)
+            cy = mpn_add_1(rp, rp, rn, cy);
+        vp += c;
+        vn -= c;
+    }
+}
+
+void
+flint_mpn_mulmod_bnm1(nn_ptr rp, mp_size_t rn, nn_srcptr ap, mp_size_t an,
+                      nn_srcptr bp, mp_size_t bn, nn_ptr tp)
+{
+    mp_size_t h, ah, bh;
+    nn_ptr a1, b1, a2, b2, v, s;
+    int ca, cb, vtop, stop;
+    ulong cy, br;
+
+    FLINT_ASSERT(an >= 1 && bn >= 1);
+    FLINT_ASSERT(an <= rn && bn <= rn);
+
+    if (rn <= MULMOD_BNM1_MUL_THRESHOLD || (rn & 1))
+    {
+        if (ap == bp && an == bn)
+            flint_mpn_sqr(tp, ap, an);
+        else if (an >= bn)
+            mpn_mul(tp, ap, an, bp, bn);
+        else
+            mpn_mul(tp, bp, bn, ap, an);
+        bnm1_fold(rp, tp, an + bn, rn);
+        return;
+    }
+
+    h = rn / 2;
+    a1 = tp;
+    b1 = a1 + h;
+    a2 = b1 + h;
+    b2 = a2 + h;
+    v = b2 + h;          /* h limbs */
+    s = v + h;           /* h + 1 limbs */
+    tp = s + h + 1;      /* deeper levels; 2expp1 needs 2h here too */
+
+    /* residues mod B^h - 1 (representative < B^h) and mod B^h + 1
+       (value in [0, B^h]: h limbs plus a top flag) */
+#define RESIDUES(x1, x2, cx, xp, xn) \
+    do { \
+        mp_size_t lo = FLINT_MIN(xn, h), hi = xn - lo; \
+        cx = 0; \
+        bnm1_fold(x1, xp, xn, h); \
+        flint_mpn_copyi(x2, xp, lo); \
+        flint_mpn_zero(x2 + lo, h - lo); \
+        if (hi > 0) \
+        { \
+            br = mpn_sub(x2, x2, h, xp + h, hi); \
+            if (br) \
+            { \
+                cy = mpn_add_1(x2, x2, h, 1);   /* += B^h + 1 */ \
+                cx = (cy != 0);                 /* value B^h */ \
+            } \
+        } \
+    } while (0)
+
+    ah = an;
+    bh = bn;
+    RESIDUES(a1, a2, ca, ap, ah);
+    if (ap == bp && an == bn)
+    {
+        b1 = a1;
+        b2 = a2;
+        cb = ca;
+    }
+    else
+        RESIDUES(b1, b2, cb, bp, bh);
+#undef RESIDUES
+
+    /* u = a1 * b1 mod B^h - 1, into the low half of rp */
+    flint_mpn_mulmod_bnm1(rp, h, a1, h, b1, h, tp);
+
+    /* v = a2 * b2 mod B^h + 1, value vtop*B^h + v in [0, B^h] */
+    vtop = flint_mpn_mulmod_2expp1_basecase(v, a2, b2,
+                    ca | (cb << 1), FLINT_BITS * h, tp);
+
+    /* s = (u - v)/2 mod B^h + 1, in [0, B^h]: h + 1 limbs */
+    flint_mpn_copyi(s, rp, h);
+    s[h] = 0;
+    br = mpn_sub(s, s, h + 1, v, h);
+    if (vtop)
+        br += mpn_sub_1(s + h, s + h, 1, 1);
+    if (br)
+    {
+        /* += B^h + 1 */
+        cy = mpn_add_1(s, s, h + 1, 1);
+        s[h] += 1;
+        (void) cy;
+    }
+    if (s[0] & 1)
+    {
+        cy = mpn_add_1(s, s, h + 1, 1);
+        s[h] += 1;
+        (void) cy;
+    }
+    mpn_rshift(s, s, h + 1, 1);
+    stop = (int) s[h];
+    FLINT_ASSERT(stop <= 1);
+
+    /* r = u + s * B^h - s  (mod B^rn - 1), u already in rp[0, h) */
+    flint_mpn_copyi(rp + h, s, h);
+    if (stop)                        /* s_h * B^rn ≡ s_h */
+    {
+        cy = mpn_add_1(rp, rp, rn, 1);
+        while (cy)
+            cy = mpn_add_1(rp, rp, rn, cy);
+    }
+    br = mpn_sub(rp, rp, rn, s, h + 1);
+    while (br)                       /* -B^rn ≡ -1 */
+        br = mpn_sub_1(rp, rp, rn, 1);
+}

--- a/src/mpn_extras/mulmod_bnm1.c
+++ b/src/mpn_extras/mulmod_bnm1.c
@@ -79,7 +79,7 @@ void
 flint_mpn_mulmod_bnm1(nn_ptr rp, mp_size_t rn, nn_srcptr ap, mp_size_t an,
                       nn_srcptr bp, mp_size_t bn, nn_ptr tp)
 {
-    mp_size_t h, ah, bh;
+    mp_size_t h;
     nn_ptr a1, b1, a2, b2, v, s;
     int ca, cb, vtop, stop;
     ulong cy, br;
@@ -128,9 +128,7 @@ flint_mpn_mulmod_bnm1(nn_ptr rp, mp_size_t rn, nn_srcptr ap, mp_size_t an,
         } \
     } while (0)
 
-    ah = an;
-    bh = bn;
-    RESIDUES(a1, a2, ca, ap, ah);
+    RESIDUES(a1, a2, ca, ap, an);
     if (ap == bp && an == bn)
     {
         b1 = a1;
@@ -138,7 +136,7 @@ flint_mpn_mulmod_bnm1(nn_ptr rp, mp_size_t rn, nn_srcptr ap, mp_size_t an,
         cb = ca;
     }
     else
-        RESIDUES(b1, b2, cb, bp, bh);
+        RESIDUES(b1, b2, cb, bp, bn);
 #undef RESIDUES
 
     /* u = a1 * b1 mod B^h - 1, into the low half of rp */
@@ -146,7 +144,7 @@ flint_mpn_mulmod_bnm1(nn_ptr rp, mp_size_t rn, nn_srcptr ap, mp_size_t an,
 
     /* v = a2 * b2 mod B^h + 1, value vtop*B^h + v in [0, B^h] */
     vtop = flint_mpn_mulmod_2expp1_basecase(v, a2, b2,
-                    ca | (cb << 1), FLINT_BITS * h, tp);
+                    (ca << 1) | cb, FLINT_BITS * h, tp);
 
     /* s = (u - v)/2 mod B^h + 1, in [0, B^h]: h + 1 limbs */
     flint_mpn_copyi(s, rp, h);

--- a/src/mpn_extras/powm.c
+++ b/src/mpn_extras/powm.c
@@ -1,0 +1,1216 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "mpn_extras.h"
+#include "ulong_extras.h"
+#include "nmod.h"
+
+#define POWM_PROFILE 0
+#if FLINT_HAVE_FFT_SMALL
+#include "fft_small.h"
+#endif
+
+/* below this, mulders mulhigh reduction; above, the wraparound fold
+   (provisional, tuned below) */
+#define FLINT_MPN_POWM_REDC_FOLD_THRESHOLD FLINT_MPN_POWM_BNM1_FOLD_THRESHOLD
+
+/* above this, the quotient q = X_lo * minv mod B^mn also runs in the
+   transform domain against a cached transform of minv */
+#define FLINT_MPN_POWM_REDC_QSTEP_FFT_THRESHOLD 480  /* re-tuned on the merged two-prime pipeline */
+
+/* moduli below the fold tiers with large exponents go to mpz_powm
+   for now: there the reduction is plain mulhigh + mullow against
+   GMP's redc_1/redc_2 assembly and low-threshold mulmod_bnm1 */
+#define FLINT_MPN_POWM_MPZ_FALLBACK_LIMBS 110
+
+/* in the basecase, replace mulmod_preinvn's mullow by the wraparound
+   fold in this limb range: below, mulders mullow wins; above,
+   flint_mpn_mullow_n dispatches to fft_small and beats the Toom-based
+   bnm1 recursion */
+#define FLINT_MPN_POWM_BASECASE_FOLD_MIN 120
+#define FLINT_MPN_POWM_BASECASE_FOLD_MAX 2000
+
+/* below this many exponent bits, a caller-supplied preinvn inverse
+   makes the division-based basecase cheaper than paying the redc
+   setup (binvert, Montgomery conversions, fold initialization) */
+#define FLINT_MPN_POWM_PREINVN_REDC_EBITS 24
+
+/* fold tiers, from in-situ per-reduction timings: mulders mulhigh,
+   then flint_mpn_mulmod_bnm1 (small working set, no fixed transform
+   costs), then the cached chain or cyclic-plan fold */
+#define FLINT_MPN_POWM_BNM1_FOLD_THRESHOLD 120
+#define FLINT_MPN_POWM_LARGE_FOLD_THRESHOLD 480
+#define FLINT_MPN_POWM_CHAIN_THRESHOLD 120
+#define FLINT_MPN_POWM_CHAIN_NEG_H 128
+#define FLINT_MPN_POWM_CHAIN_MAX_LEVELS 40
+#include "longlong.h"
+
+#define TSTBIT(x, b) ((x[(b) / FLINT_BITS] >> ((b) % FLINT_BITS)) & UWORD(1))
+
+/* window size for an ebits-bit exponent, as in _gr_pow_mpn_sliding,
+   capped so that the table of 2^(k-1) n-limb entries stays modest */
+static int
+powm_select_k(flint_bitcnt_t ebits, mp_size_t n)
+{
+    int k;
+
+    if      (ebits <= 8)     k = 1;
+    else if (ebits <= 24)    k = 2;
+    else if (ebits <= 69)    k = 3;
+    else if (ebits <= 196)   k = 4;
+    else if (ebits <= 538)   k = 5;
+    else if (ebits <= 1433)  k = 6;
+    else if (ebits <= 3714)  k = 7;
+    else if (ebits <= 9399)  k = 8;
+    else if (ebits <= 23290) k = 9;
+    else if (ebits <= 56651) k = 10;
+    else                     k = 11;
+
+    while (k > 1 && (n << (k - 1)) > (WORD(1) << 23))
+        k--;
+
+    return k;
+}
+
+/* value of the bits [j, j + len) of e */
+static ulong
+extract_bits(nn_srcptr e, slong j, slong len)
+{
+    ulong w = 0;
+    slong h;
+
+    for (h = len - 1; h >= 0; h--)
+        w = (w << 1) | TSTBIT(e, j + h);
+
+    return w;
+}
+
+/* the window at the top bit i: the longest chain of at most k bits
+   ending in a 1; returns its value and moves *i below the chain */
+static ulong
+next_window(nn_srcptr e, slong * i, int k, slong * nsqr)
+{
+    slong j = FLINT_MAX(*i - k + 1, 0);
+    ulong w;
+
+    while (TSTBIT(e, j) == 0)
+        j++;
+
+    *nsqr = *i - j + 1;
+    w = extract_bits(e, j, *i - j + 1);
+    *i = j - 1;
+    return w;
+}
+
+/*
+    r = b^e mod m via flint_mpn_mulmod_preinvn on residues shifted left
+    by norm. Requires m > 1 normalized (mn >= 1, top limb nonzero),
+    b < m (mn limbs), e nonzero with top limb nonzero.
+    No aliasing of r with the inputs.
+*/
+#if FLINT_HAVE_FFT_SMALL
+/*
+    Drop-in for flint_mpn_mulmod_preinvn with the mullow replaced by a
+    wraparound product: with the same quotient estimate
+    q = X_hi + mulhigh(X_hi, dinv), the remainder r0 = X - q*d lies in
+    [0, C*d) for a small C (the correction loop below is the same as
+    mulmod_preinvn's), and since C*d < B^rn - 1 for rn > n it is the
+    canonical value of (X - q*d) mod (B^rn - 1), with q*d computed by
+    flint_mpn_mulmod_bnm1 at about 0.6 multiplications. Needs no
+    precomputation beyond dinv. scratch: 5n + itch(rn) + 4rn limbs.
+*/
+static void
+mulmod_preinvn_fold(nn_ptr r, nn_srcptr a, nn_srcptr b, mp_size_t n,
+                    nn_srcptr d, nn_srcptr dinv, ulong norm,
+                    mp_size_t rn, nn_ptr scratch)
+{
+    nn_ptr X = scratch, q = X + 2 * n, S, FX, tp;
+    ulong cy;
+    mp_size_t c;
+
+    S = q + n + 1;
+    FX = S + rn;
+    tp = FX + rn;         /* itch(rn) limbs */
+
+    if (a == b)
+        flint_mpn_sqr(X, a, n);
+    else
+        flint_mpn_mul_n(X, a, b, n);
+    if (norm)
+        mpn_rshift(X, X, 2 * n, norm);
+
+    /* q = X_hi + mulhigh(X_hi, dinv) < B^n */
+    flint_mpn_mulhigh_n(q, X + n, dinv, n);
+    mpn_add_n(q, q, X + n, n);
+
+    /* S = q*d mod (B^rn - 1) */
+    flint_mpn_mulmod_bnm1(S, rn, q, n, d, n, tp);
+
+    /* FX = X mod (B^rn - 1) */
+    {
+        nn_srcptr v = X;
+        mp_size_t vn = 2 * n;
+        c = FLINT_MIN(vn, rn);
+        flint_mpn_copyi(FX, v, c);
+        flint_mpn_zero(FX + c, rn - c);
+        v += c; vn -= c;
+        while (vn > 0)
+        {
+            c = FLINT_MIN(vn, rn);
+            cy = mpn_add(FX, FX, rn, v, c);
+            while (cy)
+                cy = mpn_add_1(FX, FX, rn, cy);
+            v += c; vn -= c;
+        }
+    }
+
+    /* r0 = (FX - S) mod (B^rn - 1), canonical since r0 < C*d < B^rn - 1 */
+    cy = mpn_sub_n(FX, FX, S, rn);
+    while (cy)
+        cy = mpn_sub_1(FX, FX, rn, cy);
+
+    FLINT_ASSERT(flint_mpn_zero_p(FX + n + 1, rn - n - 1));
+
+    while (FX[n] != 0)
+        FX[n] -= mpn_sub_n(FX, FX, d, n);
+    if (mpn_cmp(FX, d, n) >= 0)
+        mpn_sub_n(FX, FX, d, n);
+    flint_mpn_copyi(r, FX, n);
+}
+#endif
+
+static void
+powm_basecase_core(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en,
+                   nn_srcptr msh, mp_size_t mn, nn_srcptr dinv,
+                   flint_bitcnt_t norm)
+{
+    flint_bitcnt_t ebits = (en - 1) * FLINT_BITS + FLINT_BIT_COUNT(e[en - 1]);
+    int k = powm_select_k(ebits, mn);
+    slong tlen = WORD(1) << (k - 1);
+    nn_ptr tab, acc, t;
+    slong i, nsqr, h;
+    ulong w;
+    TMP_INIT;
+
+#if FLINT_HAVE_FFT_SMALL
+    mp_size_t bf_rn = 0;
+    nn_ptr bf_scratch = NULL;
+#endif
+
+    TMP_START;
+    acc = TMP_ALLOC((2 + tlen) * mn * sizeof(ulong));
+    tab = acc + mn;
+    t = tab + tlen * mn;
+
+#if FLINT_HAVE_FFT_SMALL
+    if (mn >= FLINT_MPN_POWM_BASECASE_FOLD_MIN
+        && mn < FLINT_MPN_POWM_BASECASE_FOLD_MAX)
+    {
+        bf_rn = flint_mpn_mulmod_bnm1_next_size(mn + 1);
+        bf_scratch = TMP_ALLOC((3 * mn + 1 + 2 * bf_rn
+                        + flint_mpn_mulmod_bnm1_itch(bf_rn))
+                        * sizeof(ulong));
+    }
+#define BC_MULMOD(rr, aa, bb) \
+    do { \
+        if (bf_rn) \
+            mulmod_preinvn_fold(rr, aa, bb, mn, msh, dinv, norm, \
+                                bf_rn, bf_scratch); \
+        else \
+            flint_mpn_mulmod_preinvn(rr, aa, bb, mn, msh, dinv, norm); \
+    } while (0)
+#else
+#define BC_MULMOD(rr, aa, bb) \
+    flint_mpn_mulmod_preinvn(rr, aa, bb, mn, msh, dinv, norm)
+#endif
+
+    /* tab[i] = b^(2i+1) << norm */
+    if (norm)
+        mpn_lshift(tab, b, mn, norm);
+    else
+        flint_mpn_copyi(tab, b, mn);
+    if (tlen > 1)
+    {
+        BC_MULMOD(t, tab, tab);
+        for (i = 1; i < tlen; i++)
+            BC_MULMOD(tab + i * mn, tab + (i - 1) * mn, t);
+    }
+
+    i = ebits - 1;
+    w = next_window(e, &i, k, &nsqr);
+    flint_mpn_copyi(acc, tab + (w >> 1) * mn, mn);
+
+    while (i >= 0)
+    {
+        if (TSTBIT(e, i) == 0)
+        {
+            BC_MULMOD(acc, acc, acc);
+            i--;
+        }
+        else
+        {
+            w = next_window(e, &i, k, &nsqr);
+            for (h = 0; h < nsqr; h++)
+                BC_MULMOD(acc, acc, acc);
+            BC_MULMOD(acc, acc, tab + (w >> 1) * mn);
+        }
+    }
+#undef BC_MULMOD
+
+    if (norm)
+        mpn_rshift(r, acc, mn, norm);
+    else
+        flint_mpn_copyi(r, acc, mn);
+
+    TMP_END;
+}
+
+void
+_flint_mpn_powm_basecase(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en,
+                         nn_srcptr m, mp_size_t mn)
+{
+    flint_bitcnt_t norm = flint_clz(m[mn - 1]);
+    nn_ptr msh, dinv;
+    TMP_INIT;
+
+    TMP_START;
+    msh = TMP_ALLOC(2 * mn * sizeof(ulong));
+    dinv = msh + mn;
+    if (norm)
+        mpn_lshift(msh, m, mn, norm);
+    else
+        flint_mpn_copyi(msh, m, mn);
+    flint_mpn_preinvn(dinv, msh, mn);
+    powm_basecase_core(r, b, e, en, msh, mn, dinv, norm);
+    TMP_END;
+}
+
+/* acc = acc * s mod m for a scalar s of sl in {1, 2} limbs,
+   via a full product and division; scratch: n + 3 limbs */
+static void
+mul_scalar_mod(nn_ptr acc, nn_srcptr s, int sl, nn_srcptr m, mp_size_t n,
+               nn_ptr scratch)
+{
+    ulong q[3];
+
+    if (sl == 2 && s[1] == 0)
+        sl = 1;
+
+    mpn_mul(scratch, acc, n, s, sl);
+    mpn_tdiv_qr(q, acc, 0, scratch, n + sl, m, n);
+}
+
+#if FLINT_HAVE_FFT_SMALL
+/*
+    Montgomery reduction via a wraparound product, as in GMP's redc_n:
+    with q = X_lo * minv mod B^mn the low half of q*m is exactly
+    L = B^mn - X_lo, so the high half H = floor(q*m / B^mn) < m is
+    recovered from S = q*m mod (B^nnc - 1) as
+
+        H = (S - L) * B^(nnc - mn) mod (B^nnc - 1),
+
+    a cyclic limb rotation, unique since H < m <= B^nnc - 1. The
+    wraparound product runs against a cached cyclic transform of m, so
+    each reduction costs one mullow plus about two thirds of a
+    half-length cyclic multiplication.
+*/
+/*
+    All-cached wraparound chain: S = x * m mod (B^rn - 1) for rn a
+    power of two >= mn, splitting as in flint_mpn_mulmod_bnm1 but with
+    every m-dependent quantity precomputed per modulus: the residues of
+    m down the -1 spine, and for each +1 half of size h either the
+    cached negacyclic transform of m mod B^h + 1 (h >= 128, b = 64,
+    np = 3: 0.3-0.6 of a multiplication) or the basecase operand.
+*/
+typedef struct
+{
+    mp_size_t rn;
+    slong nlev;                        /* levels with h = rn >> (i+1) >= 64 */
+    sd_fft_mpn_mulmod_2expp1_ctx_struct * ctx;   /* nlev entries; h >= NEG_H used */
+    sd_fft_mpn_mulmod_2expp1_scratch_struct * scr;
+    double ** Fm;                      /* cached transforms, or NULL */
+    nn_ptr * m2;                       /* m mod B^h + 1, h + 1 limbs (basecase levels) */
+    nn_ptr mbase;                      /* m mod B^base - 1 */
+    mp_size_t base;
+    nn_ptr work;                       /* recursion scratch */
+    nn_ptr storage;
+}
+powm_chain_struct;
+
+/* residue of (xp, xn) mod B^h + 1 into (x2, h + 1 limbs, top in {0,1}) */
+static void
+chain_res_p1(nn_ptr x2, nn_srcptr xp, mp_size_t xn, mp_size_t h)
+{
+    mp_size_t lo = FLINT_MIN(xn, h), hi = xn - lo;
+    ulong br, cy;
+
+    flint_mpn_copyi(x2, xp, lo);
+    flint_mpn_zero(x2 + lo, h + 1 - lo);
+    if (hi > 0)
+    {
+        br = mpn_sub(x2, x2, h, xp + h, hi);
+        if (br)
+        {
+            cy = mpn_add_1(x2, x2, h, 1);
+            x2[h] = cy;
+        }
+    }
+}
+
+/* residue of (xp, xn) mod B^h - 1 into (x1, h limbs), representative */
+static void
+chain_res_m1(nn_ptr x1, nn_srcptr xp, mp_size_t xn, mp_size_t h)
+{
+    mp_size_t c = FLINT_MIN(xn, h);
+    ulong cy;
+
+    flint_mpn_copyi(x1, xp, c);
+    flint_mpn_zero(x1 + c, h - c);
+    xp += c; xn -= c;
+    while (xn > 0)
+    {
+        c = FLINT_MIN(xn, h);
+        cy = mpn_add(x1, x1, h, xp, c);
+        while (cy)
+            cy = mpn_add_1(x1, x1, h, cy);
+        xp += c; xn -= c;
+    }
+}
+
+/* S (s limbs) = x * m mod (B^s - 1) at chain level lev, s = rn >> lev;
+   x: xn <= s limbs; work: private to this level and below */
+static void
+chain_mul(powm_chain_struct * H, slong lev, nn_ptr S, nn_srcptr x,
+          mp_size_t xn, nn_ptr work)
+{
+    mp_size_t s = H->rn >> lev, h = s / 2;
+    nn_ptr x1, x2, v, sb;
+    ulong br, cy;
+    int vtop, stop;
+    mp_size_t i;
+
+    if (s <= H->base)
+    {
+        /* base: plain multiplication and fold */
+        mp_size_t xs = xn;
+        while (xs > 0 && x[xs - 1] == 0)
+            xs--;
+        if (xs == 0)
+        {
+            flint_mpn_zero(S, s);
+            return;
+        }
+        if (xs >= s)
+            mpn_mul(work, x, xs, H->mbase, s);
+        else
+            mpn_mul(work, H->mbase, s, x, xs);
+        chain_res_m1(S, work, xs + s, s);
+        return;
+    }
+
+    x1 = work;              /* h */
+    x2 = x1 + h;            /* h + 1 */
+    v = x2 + h + 1;         /* h + 1 */
+    sb = v + h + 1;         /* h + 1 */
+    work = sb + h + 1;
+
+    chain_res_m1(x1, x, xn, h);
+    chain_res_p1(x2, x, xn, h);
+
+    /* u into the low half of S */
+    chain_mul(H, lev + 1, S, x1, h, work);
+
+    /* v = x2 * (m mod B^h + 1) mod B^h + 1, in [0, B^h] */
+    if (H->Fm[lev] != NULL)
+        sd_fft_mpn_mulmod_2expp1_mul_cached(H->ctx + lev, v, x2,
+                                            H->Fm[lev], H->scr + lev);
+    else
+    {
+        int c = (x2[h] != 0) | ((H->m2[lev][h] != 0) << 1);
+        v[h] = (ulong) flint_mpn_mulmod_2expp1_basecase(v, x2,
+                    H->m2[lev], c, FLINT_BITS * h, work);
+    }
+    vtop = (int) v[h];
+
+    /* s = (u - v)/2 mod B^h + 1, then S = u + s*B^h - s mod B^s - 1;
+       identical to flint_mpn_mulmod_bnm1 */
+    flint_mpn_copyi(sb, S, h);
+    sb[h] = 0;
+    br = mpn_sub(sb, sb, h + 1, v, h);
+    if (vtop)
+        br += mpn_sub_1(sb + h, sb + h, 1, 1);
+    if (br)
+    {
+        cy = mpn_add_1(sb, sb, h + 1, 1);
+        sb[h] += 1;
+        (void) cy;
+    }
+    if (sb[0] & 1)
+    {
+        cy = mpn_add_1(sb, sb, h + 1, 1);
+        sb[h] += 1;
+        (void) cy;
+    }
+    mpn_rshift(sb, sb, h + 1, 1);
+    stop = (int) sb[h];
+
+    flint_mpn_copyi(S + h, sb, h);
+    if (stop)
+    {
+        cy = mpn_add_1(S, S, s, 1);
+        while (cy)
+            cy = mpn_add_1(S, S, s, cy);
+    }
+    br = mpn_sub(S, S, s, sb, h + 1);
+    while (br)
+        br = mpn_sub_1(S, S, s, 1);
+
+    (void) i;
+}
+
+typedef struct
+{
+    fft_small_plan_t P;
+    fft_small_op_t Fm, FC;
+    ulong nnc, zc;
+    nn_ptr w, S, V;      /* zc, nnc, nnc limbs */
+    int q_fft;           /* quotient via cached transform of minv */
+    fft_small_plan_t PL;
+    fft_small_op_t Fminv, FQ;
+    int method;          /* 0: cyclic plan, 1: chain, 2: mulmod_bnm1 */
+    powm_chain_struct H[1];
+    mp_size_t rg;        /* method 2 fold length */
+    nn_ptr tp;           /* method 2 scratch */
+}
+redc_fold_struct;
+
+/* returns 1 on success; rn = smallest power of two >= max(mn, 128) */
+static int
+powm_chain_init(powm_chain_struct * H, nn_srcptr m, mp_size_t mn)
+{
+    mp_size_t rn = 128, s, h;
+    slong lev, nlev;
+    nn_ptr mres, p;
+
+    while (rn < mn)
+        rn *= 2;
+    H->rn = rn;
+    H->base = 64;
+
+    nlev = 0;
+    for (s = rn; s > H->base; s /= 2)
+        nlev++;
+    H->nlev = nlev;
+    FLINT_ASSERT(nlev <= FLINT_MPN_POWM_CHAIN_MAX_LEVELS);
+
+    H->ctx = flint_malloc(nlev * sizeof(sd_fft_mpn_mulmod_2expp1_ctx_struct));
+    H->scr = flint_malloc(nlev * sizeof(sd_fft_mpn_mulmod_2expp1_scratch_struct));
+    H->Fm = flint_malloc(nlev * sizeof(double *));
+    H->m2 = flint_malloc(nlev * sizeof(nn_ptr));
+    /* m residues (h+1 each level) + mbase + recursion work (~5rn) */
+    H->storage = flint_malloc((3 * rn + H->base + 6 * rn + 64
+                               + 8 * H->base) * sizeof(ulong));
+    p = H->storage;
+
+    mres = p;                     /* -1-spine residue of m, reused */
+    p += rn;
+    flint_mpn_copyi(mres, m, FLINT_MIN(mn, rn));
+    if (mn < rn)
+        flint_mpn_zero(mres + mn, rn - mn);
+
+    for (lev = 0, s = rn; s > H->base; s /= 2, lev++)
+    {
+        h = s / 2;
+        H->m2[lev] = p;
+        p += h + 1;
+        chain_res_p1(H->m2[lev], mres, s, h);
+
+        if (h >= FLINT_MPN_POWM_CHAIN_NEG_H)
+        {
+            sd_fft_mpn_mulmod_2expp1_ctx_init(H->ctx + lev,
+                get_default_mpn_ctx(), FLINT_BITS * h, h);
+            sd_fft_mpn_mulmod_2expp1_scratch_init(H->scr + lev,
+                H->ctx + lev);
+            H->Fm[lev] = flint_aligned_alloc(4096, n_round_up(
+                sd_fft_mpn_mulmod_2expp1_transformed_size(H->ctx + lev)
+                * sizeof(double), 4096));
+            sd_fft_mpn_mulmod_2expp1_transform(H->ctx + lev,
+                H->Fm[lev], H->m2[lev], H->scr + lev);
+        }
+        else
+            H->Fm[lev] = NULL;
+
+        /* -1 spine: fold m's residue down to h limbs in place */
+        chain_res_m1(mres, mres, s, h);
+    }
+    H->mbase = p;
+    p += H->base;
+    flint_mpn_copyi(H->mbase, mres, H->base);
+    H->work = p;
+    return 1;
+}
+
+static void
+powm_chain_clear(powm_chain_struct * H)
+{
+    for (slong lev = 0; lev < H->nlev; lev++)
+    {
+        if (H->Fm[lev] != NULL)
+        {
+            flint_aligned_free(H->Fm[lev]);
+            sd_fft_mpn_mulmod_2expp1_scratch_clear(H->scr + lev);
+            sd_fft_mpn_mulmod_2expp1_ctx_clear(H->ctx + lev);
+        }
+    }
+    flint_free(H->ctx);
+    flint_free(H->scr);
+    flint_free(H->Fm);
+    flint_free(H->m2);
+    flint_free(H->storage);
+}
+
+/* t = X * B^(-mn) mod m, canonical in [0, m); X: 2*mn limbs < m*B^mn;
+   q: mn limbs of scratch; t must not alias X, m, minv */
+static void
+redc_fold(nn_ptr t, nn_srcptr X, nn_srcptr m, nn_srcptr minv, mp_size_t mn,
+          redc_fold_struct * F, nn_ptr q)
+{
+    mp_size_t rlen = (F->method == 2) ? F->rg :
+                     (F->method == 1) ? F->H->rn : (mp_size_t) F->nnc;
+    mp_size_t nnc = rlen, k = rlen - mn, i;
+    nn_ptr S = F->S, V = F->V;
+    ulong br, cy;
+
+    for (i = 0; i < mn; i++)
+        if (X[i] != 0)
+            break;
+    if (i == mn)
+    {
+        flint_mpn_copyi(t, X + mn, mn);
+        goto reduce;
+    }
+
+    if (F->q_fft)
+    {
+        fft_small_fft_mpn(F->FQ, X, mn, F->PL);
+        fft_small_op_mul(F->FQ, F->FQ, F->Fminv, F->PL);
+        fft_small_ifft(F->FQ, F->PL);
+        fft_small_export_mpn(q, mn, F->FQ, F->PL);
+    }
+    else
+        flint_mpn_mullow_n(q, X, minv, mn);
+
+    /* S = q*m mod (B^rlen - 1), some representative < B^rlen */
+    if (F->method == 2)
+        flint_mpn_mulmod_bnm1(S, rlen, q, mn, m, mn, F->tp);
+    else if (F->method == 1)
+        chain_mul(F->H, 0, S, q, mn, F->H->work);
+    else
+    {
+        fft_small_fft_mpn(F->FC, q, mn, F->P);
+        fft_small_op_mul(F->FC, F->FC, F->Fm, F->P);
+        fft_small_ifft(F->FC, F->P);
+        fft_small_export_mpn(F->w, F->zc, F->FC, F->P);
+        flint_mpn_zero(S, nnc);
+        {
+            nn_srcptr v = F->w;
+            mp_size_t vn = F->zc;
+            while (vn > 0)
+            {
+                mp_size_t c = FLINT_MIN(vn, nnc);
+                cy = mpn_add(S, S, nnc, v, c);
+                while (cy)
+                    cy = mpn_add_1(S, S, nnc, cy);
+                v += c;
+                vn -= c;
+            }
+        }
+    }
+
+    /* U = S - L mod (B^nnc - 1) with L = B^mn - X_lo = -X_lo mod B^mn */
+    mpn_neg(q, X, mn);               /* q now holds L; X_lo != 0 */
+    br = mpn_sub(S, S, nnc, q, mn);
+    if (br)
+        mpn_sub_1(S, S, nnc, 1);     /* wrap: -B^nnc = -1 mod B^nnc - 1 */
+
+    /* H = U * B^k mod (B^nnc - 1): rotate left by k limbs */
+    if (k > 0)
+    {
+        flint_mpn_copyi(V, S + nnc - k, k);
+        flint_mpn_copyi(V + k, S, nnc - k);
+    }
+    else
+        flint_mpn_copyi(V, S, nnc);
+
+    /* V = H exactly, or V = B^nnc - 1 (the H = 0 representative,
+       since H <= m - 1 < B^nnc - 1). Any nonzero top limb, or an
+       all-ones value when nnc == mn, forces the latter. */
+    if (nnc > mn ? !flint_mpn_zero_p(V + mn, nnc - mn)
+                 : V[mn - 1] == UWORD_MAX)
+    {
+        for (i = 0; i < nnc; i++)
+            if (V[i] != UWORD_MAX)
+                break;
+        if (i == nnc)
+            flint_mpn_zero(V, nnc);  /* H = 0 */
+        else
+            FLINT_ASSERT(nnc == mn); /* a genuine H with huge top limb */
+    }
+
+    cy = mpn_add_n(t, X + mn, V, mn);
+    cy += mpn_add_1(t, t, mn, 1);
+    if (cy)
+        mpn_sub_n(t, t, m, mn);
+
+reduce:
+    if (mpn_cmp(t, m, mn) >= 0)
+        mpn_sub_n(t, t, m, mn);
+}
+
+/* returns 1 and fills F on success */
+static int
+redc_fold_init(redc_fold_struct * F, nn_srcptr m, nn_srcptr minv,
+               mp_size_t mn)
+{
+    ulong nnc = mn, rlen, rn_chain = 128;
+
+    if (mn < FLINT_MPN_POWM_LARGE_FOLD_THRESHOLD)
+    {
+        F->method = 2;
+        F->rg = flint_mpn_mulmod_bnm1_next_size(mn);
+        F->tp = flint_malloc(flint_mpn_mulmod_bnm1_itch(F->rg)
+                             * sizeof(ulong));
+        F->nnc = 0;
+        rlen = F->rg;
+        F->zc = 0;
+        F->w = flint_malloc(2 * rlen * sizeof(ulong));
+        F->S = F->w;
+        F->V = F->S + rlen;
+        goto qstep;
+    }
+
+    if (!fft_small_plan_init_mpn_cyclic(F->P, get_default_mpn_ctx(),
+                                        &nnc, 1))
+        return 0;
+
+    while ((mp_size_t) rn_chain < mn)
+        rn_chain *= 2;
+
+    /* measured per-limb costs: chain ~ 27, cyclic-plan fold ~ 40
+       (arbitrary common unit), so the chain wins unless its
+       power-of-two padding exceeds 40/27 of the cyclic length */
+    F->method = (27 * rn_chain <= 33 * nnc) ? 1 : 0;
+    if (F->method == 1 && !powm_chain_init(F->H, m, mn))
+        F->method = 0;
+
+    F->nnc = nnc;
+    rlen = (F->method == 1) ? (ulong) F->H->rn : nnc;
+    F->zc = nnc + (2 * F->P->bits + F->P->depth) / FLINT_BITS + 2;
+    F->w = flint_malloc((F->zc + 2 * rlen) * sizeof(ulong));
+    F->S = F->w + F->zc;
+    F->V = F->S + rlen;
+    if (F->method == 0)
+    {
+        fft_small_op_init(F->Fm, F->P);
+        fft_small_op_init(F->FC, F->P);
+        fft_small_fft_mpn(F->Fm, m, mn, F->P);
+    }
+
+qstep:
+
+    F->q_fft = (mn >= FLINT_MPN_POWM_REDC_QSTEP_FFT_THRESHOLD) &&
+               fft_small_plan_init_mpn(F->PL, get_default_mpn_ctx(),
+                                       mn, mn, 1, 0);
+    if (F->q_fft)
+    {
+        fft_small_op_init(F->Fminv, F->PL);
+        fft_small_op_init(F->FQ, F->PL);
+        fft_small_fft_mpn(F->Fminv, minv, mn, F->PL);
+    }
+    return 1;
+}
+
+static void
+redc_fold_clear(redc_fold_struct * F)
+{
+    if (F->method == 2)
+    {
+        flint_free(F->tp);
+        flint_free(F->w);
+        goto qclear;
+    }
+    if (F->method == 1)
+        powm_chain_clear(F->H);
+    else
+    {
+        fft_small_op_clear(F->Fm);
+        fft_small_op_clear(F->FC);
+    }
+    fft_small_plan_clear(F->P);
+    flint_free(F->w);
+qclear:
+    if (F->q_fft)
+    {
+        fft_small_op_clear(F->Fminv);
+        fft_small_op_clear(F->FQ);
+        fft_small_plan_clear(F->PL);
+    }
+}
+#endif
+
+/*
+    r = b^e mod m for odd m > 1, via Montgomery multiplication.
+    Same conventions as _flint_mpn_powm_basecase.
+*/
+void
+_flint_mpn_powm_redc(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en,
+                     nn_srcptr m, mp_size_t mn)
+{
+    flint_bitcnt_t ebits = (en - 1) * FLINT_BITS + FLINT_BIT_COUNT(e[en - 1]);
+    int k = powm_select_k(ebits, mn);
+    mp_size_t bn = mn;
+    int small_base;
+    nn_ptr minv, acc, X, scratch, tab = NULL;
+    ulong sc[64];   /* scalar window table, 2 limbs each; k <= 6 below */
+    slong i, h, nsqr, tlen;
+    ulong w;
+    TMP_INIT;
+
+    FLINT_ASSERT(m[0] & 1);
+
+    while (bn > 0 && b[bn - 1] == 0)
+        bn--;
+
+    /* scalars b^(2i+1) must fit two limbs */
+    small_base = (bn == 1 && b[0] >= 2);
+    if (small_base)
+    {
+        flint_bitcnt_t bbits = FLINT_BIT_COUNT(b[0]);
+        while (k > 1 && ((UWORD(1) << k) - 1) * bbits > 2 * FLINT_BITS)
+            k--;
+        k = FLINT_MIN(k, 6);
+    }
+
+    TMP_START;
+    minv = TMP_ALLOC(mn * sizeof(ulong));
+    acc = TMP_ALLOC((mn + 3) * sizeof(ulong));
+    X = TMP_ALLOC((2 * mn + 3) * sizeof(ulong));
+    scratch = TMP_ALLOC(2 * mn * sizeof(ulong));
+
+    _flint_mpn_binvert(minv, m, mn);
+    mpn_neg(minv, minv, mn);
+
+#if FLINT_HAVE_FFT_SMALL
+    {
+        int use_fold = (mn >= FLINT_MPN_POWM_REDC_FOLD_THRESHOLD);
+        redc_fold_struct F[1];
+        if (use_fold)
+            use_fold = redc_fold_init(F, m, minv, mn);
+#define REDC_STEP(dst, XX) \
+        do { \
+            if (use_fold) \
+                redc_fold(dst, XX, m, minv, mn, F, scratch); \
+            else \
+                _flint_mpn_redc_n(dst, XX, m, minv, mn, scratch); \
+        } while (0)
+#else
+    {
+#define REDC_STEP(dst, XX) _flint_mpn_redc_n(dst, XX, m, minv, mn, scratch)
+#endif
+
+    if (small_base)
+    {
+        /* sc[2i], sc[2i+1] = b^(2i+1) as a two-limb value */
+        ulong s0 = b[0], s1 = 0, b2hi, b2lo;
+
+        tlen = WORD(1) << (k - 1);
+        umul_ppmm(b2hi, b2lo, b[0], b[0]);
+        for (i = 0; ; i++)
+        {
+            sc[2 * i] = s0;
+            sc[2 * i + 1] = s1;
+            if (i + 1 == tlen)
+                break;
+            /* (s1, s0) *= (b2hi, b2lo), guaranteed to fit by the k cap */
+            {
+                ulong t1, t0;
+                umul_ppmm(t1, t0, s0, b2lo);
+                t1 += s1 * b2lo + s0 * b2hi;
+                s0 = t0;
+                s1 = t1;
+            }
+        }
+
+        /* acc = 1 * B^mn mod m */
+        flint_mpn_zero(X, mn);
+        X[mn] = 1;
+        mpn_tdiv_qr(scratch, acc, 0, X, mn + 1, m, mn);
+    }
+    else
+    {
+        /* Montgomery table of b^(2i+1) */
+        nn_ptr msq;
+
+        tlen = WORD(1) << (k - 1);
+        tab = TMP_ALLOC((tlen + 1) * mn * sizeof(ulong));
+        msq = tab + tlen * mn;
+
+        /* tab[0] = b * B^mn mod m */
+        flint_mpn_zero(X, mn);
+        flint_mpn_copyi(X + mn, b, mn);
+        mpn_tdiv_qr(scratch, tab, 0, X, 2 * mn, m, mn);
+
+        if (tlen > 1)
+        {
+            flint_mpn_sqr(X, tab, mn);
+            REDC_STEP(msq, X);
+            for (i = 1; i < tlen; i++)
+            {
+                flint_mpn_mul_n(X, tab + (i - 1) * mn, msq, mn);
+                REDC_STEP(tab + i * mn, X);
+            }
+        }
+    }
+
+    i = ebits - 1;
+    if (small_base)
+    {
+        /* start from mont(1) and apply the first window as a scalar */
+        w = next_window(e, &i, k, &nsqr);
+        mul_scalar_mod(acc, sc + 2 * (w >> 1), 2, m, mn, X);
+    }
+    else
+    {
+        w = next_window(e, &i, k, &nsqr);
+        flint_mpn_copyi(acc, tab + (w >> 1) * mn, mn);
+    }
+
+    while (i >= 0)
+    {
+        if (TSTBIT(e, i) == 0)
+        {
+            flint_mpn_sqr(X, acc, mn);
+            REDC_STEP(acc, X);
+            i--;
+        }
+        else
+        {
+            w = next_window(e, &i, k, &nsqr);
+            for (h = 0; h < nsqr; h++)
+            {
+                flint_mpn_sqr(X, acc, mn);
+                REDC_STEP(acc, X);
+            }
+            if (small_base)
+                mul_scalar_mod(acc, sc + 2 * (w >> 1), 2, m, mn, X);
+            else
+            {
+                flint_mpn_mul_n(X, acc, tab + (w >> 1) * mn, mn);
+                REDC_STEP(acc, X);
+            }
+        }
+    }
+
+    /* leave the Montgomery domain */
+    flint_mpn_copyi(X, acc, mn);
+    flint_mpn_zero(X + mn, mn);
+    REDC_STEP(r, X);
+
+#undef REDC_STEP
+#if FLINT_HAVE_FFT_SMALL
+        if (use_fold)
+            redc_fold_clear(F);
+    }
+#else
+    }
+#endif
+
+    TMP_END;
+}
+
+/* x = x^e mod 2^t2 on t2l = cdiv(t2, 64) limbs, b2 = base mod 2^t2 */
+static void
+powm_2exp(nn_ptr x, nn_srcptr b2, nn_srcptr e, mp_size_t en,
+          flint_bitcnt_t t2, mp_size_t t2l, nn_ptr scratch)
+{
+    flint_bitcnt_t ebits = (en - 1) * FLINT_BITS + FLINT_BIT_COUNT(e[en - 1]);
+    ulong mask = (t2 % FLINT_BITS) ?
+                 ((UWORD(1) << (t2 % FLINT_BITS)) - 1) : UWORD_MAX;
+    slong i;
+
+    flint_mpn_zero(x, t2l);
+    x[0] = 1;
+
+    for (i = ebits - 1; i >= 0; i--)
+    {
+        flint_mpn_mullow_n(scratch, x, x, t2l);
+        flint_mpn_copyi(x, scratch, t2l);
+        if (TSTBIT(e, i))
+        {
+            flint_mpn_mullow_n(scratch, x, b2, t2l);
+            flint_mpn_copyi(x, scratch, t2l);
+        }
+        x[t2l - 1] &= mask;
+    }
+}
+
+/*
+    r = b^e mod m. r, b, m: mn limbs with m normalized and b < m;
+    e: en limbs. No aliasing of r with the inputs.
+*/
+void
+flint_mpn_powm(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en,
+               nn_srcptr m, mp_size_t mn)
+{
+    flint_bitcnt_t val2;
+    mp_size_t i0, on, t2l;
+
+    FLINT_ASSERT(mn >= 1);
+    FLINT_ASSERT(m[mn - 1] != 0);
+
+    while (en > 0 && e[en - 1] == 0)
+        en--;
+
+    if (mn == 1 && m[0] == 1)
+    {
+        r[0] = 0;
+        return;
+    }
+
+    if (en == 0)
+    {
+        flint_mpn_zero(r, mn);
+        r[0] = 1;
+        return;
+    }
+
+    if (flint_mpn_zero_p(b, mn))
+    {
+        flint_mpn_zero(r, mn);
+        return;
+    }
+
+    if (en == 1 && e[0] == 1)
+    {
+        flint_mpn_copyi(r, b, mn);
+        return;
+    }
+
+    if (mn == 1 && en == 1)
+    {
+        nmod_t mod;
+
+        /* the nmod inverse is not the n = 1 flint_mpn_preinvn inverse,
+           so it is computed on the fly in both entry points */
+        nmod_init(&mod, m[0]);
+        r[0] = nmod_pow_ui(b[0], e[0], mod);
+        return;
+    }
+
+    /* Todo: for a few-limb modulus and a large exponent, GMP's
+       redc_1/redc_2 assembly currently wins; fall back to mpz_powm
+       until we have dedicated small-n Montgomery code. mn == 1 with a
+       multi-limb exponent takes this path too. */
+    if (mn <= FLINT_MPN_POWM_MPZ_FALLBACK_LIMBS)
+    {
+        flint_bitcnt_t ebits2 = (en - 1) * FLINT_BITS
+                                + FLINT_BIT_COUNT(e[en - 1]);
+        if (ebits2 > 16)
+        {
+            mpz_t rz;
+            mpz_t bz, ez, mz;
+            mp_size_t c;
+
+            mpz_roinit_n(bz, b, mn);
+            mpz_roinit_n(ez, e, en);
+            mpz_roinit_n(mz, m, mn);
+            mpz_init2(rz, (mn + 1) * FLINT_BITS);
+            mpz_powm(rz, bz, ez, mz);
+            c = FLINT_MIN((mp_size_t) mpz_size(rz), mn);
+            flint_mpn_copyi(r, mpz_limbs_read(rz), c);
+            flint_mpn_zero(r + c, mn - c);
+            mpz_clear(rz);
+            return;
+        }
+    }
+
+    /* small exponents: the division-based basecase (computing its own
+       preinvn inverse) beats the Montgomery setup; see
+       flint_mpn_powm_preinvn for the caller-supplied-inverse variant */
+    {
+        flint_bitcnt_t ebits3 = (en - 1) * FLINT_BITS
+                                + FLINT_BIT_COUNT(e[en - 1]);
+        if (ebits3 <= FLINT_MPN_POWM_PREINVN_REDC_EBITS)
+        {
+            _flint_mpn_powm_basecase(r, b, e, en, m, mn);
+            return;
+        }
+    }
+
+    for (i0 = 0; m[i0] == 0; i0++)
+        ;
+    val2 = i0 * FLINT_BITS + flint_ctz(m[i0]);
+
+    if (val2 == 0)
+    {
+        _flint_mpn_powm_redc(r, b, e, en, m, mn);
+    }
+    else
+    {
+        /* m = modd * 2^val2: CRT of the odd and 2-power parts */
+        nn_ptr modd, bo, r2, b2, inv2, u, z, scratch;
+        flint_bitcnt_t sh = val2 % FLINT_BITS;
+        ulong mask = sh ? ((UWORD(1) << sh) - 1) : UWORD_MAX;
+        TMP_INIT;
+
+        on = mn - i0;
+        t2l = (val2 + FLINT_BITS - 1) / FLINT_BITS;
+
+        TMP_START;
+        modd = TMP_ALLOC((3 * on + mn + 1 + 6 * t2l) * sizeof(ulong));
+        bo = modd + on;
+        r2 = bo + on;
+        b2 = r2 + t2l;
+        inv2 = b2 + t2l;
+        u = inv2 + t2l;
+        z = u + t2l;                       /* on + mn + 1 (>= on + t2l + 1) */
+        scratch = z + on + mn + 1;         /* 2*t2l */
+
+        if (sh)
+            mpn_rshift(modd, m + i0, on, sh);
+        else
+            flint_mpn_copyi(modd, m + i0, on);
+        if (modd[on - 1] == 0)
+            on--;
+
+        if (on == 1 && modd[0] == 1)
+        {
+            flint_mpn_zero(bo, 1);         /* r_odd = 0 */
+            bo[0] = 0;
+            flint_mpn_zero(modd, 1);
+            modd[0] = 1;
+            flint_mpn_zero(r2, t2l);       /* keep sizes uniform below */
+            flint_mpn_zero(z, on);
+            z[0] = 0;
+            /* r = b^e mod 2^val2 */
+            flint_mpn_copyi(b2, b, t2l);
+            b2[t2l - 1] &= mask;
+            powm_2exp(r2, b2, e, en, val2, t2l, scratch);
+            flint_mpn_zero(r, mn);
+            flint_mpn_copyi(r, r2, t2l);
+            TMP_END;
+            return;
+        }
+
+        /* odd part */
+        {
+            nn_ptr q = z;                  /* scratch for the division */
+            if (mn >= on)
+                mpn_tdiv_qr(q, bo, 0, b, mn, modd, on);
+        }
+        _flint_mpn_powm_redc(z, bo, e, en, modd, on);   /* r_odd in z */
+
+        /* 2-power part */
+        flint_mpn_copyi(b2, b, t2l);
+        b2[t2l - 1] &= mask;
+        powm_2exp(r2, b2, e, en, val2, t2l, scratch);
+
+        /* u = (r2 - r_odd) * modd^(-1) mod 2^val2 */
+        {
+            mp_size_t c = FLINT_MIN(on, t2l);
+            flint_mpn_copyi(u, z, c);
+            flint_mpn_zero(u + c, t2l - c);
+            mpn_sub_n(u, r2, u, t2l);
+
+            flint_mpn_copyi(inv2, modd, c);
+            flint_mpn_zero(inv2 + c, t2l - c);
+            flint_mpn_copyi(b2, inv2, t2l);            /* reuse b2 */
+            _flint_mpn_binvert(inv2, b2, t2l);
+
+            flint_mpn_mullow_n(scratch, u, inv2, t2l);
+            flint_mpn_copyi(u, scratch, t2l);
+            u[t2l - 1] &= mask;
+        }
+
+        /* r = r_odd + modd * u  (< m) */
+        {
+            nn_ptr prod = TMP_ALLOC((on + t2l) * sizeof(ulong));
+            ulong cy;
+
+            if (on >= t2l)
+                mpn_mul(prod, modd, on, u, t2l);
+            else
+                mpn_mul(prod, u, t2l, modd, on);
+            cy = mpn_add(prod, prod, on + t2l, z, on);
+            (void) cy;
+            FLINT_ASSERT(cy == 0);
+
+            flint_mpn_copyi(r, prod, mn);
+            FLINT_ASSERT(on + t2l == mn ||
+                flint_mpn_zero_p(prod + mn, on + t2l - mn));
+        }
+
+        TMP_END;
+    }
+}
+
+/*
+    r = b^e mod m with dinv the flint_mpn_preinvn inverse of m shifted
+    left by norm = clz(m[mn-1]), as stored for instance in an
+    fmpz_preinvn_t. Conventions as flint_mpn_powm. Small exponents run
+    on the supplied inverse with no per-call precomputation; large
+    exponents fall through to the Montgomery machinery, whose setup
+    then amortizes.
+*/
+void
+flint_mpn_powm_preinvn(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en,
+                       nn_srcptr m, mp_size_t mn, nn_srcptr dinv,
+                       flint_bitcnt_t norm)
+{
+    flint_bitcnt_t ebits;
+
+    FLINT_ASSERT(mn >= 1);
+    FLINT_ASSERT(m[mn - 1] != 0);
+    FLINT_ASSERT(norm == (flint_bitcnt_t) flint_clz(m[mn - 1]));
+
+    while (en > 0 && e[en - 1] == 0)
+        en--;
+
+    if ((mn == 1 && m[0] == 1) || en == 0 || flint_mpn_zero_p(b, mn)
+        || (en == 1 && e[0] == 1) || mn == 1)
+    {
+        flint_mpn_powm(r, b, e, en, m, mn);
+        return;
+    }
+
+    ebits = (en - 1) * FLINT_BITS + FLINT_BIT_COUNT(e[en - 1]);
+
+    /* for tiny moduli the mpz fallback of flint_mpn_powm takes over
+       from fewer exponent bits */
+    if (ebits <= (mn <= 12 ? (flint_bitcnt_t) 8
+                           : (flint_bitcnt_t)
+                             FLINT_MPN_POWM_PREINVN_REDC_EBITS))
+    {
+        nn_ptr msh;
+        TMP_INIT;
+
+        TMP_START;
+        msh = TMP_ALLOC(mn * sizeof(ulong));
+        if (norm)
+            mpn_lshift(msh, m, mn, norm);
+        else
+            flint_mpn_copyi(msh, m, mn);
+        powm_basecase_core(r, b, e, en, msh, mn, dinv, norm);
+        TMP_END;
+    }
+    else
+        flint_mpn_powm(r, b, e, en, m, mn);
+}

--- a/src/mpn_extras/powm.c
+++ b/src/mpn_extras/powm.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5
 
     This file is part of FLINT.
 
@@ -24,7 +25,7 @@
 
 /* above this, the quotient q = X_lo * minv mod B^mn also runs in the
    transform domain against a cached transform of minv */
-#define FLINT_MPN_POWM_REDC_QSTEP_FFT_THRESHOLD 480  /* re-tuned on the merged two-prime pipeline */
+#define FLINT_MPN_POWM_REDC_QSTEP_FFT_THRESHOLD 480
 
 /* moduli below the fold tiers with large exponents go to mpz_powm
    for now: there the reduction is plain mulhigh + mullow against
@@ -144,6 +145,7 @@ mulmod_preinvn_fold(nn_ptr r, nn_srcptr a, nn_srcptr b, mp_size_t n,
         flint_mpn_sqr(X, a, n);
     else
         flint_mpn_mul_n(X, a, b, n);
+
     if (norm)
         mpn_rshift(X, X, 2 * n, norm);
 
@@ -161,14 +163,17 @@ mulmod_preinvn_fold(nn_ptr r, nn_srcptr a, nn_srcptr b, mp_size_t n,
         c = FLINT_MIN(vn, rn);
         flint_mpn_copyi(FX, v, c);
         flint_mpn_zero(FX + c, rn - c);
-        v += c; vn -= c;
+        v += c;
+        vn -= c;
+
         while (vn > 0)
         {
             c = FLINT_MIN(vn, rn);
             cy = mpn_add(FX, FX, rn, v, c);
             while (cy)
                 cy = mpn_add_1(FX, FX, rn, cy);
-            v += c; vn -= c;
+            v += c;
+            vn -= c;
         }
     }
 
@@ -181,8 +186,10 @@ mulmod_preinvn_fold(nn_ptr r, nn_srcptr a, nn_srcptr b, mp_size_t n,
 
     while (FX[n] != 0)
         FX[n] -= mpn_sub_n(FX, FX, d, n);
+
     if (mpn_cmp(FX, d, n) >= 0)
         mpn_sub_n(FX, FX, d, n);
+
     flint_mpn_copyi(r, FX, n);
 }
 #endif
@@ -304,8 +311,17 @@ mul_scalar_mod(nn_ptr acc, nn_srcptr s, int sl, nn_srcptr m, mp_size_t n,
     if (sl == 2 && s[1] == 0)
         sl = 1;
 
-    mpn_mul(scratch, acc, n, s, sl);
-    mpn_tdiv_qr(q, acc, 0, scratch, n + sl, m, n);
+    if (sl == 1 && s[0] == 2)
+    {
+        ulong cy = mpn_lshift(acc, acc, n, 1);
+        if (cy != 0 || mpn_cmp(acc, m, n) >= 0)
+            mpn_sub_n(acc, acc, m, n);
+    }
+    else
+    {
+        flint_mpn_mul(scratch, acc, n, s, sl);
+        mpn_tdiv_qr(q, acc, 0, scratch, n + sl, m, n);
+    }
 }
 
 #if FLINT_HAVE_FFT_SMALL
@@ -409,9 +425,9 @@ chain_mul(powm_chain_struct * H, slong lev, nn_ptr S, nn_srcptr x,
             return;
         }
         if (xs >= s)
-            mpn_mul(work, x, xs, H->mbase, s);
+            flint_mpn_mul(work, x, xs, H->mbase, s);
         else
-            mpn_mul(work, H->mbase, s, x, xs);
+            flint_mpn_mul(work, H->mbase, s, x, xs);
         chain_res_m1(S, work, xs + s, s);
         return;
     }
@@ -659,10 +675,15 @@ redc_fold(nn_ptr t, nn_srcptr X, nn_srcptr m, nn_srcptr minv, mp_size_t mn,
         for (i = 0; i < nnc; i++)
             if (V[i] != UWORD_MAX)
                 break;
+
         if (i == nnc)
+        {
             flint_mpn_zero(V, nnc);  /* H = 0 */
+        }
         else
+        {
             FLINT_ASSERT(nnc == mn); /* a genuine H with huge top limb */
+        }
     }
 
     cy = mpn_add_n(t, X + mn, V, mn);
@@ -951,6 +972,7 @@ powm_2exp(nn_ptr x, nn_srcptr b2, nn_srcptr e, mp_size_t en,
 
     for (i = ebits - 1; i >= 0; i--)
     {
+        /* TODO: flint_mpn_sqrlow */
         flint_mpn_mullow_n(scratch, x, x, t2l);
         flint_mpn_copyi(x, scratch, t2l);
         if (TSTBIT(e, i))
@@ -992,10 +1014,27 @@ flint_mpn_powm(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en,
         return;
     }
 
-    if (flint_mpn_zero_p(b, mn))
+    if (flint_mpn_zero_p(b + 1, mn - 1))
     {
-        flint_mpn_zero(r, mn);
-        return;
+        ulong b0 = b[0];
+        /* TODO: when there is an flint_mpn_pow, more small powers could
+           be special-cased here. More ambitiously, certain we could split
+           powers with a small base and a relatively small exponent into
+           a plain integer power followed by modular powering. */
+
+        if (b0 == 0 || b0 == 1)
+        {
+            flint_mpn_zero(r, mn);
+            r[0] = b0;
+            return;
+        }
+        else if (b0 == 2 && en == 1 &&
+            e[0] < (mn - 1) * FLINT_BITS + FLINT_BIT_COUNT(m[mn - 1]) - 1)
+        {
+            flint_mpn_zero(r, mn);
+            r[e[0] / FLINT_BITS] = UWORD(1) << (e[0] % FLINT_BITS);
+            return;
+        }
     }
 
     if (en == 1 && e[0] == 1)
@@ -1146,9 +1185,9 @@ flint_mpn_powm(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en,
             ulong cy;
 
             if (on >= t2l)
-                mpn_mul(prod, modd, on, u, t2l);
+                flint_mpn_mul(prod, modd, on, u, t2l);
             else
-                mpn_mul(prod, u, t2l, modd, on);
+                flint_mpn_mul(prod, u, t2l, modd, on);
             cy = mpn_add(prod, prod, on + t2l, z, on);
             (void) cy;
             FLINT_ASSERT(cy == 0);
@@ -1214,3 +1253,4 @@ flint_mpn_powm_preinvn(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en,
     else
         flint_mpn_powm(r, b, e, en, m, mn);
 }
+

--- a/src/mpn_extras/powm.c
+++ b/src/mpn_extras/powm.c
@@ -44,6 +44,18 @@
    setup (binvert, Montgomery conversions, fold initialization) */
 #define FLINT_MPN_POWM_PREINVN_REDC_EBITS 24
 
+/* above this many exponent bits, GMP's redc assembly wins for a
+   modulus of at most FLINT_MPN_POWM_MPZ_FALLBACK_LIMBS limbs. A
+   caller-supplied inverse is therefore useful up to exactly this many
+   bits at those sizes and no further; the two constants have to move
+   together, or the preinvn entry point ends up handing work to a path
+   that recomputes the inverse it was given. */
+#define FLINT_MPN_POWM_MPZ_FALLBACK_EBITS 16
+
+/* at more limbs than this the supplied inverse stays ahead of the mpz
+   fallback all the way to FLINT_MPN_POWM_PREINVN_REDC_EBITS */
+#define FLINT_MPN_POWM_PREINVN_SMALL_LIMBS 12
+
 /* fold tiers, from in-situ per-reduction timings: mulders mulhigh,
    then flint_mpn_mulmod_bnm1 (small working set, no fixed transform
    costs), then the cached chain or cyclic-plan fold */
@@ -126,7 +138,7 @@ next_window(nn_srcptr e, slong * i, int k, slong * nsqr)
     mulmod_preinvn's), and since C*d < B^rn - 1 for rn > n it is the
     canonical value of (X - q*d) mod (B^rn - 1), with q*d computed by
     flint_mpn_mulmod_bnm1 at about 0.6 multiplications. Needs no
-    precomputation beyond dinv. scratch: 5n + itch(rn) + 4rn limbs.
+    precomputation beyond dinv. scratch: 3n + 1 + 2rn + itch(rn) limbs.
 */
 static void
 mulmod_preinvn_fold(nn_ptr r, nn_srcptr a, nn_srcptr b, mp_size_t n,
@@ -280,6 +292,65 @@ powm_basecase_core(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en,
     TMP_END;
 }
 
+/*
+    Small exponents on a caller-supplied inverse, with no per-call
+    precomputation. Requires mn >= 2 and e >= 2 with the trivial cases
+    already peeled off by powm_dispatch.
+*/
+static void
+powm_preinvn_small(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en,
+                   nn_srcptr m, mp_size_t mn, nn_srcptr dinv,
+                   flint_bitcnt_t norm)
+{
+    nn_srcptr msh;
+    TMP_INIT;
+
+    TMP_START;
+
+    /* flint_mpn_mulmod_preinvn wants m shifted left by norm; when norm
+       is zero, which is the usual case for a normalised modulus, it is
+       already in that form and needs no copy */
+    if (norm == 0)
+        msh = m;
+    else
+    {
+        nn_ptr t = TMP_ALLOC(mn * sizeof(ulong));
+        mpn_lshift(t, m, mn, norm);
+        msh = t;
+    }
+
+    /* Squares and cubes are common enough in generic ring code that the
+       window bookkeeping of powm_basecase_core is a measurable share of
+       the cost; run them directly instead. */
+    if (en == 1 && e[0] <= 4)
+    {
+        nn_ptr x = TMP_ALLOC(2 * mn * sizeof(ulong));
+        nn_ptr y = x + mn;
+
+        FLINT_ASSERT(e[0] >= 2);
+
+        if (norm)
+            mpn_lshift(x, b, mn, norm);
+        else
+            flint_mpn_copyi(x, b, mn);
+
+        flint_mpn_mulmod_preinvn(y, x, x, mn, msh, dinv, norm);
+        if (e[0] == 3)
+            flint_mpn_mulmod_preinvn(y, y, x, mn, msh, dinv, norm);
+        else if (e[0] == 4)
+            flint_mpn_mulmod_preinvn(y, y, y, mn, msh, dinv, norm);
+
+        if (norm)
+            mpn_rshift(r, y, mn, norm);
+        else
+            flint_mpn_copyi(r, y, mn);
+    }
+    else
+        powm_basecase_core(r, b, e, en, msh, mn, dinv, norm);
+
+    TMP_END;
+}
+
 void
 _flint_mpn_powm_basecase(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en,
                          nn_srcptr m, mp_size_t mn)
@@ -319,7 +390,10 @@ mul_scalar_mod(nn_ptr acc, nn_srcptr s, int sl, nn_srcptr m, mp_size_t n,
     }
     else
     {
-        flint_mpn_mul(scratch, acc, n, s, sl);
+        if (n >= sl)
+            flint_mpn_mul(scratch, acc, n, s, sl);
+        else
+            flint_mpn_mul(scratch, s, sl, acc, n);
         mpn_tdiv_qr(q, acc, 0, scratch, n + sl, m, n);
     }
 }
@@ -411,7 +485,6 @@ chain_mul(powm_chain_struct * H, slong lev, nn_ptr S, nn_srcptr x,
     nn_ptr x1, x2, v, sb;
     ulong br, cy;
     int vtop, stop;
-    mp_size_t i;
 
     if (s <= H->base)
     {
@@ -450,7 +523,7 @@ chain_mul(powm_chain_struct * H, slong lev, nn_ptr S, nn_srcptr x,
                                             H->Fm[lev], H->scr + lev);
     else
     {
-        int c = (x2[h] != 0) | ((H->m2[lev][h] != 0) << 1);
+        int c = ((x2[h] != 0) << 1) | (H->m2[lev][h] != 0);
         v[h] = (ulong) flint_mpn_mulmod_2expp1_basecase(v, x2,
                     H->m2[lev], c, FLINT_BITS * h, work);
     }
@@ -488,8 +561,6 @@ chain_mul(powm_chain_struct * H, slong lev, nn_ptr S, nn_srcptr x,
     br = mpn_sub(S, S, s, sb, h + 1);
     while (br)
         br = mpn_sub_1(S, S, s, 1);
-
-    (void) i;
 }
 
 typedef struct
@@ -985,14 +1056,21 @@ powm_2exp(nn_ptr x, nn_srcptr b2, nn_srcptr e, mp_size_t en,
 }
 
 /*
-    r = b^e mod m. r, b, m: mn limbs with m normalized and b < m;
-    e: en limbs. No aliasing of r with the inputs.
+    Shared dispatcher for both public entry points. dinv, when not NULL,
+    is the flint_mpn_preinvn inverse of m shifted left by norm; when it
+    is NULL there is no precomputed inverse and norm is ignored.
+
+    Keeping one dispatcher matters for more than tidiness: the cheap
+    special cases below have to be tried before the exponent-size tiers,
+    and the tier that consumes a supplied inverse has to sit exactly
+    where the no-inverse path would otherwise recompute one.
 */
-void
-flint_mpn_powm(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en,
-               nn_srcptr m, mp_size_t mn)
+static void
+powm_dispatch(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en,
+              nn_srcptr m, mp_size_t mn, nn_srcptr dinv,
+              flint_bitcnt_t norm)
 {
-    flint_bitcnt_t val2;
+    flint_bitcnt_t val2, ebits;
     mp_size_t i0, on, t2l;
 
     FLINT_ASSERT(mn >= 1);
@@ -1054,15 +1132,28 @@ flint_mpn_powm(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en,
         return;
     }
 
+    ebits = (en - 1) * FLINT_BITS + FLINT_BIT_COUNT(e[en - 1]);
+
+    /* With an inverse in hand, run the division-based basecase on it
+       rather than falling through to a tier that would recompute one.
+       For a small modulus that is worth doing exactly as far as the mpz
+       fallback below, which takes over from there. */
+    if (dinv != NULL && mn >= 2
+        && ebits <= (mn <= FLINT_MPN_POWM_PREINVN_SMALL_LIMBS
+                     ? (flint_bitcnt_t) FLINT_MPN_POWM_MPZ_FALLBACK_EBITS
+                     : (flint_bitcnt_t) FLINT_MPN_POWM_PREINVN_REDC_EBITS))
+    {
+        powm_preinvn_small(r, b, e, en, m, mn, dinv, norm);
+        return;
+    }
+
     /* Todo: for a few-limb modulus and a large exponent, GMP's
        redc_1/redc_2 assembly currently wins; fall back to mpz_powm
        until we have dedicated small-n Montgomery code. mn == 1 with a
        multi-limb exponent takes this path too. */
     if (mn <= FLINT_MPN_POWM_MPZ_FALLBACK_LIMBS)
     {
-        flint_bitcnt_t ebits2 = (en - 1) * FLINT_BITS
-                                + FLINT_BIT_COUNT(e[en - 1]);
-        if (ebits2 > 16)
+        if (ebits > FLINT_MPN_POWM_MPZ_FALLBACK_EBITS)
         {
             mpz_t rz;
             mpz_t bz, ez, mz;
@@ -1081,17 +1172,12 @@ flint_mpn_powm(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en,
         }
     }
 
-    /* small exponents: the division-based basecase (computing its own
-       preinvn inverse) beats the Montgomery setup; see
-       flint_mpn_powm_preinvn for the caller-supplied-inverse variant */
+    /* small exponents with no inverse to hand: the division-based
+       basecase computes its own and still beats the Montgomery setup */
+    if (ebits <= FLINT_MPN_POWM_PREINVN_REDC_EBITS)
     {
-        flint_bitcnt_t ebits3 = (en - 1) * FLINT_BITS
-                                + FLINT_BIT_COUNT(e[en - 1]);
-        if (ebits3 <= FLINT_MPN_POWM_PREINVN_REDC_EBITS)
-        {
-            _flint_mpn_powm_basecase(r, b, e, en, m, mn);
-            return;
-        }
+        _flint_mpn_powm_basecase(r, b, e, en, m, mn);
+        return;
     }
 
     for (i0 = 0; m[i0] == 0; i0++)
@@ -1209,48 +1295,31 @@ flint_mpn_powm(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en,
     exponents fall through to the Montgomery machinery, whose setup
     then amortizes.
 */
+/*
+    r = b^e mod m. r, b, m: mn limbs with m normalized and b < m;
+    e: en limbs. No aliasing of r with the inputs.
+*/
+void
+flint_mpn_powm(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en,
+               nn_srcptr m, mp_size_t mn)
+{
+    powm_dispatch(r, b, e, en, m, mn, NULL, 0);
+}
+
+/*
+    r = b^e mod m with dinv the flint_mpn_preinvn inverse of m shifted
+    left by norm = clz(m[mn-1]), as stored for instance in an
+    fmpz_preinvn_t. Conventions as flint_mpn_powm. Small exponents run
+    on the supplied inverse with no per-call precomputation; large
+    exponents fall through to the Montgomery machinery, whose setup
+    then amortizes.
+*/
 void
 flint_mpn_powm_preinvn(nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en,
                        nn_srcptr m, mp_size_t mn, nn_srcptr dinv,
                        flint_bitcnt_t norm)
 {
-    flint_bitcnt_t ebits;
-
-    FLINT_ASSERT(mn >= 1);
-    FLINT_ASSERT(m[mn - 1] != 0);
     FLINT_ASSERT(norm == (flint_bitcnt_t) flint_clz(m[mn - 1]));
 
-    while (en > 0 && e[en - 1] == 0)
-        en--;
-
-    if ((mn == 1 && m[0] == 1) || en == 0 || flint_mpn_zero_p(b, mn)
-        || (en == 1 && e[0] == 1) || mn == 1)
-    {
-        flint_mpn_powm(r, b, e, en, m, mn);
-        return;
-    }
-
-    ebits = (en - 1) * FLINT_BITS + FLINT_BIT_COUNT(e[en - 1]);
-
-    /* for tiny moduli the mpz fallback of flint_mpn_powm takes over
-       from fewer exponent bits */
-    if (ebits <= (mn <= 12 ? (flint_bitcnt_t) 8
-                           : (flint_bitcnt_t)
-                             FLINT_MPN_POWM_PREINVN_REDC_EBITS))
-    {
-        nn_ptr msh;
-        TMP_INIT;
-
-        TMP_START;
-        msh = TMP_ALLOC(mn * sizeof(ulong));
-        if (norm)
-            mpn_lshift(msh, m, mn, norm);
-        else
-            flint_mpn_copyi(msh, m, mn);
-        powm_basecase_core(r, b, e, en, msh, mn, dinv, norm);
-        TMP_END;
-    }
-    else
-        flint_mpn_powm(r, b, e, en, m, mn);
+    powm_dispatch(r, b, e, en, m, mn, dinv, norm);
 }
-

--- a/src/mpn_extras/profile/p-powm.c
+++ b/src/mpn_extras/profile/p-powm.c
@@ -1,0 +1,116 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <gmp.h>
+#include "flint.h"
+#include "mpn_extras.h"
+#include "profiler.h"
+
+/* Compares the powm stages against each other and against mpz_powm,
+   for random bases and for base 3 (the PRP-shaped workload). Reports
+   milliseconds per call and the per-exponent-bit cost in units of one
+   flint_mpn_sqr at the modulus size. */
+
+static double
+time_one(void (*f)(nn_ptr, nn_srcptr, nn_srcptr, mp_size_t,
+                   nn_srcptr, mp_size_t),
+         nn_ptr r, nn_srcptr b, nn_srcptr e, mp_size_t en,
+         nn_srcptr m, mp_size_t mn, slong reps)
+{
+    timeit_t t;
+    slong i;
+    timeit_start(t);
+    for (i = 0; i < reps; i++)
+        f(r, b, e, en, m, mn);
+    timeit_stop(t);
+    return (double) t->cpu / reps;
+}
+
+int main(void)
+{
+    flint_rand_t state;
+    mp_size_t sizes[] = { 400, 800, 1600, 3200, 6400, 12800, 25600 };
+    slong nsizes = 7, si;
+
+    flint_rand_init(state);
+
+    flint_printf("powm, 256-bit exponent, times in ms "
+                 "(sqr = one flint_mpn_sqr at mn):\n");
+    flint_printf("%10s %8s %9s %9s %9s %9s %9s %11s\n",
+                 "bits", "sqr", "basecase", "redc", "(unused)", "mpz",
+                 "redc(b=3)", "ms/bit");
+
+    for (si = 0; si < nsizes; si++)
+    {
+        mp_size_t mn = sizes[si], en = 4;
+        nn_ptr m, b, e, r, X;
+        mpz_t mz, bz, ez, rz;
+        timeit_t ts;
+        slong i, reps = FLINT_MAX(1, 4000 / mn), sreps;
+        double t_sqr, t_bc, t_redc, t_fft, t_mpz, t_fft3;
+        flint_bitcnt_t ebits;
+
+        m = flint_malloc(mn * sizeof(ulong));
+        b = flint_malloc(mn * sizeof(ulong));
+        e = flint_malloc(en * sizeof(ulong));
+        r = flint_malloc(mn * sizeof(ulong));
+        X = flint_malloc(2 * mn * sizeof(ulong));
+
+        flint_mpn_rrandom(m, state, mn);
+        m[0] |= 1;
+        m[mn - 1] |= UWORD(1) << 62;
+        flint_mpn_rrandom(b, state, mn);
+        mpn_tdiv_qr(X, b, 0, b, mn, m, mn);
+        flint_mpn_rrandom(e, state, en);
+        e[en - 1] |= UWORD(1) << 62;
+        ebits = (en - 1) * FLINT_BITS + FLINT_BIT_COUNT(e[en - 1]);
+
+        mpz_init(mz); mpz_init(bz); mpz_init(ez); mpz_init(rz);
+        mpz_import(mz, mn, -1, sizeof(ulong), 0, 0, m);
+        mpz_import(bz, mn, -1, sizeof(ulong), 0, 0, b);
+        mpz_import(ez, en, -1, sizeof(ulong), 0, 0, e);
+
+        sreps = FLINT_MAX(10, 400000 / mn);
+        timeit_start(ts);
+        for (i = 0; i < sreps; i++)
+            flint_mpn_sqr(X, b, mn);
+        timeit_stop(ts);
+        t_sqr = (double) ts->cpu / sreps;
+
+        t_bc = time_one(_flint_mpn_powm_basecase, r, b, e, en, m, mn, reps);
+        t_redc = time_one(_flint_mpn_powm_redc, r, b, e, en, m, mn, reps);
+        t_fft = 0.0;
+        {
+            timeit_t t;
+            timeit_start(t);
+            for (i = 0; i < reps; i++)
+                mpz_powm(rz, bz, ez, mz);
+            timeit_stop(t);
+            t_mpz = (double) t->cpu / reps;
+        }
+
+        flint_mpn_zero(b, mn);
+        b[0] = 3;
+        t_fft3 = time_one(_flint_mpn_powm_redc, r, b, e, en, m, mn, reps);
+
+        flint_printf("%10wd %8.2f %9.1f %9.1f %9.1f %9.1f %9.1f %11.4f\n",
+                     (slong) mn * FLINT_BITS, t_sqr, t_bc, t_redc, t_fft,
+                     t_mpz, t_fft3, t_fft3 / ebits);
+
+        mpz_clear(mz); mpz_clear(bz); mpz_clear(ez); mpz_clear(rz);
+        flint_free(m); flint_free(b); flint_free(e);
+        flint_free(r); flint_free(X);
+    }
+
+    flint_rand_clear(state);
+    return 0;
+}

--- a/src/mpn_extras/profile/p-powm.c
+++ b/src/mpn_extras/profile/p-powm.c
@@ -45,8 +45,8 @@ int main(void)
 
     flint_printf("powm, 256-bit exponent, times in ms "
                  "(sqr = one flint_mpn_sqr at mn):\n");
-    flint_printf("%10s %8s %9s %9s %9s %9s %9s %11s\n",
-                 "bits", "sqr", "basecase", "redc", "(unused)", "mpz",
+    flint_printf("%10s %8s %9s %9s %9s %9s %11s\n",
+                 "bits", "sqr", "basecase", "redc", "mpz",
                  "redc(b=3)", "ms/bit");
 
     for (si = 0; si < nsizes; si++)
@@ -56,7 +56,7 @@ int main(void)
         mpz_t mz, bz, ez, rz;
         timeit_t ts;
         slong i, reps = FLINT_MAX(1, 4000 / mn), sreps;
-        double t_sqr, t_bc, t_redc, t_fft, t_mpz, t_fft3;
+        double t_sqr, t_bc, t_redc, t_mpz, t_fft3;
         flint_bitcnt_t ebits;
 
         m = flint_malloc(mn * sizeof(ulong));
@@ -88,7 +88,6 @@ int main(void)
 
         t_bc = time_one(_flint_mpn_powm_basecase, r, b, e, en, m, mn, reps);
         t_redc = time_one(_flint_mpn_powm_redc, r, b, e, en, m, mn, reps);
-        t_fft = 0.0;
         {
             timeit_t t;
             timeit_start(t);
@@ -102,8 +101,8 @@ int main(void)
         b[0] = 3;
         t_fft3 = time_one(_flint_mpn_powm_redc, r, b, e, en, m, mn, reps);
 
-        flint_printf("%10wd %8.2f %9.1f %9.1f %9.1f %9.1f %9.1f %11.4f\n",
-                     (slong) mn * FLINT_BITS, t_sqr, t_bc, t_redc, t_fft,
+        flint_printf("%10wd %8.2f %9.1f %9.1f %9.1f %9.1f %11.4f\n",
+                     (slong) mn * FLINT_BITS, t_sqr, t_bc, t_redc,
                      t_mpz, t_fft3, t_fft3 / ebits);
 
         mpz_clear(mz); mpz_clear(bz); mpz_clear(ez); mpz_clear(rz);

--- a/src/mpn_extras/redc_n.c
+++ b/src/mpn_extras/redc_n.c
@@ -1,0 +1,118 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "mpn_extras.h"
+
+/*
+    Montgomery reduction: t = X * B^(-n) mod m, canonical in [0, m),
+    for odd m of n limbs and 0 <= X < m * B^n (2n limbs).
+    minv = -m^(-1) mod B^n (negation of _flint_mpn_binvert's output).
+    scratch: 2n limbs. t must not alias X, m or minv; X is preserved.
+
+    With q = X_lo * minv mod B^n we have X + q*m = t * B^n exactly and
+    t = X_hi + floor(q*m / B^n) + (X_lo != 0) < 2m, since the low halves
+    satisfy X_lo + lo(q*m) = 0 or B^n exactly.
+
+    The floor is obtained from flint_mpn_mulhigh_n, whose result errs
+    low by at most n + 2 ulp of the returned guard limb C [1]. The exact
+    guard limb is known here: it is the top limb T of lo(q*m) = B^n - X_lo.
+    Writing T = C + e - B*carry with 0 <= e <= n + 2, the omitted carry
+    into the high limbs occurred iff T < C, so a single comparison
+    resolves the rounding whenever C is close enough to B for a wrap to
+    be possible at all.
+
+    [1] see the documentation of flint_mpn_mulhigh_n; T. Kime,
+        P. Zimmermann, "Exact high part of integer multiplication",
+        https://hal.science/hal-04861755 gives sharper variant-specific
+        bounds (Corollary 4).
+*/
+void
+_flint_mpn_redc_n(nn_ptr t, nn_srcptr X, nn_srcptr m, nn_srcptr minv,
+                  mp_size_t n, nn_ptr scratch)
+{
+    nn_ptr q = scratch, h = scratch + n;
+    ulong C, cy;
+    mp_size_t i;
+
+    if (n < 16)
+    {
+        /* small sizes: exact high product, no guard logic */
+        nn_ptr full;
+        TMP_INIT;
+
+        for (i = 0; i < n; i++)
+            if (X[i] != 0)
+                break;
+        if (i == n)
+        {
+            flint_mpn_copyi(t, X + n, n);
+            goto reduce;
+        }
+
+        flint_mpn_mullow_n(q, X, minv, n);
+
+        TMP_START;
+        full = TMP_ALLOC(2 * n * sizeof(ulong));
+        flint_mpn_mul_n(full, q, m, n);
+        cy = mpn_add_n(t, X + n, full + n, n);
+        cy += mpn_add_1(t, t, n, 1);
+        TMP_END;
+
+        if (cy)
+            mpn_sub_n(t, t, m, n);
+        goto reduce;
+    }
+
+    for (i = 0; i < n; i++)
+        if (X[i] != 0)
+            break;
+    if (i == n)
+    {
+        /* q = 0 */
+        flint_mpn_copyi(t, X + n, n);
+        goto reduce;
+    }
+
+    flint_mpn_mullow_n(q, X, minv, n);
+    C = flint_mpn_mulhigh_n(h, q, m, n);
+
+    /* a wrap of the true guard past B is possible only for C within
+       the error bound of B */
+    if (C >= UWORD_MAX - (ulong) (n + 1))
+    {
+        /* T = top limb of B^n - X_lo, with X_lo != 0 */
+        ulong T = ~X[n - 1];
+        int lower_zero = 1;
+
+        for (i = 0; i < n - 1; i++)
+        {
+            if (X[i] != 0)
+            {
+                lower_zero = 0;
+                break;
+            }
+        }
+        T += (ulong) lower_zero;
+
+        if (T < C)
+            mpn_add_1(h, h, n, 1);
+    }
+
+    cy = mpn_add_n(t, X + n, h, n);
+    cy += mpn_add_1(t, t, n, 1);   /* X_lo + lo(q*m) = B^n */
+
+    if (cy)
+        mpn_sub_n(t, t, m, n);     /* t < 2m: the borrow matches cy */
+
+reduce:
+    if (mpn_cmp(t, m, n) >= 0)
+        mpn_sub_n(t, t, m, n);
+}

--- a/src/mpn_extras/test/main.c
+++ b/src/mpn_extras/test/main.c
@@ -36,8 +36,11 @@
 #include "t-mulmod_precond_matrix.c"
 #include "t-mulmod_precond_shoup.c"
 #include "t-mulmod_preinv1.c"
+#include "t-mulmod_bnm1.c"
 #include "t-mulmod_preinvn.c"
 #include "t-multi_crt.c"
+#include "t-powm.c"
+#include "t-redc_n.c"
 #include "t-remove_2exp.c"
 #include "t-remove_power.c"
 #include "t-sqr.c"
@@ -73,8 +76,11 @@ test_struct tests[] =
     TEST_FUNCTION(flint_mpn_mulmod_precond_matrix),
     TEST_FUNCTION(flint_mpn_mulmod_precond_shoup),
     TEST_FUNCTION(flint_mpn_mulmod_preinv1),
+    TEST_FUNCTION(flint_mpn_mulmod_bnm1),
     TEST_FUNCTION(flint_mpn_mulmod_preinvn),
     TEST_FUNCTION(flint_mpn_multi_crt),
+    TEST_FUNCTION(flint_mpn_powm),
+    TEST_FUNCTION(flint_mpn_redc_n),
     TEST_FUNCTION(flint_mpn_remove_2exp),
     TEST_FUNCTION(flint_mpn_remove_power),
     TEST_FUNCTION(flint_mpn_sqr),

--- a/src/mpn_extras/test/t-mulmod_bnm1.c
+++ b/src/mpn_extras/test/t-mulmod_bnm1.c
@@ -1,0 +1,94 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "mpn_extras.h"
+
+/* canonical reduction mod B^rn - 1 for comparison */
+static void
+canon_bnm1(nn_ptr r, nn_srcptr v, mp_size_t vn, mp_size_t rn)
+{
+    mp_size_t c, i;
+    ulong cy;
+
+    c = FLINT_MIN(vn, rn);
+    flint_mpn_copyi(r, v, c);
+    flint_mpn_zero(r + c, rn - c);
+    v += c; vn -= c;
+    while (vn > 0)
+    {
+        c = FLINT_MIN(vn, rn);
+        cy = mpn_add(r, r, rn, v, c);
+        while (cy)
+            cy = mpn_add_1(r, r, rn, cy);
+        v += c; vn -= c;
+    }
+    for (i = 0; i < rn; i++)
+        if (r[i] != UWORD_MAX)
+            return;
+    flint_mpn_zero(r, rn);
+}
+
+TEST_FUNCTION_START(flint_mpn_mulmod_bnm1, state)
+{
+    for (slong iter = 0; iter < 1000 * flint_test_multiplier(); iter++)
+    {
+        mp_size_t n = 1 + n_randint(state, n_randint(state, 20) == 0 ?
+                                           900 : 120);
+        mp_size_t rn = flint_mpn_mulmod_bnm1_next_size(n);
+        mp_size_t an = 1 + n_randint(state, rn);
+        mp_size_t bn = 1 + n_randint(state, rn);
+        int sqr = n_randint(state, 4) == 0;
+        nn_ptr a, b, r, ref, v, tp;
+        mp_size_t i;
+
+        if (rn < n)
+            TEST_FUNCTION_FAIL("next_size: n = %wd, rn = %wd\n", n, rn);
+
+        a = FLINT_ARRAY_ALLOC(rn, ulong);
+        b = FLINT_ARRAY_ALLOC(rn, ulong);
+        r = FLINT_ARRAY_ALLOC(2 * rn, ulong);
+        ref = FLINT_ARRAY_ALLOC(rn, ulong);
+        v = FLINT_ARRAY_ALLOC(2 * rn, ulong);
+        tp = FLINT_ARRAY_ALLOC(flint_mpn_mulmod_bnm1_itch(rn), ulong);
+
+        flint_mpn_rrandom(a, state, an);
+        if (n_randint(state, 20) == 0)
+            for (i = 0; i < an; i++)
+                a[i] = UWORD_MAX;
+        if (sqr)
+        {
+            bn = an;
+            flint_mpn_copyi(b, a, bn);
+        }
+        else
+            flint_mpn_rrandom(b, state, bn);
+
+        flint_mpn_mulmod_bnm1(r, rn, a, an, sqr ? a : b, bn, tp);
+
+        /* representative < B^rn congruent to the true product */
+        if (an >= bn)
+            mpn_mul(v, a, an, sqr ? a : b, bn);
+        else
+            mpn_mul(v, sqr ? a : b, bn, a, an);
+        canon_bnm1(ref, v, an + bn, rn);
+        canon_bnm1(v, r, rn, rn);
+
+        if (mpn_cmp(v, ref, rn) != 0)
+            TEST_FUNCTION_FAIL("n = %wd, rn = %wd, an = %wd, bn = %wd, "
+                               "sqr = %d\n", n, rn, an, bn, sqr);
+
+        flint_free(a); flint_free(b); flint_free(r);
+        flint_free(ref); flint_free(v); flint_free(tp);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/mpn_extras/test/t-mulmod_bnm1.c
+++ b/src/mpn_extras/test/t-mulmod_bnm1.c
@@ -90,5 +90,57 @@ TEST_FUNCTION_START(flint_mpn_mulmod_bnm1, state)
         flint_free(ref); flint_free(v); flint_free(tp);
     }
 
+    /* An operand whose residue mod B^h + 1 is exactly B^h (that is,
+       x_hi = x_lo + 1, of which x = B^h is the simplest instance) is the
+       only case where the top-bit flags handed to
+       flint_mpn_mulmod_2expp1_basecase are not both equal, so it is the
+       only case that distinguishes their order. Random operands never
+       hit it. */
+    for (slong iter = 0; iter < 100 * flint_test_multiplier(); iter++)
+    {
+        mp_size_t n = 33 + n_randint(state, 160);
+        mp_size_t rn = flint_mpn_mulmod_bnm1_next_size(n);
+        mp_size_t h = rn / 2;
+        nn_ptr a, b, r, ref, v, tp;
+        mp_size_t i;
+        int which;
+
+        if (rn & 1)
+            continue;
+
+        a = FLINT_ARRAY_ALLOC(rn, ulong);
+        b = FLINT_ARRAY_ALLOC(rn, ulong);
+        r = FLINT_ARRAY_ALLOC(2 * rn, ulong);
+        ref = FLINT_ARRAY_ALLOC(rn, ulong);
+        v = FLINT_ARRAY_ALLOC(2 * rn, ulong);
+        tp = FLINT_ARRAY_ALLOC(flint_mpn_mulmod_bnm1_itch(rn), ulong);
+
+        /* a: low half random, high half equal to it plus one */
+        flint_mpn_rrandom(a, state, h);
+        flint_mpn_copyi(a + h, a, h);
+        mpn_add_1(a + h, a + h, h, 1);
+        flint_mpn_rrandom(b, state, rn);
+
+        /* exercise the flag in either operand position */
+        which = n_randint(state, 2);
+        if (which)
+        {
+            nn_ptr t = a; a = b; b = t;
+        }
+
+        flint_mpn_mulmod_bnm1(r, rn, a, rn, b, rn, tp);
+
+        mpn_mul_n(v, a, b, rn);
+        canon_bnm1(ref, v, 2 * rn, rn);
+        canon_bnm1(v, r, rn, rn);
+
+        if (mpn_cmp(v, ref, rn) != 0)
+            TEST_FUNCTION_FAIL("residue B^h: rn = %wd, operand = %d\n",
+                               rn, which);
+
+        flint_free(a); flint_free(b); flint_free(r);
+        flint_free(ref); flint_free(v); flint_free(tp);
+    }
+
     TEST_FUNCTION_END(state);
 }

--- a/src/mpn_extras/test/t-powm.c
+++ b/src/mpn_extras/test/t-powm.c
@@ -1,0 +1,157 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <gmp.h>
+#include "test_helpers.h"
+#include "mpn_extras.h"
+
+TEST_FUNCTION_START(flint_mpn_powm, state)
+{
+    for (slong iter = 0; iter < 300 * flint_test_multiplier(); iter++)
+    {
+        int large = n_randint(state, 12) == 0;
+        int huge = n_randint(state, 40) == 0;
+        mp_size_t mn = huge ? 1550 + n_randint(state, 500)
+                            : 1 + n_randint(state, large ? 350 : 25);
+        mp_size_t en = (large || huge) ? 1 : n_randint(state, 5);
+        nn_ptr m, b, e, r, r2, q;
+        mpz_t mz, bz, ez, rz, cz;
+        int mode;
+
+        m = FLINT_ARRAY_ALLOC(mn, ulong);
+        b = FLINT_ARRAY_ALLOC(mn, ulong);
+        e = FLINT_ARRAY_ALLOC(FLINT_MAX(en, 1), ulong);
+        r = FLINT_ARRAY_ALLOC(mn, ulong);
+        r2 = FLINT_ARRAY_ALLOC(mn, ulong);
+        q = FLINT_ARRAY_ALLOC(mn + 1, ulong);
+
+        /* modulus: random, sometimes even with a big 2-adic part,
+           sometimes a pure power of two */
+        flint_mpn_rrandom(m, state, mn);
+        m[mn - 1] |= (UWORD(1) << (FLINT_BITS - 1 -
+                          n_randint(state, FLINT_BITS)));
+        mode = n_randint(state, 4);
+        if (mode == 1)
+            m[0] |= 1;                                   /* odd */
+        else if (mode == 2 && mn > 1)
+            flint_mpn_zero(m, n_randint(state, mn - 1) + 1),  /* even, big val2 */
+            m[mn - 1] |= 1 + n_randint(state, 255);
+        else if (mode == 3)
+        {
+            flint_mpn_zero(m, mn);                       /* m = 2^k */
+            m[mn - 1] = UWORD(1) << n_randint(state, FLINT_BITS);
+        }
+        if (flint_mpn_zero_p(m, mn))
+            m[0] = 1;
+        while (m[mn - 1] == 0)
+            mn--;
+
+        /* base: random < m, or a small prime to hit the scalar path */
+        if (n_randint(state, 3) == 0)
+        {
+            ulong small[] = { 0, 1, 2, 3, 5, 7, 10, 255 };
+            flint_mpn_zero(b, mn);
+            b[0] = small[n_randint(state, 8)];
+            if (mn == 1 || (mn == 1 && b[0] >= m[0]))
+                b[0] = b[0] % m[0];
+            if (mn == 1)
+                b[0] %= m[0];
+        }
+        else
+        {
+            flint_mpn_rrandom(b, state, mn);
+            mpn_tdiv_qr(q, b, 0, b, mn, m, mn);
+        }
+        if (mpn_cmp(b, m, mn) >= 0)
+            mpn_sub_n(b, b, m, mn);
+
+        /* exponent: random, all-ones, a power of two (long runs), or
+           an explicit small value (the preinvn fast path) */
+        if (huge && en > 0)
+        {
+            e[0] = 17 + n_randint(state, 100);
+        }
+        else if (en > 0 && n_randint(state, 4) == 0)
+        {
+            ulong smalle[] = { 2, 3, 4, 5, 16, 100, 65537 };
+            en = 1;
+            e[0] = smalle[n_randint(state, 7)];
+        }
+        else if (en > 0)
+        {
+            slong i;
+            switch (n_randint(state, 3))
+            {
+                case 0: flint_mpn_rrandom(e, state, en); break;
+                case 1: for (i = 0; i < en; i++) e[i] = UWORD_MAX; break;
+                default:
+                    flint_mpn_zero(e, en);
+                    e[en - 1] = UWORD(1) << n_randint(state, FLINT_BITS);
+            }
+        }
+
+        flint_mpn_powm(r, b, e, en, m, mn);
+
+        /* the preinvn entry must agree everywhere */
+        {
+            flint_bitcnt_t norm = flint_clz(m[mn - 1]);
+            nn_ptr msh = FLINT_ARRAY_ALLOC(2 * mn, ulong);
+            nn_ptr dinv = msh + mn;
+            if (norm)
+                mpn_lshift(msh, m, mn, norm);
+            else
+                flint_mpn_copyi(msh, m, mn);
+            flint_mpn_preinvn(dinv, msh, mn);
+            flint_mpn_powm_preinvn(r2, b, e, en, m, mn, dinv, norm);
+            if (mpn_cmp(r, r2, mn) != 0)
+                TEST_FUNCTION_FAIL("preinvn entry: mn = %wd, en = %wd\n",
+                                   mn, en);
+            flint_free(msh);
+        }
+
+        mpz_init(mz); mpz_init(bz); mpz_init(ez); mpz_init(rz); mpz_init(cz);
+        mpz_import(mz, mn, -1, sizeof(ulong), 0, 0, m);
+        mpz_import(bz, mn, -1, sizeof(ulong), 0, 0, b);
+        if (en > 0)
+            mpz_import(ez, en, -1, sizeof(ulong), 0, 0, e);
+        mpz_powm(rz, bz, ez, mz);
+        mpz_import(cz, mn, -1, sizeof(ulong), 0, 0, r);
+
+        if (mpz_cmp(rz, cz) != 0)
+            TEST_FUNCTION_FAIL("powm vs mpz: mn = %wd, en = %wd, "
+                               "mode = %d, b0 = %wu\n", mn, en, mode, b[0]);
+
+        /* the stage functions, under their preconditions */
+        if (en > 0 && !flint_mpn_zero_p(b, mn) && e[en - 1] != 0 &&
+            mn >= 2 && !(mn == 1 && m[0] == 1))
+        {
+            _flint_mpn_powm_basecase(r2, b, e, en, m, mn);
+            if (mpn_cmp(r, r2, mn) != 0)
+                TEST_FUNCTION_FAIL("basecase: mn = %wd, en = %wd, mode = %d\n",
+                                   mn, en, mode);
+
+            if (m[0] & 1)
+            {
+                _flint_mpn_powm_redc(r2, b, e, en, m, mn);
+                if (mpn_cmp(r, r2, mn) != 0)
+                    TEST_FUNCTION_FAIL("redc: mn = %wd, en = %wd\n", mn, en);
+
+            }
+        }
+
+        mpz_clear(mz); mpz_clear(bz); mpz_clear(ez);
+        mpz_clear(rz); mpz_clear(cz);
+        flint_free(m); flint_free(b); flint_free(e);
+        flint_free(r); flint_free(r2); flint_free(q);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/mpn_extras/test/t-powm.c
+++ b/src/mpn_extras/test/t-powm.c
@@ -153,5 +153,144 @@ TEST_FUNCTION_START(flint_mpn_powm, state)
         flint_free(r); flint_free(r2); flint_free(q);
     }
 
+    /* A modulus m = m_odd * 2^t whose odd part is a single limb sends
+       one limb into _flint_mpn_powm_redc. With a small base and an
+       exponent long enough for a width-6 window, the scalar table holds
+       two-limb entries, so mul_scalar_mod multiplies a one-limb residue
+       by a two-limb scalar. The exponent must exceed 538 bits for
+       powm_select_k to reach k = 6, which the loop above never does at
+       these modulus sizes. */
+    for (slong iter = 0; iter < 20 * flint_test_multiplier(); iter++)
+    {
+        mp_size_t mn = 111 + n_randint(state, 40);
+        mp_size_t en = 10 + n_randint(state, 10);
+        nn_ptr m, b, e, r, cmp;
+        mpz_t mz, bz, ez, rz, cz;
+        ulong modd;
+        slong i;
+
+        m = FLINT_ARRAY_ALLOC(mn, ulong);
+        b = FLINT_ARRAY_ALLOC(mn, ulong);
+        e = FLINT_ARRAY_ALLOC(en, ulong);
+        r = FLINT_ARRAY_ALLOC(mn, ulong);
+        cmp = FLINT_ARRAY_ALLOC(mn, ulong);
+
+        /* m = modd * 2^t with modd odd and modd > 3, so that the base
+           below survives reduction mod modd unchanged */
+        modd = 5 + 2 * n_randint(state, 15);
+        flint_mpn_zero(m, mn);
+        m[mn - 1] = modd << (FLINT_BITS - 6);
+
+        for (i = 0; i < en; i++)
+            e[i] = n_randtest_not_zero(state);
+
+        /* base 3 exactly: two bits wide, so the window stays at k = 6 and
+           the top table entries b^41, ..., b^63 spill into two limbs.
+           Base 2 gives one-limb powers of two, and base 4 is three bits
+           wide, which caps the window at k = 5 and stays in one limb. */
+        flint_mpn_zero(b, mn);
+        b[0] = 3;
+
+        flint_mpn_powm(r, b, e, en, m, mn);
+
+        mpz_init(mz); mpz_init(bz); mpz_init(ez); mpz_init(rz); mpz_init(cz);
+        mpz_import(mz, mn, -1, sizeof(ulong), 0, 0, m);
+        mpz_import(bz, mn, -1, sizeof(ulong), 0, 0, b);
+        mpz_import(ez, en, -1, sizeof(ulong), 0, 0, e);
+        mpz_powm(rz, bz, ez, mz);
+        mpz_import(cz, mn, -1, sizeof(ulong), 0, 0, r);
+
+        if (mpz_cmp(rz, cz) != 0)
+            TEST_FUNCTION_FAIL("single-limb odd part: mn = %wd, en = %wd, "
+                               "modd = %wu\n", mn, en, modd);
+
+        mpz_clear(mz); mpz_clear(bz); mpz_clear(ez);
+        mpz_clear(rz); mpz_clear(cz);
+        flint_free(m); flint_free(b); flint_free(e);
+        flint_free(r); flint_free(cmp);
+    }
+
+    /* flint_mpn_powm_preinvn must agree with flint_mpn_powm everywhere,
+       including at the exponent-size cutoffs where one consumes the
+       supplied inverse and the other recomputes or falls back to mpz.
+       Exponents are swept bit by bit across those cutoffs, and the norm
+       is varied so the shift paths are covered. */
+    for (slong iter = 0; iter < 30 * flint_test_multiplier(); iter++)
+    {
+        mp_size_t mn = 2 + n_randint(state, 20);
+        nn_ptr m, b, e, r1, r2, msh, dinv;
+        flint_bitcnt_t norm;
+        slong i, k;
+
+        m = FLINT_ARRAY_ALLOC(mn, ulong);
+        b = FLINT_ARRAY_ALLOC(mn, ulong);
+        e = FLINT_ARRAY_ALLOC(2, ulong);
+        r1 = FLINT_ARRAY_ALLOC(mn, ulong);
+        r2 = FLINT_ARRAY_ALLOC(mn, ulong);
+        msh = FLINT_ARRAY_ALLOC(mn, ulong);
+        dinv = FLINT_ARRAY_ALLOC(mn, ulong);
+
+        flint_mpn_rrandom(m, state, mn);
+        m[mn - 1] |= UWORD(1) << (FLINT_BITS - 1);
+        m[mn - 1] >>= n_randint(state, FLINT_BITS);
+        if (m[mn - 1] == 0)
+            m[mn - 1] = 1;
+        if (n_randint(state, 2))
+            m[0] |= 1;
+
+        norm = flint_clz(m[mn - 1]);
+        if (norm)
+            mpn_lshift(msh, m, mn, norm);
+        else
+            flint_mpn_copyi(msh, m, mn);
+        flint_mpn_preinvn(dinv, msh, mn);
+
+        flint_mpn_rrandom(b, state, mn);
+        if (mpn_cmp(b, m, mn) >= 0)
+            mpn_sub_n(b, b, m, mn);
+        if (mpn_cmp(b, m, mn) >= 0)
+            goto cleanup;
+
+        /* 1 bit through 30 bits brackets every cutoff in the dispatcher */
+        for (k = 1; k <= 30; k++)
+        {
+            e[0] = (UWORD(1) << (k - 1)) | (n_randtest(state)
+                        & ((UWORD(1) << (k - 1)) - 1));
+            e[1] = 0;
+
+            flint_mpn_powm(r1, b, e, 1, m, mn);
+            flint_mpn_powm_preinvn(r2, b, e, 1, m, mn, dinv, norm);
+
+            for (i = 0; i < mn; i++)
+                if (r1[i] != r2[i])
+                    TEST_FUNCTION_FAIL("powm vs powm_preinvn: mn = %wd, "
+                                       "norm = %wu, ebits = %wd, e = %wu\n",
+                                       mn, (ulong) norm, k, e[0]);
+        }
+
+        /* tiny bases and tiny exponents share the fast branches */
+        for (k = 0; k <= 5; k++)
+        {
+            flint_mpn_zero(b, mn);
+            b[0] = (ulong) k;
+            if (mpn_cmp(b, m, mn) >= 0)
+                continue;
+            for (i = 0; i <= 5; i++)
+            {
+                e[0] = (ulong) i;
+                flint_mpn_powm(r1, b, e, 1, m, mn);
+                flint_mpn_powm_preinvn(r2, b, e, 1, m, mn, dinv, norm);
+                if (mpn_cmp(r1, r2, mn) != 0)
+                    TEST_FUNCTION_FAIL("powm vs powm_preinvn: mn = %wd, "
+                                       "b = %wd, e = %wd\n", mn, k, i);
+            }
+        }
+
+cleanup:
+        flint_free(m); flint_free(b); flint_free(e);
+        flint_free(r1); flint_free(r2);
+        flint_free(msh); flint_free(dinv);
+    }
+
     TEST_FUNCTION_END(state);
 }

--- a/src/mpn_extras/test/t-redc_n.c
+++ b/src/mpn_extras/test/t-redc_n.c
@@ -1,0 +1,115 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <gmp.h>
+#include "test_helpers.h"
+#include "mpn_extras.h"
+
+/* checks t == X * B^(-n) mod m and t < m, via t * B^n ≡ X (mod m) */
+static int
+redc_ok(nn_srcptr t, nn_srcptr X, nn_srcptr m, mp_size_t n)
+{
+    mpz_t tz, Xz, mz;
+    int ok;
+
+    if (mpn_cmp(t, m, n) >= 0)
+        return 0;
+
+    mpz_init(tz);
+    mpz_init(Xz);
+    mpz_init(mz);
+    mpz_import(tz, n, -1, sizeof(ulong), 0, 0, t);
+    mpz_import(Xz, 2 * n, -1, sizeof(ulong), 0, 0, X);
+    mpz_import(mz, n, -1, sizeof(ulong), 0, 0, m);
+
+    mpz_mul_2exp(tz, tz, n * FLINT_BITS);
+    mpz_sub(tz, tz, Xz);
+    ok = mpz_divisible_p(tz, mz);
+
+    mpz_clear(tz);
+    mpz_clear(Xz);
+    mpz_clear(mz);
+    return ok;
+}
+
+TEST_FUNCTION_START(flint_mpn_redc_n, state)
+{
+    for (slong iter = 0; iter < 500 * flint_test_multiplier(); iter++)
+    {
+        mp_size_t n = 1 + n_randint(state, n_randint(state, 10) == 0 ?
+                                           400 : 60);
+        nn_ptr m, minv, v, X, t, scratch;
+        slong j;
+
+        m = FLINT_ARRAY_ALLOC(n, ulong);
+        minv = FLINT_ARRAY_ALLOC(n, ulong);
+        v = FLINT_ARRAY_ALLOC(n, ulong);
+        X = FLINT_ARRAY_ALLOC(2 * n, ulong);
+        t = FLINT_ARRAY_ALLOC(n, ulong);
+        scratch = FLINT_ARRAY_ALLOC(2 * n, ulong);
+
+        flint_mpn_rrandom(m, state, n);
+        m[0] |= 1;
+        m[n - 1] |= (UWORD(1) << (FLINT_BITS - 1 -
+                        n_randint(state, FLINT_BITS)));
+
+        /* m * m^(-1) ≡ 1 mod B^n */
+        _flint_mpn_binvert(v, m, n);
+        flint_mpn_mullow_n(scratch, m, v, n);
+        if (scratch[0] != 1 || (n > 1 && !flint_mpn_zero_p(scratch + 1, n - 1)))
+            TEST_FUNCTION_FAIL("binvert: n = %wd\n", n);
+
+        flint_mpn_copyi(minv, v, n);
+        mpn_neg(minv, minv, n);
+
+        /* X_hi < m keeps X < m * B^n */
+        for (j = 0; j < 3; j++)
+        {
+            flint_mpn_rrandom(X, state, 2 * n);
+            if (n_randint(state, 8) == 0)
+                flint_mpn_zero(X, n);          /* the q = 0 branch */
+            mpn_tdiv_qr(scratch, X + n, 0, X + n, n, m, n);
+
+            /* crafted low halves drive the guard limb through its
+               decision boundary: X_lo = s makes lo(q*m) = B^n - s
+               (true guard UWORD_MAX-ish), X_lo = B^n - s makes
+               lo(q*m) = s (true guard 0 with a wrapped approximation) */
+            if (j == 1)
+            {
+                ulong s = 1 + n_randint(state, 2 * n + 4);
+                flint_mpn_zero(X, n);
+                X[0] = s;
+            }
+            else if (j == 2)
+            {
+                ulong s = 1 + n_randint(state, 2 * n + 4);
+                slong i;
+                for (i = 0; i < n; i++)
+                    X[i] = UWORD_MAX;
+                mpn_sub_1(X, X, n, s - 1);     /* X_lo = B^n - s */
+            }
+
+            _flint_mpn_redc_n(t, X, m, minv, n, scratch);
+
+            if (!redc_ok(t, X, m, n))
+                TEST_FUNCTION_FAIL("redc: n = %wd, j = %wd\n", n, j);
+        }
+
+        flint_free(m);
+        flint_free(minv);
+        flint_free(v);
+        flint_free(X);
+        flint_free(t);
+        flint_free(scratch);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/mpn_mod.h
+++ b/src/mpn_mod.h
@@ -185,6 +185,9 @@ mpn_mod_sqr(nn_ptr res, nn_srcptr x, gr_ctx_t ctx)
 int mpn_mod_fmma(nn_ptr res, nn_srcptr x1, nn_srcptr y1, nn_srcptr x2, nn_srcptr y2, gr_ctx_t ctx);
 
 int mpn_mod_inv(nn_ptr res, nn_srcptr x, gr_ctx_t ctx);
+int mpn_mod_pow_si(nn_ptr res, nn_srcptr x, slong e, gr_ctx_t ctx);
+int mpn_mod_pow_ui(nn_ptr res, nn_srcptr x, ulong e, gr_ctx_t ctx);
+int mpn_mod_pow_fmpz(nn_ptr res, nn_srcptr x, const fmpz_t e, gr_ctx_t ctx);
 int mpn_mod_div(nn_ptr res, nn_srcptr x, nn_srcptr y, gr_ctx_t ctx);
 
 /* Vector functions */

--- a/src/mpn_mod/ctx.c
+++ b/src/mpn_mod/ctx.c
@@ -99,10 +99,10 @@ gr_method_tab_input _mpn_mod_methods_input[] =
 
 
     {GR_METHOD_INV,             (gr_funcptr) mpn_mod_inv},
-/*
     {GR_METHOD_POW_SI,          (gr_funcptr) mpn_mod_pow_si},
     {GR_METHOD_POW_UI,          (gr_funcptr) mpn_mod_pow_ui},
     {GR_METHOD_POW_FMPZ,        (gr_funcptr) mpn_mod_pow_fmpz},
+/*
     {GR_METHOD_SQRT,            (gr_funcptr) mpn_mod_sqrt},
     {GR_METHOD_IS_SQUARE,       (gr_funcptr) mpn_mod_is_square},
 */

--- a/src/mpn_mod/pow.c
+++ b/src/mpn_mod/pow.c
@@ -1,0 +1,76 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz.h"
+#include "mpn_extras.h"
+#include "mpn_mod.h"
+
+/* powering via flint_mpn_powm_preinvn on the context's precomputed
+   inverse: no per-call setup for small exponents */
+
+int
+mpn_mod_pow_ui(nn_ptr res, nn_srcptr x, ulong e, gr_ctx_t ctx)
+{
+    mp_size_t n = MPN_MOD_CTX_NLIMBS(ctx);
+    ulong rp[MPN_MOD_MAX_LIMBS];
+
+    flint_mpn_powm_preinvn(rp, x, &e, 1, MPN_MOD_CTX_MODULUS(ctx), n,
+                           MPN_MOD_CTX_MODULUS_PREINV(ctx),
+                           MPN_MOD_CTX_NORM(ctx));
+    flint_mpn_copyi(res, rp, n);
+    return GR_SUCCESS;
+}
+
+int
+mpn_mod_pow_si(nn_ptr res, nn_srcptr x, slong e, gr_ctx_t ctx)
+{
+    if (e >= 0)
+        return mpn_mod_pow_ui(res, x, (ulong) e, ctx);
+    else
+    {
+        int status = mpn_mod_inv(res, x, ctx);
+        if (status != GR_SUCCESS)
+            return status;
+        return mpn_mod_pow_ui(res, res, -(ulong) e, ctx);
+    }
+}
+
+int
+mpn_mod_pow_fmpz(nn_ptr res, nn_srcptr x, const fmpz_t e, gr_ctx_t ctx)
+{
+    if (!COEFF_IS_MPZ(*e))
+        return mpn_mod_pow_si(res, x, *e, ctx);
+    else
+    {
+        mpz_ptr ze = COEFF_TO_PTR(*e);
+        mp_size_t n = MPN_MOD_CTX_NLIMBS(ctx);
+        mp_size_t en = ze->_mp_size;
+        ulong rp[MPN_MOD_MAX_LIMBS];
+        nn_srcptr bp = x;
+        int status = GR_SUCCESS;
+
+        if (en < 0)
+        {
+            status = mpn_mod_inv(res, x, ctx);
+            if (status != GR_SUCCESS)
+                return status;
+            bp = res;
+            en = -en;
+        }
+
+        flint_mpn_powm_preinvn(rp, bp, ze->_mp_d, en,
+                               MPN_MOD_CTX_MODULUS(ctx), n,
+                               MPN_MOD_CTX_MODULUS_PREINV(ctx),
+                               MPN_MOD_CTX_NORM(ctx));
+        flint_mpn_copyi(res, rp, n);
+        return GR_SUCCESS;
+    }
+}

--- a/src/mpn_mod/pow.c
+++ b/src/mpn_mod/pow.c
@@ -12,15 +12,25 @@
 #include "fmpz.h"
 #include "mpn_extras.h"
 #include "mpn_mod.h"
+#include "gr_generic.h"
 
 /* powering via flint_mpn_powm_preinvn on the context's precomputed
    inverse: no per-call setup for small exponents */
+
+/* Below this many exponent bits the context's own mul and sqr, which
+   are specialised for a few limbs, stay ahead of the division-based
+   basecase reached through flint_mpn_powm_preinvn. Measured crossover
+   is around 9 bits, fairly flat over 2 to 16 limbs. */
+#define MPN_MOD_POW_BINEXP_EBITS 8
 
 int
 mpn_mod_pow_ui(nn_ptr res, nn_srcptr x, ulong e, gr_ctx_t ctx)
 {
     mp_size_t n = MPN_MOD_CTX_NLIMBS(ctx);
     ulong rp[MPN_MOD_MAX_LIMBS];
+
+    if ((e >> MPN_MOD_POW_BINEXP_EBITS) == 0)
+        return gr_generic_pow_ui(res, x, e, ctx);
 
     flint_mpn_powm_preinvn(rp, x, &e, 1, MPN_MOD_CTX_MODULUS(ctx), n,
                            MPN_MOD_CTX_MODULUS_PREINV(ctx),


### PR DESCRIPTION
Developed using Claude Fable 5.

Adds `flint_mpn_powm` and `flint_mpn_powm_preinvn` and uses these when applicable in `fmpz_powm`, `fmpz_powm_ui`, `fmpz_mod_pow_fmpz`, `fmpz_mod_pow_ui`, and adds `mpn_mod_pow_*`.

For large moduli and exponents this uses Montgomery reduction with several FFT tricks; a detailed writeup by Claude is attached below.

The speedup is ~1.3x asymptotically and up to 1.8x in a narrow band (moduli around 65K bits).

Speedup for `fmpz_powm` for a modulus with pb bits and exponent with eb bits:

```
    pb \ eb     1     2     4     8    16    32    64   128   256   512  1024
       32   2.500 1.264 1.014 1.028 1.271 1.465 1.000 1.000 1.000 1.000 1.026
       64   0.925 0.986 1.000 1.033 1.032 1.023 1.000 1.017 1.000 1.000 1.000
      128   0.928 0.987 1.016 1.000 1.000 1.000 1.013 1.008 0.996 1.021 1.011
      256   0.923 0.966 1.000 1.030 1.019 1.000 1.000 0.974 1.000 1.000 1.000
      512   0.923 0.981 1.023 1.013 1.008 1.004 1.021 1.023 1.006 1.029 1.000
     1024   0.929 0.969 1.000 1.000 1.000 1.000 1.006 1.000 1.000 1.000 1.000
     2048   0.925 1.000 0.979 1.010 1.007 1.033 1.000 1.000 1.005 1.000 1.012
     4096   0.890 1.031 1.000 1.000 1.000 1.019 0.995 1.000 1.000 1.000 1.000
     8192   0.914 1.000 1.027 1.000 1.000 1.000 1.000 1.008 1.000 1.022 0.989
    16384   0.918 0.996 1.073 1.428 1.113 1.042 1.039 1.057 1.059 1.053 1.050
    32768   0.961 1.000 1.405 1.654 1.333 1.441 1.500 1.514 1.515 1.544 1.540
    65536   0.978 0.995 1.613 1.427 1.522 1.816 1.849 1.851 1.875 1.904 1.883
   131072   0.996 1.000 1.000 1.000 1.111 1.172 1.175 1.290 1.271 1.283 1.273
   262144   0.931 1.000 1.000 1.018 1.052 1.181 1.229 1.266 1.275 1.288 1.300
   524288   1.010 0.990 1.000 1.000 1.011 1.205 1.300 1.311 1.319 1.322 1.332
  1048576   1.000 1.000 1.008 0.992 1.175 1.193 1.271 1.302 1.310 1.337 1.345
  2097152   1.064 1.012 1.000 1.015 1.113 1.168 1.238 1.275 1.297 1.307 1.310
  4194304   0.989 1.000 1.000 1.007 0.959 1.160 1.216 1.243 1.257 1.268 1.264
  8388608   0.879 1.024 1.011 1.007 1.140 1.172 1.232 1.257 1.275 1.278 1.286
 16777216   0.907 0.978 1.000 1.009 1.012 1.206 1.261 1.288 1.296 1.319 1.315
```

Speedup `fmpz_powm` vs `mpz_powm`:

```
    pb \ eb     1     2     4     8    16    32    64   128   256   512  1024
       32   1.242 3.937 2.939 2.583 2.169 1.951 0.943 0.951 0.973 0.990 1.026
       64   0.587 0.684 0.803 0.744 0.809 0.867 0.970 0.983 0.991 0.990 1.026
      128   0.565 1.012 1.422 0.894 0.924 0.953 0.988 0.993 0.992 1.000 1.011
      256   0.551 1.081 0.995 0.943 0.982 0.981 0.995 1.000 1.014 1.014 1.000
      512   0.571 1.185 0.955 0.974 0.983 0.987 1.000 1.011 0.994 1.000 1.000
     1024   0.614 2.273 1.154 0.986 1.022 1.000 1.006 1.000 1.016 1.000 1.000
     2048   0.717 1.634 1.125 1.010 1.013 1.000 1.017 1.000 1.009 1.000 1.012
     4096   0.863 2.833 1.333 1.000 1.000 1.000 1.005 1.026 1.000 1.000 1.000
     8192   1.028 2.053 1.421 1.000 1.000 1.000 1.000 0.992 0.996 1.000 1.011
    16384   1.222 3.298 1.477 1.423 1.093 1.021 1.033 1.057 1.059 1.037 1.038
    32768   1.615 2.134 1.632 1.673 1.308 1.442 1.459 1.507 1.500 1.521 1.510
    65536   1.804 3.364 1.855 1.414 1.496 1.769 1.851 1.866 1.891 1.887 1.894
   131072   1.920 2.682 2.189 2.032 1.889 2.136 2.209 2.226 2.333 2.321 2.321
   262144   2.000 3.155 2.405 2.500 2.068 2.460 2.543 2.635 2.655 2.678 2.668
   524288   2.019 5.445 2.492 2.540 2.164 2.605 2.714 2.761 2.779 2.777 2.793
  1048576   2.115 3.451 2.595 2.571 2.255 2.628 2.778 2.848 2.889 2.907 2.908
  2097152   1.960 6.190 2.697 2.242 2.381 2.807 2.949 3.032 3.073 3.092 3.112
  4194304   1.950 6.190 2.595 2.302 2.320 2.729 2.870 2.926 2.961 2.975 2.974
  8388608   2.020 3.941 2.841 2.533 2.610 3.096 3.251 3.317 3.342 3.350 3.362
 16777216   1.975 7.170 2.951 2.468 2.791 3.432 3.599 3.678 3.719 3.723 3.703
```

# The algorithms behind `flint_mpn_powm` (AI-written)

This document describes the algorithms implemented in
`src/mpn_extras/powm.c` for computing

    r = b^e mod m,        0 <= r < m,

with `b`, `e`, `m` given as mpn limb vectors (limb base `B = 2^64`,
modulus of `mn` limbs, exponent of `en` limbs). It states the precise
formulas used at each size tier and explains the underlying techniques.
A final section lists optimizations that remain on the table.

Throughout, "one mul" means one full `mn x mn`-limb product at the
relevant size; costs of partial products are quoted as fractions of it.

---

## 1. Overall structure and size tiers

Exponentiation is performed by a **sliding-window square-and-multiply
ladder** (section 2) whose inner operation is a modular multiplication
or squaring. Everything else in the file is about making that inner
operation cheap and about amortizing per-call setup. The tiers, keyed
by the modulus size `mn` and the exponent bit length:

| condition                              | inner multiplication                                  |
|----------------------------------------|------------------------------------------------------|
| exponent below 25 bits                 | Barrett `mulmod_preinvn` ladder, minimal setup (§4)  |
| `mn < 110` (large exponents)           | delegated to `mpz_powm` (GMP's `redc_1/redc_2`)      |
| `110 <= mn < 120`                      | Barrett `mulmod_preinvn` ladder (§4)                 |
| `120 <= mn < 480`                      | Barrett ladder with wraparound remainder (§4.3)      |
| `mn >= 480`                            | Montgomery ladder with folded REDC (§5), quotient in the transform domain (§5.2) |

Inside the large tier, the `q*m mod (B^rlen - 1)` product at the heart
of the folded REDC is itself computed by one of three engines chosen at
setup time (§5.3): a cyclic FFT plan, the recursive
"chain" (§7), or `mpn_mulmod_bnm1`.

Even moduli are handled by the 2-adic splitting `m = 2^t * m_odd`:
the odd part runs through the machinery above, the power modulo `2^t`
is computed by a dedicated truncated ladder (`powm_2exp`, all
arithmetic modulo a power of two is plain low products), and the two
residues are recombined by CRT. The rest of this document assumes `m`
odd where Montgomery arithmetic is involved.

At the `fmpz` level, two fast paths run before any of this: an exact
power when `e <= (bits(m) - 1)/bits(b)` guarantees `|b|^e < m`, and a
`mpz_powm_ui` call for short bases with exponents under 25 bits below
the FFT tier, where per-call setup cannot be amortized.

---

## 2. Sliding-window exponentiation

For an exponent of `l` bits and window parameter `k`, the ladder
precomputes the table of odd powers

    T[j] = b^(2j+1) mod m,        j = 0, ..., 2^(k-1) - 1,

which costs one squaring plus `2^(k-1) - 1` multiplications. The
exponent is then consumed from the top: at each step the scanner
(`next_window`) finds the longest window of at most `k` bits that ends
in a set bit, so every table multiplication is by an odd power, and
runs of zeros between windows cost only squarings. For a random
exponent this gives

    l  squarings  +  approximately l/(k+1)  table multiplications.

`k` grows with `l` (as in `_gr_pow_mpn_sliding`) but is capped so that
the table of `2^(k-1)` full-size entries stays modest. When the base
fits in one or two limbs (`small_base`), table multiplications are
replaced by `mul_scalar_mod`: a full product by the 1–2-limb scalar
followed by one division — asymptotically negligible next to the
squarings — with base 2 specialized further to a shift and a
conditional subtract.

The measured cost split at `mn = 1030` reflects this design: the
squarings and the reductions dominate, the table multiplications are
a few percent.

---

## 3. Squaring

At every tier the squarings go through `flint_mpn_sqr`. In the FFT
range this detects the equal operands and computes only one forward
transform, one pointwise pass, and one inverse transform, so that

    cost(sqr) ~ 0.74 * cost(mul)

(measured at 1030 limbs: 78 vs 105 microseconds). Since half or more
of the ladder's work is squarings, this factor is a large share of the
overall advantage over a generic-multiplication ladder.

---

## 4. The Barrett basecase: precomputed inverse of the modulus

### 4.1 The precomputed inverse

`flint_mpn_preinvn` computes, for the modulus shifted into normalized
position (`norm = clz(m[mn-1])`, `d = m << norm`),

    dinv  ~  floor( (B^(2n) - 1) / d )  -  B^n,

an `n`-limb approximation of the scaled reciprocal. The powering
ladder keeps residues shifted left by `norm` so that every reduction
sees a normalized divisor.

### 4.2 Barrett reduction (`flint_mpn_mulmod_preinvn`)

Given a `2n`-limb product `X < d * B^n`, the quotient estimate is

    q = X_hi + mulhigh(X_hi, dinv),         X_hi = floor(X / B^n),

which satisfies `q <= floor(X/d) <= q + k` for a small constant `k`.
The remainder candidate

    r0 = X - q*d      (an n-limb low product: mullow(q, d), subtracted)

then lies in `[0, k*d)` and at most `k` conditional subtractions of
`d` produce the canonical remainder. One reduction therefore costs one
`mulhigh` plus one `mullow`, about one full multiplication, on top of
the product being reduced.

### 4.3 The wraparound variant (`mulmod_preinvn_fold`, 120–2000 limbs)

The `mullow(q, d)` above only ever feeds a subtraction whose result is
known to be tiny. It can therefore be replaced by a product in the
ring `Z / (B^g - 1)` for a fold length `g` slightly larger than the
bound on `r0`: with the same quotient estimate,

    r0 = ( X - q*d ) mod (B^g - 1)

computed by `mpn_mulmod_bnm1` recovers `r0` exactly because
`0 <= r0 < B^g - 1`. Reducing an argument modulo `B^g - 1` is just
folding: split it into `g`-limb chunks and add them with wraparound
carry, since `B^g ≡ 1`. The wraparound product costs roughly half of
a full product at these sizes, which is where the 120-limb tier gets
its advantage.

---

## 5. The large tier: Montgomery reduction with a folded quotient ledger

### 5.1 Montgomery representation and REDC

For odd `m`, fix `R = B^mn`. Residues are kept in Montgomery form
`x~ = x*R mod m`; the product of two Montgomery forms followed by

    REDC(X) = X * R^(-1) mod m

yields the Montgomery form of the product, and the final result is
recovered by one more REDC. The inverse used is

    minv = m^(-1) mod B^mn,

computed by `_flint_mpn_binvert` via Hensel lifting
`v <- v*(2 - m*v) mod B^(2^i)`, doubling the precision each step.

The classical REDC formula is

    q = (X mod B^mn) * minv  mod B^mn          (one mullow)
    t = (X + q*m) / B^mn                        (exact division: the
                                                 low mn limbs cancel)

with `t < 2m` when `X < m*B^mn`, so one conditional subtraction
canonicalizes. Note the signs: because `q*m ≡ X (mod B^mn)` — this
implementation uses `q = X_lo * minv` and *adds* `q*m`, making the low
half `X_lo + q*m ≡ 2*X_lo`... in fact the cancellation is arranged as
follows, which is exactly what the folded version exploits.

### 5.2 The quotient step, optionally in the transform domain

The `mullow` computing `q` is the one dense product of the reduction
that is not shared with anything else. Above
`FLINT_MPN_POWM_REDC_QSTEP_FFT_THRESHOLD = 480` limbs it is computed
in the transform domain against a **cached transform of `minv`**
(`Fminv`, built once at setup):

    q = export( ifft( fft(X_lo) . Fminv ) )  truncated to mn limbs,

replacing an `mn x mn` mullow by one forward transform, one pointwise
pass, one inverse transform and one export — measured at 1030 limbs
this takes the whole reduction from 157 to 128 microseconds per call.
The threshold was tuned by same-process A/B on the merged pipeline;
the crossover sits between 420 and 500 limbs.

### 5.3 The folded ledger: recovering `t` from a wraparound residue

Writing `X = X_hi * B^mn + X_lo`, the quantity `X_lo + q*m` is
divisible by `B^mn` by construction; call the quotient word

    c = (X_lo + q*m) / B^mn,        so that   t' = X_hi + c

is the REDC output before canonicalization (the code short-circuits
`X_lo = 0`, where `q = 0` and `c = 0`, to `t = X_hi` directly). The
entire dense work is thus computing `q*m` — and since only `c` is
needed, `q*m` never has to be produced exactly: it suffices to know it
modulo `B^rlen - 1` for any `rlen > mn`, because division by `B^mn`
in that ring is a **rotation**. Concretely, with `k = rlen - mn`:

    S =  q*m                mod (B^rlen - 1)      (the fold engine)
    U =  S - (B^mn - X_lo)  mod (B^rlen - 1)      (= q*m + X_lo - B^mn
                                                     = (c - 1) * B^mn)
    H =  U * B^k            mod (B^rlen - 1)      (rotate left k limbs;
                                                     B^(mn+k) = B^rlen ≡ 1)
      =  c - 1.

Since `0 <= H <= m - 1 < B^rlen - 1`, the only ambiguity of the
wraparound representative — `H = 0` versus the all-ones vector — is
resolved by inspecting the top limbs, and `t' = X_hi + H + 1` follows
by one addition. The reduction has become: one quotient product (§5.2),
**one multiplication modulo `B^rlen - 1`**, and linear work.

The product `S = q*m mod (B^rlen - 1)` is served by one of three
engines chosen at setup:

* **method 0, cyclic plan**: a cyclic FFT convolution of length
  `rlen = nnc` chosen by `fft_small_plan_init_mpn_cyclic` as the
  cheapest admissible wraparound length at or slightly above `mn`,
  multiplied pointwise against a **cached transform of `m`** (`Fm`).
  A cyclic convolution *is* multiplication modulo `B^N - 1`: indexing
  chunks by powers of `B^bits`, the convolution wraps index `N` back
  to `0`. Only `q` is transformed per call. Cost ~ 0.55 mul.
* **method 1, the chain** (§7): a recursive CRT factorization of
  `B^rn - 1`, `rn` the smallest power of two `>= max(mn, 128)`, with
  cached negacyclic transforms of the modulus residues at each level.
* **method 2, `mpn_mulmod_bnm1`**: GMP-style wraparound recursion, used
  in the mid band where FFT plans do not yet pay.

Methods 0 and 1 are compared at setup by the calibrated cost model
`27 * rn_chain <= 33 * nnc` (chain wins when its power-of-two padding
is mild): the constants were validated on two microarchitectures to
within a few percent of measured ratios.

---

## 6. The two-prime FFT layer underneath

The transforms used above come from FLINT's `fft_small` machinery.
Its relevant properties for `powm`:

**Chunked representation.** An integer is split into slots of `bits`
bits (`bits` around 40–50 chosen by the plan); multiplication becomes
polynomial multiplication of the slot sequences followed by carry
propagation.

**Two-prime CRT (Garner).** Slot products can exceed one word, so the
convolution is computed modulo two ~50-bit primes `p1, p2` in
double-precision FFTs. Each slot is recovered by Garner's mixed-radix
formula:

    z  =  r1  +  p1 * ( (r2 - r1) * p1^(-1)  mod p2 ),
    r1 = z mod p1,   r2 = z mod p2,   0 <= z < p1*p2,

evaluated 8 lanes at a time in floating point, followed by a scalar
sweep that shifts each `z` into its bit position `j*bits` of the
output and accumulates with carries. The reconstruction is
destructive on the transform lanes (output conversion is destructive
by default throughout `fft_small`; non-destructive conversions copy
first), and runs as one full vectorized sweep followed by one scalar
sweep — the separated shape that store-forwarding rewards.

**Truncated, low, high and window products.** The transforms support
bit-granular truncation: only `itr` slots are transformed and only an
output window `[zl, zh)` of limbs is exported, with slot bounds
guaranteeing exactness of the window. `mulhigh` and `mullow` are the
window specializations used by the Barrett and Montgomery quotient
steps. For signed accumulations the exports use centered
representatives in `(-P/2, P/2]` with the sign resolved during
recomposition.

**Cyclic and negacyclic products.** A length-`N` cyclic convolution
computes multiplication modulo `B^(N*bits/64) - 1` with no zero
padding (used by the fold engine); a negacyclic convolution — the same
transform with a weight `w^j` applied per slot, `w^(2N) = 1`,
`w^N = -1` — computes multiplication modulo `B^h + 1` (used at every
chain level). Both avoid the 2x padding of a plain product, which is
the entire point of the fold: the ladder's reductions run in rings
where the transform length matches the modulus size instead of
doubling it.

---

## 7. The chain: recursive CRT over `B^s - 1 = (B^h - 1)(B^h + 1)`

`powm_chain_init` fixes `rn`, the smallest power of two
`>= max(mn, 128)`, and builds the tower `s = rn, rn/2, ..., 64`.
At each level, multiplication modulo `B^s - 1` splits by CRT
(`gcd(B^h - 1, B^h + 1) = 1` for even `B`, using `h = s/2`):

    x1 = x mod (B^h - 1)      -> recurse to the next level
    x2 = x mod (B^h + 1)      -> one negacyclic product against the
                                 cached transform of  m mod (B^h + 1)

The negacyclic products use `sd_fft_mpn_mulmod_2expp1` with the
modulus-residue transform `Fm[lev]` **precomputed once per level** at
setup when `h >= 128` (`CHAIN_NEG_H`), and a basecase
`mulmod_2expp1` below that. Residue extraction is linear: modulo
`B^h - 1` fold-and-add, modulo `B^h + 1` alternate-and-subtract.

Recombination uses the explicit CRT for this coprime pair, in the
same form as `flint_mpn_mulmod_bnm1`: with `u ≡ y (mod B^h - 1)` and
`v ≡ y (mod B^h + 1)`,

    s  =  (u - v)/2   mod (B^h + 1),
    y  =  u + s*B^h - s          mod (B^s - 1),

where `s*B^h - s = s*(B^h - 1)` vanishes modulo `B^h - 1` (preserving
`u`) and equals `-2s ≡ v - u` modulo `B^h + 1` (correcting to `v`);
the division by 2 is a shift after a parity fix using
`B^h + 1 ≡ 0`. The recursion bottoms out at 64 limbs with a plain
product against the cached `m mod (B^64 - 1)`.

The chain's appeal is that *all* of its per-level modulus transforms
are cached — the per-reduction work is one forward transform, one
pointwise pass and one inverse transform per level on the `q` side
only, at geometrically decreasing sizes. Its weakness is the
power-of-two `rn`: at `mn` just above a power of two the padding is
nearly 2x, which is when the cyclic plan (whose admissible lengths are
much denser) wins — hence the 27:33 selector.

---

## 8. Where the constant factors come from: an accounting

Per exponent bit at `mn = 1030` limbs (measured):

    squaring (transform-reuse)         ~ 0.74 mul     81 us
    fold reduction:
        quotient step (FFT, cached Fminv)  ~ 0.28 mul
        q*m cyclic (cached Fm)             ~ 0.52 mul
        folds, rotation, carries           ~ 0.10 mul
                                       ---------------
                                       ~ 1.96 mul    209 us

against roughly 3 mul-equivalents per bit for a classical
Barrett ladder (1 squaring + ~2 for the reduction), matching the
observed ~1.3x asymptotic speedup over the previous implementation
and ~3x over `mpz_powm` at large sizes.

---

## 9. Remaining optimizations

Ordered roughly by expected value per unit of implementation effort.

1. **Cache the transforms of the sliding-window table.** Table
   multiplications currently run as full products; transforming each
   `T[j]` once at table-build time and multiplying pointwise against
   the (already transformed) accumulator would remove one forward
   transform per table multiplication, ~30% of its cost. At large
   exponents table muls are only a few percent of the total, but at
   moderate exponent lengths (a few hundred bits) the table build plus
   its multiplications are a visibly larger share, and the same cached
   transforms would accelerate the build itself
   (`T[j+1] = T[j] * T[0]^2` reuses the transform of `T[0]^2`).

2. **Cache the wraparound transforms in the 120–2000 band.** The
   `mulmod_preinvn_fold` basecase calls `mpn_mulmod_bnm1` afresh per
   reduction, re-transforming the modulus every time; likewise `dinv`
   is re-consumed by a plain `mulhigh` per reduction. A persistent
   `B^g - 1` context holding the transforms of `d` (and, where the
   quotient product is large enough to transform, of `dinv`) across
   the whole ladder would mirror what the large tier already does with
   `Fm`/`Fminv`. This band covers four octaves of sizes and currently
   pays a per-reduction setup the large tier has eliminated.

3. **Fuse the squaring with the reduction in the transform domain.**
   The fold path today exports the squaring `X = acc^2` to limbs, then
   immediately transforms `X_lo` for the quotient step and `q` for the
   ledger. The squaring's own transforms are thrown away at export.
   A window-export design could keep `acc` transformed across the
   square-reduce pair: export only `X_lo` (a truncated window) for the
   quotient, and feed the ledger from the retained transform where
   lengths allow. This is precisely the chain path's philosophy
   extended into the fold; even a partial fusion (sharing the
   `fft(X_lo)` between the quotient step and the `-X_lo` correction)
   removes one transform per bit.

4. **Bit-granular chain lengths.** The chain's 2x padding cliff at
   `mn` slightly above a power of two comes from `rn` being a power of
   two. The negacyclic machinery supports weighted lengths at finer
   granularity (as the cyclic plans already exploit); a chain over
   `B^rn - 1` with `rn` from a denser admissible set would move its
   crossover into territory the cyclic plan currently owns, and make
   the 27:33 selector nearly moot.

5. **Signed-window (NAF) recoding.** With centered signed exports
   already supported by the FFT layer, a signed sliding window would
   shrink the table by half for the same window width or lengthen the
   effective window for the same table, trading table muls for
   essentially free negations mod m.

6. **A negacyclic fold.** The ledger ring `B^rlen - 1` could equally
   be `B^rlen + 1` (the rotation trick works with a sign), and the
   negacyclic transform of the same length covers twice the integer
   size; where admissible cyclic lengths near `mn` are sparse, the
   negacyclic ring of half the transform length may be cheaper.

7. **Base-2 at large sizes.** With a base-2 exponent the table entries
   are powers `2^(2j+1)` and every table multiplication is a shift;
   the current scalar special covers this, but the squaring chain
   itself could exploit the sparsity of the initial segments (GMP does
   at some sizes; the timing grid shows a remaining 6x gap at
   `pb = 32768, eb = 16` for base 2, above the fmpz-level fallback's
   size cutoff).

8. **Per-architecture constants.** The tier thresholds and the 27:33
   selector are calibrated on two x86-64 microarchitectures and agree
   between them; they live in `powm.c` pending a `flint-mparam.h`
   migration if a future architecture (or the zen chain-selector
   observation at sizes moderately below a power of two, where the
   selector oversells the chain by up to ~4%) demands per-arch values.