### PR TITLE
Implement gr_is_integer and gr_is_rational

### DIFF
--- a/src/gr.h
+++ b/src/gr.h
@@ -1127,6 +1127,8 @@ GR_INLINE WARN_UNUSED_RESULT int gr_set_fexpr(gr_ptr res, fexpr_vec_t inputs, gr
 GR_INLINE truth_t gr_is_zero(gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_PREDICATE(ctx, IS_ZERO)(x, ctx); }
 GR_INLINE truth_t gr_is_one(gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_PREDICATE(ctx, IS_ONE)(x, ctx); }
 GR_INLINE truth_t gr_is_neg_one(gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_PREDICATE(ctx, IS_NEG_ONE)(x, ctx); }
+GR_INLINE truth_t gr_is_integer(gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_PREDICATE(ctx, IS_INTEGER)(x, ctx); }
+GR_INLINE truth_t gr_is_rational(gr_srcptr x, gr_ctx_t ctx) { return GR_UNARY_PREDICATE(ctx, IS_RATIONAL)(x, ctx); }
 
 GR_INLINE truth_t gr_equal(gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return GR_BINARY_PREDICATE(ctx, EQUAL)(x, y, ctx); }
 GR_INLINE truth_t gr_not_equal(gr_srcptr x, gr_srcptr y, gr_ctx_t ctx) { return truth_not(GR_BINARY_PREDICATE(ctx, EQUAL)(x, y, ctx)); }

--- a/src/gr/acb.c
+++ b/src/gr/acb.c
@@ -412,6 +412,43 @@ _gr_acb_is_neg_one(const acb_t x, const gr_ctx_t ctx)
 }
 
 static truth_t
+_gr_acb_is_integer(const acb_t x, const gr_ctx_t ctx)
+{
+    truth_t re, im;
+
+    if (acb_is_int(x))
+        return T_TRUE;
+
+    re = arb_contains_int(acb_realref(x)) ? T_UNKNOWN : T_FALSE;
+    if (re == T_FALSE)
+        return T_FALSE;
+
+    im = arb_contains_zero(acb_imagref(x)) ? T_UNKNOWN : T_FALSE;
+    return truth_and(re, im);
+}
+
+static truth_t
+_gr_acb_is_rational(const acb_t x, const gr_ctx_t ctx)
+{
+    truth_t re, im;
+
+    if (arb_is_exact(acb_realref(x)))
+        re = arb_is_finite(acb_realref(x)) ? T_TRUE : T_FALSE;
+    else
+        re = T_UNKNOWN;
+
+    if (re == T_FALSE)
+        return T_FALSE;
+
+    if (arb_is_zero(acb_imagref(x)))
+        im = T_TRUE;
+    else
+        im = arb_contains_zero(acb_imagref(x)) ? T_UNKNOWN : T_FALSE;
+
+    return truth_and(re, im);
+}
+
+static truth_t
 _gr_acb_equal(const acb_t x, const acb_t y, const gr_ctx_t ctx)
 {
     if (acb_is_exact(x) && acb_equal(x, y))
@@ -2264,6 +2301,8 @@ gr_method_tab_input _acb_methods_input[] =
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_acb_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_acb_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) _gr_acb_is_neg_one},
+    {GR_METHOD_IS_INTEGER,      (gr_funcptr) _gr_acb_is_integer},
+    {GR_METHOD_IS_RATIONAL,     (gr_funcptr) _gr_acb_is_rational},
     {GR_METHOD_EQUAL,           (gr_funcptr) _gr_acb_equal},
     {GR_METHOD_SET,             (gr_funcptr) _gr_acb_set},
     {GR_METHOD_SET_SI,          (gr_funcptr) _gr_acb_set_si},

--- a/src/gr/acf.c
+++ b/src/gr/acf.c
@@ -347,6 +347,18 @@ _gr_acf_is_neg_one(const acf_t x, const gr_ctx_t ctx)
 }
 
 static truth_t
+_gr_acf_is_integer(const acf_t x, const gr_ctx_t ctx)
+{
+    return (arf_is_int(acf_realref(x)) && arf_is_zero(acf_imagref(x))) ? T_TRUE : T_FALSE;
+}
+
+static truth_t
+_gr_acf_is_rational(const acf_t x, const gr_ctx_t ctx)
+{
+    return (arf_is_finite(acf_realref(x)) && arf_is_zero(acf_imagref(x))) ? T_TRUE : T_FALSE;
+}
+
+static truth_t
 _gr_acf_equal(const acf_t x, const acf_t y, const gr_ctx_t ctx)
 {
     if (arf_is_nan(acf_realref(x)) || arf_is_nan(acf_imagref(x)) ||
@@ -1341,6 +1353,8 @@ gr_method_tab_input _acf_methods_input[] =
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_acf_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_acf_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) _gr_acf_is_neg_one},
+    {GR_METHOD_IS_INTEGER,      (gr_funcptr) _gr_acf_is_integer},
+    {GR_METHOD_IS_RATIONAL,     (gr_funcptr) _gr_acf_is_rational},
     {GR_METHOD_EQUAL,           (gr_funcptr) _gr_acf_equal},
     {GR_METHOD_SET,             (gr_funcptr) _gr_acf_set},
     {GR_METHOD_SET_SI,          (gr_funcptr) _gr_acf_set_si},

--- a/src/gr/arb.c
+++ b/src/gr/arb.c
@@ -430,6 +430,24 @@ _gr_arb_is_neg_one(const arb_t x, const gr_ctx_t ctx)
 }
 
 static truth_t
+_gr_arb_is_integer(const arb_t x, const gr_ctx_t ctx)
+{
+    if (arb_is_int(x))
+        return T_TRUE;
+
+    return arb_contains_int(x) ? T_UNKNOWN : T_FALSE;
+}
+
+static truth_t
+_gr_arb_is_rational(const arb_t x, const gr_ctx_t ctx)
+{
+    if (!arb_is_exact(x))
+        return T_UNKNOWN;
+
+    return arb_is_finite(x) ? T_TRUE : T_FALSE;
+}
+
+static truth_t
 _gr_arb_equal(const arb_t x, const arb_t y, const gr_ctx_t ctx)
 {
     if (arb_is_exact(x) && arb_equal(x, y))
@@ -1725,6 +1743,8 @@ gr_method_tab_input _arb_methods_input[] =
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_arb_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_arb_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) _gr_arb_is_neg_one},
+    {GR_METHOD_IS_INTEGER,      (gr_funcptr) _gr_arb_is_integer},
+    {GR_METHOD_IS_RATIONAL,     (gr_funcptr) _gr_arb_is_rational},
     {GR_METHOD_EQUAL,           (gr_funcptr) _gr_arb_equal},
     {GR_METHOD_SET,             (gr_funcptr) _gr_arb_set},
     {GR_METHOD_SET_SI,          (gr_funcptr) _gr_arb_set_si},

--- a/src/gr/arf.c
+++ b/src/gr/arf.c
@@ -353,6 +353,18 @@ _gr_arf_is_neg_one(const arf_t x, const gr_ctx_t ctx)
 }
 
 static truth_t
+_gr_arf_is_integer(const arf_t x, const gr_ctx_t ctx)
+{
+    return arf_is_int(x) ? T_TRUE : T_FALSE;
+}
+
+static truth_t
+_gr_arf_is_rational(const arf_t x, const gr_ctx_t ctx)
+{
+    return arf_is_finite(x) ? T_TRUE : T_FALSE;
+}
+
+static truth_t
 _gr_arf_equal(const arf_t x, const arf_t y, const gr_ctx_t ctx)
 {
     if (arf_is_nan(x) || arf_is_nan(y))
@@ -1368,6 +1380,8 @@ gr_method_tab_input _arf_methods_input[] =
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_arf_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_arf_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) _gr_arf_is_neg_one},
+    {GR_METHOD_IS_INTEGER,      (gr_funcptr) _gr_arf_is_integer},
+    {GR_METHOD_IS_RATIONAL,     (gr_funcptr) _gr_arf_is_rational},
     {GR_METHOD_EQUAL,           (gr_funcptr) _gr_arf_equal},
     {GR_METHOD_SET,             (gr_funcptr) _gr_arf_set},
     {GR_METHOD_SET_SI,          (gr_funcptr) _gr_arf_set_si},

--- a/src/gr/ca.c
+++ b/src/gr/ca.c
@@ -539,6 +539,18 @@ _gr_ca_is_neg_one(const ca_t x, gr_ctx_t ctx)
 }
 
 static truth_t
+_gr_ca_is_integer(const ca_t x, gr_ctx_t ctx)
+{
+    return ca_check_is_integer(x, GR_CA_CTX(ctx));
+}
+
+static truth_t
+_gr_ca_is_rational(const ca_t x, gr_ctx_t ctx)
+{
+    return ca_check_is_rational(x, GR_CA_CTX(ctx));
+}
+
+static truth_t
 _gr_ca_equal(const ca_t x, const ca_t y, gr_ctx_t ctx)
 {
     return ca_check_equal(x, y, GR_CA_CTX(ctx));
@@ -1647,6 +1659,8 @@ gr_method_tab_input _ca_methods_input[] =
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_ca_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_ca_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) _gr_ca_is_neg_one},
+    {GR_METHOD_IS_INTEGER,      (gr_funcptr) _gr_ca_is_integer},
+    {GR_METHOD_IS_RATIONAL,     (gr_funcptr) _gr_ca_is_rational},
     {GR_METHOD_EQUAL,           (gr_funcptr) _gr_ca_equal},
 
     {GR_METHOD_SET,             (gr_funcptr) _gr_ca_set},

--- a/src/gr/complex.c
+++ b/src/gr/complex.c
@@ -402,6 +402,32 @@ _gr_complex_is_neg_one(gr_srcptr x, gr_complex_ctx_t ctx)
     return truth_and(eq1, eq2);
 }
 
+static truth_t
+_gr_complex_is_integer(gr_srcptr x, gr_complex_ctx_t ctx)
+{
+    gr_ctx_struct * real_ctx = REAL_CTX(ctx);
+    truth_t real;
+
+    real = gr_is_integer(RE(x, ctx), real_ctx);
+    if (real == T_FALSE)
+        return T_FALSE;
+
+    return truth_and(real, gr_is_zero(IM(x, ctx), real_ctx));
+}
+
+static truth_t
+_gr_complex_is_rational(gr_srcptr x, gr_complex_ctx_t ctx)
+{
+    gr_ctx_struct * real_ctx = REAL_CTX(ctx);
+    truth_t real;
+
+    real = gr_is_rational(RE(x, ctx), real_ctx);
+    if (real == T_FALSE)
+        return T_FALSE;
+
+    return truth_and(real, gr_is_zero(IM(x, ctx), real_ctx));
+}
+
 
 static int
 _gr_complex_neg(gr_ptr res, gr_srcptr x, gr_complex_ctx_t ctx)
@@ -658,6 +684,8 @@ gr_method_tab_input _gr_complex_methods_input[] =
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_complex_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_complex_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) _gr_complex_is_neg_one},
+    {GR_METHOD_IS_INTEGER,      (gr_funcptr) _gr_complex_is_integer},
+    {GR_METHOD_IS_RATIONAL,     (gr_funcptr) _gr_complex_is_rational},
     {GR_METHOD_EQUAL,           (gr_funcptr) _gr_complex_equal},
     {GR_METHOD_SET,             (gr_funcptr) _gr_complex_set},
     {GR_METHOD_SET_SI,          (gr_funcptr) _gr_complex_set_si},

--- a/src/gr/debug.c
+++ b/src/gr/debug.c
@@ -125,6 +125,12 @@ _gr_debug_ctx_is_threadsafe(gr_ctx_t ctx)
     return gr_ctx_is_threadsafe(GR_DEBUG_ELEM_CTX(ctx));
 }
 
+static truth_t
+_gr_debug_ctx_is_finite_characteristic(gr_ctx_t ctx)
+{
+    return gr_ctx_is_finite_characteristic(GR_DEBUG_ELEM_CTX(ctx));
+}
+
 static void
 _gr_debug_init(gr_ptr x, gr_ctx_t ctx)
 {
@@ -491,6 +497,7 @@ gr_method_tab_input _gr_debug_methods_input[] =
     {GR_METHOD_CTX_IS_COMMUTATIVE_RING, (gr_funcptr) gr_generic_ctx_predicate_true},
     {GR_METHOD_CTX_IS_EXACT,     (gr_funcptr) gr_generic_ctx_predicate_true},
     {GR_METHOD_CTX_IS_THREADSAFE,  (gr_funcptr) _gr_debug_ctx_is_threadsafe},
+    {GR_METHOD_CTX_IS_FINITE_CHARACTERISTIC, (gr_funcptr) _gr_debug_ctx_is_finite_characteristic},
     {GR_METHOD_INIT,            (gr_funcptr) _gr_debug_init},
     {GR_METHOD_CLEAR,           (gr_funcptr) _gr_debug_clear},
     {GR_METHOD_SWAP,            (gr_funcptr) _gr_debug_swap},

--- a/src/gr/debug.c
+++ b/src/gr/debug.c
@@ -395,6 +395,18 @@ _gr_debug_is_one(gr_srcptr x, gr_ctx_t ctx)
 }
 
 static truth_t
+_gr_debug_is_integer(gr_srcptr x, gr_ctx_t ctx)
+{
+    DEBUG_UNARY_PREDICATE(gr_is_integer)
+}
+
+static truth_t
+_gr_debug_is_rational(gr_srcptr x, gr_ctx_t ctx)
+{
+    DEBUG_UNARY_PREDICATE(gr_is_rational)
+}
+
+static truth_t
 _gr_debug_equal(gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
 {
     DEBUG_BINARY_PREDICATE(gr_equal)
@@ -490,6 +502,8 @@ gr_method_tab_input _gr_debug_methods_input[] =
     {GR_METHOD_ONE,             (gr_funcptr) _gr_debug_one},
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_debug_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_debug_is_one},
+    {GR_METHOD_IS_INTEGER,      (gr_funcptr) _gr_debug_is_integer},
+    {GR_METHOD_IS_RATIONAL,     (gr_funcptr) _gr_debug_is_rational},
     {GR_METHOD_EQUAL,           (gr_funcptr) _gr_debug_equal},
     {GR_METHOD_SET,             (gr_funcptr) _gr_debug_set},
     {GR_METHOD_NEG,             (gr_funcptr) _gr_debug_neg},
@@ -529,4 +543,3 @@ gr_ctx_init_debug(gr_ctx_t ctx, gr_ctx_t elem_ctx, int flags, double unable_prob
         _gr_debug_methods_initialized = 1;
     }
 }
