### PR TITLE
Fallbacks for BLAS sgemm/dgemm and (parts of) machine_vectors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,7 @@ endif()
 set(_BUILD_DIRS
     generic_files
     thread_pool                     thread_support
+    machine_vectors
 
     ulong_extras
     long_extras

--- a/Makefile.in
+++ b/Makefile.in
@@ -168,6 +168,7 @@ HEADLESS_DIRS := generic_files
 
 HEADER_DIRS	:=	\
 		thread_pool			thread_support					\
+		machine_vectors									\
 															\
 		ulong_extras		long_extras			perm		\
 		double_extras		d_vec				d_mat		\

--- a/doc/source/fmpz_mat.rst
+++ b/doc/source/fmpz_mat.rst
@@ -611,9 +611,12 @@ Matrix multiplication
 
 .. function:: int fmpz_mat_mul_blas(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B)
 
-    Tries to set `C = AB` using BLAS and returns `1` for success and `0` for failure.
+    Tries to set `C = AB` by multimodular reduction to floating-point
+    matrix multiplication (:func:`flint_dgemm`, which uses BLAS if FLINT
+    was built with BLAS support and FLINT's own kernels otherwise), and
+    returns `1` for success and `0` for failure.
     Dimensions must be compatible for matrix multiplication. No aliasing is allowed.
-    This function currently will fail if the matrices are empty, their dimensions are too large, or their max bits size is over one million bits.
+    This function currently will fail if the matrices are empty, their dimensions are too large, their max bits size is over one million bits, or FLINT is built with a 32-bit word size.
 
 .. function:: void fmpz_mat_mul_fft(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B)
 

--- a/doc/source/machine_vectors.rst
+++ b/doc/source/machine_vectors.rst
@@ -3,8 +3,46 @@
 **machine_vectors.h** -- SIMD-accelerated operations on fixed-length vectors
 ===============================================================================
 
-This module currently requires building FLINT with support for
-AVX2 or NEON instructions.
+Vector types and operations mapping onto the target's SIMD instructions,
+together with the ``flint_sgemm`` and ``flint_dgemm`` matrix
+multiplication kernels built on top of them.
+
+Backends are selected automatically: AVX2 (and AVX512 for the ``vec8dz``
+family) on x86, NEON on ARM, and otherwise a generic backend, using GNU
+vector extensions where the compiler supports them and plain ISO C
+structs elsewhere. The AVX2 and NEON backends require a 64-bit word
+size, since their integer vectors have :type:`ulong` lanes; a 32-bit
+build uses the generic backends, which provide only the floating-point
+types. The generic backends implement only the subset of the
+interface required by ``flint_sgemm``/``flint_dgemm``; the full
+interface, as used by ``fft_small``, still requires AVX2 or NEON.
+
+For the vector operations to use the target's instructions, FLINT must
+be built with appropriate compiler flags. ``configure`` chooses these
+from the detected CPU; ``--enable-avx2`` and ``--enable-avx512`` force
+them on.
+
+Defining ``FLINT_MACHINE_VECTORS_FORCE_GENERIC`` before including this
+header selects the generic backend even on a target with AVX2 or NEON,
+and ``FLINT_MACHINE_VECTORS_STRICT_C`` additionally selects the ISO C
+tier over GNU vector extensions. These are intended for testing and
+profiling the portable code paths.
+
+The strict ISO C tier has no way to express a vector operation, so
+whether its operations become SIMD instructions is entirely up to the
+compiler's SLP vectorizer; its performance therefore varies between
+compilers and compiler versions, unlike the other backends. It exists
+so that the header works on compilers without GNU vector extensions,
+and is not the fallback used on GCC or clang.
+
+The generic backends express a fused multiply-add as ``a * b + c``,
+which a compiler fuses into an FMA instruction only when floating-point
+contraction is enabled. GCC in a strict ISO mode, which is how FLINT is
+built, does not contract by default; code using these operations in a
+performance-critical loop should request contraction, as
+``machine_vectors/gemm.c`` does with ``#pragma GCC optimize
+("fp-contract=fast")``. The AVX2, AVX512 and NEON backends use fused
+intrinsics and are unaffected.
 
 Some functions may require that vectors are aligned in memory.
 
@@ -24,6 +62,27 @@ Types
           vec8d
 
     Vector with 1, 2, 4, or 8 ``double`` entries.
+
+.. type:: vec1f
+          vec4f
+          vec8f
+          vec16f
+
+    Vector with 1, 4, 8, or 16 ``float`` entries.
+
+.. type:: vec8dz
+          vec16dz
+          vec16fz
+          vec32fz
+          vec8nz
+
+    Vectors backed by AVX512 registers, available only when building
+    with AVX512F support: 8 or 16 ``double`` entries, 16 or 32 ``float``
+    entries, and 8 :type:`ulong` entries respectively. The ``z`` suffix
+    distinguishes these from the equally-named types built from pairs of
+    narrower registers; ``vec8d``, for instance, remains a pair of AVX2
+    registers, which gives more instruction level parallelism in
+    existing code.
 
 Printing
 -------------------------------------------------------------------------------
@@ -282,3 +341,55 @@ Other assumptions are not yet documented.
               vec8n vec8n_addmod_limited(vec8n a, vec8n b, vec8n n)
 
     Return `a + b \bmod n` in `[0,n)`, assuming that `n < 2^{63}`.
+
+Matrix multiplication
+-------------------------------------------------------------------------------
+
+These functions compute a matrix product in single or double precision.
+They are always available: when FLINT is built with BLAS, the default is
+to call it, and otherwise FLINT's own kernels are used. The intended use
+is as a building block for exact linear algebra over `\mathbb{Z}` and
+`\mathbb{Z}/n\mathbb{Z}`, for example in :func:`nmod_mat_mul_blas` and
+:func:`fmpz_mat_mul_blas`.
+
+All of these functions compute `C = AB` for row-major matrices, where
+*C* is *m* by *n*, *A* is *m* by *k* and *B* is *k* by *n*, with
+*ldc*, *lda* and *ldb* the respective leading dimensions (the number of
+entries between the start of consecutive rows, which must be at least
+the number of columns). No transposition or accumulation is performed:
+the previous contents of *C* are overwritten, and `k = 0` sets *C* to
+zero. This is equivalent to ``cblas_sgemm`` or ``cblas_dgemm`` called
+with ``CblasRowMajor``, ``CblasNoTrans``, ``CblasNoTrans``, ``alpha``
+equal to 1 and ``beta`` equal to 0. Aliasing of *C* with *A* or *B* is
+not allowed.
+
+The FLINT kernels are multithreaded internally according to
+:func:`flint_get_num_threads`, using FLINT's thread pool. They handle
+arbitrary dimensions, including thin and unbalanced shapes, without
+requiring any padding or alignment of the input.
+
+.. function:: void flint_sgemm(slong m, slong k, slong n, const float * A, slong lda, const float * B, slong ldb, float * C, slong ldc)
+              void flint_dgemm(slong m, slong k, slong n, const double * A, slong lda, const double * B, slong ldb, double * C, slong ldc)
+
+    Sets `C = AB`, calling either the BLAS or the FLINT implementation
+    according to :var:`flint_gemm_use_blas`.
+
+.. function:: void flint_sgemm_blas(slong m, slong k, slong n, const float * A, slong lda, const float * B, slong ldb, float * C, slong ldc)
+              void flint_dgemm_blas(slong m, slong k, slong n, const double * A, slong lda, const double * B, slong ldb, double * C, slong ldc)
+
+    Sets `C = AB` using ``cblas_sgemm`` or ``cblas_dgemm``. These raise
+    an exception if FLINT was built without BLAS support.
+
+.. function:: void flint_sgemm_fallback(slong m, slong k, slong n, const float * A, slong lda, const float * B, slong ldb, float * C, slong ldc)
+              void flint_dgemm_fallback(slong m, slong k, slong n, const double * A, slong lda, const double * B, slong ldb, double * C, slong ldc)
+
+    Sets `C = AB` using FLINT's own kernels, which are always available.
+
+.. var:: int flint_gemm_use_blas
+
+    Selects the implementation used by :func:`flint_sgemm` and
+    :func:`flint_dgemm`. It is initialized to 1 if FLINT was built with
+    BLAS support and 0 otherwise, and may be set to either value at
+    runtime, for example to compare the two implementations. Setting it
+    to 1 in a build without BLAS support will result in an exception
+    when a gemm is attempted.

--- a/doc/source/nmod_mat.rst
+++ b/doc/source/nmod_mat.rst
@@ -382,7 +382,14 @@ Matrix multiplication
 
 .. function:: int nmod_mat_mul_blas(nmod_mat_t C, const nmod_mat_t A, const nmod_mat_t B)
 
-    Tries to set `C = AB` using BLAS and returns `1` for success and `0` for failure. Dimensions must be compatible for matrix multiplication.
+    Tries to set `C = AB` by lifting to floating-point matrix
+    multiplication (:func:`flint_sgemm` or :func:`flint_dgemm`, which use
+    BLAS if FLINT was built with BLAS support and FLINT's own kernels
+    otherwise), with multimodular reduction and CRT when the entries do
+    not fit directly. Returns `1` for success and `0` for failure;
+    failure occurs when the dimensions or the modulus are too large, or
+    when FLINT is built with a 32-bit word size.
+    Dimensions must be compatible for matrix multiplication.
 
 .. function:: void nmod_mat_addmul(nmod_mat_t D, const nmod_mat_t C, const nmod_mat_t A, const nmod_mat_t B)
 

--- a/src/fmpz_mat/mul.c
+++ b/src/fmpz_mat/mul.c
@@ -192,7 +192,7 @@ fmpz_mat_mul(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B)
             return;
     }
 
-#if FLINT_USES_BLAS && FLINT_BITS == 64
+#if FLINT_BITS == 64
     if (dim > 50)
     {
         if (cbits <= 53)

--- a/src/fmpz_mat/mul_blas.c
+++ b/src/fmpz_mat/mul_blas.c
@@ -14,11 +14,11 @@
 
 /* todo: squaring optimizations */
 
-#if FLINT_USES_BLAS && FLINT_BITS == 64
+#if FLINT_BITS == 64
 
 #include <stdint.h>
 #include <limits.h>
-#include <cblas.h>
+#include "machine_vectors.h"
 #include "nmod.h"
 #include "fmpz.h"
 #include "thread_pool.h"
@@ -141,8 +141,7 @@ red_single:
         flint_free(args);
     }
 
-    cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
-                                       m, n, k, 1.0, dA, k, dB, n, 0.0, dC, n);
+    flint_dgemm(m, k, n, dA, k, dB, n, dC, n);
 
     for (i = 0; i < m; i++)
         for (j = 0; j < n; j++)
@@ -355,7 +354,7 @@ static void _fromd_worker(void * arg_ptr)
         {
             ulong r;
             slong a = (slong) dC[i*n + j];
-            ulong b = (a < 0) ? a + shift : a;
+            ulong b = (a < 0) ? (ulong) a + shift : (ulong) a;
             NMOD_RED(r, b, mod);
             bigC[n*(num_primes*i + l) + j] = r;
         }
@@ -567,8 +566,7 @@ int _fmpz_mat_mul_blas(
         for (i = 0; i < num_workers; i++)
             thread_pool_wait(global_thread_pool, handles[i]);
 
-        cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
-                                       m, n, k, 1.0, dA, k, dB, n, 0.0, dC, n);
+        flint_dgemm(m, k, n, dA, k, dB, n, dC, n);
 
         for (i = 0; i < num_workers; i++)
             thread_pool_wake(global_thread_pool, handles[i], 0, _fromd_worker, &args[i]);

--- a/src/fmpz_mat/mul_blas.c
+++ b/src/fmpz_mat/mul_blas.c
@@ -474,7 +474,7 @@ int _fmpz_mat_mul_blas(
     slong num_primes;
     fmpz_comb_t comb;
     thread_pool_handle * handles;
-    slong num_workers;
+    slong num_workers, max_workers;
     _worker_arg * args;
 
     FLINT_ASSERT(sign == 0 || sign == 1);
@@ -508,6 +508,7 @@ int _fmpz_mat_mul_blas(
     dC = (double *) flint_calloc(m*n, sizeof(double));
 
     num_workers = flint_request_threads(&handles, INT_MAX);
+    max_workers = num_workers;
 
     args = FLINT_ARRAY_ALLOC(num_workers + 1, _worker_arg);
     for (start = 0, i = 0; i <= num_workers; start = stop, i++)
@@ -566,7 +567,40 @@ int _fmpz_mat_mul_blas(
         for (i = 0; i < num_workers; i++)
             thread_pool_wait(global_thread_pool, handles[i]);
 
-        flint_dgemm(m, k, n, dA, k, dB, n, dC, n);
+        /*
+            The fallback gemm threads through FLINT's pool itself, so
+            the workers held for the conversions must be returned
+            before the call or it finds the pool empty and runs on one
+            thread. (An external BLAS schedules its own threads and
+            does not care.) The re-request is capped by the first
+            grant, so the args array stays large enough; if fewer
+            workers come back, the work is redistributed below.
+        */
+        {
+            slong prev_workers = num_workers;
+
+            flint_give_back_threads(handles, num_workers);
+
+            flint_dgemm(m, k, n, dA, k, dB, n, dC, n);
+
+            num_workers = flint_request_threads(&handles, max_workers + 1);
+
+            if (num_workers != prev_workers)
+            {
+                for (start = 0, i = 0; i <= num_workers; start = stop, i++)
+                {
+                    args[i].l = l;
+                    args[i].prime = primes[l];
+                    args[i].Cstartrow = ((i + 0)*m)/(num_workers + 1);
+                    args[i].Cstoprow  = ((i + 1)*m)/(num_workers + 1);
+                    stop = _thread_pool_find_work_2(m, k, k, n,
+                                                    i + 1, num_workers + 1);
+                    _thread_pool_distribute_work_2(start, stop,
+                                  &args[i].Astartrow, &args[i].Astoprow, m,
+                                  &args[i].Bstartrow, &args[i].Bstoprow, k);
+                }
+            }
+        }
 
         for (i = 0; i < num_workers; i++)
             thread_pool_wake(global_thread_pool, handles[i], 0, _fromd_worker, &args[i]);

--- a/src/fmpz_mat/profile/p-mul_blas_v_mul.c
+++ b/src/fmpz_mat/profile/p-mul_blas_v_mul.c
@@ -11,8 +11,6 @@
 
 #include "flint.h"
 
-#if FLINT_USES_BLAS
-#include <cblas.h>
 #include "longlong.h"  // for FLINT_BIT_COUNT
 #include "fmpz_mat.h"
 #include "profiler.h"
@@ -96,10 +94,3 @@ int main(void)
     FLINT_TEST_CLEAR(state);
     return 0;
 }
-
-#else
-int main(void)
-{
-    return 0;
-}
-#endif

--- a/src/fmpz_mat/test/t-mul_blas.c
+++ b/src/fmpz_mat/test/t-mul_blas.c
@@ -54,10 +54,10 @@ TEST_FUNCTION_START(fmpz_mat_mul_blas, state)
                 flint_abort();
             }
         }
-#if FLINT_USES_BLAS && FLINT_BITS == 64
+#if FLINT_BITS == 64
         else
         {
-            flint_printf("FAIL: blas should have worked\n");
+            flint_printf("FAIL: mul_blas should have worked\n");
             fflush(stdout);
             flint_abort();
         }
@@ -102,10 +102,10 @@ TEST_FUNCTION_START(fmpz_mat_mul_blas, state)
                 flint_abort();
             }
         }
-#if FLINT_USES_BLAS && FLINT_BITS == 64
+#if FLINT_BITS == 64
         else
         {
-            flint_printf("FAIL: blas should have worked\n");
+            flint_printf("FAIL: mul_blas should have worked\n");
             fflush(stdout);
             flint_abort();
         }

--- a/src/machine_vectors.h
+++ b/src/machine_vectors.h
@@ -16,29 +16,52 @@
 #define ALIGN_STRUCT(x) __attribute__((aligned(x)))
 
 #include <math.h>
+#include <string.h>
 
-#if defined(__GNUC__)
-# if defined(__AVX2__)
-#  include <immintrin.h>
-# elif defined(__ARM_NEON)
-#  include <arm_neon.h>
-# endif
-#elif defined(_MSC_VER)
-# if defined(__AVX2__)
-#  include <intrin.h>
-# elif defined(_M_ARM64)
-#  include <arm_neon.h>
+#include "flint.h"
+
+/*
+    The AVX2 and NEON backends provide integer vectors with ulong lanes
+    and use intrinsics that exist only in 64-bit mode, so they require a
+    64-bit word size; a 32-bit build uses the generic backends. This
+    matters because machine_vectors.h is included by machine_vectors/
+    gemm.c on every target, whereas it was previously reached only from
+    fft_small, which is built only in 64-bit configurations.
+
+    FLINT_MACHINE_VECTORS_FORCE_GENERIC selects the generic backends even
+    on a target that has AVX2 or NEON; FLINT_MACHINE_VECTORS_STRICT_C
+    additionally selects the strict ISO C tier over GNU vector
+    extensions. Both are intended for testing and profiling.
+*/
+#if defined(FLINT_MACHINE_VECTORS_FORCE_GENERIC) \
+        || defined(FLINT_MACHINE_VECTORS_STRICT_C) \
+        || FLINT_BITS != 64
+# define FLINT_MACHINE_VECTORS_GENERIC 1
+#endif
+
+#if !defined(FLINT_MACHINE_VECTORS_GENERIC)
+# if defined(__GNUC__)
+#  if defined(__AVX2__)
+#   include <immintrin.h>
+#  elif defined(__ARM_NEON)
+#   include <arm_neon.h>
+#  endif
+# elif defined(_MSC_VER)
+#  if defined(__AVX2__)
+#   include <intrin.h>
+#  elif defined(_M_ARM64)
+#   include <arm_neon.h>
+#  endif
 # endif
 #endif
 
