### PR TITLE
Disable multithreaded gr_mpoly division functions on arm64

### DIFF
--- a/src/gr_mpoly.h
+++ b/src/gr_mpoly.h
@@ -64,6 +64,21 @@ typedef struct
 typedef gr_ctx_struct gr_mpoly_ctx_struct;
 typedef gr_mpoly_ctx_struct gr_mpoly_ctx_t[1];
 
+/*
+    The chunked producer/consumer pipeline shared by the threaded gr_mpoly
+    division functions communicates between threads through plain volatile
+    fields (the chunk "producer" flags, the chunk list head, and the lengths
+    of the append-only quotient/remainder arrays) rather than through
+    atomics, and is only known to be correct on strongly ordered hardware.
+    Set this to 0 to make every threaded division entry point fall back to
+    its serial counterpart, as fmpz_mpoly/nmod_mpoly already do.
+*/
+#if FLINT_KNOW_STRONG_ORDER
+# define GR_MPOLY_THREADED_DIVISION 1
+#else
+# define GR_MPOLY_THREADED_DIVISION 0
+#endif
+
 #define GR_MPOLY_MCTX(ctx) (((_gr_mpoly_ctx_struct *) (ctx->data))->mctx)
 #define GR_MPOLY_CCTX(ctx) (((_gr_mpoly_ctx_struct *) (ctx->data))->cctx)
 #define GR_MPOLY_VARS(ctx) (((_gr_mpoly_ctx_struct *) (ctx->data))->vars)