-

--- a/src/gr/fexpr.c
+++ b/src/gr/fexpr.c
@@ -150,6 +150,32 @@ _gr_fexpr_is_neg_one(const fexpr_t x, const gr_ctx_t ctx)
 }
 
 static truth_t
+_gr_fexpr_is_integer(const fexpr_t x, const gr_ctx_t ctx)
+{
+    return fexpr_is_integer(x) ? T_TRUE : T_UNKNOWN;
+}
+
+static truth_t
+_gr_fexpr_is_rational(const fexpr_t x, const gr_ctx_t ctx)
+{
+    fexpr_t p, q;
+
+    if (fexpr_is_integer(x))
+        return T_TRUE;
+
+    if (fexpr_nargs(x) == 2 && fexpr_is_builtin_call(x, FEXPR_Div))
+    {
+        fexpr_view_arg(p, x, 0);
+        fexpr_view_arg(q, x, 1);
+
+        if (fexpr_is_integer(p) && fexpr_is_integer(q) && !fexpr_equal_ui(q, 0))
+            return T_TRUE;
+    }
+
+    return T_UNKNOWN;
+}
+
+static truth_t
 _gr_fexpr_equal(const fexpr_t x, const fexpr_t y, const gr_ctx_t ctx)
 {
     return fexpr_equal(x, y) ? T_TRUE : T_FALSE;
@@ -288,6 +314,8 @@ gr_method_tab_input _fexpr_methods_input[] =
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_fexpr_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_fexpr_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) _gr_fexpr_is_neg_one},
+    {GR_METHOD_IS_INTEGER,      (gr_funcptr) _gr_fexpr_is_integer},
+    {GR_METHOD_IS_RATIONAL,     (gr_funcptr) _gr_fexpr_is_rational},
     {GR_METHOD_EQUAL,           (gr_funcptr) _gr_fexpr_equal},
     {GR_METHOD_SET,             (gr_funcptr) _gr_fexpr_set},
     {GR_METHOD_SET_SI,          (gr_funcptr) _gr_fexpr_set_si},

--- a/src/gr/fmpq.c
+++ b/src/gr/fmpq.c
@@ -242,6 +242,18 @@ _gr_fmpq_is_neg_one(const fmpq_t x, const gr_ctx_t ctx)
 }
 
 static truth_t
+_gr_fmpq_is_integer(const fmpq_t x, const gr_ctx_t ctx)
+{
+    return fmpz_is_one(fmpq_denref(x)) ? T_TRUE : T_FALSE;
+}
+
+static truth_t
+_gr_fmpq_is_rational(const fmpq_t x, const gr_ctx_t ctx)
+{
+    return T_TRUE;
+}
+
+static truth_t
 _gr_fmpq_equal(const fmpq_t x, const fmpq_t y, const gr_ctx_t ctx)
 {
     return fmpq_equal(x, y) ? T_TRUE : T_FALSE;
@@ -1140,6 +1152,8 @@ gr_method_tab_input _fmpq_methods_input[] =
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_fmpq_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_fmpq_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) _gr_fmpq_is_neg_one},
+    {GR_METHOD_IS_INTEGER,      (gr_funcptr) _gr_fmpq_is_integer},
+    {GR_METHOD_IS_RATIONAL,     (gr_funcptr) _gr_fmpq_is_rational},
     {GR_METHOD_EQUAL,           (gr_funcptr) _gr_fmpq_equal},
     {GR_METHOD_SET,             (gr_funcptr) _gr_fmpq_set},
     {GR_METHOD_SET_SI,          (gr_funcptr) _gr_fmpq_set_si},

--- a/src/gr/fmpq_mpoly.c
+++ b/src/gr/fmpq_mpoly.c
@@ -198,6 +198,29 @@ _gr_fmpq_mpoly_is_one(const fmpq_mpoly_t poly, gr_ctx_t ctx)
     return fmpq_mpoly_is_one(poly, MPOLYNOMIAL_MCTX(ctx)) ? T_TRUE : T_FALSE;
 }
 
+static truth_t
+_gr_fmpq_mpoly_is_integer(const fmpq_mpoly_t poly, gr_ctx_t ctx)
+{
+    fmpq_t c;
+    int res;
+
+    if (!fmpq_mpoly_is_fmpq(poly, MPOLYNOMIAL_MCTX(ctx)))
+        return T_FALSE;
+
+    fmpq_init(c);
+    fmpq_mpoly_get_fmpq(c, poly, MPOLYNOMIAL_MCTX(ctx));
+    res = fmpz_is_one(fmpq_denref(c));
+    fmpq_clear(c);
+
+    return res ? T_TRUE : T_FALSE;
+}
+
+static truth_t
+_gr_fmpq_mpoly_is_rational(const fmpq_mpoly_t poly, gr_ctx_t ctx)
+{
+    return fmpq_mpoly_is_fmpq(poly, MPOLYNOMIAL_MCTX(ctx)) ? T_TRUE : T_FALSE;
+}
+
 static int
 _gr_fmpq_mpoly_zero(fmpq_mpoly_t res, gr_ctx_t ctx)
 {
@@ -628,6 +651,8 @@ gr_method_tab_input _gr_fmpq_mpoly_methods_input[] =
     {GR_METHOD_ONE,         (gr_funcptr) _gr_fmpq_mpoly_one},
     {GR_METHOD_IS_ZERO,     (gr_funcptr) _gr_fmpq_mpoly_is_zero},
     {GR_METHOD_IS_ONE,      (gr_funcptr) _gr_fmpq_mpoly_is_one},
+    {GR_METHOD_IS_INTEGER,  (gr_funcptr) _gr_fmpq_mpoly_is_integer},
+    {GR_METHOD_IS_RATIONAL, (gr_funcptr) _gr_fmpq_mpoly_is_rational},
     {GR_METHOD_GENS,        (gr_funcptr) _gr_fmpq_mpoly_gens},
     {GR_METHOD_EQUAL,       (gr_funcptr) _gr_fmpq_mpoly_equal},
     {GR_METHOD_SET,         (gr_funcptr) _gr_fmpq_mpoly_set},

--- a/src/gr/fmpq_poly.c
+++ b/src/gr/fmpq_poly.c
@@ -342,6 +342,19 @@ _gr_fmpq_poly_is_neg_one(const fmpq_poly_t x, const gr_ctx_t ctx)
 }
 
 static truth_t
+_gr_fmpq_poly_is_integer(const fmpq_poly_t x, const gr_ctx_t ctx)
+{
+    return (x->length == 0 ||
+            (x->length == 1 && fmpz_is_one(x->den))) ? T_TRUE : T_FALSE;
+}
+
+static truth_t
+_gr_fmpq_poly_is_rational(const fmpq_poly_t x, const gr_ctx_t ctx)
+{
+    return x->length <= 1 ? T_TRUE : T_FALSE;
+}
+
+static truth_t
 _gr_fmpq_poly_equal(const fmpq_poly_t x, const fmpq_poly_t y, const gr_ctx_t ctx)
 {
     return fmpq_poly_equal(x, y) ? T_TRUE : T_FALSE;
@@ -765,6 +778,8 @@ gr_method_tab_input _fmpq_poly_methods_input[] =
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_fmpq_poly_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_fmpq_poly_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) _gr_fmpq_poly_is_neg_one},
+    {GR_METHOD_IS_INTEGER,      (gr_funcptr) _gr_fmpq_poly_is_integer},
+    {GR_METHOD_IS_RATIONAL,     (gr_funcptr) _gr_fmpq_poly_is_rational},
     {GR_METHOD_EQUAL,           (gr_funcptr) _gr_fmpq_poly_equal},
     {GR_METHOD_SET,             (gr_funcptr) _gr_fmpq_poly_set},
     {GR_METHOD_SET_SI,          (gr_funcptr) _gr_fmpq_poly_set_si},

--- a/src/gr/fmpz.c
+++ b/src/gr/fmpz.c
@@ -238,6 +238,18 @@ _gr_fmpz_is_neg_one(const fmpz_t x, const gr_ctx_t ctx)
 }
 
 static truth_t
+_gr_fmpz_is_integer(const fmpz_t x, const gr_ctx_t ctx)
+{
+    return T_TRUE;
+}
+
+static truth_t
+_gr_fmpz_is_rational(const fmpz_t x, const gr_ctx_t ctx)
+{
+    return T_TRUE;
+}
+
+static truth_t
 _gr_fmpz_equal(const fmpz_t x, const fmpz_t y, const gr_ctx_t ctx)
 {
     return fmpz_equal(x, y) ? T_TRUE : T_FALSE;
@@ -1171,6 +1183,8 @@ gr_method_tab_input _fmpz_methods_input[] =
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_fmpz_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_fmpz_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) _gr_fmpz_is_neg_one},
+    {GR_METHOD_IS_INTEGER,      (gr_funcptr) _gr_fmpz_is_integer},
+    {GR_METHOD_IS_RATIONAL,     (gr_funcptr) _gr_fmpz_is_rational},
     {GR_METHOD_EQUAL,           (gr_funcptr) _gr_fmpz_equal},
     {GR_METHOD_SET,             (gr_funcptr) _gr_fmpz_set},
     {GR_METHOD_SET_SI,          (gr_funcptr) _gr_fmpz_set_si},

--- a/src/gr/fmpz_mpoly.c
+++ b/src/gr/fmpz_mpoly.c
@@ -200,6 +200,18 @@ _gr_fmpz_mpoly_is_one(const fmpz_mpoly_t poly, gr_ctx_t ctx)
     return fmpz_mpoly_is_one(poly, MPOLYNOMIAL_MCTX(ctx)) ? T_TRUE : T_FALSE;
 }
 
+static truth_t
+_gr_fmpz_mpoly_is_integer(const fmpz_mpoly_t poly, gr_ctx_t ctx)
+{
+    return fmpz_mpoly_is_fmpz(poly, MPOLYNOMIAL_MCTX(ctx)) ? T_TRUE : T_FALSE;
+}
+
+static truth_t
+_gr_fmpz_mpoly_is_rational(const fmpz_mpoly_t poly, gr_ctx_t ctx)
+{
+    return fmpz_mpoly_is_fmpz(poly, MPOLYNOMIAL_MCTX(ctx)) ? T_TRUE : T_FALSE;
+}
+
 static int
 _gr_fmpz_mpoly_zero(fmpz_mpoly_t res, gr_ctx_t ctx)
 {
@@ -636,6 +648,8 @@ gr_method_tab_input _gr_fmpz_mpoly_methods_input[] =
     {GR_METHOD_ONE,         (gr_funcptr) _gr_fmpz_mpoly_one},
     {GR_METHOD_IS_ZERO,     (gr_funcptr) _gr_fmpz_mpoly_is_zero},
     {GR_METHOD_IS_ONE,      (gr_funcptr) _gr_fmpz_mpoly_is_one},
+    {GR_METHOD_IS_INTEGER,  (gr_funcptr) _gr_fmpz_mpoly_is_integer},
+    {GR_METHOD_IS_RATIONAL, (gr_funcptr) _gr_fmpz_mpoly_is_rational},
     {GR_METHOD_GENS,        (gr_funcptr) _gr_fmpz_mpoly_gens},
     {GR_METHOD_EQUAL,       (gr_funcptr) _gr_fmpz_mpoly_equal},
     {GR_METHOD_SET,         (gr_funcptr) _gr_fmpz_mpoly_set},

--- a/src/gr/fmpz_mpoly_q.c
+++ b/src/gr/fmpz_mpoly_q.c
@@ -158,6 +158,18 @@ _gr_fmpz_mpoly_q_is_one(const fmpz_mpoly_q_t poly, gr_ctx_t ctx)
     return fmpz_mpoly_q_is_one(poly, MPOLYNOMIAL_MCTX(ctx)) ? T_TRUE : T_FALSE;
 }
 
+static truth_t
+_gr_fmpz_mpoly_q_is_integer(const fmpz_mpoly_q_t poly, gr_ctx_t ctx)
+{
+    return fmpz_mpoly_q_is_fmpz(poly, MPOLYNOMIAL_MCTX(ctx)) ? T_TRUE : T_FALSE;
+}
+
+static truth_t
+_gr_fmpz_mpoly_q_is_rational(const fmpz_mpoly_q_t poly, gr_ctx_t ctx)
+{
+    return fmpz_mpoly_q_is_fmpq(poly, MPOLYNOMIAL_MCTX(ctx)) ? T_TRUE : T_FALSE;
+}
+
 static int
 _gr_fmpz_mpoly_q_zero(fmpz_mpoly_q_t res, gr_ctx_t ctx)
 {
@@ -565,6 +577,8 @@ gr_method_tab_input _gr_fmpz_mpoly_q_methods_input[] =
     {GR_METHOD_ONE,         (gr_funcptr) _gr_fmpz_mpoly_q_one},
     {GR_METHOD_IS_ZERO,     (gr_funcptr) _gr_fmpz_mpoly_q_is_zero},
     {GR_METHOD_IS_ONE,      (gr_funcptr) _gr_fmpz_mpoly_q_is_one},
+    {GR_METHOD_IS_INTEGER,  (gr_funcptr) _gr_fmpz_mpoly_q_is_integer},
+    {GR_METHOD_IS_RATIONAL, (gr_funcptr) _gr_fmpz_mpoly_q_is_rational},
     {GR_METHOD_GENS,        (gr_funcptr) _gr_fmpz_mpoly_q_gens},
     {GR_METHOD_EQUAL,       (gr_funcptr) _gr_fmpz_mpoly_q_equal},
     {GR_METHOD_SET,         (gr_funcptr) _gr_fmpz_mpoly_q_set},

--- a/src/gr/fmpz_poly.c
+++ b/src/gr/fmpz_poly.c
@@ -353,6 +353,18 @@ _gr_fmpz_poly_is_neg_one(const fmpz_poly_t x, const gr_ctx_t ctx)
 }
 
 static truth_t
