### PR TITLE
Parallelize and optimize APRCL

### DIFF
--- a/src/aprcl.h
+++ b/src/aprcl.h
@@ -129,6 +129,7 @@ void aprcl_config_gauss_clear(aprcl_config conf);
 /* Jacobi test configuration */
 ulong aprcl_R_value(const fmpz_t n);
 void aprcl_config_jacobi_init(aprcl_config conf, const fmpz_t n);
+void aprcl_config_jacobi_init_R(aprcl_config conf, const fmpz_t n, ulong R);
 void aprcl_config_jacobi_clear(aprcl_config conf);
 
 /*  Gauss sums primality test */

--- a/src/aprcl/config_jacobi.c
+++ b/src/aprcl/config_jacobi.c
@@ -10,10 +10,24 @@
 */
 
 #include <math.h>
+#include <stdlib.h>
 #include "ulong_extras.h"
 #include "fmpz.h"
 #include "fmpz_factor.h"
 #include "aprcl.h"
+
+/*
+    Exponent alpha in the cost model cost(p, q) ~ phi(p^k)^alpha used when
+    choosing which primes q to keep in s.
+*/
+#define APRCL_JACOBI_COST_EXPONENT 2.0
+
+/*
+    Primes q above this bound are only kept in s when they are needed to
+    reach s^2 > n: the Jacobi sums J(p, q) are computed with tables of q
+    words, so e.g. q = R + 1 with R ~ 10^8 needs gigabytes of memory.
+*/
+#define APRCL_MAX_Q (UWORD(1) << 22)
 
 ulong
 aprcl_R_value(const fmpz_t n)
@@ -89,6 +103,11 @@ _aprcl_config_jacobi_reduce_s2(aprcl_config conf, const fmpz_t n)
         n_factor_init(&q_factors);
         n_factor(&q_factors, q - 1, 1);
 
+        /*
+            w[i] = estimated cost of the Jacobi sum tests for q per bit
+            contributed to s, with the cost of a pair (p, q) modelled as
+            phi(p^k)^APRCL_JACOBI_COST_EXPONENT.
+        */
         w[i] = 0;
 
         for (j = 0; j < q_factors.num; j++)
@@ -97,12 +116,15 @@ _aprcl_config_jacobi_reduce_s2(aprcl_config conf, const fmpz_t n)
 
             p = q_factors.p[j];
             euler_phi = n_pow(p, q_factors.exp[j] - 1) * (p - 1);
-            euler_phi = euler_phi * euler_phi;
 
-            w[i] += euler_phi;
+            w[i] += pow((double) euler_phi, APRCL_JACOBI_COST_EXPONENT);
         }
 
         w[i] /= log((double) n_pow(q, conf->qs->exp[i]));
+
+        /* large q are expensive (tables of q words): drop them first */
+        if (q > APRCL_MAX_Q)
+            w[i] += 1e6 * ((double) q / APRCL_MAX_Q);
     }
 
     while (1)
@@ -144,46 +166,79 @@ _aprcl_config_jacobi_reduce_s2(aprcl_config conf, const fmpz_t n)
     flint_free(w);
 }
 
+/* compare ulongs for qsort */
+static int
+_aprcl_ulong_cmp(const void * a, const void * b)
+{
+    ulong x = *(const ulong *) a, y = *(const ulong *) b;
+    return (x < y) ? -1 : (x > y);
+}
+
+/*
+    Sets s and the list qs of primes q with (q - 1) | R (with exponents
+    such that the powers q^k dividing s are as large as allowed), by
+    enumerating the divisors d of R and keeping those with d + 1 prime.
+*/
 static void
 _aprcl_config_jacobi_update(aprcl_config conf)
 {
-    ulong prime = 2;
+    ulong i, j, num_divisors, prime;
+    nn_ptr divisors;
+    n_factor_t factors;
 
     fmpz_set_ui(conf->s, 1);
     fmpz_factor_clear(conf->qs);
     fmpz_factor_init(conf->qs);
     conf->qs->sign = 1;
 
-    _fmpz_factor_append_ui(conf->qs, prime, aprcl_p_power_in_q(conf->R, prime) + 2);
-    fmpz_mul_ui(conf->s, conf->s, n_pow(prime, aprcl_p_power_in_q(conf->R, prime) + 2));
+    /* enumerate the divisors of R */
+    n_factor_init(&factors);
+    n_factor(&factors, conf->R, 1);
 
-    prime = 3;
-    while (2 * (prime - 1) <= conf->R)
+    num_divisors = 1;
+    for (i = 0; i < factors.num; i++)
+        num_divisors *= factors.exp[i] + 1;
+
+    divisors = flint_malloc(num_divisors * sizeof(ulong));
+    divisors[0] = 1;
+    num_divisors = 1;
+    for (i = 0; i < factors.num; i++)
     {
-        if ((conf->R % (prime - 1)) == 0)
+        ulong len = num_divisors, pk = 1;
+        for (j = 0; j < factors.exp[i]; j++)
         {
-            _fmpz_factor_append_ui(conf->qs, prime, aprcl_p_power_in_q(conf->R, prime) + 1);
-            fmpz_mul_ui(conf->s, conf->s, n_pow(prime, aprcl_p_power_in_q(conf->R, prime) + 1));
+            ulong l;
+            pk *= factors.p[i];
+            for (l = 0; l < len; l++)
+                divisors[num_divisors++] = divisors[l] * pk;
         }
-        prime++;
-        while (n_is_prime(prime) == 0)
-            prime++;
     }
 
-    if (n_is_prime(conf->R + 1))
+    qsort(divisors, num_divisors, sizeof(ulong), _aprcl_ulong_cmp);
+
+    /* q = d + 1 prime; q = 2 (from d = 1) gets one extra power of 2 */
+    for (i = 0; i < num_divisors; i++)
     {
-        _fmpz_factor_append_ui(conf->qs, conf->R + 1, 1);
-        fmpz_mul_ui(conf->s, conf->s, conf->R + 1);
+        prime = divisors[i] + 1;
+        if (n_is_prime(prime))
+        {
+            ulong k = aprcl_p_power_in_q(conf->R, prime) + 1 + (prime == 2);
+            _fmpz_factor_append_ui(conf->qs, prime, k);
+            fmpz_mul_ui(conf->s, conf->s, n_pow(prime, k));
+        }
     }
+
+    flint_free(divisors);
 }
 
 /* Computes s = \prod q^(k + 1) ; q - prime, q - 1 | R; q^k | R and q^(k + 1) not | R */
+/* configuration with a given R; s^2 > n is not checked */
 void
-aprcl_config_jacobi_init(aprcl_config conf, const fmpz_t n)
+aprcl_config_jacobi_init_R(aprcl_config conf, const fmpz_t n, ulong R)
 {
     fmpz_init(conf->s);
     fmpz_factor_init(conf->qs);
-    conf->R = aprcl_R_value(n);
+    conf->R = R;
     _aprcl_config_jacobi_update(conf);
 
     n_factor_init(&conf->rs);
@@ -191,6 +246,12 @@ aprcl_config_jacobi_init(aprcl_config conf, const fmpz_t n)
 
     conf->qs_used = (int *) flint_malloc(sizeof(int) * conf->qs->num);
     _aprcl_config_jacobi_reduce_s2(conf, n);
+}
+
+void
+aprcl_config_jacobi_init(aprcl_config conf, const fmpz_t n)
+{
+    aprcl_config_jacobi_init_R(conf, n, aprcl_R_value(n));
 }
 
 void

--- a/src/aprcl/is_prime_final_division.c
+++ b/src/aprcl/is_prime_final_division.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2015 Vladimir Glazachev
+    Copyright (C) 2026 FLINT contributors
 
     This file is part of FLINT.
 
