### PR TITLE
Increase stress test of threaded gr_mpoly_divides

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,13 +28,13 @@ env:
   GLOBAL_MULTIPLIER: 1
 
 concurrency:
-  # Group by workflow and ref, and to limit to 1 concurrent job except for main
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/main' || github.run_number }}
-  # Cancel intermediate builds for pull requests
-  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+  # Temporary: keep separate CI runs alive while probing intermittent M1 failures.
+  group: ${{ github.workflow }}-${{ github.run_number }}
+  cancel-in-progress: false
 
 jobs:
   assert-ntl-msolve-nemo:
+    if: false
     name: NTL, msolve and Nemo.jl
     runs-on: ubuntu-24.04
     env:
@@ -79,6 +79,7 @@ jobs:
           julia -e "import Pkg; Pkg.develop(path=\"./Nemo.jl\"); Pkg.test(\"Nemo\")"
 
   ubuntu-codecov:
+    if: false
     name: codecov (x10)
     runs-on: ubuntu-24.04
     env:
@@ -118,6 +119,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   regression-check:
+    if: false
     name: Regression check
     runs-on: ubuntu-24.04
     env:
@@ -140,6 +142,7 @@ jobs:
         run: $MAKE $MODULES
 
   ubuntu-arm:
+    if: false
     name: ARM (x0.5)
     runs-on: ubuntu-24.04-arm
     env:
@@ -194,6 +197,7 @@ jobs:
         run: echo "FLINT_TEST_MULTIPLIER = $FLINT_TEST_MULTIPLIER" && $MAKE check
 
   ubuntu-clang:
+    if: false
     name: ASan, BLAS, examples (x1)
     runs-on: ubuntu-24.04
     env:
@@ -225,6 +229,7 @@ jobs:
         run: $MAKE checkexamples
 
   mingw64-gcc:
+    if: false
     name: MinGW (x0.5)
     runs-on: windows-latest
     defaults:
@@ -260,6 +265,7 @@ jobs:
         run: echo "FLINT_TEST_MULTIPLIER = $FLINT_TEST_MULTIPLIER" && $MAKE check
 
   msvc:
+    if: false
     name: MSVC (x0.5)
     runs-on: windows-latest
     env:
@@ -302,6 +308,7 @@ jobs:
           ctest -j5 --output-on-failure
 
   alpine-32bit:
+    if: false
     name: 32-bit, musl, assert (x2.5)
     runs-on: ubuntu-24.04
     env:

--- a/src/gr_mpoly/test/t-divides_heap_threaded.c
+++ b/src/gr_mpoly/test/t-divides_heap_threaded.c
@@ -20,7 +20,7 @@ TEST_FUNCTION_START(gr_mpoly_divides_heap_threaded, state)
     gr_ctx_init_nmod(ctx1, 17);
 
     /* Check that the threaded quotient matches the serial heap quotient */
-    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
+    for (i = 0; i < 100 * 1000 * flint_test_multiplier(); i++)
     {
         gr_ctx_t cctx;
         gr_ctx_t debug_base_ctx;

--- a/src/gr_mpoly/test/t-divides_heap_threaded.c
+++ b/src/gr_mpoly/test/t-divides_heap_threaded.c
@@ -30,7 +30,7 @@ TEST_FUNCTION_START(gr_mpoly_divides_heap_threaded, state)
         slong lenf, leng;
         flint_bitcnt_t exp_bits;
         int status, aliasing;
-        int big = (n_randint(state, 10) == 0);
+        int big = (n_randint(state, 2) == 0);
 
         switch (n_randint(state, 5))
         {
@@ -64,7 +64,7 @@ TEST_FUNCTION_START(gr_mpoly_divides_heap_threaded, state)
                 break;
         }
 
-        gr_mpoly_ctx_init_rand(ctx, state, cctx, 4);
+        gr_mpoly_ctx_init_rand(ctx, state, cctx, big ? 20 : 4);
 
         gr_mpoly_init(f, ctx);
         gr_mpoly_init(g, ctx);
@@ -72,7 +72,7 @@ TEST_FUNCTION_START(gr_mpoly_divides_heap_threaded, state)
         gr_mpoly_init(q1, ctx);
         gr_mpoly_init(q2, ctx);
 
-        flint_set_num_threads(1 + n_randint(state, 4));
+        flint_set_num_threads(big ? 2 + n_randint(state, 3) : 1 + n_randint(state, 4));
 
         lenf = n_randint(state, big ? 80 : 20) + 1;
         leng = n_randint(state, big ? 30 : 10) + 1;

--- a/src/gr_mpoly/test/t-divides_heap_threaded.c
+++ b/src/gr_mpoly/test/t-divides_heap_threaded.c
@@ -20,7 +20,7 @@ TEST_FUNCTION_START(gr_mpoly_divides_heap_threaded, state)
     gr_ctx_init_nmod(ctx1, 17);
 
     /* Check that the threaded quotient matches the serial heap quotient */
-    for (i = 0; i < 100 * 1000 * flint_test_multiplier(); i++)
+    for (i = 0; i < 5 * 1000 * flint_test_multiplier(); i++)
     {
         gr_ctx_t cctx;
         gr_ctx_t debug_base_ctx;


### PR DESCRIPTION
See https://github.com/flintlib/flint/pull/2819#issuecomment-5477862272

This changes the parametrisation of the test for heaped gr_mpoly_divides. With these changes the test fails about 50% of the time here on Mac M3 with multiplier 1:
```console
$ FLINT_TEST_MULTIPLIER=1 build/gr_mpoly/test/main gr_mpoly_divides_heap_threaded
gr_mpoly_divides_heap_threaded...
gr_mpoly_divides_heap_threaded                    0.29   (PASS)
$ FLINT_TEST_MULTIPLIER=1 build/gr_mpoly/test/main gr_mpoly_divides_heap_threaded
gr_mpoly_divides_heap_threaded...
FAIL: exact division incorrectly reported as GR_DOMAIN
i = 168, j = 0, dstatus1 = 0, dstatus2 = 1
Integers mod 390041974493255551 (_gr_nmod)
zsh: abort      FLINT_TEST_MULTIPLIER=1 build/gr_mpoly/test/main
```