### PR TITLE
Packed basis matrices in LLL

### DIFF
--- a/doc/source/fmpz_lll.rst
+++ b/doc/source/fmpz_lll.rst
@@ -3,6 +3,93 @@
 **fmpz_lll.h** -- LLL reduction
 ==================================================================================================
 
+Packed basis matrix
+--------------------------------------------------------------------------------
+
+The floating-point LLL variants operate internally on a packed copy of the
+basis matrix, stored as a :type:`fmpz_lll_packed_t`, in which every entry
+occupies a fixed number of limbs in two's complement and the entries of a
+row are contiguous. Row operations are performed slot-wise modulo
+a power of two, which is exact by virtue of an upper bound on the bit length
+of the entries of each row which is maintained by all operations; the number
+of limbs is grown or shrunk as needed. This representation is much cheaper
+to update than a matrix of ``fmpz`` entries for the small (one to a few limbs)
+entries typical of lattice reduction, and Gram matrix entries can be computed
+exactly with fixed-size dot product kernels.
+
+.. type:: fmpz_lll_packed_struct
+
+.. type:: fmpz_lll_packed_t
+
+.. function:: slong fmpz_lll_packed_limbs(const fmpz_mat_t B)
+
+    Returns the number of limbs per entry to use for packing ``B``,
+    including some headroom. This is determined by the largest entry of
+    ``B``; since all entries use the same number of limbs, packing is
+    only used by the LLL functions when this number is small
+    (``FMPZ_LLL_PACKED_MAX_LIMBS``, respectively
+    ``FMPZ_LLL_PACKED_MAX_LIMBS_MPF`` in the multiprecision LLL where
+    the Gram matrix entries are computed exactly) and the packed matrix
+    is not too large (``FMPZ_LLL_PACKED_MAX_SIZE`` limbs). Slots are
+    shrunk during the reduction once all entries have become smaller.
+
+.. function:: void fmpz_lll_packed_init(fmpz_lll_packed_t P, slong d, slong n, slong m)
+              void fmpz_lll_packed_clear(fmpz_lll_packed_t P)
+
+    Initialises resp. clears a packed matrix with `d` rows, `n` columns
+    and `m` limbs per entry.
+
+.. function:: void fmpz_lll_packed_set_fmpz_mat(fmpz_lll_packed_t P, const fmpz_mat_t B)
+              void fmpz_lll_packed_get_fmpz_mat(fmpz_mat_t B, const fmpz_lll_packed_t P)
+
+    Packs ``B`` (whose entries must fit) into ``P``, resp. unpacks ``P``
+    into ``B``.
+
+.. function:: void fmpz_lll_packed_tighten(fmpz_lll_packed_t P, slong i)
+              void fmpz_lll_packed_grow(fmpz_lll_packed_t P)
+              void fmpz_lll_packed_maybe_shrink(fmpz_lll_packed_t P)
+
+    Recomputes the exact bit bound of row `i`; increases the number of
+    limbs per entry by one; decreases the number of limbs per entry by one
+    if all rows comfortably fit.
+
+.. function:: void fmpz_lll_packed_move_row(fmpz_lll_packed_t P, slong i, slong j)
+
+    Moves row `i` to position `j`, shifting the rows in between.
+
+.. function:: void fmpz_lll_packed_row_sub(fmpz_lll_packed_t P, slong i, slong j)
+              void fmpz_lll_packed_row_add(fmpz_lll_packed_t P, slong i, slong j)
+              void fmpz_lll_packed_row_submul_si(fmpz_lll_packed_t P, slong i, slong j, slong x)
+              void fmpz_lll_packed_row_submul_fmpz(fmpz_lll_packed_t P, slong i, slong j, const fmpz_t x)
+              void fmpz_lll_packed_row_submul_si_2exp(fmpz_lll_packed_t P, slong i, slong j, slong x, ulong e)
+
+    Sets row `i` to row `i` minus (or plus) row `j`, respectively minus
+    `x` (times `2^e`) times row `j`. The results are exact.
+
+.. function:: slong fmpz_lll_packed_get_d_vec_2exp(double * appv, fmpz_lll_packed_t P, slong i)
+
+    Equivalent to :func:`_fmpz_vec_get_d_vec_2exp` applied to row `i`.
+    Also sets the bit bound of the row to its exact value.
+
+.. function:: void fmpz_lll_packed_dot(fmpz_t res, const fmpz_lll_packed_t P, slong i, slong j, slong len)
+
+    Sets ``res`` to the exact dot product of the first ``len`` entries of
+    rows `i` and `j`.
+
+.. function:: double fmpz_lll_packed_heuristic_dot(const double * vec1, const double * vec2, slong len2, const fmpz_lll_packed_t P, slong k, slong j, slong exp_adj)
+
+    Equivalent to :func:`fmpz_lll_heuristic_dot` for a packed matrix.
+
+.. function:: int fmpz_lll_check_babai_packed(int kappa, fmpz_lll_packed_t P, fmpz_mat_t U, d_mat_t mu, d_mat_t r, double *s, d_mat_t appB, int *expo, fmpz_gram_t A, int a, int zeros, int kappamax, int n, const fmpz_lll_t fl, int heuristic)
+              int fmpz_lll_advance_check_babai_packed(int cur_kappa, int kappa, fmpz_lll_packed_t P, fmpz_mat_t U, d_mat_t mu, d_mat_t r, double *s, d_mat_t appB, int *expo, fmpz_gram_t A, int a, int zeros, int kappamax, int n, const fmpz_lll_t fl, int heuristic)
+              int fmpz_lll_check_babai_heuristic_packed(int kappa, fmpz_lll_packed_t P, fmpz_mat_t U, gr_mat_t mu, gr_mat_t r, gr_ptr s, fmpz_gram_t A, int a, int zeros, int kappamax, int n, gr_ptr tmp, gr_ptr rtmp, gr_ctx_t ctx, const fmpz_lll_t fl)
+
+    Versions of :func:`fmpz_lll_check_babai`, :func:`fmpz_lll_advance_check_babai`
+    and :func:`fmpz_lll_check_babai_heuristic` operating on a packed basis
+    matrix (``heuristic`` selects the heuristic variant). In the
+    multiprecision version the Gram matrix entries are computed exactly.
+
+
 Parameter manipulation
 --------------------------------------------------------------------------------
 

--- a/src/fmpz_lll.h
+++ b/src/fmpz_lll.h
@@ -69,6 +69,61 @@ typedef union
 
 typedef fmpz_gram_union fmpz_gram_t[1];
 
+/* Packed basis matrix  ******************************************************/
+
+typedef struct
+{
+    nn_ptr entries;     /* d * n * m limbs */
+    nn_ptr * rows;      /* row pointers, permuted by row moves */
+    slong * bits;       /* upper bound on the bit length of the entries of each row */
+    slong d;            /* rows */
+    slong n;            /* columns */
+    slong m;            /* limbs per entry (two's complement) */
+}
+fmpz_lll_packed_struct;
+
+typedef fmpz_lll_packed_struct fmpz_lll_packed_t[1];
+
+/*
+    Only pack if the entries fit in this many limbs. In the multiprecision
+    LLL the Gram matrix is computed exactly from the packed rows, which is
+    only competitive with approximate dot products for small entries.
+*/
+#define FMPZ_LLL_PACKED_MAX_LIMBS 32
+#define FMPZ_LLL_PACKED_MAX_LIMBS_MPF FLINT_MPN_DOT_TAB_N
+
+/* do not pack if the packed matrix would need more limbs than this */
+#define FMPZ_LLL_PACKED_MAX_SIZE (WORD(1) << 26)
+
+slong fmpz_lll_packed_limbs(const fmpz_mat_t B);
+void fmpz_lll_packed_init(fmpz_lll_packed_t P, slong d, slong n, slong m);
+void fmpz_lll_packed_clear(fmpz_lll_packed_t P);
+void fmpz_lll_packed_set_fmpz_mat(fmpz_lll_packed_t P, const fmpz_mat_t B);
+void fmpz_lll_packed_get_fmpz_mat(fmpz_mat_t B, const fmpz_lll_packed_t P);
+void fmpz_lll_packed_tighten(fmpz_lll_packed_t P, slong i);
+void fmpz_lll_packed_grow(fmpz_lll_packed_t P);
+void fmpz_lll_packed_maybe_shrink(fmpz_lll_packed_t P);
+void fmpz_lll_packed_move_row(fmpz_lll_packed_t P, slong i, slong j);
+void fmpz_lll_packed_row_sub(fmpz_lll_packed_t P, slong i, slong j);
+void fmpz_lll_packed_row_add(fmpz_lll_packed_t P, slong i, slong j);
+void fmpz_lll_packed_row_submul_si(fmpz_lll_packed_t P, slong i, slong j, slong x);
+void fmpz_lll_packed_row_submul_fmpz(fmpz_lll_packed_t P, slong i, slong j, const fmpz_t x);
+void fmpz_lll_packed_row_submul_si_2exp(fmpz_lll_packed_t P, slong i, slong j, slong x, ulong e);
+slong fmpz_lll_packed_get_d_vec_2exp(double * appv, fmpz_lll_packed_t P, slong i);
+void fmpz_lll_packed_dot(fmpz_t res, const fmpz_lll_packed_t P, slong i, slong j, slong len);
+double fmpz_lll_packed_heuristic_dot(const double * vec1, const double * vec2, slong len2,
+       const fmpz_lll_packed_t P, slong k, slong j, slong exp_adj);
+
+int fmpz_lll_check_babai_packed(int kappa, fmpz_lll_packed_t P, fmpz_mat_t U, d_mat_t mu, d_mat_t r, double *s,
+       d_mat_t appB, int *expo, fmpz_gram_t A,
+       int a, int zeros, int kappamax, int n, const fmpz_lll_t fl, int heuristic);
+int fmpz_lll_advance_check_babai_packed(int cur_kappa, int kappa, fmpz_lll_packed_t P, fmpz_mat_t U, d_mat_t mu, d_mat_t r, double *s,
+       d_mat_t appB, int *expo, fmpz_gram_t A,
+       int a, int zeros, int kappamax, int n, const fmpz_lll_t fl, int heuristic);
+int fmpz_lll_check_babai_heuristic_packed(int kappa, fmpz_lll_packed_t P, fmpz_mat_t U,
+       gr_mat_t mu, gr_mat_t r, gr_ptr s, fmpz_gram_t A, int a, int zeros,
+       int kappamax, int n, gr_ptr tmp, gr_ptr rtmp, gr_ctx_t ctx, const fmpz_lll_t fl);
+
 /* Parameter manipulation  ***************************************************/
 
 void fmpz_lll_context_init_default(fmpz_lll_t fl);