@@ -9,41 +10,81 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "thread_support.h"
+#if FLINT_USES_PTHREAD
+# include <pthread.h>
+#endif
+#include "mpn_extras.h"
 #include "fmpz.h"
 #include "aprcl.h"
 
-int
-aprcl_is_prime_final_division(const fmpz_t n, const fmpz_t s, ulong r)
+/* is {x, xn} divisible by {d, dn}? (both normalised, dn >= 1) */
+static int
+_aprcl_mpn_divisible(nn_srcptr x, slong xn, nn_srcptr d, slong dn)
 {
-    int result = 1;
+    __mpz_struct xz, dz;
+
+    xz._mp_d = (nn_ptr) x;
+    xz._mp_size = xz._mp_alloc = xn;
+    dz._mp_d = (nn_ptr) d;
+    dz._mp_size = dz._mp_alloc = dn;
+
+    return mpz_divisible_p(&xz, &dz);
+}
+
+/*
+    Final trial division step of APRCL (step 7 of algorithm 9.1.28 in
+    Cohen's "A Course in Computational Algebraic Number Theory").
+
+    Given n coprime to s with s^2 > n (the walk itself is correct for any
+    s, but the conclusion that n is prime needs s^2 > n), the earlier steps
+    have shown that
+    every divisor of n is congruent to n^i mod s for some 0 <= i < r.
+    If n is composite it has a prime divisor a with 1 < a <= sqrt(n) < s,
+    so a is exactly the least residue of n^i mod s for some 1 <= i < r.
+    We therefore walk the residues n^i mod s, i = 1, 2, ..., and test
+    divisibility of n by those residues a with 1 < a <= sqrt(n) (residues
+    that are even, for odd n, are skipped too). Since n^r = 1 mod s the
+    walk stops when the residue 1 is reached, or after r - 1 steps.
+
+    The walk uses mpn arithmetic with a preconditioned multiplication by
+    the fixed multiplier n mod s. The range of exponents is split into
+    chunks which are processed in parallel; each chunk computes its first
+    power with a modular exponentiation. If a chunk reaches the residue 1
+    at n^i then the residues that follow are n^1, n^2, ..., which are
+    covered by the first chunk, so the chunk may stop early.
+*/
+
+/* Reference implementation with fmpz arithmetic (used for tiny s) */
+static int
+_aprcl_is_prime_final_division_fmpz(const fmpz_t n, const fmpz_t s, ulong r,
+                                                            const fmpz_t bound)
+{
+    int result = 1, n_odd = fmpz_is_odd(n);
     ulong i;
     fmpz_t npow, nmul, rem;
 
     fmpz_init(rem);
-    fmpz_init_set(npow, n);
-    fmpz_mod(npow, npow, s); /* npow = n mod s */
-    fmpz_init_set(nmul, npow);
+    fmpz_init(nmul);
+    fmpz_init(npow);
+    fmpz_mod(nmul, n, s);       /* nmul = n mod s */
+    fmpz_set(npow, nmul);       /* npow = n^i mod s */
 
-    for (i = 1; i <= r; i++)
+    for (i = 1; i < r; i++)
     {
         if (fmpz_is_one(npow))
             break;
 
-        fmpz_mod(rem, n, npow);
-
-        /* if npow | n */
-        if (fmpz_is_zero(rem))
+        if (!(n_odd && fmpz_is_even(npow)) && fmpz_cmp(npow, bound) <= 0)
         {
-            /* if npow != n and npow != 1 */
-            if (!fmpz_equal(n, npow) && !fmpz_is_one(npow))
+            fmpz_mod(rem, n, npow);
+            if (fmpz_is_zero(rem) && !fmpz_is_one(npow))
             {
-                /* npow | n, so n is composite */
                 result = 0;
                 break;
             }
         }
 
-        /* npow = n^i mod s */
         fmpz_mul(npow, npow, nmul);
         fmpz_mod(npow, npow, s);
     }
@@ -51,6 +92,263 @@ aprcl_is_prime_final_division(const fmpz_t n, const fmpz_t s, ulong r)
     fmpz_clear(npow);
     fmpz_clear(nmul);
     fmpz_clear(rem);
+
+    return result;
+}
+
+typedef struct
+{
+    nn_srcptr n;        /* n, nn limbs */
+    slong nn;
+    nn_srcptr s;        /* s, sn limbs */
+    nn_srcptr snormed;  /* s shifted left by norm bits */
+    nn_srcptr sinv;     /* precomputed inverse of snormed */
+    slong sn;
+    ulong norm;
+    nn_srcptr nmul;     /* n mod s, unshifted */
+    nn_srcptr nmul_pre; /* precomputed data for multiplication by nmul, or NULL */
+    int precond;        /* MPN_MULMOD_PRECOND_{NONE,SHOUP,MATRIX} */
+    nn_srcptr bound;    /* floor(sqrt(n)) padded to sn limbs */
+    int n_odd;
+    ulong r;
+    ulong chunk;        /* exponents per chunk */
+    slong num_chunks;
+    int found_divisor;
+#if FLINT_USES_PTHREAD
+    pthread_mutex_t mutex;
+#endif
+} _aprcl_fd_args;
+
+#define FD_CHECK_INTERVAL 1024
+
+static void
+_aprcl_fd_worker(slong c, void * varg)
+{
+    _aprcl_fd_args * args = (_aprcl_fd_args *) varg;
+    slong sn = args->sn, nn = args->nn;
+    ulong norm = args->norm;
+    ulong i, i0, i1;
+    /* the preconditioned methods work on unshifted operands, mulmod_preinvn on shifted ones */
+    int unshifted = (args->precond != MPN_MULMOD_PRECOND_NONE);
+    int stop = 0;
+    nn_ptr npow, t, nmul_sh;
+    TMP_INIT;
+
+    /* this chunk covers exponents i0 <= i < i1 */
+    i0 = 1 + c * args->chunk;
+    i1 = FLINT_MIN(i0 + args->chunk, args->r);
+    if (i0 >= i1)
+        return;
+
+    TMP_START;
+    npow = TMP_ALLOC(3 * sn * sizeof(ulong));
+    t = npow + sn;
+    nmul_sh = t + sn;
+
+    /* npow = n^{i0} mod s */
+    {
+        fmpz_t f, e, m;
+        fmpz_init(f);
+        fmpz_init(m);
+        fmpz_init_set_ui(e, i0);
+        fmpz_set_ui_array(f, args->n, nn);
+        fmpz_set_ui_array(m, args->s, sn);
+        fmpz_powm(f, f, e, m);
+        fmpz_get_ui_array(npow, sn, f);
+        fmpz_clear(f);
+        fmpz_clear(e);
+        fmpz_clear(m);
+    }
+
+    if (!unshifted)
+    {
+        /* mulmod_preinvn works with operands shifted left by norm bits */
+        if (norm)
+        {
+            mpn_lshift(nmul_sh, args->nmul, sn, norm);
+            mpn_lshift(npow, npow, sn, norm);
+        }
+        else
+            flint_mpn_copyi(nmul_sh, args->nmul, sn);
+    }
+
+    for (i = i0; i < i1 && !stop; i++)
+    {
+        nn_srcptr a;
+        slong an;
+
+        /* a = unshifted residue n^i mod s */
+        if (unshifted || norm == 0)
+            a = npow;
+        else
+        {
+            mpn_rshift(t, npow, sn, norm);
+            a = t;
+        }
+
+        an = sn;
+        MPN_NORM(a, an);
+
+        /* residue 1: the powers cycle from here on */
+        if (an == 1 && a[0] == 1)
+            break;
+
+        /* candidate divisor: 1 < a <= sqrt(n), and a odd if n is odd */
+        if (an > 0 && !(args->n_odd && (a[0] & 1) == 0)
+                   && mpn_cmp(a, args->bound, sn) <= 0
+                   && _aprcl_mpn_divisible(args->n, nn, a, an))
+        {
+#if FLINT_USES_PTHREAD
+            pthread_mutex_lock(&args->mutex);
+#endif
+            args->found_divisor = 1;
+#if FLINT_USES_PTHREAD
+            pthread_mutex_unlock(&args->mutex);
+#endif
+            break;
+        }
+
+        /* npow = npow * nmul mod s */
+        if (args->precond == MPN_MULMOD_PRECOND_MATRIX)
+            flint_mpn_mulmod_precond_matrix(npow, args->nmul_pre, npow, sn,
+                                            args->snormed, args->sinv, norm);
+        else if (args->precond == MPN_MULMOD_PRECOND_SHOUP)
+            flint_mpn_mulmod_precond_shoup(npow, args->nmul, args->nmul_pre,
+                                                        npow, sn, args->s, norm);
+        else
+            flint_mpn_mulmod_preinvn(npow, npow, nmul_sh, sn,
+                                            args->snormed, args->sinv, norm);
+
+        /* periodically check whether another chunk found a divisor */
+        if (args->num_chunks > 1 && (i & (FD_CHECK_INTERVAL - 1)) == 0)
+        {
+#if FLINT_USES_PTHREAD
+            pthread_mutex_lock(&args->mutex);
+#endif
+            stop = args->found_divisor;
+#if FLINT_USES_PTHREAD
+            pthread_mutex_unlock(&args->mutex);
+#endif
+        }
+    }
+
+    TMP_END;
+}
+
+int
+aprcl_is_prime_final_division(const fmpz_t n, const fmpz_t s, ulong r)
+{
+    int result;
+    slong sn, nn, num_threads;
+    ulong norm;
+    fmpz_t bound, nmul;
+    nn_ptr nlimbs, slimbs, snormed, sinv, nmul_limbs, nmul_pre, bound_limbs;
+    _aprcl_fd_args args;
+
+    if (fmpz_cmp_ui(n, 3) <= 0 || r <= 1)
+        return 1;
+
+    /*
+        bound = min(floor(sqrt(n)), s - 1): only residues up to sqrt(n)
+        need testing, and every residue is below s (so the bound fits in
+        the limbs of s even if s^2 < n).
+    */
+    fmpz_init(bound);
+    fmpz_sqrt(bound, n);
+    if (fmpz_cmp(bound, s) >= 0)
+    {
+        fmpz_set(bound, s);
+        fmpz_sub_ui(bound, bound, 1);
+    }
+
+    sn = fmpz_size(s);
+
+    if (sn < 2 || fmpz_sgn(s) < 0)
+    {
+        result = _aprcl_is_prime_final_division_fmpz(n, s, r, bound);
+        fmpz_clear(bound);
+        return result;
+    }
+
+    nn = fmpz_size(n);
+
+    nlimbs = flint_malloc((nn + 6 * sn) * sizeof(ulong));
+    slimbs = nlimbs + nn;
+    snormed = slimbs + sn;
+    sinv = snormed + sn;
+    nmul_limbs = sinv + sn;
+    nmul_pre = nmul_limbs + sn;
+    bound_limbs = nmul_pre + sn;
+
+    fmpz_get_ui_array(nlimbs, nn, n);
+    fmpz_get_ui_array(slimbs, sn, s);
+    fmpz_get_ui_array(bound_limbs, sn, bound); /* bound < s fits in sn limbs */
+
+    norm = flint_clz(slimbs[sn - 1]);
+    if (norm)
+        mpn_lshift(snormed, slimbs, sn, norm);
+    else
+        flint_mpn_copyi(snormed, slimbs, sn);
+    flint_mpn_preinvn(sinv, snormed, sn);
+
+    fmpz_init(nmul);
+    fmpz_mod(nmul, n, s);
+    fmpz_get_ui_array(nmul_limbs, sn, nmul);
+    fmpz_clear(nmul);
+
+    args.n = nlimbs;
+    args.nn = nn;
+    args.s = slimbs;
+    args.snormed = snormed;
+    args.sinv = sinv;
+    args.sn = sn;
+    args.norm = norm;
+    args.nmul = nmul_limbs;
+    args.bound = bound_limbs;
+    args.n_odd = fmpz_is_odd(n);
+    args.r = r;
+    args.found_divisor = 0;
+
+    /* preconditioned multiplication by the fixed multiplier nmul */
+    args.precond = flint_mpn_mulmod_want_precond(sn, r, norm);
+    args.nmul_pre = NULL;
+    if (args.precond == MPN_MULMOD_PRECOND_MATRIX)
+    {
+        nmul_pre = flint_malloc(flint_mpn_mulmod_precond_matrix_alloc(sn) * sizeof(ulong));
+        flint_mpn_mulmod_precond_matrix_precompute(nmul_pre, nmul_limbs, sn,
+                                                            snormed, sinv, norm);
+        args.nmul_pre = nmul_pre;
+    }
+    else if (args.precond == MPN_MULMOD_PRECOND_SHOUP)
+    {
+        flint_mpn_mulmod_precond_shoup_precompute(nmul_pre, nmul_limbs, sn,
+                                                            snormed, sinv, norm);
+        args.nmul_pre = nmul_pre;
+    }
+
+    /* split the exponents 1 <= i < r into chunks, one per thread */
+    num_threads = flint_get_num_threads();
+    if (r < 4096)
+        num_threads = 1;
+    args.num_chunks = FLINT_MIN(num_threads, (slong) (r - 1));
+    args.chunk = (r - 1 + args.num_chunks - 1) / args.num_chunks;
+
+#if FLINT_USES_PTHREAD
+    pthread_mutex_init(&args.mutex, NULL);
+#endif
+
+    flint_parallel_do(_aprcl_fd_worker, &args, args.num_chunks, 0, 0);
+
+#if FLINT_USES_PTHREAD
+    pthread_mutex_destroy(&args.mutex);
+#endif
+
+    result = !args.found_divisor;
+
+    if (args.precond == MPN_MULMOD_PRECOND_MATRIX)
+        flint_free(nmul_pre);
+    flint_free(nlimbs);
+    fmpz_clear(bound);
 
     return result;
 }

