### PR TITLE
Fix compiler warnings from gcc on Linux x86-64 without fft_small

### DIFF
--- a/dev/check_examples.sh
+++ b/dev/check_examples.sh
@@ -247,6 +247,11 @@ then
         echo "FAIL"
         exit 1
     fi
+    if test "$res" = "mfcoefs requires the fft_small module.  Failing silently.";
+    then
+        echo "SKIPPED"
+        exit 0
+    fi
     echo "$res" | perl -0ne 'if (/2 2  -536 -528 -907 322/) { $found=1; last } END { exit !$found }'
     if test "$?" != "0";
     then

--- a/src/fmpz_mat/mul_fft_small.c
+++ b/src/fmpz_mat/mul_fft_small.c
@@ -64,6 +64,8 @@
     accepts any input it can compute.
 */
 
+#if FLINT_HAVE_FFT_SMALL
+
 static int
 _set_entry(gr_ptr elem, const fmpz * e, gr_ctx_t tctx)
 {
@@ -133,6 +135,8 @@ _export_entry(fmpz * e, gr_ptr acc, slong lo_limbs, int add_into,
     }
     return 1;
 }
+
+#endif
 
 static int
 _fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B,

--- a/src/fmpz_mod/pow.c
+++ b/src/fmpz_mod/pow.c
@@ -52,7 +52,7 @@ _fmpz_mod_pow_fmpz(fmpz_t res, const fmpz_t x, const fmpz_t e, const fmpz_mod_ct
 
 #else
 
-void
+static void
 _fmpz_mod_pow_fmpz(fmpz_t res, const fmpz_t x, const fmpz_t e, const fmpz_mod_ctx_t ctx)
 {
     fmpz_powm(res, x, e, ctx->n);
@@ -127,7 +127,7 @@ _fmpz_mod_pow_ui(fmpz_t res, const fmpz_t x, ulong e, const fmpz_mod_ctx_t ctx)
 
 #else
 
-void
+static void
 _fmpz_mod_pow_ui(fmpz_t res, const fmpz_t x, ulong e, const fmpz_mod_ctx_t ctx)
 {
     fmpz_powm_ui(res, x, e, ctx->n);

--- a/src/fmpz_poly/mulmid_classical_fft_small.c
+++ b/src/fmpz_poly/mulmid_classical_fft_small.c
@@ -18,6 +18,8 @@
 #include "fft_small.h"
 #include "gr.h"
 
+#if FLINT_HAVE_FFT_SMALL
+
 static nn_srcptr
 _coeff_limbs(const fmpz * f, ulong * scratch, slong * n, int * sgn)
 {
@@ -79,6 +81,8 @@ _get_coeff(fmpz * f, gr_ptr elem, gr_ctx_t ctx)
     _fmpz_demote_val(f);
     return GR_SUCCESS;
 }
+
+#endif
 
 int
 _fmpz_poly_mulmid_classical_fft_small(fmpz * res,

--- a/src/fmpz_poly/test/t-mul_toom_scalar.c
+++ b/src/fmpz_poly/test/t-mul_toom_scalar.c
@@ -27,7 +27,7 @@ TEST_FUNCTION_START(fmpz_poly_mul_toom_scalar, state)
         {
             slong n = len1 + len2 - 1;
 
-            if (n > (FLINT_BITS == 64) ? 20 : 13)
+            if (n > ((FLINT_BITS == 64) ? 20 : 13))
                 continue;
 
             for (i = 0; i < 10 * flint_test_multiplier(); i++)
@@ -71,7 +71,7 @@ TEST_FUNCTION_START(fmpz_poly_mul_toom_scalar, state)
         slong len = 1 + n_randint(state, 10);
         slong n = 2 * len - 1;
 
-        if (n > (FLINT_BITS == 64) ? 20 : 13)
+        if (n > ((FLINT_BITS == 64) ? 20 : 13))
             continue;
 
         a = _fmpz_vec_init(len);
@@ -144,7 +144,7 @@ TEST_FUNCTION_START(fmpz_poly_mul_toom_scalar, state)
             slong n = len1 + len2 - 1;
             fmpz *a, *b, *res;
 
-            if (n <= (FLINT_BITS == 64) ? 20 : 13)
+            if (n <= ((FLINT_BITS == 64) ? 20 : 13))
                 continue;
 
             a = _fmpz_vec_init(len1);

--- a/src/gr_ore_poly/sigma_delta.c
+++ b/src/gr_ore_poly/sigma_delta.c
@@ -1,9 +1,6 @@
 #include "gr_poly.h"
 #include "gr_ore_poly.h"
 
-/* gr_poly/compose.c */
-int _gr_poly_inflate(gr_ptr poly, slong len, slong n, gr_ctx_t ctx);
-
 int
 sigma_delta_unable(gr_ptr FLINT_UNUSED(sigma), gr_ptr FLINT_UNUSED(delta),
                    gr_srcptr FLINT_UNUSED(a),

--- a/src/gr_poly.h
+++ b/src/gr_poly.h
@@ -459,6 +459,7 @@ WARN_UNUSED_RESULT int _gr_poly_compose_horner(gr_ptr res, gr_srcptr poly1, slon
 WARN_UNUSED_RESULT int gr_poly_compose_horner(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int _gr_poly_compose_divconquer(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_compose_divconquer(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int _gr_poly_inflate(gr_ptr poly, slong len, slong n, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int _gr_poly_compose(gr_ptr res, gr_srcptr poly1, slong len1, gr_srcptr poly2, slong len2, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_compose(gr_poly_t res, const gr_poly_t poly1, const gr_poly_t poly2, gr_ctx_t ctx);
 

--- a/src/mpn_extras.h
+++ b/src/mpn_extras.h
@@ -475,7 +475,7 @@ mp_limb_t mpn_rsh1sub_n(mp_ptr, mp_srcptr, mp_srcptr, mp_size_t);
 # define FLINT_MPN_MUL_FUNC_TAB_WIDTH 17
 # define FLINT_MPN_SQR_FUNC_TAB_WIDTH 14
 
-# define FLINT_HAVE_MUL_FUNC(n, m) ((n) <= 16 && (m) < FLINT_MPN_MUL_FUNC_TAB_WIDTH)
+# define FLINT_HAVE_MUL_FUNC(n, m) ((n) <= 16)
 # define FLINT_HAVE_MUL_N_FUNC(n) ((n) <= 16)
 # define FLINT_HAVE_SQR_FUNC(n) ((n) <= FLINT_MPN_SQR_FUNC_TAB_WIDTH)
 
@@ -500,8 +500,7 @@ mp_limb_t flint_mpn_mul_2(mp_ptr, mp_srcptr, mp_size_t, mp_srcptr);
 # define FLINT_MPN_MUL_FUNC_TAB_WIDTH 8
 # define FLINT_MPN_SQR_FUNC_TAB_WIDTH 0
 
-# define FLINT_HAVE_MUL_FUNC(n, m) ((m) < FLINT_MPN_MUL_FUNC_TAB_WIDTH && \
-                                    ((n) <= 7 || ((n) <= 14 && (m) == 1)))
+# define FLINT_HAVE_MUL_FUNC(n, m) ((n) <= 7 || ((n) <= 14 && (m) == 1))
 # define FLINT_HAVE_MUL_N_FUNC(n) ((n) <= 7)
 # define FLINT_HAVE_SQR_FUNC(n) (0)
 
@@ -539,6 +538,9 @@ flint_mpn_mul(mp_ptr r, mp_srcptr x, mp_size_t xn, mp_srcptr y, mp_size_t yn)
     FLINT_ASSERT(yn >= 1);
     FLINT_ASSERT(r != x);
     FLINT_ASSERT(r != y);
+
+    if (yn > xn)
+        FLINT_UNREACHABLE;
 
     if (FLINT_MUL_USE_FUNC_TAB && FLINT_HAVE_MUL_FUNC(xn, yn))
         return FLINT_MPN_MUL_HARD(r, x, xn, y, yn);

--- a/src/mpn_extras.h
+++ b/src/mpn_extras.h
@@ -475,7 +475,7 @@ mp_limb_t mpn_rsh1sub_n(mp_ptr, mp_srcptr, mp_srcptr, mp_size_t);
 # define FLINT_MPN_MUL_FUNC_TAB_WIDTH 17
 # define FLINT_MPN_SQR_FUNC_TAB_WIDTH 14
 
-# define FLINT_HAVE_MUL_FUNC(n, m) ((n) <= 16)
+# define FLINT_HAVE_MUL_FUNC(n, m) ((n) <= 16 && (m) < FLINT_MPN_MUL_FUNC_TAB_WIDTH)
 # define FLINT_HAVE_MUL_N_FUNC(n) ((n) <= 16)
 # define FLINT_HAVE_SQR_FUNC(n) ((n) <= FLINT_MPN_SQR_FUNC_TAB_WIDTH)
 
@@ -500,7 +500,8 @@ mp_limb_t flint_mpn_mul_2(mp_ptr, mp_srcptr, mp_size_t, mp_srcptr);
 # define FLINT_MPN_MUL_FUNC_TAB_WIDTH 8
 # define FLINT_MPN_SQR_FUNC_TAB_WIDTH 0
 
-# define FLINT_HAVE_MUL_FUNC(n, m) ((n) <= 7 || ((n) <= 14 && (m) == 1))
+# define FLINT_HAVE_MUL_FUNC(n, m) ((m) < FLINT_MPN_MUL_FUNC_TAB_WIDTH && \
+                                    ((n) <= 7 || ((n) <= 14 && (m) == 1)))
 # define FLINT_HAVE_MUL_N_FUNC(n) ((n) <= 7)
 # define FLINT_HAVE_SQR_FUNC(n) (0)
 

--- a/src/mpn_extras/sqrhigh_basecase.c
+++ b/src/mpn_extras/sqrhigh_basecase.c
@@ -45,6 +45,7 @@ static mp_limb_t flint_mpn_sqrhigh_2(mp_ptr res, mp_srcptr u)
 {
     mp_limb_t b, low;
     FLINT_MPN_SQR_2X2(res[1], res[0], low, b, u[1], u[0]);
+    (void) b;
     return low;
 }
 

--- a/src/padic_radix/log.c
+++ b/src/padic_radix/log.c
@@ -70,7 +70,6 @@ static int
 _padic_radix_log_wrapper(padic_radix_t res, const padic_radix_t x, int algorithm, gr_ctx_t ctx)
 {
     radix_struct * radix = PADIC_RADIX_CTX_RADIX(ctx);
-    ulong p = GR_PADIC_RADIX_CTX(ctx)->p;
     slong thr = 1;    /* log converges for valuation >= 1 for every p */
     slong Nx = x->N;
     slong prec_abs = PADIC_RADIX_CTX_PREC_ABS(ctx);

--- a/src/qsieve/factor.c
+++ b/src/qsieve/factor.c
@@ -109,14 +109,6 @@ qsieve_refine_is_complete(const fmpz_t n, fmpz * facs, slong num_facs)
    return complete;
 }
 
-static int compare_facs(const void * a, const void * b)
-{
-   fmpz * x = (fmpz *) a;
-   fmpz * y = (fmpz *) b;
-
-   return fmpz_cmp(x, y);
-}
-
 /*
    Finds at least one nontrivial factor of n using the self initialising
    multiple polynomial quadratic sieve with single large prime variation,
@@ -598,4 +590,3 @@ void qsieve_factor(fmpz_factor_t factors, const fmpz_t n)
         qsieve_tune[i][4],  /* sieve_size   */
         qsieve_tune[i][5]); /* sieve_bits   */
 }
-

--- a/src/qsieve/large_prime_variant.c
+++ b/src/qsieve/large_prime_variant.c
@@ -21,6 +21,13 @@
 #define HASH_MULT (2654435761U)       /* hash function, taken from 'msieve' */
 #define HASH(a) ((ulong)((((unsigned int) a) * HASH_MULT) >> qs_inf->hash_shift))
 
+static void
+_qsieve_read(void * data, size_t size, size_t count, FILE * file)
+{
+    if (fread(data, size, count, file) != count)
+        flint_throw(FLINT_ERROR, "Failed to read relation data\n");
+}
+
 /******************************************************************************
  *
  *  Some helper function, used for debugging
@@ -194,22 +201,22 @@ relation_t qsieve_parse_relation(qs_t qs_inf)
 
     /* NOTE: We can use qs_inf->small_primes here instead of reading. */
     /* Get number of small primes */
-    fread(&rel.small_primes, sizeof(slong), 1, (FILE *) qs_inf->siqs);
+    _qsieve_read(&rel.small_primes, sizeof(slong), 1, (FILE *) qs_inf->siqs);
 
     /* Get small primes */
     rel.small = flint_malloc(rel.small_primes * sizeof(slong));
-    fread(rel.small, sizeof(slong), rel.small_primes, (FILE *) qs_inf->siqs);
+    _qsieve_read(rel.small, sizeof(slong), rel.small_primes, (FILE *) qs_inf->siqs);
 
     /* Get number of factors */
-    fread(&rel.num_factors, sizeof(slong), 1, (FILE *) qs_inf->siqs);
+    _qsieve_read(&rel.num_factors, sizeof(slong), 1, (FILE *) qs_inf->siqs);
 
     /* Get factors */
     rel.factor = flint_malloc(rel.num_factors * sizeof(fac_t));
-    fread(rel.factor, sizeof(fac_t), rel.num_factors, (FILE *) qs_inf->siqs);
+    _qsieve_read(rel.factor, sizeof(fac_t), rel.num_factors, (FILE *) qs_inf->siqs);
 
     /* Get Ysz */
     Ysz = 0;
-    fread(&Ysz, sizeof(slong), 1, (FILE *) qs_inf->siqs);
+    _qsieve_read(&Ysz, sizeof(slong), 1, (FILE *) qs_inf->siqs);
 
     /* Get Y */
     fmpz_init(rel.Y);
@@ -217,7 +224,7 @@ relation_t qsieve_parse_relation(qs_t qs_inf)
     {
         ulong abslimb = 0;
 
-        fread(&abslimb, sizeof(ulong), 1, (FILE *) qs_inf->siqs);
+        _qsieve_read(&abslimb, sizeof(ulong), 1, (FILE *) qs_inf->siqs);
 
 #if COEFF_MAX != -COEFF_MIN
 # error
@@ -234,7 +241,7 @@ relation_t qsieve_parse_relation(qs_t qs_inf)
         mY->_mp_size = Ysz;
         ptr = FLINT_MPZ_REALLOC(mY, FLINT_ABS(Ysz));
 
-        fread(ptr, sizeof(ulong), FLINT_ABS(Ysz), (FILE *) qs_inf->siqs);
+        _qsieve_read(ptr, sizeof(ulong), FLINT_ABS(Ysz), (FILE *) qs_inf->siqs);
         *rel.Y = PTR_TO_COEFF(mY);
     }
 
@@ -502,7 +509,7 @@ int qsieve_process_relation(qs_t qs_inf)
         if (siqs_eof)
             break;
 
-        fread(&prime, sizeof(ulong), 1, (FILE *) qs_inf->siqs);
+        _qsieve_read(&prime, sizeof(ulong), 1, (FILE *) qs_inf->siqs);
         entry = qsieve_get_table_entry(qs_inf, prime);
 
         if (num_relations == rel_size)


### PR DESCRIPTION
This AI generated PR fixes all compiler warnings that I see with gcc 11 on an older (no fft_small) Linux x86-64 machine.

I don't know if the changes in this PR are good but they show where changes are needed to silence all of the warnings that I see.

The warnings I see otherwise are
```
  In file included from /stuff/current/active/flint/src/mpn_extras/mulhigh_recursive.c:13:
  /stuff/current/active/flint/src/mpn_extras/mulhigh_recursive.c: In function
  ‘_flint_mpn_mulhigh_n_recursive’:
  /stuff/current/active/flint/src/mpn_extras.h:507:76: warning: array subscript 16 is above array
  bounds of ‘mp_limb_t (* const[8])(mp_limb_t *, const mp_limb_t *, const mp_limb_t *)’ {aka ‘long
  unsigned int (* const[8])(long unsigned int *, const long unsigned int *, const long unsigned int
  *)’} [-Warray-bounds]
    507 | # define FLINT_MPN_MUL_HARD(rp, xp, xn, yp, yn) (flint_mpn_mul_func_tab[xn][yn](rp, xp,
    yp))
        |                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
  /stuff/current/active/flint/src/mpn_extras.h:543:16: note: in expansion of macro
  ‘FLINT_MPN_MUL_HARD’
    543 |         return FLINT_MPN_MUL_HARD(r, x, xn, y, yn);
        |                ^~~~~~~~~~~~~~~~~~
  /stuff/current/active/flint/src/mpn_extras.h:521:45: note: while referencing
  ‘flint_mpn_mul_func_tab’
    521 | FLINT_DLL extern const flint_mpn_mul_func_t flint_mpn_mul_func_tab[]
    [FLINT_MPN_MUL_FUNC_TAB_WIDTH];
        |                                             ^~~~~~~~~~~~~~~~~~~~~~

  /stuff/current/active/flint/src/mpn_extras/sqrhigh_basecase.c: In function ‘flint_mpn_sqrhigh_2’:
  /stuff/current/active/flint/src/mpn_extras/sqrhigh_basecase.c:46:15: warning: variable ‘b’ set but
  not used [-Wunused-but-set-variable]
     46 |     mp_limb_t b, low;
        |               ^

  /stuff/current/active/flint/src/fmpz_mat/mul_fft_small.c:90:1: warning: ‘_export_entry’ defined but
  not used [-Wunused-function]
     90 | _export_entry(fmpz * e, gr_ptr acc, slong lo_limbs, int add_into,
        | ^~~~~~~~~~~~~
  /stuff/current/active/flint/src/fmpz_mat/mul_fft_small.c:68:1: warning: ‘_set_entry’ defined but
  not used [-Wunused-function]
     68 | _set_entry(gr_ptr elem, const fmpz * e, gr_ctx_t tctx)
        | ^~~~~~~~~~

  /stuff/current/active/flint/src/fmpz_poly/mulmid_classical_fft_small.c:58:1: warning: ‘_get_coeff’
  defined but not used [-Wunused-function]
     58 | _get_coeff(fmpz * f, gr_ptr elem, gr_ctx_t ctx)
        | ^~~~~~~~~~
  /stuff/current/active/flint/src/fmpz_poly/mulmid_classical_fft_small.c:44:1: warning: ‘_set_coeff’
  defined but not used [-Wunused-function]
     44 | _set_coeff(gr_ptr elem, const fmpz * f, gr_ctx_t ctx)
        | ^~~~~~~~~~

  /stuff/current/active/flint/src/fmpz_mod/pow.c:56:1: warning: no previous prototype for
  ‘_fmpz_mod_pow_fmpz’ [-Wmissing-prototypes]
     56 | _fmpz_mod_pow_fmpz(fmpz_t res, const fmpz_t x, const fmpz_t e, const fmpz_mod_ctx_t ctx)
        | ^~~~~~~~~~~~~~~~~~
  /stuff/current/active/flint/src/fmpz_mod/pow.c:131:1: warning: no previous prototype for
  ‘_fmpz_mod_pow_ui’ [-Wmissing-prototypes]
    131 | _fmpz_mod_pow_ui(fmpz_t res, const fmpz_t x, ulong e, const fmpz_mod_ctx_t ctx)
        | ^~~~~~~~~~~~~~~~

  /stuff/current/active/flint/src/padic_radix/log.c: In function ‘_padic_radix_log_wrapper’:
  /stuff/current/active/flint/src/padic_radix/log.c:73:11: warning: unused variable ‘p’ [-Wunused-
  variable]
     73 |     ulong p = GR_PADIC_RADIX_CTX(ctx)->p;
        |           ^

  /stuff/current/active/flint/src/qsieve/factor.c:112:12: warning: ‘compare_facs’ defined but not
  used [-Wunused-function]
    112 | static int compare_facs(const void * a, const void * b)
        |            ^~~~~~~~~~~~

  /stuff/current/active/flint/src/qsieve/large_prime_variant.c: In function ‘qsieve_parse_relation’:
  /stuff/current/active/flint/src/qsieve/large_prime_variant.c:197:5: warning: ignoring return value
  of ‘fread’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
    197 |     fread(&rel.small_primes, sizeof(slong), 1, (FILE *) qs_inf->siqs);
        |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /stuff/current/active/flint/src/qsieve/large_prime_variant.c:201:5: warning: ignoring return value
  of ‘fread’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
    201 |     fread(rel.small, sizeof(slong), rel.small_primes, (FILE *) qs_inf->siqs);
        |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /stuff/current/active/flint/src/qsieve/large_prime_variant.c:204:5: warning: ignoring return value
  of ‘fread’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
    204 |     fread(&rel.num_factors, sizeof(slong), 1, (FILE *) qs_inf->siqs);
        |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /stuff/current/active/flint/src/qsieve/large_prime_variant.c:208:5: warning: ignoring return value
  of ‘fread’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
    208 |     fread(rel.factor, sizeof(fac_t), rel.num_factors, (FILE *) qs_inf->siqs);
        |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /stuff/current/active/flint/src/qsieve/large_prime_variant.c:212:5: warning: ignoring return value
  of ‘fread’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
    212 |     fread(&Ysz, sizeof(slong), 1, (FILE *) qs_inf->siqs);
        |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /stuff/current/active/flint/src/qsieve/large_prime_variant.c:220:9: warning: ignoring return value
  of ‘fread’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
    220 |         fread(&abslimb, sizeof(ulong), 1, (FILE *) qs_inf->siqs);
        |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /stuff/current/active/flint/src/qsieve/large_prime_variant.c:237:9: warning: ignoring return value
  of ‘fread’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
    237 |         fread(ptr, sizeof(ulong), FLINT_ABS(Ysz), (FILE *) qs_inf->siqs);
        |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  /stuff/current/active/flint/src/qsieve/large_prime_variant.c: In function
  ‘qsieve_process_relation’:
  /stuff/current/active/flint/src/qsieve/large_prime_variant.c:505:9: warning: ignoring return value
  of ‘fread’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
    505 |         fread(&prime, sizeof(ulong), 1, (FILE *) qs_inf->siqs);
        |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  /stuff/current/active/flint/src/gr_poly/compose.c:19:1: warning: no previous prototype for
  ‘_gr_poly_inflate’ [-Wmissing-prototypes]
     19 | _gr_poly_inflate(gr_ptr poly, slong len, slong n, gr_ctx_t ctx)
        | ^~~~~~~~~~~~~~~~
```