+_gr_fmpz_poly_is_integer(const fmpz_poly_t x, const gr_ctx_t ctx)
+{
+    return x->length <= 1 ? T_TRUE : T_FALSE;
+}
+
+static truth_t
+_gr_fmpz_poly_is_rational(const fmpz_poly_t x, const gr_ctx_t ctx)
+{
+    return x->length <= 1 ? T_TRUE : T_FALSE;
+}
+
+static truth_t
 _gr_fmpz_poly_equal(const fmpz_poly_t x, const fmpz_poly_t y, const gr_ctx_t ctx)
 {
     return fmpz_poly_equal(x, y) ? T_TRUE : T_FALSE;
@@ -881,6 +893,8 @@ gr_method_tab_input _fmpz_poly_methods_input[] =
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_fmpz_poly_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_fmpz_poly_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) _gr_fmpz_poly_is_neg_one},
+    {GR_METHOD_IS_INTEGER,      (gr_funcptr) _gr_fmpz_poly_is_integer},
+    {GR_METHOD_IS_RATIONAL,     (gr_funcptr) _gr_fmpz_poly_is_rational},
     {GR_METHOD_EQUAL,           (gr_funcptr) _gr_fmpz_poly_equal},
     {GR_METHOD_SET,             (gr_funcptr) _gr_fmpz_poly_set},
     {GR_METHOD_SET_SI,          (gr_funcptr) _gr_fmpz_poly_set_si},

--- a/src/gr/fmpzi.c
+++ b/src/gr/fmpzi.c
@@ -345,6 +345,18 @@ _gr_fmpzi_is_neg_one(const fmpzi_t x, const gr_ctx_t ctx)
 }
 
 static truth_t
+_gr_fmpzi_is_integer(const fmpzi_t x, const gr_ctx_t ctx)
+{
+    return fmpz_is_zero(fmpzi_imagref(x)) ? T_TRUE : T_FALSE;
+}
+
+static truth_t
+_gr_fmpzi_is_rational(const fmpzi_t x, const gr_ctx_t ctx)
+{
+    return fmpz_is_zero(fmpzi_imagref(x)) ? T_TRUE : T_FALSE;
+}
+
+static truth_t
 _gr_fmpzi_equal(const fmpzi_t x, const fmpzi_t y, const gr_ctx_t ctx)
 {
     return fmpzi_equal(x, y) ? T_TRUE : T_FALSE;
@@ -1022,6 +1034,8 @@ gr_method_tab_input _fmpzi_methods_input[] =
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_fmpzi_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_fmpzi_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) _gr_fmpzi_is_neg_one},
+    {GR_METHOD_IS_INTEGER,      (gr_funcptr) _gr_fmpzi_is_integer},
+    {GR_METHOD_IS_RATIONAL,     (gr_funcptr) _gr_fmpzi_is_rational},
     {GR_METHOD_EQUAL,           (gr_funcptr) _gr_fmpzi_equal},
     {GR_METHOD_SET,             (gr_funcptr) _gr_fmpzi_set},
     {GR_METHOD_SET_SI,          (gr_funcptr) _gr_fmpzi_set_si},

--- a/src/gr/fraction.c
+++ b/src/gr/fraction.c
@@ -512,28 +512,11 @@ _gr_fraction_is_integer(gr_srcptr x, gr_fraction_ctx_t ctx)
 {
     gr_srcptr a = NUMER(x, ctx), b = DENOM(x, ctx);
     gr_ctx_struct * domain_ctx = DOMAIN(ctx);
-    gr_ptr q;
-    truth_t res;
-    int status;
 
-    if (gr_is_zero(b, domain_ctx) != T_FALSE)
-        return T_UNKNOWN;
+    if (gr_is_one(b, domain_ctx) == T_TRUE)
+        return gr_is_integer(a, domain_ctx);
 
-    if (gr_ctx_is_finite_characteristic(domain_ctx) != T_FALSE)
-        return T_UNKNOWN;
-
-    GR_TMP_INIT(q, domain_ctx);
-    status = gr_divexact(q, a, b, domain_ctx);
-
-    if (status == GR_SUCCESS)
-        res = gr_is_integer(q, domain_ctx);
-    else if (status & GR_DOMAIN)
-        res = T_FALSE;
-    else
-        res = T_UNKNOWN;
-
-    GR_TMP_CLEAR(q, domain_ctx);
-    return res;
+    return T_UNKNOWN;
 }
 
 static truth_t
@@ -541,32 +524,17 @@ _gr_fraction_is_rational(gr_srcptr x, gr_fraction_ctx_t ctx)
 {
     gr_srcptr a = NUMER(x, ctx), b = DENOM(x, ctx);
     gr_ctx_struct * domain_ctx = DOMAIN(ctx);
-    truth_t a_is_rational, b_is_rational, res;
-    gr_ptr q;
-    int status;
+    truth_t a_is_rational;
 
     if (gr_is_zero(b, domain_ctx) != T_FALSE)
         return T_UNKNOWN;
 
-    if (gr_ctx_is_finite_characteristic(domain_ctx) != T_FALSE)
+    a_is_rational = gr_is_rational(a, domain_ctx);
+
+    if (a_is_rational == T_UNKNOWN)
         return T_UNKNOWN;
 
-    a_is_rational = gr_is_rational(a, domain_ctx);
-    b_is_rational = gr_is_rational(b, domain_ctx);
-
-    if (a_is_rational == T_TRUE && b_is_rational == T_TRUE)
-        return T_TRUE;
-
-    GR_TMP_INIT(q, domain_ctx);
-    status = gr_divexact(q, a, b, domain_ctx);
-
-    if (status == GR_SUCCESS)
-        res = gr_is_rational(q, domain_ctx);
-    else
-        res = T_UNKNOWN;
-
-    GR_TMP_CLEAR(q, domain_ctx);
-    return res;
+    return gr_is_rational(b, domain_ctx) == T_TRUE ? a_is_rational : T_UNKNOWN;
 }
 
 

--- a/src/gr/fraction.c
+++ b/src/gr/fraction.c
@@ -507,6 +507,68 @@ _gr_fraction_is_neg_one(gr_srcptr x, gr_fraction_ctx_t ctx)
     }
 }
 
+static truth_t
+_gr_fraction_is_integer(gr_srcptr x, gr_fraction_ctx_t ctx)
+{
+    gr_srcptr a = NUMER(x, ctx), b = DENOM(x, ctx);
+    gr_ctx_struct * domain_ctx = DOMAIN(ctx);
+    gr_ptr q;
+    truth_t res;
+    int status;
+
+    if (gr_is_zero(b, domain_ctx) != T_FALSE)
+        return T_UNKNOWN;
+
+    if (gr_ctx_is_finite_characteristic(domain_ctx) != T_FALSE)
+        return T_UNKNOWN;
+
+    GR_TMP_INIT(q, domain_ctx);
+    status = gr_divexact(q, a, b, domain_ctx);
+
+    if (status == GR_SUCCESS)
+        res = gr_is_integer(q, domain_ctx);
+    else if (status & GR_DOMAIN)
+        res = T_FALSE;
+    else
+        res = T_UNKNOWN;
+
+    GR_TMP_CLEAR(q, domain_ctx);
+    return res;
+}
+
+static truth_t
+_gr_fraction_is_rational(gr_srcptr x, gr_fraction_ctx_t ctx)
+{
+    gr_srcptr a = NUMER(x, ctx), b = DENOM(x, ctx);
+    gr_ctx_struct * domain_ctx = DOMAIN(ctx);
+    truth_t a_is_rational, b_is_rational, res;
+    gr_ptr q;
+    int status;
+
+    if (gr_is_zero(b, domain_ctx) != T_FALSE)
+        return T_UNKNOWN;
+
+    if (gr_ctx_is_finite_characteristic(domain_ctx) != T_FALSE)
+        return T_UNKNOWN;
+
+    a_is_rational = gr_is_rational(a, domain_ctx);
+    b_is_rational = gr_is_rational(b, domain_ctx);
+
+    if (a_is_rational == T_TRUE && b_is_rational == T_TRUE)
+        return T_TRUE;
+
+    GR_TMP_INIT(q, domain_ctx);
+    status = gr_divexact(q, a, b, domain_ctx);
+
+    if (status == GR_SUCCESS)
+        res = gr_is_rational(q, domain_ctx);
+    else
+        res = T_UNKNOWN;
+
+    GR_TMP_CLEAR(q, domain_ctx);
+    return res;
+}
+
 
 static int
 _gr_fraction_neg(gr_ptr res, gr_srcptr x, gr_fraction_ctx_t ctx)
@@ -1167,6 +1229,8 @@ gr_method_tab_input _gr_fraction_methods_input[] =
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_fraction_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_fraction_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) _gr_fraction_is_neg_one},
+    {GR_METHOD_IS_INTEGER,      (gr_funcptr) _gr_fraction_is_integer},
+    {GR_METHOD_IS_RATIONAL,     (gr_funcptr) _gr_fraction_is_rational},
     {GR_METHOD_EQUAL,           (gr_funcptr) _gr_fraction_equal},
     {GR_METHOD_SET,             (gr_funcptr) _gr_fraction_set},
     {GR_METHOD_SET_SI,          (gr_funcptr) _gr_fraction_set_si},
@@ -1248,4 +1312,3 @@ gr_ctx_init_gr_fraction(gr_ctx_t ctx, gr_ctx_t domain, int flags)
         _gr_fraction_methods_initialized = 1;
     }
 }
-

--- a/src/gr/mpf.c
+++ b/src/gr/mpf.c
@@ -381,6 +381,7 @@ gr_method_tab_input _gr_mpf_methods_input[] =
     {GR_METHOD_CTX_WRITE,       (gr_funcptr) _gr_mpf_ctx_write},
     {GR_METHOD_CTX_IS_RING,     (gr_funcptr) gr_generic_ctx_predicate_false},
     {GR_METHOD_CTX_IS_EXACT,    (gr_funcptr) gr_generic_ctx_predicate_false},
+    {GR_METHOD_CTX_IS_FINITE_CHARACTERISTIC, (gr_funcptr) gr_generic_ctx_predicate_false},
     {GR_METHOD_CTX_IS_APPROX_COMMUTATIVE_RING, (gr_funcptr) gr_generic_ctx_predicate_true},
     {GR_METHOD_CTX_HAS_REAL_PREC, (gr_funcptr) gr_generic_ctx_predicate_true},
     {GR_METHOD_CTX_SET_REAL_PREC, (gr_funcptr) _gr_mpf_ctx_set_real_prec},
@@ -441,4 +442,3 @@ gr_ctx_init_mpf(gr_ctx_t ctx, slong prec)
         _gr_mpf_methods_initialized = 1;
     }
 }
-

--- a/src/gr/mpf.c
+++ b/src/gr/mpf.c
@@ -254,6 +254,16 @@ static truth_t _gr_mpf_is_neg_one(const mpf_t x, gr_ctx_t ctx)
     return (mpf_cmp_si(x, -1) == 0) ? T_TRUE : T_FALSE;
 }
 
+static truth_t _gr_mpf_is_integer(const mpf_t x, gr_ctx_t ctx)
+{
+    return mpf_integer_p(x) ? T_TRUE : T_FALSE;
+}
+
+static truth_t _gr_mpf_is_rational(const mpf_t x, gr_ctx_t ctx)
+{
+    return T_TRUE;
+}
+
 static int _gr_mpf_neg(mpf_t res, const mpf_t x, gr_ctx_t ctx)
 {
     mpf_neg(res, x);
@@ -387,6 +397,8 @@ gr_method_tab_input _gr_mpf_methods_input[] =
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_mpf_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_mpf_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) _gr_mpf_is_neg_one},
+    {GR_METHOD_IS_INTEGER,      (gr_funcptr) _gr_mpf_is_integer},
+    {GR_METHOD_IS_RATIONAL,     (gr_funcptr) _gr_mpf_is_rational},
     {GR_METHOD_EQUAL,           (gr_funcptr) _gr_mpf_equal},
     {GR_METHOD_SET,             (gr_funcptr) _gr_mpf_set},
     {GR_METHOD_SET_SI,          (gr_funcptr) _gr_mpf_set_si},

--- a/src/gr/nf.c
+++ b/src/gr/nf.c
@@ -269,6 +269,18 @@ _gr_nf_is_neg_one(const nf_elem_t x, const gr_ctx_t ctx)
 }
 
 static truth_t
+_gr_nf_is_integer(const nf_elem_t x, const gr_ctx_t ctx)
+{
+    return nf_elem_is_integer(x, NF_CTX(ctx)) ? T_TRUE : T_FALSE;
+}
+
+static truth_t
+_gr_nf_is_rational(const nf_elem_t x, const gr_ctx_t ctx)
+{
+    return nf_elem_is_rational(x, NF_CTX(ctx)) ? T_TRUE : T_FALSE;
+}
+
+static truth_t
 _gr_nf_equal(const nf_elem_t x, const nf_elem_t y, const gr_ctx_t ctx)
 {
     return nf_elem_equal(x, y, NF_CTX(ctx)) ? T_TRUE : T_FALSE;
@@ -575,6 +587,8 @@ gr_method_tab_input _nf_methods_input[] =
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_nf_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_nf_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) _gr_nf_is_neg_one},
+    {GR_METHOD_IS_INTEGER,      (gr_funcptr) _gr_nf_is_integer},
+    {GR_METHOD_IS_RATIONAL,     (gr_funcptr) _gr_nf_is_rational},
     {GR_METHOD_EQUAL,           (gr_funcptr) _gr_nf_equal},
     {GR_METHOD_SET,             (gr_funcptr) _gr_nf_set},
     {GR_METHOD_SET_SI,          (gr_funcptr) _gr_nf_set_si},

--- a/src/gr/polynomial.c
+++ b/src/gr/polynomial.c
@@ -431,6 +431,40 @@ polynomial_is_one(const gr_poly_t poly, gr_ctx_t ctx)
     return gr_poly_is_one(poly, POLYNOMIAL_ELEM_CTX(ctx));
 }
 