--- a/src/aprcl/is_prime_jacobi.c
+++ b/src/aprcl/is_prime_jacobi.c
@@ -9,6 +9,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include <stdlib.h>
+#include "thread_support.h"
+#if FLINT_USES_PTHREAD
+# include <pthread.h>
+#endif
 #include "ulong_extras.h"
 #include "fmpz.h"
 #include "fmpz_mod.h"
@@ -89,8 +94,8 @@ slong
 _aprcl_is_prime_jacobi_check_pk(const unity_zp j, const fmpz_t u, ulong v)
 {
     slong h;
-    ulong i, r;
-    unity_zp j0, jv, temp, aut;
+    ulong i, r, e;
+    unity_zp j0, jv, temp, aut, jr, ji, je;
 
     /* use mpn_mod arithmetic whenever the modulus is in range */
     if (_aprcl_is_prime_jacobi_check_pk_mpn(&h, j, u, v))
@@ -102,34 +107,48 @@ _aprcl_is_prime_jacobi_check_pk(const unity_zp j, const fmpz_t u, ulong v)
     unity_zp_init(jv, j->p, j->exp, fmpz_mod_ctx_modulus(j->ctx));
     unity_zp_init(temp, j->p, j->exp, fmpz_mod_ctx_modulus(j->ctx));
     unity_zp_init(aut, j->p, j->exp, fmpz_mod_ctx_modulus(j->ctx));
+    unity_zp_init(jr, j->p, j->exp, fmpz_mod_ctx_modulus(j->ctx));
+    unity_zp_init(ji, j->p, j->exp, fmpz_mod_ctx_modulus(j->ctx));
+    unity_zp_init(je, j->p, j->exp, fmpz_mod_ctx_modulus(j->ctx));
 
     unity_zp_coeff_set_ui(j0, 0, 1);    /* j0 = 1 */
     unity_zp_coeff_set_ui(jv, 0, 1);    /* jv = 1 */
 
+    /*
+        The powers j^i and j^{(v * i) / r} are maintained incrementally:
+        ji = j^i and je = j^e with e = (v * i) / r, which grows by at most
+        one per step since v < r.
+    */
+    unity_zp_reduce_cyclotomic(jr, j);  /* jr = j reduced mod Phi_{p^k} */
+    unity_zp_coeff_set_ui(ji, 0, 1);
+    unity_zp_coeff_set_ui(je, 0, 1);
+    e = 0;
+
     /* for i in 1..p^k */
     for (i = 1; i <= r; i++)
     {
+        /* ji = j^i */
+        unity_zp_mul(temp, ji, jr);
+        unity_zp_swap(temp, ji);
+
+        /* je = j^{(v * i) / r}; note: overflow in v * i is not a concern */
+        while (e < (v * i) / r)
+        {
+            unity_zp_mul(temp, je, jr);
+            unity_zp_swap(temp, je);
+            e++;
+        }
+
         /* only for i that coprime to p */
         if (i % j->p == 0) continue;
 
-        /* update j0 = \prod{\sigma_i^{-1}(j^i)} */
-        unity_zp_pow_ui(temp, j, i);
-        _unity_zp_reduce_cyclotomic(temp);
-        /* aut = \sigma_i^{-1}(temp) */
-        unity_zp_aut_inv(aut, temp, i);
-
-        /* j0 *= aut */
+        /* j0 *= \sigma_i^{-1}(j^i) */
+        unity_zp_aut_inv(aut, ji, i);
         unity_zp_mul(temp, j0, aut);
         unity_zp_swap(temp, j0);
 
-        /* update jv = \prod{\sigma_i^{-1}(j^{(v * i) / r})} */
-        /* note: overflow in v * i is not a concern here */
-        unity_zp_pow_ui(temp, j, (v * i) / r);
-        _unity_zp_reduce_cyclotomic(temp);
-        /* aut = \sigma_i^{-1}(temp) */
-        unity_zp_aut_inv(aut, temp, i);
-
-        /* jv *= aut */
+        /* jv *= \sigma_i^{-1}(j^{(v * i) / r}) */
+        unity_zp_aut_inv(aut, je, i);
         unity_zp_mul(temp, jv, aut);
         unity_zp_swap(temp, jv);
     }
@@ -147,6 +166,9 @@ _aprcl_is_prime_jacobi_check_pk(const unity_zp j, const fmpz_t u, ulong v)
     unity_zp_clear(j0);
     unity_zp_clear(jv);
     unity_zp_clear(temp);
+    unity_zp_clear(jr);
+    unity_zp_clear(ji);
+    unity_zp_clear(je);
 
     return h;
 }