--- a/src/fmpz_lll/check_babai_heuristic.c
+++ b/src/fmpz_lll/check_babai_heuristic.c
@@ -70,8 +70,8 @@ static int _gr_vec_norm2(gr_ptr res, gr_srcptr vec, slong len, gr_ctx_t ctx)
 
 /* XXX: dubious use of DBL_MIN */
 
-int
-fmpz_lll_check_babai_heuristic(int kappa, fmpz_mat_t B, fmpz_mat_t U,
+static int
+_fmpz_lll_check_babai_heuristic(int kappa, fmpz_mat_t B, fmpz_lll_packed_struct * P, fmpz_mat_t U,
                                gr_mat_t mu, gr_mat_t r, gr_ptr s,
                                gr_mat_t appB, fmpz_gram_t A, int a, int zeros,
                                int kappamax, int n, gr_ptr tmp, gr_ptr rtmp,
@@ -112,7 +112,13 @@ fmpz_lll_check_babai_heuristic(int kappa, fmpz_mat_t B, fmpz_mat_t U,
             {
                 if (_gr_cmp_d(ENTRY(A->appSP2, kappa, j), DBL_MIN, ctx) == 0)
                 {
-                    status |= _gr_vec_dot(ENTRY(A->appSP2, kappa, j), NULL, 0, ROW(appB, kappa), ROW(appB, j), n, ctx);
+                    if (P != NULL)
+                    {
+                        fmpz_lll_packed_dot(ztmp, P, kappa, j, n);
+                        status |= gr_set_fmpz(ENTRY(A->appSP2, kappa, j), ztmp, ctx);
+                    }
+                    else
+                        status |= _gr_vec_dot(ENTRY(A->appSP2, kappa, j), NULL, 0, ROW(appB, kappa), ROW(appB, j), n, ctx);
 
 #if 0
                     /* If a heuristic told us that some cancellation probably happened,
@@ -167,14 +173,20 @@ fmpz_lll_check_babai_heuristic(int kappa, fmpz_mat_t B, fmpz_mat_t U,
                         if (sgn >= 0)   /* in this case, X is 1 */
                         {
                             status |= _gr_vec_sub(ENTRY(mu, kappa, zeros + 1), ENTRY(mu, kappa, zeros + 1), ENTRY(mu, j, zeros + 1), j - (zeros + 1), ctx);
-                            _fmpz_vec_sub(fmpz_mat_row(B, kappa), fmpz_mat_row(B, kappa), fmpz_mat_row(B, j), n);
+                            if (P != NULL)
+                                fmpz_lll_packed_row_sub(P, kappa, j);
+                            else
+                                _fmpz_vec_sub(fmpz_mat_row(B, kappa), fmpz_mat_row(B, kappa), fmpz_mat_row(B, j), n);
                             if (U != NULL)
                                 _fmpz_vec_sub(fmpz_mat_row(U, kappa), fmpz_mat_row(U, kappa), fmpz_mat_row(U, j), U->c);
                         }
                         else    /* otherwise X is -1 */
                         {
                             status |= _gr_vec_add(ENTRY(mu, kappa, zeros + 1), ENTRY(mu, kappa, zeros + 1), ENTRY(mu, j, zeros + 1), j - (zeros + 1), ctx);
-                            _fmpz_vec_add(fmpz_mat_row(B, kappa), fmpz_mat_row(B, kappa), fmpz_mat_row(B, j), n);
+                            if (P != NULL)
+                                fmpz_lll_packed_row_add(P, kappa, j);
+                            else
+                                _fmpz_vec_add(fmpz_mat_row(B, kappa), fmpz_mat_row(B, kappa), fmpz_mat_row(B, j), n);
                             if (U != NULL)
                                 _fmpz_vec_add(fmpz_mat_row(U, kappa), fmpz_mat_row(U, kappa), fmpz_mat_row(U, j), U->c);
                         }
@@ -200,7 +212,10 @@ fmpz_lll_check_babai_heuristic(int kappa, fmpz_mat_t B, fmpz_mat_t U,
                         status |= _gr_vec_submul_scalar(ENTRY(mu, kappa, zeros + 1), ENTRY(mu, j, zeros + 1), j - (zeros + 1), tmp, ctx);
                         status |= gr_get_fmpz(ztmp, tmp, ctx);
 
-                        _fmpz_vec_scalar_submul_fmpz(fmpz_mat_row(B, kappa), fmpz_mat_row(B, j), n, ztmp);
+                        if (P != NULL)
+                            fmpz_lll_packed_row_submul_fmpz(P, kappa, j, ztmp);
+                        else
+                            _fmpz_vec_scalar_submul_fmpz(fmpz_mat_row(B, kappa), fmpz_mat_row(B, j), n, ztmp);
                         if (U != NULL)
                             _fmpz_vec_scalar_submul_fmpz(fmpz_mat_row(U, kappa), fmpz_mat_row(U, j), U->c, ztmp);
                     }
@@ -209,7 +224,10 @@ fmpz_lll_check_babai_heuristic(int kappa, fmpz_mat_t B, fmpz_mat_t U,
 
             if (test)           /* Anything happened? */
             {
-                status |= _gr_vec_set_fmpz_vec(ROW(appB, kappa), fmpz_mat_row(B, kappa), n, ctx);
+                if (P != NULL)
+                    fmpz_lll_packed_tighten(P, kappa);
+                else
+                    status |= _gr_vec_set_fmpz_vec(ROW(appB, kappa), fmpz_mat_row(B, kappa), n, ctx);
                 aa = zeros + 1;
 
                 for (i = zeros + 1; i <= kappa; i++)
@@ -222,7 +240,15 @@ fmpz_lll_check_babai_heuristic(int kappa, fmpz_mat_t B, fmpz_mat_t U,
         } while (test);
 
         if (_gr_cmp_d(ENTRY(A->appSP2, kappa, kappa), DBL_MIN, ctx) == 0)
-            status |= _gr_vec_norm2(ENTRY(A->appSP2, kappa, kappa), ROW(appB, kappa), n, ctx);
+        {
+            if (P != NULL)
+            {
+                fmpz_lll_packed_dot(ztmp, P, kappa, kappa, n);
+                status |= gr_set_fmpz(ENTRY(A->appSP2, kappa, kappa), ztmp, ctx);
+            }
+            else
+                status |= _gr_vec_norm2(ENTRY(A->appSP2, kappa, kappa), ROW(appB, kappa), n, ctx);
+        }
 
         status |= gr_set(GR_ENTRY(s, zeros + 1, sz), ENTRY(A->appSP2, kappa, kappa), ctx);
 
@@ -462,3 +488,22 @@ fmpz_lll_check_babai_heuristic(int kappa, fmpz_mat_t B, fmpz_mat_t U,
 }
 
 #undef GM
+
+int
+fmpz_lll_check_babai_heuristic(int kappa, fmpz_mat_t B, fmpz_mat_t U,
+                               gr_mat_t mu, gr_mat_t r, gr_ptr s,
+                               gr_mat_t appB, fmpz_gram_t A, int a, int zeros,
+                               int kappamax, int n, gr_ptr tmp, gr_ptr rtmp,
+                               gr_ctx_t ctx, const fmpz_lll_t fl)
+{
+    return _fmpz_lll_check_babai_heuristic(kappa, B, NULL, U, mu, r, s, appB, A, a, zeros, kappamax, n, tmp, rtmp, ctx, fl);
+}
+
+int
+fmpz_lll_check_babai_heuristic_packed(int kappa, fmpz_lll_packed_t P, fmpz_mat_t U,
+                               gr_mat_t mu, gr_mat_t r, gr_ptr s, fmpz_gram_t A, int a, int zeros,
+                               int kappamax, int n, gr_ptr tmp, gr_ptr rtmp,
+                               gr_ctx_t ctx, const fmpz_lll_t fl)
+{
+    return _fmpz_lll_check_babai_heuristic(kappa, NULL, P, U, mu, r, s, NULL, A, a, zeros, kappamax, n, tmp, rtmp, ctx, fl);
+}

--- a/src/fmpz_lll/heuristic_dot.c
+++ b/src/fmpz_lll/heuristic_dot.c
@@ -36,7 +36,7 @@ fmpz_lll_heuristic_dot(const double *vec1, const double *vec2, slong len2,
         fmpz_init(sp);
         _fmpz_vec_dot(sp, fmpz_mat_row(B, k), fmpz_mat_row(B, j), len2);
         sum = fmpz_get_d_2exp(&exp, sp);
-        sum = ldexp(sum, sum - exp_adj);
+        sum = ldexp(sum, exp - exp_adj);
         fmpz_clear(sp);
     }
 

--- a/src/fmpz_lll/lll_check_babai.c
+++ b/src/fmpz_lll/lll_check_babai.c
@@ -31,7 +31,10 @@
     do { \
         if (heuristic) \
         { \
-            d_mat_entry(G, I, J) = fmpz_lll_heuristic_dot(appB->rows[I], appB->rows[J], C, B, I, J, expo[I] + expo[J]); \
+            if (P != NULL) \
+                d_mat_entry(G, I, J) = fmpz_lll_packed_heuristic_dot(appB->rows[I], appB->rows[J], C, P, I, J, expo[I] + expo[J]); \
+            else \
+                d_mat_entry(G, I, J) = fmpz_lll_heuristic_dot(appB->rows[I], appB->rows[J], C, B, I, J, expo[I] + expo[J]); \
         } \
         else if (advance) \
         { \
@@ -47,7 +50,7 @@
     } while (0)
 
 static int _fmpz_lll_check_babai(int cur_kappa, int kappa,
-    fmpz_mat_t B, fmpz_mat_t U, d_mat_t mu, d_mat_t r, double *s,
+    fmpz_mat_t B, fmpz_lll_packed_struct * P, fmpz_mat_t U, d_mat_t mu, d_mat_t r, double *s,
     d_mat_t appB, int *expo, fmpz_gram_t A, int a, int zeros,
     int kappamax, int n, const fmpz_lll_t fl, int advance, int heuristic)
 {
@@ -158,7 +161,10 @@ static int _fmpz_lll_check_babai(int cur_kappa, int kappa,
                                 d_mat_entry(mu, kappa, k) =
                                     d_mat_entry(mu, kappa, k) - tmp;
                             }
-                            _fmpz_vec_sub(fmpz_mat_row(B, kappa), fmpz_mat_row(B, kappa),
+                            if (P != NULL)
+                                fmpz_lll_packed_row_sub(P, kappa, j);
+                            else
+                                _fmpz_vec_sub(fmpz_mat_row(B, kappa), fmpz_mat_row(B, kappa),
                                           fmpz_mat_row(B, j), n);
                             if (U != NULL)
                             {
@@ -175,7 +181,10 @@ static int _fmpz_lll_check_babai(int cur_kappa, int kappa,
                                 d_mat_entry(mu, kappa, k) =
                                     d_mat_entry(mu, kappa, k) + tmp;
                             }
-                            _fmpz_vec_add(fmpz_mat_row(B, kappa), fmpz_mat_row(B, kappa),
+                            if (P != NULL)
+                                fmpz_lll_packed_row_add(P, kappa, j);
+                            else
+                                _fmpz_vec_add(fmpz_mat_row(B, kappa), fmpz_mat_row(B, kappa),
                                           fmpz_mat_row(B, j), n);
                             if (U != NULL)
                             {
@@ -205,7 +214,10 @@ static int _fmpz_lll_check_babai(int cur_kappa, int kappa,
                             }
 
                             xx = (slong) tmp;
-                            _fmpz_vec_scalar_submul_si(fmpz_mat_row(B, kappa),
+                            if (P != NULL)
+                                fmpz_lll_packed_row_submul_si(P, kappa, j, xx);
+                            else
+                                _fmpz_vec_scalar_submul_si(fmpz_mat_row(B, kappa),
                                                        fmpz_mat_row(B, j), n, xx);
                             if (U != NULL)
                             {
@@ -230,7 +242,10 @@ static int _fmpz_lll_check_babai(int cur_kappa, int kappa,
                                 xx = xx << -exponent;
                                 exponent = 0;
 
-                                _fmpz_vec_scalar_submul_si(fmpz_mat_row(B, kappa),
+                                if (P != NULL)
+                                    fmpz_lll_packed_row_submul_si(P, kappa, j, xx);
+                                else
+                                    _fmpz_vec_scalar_submul_si(fmpz_mat_row(B, kappa),
                                                            fmpz_mat_row(B, j), n, xx);
                                 if (U != NULL)
                                 {
@@ -250,7 +265,10 @@ static int _fmpz_lll_check_babai(int cur_kappa, int kappa,
                             }
                             else
                             {
-                                _fmpz_vec_scalar_submul_si_2exp(fmpz_mat_row(B, kappa),
+                                if (P != NULL)
+                                    fmpz_lll_packed_row_submul_si_2exp(P, kappa, j, xx, exponent);
+                                else
+                                    _fmpz_vec_scalar_submul_si_2exp(fmpz_mat_row(B, kappa),
                                                                 fmpz_mat_row(B, j),
                                                                 n, xx,
                                                                 exponent);
@@ -282,8 +300,11 @@ static int _fmpz_lll_check_babai(int cur_kappa, int kappa,
 
             if (test)           /* Anything happened? */
             {
-                expo[kappa] =
-                    _fmpz_vec_get_d_vec_2exp(appB->rows[kappa],
+                if (P != NULL)
+                    expo[kappa] = fmpz_lll_packed_get_d_vec_2exp(appB->rows[kappa], P, kappa);
+                else
+                    expo[kappa] =
+                        _fmpz_vec_get_d_vec_2exp(appB->rows[kappa],
                                              fmpz_mat_row(B, kappa), n);
                 aa = zeros + 1;
 
@@ -662,27 +683,41 @@ int fmpz_lll_advance_check_babai(int cur_kappa, int kappa, fmpz_mat_t B, fmpz_ma
     d_mat_t mu, d_mat_t r, double *s, d_mat_t appB, int *expo, fmpz_gram_t A,
     int a, int zeros, int kappamax, int n, const fmpz_lll_t fl)
 {
-    return _fmpz_lll_check_babai(cur_kappa, kappa, B, U, mu, r, s, appB, expo, A, a, zeros, kappamax, n, fl, 1, 0);
+    return _fmpz_lll_check_babai(cur_kappa, kappa, B, NULL, U, mu, r, s, appB, expo, A, a, zeros, kappamax, n, fl, 1, 0);
 }
 
 int fmpz_lll_advance_check_babai_heuristic_d(int cur_kappa, int kappa, fmpz_mat_t B, fmpz_mat_t U,
     d_mat_t mu, d_mat_t r, double *s, d_mat_t appB, int *expo, fmpz_gram_t A,
     int a, int zeros, int kappamax, int n, const fmpz_lll_t fl)
 {
-    return _fmpz_lll_check_babai(cur_kappa, kappa, B, U, mu, r, s, appB, expo, A, a, zeros, kappamax, n, fl, 1, 1);
+    return _fmpz_lll_check_babai(cur_kappa, kappa, B, NULL, U, mu, r, s, appB, expo, A, a, zeros, kappamax, n, fl, 1, 1);
 }
 
 int fmpz_lll_check_babai(int kappa, fmpz_mat_t B, fmpz_mat_t U,
     d_mat_t mu, d_mat_t r, double *s, d_mat_t appB, int *expo, fmpz_gram_t A,
     int a, int zeros, int kappamax, int n, const fmpz_lll_t fl)
 {
-    return _fmpz_lll_check_babai(INT_MIN, kappa, B, U, mu, r, s, appB, expo, A, a, zeros, kappamax, n, fl, 0, 0);
+    return _fmpz_lll_check_babai(INT_MIN, kappa, B, NULL, U, mu, r, s, appB, expo, A, a, zeros, kappamax, n, fl, 0, 0);
 }
 
 int fmpz_lll_check_babai_heuristic_d(int kappa, fmpz_mat_t B, fmpz_mat_t U,
     d_mat_t mu, d_mat_t r, double *s, d_mat_t appB, int *expo, fmpz_gram_t A,
     int a, int zeros, int kappamax, int n, const fmpz_lll_t fl)
 {
-    return _fmpz_lll_check_babai(INT_MIN, kappa, B, U, mu, r, s, appB, expo, A, a, zeros, kappamax, n, fl, 0, 1);
+    return _fmpz_lll_check_babai(INT_MIN, kappa, B, NULL, U, mu, r, s, appB, expo, A, a, zeros, kappamax, n, fl, 0, 1);
 }
 
+
+int fmpz_lll_advance_check_babai_packed(int cur_kappa, int kappa, fmpz_lll_packed_t P, fmpz_mat_t U,
+    d_mat_t mu, d_mat_t r, double *s, d_mat_t appB, int *expo, fmpz_gram_t A,
+    int a, int zeros, int kappamax, int n, const fmpz_lll_t fl, int heuristic)
+{
+    return _fmpz_lll_check_babai(cur_kappa, kappa, NULL, P, U, mu, r, s, appB, expo, A, a, zeros, kappamax, n, fl, 1, heuristic);
+}
+
+int fmpz_lll_check_babai_packed(int kappa, fmpz_lll_packed_t P, fmpz_mat_t U,
+    d_mat_t mu, d_mat_t r, double *s, d_mat_t appB, int *expo, fmpz_gram_t A,
+    int a, int zeros, int kappamax, int n, const fmpz_lll_t fl, int heuristic)
+{
+    return _fmpz_lll_check_babai(INT_MIN, kappa, NULL, P, U, mu, r, s, appB, expo, A, a, zeros, kappamax, n, fl, 0, heuristic);
+}

--- a/src/fmpz_lll/lll_d.c
+++ b/src/fmpz_lll/lll_d.c
@@ -59,6 +59,8 @@ static int _fmpz_lll_d(fmpz_mat_t B, fmpz_mat_t U, const fmpz_t gs_B, const fmpz
         double ctt;
         int *alpha;
         ulong max_exp, iter, max_iter, newvec, newvec_max;
+        fmpz_lll_packed_t P;
+        int use_packed;
 
         n = B->c;
         d = B->r;
@@ -66,6 +68,17 @@ static int _fmpz_lll_d(fmpz_mat_t B, fmpz_mat_t U, const fmpz_t gs_B, const fmpz
         ctt = (fl->delta + 1) / 2;
 
         shift = fmpz_lll_shift(B);
+
+        /* pack B into a homogeneous limb representation if the entries are small */
+        {
+            slong m = fmpz_lll_packed_limbs(B);
+            use_packed = (m <= FMPZ_LLL_PACKED_MAX_LIMBS && d * n * m <= FMPZ_LLL_PACKED_MAX_SIZE);
+            if (use_packed)
+            {
+                fmpz_lll_packed_init(P, d, n, m);
+                fmpz_lll_packed_set_fmpz_mat(P, B);
+            }
+        }
 
         alpha = (int *) flint_malloc(d * sizeof(int));
         expo = (int *) flint_malloc(d * sizeof(int));
@@ -101,7 +114,10 @@ static int _fmpz_lll_d(fmpz_mat_t B, fmpz_mat_t U, const fmpz_t gs_B, const fmpz
         max_exp = 0;
         for (i = 0; i < d; i++)
         {
-            expo[i] = _fmpz_vec_get_d_vec_2exp(appB->rows[i], fmpz_mat_row(B, i), n);
+            if (use_packed)
+                expo[i] = fmpz_lll_packed_get_d_vec_2exp(appB->rows[i], P, i);
+            else
+                expo[i] = _fmpz_vec_get_d_vec_2exp(appB->rows[i], fmpz_mat_row(B, i), n);
             max_exp = FLINT_MAX(max_exp, expo[i]);
         }
         max_iter =
@@ -168,6 +184,14 @@ static int _fmpz_lll_d(fmpz_mat_t B, fmpz_mat_t U, const fmpz_t gs_B, const fmpz
 
             if (num_failed_fast < nff_cutoff)
             {
+                if (use_packed)
+                {
+                    fmpz_lll_packed_maybe_shrink(P);
+                    babai_ok = fmpz_lll_check_babai_packed(
+                        kappa, P, U, mu, r, s, appB, expo, A, alpha[kappa],
+                        zeros, kappamax, FLINT_MIN(kappamax + 1 + shift, n), fl, heuristic);
+                }
+                else
                 babai_ok = (heuristic ? fmpz_lll_check_babai_heuristic_d : fmpz_lll_check_babai)(
                         kappa, B, U, mu, r, s, appB, expo, A, alpha[kappa],
                         zeros, kappamax, FLINT_MIN(kappamax + 1 + shift, n), fl);
@@ -179,6 +203,11 @@ static int _fmpz_lll_d(fmpz_mat_t B, fmpz_mat_t U, const fmpz_t gs_B, const fmpz
             if (babai_ok == -1)
             {
                 num_failed_fast++;
+                if (use_packed)
+                    heuristic_fail = fmpz_lll_check_babai_packed(kappa, P, U, mu,
+                        r, s, appB, expo, A, alpha[kappa], zeros, kappamax,
+                        FLINT_MIN(kappamax + 1 + shift, n), fl, 1);
+                else
                 heuristic_fail = fmpz_lll_check_babai_heuristic_d(kappa, B, U, mu,
                         r, s, appB, expo, A, alpha[kappa], zeros, kappamax,
                         FLINT_MIN(kappamax + 1 + shift, n), fl);
@@ -186,6 +215,11 @@ static int _fmpz_lll_d(fmpz_mat_t B, fmpz_mat_t U, const fmpz_t gs_B, const fmpz
 
             if (heuristic_fail == -1)
             {
+                if (use_packed)
+                {
+                    fmpz_lll_packed_get_fmpz_mat(B, P);
+                    fmpz_lll_packed_clear(P);
+                }
                 flint_free(alpha);
                 flint_free(expo);
                 d_mat_clear(mu);
@@ -206,6 +240,13 @@ static int _fmpz_lll_d(fmpz_mat_t B, fmpz_mat_t U, const fmpz_t gs_B, const fmpz
                     /* running ahead to kappa = d, without upsetting LLL... */
                     for (kappa2 = d - 1; kappa2 > kappa; kappa2--)
                     {
+                        if (use_packed)
+                            babai_ok =
+                                fmpz_lll_advance_check_babai_packed(kappa, kappa2, P, U,
+                                                         mu, r, s, appB, expo,
+                                                         A, alpha[kappa2],
+                                                         zeros, kappa + 1, n, fl, 0);
+                        else
                         babai_ok =
                             fmpz_lll_advance_check_babai(kappa, kappa2, B, U,
                                                          mu, r, s, appB, expo,
@@ -213,6 +254,13 @@ static int _fmpz_lll_d(fmpz_mat_t B, fmpz_mat_t U, const fmpz_t gs_B, const fmpz
                                                          zeros, kappa + 1, n, fl);
                         if (babai_ok == -1)
                         {
+                            if (use_packed)
+                                heuristic_fail =
+                                    fmpz_lll_advance_check_babai_packed(kappa, kappa2, P, U,
+                                                         mu, r, s, appB, expo,
+                                                         A, alpha[kappa2],
+                                                         zeros, kappa + 1, n, fl, 1);
+                            else
                             heuristic_fail =
                                 fmpz_lll_advance_check_babai_heuristic_d(kappa,
                                                                          kappa2,
@@ -325,7 +373,10 @@ static int _fmpz_lll_d(fmpz_mat_t B, fmpz_mat_t U, const fmpz_t gs_B, const fmpz
                 /* Step7: Update B and appB */
                 /* ************************ */
 
-                fmpz_mat_move_row(B, kappa2, kappa);
+                if (use_packed)
+                    fmpz_lll_packed_move_row(P, kappa2, kappa);
+                else
+                    fmpz_mat_move_row(B, kappa2, kappa);
 
                 if (U != NULL)
                     fmpz_mat_move_row(U, kappa2, kappa);
@@ -404,6 +455,12 @@ static int _fmpz_lll_d(fmpz_mat_t B, fmpz_mat_t U, const fmpz_t gs_B, const fmpz
                 }
                 fmpz_clear(rii);
             }
+        }
+
+        if (use_packed)
+        {
+            fmpz_lll_packed_get_fmpz_mat(B, P);
+            fmpz_lll_packed_clear(P);
         }
 
         flint_free(alpha);

--- a/src/fmpz_lll/lll_mpf.c
+++ b/src/fmpz_lll/lll_mpf.c
@@ -88,6 +88,9 @@ int fmpz_lll_mpf2_with_removal(fmpz_mat_t B, fmpz_mat_t U, flint_bitcnt_t prec, 
     if (fl->rt == Z_BASIS && fl->gt == APPROX)
     {
         int kappa, kappa2, d, n, i, j, zeros, kappamax;
+        fmpz_lll_packed_t P;
+        int use_packed = 0;
+        fmpz_t zt;
         gr_mat_t mu, r, appB;
         fmpz_gram_t A;
         gr_ptr s, appSPtmp;
@@ -107,6 +110,7 @@ int fmpz_lll_mpf2_with_removal(fmpz_mat_t B, fmpz_mat_t U, flint_bitcnt_t prec, 
         gr_mat_init(r, d, d, ctx);
         gr_mat_init(appB, d, n, ctx);
         gr_mat_init(A->appSP2, d, d, ctx);
+        fmpz_init(zt);
 
         if (U != NULL)
         {
@@ -127,7 +131,19 @@ int fmpz_lll_mpf2_with_removal(fmpz_mat_t B, fmpz_mat_t U, flint_bitcnt_t prec, 
         /* Step1: Initialization Step */
         /* ************************** */
 
-        status |= gr_mat_set_fmpz_mat(appB, B, ctx);
+        /* pack B into a homogeneous limb representation; the Gram matrix
+           entries are then computed exactly from the packed rows */
+        {
+            slong m = fmpz_lll_packed_limbs(B);
+            use_packed = (m <= FMPZ_LLL_PACKED_MAX_LIMBS_MPF && d * n * m <= FMPZ_LLL_PACKED_MAX_SIZE);
+            if (use_packed)
+            {
+                fmpz_lll_packed_init(P, d, n, m);
+                fmpz_lll_packed_set_fmpz_mat(P, B);
+            }
+            else
+                status |= gr_mat_set_fmpz_mat(appB, B, ctx);
+        }
 
         /* ********************************* */
         /* Step2: Initializing the main loop */
@@ -138,7 +154,13 @@ int fmpz_lll_mpf2_with_removal(fmpz_mat_t B, fmpz_mat_t U, flint_bitcnt_t prec, 
 
         do
         {
-            status |= _gr_vec_norm2(ENTRY(A->appSP2, i, i), ROW(appB, i), n, ctx);
+            if (use_packed)
+            {
+                fmpz_lll_packed_dot(zt, P, i, i, n);
+                status |= gr_set_fmpz(ENTRY(A->appSP2, i, i), zt, ctx);
+            }
+            else
+                status |= _gr_vec_norm2(ENTRY(A->appSP2, i, i), ROW(appB, i), n, ctx);
         } while ((_gr_sgn(ENTRY(A->appSP2, i, i), ctx) == 0)
                  && (++i < d));
 
@@ -164,6 +186,14 @@ int fmpz_lll_mpf2_with_removal(fmpz_mat_t B, fmpz_mat_t U, flint_bitcnt_t prec, 
             /* ********************************** */
             /* Step3: Call to the Babai algorithm */
             /* ********************************** */
+            if (use_packed)
+            {
+                fmpz_lll_packed_maybe_shrink(P);
+                babai_ok = fmpz_lll_check_babai_heuristic_packed(kappa, P, U, mu, r, s,
+                                               A, alpha[kappa], zeros, kappamax, n,
+                                               tmp, rtmp, ctx, fl);
+            }
+            else
             babai_ok =
                 fmpz_lll_check_babai_heuristic(kappa, B, U, mu, r, s, appB,
                                                A, alpha[kappa], zeros,
@@ -176,6 +206,12 @@ int fmpz_lll_mpf2_with_removal(fmpz_mat_t B, fmpz_mat_t U, flint_bitcnt_t prec, 
                 GR_TMP_CLEAR3(ctt, tmp, rtmp, ctx);
                 gr_mat_clear(mu, ctx);
                 gr_mat_clear(r, ctx);
+                if (use_packed)
+                {
+                    fmpz_lll_packed_get_fmpz_mat(B, P);
+                    fmpz_lll_packed_clear(P);
+                }
+                fmpz_clear(zt);
                 gr_mat_clear(appB, ctx);
                 gr_mat_clear(A->appSP2, ctx);
                 GR_TMP_CLEAR_VEC(s, d, ctx);
@@ -264,7 +300,10 @@ int fmpz_lll_mpf2_with_removal(fmpz_mat_t B, fmpz_mat_t U, flint_bitcnt_t prec, 
                 /* Step7: Update B and appB */
                 /* ************************ */
 
-                fmpz_mat_move_row(B, kappa2, kappa);
+                if (use_packed)
+                    fmpz_lll_packed_move_row(P, kappa2, kappa);
+                else
+                    fmpz_mat_move_row(B, kappa2, kappa);
 
                 if (U != NULL)
                     fmpz_mat_move_row(U, kappa2, kappa);
@@ -306,7 +345,13 @@ int fmpz_lll_mpf2_with_removal(fmpz_mat_t B, fmpz_mat_t U, flint_bitcnt_t prec, 
                 {
                     zeros++;
                     kappa++;
-                    status |= _gr_vec_norm2(ENTRY(A->appSP2, kappa, kappa), ROW(appB, kappa), n, ctx);
+                    if (use_packed)
+                    {
+                        fmpz_lll_packed_dot(zt, P, kappa, kappa, n);
+                        status |= gr_set_fmpz(ENTRY(A->appSP2, kappa, kappa), zt, ctx);
+                    }
+                    else
+                        status |= _gr_vec_norm2(ENTRY(A->appSP2, kappa, kappa), ROW(appB, kappa), n, ctx);
                     status |= gr_set(ENTRY(r, kappa, kappa), ENTRY(A->appSP2, kappa, kappa), ctx);
                 }
 
@@ -340,6 +385,12 @@ int fmpz_lll_mpf2_with_removal(fmpz_mat_t B, fmpz_mat_t U, flint_bitcnt_t prec, 
         GR_TMP_CLEAR3(ctt, tmp, rtmp, ctx);
         gr_mat_clear(mu, ctx);
         gr_mat_clear(r, ctx);
+        if (use_packed)
+        {
+            fmpz_lll_packed_get_fmpz_mat(B, P);
+            fmpz_lll_packed_clear(P);
+        }
+        fmpz_clear(zt);
         gr_mat_clear(appB, ctx);
         gr_mat_clear(A->appSP2, ctx);
         GR_TMP_CLEAR_VEC(s, d, ctx);

--- a/src/fmpz_lll/packed.c
+++ b/src/fmpz_lll/packed.c
@@ -413,12 +413,8 @@ fmpz_lll_packed_row_submul_fmpz(fmpz_lll_packed_t P, slong i, slong j, const fmp
     a = P->rows[i];
     b = P->rows[j];
 
-    if (m == 1)
-    {
-        for (k = 0; k < n; k++)
-            a[k] -= b[k] * xl[0];
-    }
-    else if (m == 2)
+    /* m == 1 cannot occur here: |x| >= 2^(FLINT_BITS-1) forces at least two limbs */
+    if (m == 2)
     {
         for (k = 0; k < n; k++)
         {

--- a/src/fmpz_lll/packed.c
+++ b/src/fmpz_lll/packed.c
@@ -1,0 +1,634 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+/*
+    Packed representation of the basis matrix used inside the floating-point
+    LLL variants.
+
+    Every entry is stored as a fixed number m of limbs in two's complement,
+    the entries of a row being contiguous (n * m limbs per row). Rows are
+    addressed through a pointer array so that row rotations are O(d).
+
+    All row operations are computed slot-wise modulo 2^(m*FLINT_BITS), with
+    no carries between entries. This is exact because a conservative upper
+    bound on the bit length of the entries is maintained for every row: an
+    operation is only performed if the bound on its result fits in the slots;
+    otherwise the exact bit lengths are recomputed and, if necessary, the
+    representation is grown to m + 1 limbs per entry. Growth is rare since
+    size reduction shrinks the entries; conversely the slots are shrunk when
+    all rows comfortably fit in m - 1 limbs.
+
+    Working modulo 2^(m*FLINT_BITS) has the additional advantage that a row
+    operation with a multi-limb scalar x only requires x mod 2^(m*FLINT_BITS).
+
+    Exact dot products of rows (used to compute Gram matrix entries in the
+    multiprecision LLL) are computed with the fixed-size signed mpn dot
+    product kernels.
+*/
+
+#include <math.h>
+#include "double_extras.h"
+#include "d_vec.h"
+#include "mpn_extras.h"
+#include "fmpz.h"
+#include "fmpz_vec.h"
+#include "fmpz_mat.h"
+#include "fmpz_lll.h"
+
+/* entries with this many bits (magnitude) fit in slots of m limbs */
+#define SLOT_MAX_BITS(m) ((m) * FLINT_BITS - 2)
+
+/* headroom in bits when choosing the number of limbs */
+#define PACKED_HEADROOM 16
+
+slong
+fmpz_lll_packed_limbs(const fmpz_mat_t B)
+{
+    slong bits = fmpz_mat_max_bits(B);
+    bits = FLINT_ABS(bits);
+    return (bits + 2 + PACKED_HEADROOM + FLINT_BITS - 1) / FLINT_BITS;
+}
+
+void
+fmpz_lll_packed_init(fmpz_lll_packed_t P, slong d, slong n, slong m)
+{
+    slong i;
+
+    P->d = d;
+    P->n = n;
+    P->m = m;
+    P->entries = flint_malloc(sizeof(ulong) * FLINT_MAX(d * n * m, 1));
+    P->rows = flint_malloc(sizeof(nn_ptr) * FLINT_MAX(d, 1));
+    P->bits = flint_malloc(sizeof(slong) * FLINT_MAX(d, 1));
+
+    for (i = 0; i < d; i++)
+    {
+        P->rows[i] = P->entries + i * n * m;
+        P->bits[i] = 0;
+    }
+}
+
+void
+fmpz_lll_packed_clear(fmpz_lll_packed_t P)
+{
+    flint_free(P->entries);
+    flint_free(P->rows);
+    flint_free(P->bits);
+}
+
+void
+fmpz_lll_packed_set_fmpz_mat(fmpz_lll_packed_t P, const fmpz_mat_t B)
+{
+    slong i, j, m = P->m;
+
+    for (i = 0; i < P->d; i++)
+    {
+        slong bits = 0;
+
+        for (j = 0; j < P->n; j++)
+        {
+            const fmpz * c = fmpz_mat_entry(B, i, j);
+            bits = FLINT_MAX(bits, (slong) fmpz_bits(c));
+            fmpz_get_signed_ui_array(P->rows[i] + j * m, m, c);
+        }
+
+        P->bits[i] = bits;
+    }
+}
+
+void
+fmpz_lll_packed_get_fmpz_mat(fmpz_mat_t B, const fmpz_lll_packed_t P)
+{
+    slong i, j, m = P->m;
+
+    for (i = 0; i < P->d; i++)
+        for (j = 0; j < P->n; j++)
+            fmpz_set_signed_ui_array(fmpz_mat_entry(B, i, j), P->rows[i] + j * m, m);
+}
+
+/* bit length of the magnitude of an m-limb two's complement value */
+static slong
+_twos_bits(nn_srcptr x, slong m, nn_ptr tmp)
+{
+    slong size = m;
+
+    if ((slong) x[m - 1] < 0)
+    {
+        mpn_neg(tmp, x, m);
+        x = tmp;
+    }
+
+    while (size > 0 && x[size - 1] == 0)
+        size--;
+
+    if (size == 0)
+        return 0;
+
+    return (size - 1) * FLINT_BITS + FLINT_BIT_COUNT(x[size - 1]);
+}
+
+/* recompute the exact bit bound of row i */
+void
+fmpz_lll_packed_tighten(fmpz_lll_packed_t P, slong i)
+{
+    slong j, m = P->m, bits = 0;
+    nn_ptr tmp;
+    TMP_INIT;
+
+    TMP_START;
+    tmp = TMP_ALLOC(sizeof(ulong) * m);
+
+    for (j = 0; j < P->n; j++)
+        bits = FLINT_MAX(bits, _twos_bits(P->rows[i] + j * m, m, tmp));
+
+    TMP_END;
+    P->bits[i] = bits;
+}
+
+/* change the number of limbs per entry to m2 (values must fit) */
+static void
+_packed_resize(fmpz_lll_packed_t P, slong m2)
+{
+    slong i, j, d = P->d, n = P->n, m = P->m, mm = FLINT_MIN(m, m2);
+    nn_ptr entries2 = flint_malloc(sizeof(ulong) * FLINT_MAX(d * n * m2, 1));
+
+    for (i = 0; i < d; i++)
+    {
+        nn_srcptr src = P->rows[i];
+        nn_ptr dst = entries2 + i * n * m2;
+
+        for (j = 0; j < n; j++)
+        {
+            slong k;
+            ulong ext;
+
+            flint_mpn_copyi(dst + j * m2, src + j * m, mm);
+            ext = (ulong) (((slong) src[j * m + m - 1]) >> (FLINT_BITS - 1));
+
+            for (k = mm; k < m2; k++)
+                dst[j * m2 + k] = ext;
+        }
+    }
+
+    flint_free(P->entries);
+    P->entries = entries2;
+    P->m = m2;
+
+    for (i = 0; i < d; i++)
+        P->rows[i] = entries2 + i * n * m2;
+}
+
+void
+fmpz_lll_packed_grow(fmpz_lll_packed_t P)
+{
+    _packed_resize(P, P->m + 1);
+}
+
+void
+fmpz_lll_packed_maybe_shrink(fmpz_lll_packed_t P)
+{
+    slong i, maxbits = 0;
+
+    if (P->m <= 1)
+        return;
+
+    for (i = 0; i < P->d; i++)
+        maxbits = FLINT_MAX(maxbits, P->bits[i]);
+
+    /* hysteresis: require half the initial headroom */
+    if (maxbits + 2 + PACKED_HEADROOM / 2 <= SLOT_MAX_BITS(P->m - 1))
+        _packed_resize(P, P->m - 1);
+}
+
+/* move row i to position j, shifting the rows in between */
+void
+fmpz_lll_packed_move_row(fmpz_lll_packed_t P, slong i, slong j)
+{
+    slong k;
+    nn_ptr tmp = P->rows[i];
+    slong tmpbits = P->bits[i];
+
+    if (i > j)
+    {
+        for (k = i; k > j; k--)
+        {
+            P->rows[k] = P->rows[k - 1];
+            P->bits[k] = P->bits[k - 1];
+        }
+    }
+    else
+    {
+        for (k = i; k < j; k++)
+        {
+            P->rows[k] = P->rows[k + 1];
+            P->bits[k] = P->bits[k + 1];
+        }
+    }
+
+    P->rows[j] = tmp;
+    P->bits[j] = tmpbits;
+}
+
+/*
+    Make sure that the slots can hold the result of an operation on rows
+    i and j whose entries are bounded by `bound` bits, where the bound was
+    computed from the (possibly pessimistic) row bounds as
+    max(bits[i], bits[j] + extra_j) + 1. First tighten the bounds, then
+    grow if still necessary. Returns the recomputed bound.
+*/
+static slong
+_ensure(fmpz_lll_packed_t P, slong i, slong j, slong extra_j, slong bound)
+{
+    if (bound <= SLOT_MAX_BITS(P->m))
+        return bound;
+
+    fmpz_lll_packed_tighten(P, i);
+    fmpz_lll_packed_tighten(P, j);
+    bound = FLINT_MAX(P->bits[i], P->bits[j] + extra_j) + 1;
+
+    while (bound > SLOT_MAX_BITS(P->m))
+        fmpz_lll_packed_grow(P);
+
+    return bound;
+}
+
+/*
+    Slot-wise kernels a_j <- a_j - u*b_j and a_j <- a_j + u*b_j modulo
+    2^(m*FLINT_BITS), and a_j <- a_j -/+ b_j. The add and sub variants are
+    generated as separate functions so that the inner loops are branch-free
+    regardless of compiler optimizations.
+*/
+
+#define DEFINE_AORSMUL_1(name, AORS, add_ssaaaa_or_sub_ddmmss, add_sssaaaaaa_or_sub_dddmmmsss, mpn_aorsmul_1) \
+static void \
+name(nn_ptr a, nn_srcptr b, slong n, slong m, ulong u) \
+{ \
+    slong j; \
+ \
+    if (m == 1) \
+    { \
+        for (j = 0; j < n; j++) \
+            a[j] = a[j] AORS b[j] * u; \
+    } \
+    else if (m == 2) \
+    { \
+        for (j = 0; j < n; j++) \
+        { \
+            ulong p1, p0, t1, t0; \
+            umul_ppmm(p1, p0, b[2 * j], u); \
+            p1 += b[2 * j + 1] * u; \
+            add_ssaaaa_or_sub_ddmmss(t1, t0, a[2 * j + 1], a[2 * j], p1, p0); \
+            a[2 * j] = t0; \
+            a[2 * j + 1] = t1; \
+        } \
+    } \
+    else if (m == 3) \
+    { \
+        for (j = 0; j < n; j++) \
+        { \
+            ulong p1, p0, q1, q0, t2, t1, t0; \
+            umul_ppmm(p1, p0, b[3 * j], u); \
+            umul_ppmm(q1, q0, b[3 * j + 1], u); \
+            q1 += b[3 * j + 2] * u; \
+            add_ssaaaa(q1, q0, q1, q0, 0, p1); \
+            add_sssaaaaaa_or_sub_dddmmmsss(t2, t1, t0, a[3 * j + 2], a[3 * j + 1], a[3 * j], q1, q0, p0); \
+            a[3 * j] = t0; \
+            a[3 * j + 1] = t1; \
+            a[3 * j + 2] = t2; \
+        } \
+    } \
+    else \
+    { \
+        for (j = 0; j < n; j++) \
+            mpn_aorsmul_1(a + j * m, b + j * m, m, u); \
+    } \
+}
+
+DEFINE_AORSMUL_1(_submul_1, -, sub_ddmmss, sub_dddmmmsss, mpn_submul_1)
+DEFINE_AORSMUL_1(_addmul_1, +, add_ssaaaa, add_sssaaaaaa, mpn_addmul_1)
+
+#define DEFINE_AORS(name, AORS, add_ssaaaa_or_sub_ddmmss, mpn_aors_n) \
+static void \
+name(nn_ptr a, nn_srcptr b, slong n, slong m) \
+{ \
+    slong j; \
+ \
+    if (m == 1) \
+    { \
+        for (j = 0; j < n; j++) \
+            a[j] = a[j] AORS b[j]; \
+    } \
+    else if (m == 2) \
+    { \
+        for (j = 0; j < n; j++) \
+        { \
+            ulong t1, t0; \
+            add_ssaaaa_or_sub_ddmmss(t1, t0, a[2 * j + 1], a[2 * j], b[2 * j + 1], b[2 * j]); \
+            a[2 * j] = t0; \
+            a[2 * j + 1] = t1; \
+        } \
+    } \
+    else \
+    { \
+        for (j = 0; j < n; j++) \
+            mpn_aors_n(a + j * m, a + j * m, b + j * m, m); \
+    } \
+}
+
+DEFINE_AORS(_sub, -, sub_ddmmss, mpn_sub_n)
+DEFINE_AORS(_add, +, add_ssaaaa, mpn_add_n)
+
+void
+fmpz_lll_packed_row_sub(fmpz_lll_packed_t P, slong i, slong j)
+{
+    slong bound = FLINT_MAX(P->bits[i], P->bits[j]) + 1;
+    bound = _ensure(P, i, j, 0, bound);
+    _sub(P->rows[i], P->rows[j], P->n, P->m);
+    P->bits[i] = bound;
+}
+
+void
+fmpz_lll_packed_row_add(fmpz_lll_packed_t P, slong i, slong j)
+{
+    slong bound = FLINT_MAX(P->bits[i], P->bits[j]) + 1;
+    bound = _ensure(P, i, j, 0, bound);
+    _add(P->rows[i], P->rows[j], P->n, P->m);
+    P->bits[i] = bound;
+}
+
+void
+fmpz_lll_packed_row_submul_si(fmpz_lll_packed_t P, slong i, slong j, slong x)
+{
+    ulong u;
+    slong bx, bound;
+
+    if (x == 0)
+        return;
+
+    u = (x < 0) ? -(ulong) x : (ulong) x;
+    bx = FLINT_BIT_COUNT(u);
+    bound = FLINT_MAX(P->bits[i], P->bits[j] + bx) + 1;
+    bound = _ensure(P, i, j, bx, bound);
+    if (x > 0)
+        _submul_1(P->rows[i], P->rows[j], P->n, P->m, u);
+    else
+        _addmul_1(P->rows[i], P->rows[j], P->n, P->m, u);
+    P->bits[i] = bound;
+}
+
+void
+fmpz_lll_packed_row_submul_fmpz(fmpz_lll_packed_t P, slong i, slong j, const fmpz_t x)
+{
+    slong bx, bound, m, n, k;
+    nn_ptr xl, a;
+    nn_srcptr b;
+    TMP_INIT;
+
+    if (fmpz_is_zero(x))
+        return;
+
+    if (fmpz_fits_si(x))
+    {
+        fmpz_lll_packed_row_submul_si(P, i, j, fmpz_get_si(x));
+        return;
+    }
+
+    bx = fmpz_bits(x);
+    bound = FLINT_MAX(P->bits[i], P->bits[j] + bx) + 1;
+    bound = _ensure(P, i, j, bx, bound);
+    m = P->m;
+    n = P->n;
+
+    TMP_START;
+    xl = TMP_ALLOC(sizeof(ulong) * m);
+    fmpz_get_signed_ui_array(xl, m, x);   /* x mod 2^(m*FLINT_BITS) */
+    a = P->rows[i];
+    b = P->rows[j];
+
+    if (m == 1)
+    {
+        for (k = 0; k < n; k++)
+            a[k] -= b[k] * xl[0];
+    }
+    else if (m == 2)
+    {
+        for (k = 0; k < n; k++)
+        {
+            ulong p1, p0, t1, t0;
+            umul_ppmm(p1, p0, b[2 * k], xl[0]);
+            p1 += b[2 * k] * xl[1] + b[2 * k + 1] * xl[0];
+            sub_ddmmss(t1, t0, a[2 * k + 1], a[2 * k], p1, p0);
+            a[2 * k] = t0;
+            a[2 * k + 1] = t1;
+        }
+    }
+    else
+    {
+        nn_ptr t = TMP_ALLOC(sizeof(ulong) * 2 * m);
+        for (k = 0; k < n; k++)
+        {
+            flint_mpn_mul_n(t, b + k * m, xl, m);   /* low m limbs are the product mod 2^(m*FLINT_BITS) */
+            mpn_sub_n(a + k * m, a + k * m, t, m);
+        }
+    }
+
+    TMP_END;
+    P->bits[i] = bound;
+}
+
+/* a_j <- a_j -/+ u * 2^e * b_j modulo 2^(m*FLINT_BITS) */
+void
+fmpz_lll_packed_row_submul_si_2exp(fmpz_lll_packed_t P, slong i, slong j, slong x, ulong e)
+{
+    ulong u;
+    slong bx, bound, k, m, n, s, r;
+    nn_ptr tmp;
+    mp_limb_t (* mpn_aorsmul_1)(mp_ptr, mp_srcptr, mp_size_t, mp_limb_t);
+    TMP_INIT;
+
+    if (x == 0)
+        return;
+
+    if (e == 0)
+    {
+        fmpz_lll_packed_row_submul_si(P, i, j, x);
+        return;
+    }
+
+    u = (x < 0) ? -(ulong) x : (ulong) x;
+    bx = FLINT_BIT_COUNT(u) + e;
+    bound = FLINT_MAX(P->bits[i], P->bits[j] + bx) + 1;
+    bound = _ensure(P, i, j, bx, bound);
+    m = P->m;
+    n = P->n;
+    s = e / FLINT_BITS;
+    r = e % FLINT_BITS;
+
+    mpn_aorsmul_1 = (x < 0) ? mpn_addmul_1 : mpn_submul_1;
+
+    TMP_START;
+    tmp = TMP_ALLOC(sizeof(ulong) * m);
+
+    for (k = 0; k < n; k++)
+    {
+        nn_srcptr bk = P->rows[j] + k * m;
+
+        flint_mpn_zero(tmp, m);
+        if (s < m)
+        {
+            if (r == 0)
+                flint_mpn_copyi(tmp + s, bk, m - s);
+            else
+                mpn_lshift(tmp + s, bk, m - s, r);
+        }
+
+        mpn_aorsmul_1(P->rows[i] + k * m, tmp, m, u);
+    }
+
+    TMP_END;
+    P->bits[i] = bound;
+}
+
+/* same semantics as _fmpz_vec_get_d_vec_2exp on the unpacked row; also sets the exact row bound */
+slong
+fmpz_lll_packed_get_d_vec_2exp(double * appv, fmpz_lll_packed_t P, slong i)
+{
+    slong j, n = P->n, m = P->m, maxexp = 0;
+    nn_srcptr row = P->rows[i];
+    slong * exp;
+    nn_ptr tmp;
+    TMP_INIT;
+
+    TMP_START;
+    exp = TMP_ALLOC(n * sizeof(slong));
+    tmp = TMP_ALLOC(m * sizeof(ulong));
+
+    for (j = 0; j < n; j++)
+    {
+        nn_srcptr e = row + j * m;
+        slong size = m;
+        int neg = ((slong) e[m - 1]) < 0;
+
+        if (neg)
+        {
+            mpn_neg(tmp, e, m);
+            e = tmp;
+        }
+
+        while (size > 0 && e[size - 1] == 0)
+            size--;
+
+        if (size == 0)
+        {
+            appv[j] = 0.0;
+            exp[j] = 0;
+        }
+        else
+        {
+            exp[j] = (size - 1) * FLINT_BITS + FLINT_BIT_COUNT(e[size - 1]);
+            appv[j] = flint_mpn_get_d(e, size, neg ? -1 : 1, -exp[j]);
+            if (exp[j] > maxexp)
+                maxexp = exp[j];
+        }
+    }
+
+    for (j = 0; j < n; j++)
+        appv[j] = d_mul_2exp(appv[j], exp[j] - maxexp);
+
+    P->bits[i] = maxexp;
+
+    TMP_END;
+    return maxexp;
+}
+
+/* exact dot product of the first len entries of rows i and j */
+void
+fmpz_lll_packed_dot(fmpz_t res, const fmpz_lll_packed_t P, slong i, slong j, slong len)
+{
+    slong k, m = P->m;
+
+    if (len == 0)
+    {
+        fmpz_zero(res);
+        return;
+    }
+
+    /* signed fixed-width kernels; the output size is chosen from the row bounds */
+    if (m <= FLINT_MPN_DOT_TAB_N)
+    {
+        ulong acc[2 * FLINT_MPN_DOT_TAB_N + 1];
+        slong need = P->bits[i] + P->bits[j] + FLINT_BIT_COUNT(len) + 1;   /* signed result bits */
+        slong sz = FLINT_MAX((need + FLINT_BITS - 1) / FLINT_BITS, 2 * m - 1);
+
+        if (sz <= 2 * m + 1)
+        {
+            slong idx = sz - (2 * m - 1);
+
+            if (m <= FLINT_MPN_DOT_DEDICATED_TAB_N && flint_mpn_dot_tab[1][m][m][idx] != NULL)
+            {
+                flint_mpn_dot_tab[1][m][m][idx](acc, P->rows[i], P->rows[j], len);
+                fmpz_set_signed_ui_array(res, acc, sz);
+                return;
+            }
+            else if (flint_mpn_dot_strided_tab[1][m][m][idx] != NULL)
+            {
+                flint_mpn_dot_strided_tab[1][m][m][idx](acc, P->rows[i], m, P->rows[j], m, len);
+                fmpz_set_signed_ui_array(res, acc, sz);
+                return;
+            }
+        }
+    }
+
+    /* generic fallback */
+    {
+        fmpz_t ta, tb;
+
+        fmpz_init(ta);
+        fmpz_init(tb);
+        fmpz_zero(res);
+
+        for (k = 0; k < len; k++)
+        {
+            fmpz_set_signed_ui_array(ta, P->rows[i] + k * m, m);
+            fmpz_set_signed_ui_array(tb, P->rows[j] + k * m, m);
+            fmpz_addmul(res, ta, tb);
+        }
+
+        fmpz_clear(ta);
+        fmpz_clear(tb);
+    }
+}
+
+/* same semantics as fmpz_lll_heuristic_dot */
+double
+fmpz_lll_packed_heuristic_dot(const double * vec1, const double * vec2, slong len2,
+                              const fmpz_lll_packed_t P, slong k, slong j, slong exp_adj)
+{
+    double sum = _d_vec_dot(vec1, vec2, len2);
+    double tmp = _d_vec_norm(vec1, len2);
+    double tmp2 = _d_vec_norm(vec2, len2);
+
+    tmp = tmp * tmp2 * ldexp(1.0, -70);
+    tmp2 = sum * sum;
+
+    if (tmp2 <= tmp)
+    {
+        slong exp;
+        fmpz_t sp;
+        fmpz_init(sp);
+        fmpz_lll_packed_dot(sp, P, k, j, len2);
+        sum = fmpz_get_d_2exp(&exp, sp);
+        sum = ldexp(sum, exp - exp_adj);
+        fmpz_clear(sp);
+    }
+
+    return sum;
+}

--- a/src/fmpz_lll/test/main.c
+++ b/src/fmpz_lll/test/main.c
@@ -20,6 +20,7 @@
 #include "t-lll_d_with_removal_knapsack.c"
 #include "t-lll_is_reduced.c"
 #include "t-lll_mpf.c"
+#include "t-packed.c"
 #include "t-lll_mpf_with_removal.c"
 #include "t-lll_with_removal.c"
 #include "t-wrapper.c"
@@ -39,6 +40,7 @@ test_struct tests[] =
     TEST_FUNCTION(fmpz_lll_d_with_removal_knapsack),
     TEST_FUNCTION(fmpz_lll_is_reduced),
     TEST_FUNCTION(fmpz_lll_mpf),
+    TEST_FUNCTION(fmpz_lll_packed),
     TEST_FUNCTION(fmpz_lll_mpf_with_removal),
     TEST_FUNCTION(fmpz_lll_with_removal),
     TEST_FUNCTION(fmpz_lll_wrapper),

--- a/src/fmpz_lll/test/main.c
+++ b/src/fmpz_lll/test/main.c
@@ -20,6 +20,7 @@
 #include "t-lll_d_with_removal_knapsack.c"
 #include "t-lll_is_reduced.c"
 #include "t-lll_mpf.c"
+#include "t-lll_unpacked.c"
 #include "t-packed.c"
 #include "t-lll_mpf_with_removal.c"
 #include "t-lll_with_removal.c"
@@ -40,6 +41,7 @@ test_struct tests[] =
     TEST_FUNCTION(fmpz_lll_d_with_removal_knapsack),
     TEST_FUNCTION(fmpz_lll_is_reduced),
     TEST_FUNCTION(fmpz_lll_mpf),
+    TEST_FUNCTION(fmpz_lll_unpacked),
     TEST_FUNCTION(fmpz_lll_packed),
     TEST_FUNCTION(fmpz_lll_mpf_with_removal),
     TEST_FUNCTION(fmpz_lll_with_removal),

--- a/src/fmpz_lll/test/t-lll_unpacked.c
+++ b/src/fmpz_lll/test/t-lll_unpacked.c
@@ -1,0 +1,223 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "mpn_extras.h"
+#include "fmpz.h"
+#include "fmpz_vec.h"
+#include "fmpz_mat.h"
+#include "fmpz_lll.h"
+#include "ulong_extras.h"
+
+/*
+    Exercises code paths of the floating-point LLL variants not covered by
+    the other tests: inputs with entries too large to use the packed
+    representation, inputs that make the double precision Babai step fail
+    (a huge entry next to tiny ones underflows in the scaled double
+    approximation), and linearly dependent rows in the multiprecision LLL,
+    with packed and unpacked matrices.
+
+    Since these inputs are ill-conditioned, the output is not required to
+    be reduced; what is verified is that the output is the given unimodular
+    transformation of the input, which checks that all row operations are
+    performed exactly.
+*/
+
+/* random small matrix with one entry of about hugebits bits */
+static void
+randmat_huge(fmpz_mat_t A, flint_rand_t state, slong hugebits)
+{
+    fmpz * c;
+    fmpz_mat_randtest(A, state, 1 + n_randint(state, 30));
+    c = fmpz_mat_entry(A, n_randint(state, A->r), n_randint(state, A->c));
+    fmpz_randbits(c, state, hugebits);
+    if (n_randint(state, 2))
+        fmpz_neg(c, c);
+}
+
+/* is B = U * A with U unimodular? */
+static int
+check_transform(const fmpz_mat_t A, const fmpz_mat_t U, const fmpz_mat_t B)
+{
+    fmpz_mat_t T;
+    fmpz_t det;
+    int ok;
+
+    fmpz_mat_init(T, B->r, B->c);
+    fmpz_init(det);
+    fmpz_mat_mul(T, U, A);
+    fmpz_mat_det(det, U);
+    ok = fmpz_mat_equal(T, B) && fmpz_is_pm1(det);
+    fmpz_mat_clear(T);
+    fmpz_clear(det);
+    return ok;
+}
+
+TEST_FUNCTION_START(fmpz_lll_unpacked, state)
+{
+    slong iter;
+
+    /* double precision LLL: unpacked (huge entries) and packed but failing (underflow) */
+    for (iter = 0; iter < 50 * flint_test_multiplier(); iter++)
+    {
+        fmpz_mat_t A, B, U;
+        fmpz_lll_t fl;
+        fmpz_t gs_B;
+        slong d, n, hugebits;
+        const slong packed_max_bits = FMPZ_LLL_PACKED_MAX_LIMBS * FLINT_BITS;
+        int res, kind = n_randint(state, 4), unpacked = n_randint(state, 2);
+
+        d = 2 + n_randint(state, 8);
+        n = d + n_randint(state, 3);
+
+        /*
+            Packed, but as large as possible: with 64-bit limbs the entry
+            exceeds the double exponent range relative to the small entries,
+            which makes the Babai step fail (with 32-bit limbs the packable
+            range is too small for this to happen).
+        */
+        if (unpacked)
+            hugebits = FMPZ_LLL_PACKED_MAX_LIMBS * FLINT_BITS + 100 + n_randint(state, 200);
+        else
+            hugebits = packed_max_bits * 5 / 8 + n_randint(state, packed_max_bits * 3 / 8 - 64);
+
+        fmpz_mat_init(A, d, n);
+        fmpz_mat_init(B, d, n);
+        fmpz_mat_init(U, d, d);
+        fmpz_mat_one(U);
+        fmpz_init(gs_B);
+        randmat_huge(A, state, hugebits);
+        fmpz_mat_set(B, A);
+        fmpz_set_ui(gs_B, 1);
+        fmpz_mul_2exp(gs_B, gs_B, n_randint(state, 200));
+        fmpz_lll_context_init(fl, 0.75, 0.81, Z_BASIS, APPROX);
+
+        if (unpacked != (fmpz_lll_packed_limbs(A) > FMPZ_LLL_PACKED_MAX_LIMBS))
+            TEST_FUNCTION_FAIL("unexpected packing decision\n");
+
+        if (kind == 0)
+            res = fmpz_lll_d(B, U, fl);
+        else if (kind == 1)
+            res = fmpz_lll_d_heuristic(B, U, fl);
+        else if (kind == 2)
+            res = fmpz_lll_d_with_removal(B, U, gs_B, fl);
+        else
+            res = fmpz_lll_d_with_removal_knapsack(B, U, gs_B, fl);
+
+        if (!check_transform(A, U, B))
+            TEST_FUNCTION_FAIL("lll_d kind %d res %d: output is not a unimodular transformation of the input\nA = %{fmpz_mat}\nB = %{fmpz_mat}\nU = %{fmpz_mat}\n", kind, res, A, B, U);
+
+        fmpz_mat_clear(A);
+        fmpz_mat_clear(B);
+        fmpz_mat_clear(U);
+        fmpz_clear(gs_B);
+    }
+
+    /* knapsack variant with early size reduction of the later rows, with Babai failures */
+    for (iter = 0; iter < 100 * flint_test_multiplier(); iter++)
+    {
+        fmpz_mat_t A, B, U;
+        fmpz_lll_t fl;
+        fmpz_t gs_B;
+        slong d, n, i;
+        const slong packed_max_bits = FMPZ_LLL_PACKED_MAX_LIMBS * FLINT_BITS;
+        int res;
+
+        d = 6 + n_randint(state, 8);
+        n = d + n_randint(state, 3);
+
+        fmpz_mat_init(A, d, n);
+        fmpz_mat_init(B, d, n);
+        fmpz_mat_init(U, d, d);
+        fmpz_mat_one(U);
+        fmpz_init(gs_B);
+        fmpz_mat_randtest(A, state, 1 + n_randint(state, 30));
+
+        /* several rows with a huge entry each */
+        for (i = 0; i < d; i++)
+            if (n_randint(state, 3) == 0)
+                fmpz_randbits(fmpz_mat_entry(A, i, n_randint(state, n)), state,
+                    packed_max_bits * 5 / 8 + n_randint(state, packed_max_bits * 3 / 8 - 64));
+
+        fmpz_mat_set(B, A);
+        fmpz_set_ui(gs_B, 1);
+        fmpz_mul_2exp(gs_B, gs_B, n_randint(state, 200));
+        fmpz_lll_context_init(fl, 0.75, 0.81, Z_BASIS, APPROX);
+
+        res = fmpz_lll_d_with_removal_knapsack(B, U, gs_B, fl);
+
+        if (!check_transform(A, U, B))
+            TEST_FUNCTION_FAIL("knapsack res %d: output is not a unimodular transformation of the input\nA = %{fmpz_mat}\nB = %{fmpz_mat}\nU = %{fmpz_mat}\n", res, A, B, U);
+
+        fmpz_mat_clear(A);
+        fmpz_mat_clear(B);
+        fmpz_mat_clear(U);
+        fmpz_clear(gs_B);
+    }
+
+    /* multiprecision LLL: unpacked (m > FMPZ_LLL_PACKED_MAX_LIMBS_MPF) and linearly dependent rows */
+    for (iter = 0; iter < 50 * flint_test_multiplier(); iter++)
+    {
+        fmpz_mat_t A, B, U;
+        fmpz_lll_t fl;
+        fmpz_t gs_B;
+        slong d, n, i;
+        int res, with_removal = n_randint(state, 2), unpacked = n_randint(state, 2);
+        flint_bitcnt_t prec = 64 * (1 + n_randint(state, 3));
+
+        d = 2 + n_randint(state, 8);
+        n = 1 + n_randint(state, d);   /* usually more rows than columns */
+
+        fmpz_mat_init(A, d, n);
+        fmpz_mat_init(B, d, n);
+        fmpz_mat_init(U, d, d);
+        fmpz_mat_one(U);
+        fmpz_init(gs_B);
+
+        fmpz_mat_randtest(A, state, 1 + n_randint(state, 60));
+
+        /* duplicated row */
+        if (n_randint(state, 2))
+        {
+            i = n_randint(state, d - 1);
+            _fmpz_vec_set(fmpz_mat_row(A, i + 1), fmpz_mat_row(A, i), n);
+        }
+
+        if (unpacked)
+        {
+            fmpz * c = fmpz_mat_entry(A, n_randint(state, d), n_randint(state, n));
+            fmpz_randbits(c, state, FMPZ_LLL_PACKED_MAX_LIMBS_MPF * FLINT_BITS + 50 + n_randint(state, 300));
+        }
+
+        fmpz_mat_set(B, A);
+        fmpz_set_ui(gs_B, 1);
+        fmpz_mul_2exp(gs_B, gs_B, n_randint(state, 50));
+        fmpz_lll_context_init(fl, 0.75, 0.81, Z_BASIS, APPROX);
+
+        if (unpacked != (fmpz_lll_packed_limbs(A) > FMPZ_LLL_PACKED_MAX_LIMBS_MPF))
+            TEST_FUNCTION_FAIL("unexpected packing decision\n");
+
+        if (with_removal)
+            res = fmpz_lll_mpf2_with_removal(B, U, prec, gs_B, fl);
+        else
+            res = fmpz_lll_mpf2(B, U, prec, fl);
+
+        if (!check_transform(A, U, B))
+            TEST_FUNCTION_FAIL("mpf2 removal %d res %d: output is not a unimodular transformation of the input\nA = %{fmpz_mat}\nB = %{fmpz_mat}\nU = %{fmpz_mat}\n", with_removal, res, A, B, U);
+
+        fmpz_mat_clear(A);
+        fmpz_mat_clear(B);
+        fmpz_mat_clear(U);
+        fmpz_clear(gs_B);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/fmpz_lll/test/t-packed.c
+++ b/src/fmpz_lll/test/t-packed.c
@@ -1,0 +1,157 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <string.h>
+#include "test_helpers.h"
+#include "fmpz.h"
+#include "fmpz_vec.h"
+#include "fmpz_mat.h"
+#include "long_extras.h"
+#include "fmpz_lll.h"
+
+TEST_FUNCTION_START(fmpz_lll_packed, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 500 * flint_test_multiplier(); iter++)
+    {
+        fmpz_mat_t B, C;
+        fmpz_lll_packed_t P;
+        slong d, n, bits, m, k, i, j, len;
+        fmpz_t x, dot1, dot2;
+        double * v1, * v2;
+        slong e1, e2;
+
+        d = 1 + n_randint(state, 8);
+        n = 1 + n_randint(state, 12);
+        bits = 1 + n_randint(state, 300);
+
+        fmpz_mat_init(B, d, n);
+        fmpz_mat_init(C, d, n);
+        fmpz_init(x);
+        fmpz_init(dot1);
+        fmpz_init(dot2);
+        fmpz_mat_randtest(B, state, bits);
+
+        m = fmpz_lll_packed_limbs(B);
+        if (n_randint(state, 2))
+            m += n_randint(state, 3);
+
+        fmpz_lll_packed_init(P, d, n, m);
+        fmpz_lll_packed_set_fmpz_mat(P, B);
+
+        /* random sequence of row operations, mirrored on B */
+        for (k = 0; k < 30; k++)
+        {
+            int op = n_randint(state, 7);
+            i = n_randint(state, d);
+            j = n_randint(state, d);
+
+            if (op == 0 && i != j)
+            {
+                fmpz_lll_packed_row_sub(P, i, j);
+                _fmpz_vec_sub(fmpz_mat_row(B, i), fmpz_mat_row(B, i), fmpz_mat_row(B, j), n);
+            }
+            else if (op == 1 && i != j)
+            {
+                fmpz_lll_packed_row_add(P, i, j);
+                _fmpz_vec_add(fmpz_mat_row(B, i), fmpz_mat_row(B, i), fmpz_mat_row(B, j), n);
+            }
+            else if (op == 2 && i != j)
+            {
+                slong xs = z_randtest(state);
+                fmpz_lll_packed_row_submul_si(P, i, j, xs);
+                _fmpz_vec_scalar_submul_si(fmpz_mat_row(B, i), fmpz_mat_row(B, j), n, xs);
+            }
+            else if (op == 3 && i != j)
+            {
+                ulong e = n_randint(state, 200);
+                slong xs = z_randtest(state);
+                fmpz_lll_packed_row_submul_si_2exp(P, i, j, xs, e);
+                _fmpz_vec_scalar_submul_si_2exp(fmpz_mat_row(B, i), fmpz_mat_row(B, j), n, xs, e);
+            }
+            else if (op == 4 && i != j)
+            {
+                fmpz_randtest(x, state, 1 + n_randint(state, 200));
+                fmpz_lll_packed_row_submul_fmpz(P, i, j, x);
+                _fmpz_vec_scalar_submul_fmpz(fmpz_mat_row(B, i), fmpz_mat_row(B, j), n, x);
+            }
+            else if (op == 5)
+            {
+                fmpz_lll_packed_move_row(P, i, j);
+                if (i > j)
+                {
+                    for (k = i; k > j; k--) fmpz_mat_swap_rows(B, NULL, k, k - 1);
+                }
+                else
+                {
+                    for (k = i; k < j; k++) fmpz_mat_swap_rows(B, NULL, k, k + 1);
+                }
+                k = 0;
+            }
+            else
+            {
+                fmpz_lll_packed_tighten(P, i);
+                fmpz_lll_packed_maybe_shrink(P);
+            }
+
+            /* row bounds must be valid upper bounds */
+            for (i = 0; i < d; i++)
+            {
+                slong b = 0;
+                for (j = 0; j < n; j++)
+                    b = FLINT_MAX(b, (slong) fmpz_bits(fmpz_mat_entry(B, i, j)));
+                if (b > P->bits[i])
+                    TEST_FUNCTION_FAIL("row bound not an upper bound\n");
+            }
+        }
+
+        fmpz_lll_packed_get_fmpz_mat(C, P);
+
+        if (!fmpz_mat_equal(B, C))
+        {
+            TEST_FUNCTION_FAIL("row operations differ\nB = %{fmpz_mat}\nC = %{fmpz_mat}\n", B, C);
+        }
+
+        /* dot product and double conversion */
+        i = n_randint(state, d);
+        j = n_randint(state, d);
+        len = n_randint(state, n + 1);
+        fmpz_lll_packed_dot(dot1, P, i, j, len);
+        _fmpz_vec_dot(dot2, fmpz_mat_row(B, i), fmpz_mat_row(B, j), len);
+
+        if (!fmpz_equal(dot1, dot2))
+        {
+            TEST_FUNCTION_FAIL("dot products differ: %{fmpz} vs %{fmpz}\n", dot1, dot2);
+        }
+
+        v1 = flint_malloc(sizeof(double) * n);
+        v2 = flint_malloc(sizeof(double) * n);
+        e1 = fmpz_lll_packed_get_d_vec_2exp(v1, P, i);
+        e2 = _fmpz_vec_get_d_vec_2exp(v2, fmpz_mat_row(B, i), n);
+
+        if (e1 != e2 || memcmp(v1, v2, sizeof(double) * n) != 0)
+        {
+            TEST_FUNCTION_FAIL("double conversion differs\n");
+        }
+
+        flint_free(v1);
+        flint_free(v2);
+        fmpz_lll_packed_clear(P);
+        fmpz_mat_clear(B);
+        fmpz_mat_clear(C);
+        fmpz_clear(x);
+        fmpz_clear(dot1);
+        fmpz_clear(dot2);
+    }
+
+    TEST_FUNCTION_END(state);
+}


### PR DESCRIPTION
Allow `fmpz_lll` to use packed `mpn` representation of basis matrices instead of `fmpz`. Fixes #2389. For the multiprecision approximate LLL, few-limb dot products in the Gram basis are moreover done exactly via the dot product kernels introduced in #2824.

This turned out to have a bigger impact than I anticipated; factoring S10 got 1.7x faster. Improved timings on the hard polynomials in `build/fmpz_poly_factor/profile/p-factor_hard -hard` (the easier polynomials are unaffected):

```
                  old       new    speedup
H1              1.047     0.744     1.41x
S7              0.019     0.018     1.06x
S8              0.187     0.162     1.15x
C1              0.081     0.076     1.07x
S9              1.875     1.425     1.32x
H2              0.342     0.330     1.04x
P7*M12_5       27.568    21.049     1.31x
P7*M12_6       48.307    34.689     1.39x
S10            65.694    38.124     1.72x
```

Implemented using Claude Fable 5.1.

Also fixes a bug in `fmpz_lll_heuristic_dot` (apparently was harmless, but a bug nonetheless).