-#include "flint.h"
 #include "templates.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#if defined(__AVX2__)
+#if defined(__AVX2__) && !defined(FLINT_MACHINE_VECTORS_GENERIC)
 /*
     In general the machine vector types should either be passed by const ref or
     the whole function should be forced inline as some platforms have buggy
@@ -54,6 +77,24 @@ typedef double vec1d;
 typedef __m128d vec2d;
 typedef __m256d vec4d;
 typedef struct {__m256d e1, e2;} vec8d;
+
+typedef float vec1f;
+typedef __m128 vec4f;
+typedef __m256 vec8f;
+typedef struct {__m256 e1, e2;} vec16f;
+
+# if defined(__AVX512F__)
+/*
+    Types backed by a single zmm register. vec8d is already taken (and is
+    deliberately two ymm: one zmm has been found to reduce instruction level
+    parallelism in existing code), so zmm-backed types carry a "z" suffix.
+*/
+typedef __m512i vec8nz;
+typedef __m512d vec8dz;
+typedef struct {vec8dz e1, e2;} vec16dz;
+typedef __m512 vec16fz;
+typedef struct {vec16fz e1, e2;} vec32fz;
+# endif
 
 
 
@@ -774,6 +815,7 @@ EXTEND_VEC_DEF3(vec4n, vec8n, _addmod_limited)
 EXTEND_VEC_DEF4(vec4d, vec8d, _mulmod)
 EXTEND_VEC_DEF4(vec4d, vec8d, _nmulmod)
 
+
 #undef EXTEND_VEC_DEF4
 #undef EXTEND_VEC_DEF3
 #undef EXTEND_VEC_DEF2
@@ -809,7 +851,315 @@ FLINT_FORCE_INLINE vec8n vec8n_bit_and(vec8n a, vec8n b) {
 
 
 
-#elif defined(__ARM_NEON) || defined(_M_ARM64)
+
+/* vec1f -- AVX2 ***********************************************************/
+
+FLINT_FORCE_INLINE vec1f vec1f_load(const float* a) {
+    return a[0];
+}
+
+FLINT_FORCE_INLINE vec1f vec1f_load_aligned(const float* a) {
+    return a[0];
+}
+
+FLINT_FORCE_INLINE vec1f vec1f_load_unaligned(const float* a) {
+    return a[0];
+}
+
+FLINT_FORCE_INLINE void vec1f_store(float* z, vec1f a) {
+    z[0] = a;
+}
+
+FLINT_FORCE_INLINE void vec1f_store_aligned(float* z, vec1f a) {
+    z[0] = a;
+}
+
+FLINT_FORCE_INLINE void vec1f_store_unaligned(float* z, vec1f a) {
+    z[0] = a;
+}
+
+FLINT_FORCE_INLINE vec1f vec1f_zero(void) {
+    return 0.0f;
+}
+
+FLINT_FORCE_INLINE vec1f vec1f_set_f(float a) {
+    return a;
+}
+
+FLINT_FORCE_INLINE vec1f vec1f_add(vec1f a, vec1f b) {
+    return a + b;
+}
+
+FLINT_FORCE_INLINE vec1f vec1f_sub(vec1f a, vec1f b) {
+    return a - b;
+}
+
+FLINT_FORCE_INLINE vec1f vec1f_mul(vec1f a, vec1f b) {
+    return a * b;
+}
+
+FLINT_FORCE_INLINE vec1f vec1f_fmadd(vec1f a, vec1f b, vec1f c) {
+    return fmaf(a, b, c);
+}
+
+FLINT_FORCE_INLINE vec1f vec1f_fnmadd(vec1f a, vec1f b, vec1f c) {
+    return fmaf(-a, b, c);
+}
+
+FLINT_FORCE_INLINE vec1f vec1f_floor(vec1f a) {
+    return floorf(a);
+}
+
+/* vec4f -- AVX2 ***********************************************************/
+
+FLINT_FORCE_INLINE vec4f vec4f_load(const float* a) {
+    return _mm_load_ps(a);
+}
+
+FLINT_FORCE_INLINE vec4f vec4f_load_aligned(const float* a) {
+    return _mm_load_ps(a);
+}
+
+FLINT_FORCE_INLINE vec4f vec4f_load_unaligned(const float* a) {
+    return _mm_loadu_ps(a);
+}
+
+FLINT_FORCE_INLINE void vec4f_store(float* z, vec4f a) {
+    _mm_store_ps(z, a);
+}
+
+FLINT_FORCE_INLINE void vec4f_store_aligned(float* z, vec4f a) {
+    _mm_store_ps(z, a);
+}
+
+FLINT_FORCE_INLINE void vec4f_store_unaligned(float* z, vec4f a) {
+    _mm_storeu_ps(z, a);
+}
+
+FLINT_FORCE_INLINE vec4f vec4f_zero(void) {
+    return _mm_setzero_ps();
+}
+
+FLINT_FORCE_INLINE vec4f vec4f_set_f(float a) {
+    return _mm_set1_ps(a);
+}
+
+FLINT_FORCE_INLINE vec4f vec4f_add(vec4f a, vec4f b) {
+    return _mm_add_ps(a, b);
+}
+
+FLINT_FORCE_INLINE vec4f vec4f_sub(vec4f a, vec4f b) {
+    return _mm_sub_ps(a, b);
+}
+
+FLINT_FORCE_INLINE vec4f vec4f_mul(vec4f a, vec4f b) {
+    return _mm_mul_ps(a, b);
+}
+
+FLINT_FORCE_INLINE vec4f vec4f_fmadd(vec4f a, vec4f b, vec4f c) {
+    return _mm_fmadd_ps(a, b, c);
+}
+
+FLINT_FORCE_INLINE vec4f vec4f_fnmadd(vec4f a, vec4f b, vec4f c) {
+    return _mm_fnmadd_ps(a, b, c);
+}
+
+FLINT_FORCE_INLINE vec4f vec4f_floor(vec4f a) {
+    return _mm_floor_ps(a);
+}
+
+/* vec8f -- AVX2 ***********************************************************/
+
+FLINT_FORCE_INLINE vec8f vec8f_load(const float* a) {
+    return _mm256_load_ps(a);
+}
+
+FLINT_FORCE_INLINE vec8f vec8f_load_aligned(const float* a) {
+    return _mm256_load_ps(a);
+}
+
+FLINT_FORCE_INLINE vec8f vec8f_load_unaligned(const float* a) {
+    return _mm256_loadu_ps(a);
+}
+
+FLINT_FORCE_INLINE void vec8f_store(float* z, vec8f a) {
+    _mm256_store_ps(z, a);
+}
+
+FLINT_FORCE_INLINE void vec8f_store_aligned(float* z, vec8f a) {
+    _mm256_store_ps(z, a);
+}
+
+FLINT_FORCE_INLINE void vec8f_store_unaligned(float* z, vec8f a) {
+    _mm256_storeu_ps(z, a);
+}
+
+FLINT_FORCE_INLINE vec8f vec8f_zero(void) {
+    return _mm256_setzero_ps();
+}
+
+FLINT_FORCE_INLINE vec8f vec8f_set_f(float a) {
+    return _mm256_set1_ps(a);
+}
+
+FLINT_FORCE_INLINE vec8f vec8f_add(vec8f a, vec8f b) {
+    return _mm256_add_ps(a, b);
+}
+
+FLINT_FORCE_INLINE vec8f vec8f_sub(vec8f a, vec8f b) {
+    return _mm256_sub_ps(a, b);
+}
+
+FLINT_FORCE_INLINE vec8f vec8f_mul(vec8f a, vec8f b) {
+    return _mm256_mul_ps(a, b);
+}
+
+FLINT_FORCE_INLINE vec8f vec8f_fmadd(vec8f a, vec8f b, vec8f c) {
+    return _mm256_fmadd_ps(a, b, c);
+}
+
+FLINT_FORCE_INLINE vec8f vec8f_fnmadd(vec8f a, vec8f b, vec8f c) {
+    return _mm256_fnmadd_ps(a, b, c);
+}
+
+FLINT_FORCE_INLINE vec8f vec8f_floor(vec8f a) {
+    return _mm256_floor_ps(a);
+}
+
+/* floor for the double types -- AVX2 **************************************/
+
+FLINT_FORCE_INLINE vec1d vec1d_floor(vec1d a) {
+    return floor(a);
+}
+
+FLINT_FORCE_INLINE vec2d vec2d_floor(vec2d a) {
+    return _mm_floor_pd(a);
+}
+
+FLINT_FORCE_INLINE vec4d vec4d_floor(vec4d a) {
+    return _mm256_floor_pd(a);
+}
+
+#if defined(__AVX512F__)
+/* vec8dz -- AVX512F *******************************************************/
+
+FLINT_FORCE_INLINE vec8dz vec8dz_load(const double* a) {
+    return _mm512_load_pd(a);
+}
+
+FLINT_FORCE_INLINE vec8dz vec8dz_load_aligned(const double* a) {
+    return _mm512_load_pd(a);
+}
+
+FLINT_FORCE_INLINE vec8dz vec8dz_load_unaligned(const double* a) {
+    return _mm512_loadu_pd(a);
+}
+
+FLINT_FORCE_INLINE void vec8dz_store(double* z, vec8dz a) {
+    _mm512_store_pd(z, a);
+}
+
+FLINT_FORCE_INLINE void vec8dz_store_aligned(double* z, vec8dz a) {
+    _mm512_store_pd(z, a);
+}
+
+FLINT_FORCE_INLINE void vec8dz_store_unaligned(double* z, vec8dz a) {
+    _mm512_storeu_pd(z, a);
+}
+
+FLINT_FORCE_INLINE vec8dz vec8dz_zero(void) {
+    return _mm512_setzero_pd();
+}
+
+FLINT_FORCE_INLINE vec8dz vec8dz_set_d(double a) {
+    return _mm512_set1_pd(a);
+}
+
+FLINT_FORCE_INLINE vec8dz vec8dz_add(vec8dz a, vec8dz b) {
+    return _mm512_add_pd(a, b);
+}
+
+FLINT_FORCE_INLINE vec8dz vec8dz_sub(vec8dz a, vec8dz b) {
+    return _mm512_sub_pd(a, b);
+}
+
+FLINT_FORCE_INLINE vec8dz vec8dz_mul(vec8dz a, vec8dz b) {
+    return _mm512_mul_pd(a, b);
+}
+
+FLINT_FORCE_INLINE vec8dz vec8dz_fmadd(vec8dz a, vec8dz b, vec8dz c) {
+    return _mm512_fmadd_pd(a, b, c);
+}
+
+FLINT_FORCE_INLINE vec8dz vec8dz_fnmadd(vec8dz a, vec8dz b, vec8dz c) {
+    return _mm512_fnmadd_pd(a, b, c);
+}
+
+FLINT_FORCE_INLINE vec8dz vec8dz_floor(vec8dz a) {
+    return _mm512_floor_pd(a);
+}
+
+/* vec16fz -- AVX512F ******************************************************/
+
+FLINT_FORCE_INLINE vec16fz vec16fz_load(const float* a) {
+    return _mm512_load_ps(a);
+}
+
+FLINT_FORCE_INLINE vec16fz vec16fz_load_aligned(const float* a) {
+    return _mm512_load_ps(a);
+}
+
+FLINT_FORCE_INLINE vec16fz vec16fz_load_unaligned(const float* a) {
+    return _mm512_loadu_ps(a);
+}
+
+FLINT_FORCE_INLINE void vec16fz_store(float* z, vec16fz a) {
+    _mm512_store_ps(z, a);
+}
+
+FLINT_FORCE_INLINE void vec16fz_store_aligned(float* z, vec16fz a) {
+    _mm512_store_ps(z, a);
+}
+
+FLINT_FORCE_INLINE void vec16fz_store_unaligned(float* z, vec16fz a) {
+    _mm512_storeu_ps(z, a);
+}
+
+FLINT_FORCE_INLINE vec16fz vec16fz_zero(void) {
+    return _mm512_setzero_ps();
+}
+
+FLINT_FORCE_INLINE vec16fz vec16fz_set_f(float a) {
+    return _mm512_set1_ps(a);
+}
+
+FLINT_FORCE_INLINE vec16fz vec16fz_add(vec16fz a, vec16fz b) {
+    return _mm512_add_ps(a, b);
+}
+
+FLINT_FORCE_INLINE vec16fz vec16fz_sub(vec16fz a, vec16fz b) {
+    return _mm512_sub_ps(a, b);
+}
+
+FLINT_FORCE_INLINE vec16fz vec16fz_mul(vec16fz a, vec16fz b) {
+    return _mm512_mul_ps(a, b);
+}
+
+FLINT_FORCE_INLINE vec16fz vec16fz_fmadd(vec16fz a, vec16fz b, vec16fz c) {
+    return _mm512_fmadd_ps(a, b, c);
+}
+
+FLINT_FORCE_INLINE vec16fz vec16fz_fnmadd(vec16fz a, vec16fz b, vec16fz c) {
+    return _mm512_fnmadd_ps(a, b, c);
+}
+
+FLINT_FORCE_INLINE vec16fz vec16fz_floor(vec16fz a) {
+    return _mm512_floor_ps(a);
+}
+#endif
+
+#elif (defined(__ARM_NEON) || defined(_M_ARM64)) \
+        && !defined(FLINT_MACHINE_VECTORS_GENERIC)
 
 typedef ulong vec1n;
 typedef uint64x2_t vec2n;
@@ -820,6 +1170,11 @@ typedef double vec1d;
 typedef float64x2_t vec2d;
 typedef struct {vec2d e1, e2;} vec4d;
 typedef struct {vec4d e1, e2;} vec8d;
+
+typedef float vec1f;
+typedef float32x4_t vec4f;
+typedef struct {vec4f e1, e2;} vec8f;
+typedef struct {vec8f e1, e2;} vec16f;
 
 #define EXTEND_VEC_DEF0(U, V, f) \
 FLINT_FORCE_INLINE V V##f(void) { \
@@ -1619,6 +1974,139 @@ FLINT_FORCE_INLINE vec8n vec8n_bit_shift_right(vec8n a, ulong n)
 #endif
 
 
+
+/* vec1f -- NEON/ARM64 *****************************************************/
+
+FLINT_FORCE_INLINE vec1f vec1f_load(const float* a) { return a[0]; }
+FLINT_FORCE_INLINE vec1f vec1f_load_aligned(const float* a) { return a[0]; }
+FLINT_FORCE_INLINE vec1f vec1f_load_unaligned(const float* a) { return a[0]; }
+FLINT_FORCE_INLINE void vec1f_store(float* z, vec1f a) { z[0] = a; }
+FLINT_FORCE_INLINE void vec1f_store_aligned(float* z, vec1f a) { z[0] = a; }
+FLINT_FORCE_INLINE void vec1f_store_unaligned(float* z, vec1f a) { z[0] = a; }
+FLINT_FORCE_INLINE vec1f vec1f_zero(void) { return 0.0f; }
+FLINT_FORCE_INLINE vec1f vec1f_set_f(float a) { return a; }
+FLINT_FORCE_INLINE vec1f vec1f_add(vec1f a, vec1f b) { return a + b; }
+FLINT_FORCE_INLINE vec1f vec1f_sub(vec1f a, vec1f b) { return a - b; }
+FLINT_FORCE_INLINE vec1f vec1f_mul(vec1f a, vec1f b) { return a * b; }
+FLINT_FORCE_INLINE vec1f vec1f_fmadd(vec1f a, vec1f b, vec1f c) {
+    return fmaf(a, b, c);
+}
+FLINT_FORCE_INLINE vec1f vec1f_fnmadd(vec1f a, vec1f b, vec1f c) {
+    return fmaf(-a, b, c);
+}
+FLINT_FORCE_INLINE vec1f vec1f_floor(vec1f a) { return floorf(a); }
+
+/* vec4f -- NEON/ARM64 *****************************************************/
+
+FLINT_FORCE_INLINE vec4f vec4f_load(const float* a) {
+    return vld1q_f32(a);
+}
+
+FLINT_FORCE_INLINE vec4f vec4f_load_aligned(const float* a) {
+    return vld1q_f32(a);
+}
+
+FLINT_FORCE_INLINE vec4f vec4f_load_unaligned(const float* a) {
+    return vld1q_f32(a);
+}
+
+FLINT_FORCE_INLINE void vec4f_store(float* z, vec4f a) {
+    vst1q_f32(z, a);
+}
+
+FLINT_FORCE_INLINE void vec4f_store_aligned(float* z, vec4f a) {
+    vst1q_f32(z, a);
+}
+
+FLINT_FORCE_INLINE void vec4f_store_unaligned(float* z, vec4f a) {
+    vst1q_f32(z, a);
+}
+
+FLINT_FORCE_INLINE vec4f vec4f_zero(void) {
+    return vdupq_n_f32(0.0f);
+}
+
+FLINT_FORCE_INLINE vec4f vec4f_set_f(float a) {
+    return vdupq_n_f32(a);
+}
+
+FLINT_FORCE_INLINE vec4f vec4f_add(vec4f a, vec4f b) {
+    return vaddq_f32(a, b);
+}
+
+FLINT_FORCE_INLINE vec4f vec4f_sub(vec4f a, vec4f b) {
+    return vsubq_f32(a, b);
+}
+
+FLINT_FORCE_INLINE vec4f vec4f_mul(vec4f a, vec4f b) {
+    return vmulq_f32(a, b);
+}
+
+FLINT_FORCE_INLINE vec4f vec4f_fmadd(vec4f a, vec4f b, vec4f c) {
+    return vfmaq_f32(c, a, b);
+}
+
+FLINT_FORCE_INLINE vec4f vec4f_fnmadd(vec4f a, vec4f b, vec4f c) {
+    return vfmsq_f32(c, a, b);
+}
+
+FLINT_FORCE_INLINE vec4f vec4f_floor(vec4f a) {
+    return vrndmq_f32(a);
+}
+
+/* floor for the double types -- NEON/ARM64 ********************************/
+
+FLINT_FORCE_INLINE vec1d vec1d_floor(vec1d a) {
+    return floor(a);
+}
+
+FLINT_FORCE_INLINE vec2d vec2d_floor(vec2d a) {
+    return vrndmq_f64(a);
+}
+
+/* vec8f -- NEON/ARM64 (pair of vec4f) *************************************/
+
+EXTEND_VEC_DEF0(vec4f, vec8f, _zero)
+EXTEND_VEC_DEF1(vec4f, vec8f, _floor)
+EXTEND_VEC_DEF2(vec4f, vec8f, _add)
+EXTEND_VEC_DEF2(vec4f, vec8f, _sub)
+EXTEND_VEC_DEF2(vec4f, vec8f, _mul)
+EXTEND_VEC_DEF3(vec4f, vec8f, _fmadd)
+EXTEND_VEC_DEF3(vec4f, vec8f, _fnmadd)
+
+FLINT_FORCE_INLINE vec8f vec8f_set_f(float a) {
+    vec8f z = {vec4f_set_f(a), vec4f_set_f(a)};
+    return z;
+}
+
+FLINT_FORCE_INLINE vec8f vec8f_load_unaligned(const float* a) {
+    vec8f z = {vec4f_load_unaligned(a), vec4f_load_unaligned(a + 4)};
+    return z;
+}
+
+FLINT_FORCE_INLINE vec8f vec8f_load_aligned(const float* a) {
+    vec8f z = {vec4f_load_aligned(a), vec4f_load_aligned(a + 4)};
+    return z;
+}
+
+FLINT_FORCE_INLINE vec8f vec8f_load(const float* a) {
+    return vec8f_load_aligned(a);
+}
+
+FLINT_FORCE_INLINE void vec8f_store_unaligned(float* z, vec8f a) {
+    vec4f_store_unaligned(z, a.e1);
+    vec4f_store_unaligned(z + 4, a.e2);
+}
+
+FLINT_FORCE_INLINE void vec8f_store_aligned(float* z, vec8f a) {
+    vec4f_store_aligned(z, a.e1);
+    vec4f_store_aligned(z + 4, a.e2);
+}
+
+FLINT_FORCE_INLINE void vec8f_store(float* z, vec8f a) {
+    vec8f_store_aligned(z, a);
+}
+
 #undef EXTEND_VEC_DEF4
 #undef EXTEND_VEC_DEF3
 #undef EXTEND_VEC_DEF2
@@ -1628,10 +2116,326 @@ FLINT_FORCE_INLINE vec8n vec8n_bit_shift_right(vec8n a, ulong n)
 
 #else
 
-#error machine_vector.h not implemented
+/*
+    Generic backends, so that this header is usable on every platform rather
+    than only AVX2 and NEON. Two tiers:
+
+    (a) GNU vector extensions (GCC/Clang on any architecture: RISC-V, POWER,
+        s390x, ARM without NEON, ...). These are compiler extensions rather
+        than target intrinsics, so one source maps onto whatever SIMD the
+        target actually has, and -- importantly -- the operations are already
+        vector operations, so the compiler does not try to auto-vectorize
+        loops over them in unprofitable ways.
+
+    (b) Strict ISO C structs, for any other compiler. Correct everywhere;
+        quality of codegen is up to the compiler's own auto-vectorizer.
+        Define FLINT_MACHINE_VECTORS_STRICT_C to force this tier.
+
+    These tiers currently implement the subset of the interface needed by
+    flint_sgemm/flint_dgemm: load/store (plain, aligned, unaligned), zero,
+    set_d/set_f, add, sub, mul, fmadd, fnmadd, floor, for
+    vec1d/vec2d/vec4d/vec8d and vec1f/vec4f/vec8f/vec16f. Other operations are
+    deliberately absent rather than emulated badly; add them here as
+    callers need them.
+*/
+
+typedef double vec1d;
+typedef float vec1f;
+
+#if defined(__GNUC__) && !defined(FLINT_MACHINE_VECTORS_STRICT_C)
+
+# define FLINT_MACHINE_VECTORS_GNU_VECTOR_EXTENSIONS 1
+
+/*
+    These vectors may be wider than the target's native SIMD width, which
+    is intentional (extra instruction level parallelism, and the compiler
+    splits them). All functions here are force-inlined, so the psabi
+    warning about passing such types across function boundaries does not
+    apply to any code we actually generate.
+*/
+# if defined(__GNUC__) && !defined(__clang__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wpsabi"
+# endif
+
+typedef double vec2d __attribute__((vector_size(16)));
+typedef double vec4d __attribute__((vector_size(32)));
+typedef float vec4f __attribute__((vector_size(16)));
+typedef float vec8f __attribute__((vector_size(32)));
+
+# define VEC_GENERIC_DEF(V, S, N, SUF, FLOOR1) \
+FLINT_FORCE_INLINE V V##_load_unaligned(const S* a) { \
+    V z; memcpy(&z, a, sizeof(z)); return z; \
+} \
+FLINT_FORCE_INLINE V V##_load_aligned(const S* a) { \
+    V z; memcpy(&z, a, sizeof(z)); return z; \
+} \
+FLINT_FORCE_INLINE V V##_load(const S* a) { \
+    return V##_load_aligned(a); \
+} \
+FLINT_FORCE_INLINE void V##_store_unaligned(S* z, V a) { \
+    memcpy(z, &a, sizeof(a)); \
+} \
+FLINT_FORCE_INLINE void V##_store_aligned(S* z, V a) { \
+    memcpy(z, &a, sizeof(a)); \
+} \
+FLINT_FORCE_INLINE void V##_store(S* z, V a) { \
+    V##_store_aligned(z, a); \
+} \
+FLINT_FORCE_INLINE V V##_zero(void) { V z = {0}; return z; } \
+FLINT_FORCE_INLINE V V##_set_##SUF(S a) { V z = {0}; return z + a; } \
+FLINT_FORCE_INLINE V V##_add(V a, V b) { return a + b; } \
+FLINT_FORCE_INLINE V V##_sub(V a, V b) { return a - b; } \
+FLINT_FORCE_INLINE V V##_mul(V a, V b) { return a * b; } \
+FLINT_FORCE_INLINE V V##_fmadd(V a, V b, V c) { return a * b + c; } \
+FLINT_FORCE_INLINE V V##_fnmadd(V a, V b, V c) { return c - a * b; } \
+FLINT_FORCE_INLINE V V##_floor(V a) { \
+    for (int i = 0; i < N; i++) a[i] = FLOOR1(a[i]); \
+    return a; \
+}
+
+#else
+
+typedef struct {double v[2];} vec2d;
+typedef struct {double v[4];} vec4d;
+typedef struct {float v[4];} vec4f;
+typedef struct {float v[8];} vec8f;
+
+/*
+    The elementwise operations are written as straight-line code rather
+    than loops: whether they become SIMD instructions is up to the
+    compiler's SLP vectorizer, and an unrolled basic block is
+    considerably more reliable across compilers and versions than a loop
+    the vectorizer must first unroll. This tier is only reached on
+    compilers without GNU vector extensions, so the generated code is
+    otherwise outside our control.
+*/
+
+# define VEC_SC_EACH2(F) F(0) F(1)
+# define VEC_SC_EACH4(F) F(0) F(1) F(2) F(3)
+# define VEC_SC_EACH8(F) F(0) F(1) F(2) F(3) F(4) F(5) F(6) F(7)
+
+# define VEC_SC_LOAD(i) z.v[i] = a[i];
+# define VEC_SC_STORE(i) z[i] = a.v[i];
+# define VEC_SC_ZERO(i) z.v[i] = 0;
+# define VEC_SC_SET1(i) z.v[i] = a;
+# define VEC_SC_ADD(i) z.v[i] = a.v[i] + b.v[i];
+# define VEC_SC_SUB(i) z.v[i] = a.v[i] - b.v[i];
+# define VEC_SC_MUL(i) z.v[i] = a.v[i] * b.v[i];
+# define VEC_SC_FMADD(i) z.v[i] = a.v[i] * b.v[i] + c.v[i];
+# define VEC_SC_FNMADD(i) z.v[i] = c.v[i] - a.v[i] * b.v[i];
+
+# define VEC_GENERIC_DEF(V, S, N, SUF, FLOOR1) \
+FLINT_FORCE_INLINE V V##_load_unaligned(const S* a) { \
+    V z; VEC_SC_EACH##N(VEC_SC_LOAD) return z; \
+} \
+FLINT_FORCE_INLINE V V##_load_aligned(const S* a) { \
+    return V##_load_unaligned(a); \
+} \
+FLINT_FORCE_INLINE V V##_load(const S* a) { \
+    return V##_load_unaligned(a); \
+} \
+FLINT_FORCE_INLINE void V##_store_unaligned(S* z, V a) { \
+    VEC_SC_EACH##N(VEC_SC_STORE) \
+} \
+FLINT_FORCE_INLINE void V##_store_aligned(S* z, V a) { \
+    V##_store_unaligned(z, a); \
+} \
+FLINT_FORCE_INLINE void V##_store(S* z, V a) { \
+    V##_store_unaligned(z, a); \
+} \
+FLINT_FORCE_INLINE V V##_zero(void) { \
+    V z; VEC_SC_EACH##N(VEC_SC_ZERO) return z; \
+} \
+FLINT_FORCE_INLINE V V##_set_##SUF(S a) { \
+    V z; VEC_SC_EACH##N(VEC_SC_SET1) return z; \
+} \
+FLINT_FORCE_INLINE V V##_add(V a, V b) { \
+    V z; VEC_SC_EACH##N(VEC_SC_ADD) return z; \
+} \
+FLINT_FORCE_INLINE V V##_sub(V a, V b) { \
+    V z; VEC_SC_EACH##N(VEC_SC_SUB) return z; \
+} \
+FLINT_FORCE_INLINE V V##_mul(V a, V b) { \
+    V z; VEC_SC_EACH##N(VEC_SC_MUL) return z; \
+} \
+FLINT_FORCE_INLINE V V##_fmadd(V a, V b, V c) { \
+    V z; VEC_SC_EACH##N(VEC_SC_FMADD) return z; \
+} \
+FLINT_FORCE_INLINE V V##_fnmadd(V a, V b, V c) { \
+    V z; VEC_SC_EACH##N(VEC_SC_FNMADD) return z; \
+} \
+FLINT_FORCE_INLINE V V##_floor(V a) { \
+    int i; \
+    for (i = 0; i < N; i++) \
+        a.v[i] = FLOOR1(a.v[i]); \
+    return a; \
+}
 
 #endif
 