+static truth_t
+polynomial_is_integer(const gr_poly_t poly, gr_ctx_t ctx)
+{
+    gr_ctx_struct * cctx = POLYNOMIAL_ELEM_CTX(ctx);
+    truth_t is_scalar;
+
+    is_scalar = gr_poly_is_scalar(poly, cctx);
+
+    if (is_scalar == T_FALSE)
+        return T_FALSE;
+
+    if (poly->length == 0)
+        return T_TRUE;
+
+    return truth_and(is_scalar, gr_is_integer(poly->coeffs, cctx));
+}
+
+static truth_t
+polynomial_is_rational(const gr_poly_t poly, gr_ctx_t ctx)
+{
+    gr_ctx_struct * cctx = POLYNOMIAL_ELEM_CTX(ctx);
+    truth_t is_scalar;
+
+    is_scalar = gr_poly_is_scalar(poly, cctx);
+
+    if (is_scalar == T_FALSE)
+        return T_FALSE;
+
+    if (poly->length == 0)
+        return T_TRUE;
+
+    return truth_and(is_scalar, gr_is_rational(poly->coeffs, cctx));
+}
+
 /*
 static truth_t
 polynomial_is_neg_one(const gr_poly_t poly, gr_ctx_t ctx)
@@ -826,6 +860,8 @@ gr_method_tab_input _gr_poly_methods_input[] =
     {GR_METHOD_BIG_O_BASE_FMPZ,   (gr_funcptr) polynomial_big_o_base_fmpz},
     {GR_METHOD_IS_ZERO,     (gr_funcptr) polynomial_is_zero},
     {GR_METHOD_IS_ONE,      (gr_funcptr) polynomial_is_one},
+    {GR_METHOD_IS_INTEGER,  (gr_funcptr) polynomial_is_integer},
+    {GR_METHOD_IS_RATIONAL, (gr_funcptr) polynomial_is_rational},
 /*
     {GR_METHOD_IS_NEG_ONE,  (gr_funcptr) polynomial_is_neg_one},
 */

--- a/src/gr/polynomial.c
+++ b/src/gr/polynomial.c
@@ -140,6 +140,12 @@ polynomial_ctx_is_threadsafe(gr_ctx_t ctx)
     return gr_ctx_is_threadsafe(POLYNOMIAL_ELEM_CTX(ctx));
 }
 
+static truth_t
+polynomial_ctx_is_finite_characteristic(gr_ctx_t ctx)
+{
+    return gr_ctx_is_finite_characteristic(POLYNOMIAL_ELEM_CTX(ctx));
+}
+
 
 static void
 polynomial_clear(gr_poly_t res, gr_ctx_t ctx)
@@ -442,6 +448,9 @@ polynomial_is_integer(const gr_poly_t poly, gr_ctx_t ctx)
     if (is_scalar == T_FALSE)
         return T_FALSE;
 
+    if (gr_ctx_is_finite_characteristic(cctx) != T_FALSE)
+        return T_UNKNOWN;
+
     if (poly->length == 0)
         return T_TRUE;
 
@@ -458,6 +467,9 @@ polynomial_is_rational(const gr_poly_t poly, gr_ctx_t ctx)
 
     if (is_scalar == T_FALSE)
         return T_FALSE;
+
+    if (gr_ctx_is_finite_characteristic(cctx) != T_FALSE)
+        return T_UNKNOWN;
 
     if (poly->length == 0)
         return T_TRUE;
@@ -838,6 +850,7 @@ gr_method_tab_input _gr_poly_methods_input[] =
     {GR_METHOD_CTX_IS_COMPLEX_VECTOR_SPACE, (gr_funcptr) polynomial_ctx_is_complex_vector_space},
     {GR_METHOD_CTX_IS_APPROX_COMMUTATIVE_RING, (gr_funcptr) polynomial_ctx_is_approx_commutative_ring},
     {GR_METHOD_CTX_IS_THREADSAFE,       (gr_funcptr) polynomial_ctx_is_threadsafe},
+    {GR_METHOD_CTX_IS_FINITE_CHARACTERISTIC, (gr_funcptr) polynomial_ctx_is_finite_characteristic},
     {GR_METHOD_CTX_SET_GEN_NAME,        (gr_funcptr) _gr_gr_poly_ctx_set_gen_name},
     {GR_METHOD_CTX_SET_GEN_NAMES,       (gr_funcptr) _gr_gr_poly_ctx_set_gen_names},
     {GR_METHOD_CTX_NGENS,               (gr_funcptr) gr_generic_ctx_ngens_1},

--- a/src/gr/qqbar.c
+++ b/src/gr/qqbar.c
@@ -261,6 +261,18 @@ _gr_qqbar_is_neg_one(const qqbar_t x, const gr_ctx_t ctx)
 }
 
 static truth_t
+_gr_qqbar_is_integer(const qqbar_t x, const gr_ctx_t ctx)
+{
+    return qqbar_is_integer(x) ? T_TRUE : T_FALSE;
+}
+
+static truth_t
+_gr_qqbar_is_rational(const qqbar_t x, const gr_ctx_t ctx)
+{
+    return qqbar_is_rational(x) ? T_TRUE : T_FALSE;
+}
+
+static truth_t
 _gr_qqbar_equal(const qqbar_t x, const qqbar_t y, const gr_ctx_t ctx)
 {
     return qqbar_equal(x, y) ? T_TRUE : T_FALSE;
@@ -1393,6 +1405,8 @@ gr_method_tab_input _qqbar_methods_input[] =
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_qqbar_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_qqbar_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) _gr_qqbar_is_neg_one},
+    {GR_METHOD_IS_INTEGER,      (gr_funcptr) _gr_qqbar_is_integer},
+    {GR_METHOD_IS_RATIONAL,     (gr_funcptr) _gr_qqbar_is_rational},
     {GR_METHOD_EQUAL,           (gr_funcptr) _gr_qqbar_equal},
 
     {GR_METHOD_SET,             (gr_funcptr) _gr_qqbar_set},

--- a/src/gr/test_ring.c
+++ b/src/gr/test_ring.c
@@ -3178,8 +3178,14 @@ static int
 gr_test_sqrt(gr_ctx_t R, flint_rand_t state, int test_flags)
 {
     int status = GR_SUCCESS;
+    int status_sqr_x = GR_SUCCESS;
+    int status_set_y = GR_SUCCESS;
+    int status_sqrt = GR_SUCCESS;
+    int status_sqr_y2 = GR_SUCCESS;
     gr_ptr x, y, y2;
     int perfect;
+    int alias;
+    truth_t is_square = T_UNKNOWN;
     char * fail_str = "";
 
     GR_TMP_INIT3(x, y, y2, R);
@@ -3190,19 +3196,25 @@ gr_test_sqrt(gr_ctx_t R, flint_rand_t state, int test_flags)
     perfect = n_randint(state, 2);
 
     if (perfect)
-        status |= gr_sqr(x, x, R);
-
-    if (n_randint(state, 2))
     {
-        status |= gr_set(y, x, R);
-        status |= gr_sqrt(y, y, R);
+        status_sqr_x = gr_sqr(x, x, R);
+        status |= status_sqr_x;
+    }
+
+    alias = n_randint(state, 2);
+    if (alias)
+    {
+        status_set_y = gr_set(y, x, R);
+        status_sqrt = gr_sqrt(y, y, R);
     }
     else
     {
-        status |= gr_sqrt(y, x, R);
+        status_sqrt = gr_sqrt(y, x, R);
     }
+    status |= status_set_y | status_sqrt;
 
-    status |= gr_sqr(y2, y, R);
+    status_sqr_y2 = gr_sqr(y2, y, R);
+    status |= status_sqr_y2;
 
     if (status == GR_SUCCESS && gr_equal(y2, x, R) == T_FALSE)
     {
@@ -3216,10 +3228,14 @@ gr_test_sqrt(gr_ctx_t R, flint_rand_t state, int test_flags)
         status = GR_TEST_FAIL;
     }
 
-    if (status == GR_SUCCESS && perfect && gr_is_square(x, R) == T_FALSE)
+    if (perfect)
     {
-        fail_str = "is_square(x) returns T_FALSE but input is a perfect square\n";
-        status = GR_TEST_FAIL;
+        is_square = gr_is_square(x, R);
+        if (status == GR_SUCCESS && is_square == T_FALSE)
+        {
+            fail_str = "is_square(x) returns T_FALSE but input is a perfect square\n";
+            status = GR_TEST_FAIL;
+        }
     }
 
     if ((test_flags & GR_TEST_ALWAYS_ABLE) && (status & GR_UNABLE))
@@ -3229,6 +3245,13 @@ gr_test_sqrt(gr_ctx_t R, flint_rand_t state, int test_flags)
     {
         flint_printf("FAIL: sqrt\n");
         flint_printf("%s\n", fail_str);
+        flint_printf("perfect = %d, alias = %d\n", perfect, alias);
+        flint_printf("status = %d\n", status);
+        flint_printf("status_sqr_x = %d\n", status_sqr_x);
+        flint_printf("status_set_y = %d\n", status_set_y);
+        flint_printf("status_sqrt = %d\n", status_sqrt);
+        flint_printf("status_sqr_y2 = %d\n", status_sqr_y2);
+        flint_printf("is_square = %{truth}\n", is_square);
         flint_printf("R = "); gr_ctx_println(R);
         flint_printf("x = \n"); gr_println(x, R);
         flint_printf("y = \n"); gr_println(y, R);

--- a/src/gr/test_ring.c
+++ b/src/gr/test_ring.c
@@ -3178,14 +3178,8 @@ static int
 gr_test_sqrt(gr_ctx_t R, flint_rand_t state, int test_flags)
 {
     int status = GR_SUCCESS;
-    int status_sqr_x = GR_SUCCESS;
-    int status_set_y = GR_SUCCESS;
-    int status_sqrt = GR_SUCCESS;
-    int status_sqr_y2 = GR_SUCCESS;
     gr_ptr x, y, y2;
     int perfect;
-    int alias;
-    truth_t is_square = T_UNKNOWN;
     char * fail_str = "";
 
     GR_TMP_INIT3(x, y, y2, R);
@@ -3196,25 +3190,19 @@ gr_test_sqrt(gr_ctx_t R, flint_rand_t state, int test_flags)
     perfect = n_randint(state, 2);
 
     if (perfect)
-    {
-        status_sqr_x = gr_sqr(x, x, R);
-        status |= status_sqr_x;
-    }
+        status |= gr_sqr(x, x, R);
 
-    alias = n_randint(state, 2);
-    if (alias)
+    if (n_randint(state, 2))
     {
-        status_set_y = gr_set(y, x, R);
-        status_sqrt = gr_sqrt(y, y, R);
+        status |= gr_set(y, x, R);
+        status |= gr_sqrt(y, y, R);
     }
     else
     {
-        status_sqrt = gr_sqrt(y, x, R);
+        status |= gr_sqrt(y, x, R);
     }
-    status |= status_set_y | status_sqrt;
 
-    status_sqr_y2 = gr_sqr(y2, y, R);
-    status |= status_sqr_y2;
+    status |= gr_sqr(y2, y, R);
 
     if (status == GR_SUCCESS && gr_equal(y2, x, R) == T_FALSE)
     {
@@ -3228,14 +3216,10 @@ gr_test_sqrt(gr_ctx_t R, flint_rand_t state, int test_flags)
         status = GR_TEST_FAIL;
     }
 
-    if (perfect)
+    if (status == GR_SUCCESS && perfect && gr_is_square(x, R) == T_FALSE)
     {
-        is_square = gr_is_square(x, R);
-        if (status == GR_SUCCESS && is_square == T_FALSE)
-        {
-            fail_str = "is_square(x) returns T_FALSE but input is a perfect square\n";
-            status = GR_TEST_FAIL;
-        }
+        fail_str = "is_square(x) returns T_FALSE but input is a perfect square\n";
+        status = GR_TEST_FAIL;
     }
 
     if ((test_flags & GR_TEST_ALWAYS_ABLE) && (status & GR_UNABLE))
@@ -3245,13 +3229,6 @@ gr_test_sqrt(gr_ctx_t R, flint_rand_t state, int test_flags)
     {
         flint_printf("FAIL: sqrt\n");
         flint_printf("%s\n", fail_str);
-        flint_printf("perfect = %d, alias = %d\n", perfect, alias);
-        flint_printf("status = %d\n", status);
-        flint_printf("status_sqr_x = %d\n", status_sqr_x);
-        flint_printf("status_set_y = %d\n", status_set_y);
-        flint_printf("status_sqrt = %d\n", status_sqrt);
-        flint_printf("status_sqr_y2 = %d\n", status_sqr_y2);
-        flint_printf("is_square = %{truth}\n", is_square);
         flint_printf("R = "); gr_ctx_println(R);
         flint_printf("x = \n"); gr_println(x, R);
         flint_printf("y = \n"); gr_println(y, R);

--- a/src/gr/test_ring.c
+++ b/src/gr/test_ring.c
@@ -543,6 +543,80 @@ gr_test_get_fmpq(gr_ctx_t R, flint_rand_t state, int test_flags)
 }
 
 static int
+gr_test_is_integer(gr_ctx_t R, flint_rand_t state, int test_flags)
+{
+    int status;
+    truth_t is_integer;
+    gr_ptr x;
+    fmpz_t a;
+
+    GR_TMP_INIT(x, R);
+    fmpz_init(a);
+
+    GR_MUST_SUCCEED(gr_randtest(x, state, R));
+
+    status = gr_get_fmpz(a, x, R);
+    is_integer = gr_is_integer(x, R);
+
+    if ((status == GR_SUCCESS && is_integer == T_FALSE) ||
+        ((status & GR_DOMAIN) && is_integer == T_TRUE))
+    {
+        status = GR_TEST_FAIL;
+    }
+
+    if ((test_flags & GR_TEST_VERBOSE) || status == GR_TEST_FAIL)
+    {
+        flint_printf("is_integer\n");
+        gr_ctx_println(R);
+        flint_printf("x = "); gr_println(x, R);
+        flint_printf("status = %d, is_integer = %{truth}\n", status, is_integer);
+        flint_printf("\n");
+    }
+
+    GR_TMP_CLEAR(x, R);
+    fmpz_clear(a);
+
+    return status;
+}
+
+static int
+gr_test_is_rational(gr_ctx_t R, flint_rand_t state, int test_flags)
+{
+    int status;
+    truth_t is_rational;
+    gr_ptr x;
+    fmpq_t a;
+
+    GR_TMP_INIT(x, R);
+    fmpq_init(a);
+
+    GR_MUST_SUCCEED(gr_randtest(x, state, R));
+
+    status = gr_get_fmpq(a, x, R);
+    is_rational = gr_is_rational(x, R);
+
+    if ((status == GR_SUCCESS && is_rational == T_FALSE) ||
+        ((status & GR_DOMAIN) && is_rational == T_TRUE))
+    {
+        status = GR_TEST_FAIL;
+    }
+
+    if ((test_flags & GR_TEST_VERBOSE) || status == GR_TEST_FAIL)
+    {
+        flint_printf("is_rational\n");
+        gr_ctx_println(R);
+        flint_printf("x = "); gr_println(x, R);
+        flint_printf("status = %d, is_rational = %{truth}\n", status, is_rational);
+        flint_printf("\n");
+    }
+
+    GR_TMP_CLEAR(x, R);
+    fmpq_clear(a);
+
+    return status;
+}
+
+static int
 gr_test_get_fmpz_2exp_fmpz(gr_ctx_t R, flint_rand_t state, int test_flags)
 {
     int status;
@@ -4957,6 +5031,8 @@ gr_test_ring(gr_ctx_t R, slong iters, int test_flags)
     gr_test_iter(R, state, "get_si", gr_test_get_si, iters, test_flags);
     gr_test_iter(R, state, "get_fmpz", gr_test_get_fmpz, iters, test_flags);
     gr_test_iter(R, state, "get_fmpq", gr_test_get_fmpq, iters, test_flags);
+    gr_test_iter(R, state, "is_integer", gr_test_is_integer, iters, test_flags);
+    gr_test_iter(R, state, "is_rational", gr_test_is_rational, iters, test_flags);
     gr_test_iter(R, state, "get_fmpz_2exp_fmpz", gr_test_get_fmpz_2exp_fmpz, iters, test_flags);
 
     gr_test_iter(R, state, "get_set_d", gr_test_get_set_d, iters, test_flags);

--- a/src/gr_generic.h
+++ b/src/gr_generic.h
@@ -107,6 +107,8 @@ WARN_UNUSED_RESULT int gr_generic_gens_recursive(gr_vec_t vec, gr_ctx_t ctx);
 WARN_UNUSED_RESULT truth_t gr_generic_is_zero(gr_srcptr x, gr_ctx_t ctx);
 WARN_UNUSED_RESULT truth_t gr_generic_is_one(gr_srcptr x, gr_ctx_t ctx);
 WARN_UNUSED_RESULT truth_t gr_generic_is_neg_one(gr_srcptr x, gr_ctx_t ctx);
+WARN_UNUSED_RESULT truth_t gr_generic_is_integer(gr_srcptr x, gr_ctx_t ctx);
+WARN_UNUSED_RESULT truth_t gr_generic_is_rational(gr_srcptr x, gr_ctx_t ctx);
 
 WARN_UNUSED_RESULT int gr_generic_neg_one(gr_ptr res, gr_ctx_t ctx);
 

--- a/src/gr_generic/generic.c
+++ b/src/gr_generic/generic.c
@@ -283,38 +283,14 @@ truth_t gr_generic_is_neg_one(gr_srcptr x, gr_ctx_t ctx)
     return eq;
 }
 
-truth_t gr_generic_is_integer(gr_srcptr x, gr_ctx_t ctx)
+truth_t gr_generic_is_integer(gr_srcptr FLINT_UNUSED(x), gr_ctx_t FLINT_UNUSED(ctx))
 {
-    fmpz_t t;
-    int status;
-
-    fmpz_init(t);
-    status = gr_get_fmpz(t, x, ctx);
-    fmpz_clear(t);
-
-    if (status == GR_SUCCESS)
-        return T_TRUE;
-    else if (status & GR_DOMAIN)
-        return T_FALSE;
-    else
-        return T_UNKNOWN;
+    return T_UNKNOWN;
 }
 
-truth_t gr_generic_is_rational(gr_srcptr x, gr_ctx_t ctx)
+truth_t gr_generic_is_rational(gr_srcptr FLINT_UNUSED(x), gr_ctx_t FLINT_UNUSED(ctx))
 {
-    fmpq_t t;
-    int status;
-
-    fmpq_init(t);
-    status = gr_get_fmpq(t, x, ctx);
-    fmpq_clear(t);
-
-    if (status == GR_SUCCESS)
-        return T_TRUE;
-    else if (status & GR_DOMAIN)
-        return T_FALSE;
-    else
-        return T_UNKNOWN;
+    return T_UNKNOWN;
 }
 
 int gr_generic_neg_one(gr_ptr res, gr_ctx_t ctx)
@@ -3266,4 +3242,3 @@ gr_method_tab_extend(gr_funcptr * methods, gr_method_tab_input * tab)
         methods[tab[i].index] = tab[i].function;
     }
 }
-

--- a/src/gr_generic/generic.c
+++ b/src/gr_generic/generic.c
@@ -283,6 +283,40 @@ truth_t gr_generic_is_neg_one(gr_srcptr x, gr_ctx_t ctx)
     return eq;
 }
 
