### PR TITLE
Use __int128 for generic umul_ppmm and smul_ppmm

### DIFF
--- a/src/longlong.h
+++ b/src/longlong.h
@@ -258,6 +258,22 @@ flint_bitcnt_t FLINT_BIT_COUNT(ulong x)
 #endif
 
 /* Multiplication */
+#if !defined(umul_ppmm) && defined(__GNUC__) && defined(__SIZEOF_INT128__) && FLINT_BITS == 64
+# define umul_ppmm(w1, w0, u, v) \
+  do { \
+    __uint128_t __rx = (__uint128_t) (ulong) (u) * (ulong) (v); \
+    (w0) = (ulong) __rx; \
+    (w1) = (ulong) (__rx >> FLINT_BITS); \
+  } while (0)
+
+# define smul_ppmm(w1, w0, u, v) \
+  do { \
+    __int128_t __rx = (__int128_t) (slong) (u) * (slong) (v); \
+    (w0) = (ulong) __rx; \
+    (w1) = (ulong) (__rx >> FLINT_BITS); \
+  } while (0)
+#endif
+
 #if !defined(umul_ppmm)
 # define umul_ppmm(w1, w0, u, v) \
   do { \


### PR DESCRIPTION
The generic fallback for `umul_ppmm`/`smul_ppmm` in `src/longlong.h` builds a 64x64 -> 128 product out of four half-word multiplications. Where the compiler has a 128-bit integer type, one widening multiply does the same job. Platforms that already have inline asm for `umul_ppmm` are untouched: the new block sits behind `!defined(umul_ppmm)`, like the generic one it precedes.

This is not a rare path, at least under gcc. Even with assembly enabled, gcc has inline asm for `umul_ppmm` only on amd64/i386 (`longlong_asm_gcc.h:21`) and arm/aarch64 (`:247`), so riscv64, ppc64, s390x, loongarch64 and mips64 always get the generic block; and `./configure --disable-assembly` puts every architecture on it, x86-64 included. None of this applies to clang, which gets `longlong_asm_clang.h` unconditionally (`src/longlong.h:47-48`), outside the `FLINT_WANT_ASSEMBLY` gate.

That last one makes the change easy to see without RISC-V hardware. On x86-64 with gcc, configure with `--disable-assembly` and preprocess a file that uses the macro, say `src/ulong_extras/mulmod_preinv.c`: before the patch `umul_ppmm` expands to the four-multiplication version (`grep -c __x0` gives 8, `__rx` 0), after it to a single `__uint128_t` product (`__rx` 8, `__x0` 0). Both configurations build and pass `make check` for `ulong_extras`, `nmod`, `nmod_mat`, `nmod_vec`, `fmpz` and `mpn_extras`: 355 tests, same count either way.

FLINT already uses the same widening multiply on the generic GNU path elsewhere: `n_mulhi` (`src/ulong_extras.h:47-48`), `ull_t` (`src/nmod.h:296-299`) and `_mul` (`src/crt_helpers.h:309-315`). The guard here is copied from `crt_helpers.h:309`.

For gcc this also completes the `umul_ppmm` and `smul_ppmm` items ticked off in #1636, which until now only took effect for clang through `longlong_asm_clang.h:194-195`.

### Codegen

gcc 16, `-O2`, counting the final `ret`:

| target | generic | with this patch |
| --- | --- | --- |
| x86-64 | 28 instructions, 4 `imul` | 5 instructions, 1 `mul` |
| riscv64 `-march=rv64gc` | 26 instructions, 4 `mul` | 5 instructions, `mul` + `mulhu` |

`smul_ppmm` on riscv64 goes from 32 instructions and 4 `mul` to `mul` + `mulh`. Both `mulhu` and `mulh` belong to the base M extension, so nothing beyond a stock rv64gc build is needed.

### Benchmark

SiFive U74 (VisionFive 2, rv64gc), gcc 16 cross build, governor pinned to `performance` at 1.5 GHz, master and patched runs interleaved, 4 runs each, spread <= 0.4%. Modulus a 60-bit prime:

| | master | patched | speedup |
| --- | --- | --- | --- |
| `nmod_mat_mul`, 200x200 | 0.4894 s | 0.2133 s | 2.29x |
| `nmod_poly_gcd`, length 800 | 0.04798 s | 0.04690 s | 1.02x |
| `nmod_poly_mul`, length 4000 | 0.2172 s | 0.2152 s | 1.01x |

The gain is not uniform. It is large where `nmod_mul` dominates the inner loop and almost nothing for the polynomial routines, which spend their time elsewhere.

Both libraries were built from 00e660a with `./configure --host=riscv64-linux-gnu --disable-shared --disable-pthread`, with only `src/longlong.h` differing between them.

Division is deliberately left alone: the same treatment applied to `udiv_qrnnd` makes gcc emit calls to `__udivti3` and `__umodti3` instead of the hardware divide, so it would be a pessimisation.

### Testing

Test suites cross-compiled for riscv64 and run natively on the U74 against the patched library: `test` (which contains `t-umul_ppmm` and `t-smul_ppmm`), `nmod_mat`, `nmod`, `nmod_vec`, `ulong_extras`, `fmpz`, `mpn_extras`. All exit 0, 371 PASS in total, no failures.

Worth flagging: no CI job compiles the new branch. On every platform CI covers, `umul_ppmm` is already defined before this point, by inline asm on x86-64/aarch64 with autotools, by `longlong_asm_clang.h` for clang, by `longlong_msc_*.h` for MSVC, while the 32-bit Alpine job has no `__int128` at all. The ways to exercise it are `--disable-assembly` or an architecture without inline asm.

### One regression I found

On sparc64, gcc compiles the 128-bit product into a `call __multi3` rather than inlining it (gcc 15.2 at `-O2`, also with `-mcpu=niagara4`). Every other target I checked inlines it: riscv64, ppc64, s390x, loongarch64, mips64el, aarch64. Since FLINT has no sparc CI and no sparc-specific code I left the guard as it is, but I am happy to add `&& !defined(__sparc__)` if you prefer.