+typedef struct {vec4d e1, e2;} vec8d;
+typedef struct {vec8f e1, e2;} vec16f;
+
+/* vec1d, vec1f -- generic *************************************************/
+
+FLINT_FORCE_INLINE vec1d vec1d_load(const double* a) { return a[0]; }
+FLINT_FORCE_INLINE vec1d vec1d_load_aligned(const double* a) { return a[0]; }
+FLINT_FORCE_INLINE vec1d vec1d_load_unaligned(const double* a) { return a[0]; }
+FLINT_FORCE_INLINE void vec1d_store(double* z, vec1d a) { z[0] = a; }
+FLINT_FORCE_INLINE void vec1d_store_aligned(double* z, vec1d a) { z[0] = a; }
+FLINT_FORCE_INLINE void vec1d_store_unaligned(double* z, vec1d a) { z[0] = a; }
+FLINT_FORCE_INLINE vec1d vec1d_zero(void) { return 0.0; }
+FLINT_FORCE_INLINE vec1d vec1d_set_d(double a) { return a; }
+FLINT_FORCE_INLINE vec1d vec1d_add(vec1d a, vec1d b) { return a + b; }
+FLINT_FORCE_INLINE vec1d vec1d_sub(vec1d a, vec1d b) { return a - b; }
+FLINT_FORCE_INLINE vec1d vec1d_mul(vec1d a, vec1d b) { return a * b; }
+FLINT_FORCE_INLINE vec1d vec1d_fmadd(vec1d a, vec1d b, vec1d c) {
+    return fma(a, b, c);
+}
+FLINT_FORCE_INLINE vec1d vec1d_fnmadd(vec1d a, vec1d b, vec1d c) {
+    return fma(-a, b, c);
+}
+FLINT_FORCE_INLINE vec1d vec1d_floor(vec1d a) { return floor(a); }
+
+FLINT_FORCE_INLINE vec1f vec1f_load(const float* a) { return a[0]; }
+FLINT_FORCE_INLINE vec1f vec1f_load_aligned(const float* a) { return a[0]; }
+FLINT_FORCE_INLINE vec1f vec1f_load_unaligned(const float* a) { return a[0]; }
+FLINT_FORCE_INLINE void vec1f_store(float* z, vec1f a) { z[0] = a; }
+FLINT_FORCE_INLINE void vec1f_store_aligned(float* z, vec1f a) { z[0] = a; }
+FLINT_FORCE_INLINE void vec1f_store_unaligned(float* z, vec1f a) { z[0] = a; }
+FLINT_FORCE_INLINE vec1f vec1f_zero(void) { return 0.0f; }
+FLINT_FORCE_INLINE vec1f vec1f_set_f(float a) { return a; }
+FLINT_FORCE_INLINE vec1f vec1f_add(vec1f a, vec1f b) { return a + b; }
+FLINT_FORCE_INLINE vec1f vec1f_sub(vec1f a, vec1f b) { return a - b; }
+FLINT_FORCE_INLINE vec1f vec1f_mul(vec1f a, vec1f b) { return a * b; }
+FLINT_FORCE_INLINE vec1f vec1f_fmadd(vec1f a, vec1f b, vec1f c) {
+    return fmaf(a, b, c);
+}
+FLINT_FORCE_INLINE vec1f vec1f_fnmadd(vec1f a, vec1f b, vec1f c) {
+    return fmaf(-a, b, c);
+}
+FLINT_FORCE_INLINE vec1f vec1f_floor(vec1f a) { return floorf(a); }
+
+/* vec4d, vec4f, vec8f -- generic ******************************************/
+
+VEC_GENERIC_DEF(vec2d, double, 2, d, floor)
+VEC_GENERIC_DEF(vec4d, double, 4, d, floor)
+VEC_GENERIC_DEF(vec4f, float, 4, f, floorf)
+VEC_GENERIC_DEF(vec8f, float, 8, f, floorf)
+
+#undef VEC_GENERIC_DEF
+
+/* vec8d, vec16f -- generic (pairs) ****************************************/
+
+#define VEC_GENERIC_PAIR_DEF(U, V, S, SUF) \
+FLINT_FORCE_INLINE V V##_load_unaligned(const S* a) { \
+    V z = {U##_load_unaligned(a), U##_load_unaligned(a + sizeof(U)/sizeof(S))}; \
+    return z; \
+} \
+FLINT_FORCE_INLINE V V##_load_aligned(const S* a) { \
+    V z = {U##_load_aligned(a), U##_load_aligned(a + sizeof(U)/sizeof(S))}; \
+    return z; \
+} \
+FLINT_FORCE_INLINE V V##_load(const S* a) { return V##_load_aligned(a); } \
+FLINT_FORCE_INLINE void V##_store_unaligned(S* z, V a) { \
+    U##_store_unaligned(z, a.e1); \
+    U##_store_unaligned(z + sizeof(U)/sizeof(S), a.e2); \
+} \
+FLINT_FORCE_INLINE void V##_store_aligned(S* z, V a) { \
+    U##_store_aligned(z, a.e1); \
+    U##_store_aligned(z + sizeof(U)/sizeof(S), a.e2); \
+} \
+FLINT_FORCE_INLINE void V##_store(S* z, V a) { V##_store_aligned(z, a); } \
+FLINT_FORCE_INLINE V V##_zero(void) { \
+    V z = {U##_zero(), U##_zero()}; return z; \
+} \
+FLINT_FORCE_INLINE V V##_set_##SUF(S a) { \
+    V z = {U##_set_##SUF(a), U##_set_##SUF(a)}; return z; \
+} \
+FLINT_FORCE_INLINE V V##_add(V a, V b) { \
+    V z = {U##_add(a.e1, b.e1), U##_add(a.e2, b.e2)}; return z; \
+} \
+FLINT_FORCE_INLINE V V##_sub(V a, V b) { \
+    V z = {U##_sub(a.e1, b.e1), U##_sub(a.e2, b.e2)}; return z; \
+} \
+FLINT_FORCE_INLINE V V##_mul(V a, V b) { \
+    V z = {U##_mul(a.e1, b.e1), U##_mul(a.e2, b.e2)}; return z; \
+} \
+FLINT_FORCE_INLINE V V##_fmadd(V a, V b, V c) { \
+    V z = {U##_fmadd(a.e1, b.e1, c.e1), U##_fmadd(a.e2, b.e2, c.e2)}; \
+    return z; \
+} \
+FLINT_FORCE_INLINE V V##_fnmadd(V a, V b, V c) { \
+    V z = {U##_fnmadd(a.e1, b.e1, c.e1), U##_fnmadd(a.e2, b.e2, c.e2)}; \
+    return z; \
+} \
+FLINT_FORCE_INLINE V V##_floor(V a) { \
+    V z = {U##_floor(a.e1), U##_floor(a.e2)}; return z; \
+}
+
+VEC_GENERIC_PAIR_DEF(vec4d, vec8d, double, d)
+VEC_GENERIC_PAIR_DEF(vec8f, vec16f, float, f)
+
+#undef VEC_GENERIC_PAIR_DEF
+
+#if defined(FLINT_MACHINE_VECTORS_GNU_VECTOR_EXTENSIONS) \
+        && defined(__GNUC__) && !defined(__clang__)
+# pragma GCC diagnostic pop
+#endif
+
+#endif
+
+
+
+/* gemm ********************************************************************/
+
+/*
+    C = A * B for row-major matrices with no transposes and no
+    accumulation: C is m x n, A is m x k, B is k x n, with leading
+    dimensions ldc, lda, ldb. Equivalent to cblas_sgemm/cblas_dgemm with
+    CblasRowMajor, CblasNoTrans, CblasNoTrans, alpha = 1, beta = 0.
+    These are always available; they use FLINT's thread pool according to
+    flint_get_num_threads().
+*/
+/*
+    Three interchangeable implementations of each. The _blas versions
+    call cblas (and abort if FLINT was built without BLAS); the
+    _fallback versions are FLINT's own kernels, always available. The
+    unsuffixed versions dispatch on flint_gemm_use_blas, which is
+    initialized to FLINT_USES_BLAS and may be set at runtime.
+*/
+FLINT_DLL extern int flint_gemm_use_blas;
+
+void flint_sgemm(slong m, slong k, slong n,
+                 const float * A, slong lda,
+                 const float * B, slong ldb,
+                 float * C, slong ldc);
+
+void flint_dgemm(slong m, slong k, slong n,
+                 const double * A, slong lda,
+                 const double * B, slong ldb,
+                 double * C, slong ldc);
+
+void flint_sgemm_blas(slong m, slong k, slong n,
+                      const float * A, slong lda,
+                      const float * B, slong ldb,
+                      float * C, slong ldc);
+
+void flint_dgemm_blas(slong m, slong k, slong n,
+                      const double * A, slong lda,
+                      const double * B, slong ldb,
+                      double * C, slong ldc);
+
+void flint_sgemm_fallback(slong m, slong k, slong n,
+                          const float * A, slong lda,
+                          const float * B, slong ldb,
+                          float * C, slong ldc);
+
+void flint_dgemm_fallback(slong m, slong k, slong n,
+                          const double * A, slong lda,
+                          const double * B, slong ldb,
+                          double * C, slong ldc);
 
 #ifdef __cplusplus
 }

