### PR TITLE
mpn_mod: add batched AVX2 Montgomery 4x4 matrix power

### DIFF
--- a/doc/source/mpn_mod.rst
+++ b/doc/source/mpn_mod.rst
@@ -188,6 +188,27 @@ used by higher-level generic routines.
     Reduces matrix multiplication to several ``nmod_mat`` matrix multiplications
     followed by CRT reconstruction. Supports multithreading.
 
+.. function:: int mpn_mod_mat_mul_batched_mont(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx)
+
+    Multiplies two `4 \times 4` matrices using a batched AVX2 Montgomery kernel.
+    Each number is held as 31-bit limbs across the four SIMD lanes (one output
+    column per lane), and the four products of a dot product are summed into a
+    wide accumulator before a single lazy Montgomery reduction. Requires AVX2,
+    an odd modulus, and `n < 2^{246}`; otherwise, and for any other size, it
+    falls back to :func:`gr_mat_mul_classical`. A single call pays the cost of
+    converting `A`, `B` into and `C` out of Montgomery form, so it is primarily
+    useful as the building block of :func:`mpn_mod_mat_pow_ui_batched_mont`,
+    where that conversion is amortized over many multiplications.
+
+.. function:: int mpn_mod_mat_pow_ui_batched_mont(gr_mat_t res, const gr_mat_t A, ulong exp, gr_ctx_t ctx)
+
+    Computes ``res = A^exp`` for a `4 \times 4` matrix `A` using the batched
+    Montgomery kernel. `A` is converted to Montgomery form once, the whole
+    square-and-multiply chain runs in the batched representation, and the result
+    is converted back once, so the conversion overhead is amortized. Requires
+    AVX2, an odd modulus, and `n < 2^{246}`; otherwise it falls back to
+    :func:`gr_mat_pow_ui`.
+
 .. function:: int mpn_mod_mat_mul(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx)
 
     Dispatches among classical, Waksman and multimodular