@@ -286,8 +308,8 @@ _aprcl_is_prime_jacobi_check_2k(const unity_zp j, const unity_zp j2_1,
         const unity_zp j2_2, const fmpz_t u, ulong v)
 {
     slong h;
-    ulong i, r;
-    unity_zp j_j0, j0, jv, temp, aut;
+    ulong i, r, e;
+    unity_zp j_j0, j0, jv, temp, aut, ji, je, jj2, jj6;
 
     /* use mpn_mod arithmetic whenever the modulus is in range */
     if (_aprcl_is_prime_jacobi_check_2k_mpn(&h, j, j2_1, j2_2, u, v))
@@ -300,6 +322,10 @@ _aprcl_is_prime_jacobi_check_2k(const unity_zp j, const unity_zp j2_1,
     unity_zp_init(aut, 2, j->exp, fmpz_mod_ctx_modulus(j->ctx));
     unity_zp_init(j0, 2, j->exp, fmpz_mod_ctx_modulus(j->ctx));
     unity_zp_init(jv, 2, j->exp, fmpz_mod_ctx_modulus(j->ctx));
+    unity_zp_init(ji, 2, j->exp, fmpz_mod_ctx_modulus(j->ctx));
+    unity_zp_init(je, 2, j->exp, fmpz_mod_ctx_modulus(j->ctx));
+    unity_zp_init(jj2, 2, j->exp, fmpz_mod_ctx_modulus(j->ctx));
+    unity_zp_init(jj6, 2, j->exp, fmpz_mod_ctx_modulus(j->ctx));
 
     unity_zp_coeff_set_ui(j0, 0, 1);    /* j0 = 1 */
     unity_zp_coeff_set_ui(jv, 0, 1);    /* jv = 1 */
@@ -307,56 +333,43 @@ _aprcl_is_prime_jacobi_check_2k(const unity_zp j, const unity_zp j2_1,
     /* j_j0 = J(2, q) * J_3(q) */
     unity_zp_mul(j_j0, j, j2_1);
 
-    /* for i in 1..p^k and (i == 1 or i == 3 mod 8) */
-    for (i = 1; i < r;)
+    /*
+        The loop runs over i = 1, 3, 9, 11, 17, 19, ... (i = 1 or 3 mod 8).
+        The powers j_j0^i and j_j0^{(v * i) / r} are maintained
+        incrementally: ji = j_j0^i is multiplied by jj2 = j_j0^2 or
+        jj6 = j_j0^6 as i steps by 2 or 6, and je = j_j0^e picks up
+        one factor of j_j0 each time e = (v * i) / r increases.
+    */
+    unity_zp_mul(jj2, j_j0, j_j0);
+    unity_zp_mul(temp, jj2, jj2);
+    unity_zp_mul(jj6, temp, jj2);
+    unity_zp_copy(ji, j_j0);
+    unity_zp_coeff_set_ui(je, 0, 1);
+    e = 0;
+
+    for (i = 1; i < r; i += (i % 8 == 1) ? 2 : 6)
     {
-        /* i == 1 mod 8 */
+        /* je = j_j0^{(v * i) / r} */
+        while (e < (v * i) / r)
+        {
+            unity_zp_mul(temp, je, j_j0);
+            unity_zp_swap(temp, je);
+            e++;
+        }
 
-        /* update j0 = \prod{\sigma_i^{-1}(j^i)} */
-        unity_zp_pow_ui(temp, j_j0, i);
-        _unity_zp_reduce_cyclotomic(temp);
-        /* aut = \sigma_i^{-1}(temp) */
-        unity_zp_aut_inv(aut, temp, i);
-
-        /* j0 *= aut */
+        /* j0 *= \sigma_i^{-1}(j_j0^i) */
+        unity_zp_aut_inv(aut, ji, i);
         unity_zp_mul(temp, j0, aut);
         unity_zp_swap(temp, j0);
 
-        /* update jv = \prod{\sigma_i^{-1}(j^{(v * i) / r})} */
-        unity_zp_pow_ui(temp, j_j0, (v * i) / r);
-        _unity_zp_reduce_cyclotomic(temp);
-        /* aut = \sigma_i^{-1}(temp) */
-        unity_zp_aut_inv(aut, temp, i);
-
-        /* jv *= aut */
+        /* jv *= \sigma_i^{-1}(j_j0^{(v * i) / r}) */
+        unity_zp_aut_inv(aut, je, i);
         unity_zp_mul(temp, jv, aut);
         unity_zp_swap(temp, jv);
 
-        /* i == 3 mod 8 */
-        i += 2;
-
-        /* update j0 = \prod{\sigma_i^{-1}(j^i)} */
-        unity_zp_pow_ui(temp, j_j0, i);
-        _unity_zp_reduce_cyclotomic(temp);
-        /* aut = \sigma_i^{-1}(temp) */
-        unity_zp_aut_inv(aut, temp, i);
-
-        /* j0 *= aut */
-        unity_zp_mul(temp, j0, aut);
-        unity_zp_swap(temp, j0);
-
-        /* update jv = \prod{\sigma_i^{-1}(j^{(v * i) / r})} */
-        unity_zp_pow_ui(temp, j_j0, (v * i) / r);
-        _unity_zp_reduce_cyclotomic(temp);
-        /* aut = \sigma_i^{-1}(temp) */
-        unity_zp_aut_inv(aut, temp, i);
-
-        /* jv *= aut */
-        unity_zp_mul(temp, jv, aut);
-        unity_zp_swap(temp, jv);
-
-        /* now again i == 1 mod 8 */
-        i += 6;
+        /* ji = j_j0^{next i} */
+        unity_zp_mul(temp, ji, (i % 8 == 1) ? jj2 : jj6);
+        unity_zp_swap(temp, ji);
     }
 
     /* if v % 8 not congruent 1 or 3 modulo 8 then jv *= J_2(q)^2 */
@@ -380,6 +393,10 @@ _aprcl_is_prime_jacobi_check_2k(const unity_zp j, const unity_zp j2_1,
     unity_zp_clear(jv);
     unity_zp_clear(j_j0);
     unity_zp_clear(temp);
+    unity_zp_clear(ji);
+    unity_zp_clear(je);
+    unity_zp_clear(jj2);
+    unity_zp_clear(jj6);
 
     return h;
 }
@@ -550,31 +567,194 @@ _aprcl_is_prime_jacobi_additional_test(const fmpz_t n, ulong p)
     return result;
 }
 
+/*
+    One (q, p) pair of the Jacobi sum test. The pairs are independent, so
+    they are run as a task list, possibly in parallel. Each task computes h
+    (or -1 if n is proven composite) and, for p = 2, k >= 2, whether
+    q^{(n - 1) / 2} = -1 mod n, which is needed for the (L_p) check.
+*/
+typedef struct
+{
+    ulong q;
+    ulong p;
+    ulong k;
+    int pind;           /* index of p in config->rs */
+    slong h;            /* result: h, or -1 if n is composite */
+    int qpow_is_minus1; /* result: q^{(n - 1) / 2} = -1 mod n (p = 2, k >= 2) */
+} _aprcl_jacobi_task;
+
+typedef struct
+{
+    const fmpz * n;
+    const fmpz * ndec;      /* n - 1 */
+    const fmpz * ndecdiv;   /* (n - 1) / 2 */
+    _aprcl_jacobi_task * tasks;
+    slong num_tasks;
+    slong next_task;
+    int composite;
+#if FLINT_USES_PTHREAD
+    pthread_mutex_t mutex;
+#endif
+} _aprcl_jacobi_args;
+
+static void
+_aprcl_jacobi_run_task(_aprcl_jacobi_task * t, const _aprcl_jacobi_args * args)
+{
+    ulong p = t->p, k = t->k, q = t->q;
+    ulong r = n_pow(p, k);
+    ulong v;
+    fmpz_t u;
+
+    t->qpow_is_minus1 = 0;
+
+    if (p == 2 && k == 1)
+    {
+        t->h = _aprcl_is_prime_jacobi_check_21(q, args->n);
+        return;
+    }
+
+    fmpz_init(u);
+    fmpz_tdiv_q_ui(u, args->n, r);      /* u = n / r */
+    v = fmpz_tdiv_ui(args->n, r);       /* v = n % r */
+
+    if (p == 2)
+    {
+        unity_zp jacobi_sum, jacobi_sum2_1, jacobi_sum2_2;
+        fmpz_t q_pow;
+
+        /* q_pow = q^{(n - 1) / 2} mod n, needed for the (L_2) check */
+        fmpz_init_set_ui(q_pow, q);
+        fmpz_powm(q_pow, q_pow, args->ndecdiv, args->n);
+        t->qpow_is_minus1 = fmpz_equal(q_pow, args->ndec);
+        fmpz_clear(q_pow);
+
+        unity_zp_init(jacobi_sum, p, k, args->n);
+        unity_zp_jacobi_sum_pq(jacobi_sum, q, p);
+
+        if (k == 2)
+        {
+            t->h = _aprcl_is_prime_jacobi_check_22(jacobi_sum, u, v, q);
+        }
+        else
+        {
+            /* for k >= 3 we also need J_2(q) and J_3(q) */
+            unity_zp_init(jacobi_sum2_1, p, k, args->n);
+            unity_zp_init(jacobi_sum2_2, p, k, args->n);
+            unity_zp_jacobi_sum_2q_one(jacobi_sum2_1, q);
+            unity_zp_jacobi_sum_2q_two(jacobi_sum2_2, q);
+            t->h = _aprcl_is_prime_jacobi_check_2k(jacobi_sum,
+                                jacobi_sum2_1, jacobi_sum2_2, u, v);
+            unity_zp_clear(jacobi_sum2_1);
+            unity_zp_clear(jacobi_sum2_2);
+        }
+
+        unity_zp_clear(jacobi_sum);
+    }
+    else
+    {
+        unity_zp jacobi_sum;
+
+        unity_zp_init(jacobi_sum, p, k, args->n);
+        unity_zp_jacobi_sum_pq(jacobi_sum, q, p);
+        t->h = _aprcl_is_prime_jacobi_check_pk(jacobi_sum, u, v);
+        unity_zp_clear(jacobi_sum);
+    }
+
+    fmpz_clear(u);
+}
+
+/* worker: grab the next unclaimed task until none are left or n is composite */
+static void
+_aprcl_jacobi_worker(slong FLINT_UNUSED(i), void * varg)
+{
+    _aprcl_jacobi_args * args = (_aprcl_jacobi_args *) varg;
+
+    while (1)
+    {
+        slong t;
+
+#if FLINT_USES_PTHREAD
+        pthread_mutex_lock(&args->mutex);
+#endif
+        t = (args->composite) ? args->num_tasks : args->next_task;
+        if (t < args->num_tasks)
+            args->next_task = t + 1;
+#if FLINT_USES_PTHREAD
+        pthread_mutex_unlock(&args->mutex);
+#endif
+
+        if (t >= args->num_tasks)
+            break;
+
+        _aprcl_jacobi_run_task(args->tasks + t, args);
+
+        if (args->tasks[t].h < 0)
+        {
+#if FLINT_USES_PTHREAD
+            pthread_mutex_lock(&args->mutex);
+#endif
+            args->composite = 1;
+#if FLINT_USES_PTHREAD
+            pthread_mutex_unlock(&args->mutex);
+#endif
+        }
+    }
+}
+
+/* order tasks by decreasing phi(p^k), i.e. decreasing cost, for load balance */
+static int
+_aprcl_jacobi_task_cmp(const void * a, const void * b)
+{
+    const _aprcl_jacobi_task * x = (const _aprcl_jacobi_task *) a;
+    const _aprcl_jacobi_task * y = (const _aprcl_jacobi_task *) b;
+    ulong px = n_pow(x->p, x->k - 1) * (x->p - 1);
+    ulong py = n_pow(y->p, y->k - 1) * (y->p - 1);
+
+    if (px != py)
+        return (px < py) ? 1 : -1;
+    if (x->q != y->q)
+        return (x->q < y->q) ? 1 : -1;
+    return 0;
+}
+
+/*
+    Steps (2.), (3.) and (4.) of the test. The pairs (q, p) with q | s and
+    p | q - 1 are independent and are processed as a task list using all
+    available threads; the (L_p) bookkeeping is done afterwards.
+*/
 primality_test_status
 _aprcl_is_prime_jacobi(const fmpz_t n, const aprcl_config config)
 {
-    int *lambdas;
+    int * lambdas;
     ulong i, j, nmod4;
+    slong num_tasks, t;
     primality_test_status result;
-    fmpz_t temp, p2, ndec, ndecdiv, u, q_pow;
+    fmpz_t temp, p2, ndec, ndecdiv;
+    _aprcl_jacobi_task * tasks;
+    _aprcl_jacobi_args args;
 
     /* deal with primes that can divide R */
     if (fmpz_cmp_ui(n, 2) == 0)
        return PRIME;
-
     if (fmpz_cmp_ui(n, 3) == 0)
        return PRIME;
 
+    /* if n is one of the primes q, then n is prime */
+    for (i = 0; i < config->qs->num; i++)
+        if (config->qs_used[i] && fmpz_equal(n, config->qs->p + i))
+            return PRIME;
+
+    /* check that s*R and n are coprime; if not then n is composite */
+    if (aprcl_is_mul_coprime_ui_fmpz(config->R, config->s, n) == 0)
+        return COMPOSITE;
+
     /* initialization */
-    fmpz_init(q_pow);
-    fmpz_init(u);
     fmpz_init(temp);
     fmpz_init(p2);
     fmpz_init(ndecdiv);
     fmpz_init_set(ndec, n);
     fmpz_sub_ui(ndec, ndec, 1);
     fmpz_fdiv_q_2exp(ndecdiv, ndec, 1);
-
     result = PROBABPRIME;
 
     /*
@@ -582,7 +762,6 @@ _aprcl_is_prime_jacobi(const fmpz_t n, const aprcl_config config)
         For each p | R we must show that for all prime r | n and all
         positive integers a there exists l such that:
             r^(p-1) congruent n^(l(p-1)) mod p^a
-
         If (Lp), then lambdas_p = 1.
     */
     lambdas = (int*) flint_malloc(sizeof(int) * config->rs.num);
@@ -598,25 +777,32 @@ _aprcl_is_prime_jacobi(const fmpz_t n, const aprcl_config config)
     for (i = 0; i < config->rs.num; i++)
     {
         ulong p = config->rs.p[i];
+        lambdas[i] = 0;
         if (p > 2)
         {
             fmpz_set_ui(p2, p * p);
             fmpz_powm_ui(temp, n, p - 1, p2);
             if (fmpz_equal_ui(temp, 1) == 0)
                 lambdas[i] = 1;
-            else
-                lambdas[i] = 0;
         }
-        else
-            lambdas[i] = 0;
     }
 
-    /* check that s*R and n are coprime; if not then n is composite */
-    if (aprcl_is_mul_coprime_ui_fmpz(config->R, config->s, n) == 0)
-        result = COMPOSITE;
+    /* Build the list of tasks: one for every prime q | s and prime p | q - 1 */
+    num_tasks = 0;
+    for (i = 0; i < config->qs->num; i++)
+    {
+        n_factor_t q_factors;
 
-    /* Begin pseudoprime tests with Jacobi sums step. */
-    /* for every prime q | s */
+        if (config->qs_used[i] == 0)
+            continue;
+
+        n_factor_init(&q_factors);
+        n_factor(&q_factors, fmpz_get_ui(config->qs->p + i) - 1, 1);
+        num_tasks += q_factors.num;
+    }
+
+    tasks = (_aprcl_jacobi_task *) flint_malloc(sizeof(_aprcl_jacobi_task) * num_tasks);
+    t = 0;
     for (i = 0; i < config->qs->num; i++)
     {
         n_factor_t q_factors;
@@ -625,142 +811,85 @@ _aprcl_is_prime_jacobi(const fmpz_t n, const aprcl_config config)
         if (config->qs_used[i] == 0)
             continue;
 
-        if (result == COMPOSITE)
-            break;
-
-        q = fmpz_get_ui(config->qs->p + i); /* set q; q must get into ulong */
-
-        /* if n == q; q - prime => n - prime */
-        if (fmpz_equal_ui(n, q))
-        {
-            result = PRIME;
-            break;
-        }
-
-        /* find prime factors of q - 1 */
+        q = fmpz_get_ui(config->qs->p + i); /* q must fit into an ulong */
         n_factor_init(&q_factors);
         n_factor(&q_factors, q - 1, 1);
 
-        /* for every prime p | q - 1 */
         for (j = 0; j < q_factors.num; j++)
         {
-            int pind;
-            slong h;
-            ulong v, p, r, k;
-            unity_zp jacobi_sum, jacobi_sum2_1, jacobi_sum2_2;
+            tasks[t].q = q;
+            tasks[t].p = q_factors.p[j];
+            tasks[t].k = q_factors.exp[j];
+            tasks[t].pind = _aprcl_p_ind(config, q_factors.p[j]);
+            tasks[t].h = 0;
+            tasks[t].qpow_is_minus1 = 0;
+            t++;
+        }
+    }
 
-            if (result == COMPOSITE)
-                break;
+    qsort(tasks, num_tasks, sizeof(_aprcl_jacobi_task), _aprcl_jacobi_task_cmp);
 
-            p = q_factors.p[j];     /* set p; p | q - 1 */
-            k = q_factors.exp[j];   /* set max k for which p^k | q - 1 */
-            r = n_pow(p, k);        /* set r = p^k */
-            pind = _aprcl_p_ind(config, p);  /* find index of p in lambdas */
+    /* Begin pseudoprime tests with Jacobi sums step: run the tasks */
+    args.n = n;
+    args.ndec = ndec;
+    args.ndecdiv = ndecdiv;
+    args.tasks = tasks;
+    args.num_tasks = num_tasks;
+    args.next_task = 0;
+    args.composite = 0;
+#if FLINT_USES_PTHREAD
+    pthread_mutex_init(&args.mutex, NULL);
+#endif
 
-            /* if lambdas_p == 0 set q_pow = q^{(n - 1) / 2} and p == 2 */
-            fmpz_set_ui(q_pow, q);
-            if (lambdas[pind] == 0 && p == 2)
-                fmpz_powm(q_pow, q_pow, ndecdiv, n);
+    flint_parallel_do(_aprcl_jacobi_worker, &args,
+            FLINT_MIN(num_tasks, flint_get_num_threads()), 0, FLINT_PARALLEL_STRIDED);
 
-            /* compute u = n / r and v = n % r */
-            fmpz_tdiv_q_ui(u, n, r);
-            v = fmpz_tdiv_ui(n, r);
+#if FLINT_USES_PTHREAD
+    pthread_mutex_destroy(&args.mutex);
+#endif
 
-            /* init unity_zp for jacobi sums */
-            unity_zp_init(jacobi_sum, p, k, n);
-            unity_zp_init(jacobi_sum2_1, p, k, n);
-            unity_zp_init(jacobi_sum2_2, p, k, n);
+    if (args.composite)
+        result = COMPOSITE;
 
-            /* compute set jacobi_sum = J(p, q) */
-            unity_zp_jacobi_sum_pq(jacobi_sum, q, p);
-            /* if p == 2 and k >= 3 we also need to compute J_2(q) and J_3(q) */
-            if (p == 2 && k >= 3)
-            {
-                /* compute J_3(q) */
-                unity_zp_jacobi_sum_2q_one(jacobi_sum2_1, q);
-                /* compute J_2(q) */
-                unity_zp_jacobi_sum_2q_two(jacobi_sum2_2, q);
-            }
+    /* Collect the (Lp) information from the tasks */
+    if (result == PROBABPRIME)
+    {
+        for (t = 0; t < num_tasks; t++)
+        {
+            ulong p = tasks[t].p, k = tasks[t].k;
+            slong h = tasks[t].h;
+            int pind = tasks[t].pind;
+
+            if (lambdas[pind] == 1)
+                continue;
 
             if (p == 2 && k == 1)
             {
-                h = _aprcl_is_prime_jacobi_check_21(q, n);
-
-                /* if h not found then n is composite */
-                if (h < 0)
-                    result = COMPOSITE;
-
-                /*
-                    check (Lp);
-                    if h == 1 (unity root = -1)
-                    and n % 4 == 1 then lambdas_2 = 1
-                */
-                if (lambdas[pind] == 0 && h == 1 && nmod4 == 1)
+                /* if h == 1 (unity root = -1) and n % 4 == 1 then lambdas_2 = 1 */
+                if (h == 1 && nmod4 == 1)
                     lambdas[pind] = 1;
             }
-
-            if (p == 2 && k == 2)
+            else if (p == 2)
             {
-                h = _aprcl_is_prime_jacobi_check_22(jacobi_sum, u, v, q);
-
-                /* if h not found then n is composite */
-                if (h < 0)
-                    result = COMPOSITE;
-
                 /*
-                    check (Lp);
-                    if h == 1 or 3 (unity root = -i or i)
+                    if h is odd (primitive unity root)
                     and q^{(n - 1) / 2} = -1 mod n then lambdas_2 = 1
                 */
-                if (h % 2 != 0 && lambdas[pind] == 0 && fmpz_equal(q_pow, ndec))
+                if (h % 2 != 0 && tasks[t].qpow_is_minus1)
                     lambdas[pind] = 1;
             }
-
-            if (p == 2 && k >= 3)
+            else
             {
-                h = _aprcl_is_prime_jacobi_check_2k(jacobi_sum,
-                        jacobi_sum2_1, jacobi_sum2_2, u, v);
-
-                /* if h not found then n is composite */
-                if (h < 0)
-                    result = COMPOSITE;
-
-                /*
-                    check (Lp);
-                    if h % 2 != 0 (primitive unity root)
-                    and q^{(n - 1) / 2} = -1 mod n then lambdas_2 = 1
-                */
-                if (h % 2 != 0 && lambdas[pind] == 0 && fmpz_equal(q_pow, ndec))
+                /* if h % p != 0 (primitive unity root) then lambdas_p = 1 */
+                if (h % p != 0)
                     lambdas[pind] = 1;
             }
-
-            if (p != 2)
-            {
-                h = _aprcl_is_prime_jacobi_check_pk(jacobi_sum, u, v);
-
-                /* if h not found then n is composite */
-                if (h < 0)
-                    result = COMPOSITE;
-
-                /*
-                    check (Lp);
-                    if h % p != 0 (primitive unity root)
-                    then lambdas_p = 1
-                */
-                if (h % p != 0 && lambdas[pind] == 0)
-                    lambdas[pind] = 1;
-            }
-
-            /* clear unity_zp for jacobi sums */
-            unity_zp_clear(jacobi_sum);
-            unity_zp_clear(jacobi_sum2_1);
-            unity_zp_clear(jacobi_sum2_2);
         }
-
     }
 
-    /* Begin L_p tests */
+    flint_free(tasks);
 
+    /* Begin L_p tests */
     /* if n can be prime */
     if (result == PROBABPRIME)
     {
@@ -795,7 +924,6 @@ _aprcl_is_prime_jacobi(const fmpz_t n, const aprcl_config config)
     }
 
     /* Trial division and primality proving step */
-
     /*
         If result = PROBAPRIME then all lambdas_p = 1.
         Using this information we know that:
@@ -814,8 +942,6 @@ _aprcl_is_prime_jacobi(const fmpz_t n, const aprcl_config config)
 
     /* clear */
     flint_free(lambdas);
-    fmpz_clear(u);
-    fmpz_clear(q_pow);
     fmpz_clear(p2);
     fmpz_clear(ndec);
     fmpz_clear(ndecdiv);

--- a/src/aprcl/test/main.c
+++ b/src/aprcl/test/main.c
@@ -15,6 +15,7 @@
 #include "t-config_jacobi.c"
 #include "t-f_table.c"
 #include "t-is_prime.c"
+#include "t-is_prime_final_division.c"
 #include "t-is_prime_gauss.c"
 #include "t-is_prime_jacobi.c"
 #include "t-unity_zp_add.c"
@@ -47,6 +48,7 @@ test_struct tests[] =
     TEST_FUNCTION(aprcl_config_jacobi),
     TEST_FUNCTION(aprcl_f_table),
     TEST_FUNCTION(aprcl_is_prime),
+    TEST_FUNCTION(aprcl_is_prime_final_division),
     TEST_FUNCTION(aprcl_is_prime_gauss),
     TEST_FUNCTION(aprcl_is_prime_jacobi),
     TEST_FUNCTION(aprcl_unity_zp_add),

--- a/src/aprcl/test/t-is_prime_final_division.c
+++ b/src/aprcl/test/t-is_prime_final_division.c
@@ -1,0 +1,219 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "thread_support.h"
+#include "fmpz.h"
+#include "aprcl.h"
+
+/* naive version: walk n^i mod s and test the residues 1 < a <= sqrt(n) */
+static int
+final_division_naive(const fmpz_t n, const fmpz_t s, ulong r)
+{
+    int result = 1;
+    ulong i;
+    fmpz_t npow, nmul, rem, bound;
+
+    fmpz_init(rem);
+    fmpz_init(bound);
+    fmpz_init(nmul);
+    fmpz_init(npow);
+    fmpz_sqrt(bound, n);
+    fmpz_mod(nmul, n, s);
+    fmpz_set(npow, nmul);
+
+    for (i = 1; i < r; i++)
+    {
+        if (fmpz_is_one(npow))
+            break;
+
+        if (fmpz_cmp(npow, bound) <= 0)
+        {
+            fmpz_mod(rem, n, npow);
+            if (fmpz_is_zero(rem))
+            {
+                result = 0;
+                break;
+            }
+        }
+
+        fmpz_mul(npow, npow, nmul);
+        fmpz_mod(npow, npow, s);
+    }
+
+    fmpz_clear(npow);
+    fmpz_clear(nmul);
+    fmpz_clear(rem);
+    fmpz_clear(bound);
+
+    return result;
+}
+
+TEST_FUNCTION_START(aprcl_is_prime_final_division, state)
+{
+    slong iter;
+    int old_threads = flint_get_num_threads();
+
+    for (iter = 0; iter < 100 * flint_test_multiplier(); iter++)
+    {
+        fmpz_t n, a, b, g;
+        aprcl_config conf;
+        int r1, r2, type;
+        ulong bits = 20 + n_randint(state, 300);
+
+        fmpz_init(n);
+        fmpz_init(a);
+        fmpz_init(b);
+        fmpz_init(g);
+
+        type = n_randint(state, 4);
+        if (type == 0)
+        {
+            /* prime */
+            fmpz_randprime(n, state, bits, 0);
+        }
+        else if (type == 1)
+        {
+            /* product of two primes of about the same size */
+            fmpz_randprime(a, state, bits / 2 + 1, 0);
+            fmpz_randprime(b, state, bits / 2 + 1 + n_randint(state, 3), 0);
+            fmpz_mul(n, a, b);
+        }
+        else if (type == 2)
+        {
+            /* square of a prime */
+            fmpz_randprime(a, state, bits / 2 + 1, 0);
+            fmpz_mul(n, a, a);
+        }
+        else
+        {
+            /* random odd composite */
+            fmpz_randtest_unsigned(n, state, bits);
+            fmpz_setbit(n, 0);
+            fmpz_add_ui(n, n, 4);
+        }
+
+        /* s, R with s^2 > n as chosen by the Jacobi configuration */
+        aprcl_config_jacobi_init(conf, n);
+
+        /* the final division requires gcd(n, s) = 1 */
+        fmpz_gcd(g, n, conf->s);
+        if (fmpz_is_one(g))
+        {
+            flint_set_num_threads(1 + n_randint(state, 4));
+
+            r1 = aprcl_is_prime_final_division(n, conf->s, conf->R);
+            r2 = final_division_naive(n, conf->s, conf->R);
+
+            if (r1 != r2)
+            {
+                flint_printf("FAIL:\n");
+                flint_printf("n = "); fmpz_print(n);
+                flint_printf("\ns = "); fmpz_print(conf->s);
+                flint_printf("\nR = %wu\n", conf->R);
+                flint_printf("result = %d, naive = %d\n", r1, r2);
+                fflush(stdout);
+                flint_abort();
+            }
+
+            /* a prime always passes */
+            if (type == 0 && r1 != 1)
+            {
+                flint_printf("FAIL: prime rejected\n");
+                fflush(stdout);
+                flint_abort();
+            }
+        }
+
+        aprcl_config_jacobi_clear(conf);
+        fmpz_clear(n);
+        fmpz_clear(a);
+        fmpz_clear(b);
+        fmpz_clear(g);
+    }
+
+    /*
+        Constructed cases with a divisor at a known position: for a prime s,
+        any a < s and an exponent i coprime to s - 1, choose b with
+        b^i = a^{1 - i} mod s; then n = a b satisfies n^i = a mod s, so the
+        walk must find the divisor a at step i (and must not if r <= i).
+        Sizes cover the fmpz, plain, Shoup and matrix multiplication paths;
+        an s of exactly 128 bits (2 limbs, no normalisation shift) reaches
+        the plain mulmod_preinvn path.
+    */
+    {
+        fmpz_t n, s, a, b, sm1, i, e, t;
+        slong j;
+        const slong sizes[] = {40, 64, 128, 130, 200, 400, 700, 1000};
+
+        fmpz_init(n); fmpz_init(s); fmpz_init(a); fmpz_init(b);
+        fmpz_init(sm1); fmpz_init(i); fmpz_init(e); fmpz_init(t);
+
+        for (j = 0; j < 4 * (slong) (sizeof(sizes) / sizeof(sizes[0])); j++)
+        {
+            slong sbits = sizes[j % (sizeof(sizes) / sizeof(sizes[0]))];
+            ulong r = 1000 + n_randint(state, 100000), ii;
+            int r1, r2, r3;
+
+            fmpz_randprime(s, state, sbits, 0);
+            fmpz_sub_ui(sm1, s, 1);
+
+            /* a: random odd number below s, at least 3 */
+            do
+            {
+                fmpz_randm(a, state, s);
+                fmpz_setbit(a, 0);
+            } while (fmpz_cmp_ui(a, 3) < 0 || fmpz_cmp(a, s) >= 0);
+
+            /* exponent i coprime to s - 1, with 1 <= i < r */
+            do
+            {
+                ii = 1 + n_randint(state, r - 1);
+                fmpz_set_ui(i, ii);
+                fmpz_gcd(t, i, sm1);
+            } while (!fmpz_is_one(t));
+
+            /* b = b0 + k s with b0 = a^{(1 - i) e} mod s, e = 1/i mod (s - 1) */
+            fmpz_invmod(e, i, sm1);
+            fmpz_sub(t, sm1, i);
+            fmpz_add_ui(t, t, 1);           /* t = 1 - i mod (s - 1) */
+            fmpz_mul(t, t, e);
+            fmpz_mod(t, t, sm1);
+            fmpz_powm(b, a, t, s);
+            fmpz_addmul_ui(b, s, 1 + n_randint(state, 4));
+            fmpz_mul(n, a, b);              /* a < s < b, so a <= sqrt(n) */
+
+            flint_set_num_threads(1 + n_randint(state, 4));
+
+            r1 = aprcl_is_prime_final_division(n, s, r);
+            r2 = final_division_naive(n, s, r);
+            r3 = aprcl_is_prime_final_division(n, s, ii);   /* divisor out of range */
+
+            if (r1 != 0 || r2 != 0 || r3 != 1)
+            {
+                flint_printf("FAIL (constructed divisor):\n");
+                flint_printf("s bits = %wd, i = %wu, r = %wu, results %d %d %d\n",
+                             sbits, ii, r, r1, r2, r3);
+                flint_printf("n = "); fmpz_print(n);
+                flint_printf("\ns = "); fmpz_print(s); flint_printf("\n");
+                fflush(stdout);
+                flint_abort();
+            }
+        }
+
+        fmpz_clear(n); fmpz_clear(s); fmpz_clear(a); fmpz_clear(b);
+        fmpz_clear(sm1); fmpz_clear(i); fmpz_clear(e); fmpz_clear(t);
+    }
+
+    flint_set_num_threads(old_threads);
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/aprcl/test/t-is_prime_jacobi.c
+++ b/src/aprcl/test/t-is_prime_jacobi.c
@@ -10,6 +10,7 @@
 */
 
 #include "test_helpers.h"
+#include "thread_support.h"
 #include "fmpz.h"
 #include "aprcl.h"
 
@@ -156,6 +157,7 @@ TEST_FUNCTION_START(aprcl_is_prime_jacobi, state)
                 fmpz_randtest_unsigned(n, state, 1000);
 
             pbprime = fmpz_is_probabprime(n);
+            flint_set_num_threads(1 + n_randint(state, 4));
             cycloprime = aprcl_is_prime_jacobi(n);
 
             if (pbprime != cycloprime)
@@ -216,6 +218,24 @@ TEST_FUNCTION_START(aprcl_is_prime_jacobi, state)
             fmpz_set_str(n, "3194984256290911228520362769161858765901", 10);
             if (aprcl_is_prime_jacobi(n) == 1)
                 result = 0;
+
+            /* moduli beyond the mpn_mod range exercise the fmpz arithmetic */
+            {
+                fmpz_t a, b;
+                fmpz_init(a);
+                fmpz_init(b);
+                flint_set_num_threads(1 + n_randint(state, 4));
+                fmpz_randprime(n, state, 1100, 0);
+                if (aprcl_is_prime_jacobi(n) == 0)
+                    result = 0;
+                fmpz_randprime(a, state, 550, 0);
+                fmpz_randprime(b, state, 560, 0);
+                fmpz_mul(n, a, b);
+                if (aprcl_is_prime_jacobi(n) == 1)
+                    result = 0;
+                fmpz_clear(a);
+                fmpz_clear(b);
+            }
 
             if (result == 0)
             {


### PR DESCRIPTION
Make the embarrassingly parallel batched Jacobi sums and final trial divisions in the APRCL primality test multithreaded: on an 8-core machine this is an easy 5-6x speedup.

Also optimize the code a bit (avoid redundant computations, use mpn code with preconditioned Shoup/matrix mulmods, etc). The serial speedup is around 5-20%.

Timings for `aprcl_is_prime` (and effectively for `fmpz_is_prime`):

```
    bits            old      new    new (8 threads)
     100       0.000431   0.000419    0.00011
     200         0.0036    0.00351     0.0007
     300         0.0129     0.0126     0.0024
     400         0.0345     0.0311     0.0054
     500         0.0638     0.0605     0.0105
     600          0.135       0.13      0.022
     700          0.233      0.219      0.038
     800          0.499      0.408       0.07
     900          0.714      0.598      0.099
    1000          0.982      0.859      0.141
    1100          1.426      1.278      0.208
    1200          1.886      1.732      0.282
    1300          2.459      2.288      0.372
    1400          2.925      2.761      0.448
    1500          3.838      3.647      0.592
    2000         15.066     14.195       2.31
    2500         37.462      35.56      5.901
    3000         56.669     53.311      8.823
    3500        103.379     92.148     15.883
    4000        197.331    169.065     29.724
    4500        289.037    253.939     50.566
    5000        433.163    365.193     67.203
```

This patch also adds a constructor `aprcl_config_jacobi_init_R` for choosing a custom R value. Quick experiments suggest that the current tuning is OK, but a different R can gain 5-10% at certain bit sizes. I didn't update the tuning values in this patch.

Implemented using Claude Fable 5.1.