--- a/src/machine_vectors/gemm.c
+++ b/src/machine_vectors/gemm.c
@@ -1,0 +1,523 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+/*
+    flint_sgemm and flint_dgemm: always-available single/double precision
+    matrix multiplication, so that FLINT modules can use a GEMM building
+    block whether or not an external BLAS is configured.
+
+    C = A * B, row-major, no transposes, no accumulation (alpha = 1,
+    beta = 0), arbitrary dimensions and leading dimensions. This is the
+    subset of xGEMM that FLINT actually uses in nmod_mat and fmpz_mat.
+
+    Structure: BLIS-style three-level blocking (NC/KC/MC), packed A
+    blocks and B panels, a register-tile microkernel, plus streaming
+    no-pack paths for thin and small shapes. All SIMD goes through
+    machine_vectors.h. Multithreading uses FLINT's thread pool: one
+    thread_pool_wake/wait per worker per call, with the phases inside
+    separated by spin barriers.
+*/
+
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+/*
+    The generic vector backends express a fused multiply-add as the
+    expression a * b + c, which the compiler contracts into an FMA only
+    if it is allowed to. GCC in a strict ISO mode (FLINT builds with
+    -std=c11) defaults to -ffp-contract=on and does not contract, which
+    costs about 1.4x here; clang contracts under its default. Requesting
+    fast contraction for this file restores it. Contraction is safe for
+    everything in this file: no operation depends on the intermediate
+    product being rounded, and an FMA is at least as accurate.
+
+    The AVX2/AVX512/NEON backends are unaffected either way, since they
+    use fused intrinsics directly.
+*/
+#if defined(__GNUC__) && !defined(__clang__)
+# pragma GCC optimize("fp-contract=fast")
+#endif
+
+#include "flint.h"
+
+/*
+    For profiling and testing the portable code paths without rebuilding
+    FLINT: uncomment one of these to override the vector backend that
+    machine_vectors.h would select for this file. FLINT_MACHINE_VECTORS_-
+    FORCE_GENERIC gives the GNU vector extension backend (the fallback on
+    targets with no AVX2/NEON support in machine_vectors.h) and
+    FLINT_MACHINE_VECTORS_STRICT_C gives the strict ISO C backend. Only
+    this translation unit is affected, so the rest of FLINT keeps using
+    the native vectors.
+
+#define FLINT_MACHINE_VECTORS_FORCE_GENERIC
+#define FLINT_MACHINE_VECTORS_STRICT_C
+*/
+
+#include "machine_vectors.h"
+#include "thread_pool.h"
+#include "thread_support.h"
+
+/*
+    The single point in FLINT where a BLAS header is included. Everything
+    else calls flint_sgemm/flint_dgemm (or the _blas/_fallback variants)
+    unconditionally.
+*/
+#if FLINT_USES_BLAS
+# include <cblas.h>
+#endif
+
+/* Blocking parameters, in elements. */
+#define SG_KC 256
+#define SG_MC 96
+#define SG_NC 2048
+
+/* Widest vector per element type, and microkernel rows; MR x 2 vectors
+   of accumulators plus the two B vectors must fit the register file. */
+#if defined(FLINT_MACHINE_VECTORS_GENERIC)
+/*
+    Generic backends. The logical vector width follows the target: the
+    GNU vector extension types lower directly onto whatever registers
+    exist, and the ISO C struct loops are what the auto-vectorizer is
+    given to work with, so a width narrower than the hardware wastes the
+    datapath. 32 bytes is the largest used here, for two reasons: only
+    the flat types (vec2d/vec4d, vec4f/vec8f) are single objects, the
+    wider ones being structs of two, which doubles register pressure and
+    defeats auto-vectorization of the ISO C tier; and MR x 2 accumulators
+    of 32 bytes plus two B vectors is exactly the 16 architectural
+    registers of pre-AVX512 x86.
+*/
+# if defined(FLINT_MACHINE_VECTORS_STRICT_C)
+#  define GEMM_VD vec4d
+#  define GEMM_VF GEMM_SC_VF
+#  define GEMM_VLD 4
+#  define GEMM_VLF GEMM_SC_VLF
+# elif defined(__AVX__)
+#  define GEMM_VD vec4d
+#  define GEMM_VF vec8f
+#  define GEMM_VLD 4
+#  define GEMM_VLF 8
+# else
+#  define GEMM_VD vec2d
+#  define GEMM_VF vec4f
+#  define GEMM_VLD 2
+#  define GEMM_VLF 4
+# endif
+# ifndef GEMM_MRD
+#  define GEMM_MRD GEMM_GEN_MR
+# endif
+# ifndef GEMM_MRF
+#  define GEMM_MRF GEMM_GEN_MR
+# endif
+#elif defined(__AVX512F__)
+# define GEMM_VD vec8dz
+# define GEMM_VF vec16fz
+# define GEMM_VLD 8
+# define GEMM_VLF 16
+# define GEMM_MRD 8
+# define GEMM_MRF 8
+#elif defined(__AVX2__)
+# define GEMM_VD vec4d
+# define GEMM_VF vec8f
+# define GEMM_VLD 4
+# define GEMM_VLF 8
+# define GEMM_MRD 6
+# define GEMM_MRF 6
+#elif defined(__ARM_NEON) || defined(_M_ARM64)
+# define GEMM_VD vec2d
+# define GEMM_VF vec4f
+# define GEMM_VLD 2
+# define GEMM_VLF 4
+# define GEMM_MRD 8
+# define GEMM_MRF 8
+#else
+/* Generic backends: 128-bit logical vectors. Every target reaching this
+   branch (neither AVX2 nor NEON) has at most 128-bit SIMD and 16 vector
+   registers in practice, and wider logical vectors then spill. */
+# define GEMM_VD vec2d
+# define GEMM_VF vec4f
+# define GEMM_VLD 2
+# define GEMM_VLF 4
+# define GEMM_MRD 6
+# define GEMM_MRF 6
+#endif
+
+/* The direct no-pack kernel for small problems is a win when the vector
+   layer is real SIMD, and a loss for the strict ISO C structs, where the
+   compiler vectorizes the k-loop over a strided B instead of the lanes. */
+#ifndef GEMM_SMALL_DIM
+# if defined(FLINT_MACHINE_VECTORS_STRICT_C)
+#  define GEMM_SMALL_DIM 0
+# else
+#  define GEMM_SMALL_DIM 96
+# endif
+#endif
+
+/* work below which threading cannot pay for itself */
+#define SG_MT_FLOP_PER_THREAD 1.0e6
+
+/*
+    Two parallel drivers are available.
+
+    GEMM_MT_ATOMIC: workers cooperate on one packed B panel at a time,
+    coordinated by atomic work queues and sense-reversing spin barriers.
+    This is the faster of the two, but it exercises C11 atomics and
+    relaxed/acquire-release ordering that we have so far only stress
+    tested on x86-64.
+
+    Otherwise: the row range of C is split into one independent serial
+    multiplication per worker. No atomics, no barriers, nothing shared
+    but read-only inputs and disjoint output blocks. Slightly slower at
+    high thread counts (B is packed once per worker rather than once per
+    team) but portable with no assumptions beyond the thread pool.
+
+    Define GEMM_MT_FORCE_ATOMIC or GEMM_MT_FORCE_SPLIT to override.
+*/
+#if defined(GEMM_MT_FORCE_ATOMIC)
+# define GEMM_MT_ATOMIC 1
+#elif defined(GEMM_MT_FORCE_SPLIT)
+# undef GEMM_MT_ATOMIC
+#elif defined(__x86_64__) || defined(_M_X64)
+# define GEMM_MT_ATOMIC 1
+#endif
+
+#if defined(GEMM_MT_ATOMIC)
+# include <stdatomic.h>
+# if !defined(_WIN32) && !defined(_MSC_VER)
+#  include <sched.h>
+# endif
+#endif
+
+#ifndef GEMM_GEN_MR
+# define GEMM_GEN_MR 4
+#endif
+#ifndef GEMM_SC_VF
+# define GEMM_SC_VF vec4f
+# define GEMM_SC_VLF 4
+#endif
+
+#define GEMM_CAT_(a, b) a##b
+#define GEMM_CAT(a, b) GEMM_CAT_(a, b)
+
+/*
+    Packing scratch. With thread-local storage this is a grow-only buffer
+    reused across calls, which matters for small matrices where an
+    allocation would otherwise dominate; without TLS the serial core must
+    allocate per call, since it may be entered concurrently.
+*/
+#if FLINT_USES_TLS
+
+static FLINT_TLS_PREFIX char * gemm_scratch_buf = NULL;
+static FLINT_TLS_PREFIX slong gemm_scratch_sz = 0;
+
+static void
+gemm_scratch_cleanup(void)
+{
+    flint_aligned_free(gemm_scratch_buf);
+    gemm_scratch_buf = NULL;
+    gemm_scratch_sz = 0;
+}
+
+#if !defined(GEMM_MT_ATOMIC)
+/* release the calling thread's scratch: thread pool threads outlive the
+   call and do not run registered cleanup functions, so the split driver
+   makes each worker drop its cache before returning */
+static void
+gemm_scratch_free_local(void)
+{
+    flint_aligned_free(gemm_scratch_buf);
+    gemm_scratch_buf = NULL;
+    gemm_scratch_sz = 0;
+}
+#endif
+
+static char *
+gemm_get_scratch(slong bytes)
+{
+    if (bytes > gemm_scratch_sz)
+    {
+        slong sz = (bytes + 4095) & ~(slong) 4095;
+
+        if (gemm_scratch_buf == NULL)
+            flint_register_cleanup_function(gemm_scratch_cleanup);
+        else
+            flint_aligned_free(gemm_scratch_buf);
+
+        gemm_scratch_buf = flint_aligned_alloc(64, sz);
+        gemm_scratch_sz = sz;
+    }
+
+    return gemm_scratch_buf;
+}
+
+# define gemm_put_scratch(ptr) do { } while (0)
+
+#else
+
+static char *
+gemm_get_scratch(slong bytes)
+{
+    return flint_aligned_alloc(64, (bytes + 63) & ~(slong) 63);
+}
+
+# define gemm_put_scratch(ptr) flint_aligned_free(ptr)
+# define gemm_scratch_free_local() do { } while (0)
+
+#endif
+
+#if defined(GEMM_MT_ATOMIC)
+
+/* pause/yield hints for the spin barrier */
+#if defined(__x86_64__) || defined(__i386__) || defined(_M_X64)
+# if defined(__GNUC__)
+#  define GEMM_CPU_RELAX() __builtin_ia32_pause()
+# else
+#  include <intrin.h>
+#  define GEMM_CPU_RELAX() _mm_pause()
+# endif
+#elif defined(__aarch64__) || defined(__arm__)
+# define GEMM_CPU_RELAX() __asm__ __volatile__("yield")
+#else
+# define GEMM_CPU_RELAX() ((void) 0)
+#endif
+
+static void
+gemm_thread_yield(void)
+{
+#if defined(_WIN32) || defined(_MSC_VER)
+    /* no portable yield; spinning is acceptable here since the barrier
+       waits are short and oversubscription is the only case that hits
+       this path */
+#else
+    sched_yield();
+#endif
+}
+
+/* sense-reversing barrier shared by both stamps */
+static void
+gemm_mt_barrier(_Atomic int * count, _Atomic int * bsense,
+                _Atomic slong * q1, _Atomic slong * q2,
+                int nt, int * sense)
+{
+    *sense ^= 1;
+    if (atomic_fetch_add_explicit(count, 1, memory_order_acq_rel) == nt - 1)
+    {
+        atomic_store_explicit(count, 0, memory_order_relaxed);
+        atomic_store_explicit(q1, 0, memory_order_relaxed);
+        atomic_store_explicit(q2, 0, memory_order_relaxed);
+        atomic_store_explicit(bsense, *sense, memory_order_release);
+    }
+    else
+    {
+        unsigned spins = 0;
+
+        while (atomic_load_explicit(bsense, memory_order_acquire) != *sense)
+        {
+            if (++spins < 2048)
+                GEMM_CPU_RELAX();
+            else
+            {
+                spins = 0;
+                gemm_thread_yield();
+            }
+        }
+    }
+}
+
+#endif /* GEMM_MT_ATOMIC */
+
+/* single precision **********************************************************/
+
+#define GEMM_PART_SERIAL
+#define GEMM_PART_MT
+#define GT_PRE flint_gemm_f32_
+#define GT_T float
+#define GT_VEC GEMM_VF
+#define GT_VL GEMM_VLF
+#define GT_MR GEMM_MRF
+#define GT_LOADU(p) GEMM_CAT(GEMM_VF, _load_unaligned)(p)
+#define GT_LOADA(p) GEMM_CAT(GEMM_VF, _load_aligned)(p)
+#define GT_STOREU(p, v) GEMM_CAT(GEMM_VF, _store_unaligned)(p, v)
+#define GT_SETZERO() GEMM_CAT(GEMM_VF, _zero)()
+#define GT_BCAST(p) GEMM_CAT(GEMM_VF, _set_f)(*(p))
+#define GT_FMADD(a, b, c) GEMM_CAT(GEMM_VF, _fmadd)(a, b, c)
+#include "gemm_templ.h"
+#undef GT_PRE
+#undef GT_T
+#undef GT_VEC
+#undef GT_VL
+#undef GT_MR
+#undef GT_LOADU
+#undef GT_LOADA
+#undef GT_STOREU
+#undef GT_SETZERO
+#undef GT_BCAST
+#undef GT_FMADD
+
+/* double precision **********************************************************/
+
+#define GT_PRE flint_gemm_f64_
+#define GT_T double
+#define GT_VEC GEMM_VD
+#define GT_VL GEMM_VLD
+#define GT_MR GEMM_MRD
+#define GT_LOADU(p) GEMM_CAT(GEMM_VD, _load_unaligned)(p)
+#define GT_LOADA(p) GEMM_CAT(GEMM_VD, _load_aligned)(p)
+#define GT_STOREU(p, v) GEMM_CAT(GEMM_VD, _store_unaligned)(p, v)
+#define GT_SETZERO() GEMM_CAT(GEMM_VD, _zero)()
+#define GT_BCAST(p) GEMM_CAT(GEMM_VD, _set_d)(*(p))
+#define GT_FMADD(a, b, c) GEMM_CAT(GEMM_VD, _fmadd)(a, b, c)
+#include "gemm_templ.h"
+#undef GT_PRE
+#undef GT_T
+#undef GT_VEC
+#undef GT_VL
+#undef GT_MR
+#undef GT_LOADU
+#undef GT_LOADA
+#undef GT_STOREU
+#undef GT_SETZERO
+#undef GT_BCAST
+#undef GT_FMADD
+#undef GEMM_PART_SERIAL
+#undef GEMM_PART_MT
+
+/* fallback implementations *************************************************/
+
+void
+flint_sgemm_fallback(slong m, slong k, slong n,
+                     const float * A, slong lda,
+                     const float * B, slong ldb,
+                     float * C, slong ldc)
+{
+    slong i;
+
+    if (m <= 0 || n <= 0)
+        return;
+
+    if (k <= 0)
+    {
+        for (i = 0; i < m; i++)
+            memset(C + i * ldc, 0, n * sizeof(float));
+        return;
+    }
+
+#if defined(GEMM_MT_ATOMIC)
+    flint_gemm_f32_core_mt(C, ldc, A, lda, B, ldb, m, k, n,
+                           flint_get_num_threads());
+#else
+    flint_gemm_f32_core_split_mt(C, ldc, A, lda, B, ldb, m, k, n,
+                                 flint_get_num_threads());
+#endif
+}
+
+void
+flint_dgemm_fallback(slong m, slong k, slong n,
+                     const double * A, slong lda,
+                     const double * B, slong ldb,
+                     double * C, slong ldc)
+{
+    slong i;
+
+    if (m <= 0 || n <= 0)
+        return;
+
+    if (k <= 0)
+    {
+        for (i = 0; i < m; i++)
+            memset(C + i * ldc, 0, n * sizeof(double));
+        return;
+    }
+
+#if defined(GEMM_MT_ATOMIC)
+    flint_gemm_f64_core_mt(C, ldc, A, lda, B, ldb, m, k, n,
+                           flint_get_num_threads());
+#else
+    flint_gemm_f64_core_split_mt(C, ldc, A, lda, B, ldb, m, k, n,
+                                 flint_get_num_threads());
+#endif
+}
+
+/* BLAS wrappers ************************************************************/
+
+void
+flint_sgemm_blas(slong m, slong k, slong n,
+                 const float * A, slong lda,
+                 const float * B, slong ldb,
+                 float * C, slong ldc)
+{
+#if FLINT_USES_BLAS
+    if (m <= 0 || n <= 0)
+        return;
+
+    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
+                m, n, k, 1.0f, A, lda, B, ldb, 0.0f, C, ldc);
+#else
+    (void) m; (void) k; (void) n;
+    (void) A; (void) lda; (void) B; (void) ldb; (void) C; (void) ldc;
+
+    flint_throw(FLINT_ERROR, "flint_sgemm_blas: FLINT was built without BLAS\n");
+#endif
+}
+
+void
+flint_dgemm_blas(slong m, slong k, slong n,
+                 const double * A, slong lda,
+                 const double * B, slong ldb,
+                 double * C, slong ldc)
+{
+#if FLINT_USES_BLAS
+    if (m <= 0 || n <= 0)
+        return;
+
+    cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
+                m, n, k, 1.0, A, lda, B, ldb, 0.0, C, ldc);
+#else
+    (void) m; (void) k; (void) n;
+    (void) A; (void) lda; (void) B; (void) ldb; (void) C; (void) ldc;
+
+    flint_throw(FLINT_ERROR, "flint_dgemm_blas: FLINT was built without BLAS\n");
+#endif
+}
+
+/* dispatch *****************************************************************/
+
+/* FLINT_USES_BLAS is left undefined rather than 0 when BLAS is absent,
+   so it cannot be used directly as an initializer */
+#if FLINT_USES_BLAS
+int flint_gemm_use_blas = 1;
+#else
+int flint_gemm_use_blas = 0;
+#endif
+
+void
+flint_sgemm(slong m, slong k, slong n,
+            const float * A, slong lda,
+            const float * B, slong ldb,
+            float * C, slong ldc)
+{
+    if (flint_gemm_use_blas)
+        flint_sgemm_blas(m, k, n, A, lda, B, ldb, C, ldc);
+    else
+        flint_sgemm_fallback(m, k, n, A, lda, B, ldb, C, ldc);
+}
+
+void
+flint_dgemm(slong m, slong k, slong n,
+            const double * A, slong lda,
+            const double * B, slong ldb,
+            double * C, slong ldc)
+{
+    if (flint_gemm_use_blas)
+        flint_dgemm_blas(m, k, n, A, lda, B, ldb, C, ldc);
+    else
+        flint_dgemm_fallback(m, k, n, A, lda, B, ldb, C, ldc);
+}