--- a/src/gr_mpoly/divides_heap_threaded.c
+++ b/src/gr_mpoly/divides_heap_threaded.c
@@ -2281,7 +2281,8 @@ int gr_mpoly_divides_heap_threaded(
 
     /* fall back to the single-threaded algorithm for small inputs, or when
        the coefficient ring does not allow concurrent operations */
-    if (B->length < 2 || A->length < 2 || gr_ctx_is_threadsafe(cctx) != T_TRUE)
+    if (!GR_MPOLY_THREADED_DIVISION ||
+        B->length < 2 || A->length < 2 || gr_ctx_is_threadsafe(cctx) != T_TRUE)
         return gr_mpoly_divides_heap(Q, A, B, ctx);
 
     thread_limit = A->length/32;

--- a/src/gr_mpoly/divides_heap_threaded.c
+++ b/src/gr_mpoly/divides_heap_threaded.c
@@ -1730,6 +1730,17 @@ void trychunk(worker_arg_t W, divides_heap_chunk_t L)
         ulong * Rexp;
         slong Rlen;
 
+#if FLINT_USES_PTHREAD
+        /* Pairs with the release fence before "next->producer = 1" in the
+           previous chunk's producer.  Having observed L->producer == 1 we
+           are entitled to assume that every quotient term of every earlier
+           chunk is already in Q; that assumption is only sound if this load
+           of L->producer is ordered before the load of Q->length below.
+           The two are plain loads from different addresses, so on weakly
+           ordered hardware they may otherwise be satisfied out of order. */
+        atomic_thread_fence(memory_order_acquire);
+#endif
+
         /* process the remaining quotient terms */
         q_prev_length = Q->length;
 #if FLINT_USES_PTHREAD
@@ -1878,6 +1889,24 @@ void trychunk(worker_arg_t W, divides_heap_chunk_t L)
 
         next = L->next;
         H->length--;
+
+#if FLINT_USES_PTHREAD
+        /* Publish the producer handoff.  Everything this thread wrote before
+           this point -- in particular the gr_mpoly_ts_append calls above,
+           including their stores to H->polyQ->length -- must be visible to
+           the thread that later observes next->producer == 1 (see the
+           matching acquire fence in trychunk).  Without this, on weakly
+           ordered hardware the store to next->producer can become visible
+           to another core before the store to H->polyQ->length, so the next
+           producer starts reducing its chunk against a quotient that is
+           missing our final terms; the leftover terms are then not divisible
+           by B and the division is wrongly reported as inexact (GR_DOMAIN).
+           The release fence in gr_mpoly_ts_append does not help here: it
+           orders the term data before the length store, not the length store
+           before the producer store. */
+        atomic_thread_fence(memory_order_release);
+#endif
+
         H->cur = next;
 
         if (next != NULL)

--- a/src/gr_mpoly/divrem_heap_threaded.c
+++ b/src/gr_mpoly/divrem_heap_threaded.c
@@ -1080,7 +1080,8 @@ static int _gr_mpoly_divrem_heap_threaded_dispatch(
 
     /* fall back to the single-threaded algorithm for small inputs, or when
        the coefficient ring does not allow concurrent operations */
-    if (B->length < 2 || A->length < 2 || gr_ctx_is_threadsafe(cctx) != T_TRUE)
+    if (!GR_MPOLY_THREADED_DIVISION ||
+        B->length < 2 || A->length < 2 || gr_ctx_is_threadsafe(cctx) != T_TRUE)
         return _gr_mpoly_divrem_serial(Q, R, A, B, nonfield, unchecked, ctx);
 
     thread_limit = A->length/32;

--- a/src/gr_mpoly/divrem_ideal_heap_threaded.c
+++ b/src/gr_mpoly/divrem_ideal_heap_threaded.c
@@ -1151,6 +1151,13 @@ static void ideal_trychunk(ideal_worker_arg_t W, ideal_chunk_t L)
         ulong * Rexp;
         slong Rlen;
 
+#if FLINT_USES_PTHREAD
+        /* Pairs with the release fence before "next->producer = 1" above:
+           orders this load of L->producer before the loads of
+           (H->polyQ + w)->length below. */
+        atomic_thread_fence(memory_order_acquire);
+#endif
+
         /* process any further quotient terms that trickled in */
         for (w = 0; w < H->len; w++)
             q_prev_length[w] = (H->polyQ + w)->length;
@@ -1278,6 +1285,16 @@ static void ideal_trychunk(ideal_worker_arg_t W, ideal_chunk_t L)
 
         next = L->next;
         H->length--;
+
+#if FLINT_USES_PTHREAD
+        /* Publish the producer handoff; see the identical fence in
+           gr_mpoly/divides_heap_threaded.c.  Everything written before this
+           point, including the stores to (H->polyQ + w)->length made by the
+           gr_mpoly_ts_append calls above, must be visible to the thread that
+           observes next->producer == 1. */
+        atomic_thread_fence(memory_order_release);
+#endif
+
         H->cur = next;
 
         if (next != NULL)

--- a/src/gr_mpoly/divrem_ideal_heap_threaded.c
+++ b/src/gr_mpoly/divrem_ideal_heap_threaded.c
@@ -1785,7 +1785,8 @@ static int _gr_mpoly_divrem_ideal_heap_threaded_dispatch(
 
     /* fall back to the single-threaded algorithm for small inputs, or when
        the coefficient ring does not allow concurrent operations */
-    if (A->length < 2 || B[0].length < 2 || gr_ctx_is_threadsafe(cctx) != T_TRUE)
+    if (!GR_MPOLY_THREADED_DIVISION ||
+        A->length < 2 || B[0].length < 2 || gr_ctx_is_threadsafe(cctx) != T_TRUE)
         return _gr_mpoly_divrem_ideal_serial(Q, R, A, B, len, nonfield, ctx);
 
     thread_limit = A->length/32;


### PR DESCRIPTION
The multithreaded `gr_mpoly` division fails sporadically on M1; see https://github.com/flintlib/flint/pull/2815#issuecomment-5471343990.

The first patch in this PR is a plausible but untested fix generated by Claude Opus 5.

The second patch conservatively disables the multithreaded `gr_mpoly` division code when `FLINT_KNOW_STRONG_ORDER == 0`. This could be rolled back once someone has stress tested the multithreaded division on M1 or similar.