### PR TITLE
fmpz_poly: use basecase division for small balanced cases

### DIFF
--- a/src/fmpz_poly/div.c
+++ b/src/fmpz_poly/div.c
@@ -15,6 +15,11 @@ int
 _fmpz_poly_div(fmpz * Q, const fmpz * A, slong lenA,
                                          const fmpz * B, slong lenB, int exact)
 {
+    slong lenQ = lenA - lenB + 1;
+
+    if (!exact && lenQ > lenB && lenB * lenQ <= 2048)
+        return _fmpz_poly_div_basecase(Q, NULL, A, lenA, B, lenB, exact);
+
     return _fmpz_poly_div_divconquer(Q, A, lenA, B, lenB, exact);
 }
 


### PR DESCRIPTION
## Summary

Use the basecase algorithm for `fmpz_poly_div` in the small moderately balanced region where it is faster than divide-and-conquer.

At present `_fmpz_poly_div` always calls `_fmpz_poly_div_divconquer`. Benchmarks of the existing basecase and divide-and-conquer kernels show that the crossover is not a single divisor-length cutoff: divide-and-conquer is best for short quotients, basecase wins in a finite region where quotient and divisor lengths are comparable, and divide-and-conquer wins again as the product of the lengths grows.

The proposed dispatcher therefore uses basecase when

```c
lenQ > lenB && lenB * lenQ <= 2048
```

for non-exact division. Exact division keeps the existing divide-and-conquer path, since that path is also used by `div_series_divconquer` and was not part of this tuning experiment.

The selector is deliberately simple: two length comparisons and one integer multiplication, with no coefficient-size inspection.

## Benchmarks

Benchmarks were run on an AMD Ryzen 7 5800H with `-O3 -march=native --enable-avx2`, using the same GMP/MPFR installation for baseline and candidate builds. Inputs were deterministic division cases of the form `A = B Q + R`, and baseline/candidate execution order was varied between paired runs. Timings used repeated samples and medians to reduce noise.

The end-to-end dispatcher sweep covered 990 combinations of divisor length, quotient length, and coefficient sizes from 32 to 1024 bits. Reclassifying the measured points using the final strict `lenQ > lenB` rule gives 684 points where the dispatcher switches to basecase. Among those points:

- 665 improve by more than 5%;
- 642 improve by more than 10%;
- 538 improve by more than 20%;
- the median speedup is 1.42x;
- only 2 regress by more than 2%;
- none regress by 5% or more.

Representative end-to-end dispatcher speedups are:

| len(B) | len(Q) | 32-bit coeffs | 128-bit coeffs | 1024-bit coeffs |
| ---: | ---: | ---: | ---: | ---: |
| 2 | 4 | 1.78x | 1.74x | 1.60x |
| 4 | 8 | 1.76x | 1.77x | 1.48x |
| 8 | 16 | 1.73x | 1.68x | 1.41x |
| 16 | 32 | 1.58x | 1.57x | 1.36x |
| 24 | 48 | 1.26x | 1.27x | 1.20x |
| 32 | 64 | 1.13x | 1.16x | 1.11x |
| 40 | 48 | 1.07x | 1.12x | 1.23x |

A separate high-statistics dispatcher A/B run at `len(B) = 24`, `len(Q) = 48`, with 128-bit coefficients gave a median speedup of **1.263x** over 15 paired runs, with a MAD ratio of 0.0086.

The cutoff is intentionally coarse. It is meant to capture the broad basecase island with negligible dispatch overhead rather than model machine-specific crossover details.

## Testing

The change was tested against a clone of `flintlib/flint`:

- `make -j$(($(nproc) + 1)) check MOD=fmpz_poly`: PASS
- `make -j$(($(nproc) + 1)) check`: PASS