--- a/src/machine_vectors/gemm_templ.h
+++ b/src/machine_vectors/gemm_templ.h
@@ -1,0 +1,705 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+/*
+   Internal single-source GEMM implementation, stamped per element type
+   (float/double) by gemm.c. All SIMD goes through machine_vectors.h, so
+   the same source covers AVX-512 (vec8dz/vec16fz), AVX2 (vec4d/vec8f),
+   NEON (vec2d/vec4f), the generic GNU-vector-extension backend and the
+   strict ISO C backend with no target #ifdef in this file.
+
+   Expected macros:
+     GT_PRE        name prefix (e.g. sg_f32_)
+     GT_T          element type (float / double)
+     GT_VEC        vector type
+     GT_VL         lanes per vector
+     GT_MR         microkernel rows (accumulators = GT_MR x 2 vectors)
+     GT_LOADU/GT_LOADA/GT_STOREU  vector load/store
+     GT_SETZERO/GT_BCAST(ptr)
+     GT_FMADD(a,b,c) = a*b + c
+     GEMM_PART_SERIAL or GEMM_PART_MT  -- which section to emit
+
+   The serial section emits: _micro, _pack_a, _pack_b, _core.
+   The MT section (requires FLINT headers and gemm_mt_barrier from the
+   includer) emits: _mt_ctx, _mt_run, _core_mt.
+
+   The includer defines GEMM_PART_SERIAL to emit micro/pack/core, and
+   GEMM_PART_MT to emit the thread-pool driver. */
+
+#define GT_CAT_(a, b) a##b
+#define GT_CAT(a, b) GT_CAT_(a, b)
+#define GT_N(name) GT_CAT(GT_PRE, name)
+
+#define GT_NR (2 * GT_VL)
+
+#ifdef GEMM_PART_SERIAL
+
+/* microkernel: c(GT_MR x GT_NR, row stride ldc) (+)= Ap * Bp over kc */
+static void GT_N(micro)(GT_T *c, slong ldc, const GT_T *ap,
+                        const GT_T *bp, slong kc, int first)
+{
+    GT_VEC acc[GT_MR][2];
+    for (int r = 0; r < GT_MR; r++)
+    {
+        acc[r][0] = first ? GT_SETZERO() : GT_LOADU(c + r * ldc);
+        acc[r][1] = first ? GT_SETZERO() : GT_LOADU(c + r * ldc + GT_VL);
+    }
+    for (slong l = 0; l < kc; l++)
+    {
+        GT_VEC b0 = GT_LOADA(bp + GT_NR * l);
+        GT_VEC b1 = GT_LOADA(bp + GT_NR * l + GT_VL);
+        for (int r = 0; r < GT_MR; r++)
+        {
+            GT_VEC a = GT_BCAST(ap + GT_MR * l + r);
+            acc[r][0] = GT_FMADD(a, b0, acc[r][0]);
+            acc[r][1] = GT_FMADD(a, b1, acc[r][1]);
+        }
+    }
+    for (int r = 0; r < GT_MR; r++)
+    {
+        GT_STOREU(c + r * ldc, acc[r][0]);
+        GT_STOREU(c + r * ldc + GT_VL, acc[r][1]);
+    }
+}
+
+/* pack (rows x kc) of A into MR-wide l-major panels, zero-filled */
+static void GT_N(pack_a)(GT_T *ap, const GT_T *a, slong lda,
+                         slong rows, slong kc)
+{
+    for (slong ir = 0; ir < rows; ir += GT_MR)
+    {
+        slong rr = rows - ir < GT_MR ? rows - ir : GT_MR;
+        for (slong l = 0; l < kc; l++)
+        {
+            for (slong r = 0; r < rr; r++)
+                ap[l * GT_MR + r] = a[(ir + r) * lda + l];
+            for (slong r = rr; r < GT_MR; r++)
+                ap[l * GT_MR + r] = 0;
+        }
+        ap += kc * GT_MR;
+    }
+}
+
+static void GT_N(pack_b)(GT_T *bp, const GT_T *b, slong ldb,
+                         slong kc, slong cols)
+{
+    for (slong jr = 0; jr < cols; jr += GT_NR)
+    {
+        slong cc = cols - jr < GT_NR ? cols - jr : GT_NR;
+        for (slong l = 0; l < kc; l++)
+        {
+            for (slong j = 0; j < cc; j++)
+                bp[l * GT_NR + j] = b[l * ldb + jr + j];
+            for (slong j = cc; j < GT_NR; j++)
+                bp[l * GT_NR + j] = 0;
+        }
+        bp += kc * GT_NR;
+    }
+}
+
+/* thin-shape paths (native element type, non-modular): these shapes
+   make panel packing a bad trade -- with m <= MR the B pack dominates
+   the row sweep, and with n <= NR the padded microkernel wastes most
+   of its width. Both use streaming no-pack kernels instead. */
+
+/* m <= GT_MR: B streamed exactly once, C strips held in registers */
+static void GT_N(core_thin_m)(GT_T *C, slong ldc, const GT_T *A,
+                              slong lda, const GT_T *B, slong ldb,
+                              slong m, slong k, slong n)
+{
+    slong j0 = 0;
+    for (; j0 + 4 * GT_VL <= n; j0 += 4 * GT_VL)
+    {
+        GT_VEC acc[GT_MR][4];
+        for (slong r = 0; r < m; r++)
+            for (int v = 0; v < 4; v++) acc[r][v] = GT_SETZERO();
+        for (slong l = 0; l < k; l++)
+        {
+            const GT_T *b = B + l * ldb + j0;
+            GT_VEC b0 = GT_LOADU(b), b1 = GT_LOADU(b + GT_VL);
+            GT_VEC b2 = GT_LOADU(b + 2 * GT_VL), b3 = GT_LOADU(b + 3 * GT_VL);
+            for (slong r = 0; r < m; r++)
+            {
+                GT_VEC a = GT_BCAST(A + r * lda + l);
+                acc[r][0] = GT_FMADD(a, b0, acc[r][0]);
+                acc[r][1] = GT_FMADD(a, b1, acc[r][1]);
+                acc[r][2] = GT_FMADD(a, b2, acc[r][2]);
+                acc[r][3] = GT_FMADD(a, b3, acc[r][3]);
+            }
+        }
+        for (slong r = 0; r < m; r++)
+            for (int v = 0; v < 4; v++)
+                GT_STOREU(C + r * ldc + j0 + v * GT_VL, acc[r][v]);
+    }
+    for (; j0 < n; j0++)   /* scalar column tail */
+        for (slong r = 0; r < m; r++)
+        {
+            GT_T sacc = 0;
+            for (slong l = 0; l < k; l++)
+                sacc += A[r * lda + l] * B[l * ldb + j0];
+            C[r * ldc + j0] = sacc;
+        }
+}
+
+/* n <= GT_NR: B packed once into a tiny k x NR panel; A streamed */
+static void GT_N(core_thin_n)(GT_T *C, slong ldc, const GT_T *A,
+                              slong lda, const GT_T *B, slong ldb,
+                              slong m, slong k, slong n)
+{
+    GT_T *bp = flint_aligned_alloc(64,
+        (k * GT_NR * (slong) sizeof(GT_T) + 63) & ~(slong) 63);
+    for (slong l = 0; l < k; l++)
+    {
+        for (slong j = 0; j < n; j++) bp[l * GT_NR + j] = B[l * ldb + j];
+        for (slong j = n; j < GT_NR; j++) bp[l * GT_NR + j] = 0;
+    }
+    GT_T stage[GT_NR];
+    slong i0 = 0;
+    for (; i0 + GT_MR <= m; i0 += GT_MR)
+    {
+        GT_VEC acc[GT_MR][2];
+        for (int r = 0; r < GT_MR; r++)
+            acc[r][0] = acc[r][1] = GT_SETZERO();
+        for (slong l = 0; l < k; l++)
+        {
+            GT_VEC b0 = GT_LOADA(bp + l * GT_NR);
+            GT_VEC b1 = GT_LOADA(bp + l * GT_NR + GT_VL);
+            for (int r = 0; r < GT_MR; r++)
+            {
+                GT_VEC a = GT_BCAST(A + (i0 + r) * lda + l);
+                acc[r][0] = GT_FMADD(a, b0, acc[r][0]);
+                acc[r][1] = GT_FMADD(a, b1, acc[r][1]);
+            }
+        }
+        for (int r = 0; r < GT_MR; r++)
+        {
+            GT_STOREU(stage, acc[r][0]);
+            GT_STOREU(stage + GT_VL, acc[r][1]);
+            memcpy(C + (i0 + r) * ldc, stage, n * sizeof(GT_T));
+        }
+    }
+    for (; i0 < m; i0++)   /* single-row tail */
+    {
+        GT_VEC a0 = GT_SETZERO(), a1 = GT_SETZERO();
+        for (slong l = 0; l < k; l++)
+        {
+            GT_VEC av = GT_BCAST(A + i0 * lda + l);
+            a0 = GT_FMADD(av, GT_LOADA(bp + l * GT_NR), a0);
+            a1 = GT_FMADD(av, GT_LOADA(bp + l * GT_NR + GT_VL), a1);
+        }
+        GT_STOREU(stage, a0);
+        GT_STOREU(stage + GT_VL, a1);
+        memcpy(C + i0 * ldc, stage, n * sizeof(GT_T));
+    }
+    flint_aligned_free(bp);
+}
+
+#if GEMM_SMALL_DIM > 0
+
+/* all dims <= GEMM_SMALL_DIM (native type, non-modular): direct
+   no-pack kernel. The whole problem is L2-resident, so panel packing
+   and edge-tile staging only add overhead; instead sweep VL-wide
+   column strips with MR-row register accumulators, loading A and B
+   in place, with a scalar tail for the last n % VL columns. */
+static void GT_N(core_small)(GT_T *C, slong ldc, const GT_T *A,
+                             slong lda, const GT_T *B, slong ldb,
+                             slong m, slong k, slong n)
+{
+    slong nv = n / GT_VL * GT_VL;
+    slong rem = n - nv;
+    /* pad the tail columns once (k <= GEMM_SMALL_DIM, so tiny): the
+       vector kernel then covers them too; a scalar tail would be a
+       per-element FMA latency chain and dominates at awkward n */
+    GT_T btail[GEMM_SMALL_DIM * GT_VL] __attribute__((aligned(64)));
+    GT_T stage[GT_VL];
+    if (rem)
+        for (slong l = 0; l < k; l++)
+        {
+            for (slong j = 0; j < rem; j++)
+                btail[l * GT_VL + j] = B[l * ldb + nv + j];
+            for (slong j = rem; j < GT_VL; j++)
+                btail[l * GT_VL + j] = 0;
+        }
+    for (slong i0 = 0; i0 < m; i0 += GT_MR)
+    {
+        slong rr = m - i0 < GT_MR ? m - i0 : GT_MR;
+        for (slong j0 = 0; j0 < nv; j0 += GT_VL)
+        {
+            if (rr == GT_MR)   /* constant bounds: accs stay in regs */
+            {
+                GT_VEC acc[GT_MR];
+                for (int r = 0; r < GT_MR; r++) acc[r] = GT_SETZERO();
+                for (slong l = 0; l < k; l++)
+                {
+                    GT_VEC b0 = GT_LOADU(B + l * ldb + j0);
+                    for (int r = 0; r < GT_MR; r++)
+                        acc[r] = GT_FMADD(GT_BCAST(A + (i0 + r) * lda + l),
+                                          b0, acc[r]);
+                }
+                for (int r = 0; r < GT_MR; r++)
+                    GT_STOREU(C + (i0 + r) * ldc + j0, acc[r]);
+            }
+            else               /* single tail row-block per matrix */
+            {
+                for (slong r = 0; r < rr; r++)
+                {
+                    GT_VEC a0 = GT_SETZERO();
+                    for (slong l = 0; l < k; l++)
+                        a0 = GT_FMADD(GT_BCAST(A + (i0 + r) * lda + l),
+                                      GT_LOADU(B + l * ldb + j0), a0);
+                    GT_STOREU(C + (i0 + r) * ldc + j0, a0);
+                }
+            }
+        }
+        if (rem)
+        {
+            if (rr == GT_MR)
+            {
+                GT_VEC acc[GT_MR];
+                for (int r = 0; r < GT_MR; r++) acc[r] = GT_SETZERO();
+                for (slong l = 0; l < k; l++)
+                {
+                    GT_VEC b0 = GT_LOADA(btail + l * GT_VL);
+                    for (int r = 0; r < GT_MR; r++)
+                        acc[r] = GT_FMADD(GT_BCAST(A + (i0 + r) * lda + l),
+                                          b0, acc[r]);
+                }
+                for (int r = 0; r < GT_MR; r++)
+                {
+                    GT_STOREU(stage, acc[r]);
+                    memcpy(C + (i0 + r) * ldc + nv, stage,
+                           rem * sizeof(GT_T));
+                }
+            }
+            else
+                for (slong r = 0; r < rr; r++)
+                {
+                    GT_VEC a0 = GT_SETZERO();
+                    for (slong l = 0; l < k; l++)
+                        a0 = GT_FMADD(GT_BCAST(A + (i0 + r) * lda + l),
+                                      GT_LOADA(btail + l * GT_VL), a0);
+                    GT_STOREU(stage, a0);
+                    memcpy(C + (i0 + r) * ldc + nv, stage,
+                           rem * sizeof(GT_T));
+                }
+        }
+    }
+}
+
+#endif /* GEMM_SMALL_DIM > 0 */
+
+static void GT_N(core)(GT_T *C, slong ldc,
+                       const GT_T *A, slong lda,
+                       const GT_T *B, slong ldb,
+                       slong m, slong k, slong n)
+{
+    if (k > 0)
+    {
+        if (m <= GT_MR)
+        {
+            GT_N(core_thin_m)(C, ldc, A, lda, B, ldb, m, k, n);
+            return;
+        }
+#if GEMM_SMALL_DIM > 0
+        if (m <= GEMM_SMALL_DIM && n <= GEMM_SMALL_DIM &&
+            k <= GEMM_SMALL_DIM)
+        {
+            GT_N(core_small)(C, ldc, A, lda, B, ldb, m, k, n);
+            return;
+        }
+#endif
+        if (n <= GT_NR)
+        {
+            GT_N(core_thin_n)(C, ldc, A, lda, B, ldb, m, k, n);
+            return;
+        }
+    }
+    slong kcap = k < SG_KC ? k : SG_KC;
+    slong ncap = n < SG_NC ? n : SG_NC;
+    slong mcap = m < SG_MC ? m : SG_MC;
+    slong bpsz = kcap * (ncap + GT_NR) * (slong) sizeof(GT_T);
+    slong apsz = kcap * (mcap + GT_MR) * (slong) sizeof(GT_T);
+    char *scratch = gemm_get_scratch(bpsz + apsz + 64);
+    GT_T *bp = (GT_T *) scratch;
+    GT_T *ap = (GT_T *)(scratch + ((bpsz + 63) & ~(slong) 63));
+    GT_T stage[GT_MR * GT_NR];
+
+    for (slong jc = 0; jc < n; jc += SG_NC)
+    {
+        slong nc = n - jc < SG_NC ? n - jc : SG_NC;
+        for (slong pc = 0; pc < k; pc += SG_KC)
+        {
+            slong kc = k - pc < SG_KC ? k - pc : SG_KC;
+            int first = pc == 0;
+            GT_N(pack_b)(bp, B + pc * ldb + jc, ldb, kc, nc);
+            for (slong ic = 0; ic < m; ic += SG_MC)
+            {
+                slong mc = m - ic < SG_MC ? m - ic : SG_MC;
+                GT_N(pack_a)(ap, A + ic * lda + pc, lda, mc, kc);
+                for (slong jr = 0; jr < nc; jr += GT_NR)
+                {
+                    slong cc = nc - jr < GT_NR ? nc - jr : GT_NR;
+                    const GT_T *bpp = bp + (jr / GT_NR) * kc * GT_NR;
+                    for (slong ir = 0; ir < mc; ir += GT_MR)
+                    {
+                        slong rr = mc - ir < GT_MR ? mc - ir : GT_MR;
+                        const GT_T *app = ap + (ir / GT_MR) * kc * GT_MR;
+                        GT_T *ct = C + (ic + ir) * ldc + jc + jr;
+                        if (rr == GT_MR && cc == GT_NR)
+                            GT_N(micro)(ct, ldc, app, bpp, kc, first);
+                        else
+                        {
+                            if (first)
+                                memset(stage, 0, sizeof stage);
+                            else
+                            {
+                                for (slong r = 0; r < rr; r++)
+                                    memcpy(stage + r * GT_NR, ct + r * ldc,
+                                           cc * sizeof(GT_T));
+                                for (slong r = rr; r < GT_MR; r++)
+                                    memset(stage + r * GT_NR, 0,
+                                           GT_NR * sizeof(GT_T));
+                                for (slong r = 0; r < rr; r++)
+                                    memset(stage + r * GT_NR + cc, 0,
+                                           (GT_NR - cc) * sizeof(GT_T));
+                            }
+                            GT_N(micro)(stage, GT_NR, app, bpp, kc, 0);
+                            for (slong r = 0; r < rr; r++)
+                                memcpy(ct + r * ldc, stage + r * GT_NR,
+                                       cc * sizeof(GT_T));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    gemm_put_scratch(scratch);
+}
+
+#endif /* GEMM_PART_SERIAL */
+
+#if defined(GEMM_PART_MT) && defined(GEMM_MT_ATOMIC)
+
+typedef struct
+{
+    GT_T *C; slong ldc;
+    const GT_T *A; slong lda;
+    const GT_T *B; slong ldb;
+    slong m, k, n;
+    int nt;
+    slong mc;
+    GT_T *bp;
+    GT_T **ap;
+    _Atomic slong next_jr;
+    _Atomic slong next_ic;
+    _Atomic int bar_count;
+    _Atomic int bar_sense;
+} GT_N(mt_ctx);
+
+typedef struct { GT_N(mt_ctx) *ctx; int tid; int sense; } GT_N(mt_arg);
+
+#define GT_BARRIER(g, sensep) \
+    gemm_mt_barrier(&(g)->bar_count, &(g)->bar_sense, &(g)->next_jr, \
+                    &(g)->next_ic, (g)->nt, sensep)
+
+static void GT_N(mt_run)(void *varg)
+{
+    GT_N(mt_arg) *w = varg;
+    GT_N(mt_ctx) *g = w->ctx;
+    GT_T *ap = g->ap[w->tid];
+    GT_T stage[GT_MR * GT_NR];
+
+    for (slong jc = 0; jc < g->n; jc += SG_NC)
+    {
+        slong nc = g->n - jc < SG_NC ? g->n - jc : SG_NC;
+        slong npan = (nc + GT_NR - 1) / GT_NR;
+        for (slong pc = 0; pc < g->k; pc += SG_KC)
+        {
+            slong kc = g->k - pc < SG_KC ? g->k - pc : SG_KC;
+            int first = pc == 0;
+
+            GT_BARRIER(g, &w->sense);
+
+            for (;;)
+            {
+                slong jr = atomic_fetch_add(&g->next_jr, 1);
+                if (jr >= npan) break;
+                slong cols = nc - jr * GT_NR < GT_NR ? nc - jr * GT_NR : GT_NR;
+                GT_N(pack_b)(g->bp + jr * kc * GT_NR,
+                             g->B + pc * g->ldb + jc + jr * GT_NR,
+                             g->ldb, kc, cols);
+            }
+
+            GT_BARRIER(g, &w->sense);
+
+            for (;;)
+            {
+                slong ic = atomic_fetch_add(&g->next_ic, 1) * g->mc;
+                if (ic >= g->m) break;
+                slong mc = g->m - ic < g->mc ? g->m - ic : g->mc;
+                GT_N(pack_a)(ap, g->A + ic * g->lda + pc, g->lda, mc, kc);
+                for (slong jr = 0; jr < nc; jr += GT_NR)
+                {
+                    slong cc = nc - jr < GT_NR ? nc - jr : GT_NR;
+                    const GT_T *bpp = g->bp + (jr / GT_NR) * kc * GT_NR;
+                    for (slong ir = 0; ir < mc; ir += GT_MR)
+                    {
+                        slong rr = mc - ir < GT_MR ? mc - ir : GT_MR;
+                        const GT_T *app = ap + (ir / GT_MR) * kc * GT_MR;
+                        GT_T *ct = g->C + (ic + ir) * g->ldc + jc + jr;
+                        if (rr == GT_MR && cc == GT_NR)
+                            GT_N(micro)(ct, g->ldc, app, bpp, kc, first);
+                        else
+                        {
+                            if (first)
+                                memset(stage, 0, sizeof stage);
+                            else
+                            {
+                                for (slong r = 0; r < rr; r++)
+                                    memcpy(stage + r * GT_NR,
+                                           ct + r * g->ldc,
+                                           cc * sizeof(GT_T));
+                                for (slong r = rr; r < GT_MR; r++)
+                                    memset(stage + r * GT_NR, 0,
+                                           GT_NR * sizeof(GT_T));
+                                for (slong r = 0; r < rr; r++)
+                                    memset(stage + r * GT_NR + cc, 0,
+                                           (GT_NR - cc) * sizeof(GT_T));
+                            }
+                            GT_N(micro)(stage, GT_NR, app, bpp, kc, 0);
+                            for (slong r = 0; r < rr; r++)
+                                memcpy(ct + r * g->ldc, stage + r * GT_NR,
+                                       cc * sizeof(GT_T));
+                        }
+                    }
+                }
+            }
+
+            GT_BARRIER(g, &w->sense);
+        }
+    }
+
+}
+
+static void GT_N(core_mt)(GT_T *C, slong ldc,
+                          const GT_T *A, slong lda,
+                          const GT_T *B, slong ldb,
+                          slong m, slong k, slong n, slong thread_limit)
+{
+    /* thin shapes are bandwidth bound; the streaming serial paths win */
+    if (m <= GT_MR || n <= GT_NR)
+    {
+        GT_N(core)(C, ldc, A, lda, B, ldb, m, k, n);
+        return;
+    }
+    if (thread_limit <= 0) thread_limit = flint_get_num_threads();
+    double flop = 2.0 * (double) m * (double) n * (double) k;
+    slong tcap = (slong)(flop / SG_MT_FLOP_PER_THREAD) + 1;
+    if (thread_limit > tcap) thread_limit = tcap;
+
+    thread_pool_handle *handles = NULL;
+    slong nw = 0;
+    if (thread_limit > 1)
+        nw = flint_request_threads(&handles, thread_limit);
+    if (nw == 0)
+    {
+        GT_N(core)(C, ldc, A, lda, B, ldb, m, k, n);
+        if (handles != NULL)
+            flint_give_back_threads(handles, nw);
+        return;
+    }
+    slong nt = nw + 1;
+
+    GT_N(mt_ctx) g;
+    g.C = C; g.ldc = ldc; g.A = A; g.lda = lda; g.B = B; g.ldb = ldb;
+    g.m = m; g.k = k; g.n = n;
+    g.nt = (int) nt;
+    {
+        slong tgt = (m + 4 * nt - 1) / (4 * nt);
+        tgt = (tgt + GT_MR - 1) / GT_MR * GT_MR;
+        if (tgt < GT_MR) tgt = GT_MR;
+        if (tgt > SG_MC) tgt = SG_MC;
+        g.mc = tgt;
+    }
+    slong kcap = k < SG_KC ? k : SG_KC;
+    slong ncap = n < SG_NC ? n : SG_NC;
+    slong mcap = m < SG_MC ? m : SG_MC;
+    slong bpsz, apsz;
+
+    /* aligned_alloc requires the size to be a multiple of the alignment */
+    bpsz = (kcap * (ncap + GT_NR) * (slong) sizeof(GT_T) + 63) & ~(slong) 63;
+    apsz = (kcap * (mcap + GT_MR) * (slong) sizeof(GT_T) + 63) & ~(slong) 63;
+
+    g.bp = flint_aligned_alloc(64, bpsz);
+    g.ap = flint_malloc(nt * sizeof(GT_T *));
+    for (slong t = 0; t < nt; t++)
+        g.ap[t] = flint_aligned_alloc(64, apsz);
+    atomic_store(&g.next_jr, 0);
+    atomic_store(&g.next_ic, 0);
+    atomic_store(&g.bar_count, 0);
+    atomic_store(&g.bar_sense, 0);
+
+    GT_N(mt_arg) *args = flint_malloc(nt * sizeof(GT_N(mt_arg)));
+    for (slong t = 0; t < nt; t++)
+    {
+        args[t].ctx = &g;
+        args[t].tid = (int) t;
+        args[t].sense = 0;
+    }
+
+    for (slong t = 0; t < nw; t++)
+        thread_pool_wake(global_thread_pool, handles[t], 0,
+                         GT_N(mt_run), &args[t]);
+    GT_N(mt_run)(&args[nw]);
+    for (slong t = 0; t < nw; t++)
+        thread_pool_wait(global_thread_pool, handles[t]);
+
+    flint_give_back_threads(handles, nw);
+    for (slong t = 0; t < nt; t++)
+        flint_aligned_free(g.ap[t]);
+
+    flint_free(g.ap);
+    flint_aligned_free(g.bp);
+    flint_free(args);
+}
+
+#undef GT_BARRIER
+
+#endif /* GEMM_PART_MT */
+
+#if defined(GEMM_PART_MT) && !defined(GEMM_MT_ATOMIC)
+
+/*
+    Split-only parallel driver: no atomics and no barriers of any kind.
+    The row range of C is divided into one independent sub-problem per
+    worker, each of which is an ordinary serial multiplication of a row
+    block of A by the whole of B. Blocks are disjoint, so the only
+    synchronization is the thread pool's own wake/wait.
+
+    This duplicates the packing of B across workers (an O(k*n) cost per
+    worker against O(m*k*n/T) of work per worker), so it is slightly
+    slower than the cooperative driver at high thread counts, but it has
+    no portability surface beyond the thread pool itself.
+*/
+
+typedef struct
+{
+    GT_T * C; slong ldc;
+    const GT_T * A; slong lda;
+    const GT_T * B; slong ldb;
+    slong m, k, n;
+    slong i0, rows;
+    int is_worker;
+}
+GT_N(split_arg);
+
+static void GT_N(split_worker)(void * varg)
+{
+    GT_N(split_arg) * w = (GT_N(split_arg) *) varg;
+
+    GT_N(core)(w->C + w->i0 * w->ldc, w->ldc,
+               w->A + w->i0 * w->lda, w->lda,
+               w->B, w->ldb, w->rows, w->k, w->n);
+
+    /*
+        Thread pool threads outlive the call, and their packing scratch
+        is thread-local, so a worker must release it rather than leave a
+        cache attached to a thread that will not run our cleanup
+        function. The master keeps its cache for the next call.
+    */
+    if (w->is_worker)
+        gemm_scratch_free_local();
+}
+
+static void GT_N(core_split_mt)(GT_T *C, slong ldc,
+                                const GT_T *A, slong lda,
+                                const GT_T *B, slong ldb,
+                                slong m, slong k, slong n,
+                                slong thread_limit)
+{
+    thread_pool_handle * handles;
+    GT_N(split_arg) * args;
+    slong i, nw, nt, given, pos, tcap;
+    double flop;
+
+    /* thin shapes are bandwidth bound; the streaming serial paths win */
+    if (m <= GT_MR || n <= GT_NR)
+    {
+        GT_N(core)(C, ldc, A, lda, B, ldb, m, k, n);
+        return;
+    }
+
+    /* do not thread work that cannot pay for the hand-off */
+    flop = 2.0 * (double) m * (double) n * (double) k;
+    tcap = (slong) (flop / SG_MT_FLOP_PER_THREAD) + 1;
+
+    if (thread_limit > tcap)
+        thread_limit = tcap;
+
+    if (thread_limit > m)
+        thread_limit = m;
+
+    nw = 0;
+    handles = NULL;
+
+    if (thread_limit > 1)
+        nw = flint_request_threads(&handles, thread_limit);
+
+    if (nw == 0)
+    {
+        GT_N(core)(C, ldc, A, lda, B, ldb, m, k, n);
+        if (handles != NULL)
+            flint_give_back_threads(handles, nw);
+        return;
+    }
+
+    nt = nw + 1;
+    args = flint_malloc(nt * sizeof(GT_N(split_arg)));
+
+    /* rows split as evenly as possible; earlier blocks take the
+       remainder so the master's block is never the largest */
+    pos = 0;
+
+    for (i = 0; i < nt; i++)
+    {
+        given = m / nt + (i < m % nt ? 1 : 0);
+
+        args[i].C = C; args[i].ldc = ldc;
+        args[i].A = A; args[i].lda = lda;
+        args[i].B = B; args[i].ldb = ldb;
+        args[i].m = m; args[i].k = k; args[i].n = n;
+        args[i].i0 = pos;
+        args[i].rows = given;
+        args[i].is_worker = (i < nw);
+
+        pos += given;
+    }
+
+    for (i = 0; i < nw; i++)
+        thread_pool_wake(global_thread_pool, handles[i], 0,
+                         GT_N(split_worker), &args[i]);
+
+    GT_N(split_worker)(&args[nw]);
+
+    for (i = 0; i < nw; i++)
+        thread_pool_wait(global_thread_pool, handles[i]);
+
+    flint_give_back_threads(handles, nw);
+    flint_free(args);
+}
+
+#endif /* GEMM_PART_MT */
+
+#undef GT_NR
+#undef GT_N
+#undef GT_CAT
+#undef GT_CAT_

--- a/src/machine_vectors/profile/p-gemm.c
+++ b/src/machine_vectors/profile/p-gemm.c
@@ -1,0 +1,383 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+/*
+    Benchmark FLINT's own gemm kernels (flint_sgemm_fallback,
+    flint_dgemm_fallback) over a range of shapes and thread counts,
+    against the BLAS wrappers (flint_sgemm_blas, flint_dgemm_blas) where
+    FLINT is configured with BLAS. Both are called directly rather than
+    through flint_sgemm/flint_dgemm, so the comparison does not depend on
+    the value of flint_gemm_use_blas.
+
+    To profile the portable backends instead of the native vectors,
+    uncomment one of the FLINT_MACHINE_VECTORS_* overrides at the top of
+    machine_vectors/gemm.c and rebuild that file.
+
+        p-gemm [options]
+
+          -s          single precision only
+          -d          double precision only
+          -threads t  comma separated thread counts (default 1,2,4,8)
+          -set name   shape set: pow2, round, odd, thin, all (default all)
+          -max d      skip shapes with any dimension above d
+          -reps r     minimum repetitions per measurement (default 3)
+
+    The BLAS thread count is set to match FLINT's, so that the two are
+    compared at equal parallelism. This uses vendor entry points looked
+    up as weak symbols, since there is no portable way to do it; if none
+    is found, the program says so, and the environment variable for the
+    BLAS in use (e.g. OPENBLAS_NUM_THREADS) must be set to get a
+    meaningful comparison.
+*/
+
+#include <string.h>
+#include <stdlib.h>
+#include "profiler.h"
+#include "flint.h"
+#include "machine_vectors.h"
+#include "thread_support.h"
+#include "ulong_extras.h"
+
+/*
+    Vendor thread controls, declared weak so that this links whether or
+    not the BLAS in use provides them (and when there is no BLAS at all).
+*/
+#if defined(__GNUC__) && FLINT_USES_BLAS
+extern void openblas_set_num_threads(int) __attribute__((weak));
+extern void goto_set_num_threads(int) __attribute__((weak));
+extern void mkl_set_num_threads(int) __attribute__((weak));
+extern void bli_thread_set_num_threads(long) __attribute__((weak));
+# define HAVE_WEAK_BLAS_THREADS 1
+#endif
+
+static int
+blas_set_num_threads(slong n)
+{
+#if defined(HAVE_WEAK_BLAS_THREADS)
+    if (openblas_set_num_threads != NULL)
+    {
+        openblas_set_num_threads((int) n);
+        return 1;
+    }
+
+    if (goto_set_num_threads != NULL)
+    {
+        goto_set_num_threads((int) n);
+        return 1;
+    }
+
+    if (mkl_set_num_threads != NULL)
+    {
+        mkl_set_num_threads((int) n);
+        return 1;
+    }
+
+    if (bli_thread_set_num_threads != NULL)
+    {
+        bli_thread_set_num_threads((long) n);
+        return 1;
+    }
+#else
+    (void) n;
+#endif
+
+    return 0;
+}
+
+typedef struct
+{
+    slong m, k, n;
+    const char * set;
+}
+shape_t;
+
+static const shape_t shapes[] =
+{
+    /* all powers of two up to 4096 */
+    {    8,    8,    8, "pow2" },
+    {   16,   16,   16, "pow2" },
+    {   32,   32,   32, "pow2" },
+    {   64,   64,   64, "pow2" },
+    {  128,  128,  128, "pow2" },
+    {  256,  256,  256, "pow2" },
+    {  512,  512,  512, "pow2" },
+    { 1024, 1024, 1024, "pow2" },
+    { 2048, 2048, 2048, "pow2" },
+    { 4096, 4096, 4096, "pow2" },
+
+    /* multiples of 10, 100, 1000 */
+    {   10,   10,   10, "round" },
+    {   50,   50,   50, "round" },
+    {  100,  100,  100, "round" },
+    {  300,  300,  300, "round" },
+    {  500,  500,  500, "round" },
+    { 1000, 1000, 1000, "round" },
+    { 2000, 2000, 2000, "round" },
+    { 3000, 3000, 3000, "round" },
+
+    /* odd and near-power-of-two sizes */
+    {    7,    7,    7, "odd" },
+    {   17,   17,   17, "odd" },
+    {   31,   33,   29, "odd" },
+    {  101,  103,   97, "odd" },
+    {  255,  257,  255, "odd" },
+    {  999, 1001, 1003, "odd" },
+    { 1234,  777, 1919, "odd" },
+    { 2047, 2049, 2048, "odd" },
+
+    /* unbalanced shapes */
+    {    1, 2048, 2048, "thin" },
+    { 2048, 2048,    1, "thin" },
+    {    8, 2048, 2048, "thin" },
+    { 2048, 2048,    8, "thin" },
+    { 2048,    8, 2048, "thin" },
+    {   64, 4096, 4096, "thin" },
+    { 4096,   64, 4096, "thin" },
+    { 4096, 4096,   64, "thin" },
+    {  100, 5000,  300, "thin" },
+};
+
+#define NUM_SHAPES (sizeof(shapes) / sizeof(shape_t))
+
+static double
+gflops(slong m, slong k, slong n, double t)
+{
+    if (t <= 0.0)
+        return 0.0;
+
+    return 2.0 * (double) m * (double) k * (double) n / t * 1e-9;
+}
+
+/*
+    Best of several timing windows, each running enough repetitions to
+    exceed 50 ms; microsecond timers, since a single small multiplication
+    is far below millisecond resolution.
+*/
+#define TIME_BEST(t, minreps, expr) \
+    do { \
+        slong __reps = (minreps), __i, __w; \
+        double __best = 1e300, __cur; \
+        timeit_t __timer; \
+        for (;;) \
+        { \
+            timeit_start_us(__timer); \
+            for (__i = 0; __i < __reps; __i++) { expr; } \
+            timeit_stop_us(__timer); \
+            if (__timer->wall >= 50000 || __reps >= WORD(1) << 22) \
+                break; \
+            __reps *= 4; \
+        } \
+        __best = (double) __timer->wall * 1e-6 / (double) __reps; \
+        for (__w = 0; __w < 2; __w++) \
+        { \
+            timeit_start_us(__timer); \
+            for (__i = 0; __i < __reps; __i++) { expr; } \
+            timeit_stop_us(__timer); \
+            __cur = (double) __timer->wall * 1e-6 / (double) __reps; \
+            if (__cur < __best) \
+                __best = __cur; \
+        } \
+        (t) = __best; \
+    } while (0)
+
+/* flint_printf does not take width flags with %wd */
+static void
+print_slong_padded(slong x, slong width)
+{
+    slong digits = 1, tmp = x;
+
+    while (tmp >= 10)
+    {
+        tmp /= 10;
+        digits++;
+    }
+
+    flint_printf("%wd", x);
+
+    while (digits++ < width)
+        flint_printf(" ");
+}
+
+int
+main(int argc, char ** argv)
+{
+    slong i, j;
+    int do_single = 1, do_double = 1;
+    slong nthreads[16];
+    slong num_thread_counts = 4;
+    const char * set = "all";
+    slong maxdim = WORD_MAX;
+    slong reps = 3;
+    flint_rand_t state;
+
+    nthreads[0] = 1; nthreads[1] = 2; nthreads[2] = 4; nthreads[3] = 8;
+
+    for (i = 1; i < argc; i++)
+    {
+        if (!strcmp(argv[i], "-s"))
+            do_double = 0;
+        else if (!strcmp(argv[i], "-d"))
+            do_single = 0;
+        else if (!strcmp(argv[i], "-threads") && i + 1 < argc)
+        {
+            char * s = argv[++i];
+
+            num_thread_counts = 0;
+            while (*s != '\0' && num_thread_counts < 16)
+            {
+                nthreads[num_thread_counts++] = atol(s);
+                while (*s != '\0' && *s != ',')
+                    s++;
+                if (*s == ',')
+                    s++;
+            }
+        }
+        else if (!strcmp(argv[i], "-set") && i + 1 < argc)
+            set = argv[++i];
+        else if (!strcmp(argv[i], "-max") && i + 1 < argc)
+            maxdim = atol(argv[++i]);
+        else if (!strcmp(argv[i], "-reps") && i + 1 < argc)
+            reps = atol(argv[++i]);
+        else
+        {
+            flint_printf("usage: %s [-s] [-d] [-threads 1,2,4,8] "
+                         "[-set pow2|round|odd|thin|all] [-max d] "
+                         "[-reps r]\n", argv[0]);
+            return 1;
+        }
+    }
+
+    flint_rand_init(state);
+
+#if FLINT_USES_BLAS
+    flint_printf("flint gemm kernels vs BLAS (FLINT_USES_BLAS)\n");
+    flint_printf("ratio = blas time / flint time; > 1 means flint is faster\n");
+
+    if (!blas_set_num_threads(1))
+        flint_printf("WARNING: cannot set the BLAS thread count from here; "
+                     "set it in the environment (e.g. OPENBLAS_NUM_THREADS) "
+                     "to match, or the comparison is meaningless\n");
+#else
+    flint_printf("no BLAS configured; timing the flint kernels only\n");
+#endif
+    flint_printf("times are best of >= %wd runs, in ms\n\n", reps);
+
+    for (i = 0; i < (slong) NUM_SHAPES; i++)
+    {
+        slong m = shapes[i].m, k = shapes[i].k, n = shapes[i].n;
+        float *Af, *Bf, *Cf;
+        double *Ad, *Bd, *Cd;
+        slong e;
+
+        if (strcmp(set, "all") != 0 && strcmp(set, shapes[i].set) != 0)
+            continue;
+
+        if (m > maxdim || k > maxdim || n > maxdim)
+            continue;
+
+        Af = flint_malloc(m * k * sizeof(float));
+        Bf = flint_malloc(k * n * sizeof(float));
+        Cf = flint_malloc(m * n * sizeof(float));
+        Ad = flint_malloc(m * k * sizeof(double));
+        Bd = flint_malloc(k * n * sizeof(double));
+        Cd = flint_malloc(k * n * sizeof(double));
+        Cd = flint_realloc(Cd, m * n * sizeof(double));
+
+        for (e = 0; e < m * k; e++)
+        {
+            Ad[e] = (double) n_randint(state, 100) / 8.0;
+            Af[e] = (float) Ad[e];
+        }
+
+        for (e = 0; e < k * n; e++)
+        {
+            Bd[e] = (double) n_randint(state, 100) / 8.0;
+            Bf[e] = (float) Bd[e];
+        }
+
+        flint_printf("%5wd x %5wd x %5wd  [%s]\n", m, k, n, shapes[i].set);
+        flint_printf("  %-8s", "threads");
+        if (do_single)
+            flint_printf("  %10s %9s", "sgemm", "GFLOP/s");
+#if FLINT_USES_BLAS
+        if (do_single)
+            flint_printf("  %10s %9s %7s", "blas_s", "GFLOP/s", "ratio");
+#endif
+        if (do_double)
+            flint_printf("  %10s %9s", "dgemm", "GFLOP/s");
+#if FLINT_USES_BLAS
+        if (do_double)
+            flint_printf("  %10s %9s %7s", "blas_d", "GFLOP/s", "ratio");
+#endif
+        flint_printf("\n");
+
+        for (j = 0; j < num_thread_counts; j++)
+        {
+            slong t = nthreads[j];
+            double tf = 0.0, td = 0.0, tbf = 0.0, tbd = 0.0;
+
+            flint_set_num_threads(t);
+#if FLINT_USES_BLAS
+            blas_set_num_threads(t);
+#endif
+
+            if (do_single)
+                TIME_BEST(tf, reps,
+                    flint_sgemm_fallback(m, k, n, Af, k, Bf, n, Cf, n));
+
+            if (do_double)
+                TIME_BEST(td, reps,
+                    flint_dgemm_fallback(m, k, n, Ad, k, Bd, n, Cd, n));
+
+#if FLINT_USES_BLAS
+            if (do_single)
+                TIME_BEST(tbf, reps,
+                    flint_sgemm_blas(m, k, n, Af, k, Bf, n, Cf, n));
+
+            if (do_double)
+                TIME_BEST(tbd, reps,
+                    flint_dgemm_blas(m, k, n, Ad, k, Bd, n, Cd, n));
+#endif
+
+            flint_printf("  ");
+            print_slong_padded(t, 8);
+
+            if (do_single)
+                flint_printf("  %10.4f %9.2f", tf * 1e3, gflops(m, k, n, tf));
+#if FLINT_USES_BLAS
+            if (do_single)
+                flint_printf("  %10.4f %9.2f %7.2f", tbf * 1e3,
+                             gflops(m, k, n, tbf),
+                             tbf > 0.0 ? tbf / tf : 0.0);
+#endif
+            if (do_double)
+                flint_printf("  %10.4f %9.2f", td * 1e3, gflops(m, k, n, td));
+#if FLINT_USES_BLAS
+            if (do_double)
+                flint_printf("  %10.4f %9.2f %7.2f", tbd * 1e3,
+                             gflops(m, k, n, tbd),
+                             tbd > 0.0 ? tbd / td : 0.0);
+#endif
+            flint_printf("\n");
+        }
+
+        flint_printf("\n");
+
+        flint_free(Af); flint_free(Bf); flint_free(Cf);
+        flint_free(Ad); flint_free(Bd); flint_free(Cd);
+    }
+
+    flint_set_num_threads(1);
+    flint_rand_clear(state);
+    flint_cleanup_master();
+
+    return 0;
+}

--- a/src/machine_vectors/test/main.c
+++ b/src/machine_vectors/test/main.c
@@ -1,0 +1,25 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+/* Include functions *********************************************************/
+
+#include "t-gemm.c"
+
+/* Array of test functions ***************************************************/
+
+test_struct tests[] =
+{
+    TEST_FUNCTION(machine_vectors_gemm)
+};
+
+/* main function *************************************************************/
+
+TEST_MAIN(tests)

--- a/src/machine_vectors/test/t-gemm.c
+++ b/src/machine_vectors/test/t-gemm.c
@@ -1,0 +1,196 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "machine_vectors.h"
+#include "ulong_extras.h"
+#include "thread_support.h"
+
+/*
+    Entries are small integers, so every product is exact in both
+    precisions and the reference comparison is an equality test. This
+    covers all the internal paths: packed, small (all dims <= 96), thin-m
+    (m <= MR), thin-n (n <= NR), the k = 0 case, and every combination
+    with leading dimensions larger than the matrices.
+
+    flint_sgemm_fallback/flint_dgemm_fallback are tested rather than
+    flint_sgemm/flint_dgemm so that our own kernels are exercised even
+    in a BLAS build; the dispatch itself is tested separately below.
+*/
+
+TEST_FUNCTION_START(machine_vectors_gemm, state)
+{
+    slong iter;
+
+    /* the dispatcher must agree with both implementations */
+    {
+        slong m = 40, k = 33, n = 51, i, j, l;
+        double * A = flint_malloc(m * k * sizeof(double));
+        double * B = flint_malloc(k * n * sizeof(double));
+        double * C = flint_malloc(m * n * sizeof(double));
+        int saved = flint_gemm_use_blas;
+        /* FLINT_USES_BLAS is undefined rather than 0 without BLAS */
+#if FLINT_USES_BLAS
+        int max_use_blas = 1;
+#else
+        int max_use_blas = 0;
+#endif
+
+        for (i = 0; i < m * k; i++)
+            A[i] = (double) (slong) (n_randint(state, 21) - 10);
+        for (i = 0; i < k * n; i++)
+            B[i] = (double) (slong) (n_randint(state, 21) - 10);
+
+        for (flint_gemm_use_blas = 0; flint_gemm_use_blas <= max_use_blas;
+             flint_gemm_use_blas++)
+        {
+            flint_dgemm(m, k, n, A, k, B, n, C, n);
+
+            for (i = 0; i < m; i++)
+                for (j = 0; j < n; j++)
+                {
+                    double s = 0.0;
+
+                    for (l = 0; l < k; l++)
+                        s += A[i * k + l] * B[l * n + j];
+
+                    if (C[i * n + j] != s)
+                        TEST_FUNCTION_FAIL("dispatch (use_blas = %d) "
+                            "wrong at %wd, %wd: got %g, want %g\n",
+                            flint_gemm_use_blas, i, j, C[i * n + j], s);
+                }
+        }
+
+        flint_gemm_use_blas = saved;
+        flint_free(A); flint_free(B); flint_free(C);
+    }
+
+    for (iter = 0; iter < 300 * flint_test_multiplier(); iter++)
+    {
+        slong m, k, n, lda, ldb, ldc, i, j, l;
+        float *Af, *Bf, *Cf;
+        double *Ad, *Bd, *Cd;
+        int nthreads;
+
+        if (n_randint(state, 4) == 0)
+        {
+            /* occasionally exercise sizes that reach the packed path */
+            m = 1 + n_randint(state, 200);
+            k = 1 + n_randint(state, 200);
+            n = 1 + n_randint(state, 200);
+        }
+        else
+        {
+            m = n_randint(state, 40);
+            k = n_randint(state, 40);
+            n = n_randint(state, 40);
+        }
+
+        lda = k + n_randint(state, 3);
+        ldb = n + n_randint(state, 3);
+        ldc = n + n_randint(state, 3);
+
+        nthreads = 1 + n_randint(state, 4);
+        flint_set_num_threads(nthreads);
+
+        Af = flint_malloc(FLINT_MAX(1, m * lda) * sizeof(float));
+        Bf = flint_malloc(FLINT_MAX(1, k * ldb) * sizeof(float));
+        Cf = flint_malloc(FLINT_MAX(1, m * ldc) * sizeof(float));
+        Ad = flint_malloc(FLINT_MAX(1, m * lda) * sizeof(double));
+        Bd = flint_malloc(FLINT_MAX(1, k * ldb) * sizeof(double));
+        Cd = flint_malloc(FLINT_MAX(1, m * ldc) * sizeof(double));
+
+        for (i = 0; i < m * lda; i++)
+        {
+            Ad[i] = (double) (slong) (n_randint(state, 21) - 10);
+            Af[i] = (float) Ad[i];
+        }
+
+        for (i = 0; i < k * ldb; i++)
+        {
+            Bd[i] = (double) (slong) (n_randint(state, 21) - 10);
+            Bf[i] = (float) Bd[i];
+        }
+
+        for (i = 0; i < m * ldc; i++)
+        {
+            Cd[i] = 1234.0;
+            Cf[i] = 1234.0f;
+        }
+
+        /* always exercise our own kernels, whatever the BLAS default is */
+        flint_sgemm_fallback(m, k, n, Af, lda, Bf, ldb, Cf, ldc);
+        flint_dgemm_fallback(m, k, n, Ad, lda, Bd, ldb, Cd, ldc);
+
+        for (i = 0; i < m; i++)
+        {
+            for (j = 0; j < n; j++)
+            {
+                double s = 0.0;
+
+                for (l = 0; l < k; l++)
+                    s += Ad[i * lda + l] * Bd[l * ldb + j];
+
+                if (Cd[i * ldc + j] != s || Cf[i * ldc + j] != (float) s)
+                    TEST_FUNCTION_FAIL(
+                        "m = %wd, k = %wd, n = %wd\n"
+                        "lda = %wd, ldb = %wd, ldc = %wd\n"
+                        "threads = %d\n"
+                        "i = %wd, j = %wd\n"
+                        "sgemm gave %g, dgemm gave %g, want %g\n",
+                        m, k, n, lda, ldb, ldc, nthreads, i, j,
+                        (double) Cf[i * ldc + j], Cd[i * ldc + j], s);
+            }
+
+            /* padding columns of C must be untouched */
+            for (j = n; j < ldc; j++)
+                if (Cd[i * ldc + j] != 1234.0 || Cf[i * ldc + j] != 1234.0f)
+                    TEST_FUNCTION_FAIL(
+                        "wrote past column n\n"
+                        "m = %wd, k = %wd, n = %wd, ldc = %wd, i = %wd, "
+                        "j = %wd\n", m, k, n, ldc, i, j);
+        }
+
+        flint_free(Af); flint_free(Bf); flint_free(Cf);
+        flint_free(Ad); flint_free(Bd); flint_free(Cd);
+    }
+
+    /*
+        Cleanup and reuse cycles: the packing scratch registers a cleanup
+        function with FLINT, and must re-register correctly after
+        flint_cleanup has emptied the registry.
+    */
+    {
+        slong d = 200, i;
+        double * A = flint_malloc(d * d * sizeof(double));
+        double * B = flint_malloc(d * d * sizeof(double));
+        double * C = flint_malloc(d * d * sizeof(double));
+
+        for (i = 0; i < d * d; i++)
+        {
+            A[i] = (double) (i % 5);
+            B[i] = (double) (i % 3);
+        }
+
+        for (i = 0; i < 3; i++)
+        {
+            flint_set_num_threads(4);
+            flint_dgemm(d, d, d, A, d, B, d, C, d);
+            flint_cleanup();
+        }
+
+        flint_free(A); flint_free(B); flint_free(C);
+    }
+
+    flint_set_num_threads(1);
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/mpn_mod/mat_mul.c
+++ b/src/mpn_mod/mat_mul.c
@@ -105,11 +105,12 @@ mpn_mod_mat_mul(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx)
     if (ar < cutoff_multi_mod || ac < cutoff_multi_mod || bc < cutoff_multi_mod)
         return mpn_mod_mat_mul_waksman(C, A, B, ctx);
 
-    /* special case: near the two-limb boundary, strassen beats multi_mod on a single thread */
-#ifndef FLINT_USES_BLAS
-    if (bits >= 113 && bits <= 128 && flint_get_num_available_threads() == 1)
-        return gr_mat_mul_strassen(C, A, B, ctx);
-#endif
+    /*
+        This special case (near the two-limb boundary, strassen beat
+        multi_mod on a single thread) applied only to builds without
+        BLAS; multi_mod now always has a gemm-backed path, so it is
+        gone. Worth re-checking against the fallback kernels.
+    */
 
     return mpn_mod_mat_mul_multi_mod(C, A, B, ctx);
 }

--- a/src/nmod_mat/lu.c
+++ b/src/nmod_mat/lu.c
@@ -13,25 +13,18 @@
 #include "nmod_vec.h"
 #include "nmod_mat.h"
 
-#if FLINT_USES_BLAS || (FLINT_BITS == 32) || !defined(__AVX2__)
-
-/* Tuned for Zen 3 with BLAS */
+/*
+    Tuned for Zen 3 with BLAS. A gemm-backed nmod_mat_mul is now always
+    available (nmod_mat_mul_blas uses flint_dgemm/flint_sgemm, which
+    fall back to FLINT's own kernels when no external BLAS is
+    configured), so the "without BLAS" table has been retired. It may be
+    worth re-tuning against the fallback kernels.
+*/
 static const slong lu_cutoff_tab[64] = { 64, 64, 244, 280, 296, 320, 332,
     792, 800, 800, 800, 400, 400, 400, 400, 404, 404, 400, 408, 416, 400,
     412, 424, 408, 484, 1352, 1032, 260, 68, 56, 56, 56, 148, 160, 148, 156,
     156, 156, 120, 168, 160, 124, 156, 124, 156, 148, 112, 156, 148, 136,
     156, 160, 116, 136, 168, 148, 156, 160, 120, 128, 68, 64, 104, 104 };
-
-#else
-
-/* Tuned for Zen 3 without BLAS */
-static const slong lu_cutoff_tab[64] = { 64, 64, 212, 260, 280, 316, 344,
-    792, 872, 904, 856, 1016, 1136, 1456, 1440, 1464, 1376, 1392, 1448, 1448,
-    1360, 1392, 1400, 1392, 1448, 1416, 1032, 260, 68, 56, 56, 60, 168, 164,
-    152, 152, 156, 148, 148, 148, 152, 164, 160, 148, 164, 148, 164, 160, 160,
-    148, 156, 156, 148, 164, 148, 164, 148, 148, 148, 128, 68, 64, 96, 96 };
-
-#endif
 
 slong
 nmod_mat_lu(slong * P, nmod_mat_t A, int rank_check)

--- a/src/nmod_mat/mul.c
+++ b/src/nmod_mat/mul.c
@@ -15,10 +15,7 @@
 #include "nmod_mat.h"
 #include "thread_support.h"
 
-#if FLINT_USES_BLAS
-# include <cblas.h>
-# include "longlong.h"
-#endif
+#include "longlong.h"
 
 void
 nmod_mat_mul(nmod_mat_t C, const nmod_mat_t A, const nmod_mat_t B)
@@ -34,10 +31,11 @@ nmod_mat_mul(nmod_mat_t C, const nmod_mat_t A, const nmod_mat_t B)
     FLINT_ASSERT(C->c == B->c);
     FLINT_ASSERT(A->c == B->r);
 
-#if FLINT_USES_BLAS
     /*
         tuning is based on several assumptions:
-        (1) blas_num_threads >= flint_num_threads.
+        (1) the gemm used by nmod_mat_mul_blas is at least as parallel
+            as the rest of FLINT (it uses FLINT's thread pool, or an
+            external BLAS with at least flint_num_threads threads).
         (2) nmod_mat_mul_blas (with crt) only beats
             nmod_mat_mul_classical on square multiplications
             of large enough dimension
@@ -69,7 +67,6 @@ nmod_mat_mul(nmod_mat_t C, const nmod_mat_t A, const nmod_mat_t B)
         if (min_dim > cutoff && nmod_mat_mul_blas(C, A, B))
             return;
     }
-#endif
 
     if (C == A || C == B)
     {

--- a/src/nmod_mat/mul_blas.c
+++ b/src/nmod_mat/mul_blas.c
@@ -11,10 +11,10 @@
 
 #include "nmod_mat.h"
 
-#if FLINT_USES_BLAS && FLINT_BITS == 64
+#if FLINT_BITS == 64
 
 #include <limits.h>
-#include <cblas.h>
+#include "machine_vectors.h"
 #include "thread_pool.h"
 #include "thread_support.h"
 #include "nmod.h"
@@ -152,7 +152,7 @@ static void _reduce_sp_worker(void * arg_ptr)
         for (j = 0; j < n; j++)
         {
             slong a = (slong) dC[i*n + j];
-            ulong b = (a < 0) ? a + shift : a;
+            ulong b = (a < 0) ? (ulong) a + shift : (ulong) a;
             NMOD_RED(Centries[i * Cstride + j], b, ctx);
         }
     }
@@ -210,8 +210,7 @@ static int _nmod_mat_mul_blas_sp(nmod_mat_t C,
             thread_pool_wait(global_thread_pool, handles[i]);
     }
 
-    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, m, n, k,
-                                                1.0, dA, k, dB, n, 0.0, dC, n);
+    flint_sgemm(m, k, n, dA, k, dB, n, dC, n);
 
     /* convert output */
 
@@ -382,7 +381,7 @@ static void _reduce_crt_worker(void * arg_ptr)
             for (pi = 0; pi < crtnum; pi++)
             {
                 slong a = (slong) dC[i*n + j + pi*m*n];
-                ulong b = (a < 0) ? a + shifts[pi] : a;
+                ulong b = (a < 0) ? (ulong) a + shifts[pi] : (ulong) a;
                 NMOD_RED(u[pi], b, crtmod[pi]);
             }
 
@@ -497,8 +496,7 @@ static int _nmod_mat_mul_blas_crt(nmod_mat_t C,
         for (i = 0; i < num_workers; i++)
             thread_pool_wait(global_thread_pool, handles[i]);
 
-        cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, m, n, k,
-                                       1.0, dA, k, dB, n, 0.0, dC + pi*m*n, n);
+        flint_dgemm(m, k, n, dA, k, dB, n, dC + pi*m*n, n);
     }
 
     {
@@ -619,7 +617,7 @@ static void _reduce_dp_worker(void * arg_ptr)
         for (j = 0; j < n; j++)
         {
             slong a = (slong) dC[i*n + j];
-            ulong b = (a < 0) ? a + shift : a;
+            ulong b = (a < 0) ? (ulong) a + shift : (ulong) a;
             NMOD_RED(Centries[i * Cstride + j], b, ctx);
         }
     }
@@ -695,8 +693,7 @@ int nmod_mat_mul_blas(nmod_mat_t C, const nmod_mat_t A, const nmod_mat_t B)
             thread_pool_wait(global_thread_pool, handles[i]);
     }
 
-    cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, m, n, k,
-                                                1.0, dA, k, dB, n, 0.0, dC, n);
+    flint_dgemm(m, k, n, dA, k, dB, n, dC, n);
 
     /* convert output */
 
@@ -743,6 +740,7 @@ int nmod_mat_mul_blas(nmod_mat_t C, const nmod_mat_t A, const nmod_mat_t B)
 
 #else
 
+/* the lifting and CRT here assume 64-bit words */
 int nmod_mat_mul_blas(nmod_mat_t FLINT_UNUSED(C),
                 const nmod_mat_t FLINT_UNUSED(A),
                 const nmod_mat_t FLINT_UNUSED(B))

--- a/src/nmod_mat/mul_blas.c
+++ b/src/nmod_mat/mul_blas.c
@@ -210,7 +210,21 @@ static int _nmod_mat_mul_blas_sp(nmod_mat_t C,
             thread_pool_wait(global_thread_pool, handles[i]);
     }
 
-    flint_sgemm(m, k, n, dA, k, dB, n, dC, n);
+    /*
+        The fallback gemm threads through FLINT's pool itself, so the
+        workers held for the conversions must be returned before the
+        call or it finds the pool empty and runs on one thread. (An
+        external BLAS schedules its own threads and does not care.)
+        Re-requests are capped by the first grant so the args buffer
+        stays large enough.
+    */
+    {
+        slong max_workers = num_workers;
+
+        flint_give_back_threads(handles, num_workers);
+        flint_sgemm(m, k, n, dA, k, dB, n, dC, n);
+        num_workers = flint_request_threads(&handles, max_workers + 1);
+    }
 
     /* convert output */
 
@@ -496,7 +510,21 @@ static int _nmod_mat_mul_blas_crt(nmod_mat_t C,
         for (i = 0; i < num_workers; i++)
             thread_pool_wait(global_thread_pool, handles[i]);
 
-        flint_dgemm(m, k, n, dA, k, dB, n, dC + pi*m*n, n);
+        /*
+            The fallback gemm threads through FLINT's pool itself, so the
+            workers held for the conversions must be returned before the
+            call or it finds the pool empty and runs on one thread. (An
+            external BLAS schedules its own threads and does not care.)
+            Re-requests are capped by the first grant so the args buffer
+            stays large enough.
+        */
+        {
+            slong max_workers = num_workers;
+
+            flint_give_back_threads(handles, num_workers);
+            flint_dgemm(m, k, n, dA, k, dB, n, dC + pi*m*n, n);
+            num_workers = flint_request_threads(&handles, max_workers + 1);
+        }
     }
 
     {
@@ -693,7 +721,21 @@ int nmod_mat_mul_blas(nmod_mat_t C, const nmod_mat_t A, const nmod_mat_t B)
             thread_pool_wait(global_thread_pool, handles[i]);
     }
 
-    flint_dgemm(m, k, n, dA, k, dB, n, dC, n);
+    /*
+        The fallback gemm threads through FLINT's pool itself, so the
+        workers held for the conversions must be returned before the
+        call or it finds the pool empty and runs on one thread. (An
+        external BLAS schedules its own threads and does not care.)
+        Re-requests are capped by the first grant so the args buffer
+        stays large enough.
+    */
+    {
+        slong max_workers = num_workers;
+
+        flint_give_back_threads(handles, num_workers);
+        flint_dgemm(m, k, n, dA, k, dB, n, dC, n);
+        num_workers = flint_request_threads(&handles, max_workers + 1);
+    }
 
     /* convert output */
 

--- a/src/nmod_mat/profile/p-mul.c
+++ b/src/nmod_mat/profile/p-mul.c
@@ -16,10 +16,6 @@
 #include "ulong_extras.h"
 #include "thread_support.h"
 
-#if FLINT_USES_BLAS
-# include <cblas.h>
-#endif
-
 typedef struct
 {
     slong dim_m;
@@ -112,10 +108,6 @@ int main(void)
             for (blas_num = flint_num; blas_num <= flint_num; blas_num *= 2)
             {
                 double min_old, min_new, min_ratio = 100;
-
-#if FLINT_USES_BLAS
-                //openblas_set_num_threads(blas_num);
-#endif
 
                 flint_printf("[flint %wd, blas %wd]: (", flint_num, blas_num);
 

--- a/src/nmod_mat/test/t-mul_blas.c
+++ b/src/nmod_mat/test/t-mul_blas.c
@@ -84,9 +84,9 @@ TEST_FUNCTION_START(nmod_mat_mul_blas, state)
             if (!nmod_mat_equal(C, D))
                 TEST_FUNCTION_FAIL("m: %wd, k: %wd, n: %wd, mod: %wu\n", m, k, n, modulus);
         }
-#if FLINT_USES_BLAS && FLINT_BITS == 64
+#if FLINT_BITS == 64
         else
-            TEST_FUNCTION_FAIL("BLAS should have worked\n");
+            TEST_FUNCTION_FAIL("mul_blas should have worked\n");
 #endif
 
         nmod_mat_clear(A);


### PR DESCRIPTION
We (using Claude Fable 5 and Claude Opus 5) implement `flint_sgemm` and `flint_dgemm` and make algorithms like `nmod_mat_mul_blas` available unconditionally, obsoleting non-BLAS tuning values.

This should make `--with-blas` unnecessary (actually, undesirable) for most users. On my Zen3 machine with AVX2, `flint_sgemm` and `flint_dgemm` match the speed of their OpenBLAS counterparts to within a few % both single-threaded and multi-threaded. Claude also claims that the speed matches OpenBLAS in its AVX512-enabled virtual machine, but someone should verify that, and also on NEON.

For the AVX512 variant, this uses the `z` extensions of `machine_vectors.h` proposed by @user202729 in #2715. This PR also adds a plain-C fallback for `machine_vectors.h`. The fallbacks don't cover enough ground to build `fft_small` just yet, but they allow `flint_sgemm` and `flint_dgemm` to work in any environment. On my machine, forcing the plain-C `machine_vectors.h` fallback and letting GCC auto-vectorize results in just ~2x worse performance than the specialized version using AVX2 intrinsics.

As noted above, linking to OpenBLAS is undesirable as it uses an OpenMP thread pool rather than FLINT's thread pool so that `flint_set_num_threads` does not have the intended effect (and parallel FLINT / BLAS work would compete for resources). At least on my machine, the OpenMP thread pool also adds a ridiculous ~1 second of startup CPU time to FLINT programs that link in OpenBLAS whether BLAS is actually used or not.

If FLINT is compiled with `--with-blas`, use of BLAS in `flint_sgemm`/`flint_dgemm` can be toggled with a switch `flint_gemm_use_blas`.

Some timings comparisons between `flint_sgemm/dgemm` ("sgemm/dgemm") and OpenBLAS ("blas_s/blas_d"), excerpted from `build/machine_vectors/profile/p-gemm`:

```
  128 x   128 x   128  [pow2]
  threads        sgemm   GFLOP/s      blas_s   GFLOP/s   ratio       dgemm   GFLOP/s      blas_d   GFLOP/s   ratio
  1             0.0426     98.48      0.0472     88.88    1.11      0.0814     51.53      0.0840     49.92    1.03
  2             0.0339    123.55      0.0295    142.22    0.87      0.0582     72.02      0.0542     77.32    0.93
  4             0.0212    197.61      0.0191    219.84    0.90      0.0344    121.85      0.0338    123.96    0.98
  8             0.0231    181.69      0.0159    264.55    0.69      0.0366    114.72      0.0232    180.66    0.63

  512 x   512 x   512  [pow2]
  threads        sgemm   GFLOP/s      blas_s   GFLOP/s   ratio       dgemm   GFLOP/s      blas_d   GFLOP/s   ratio
  1             2.4647    108.91      2.4674    108.79    1.00      4.9720     53.99      5.1853     51.77    1.04
  2             1.3332    201.35      1.3455    199.51    1.01      2.6928     99.69      2.8227     95.10    1.05
  4             0.8283    324.09      0.7242    370.68    0.87      1.6634    161.38      1.5701    170.96    0.94
  8             0.5051    531.43      0.5085    527.85    1.01      1.0017    267.97      1.0639    252.32    1.06

 1024 x  1024 x  1024  [pow2]
  threads        sgemm   GFLOP/s      blas_s   GFLOP/s   ratio       dgemm   GFLOP/s      blas_d   GFLOP/s   ratio
  1            20.4587    104.97     19.3027    111.25    0.94     41.1767     52.15     41.3800     51.90    1.00
  2            11.2055    191.65     10.4636    205.23    0.93     23.0270     93.26     22.3943     95.89    0.97
  4             6.2173    345.40      5.4953    390.78    0.88     12.8162    167.56     12.0377    178.40    0.94
  8             4.7759    449.65      3.5060    612.52    0.73      8.3332    257.70      7.6837    279.48    0.92

 2048 x  2048 x  2048  [pow2]
  threads        sgemm   GFLOP/s      blas_s   GFLOP/s   ratio       dgemm   GFLOP/s      blas_d   GFLOP/s   ratio
  1           166.2027    103.37    151.1250    113.68    0.91    330.6360     51.96    326.5663     52.61    0.99
  2            88.6977    193.69     81.8490    209.90    0.92    180.5517     95.15    176.6093     97.28    0.98
  4            52.4010    327.85     43.9717    390.70    0.84    108.1677    158.83     96.8657    177.36    0.90
  8            31.6117    543.47     28.2883    607.31    0.89     63.8087    269.24     62.1223    276.55    0.97

 4096 x  4096 x  4096  [pow2]
  threads        sgemm   GFLOP/s      blas_s   GFLOP/s   ratio       dgemm   GFLOP/s      blas_d   GFLOP/s   ratio
  1          1306.9447    105.16   1184.6850    116.01    0.91   2568.5930     53.51   2583.5690     53.20    1.01
  2           698.3930    196.79    668.1973    205.69    0.96   1424.2030     96.50   1455.6393     94.42    1.02
  4           423.1823    324.77    379.4470    362.21    0.90    863.0640    159.25    855.1230    160.72    0.99
  8           277.0863    496.01    237.0113    579.88    0.86    577.4873    237.99    516.7377    265.97    0.89
```

Fortunately, it isn't that hard to match BLAS these days: this is a very standard design with a tiling microkernel.

The most complex part of gemm code is the multithreading. There is a complex version using synchronization, invented by Claude, and a simpler version that just splits the work into independent submatrices. The complex version seems to work and is slightly more efficient, but it's only enabled by default on x86-64 for now pending stress-testing in other environments.