--- a/src/mpn_mod.h
+++ b/src/mpn_mod.h
@@ -208,6 +208,9 @@ int _mpn_mod_vec_dot_strided(nn_ptr res, nn_srcptr initial, int subtract, nn_src
 
 int mpn_mod_mat_mul_waksman(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
 int mpn_mod_mat_mul_multi_mod(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
+int mpn_mod_mat_pow_ui_batched_mont(gr_mat_t res, const gr_mat_t A, ulong exp, gr_ctx_t ctx);
+
+int mpn_mod_mat_mul_batched_mont(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
 int mpn_mod_mat_mul(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx);
 
 int mpn_mod_mat_nonsingular_solve_tril(gr_mat_t X, const gr_mat_t L, const gr_mat_t B, int unit, gr_ctx_t ctx);

--- a/src/mpn_mod/mat_mul_batched_mont.c
+++ b/src/mpn_mod/mat_mul_batched_mont.c
@@ -1,0 +1,68 @@
+/*
+    Copyright (C) 2026 Brian Heckel
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+/*
+    One-shot batched Montgomery 4x4 matrix multiply over Z/nZ (n odd, AVX2),
+    using lazy reduction: for each output entry the 4 raw products are summed
+    into a wide accumulator and reduced once. Summing 4 products reaches
+    4n^2, so single-subtract REDC is valid only for n < 2^246;
+    the dispatch guard enforces that.
+
+    NOTE: unlike a chain, a one-shot matmul cannot amortize the to/from-
+    Montgomery conversion (A, B in and C out), which adds ~12 CIOS multiplies on
+    top of the matmul. So this is expected to be competitive only when the
+    conversion is amortized (matrix powers / long chains); it is provided here
+    mainly to measure the one-shot case. Falls back to gr_mat_mul_classical for
+    non-4x4, even n, n >= 2^246, or a non-AVX2 build.
+
+    See mpn_mod_batched_mont.h for the batched kernel and its representation.
+*/
+
+#include "mpn_mod_batched_mont.h"
+
+#ifdef __AVX2__
+
+/* cast a (non-const) bm_mat to the const-qualified pointer the kernel reads;
+   the implicit conversion is a -Wpedantic warning in C before C23 */
+#define BM_CONST(m) ((const ulong (*)[BM_DIM][BM_MAXLIMB]) (m))
+
+int
+mpn_mod_mat_mul_batched_mont(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx)
+{
+    slong bits = MPN_MOD_CTX_MODULUS_BITS(ctx);
+    slong s = (bits + 2 + BM_BITS - 1) / BM_BITS;
+
+    // check for either lazy montgomery reduction or regular matrix multiplication
+    if (A->r == 4 && A->c == 4 && B->r == 4 && B->c == 4 && C->r == 4 && C->c == 4
+        && (MPN_MOD_CTX_MODULUS(ctx)[0] & 1) && s <= BM_MAXLIMB)
+    {
+        bm_ctx_t bc;
+        bm_mat mA, mB, mC;
+        bm_ctx_init(&bc, ctx);
+        bm_load(mA, A, ctx, &bc);
+        bm_load(mB, B, ctx, &bc);
+        bm_matmul(mC, BM_CONST(mA), BM_CONST(mB), &bc);
+        bm_store(C, BM_CONST(mC), ctx, &bc);
+        return GR_SUCCESS;
+    }
+
+    return gr_mat_mul_classical(C, A, B, ctx);
+}
+
+#else
+
+int
+mpn_mod_mat_mul_batched_mont(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, gr_ctx_t ctx)
+{
+    return gr_mat_mul_classical(C, A, B, ctx);
+}
+
+#endif

--- a/src/mpn_mod/mat_pow_batched_mont.c
+++ b/src/mpn_mod/mat_pow_batched_mont.c
@@ -1,0 +1,93 @@
+/*
+    Copyright (C) 2026 Brian Heckel
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+/*
+    Batched Montgomery 4x4 matrix power A^exp over Z/nZ (n odd), AVX2.
+
+    Batched Montgomery only pays off when many multiplies happen between a single
+    pair of to/from-Montgomery conversions, so this converts A once, runs the
+    whole square-and-multiply chain in Montgomery form, and converts back once.
+    The limb count s = ceil((bits+2)/31) is a runtime parameter (see
+    mpn_mod_batched_mont.h), so the work scales with the modulus size.
+
+    Falls back to the generic gr_mat_pow_ui for anything this path does not
+    handle: non-4x4 matrices, even moduli, moduli too large for the batched
+    representation, or a non-AVX2 build.
+*/
+
+// TODO: Not sure if flint has a specific function for memset or
+// an alternative
+#include <string.h>
+#include "mpn_mod_batched_mont.h"
+
+#ifdef __AVX2__
+
+/* The square-and-multiply buffers are rotated as plain (non-const) pointers;
+   cast them to the const-qualified bm_mat the kernel reads.  A direct implicit
+   conversion of a pointer-to-array to a const-qualified one is a -Wpedantic
+   warning in C before C23. */
+#define BM_CONST(m) ((const ulong (*)[BM_DIM][BM_MAXLIMB]) (m))
+
+int
+mpn_mod_mat_pow_ui_batched_mont(gr_mat_t res, const gr_mat_t A, ulong exp, gr_ctx_t ctx)
+{
+    bm_ctx_t bc;
+    bm_mat buf0, buf1, buf2;
+    ulong (*base)[BM_DIM][BM_MAXLIMB];
+    ulong (*acc)[BM_DIM][BM_MAXLIMB];
+    ulong (*scr)[BM_DIM][BM_MAXLIMB];
+    ulong (*sw)[BM_DIM][BM_MAXLIMB];
+    slong bits = MPN_MOD_CTX_MODULUS_BITS(ctx);
+    slong s = (bits + 2 + BM_BITS - 1) / BM_BITS;
+    slong bit;
+
+    // check if we don't match conditions for batched montgomery
+    if (A->r != 4 || A->c != 4 || res->r != 4 || res->c != 4
+        || !(MPN_MOD_CTX_MODULUS(ctx)[0] & 1) || s > BM_MAXLIMB)
+        return gr_mat_pow_ui(res, A, exp, ctx);
+
+    if (exp == 0)
+        return gr_mat_one(res, ctx);
+
+    memset(buf0, 0, sizeof(bm_mat));
+    memset(buf1, 0, sizeof(bm_mat));
+    memset(buf2, 0, sizeof(bm_mat));
+
+    bm_ctx_init(&bc, ctx);
+    bm_load(buf0, A, ctx, &bc);
+    memcpy(buf1, buf0, sizeof(bm_mat));
+    base = buf0; acc = buf1; scr = buf2;
+
+    // left-to-right square-and-multiply; the top set bit is already in acc
+    for (bit = (slong) FLINT_BIT_COUNT(exp) - 2; bit >= 0; bit--)
+    {
+        bm_matmul(scr, BM_CONST(acc), BM_CONST(acc), &bc);       /* square */
+        sw = acc; acc = scr; scr = sw;
+        if ((exp >> bit) & 1)
+        {
+            bm_matmul(scr, BM_CONST(acc), BM_CONST(base), &bc);  /* multiply by base */
+            sw = acc; acc = scr; scr = sw;
+        }
+    }
+
+    bm_store(res, BM_CONST(acc), ctx, &bc);
+    return GR_SUCCESS;
+}
+
+#else
+
+int
+mpn_mod_mat_pow_ui_batched_mont(gr_mat_t res, const gr_mat_t A, ulong exp, gr_ctx_t ctx)
+{
+    return gr_mat_pow_ui(res, A, exp, ctx);
+}
+
+#endif

--- a/src/mpn_mod/profile/p-mat_mul_kernel_sweep.c
+++ b/src/mpn_mod/profile/p-mat_mul_kernel_sweep.c
@@ -1,0 +1,145 @@
+/*
+    Copyright (C) 2026 Brian Heckel
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+/*
+    Speedup sweep: kernel-only 4x4 matmul (conversion excluded), batched
+    Montgomery (lazy) vs gr_mat_mul (classical), across modulus bit sizes.
+
+    The batched kernel is compile-time specialized on the 31-bit limb count
+    s = ceil((bits+2)/31) (bm_matmul dispatches on ctx->s), so its cost steps up
+    with s; classical steps up with the modulus's 64-bit limb count (MPN_MOD
+    nlimbs).  The two step at different boundaries, so the speedup is largest
+    just after an s-step and smallest just before the next one.  n < 2^246 (lazy
+    single-subtract validity).
+*/
+
+#include <stdlib.h>
+#include "fmpz.h"
+#include "gr.h"
+#include "gr_mat.h"
+#include "mpn_mod.h"
+#include "profiler.h"
+#include "mpn_mod_batched_mont.h"
+
+#define DIM  4
+#define REPS 100000
+
+static volatile ulong sink;
+
+static void
+randmat(gr_mat_t mat, const fmpz_t N, flint_rand_t state, gr_ctx_t ctx)
+{
+    fmpz_t t;
+    slong i, j;
+    fmpz_init(t);
+    for (i = 0; i < DIM; i++)
+        for (j = 0; j < DIM; j++)
+        {
+            fmpz_randm(t, state, N);
+            GR_MUST_SUCCEED(gr_set_fmpz(gr_mat_entry_ptr(mat, i, j, ctx), t, ctx));
+        }
+    fmpz_clear(t);
+}
+
+FLINT_STATIC_NOINLINE ulong
+run_classical(gr_mat_t C, const gr_mat_t A, const gr_mat_t B, slong reps, gr_ctx_t ctx)
+{
+    slong k;
+    for (k = 0; k < reps; k++)
+        GR_MUST_SUCCEED(gr_mat_mul_classical(C, A, B, ctx));
+    return ((nn_srcptr) gr_mat_entry_srcptr(C, 0, 0, ctx))[0];
+}
+
+#ifdef __AVX2__
+FLINT_STATIC_NOINLINE ulong
+run_kernel(bm_mat Cm, const bm_mat Am, const bm_mat Bm, slong reps, const bm_ctx_t * bc)
+{
+    slong k;
+    for (k = 0; k < reps; k++)
+        bm_matmul(Cm, Am, Bm, bc);
+    return Cm[0][0][0];
+}
+#endif
+
+static void
+bench(slong bits, flint_rand_t state)
+{
+    gr_ctx_t ctx;
+    fmpz_t N;
+    gr_mat_t A, B, C;
+    slong nlimbs;
+    double tcpu, t_classical;
+#ifdef __AVX2__
+    double t_kernel;
+    bm_ctx_t bc;
+    bm_mat mA, mB, mC;
+#endif
+
+    fmpz_init(N);
+    fmpz_randtest_unsigned(N, state, bits);
+    fmpz_setbit(N, bits - 1);
+    fmpz_setbit(N, 0);
+    GR_MUST_SUCCEED(gr_ctx_init_mpn_mod(ctx, N));
+    nlimbs = MPN_MOD_CTX_NLIMBS(ctx);
+
+    gr_mat_init(A, DIM, DIM, ctx);
+    gr_mat_init(B, DIM, DIM, ctx);
+    gr_mat_init(C, DIM, DIM, ctx);
+    randmat(A, N, state, ctx);
+    randmat(B, N, state, ctx);
+
+    TIMEIT_START;
+    sink ^= run_classical(C, A, B, REPS, ctx);
+    TIMEIT_STOP_VALUES(tcpu, t_classical);
+
+#ifdef __AVX2__
+    bm_ctx_init(&bc, ctx);
+    bm_load(mA, A, ctx, &bc);       /* converted once, outside the timed region */
+    bm_load(mB, B, ctx, &bc);
+    TIMEIT_START;
+    sink ^= run_kernel(mC, (const ulong (*)[DIM][BM_MAXLIMB]) mA,
+                           (const ulong (*)[DIM][BM_MAXLIMB]) mB, REPS, &bc);
+    TIMEIT_STOP_VALUES(tcpu, t_kernel);
+#endif
+
+    flint_printf("%4wd bits  (nlimbs=%wd):  classical %7.1f ns", bits, nlimbs,
+                 t_classical / REPS / 1e-9);
+#ifdef __AVX2__
+    flint_printf(",  batched %7.1f ns,  speedup %.2fx",
+                 t_kernel / REPS / 1e-9, t_classical / t_kernel);
+#else
+    flint_printf(",  (no AVX2)");
+#endif
+    flint_printf("\n");
+
+    (void) tcpu;
+    gr_mat_clear(A, ctx);
+    gr_mat_clear(B, ctx);
+    gr_mat_clear(C, ctx);
+    gr_ctx_clear(ctx);
+    fmpz_clear(N);
+}
+
+int main(void)
+{
+    flint_rand_t state;
+    slong sizes[] = { 65, 80, 96, 112, 127, 129, 144, 160, 176, 191,
+                      193, 208, 224, 240, 246 };
+    int i, nsizes = sizeof(sizes) / sizeof(sizes[0]);
+
+    flint_rand_init(state);
+    flint_printf("kernel-only 4x4 matmul speedup vs modulus size "
+                 "(per-s specialized lazy kernel, conversion excluded):\n\n");
+    for (i = 0; i < nsizes; i++)
+        bench(sizes[i], state);
+    flint_rand_clear(state);
+    return 0;
+}

--- a/src/mpn_mod/profile/p-mat_pow_batched_mont.c
+++ b/src/mpn_mod/profile/p-mat_pow_batched_mont.c
@@ -1,0 +1,130 @@
+/*
+    Copyright (C) 2026 Brian Heckel
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+/*
+    Chained multiplication: 4x4 matrix power A^exp over odd moduli < 2^246.
+    Batched Montgomery (AVX2) converts to/from Montgomery form once and runs the
+    whole square-and-multiply chain in that form, vs gr_mat_pow_ui (which for 4x4
+    chains gr_mat_mul_classical on plain residues).
+*/
+
+#include <stdlib.h>
+#include "fmpz.h"
+#include "gr.h"
+#include "gr_mat.h"
+#include "mpn_mod.h"
+#include "profiler.h"
+
+#define DIM  4
+#define REPS 500
+
+static volatile ulong sink;
+
+static void
+randmat(gr_mat_t mat, const fmpz_t N, flint_rand_t state, gr_ctx_t ctx)
+{
+    fmpz_t t;
+    slong i, j;
+    fmpz_init(t);
+    for (i = 0; i < DIM; i++)
+        for (j = 0; j < DIM; j++)
+        {
+            fmpz_randm(t, state, N);
+            GR_MUST_SUCCEED(gr_set_fmpz(gr_mat_entry_ptr(mat, i, j, ctx), t, ctx));
+        }
+    fmpz_clear(t);
+}
+
+FLINT_STATIC_NOINLINE ulong
+run_gr(gr_mat_t C, const gr_mat_t A, ulong exp, slong reps, gr_ctx_t ctx)
+{
+    slong k;
+    for (k = 0; k < reps; k++)
+        GR_MUST_SUCCEED(gr_mat_pow_ui(C, A, exp, ctx));
+    return ((nn_srcptr) gr_mat_entry_srcptr(C, 0, 0, ctx))[0];
+}
+
+#ifdef __AVX2__
+FLINT_STATIC_NOINLINE ulong
+run_batched(gr_mat_t C, const gr_mat_t A, ulong exp, slong reps, gr_ctx_t ctx)
+{
+    slong k;
+    for (k = 0; k < reps; k++)
+        GR_MUST_SUCCEED(mpn_mod_mat_pow_ui_batched_mont(C, A, exp, ctx));
+    return ((nn_srcptr) gr_mat_entry_srcptr(C, 0, 0, ctx))[0];
+}
+#endif
+
+static void
+bench(slong bits, ulong exp, flint_rand_t state)
+{
+    gr_ctx_t ctx;
+    fmpz_t N;
+    gr_mat_t A, C;
+    // TODO: Don't know how to get rid of the warning that this is unused
+    double tcpu, t_gr;
+#ifdef __AVX2__
+    double t_batched;
+#endif
+
+    fmpz_init(N);
+    fmpz_randtest_unsigned(N, state, bits);
+    fmpz_setbit(N, bits - 1);
+    fmpz_setbit(N, 0);
+    GR_MUST_SUCCEED(gr_ctx_init_mpn_mod(ctx, N));
+
+    gr_mat_init(A, DIM, DIM, ctx);
+    gr_mat_init(C, DIM, DIM, ctx);
+    randmat(A, N, state, ctx);
+
+    TIMEIT_START;
+    sink ^= run_gr(C, A, exp, REPS, ctx);
+    TIMEIT_STOP_VALUES(tcpu, t_gr);
+
+#ifdef __AVX2__
+    TIMEIT_START;
+    sink ^= run_batched(C, A, exp, REPS, ctx);
+    TIMEIT_STOP_VALUES(tcpu, t_batched);
+#endif
+
+    flint_printf("n = %wd bits (odd), A^exp, exp = %wu (%u-bit chain):\n",
+                 bits, exp, (unsigned) FLINT_BIT_COUNT(exp));
+    flint_printf("  gr_mat_pow_ui (classical): %8.2f us/pow\n", t_gr / REPS / 1e-6);
+#ifdef __AVX2__
+    flint_printf("  batched_mont             : %8.2f us/pow\n", t_batched / REPS / 1e-6);
+    flint_printf("  speedup batched vs classical: %.2fx\n", t_gr / t_batched);
+#else
+    flint_printf("  (batched_mont skipped: built without AVX2)\n");
+#endif
+    flint_printf("\n");
+
+    gr_mat_clear(A, ctx);
+    gr_mat_clear(C, ctx);
+    gr_ctx_clear(ctx);
+    fmpz_clear(N);
+
+    (void) tcpu;
+}
+
+int main(void)
+{
+    flint_rand_t state;
+    slong sizes[] = { 96, 128, 192, 246 };
+    // 39 squarings
+    ulong exp = (UWORD(1) << 40) - 1;
+    int i;
+
+    flint_rand_init(state);
+    for (i = 0; i < 4; i++)
+        bench(sizes[i], exp, state);
+    flint_rand_clear(state);
+    return 0;
+}

--- a/src/mpn_mod/test/main.c
+++ b/src/mpn_mod/test/main.c
@@ -15,8 +15,10 @@
 #include "t-mat.c"
 #include "t-mat_lu.c"
 #include "t-mat_lu_classical_delayed.c"
+#include "t-mat_mul_batched_mont.c"
 #include "t-mat_mul_multi_mod.c"
 #include "t-mat_mul_waksman.c"
+#include "t-mat_pow_batched_mont.c"
 #include "t-poly_divrem_basecase.c"
 #include "t-poly.c"
 #include "t-poly_mullow.c"
@@ -33,7 +35,9 @@ test_struct tests[] =
     TEST_FUNCTION(mpn_mod_mat),
     TEST_FUNCTION(mpn_mod_mat_lu),
     TEST_FUNCTION(mpn_mod_mat_lu_classical_delayed),
+    TEST_FUNCTION(mpn_mod_mat_mul_batched_mont),
     TEST_FUNCTION(mpn_mod_mat_mul_multi_mod),
+    TEST_FUNCTION(mpn_mod_mat_pow_ui_batched_mont),
     TEST_FUNCTION(mpn_mod_mat_mul_waksman),
     TEST_FUNCTION(mpn_mod_poly_divrem_basecase),
     TEST_FUNCTION(mpn_mod_poly),

--- a/src/mpn_mod/test/t-mat_mul_batched_mont.c
+++ b/src/mpn_mod/test/t-mat_mul_batched_mont.c
@@ -1,0 +1,90 @@
+/*
+    Copyright (C) 2026 Brian Heckel
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "mpn_mod.h"
+#include "gr_mat.h"
+#include "fmpz.h"
+#include "ulong_extras.h"
+
+TEST_FUNCTION_START(mpn_mod_mat_mul_batched_mont, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 300 * flint_test_multiplier(); iter++)
+    {
+        gr_ctx_t ctx;
+        fmpz_t N, val;
+        gr_mat_t A, B, C, D;
+        slong i, j, bits;
+
+        /* odd modulus with 65 <= bits <= 246 (>= 2 limbs; lazy REDC valid) */
+        bits = 65 + n_randint(state, 246 - 65 + 1);
+        fmpz_init(N);
+        fmpz_randtest_unsigned(N, state, bits);
+        fmpz_setbit(N, bits - 1);
+        fmpz_setbit(N, 0);
+
+        if (gr_ctx_init_mpn_mod(ctx, N) != GR_SUCCESS)
+        {
+            fmpz_clear(N);
+            continue;
+        }
+
+        gr_mat_init(A, 4, 4, ctx);
+        gr_mat_init(B, 4, 4, ctx);
+        gr_mat_init(C, 4, 4, ctx);
+        gr_mat_init(D, 4, 4, ctx);
+
+        fmpz_init(val);
+        for (i = 0; i < 4; i++)
+            for (j = 0; j < 4; j++)
+            {
+                fmpz_randm(val, state, N);
+                GR_MUST_SUCCEED(gr_set_fmpz(gr_mat_entry_ptr(A, i, j, ctx), val, ctx));
+                fmpz_randm(val, state, N);
+                GR_MUST_SUCCEED(gr_set_fmpz(gr_mat_entry_ptr(B, i, j, ctx), val, ctx));
+            }
+        fmpz_clear(val);
+
+        GR_MUST_SUCCEED(gr_mat_mul_classical(D, A, B, ctx));
+
+        GR_MUST_SUCCEED(mpn_mod_mat_mul_batched_mont(C, A, B, ctx));
+        if (gr_mat_equal(C, D, ctx) != T_TRUE)
+        {
+            flint_printf("FAIL (A*B): iter %wd\n", iter);
+            flint_printf("n = "); fmpz_print(N); flint_printf("\n");
+            gr_mat_print(A, ctx); gr_mat_print(B, ctx);
+            gr_mat_print(C, ctx); gr_mat_print(D, ctx);
+            TEST_FUNCTION_FAIL("batched_mont != classical\n");
+        }
+
+        /* aliasing C == A, and squaring A*A */
+        GR_MUST_SUCCEED(gr_mat_set(C, A, ctx));
+        GR_MUST_SUCCEED(mpn_mod_mat_mul_batched_mont(C, C, B, ctx));
+        if (gr_mat_equal(C, D, ctx) != T_TRUE)
+            TEST_FUNCTION_FAIL("batched_mont aliasing (C==A) mismatch\n");
+
+        GR_MUST_SUCCEED(gr_mat_mul_classical(D, A, A, ctx));
+        GR_MUST_SUCCEED(mpn_mod_mat_mul_batched_mont(C, A, A, ctx));
+        if (gr_mat_equal(C, D, ctx) != T_TRUE)
+            TEST_FUNCTION_FAIL("batched_mont squaring mismatch\n");
+
+        gr_mat_clear(A, ctx);
+        gr_mat_clear(B, ctx);
+        gr_mat_clear(C, ctx);
+        gr_mat_clear(D, ctx);
+        gr_ctx_clear(ctx);
+        fmpz_clear(N);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/mpn_mod/test/t-mat_pow_batched_mont.c
+++ b/src/mpn_mod/test/t-mat_pow_batched_mont.c
@@ -1,0 +1,96 @@
+/*
+    Copyright (C) 2026 Brian Heckel
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "mpn_mod.h"
+#include "gr_mat.h"
+#include "fmpz.h"
+#include "ulong_extras.h"
+
+TEST_FUNCTION_START(mpn_mod_mat_pow_ui_batched_mont, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 300 * flint_test_multiplier(); iter++)
+    {
+        gr_ctx_t ctx;
+        fmpz_t N, val;
+        gr_mat_t A, C, D;
+        slong i, j, bits;
+        ulong exp;
+
+        /* odd modulus with 65 <= bits <= 248 (>= 2 limbs, < 2^248) */
+        bits = 65 + n_randint(state, 248 - 65 + 1);
+        fmpz_init(N);
+        fmpz_randtest_unsigned(N, state, bits);
+        fmpz_setbit(N, bits - 1);
+        fmpz_setbit(N, 0);
+
+        if (gr_ctx_init_mpn_mod(ctx, N) != GR_SUCCESS)
+        {
+            fmpz_clear(N);
+            continue;
+        }
+
+        gr_mat_init(A, 4, 4, ctx);
+        gr_mat_init(C, 4, 4, ctx);
+        gr_mat_init(D, 4, 4, ctx);
+
+        fmpz_init(val);
+        for (i = 0; i < 4; i++)
+            for (j = 0; j < 4; j++)
+            {
+                fmpz_randm(val, state, N);
+                GR_MUST_SUCCEED(gr_set_fmpz(gr_mat_entry_ptr(A, i, j, ctx), val, ctx));
+            }
+        fmpz_clear(val);
+
+        /* mix of edge and random exponents, including 0 and 1 */
+        switch (n_randint(state, 4))
+        {
+            case 0:  exp = 0; break;
+            case 1:  exp = 1; break;
+            case 2:  exp = n_randint(state, 64); break;
+            default: exp = n_randtest(state); break;   /* full-width chain */
+        }
+
+        GR_MUST_SUCCEED(mpn_mod_mat_pow_ui_batched_mont(C, A, exp, ctx));
+        GR_MUST_SUCCEED(gr_mat_pow_ui(D, A, exp, ctx));
+
+        if (gr_mat_equal(C, D, ctx) != T_TRUE)
+        {
+            flint_printf("FAIL: iter %wd, exp = %wu\n", iter, exp);
+            flint_printf("n = "); fmpz_print(N); flint_printf("\n");
+            gr_mat_print(A, ctx);
+            gr_mat_print(C, ctx);
+            gr_mat_print(D, ctx);
+            TEST_FUNCTION_FAIL("batched-mont A^exp != gr_mat_pow_ui\n");
+        }
+
+        /* aliasing: res == A */
+        GR_MUST_SUCCEED(gr_mat_set(C, A, ctx));
+        GR_MUST_SUCCEED(mpn_mod_mat_pow_ui_batched_mont(C, C, exp, ctx));
+        if (gr_mat_equal(C, D, ctx) != T_TRUE)
+        {
+            flint_printf("FAIL (aliased res==A): iter %wd, exp = %wu\n", iter, exp);
+            flint_printf("n = "); fmpz_print(N); flint_printf("\n");
+            TEST_FUNCTION_FAIL("batched-mont aliasing mismatch\n");
+        }
+
+        gr_mat_clear(A, ctx);
+        gr_mat_clear(C, ctx);
+        gr_mat_clear(D, ctx);
+        gr_ctx_clear(ctx);
+        fmpz_clear(N);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/mpn_mod_batched_mont.h
+++ b/src/mpn_mod_batched_mont.h
@@ -1,0 +1,431 @@
+/*
+    Copyright (C) 2026 Brian Heckel
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+/*
+    Internal (not installed) helpers for batched AVX2 Montgomery arithmetic on
+    4x4 matrices over Z/nZ (n odd, n < 2^246), using LAZY reduction: each output
+    entry sums its 4 raw products into a wide accumulator and reduces once.
+
+    A value is s = ceil((bits+2)/31) limbs of 31 bits (2 guard bits so the
+    single-subtract lazy REDC is valid for n < 2^(31s-2)).  The matmul takes
+    s as a COMPILE-TIME argument and is force-inlined; bm_matmul dispatches on
+    ctx->s through a switch so each size gets a fully-unrolled, right-sized
+    instantiation (a runtime-s loop does not unroll and was measurably slower).
+    Arrays are sized to the s=8 (248-bit) maximum; only limbs [0,s) are touched.
+    AVX2-only; guard the use site with #ifdef __AVX2__.
+*/
+
+#ifndef MPN_MOD_BATCHED_MONT_H
+#define MPN_MOD_BATCHED_MONT_H
+
+#include "mpn_mod.h"
+#include "gr_mat.h"
+#include "fmpz.h"
+
+#ifdef __AVX2__
+
+#include <immintrin.h>
+
+#if defined(__GNUC__)
+#define BM_FORCE_INLINE static inline __attribute__((always_inline))
+#else
+#define BM_FORCE_INLINE static inline
+#endif
+
+#define BM_BITS     31
+#define BM_MAXLIMB  8                               /* max 31-bit limbs (248-bit) */
+#define BM_DIM      4
+#define BM_MASK     (((slong) 1 << BM_BITS) - 1)
+
+typedef struct
+{
+    __m256i n[BM_MAXLIMB];
+    __m256i r2[BM_MAXLIMB];
+    __m256i n0inv;
+    __m256i mask;
+    slong   s;
+}
+bm_ctx_t;
+
+typedef ulong bm_mat[BM_DIM][BM_DIM][BM_MAXLIMB];
+
+static inline void
+bm_pack31(ulong * out, nn_srcptr a, slong nlimbs, slong s)
+{
+    slong o;
+    for (o = 0; o < s; o++)
+    {
+        ulong p = (ulong) o * BM_BITS;
+        slong w = (slong) (p >> 6);
+        int off = (int) (p & 63);
+        ulong bits = 0;
+        if (w < nlimbs)
+            bits = a[w] >> off;
+        if (off + BM_BITS > 64 && w + 1 < nlimbs)
+            bits |= a[w + 1] << (64 - off);
+        out[o] = bits & BM_MASK;
+    }
+}
+
+static inline void
+bm_unpack31(nn_ptr a, const ulong * in, slong nlimbs, slong s)
+{
+    slong o, w;
+    for (w = 0; w < nlimbs; w++)
+        a[w] = 0;
+    for (o = 0; o < s; o++)
+    {
+        ulong p = (ulong) o * BM_BITS;
+        ulong v = in[o];
+        w = (slong) (p >> 6);
+        int off = (int) (p & 63);
+        if (w < nlimbs)
+            a[w] |= v << off;
+        if (off + BM_BITS > 64 && w + 1 < nlimbs)
+            a[w + 1] |= v >> (64 - off);
+    }
+}
+
+static inline ulong
+bm_n0inv(ulong n0)
+{
+    ulong inv = n0;
+    inv *= 2 - n0 * inv;
+    inv *= 2 - n0 * inv;
+    inv *= 2 - n0 * inv;
+    inv *= 2 - n0 * inv;
+    return ((ulong) (-inv)) & BM_MASK;
+}
+
+static inline void
+bm_ctx_init(bm_ctx_t * C, gr_ctx_t ctx)
+{
+    slong nlimbs = MPN_MOD_CTX_NLIMBS(ctx);
+    nn_srcptr nd = MPN_MOD_CTX_MODULUS(ctx);
+    slong bits = MPN_MOD_CTX_MODULUS_BITS(ctx);
+    slong s = (bits + 2 + BM_BITS - 1) / BM_BITS;
+    ulong n31[BM_MAXLIMB], r2nn[BM_MAXLIMB], r231[BM_MAXLIMB];
+    fmpz_t N, R2;
+    slong l;
+
+    C->s = s;
+    bm_pack31(n31, nd, nlimbs, s);
+    for (l = 0; l < s; l++)
+        C->n[l] = _mm256_set1_epi64x(n31[l]);
+    C->n0inv = _mm256_set1_epi64x(bm_n0inv(n31[0]));
+    C->mask  = _mm256_set1_epi64x(BM_MASK);
+
+    fmpz_init(N);
+    fmpz_init(R2);
+    fmpz_set_ui_array(N, nd, nlimbs);
+    fmpz_one(R2);
+    fmpz_mul_2exp(R2, R2, 2 * BM_BITS * s);
+    fmpz_mod(R2, R2, N);
+    for (l = 0; l < nlimbs; l++)
+        r2nn[l] = 0;
+    fmpz_get_ui_array(r2nn, nlimbs, R2);
+    bm_pack31(r231, r2nn, nlimbs, s);
+    for (l = 0; l < s; l++)
+        C->r2[l] = _mm256_set1_epi64x(r231[l]);
+    fmpz_clear(N);
+    fmpz_clear(R2);
+}
+
+/*
+   Shared building blocks (all force-inlined; s is a compile-time constant at the
+   hot call sites, so every loop below unrolls to a size-s specialization).
+   Each lane holds an independent number; carries ripple *within* a lane across
+   the limb array, so there are no cross-lane permutes.
+*/
+
+/*
+   T[off .. off+s] += a[0..s-1] * b, propagating 31-bit carries.  The top limb
+   ACCUMULATES (T[off+s] += carry) rather than being overwritten, so several
+   calls at different offsets sum into one wide accumulator (lazy reduction).
+*/
+BM_FORCE_INLINE void
+bm_fma_column(__m256i * T, const __m256i * a, __m256i b, __m256i mask,
+              int off, const int s)
+{
+    __m256i carry = _mm256_setzero_si256();
+    int j;
+    for (j = 0; j < s; j++)
+    {
+        __m256i p = _mm256_add_epi64(_mm256_add_epi64(T[off + j],
+                          _mm256_mul_epu32(a[j], b)), carry);
+        T[off + j] = _mm256_and_si256(p, mask);
+        carry = _mm256_srli_epi64(p, BM_BITS);
+    }
+    T[off + s] = _mm256_add_epi64(T[off + s], carry);
+}
+
+/* Ripple 31-bit carries left across T[0..len], leaving T[0..len-1] < 2^31. */
+BM_FORCE_INLINE void
+bm_normalize(__m256i * T, __m256i mask, const int len)
+{
+    int j;
+    for (j = 0; j < len; j++)
+    {
+        __m256i carry = _mm256_srli_epi64(T[j], BM_BITS);
+        T[j] = _mm256_and_si256(T[j], mask);
+        T[j + 1] = _mm256_add_epi64(T[j + 1], carry);
+    }
+}
+
+/*
+   One Montgomery reduction step: cancel limb T[pos] by adding m*n, where
+   m = T[pos] * n0inv (mod 2^31), then ripple the carry up through T[.. top].
+*/
+BM_FORCE_INLINE void
+bm_redc_step(__m256i * T, int pos, const bm_ctx_t * bc, __m256i mask,
+             const int s, int top)
+{
+    __m256i m = _mm256_and_si256(_mm256_mul_epu32(T[pos], bc->n0inv), mask);
+    __m256i carry = _mm256_setzero_si256();
+    int j;
+    for (j = 0; j < s; j++)
+    {
+        __m256i p = _mm256_add_epi64(_mm256_add_epi64(T[pos + j],
+                          _mm256_mul_epu32(m, bc->n[j])), carry);
+        T[pos + j] = _mm256_and_si256(p, mask);
+        carry = _mm256_srli_epi64(p, BM_BITS);
+    }
+    for (j = pos + s; j <= top; j++)
+    {
+        __m256i p = _mm256_add_epi64(T[j], carry);
+        T[j] = _mm256_and_si256(p, mask);
+        carry = _mm256_srli_epi64(p, BM_BITS);
+    }
+}
+
+/*
+   Final conditional subtraction.  hi[0..s-1] is the tentative result and
+   overflow its (s+1)-th limb; subtract n once when hi >= n (i.e. no borrow, or
+   the overflow limb is set), writing the canonical residue in [0,n) to out.
+*/
+BM_FORCE_INLINE void
+bm_final_reduce(__m256i * out, const __m256i * hi, __m256i overflow,
+                const bm_ctx_t * bc, __m256i mask, const int s)
+{
+    __m256i d[BM_MAXLIMB];
+    __m256i borrow = _mm256_setzero_si256();
+    __m256i take_d;
+    int j;
+    for (j = 0; j < s; j++)
+    {
+        __m256i sub = _mm256_sub_epi64(_mm256_sub_epi64(hi[j], bc->n[j]), borrow);
+        borrow = _mm256_srli_epi64(sub, 63);
+        d[j] = _mm256_and_si256(sub, mask);
+    }
+    take_d = _mm256_or_si256(_mm256_cmpeq_epi64(borrow, _mm256_setzero_si256()),
+                             _mm256_cmpgt_epi64(overflow, _mm256_setzero_si256()));
+    for (j = 0; j < s; j++)
+        out[j] = _mm256_blendv_epi8(hi[j], d[j], take_d);
+}
+
+/*
+   One CIOS iteration for the conversion path: t += a[]*xi, then cancel t[0] and
+   shift the array down one limb (classic interleaved multiply-and-reduce).
+*/
+BM_FORCE_INLINE void
+bm_cios_step(__m256i * t, const __m256i * a, __m256i xi, const bm_ctx_t * C,
+             __m256i mask, const int s)
+{
+    __m256i carry, m;
+    int j;
+
+    carry = _mm256_setzero_si256();
+    for (j = 0; j < s; j++)
+    {
+        __m256i p = _mm256_add_epi64(_mm256_add_epi64(t[j],
+                          _mm256_mul_epu32(a[j], xi)), carry);
+        t[j]  = _mm256_and_si256(p, mask);
+        carry = _mm256_srli_epi64(p, BM_BITS);
+    }
+    {
+        __m256i p = _mm256_add_epi64(t[s], carry);
+        t[s]     = _mm256_and_si256(p, mask);
+        t[s + 1] = _mm256_srli_epi64(p, BM_BITS);
+    }
+
+    m = _mm256_and_si256(_mm256_mul_epu32(t[0], C->n0inv), mask);
+    carry = _mm256_srli_epi64(
+                _mm256_add_epi64(t[0], _mm256_mul_epu32(m, C->n[0])), BM_BITS);
+    for (j = 1; j < s; j++)
+    {
+        __m256i p = _mm256_add_epi64(_mm256_add_epi64(t[j],
+                          _mm256_mul_epu32(m, C->n[j])), carry);
+        t[j - 1] = _mm256_and_si256(p, mask);
+        carry    = _mm256_srli_epi64(p, BM_BITS);
+    }
+    {
+        __m256i p = _mm256_add_epi64(t[s], carry);
+        t[s - 1] = _mm256_and_si256(p, mask);
+        carry = _mm256_srli_epi64(p, BM_BITS);
+        t[s] = _mm256_add_epi64(t[s + 1], carry);
+    }
+}
+
+/*
+   Reducing CIOS multiply r = a*x*R^-1 mod n, used only for the to/from-
+   Montgomery conversions (runtime s; not the hot path).
+*/
+static inline void
+bm_mul(__m256i * r, const __m256i * a, const __m256i * x, const bm_ctx_t * C)
+{
+    const __m256i mask = C->mask;
+    const slong s = C->s;
+    __m256i t[BM_MAXLIMB + 2];
+    slong i;
+
+    for (i = 0; i < s + 2; i++)
+        t[i] = _mm256_setzero_si256();
+    for (i = 0; i < s; i++)
+        bm_cios_step(t, a, x[i], C, mask, s);
+
+    bm_final_reduce(r, t, t[s], C, mask, s);
+}
+
+static inline void
+bm_from(__m256i * r, const __m256i * a, const bm_ctx_t * C)
+{
+    __m256i one[BM_MAXLIMB];
+    slong j;
+    one[0] = _mm256_set1_epi64x(1);
+    for (j = 1; j < C->s; j++)
+        one[j] = _mm256_setzero_si256();
+    bm_mul(r, a, one, C);
+}
+
+static inline void
+bm_load(bm_mat Mm, const gr_mat_t A, gr_ctx_t ctx, const bm_ctx_t * bc)
+{
+    slong nlimbs = MPN_MOD_CTX_NLIMBS(ctx);
+    const slong s = bc->s;
+    ulong tmp[4];
+    slong i, j, l;
+    for (i = 0; i < BM_DIM; i++)
+    {
+        ulong pa[BM_DIM][BM_MAXLIMB];
+        __m256i soa[BM_MAXLIMB], mo[BM_MAXLIMB];
+        for (j = 0; j < BM_DIM; j++)
+            bm_pack31(pa[j], (nn_srcptr) gr_mat_entry_srcptr(A, i, j, ctx), nlimbs, s);
+        for (l = 0; l < s; l++)
+            soa[l] = _mm256_setr_epi64x(pa[0][l], pa[1][l], pa[2][l], pa[3][l]);
+        bm_mul(mo, soa, bc->r2, bc);
+        for (l = 0; l < s; l++)
+        {
+            _mm256_storeu_si256((__m256i *) tmp, mo[l]);
+            Mm[i][0][l] = tmp[0]; Mm[i][1][l] = tmp[1];
+            Mm[i][2][l] = tmp[2]; Mm[i][3][l] = tmp[3];
+        }
+    }
+}
+
+static inline void
+bm_store(gr_mat_t C, const bm_mat Mm, gr_ctx_t ctx, const bm_ctx_t * bc)
+{
+    slong nlimbs = MPN_MOD_CTX_NLIMBS(ctx);
+    const slong s = bc->s;
+    slong i, j, l;
+    for (i = 0; i < BM_DIM; i++)
+    {
+        __m256i soa[BM_MAXLIMB], mo[BM_MAXLIMB];
+        ulong lanes[BM_MAXLIMB][4];
+        for (l = 0; l < s; l++)
+            soa[l] = _mm256_setr_epi64x(Mm[i][0][l], Mm[i][1][l],
+                                        Mm[i][2][l], Mm[i][3][l]);
+        bm_from(mo, soa, bc);
+        for (l = 0; l < s; l++)
+            _mm256_storeu_si256((__m256i *) lanes[l], mo[l]);
+        for (j = 0; j < BM_DIM; j++)
+        {
+            ulong out31[BM_MAXLIMB];
+            for (l = 0; l < s; l++)
+                out31[l] = lanes[l][j];
+            bm_unpack31((nn_ptr) gr_mat_entry_ptr(C, i, j, ctx), out31, nlimbs, s);
+        }
+    }
+}
+
+/*
+   Cm = Am * Bm, lazy reduction.  s is a COMPILE-TIME constant at each call site
+   (see bm_matmul), so all loops unroll to a size-s specialization.
+*/
+BM_FORCE_INLINE void
+bm_matmul_lazy(bm_mat Cm, const bm_mat Am, const bm_mat Bm, const bm_ctx_t * bc,
+               const int s)
+{
+    const __m256i mask = bc->mask;
+    __m256i Brow[BM_DIM][BM_MAXLIMB];
+    ulong tmp[4];
+    int i, d, bi, j;
+
+    // Pack each row of B into SoA lanes: lane j carries output column j.
+    for (d = 0; d < BM_DIM; d++)
+        for (j = 0; j < s; j++)
+            Brow[d][j] = _mm256_setr_epi64x(Bm[d][0][j], Bm[d][1][j],
+                                            Bm[d][2][j], Bm[d][3][j]);
+
+    for (i = 0; i < BM_DIM; i++)
+    {
+        __m256i T[2 * BM_MAXLIMB + 1];
+        __m256i av[BM_MAXLIMB];
+        __m256i out[BM_MAXLIMB];
+
+        for (j = 0; j < 2 * s + 1; j++)
+            T[j] = _mm256_setzero_si256();
+
+        // Lazy: sum all four raw products A[i][d]*B[d] into the accumulator T
+        // before reducing (one REDC per output entry instead of four).
+        for (d = 0; d < BM_DIM; d++)
+        {
+            for (j = 0; j < s; j++)
+                av[j] = _mm256_set1_epi64x(Am[i][d][j]);
+            for (bi = 0; bi < s; bi++)
+                bm_fma_column(T, av, Brow[d][bi], mask, bi, s);
+        }
+
+        // Reduce the summed 2s-limb accumulator once: normalize carries, run s
+        // Montgomery reduction steps, then the final conditional subtract.
+        bm_normalize(T, mask, 2 * s);
+        for (bi = 0; bi < s; bi++)
+            bm_redc_step(T, bi, bc, mask, s, 2 * s);
+        bm_final_reduce(out, T + s, T[2 * s], bc, mask, s);
+
+        for (j = 0; j < s; j++)
+        {
+            _mm256_storeu_si256((__m256i *) tmp, out[j]);
+            Cm[i][0][j] = tmp[0]; Cm[i][1][j] = tmp[1];
+            Cm[i][2][j] = tmp[2]; Cm[i][3][j] = tmp[3];
+        }
+    }
+}
+
+/* dispatch to the size-specialized (unrolled) instantiation */
+static inline void
+bm_matmul(bm_mat Cm, const bm_mat Am, const bm_mat Bm, const bm_ctx_t * bc)
+{
+    switch (bc->s)
+    {
+        case 2: bm_matmul_lazy(Cm, Am, Bm, bc, 2); break;
+        case 3: bm_matmul_lazy(Cm, Am, Bm, bc, 3); break;
+        case 4: bm_matmul_lazy(Cm, Am, Bm, bc, 4); break;
+        case 5: bm_matmul_lazy(Cm, Am, Bm, bc, 5); break;
+        case 6: bm_matmul_lazy(Cm, Am, Bm, bc, 6); break;
+        case 7: bm_matmul_lazy(Cm, Am, Bm, bc, 7); break;
+        default: bm_matmul_lazy(Cm, Am, Bm, bc, 8); break;
+    }
+}
+
+#endif /* __AVX2__ */
+
+#endif /* MPN_MOD_BATCHED_MONT_H */


### PR DESCRIPTION
Adds an AVX2 batched-Montgomery kernel for **4×4** matrices over `Z/nZ` and uses it to accelerate matrix powering (`A^exp`) called `mpn_mod_mat_mul_batched_mont`. On a 4×4 power over an odd modulus it is faster (1.60x) than the current generic path (`gr_mat_pow_ui`, which uses classical multiplies for 4×4), with the largest gains at smaller moduli. It falls back to the generic path whenever it does not apply. The matrix multiplication shouldn't be used for a generic multiply since conversion to Montgomery form has been profiled to end up taking more time than classic matrix multiplication. The `mpn_mod_mat_mul_batched_mont` is provided as a function but doesn't provide a speedup in itself. Tests and profiles are provided.

I'm leaving this as a draft in case details or specifics need to be addressed before merging.

Claude was used in the development and implementation of this PR.