+truth_t gr_generic_is_integer(gr_srcptr x, gr_ctx_t ctx)
+{
+    fmpz_t t;
+    int status;
+
+    fmpz_init(t);
+    status = gr_get_fmpz(t, x, ctx);
+    fmpz_clear(t);
+
+    if (status == GR_SUCCESS)
+        return T_TRUE;
+    else if (status & GR_DOMAIN)
+        return T_FALSE;
+    else
+        return T_UNKNOWN;
+}
+
+truth_t gr_generic_is_rational(gr_srcptr x, gr_ctx_t ctx)
+{
+    fmpq_t t;
+    int status;
+
+    fmpq_init(t);
+    status = gr_get_fmpq(t, x, ctx);
+    fmpq_clear(t);
+
+    if (status == GR_SUCCESS)
+        return T_TRUE;
+    else if (status & GR_DOMAIN)
+        return T_FALSE;
+    else
+        return T_UNKNOWN;
+}
+
 int gr_generic_neg_one(gr_ptr res, gr_ctx_t ctx)
 {
     int status;
@@ -2833,6 +2867,8 @@ const gr_method_tab_input _gr_generic_methods[] =
     {GR_METHOD_IS_ZERO,                 (gr_funcptr) gr_generic_is_zero},
     {GR_METHOD_IS_ONE,                  (gr_funcptr) gr_generic_is_one},
     {GR_METHOD_IS_NEG_ONE,              (gr_funcptr) gr_generic_is_neg_one},
+    {GR_METHOD_IS_INTEGER,              (gr_funcptr) gr_generic_is_integer},
+    {GR_METHOD_IS_RATIONAL,             (gr_funcptr) gr_generic_is_rational},
 
     {GR_METHOD_EQUAL,                   (gr_funcptr) gr_generic_equal},
 

--- a/src/gr_mpoly.h
+++ b/src/gr_mpoly.h
@@ -214,6 +214,8 @@ int gr_mpoly_zero(gr_mpoly_t A, gr_mpoly_ctx_t ctx)
 
 truth_t gr_mpoly_is_zero(const gr_mpoly_t A, gr_mpoly_ctx_t ctx);
 truth_t gr_mpoly_is_scalar(const gr_mpoly_t A, gr_mpoly_ctx_t ctx);
+truth_t gr_mpoly_is_integer(const gr_mpoly_t A, gr_mpoly_ctx_t ctx);
+truth_t gr_mpoly_is_rational(const gr_mpoly_t A, gr_mpoly_ctx_t ctx);
 
 WARN_UNUSED_RESULT int gr_mpoly_gen(gr_mpoly_t A, slong var, gr_mpoly_ctx_t ctx);
 truth_t gr_mpoly_is_gen(const gr_mpoly_t A, slong var, gr_mpoly_ctx_t ctx);

--- a/src/gr_mpoly.h
+++ b/src/gr_mpoly.h
@@ -213,6 +213,7 @@ int gr_mpoly_zero(gr_mpoly_t A, gr_mpoly_ctx_t ctx)
 }
 
 truth_t gr_mpoly_is_zero(const gr_mpoly_t A, gr_mpoly_ctx_t ctx);
+truth_t gr_mpoly_is_scalar(const gr_mpoly_t A, gr_mpoly_ctx_t ctx);
 
 WARN_UNUSED_RESULT int gr_mpoly_gen(gr_mpoly_t A, slong var, gr_mpoly_ctx_t ctx);
 truth_t gr_mpoly_is_gen(const gr_mpoly_t A, slong var, gr_mpoly_ctx_t ctx);

--- a/src/gr_mpoly/ctx.c
+++ b/src/gr_mpoly/ctx.c
@@ -157,6 +157,12 @@ gr_mpoly_ctx_is_threadsafe(gr_mpoly_ctx_t ctx)
     return gr_ctx_is_threadsafe(GR_MPOLY_CCTX(ctx));
 }
 
+static truth_t
+gr_mpoly_ctx_is_finite_characteristic(gr_mpoly_ctx_t ctx)
+{
+    return gr_ctx_is_finite_characteristic(GR_MPOLY_CCTX(ctx));
+}
+
 static gr_ptr _gr_mpoly_ctx_base(gr_ctx_t ctx) { return GR_MPOLY_CCTX(ctx); }
 
 
@@ -334,6 +340,7 @@ gr_method_tab_input _gr_mpoly_methods_input[] =
     {GR_METHOD_CTX_IS_INTEGRAL_DOMAIN,  (gr_funcptr) gr_mpoly_ctx_is_integral_domain},
     {GR_METHOD_CTX_IS_FIELD,            (gr_funcptr) gr_mpoly_ctx_is_field},
     {GR_METHOD_CTX_IS_THREADSAFE,       (gr_funcptr) gr_mpoly_ctx_is_threadsafe},
+    {GR_METHOD_CTX_IS_FINITE_CHARACTERISTIC, (gr_funcptr) gr_mpoly_ctx_is_finite_characteristic},
     {GR_METHOD_CTX_IS_RATIONAL_VECTOR_SPACE,     (gr_funcptr) gr_mpoly_ctx_is_rational_vector_space},
     {GR_METHOD_CTX_IS_REAL_VECTOR_SPACE,     (gr_funcptr) gr_mpoly_ctx_is_real_vector_space},
     {GR_METHOD_CTX_IS_COMPLEX_VECTOR_SPACE,     (gr_funcptr) gr_mpoly_ctx_is_complex_vector_space},

--- a/src/gr_mpoly/ctx.c
+++ b/src/gr_mpoly/ctx.c
@@ -355,6 +355,8 @@ gr_method_tab_input _gr_mpoly_methods_input[] =
     {GR_METHOD_ONE,         (gr_funcptr) gr_mpoly_one},
     {GR_METHOD_IS_ZERO,     (gr_funcptr) gr_mpoly_is_zero},
     {GR_METHOD_IS_ONE,      (gr_funcptr) gr_mpoly_is_one},
+    {GR_METHOD_IS_INTEGER,  (gr_funcptr) gr_mpoly_is_integer},
+    {GR_METHOD_IS_RATIONAL, (gr_funcptr) gr_mpoly_is_rational},
     {GR_METHOD_EQUAL,       (gr_funcptr) gr_mpoly_equal},
     {GR_METHOD_SET,         (gr_funcptr) gr_mpoly_set},
     {GR_METHOD_SET_OTHER,   (gr_funcptr) gr_mpoly_set_other},

--- a/src/gr_mpoly/is_integer.c
+++ b/src/gr_mpoly/is_integer.c
@@ -51,6 +51,9 @@ gr_mpoly_is_integer(const gr_mpoly_t A, gr_mpoly_ctx_t ctx)
         }
     }
 
+    if (gr_ctx_is_finite_characteristic(cctx) != T_FALSE)
+        return T_UNKNOWN;
+
     if (cindex >= 0)
         res = truth_and(res, gr_is_integer(
             GR_ENTRY(A->coeffs, cindex, cctx->sizeof_elem), cctx));

--- a/src/gr_mpoly/is_integer.c
+++ b/src/gr_mpoly/is_integer.c
@@ -1,0 +1,59 @@
+/*
+    Copyright (C) 2026 Oscar Benjamin
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "mpoly.h"
+#include "gr_mpoly.h"
+
+truth_t
+gr_mpoly_is_integer(const gr_mpoly_t A, gr_mpoly_ctx_t ctx)
+{
+    gr_ctx_struct * cctx = GR_MPOLY_CCTX(ctx);
+    mpoly_ctx_struct * mctx = GR_MPOLY_MCTX(ctx);
+    truth_t res = T_TRUE;
+    truth_t canonical = gr_ctx_is_canonical(cctx);
+    slong i, N, cindex = -1;
+
+    N = mpoly_words_per_exp(A->bits, mctx);
+
+    if (canonical == T_TRUE)
+    {
+        for (i = 0; i < A->length; i++)
+        {
+            if (mpoly_monomial_is_zero(A->exps + N*i, N))
+                cindex = i;
+            else
+                return T_FALSE;
+        }
+    }
+    else
+    {
+        for (i = 0; i < A->length; i++)
+        {
+            if (mpoly_monomial_is_zero(A->exps + N*i, N))
+                cindex = i;
+            else
+            {
+                truth_t is_zero = gr_is_zero(
+                    GR_ENTRY(A->coeffs, i, cctx->sizeof_elem), cctx);
+                if (is_zero == T_FALSE)
+                    return T_FALSE;
+                if (is_zero == T_UNKNOWN)
+                    res = T_UNKNOWN;
+            }
+        }
+    }
+
+    if (cindex >= 0)
+        res = truth_and(res, gr_is_integer(
+            GR_ENTRY(A->coeffs, cindex, cctx->sizeof_elem), cctx));
+
+    return res;
+}

--- a/src/gr_mpoly/is_rational.c
+++ b/src/gr_mpoly/is_rational.c
@@ -51,6 +51,9 @@ gr_mpoly_is_rational(const gr_mpoly_t A, gr_mpoly_ctx_t ctx)
         }
     }
 
+    if (gr_ctx_is_finite_characteristic(cctx) != T_FALSE)
+        return T_UNKNOWN;
+
     if (cindex >= 0)
         res = truth_and(res, gr_is_rational(
             GR_ENTRY(A->coeffs, cindex, cctx->sizeof_elem), cctx));

--- a/src/gr_mpoly/is_rational.c
+++ b/src/gr_mpoly/is_rational.c
@@ -1,0 +1,59 @@
+/*
+    Copyright (C) 2026 Oscar Benjamin
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "mpoly.h"
+#include "gr_mpoly.h"
+
+truth_t
+gr_mpoly_is_rational(const gr_mpoly_t A, gr_mpoly_ctx_t ctx)
+{
+    gr_ctx_struct * cctx = GR_MPOLY_CCTX(ctx);
+    mpoly_ctx_struct * mctx = GR_MPOLY_MCTX(ctx);
+    truth_t res = T_TRUE;
+    truth_t canonical = gr_ctx_is_canonical(cctx);
+    slong i, N, cindex = -1;
+
+    N = mpoly_words_per_exp(A->bits, mctx);
+
+    if (canonical == T_TRUE)
+    {
+        for (i = 0; i < A->length; i++)
+        {
+            if (mpoly_monomial_is_zero(A->exps + N*i, N))
+                cindex = i;
+            else
+                return T_FALSE;
+        }
+    }
+    else
+    {
+        for (i = 0; i < A->length; i++)
+        {
+            if (mpoly_monomial_is_zero(A->exps + N*i, N))
+                cindex = i;
+            else
+            {
+                truth_t is_zero = gr_is_zero(
+                    GR_ENTRY(A->coeffs, i, cctx->sizeof_elem), cctx);
+                if (is_zero == T_FALSE)
+                    return T_FALSE;
+                if (is_zero == T_UNKNOWN)
+                    res = T_UNKNOWN;
+            }
+        }
+    }
+
+    if (cindex >= 0)
+        res = truth_and(res, gr_is_rational(
+            GR_ENTRY(A->coeffs, cindex, cctx->sizeof_elem), cctx));
+
+    return res;
+}

--- a/src/gr_mpoly/is_scalar.c
+++ b/src/gr_mpoly/is_scalar.c
@@ -1,0 +1,50 @@
+/*
+    Copyright (C) 2026 Oscar Benjamin
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "mpoly.h"
+#include "gr_mpoly.h"
+
+truth_t
+gr_mpoly_is_scalar(const gr_mpoly_t A, gr_mpoly_ctx_t ctx)
+{
+    gr_ctx_struct * cctx = GR_MPOLY_CCTX(ctx);
+    mpoly_ctx_struct * mctx = GR_MPOLY_MCTX(ctx);
+    truth_t res = T_TRUE;
+    slong i, N;
+
+    if (gr_ctx_is_canonical(cctx) == T_TRUE)
+    {
+        N = mpoly_words_per_exp(A->bits, mctx);
+
+        for (i = 0; i < A->length; i++)
+            if (!mpoly_monomial_is_zero(A->exps + N*i, N))
+                return T_FALSE;
+
+        return T_TRUE;
+    }
+
+    N = mpoly_words_per_exp(A->bits, mctx);
+
+    for (i = 0; i < A->length; i++)
+    {
+        if (!mpoly_monomial_is_zero(A->exps + N*i, N))
+        {
+            truth_t is_zero = gr_is_zero(GR_ENTRY(A->coeffs, i, cctx->sizeof_elem), cctx);
+
+            if (is_zero == T_FALSE)
+                return T_FALSE;
+            if (is_zero == T_UNKNOWN)
+                res = T_UNKNOWN;
+        }
+    }
+
+    return res;
+}

--- a/src/gr_mpoly/test/t-ring.c
+++ b/src/gr_mpoly/test/t-ring.c
@@ -53,15 +53,7 @@ TEST_FUNCTION_START(gr_mpoly_ring, state)
         {
             const char * vars[] = { "mv1", "mv2", "mv3", "mv4" };
 
-            status = gr_ctx_set_gen_names(ctx, vars);
-            if (status != GR_SUCCESS)
-            {
-                flint_printf("gr_mpoly_ring: gr_ctx_set_gen_names failed "
-                             "at iteration %wd with status %d\n", iter, status);
-                flint_printf("coefficient context: "); gr_ctx_println(cctx);
-                flint_printf("polynomial context: "); gr_ctx_println(ctx);
-            }
-            GR_MUST_SUCCEED(status);
+            GR_MUST_SUCCEED(gr_ctx_set_gen_names(ctx, vars));
 
         }
         gr_vec_clear(vec, cctx);
@@ -75,29 +67,14 @@ TEST_FUNCTION_START(gr_mpoly_ring, state)
             gr_mpoly_init(A, ctx);
 
             status = gr_mpoly_set_ui(A, 1, ctx);
-            if (status != GR_SUCCESS)
-            {
-                flint_printf("gr_mpoly_ring: gr_mpoly_set_ui failed "
-                             "at iteration %wd with status %d\n", iter, status);
-                flint_printf("coefficient context: "); gr_ctx_println(cctx);
-                flint_printf("polynomial context: "); gr_ctx_println(ctx);
-            }
-            GR_MUST_SUCCEED(status);
-            if (gr_mpoly_is_scalar(A, ctx) != T_TRUE)
+            if (status == GR_SUCCESS && gr_mpoly_is_scalar(A, ctx) != T_TRUE)
                 flint_abort();
 
             if (GR_MPOLY_MCTX(ctx)->nvars > 0)
             {
                 status = gr_mpoly_gen(A, 0, ctx);
-                if (status != GR_SUCCESS)
-                {
-                    flint_printf("gr_mpoly_ring: gr_mpoly_gen failed "
-                                 "at iteration %wd with status %d\n", iter, status);
-                    flint_printf("coefficient context: "); gr_ctx_println(cctx);
-                    flint_printf("polynomial context: "); gr_ctx_println(ctx);
-                }
-                GR_MUST_SUCCEED(status);
-                if (A->length > 0 && gr_mpoly_is_scalar(A, ctx) != T_FALSE)
+                if (status == GR_SUCCESS && A->length > 0 &&
+                    gr_mpoly_is_scalar(A, ctx) != T_FALSE)
                     flint_abort();
             }
 

--- a/src/gr_mpoly/test/t-ring.c
+++ b/src/gr_mpoly/test/t-ring.c
@@ -60,6 +60,25 @@ TEST_FUNCTION_START(gr_mpoly_ring, state)
         /* gr_ctx_println(ctx); */
         gr_test_ring(ctx, reps, 0 * GR_TEST_VERBOSE);
 
+        {
+            gr_mpoly_t A;
+
+            gr_mpoly_init(A, ctx);
+
+            GR_MUST_SUCCEED(gr_mpoly_set_ui(A, 1, ctx));
+            if (gr_mpoly_is_scalar(A, ctx) != T_TRUE)
+                flint_abort();
+
+            if (GR_MPOLY_MCTX(ctx)->nvars > 0)
+            {
+                GR_MUST_SUCCEED(gr_mpoly_gen(A, 0, ctx));
+                if (A->length > 0 && gr_mpoly_is_scalar(A, ctx) != T_FALSE)
+                    flint_abort();
+            }
+
+            gr_mpoly_clear(A, ctx);
+        }
+
         gr_mpoly_ctx_clear(ctx);
         gr_ctx_clear(cctx);
     }

--- a/src/gr_mpoly/test/t-ring.c
+++ b/src/gr_mpoly/test/t-ring.c
@@ -18,6 +18,7 @@ FLINT_DLL extern gr_static_method_table _ca_methods;
 TEST_FUNCTION_START(gr_mpoly_ring, state)
 {
     slong iter;
+    int status;
 
     for (iter = 0; iter < 30 * flint_test_multiplier(); iter++)
     {
@@ -52,7 +53,15 @@ TEST_FUNCTION_START(gr_mpoly_ring, state)
         {
             const char * vars[] = { "mv1", "mv2", "mv3", "mv4" };
 
-            GR_MUST_SUCCEED(gr_ctx_set_gen_names(ctx, vars));
+            status = gr_ctx_set_gen_names(ctx, vars);
+            if (status != GR_SUCCESS)
+            {
+                flint_printf("gr_mpoly_ring: gr_ctx_set_gen_names failed "
+                             "at iteration %wd with status %d\n", iter, status);
+                flint_printf("coefficient context: "); gr_ctx_println(cctx);
+                flint_printf("polynomial context: "); gr_ctx_println(ctx);
+            }
+            GR_MUST_SUCCEED(status);
 
         }
         gr_vec_clear(vec, cctx);
@@ -65,13 +74,29 @@ TEST_FUNCTION_START(gr_mpoly_ring, state)
 
             gr_mpoly_init(A, ctx);
 
-            GR_MUST_SUCCEED(gr_mpoly_set_ui(A, 1, ctx));
+            status = gr_mpoly_set_ui(A, 1, ctx);
+            if (status != GR_SUCCESS)
+            {
+                flint_printf("gr_mpoly_ring: gr_mpoly_set_ui failed "
+                             "at iteration %wd with status %d\n", iter, status);
+                flint_printf("coefficient context: "); gr_ctx_println(cctx);
+                flint_printf("polynomial context: "); gr_ctx_println(ctx);
+            }
+            GR_MUST_SUCCEED(status);
             if (gr_mpoly_is_scalar(A, ctx) != T_TRUE)
                 flint_abort();
 
             if (GR_MPOLY_MCTX(ctx)->nvars > 0)
             {
-                GR_MUST_SUCCEED(gr_mpoly_gen(A, 0, ctx));
+                status = gr_mpoly_gen(A, 0, ctx);
+                if (status != GR_SUCCESS)
+                {
+                    flint_printf("gr_mpoly_ring: gr_mpoly_gen failed "
+                                 "at iteration %wd with status %d\n", iter, status);
+                    flint_printf("coefficient context: "); gr_ctx_println(cctx);
+                    flint_printf("polynomial context: "); gr_ctx_println(ctx);
+                }
+                GR_MUST_SUCCEED(status);
                 if (A->length > 0 && gr_mpoly_is_scalar(A, ctx) != T_FALSE)
                     flint_abort();
             }

--- a/src/gr_ore_poly.h
+++ b/src/gr_ore_poly.h
@@ -120,6 +120,7 @@ truth_t gr_ore_poly_ctx_is_ring(gr_ore_poly_ctx_t ctx);
 truth_t gr_ore_poly_ctx_is_zero_ring(gr_ore_poly_ctx_t ctx);
 truth_t gr_ore_poly_ctx_is_commutative_ring(gr_ore_poly_ctx_t ctx);
 truth_t gr_ore_poly_ctx_is_integral_domain(gr_ore_poly_ctx_t ctx);
+truth_t gr_ore_poly_ctx_is_finite_characteristic(gr_ore_poly_ctx_t ctx);
 truth_t gr_ore_poly_ctx_is_threadsafe(gr_ore_poly_ctx_t ctx);
 
 /* Memory management */
@@ -183,6 +184,9 @@ truth_t gr_ore_poly_equal(const gr_ore_poly_t poly1, const gr_ore_poly_t poly2, 
 
 truth_t gr_ore_poly_is_zero(const gr_ore_poly_t poly, gr_ore_poly_ctx_t ctx);
 truth_t gr_ore_poly_is_one(const gr_ore_poly_t poly, gr_ore_poly_ctx_t ctx);
+truth_t gr_ore_poly_is_scalar(const gr_ore_poly_t poly, gr_ore_poly_ctx_t ctx);
+truth_t gr_ore_poly_is_integer(const gr_ore_poly_t poly, gr_ore_poly_ctx_t ctx);
+truth_t gr_ore_poly_is_rational(const gr_ore_poly_t poly, gr_ore_poly_ctx_t ctx);
 truth_t gr_ore_poly_is_gen(const gr_ore_poly_t poly, gr_ore_poly_ctx_t ctx);
 
 /* Input and output */

--- a/src/gr_ore_poly/ctx.c
+++ b/src/gr_ore_poly/ctx.c
@@ -158,6 +158,12 @@ gr_ore_poly_ctx_is_integral_domain(gr_ore_poly_ctx_t ctx)
     return T_UNKNOWN;
 }
 
+truth_t
+gr_ore_poly_ctx_is_finite_characteristic(gr_ore_poly_ctx_t ctx)
+{
+    return gr_ctx_is_finite_characteristic(GR_ORE_POLY_ELEM_CTX(ctx));
+}
+
 static truth_t
 gr_ore_poly_ctx_is_unique_factorization_domain(gr_ore_poly_ctx_t ctx)
 {
@@ -230,6 +236,7 @@ gr_method_tab_input _gr_ore_poly_methods_input[] =
     {GR_METHOD_CTX_IS_INTEGRAL_DOMAIN,  (gr_funcptr) gr_ore_poly_ctx_is_integral_domain},
     {GR_METHOD_CTX_IS_UNIQUE_FACTORIZATION_DOMAIN,  (gr_funcptr) gr_ore_poly_ctx_is_unique_factorization_domain},
     {GR_METHOD_CTX_IS_FIELD,            (gr_funcptr) gr_generic_ctx_predicate_false},
+    {GR_METHOD_CTX_IS_FINITE_CHARACTERISTIC, (gr_funcptr) gr_ore_poly_ctx_is_finite_characteristic},
     {GR_METHOD_CTX_IS_THREADSAFE,       (gr_funcptr) gr_ore_poly_ctx_is_threadsafe},
     {GR_METHOD_CTX_SET_GEN_NAME,        (gr_funcptr) _gr_ore_poly_ctx_set_gen_name},
     {GR_METHOD_CTX_SET_GEN_NAMES,       (gr_funcptr) _gr_ore_poly_ctx_set_gen_names},
@@ -254,6 +261,8 @@ gr_method_tab_input _gr_ore_poly_methods_input[] =
 
     {GR_METHOD_IS_ZERO,     (gr_funcptr) gr_ore_poly_is_zero},
     {GR_METHOD_IS_ONE,      (gr_funcptr) gr_ore_poly_is_one},
+    {GR_METHOD_IS_INTEGER,  (gr_funcptr) gr_ore_poly_is_integer},
+    {GR_METHOD_IS_RATIONAL, (gr_funcptr) gr_ore_poly_is_rational},
 /*
     {GR_METHOD_IS_NEG_ONE,  (gr_funcptr) gr_ore_poly_is_neg_one},
 */

--- a/src/gr_ore_poly/ring.c
+++ b/src/gr_ore_poly/ring.c
@@ -159,6 +159,47 @@ gr_ore_poly_is_one(const gr_ore_poly_t poly, gr_ore_poly_ctx_t ctx)
 }
 
 truth_t
+gr_ore_poly_is_scalar(const gr_ore_poly_t poly, gr_ore_poly_ctx_t ctx)
+{
+    return gr_poly_is_scalar((const gr_poly_struct *) poly, GR_ORE_POLY_ELEM_CTX(ctx));
+}
+
+static truth_t
+_gr_ore_poly_is_integer_or_rational(const gr_ore_poly_t poly,
+                                    gr_ore_poly_ctx_t ctx, int rational)
+{
+    gr_ctx_struct * cctx = GR_ORE_POLY_ELEM_CTX(ctx);
+    truth_t is_scalar;
+
+    is_scalar = gr_ore_poly_is_scalar(poly, ctx);
+
+    if (is_scalar == T_FALSE)
+        return T_FALSE;
+
+    if (gr_ctx_is_finite_characteristic(cctx) != T_FALSE)
+        return T_UNKNOWN;
+
+    if (poly->length == 0)
+        return T_TRUE;
+
+    return truth_and(is_scalar,
+        rational ? gr_is_rational(poly->coeffs, cctx) :
+                   gr_is_integer(poly->coeffs, cctx));
+}
+
+truth_t
+gr_ore_poly_is_integer(const gr_ore_poly_t poly, gr_ore_poly_ctx_t ctx)
+{
+    return _gr_ore_poly_is_integer_or_rational(poly, ctx, 0);
+}
+
+truth_t
+gr_ore_poly_is_rational(const gr_ore_poly_t poly, gr_ore_poly_ctx_t ctx)
+{
+    return _gr_ore_poly_is_integer_or_rational(poly, ctx, 1);
+}
+
+truth_t
 gr_ore_poly_is_gen(const gr_ore_poly_t poly, gr_ore_poly_ctx_t ctx)
 {
     return gr_poly_is_gen((const gr_poly_struct *) poly, GR_ORE_POLY_ELEM_CTX(ctx));

--- a/src/gr_series.h
+++ b/src/gr_series.h
@@ -113,6 +113,9 @@ WARN_UNUSED_RESULT int gr_series_set_fmpq(gr_series_t res, const fmpq_t c, gr_ct
 WARN_UNUSED_RESULT int gr_series_set_other(gr_series_t res, gr_srcptr x, gr_ctx_t x_ctx, gr_ctx_t ctx);
 truth_t gr_series_is_zero(const gr_series_t x, gr_ctx_t ctx);
 truth_t gr_series_is_one(const gr_series_t x, gr_ctx_t ctx);
+truth_t gr_series_is_scalar(const gr_series_t x, gr_ctx_t ctx);
+truth_t gr_series_is_integer(const gr_series_t x, gr_ctx_t ctx);
+truth_t gr_series_is_rational(const gr_series_t x, gr_ctx_t ctx);
 truth_t gr_series_coeff_is_zero(const gr_series_t x, slong i, gr_ctx_t ctx);
 truth_t gr_series_equal(const gr_series_t x, const gr_series_t y, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_series_add(gr_series_t res, const gr_series_t x, const gr_series_t y, gr_ctx_t ctx);
@@ -220,6 +223,9 @@ WARN_UNUSED_RESULT int gr_series_mod_set_fmpz(gr_poly_t res, const fmpz_t c, gr_
 WARN_UNUSED_RESULT int gr_series_mod_set_fmpq(gr_poly_t res, const fmpq_t c, gr_ctx_t ctx);
 truth_t gr_series_mod_is_zero(const gr_poly_t x, gr_ctx_t ctx);
 truth_t gr_series_mod_is_one(const gr_poly_t x, gr_ctx_t ctx);
+truth_t gr_series_mod_is_scalar(const gr_poly_t x, gr_ctx_t ctx);
+truth_t gr_series_mod_is_integer(const gr_poly_t x, gr_ctx_t ctx);
+truth_t gr_series_mod_is_rational(const gr_poly_t x, gr_ctx_t ctx);
 truth_t gr_series_mod_equal(const gr_poly_t x, const gr_poly_t y, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_series_mod_neg(gr_poly_t res, const gr_poly_t x, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_series_mod_add(gr_poly_t res, const gr_poly_t x, const gr_poly_t y, gr_ctx_t ctx);

--- a/src/gr_series/series.c
+++ b/src/gr_series/series.c
@@ -423,6 +423,63 @@ gr_series_is_one(const gr_series_t x, gr_ctx_t ctx)
     return T_UNKNOWN;
 }
 
+truth_t
+gr_series_is_scalar(const gr_series_t x, gr_ctx_t ctx)
+{
+    gr_ctx_struct * cctx = GR_SERIES_ELEM_CTX(ctx);
+    slong err = GR_SERIES_ERROR(x);
+    slong len = GR_SERIES_POLY(x)->length;
+    slong known_len;
+    truth_t is_scalar;
+
+    if (err == 0)
+        return T_UNKNOWN;
+
+    known_len = FLINT_MIN(err, len);
+    is_scalar = known_len <= 1 ? T_TRUE :
+        _gr_vec_is_zero(GR_ENTRY(GR_SERIES_POLY(x)->coeffs, 1, cctx->sizeof_elem),
+                        known_len - 1, cctx);
+
+    if (is_scalar == T_FALSE || err == GR_SERIES_ERR_EXACT)
+        return is_scalar;
+
+    return T_UNKNOWN;
+}
+
+static truth_t
+_gr_series_is_integer_or_rational(const gr_series_t x, gr_ctx_t ctx, int rational)
+{
+    gr_ctx_struct * cctx = GR_SERIES_ELEM_CTX(ctx);
+    slong len = GR_SERIES_POLY(x)->length;
+    truth_t is_scalar, is_constant;
+
+    is_scalar = gr_series_is_scalar(x, ctx);
+
+    if (is_scalar == T_FALSE)
+        return T_FALSE;
+
+    if (gr_ctx_is_finite_characteristic(ctx) != T_FALSE)
+        return T_UNKNOWN;
+
+    is_constant = len == 0 ? T_TRUE :
+        (rational ? gr_is_rational(GR_SERIES_POLY(x)->coeffs, cctx) :
+                    gr_is_integer(GR_SERIES_POLY(x)->coeffs, cctx));
+
+    return truth_and(is_scalar, is_constant);
+}
+
+truth_t
+gr_series_is_integer(const gr_series_t x, gr_ctx_t ctx)
+{
+    return _gr_series_is_integer_or_rational(x, ctx, 0);
+}
+
+truth_t
+gr_series_is_rational(const gr_series_t x, gr_ctx_t ctx)
+{
+    return _gr_series_is_integer_or_rational(x, ctx, 1);
+}
+
 
 truth_t
 gr_series_equal(const gr_series_t x, const gr_series_t y, gr_ctx_t ctx)
@@ -2202,6 +2259,8 @@ gr_method_tab_input _gr_series_methods_input[] =
     {GR_METHOD_ONE,         (gr_funcptr) gr_series_one},
     {GR_METHOD_IS_ZERO,     (gr_funcptr) gr_series_is_zero},
     {GR_METHOD_IS_ONE,      (gr_funcptr) gr_series_is_one},
+    {GR_METHOD_IS_INTEGER,  (gr_funcptr) gr_series_is_integer},
+    {GR_METHOD_IS_RATIONAL, (gr_funcptr) gr_series_is_rational},
     {GR_METHOD_EQUAL,       (gr_funcptr) gr_series_equal},
     {GR_METHOD_GEN,         (gr_funcptr) gr_series_gen},
     {GR_METHOD_GENS,        (gr_funcptr) gr_generic_gens_single},
@@ -2316,4 +2375,3 @@ gr_ctx_init_gr_series(gr_ctx_t ctx, gr_ctx_t base_ring, slong n)
 {
     gr_series_ctx_init(ctx, base_ring, n);
 }
-

--- a/src/gr_series/series_mod.c
+++ b/src/gr_series/series_mod.c
@@ -274,6 +274,42 @@ truth_t gr_series_mod_is_one(const gr_poly_t x, gr_ctx_t ctx)
     return (GR_SERIES_MOD_N(ctx) == 0) ? T_TRUE : gr_poly_is_one(x, GR_SERIES_MOD_ELEM_CTX(ctx));
 }
 
+truth_t gr_series_mod_is_scalar(const gr_poly_t x, gr_ctx_t ctx)
+{
+    return gr_poly_is_scalar(x, GR_SERIES_MOD_ELEM_CTX(ctx));
+}
+
+static truth_t
+_gr_series_mod_is_integer_or_rational(const gr_poly_t x, gr_ctx_t ctx, int rational)
+{
+    gr_ctx_struct * cctx = GR_SERIES_MOD_ELEM_CTX(ctx);
+    truth_t is_scalar;
+
+    is_scalar = gr_series_mod_is_scalar(x, ctx);
+
+    if (is_scalar == T_FALSE)
+        return T_FALSE;
+
+    if (gr_ctx_is_finite_characteristic(ctx) != T_FALSE)
+        return T_UNKNOWN;
+
+    if (x->length == 0)
+        return T_TRUE;
+
+    return truth_and(is_scalar,
+        rational ? gr_is_rational(x->coeffs, cctx) : gr_is_integer(x->coeffs, cctx));
+}
+
+truth_t gr_series_mod_is_integer(const gr_poly_t x, gr_ctx_t ctx)
+{
+    return _gr_series_mod_is_integer_or_rational(x, ctx, 0);
+}
+
+truth_t gr_series_mod_is_rational(const gr_poly_t x, gr_ctx_t ctx)
+{
+    return _gr_series_mod_is_integer_or_rational(x, ctx, 1);
+}
+
 truth_t gr_series_mod_equal(const gr_poly_t x, const gr_poly_t y, gr_ctx_t ctx)
 {
     return gr_poly_equal(x, y, GR_SERIES_MOD_ELEM_CTX(ctx));
@@ -483,6 +519,8 @@ gr_method_tab_input _gr_series_mod_methods_input[] =
     {GR_METHOD_ONE,         (gr_funcptr) gr_series_mod_one},
     {GR_METHOD_IS_ZERO,     (gr_funcptr) gr_series_mod_is_zero},
     {GR_METHOD_IS_ONE,      (gr_funcptr) gr_series_mod_is_one},
+    {GR_METHOD_IS_INTEGER,  (gr_funcptr) gr_series_mod_is_integer},
+    {GR_METHOD_IS_RATIONAL, (gr_funcptr) gr_series_mod_is_rational},
     {GR_METHOD_EQUAL,       (gr_funcptr) gr_series_mod_equal},
     {GR_METHOD_GEN,         (gr_funcptr) gr_series_mod_gen},
     {GR_METHOD_GENS,        (gr_funcptr) gr_generic_gens_single},
@@ -592,4 +630,3 @@ gr_ctx_init_series_mod_gr_poly(gr_ctx_t ctx, gr_ctx_t base_ring, slong n)
 {
     gr_series_mod_ctx_init(ctx, base_ring, n);
 }
-

--- a/src/gr_special/test/t-chebyshev.c
+++ b/src/gr_special/test/t-chebyshev.c
@@ -28,7 +28,7 @@ test_chebyshev_fmpz_rec1(flint_rand_t state)
     fmpz_init(n1);
     fmpz_init(n2);
 
-    if (gr_ctx_has_real_prec(ctx) == T_TRUE || gr_ctx_is_finite_characteristic(ctx) == T_TRUE)
+    if (gr_ctx_has_real_prec(ctx) == T_TRUE || gr_ctx_is_finite(ctx) == T_TRUE)
         fmpz_randtest(n, state, 100);
     else
         fmpz_randtest(n, state, 5);

--- a/src/nfloat.h
+++ b/src/nfloat.h
@@ -488,6 +488,8 @@ int nfloat_complex_neg_one(nfloat_complex_ptr res, gr_ctx_t ctx);
 truth_t nfloat_complex_is_zero(nfloat_complex_srcptr x, gr_ctx_t ctx);
 truth_t nfloat_complex_is_one(nfloat_complex_srcptr x, gr_ctx_t ctx);
 truth_t nfloat_complex_is_neg_one(nfloat_complex_srcptr x, gr_ctx_t ctx);
+truth_t nfloat_complex_is_integer(nfloat_complex_srcptr x, gr_ctx_t ctx);
+truth_t nfloat_complex_is_rational(nfloat_complex_srcptr x, gr_ctx_t ctx);
 int nfloat_complex_i(nfloat_complex_ptr res, gr_ctx_t ctx);
 int nfloat_complex_pi(nfloat_complex_ptr res, gr_ctx_t ctx);
 int nfloat_complex_conj(nfloat_complex_ptr res, nfloat_complex_srcptr x, gr_ctx_t ctx);

--- a/src/nfloat.h
+++ b/src/nfloat.h
@@ -200,6 +200,8 @@ nfloat_is_zero(nfloat_srcptr x, gr_ctx_t FLINT_UNUSED(ctx))
 
 truth_t nfloat_is_one(nfloat_srcptr x, gr_ctx_t ctx);
 truth_t nfloat_is_neg_one(nfloat_srcptr x, gr_ctx_t ctx);
+truth_t nfloat_is_integer(nfloat_srcptr x, gr_ctx_t ctx);
+truth_t nfloat_is_rational(nfloat_srcptr x, gr_ctx_t ctx);
 
 int nfloat_set_ui(nfloat_ptr res, ulong x, gr_ctx_t ctx);
 int nfloat_set_si(nfloat_ptr res, slong x, gr_ctx_t ctx);

--- a/src/nfloat/complex.c
+++ b/src/nfloat/complex.c
@@ -218,8 +218,8 @@ nfloat_complex_is_neg_one(nfloat_complex_srcptr x, gr_ctx_t ctx)
                      nfloat_is_zero(NFLOAT_COMPLEX_IM(x, ctx), ctx));
 }
 
-static truth_t
-_nfloat_complex_is_integer(nfloat_complex_srcptr x, gr_ctx_t ctx)
+truth_t
+nfloat_complex_is_integer(nfloat_complex_srcptr x, gr_ctx_t ctx)
 {
     truth_t real;
 
@@ -230,8 +230,8 @@ _nfloat_complex_is_integer(nfloat_complex_srcptr x, gr_ctx_t ctx)
     return truth_and(real, nfloat_is_zero(NFLOAT_COMPLEX_IM(x, ctx), ctx));
 }
 
-static truth_t
-_nfloat_complex_is_rational(nfloat_complex_srcptr x, gr_ctx_t ctx)
+truth_t
+nfloat_complex_is_rational(nfloat_complex_srcptr x, gr_ctx_t ctx)
 {
     truth_t is_rational;
 
@@ -1924,8 +1924,8 @@ gr_method_tab_input _nfloat_complex_methods_input[] =
     {GR_METHOD_IS_ZERO,         (gr_funcptr) nfloat_complex_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) nfloat_complex_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) nfloat_complex_is_neg_one},
-    {GR_METHOD_IS_INTEGER,      (gr_funcptr) _nfloat_complex_is_integer},
-    {GR_METHOD_IS_RATIONAL,     (gr_funcptr) _nfloat_complex_is_rational},
+    {GR_METHOD_IS_INTEGER,      (gr_funcptr) nfloat_complex_is_integer},
+    {GR_METHOD_IS_RATIONAL,     (gr_funcptr) nfloat_complex_is_rational},
     {GR_METHOD_EQUAL,           (gr_funcptr) nfloat_complex_equal},
     {GR_METHOD_SET,             (gr_funcptr) nfloat_complex_set},
     {GR_METHOD_SET_SI,          (gr_funcptr) nfloat_complex_set_si},

--- a/src/nfloat/complex.c
+++ b/src/nfloat/complex.c
@@ -218,6 +218,31 @@ nfloat_complex_is_neg_one(nfloat_complex_srcptr x, gr_ctx_t ctx)
                      nfloat_is_zero(NFLOAT_COMPLEX_IM(x, ctx), ctx));
 }
 
+static truth_t
+_nfloat_complex_is_integer(nfloat_complex_srcptr x, gr_ctx_t ctx)
+{
+    truth_t real;
+
+    real = nfloat_is_integer(NFLOAT_COMPLEX_RE(x, ctx), ctx);
+    if (real == T_FALSE)
+        return T_FALSE;
+
+    return truth_and(real, nfloat_is_zero(NFLOAT_COMPLEX_IM(x, ctx), ctx));
+}
+
+static truth_t
+_nfloat_complex_is_rational(nfloat_complex_srcptr x, gr_ctx_t ctx)
+{
+    truth_t is_rational;
+
+    is_rational = nfloat_is_rational(NFLOAT_COMPLEX_RE(x, ctx), ctx);
+    if (is_rational == T_FALSE)
+        return T_FALSE;
+
+    return truth_and(is_rational,
+                     nfloat_is_zero(NFLOAT_COMPLEX_IM(x, ctx), ctx));
+}
+
 int
 nfloat_complex_i(nfloat_complex_ptr res, gr_ctx_t ctx)
 {
@@ -1899,6 +1924,8 @@ gr_method_tab_input _nfloat_complex_methods_input[] =
     {GR_METHOD_IS_ZERO,         (gr_funcptr) nfloat_complex_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) nfloat_complex_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) nfloat_complex_is_neg_one},
+    {GR_METHOD_IS_INTEGER,      (gr_funcptr) _nfloat_complex_is_integer},
+    {GR_METHOD_IS_RATIONAL,     (gr_funcptr) _nfloat_complex_is_rational},
     {GR_METHOD_EQUAL,           (gr_funcptr) nfloat_complex_equal},
     {GR_METHOD_SET,             (gr_funcptr) nfloat_complex_set},
     {GR_METHOD_SET_SI,          (gr_funcptr) nfloat_complex_set_si},

--- a/src/nfloat/ctx.c
+++ b/src/nfloat/ctx.c
@@ -55,6 +55,8 @@ gr_method_tab_input _nfloat_methods_input[] =
     {GR_METHOD_IS_ZERO,         (gr_funcptr) nfloat_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) nfloat_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) nfloat_is_neg_one},
+    {GR_METHOD_IS_INTEGER,      (gr_funcptr) nfloat_is_integer},
+    {GR_METHOD_IS_RATIONAL,     (gr_funcptr) nfloat_is_rational},
     {GR_METHOD_EQUAL,           (gr_funcptr) nfloat_equal},
     {GR_METHOD_SET,             (gr_funcptr) nfloat_set},
     {GR_METHOD_SET_SI,          (gr_funcptr) nfloat_set_si},

--- a/src/nfloat/nfloat.c
+++ b/src/nfloat/nfloat.c
@@ -695,6 +695,45 @@ nfloat_get_fmpz(fmpz_t res, nfloat_srcptr x, gr_ctx_t ctx)
     }
 }
 
+truth_t
+nfloat_is_integer(nfloat_srcptr x, gr_ctx_t ctx)
+{
+    slong exp, n;
+    nn_srcptr d;
+
+    if (NFLOAT_IS_SPECIAL(x))
+    {
+        if (NFLOAT_IS_NAN(x))
+            return T_UNKNOWN;
+
+        return NFLOAT_IS_ZERO(x) ? T_TRUE : T_FALSE;
+    }
+
+    exp = NFLOAT_EXP(x);
+    if (exp <= 0)
+        return T_FALSE;
+
+    d = NFLOAT_D(x);
+    n = NFLOAT_CTX_NLIMBS(ctx);
+
+    while (d[0] == 0)
+    {
+        d++;
+        n--;
+    }
+
+    return n * FLINT_BITS - flint_ctz(d[0]) <= exp ? T_TRUE : T_FALSE;
+}
+
+truth_t
+nfloat_is_rational(nfloat_srcptr x, gr_ctx_t ctx)
+{
+    if (NFLOAT_IS_NAN(x))
+        return T_UNKNOWN;
+
+    return NFLOAT_IS_INF(x) ? T_FALSE : T_TRUE;
+}
+
 int
 nfloat_neg(nfloat_ptr res, nfloat_srcptr x, gr_ctx_t ctx)
 {

--- a/src/nfloat/test/t-nfloat.c
+++ b/src/nfloat/test/t-nfloat.c
@@ -32,6 +32,37 @@ TEST_FUNCTION_START(nfloat, state)
         gr_test_floating_point(ctx, 100 * flint_test_multiplier(), 0);
 
         {
+            gr_ptr x;
+            fmpz_t z;
+            slong i;
+
+            x = gr_heap_init(ctx);
+            fmpz_init(z);
+
+            for (i = 0; i < 100 * flint_test_multiplier(); i++)
+            {
+                int status;
+                truth_t is_integer;
+
+                GR_MUST_SUCCEED(gr_randtest(x, state, ctx));
+                status = nfloat_get_fmpz(z, x, ctx);
+                is_integer = nfloat_is_integer(x, ctx);
+
+                if ((status == GR_SUCCESS && is_integer != T_TRUE) ||
+                    ((status & GR_DOMAIN) && is_integer != T_FALSE))
+                {
+                    flint_printf("FAIL: nfloat_is_integer\n");
+                    flint_printf("x = "); gr_println(x, ctx);
+                    flint_printf("status = %d, is_integer = %{truth}\n", status, is_integer);
+                    flint_abort();
+                }
+            }
+
+            gr_heap_clear(x, ctx);
+            fmpz_clear(z);
+        }
+
+        {
             gr_ptr x, x2;
             slong i;
 

--- a/src/padic_radix.h
+++ b/src/padic_radix.h
@@ -113,6 +113,8 @@ truth_t padic_radix_is_square(const padic_radix_t x, gr_ctx_t ctx);
 truth_t padic_radix_is_zero(const padic_radix_t x, gr_ctx_t ctx);
 truth_t padic_radix_is_one(const padic_radix_t x, gr_ctx_t ctx);
 truth_t padic_radix_is_neg_one(const padic_radix_t x, gr_ctx_t ctx);
+truth_t padic_radix_is_integer(const padic_radix_t x, gr_ctx_t ctx);
+truth_t padic_radix_is_rational(const padic_radix_t x, gr_ctx_t ctx);
 truth_t padic_radix_is_invertible(const padic_radix_t x, gr_ctx_t ctx);
 truth_t padic_radix_equal(const padic_radix_t x, const padic_radix_t y, gr_ctx_t ctx);
 

--- a/src/padic_radix/padic.c
+++ b/src/padic_radix/padic.c
@@ -1777,10 +1777,13 @@ padic_radix_is_neg_one(const padic_radix_t x, gr_ctx_t ctx)
 truth_t
 padic_radix_is_integer(const padic_radix_t x, gr_ctx_t ctx)
 {
+    if (x->u.size != 0 && x->v < 0)
+        return T_FALSE;
+
     if (x->N != PADIC_RADIX_EXACT)
         return T_UNKNOWN;
 
-    return x->v >= 0 ? T_TRUE : T_FALSE;
+    return T_TRUE;
 }
 
 truth_t

--- a/src/padic_radix/padic.c
+++ b/src/padic_radix/padic.c
@@ -524,6 +524,11 @@ padic_radix_get_fmpz(fmpz_t res, const padic_radix_t x, gr_ctx_t ctx)
     if (x->v > ctx->size_limit)
         return GR_UNABLE;
 
+#if FLINT_BITS >= 64
+    if (x->v >= ((slong) 1 << 32))
+        return GR_UNABLE;
+#endif
+
     radix_integer_get_fmpz(res, &x->u, radix);
 
     if (x->v != 0)
@@ -1770,6 +1775,21 @@ padic_radix_is_neg_one(const padic_radix_t x, gr_ctx_t ctx)
 }
 
 truth_t
+padic_radix_is_integer(const padic_radix_t x, gr_ctx_t ctx)
+{
+    if (x->N != PADIC_RADIX_EXACT)
+        return T_UNKNOWN;
+
+    return x->v >= 0 ? T_TRUE : T_FALSE;
+}
+
+truth_t
+padic_radix_is_rational(const padic_radix_t x, gr_ctx_t ctx)
+{
+    return x->N == PADIC_RADIX_EXACT ? T_TRUE : T_UNKNOWN;
+}
+
+truth_t
 padic_radix_equal(const padic_radix_t x, const padic_radix_t y, gr_ctx_t ctx)
 {
     radix_struct * radix = PADIC_RADIX_CTX_RADIX(ctx);
@@ -2001,6 +2021,8 @@ gr_method_tab_input _padic_radix_methods_input[] =
     {GR_METHOD_IS_ZERO,         (gr_funcptr) padic_radix_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) padic_radix_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) padic_radix_is_neg_one},
+    {GR_METHOD_IS_INTEGER,      (gr_funcptr) padic_radix_is_integer},
+    {GR_METHOD_IS_RATIONAL,     (gr_funcptr) padic_radix_is_rational},
     {GR_METHOD_IS_INVERTIBLE,   (gr_funcptr) padic_radix_is_invertible},
     {GR_METHOD_EQUAL,           (gr_funcptr) padic_radix_equal},
     {GR_METHOD_SET,             (gr_funcptr) padic_radix_set},
@@ -2074,7 +2096,7 @@ gr_ctx_init_padic_radix_randtest(gr_ctx_t ctx, flint_rand_t state, slong maxprec
 {
     ulong p = n_randtest_prime(state, 0);
     slong prec_abs, prec_rel;
-    int flags = 0;
+    int flags = 0, status;
 
     if (n_randint(state, 2))
         flags |= PADIC_RADIX_SIGNED;
@@ -2102,11 +2124,11 @@ gr_ctx_init_padic_radix_randtest(gr_ctx_t ctx, flint_rand_t state, slong maxprec
     if (n_randint(state, 2))
         flags |= PADIC_RADIX_TEST_LIMITS;
 
+    status = gr_ctx_init_padic_radix(ctx, p, prec_rel, prec_abs, flags);
+
     /* allow e.g. get_fmpz roundtrip to return unable for huge test values */
     if (flags & PADIC_RADIX_TEST_LIMITS)
         ctx->size_limit = (1 << 16);
 
-    return gr_ctx_init_padic_radix(ctx, p, prec_rel, prec_abs, flags);
+    return status;
 }
-
-

--- a/src/padic_radix/test/t-padic.c
+++ b/src/padic_radix/test/t-padic.c
@@ -199,10 +199,28 @@ TEST_FUNCTION_START(padic_radix, state)
             padic_radix_clear(r2, ctx);
         }
 
+        /* A known negative-valuation digit proves non-integrality even when
+           the higher p-adic digits are inexact. */
+        {
+            padic_radix_t x;
+
+            padic_radix_init(x, ctx);
+            radix_integer_one(&x->u, PADIC_RADIX_CTX_RADIX(ctx));
+            x->v = -1 - (slong) n_randint(state, 20);
+            x->N = x->v + 1 + (slong) n_randint(state, 20);
+
+            if (padic_radix_is_integer(x, ctx) != T_FALSE)
+            {
+                flint_printf("FAIL: inexact p-adic with negative valuation is not an integer\n");
+                flint_printf("x = "); gr_println(x, ctx);
+                flint_abort();
+            }
+
+            padic_radix_clear(x, ctx);
+        }
 
         gr_ctx_clear(ctx);
     }
 
     TEST_FUNCTION_END(state);
 }
-

--- a/src/radix/integer.c
+++ b/src/radix/integer.c
@@ -1997,6 +1997,16 @@ static int _gr_radix_integer_get_fmpz(fmpz_t res, const radix_integer_t x, gr_ct
     return GR_SUCCESS;
 }
 
+static truth_t _gr_radix_integer_is_integer(const radix_integer_t x, gr_ctx_t ctx)
+{
+    return T_TRUE;
+}
+
+static truth_t _gr_radix_integer_is_rational(const radix_integer_t x, gr_ctx_t ctx)
+{
+    return T_TRUE;
+}
+
 static int _gr_radix_integer_get_ui(ulong * res, const radix_integer_t x, gr_ctx_t ctx)
 {
     if (x->size < 0)
@@ -2211,6 +2221,8 @@ gr_method_tab_input _gr_radix_integer_methods_input[] =
     {GR_METHOD_IS_ZERO,         (gr_funcptr) _gr_radix_integer_is_zero},
     {GR_METHOD_IS_ONE,          (gr_funcptr) _gr_radix_integer_is_one},
     {GR_METHOD_IS_NEG_ONE,      (gr_funcptr) _gr_radix_integer_is_neg_one},
+    {GR_METHOD_IS_INTEGER,      (gr_funcptr) _gr_radix_integer_is_integer},
+    {GR_METHOD_IS_RATIONAL,     (gr_funcptr) _gr_radix_integer_is_rational},
     {GR_METHOD_EQUAL,           (gr_funcptr) _gr_radix_integer_equal},
     {GR_METHOD_SET,             (gr_funcptr) _gr_radix_integer_set},
     {GR_METHOD_SET_SI,          (gr_funcptr) _gr_radix_integer_set_si},

--- a/src/radix/sqrt.c
+++ b/src/radix/sqrt.c
@@ -810,8 +810,9 @@ radix_sqrt(nn_ptr s, nn_srcptr a, slong an, const radix_t radix)
     if (an == 1)
     {
         ulong s0 = n_sqrt(a[0]);
+        int exact = s0 * s0 == a[0];
         s[0] = s0;
-        return s0 * s0 == a[0];
+        return exact;
     }
 
     sn = (an + 1) / 2;


### PR DESCRIPTION
The `gr_is_integer` and `gr_is_rational` functions have been documented since maybe FLINT 3.3 or some time but the functions did not exist.

I'm not sure if it is better to add the functions or just to remove them from the docs but this PR adds the functions with generic implementations based on `gr_get_fmpz` and `gr_get_fmpq`.