### PR TITLE
Elliptic curve primality proving

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,7 +247,7 @@ set(_BUILD_DIRS
     fq_nmod_mpoly_factor            fq_zech_mpoly_factor
 
     fft             ${FFT_SMALL}    fmpz_poly_q     fmpz_lll
-    n_poly          arith           qsieve          aprcl
+    n_poly          arith           qsieve          aprcl           ecpp
 
     nf              nf_elem         qfb
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -192,7 +192,7 @@ HEADER_DIRS	:=	\
 		fft			@FFT_SMALL@								\
 		fmpz_lll											\
 		arith												\
-		qsieve		aprcl									\
+		qsieve		aprcl		ecpp							\
 															\
 		fq_default		fq_default_mat	fq_default_poly		\
 		fq_nmod_embed	fq_zech_embed	fq_embed			\

--- a/doc/source/ecpp.rst
+++ b/doc/source/ecpp.rst
@@ -1,0 +1,310 @@
+.. _ecpp:
+
+**ecpp.h** -- elliptic curve primality proving
+===============================================================================
+
+Elliptic curve primality proving (ECPP) in the Atkin-Morain form. Unlike
+APRCL, the proof produces a certificate that can be verified independently
+and much faster than it was produced, and the running time scales better
+with the size of the input.
+
+A certificate is a chain of steps `(n_i, a_i, b_i, m_i, q_i, P_i)`. Step `i`
+shows that `n_i` is prime provided `q_i` is prime: the point `P_i` on the
+curve `y^2 = x^3 + a_i x + b_i` modulo `n_i` satisfies `m_i P_i = O` and
+`(m_i / q_i) P_i \neq O` with `q_i \mid m_i` and `q_i > (n_i^{1/4} + 1)^2`.
+The chain continues with `n_{i+1} = q_i` until `q < 2^{64}`, which is
+checked directly.
+
+The prover uses the organisation of the discriminant search of fastECPP
+(Franke, Kleinjung, Morain, Wirth). A pool of fundamental discriminants
+`D < 0` that are smooth over a fixed set of small primes (the set, the
+class number bound and the trial division bound depend on the size of the
+input) is built once, sorted by the cost of realising a step with `D`:
+number of units, class number `h(D)`, odd part of `h(D)`. For each `n`
+the pool is scanned in that order. A discriminant is only used when all
+its genus characters `(p^*/n)` are 1, since otherwise `n` cannot be
+represented by the principal form; then `\sqrt{D} \bmod n` is the product
+of the square roots of the `p^* \mid D`, which are computed once per `n`,
+and Cornacchia writes `4n = t^2 + |D| v^2`. The possible curve orders
+`n + 1 \pm t` (and the extra twists for `D = -3, -4`) are collected in
+batches; one remainder tree removes all their prime factors below the
+trial division bound, and the cofactors `q` with `(n^{1/4} + 1)^2 < q
+\le n/2` are tested for probable primality. The candidate with the best
+estimated cost per bit gained (the cost being that of finding a root of
+the factor of `H_D` over the genus field, see ``ecpp_class_poly_genus``,
+of degree `h / 2^{g-1}` where `g` is the number of genus characters,
+by radicals up to degree 4) is realised: a root modulo `n` of the
+Hilbert class polynomial `H_D` gives the curve, the right twist and a point
+are found by testing, and the prover recurses on `q`. Dead ends continue
+with the next candidate of the batch, then with the next batch.
+
+``fmpz_is_prime`` uses ECPP instead of APRCL for its final proof from a
+size that depends on the number of available threads: 250 bits with one
+thread, 550 with two, 1000 with three, 2000 with four and 8000 with up
+to eight (APRCL parallelises better than the largely serial ECPP chain;
+these are crossovers measured on random primes). With threads, the
+square roots, the Cornacchia steps, the probable prime tests and the
+reduction of the primorial are distributed, the two twists of a curve are
+tried at once, and the realisation of a step (class polynomial, root,
+curve and point) runs on a pool thread while the search for the next
+step proceeds.
+
+Prior art. The organisation of the search follows the fastECPP of
+Franke, Kleinjung, Morain and Wirth [FKMW2004]_ and Morain [Morain2007]_,
+in the form of the FastECPP implementations by Jared Asuncion in PARI/GP
+(``primecert``, [PARI]_) and by Andreas Enge in the CM library
+[EngeCM]_, [Enge2024]_: the discriminants smooth over a set of small
+primes, the square roots of the primes computed once per `n`, the batch
+factoring of the curve orders with a remainder tree and the choice of
+the trial division bound and of the minimum gain per step; the rounds
+of the search extending the prime set until a few prime cofactors are
+expected, the trial division bound fixed for the whole chain, the
+cache-blocked class number sieve and the class field tower with the
+Hecke representation of its coefficients are as in CM, which also
+provided the reference for the normalisations of Weber's function as a
+class invariant ([Schertz2002]_, [YuiZagier1997]_). The class field tower
+is the decomposition of Enge and Morain [EngeMorain2003]_; the factor of
+`H_D` over the genus field and the descent by radicals and by Kummer
+theory through the tower are original to this implementation. The
+timings of both PARI/GP and CM on the same inputs were used throughout
+to tune the parameters.
+
+``ecpp_set_verbose(1)`` reports the steps of a proof as they are found;
+compiling ``prove.c`` with ``-DECPP_PROFILE`` prints a breakdown of the
+time at the end, and ``profile/p-prove.c`` times ECPP against APRCL.
+
+Example. ``build/examples/factor_integer -certify n`` proves each prime
+factor above 64 bits with ECPP and prints the certificate; ``-pari``
+prints it in the ``primecert`` syntax of PARI/GP instead, ``-verbose``
+reports the steps::
+
+    $ build/examples/factor_integer -certify "2^128+1"
+    340282366920938463463374607431768211457 =
+    59649589127497217 * 5704689200685129054721
+
+    ECPP certificate for 5704689200685129054721 (verified):
+    ecpp certificate, 1 steps
+    [0] n = 5704689200685129054721
+        D = -40
+        a = 580466530013776483294
+        b = 4831761323372247440219
+        m = 5704689200761597106060
+        q = 636165875659
+        x = 2451296810544034633782
+        y = 5469387309100357564736
+
+    $ build/examples/factor_integer -pari "2^128+1"
+    ...
+    [[5704689200685129054721, -76468051338, 8967298340, 580466530013776483294, [2451296810544034633782, 5469387309100357564736]]]
+
+The step reads: the curve `y^2 = x^3 + a x + b` over `\mathbb{Z}/n`
+has `m = n + 1 - t = s q` points with `q = 636165875659` prime and
+`(n^{1/4} + 1)^2 < q`, and `P = (x, y)` satisfies `m P = O`,
+`(m/q) P \ne O`; hence `n` is prime. In the PARI/GP form the entries
+are `[n, t, s, a, [x, y]]`, with `b` implied by the point, and each
+step's `q = (n + 1 - t)/s` is the `n` of the next one (the last `q` is
+a word-size prime). ``primecertisvalid`` in PARI/GP accepts the output
+of ``-pari``.
+
+Point arithmetic modulo `n` is done in Jacobian coordinates; every quantity
+whose invertibility a formula assumes is accumulated and checked with a
+single gcd at the end, so that a composite `n` is detected rather than
+producing a wrong proof.
+
+Types, macros and constants
+-------------------------------------------------------------------------------
+
+.. type:: ecpp_step_struct
+
+    One step of a certificate: `n`, `D`, curve `(a, b)`, `m`, `q` and the
+    point `(x, y)`.
+
+.. type:: ecpp_cert_struct
+
+.. type:: ecpp_cert_t
+
+    A certificate: an array of steps.
+
+.. type:: ecpp_point_struct
+
+.. type:: ecpp_point_t
+
+    A point `(X : Y : Z)` in Jacobian coordinates; `Z = 0` is the point at
+    infinity.
+
+Certificates
+-------------------------------------------------------------------------------
+
+.. function:: void ecpp_cert_init(ecpp_cert_t cert)
+              void ecpp_cert_clear(ecpp_cert_t cert)
+
+.. function:: ecpp_step_struct * ecpp_cert_push(ecpp_cert_t cert)
+              void ecpp_cert_pop(ecpp_cert_t cert)
+
+    Appends an initialised step, respectively removes the last step.
+
+.. macro:: ECPP_CERT_FORMAT_FLINT
+           ECPP_CERT_FORMAT_PARI
+
+    Text formats of a certificate: the labelled form shown above, and the
+    ``primecert`` syntax of PARI/GP, ``[[n, t, s, a, [x, y]], ...]`` with
+    `n + 1 - t = s q`.
+
+.. function:: void ecpp_cert_print(const ecpp_cert_t cert, int format)
+              void ecpp_cert_fprint(FILE * file, const ecpp_cert_t cert, int format)
+              char * ecpp_cert_get_str(const ecpp_cert_t cert, int format)
+
+    Prints, respectively returns as a string (to be freed with
+    ``flint_free``), the certificate in the given format.
+
+.. function:: int ecpp_cert_set_str(ecpp_cert_t cert, const char * str)
+
+    Reads a certificate in either format (recognised by the first
+    character). Returns 1 on success, 0 (with an empty certificate) if
+    the string is malformed. In the PARI/GP format `b` is recovered from
+    the point and the discriminant is not available (set to 0); the
+    certificate verifies all the same.
+
+.. function:: void ecpp_set_verbose(int verbose)
+
+    With ``verbose`` nonzero, ``ecpp_prove`` prints each step as it is
+    found (the sizes, the discriminant, the class number and the degree
+    of the polynomial whose root is needed).
+
+Proving and verifying
+-------------------------------------------------------------------------------
+
+.. function:: int ecpp_prove(ecpp_cert_t cert, const fmpz_t n)
+
+    Attempts to prove that `n` is prime. Returns 1 and fills ``cert`` with
+    a certificate if `n` is prime, 0 if `n` is composite, and -1 if no proof
+    could be found. For `n < 2^{64}` the certificate is empty. The input
+    is expected to be a probable prime; composites are usually detected
+    quickly by the initial BPSW test.
+
+.. function:: int ecpp_verify(const ecpp_cert_t cert, const fmpz_t n)
+
+    Returns 1 if ``cert`` is a valid certificate proving that `n` is prime,
+    0 otherwise. An empty certificate is valid exactly for `n < 2^{64}`
+    prime.
+
+.. function:: int ecpp_verify_step(const ecpp_step_struct * s)
+
+    Checks one step, i.e. that `n` is prime if `q` is prime.
+
+.. function:: int ecpp_is_prime(const fmpz_t n)
+
+    Runs ``ecpp_prove`` and discards the certificate.
+
+Curve arithmetic
+-------------------------------------------------------------------------------
+
+.. function:: void ecpp_point_init(ecpp_point_t P)
+              void ecpp_point_clear(ecpp_point_t P)
+              void ecpp_point_set_affine(ecpp_point_t P, const fmpz_t x, const fmpz_t y)
+              int ecpp_point_is_zero(const ecpp_point_t P)
+
+.. function:: void ecpp_gr_ctx_init(gr_ctx_t gctx, const fmpz_mod_ctx_t ctx)
+
+    Initialises ``gctx`` as the ring of integers modulo the modulus of
+    ``ctx``: ``mpn_mod`` for moduli of 2 to ``MPN_MOD_MAX_LIMBS`` limbs,
+    ``fmpz_mod`` otherwise.
+
+.. function:: int ecpp_point_mul_gr(gr_ptr R, gr_srcptr P, const fmpz_t k, gr_srcptr a, gr_ptr acc, gr_ctx_t ctx)
+
+    The scalar multiplication over a generic ring (a point is three
+    consecutive elements X, Y, Z), the implementation behind
+    ``ecpp_point_mul``, which converts to the ring given by
+    ``ecpp_gr_ctx_init``; about 1.7 times faster than the ``fmpz_mod``
+    arithmetic at 200 bits and 1.6 at 400.
+
+.. function:: int ecpp_point_mul(ecpp_point_t R, const ecpp_point_t P, const fmpz_t k, const fmpz_t a, fmpz_t acc, const fmpz_mod_ctx_t ctx)
+
+    Sets `R = k P` on `y^2 = x^3 + a x + b` modulo the modulus of ``ctx``,
+    for an affine point `P` (`Z = 1`) and `k \ge 0`. Every quantity whose
+    invertibility the formulas assume is multiplied into ``acc``; the
+    result is only meaningful if `\gcd(\mathrm{acc}, n) = 1` at the end,
+    otherwise `n` is composite. Returns 0 if ``acc`` became zero.
+
+Discriminants and Cornacchia
+-------------------------------------------------------------------------------
+
+.. function:: slong ecpp_disc_table(ecpp_disc_struct ** table, const ulong * primes, slong nprimes, slong Dmax, slong hmax, slong omax, double costmax)
+
+    Fills ``*table`` (allocated with ``flint_malloc``) with the fundamental
+    discriminants `-D_{\max} \le D < 0` of class number at most ``hmax``
+    whose odd prime factors are among the ``nprimes`` odd primes in
+    ``primes``, sorted by number of units, class number, odd part of the
+    class number and `|D|`, and returns their number. Each entry records
+    the class number, the number `g` of genus characters, the odd part
+    `o = h / 2^{g-1}`, the factor `q_0 \in \{1, -4, 8, -8\}` of `D` at 2
+    and the indices of the odd primes dividing `D`.
+
+.. function:: int ecpp_root_radicals(fmpz_t x, const fmpz_mod_poly_t f, flint_rand_t state, const fmpz_mod_ctx_t ctx)
+
+    Sets ``x`` to a root of the monic polynomial ``f`` of degree 2, 3 or 4,
+    assumed to split completely modulo the prime modulus `n` of ``ctx``,
+    by radicals (Cardano, Ferrari): a few square and cube roots modulo
+    `n`, some ten times cheaper than a powering of a polynomial modulo
+    ``f``. Degrees 3 and 4 require `n \equiv 1 \pmod 3`. Returns 1 on
+    success and 0 if the degree or `n` is not handled or the computation
+    failed.
+
+.. function:: int ecpp_poly_root(fmpz_t x, const fmpz_mod_poly_t f, flint_rand_t state, const fmpz_mod_ctx_t ctx)
+
+    Sets ``x`` to a root of the monic polynomial ``f``, assumed to split
+    completely modulo the prime modulus of ``ctx``: by radicals when
+    possible, else by random splitting with `(x + r)^{(n-1)/2}`. Returns
+    1 on success, 0 otherwise.
+
+.. function:: int ecpp_class_poly_tower(fmpz_t j, slong D, flint_rand_t state, const fmpz_mod_ctx_t ctx)
+
+    Sets ``j`` to a root modulo the prime modulus `n` of ``ctx`` of the
+    Hilbert class polynomial `H_D`, for a fundamental discriminant `D`
+    such that `n` splits completely in the Hilbert class field (`4n = t^2
+    + |D| v^2`), through the class field tower (Enge, Morain): a
+    composition series of the class group with prime quotients `p_i` gives
+    a tower of fields with relative polynomials whose coefficients are
+    stored in Hecke form (numerators over the derivative of the polynomial
+    of the level below, so that all coefficients are integers), computed
+    numerically from the `j`-values ordered by cosets, and modulo `n` a
+    root is found level by level in degrees `p_i` instead of `h`. Returns
+    1 on success, 0 on failure. For even `D` the values of Weber's
+    function `f` (a class invariant of height `72/e` times smaller than
+    `j`'s, with the normalisations of Enge's CM library) are used instead
+    of `j`, and `j` is recovered from the root modulo `n` by a closed
+    formula. The Lagrange numerators are built by a subproduct tree, so
+    that about 1.5 times the height of the class polynomial suffices:
+    `h = 256` takes 0.13 s with the Weber invariant and 3.4 s with `j`.
+    For odd `D` the caller may pass `4D`: the order of conductor 2 has the
+    same class field (for `D \equiv 1 \pmod 8`, or three times the class
+    number for `D \equiv 5 \pmod 8`) and admits the Weber invariant; its
+    curves have the right order when `v` is even. Levels of prime degree
+    `p \ge 5` also carry Kummer data (the `p`-th power of the Lagrange
+    resolvent and the ratios of the resolvents, as elements of the level
+    below tensored with `\mathbb{Q}(\zeta_p)`), so that when `p \mid n - 1`
+    the level is descended with one `p`-th root instead of a root of a
+    degree-`p` polynomial.
+
+.. function:: int ecpp_class_poly_genus(fmpz_mod_poly_t F, slong D, const slong * pstar, slong g, const fmpz * sqrts, const fmpz_mod_ctx_t ctx)
+
+    Sets ``F`` to the factor of the Hilbert class polynomial `H_D` modulo
+    `n` (the modulus of ``ctx``) corresponding to the principal genus. Here
+    `D = p_1^* \cdots p_g^*` with the `p_i^*` given in ``pstar`` (the
+    signed odd primes `p^* = (-1)^{(p-1)/2} p` dividing `D` and, for even
+    `D`, the factor `q_0 \in \{-4, 8, -8\}`), and ``sqrts[i]`` is a square
+    root of ``pstar[i]`` modulo `n`, which must exist. `H_D` factors over
+    the genus field `K(\sqrt{p_1^*}, \ldots, \sqrt{p_g^*})` into `2^{g-1}`
+    conjugate factors of degree `h(D) / 2^{g-1}`, whose coefficients are
+    identified numerically from the values of `j` at the reduced forms
+    grouped by genus, and ``F`` is the image of one of them modulo `n`. Its
+    roots are `j`-invariants of curves with CM by the maximal order of
+    `\mathbb{Q}(\sqrt{D})`, and finding one costs a fraction `2^{-(g-1)}`
+    of a root of `H_D`. Returns 1 on success, 0 if `g < 2` or the
+    coefficients could not be identified. Requires `D` fundamental.
+
+.. function:: int ecpp_cornacchia(fmpz_t t, fmpz_t v, const fmpz_t n, slong D, const fmpz_t sqrtD)
+
+    Given `D < 0`, `n` odd with `\gcd(n, D) = 1` and a square root of `D`
+    modulo `n`, finds `t, v \ge 0` with `t^2 + |D| v^2 = 4n` and returns 1,
+    or returns 0 if there is no solution.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -93,6 +93,7 @@ Integers
    mpn_extras.rst
    fixed.rst
    aprcl.rst
+   ecpp.rst
    arith.rst
    fft.rst
    fft_small.rst

--- a/doc/source/references.rst
+++ b/doc/source/references.rst
@@ -117,6 +117,22 @@ References
 
 .. [EHJ2016] \A. Enge, W. Hart and F. Johansson, "Short addition sequences for theta functions", preprint (2016), https://arxiv.org/abs/1608.06810
 
+.. [Enge2024] \A. Enge, "FastECPP over MPI", Mathematical Software - ICMS 2024: 8th International Conference, Durham, UK, July 22-25, 2024, Proceedings, Springer-Verlag, Berlin, Heidelberg, 36-45. https://doi.org/10.1007/978-3-031-64529-7_4
+
+.. [EngeCM] \A. Enge, CM - a library for the computation of class polynomials and elliptic curve primality proving, https://www.multiprecision.org/cm/
+
+.. [EngeMorain2003] \A. Enge and F. Morain, "Fast decomposition of polynomials with known Galois group", Applied Algebra, Algebraic Algorithms and Error-Correcting Codes (AAECC-15), LNCS 2643, Springer (2003), 254-264
+
+.. [FKMW2004] \J. Franke, T. Kleinjung, F. Morain and T. Wirth, "Proving the primality of very large numbers with fastECPP", Algorithmic Number Theory (ANTS-VI), LNCS 3076, Springer (2004), 194-207
+
+.. [Morain2007] \F. Morain, "Implementing the asymptotically fast version of the elliptic curve primality proving algorithm", Mathematics of Computation 76 (2007), 493-505
+
+.. [PARI] \The PARI Group, PARI/GP, https://pari.math.u-bordeaux.fr/ ; the ``primecert`` implementation of FastECPP is by Jared Asuncion
+
+.. [Schertz2002] \R. Schertz, "Weber's class invariants revisited", Journal de Theorie des Nombres de Bordeaux 14 (2002), 325-343
+
+.. [YuiZagier1997] \N. Yui and D. Zagier, "On the singular values of Weber modular functions", Mathematics of Computation 66 (1997), 1645-1662
+
 .. [EM2004] \O. Espinosa and V. Moll, "A generalized polygamma function", Integral Transforms and Special Functions (2004), 101-115.
 
 .. [EK2025] \N. D. Elkies and J. Kieffer, "A uniform quasi-linear time algorithm for evaluating theta functions in any dimension", in preparation.

--- a/examples/factor_integer.c
+++ b/examples/factor_integer.c
@@ -18,6 +18,7 @@
 #include <flint/fmpz_factor.h>
 #include <flint/gr.h>
 #include <flint/profiler.h>
+#include <flint/ecpp.h>
 
 int
 main(int argc, char * argv[])
@@ -26,12 +27,15 @@ main(int argc, char * argv[])
     fmpz_factor_t fac;
     slong i;
     int num_threads = 1;
-    int timing = 0;
+    int timing = 0, certify = 0, format = ECPP_CERT_FORMAT_FLINT;
 
     if (argc < 2)
     {
-        flint_printf("usage: factor_integer [-threads t] [-timing] n\n");
+        flint_printf("usage: factor_integer [-threads t] [-timing] [-certify] [-pari] [-verbose] n\n");
         flint_printf("n can be given as an expression (no spaces)\n");
+        flint_printf("-certify: prove the primality of each prime factor above 64 bits with\n");
+        flint_printf("          ECPP and print the certificate (-pari: in PARI/GP primecert\n");
+        flint_printf("          syntax); -verbose: report the steps of the proofs\n");
         return 1;
     }
 
@@ -48,6 +52,19 @@ main(int argc, char * argv[])
         else if (!strcmp(argv[i], "-timing"))
         {
             timing = 1;
+        }
+        else if (!strcmp(argv[i], "-certify"))
+        {
+            certify = 1;
+        }
+        else if (!strcmp(argv[i], "-pari"))
+        {
+            certify = 1;
+            format = ECPP_CERT_FORMAT_PARI;
+        }
+        else if (!strcmp(argv[i], "-verbose"))
+        {
+            ecpp_set_verbose(1);
         }
         else
         {
@@ -98,6 +115,30 @@ main(int argc, char * argv[])
             flint_printf(" * ");
     }
     flint_printf("\n");
+
+    if (certify)
+    {
+        for (i = 0; i < fac->num; i++)
+        {
+            if (fmpz_bits(fac->p + i) > 64)
+            {
+                ecpp_cert_t cert;
+                int r;
+                ecpp_cert_init(cert);
+                r = ecpp_prove(cert, fac->p + i);
+                flint_printf("\nECPP certificate for ");
+                fmpz_print(fac->p + i);
+                if (r == 1 && ecpp_verify(cert, fac->p + i))
+                {
+                    flint_printf(" (verified):\n");
+                    ecpp_cert_print(cert, format);
+                }
+                else
+                    flint_printf(": not found (%d)\n", r);
+                ecpp_cert_clear(cert);
+            }
+        }
+    }
 
     fmpz_factor_clear(fac);
     fmpz_clear(n);

--- a/src/ecpp.h
+++ b/src/ecpp.h
@@ -155,6 +155,15 @@ int ecpp_root_radicals(fmpz_t x, const fmpz_mod_poly_t f, flint_rand_t state,
 int ecpp_poly_root(fmpz_t x, const fmpz_mod_poly_t f, flint_rand_t state,
                                                         const fmpz_mod_ctx_t ctx);
 
+/* options of _ecpp_class_poly_tower: compute the Kummer data (done by
+   ecpp_class_poly_tower from ECPP_KUMMER_BITS), use j rather than the Weber
+   invariant */
+#define ECPP_TOWER_KUMMER 1
+#define ECPP_TOWER_J 2
+
+int _ecpp_class_poly_tower(fmpz_t j, slong D, int flags, flint_rand_t state,
+                                                        const fmpz_mod_ctx_t ctx);
+
 int ecpp_class_poly_tower(fmpz_t j, slong D, flint_rand_t state,
                                                         const fmpz_mod_ctx_t ctx);
 

--- a/src/ecpp.h
+++ b/src/ecpp.h
@@ -1,0 +1,178 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5.1
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef ECPP_H
+#define ECPP_H
+
+#include <stdio.h>
+#include "fmpz_types.h"
+#include "fmpz_mod_types.h"
+#include "fmpz_mod_poly.h"
+#include "gr_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+    Elliptic curve primality proving (Atkin-Morain).
+
+    A certificate is a chain of steps. Step i proves that n_i is prime
+    assuming that q_i is prime: the curve y^2 = x^3 + a x + b over Z/n_i
+    has a point P with m P = O and (m / q) P != O, where q | m and
+    q > (n^{1/4} + 1)^2. The next step has n_{i+1} = q_i. The last q
+    is small enough to be proved prime by other means (q < 2^64).
+*/
+
+typedef struct
+{
+    fmpz_t n;
+    slong D;    /* discriminant used (informational) */
+    fmpz_t a;
+    fmpz_t b;
+    fmpz_t m;
+    fmpz_t q;
+    fmpz_t x;   /* point P = (x, y) */
+    fmpz_t y;
+}
+ecpp_step_struct;
+
+typedef struct
+{
+    ecpp_step_struct * steps;
+    slong num;
+    slong alloc;
+}
+ecpp_cert_struct;
+
+typedef ecpp_cert_struct ecpp_cert_t[1];
+
+/* affine or Jacobian point on y^2 = x^3 + a x + b modulo n */
+typedef struct
+{
+    fmpz_t X;
+    fmpz_t Y;
+    fmpz_t Z;   /* Z = 0 is the point at infinity */
+}
+ecpp_point_struct;
+
+typedef ecpp_point_struct ecpp_point_t[1];
+
+/* certificate */
+
+void ecpp_cert_init(ecpp_cert_t cert);
+void ecpp_cert_clear(ecpp_cert_t cert);
+ecpp_step_struct * ecpp_cert_push(ecpp_cert_t cert);
+void ecpp_cert_pop(ecpp_cert_t cert);
+#define ECPP_CERT_FORMAT_FLINT 0
+#define ECPP_CERT_FORMAT_PARI 1
+
+void ecpp_cert_print(const ecpp_cert_t cert, int format);
+void ecpp_cert_fprint(FILE * file, const ecpp_cert_t cert, int format);
+char * ecpp_cert_get_str(const ecpp_cert_t cert, int format);
+int ecpp_cert_set_str(ecpp_cert_t cert, const char * str);
+
+/* elliptic curves modulo n */
+
+void ecpp_point_init(ecpp_point_t P);
+void ecpp_point_clear(ecpp_point_t P);
+void ecpp_point_set_affine(ecpp_point_t P, const fmpz_t x, const fmpz_t y);
+int ecpp_point_is_zero(const ecpp_point_t P);
+
+void ecpp_gr_ctx_init(gr_ctx_t gctx, const fmpz_mod_ctx_t ctx);
+
+int ecpp_point_mul_gr(gr_ptr R, gr_srcptr P, const fmpz_t k, gr_srcptr a,
+                                                gr_ptr acc, gr_ctx_t ctx);
+
+int ecpp_point_mul(ecpp_point_t R, const ecpp_point_t P, const fmpz_t k,
+                        const fmpz_t a, fmpz_t acc, const fmpz_mod_ctx_t ctx);
+
+/* discriminants */
+
+#define ECPP_DISC_MAXFAC 8
+
+/* Tuning parameters of the prover (see prove.c) */
+
+/* expected prime cofactors per round of the discriminant search */
+#define ECPP_MIN_PRIME 4.0
+/* from this size, the pool admits all discriminants with a cheap class
+   field tower rather than only those with a small genus factor */
+#define ECPP_BIGPOOL_BITS 2500
+/* class number and odd part bounds of the discriminant pool */
+#define ECPP_POOL_HMAX 400
+#define ECPP_POOL_OMAX 16
+/* bound on the size of the discriminants, as a power of two */
+#define ECPP_DMAX_BITS(bits) ((bits) < 1500 ? 20 : (bits) < 3000 ? 21 : (bits) < 4000 ? 22 : 23)
+/* the primorial for the batch factoring is reduced in this many chunks
+   when threads are used */
+#define ECPP_PRIMORIAL_CHUNKS 8
+
+/* from this size the class field tower carries Kummer data: levels of
+   prime degree p >= 5 are descended with a p-th root when n = +-1 mod p */
+#define ECPP_KUMMER_BITS 1500
+
+typedef struct
+{
+    slong D;
+    slong h;
+    slong g;                /* number of genus characters */
+    slong o;                /* odd part h / 2^(g-1) of the class number */
+    slong q0;               /* 1, -4, 8 or -8: D = q0 prod p^* */
+    slong nfac;             /* odd primes dividing D, as indices into the prime list */
+    unsigned short fac[ECPP_DISC_MAXFAC];
+    double cost;            /* estimated realisation cost, see ecpp_disc_cost */
+}
+ecpp_disc_struct;
+
+#ifndef ECPP_DISC_COST_MAX
+#define ECPP_DISC_COST_MAX 20.0
+#endif
+
+double ecpp_disc_cost(const ecpp_disc_struct * d);
+double ecpp_disc_cost_v(const ecpp_disc_struct * d, int veven);
+double ecpp_disc_cost_n(const ecpp_disc_struct * d, int veven, const ulong * nmodp, slong bits);
+int ecpp_disc_use_tower(const ecpp_disc_struct * d, int veven, slong * Dt);
+
+slong ecpp_disc_table(ecpp_disc_struct ** table, const ulong * primes,
+            slong nprimes, slong Dmax, slong hmax, slong omax, double costmax);
+
+/* number theory helpers */
+
+int ecpp_cornacchia(fmpz_t t, fmpz_t v, const fmpz_t n, slong D, const fmpz_t sqrtD);
+
+int ecpp_root_radicals(fmpz_t x, const fmpz_mod_poly_t f, flint_rand_t state,
+                                                        const fmpz_mod_ctx_t ctx);
+
+int ecpp_poly_root(fmpz_t x, const fmpz_mod_poly_t f, flint_rand_t state,
+                                                        const fmpz_mod_ctx_t ctx);
+
+int ecpp_class_poly_tower(fmpz_t j, slong D, flint_rand_t state,
+                                                        const fmpz_mod_ctx_t ctx);
+
+int ecpp_class_poly_genus(fmpz_mod_poly_t F, slong D, const slong * pstar, slong g,
+                                const fmpz * sqrts, const fmpz_mod_ctx_t ctx);
+
+/* proving and verifying */
+
+int ecpp_prove(ecpp_cert_t cert, const fmpz_t n);
+
+/* prints the steps of the proof as they are found (0 to disable) */
+void ecpp_set_verbose(int verbose);
+int ecpp_verify(const ecpp_cert_t cert, const fmpz_t n);
+int ecpp_verify_step(const ecpp_step_struct * s);
+int ecpp_is_prime(const fmpz_t n);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/ecpp/cert.c
+++ b/src/ecpp/cert.c
@@ -1,0 +1,353 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5.1
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <string.h>
+#include <stdio.h>
+#include "fmpz.h"
+#include "fmpz_mod.h"
+#include "ecpp.h"
+
+void
+ecpp_cert_init(ecpp_cert_t cert)
+{
+    cert->steps = NULL;
+    cert->num = 0;
+    cert->alloc = 0;
+}
+
+void
+ecpp_cert_clear(ecpp_cert_t cert)
+{
+    slong i;
+
+    for (i = 0; i < cert->alloc; i++)
+    {
+        ecpp_step_struct * s = cert->steps + i;
+        fmpz_clear(s->n);
+        fmpz_clear(s->a);
+        fmpz_clear(s->b);
+        fmpz_clear(s->m);
+        fmpz_clear(s->q);
+        fmpz_clear(s->x);
+        fmpz_clear(s->y);
+    }
+
+    flint_free(cert->steps);
+}
+
+/* append an (initialised, zero) step and return it */
+ecpp_step_struct *
+ecpp_cert_push(ecpp_cert_t cert)
+{
+    ecpp_step_struct * s;
+
+    if (cert->num == cert->alloc)
+    {
+        slong i, new_alloc = FLINT_MAX(2 * cert->alloc, 8);
+
+        cert->steps = flint_realloc(cert->steps, new_alloc * sizeof(ecpp_step_struct));
+        for (i = cert->alloc; i < new_alloc; i++)
+        {
+            s = cert->steps + i;
+            fmpz_init(s->n);
+            fmpz_init(s->a);
+            fmpz_init(s->b);
+            fmpz_init(s->m);
+            fmpz_init(s->q);
+            fmpz_init(s->x);
+            fmpz_init(s->y);
+            s->D = 0;
+        }
+        cert->alloc = new_alloc;
+    }
+
+    return cert->steps + cert->num++;
+}
+
+void
+ecpp_cert_pop(ecpp_cert_t cert)
+{
+    if (cert->num > 0)
+        cert->num--;
+}
+
+/*
+    Text formats. ECPP_CERT_FORMAT_FLINT:
+
+        ecpp certificate, k steps
+        [0] n = ...
+            D = ...
+            a = ...
+            b = ...
+            m = ...
+            q = ...
+            x = ...
+            y = ...
+        ...
+
+    ECPP_CERT_FORMAT_PARI, the primecert format of PARI/GP: a vector of
+    [N, t, s, a, [x, y]] with N + 1 - t = s q the order of the curve
+    y^2 = x^3 + a x + b (b = y^2 - x^3 - a x mod N) and q the next N.
+*/
+
+static void
+_cert_write(char ** str, slong * len, slong * alloc, const char * piece)
+{
+    slong l = strlen(piece);
+    if (*len + l + 1 > *alloc)
+    {
+        *alloc = FLINT_MAX(2 * *alloc, *len + l + 1);
+        *str = flint_realloc(*str, *alloc);
+    }
+    memcpy(*str + *len, piece, l + 1);
+    *len += l;
+}
+
+static void
+_cert_write_fmpz(char ** str, slong * len, slong * alloc, const fmpz_t x)
+{
+    char * t = fmpz_get_str(NULL, 10, x);
+    _cert_write(str, len, alloc, t);
+    flint_free(t);
+}
+
+char *
+ecpp_cert_get_str(const ecpp_cert_t cert, int format)
+{
+    slong i, len = 0, alloc = 256;
+    char * str = flint_malloc(alloc);
+    char buf[64];
+    str[0] = '\0';
+
+    if (format == ECPP_CERT_FORMAT_PARI)
+    {
+        fmpz_t t, s;
+        fmpz_init(t);
+        fmpz_init(s);
+        _cert_write(&str, &len, &alloc, "[");
+        for (i = 0; i < cert->num; i++)
+        {
+            const ecpp_step_struct * st = cert->steps + i;
+            fmpz_add_ui(t, st->n, 1);
+            fmpz_sub(t, t, st->m);              /* t = n + 1 - m */
+            fmpz_divexact(s, st->m, st->q);     /* s = m / q */
+            _cert_write(&str, &len, &alloc, i > 0 ? ", [" : "[");
+            _cert_write_fmpz(&str, &len, &alloc, st->n);
+            _cert_write(&str, &len, &alloc, ", ");
+            _cert_write_fmpz(&str, &len, &alloc, t);
+            _cert_write(&str, &len, &alloc, ", ");
+            _cert_write_fmpz(&str, &len, &alloc, s);
+            _cert_write(&str, &len, &alloc, ", ");
+            _cert_write_fmpz(&str, &len, &alloc, st->a);
+            _cert_write(&str, &len, &alloc, ", [");
+            _cert_write_fmpz(&str, &len, &alloc, st->x);
+            _cert_write(&str, &len, &alloc, ", ");
+            _cert_write_fmpz(&str, &len, &alloc, st->y);
+            _cert_write(&str, &len, &alloc, "]]");
+        }
+        _cert_write(&str, &len, &alloc, "]");
+        fmpz_clear(t);
+        fmpz_clear(s);
+    }
+    else
+    {
+        flint_sprintf(buf, "ecpp certificate, %wd steps\n", cert->num);
+        _cert_write(&str, &len, &alloc, buf);
+        for (i = 0; i < cert->num; i++)
+        {
+            const ecpp_step_struct * st = cert->steps + i;
+            flint_sprintf(buf, "[%wd] n = ", i);
+            _cert_write(&str, &len, &alloc, buf);
+            _cert_write_fmpz(&str, &len, &alloc, st->n);
+            flint_sprintf(buf, "\n    D = %wd\n    a = ", st->D);
+            _cert_write(&str, &len, &alloc, buf);
+            _cert_write_fmpz(&str, &len, &alloc, st->a);
+            _cert_write(&str, &len, &alloc, "\n    b = ");
+            _cert_write_fmpz(&str, &len, &alloc, st->b);
+            _cert_write(&str, &len, &alloc, "\n    m = ");
+            _cert_write_fmpz(&str, &len, &alloc, st->m);
+            _cert_write(&str, &len, &alloc, "\n    q = ");
+            _cert_write_fmpz(&str, &len, &alloc, st->q);
+            _cert_write(&str, &len, &alloc, "\n    x = ");
+            _cert_write_fmpz(&str, &len, &alloc, st->x);
+            _cert_write(&str, &len, &alloc, "\n    y = ");
+            _cert_write_fmpz(&str, &len, &alloc, st->y);
+            _cert_write(&str, &len, &alloc, "\n");
+        }
+    }
+    return str;
+}
+
+void
+ecpp_cert_fprint(FILE * file, const ecpp_cert_t cert, int format)
+{
+    char * str = ecpp_cert_get_str(cert, format);
+    fputs(str, file);
+    if (format == ECPP_CERT_FORMAT_PARI)
+        fputc('\n', file);
+    flint_free(str);
+}
+
+void
+ecpp_cert_print(const ecpp_cert_t cert, int format)
+{
+    ecpp_cert_fprint(stdout, cert, format);
+}
+
+/* reads the decimal integer at *p (optional sign), advances *p; 0 on failure */
+static int
+_read_int(fmpz_t x, const char ** p)
+{
+    const char * q;
+    char * buf;
+    slong l;
+    int ok;
+    while (**p == ' ' || **p == '\n' || **p == '\t' || **p == '\r')
+        (*p)++;
+    q = *p;
+    if (*q == '-' || *q == '+')
+        q++;
+    if (*q < '0' || *q > '9')
+        return 0;
+    while (*q >= '0' && *q <= '9')
+        q++;
+    l = q - *p;
+    buf = flint_malloc(l + 1);
+    memcpy(buf, *p, l);
+    buf[l] = '\0';
+    ok = (fmpz_set_str(x, buf, 10) == 0);
+    flint_free(buf);
+    *p = q;
+    return ok;
+}
+
+/* skips whitespace and the expected character; 0 if absent */
+static int
+_expect(const char ** p, char c)
+{
+    while (**p == ' ' || **p == '\n' || **p == '\t' || **p == '\r')
+        (*p)++;
+    if (**p != c)
+        return 0;
+    (*p)++;
+    return 1;
+}
+
+int
+ecpp_cert_set_str(ecpp_cert_t cert, const char * str)
+{
+    const char * p = str;
+    int ok = 1;
+
+    cert->num = 0;
+    while (*p == ' ' || *p == '\n' || *p == '\t' || *p == '\r')
+        p++;
+
+    if (*p == '[')
+    {
+        /* PARI/GP: [[N, t, s, a, [x, y]], ...] */
+        fmpz_t t, s, u;
+        fmpz_mod_ctx_t ctx;
+        fmpz_init(t); fmpz_init(s); fmpz_init(u);
+        p++;
+        while (ok)
+        {
+            ecpp_step_struct * st;
+            while (*p == ' ' || *p == '\n' || *p == '\t' || *p == '\r')
+                p++;
+            if (*p == ']')
+            {
+                p++;
+                break;
+            }
+            if (cert->num > 0 && !_expect(&p, ','))
+            {
+                ok = 0;
+                break;
+            }
+            if (!_expect(&p, '['))
+            {
+                ok = 0;
+                break;
+            }
+            st = ecpp_cert_push(cert);
+            ok = _read_int(st->n, &p) && _expect(&p, ',') && _read_int(t, &p) && _expect(&p, ',')
+              && _read_int(s, &p) && _expect(&p, ',') && _read_int(st->a, &p) && _expect(&p, ',')
+              && _expect(&p, '[') && _read_int(st->x, &p) && _expect(&p, ',') && _read_int(st->y, &p)
+              && _expect(&p, ']') && _expect(&p, ']');
+            if (!ok || fmpz_cmp_ui(st->n, 3) < 0 || fmpz_sgn(s) <= 0)
+            {
+                ok = 0;
+                break;
+            }
+            /* m = n + 1 - t, q = m / s (must be exact), b = y^2 - x^3 - a x */
+            fmpz_add_ui(st->m, st->n, 1);
+            fmpz_sub(st->m, st->m, t);
+            fmpz_fdiv_qr(st->q, u, st->m, s);
+            if (!fmpz_is_zero(u))
+            {
+                ok = 0;
+                break;
+            }
+            fmpz_mod_ctx_init(ctx, st->n);
+            fmpz_mod_set_fmpz(st->a, st->a, ctx);
+            fmpz_mod_set_fmpz(st->x, st->x, ctx);
+            fmpz_mod_set_fmpz(st->y, st->y, ctx);
+            fmpz_mod_mul(u, st->x, st->x, ctx);
+            fmpz_mod_mul(u, u, st->x, ctx);         /* x^3 */
+            fmpz_mod_mul(st->b, st->y, st->y, ctx);
+            fmpz_mod_sub(st->b, st->b, u, ctx);
+            fmpz_mod_mul(u, st->a, st->x, ctx);
+            fmpz_mod_sub(st->b, st->b, u, ctx);
+            fmpz_mod_ctx_clear(ctx);
+            st->D = 0;                              /* not part of the format */
+        }
+        fmpz_clear(t); fmpz_clear(s); fmpz_clear(u);
+    }
+    else
+    {
+        /* FLINT: "ecpp certificate, k steps" then the labelled steps */
+        const char * labels[8] = {"n =", "D =", "a =", "b =", "m =", "q =", "x =", "y ="};
+        fmpz_t Dz;
+        fmpz_init(Dz);
+        p = strstr(p, "[0]");
+        while (ok && p != NULL)
+        {
+            ecpp_step_struct * st = ecpp_cert_push(cert);
+            fmpz * fields[8] = {st->n, Dz, st->a, st->b, st->m, st->q, st->x, st->y};
+            slong f;
+            for (f = 0; f < 8 && ok; f++)
+            {
+                const char * q = strstr(p, labels[f]);
+                if (q == NULL)
+                {
+                    ok = 0;
+                    break;
+                }
+                q += 3;
+                ok = _read_int(fields[f], &q);
+                p = q;
+            }
+            if (ok)
+                st->D = fmpz_get_si(Dz);
+            p = strstr(p, "\n[");
+        }
+        fmpz_clear(Dz);
+    }
+
+    if (!ok || cert->num == 0)
+    {
+        cert->num = 0;
+        return 0;
+    }
+    return 1;
+}

--- a/src/ecpp/cornacchia.c
+++ b/src/ecpp/cornacchia.c
@@ -1,0 +1,82 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5.1
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz.h"
+#include "ecpp.h"
+
+/*
+    Modified Cornacchia (Cohen, Algorithm 1.5.3): given a discriminant
+    D < 0, an odd n with gcd(n, D) = 1 and a square root sqrtD of D
+    modulo n, finds t, v >= 0 with t^2 + |D| v^2 = 4n. Returns 1 on
+    success, 0 if there is no solution (or n is composite and the
+    algorithm fails).
+*/
+int
+ecpp_cornacchia(fmpz_t t, fmpz_t v, const fmpz_t n, slong D, const fmpz_t sqrtD)
+{
+    fmpz_t x0, a, b, l, r, absD;
+    int result = 0;
+
+    fmpz_init(x0);
+    fmpz_init(a);
+    fmpz_init(b);
+    fmpz_init(l);
+    fmpz_init(r);
+    fmpz_init_set_si(absD, -D);
+
+    /* x0 = sqrt(D) mod n, with x0 = D mod 2, 0 < x0 < 2n */
+    fmpz_mod(x0, sqrtD, n);
+    if (fmpz_is_odd(x0) != (FLINT_ABS(D) % 2 == 1))
+        fmpz_sub(x0, n, x0);
+    /* now x0 = D mod 2 provided n odd; x0 is a root of x^2 = D mod 4n */
+
+    /* Euclid on (2n, x0) until the remainder drops below 2 sqrt(n) */
+    fmpz_mul_2exp(a, n, 1);
+    fmpz_set(b, x0);
+    fmpz_mul_2exp(l, n, 2);
+    fmpz_sqrt(l, l);            /* l = floor(sqrt(4n)) */
+
+    /* Lehmer partial gcd: (a, b) become the last two remainders, b <= l */
+    if (fmpz_cmp(b, l) > 0)
+    {
+        fmpz_t co1, co2;
+        fmpz_init(co1);
+        fmpz_init(co2);
+        fmpz_xgcd_partial(co2, co1, a, b, l);
+        fmpz_clear(co1);
+        fmpz_clear(co2);
+    }
+
+    /* b^2 + |D| v^2 = 4n ? */
+    fmpz_mul(r, b, b);
+    fmpz_mul_2exp(l, n, 2);
+    fmpz_sub(r, l, r);          /* r = 4n - b^2 */
+    if (fmpz_sgn(r) > 0 && fmpz_divisible(r, absD))
+    {
+        fmpz_divexact(r, r, absD);
+        if (fmpz_is_square(r))
+        {
+            fmpz_sqrt(v, r);
+            fmpz_set(t, b);
+            result = 1;
+        }
+    }
+
+    fmpz_clear(x0);
+    fmpz_clear(a);
+    fmpz_clear(b);
+    fmpz_clear(l);
+    fmpz_clear(r);
+    fmpz_clear(absD);
+
+    return result;
+}

--- a/src/ecpp/disc.c
+++ b/src/ecpp/disc.c
@@ -1,0 +1,344 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5.1
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdlib.h>
+#include <math.h>
+#include "ulong_extras.h"
+#include "fmpz.h"
+#include "ecpp.h"
+
+/*
+    Discriminant pool for ECPP (in the spirit of fastECPP, Franke,
+    Kleinjung, Morain, Wirth 2004).
+
+    A fundamental discriminant D < 0 factors as D = q0 * prod p^*, where
+    p^* = (-1)^{(p-1)/2} p runs over the odd primes dividing D and q0 is 1,
+    -4, 8 or -8. The Kronecker symbols (p^* / n), (q0 / n) are the genus
+    characters. n is represented by the principal form of discriminant D
+    (which is what Cornacchia decides) only if all of them are 1, and in
+    that case it is with probability 2^{g-1} / h, where g is the number of
+    characters: one over the odd part o = h / 2^{g-1} of the class number.
+
+    Consequently the square root of D modulo n is only ever needed when
+    every p^* dividing D is a square modulo n, and it is the product of the
+    square roots of the p^*, which are computed once per n. The pool
+    therefore consists of the fundamental discriminants that are smooth
+    over a fixed set of small primes: their square roots cost nothing
+    beyond that fixed set, and a pool of thousands of D's is available
+    for every n.
+
+    The pool is sorted by increasing cost of realising a step with D: by
+    number of units (D = -3, -4 first: more curves per solution), then
+    odd part o (the degree of the factor of the class polynomial over the
+    genus field whose root is needed, see genus_poly.c, and the inverse of
+    the probability of a Cornacchia success), then class number, then |D|.
+*/
+
+/*
+    Estimated cost of realising a step with D, in units of one scalar
+    multiplication on the curve at a few thousand bits: the twists, the
+    class polynomial numerics of the class field tower (cheap with the
+    Weber invariant, i.e. for even D; about 30 units per hundred classes
+    with j), and the descent through the prime factors p of h: a square
+    root for p = 2, radicals or a small powering for p = 3, powerings of
+    degree p otherwise. Class numbers with a prime factor above 13 are
+    not used (cost above ECPP_DISC_COST_MAX).
+*/
+double
+ecpp_disc_cost_v(const ecpp_disc_struct * d, int veven)
+{
+    return ecpp_disc_cost_n(d, veven, NULL, 4000);
+}
+
+/*
+    With nmodp = {n mod 5, n mod 7, n mod 11, n mod 13} the actual descent
+    costs are used: a level of prime degree p is a single p-th root (in
+    F_n or F_{n^2}) when n = +-1 mod p, and a powering of a degree-p
+    polynomial otherwise; without nmodp the average over n.
+*/
+double
+ecpp_disc_cost_n(const ecpp_disc_struct * d, int veven, const ulong * nmodp, slong bits)
+{
+    /*
+        The class polynomial numerics do not depend on n, while the unit
+        (a scalar multiplication) shrinks with n: their relative cost at
+        bits is that at 4000 bits times (4000 / bits)^2.6, so that for
+        small n only small class numbers are worth it.
+    */
+    double numfac = pow(4000.0 / FLINT_MAX(bits, 200), 2.6);
+    numfac = FLINT_MIN(numfac, 500.0);
+    numfac = FLINT_MAX(numfac, 1.0);
+    slong h = d->h, p, m = -d->D / 4;
+    /*
+        Weber's function: even D directly; odd D through the order of
+        conductor 2 (discriminant 4D) when the v of 4n = t^2 + |D| v^2 is
+        even, since then a curve with that endomorphism ring and the right
+        order exists (any curve of the right order serves the proof). For
+        D = 1 mod 8 the order has the same class number, for D = 5 mod 8
+        three times it.
+    */
+    int weber = ((d->D % 4 == 0) && (m % 8 != 4 && m % 8 != 0))
+                || (d->D % 2 != 0 && veven);
+    double cost = 1.5, genus;
+
+    /* the twists are tried in turn: 6 for D = -3, 4 for D = -4, 2 else */
+    if (d->D == -3)
+        cost = 1.0 + 3.5;
+    else if (d->D == -4)
+        cost = 1.0 + 2.5;
+    if (h == 1)
+        return cost;
+    if (weber && d->D % 2 != 0 && (-d->D) % 8 == 3)
+        h *= 3;
+    /* the alternative: a root of the factor of H_D over the genus field,
+       of degree o (by radicals up to 4) */
+    genus = 1.5 + ((d->o <= 4) ? 0.3 * d->o : 1.4 * d->o + 4.0);
+    /* class polynomial numerics: with the Weber invariant about 0.13 s for
+       h = 256, with j about 3.5 s for h = 230 (dominated by the
+       evaluations of j at high precision), so j is only worth it for
+       small class numbers */
+    if (weber)
+        cost += 0.03 * h * numfac;
+    else if (h <= 48)
+        cost += 1.0 * h * numfac;
+    else
+        cost += 1e6;
+    for (p = 2; h > 1; p++)
+    {
+        while (h % p == 0)
+        {
+            double powmod, cheap = 1.0, prob;
+            slong idx = (p == 5) ? 0 : (p == 7) ? 1 : (p == 11) ? 2 : (p == 13) ? 3 : -1;
+            h /= p;
+            if (p == 2) { cost += 0.3; continue; }
+            if (p == 3) { cost += 1.5; continue; }
+            if (p > 13) { cost += 1e6; continue; }
+            powmod = (p == 5) ? 6.0 : (p == 7) ? 10.0 : 3.0 * p;
+            if (nmodp != NULL)
+                cost += (bits >= ECPP_KUMMER_BITS && (nmodp[idx] == 1 || nmodp[idx] == (ulong) p - 1)) ? cheap : powmod;
+            else
+            {
+                prob = 2.0 / (p - 1);       /* n = +-1 mod p */
+                cost += prob * cheap + (1 - prob) * powmod;
+            }
+        }
+    }
+    return FLINT_MIN(cost, genus);
+}
+
+/* the optimistic estimate (v even), used to order and admit the pool */
+double
+ecpp_disc_cost(const ecpp_disc_struct * d)
+{
+    return ecpp_disc_cost_v(d, 1);
+}
+
+/* whether the class field tower (with the Weber invariant when possible)
+   is the cheaper way to a curve for this discriminant; sets *Dt to the
+   discriminant to build the tower on (D or 4D) */
+int
+ecpp_disc_use_tower(const ecpp_disc_struct * d, int veven, slong * Dt)
+{
+    slong m = -d->D / 4;
+    int weber = ((d->D % 4 == 0) && (m % 8 != 4 && m % 8 != 0))
+                || (d->D % 2 != 0 && veven);
+    *Dt = (d->D % 2 != 0 && veven) ? 4 * d->D : d->D;
+    return d->h >= 2 && (weber || d->h <= 48);
+}
+
+static int
+_disc_cmp(const void * x, const void * y)
+{
+    const ecpp_disc_struct * a = (const ecpp_disc_struct *) x;
+    const ecpp_disc_struct * b = (const ecpp_disc_struct *) y;
+    int wa = (a->D == -3) ? 6 : (a->D == -4) ? 4 : 2;
+    int wb = (b->D == -3) ? 6 : (b->D == -4) ? 4 : 2;
+
+    if (wa != wb)
+        return (wa > wb) ? -1 : 1;
+    if (a->o != b->o)
+        return (a->o < b->o) ? -1 : 1;
+    if (a->cost != b->cost)
+        return (a->cost < b->cost) ? -1 : 1;
+    return (a->D > b->D) ? -1 : (a->D < b->D);
+}
+
+/*
+    Fills *table with the fundamental discriminants D, -Dmax <= D < 0,
+    whose odd prime factors are among the nprimes odd primes in primes
+    (increasing), with class number h(D) <= hmax and odd part o <= omax,
+    sorted as described above. Returns the number of entries; the table is allocated with
+    flint_malloc.
+
+    Class numbers are obtained by counting reduced forms
+    (a, b, c) of discriminant b^2 - 4ac = D, i.e. |b| <= a <= c with
+    b >= 0 when |b| = a or a = c, in one pass over all (a, b, c).
+*/
+slong
+ecpp_disc_table(ecpp_disc_struct ** table, const ulong * primes, slong nprimes,
+                            slong Dmax, slong hmax, slong omax, double costmax)
+{
+    unsigned short * h;
+    unsigned int * rem;
+    slong a, b, D, amax, num, i, k;
+    ecpp_disc_struct * t;
+
+    h = flint_calloc(Dmax + 1, sizeof(unsigned short));
+    rem = flint_malloc((Dmax + 1) * sizeof(unsigned int));
+
+    /*
+        Class numbers: reduced forms (a, b, c), |b| <= a <= c, with b >= 0
+        when |b| = a or a = c; for fixed (a, b) the discriminants
+        |D| = 4ac - b^2, c >= a, form an arithmetic progression with step
+        4a. Forms with 0 < |b| < a < c count twice (b and -b). The range
+        of D is processed in chunks that fit in the cache, as in Enge's CM
+        library, which is what makes the sieve fast. Forms of fundamental
+        discriminant are primitive, and only those are used, so no gcd
+        check.
+    */
+    {
+        const slong chunk = WORD(1) << 18;
+        slong lo;
+
+        amax = (slong) sqrt((double) Dmax / 3.0) + 1;
+        for (lo = 0; lo <= Dmax; lo += chunk)
+        {
+            slong hi = FLINT_MIN(lo + chunk, Dmax + 1);
+            unsigned short * hh = h;
+
+            for (a = 1; a <= amax; a++)
+            {
+                slong step = 4 * a, D0;
+
+                /* b = 0 and b = a: once each, c >= a */
+                for (b = 0; b <= a; b += a)
+                {
+                    D0 = 4 * a * a - b * b;
+                    if (D0 >= hi)
+                        continue;
+                    if (D0 < lo)
+                        D0 += step * ((lo - D0 + step - 1) / step);
+                    for (D = D0; D < hi; D += step)
+                        hh[D]++;
+                    if (a == 0)
+                        break;
+                }
+                /* 0 < b < a: c = a once, c > a twice */
+                for (b = 1; b < a; b++)
+                {
+                    D0 = 4 * a * a - b * b;
+                    if (D0 >= hi)
+                        continue;
+                    if (D0 >= lo)
+                    {
+                        hh[D0]++;
+                        D0 += step;
+                    }
+                    else
+                        D0 += step * ((lo - D0 + step - 1) / step);
+                    for (D = D0; D < hi; D += step)
+                        hh[D] += 2;
+                }
+            }
+        }
+    }
+
+    /* smooth part: rem[D] = D with the primes of the set divided out */
+    for (D = 0; D <= Dmax; D++)
+        rem[D] = (unsigned int) D;
+    for (D = 2; D <= Dmax; D += 2)
+        while (rem[D] % 2 == 0)
+            rem[D] /= 2;
+    for (i = 0; i < nprimes; i++)
+    {
+        ulong p = primes[i];
+        for (D = p; D <= Dmax; D += p)
+            while (rem[D] % p == 0)
+                rem[D] /= p;
+    }
+
+    /*
+        Fundamental: -D = 1 mod 4 squarefree, or -D = 4m with m = 2, 3
+        mod 4 squarefree. Squarefreeness of the smooth ones is checked
+        while factoring below.
+    */
+    num = 0;
+    for (D = 3; D <= Dmax; D++)
+        if (h[D] > 0 && h[D] <= hmax && rem[D] == 1
+                && (D % 4 == 3 || (D % 4 == 0 && ((D / 4) % 4 == 1 || (D / 4) % 4 == 2))))
+            num++;
+
+    t = flint_malloc(FLINT_MAX(num, 1) * sizeof(ecpp_disc_struct));
+    num = 0;
+    for (D = 3; D <= Dmax; D++)
+    {
+        slong m, g, prodstar, o;
+
+        if (!(h[D] > 0 && h[D] <= hmax && rem[D] == 1))
+            continue;
+        if (D % 4 == 3)
+            m = D;
+        else if (D % 4 == 0 && ((D / 4) % 4 == 1 || (D / 4) % 4 == 2))
+            m = D / 4;
+        else
+            continue;
+
+        /* factor m; the odd part of m must be squarefree */
+        t[num].nfac = 0;
+        g = 0;
+        prodstar = 1;
+        if (m % 2 == 0)
+            m /= 2;
+        for (i = 0; m > 1; i++)
+        {
+            slong p = primes[i];
+            if (m % p == 0)
+            {
+                m /= p;
+                if (m % p == 0)
+                    break;
+                if (t[num].nfac == ECPP_DISC_MAXFAC)
+                    break;
+                t[num].fac[t[num].nfac++] = (unsigned short) i;
+                prodstar *= (p % 4 == 1) ? p : -p;
+                g++;
+            }
+        }
+        if (m != 1)
+            continue;
+
+        t[num].D = -D;
+        t[num].h = h[D];
+        t[num].q0 = (-D) / prodstar;    /* 1, -4, 8 or -8 */
+        if (t[num].q0 != 1)
+            g++;
+        /* o = h / 2^{g-1} (h is divisible by 2^{g-1} for fundamental D) */
+        o = h[D];
+        for (k = 1; k < g; k++)
+            o = (o + 1) / 2;
+        t[num].g = g;
+        t[num].o = FLINT_MAX(o, 1);
+        t[num].cost = ecpp_disc_cost(t + num);
+        /* admitted if the genus factor is small, or if the class field
+           tower is cheap: class number with small prime factors only */
+        if (t[num].o > omax && !(t[num].cost < costmax))
+            continue;
+        num++;
+    }
+
+    qsort(t, num, sizeof(ecpp_disc_struct), _disc_cmp);
+
+    flint_free(h);
+    flint_free(rem);
+    *table = t;
+    return num;
+}

--- a/src/ecpp/disc.c
+++ b/src/ecpp/disc.c
@@ -77,7 +77,8 @@ ecpp_disc_cost_n(const ecpp_disc_struct * d, int veven, const ulong * nmodp, slo
     double numfac = pow(4000.0 / FLINT_MAX(bits, 200), 2.6);
     numfac = FLINT_MIN(numfac, 500.0);
     numfac = FLINT_MAX(numfac, 1.0);
-    slong h = d->h, p, m = -d->D / 4;
+    slong h = d->h, p;
+    ulong absD = (ulong) (-d->D), m = absD >> 2;
     /*
         Weber's function: even D directly; odd D through the order of
         conductor 2 (discriminant 4D) when the v of 4n = t^2 + |D| v^2 is
@@ -88,8 +89,8 @@ ecpp_disc_cost_n(const ecpp_disc_struct * d, int veven, const ulong * nmodp, slo
         D = 5 mod 8 the class number is three times that of D and v is
         even half of the time.
     */
-    int weber = ((d->D % 4 == 0) && (m % 8 != 4 && m % 8 != 0))
-                || (d->D % 2 != 0 && veven);
+    int weber = (((absD & 3) == 0) && ((m & 7) != 4 && (m & 7) != 0))
+                || (((absD & 1) != 0) && veven);
     double cost = 1.5, genus;
 
     /* the twists are tried in turn: 6 for D = -3, 4 for D = -4, 2 else */
@@ -99,7 +100,7 @@ ecpp_disc_cost_n(const ecpp_disc_struct * d, int veven, const ulong * nmodp, slo
         cost = 1.0 + 2.5;
     if (h == 1)
         return cost;
-    if (weber && d->D % 2 != 0 && (-d->D) % 8 == 3)
+    if (weber && (absD & 1) != 0 && (absD & 7) == 3)
         h *= 3;
     /* the alternative: a root of the factor of H_D over the genus field,
        of degree o (by radicals up to 4) */
@@ -150,10 +151,10 @@ ecpp_disc_cost(const ecpp_disc_struct * d)
 int
 ecpp_disc_use_tower(const ecpp_disc_struct * d, int veven, slong * Dt)
 {
-    slong m = -d->D / 4;
-    int weber = ((d->D % 4 == 0) && (m % 8 != 4 && m % 8 != 0))
-                || (d->D % 2 != 0 && veven);
-    *Dt = (d->D % 2 != 0 && veven) ? 4 * d->D : d->D;
+    ulong absD = (ulong) (-d->D), m = absD >> 2;
+    int weber = (((absD & 3) == 0) && ((m & 7) != 4 && (m & 7) != 0))
+                || (((absD & 1) != 0) && veven);
+    *Dt = (((absD & 1) != 0) && veven) ? 4 * d->D : d->D;
     return d->h >= 2 && (weber || d->h <= 48);
 }
 

--- a/src/ecpp/disc.c
+++ b/src/ecpp/disc.c
@@ -83,8 +83,10 @@ ecpp_disc_cost_n(const ecpp_disc_struct * d, int veven, const ulong * nmodp, slo
         conductor 2 (discriminant 4D) when the v of 4n = t^2 + |D| v^2 is
         even, since then a curve with that endomorphism ring and the right
         order exists (any curve of the right order serves the proof). For
-        D = 1 mod 8 the order has the same class number, for D = 5 mod 8
-        three times it.
+        D = 1 mod 8 the order has the same class number and v is always
+        even (t^2 + |D| v^2 = 4n with |D| = 7 mod 8 forces t, v even); for
+        D = 5 mod 8 the class number is three times that of D and v is
+        even half of the time.
     */
     int weber = ((d->D % 4 == 0) && (m % 8 != 4 && m % 8 != 0))
                 || (d->D % 2 != 0 && veven);

--- a/src/ecpp/genus_poly.c
+++ b/src/ecpp/genus_poly.c
@@ -1,0 +1,357 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5.1
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <math.h>
+#include "ulong_extras.h"
+#include "fmpz.h"
+#include "fmpz_vec.h"
+#include "fmpz_mod.h"
+#include "fmpz_mod_poly.h"
+#include "arb.h"
+#include "acb.h"
+#include "arb_poly.h"
+#include "acb_modular.h"
+#include "ecpp.h"
+
+/*
+    The factor of the Hilbert class polynomial over the genus field.
+
+    Let D = p_1^* ... p_g^* be a fundamental discriminant (with q0 in
+    {-4, 8, -8} counted among the p_i^* when D is even), K = Q(sqrt D), H
+    its Hilbert class field and L = K(sqrt(p_1^*), ..., sqrt(p_g^*)) the
+    genus field, the fixed field of the subgroup Cl^2 of the class group
+    Cl = Gal(H/K); [L : K] = 2^{g-1}. Accordingly
+
+        H_D = prod_{gamma in Cl / Cl^2} F_gamma,
+        F_gamma = prod_{[a] in the coset gamma} (X - j(a)),
+
+    where the F_gamma are the conjugates over K of F_0, the factor of the
+    principal genus, whose coefficients lie in L. By Artin reciprocity the
+    class [a] acts on sqrt(p_i^*) by the genus character chi_i([a]) =
+    (p_i^* / a). Writing a coefficient of F_0 as sum_S kappa_S b_S with
+    b_S = prod_{i in S} sqrt(p_i^*) over the subsets S of {1, ..., g-1}
+    and kappa_S in K, the coefficients of the conjugates are
+    sum_S chi_gamma(S) kappa_S b_S, so that kappa_S b_S is recovered by a
+    character sum over the genera. The kappa_S = u + v sqrt(D) have 2-power
+    denominators.
+
+    Modulo a prime n with all chi_i(n) = 1, the square roots of the p_i^*
+    exist and F_0 maps to a factor of H_D mod n of degree
+    o = h / 2^{g-1}, whose roots are j-invariants of curves with CM by
+    the maximal order of K just as well as those of H_D. Finding a root of
+    F_0 instead of H_D costs a fraction 1 / 2^{g-1} of the work.
+
+    Input: D, the pstar[0..g-1] (the p_i^* and possibly q0), sqrts[i] a
+    square root of pstar[i] modulo n. On success (return 1) F is monic of
+    degree o with F | H_D mod n; returns 0 if the coefficients could not be
+    identified (the caller then falls back to H_D).
+*/
+
+/* genus of the form (a, b, c): bit i set if chi_i = -1 */
+static slong
+_form_genus(slong a, slong c, const slong * pstar, slong g)
+{
+    slong i, code = 0;
+    fmpz_t t, u;
+    fmpz_init(t);
+    fmpz_init(u);
+    for (i = 0; i < g; i++)
+    {
+        slong p = FLINT_ABS(pstar[i]);
+        slong x = (a % (p == 4 || p == 8 ? 2 : p) != 0) ? a : c;
+        fmpz_set_si(t, pstar[i]);
+        fmpz_set_si(u, x);
+        if (fmpz_kronecker(t, u) == -1)
+            code |= WORD(1) << i;
+    }
+    fmpz_clear(t);
+    fmpz_clear(u);
+    return code;
+}
+
+int
+ecpp_class_poly_genus(fmpz_mod_poly_t F, slong D, const slong * pstar, slong g,
+                                const fmpz * sqrts, const fmpz_mod_ctx_t ctx)
+{
+    slong i, k, a, b, c, ac, nforms, ngenus, o, prec, S, gamma, den;
+    slong * forms;          /* a, b (negative: b and -b), c, genus */
+    slong * genus_of;       /* genus code -> index 0 .. 2^{g-1} - 1, or -1 */
+    slong * genus_code;
+    arb_poly_struct * Fg;
+    arb_t sqrtD;
+    acb_t z, bS, sqrtDnum, kappa;
+    arb_t t, u, v;
+    fmpz_t U, V, inv2, tmp, tmp2;
+    double lgh, lgmax;
+    int success = 1;
+
+    if (g < 2)
+        return 0;
+
+    /* reduced forms (Cohen 5.3.5), as in acb_modular_hilbert_class_poly */
+    nforms = 0;
+    forms = NULL;
+    {
+        slong alloc = 0;
+        b = D & 1;
+        do
+        {
+            ac = (b * b - D) / 4;
+            a = FLINT_MAX(b, 1);
+            do
+            {
+                if (ac % a == 0 && n_gcd(n_gcd(a, b), ac / a) == 1)
+                {
+                    c = ac / a;
+                    if (nforms >= alloc)
+                    {
+                        alloc = FLINT_MAX(8, 2 * alloc);
+                        forms = flint_realloc(forms, 4 * alloc * sizeof(slong));
+                    }
+                    forms[4 * nforms + 0] = a;
+                    forms[4 * nforms + 1] = (a == b || a * a == ac || b == 0) ? b : -b;
+                    forms[4 * nforms + 2] = c;
+                    forms[4 * nforms + 3] = _form_genus(a, c, pstar, g);
+                    nforms++;
+                }
+                a++;
+            }
+            while (a * a <= ac);
+            b += 2;
+        }
+        while (3 * b * b <= -D);
+    }
+
+    /* the genera that occur (2^{g-1} of them) */
+    ngenus = WORD(1) << (g - 1);
+    genus_of = flint_malloc((WORD(1) << g) * sizeof(slong));
+    genus_code = flint_malloc(ngenus * sizeof(slong));
+    for (i = 0; i < (WORD(1) << g); i++)
+        genus_of[i] = -1;
+    k = 0;
+    for (i = 0; i < nforms; i++)
+    {
+        slong code = forms[4 * i + 3];
+        if (genus_of[code] == -1)
+        {
+            if (k == ngenus)
+            {
+                flint_free(forms);
+                flint_free(genus_of);
+                flint_free(genus_code);
+                return 0;   /* should not happen */
+            }
+            genus_code[k] = code;
+            genus_of[code] = k++;
+        }
+    }
+    if (k != ngenus || genus_of[0] != 0)
+    {
+        flint_free(forms);
+        flint_free(genus_of);
+        flint_free(genus_code);
+        return 0;
+    }
+
+    /* precision from the largest factor height (heuristic as for H_D) */
+    lgmax = 0.0;
+    for (gamma = 0; gamma < ngenus; gamma++)
+    {
+        lgh = 0.0;
+        for (i = 0; i < nforms; i++)
+            if (genus_of[forms[4 * i + 3]] == gamma)
+                lgh += (forms[4 * i + 1] < 0 ? 2.0 : 1.0) / forms[4 * i];
+        lgmax = FLINT_MAX(lgmax, lgh);
+    }
+    prec = 3.141593 * sqrt((double) -D) * lgmax * 1.442696;
+    prec = prec * 1.01 + 40 + 2 * g;
+
+    Fg = flint_malloc(ngenus * sizeof(arb_poly_struct));
+    for (gamma = 0; gamma < ngenus; gamma++)
+        arb_poly_init(Fg + gamma);
+    arb_init(sqrtD);
+    acb_init(z); acb_init(bS); acb_init(sqrtDnum); acb_init(kappa);
+    arb_init(t); arb_init(u); arb_init(v);
+    fmpz_init(U); fmpz_init(V); fmpz_init(inv2); fmpz_init(tmp); fmpz_init(tmp2);
+
+    for (;;)
+    {
+        arb_poly_t lin;
+        arb_poly_init(lin);
+
+        arb_set_si(sqrtD, -D);
+        arb_sqrt(sqrtD, sqrtD, prec);
+        for (gamma = 0; gamma < ngenus; gamma++)
+            arb_poly_one(Fg + gamma);
+
+        for (i = 0; i < nforms; i++)
+        {
+            a = forms[4 * i];
+            b = forms[4 * i + 1];
+            gamma = genus_of[forms[4 * i + 3]];
+            arb_set_si(acb_realref(z), -FLINT_ABS(b));
+            arb_set(acb_imagref(z), sqrtD);
+            acb_div_si(z, z, 2 * a, prec);
+            acb_modular_j(z, z, prec);
+            if (b < 0)
+            {
+                /* (x^2 - 2 re(j) x + |j|^2) */
+                arb_poly_fit_length(lin, 3);
+                arb_mul(lin->coeffs, acb_realref(z), acb_realref(z), prec);
+                arb_addmul(lin->coeffs, acb_imagref(z), acb_imagref(z), prec);
+                arb_mul_2exp_si(lin->coeffs + 1, acb_realref(z), 1);
+                arb_neg(lin->coeffs + 1, lin->coeffs + 1);
+                arb_one(lin->coeffs + 2);
+                _arb_poly_set_length(lin, 3);
+            }
+            else
+            {
+                arb_poly_fit_length(lin, 2);
+                arb_neg(lin->coeffs, acb_realref(z));
+                arb_one(lin->coeffs + 1);
+                _arb_poly_set_length(lin, 2);
+            }
+            arb_poly_mul(Fg + gamma, Fg + gamma, lin, prec);
+        }
+        arb_poly_clear(lin);
+
+        o = arb_poly_degree(Fg + 0);
+        for (gamma = 1; gamma < ngenus && success; gamma++)
+            if (arb_poly_degree(Fg + gamma) != o)
+                success = 0;
+        if (!success)
+            break;
+
+        /* numerical square roots: sqrt(p^*) real or i sqrt(-p^*); sqrt(D) = product */
+        acb_one(sqrtDnum);
+        for (i = 0; i < g; i++)
+        {
+            arb_set_si(t, FLINT_ABS(pstar[i]));
+            arb_sqrt(t, t, prec);
+            if (pstar[i] > 0)
+                acb_mul_arb(sqrtDnum, sqrtDnum, t, prec);
+            else
+            {
+                acb_mul_arb(sqrtDnum, sqrtDnum, t, prec);
+                acb_mul_onei(sqrtDnum, sqrtDnum);
+            }
+        }
+
+        /* modular square root of D consistent with the numerical one */
+        fmpz_one(tmp2);
+        for (i = 0; i < g; i++)
+            fmpz_mod_mul(tmp2, tmp2, sqrts + i, ctx);
+
+        fmpz_set_ui(inv2, UWORD(1) << (g + 1));
+        fmpz_mod_inv(inv2, inv2, ctx);
+
+        fmpz_mod_poly_zero(F, ctx);
+        fmpz_mod_poly_set_coeff_ui(F, o, 1, ctx);
+
+        for (k = 0; k < o && success; k++)
+        {
+            fmpz_t coeff;
+            fmpz_init(coeff);
+
+            for (S = 0; S < ngenus && success; S++)
+            {
+                /* t_S = 2^{-(g-1)} sum_gamma chi_gamma(S) c_{gamma,k} */
+                arb_zero(t);
+                for (gamma = 0; gamma < ngenus; gamma++)
+                {
+                    slong code = genus_code[gamma], bitsSg = code & S, par = 0;
+                    while (bitsSg)
+                    {
+                        par ^= 1;
+                        bitsSg &= bitsSg - 1;
+                    }
+                    if (par)
+                        arb_sub(t, t, arb_poly_get_coeff_ptr(Fg + gamma, k), prec);
+                    else
+                        arb_add(t, t, arb_poly_get_coeff_ptr(Fg + gamma, k), prec);
+                }
+                arb_mul_2exp_si(t, t, -(g - 1));
+
+                /* b_S numerically and modulo n; den = prod_{i in S} |p_i^*| */
+                acb_one(bS);
+                fmpz_one(tmp);
+                den = 1;
+                for (i = 0; i < g - 1; i++)
+                {
+                    if (S & (WORD(1) << i))
+                    {
+                        arb_set_si(u, FLINT_ABS(pstar[i]));
+                        arb_sqrt(u, u, prec);
+                        acb_mul_arb(bS, bS, u, prec);
+                        if (pstar[i] < 0)
+                            acb_mul_onei(bS, bS);
+                        fmpz_mod_mul(tmp, tmp, sqrts + i, ctx);
+                        den *= FLINT_ABS(pstar[i]);
+                    }
+                }
+
+                /* kappa_S = t_S / b_S = (U + V sqrt(D)) / (2^{g+1} den): dividing
+                   an algebraic integer by b_S brings in the primes of S */
+                acb_set_arb(kappa, t);
+                acb_div(kappa, kappa, bS, prec);
+                arb_set(u, acb_realref(kappa));
+                arb_div(v, acb_imagref(kappa), acb_imagref(sqrtDnum), prec);
+                arb_mul_2exp_si(u, u, g + 1);
+                arb_mul_2exp_si(v, v, g + 1);
+                arb_mul_si(u, u, den, prec);
+                arb_mul_si(v, v, den, prec);
+                if (!arb_get_unique_fmpz(U, u) || !arb_get_unique_fmpz(V, v))
+                {
+                    success = 0;
+                    break;
+                }
+
+                /* coefficient += b_S (U + V sqrt(D)) / (2^{g+1} den) */
+                fmpz_mod_set_fmpz(U, U, ctx);
+                fmpz_mod_set_fmpz(V, V, ctx);
+                fmpz_mod_mul(V, V, tmp2, ctx);
+                fmpz_mod_add(U, U, V, ctx);
+                fmpz_mod_mul(U, U, inv2, ctx);
+                fmpz_set_si(V, den);
+                fmpz_mod_inv(V, V, ctx);
+                fmpz_mod_mul(U, U, V, ctx);
+                fmpz_mod_mul(U, U, tmp, ctx);
+                fmpz_mod_add(coeff, coeff, U, ctx);
+            }
+
+            fmpz_mod_poly_set_coeff_fmpz(F, k, coeff, ctx);
+            fmpz_clear(coeff);
+        }
+
+        if (success)
+            break;
+
+        /* not enough precision: retry, at most a few times */
+        if (prec > 20 * (3.141593 * sqrt((double) -D) * lgmax * 1.442696 + 100))
+            break;
+        success = 1;
+        prec = prec * 1.5 + 50;
+    }
+
+    for (gamma = 0; gamma < ngenus; gamma++)
+        arb_poly_clear(Fg + gamma);
+    flint_free(Fg);
+    arb_clear(sqrtD);
+    acb_clear(z); acb_clear(bS); acb_clear(sqrtDnum); acb_clear(kappa);
+    arb_clear(t); arb_clear(u); arb_clear(v);
+    fmpz_clear(U); fmpz_clear(V); fmpz_clear(inv2); fmpz_clear(tmp); fmpz_clear(tmp2);
+    flint_free(forms);
+    flint_free(genus_of);
+    flint_free(genus_code);
+
+    return success;
+}

--- a/src/ecpp/point.c
+++ b/src/ecpp/point.c
@@ -1,0 +1,50 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5.1
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz.h"
+#include "fmpz_mod.h"
+#include "ecpp.h"
+
+/*
+    Points in Jacobian coordinates (X : Y : Z), Z = 0 for the point at
+    infinity. The arithmetic is in point_gr.c, over a generic ring.
+*/
+
+void
+ecpp_point_init(ecpp_point_t P)
+{
+    fmpz_init(P->X);
+    fmpz_init(P->Y);
+    fmpz_init(P->Z);
+}
+
+void
+ecpp_point_clear(ecpp_point_t P)
+{
+    fmpz_clear(P->X);
+    fmpz_clear(P->Y);
+    fmpz_clear(P->Z);
+}
+
+void
+ecpp_point_set_affine(ecpp_point_t P, const fmpz_t x, const fmpz_t y)
+{
+    fmpz_set(P->X, x);
+    fmpz_set(P->Y, y);
+    fmpz_one(P->Z);
+}
+
+int
+ecpp_point_is_zero(const ecpp_point_t P)
+{
+    return fmpz_is_zero(P->Z);
+}

--- a/src/ecpp/point_gr.c
+++ b/src/ecpp/point_gr.c
@@ -1,0 +1,379 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5.1
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz.h"
+#include "fmpz_mod.h"
+#include "gr.h"
+#include "mpn_mod.h"
+#include "ecpp.h"
+
+/*
+    Point arithmetic on y^2 = x^3 + a x + b over a generic ring (gr): the
+    same Jacobian formulas as point.c, so that the modular arithmetic can
+    be mpn_mod for moduli of up to MPN_MOD_MAX_LIMBS limbs and fmpz_mod
+    beyond. A point is three consecutive ring elements (X, Y, Z); Z = 0 is
+    the point at infinity. All operations are in a ring where every
+    nonzero element is expected to be a unit (n prime); the quantities
+    whose invertibility is assumed are multiplied into acc, and the
+    functions return 0 as soon as acc is zero.
+*/
+
+#define PX(P) (P)
+#define PY(P) GR_ENTRY(P, 1, sz)
+#define PZ(P) GR_ENTRY(P, 2, sz)
+
+#define GR_MUST(expr) do { if ((expr) != GR_SUCCESS) return 0; } while (0)
+
+static int
+_gpoint_set(gr_ptr R, gr_srcptr P, gr_ctx_t ctx)
+{
+    slong sz = ctx->sizeof_elem;
+    GR_MUST(gr_set(PX(R), PX(P), ctx));
+    GR_MUST(gr_set(PY(R), PY(P), ctx));
+    GR_MUST(gr_set(PZ(R), PZ(P), ctx));
+    return 1;
+}
+
+static int
+_gpoint_double(gr_ptr R, gr_srcptr P, gr_srcptr a, gr_ptr acc,
+        gr_ptr t1, gr_ptr t2, gr_ptr t3, gr_ptr t4, gr_ctx_t ctx)
+{
+    slong sz = ctx->sizeof_elem;
+
+    if (gr_is_zero(PZ(P), ctx) == T_TRUE || gr_is_zero(PY(P), ctx) == T_TRUE)
+    {
+        GR_MUST(gr_zero(PZ(R), ctx));
+        return 1;
+    }
+    GR_MUST(gr_mul(acc, acc, PY(P), ctx));
+
+    /* t1 = M = 3 X^2 + a Z^4 */
+    GR_MUST(gr_sqr(t1, PX(P), ctx));
+    GR_MUST(gr_add(t2, t1, t1, ctx));
+    GR_MUST(gr_add(t1, t1, t2, ctx));
+    GR_MUST(gr_sqr(t2, PZ(P), ctx));
+    GR_MUST(gr_sqr(t2, t2, ctx));
+    GR_MUST(gr_mul(t2, t2, a, ctx));
+    GR_MUST(gr_add(t1, t1, t2, ctx));
+
+    /* t2 = S = 4 X Y^2, t3 = 8 Y^4 */
+    GR_MUST(gr_sqr(t3, PY(P), ctx));
+    GR_MUST(gr_mul(t2, PX(P), t3, ctx));
+    GR_MUST(gr_add(t2, t2, t2, ctx));
+    GR_MUST(gr_add(t2, t2, t2, ctx));
+    GR_MUST(gr_sqr(t3, t3, ctx));
+    GR_MUST(gr_add(t3, t3, t3, ctx));
+    GR_MUST(gr_add(t3, t3, t3, ctx));
+    GR_MUST(gr_add(t3, t3, t3, ctx));
+
+    /* Z3 = 2 Y Z */
+    GR_MUST(gr_mul(t4, PY(P), PZ(P), ctx));
+    GR_MUST(gr_add(PZ(R), t4, t4, ctx));
+
+    /* X3 = M^2 - 2S */
+    GR_MUST(gr_sqr(t4, t1, ctx));
+    GR_MUST(gr_sub(t4, t4, t2, ctx));
+    GR_MUST(gr_sub(PX(R), t4, t2, ctx));
+
+    /* Y3 = M (S - X3) - 8 Y^4 */
+    GR_MUST(gr_sub(t2, t2, PX(R), ctx));
+    GR_MUST(gr_mul(t2, t2, t1, ctx));
+    GR_MUST(gr_sub(PY(R), t2, t3, ctx));
+    return 1;
+}
+
+/* R = P + Q with Q affine (Z = 1) */
+static int
+_gpoint_add_affine(gr_ptr R, gr_srcptr P, gr_srcptr Q, gr_srcptr a, gr_ptr acc,
+        gr_ptr t1, gr_ptr t2, gr_ptr t3, gr_ptr t4, gr_ctx_t ctx)
+{
+    slong sz = ctx->sizeof_elem;
+
+    if (gr_is_zero(PZ(P), ctx) == T_TRUE)
+        return _gpoint_set(R, Q, ctx);
+
+    /* t1 = Z1^2, t2 = U2 = X2 Z1^2, t3 = S2 = Y2 Z1^3 */
+    GR_MUST(gr_sqr(t1, PZ(P), ctx));
+    GR_MUST(gr_mul(t2, PX(Q), t1, ctx));
+    GR_MUST(gr_mul(t1, t1, PZ(P), ctx));
+    GR_MUST(gr_mul(t3, PY(Q), t1, ctx));
+
+    /* t2 = H = U2 - X1, t3 = r = S2 - Y1 */
+    GR_MUST(gr_sub(t2, t2, PX(P), ctx));
+    GR_MUST(gr_sub(t3, t3, PY(P), ctx));
+
+    if (gr_is_zero(t2, ctx) == T_TRUE)
+    {
+        if (gr_is_zero(t3, ctx) == T_TRUE)
+            return _gpoint_double(R, P, a, acc, t1, t2, t3, t4, ctx);
+        GR_MUST(gr_zero(PZ(R), ctx));   /* P = -Q */
+        return 1;
+    }
+
+    GR_MUST(gr_mul(acc, acc, t2, ctx));
+
+    /* Z3 = Z1 H */
+    GR_MUST(gr_mul(PZ(R), PZ(P), t2, ctx));
+
+    /* t1 = H^2, t4 = H^3, t1 = V = X1 H^2 */
+    GR_MUST(gr_sqr(t1, t2, ctx));
+    GR_MUST(gr_mul(t4, t1, t2, ctx));
+    GR_MUST(gr_mul(t1, t1, PX(P), ctx));
+
+    /* X3 = r^2 - H^3 - 2V */
+    GR_MUST(gr_sqr(t2, t3, ctx));
+    GR_MUST(gr_sub(t2, t2, t4, ctx));
+    GR_MUST(gr_sub(t2, t2, t1, ctx));
+    GR_MUST(gr_sub(PX(R), t2, t1, ctx));
+
+    /* Y3 = r (V - X3) - Y1 H^3 */
+    GR_MUST(gr_sub(t1, t1, PX(R), ctx));
+    GR_MUST(gr_mul(t1, t1, t3, ctx));
+    GR_MUST(gr_mul(t4, t4, PY(P), ctx));
+    GR_MUST(gr_sub(PY(R), t1, t4, ctx));
+    return 1;
+}
+
+/* plain double-and-add; P affine */
+static int
+_gpoint_mul_binary(gr_ptr R, gr_srcptr P, const fmpz_t k, gr_srcptr a, gr_ptr acc,
+        gr_ptr t1, gr_ptr t2, gr_ptr t3, gr_ptr t4, gr_ctx_t ctx)
+{
+    slong i, bits = fmpz_bits(k);
+    gr_ptr T = gr_heap_init_vec(3, ctx);
+    int ok = 1;
+
+    ok = _gpoint_set(T, P, ctx);
+    for (i = bits - 2; i >= 0 && ok; i--)
+    {
+        ok = _gpoint_double(T, T, a, acc, t1, t2, t3, t4, ctx);
+        if (ok && fmpz_tstbit(k, i))
+            ok = _gpoint_add_affine(T, T, P, a, acc, t1, t2, t3, t4, ctx);
+        if (gr_is_zero(acc, ctx) == T_TRUE)
+            ok = 0;
+    }
+    if (ok)
+        ok = _gpoint_set(R, T, ctx);
+    gr_heap_clear_vec(T, 3, ctx);
+    return ok;
+}
+
+/*
+    Normalises num Jacobian points to affine coordinates with one
+    inversion, multiplying acc by the Z's. Returns 0 if some Z is zero or
+    the product is not invertible (the points are then left alone).
+*/
+static int
+_gpoints_to_affine(gr_ptr T, slong num, gr_ptr acc, gr_ctx_t ctx)
+{
+    slong sz = ctx->sizeof_elem, i;
+    gr_ptr prod = gr_heap_init_vec(num, ctx);
+    gr_ptr inv, t, g;
+    int ok = 1;
+
+    GR_TMP_INIT3(inv, t, g, ctx);
+    for (i = 0; i < num && ok; i++)
+        if (gr_is_zero(PZ(GR_ENTRY(T, 3 * i, sz)), ctx) == T_TRUE)
+            ok = 0;
+    if (ok)
+    {
+        ok = (gr_set(prod, PZ(T), ctx) == GR_SUCCESS);
+        for (i = 1; i < num && ok; i++)
+            ok = (gr_mul(GR_ENTRY(prod, i, sz), GR_ENTRY(prod, i - 1, sz),
+                            PZ(GR_ENTRY(T, 3 * i, sz)), ctx) == GR_SUCCESS);
+    }
+    if (ok)
+        ok = (gr_mul(acc, acc, GR_ENTRY(prod, num - 1, sz), ctx) == GR_SUCCESS);
+    if (ok)
+        ok = (gr_inv(inv, GR_ENTRY(prod, num - 1, sz), ctx) == GR_SUCCESS);
+    for (i = num - 1; i >= 0 && ok; i--)
+    {
+        gr_ptr Pi = GR_ENTRY(T, 3 * i, sz);
+        if (i > 0)
+        {
+            ok = ok && (gr_mul(t, inv, GR_ENTRY(prod, i - 1, sz), ctx) == GR_SUCCESS);
+            ok = ok && (gr_mul(inv, inv, PZ(Pi), ctx) == GR_SUCCESS);
+        }
+        else
+            ok = ok && (gr_set(t, inv, ctx) == GR_SUCCESS);
+        ok = ok && (gr_sqr(g, t, ctx) == GR_SUCCESS);
+        ok = ok && (gr_mul(PX(Pi), PX(Pi), g, ctx) == GR_SUCCESS);
+        ok = ok && (gr_mul(g, g, t, ctx) == GR_SUCCESS);
+        ok = ok && (gr_mul(PY(Pi), PY(Pi), g, ctx) == GR_SUCCESS);
+        ok = ok && (gr_one(PZ(Pi), ctx) == GR_SUCCESS);
+    }
+    GR_TMP_CLEAR3(inv, t, g, ctx);
+    gr_heap_clear_vec(prod, num, ctx);
+    return ok;
+}
+
+#define NAF_W 4
+
+/*
+    R = k P for an affine point P and k >= 0, multiplying acc by all
+    quantities whose invertibility was assumed; returns 0 if acc became
+    zero or an operation failed (n composite), else 1. Width-4 signed
+    sliding window with the odd multiples in affine coordinates.
+*/
+int
+ecpp_point_mul_gr(gr_ptr R, gr_srcptr P, const fmpz_t k, gr_srcptr a, gr_ptr acc,
+                                                                gr_ctx_t ctx)
+{
+    slong sz = ctx->sizeof_elem, i, bits = fmpz_bits(k), len;
+    const slong ntab = 1 << (NAF_W - 2);
+    gr_ptr t1, t2, t3, t4, Q, P2, T, Tn;
+    signed char * naf;
+    fmpz_t kk;
+    int ok = 1;
+
+    if (bits == 0 || gr_is_zero(PZ(P), ctx) == T_TRUE)
+        return gr_zero(PZ(R), ctx) == GR_SUCCESS;
+
+    GR_TMP_INIT4(t1, t2, t3, t4, ctx);
+
+    if (bits < 32)
+    {
+        ok = _gpoint_mul_binary(R, P, k, a, acc, t1, t2, t3, t4, ctx);
+        GR_TMP_CLEAR4(t1, t2, t3, t4, ctx);
+        return ok && gr_is_zero(acc, ctx) != T_TRUE;
+    }
+
+    Q = gr_heap_init_vec(3, ctx);
+    P2 = gr_heap_init_vec(3, ctx);
+    T = gr_heap_init_vec(3 * ntab, ctx);
+    Tn = gr_heap_init_vec(3 * ntab, ctx);
+
+    /* odd multiples: 2P affine, T[i] = (2i + 1) P, Tn[i] = -T[i] */
+    ok = _gpoint_double(P2, P, a, acc, t1, t2, t3, t4, ctx);
+    if (ok && !_gpoints_to_affine(P2, 1, acc, ctx))
+        goto fallback;
+    if (ok) ok = _gpoint_set(T, P, ctx);
+    for (i = 1; i < ntab && ok; i++)
+        ok = _gpoint_add_affine(GR_ENTRY(T, 3 * i, sz), GR_ENTRY(T, 3 * (i - 1), sz),
+                                P2, a, acc, t1, t2, t3, t4, ctx);
+    if (ok && !_gpoints_to_affine(GR_ENTRY(T, 3, sz), ntab - 1, acc, ctx))
+        goto fallback;
+    for (i = 0; i < ntab && ok; i++)
+    {
+        gr_ptr Ti = GR_ENTRY(T, 3 * i, sz), Ni = GR_ENTRY(Tn, 3 * i, sz);
+        ok = ok && (gr_set(PX(Ni), PX(Ti), ctx) == GR_SUCCESS);
+        ok = ok && (gr_neg(PY(Ni), PY(Ti), ctx) == GR_SUCCESS);
+        ok = ok && (gr_one(PZ(Ni), ctx) == GR_SUCCESS);
+    }
+    if (!ok)
+        goto cleanup;
+
+    /* NAF digits, least significant first */
+    naf = flint_malloc(bits + 2);
+    fmpz_init_set(kk, k);
+    len = 0;
+    while (!fmpz_is_zero(kk))
+    {
+        if (fmpz_is_odd(kk))
+        {
+            slong d = fmpz_fdiv_ui(kk, 1 << NAF_W);
+            if (d >= (1 << (NAF_W - 1)))
+                d -= 1 << NAF_W;
+            naf[len++] = (signed char) d;
+            fmpz_sub_si(kk, kk, d);
+        }
+        else
+            naf[len++] = 0;
+        fmpz_fdiv_q_2exp(kk, kk, 1);
+    }
+    fmpz_clear(kk);
+
+    ok = (gr_zero(PZ(Q), ctx) == GR_SUCCESS);
+    for (i = len - 1; i >= 0 && ok; i--)
+    {
+        ok = _gpoint_double(Q, Q, a, acc, t1, t2, t3, t4, ctx);
+        if (ok && naf[i] > 0)
+            ok = _gpoint_add_affine(Q, Q, GR_ENTRY(T, 3 * ((naf[i] - 1) / 2), sz), a, acc, t1, t2, t3, t4, ctx);
+        else if (ok && naf[i] < 0)
+            ok = _gpoint_add_affine(Q, Q, GR_ENTRY(Tn, 3 * ((-naf[i] - 1) / 2), sz), a, acc, t1, t2, t3, t4, ctx);
+        if (gr_is_zero(acc, ctx) == T_TRUE)
+            ok = 0;
+    }
+    flint_free(naf);
+    if (ok)
+        ok = _gpoint_set(R, Q, ctx);
+    goto cleanup;
+
+fallback:
+    /* some small multiple of P is O or not normalisable: plain method */
+    ok = (gr_is_zero(acc, ctx) != T_TRUE) && _gpoint_mul_binary(R, P, k, a, acc, t1, t2, t3, t4, ctx);
+
+cleanup:
+    gr_heap_clear_vec(Q, 3, ctx);
+    gr_heap_clear_vec(P2, 3, ctx);
+    gr_heap_clear_vec(T, 3 * ntab, ctx);
+    gr_heap_clear_vec(Tn, 3 * ntab, ctx);
+    GR_TMP_CLEAR4(t1, t2, t3, t4, ctx);
+    return ok && gr_is_zero(acc, ctx) != T_TRUE;
+}
+
+/*
+    The ring for the modulus n: mpn_mod for 2 to MPN_MOD_MAX_LIMBS limbs
+    (much faster than fmpz_mod at these sizes), else fmpz_mod. (A context
+    wrapping the given fmpz_mod one without copying would be freed by
+    gr_ctx_clear; the copy is cheap next to a scalar multiplication.)
+*/
+void
+ecpp_gr_ctx_init(gr_ctx_t gctx, const fmpz_mod_ctx_t ctx)
+{
+    const fmpz * n = fmpz_mod_ctx_modulus(ctx);
+    if (fmpz_size(n) >= MPN_MOD_MIN_LIMBS && fmpz_size(n) <= MPN_MOD_MAX_LIMBS
+            && gr_ctx_init_mpn_mod(gctx, n) == GR_SUCCESS)
+        return;
+    gr_ctx_init_fmpz_mod(gctx, n);
+}
+
+/* the fmpz_mod interface of point.c, through gr */
+int
+ecpp_point_mul(ecpp_point_t R, const ecpp_point_t P, const fmpz_t k,
+                        const fmpz_t a, fmpz_t acc, const fmpz_mod_ctx_t ctx)
+{
+    gr_ctx_t gctx;
+    gr_ptr gP, gR, ga, gacc;
+    slong sz;
+    int ok;
+
+    ecpp_gr_ctx_init(gctx, ctx);
+    sz = gctx->sizeof_elem;
+    gP = gr_heap_init_vec(3, gctx);
+    gR = gr_heap_init_vec(3, gctx);
+    ga = gr_heap_init(gctx);
+    gacc = gr_heap_init(gctx);
+    ok = (gr_set_fmpz(PX(gP), P->X, gctx) == GR_SUCCESS)
+      && (gr_set_fmpz(PY(gP), P->Y, gctx) == GR_SUCCESS)
+      && (gr_set_fmpz(PZ(gP), P->Z, gctx) == GR_SUCCESS)
+      && (gr_set_fmpz(ga, a, gctx) == GR_SUCCESS)
+      && (gr_set_fmpz(gacc, acc, gctx) == GR_SUCCESS);
+    if (ok)
+        ok = ecpp_point_mul_gr(gR, gP, k, ga, gacc, gctx);
+    /* acc and R are read back even on failure (acc may be zero) */
+    GR_MUST_SUCCEED(gr_get_fmpz(acc, gacc, gctx));
+    if (ok)
+    {
+        GR_MUST_SUCCEED(gr_get_fmpz(R->X, PX(gR), gctx));
+        GR_MUST_SUCCEED(gr_get_fmpz(R->Y, PY(gR), gctx));
+        GR_MUST_SUCCEED(gr_get_fmpz(R->Z, PZ(gR), gctx));
+    }
+    else
+        fmpz_zero(R->Z);
+    gr_heap_clear_vec(gP, 3, gctx);
+    gr_heap_clear_vec(gR, 3, gctx);
+    gr_heap_clear(ga, gctx);
+    gr_heap_clear(gacc, gctx);
+    gr_ctx_clear(gctx);
+    return ok;
+}

--- a/src/ecpp/profile/p-prove.c
+++ b/src/ecpp/profile/p-prove.c
@@ -1,0 +1,63 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5.1
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+/*
+    Timing of ECPP against APRCL on random primes.
+
+    Usage: p-prove [bits] [threads] [seed] [aprcl]
+
+    Compile prove.c with -DECPP_PROFILE for a breakdown of the ECPP time.
+*/
+
+#include <stdlib.h>
+#include "profiler.h"
+#include "fmpz.h"
+#include "aprcl.h"
+#include "ecpp.h"
+
+int
+main(int argc, char ** argv)
+{
+    slong bits = argc > 1 ? atol(argv[1]) : 1000;
+    int nthreads = argc > 2 ? atoi(argv[2]) : 1;
+    ulong seed = argc > 3 ? atol(argv[3]) : 1;
+    int aprcl = argc > 4 ? atoi(argv[4]) : 0;
+    fmpz_t n;
+    flint_rand_t state;
+    ecpp_cert_t cert;
+    timeit_t t;
+    int r;
+
+    flint_set_num_threads(nthreads);
+    fmpz_init(n);
+    flint_rand_init(state);
+    flint_rand_set_seed(state, seed, seed + 7);
+    fmpz_randprime(n, state, bits, 0);
+    ecpp_cert_init(cert);
+
+    timeit_start(t);
+    if (aprcl)
+        r = aprcl_is_prime(n);
+    else
+        r = ecpp_prove(cert, n);
+    timeit_stop(t);
+
+    flint_printf("%s: %wd bits, %d threads, result %d, %wd steps, %.3f s\n",
+        aprcl ? "aprcl" : "ecpp", bits, nthreads, r, cert->num, t->wall / 1000.0);
+    if (!aprcl && r == 1 && !ecpp_verify(cert, n))
+        flint_printf("certificate does not verify!\n");
+
+    ecpp_cert_clear(cert);
+    fmpz_clear(n);
+    flint_rand_clear(state);
+    return 0;
+}

--- a/src/ecpp/prove.c
+++ b/src/ecpp/prove.c
@@ -1,0 +1,2065 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5.1
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdlib.h>
+#include <string.h>
+#include "ulong_extras.h"
+#include "fmpz.h"
+#include "fmpz_vec.h"
+#include "fmpz_poly.h"
+#include "fmpz_mod.h"
+#include "fmpz_mod_poly.h"
+#include "fmpz_mod_poly_factor.h"
+#include "thread_support.h"
+#include "thread_pool.h"
+#include "acb_modular.h"
+#include "ecpp.h"
+
+/*
+    Atkin-Morain ECPP with the fastECPP organisation of the discriminant
+    search (Franke, Kleinjung, Morain, Wirth 2004; Morain 2007), in the
+    form of the implementations in PARI/GP (primecert, by Jared Asuncion)
+    and in Andreas Enge's CM library (see the documentation for what was
+    taken from each; the parameters were tuned against both).
+
+    For each n in the chain:
+      1. run through the pool of fundamental discriminants D that are
+         smooth over a fixed set of small primes (see disc.c), skipping
+         those with a genus character (p^* / n) = -1 (Cornacchia cannot
+         succeed for them); sqrt(D) mod n is the product of the square
+         roots of the p^*, each computed once per n; Cornacchia writes
+         4n = t^2 + |D| v^2 and yields the possible curve orders;
+      2. once a batch of orders is collected, remove all their prime
+         factors below 2^tdivexp at once with a remainder tree, keep the
+         cofactors q with (n^{1/4} + 1)^2 < q <= n/2, sort them by size
+         and test them for probable primality in that order: the first
+         probable prime is the smallest, i.e. the largest gain in bits
+         that the batch offers;
+      3. realise the candidate: a root of the Hilbert class polynomial
+         H_D modulo n gives the curve, the right twist and a point P
+         with m P = O and (m/q) P != O are found by testing; recurse on q.
+         A dead end continues with the next probable prime of the batch,
+         then with the next batch.
+*/
+
+#ifdef ECPP_PROFILE
+#include <time.h>
+static double _now(void)
+{
+    struct timespec t;
+    timespec_get(&t, TIME_UTC);
+    return t.tv_sec + 1e-9 * t.tv_nsec;
+}
+static double prof_scan, prof_hilbert, prof_roots, prof_points;
+static double prof_sqrt, prof_corn, prof_split, prof_bpsw;
+static slong prof_hsum, prof_nsteps, prof_twists, prof_gain;
+static slong prof_nsqrt, prof_ncorn, prof_ncornok, prof_nsplit, prof_nbpsw, prof_nbatch, prof_ndisc;
+static slong prof_nobatch, prof_nobatch_tests, prof_fullbatch;
+#define PROF_START(v) double v = _now()
+#define PROF_ADD(acc, v) acc += _now() - v
+#else
+#define PROF_START(v)
+#define PROF_ADD(acc, v)
+#endif
+
+typedef struct
+{
+    slong D;
+    slong h;
+    slong o;                            /* degree of the genus factor of H_D */
+    double cost;                        /* estimated realisation cost */
+    int use_tower;
+    slong Dtower;                       /* D or 4D */
+    int veven;                          /* v even in 4n = t^2 + |D| v^2 */
+    slong g;
+    slong pstar[ECPP_DISC_MAXFAC + 1];  /* the p_i^* and q0 */
+    fmpz sqrts[ECPP_DISC_MAXFAC + 1];   /* their square roots mod n */
+    fmpz_t m;
+    fmpz_t q;
+}
+ecpp_cand_struct;
+
+/* runtime verbosity (ecpp_set_verbose) */
+int ecpp_verbose = 0;
+
+void
+ecpp_set_verbose(int verbose)
+{
+    ecpp_verbose = verbose;
+}
+
+typedef struct
+{
+    ecpp_disc_struct * discs;
+    slong ndiscs;
+    ulong * primes;         /* odd primes up to pmax */
+    slong nprimes;
+    fmpz primorial[32];     /* product of the primes below 2^i, computed on demand */
+    int have_primorial[32];
+    fmpz primorial_chunk[32][ECPP_PRIMORIAL_CHUNKS]; /* as a product of chunks of
+                               equal size, for a parallel reduction */
+    flint_rand_t state;
+    slong max_tries;        /* candidates realised per n before giving up */
+    slong tdivexp;          /* trial division exponent, fixed from the size of
+                               the input for the whole chain (as in CM): the
+                               gain per step does not decrease down the
+                               chain, and the primorial is computed once */
+    /*
+        The realisation of a step (class polynomial, root, curve, point)
+        is independent of the search for the next step, which only needs
+        the cofactor q: with threads it runs on a pool thread while the
+        search for q proceeds. At most one realisation is pending; it is
+        joined by the next level before that level starts its own.
+    */
+    struct
+    {
+        int active;             /* a realisation is pending */
+        int threaded;           /* on a pool thread (else already done) */
+        slong cert_index;       /* the step's position in the certificate */
+        thread_pool_handle handle;
+        ecpp_step_struct step;
+        ecpp_cand_struct cand;
+        fmpz_t n;
+        fmpz_mod_ctx_struct * mctx;
+        flint_rand_t state;
+        int result;
+    }
+    pending;
+    int * results;          /* result of the realisation, per certificate index */
+    slong results_alloc;
+    int use_threads;        /* threads available and n large enough */
+}
+ecpp_ctx_struct;
+
+
+
+/*
+    Size dependent parameters: bits, largest prime of the set, class number
+    bound, trial division exponent. The class number bound and the trial
+    division exponent follow PARI/GP (with one more bit of trial division
+    from 2000 bits on: the batch factoring gets twice as expensive but the
+    batches are twice as large and the gain per step grows by a few bits,
+    which was measured to pay). The prime set is much smaller than PARI's:
+    since only discriminants with many small prime factors have a small
+    odd class number part, discriminants with a large prime factor are
+    rarely useful, while each such prime costs a square root per step;
+    at 4000 bits, primes up to 400 instead of 1400 cut the square roots
+    per step from 54 to 29 and the total time by a quarter.
+*/
+static const slong ecpp_tune[][4] =
+{
+    {  300,  100,   4, 16 },
+    {  400,  120,   5, 17 },
+    {  600,  150,   6, 18 },
+    {  700,  250,   8, 20 },
+    { 1000,  350,  14, 21 },
+    { 1200,  400,  16, 21 },
+    { 1500,  450,  18, 22 },
+    { 2000,  450,  22, 23 },
+    { 2500,  500,  26, 24 },
+    { 3000,  500,  32, 24 },
+    { 3500,  500,  38, 25 },
+    { 4000,  500,  44, 25 },
+    { 4500,  550,  50, 25 },
+    { 5000,  600,  56, 26 },
+    { 6000,  700,  68, 27 },
+    { 7000,  800,  80, 27 },
+    { 8000,  900,  92, 28 },
+    { 9000, 1000, 104, 29 },
+    {10000, 1100, 116, 30 },
+};
+
+static void
+_ecpp_tune(slong bits, slong * pmax, slong * hmax, slong * tdivexp)
+{
+    slong i, n = sizeof(ecpp_tune) / sizeof(ecpp_tune[0]);
+    for (i = 0; i < n; i++)
+        if (bits <= ecpp_tune[i][0])
+            break;
+    if (i == n)
+    {
+        i = n - 1;
+        *pmax = ecpp_tune[i][1] + (bits - ecpp_tune[i][0]) * 2 / 5;
+        *hmax = ecpp_tune[i][2] + (bits - ecpp_tune[i][0]) / 80;
+        *tdivexp = FLINT_MIN(30, ecpp_tune[i][3] + (bits - ecpp_tune[i][0]) / 4000);
+    }
+    else
+    {
+        *pmax = ecpp_tune[i][1];
+        *hmax = ecpp_tune[i][2];
+        *tdivexp = ecpp_tune[i][3];
+    }
+}
+
+
+
+/*
+    The product of the primes below 2^e. With threads it is also kept as
+    a product of ECPP_PRIMORIAL_CHUNKS chunks of nearly equal size (the
+    primes in ranges of equal length), for a parallel reduction; the
+    chunks are products of the primes of their range, so that the whole
+    costs about one primorial.
+*/
+static const fmpz *
+_ecpp_primorial(ecpp_ctx_struct * ctx, slong e)
+{
+    if (!ctx->have_primorial[e])
+    {
+        fmpz_init(ctx->primorial + e);
+        if (!ctx->use_threads)
+            fmpz_primorial(ctx->primorial + e, UWORD(1) << e);
+        else
+        {
+            slong k, np, alloc = 1024;
+            ulong p, B = UWORD(1) << e, lim;
+            fmpz * v = _fmpz_vec_init(alloc);
+            n_primes_t it;
+
+            n_primes_init(it);
+            p = n_primes_next(it);
+            fmpz_one(ctx->primorial + e);
+            for (k = 0; k < ECPP_PRIMORIAL_CHUNKS; k++)
+            {
+                lim = (k == ECPP_PRIMORIAL_CHUNKS - 1) ? B : (B / ECPP_PRIMORIAL_CHUNKS) * (k + 1);
+                np = 0;
+                while (p < lim)
+                {
+                    if (np == alloc)
+                    {
+                        slong q;
+                        alloc *= 2;
+                        v = flint_realloc(v, alloc * sizeof(fmpz));
+                        for (q = np; q < alloc; q++)
+                            v[q] = 0;
+                    }
+                    fmpz_set_ui(v + np, p);
+                    np++;
+                    p = n_primes_next(it);
+                }
+                fmpz_init(ctx->primorial_chunk[e] + k);
+                if (np > 0)
+                    _fmpz_vec_prod(ctx->primorial_chunk[e] + k, v, np);
+                else
+                    fmpz_one(ctx->primorial_chunk[e] + k);
+                fmpz_mul(ctx->primorial + e, ctx->primorial + e, ctx->primorial_chunk[e] + k);
+            }
+            n_primes_clear(it);
+            _fmpz_vec_clear(v, alloc);
+        }
+        ctx->have_primorial[e] = 1;
+    }
+    return ctx->primorial + e;
+}
+
+/* r_k = chunk_k mod prod, in parallel */
+typedef struct
+{
+    const fmpz * chunks;
+    const fmpz * prod;
+    const fmpz_preinvn_struct * inv;
+    fmpz * r;
+}
+_chunk_args;
+
+static void
+_chunk_worker(slong k, void * varg)
+{
+    _chunk_args * args = (_chunk_args *) varg;
+    fmpz_fdiv_r_preinvn(args->r + k, args->chunks + k, args->prod, args->inv);
+}
+
+/*
+    Per-n state of the discriminant search: genus characters and square
+    roots of the p^*, position in the pool, and the current batch of
+    cofactors sorted by size with the position of the next one to test.
+*/
+typedef struct
+{
+    const fmpz * n;
+    const fmpz_mod_ctx_struct * mctx;
+    slong bits;
+    signed char * sym;      /* (p^* / n): 0 unknown, 1, -1 */
+    signed char sym2[3];    /* (-4 / n), (8 / n), (-8 / n) */
+    fmpz * sqrt;            /* sqrt(p^*) mod n */
+    signed char * have;     /* 0 unknown, 1 known, 2 failed (n composite) */
+    fmpz_t sqrt2[3];        /* sqrt(-1), sqrt(2), sqrt(-2) */
+    signed char have2[3];
+    slong pos;              /* next discriminant of the pool (persevere mode) */
+    slong pprime;           /* next prime of the set to consider */
+    signed char * active;   /* primes with square root computed (or known non-residues) */
+    signed char * used;     /* discriminants already tried for this n */
+    slong delta;            /* minimum gain in bits */
+    fmpz_t ts_r, ts_g;      /* n - 1 = 2^ts_e ts_r, ts_g = z^ts_r of order 2^ts_e
+                               for a non-residue z: shared Tonelli-Shanks data */
+    slong ts_e;
+    ulong nmodp[4];         /* n mod 5, 7, 11, 13: cheap Kummer descents */
+    fmpz_t qmin, qmax, np1;
+    /* batch: orders m, cofactors q sorted by size, pool index of D, status
+       (0 untested, 1 probable prime not yet used, 2 composite or used) */
+    fmpz * bm, * bq;
+    slong * bD;
+    signed char * bstat;
+    signed char * bveven;
+    slong nb, balloc, bpos;
+    /* q's already tried for this n */
+    fmpz * tried;
+    slong ntried;
+    int composite;
+}
+ecpp_scan_struct;
+
+static void
+scan_init(ecpp_scan_struct * s, const fmpz_t n, const fmpz_mod_ctx_t mctx,
+                                                        const ecpp_ctx_struct * ctx)
+{
+    ulong n8;
+    slong i;
+
+    s->n = n;
+    s->mctx = mctx;
+    s->bits = fmpz_bits(n);
+    s->sym = flint_calloc(ctx->nprimes, sizeof(signed char));
+    s->sqrt = _fmpz_vec_init(ctx->nprimes);
+    s->have = flint_calloc(ctx->nprimes, sizeof(signed char));
+    for (i = 0; i < 3; i++)
+    {
+        fmpz_init(s->sqrt2[i]);
+        s->have2[i] = 0;
+    }
+    n8 = fmpz_fdiv_ui(n, 8);
+    s->sym2[0] = (n8 % 4 == 1) ? 1 : -1;            /* (-4 / n) */
+    s->sym2[1] = (n8 == 1 || n8 == 7) ? 1 : -1;     /* (8 / n)  */
+    s->sym2[2] = (n8 == 1 || n8 == 3) ? 1 : -1;     /* (-8 / n) */
+    s->pos = 0;
+    s->pprime = 0;
+    s->nmodp[0] = fmpz_fdiv_ui(n, 5);
+    s->nmodp[1] = fmpz_fdiv_ui(n, 7);
+    s->nmodp[2] = fmpz_fdiv_ui(n, 11);
+    s->nmodp[3] = fmpz_fdiv_ui(n, 13);
+    /* shared Tonelli-Shanks data: one exponentiation per n instead of one
+       per square root (and no search for a non-residue per root) */
+    fmpz_init(s->ts_r);
+    fmpz_init(s->ts_g);
+    fmpz_sub_ui(s->ts_r, n, 1);
+    s->ts_e = fmpz_val2(s->ts_r);
+    fmpz_fdiv_q_2exp(s->ts_r, s->ts_r, s->ts_e);
+    {
+        ulong z = 2;
+        fmpz_t t;
+        fmpz_init(t);
+        while (1)
+        {
+            fmpz_set_ui(t, z);
+            if (fmpz_jacobi(t, n) == -1)
+                break;
+            z++;
+        }
+        fmpz_powm(s->ts_g, t, s->ts_r, n);
+        fmpz_clear(t);
+    }
+    s->active = flint_calloc(ctx->nprimes, sizeof(signed char));
+    s->used = flint_calloc(ctx->ndiscs, sizeof(signed char));
+    fmpz_init(s->qmin);
+    fmpz_init(s->qmax);
+    fmpz_init(s->np1);
+    /* q must exceed (n^{1/4} + 1)^2; qmin = (floor(n^{1/4}) + 2)^2 suffices */
+    fmpz_root(s->qmin, n, 4);
+    fmpz_add_ui(s->qmin, s->qmin, 2);
+    fmpz_mul(s->qmin, s->qmin, s->qmin);
+    /* minimum gain: half the bits removed on average by the trial
+       division (Franke, Kleinjung, Morain, Wirth), for large n */
+    s->delta = (s->bits >= 1000) ? ctx->tdivexp / 2 + 1 : 1;
+    fmpz_fdiv_q_2exp(s->qmax, n, s->delta);
+    fmpz_add_ui(s->np1, n, 1);
+    s->balloc = 64;
+    s->bm = _fmpz_vec_init(s->balloc);
+    s->bq = _fmpz_vec_init(s->balloc);
+    s->bD = flint_malloc(s->balloc * sizeof(slong));
+    s->bstat = flint_malloc(s->balloc * sizeof(signed char));
+    s->bveven = flint_malloc(s->balloc * sizeof(signed char));
+    s->nb = s->bpos = 0;
+    s->tried = _fmpz_vec_init(ctx->max_tries + 2);
+    s->ntried = 0;
+    s->composite = 0;
+}
+
+static void
+scan_clear(ecpp_scan_struct * s, const ecpp_ctx_struct * ctx)
+{
+    slong i;
+    flint_free(s->sym);
+    _fmpz_vec_clear(s->sqrt, ctx->nprimes);
+    flint_free(s->have);
+    for (i = 0; i < 3; i++)
+        fmpz_clear(s->sqrt2[i]);
+    flint_free(s->active);
+    flint_free(s->used);
+    fmpz_clear(s->ts_r);
+    fmpz_clear(s->ts_g);
+    fmpz_clear(s->qmin);
+    fmpz_clear(s->qmax);
+    fmpz_clear(s->np1);
+    _fmpz_vec_clear(s->bm, s->balloc);
+    _fmpz_vec_clear(s->bq, s->balloc);
+    flint_free(s->bD);
+    flint_free(s->bstat);
+    flint_free(s->bveven);
+    _fmpz_vec_clear(s->tried, ctx->max_tries + 2);
+}
+
+static void
+scan_batch_fit(ecpp_scan_struct * s, slong len)
+{
+    if (len > s->balloc)
+    {
+        slong i, old = s->balloc;
+        s->balloc = FLINT_MAX(len, 2 * old);
+        s->bm = flint_realloc(s->bm, s->balloc * sizeof(fmpz));
+        s->bq = flint_realloc(s->bq, s->balloc * sizeof(fmpz));
+        s->bD = flint_realloc(s->bD, s->balloc * sizeof(slong));
+        s->bstat = flint_realloc(s->bstat, s->balloc * sizeof(signed char));
+        s->bveven = flint_realloc(s->bveven, s->balloc * sizeof(signed char));
+        for (i = old; i < s->balloc; i++)
+            s->bm[i] = s->bq[i] = 0;    /* fresh (uninitialised) memory: cannot use fmpz_zero */
+    }
+}
+
+/* parallel computation of the missing square roots for a set of discriminants */
+typedef struct
+{
+    ecpp_scan_struct * s;
+    const ulong * primes;
+    slong * which;      /* prime indices; -1, -2, -3 stand for -1, 2, -2 */
+}
+_sqrt_args;
+
+/* square root of a (a square) modulo n with the shared Tonelli-Shanks data */
+static int
+_sqrtmod_shared(fmpz_t x, const fmpz_t a, const ecpp_scan_struct * s)
+{
+    const fmpz * n = s->n;
+    fmpz_t b, g, t, e;
+    slong m, r, i;
+    int ok = 1;
+
+    fmpz_init(b); fmpz_init(g); fmpz_init(t); fmpz_init(e);
+    /* x = a^{(r+1)/2}, b = a^r = x^2 / a */
+    fmpz_add_ui(e, s->ts_r, 1);
+    fmpz_fdiv_q_2exp(e, e, 1);
+    fmpz_powm(x, a, e, n);
+    fmpz_mod_mul(b, x, x, s->mctx);
+    fmpz_mod_inv(t, a, s->mctx);
+    fmpz_mod_mul(b, b, t, s->mctx);
+    fmpz_set(g, s->ts_g);
+    r = s->ts_e;
+    while (!fmpz_is_one(b))
+    {
+        /* smallest m with b^(2^m) = 1 */
+        fmpz_set(t, b);
+        for (m = 0; m < r && !fmpz_is_one(t); m++)
+            fmpz_mod_mul(t, t, t, s->mctx);
+        if (m == r)
+        {
+            ok = 0;
+            break;
+        }
+        /* t = g^(2^(r-m-1)) */
+        fmpz_set(t, g);
+        for (i = 0; i < r - m - 1; i++)
+            fmpz_mod_mul(t, t, t, s->mctx);
+        fmpz_mod_mul(g, t, t, s->mctx);
+        fmpz_mod_mul(x, x, t, s->mctx);
+        fmpz_mod_mul(b, b, g, s->mctx);
+        r = m;
+    }
+    fmpz_clear(b); fmpz_clear(g); fmpz_clear(t); fmpz_clear(e);
+    return ok;
+}
+
+static void
+_sqrt_worker(slong i, void * varg)
+{
+    _sqrt_args * args = (_sqrt_args *) varg;
+    ecpp_scan_struct * s = args->s;
+    slong k = args->which[i];
+    fmpz_t t;
+    int ok;
+
+    fmpz_init(t);
+    if (k < 0)
+    {
+        if (k == -1) fmpz_sub_ui(t, s->n, 1);
+        else if (k == -2) fmpz_set_ui(t, 2);
+        else fmpz_sub_ui(t, s->n, 2);
+        ok = _sqrtmod_shared(s->sqrt2[-k - 1], t, s);
+        s->have2[-k - 1] = ok ? 1 : 2;
+    }
+    else
+    {
+        ulong p = args->primes[k];
+        if (p % 4 == 1)
+            fmpz_set_ui(t, p);
+        else
+            fmpz_sub_ui(t, s->n, p);
+        ok = _sqrtmod_shared(s->sqrt + k, t, s);
+        s->have[k] = ok ? 1 : 2;
+    }
+    fmpz_clear(t);
+}
+
+static void
+_scan_sqrt_prefetch(ecpp_scan_struct * s, const ecpp_ctx_struct * ctx,
+                                                const slong * idx, slong num)
+{
+    slong i, j, count = 0;
+    slong * which = flint_malloc((ctx->nprimes + 3) * sizeof(slong));
+    signed char * need = flint_calloc(ctx->nprimes + 3, sizeof(signed char));
+    _sqrt_args args;
+
+    for (i = 0; i < num; i++)
+    {
+        const ecpp_disc_struct * d = ctx->discs + idx[i];
+        if (d->q0 == -4) need[ctx->nprimes + 0] = 1;
+        if (d->q0 == 8) need[ctx->nprimes + 1] = 1;
+        if (d->q0 == -8) need[ctx->nprimes + 2] = 1;
+        for (j = 0; j < d->nfac; j++)
+            need[d->fac[j]] = 1;
+    }
+    for (j = 0; j < 3; j++)
+        if (need[ctx->nprimes + j] && s->have2[j] == 0)
+            which[count++] = -1 - j;
+    for (j = 0; j < ctx->nprimes; j++)
+        if (need[j] && s->have[j] == 0)
+            which[count++] = j;
+
+    args.s = s;
+    args.primes = ctx->primes;
+    args.which = which;
+    if (count == 1 || !ctx->use_threads)
+    {
+        slong q;
+        for (q = 0; q < count; q++)
+            _sqrt_worker(q, &args);
+    }
+    else if (count > 1)
+        flint_parallel_do(_sqrt_worker, &args, count, 0, FLINT_PARALLEL_STRIDED);
+#ifdef ECPP_PROFILE
+    prof_nsqrt += count;
+#endif
+
+    flint_free(which);
+    flint_free(need);
+}
+
+/* sqrt(D) mod n from the cached roots; 0 if some root is missing */
+static int
+_scan_sqrt_disc(fmpz_t r, const ecpp_scan_struct * s, const ecpp_disc_struct * d)
+{
+    slong i;
+
+    if (d->q0 == 1)
+        fmpz_one(r);
+    else
+    {
+        slong j = (d->q0 == -4) ? 0 : (d->q0 == 8) ? 1 : 2;
+        if (s->have2[j] != 1)
+            return 0;
+        fmpz_mod_add(r, s->sqrt2[j], s->sqrt2[j], s->mctx);
+    }
+    for (i = 0; i < d->nfac; i++)
+    {
+        slong k = d->fac[i];
+        if (s->have[k] != 1)
+            return 0;
+        fmpz_mod_mul(r, r, s->sqrt + k, s->mctx);
+    }
+    return 1;
+}
+
+/* Cornacchia and the possible orders for a set of discriminants, in parallel */
+typedef struct
+{
+    ecpp_scan_struct * s;
+    const ecpp_ctx_struct * ctx;
+    const slong * idx;
+    fmpz * m;           /* 6 per discriminant */
+    slong * norders;
+    signed char * veven;
+}
+_corn_args;
+
+static void
+_corn_worker(slong w, void * varg)
+{
+    _corn_args * args = (_corn_args *) varg;
+    ecpp_scan_struct * s = args->s;
+    const ecpp_disc_struct * d = args->ctx->discs + args->idx[w];
+    fmpz * ms = args->m + 6 * w;
+    fmpz_t sqrtD, t, v, u;
+    slong norders = 0;
+
+    fmpz_init(sqrtD); fmpz_init(t); fmpz_init(v); fmpz_init(u);
+
+    if (_scan_sqrt_disc(sqrtD, s, d) && ecpp_cornacchia(t, v, s->n, d->D, sqrtD))
+    {
+        fmpz_add((ms + 0), s->np1, t);
+        fmpz_sub((ms + 1), s->np1, t);
+        norders = 2;
+        if (d->D == -4)
+        {
+            fmpz_mul_2exp(u, v, 1);
+            fmpz_add((ms + 2), s->np1, u);
+            fmpz_sub((ms + 3), s->np1, u);
+            norders = 4;
+        }
+        else if (d->D == -3)
+        {
+            fmpz_mul_ui(u, v, 3);
+            fmpz_add((ms + 2), t, u);
+            fmpz_fdiv_q_2exp((ms + 2), (ms + 2), 1);
+            fmpz_sub((ms + 3), t, u);
+            fmpz_fdiv_q_2exp((ms + 3), (ms + 3), 1);
+            fmpz_add((ms + 4), s->np1, (ms + 2));
+            fmpz_sub((ms + 5), s->np1, (ms + 2));
+            fmpz_add((ms + 2), s->np1, (ms + 3));
+            fmpz_sub((ms + 3), s->np1, (ms + 3));
+            norders = 6;
+        }
+    }
+    args->norders[w] = norders;
+    args->veven[w] = (norders > 0) ? fmpz_is_even(v) : 0;
+
+    fmpz_clear(sqrtD); fmpz_clear(t); fmpz_clear(v); fmpz_clear(u);
+}
+
+typedef struct
+{
+    fmpz q;
+    fmpz m;
+    slong D;
+    int veven;
+}
+_bq_entry;
+
+static int
+_bq_cmp(const void * x, const void * y)
+{
+    return fmpz_cmp(&((const _bq_entry *) x)->q, &((const _bq_entry *) y)->q);
+}
+
+/*
+    Collects the next batch of orders. As in Enge's CM library (following
+    Franke, Kleinjung, Morain and Wirth), the set of primes with a square
+    root modulo n is extended, in increasing order and skipping the
+    non-residues, until the discriminants of the pool that become
+    available (all their odd primes in the set, the character at 2 equal
+    to 1, not yet used for this n) are expected to yield about three
+    prime cofactors; then square roots (in parallel), Cornacchia for all
+    those discriminants (in parallel), removal of the small prime factors
+    of the orders with one remainder tree, and the admissible cofactors
+    sorted by size. Returns the number of cofactors, 0 when the primes are
+    exhausted.
+*/
+static slong
+_scan_fill_batch(ecpp_scan_struct * s, ecpp_ctx_struct * ctx)
+{
+    slong pmax_tune, hmax, tdivexp, i, j, w;
+    slong * idx, * norders;
+    fmpz * ms;
+    signed char * veven, * mveven;
+    _corn_args cargs;
+    slong nm = 0, malloc_m = 64, nidx = 0, idx_alloc = 256;
+    fmpz * mlist;
+    slong * mD;
+    double prob_prime, expected;
+/* expected prime cofactors per round; the estimate below is optimistic
+   (the admissibility of a cofactor is not accounted for): with 3.0 about
+   11% of the rounds yield no prime and cost a full batch of tests */
+    const double min_prime = ECPP_MIN_PRIME;
+
+    _ecpp_tune(s->bits, &pmax_tune, &hmax, &tdivexp);
+    tdivexp = ctx->tdivexp;
+    if (s->bits < 1000)
+    {
+        /* down the chain of a small input, the primorial's size matters:
+           the size-tuned bound rather than the input's */
+        slong pm2, hm2;
+        _ecpp_tune(s->bits, &pm2, &hm2, &tdivexp);
+        tdivexp = FLINT_MIN(tdivexp, ctx->tdivexp);
+    }
+    prob_prime = 1.7811 * tdivexp / (double) s->bits;
+
+    idx = flint_malloc(idx_alloc * sizeof(slong));
+    mlist = _fmpz_vec_init(malloc_m);
+    mD = flint_malloc(malloc_m * sizeof(slong));
+    mveven = flint_malloc(malloc_m * sizeof(signed char));
+
+    s->nb = s->bpos = 0;
+
+    while (nm == 0 && s->pprime < ctx->nprimes)
+    {
+        slong * newp = flint_malloc(ctx->nprimes * sizeof(slong));
+        slong nnew = 0;
+
+        /* extend the prime set until enough is expected */
+        expected = 0.0;
+        while (expected < min_prime && s->pprime < ctx->nprimes)
+        {
+            slong k = s->pprime++;
+            ulong p = ctx->primes[k];
+
+            if (s->sym[k] == 0)
+                s->sym[k] = n_jacobi(fmpz_fdiv_ui(s->n, p), p) == 1 ? 1 : -1;
+            if (s->sym[k] != 1)
+                continue;
+            s->active[k] = 1;
+            newp[nnew++] = k;
+
+            /* discriminants that become available with p */
+            for (i = 0; i < ctx->ndiscs; i++)
+            {
+                const ecpp_disc_struct * d = ctx->discs + i;
+                int ok = !s->used[i], has = 0;
+                if (d->q0 == -4 && s->sym2[0] != 1) ok = 0;
+                if (d->q0 == 8 && s->sym2[1] != 1) ok = 0;
+                if (d->q0 == -8 && s->sym2[2] != 1) ok = 0;
+                for (j = 0; j < d->nfac && ok; j++)
+                {
+                    if (d->fac[j] == k)
+                        has = 1;
+                    else if (!s->active[d->fac[j]])
+                        ok = 0;
+                }
+                if (!ok || !has)
+                    continue;
+                s->used[i] = 1;
+                if (nidx == idx_alloc)
+                {
+                    idx_alloc *= 2;
+                    idx = flint_realloc(idx, idx_alloc * sizeof(slong));
+                }
+                idx[nidx++] = i;
+                /* orders per success times the success probability 2^{g-1}/h */
+                expected += prob_prime * ((d->D == -3) ? 6.0 : (d->D == -4) ? 4.0 : 2.0) / d->o;
+            }
+        }
+        /* discriminants without odd prime factor (-4, -8) on the first round */
+        if (s->pprime <= nnew + 1)
+        {
+            for (i = 0; i < ctx->ndiscs; i++)
+            {
+                const ecpp_disc_struct * d = ctx->discs + i;
+                if (d->nfac == 0 && !s->used[i])
+                {
+                    if ((d->q0 == -4 && s->sym2[0] == 1) || (d->q0 == 8 && s->sym2[1] == 1)
+                                                        || (d->q0 == -8 && s->sym2[2] == 1))
+                    {
+                        s->used[i] = 1;
+                        idx[nidx++] = i;
+                    }
+                }
+            }
+        }
+        flint_free(newp);
+        if (nidx == 0)
+            continue;
+#ifdef ECPP_PROFILE
+        prof_ndisc += nidx;
+#endif
+
+        {
+            PROF_START(ta);
+            _scan_sqrt_prefetch(s, ctx, idx, nidx);
+            PROF_ADD(prof_sqrt, ta);
+        }
+
+        norders = flint_malloc(nidx * sizeof(slong));
+        ms = _fmpz_vec_init(6 * nidx);
+        veven = flint_malloc(nidx * sizeof(signed char));
+        {
+            PROF_START(tb);
+            cargs.s = s; cargs.ctx = ctx; cargs.idx = idx; cargs.m = ms; cargs.norders = norders;
+            cargs.veven = veven;
+            if (nidx == 1 || !ctx->use_threads)
+            {
+                for (w = 0; w < nidx; w++)
+                    _corn_worker(w, &cargs);
+            }
+            else
+                flint_parallel_do(_corn_worker, &cargs, nidx, 0, FLINT_PARALLEL_STRIDED);
+            PROF_ADD(prof_corn, tb);
+        }
+
+        for (w = 0; w < nidx; w++)
+        {
+            for (j = 0; j < norders[w]; j++)
+            {
+                if (fmpz_sgn(ms + 6 * w + j) <= 0)
+                    continue;
+                if (nm == malloc_m)
+                {
+                    malloc_m *= 2;
+                    mlist = flint_realloc(mlist, malloc_m * sizeof(fmpz));
+                    mD = flint_realloc(mD, malloc_m * sizeof(slong));
+                    mveven = flint_realloc(mveven, malloc_m * sizeof(signed char));
+                    for (i = nm; i < malloc_m; i++)
+                        mlist[i] = 0;
+                }
+                fmpz_set(mlist + nm, ms + 6 * w + j);
+                mD[nm] = idx[w];
+                mveven[nm] = veven[w];
+                nm++;
+            }
+        }
+        flint_free(norders);
+        flint_free(veven);
+        _fmpz_vec_clear(ms, 6 * nidx);
+        nidx = 0;
+    }
+
+    if (nm > 0)
+    {
+        /* batch removal of the primes below 2^tdivexp: r_i = primorial mod m_i */
+        fmpz_multi_mod_t P;
+        fmpz * r;
+        fmpz_t g, q;
+        _bq_entry * ent;
+        slong ne = 0;
+        PROF_START(tc);
+
+        r = _fmpz_vec_init(nm);
+        /* the primorial is huge: reduce it once modulo the product of the
+           orders (fmpz_multi_mod_precomp would do this twice), then the
+           remainder tree */
+        fmpz_multi_mod_init(P);
+        fmpz_multi_mod_precompute(P, mlist, nm);
+        {
+            /* the big division with a precomputed inverse (about three
+               times faster than GMP's division at these sizes) */
+            fmpz_t prod, r0;
+            fmpz_preinvn_t inv;
+            fmpz_init(prod);
+            fmpz_init(r0);
+            _fmpz_vec_prod(prod, mlist, nm);
+            fmpz_preinvn_init(inv, prod);
+            {
+                /* the primorial as a product of chunks: reduced in
+                   parallel, then multiplied modulo prod */
+                _chunk_args cargs2;
+                fmpz * rk = _fmpz_vec_init(ECPP_PRIMORIAL_CHUNKS);
+                slong k;
+                _ecpp_primorial(ctx, tdivexp);
+                cargs2.chunks = ctx->primorial_chunk[tdivexp];
+                cargs2.prod = prod;
+                cargs2.inv = inv;
+                cargs2.r = rk;
+                if (ctx->use_threads)
+                {
+                    flint_parallel_do(_chunk_worker, &cargs2, ECPP_PRIMORIAL_CHUNKS, 0, FLINT_PARALLEL_STRIDED);
+                    fmpz_set(r0, rk + 0);
+                    for (k = 1; k < ECPP_PRIMORIAL_CHUNKS; k++)
+                    {
+                        fmpz_mul(r0, r0, rk + k);
+                        fmpz_fdiv_r_preinvn(r0, r0, prod, inv);
+                    }
+                }
+                else
+                    fmpz_fdiv_r_preinvn(r0, ctx->primorial + tdivexp, prod, inv);
+                _fmpz_vec_clear(rk, ECPP_PRIMORIAL_CHUNKS);
+            }
+            fmpz_preinvn_clear(inv);
+            fmpz_multi_mod_precomp(r, P, r0, 0);
+            fmpz_clear(prod);
+            fmpz_clear(r0);
+        }
+        fmpz_multi_mod_clear(P);
+
+        fmpz_init(g);
+        fmpz_init(q);
+        ent = flint_malloc(nm * sizeof(_bq_entry));
+
+        for (i = 0; i < nm; i++)
+        {
+            fmpz_gcd(g, r + i, mlist + i);
+            if (fmpz_is_one(g))
+                continue;       /* no small factor at all: unusable */
+            fmpz_set(q, mlist + i);
+            while (!fmpz_is_one(g))
+            {
+                fmpz_divexact(q, q, g);
+                fmpz_gcd(g, q, g);
+            }
+            if (fmpz_cmp(q, s->qmin) < 0 || fmpz_cmp(q, s->qmax) > 0)
+                continue;
+            for (j = 0; j < s->ntried; j++)
+                if (fmpz_equal(q, s->tried + j))
+                    break;
+            if (j < s->ntried)
+                continue;
+            fmpz_init_set(&ent[ne].q, q);
+            fmpz_init_set(&ent[ne].m, mlist + i);
+            ent[ne].D = mD[i];
+            ent[ne].veven = mveven[i];
+            ne++;
+        }
+        qsort(ent, ne, sizeof(_bq_entry), _bq_cmp);
+
+        scan_batch_fit(s, ne);
+        for (i = 0; i < ne; i++)
+        {
+            fmpz_swap(s->bq + i, &ent[i].q);
+            fmpz_swap(s->bm + i, &ent[i].m);
+            s->bD[i] = ent[i].D;
+            s->bveven[i] = ent[i].veven;
+            s->bstat[i] = 0;
+            fmpz_clear(&ent[i].q);
+            fmpz_clear(&ent[i].m);
+        }
+        s->nb = ne;
+        flint_free(ent);
+        _fmpz_vec_clear(r, nm);
+        fmpz_clear(g);
+        fmpz_clear(q);
+        PROF_ADD(prof_split, tc);
+#ifdef ECPP_PROFILE
+        prof_nsplit += nm; prof_nbatch++;
+#endif
+    }
+
+    flint_free(idx);
+    _fmpz_vec_clear(mlist, malloc_m);
+    flint_free(mD);
+    flint_free(mveven);
+
+    return s->nb;
+}
+
+/* probable primality of a chunk of cofactors, in parallel */
+typedef struct
+{
+    const fmpz * q;
+    int * res;
+}
+_bpsw_args;
+
+static void
+_bpsw_worker(slong i, void * varg)
+{
+    _bpsw_args * args = (_bpsw_args *) varg;
+    /* the cofactors have no small prime factors: straight to BPSW */
+    args->res[i] = fmpz_is_probabprime_BPSW(args->q + i);
+}
+
+/*
+    The next candidate (D, m, q) for n: among the probable prime cofactors
+    of the current batch (all of which are tested, in parallel, when the
+    batch is new), the one with the best estimated cost per bit gained that
+    has not been returned yet; when the batch is used up, the next batch.
+    Returns 1 and fills c, or 0 if the pool is exhausted.
+*/
+static int
+_scan_next_candidate(ecpp_scan_struct * s, ecpp_ctx_struct * ctx, ecpp_cand_struct * c)
+{
+    slong nthreads = ctx->use_threads ? flint_get_num_threads() : 1;
+    int * res = flint_malloc(nthreads * sizeof(int));
+    _bpsw_args args;
+    int found = 0;
+
+    /* tests beyond the first probable prime when its degree is not small */
+    const slong extra = FLINT_MAX(16, 4 * nthreads);
+
+    while (!found)
+    {
+        slong i, best = -1;
+        double best_score = 0;
+
+        {
+            int unused = 0;
+            for (i = 0; i < s->bpos; i++)
+                if (s->bstat[i] == 1)
+                    unused = 1;
+            if (s->bpos >= s->nb && !unused)
+            {
+                /* current batch used up: next one */
+                if (s->pprime >= ctx->nprimes)
+                {
+                    /*
+                        The prime set is exhausted without a candidate
+                        (an n for which few discriminants are usable, e.g.
+                        n = 7 mod 8 excludes all D = -4m, -8m, and no
+                        cofactor happened to be prime). Before giving up,
+                        run the pool again with every gain accepted: the
+                        minimum gain is only a speed heuristic. The square
+                        roots are kept.
+                    */
+                    if (s->delta > 1)
+                    {
+                        s->delta = 1;
+                        fmpz_fdiv_q_2exp(s->qmax, s->n, 1);
+                        s->pprime = 0;
+                        s->pos = 0;
+                        memset(s->active, 0, ctx->nprimes);
+                        memset(s->used, 0, ctx->ndiscs);
+                        s->nb = s->bpos = 0;
+                        continue;
+                    }
+                    break;
+                }
+                if (_scan_fill_batch(s, ctx) == 0)
+                    continue;
+            }
+        }
+
+        /*
+            Test the untested cofactors, smallest first. The first probable
+            prime is the one with the largest gain; testing further only
+            pays if a candidate with a much cheaper realisation turns up,
+            so stop as soon as one with a cheap realisation has been
+            found, and otherwise after a few more tests.
+        */
+        while (s->bpos < s->nb)
+        {
+            if (best >= 0 && (ecpp_disc_cost_n(ctx->discs + s->bD[best], s->bveven[best], s->nmodp, s->bits) < 6.0
+                                || s->bpos >= best + extra))
+                break;
+            slong chunk = FLINT_MIN(nthreads, s->nb - s->bpos), b;
+            PROF_START(td);
+
+            args.q = s->bq + s->bpos;
+            args.res = res;
+            if (chunk == 1 || !ctx->use_threads)
+            {
+                for (b = 0; b < chunk; b++)
+                    _bpsw_worker(b, &args);
+            }
+            else
+                flint_parallel_do(_bpsw_worker, &args, chunk, 0, FLINT_PARALLEL_STRIDED);
+            PROF_ADD(prof_bpsw, td);
+#ifdef ECPP_PROFILE
+            prof_nbpsw += chunk;
+#endif
+            for (b = 0; b < chunk; b++)
+            {
+                s->bstat[s->bpos + b] = res[b] ? 1 : 2;
+                if (res[b] && best == -1)
+                    best = s->bpos + b;
+            }
+            s->bpos += chunk;
+        }
+
+#ifdef ECPP_PROFILE
+        {
+            slong np = 0;
+            for (i = 0; i < s->bpos; i++)
+                np += (s->bstat[i] == 1);
+            if (np == 0 && s->bpos >= s->nb)
+                prof_nobatch++, prof_nobatch_tests += s->nb;
+            if (s->bpos == s->nb) prof_fullbatch++;
+        }
+#endif
+        best = -1;
+        for (i = 0; i < s->bpos; i++)
+        {
+            if (s->bstat[i] == 1)
+            {
+                slong gain = FLINT_MAX(1, s->bits - (slong) fmpz_bits(s->bq + i));
+                /* realisation cost plus the per-step cost of the scan
+                   (square roots, batch factoring, tests), in units of a
+                   scalar multiplication, per bit gained */
+                double cst = ecpp_disc_cost_n(ctx->discs + s->bD[i], s->bveven[i], s->nmodp, s->bits);
+                double score = (cst + 4.0 + s->bits / 500.0) / gain;
+                if (cst >= 1e5)
+                {
+                    s->bstat[i] = 2;    /* never realised (no way to a curve) */
+                    continue;
+                }
+                if (best == -1 || score < best_score)
+                {
+                    best = i;
+                    best_score = score;
+                }
+            }
+        }
+
+        if (best >= 0)
+        {
+            const ecpp_disc_struct * d = ctx->discs + s->bD[best];
+            c->D = d->D;
+            c->h = d->h;
+            c->o = d->o;
+            c->cost = d->cost;
+            c->veven = s->bveven[best];
+            c->use_tower = ecpp_disc_use_tower(d, c->veven, &c->Dtower);
+            c->cost = ecpp_disc_cost_n(d, c->veven, s->nmodp, s->bits);
+            c->g = 0;
+            for (i = 0; i < d->nfac; i++)
+            {
+                ulong p = ctx->primes[d->fac[i]];
+                c->pstar[c->g] = (p % 4 == 1) ? (slong) p : -(slong) p;
+                fmpz_set(c->sqrts + c->g, s->sqrt + d->fac[i]);
+                c->g++;
+            }
+            if (d->q0 != 1)
+            {
+                slong j = (d->q0 == -4) ? 0 : (d->q0 == 8) ? 1 : 2;
+                c->pstar[c->g] = d->q0;
+                fmpz_mod_add(c->sqrts + c->g, s->sqrt2[j], s->sqrt2[j], s->mctx);
+                c->g++;
+            }
+            fmpz_set(c->m, s->bm + best);
+            fmpz_set(c->q, s->bq + best);
+            s->bstat[best] = 2;
+            found = 1;
+        }
+    }
+
+    flint_free(res);
+    return found;
+}
+
+/* the curve y^2 = x^3 + a x + b with given j-invariant (j != 0, 1728) */
+static void
+_ecpp_curve_from_j(fmpz_t a, fmpz_t b, const fmpz_t j, const fmpz_mod_ctx_t ctx)
+{
+    fmpz_t k, t;
+
+    fmpz_init(k);
+    fmpz_init(t);
+
+    /* k = j / (1728 - j); a = 3k, b = 2k */
+    fmpz_set_ui(t, 1728);
+    fmpz_mod_sub(t, t, j, ctx);
+    fmpz_mod_inv(t, t, ctx);
+    fmpz_mod_mul(k, j, t, ctx);
+    fmpz_mod_add(a, k, k, ctx);
+    fmpz_mod_add(b, a, k, ctx);     /* b = 3k for the moment */
+    fmpz_swap(a, b);                /* a = 3k, b = 2k */
+
+    fmpz_clear(k);
+    fmpz_clear(t);
+}
+
+/* a random point on y^2 = x^3 + a x + b; returns 0 if none was found */
+static int
+_ecpp_random_point(fmpz_t x, fmpz_t y, const fmpz_t a, const fmpz_t b,
+                                    flint_rand_t state, const fmpz_mod_ctx_t ctx)
+{
+    const fmpz * n = fmpz_mod_ctx_modulus(ctx);
+    fmpz_t rhs, t;
+    slong tries;
+    int found = 0;
+
+    fmpz_init(rhs);
+    fmpz_init(t);
+
+    for (tries = 0; tries < 200 && !found; tries++)
+    {
+        fmpz_randm(x, state, n);
+        fmpz_mod_mul(rhs, x, x, ctx);
+        fmpz_mod_add(rhs, rhs, a, ctx);
+        fmpz_mod_mul(rhs, rhs, x, ctx);
+        fmpz_mod_add(rhs, rhs, b, ctx);
+
+        if (fmpz_jacobi(rhs, n) != 1)
+            continue;
+        if (!fmpz_sqrtmod(y, rhs, n))
+            continue;
+        fmpz_mod_mul(t, y, y, ctx);
+        found = fmpz_equal(t, rhs);
+    }
+
+    fmpz_clear(rhs);
+    fmpz_clear(t);
+    return found;
+}
+
+/*
+    Given a curve (a, b) and m = k q, look for a point P with m P = O and
+    k P != O. Returns 1 and sets (x, y) on success, 0 if m is not the
+    order of the curve (or the point was unlucky), -1 if n was found to be
+    composite. m P is computed as q (k P), with k P normalised to affine
+    coordinates first, so that the cost is that of a multiplication by q
+    plus one by k.
+*/
+static int
+_ecpp_find_point(fmpz_t x, fmpz_t y, const fmpz_t a, const fmpz_t b,
+        const fmpz_t q, const fmpz_t k, flint_rand_t state,
+        const fmpz_mod_ctx_t ctx)
+{
+    const fmpz * n = fmpz_mod_ctx_modulus(ctx);
+    ecpp_point_t P, R;
+    fmpz_t acc, g, zi;
+    slong tries;
+    int result = 0;
+
+    ecpp_point_init(P);
+    ecpp_point_init(R);
+    fmpz_init(acc);
+    fmpz_init(g);
+    fmpz_init(zi);
+
+    for (tries = 0; tries < 4; tries++)
+    {
+        if (!_ecpp_random_point(x, y, a, b, state, ctx))
+        {
+            result = 0;
+            break;
+        }
+
+        ecpp_point_set_affine(P, x, y);
+        fmpz_one(acc);
+
+        /* R = k P; then q R should be O and R != O */
+        ecpp_point_mul(R, P, k, a, acc, ctx);
+        if (ecpp_point_is_zero(R))
+            continue;   /* unlucky point (or wrong order); try another */
+
+        /* affine R = (X / Z^2, Y / Z^3) */
+        fmpz_gcd(g, R->Z, n);
+        if (!fmpz_is_one(g))
+        {
+            result = -1;
+            break;
+        }
+        fmpz_mod_inv(zi, R->Z, ctx);
+        fmpz_mod_mul(g, zi, zi, ctx);
+        fmpz_mod_mul(R->X, R->X, g, ctx);
+        fmpz_mod_mul(g, g, zi, ctx);
+        fmpz_mod_mul(R->Y, R->Y, g, ctx);
+        fmpz_one(R->Z);
+
+        ecpp_point_mul(P, R, q, a, acc, ctx);
+
+        fmpz_gcd(g, acc, n);
+        if (!fmpz_is_one(g))
+        {
+            result = -1;
+            break;
+        }
+
+        if (!ecpp_point_is_zero(P))
+        {
+            result = 0;     /* m is not the order of this twist */
+            break;
+        }
+
+        result = 1;
+        break;
+    }
+
+    ecpp_point_clear(P);
+    ecpp_point_clear(R);
+    fmpz_clear(acc);
+    fmpz_clear(g);
+    fmpz_clear(zi);
+
+    return result;
+}
+
+/*
+    One root modulo n of the Hilbert class polynomial H_D, which splits
+    into linear factors modulo n when Cornacchia succeeded for D (n splits
+    completely in the Hilbert class field). We therefore skip the
+    computation of gcd(x^n - x, H_D) and split directly with random
+    (x + r)^{(n-1)/2} - 1, keeping a smaller factor each time.
+*/
+static int
+_ecpp_class_poly_root(fmpz_t j, const ecpp_cand_struct * c, flint_rand_t state, const fmpz_mod_ctx_t ctx)
+{
+    const fmpz * n = fmpz_mod_ctx_modulus(ctx);
+    slong D = c->D;
+    fmpz_poly_t H;
+    fmpz_mod_poly_t f, g, base, pw, finv;
+    fmpz_t e, r, t;
+    slong tries = 0;
+    int found = 0;
+
+    fmpz_poly_init(H);
+    fmpz_mod_poly_init(f, ctx);
+    fmpz_mod_poly_init(g, ctx);
+    fmpz_mod_poly_init(base, ctx);
+    fmpz_mod_poly_init(pw, ctx);
+    fmpz_mod_poly_init(finv, ctx);
+    fmpz_init(e);
+    fmpz_init(r);
+    fmpz_init(t);
+
+    {
+        PROF_START(t0);
+        /* the class field tower first (Weber invariant for even D), then
+           the factor of H_D over the genus field (degree h / 2^{g-1}) when
+           there is one, else H_D itself */
+        /* odd D with v even: the order of conductor 2 admits the Weber
+           invariant, and its curves have Frobenius (t + v sqrt D) / 2 in
+           Z[sqrt D], so a curve of the right order is among them */
+        if (c->use_tower && ecpp_class_poly_tower(j, c->Dtower, state, ctx))
+        {
+            PROF_ADD(prof_hilbert, t0);
+            found = 1;
+            goto cleanup;
+        }
+        if (c->g < 2 || !ecpp_class_poly_genus(f, D, c->pstar, c->g, c->sqrts, ctx))
+        {
+            if (c->g >= 2 && c->h > 4 * c->o + 8)
+            {
+                /* the genus factor failed and H_D is much larger than what
+                   the candidate was priced at: give up on this candidate */
+                PROF_ADD(prof_hilbert, t0);
+                goto cleanup;
+            }
+            acb_modular_hilbert_class_poly(H, D);
+            fmpz_mod_poly_set_fmpz_poly(f, H, ctx);
+            fmpz_mod_poly_make_monic(f, f, ctx);
+        }
+        PROF_ADD(prof_hilbert, t0);
+    }
+
+    fmpz_sub_ui(e, n, 1);
+    fmpz_fdiv_q_2exp(e, e, 1);          /* e = (n - 1) / 2 */
+
+    {
+    PROF_START(t1);
+    /* degrees 2, 3, 4 by radicals when possible (a few square and cube roots) */
+    if (fmpz_mod_poly_degree(f, ctx) >= 2 && fmpz_mod_poly_degree(f, ctx) <= 4
+            && ecpp_root_radicals(j, f, state, ctx))
+        found = 1;
+    while (!found && fmpz_mod_poly_degree(f, ctx) > 1 && tries < 20)
+    {
+        slong d = fmpz_mod_poly_degree(f, ctx);
+
+        if (d == 2)
+        {
+            /* x^2 + c1 x + c0: root = (-c1 +- sqrt(c1^2 - 4 c0)) / 2 */
+            fmpz_t c0, c1;
+            fmpz_init(c0);
+            fmpz_init(c1);
+            fmpz_mod_poly_get_coeff_fmpz(c0, f, 0, ctx);
+            fmpz_mod_poly_get_coeff_fmpz(c1, f, 1, ctx);
+            fmpz_mod_mul(t, c1, c1, ctx);
+            fmpz_mod_mul_ui(r, c0, 4, ctx);
+            fmpz_mod_sub(t, t, r, ctx);
+            if (fmpz_sqrtmod(r, t, n))
+            {
+                fmpz_mod_sub(r, r, c1, ctx);
+                fmpz_set_ui(t, 2);
+                fmpz_mod_inv(t, t, ctx);
+                fmpz_mod_mul(j, r, t, ctx);
+                found = 1;
+            }
+            fmpz_clear(c0);
+            fmpz_clear(c1);
+            break;
+        }
+
+        /* g = gcd((x + r)^e - 1, f), with a precomputed inverse of rev(f) */
+        tries++;
+        fmpz_randm(r, state, n);
+        fmpz_mod_poly_zero(base, ctx);
+        fmpz_mod_poly_set_coeff_fmpz(base, 0, r, ctx);
+        fmpz_mod_poly_set_coeff_ui(base, 1, 1, ctx);
+        if (d >= 12)
+        {
+            fmpz_mod_poly_reverse(finv, f, d + 1, ctx);
+            fmpz_mod_poly_inv_series(finv, finv, d + 1, ctx);
+            fmpz_mod_poly_powmod_fmpz_binexp_preinv(pw, base, e, f, finv, ctx);
+        }
+        else
+            fmpz_mod_poly_powmod_fmpz_binexp(pw, base, e, f, ctx);
+        fmpz_mod_poly_get_coeff_fmpz(t, pw, 0, ctx);
+        fmpz_sub_ui(t, t, 1);
+        fmpz_mod_poly_set_coeff_fmpz(pw, 0, t, ctx);
+        if (fmpz_mod_poly_is_zero(pw, ctx))
+            continue;
+        fmpz_mod_poly_gcd(g, pw, f, ctx);
+
+        {
+            slong dg = fmpz_mod_poly_degree(g, ctx);
+            if (dg <= 0 || dg >= d)
+                continue;
+            /* keep the smaller of g and f / g */
+            if (2 * dg > d)
+                fmpz_mod_poly_divrem(g, pw, f, g, ctx);
+            fmpz_mod_poly_swap(f, g, ctx);
+        }
+    }
+    PROF_ADD(prof_roots, t1);
+    }
+
+    if (!found && fmpz_mod_poly_degree(f, ctx) == 1)
+    {
+        fmpz_mod_poly_get_coeff_fmpz(j, f, 0, ctx);
+        fmpz_mod_neg(j, j, ctx);
+        found = 1;
+    }
+
+cleanup:
+    fmpz_mod_poly_clear(f, ctx);
+    fmpz_mod_poly_clear(g, ctx);
+    fmpz_mod_poly_clear(base, ctx);
+    fmpz_mod_poly_clear(pw, ctx);
+    fmpz_mod_poly_clear(finv, ctx);
+    fmpz_poly_clear(H);
+    fmpz_clear(e);
+    fmpz_clear(r);
+    fmpz_clear(t);
+
+    return found;
+}
+
+/* the two twists of a curve with j != 0, 1728 tried in parallel */
+typedef struct
+{
+    const fmpz * a;
+    const fmpz * b;
+    const fmpz * g;
+    const fmpz * q;
+    const fmpz * k;
+    const fmpz_mod_ctx_struct * ctx;
+    fmpz * x;   /* 2 each */
+    fmpz * y;
+    fmpz * ta;
+    fmpz * tb;
+    int * res;
+    ulong seed;
+}
+_twist_args;
+
+static void
+_twist_worker(slong i, void * varg)
+{
+    _twist_args * args = (_twist_args *) varg;
+    flint_rand_t state;
+    fmpz_t t;
+
+    flint_rand_init(state);
+    flint_rand_set_seed(state, args->seed + 1000003 * i, 87654321 + i);
+    fmpz_init(t);
+    if (i == 0)
+    {
+        fmpz_set(args->ta + 0, args->a);
+        fmpz_set(args->tb + 0, args->b);
+    }
+    else
+    {
+        /* (a, b) -> (a g^2, b g^3) */
+        fmpz_mod_mul(t, args->g, args->g, args->ctx);
+        fmpz_mod_mul(args->ta + 1, args->a, t, args->ctx);
+        fmpz_mod_mul(t, t, args->g, args->ctx);
+        fmpz_mod_mul(args->tb + 1, args->b, t, args->ctx);
+    }
+    args->res[i] = _ecpp_find_point(args->x + i, args->y + i, args->ta + i,
+                                    args->tb + i, args->q, args->k, state, args->ctx);
+    fmpz_clear(t);
+    flint_rand_clear(state);
+}
+
+/*
+    Realise a candidate (D, m, q) for n: find curve and point. Returns 1
+    and fills the step, 0 if it did not work out, -1 if n is composite.
+*/
+static int
+_ecpp_realise(ecpp_step_struct * s, const fmpz_t n, const ecpp_cand_struct * c,
+                                flint_rand_t state, const fmpz_mod_ctx_t ctx)
+{
+    fmpz_t j, a, b, g, k, t, x, y;
+    slong twist, ntwists;
+    int result = 0;
+
+    fmpz_init(j); fmpz_init(a); fmpz_init(b); fmpz_init(g);
+    fmpz_init(k); fmpz_init(t); fmpz_init(x); fmpz_init(y);
+
+    fmpz_divexact(k, c->m, c->q);
+
+    /* a generator of the twists: a non-square (and non-cube for D = -3) */
+    fmpz_sub_ui(t, n, 1);
+    while (1)
+    {
+        fmpz_randm(g, state, n);
+        if (fmpz_jacobi(g, n) != -1)
+            continue;
+        if (c->D == -3)
+        {
+            fmpz_divexact_ui(t, t, 3);
+            fmpz_powm(b, g, t, n);
+            fmpz_mul_ui(t, t, 3);
+            if (fmpz_is_one(b))
+                continue;
+        }
+        break;
+    }
+
+    if (c->D == -3)
+    {
+        /* y^2 = x^3 + g^i, i = 0..5 */
+        fmpz_zero(a);
+        fmpz_one(b);
+        ntwists = 6;
+    }
+    else if (c->D == -4)
+    {
+        /* y^2 = x^3 + g^i x, i = 0..3 */
+        fmpz_one(a);
+        fmpz_zero(b);
+        ntwists = 4;
+    }
+    else
+    {
+        if (!_ecpp_class_poly_root(j, c, state, ctx))
+            goto cleanup;
+        _ecpp_curve_from_j(a, b, j, ctx);
+        ntwists = 2;
+    }
+
+    if (ntwists == 2 && flint_get_num_threads() >= 2)
+    {
+        /* both twists at once: costs one more scalar multiplication on
+           average, halves the wall time */
+        _twist_args args;
+        fmpz xs[2], ys[2], tas[2], tbs[2];
+        int res[2];
+        slong w;
+
+        for (w = 0; w < 2; w++)
+        {
+            fmpz_init(xs + w); fmpz_init(ys + w);
+            fmpz_init(tas + w); fmpz_init(tbs + w);
+        }
+        args.a = a; args.b = b; args.g = g; args.q = c->q; args.k = k; args.ctx = ctx;
+        args.x = xs; args.y = ys; args.ta = tas; args.tb = tbs; args.res = res;
+        args.seed = n_randlimb(state);
+        {
+            PROF_START(t2);
+            flint_parallel_do(_twist_worker, &args, 2, 2, FLINT_PARALLEL_STRIDED);
+            PROF_ADD(prof_points, t2);
+#ifdef ECPP_PROFILE
+            prof_twists += 2;
+#endif
+        }
+        for (w = 0; w < 2; w++)
+        {
+            if (res[w] == -1)
+                result = -1;
+            else if (res[w] == 1 && result != -1)
+            {
+                fmpz_set(s->n, n);
+                s->D = c->D;
+                fmpz_set(s->a, tas + w);
+                fmpz_set(s->b, tbs + w);
+                fmpz_set(s->m, c->m);
+                fmpz_set(s->q, c->q);
+                fmpz_set(s->x, xs + w);
+                fmpz_set(s->y, ys + w);
+                result = 1;
+            }
+        }
+        for (w = 0; w < 2; w++)
+        {
+            fmpz_clear(xs + w); fmpz_clear(ys + w);
+            fmpz_clear(tas + w); fmpz_clear(tbs + w);
+        }
+        goto cleanup;
+    }
+
+    for (twist = 0; twist < ntwists; twist++)
+    {
+        int r;
+
+        if (twist > 0)
+        {
+            if (c->D == -3)
+                fmpz_mod_mul(b, b, g, ctx);
+            else if (c->D == -4)
+                fmpz_mod_mul(a, a, g, ctx);
+            else
+            {
+                /* (a, b) -> (a g^2, b g^3) */
+                fmpz_mod_mul(t, g, g, ctx);
+                fmpz_mod_mul(a, a, t, ctx);
+                fmpz_mod_mul(t, t, g, ctx);
+                fmpz_mod_mul(b, b, t, ctx);
+            }
+        }
+
+        {
+            PROF_START(t2);
+            r = _ecpp_find_point(x, y, a, b, c->q, k, state, ctx);
+            PROF_ADD(prof_points, t2);
+#ifdef ECPP_PROFILE
+            prof_twists++;
+#endif
+        }
+        if (r == -1)
+        {
+            result = -1;
+            goto cleanup;
+        }
+        if (r == 1)
+        {
+            fmpz_set(s->n, n);
+            s->D = c->D;
+            fmpz_set(s->a, a);
+            fmpz_set(s->b, b);
+            fmpz_set(s->m, c->m);
+            fmpz_set(s->q, c->q);
+            fmpz_set(s->x, x);
+            fmpz_set(s->y, y);
+            result = 1;
+            goto cleanup;
+        }
+    }
+
+cleanup:
+    fmpz_clear(j); fmpz_clear(a); fmpz_clear(b); fmpz_clear(g);
+    fmpz_clear(k); fmpz_clear(t); fmpz_clear(x); fmpz_clear(y);
+
+    return result;
+}
+
+static void
+_cand_init(ecpp_cand_struct * c)
+{
+    slong i;
+    fmpz_init(c->m);
+    fmpz_init(c->q);
+    for (i = 0; i <= ECPP_DISC_MAXFAC; i++)
+        fmpz_init(c->sqrts + i);
+}
+
+static void
+_cand_clear(ecpp_cand_struct * c)
+{
+    slong i;
+    fmpz_clear(c->m);
+    fmpz_clear(c->q);
+    for (i = 0; i <= ECPP_DISC_MAXFAC; i++)
+        fmpz_clear(c->sqrts + i);
+}
+
+static void
+_cand_set(ecpp_cand_struct * r, const ecpp_cand_struct * c)
+{
+    slong i;
+    r->D = c->D; r->h = c->h; r->o = c->o; r->cost = c->cost;
+    r->use_tower = c->use_tower; r->Dtower = c->Dtower; r->veven = c->veven;
+    r->g = c->g;
+    for (i = 0; i <= ECPP_DISC_MAXFAC; i++)
+        r->pstar[i] = c->pstar[i];
+    fmpz_set(r->m, c->m);
+    fmpz_set(r->q, c->q);
+    for (i = 0; i <= ECPP_DISC_MAXFAC; i++)
+        fmpz_set(r->sqrts + i, c->sqrts + i);
+}
+
+static void
+_step_init(ecpp_step_struct * st)
+{
+    fmpz_init(st->n); fmpz_init(st->a); fmpz_init(st->b); fmpz_init(st->m);
+    fmpz_init(st->q); fmpz_init(st->x); fmpz_init(st->y);
+    st->D = 0;
+}
+
+static void
+_step_clear(ecpp_step_struct * st)
+{
+    fmpz_clear(st->n); fmpz_clear(st->a); fmpz_clear(st->b); fmpz_clear(st->m);
+    fmpz_clear(st->q); fmpz_clear(st->x); fmpz_clear(st->y);
+}
+
+static void
+_step_swap(ecpp_step_struct * a, ecpp_step_struct * b)
+{
+    slong t = a->D; a->D = b->D; b->D = t;
+    fmpz_swap(a->n, b->n); fmpz_swap(a->a, b->a); fmpz_swap(a->b, b->b);
+    fmpz_swap(a->m, b->m); fmpz_swap(a->q, b->q); fmpz_swap(a->x, b->x); fmpz_swap(a->y, b->y);
+}
+
+/* the pending realisation, as a thread pool task */
+static void
+_pending_task(void * varg)
+{
+    ecpp_ctx_struct * ctx = (ecpp_ctx_struct *) varg;
+    ctx->pending.result = _ecpp_realise(&ctx->pending.step, ctx->pending.n,
+                        &ctx->pending.cand, ctx->pending.state, ctx->pending.mctx);
+}
+
+/*
+    Starts the realisation of (n, cand) as the pending one, on a pool
+    thread if available, else immediately. The modulus context is
+    duplicated so that the caller's may be cleared.
+*/
+static void
+_pending_start(ecpp_ctx_struct * ctx, const fmpz_t n, const ecpp_cand_struct * cand,
+                                                        slong cert_index)
+{
+    thread_pool_handle * handles = NULL;
+    slong got = 0;
+
+    ctx->pending.active = 1;
+    ctx->pending.cert_index = cert_index;
+    fmpz_set(ctx->pending.n, n);
+    _cand_set(&ctx->pending.cand, cand);
+    ctx->pending.mctx = flint_malloc(sizeof(fmpz_mod_ctx_struct));
+    fmpz_mod_ctx_init(ctx->pending.mctx, n);
+    flint_rand_set_seed(ctx->pending.state, n_randlimb(ctx->state), n_randlimb(ctx->state));
+
+    if (ctx->use_threads)
+        got = flint_request_threads(&handles, 1);
+    if (got == 1)
+    {
+        ctx->pending.threaded = 1;
+        ctx->pending.handle = handles[0];
+        flint_free(handles);
+        thread_pool_wake(global_thread_pool, ctx->pending.handle, 0, _pending_task, ctx);
+    }
+    else
+    {
+        if (handles != NULL)
+            flint_give_back_threads(handles, got);
+        ctx->pending.threaded = 0;
+        _pending_task(ctx);
+    }
+}
+
+/*
+    Joins the pending realisation, records its result for its certificate
+    index and, on success, puts the step into the certificate. Returns the
+    result (1, 0, -1), or 1 if nothing was pending.
+*/
+static int
+_pending_join(ecpp_ctx_struct * ctx, ecpp_cert_t cert)
+{
+    slong idx;
+    if (!ctx->pending.active)
+        return 1;
+    if (ctx->pending.threaded)
+    {
+        thread_pool_wait(global_thread_pool, ctx->pending.handle);
+        thread_pool_give_back(global_thread_pool, ctx->pending.handle);
+    }
+    fmpz_mod_ctx_clear(ctx->pending.mctx);
+    flint_free(ctx->pending.mctx);
+    ctx->pending.active = 0;
+    idx = ctx->pending.cert_index;
+    if (idx >= ctx->results_alloc)
+    {
+        slong old = ctx->results_alloc;
+        ctx->results_alloc = FLINT_MAX(2 * old, idx + 16);
+        ctx->results = flint_realloc(ctx->results, ctx->results_alloc * sizeof(int));
+        while (old < ctx->results_alloc)
+            ctx->results[old++] = 0;
+    }
+    ctx->results[idx] = ctx->pending.result;
+    if (ctx->pending.result == 1 && idx < cert->num)
+        _step_swap(cert->steps + idx, &ctx->pending.step);
+    return ctx->pending.result;
+}
+
+/*
+    1: proved prime (steps appended), 0: composite, -1: gave up,
+    -2: the realisation of the parent's step failed (its subtree,
+    including this call, is abandoned).
+*/
+static int
+_ecpp_prove_rec(ecpp_cert_t cert, const fmpz_t n, ecpp_ctx_struct * ctx, slong depth)
+{
+    ecpp_scan_struct scan;
+    ecpp_cand_struct cand;
+    fmpz_mod_ctx_t mctx;
+    slong tries, my_index;
+    int result = -1;
+
+    /* fmpz_is_prime does not use ECPP for such small inputs */
+    if (fmpz_bits(n) <= 64)
+        return (fmpz_sgn(n) > 0 && fmpz_is_prime(n)) ? 1 : 0;
+
+    if (depth > 4 * (slong) fmpz_bits(n))
+        return -1;
+
+    if (fmpz_is_even(n) || fmpz_divisible_si(n, 3))
+        return 0;
+
+    fmpz_mod_ctx_init(mctx, n);
+    scan_init(&scan, n, mctx, ctx);
+    _cand_init(&cand);
+
+    for (tries = 0; tries < ctx->max_tries && result == -1; tries++)
+    {
+        int r, got, parent_ok;
+
+        {
+            PROF_START(t3);
+            got = _scan_next_candidate(&scan, ctx, &cand);
+            PROF_ADD(prof_scan, t3);
+        }
+        if (!got)
+            break;
+
+        /* before starting our realisation, join the parent's */
+        parent_ok = _pending_join(ctx, cert);
+        if (parent_ok != 1)
+        {
+            result = -2;
+            break;
+        }
+
+        my_index = cert->num;
+        ecpp_cert_push(cert);
+        _pending_start(ctx, n, &cand, my_index);
+
+#ifdef ECPP_PROFILE
+        prof_nsteps++; prof_hsum += cand.o;
+        prof_gain += fmpz_bits(n) - fmpz_bits(cand.q);
+#endif
+        if (ecpp_verbose)
+            flint_printf("ecpp: %wd bits -> %wd bits, D = %wd (h = %wd, degree %wd)\n",
+                fmpz_bits(n), fmpz_bits(cand.q), cand.D, cand.h, cand.o);
+        /* not s->q: pushes may reallocate the steps */
+        r = _ecpp_prove_rec(cert, cand.q, ctx, depth + 1);
+
+        /* our realisation: joined by the child, or here */
+        if (ctx->pending.active && ctx->pending.cert_index == my_index)
+            _pending_join(ctx, cert);
+        {
+            int mine = ctx->results[my_index];
+            if (mine != 1 && ecpp_verbose)
+                flint_printf("ecpp: realisation failed (%d): D = %wd h = %wd\n", mine, cand.D, cand.h);
+            if (mine == -1)
+            {
+                cert->num = my_index;
+                result = 0;         /* composite */
+                break;
+            }
+            if (mine != 1)
+            {
+                /* our step is invalid: the subtree below is discarded */
+                cert->num = my_index;
+                fmpz_set(scan.tried + scan.ntried++, cand.q);
+                continue;
+            }
+        }
+        if (r == 1)
+        {
+            result = 1;
+            break;
+        }
+        /* composite q (impossible for a genuine candidate), dead end below,
+           or abandoned by a failure above: next candidate */
+        cert->num = my_index;
+        fmpz_set(scan.tried + scan.ntried++, cand.q);
+    }
+
+    _cand_clear(&cand);
+    scan_clear(&scan, ctx);
+    fmpz_mod_ctx_clear(mctx);
+
+    return result;
+}
+
+/*
+    Returns 1 if n is proved prime (cert holds the certificate), 0 if n is
+    proved composite, -1 if no proof could be found. n should be a probable
+    prime; composites are usually detected quickly but not always cheaply.
+*/
+int
+ecpp_prove(ecpp_cert_t cert, const fmpz_t n)
+{
+    ecpp_ctx_struct ctx;
+    slong bits, i, pmax, hmax, tdivexp, Dmax, attempt;
+    int result, bigpool;
+    n_primes_t iter;
+
+    cert->num = 0;
+
+    if (fmpz_cmp_ui(n, 1) <= 0)
+        return 0;
+    if (fmpz_bits(n) <= 64)
+        return fmpz_is_prime(n);                /* n > 1 here; no ECPP inside */
+    if (!fmpz_is_probabprime(n))
+        return 0;
+
+    bits = fmpz_bits(n);
+    _ecpp_tune(bits, &pmax, &hmax, &tdivexp);
+    result = -1;
+
+    /* if the pool is exhausted somewhere in the chain (rare, and only for
+       small n), retry with a larger pool */
+    /*
+        If the pool is exhausted somewhere in the chain, retry with a
+        larger one: more primes, and (the more important part) larger
+        class numbers and odd parts admitted, at the price of more
+        expensive realisations. This happens for the occasional n with
+        few usable discriminants (e.g. n = 7 mod 8, which rules out every
+        D = -4m and -8m with m = 3 mod 4) and no prime cofactor among them.
+    */
+    for (attempt = 0; result == -1 && pmax <= 100000; attempt++, pmax *= 2, hmax *= 2)
+    {
+
+    /* (the prime set is not reduced for the CM-style pool: the rounds
+       take the primes in increasing order anyway, and a set that is too
+       small leaves some n in the chain without candidates) */
+
+    /* odd primes up to pmax */
+    {
+        slong alloc = 64;
+        ulong p;
+        ctx.primes = flint_malloc(alloc * sizeof(ulong));
+        ctx.nprimes = 0;
+        n_primes_init(iter);
+        n_primes_next(iter);    /* skip 2 */
+        while ((p = n_primes_next(iter)) <= (ulong) pmax)
+        {
+            if (ctx.nprimes == alloc)
+            {
+                alloc *= 2;
+                ctx.primes = flint_realloc(ctx.primes, alloc * sizeof(ulong));
+            }
+            ctx.primes[ctx.nprimes++] = p;
+        }
+        n_primes_clear(iter);
+    }
+
+    /* the pool: smooth discriminants up to pmax^2, with a generous class
+       number bound so that the search can persevere when the cheap part
+       of the pool is exhausted */
+    /*
+        The pool: smooth discriminants up to Dmax. Only the odd part o of
+        the class number matters for the realisation (the degree of the
+        genus factor), so large class numbers are admitted as long as o is
+        small (and h is not so large that the class polynomial itself
+        becomes expensive); products of many small primes with |D| in the
+        millions typically have h in the hundreds and o below 10. The
+        table costs O(Dmax^{3/2}), hence the size dependent bound.
+    */
+    /*
+        From 2500 bits on, the CM-style pool: all smooth discriminants
+        up to Dmax with a cheap class field tower
+        (measured at 4000 bits: 123 s instead of 137 s, square roots
+        77 s -> 13 s; at 3000 bits parity, at 2000 bits slightly worse).
+    */
+    bigpool = (bits >= ECPP_BIGPOOL_BITS);
+    Dmax = bigpool ? (WORD(1) << ECPP_DMAX_BITS(bits))
+                   : FLINT_MIN(pmax * pmax, WORD(1) << ECPP_DMAX_BITS(bits));
+    /*
+        Not done yet: the class field tower with the Weber invariant makes
+        discriminants with class numbers in the hundreds (h a product of
+        small primes) realisable in about 0.1 s, as in Enge's CM library,
+        which uses all such D up to 2^23 over a set of some 35 primes and
+        gets ~45 bits per step from ~2500 Cornacchia attempts per step.
+        Admitting them here (-DECPP_DISC_COST_MAX=60 and a larger Dmax)
+        currently lowers the gain per step: the batch of orders is of
+        fixed size, so more available orders do not become more candidates
+        per probable prime test. Exploiting the larger pool needs the
+        batch policy (size and trial division bound) retuned with it.
+    */
+    Dmax = FLINT_MAX(Dmax, 40000);
+    ctx.ndiscs = ecpp_disc_table(&ctx.discs, ctx.primes, ctx.nprimes, Dmax,
+                                        FLINT_MIN(4000, ECPP_POOL_HMAX << attempt),
+                                        FLINT_MIN(256, ECPP_POOL_OMAX << attempt),
+                                        (bigpool ? ECPP_DISC_COST_MAX : 0.0) * (attempt == 0 ? 1 : 3 << attempt));
+
+    for (i = 0; i < 32; i++)
+        ctx.have_primorial[i] = 0;
+    ctx.max_tries = 16;
+    ctx.tdivexp = tdivexp;
+    flint_rand_init(ctx.state);
+    ctx.pending.active = 0;
+    ctx.pending.cert_index = -1;
+    ctx.results_alloc = 64;
+    ctx.results = flint_calloc(ctx.results_alloc, sizeof(int));
+    _step_init(&ctx.pending.step);
+    _cand_init(&ctx.pending.cand);
+    fmpz_init(ctx.pending.n);
+    flint_rand_init(ctx.pending.state);
+    /* below a thousand bits or so the steps are too small for the thread
+       pool's latency */
+    ctx.use_threads = (flint_get_num_threads() >= 2 && bits >= 1000);
+
+    if (ecpp_verbose)
+        flint_printf("ecpp: %wd bits, %wd primes up to %wd, %wd discriminants up to %wd, trial division to 2^%wd\n",
+                bits, ctx.nprimes, pmax, ctx.ndiscs, Dmax, tdivexp);
+
+    result = _ecpp_prove_rec(cert, n, &ctx, 0);
+    if (ctx.pending.active)
+        _pending_join(&ctx, cert);
+    if (result == -2)
+        result = -1;
+
+#ifdef ECPP_PROFILE
+    flint_printf("ecpp profile: scan %.4fs classpoly %.4fs roots %.4fs points %.4fs | steps %wd avg degree %.1f avg gain %.1f twists tried %wd\n",
+        prof_scan, prof_hilbert, prof_roots, prof_points, prof_nsteps,
+        (double) prof_hsum / FLINT_MAX(prof_nsteps, 1), (double) prof_gain / FLINT_MAX(prof_nsteps, 1), prof_twists);
+    flint_printf("  batches without a prime: %wd (%wd tests), batches tested to the end: %wd\n", prof_nobatch, prof_nobatch_tests, prof_fullbatch);
+    {
+        extern double ecpp_tower_prof[4];
+        extern slong ecpp_tower_count, ecpp_tower_hsum, ecpp_tower_retries;
+        flint_printf("  towers: %wd (avg h %.1f, %wd retries): class group %.4fs, values (arb) %.4fs, decomposition (arb) %.4fs, descent (mod n) %.4fs\n",
+            ecpp_tower_count, (double) ecpp_tower_hsum / FLINT_MAX(1, ecpp_tower_count), ecpp_tower_retries,
+            ecpp_tower_prof[0], ecpp_tower_prof[1], ecpp_tower_prof[2], ecpp_tower_prof[3]);
+    }
+    flint_printf("  scan: sqrt %.4fs (%wd) cornacchia %.4fs (%wd disc, %wd tried, %wd ok) split %.4fs (%wd orders, %wd batches) bpsw %.4fs (%wd)\n",
+        prof_sqrt, prof_nsqrt, prof_corn, prof_ndisc, prof_ncorn, prof_ncornok, prof_split, prof_nsplit, prof_nbatch, prof_bpsw, prof_nbpsw);
+#endif
+
+    /* a proof must be a chain from n down: the steps are installed by
+       whichever level joins their realisation, so check the structure
+       (cheap; the verifier checks the mathematics) */
+    if (result == 1)
+    {
+        slong k;
+        int chain = (cert->num >= 1) && fmpz_equal(cert->steps[0].n, n);
+        for (k = 1; k < cert->num && chain; k++)
+            chain = fmpz_equal(cert->steps[k].n, cert->steps[k - 1].q);
+        if (chain && fmpz_bits(cert->steps[cert->num - 1].q) > 64)
+            chain = 0;
+        if (!chain)
+        {
+            flint_printf("ecpp_prove: inconsistent certificate (internal error)\n");
+            result = -1;
+        }
+    }
+    if (result != 1)
+        cert->num = 0;
+
+    flint_rand_clear(ctx.state);
+    _step_clear(&ctx.pending.step);
+    _cand_clear(&ctx.pending.cand);
+    flint_free(ctx.results);
+    fmpz_clear(ctx.pending.n);
+    flint_rand_clear(ctx.pending.state);
+    for (i = 0; i < 32; i++)
+        if (ctx.have_primorial[i])
+        {
+            slong k;
+            fmpz_clear(ctx.primorial + i);
+            if (ctx.use_threads)
+                for (k = 0; k < ECPP_PRIMORIAL_CHUNKS; k++)
+                    fmpz_clear(ctx.primorial_chunk[i] + k);
+        }
+    flint_free(ctx.primes);
+    flint_free(ctx.discs);
+    }
+
+    return result;
+}
+
+int
+ecpp_is_prime(const fmpz_t n)
+{
+    ecpp_cert_t cert;
+    int r;
+
+    ecpp_cert_init(cert);
+    r = ecpp_prove(cert, n);
+    ecpp_cert_clear(cert);
+
+    return r;
+}

--- a/src/ecpp/prove.c
+++ b/src/ecpp/prove.c
@@ -18,7 +18,6 @@
 #include "fmpz_poly.h"
 #include "fmpz_mod.h"
 #include "fmpz_mod_poly.h"
-#include "fmpz_mod_poly_factor.h"
 #include "thread_support.h"
 #include "thread_pool.h"
 #include "acb_modular.h"
@@ -1275,23 +1274,13 @@ _ecpp_find_point(fmpz_t x, fmpz_t y, const fmpz_t a, const fmpz_t b,
 static int
 _ecpp_class_poly_root(fmpz_t j, const ecpp_cand_struct * c, flint_rand_t state, const fmpz_mod_ctx_t ctx)
 {
-    const fmpz * n = fmpz_mod_ctx_modulus(ctx);
     slong D = c->D;
     fmpz_poly_t H;
-    fmpz_mod_poly_t f, g, base, pw, finv;
-    fmpz_t e, r, t;
-    slong tries = 0;
+    fmpz_mod_poly_t f;
     int found = 0;
 
     fmpz_poly_init(H);
     fmpz_mod_poly_init(f, ctx);
-    fmpz_mod_poly_init(g, ctx);
-    fmpz_mod_poly_init(base, ctx);
-    fmpz_mod_poly_init(pw, ctx);
-    fmpz_mod_poly_init(finv, ctx);
-    fmpz_init(e);
-    fmpz_init(r);
-    fmpz_init(t);
 
     {
         PROF_START(t0);
@@ -1323,94 +1312,16 @@ _ecpp_class_poly_root(fmpz_t j, const ecpp_cand_struct * c, flint_rand_t state, 
         PROF_ADD(prof_hilbert, t0);
     }
 
-    fmpz_sub_ui(e, n, 1);
-    fmpz_fdiv_q_2exp(e, e, 1);          /* e = (n - 1) / 2 */
-
     {
-    PROF_START(t1);
-    /* degrees 2, 3, 4 by radicals when possible (a few square and cube roots) */
-    if (fmpz_mod_poly_degree(f, ctx) >= 2 && fmpz_mod_poly_degree(f, ctx) <= 4
-            && ecpp_root_radicals(j, f, state, ctx))
-        found = 1;
-    while (!found && fmpz_mod_poly_degree(f, ctx) > 1 && tries < 20)
-    {
-        slong d = fmpz_mod_poly_degree(f, ctx);
-
-        if (d == 2)
-        {
-            /* x^2 + c1 x + c0: root = (-c1 +- sqrt(c1^2 - 4 c0)) / 2 */
-            fmpz_t c0, c1;
-            fmpz_init(c0);
-            fmpz_init(c1);
-            fmpz_mod_poly_get_coeff_fmpz(c0, f, 0, ctx);
-            fmpz_mod_poly_get_coeff_fmpz(c1, f, 1, ctx);
-            fmpz_mod_mul(t, c1, c1, ctx);
-            fmpz_mod_mul_ui(r, c0, 4, ctx);
-            fmpz_mod_sub(t, t, r, ctx);
-            if (fmpz_sqrtmod(r, t, n))
-            {
-                fmpz_mod_sub(r, r, c1, ctx);
-                fmpz_set_ui(t, 2);
-                fmpz_mod_inv(t, t, ctx);
-                fmpz_mod_mul(j, r, t, ctx);
-                found = 1;
-            }
-            fmpz_clear(c0);
-            fmpz_clear(c1);
-            break;
-        }
-
-        /* g = gcd((x + r)^e - 1, f), with a precomputed inverse of rev(f) */
-        tries++;
-        fmpz_randm(r, state, n);
-        fmpz_mod_poly_zero(base, ctx);
-        fmpz_mod_poly_set_coeff_fmpz(base, 0, r, ctx);
-        fmpz_mod_poly_set_coeff_ui(base, 1, 1, ctx);
-        if (d >= 12)
-        {
-            fmpz_mod_poly_reverse(finv, f, d + 1, ctx);
-            fmpz_mod_poly_inv_series(finv, finv, d + 1, ctx);
-            fmpz_mod_poly_powmod_fmpz_binexp_preinv(pw, base, e, f, finv, ctx);
-        }
-        else
-            fmpz_mod_poly_powmod_fmpz_binexp(pw, base, e, f, ctx);
-        fmpz_mod_poly_get_coeff_fmpz(t, pw, 0, ctx);
-        fmpz_sub_ui(t, t, 1);
-        fmpz_mod_poly_set_coeff_fmpz(pw, 0, t, ctx);
-        if (fmpz_mod_poly_is_zero(pw, ctx))
-            continue;
-        fmpz_mod_poly_gcd(g, pw, f, ctx);
-
-        {
-            slong dg = fmpz_mod_poly_degree(g, ctx);
-            if (dg <= 0 || dg >= d)
-                continue;
-            /* keep the smaller of g and f / g */
-            if (2 * dg > d)
-                fmpz_mod_poly_divrem(g, pw, f, g, ctx);
-            fmpz_mod_poly_swap(f, g, ctx);
-        }
-    }
-    PROF_ADD(prof_roots, t1);
-    }
-
-    if (!found && fmpz_mod_poly_degree(f, ctx) == 1)
-    {
-        fmpz_mod_poly_get_coeff_fmpz(j, f, 0, ctx);
-        fmpz_mod_neg(j, j, ctx);
-        found = 1;
+        PROF_START(t1);
+        /* a root of f: by radicals up to degree 4, else by random splitting */
+        found = ecpp_poly_root(j, f, state, ctx);
+        PROF_ADD(prof_roots, t1);
     }
 
 cleanup:
     fmpz_mod_poly_clear(f, ctx);
-    fmpz_mod_poly_clear(g, ctx);
-    fmpz_mod_poly_clear(base, ctx);
-    fmpz_mod_poly_clear(pw, ctx);
-    fmpz_mod_poly_clear(finv, ctx);
     fmpz_poly_clear(H);
-    fmpz_clear(e);
-    fmpz_clear(r);
-    fmpz_clear(t);
 
     return found;
 }
@@ -1711,8 +1622,10 @@ _pending_start(ecpp_ctx_struct * ctx, const fmpz_t n, const ecpp_cand_struct * c
     fmpz_mod_ctx_init(ctx->pending.mctx, n);
     flint_rand_set_seed(ctx->pending.state, n_randlimb(ctx->state), n_randlimb(ctx->state));
 
+    /* one worker (the argument of flint_request_threads is a limit on the
+       number of threads including the caller) */
     if (ctx->use_threads)
-        got = flint_request_threads(&handles, 1);
+        got = flint_request_threads(&handles, 2);
     if (got == 1)
     {
         ctx->pending.threaded = 1;
@@ -1973,7 +1886,7 @@ ecpp_prove(ecpp_cert_t cert, const fmpz_t n)
     flint_rand_init(ctx.state);
     ctx.pending.active = 0;
     ctx.pending.cert_index = -1;
-    ctx.results_alloc = 64;
+    ctx.results_alloc = 8;
     ctx.results = flint_calloc(ctx.results_alloc, sizeof(int));
     _step_init(&ctx.pending.step);
     _cand_init(&ctx.pending.cand);

--- a/src/ecpp/roots.c
+++ b/src/ecpp/roots.c
@@ -1,0 +1,585 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5.1
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "ulong_extras.h"
+#include "fmpz.h"
+#include "fmpz_mod.h"
+#include "fmpz_mod_poly.h"
+#include "ecpp.h"
+
+/*
+    Roots of polynomials of degree 2, 3 and 4 that split completely modulo
+    a prime n, by radicals: a few square and cube roots instead of a
+    powering of a polynomial modulo the polynomial, which costs some ten
+    times more at these degrees. For degrees 3 and 4 the cube roots are
+    taken in F_n when n = 1 mod 3 and in F_{n^2} when n = 2, 5 mod 9; the
+    caller falls back to the generic method otherwise or on failure. n is assumed prime: for
+    composite n the functions may fail, but a wrong root is harmless since
+    the curve is tested afterwards.
+*/
+
+/* w^3 = z for a cube z modulo n = 1 mod 3 (Adleman-Manders-Miller for r = 3) */
+static int
+_cbrtmod(fmpz_t w, const fmpz_t z, flint_rand_t state, const fmpz_mod_ctx_t ctx)
+{
+    const fmpz * n = fmpz_mod_ctx_modulus(ctx);
+    fmpz_t t, e, y, g, G, tmp, pw;
+    slong s = 0, k, j, tries;
+    int result = 0;
+
+    if (fmpz_is_zero(z))
+    {
+        fmpz_zero(w);
+        return 1;
+    }
+
+    fmpz_init(t); fmpz_init(e); fmpz_init(y); fmpz_init(g); fmpz_init(G);
+    fmpz_init(tmp); fmpz_init(pw);
+
+    /* n - 1 = 3^s t */
+    fmpz_sub_ui(t, n, 1);
+    while (fmpz_divisible_si(t, 3))
+    {
+        fmpz_divexact_si(t, t, 3);
+        s++;
+    }
+    if (s == 0)
+        goto cleanup;
+
+    /* w = z^e with 3 e = 1 mod t; then w^3 = z y^k, y = z^t of order | 3^{s-1} */
+    fmpz_set_ui(e, 3);
+    fmpz_invmod(e, e, t);
+    fmpz_powm(w, z, e, n);
+    fmpz_powm(y, z, t, n);
+    if (fmpz_is_one(y))
+    {
+        result = 1;
+        goto cleanup;
+    }
+    /* k = (3 e - 1) / t */
+    fmpz_mul_ui(tmp, e, 3);
+    fmpz_sub_ui(tmp, tmp, 1);
+    fmpz_divexact(tmp, tmp, t);
+    fmpz_powm(y, y, tmp, n);        /* y^k, in the 3-Sylow subgroup, a cube there */
+
+    /* G = g^t of order 3^s for a non-cube g */
+    for (tries = 0; tries < 100; tries++)
+    {
+        fmpz_randm(g, state, n);
+        fmpz_powm(G, g, t, n);
+        fmpz_set(pw, G);
+        for (j = 0; j < s - 1; j++)
+            fmpz_mod_pow_ui(pw, pw, 3, ctx);
+        if (!fmpz_is_one(pw) && !fmpz_is_zero(pw))
+            break;
+    }
+    if (tries == 100)
+        goto cleanup;
+
+    /*
+        Discrete logarithm of y^k = G^{3 m} to base G (Pohlig-Hellman in a
+        cyclic group of order 3^s, digit by digit); then w /= G^m.
+    */
+    {
+        fmpz_t m, Gi, target, cur;
+        slong digit;
+        fmpz_init(m); fmpz_init(Gi); fmpz_init(target); fmpz_init(cur);
+        fmpz_zero(m);           /* accumulates 3 m */
+        fmpz_set(target, y);
+        fmpz_mod_inv(Gi, G, ctx);
+        for (k = 0; k < s; k++)
+        {
+            /* digit d: (target / G^{3m})^{3^{s-1-k}} = (G^{3^{s-1}})^d */
+            fmpz_powm(cur, Gi, m, n);
+            fmpz_mod_mul(cur, cur, target, ctx);
+            for (j = 0; j < s - 1 - k; j++)
+                fmpz_mod_pow_ui(cur, cur, 3, ctx);
+            fmpz_set(pw, G);
+            for (j = 0; j < s - 1; j++)
+                fmpz_mod_pow_ui(pw, pw, 3, ctx);    /* element of order 3 */
+            for (digit = 0; digit < 3; digit++)
+            {
+                if (fmpz_is_one(cur))
+                    break;
+                fmpz_mod_mul(cur, cur, pw, ctx);    /* multiply by pw^{-1}... use pw^2 = pw^{-1} */
+                fmpz_mod_mul(cur, cur, pw, ctx);
+            }
+            if (digit == 3)
+                break;
+            fmpz_set_ui(tmp, 1);
+            for (j = 0; j < k; j++)
+                fmpz_mul_ui(tmp, tmp, 3);
+            fmpz_addmul_ui(m, tmp, digit);
+        }
+        if (k == s && fmpz_divisible_si(m, 3))
+        {
+            fmpz_divexact_si(m, m, 3);
+            fmpz_powm(cur, Gi, m, n);
+            fmpz_mod_mul(w, w, cur, ctx);
+            fmpz_mod_pow_ui(cur, w, 3, ctx);
+            result = fmpz_equal(cur, z);
+        }
+        fmpz_clear(m); fmpz_clear(Gi); fmpz_clear(target); fmpz_clear(cur);
+    }
+
+cleanup:
+    fmpz_clear(t); fmpz_clear(e); fmpz_clear(y); fmpz_clear(g); fmpz_clear(G);
+    fmpz_clear(tmp); fmpz_clear(pw);
+    return result;
+}
+
+/*
+    Arithmetic in F_{n^2} = F_n[s] / (s^2 + 3) for n = 2 mod 3 (where -3 is
+    not a square): elements a + b s.
+*/
+static void
+_fn2_mul(fmpz_t ra, fmpz_t rb, const fmpz_t a1, const fmpz_t b1,
+                        const fmpz_t a2, const fmpz_t b2, const fmpz_mod_ctx_t ctx)
+{
+    fmpz_t t, u;
+    fmpz_init(t); fmpz_init(u);
+    fmpz_mod_mul(t, a1, a2, ctx);
+    fmpz_mod_mul(u, b1, b2, ctx);
+    fmpz_mod_mul_ui(u, u, 3, ctx);
+    fmpz_mod_sub(t, t, u, ctx);             /* a1 a2 - 3 b1 b2 */
+    fmpz_mod_mul(u, a1, b2, ctx);
+    fmpz_mod_addmul(u, u, a2, b1, ctx);     /* a1 b2 + a2 b1 */
+    fmpz_swap(ra, t);
+    fmpz_swap(rb, u);
+    fmpz_clear(t); fmpz_clear(u);
+}
+
+static void
+_fn2_pow(fmpz_t ra, fmpz_t rb, const fmpz_t a, const fmpz_t b, const fmpz_t e,
+                                                        const fmpz_mod_ctx_t ctx)
+{
+    fmpz_t xa, xb;
+    slong i;
+    fmpz_init(xa); fmpz_init(xb);
+    fmpz_one(xa);
+    fmpz_zero(xb);
+    for (i = fmpz_bits(e) - 1; i >= 0; i--)
+    {
+        _fn2_mul(xa, xb, xa, xb, xa, xb, ctx);
+        if (fmpz_tstbit(e, i))
+            _fn2_mul(xa, xb, xa, xb, a, b, ctx);
+    }
+    fmpz_swap(ra, xa);
+    fmpz_swap(rb, xb);
+    fmpz_clear(xa); fmpz_clear(xb);
+}
+
+/*
+    u^3 = z in F_{n^2} for n = 2, 5 mod 9 (so that 3 divides n^2 - 1 exactly
+    once and a cube root of a cube z is z^e with 3 e = 1 mod (n^2 - 1) / 3).
+*/
+static int
+_cbrt_fn2(fmpz_t ua, fmpz_t ub, const fmpz_t za, const fmpz_t zb, const fmpz_mod_ctx_t ctx)
+{
+    const fmpz * n = fmpz_mod_ctx_modulus(ctx);
+    fmpz_t t, e, ca, cb;
+    int ok;
+    fmpz_init(t); fmpz_init(e); fmpz_init(ca); fmpz_init(cb);
+    fmpz_mul(t, n, n);
+    fmpz_sub_ui(t, t, 1);
+    fmpz_divexact_ui(t, t, 3);
+    fmpz_set_ui(e, 3);
+    fmpz_invmod(e, e, t);
+    _fn2_pow(ua, ub, za, zb, e, ctx);
+    _fn2_mul(ca, cb, ua, ub, ua, ub, ctx);
+    _fn2_mul(ca, cb, ca, cb, ua, ub, ctx);
+    ok = fmpz_equal(ca, za) && fmpz_equal(cb, zb);
+    fmpz_clear(t); fmpz_clear(e); fmpz_clear(ca); fmpz_clear(cb);
+    return ok;
+}
+
+/* a root of x^2 + c1 x + c0 */
+static int
+_root_quadratic(fmpz_t x, const fmpz_t c1, const fmpz_t c0, const fmpz_mod_ctx_t ctx)
+{
+    const fmpz * n = fmpz_mod_ctx_modulus(ctx);
+    fmpz_t d, r, h;
+    int ok;
+
+    fmpz_init(d); fmpz_init(r); fmpz_init(h);
+    fmpz_mod_mul(d, c1, c1, ctx);
+    fmpz_mod_mul_ui(r, c0, 4, ctx);
+    fmpz_mod_sub(d, d, r, ctx);
+    ok = fmpz_sqrtmod(r, d, n);
+    if (ok)
+    {
+        fmpz_mod_sub(r, r, c1, ctx);
+        fmpz_set_ui(h, 2);
+        fmpz_mod_inv(h, h, ctx);
+        fmpz_mod_mul(x, r, h, ctx);
+    }
+    fmpz_clear(d); fmpz_clear(r); fmpz_clear(h);
+    return ok;
+}
+
+/* a root of x^3 + c2 x^2 + c1 x + c0 (Cardano) */
+static int
+_root_cubic(fmpz_t x, const fmpz_t c2, const fmpz_t c1, const fmpz_t c0,
+                                    flint_rand_t state, const fmpz_mod_ctx_t ctx)
+{
+    const fmpz * n = fmpz_mod_ctx_modulus(ctx);
+    fmpz_t p, q, t, u, v, i3, shift;
+    int ok = 0;
+
+    fmpz_init(p); fmpz_init(q); fmpz_init(t); fmpz_init(u); fmpz_init(v);
+    fmpz_init(i3); fmpz_init(shift);
+
+    /* x = y - c2/3: y^3 + p y + q, p = c1 - c2^2/3, q = c0 - c1 c2/3 + 2 c2^3/27 */
+    fmpz_set_ui(i3, 3);
+    fmpz_mod_inv(i3, i3, ctx);
+    fmpz_mod_mul(shift, c2, i3, ctx);           /* c2 / 3 */
+    fmpz_mod_mul(t, c2, shift, ctx);            /* c2^2 / 3 */
+    fmpz_mod_sub(p, c1, t, ctx);
+    fmpz_mod_mul(t, shift, shift, ctx);         /* c2^2 / 9 */
+    fmpz_mod_mul(t, t, shift, ctx);             /* c2^3 / 27 */
+    fmpz_mod_add(q, t, t, ctx);
+    fmpz_mod_mul(t, c1, shift, ctx);
+    fmpz_mod_sub(q, q, t, ctx);
+    fmpz_mod_add(q, q, c0, ctx);
+
+    if (fmpz_is_zero(p))
+    {
+        /* y^3 = -q */
+        fmpz_mod_neg(t, q, ctx);
+        if (fmpz_fdiv_ui(n, 3) == 1)
+            ok = _cbrtmod(u, t, state, ctx);
+        else
+        {
+            /* cube roots are unique: (-q)^e with 3 e = 1 mod n - 1 */
+            fmpz_sub_ui(v, n, 1);
+            fmpz_set_ui(u, 3);
+            fmpz_invmod(u, u, v);
+            fmpz_powm(u, t, u, n);
+            ok = 1;
+        }
+        if (ok)
+            fmpz_mod_sub(x, u, shift, ctx);
+        goto cleanup;
+    }
+
+    if (fmpz_fdiv_ui(n, 3) != 1)
+    {
+        /*
+            n = 2 mod 3: the resolvent z = -q/2 + sqrt(disc) s / 18, with
+            s = sqrt(-3), lies in F_{n^2}; for a cube root u of z the
+            conjugate of u is -p/(3u), so y = u + conj(u) = 2 re(u).
+        */
+        fmpz_t za, zb, ua, ub, disc;
+        fmpz_init(za); fmpz_init(zb); fmpz_init(ua); fmpz_init(ub); fmpz_init(disc);
+        /* disc = -(4 p^3 + 27 q^2) */
+        fmpz_mod_mul(t, p, p, ctx);
+        fmpz_mod_mul(t, t, p, ctx);
+        fmpz_mod_mul_ui(t, t, 4, ctx);
+        fmpz_mod_mul(u, q, q, ctx);
+        fmpz_mod_mul_ui(u, u, 27, ctx);
+        fmpz_mod_add(disc, t, u, ctx);
+        fmpz_mod_neg(disc, disc, ctx);
+        if (fmpz_sqrtmod(disc, disc, n))
+        {
+            fmpz_set_ui(t, 2);
+            fmpz_mod_inv(t, t, ctx);
+            fmpz_mod_mul(za, q, t, ctx);
+            fmpz_mod_neg(za, za, ctx);
+            fmpz_set_ui(t, 18);
+            fmpz_mod_inv(t, t, ctx);
+            fmpz_mod_mul(zb, disc, t, ctx);
+            if (_cbrt_fn2(ua, ub, za, zb, ctx))
+            {
+                fmpz_mod_add(x, ua, ua, ctx);
+                fmpz_mod_sub(x, x, shift, ctx);
+                fmpz_mod_add(t, x, c2, ctx);
+                fmpz_mod_mul(t, t, x, ctx);
+                fmpz_mod_add(t, t, c1, ctx);
+                fmpz_mod_mul(t, t, x, ctx);
+                fmpz_mod_add(t, t, c0, ctx);
+                ok = fmpz_is_zero(t);
+            }
+        }
+        fmpz_clear(za); fmpz_clear(zb); fmpz_clear(ua); fmpz_clear(ub); fmpz_clear(disc);
+        goto cleanup;
+    }
+
+    /* u^3 = (-q + sqrt(q^2 + 4 p^3 / 27)) / 2, v = -p / (3 u) */
+    fmpz_mod_mul(t, p, p, ctx);
+    fmpz_mod_mul(t, t, p, ctx);
+    fmpz_mod_mul_ui(t, t, 4, ctx);
+    fmpz_mod_mul(t, t, i3, ctx);
+    fmpz_mod_mul(t, t, i3, ctx);
+    fmpz_mod_mul(t, t, i3, ctx);                /* 4 p^3 / 27 */
+    fmpz_mod_mul(u, q, q, ctx);
+    fmpz_mod_add(t, t, u, ctx);
+    if (!fmpz_sqrtmod(t, t, n))
+        goto cleanup;
+    fmpz_mod_sub(t, t, q, ctx);
+    fmpz_set_ui(u, 2);
+    fmpz_mod_inv(u, u, ctx);
+    fmpz_mod_mul(t, t, u, ctx);
+    if (fmpz_is_zero(t))
+    {
+        /* the other sign */
+        fmpz_mod_neg(t, q, ctx);
+    }
+    if (!_cbrtmod(u, t, state, ctx))
+        goto cleanup;
+    if (fmpz_is_zero(u))
+        goto cleanup;
+    fmpz_mod_mul_ui(v, u, 3, ctx);
+    fmpz_mod_inv(v, v, ctx);
+    fmpz_mod_mul(v, v, p, ctx);
+    fmpz_mod_sub(x, u, v, ctx);                 /* u - p/(3u) */
+    fmpz_mod_sub(x, x, shift, ctx);
+
+    /* check */
+    fmpz_mod_add(t, x, c2, ctx);
+    fmpz_mod_mul(t, t, x, ctx);
+    fmpz_mod_add(t, t, c1, ctx);
+    fmpz_mod_mul(t, t, x, ctx);
+    fmpz_mod_add(t, t, c0, ctx);
+    ok = fmpz_is_zero(t);
+
+cleanup:
+    fmpz_clear(p); fmpz_clear(q); fmpz_clear(t); fmpz_clear(u); fmpz_clear(v);
+    fmpz_clear(i3); fmpz_clear(shift);
+    return ok;
+}
+
+/* a root of x^4 + c3 x^3 + c2 x^2 + c1 x + c0 (Ferrari) */
+static int
+_root_quartic(fmpz_t x, const fmpz_t c3, const fmpz_t c2, const fmpz_t c1,
+                    const fmpz_t c0, flint_rand_t state, const fmpz_mod_ctx_t ctx)
+{
+    const fmpz * n = fmpz_mod_ctx_modulus(ctx);
+    fmpz_t p, q, r, shift, t, u, m, s, i2, a1, a0;
+    int ok = 0;
+
+    fmpz_init(p); fmpz_init(q); fmpz_init(r); fmpz_init(shift); fmpz_init(t);
+    fmpz_init(u); fmpz_init(m); fmpz_init(s); fmpz_init(i2); fmpz_init(a1); fmpz_init(a0);
+
+    /* x = y - c3/4: y^4 + p y^2 + q y + r */
+    fmpz_set_ui(i2, 2);
+    fmpz_mod_inv(i2, i2, ctx);
+    fmpz_mod_mul(shift, c3, i2, ctx);
+    fmpz_mod_mul(shift, shift, i2, ctx);        /* c3 / 4 */
+    /* p = c2 - 6 shift^2, q = c1 - 2 c2 shift + 8 shift^3,
+       r = c0 - c1 shift + c2 shift^2 - 3 shift^4 */
+    fmpz_mod_mul(t, shift, shift, ctx);         /* shift^2 */
+    fmpz_mod_mul_ui(p, t, 6, ctx);
+    fmpz_mod_sub(p, c2, p, ctx);
+    fmpz_mod_mul(u, t, shift, ctx);             /* shift^3 */
+    fmpz_mod_mul_ui(q, u, 8, ctx);
+    fmpz_mod_mul(s, c2, shift, ctx);
+    fmpz_mod_sub(q, q, s, ctx);
+    fmpz_mod_sub(q, q, s, ctx);
+    fmpz_mod_add(q, q, c1, ctx);
+    fmpz_mod_mul(r, t, t, ctx);                 /* shift^4 */
+    fmpz_mod_mul_ui(r, r, 3, ctx);
+    fmpz_mod_neg(r, r, ctx);
+    fmpz_mod_mul(s, c2, t, ctx);
+    fmpz_mod_add(r, r, s, ctx);
+    fmpz_mod_mul(s, c1, shift, ctx);
+    fmpz_mod_sub(r, r, s, ctx);
+    fmpz_mod_add(r, r, c0, ctx);
+
+    if (fmpz_is_zero(q))
+    {
+        /* biquadratic: z = y^2 root of z^2 + p z + r */
+        if (!_root_quadratic(t, p, r, ctx))
+            goto cleanup;
+        if (!fmpz_sqrtmod(t, t, n))
+            goto cleanup;
+        fmpz_mod_sub(x, t, shift, ctx);
+        ok = 1;
+        goto cleanup;
+    }
+
+    /*
+        Resolvent: 8 m^3 + 8 p m^2 + (2 p^2 - 8 r) m - q^2 = 0, i.e.
+        m^3 + p m^2 + (p^2/4 - r) m - q^2/8 = 0; then
+        y^4 + p y^2 + q y + r = (y^2 + p/2 + m)^2 - (sqrt(2m) y - q / (2 sqrt(2m)))^2.
+    */
+    fmpz_mod_mul(a1, p, p, ctx);
+    fmpz_mod_mul(a1, a1, i2, ctx);
+    fmpz_mod_mul(a1, a1, i2, ctx);
+    fmpz_mod_sub(a1, a1, r, ctx);
+    fmpz_mod_mul(a0, q, q, ctx);
+    fmpz_mod_mul(a0, a0, i2, ctx);
+    fmpz_mod_mul(a0, a0, i2, ctx);
+    fmpz_mod_mul(a0, a0, i2, ctx);
+    fmpz_mod_neg(a0, a0, ctx);
+    if (!_root_cubic(m, p, a1, a0, state, ctx))
+        goto cleanup;
+    if (fmpz_is_zero(m))
+        goto cleanup;
+    fmpz_mod_add(s, m, m, ctx);
+    if (!fmpz_sqrtmod(s, s, n))                  /* s = sqrt(2m) */
+        goto cleanup;
+    /* y^2 - s y + (p/2 + m + q/(2s)) = 0 */
+    fmpz_mod_add(t, s, s, ctx);
+    fmpz_mod_inv(t, t, ctx);
+    fmpz_mod_mul(t, t, q, ctx);
+    fmpz_mod_mul(u, p, i2, ctx);
+    fmpz_mod_add(u, u, m, ctx);
+    fmpz_mod_add(u, u, t, ctx);
+    fmpz_mod_neg(t, s, ctx);
+    if (!_root_quadratic(x, t, u, ctx))
+    {
+        /* the other factor: y^2 + s y + (p/2 + m - q/(2s)) */
+        fmpz_mod_sub(u, u, t, ctx);
+        fmpz_mod_sub(u, u, t, ctx);
+        if (!_root_quadratic(x, s, u, ctx))
+            goto cleanup;
+    }
+    fmpz_mod_sub(x, x, shift, ctx);
+
+    /* check */
+    fmpz_mod_add(t, x, c3, ctx);
+    fmpz_mod_mul(t, t, x, ctx);
+    fmpz_mod_add(t, t, c2, ctx);
+    fmpz_mod_mul(t, t, x, ctx);
+    fmpz_mod_add(t, t, c1, ctx);
+    fmpz_mod_mul(t, t, x, ctx);
+    fmpz_mod_add(t, t, c0, ctx);
+    ok = fmpz_is_zero(t);
+
+cleanup:
+    fmpz_clear(p); fmpz_clear(q); fmpz_clear(r); fmpz_clear(shift); fmpz_clear(t);
+    fmpz_clear(u); fmpz_clear(m); fmpz_clear(s); fmpz_clear(i2); fmpz_clear(a1); fmpz_clear(a0);
+    return ok;
+}
+
+/*
+    A root of the monic polynomial f of degree 2, 3 or 4, assumed to split
+    completely modulo the prime modulus of ctx, by radicals. Returns 1 and
+    sets x on success, 0 if the degree is not handled (degrees 3 and 4
+    require n = 1 mod 3) or the computation failed.
+*/
+int
+ecpp_root_radicals(fmpz_t x, const fmpz_mod_poly_t f, flint_rand_t state,
+                                                        const fmpz_mod_ctx_t ctx)
+{
+    slong d = fmpz_mod_poly_degree(f, ctx);
+    fmpz c[4];
+    slong i;
+    int ok = 0;
+
+    if (d < 2 || d > 4)
+        return 0;
+    if (d >= 3)
+    {
+        ulong n9 = fmpz_fdiv_ui(fmpz_mod_ctx_modulus(ctx), 9);
+        /* n = 1 mod 3 in F_n; n = 2, 5 mod 9 through F_{n^2} */
+        if (n9 % 3 != 1 && n9 != 2 && n9 != 5)
+            return 0;
+    }
+    if (!fmpz_is_one(f->coeffs + d))
+        return 0;
+
+    for (i = 0; i < 4; i++)
+        fmpz_init(c + i);
+    for (i = 0; i < d; i++)
+        fmpz_mod_poly_get_coeff_fmpz(c + i, f, i, ctx);
+
+    if (d == 2)
+        ok = _root_quadratic(x, c + 1, c + 0, ctx);
+    else if (d == 3)
+        ok = _root_cubic(x, c + 2, c + 1, c + 0, state, ctx);
+    else
+        ok = _root_quartic(x, c + 3, c + 2, c + 1, c + 0, state, ctx);
+
+    for (i = 0; i < 4; i++)
+        fmpz_clear(c + i);
+    return ok;
+}
+
+/*
+    A root of the monic polynomial f, assumed to split completely modulo
+    the prime modulus of ctx: by radicals when possible, else by random
+    splitting with (x + r)^((n-1)/2). Returns 1 and sets x, or 0.
+*/
+int
+ecpp_poly_root(fmpz_t x, const fmpz_mod_poly_t f, flint_rand_t state,
+                                                        const fmpz_mod_ctx_t ctx)
+{
+    const fmpz * n = fmpz_mod_ctx_modulus(ctx);
+    fmpz_mod_poly_t g, base, pw, finv;
+    fmpz_t e, r;
+    slong tries = 0;
+    int found = 0;
+
+    if (fmpz_mod_poly_degree(f, ctx) < 1)
+        return 0;
+    if (fmpz_mod_poly_degree(f, ctx) == 1)
+    {
+        fmpz_mod_poly_get_coeff_fmpz(x, f, 0, ctx);
+        fmpz_mod_neg(x, x, ctx);
+        return 1;
+    }
+    if (fmpz_mod_poly_degree(f, ctx) <= 4 && ecpp_root_radicals(x, f, state, ctx))
+        return 1;
+
+    fmpz_mod_poly_init(g, ctx);
+    fmpz_mod_poly_init(base, ctx);
+    fmpz_mod_poly_init(pw, ctx);
+    fmpz_mod_poly_init(finv, ctx);
+    fmpz_init(e);
+    fmpz_init(r);
+    fmpz_mod_poly_set(g, f, ctx);
+    fmpz_sub_ui(e, n, 1);
+    fmpz_fdiv_q_2exp(e, e, 1);
+
+    while (!found && fmpz_mod_poly_degree(g, ctx) > 1 && tries < 30)
+    {
+        slong d = fmpz_mod_poly_degree(g, ctx);
+
+        if (d <= 4 && ecpp_root_radicals(x, g, state, ctx))
+        {
+            found = 1;
+            break;
+        }
+        /* gcd(g, (x + r)^((n-1)/2) - 1) */
+        fmpz_randm(r, state, n);
+        fmpz_mod_poly_zero(base, ctx);
+        fmpz_mod_poly_set_coeff_ui(base, 1, 1, ctx);
+        fmpz_mod_poly_set_coeff_fmpz(base, 0, r, ctx);
+        fmpz_mod_poly_reverse(finv, g, d + 1, ctx);
+        fmpz_mod_poly_inv_series(finv, finv, d + 1, ctx);
+        fmpz_mod_poly_powmod_fmpz_binexp_preinv(pw, base, e, g, finv, ctx);
+        fmpz_mod_poly_sub_si(pw, pw, 1, ctx);
+        fmpz_mod_poly_gcd(pw, pw, g, ctx);
+        if (fmpz_mod_poly_degree(pw, ctx) >= 1 && fmpz_mod_poly_degree(pw, ctx) < d)
+        {
+            if (2 * fmpz_mod_poly_degree(pw, ctx) > d)
+                fmpz_mod_poly_div(pw, g, pw, ctx);
+            fmpz_mod_poly_make_monic(g, pw, ctx);
+        }
+        tries++;
+    }
+    if (!found && fmpz_mod_poly_degree(g, ctx) == 1)
+    {
+        fmpz_mod_poly_get_coeff_fmpz(x, g, 0, ctx);
+        fmpz_mod_neg(x, x, ctx);
+        found = 1;
+    }
+
+    fmpz_mod_poly_clear(g, ctx);
+    fmpz_mod_poly_clear(base, ctx);
+    fmpz_mod_poly_clear(pw, ctx);
+    fmpz_mod_poly_clear(finv, ctx);
+    fmpz_clear(e);
+    fmpz_clear(r);
+    return found;
+}

--- a/src/ecpp/test/main.c
+++ b/src/ecpp/test/main.c
@@ -1,0 +1,38 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5.1
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+/* Include functions *********************************************************/
+
+#include "t-cert_str.c"
+#include "t-class_poly_genus.c"
+#include "t-class_poly_tower.c"
+#include "t-cornacchia.c"
+#include "t-point_mul.c"
+#include "t-prove.c"
+#include "t-root_radicals.c"
+
+/* Array of test functions ***************************************************/
+
+test_struct tests[] =
+{
+    TEST_FUNCTION(ecpp_cert_str),
+    TEST_FUNCTION(ecpp_class_poly_genus),
+    TEST_FUNCTION(ecpp_class_poly_tower),
+    TEST_FUNCTION(ecpp_cornacchia),
+    TEST_FUNCTION(ecpp_point_mul),
+    TEST_FUNCTION(ecpp_prove),
+    TEST_FUNCTION(ecpp_root_radicals)
+};
+
+/* main function *************************************************************/
+
+TEST_MAIN(tests)

--- a/src/ecpp/test/t-cert_str.c
+++ b/src/ecpp/test/t-cert_str.c
@@ -1,0 +1,76 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5.1
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <string.h>
+#include "test_helpers.h"
+#include "fmpz.h"
+#include "ecpp.h"
+
+TEST_FUNCTION_START(ecpp_cert_str, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 10 * flint_test_multiplier(); iter++)
+    {
+        fmpz_t n;
+        ecpp_cert_t cert, cert2;
+        char * str;
+        int format = ECPP_CERT_FORMAT_FLINT + n_randint(state, 2);
+
+        fmpz_init(n);
+        fmpz_randprime(n, state, 80 + n_randint(state, 120), 0);
+        ecpp_cert_init(cert);
+        ecpp_cert_init(cert2);
+
+        if (ecpp_prove(cert, n) != 1)
+        {
+            flint_printf("FAIL: not proved\n");
+            flint_abort();
+        }
+        str = ecpp_cert_get_str(cert, format);
+        if (!ecpp_cert_set_str(cert2, str))
+        {
+            flint_printf("FAIL: cannot read back the certificate (format %d)\n%s\n", format, str);
+            flint_abort();
+        }
+        if (cert2->num != cert->num || !ecpp_verify(cert2, n))
+        {
+            flint_printf("FAIL: certificate read back does not verify (format %d)\n%s\n", format, str);
+            flint_abort();
+        }
+        /* the PARI format drops D; everything else round-trips */
+        if (format == ECPP_CERT_FORMAT_FLINT)
+        {
+            slong i;
+            for (i = 0; i < cert->num; i++)
+                if (cert2->steps[i].D != cert->steps[i].D || !fmpz_equal(cert2->steps[i].b, cert->steps[i].b))
+                {
+                    flint_printf("FAIL: round trip\n");
+                    flint_abort();
+                }
+        }
+        flint_free(str);
+
+        /* garbage is rejected */
+        if (ecpp_cert_set_str(cert2, "[[12, 3, 4") || ecpp_cert_set_str(cert2, "ecpp certificate, 1 steps\n[0] n = x"))
+        {
+            flint_printf("FAIL: malformed string accepted\n");
+            flint_abort();
+        }
+
+        ecpp_cert_clear(cert);
+        ecpp_cert_clear(cert2);
+        fmpz_clear(n);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/ecpp/test/t-cert_str.c
+++ b/src/ecpp/test/t-cert_str.c
@@ -10,6 +10,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include <stdio.h>
 #include <string.h>
 #include "test_helpers.h"
 #include "fmpz.h"
@@ -59,6 +60,17 @@ TEST_FUNCTION_START(ecpp_cert_str, state)
                 }
         }
         flint_free(str);
+
+        /* printing (to a temporary file) in both formats */
+        {
+            FILE * tmp = tmpfile();
+            if (tmp != NULL)
+            {
+                ecpp_cert_fprint(tmp, cert, ECPP_CERT_FORMAT_FLINT);
+                ecpp_cert_fprint(tmp, cert, ECPP_CERT_FORMAT_PARI);
+                fclose(tmp);
+            }
+        }
 
         /* garbage is rejected */
         if (ecpp_cert_set_str(cert2, "[[12, 3, 4") || ecpp_cert_set_str(cert2, "ecpp certificate, 1 steps\n[0] n = x"))

--- a/src/ecpp/test/t-class_poly_genus.c
+++ b/src/ecpp/test/t-class_poly_genus.c
@@ -1,0 +1,143 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5.1
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "ulong_extras.h"
+#include "fmpz.h"
+#include "fmpz_poly.h"
+#include "fmpz_mod.h"
+#include "fmpz_mod_poly.h"
+#include "acb_modular.h"
+#include "ecpp.h"
+
+TEST_FUNCTION_START(ecpp_class_poly_genus, state)
+{
+    slong iter;
+    ulong primes[64];
+    slong nprimes = 0, i;
+    n_primes_t it;
+
+    n_primes_init(it);
+    n_primes_next(it);
+    for (i = 0; i < 64; i++)
+        primes[nprimes++] = n_primes_next(it);
+    n_primes_clear(it);
+
+    for (iter = 0; iter < 30 * flint_test_multiplier(); iter++)
+    {
+        ecpp_disc_struct * discs;
+        slong ndiscs, k, g, o, tries;
+        fmpz_t n, np, s;
+        fmpz_mod_ctx_t ctx;
+        fmpz_mod_poly_t F, H, R;
+        fmpz_poly_t HZ;
+        slong pstar[ECPP_DISC_MAXFAC + 1];
+        fmpz sqrts[ECPP_DISC_MAXFAC + 1];
+        const ecpp_disc_struct * d;
+
+        ndiscs = ecpp_disc_table(&discs, primes, nprimes, 20000, 64, 64, 0.0);
+        /* a discriminant with at least two genus characters */
+        do
+            k = n_randint(state, ndiscs);
+        while (discs[k].g < 2);
+        d = discs + k;
+
+        fmpz_init(n); fmpz_init(np); fmpz_init(s);
+        for (i = 0; i <= ECPP_DISC_MAXFAC; i++)
+            fmpz_init(sqrts + i);
+
+        /* a prime with all characters 1 */
+        for (tries = 0; ; tries++)
+        {
+            int ok = 1;
+            ulong n8;
+            fmpz_randprime(n, state, 60 + n_randint(state, 100), 0);
+            n8 = fmpz_fdiv_ui(n, 8);
+            if (d->q0 == -4 && n8 % 4 != 1) ok = 0;
+            if (d->q0 == 8 && !(n8 == 1 || n8 == 7)) ok = 0;
+            if (d->q0 == -8 && !(n8 == 1 || n8 == 3)) ok = 0;
+            for (i = 0; i < d->nfac && ok; i++)
+                if (n_jacobi(fmpz_fdiv_ui(n, primes[d->fac[i]]), primes[d->fac[i]]) != 1)
+                    ok = 0;
+            if (ok)
+                break;
+        }
+
+        fmpz_mod_ctx_init(ctx, n);
+        g = 0;
+        for (i = 0; i < d->nfac; i++)
+        {
+            ulong p = primes[d->fac[i]];
+            pstar[g] = (p % 4 == 1) ? (slong) p : -(slong) p;
+            fmpz_set_si(s, pstar[g]);
+            fmpz_mod_set_fmpz(s, s, ctx);
+            if (!fmpz_sqrtmod(sqrts + g, s, n))
+                flint_abort();
+            g++;
+        }
+        if (d->q0 != 1)
+        {
+            pstar[g] = d->q0;
+            fmpz_set_si(s, d->q0 / 4);
+            fmpz_mod_set_fmpz(s, s, ctx);
+            if (!fmpz_sqrtmod(sqrts + g, s, n))
+                flint_abort();
+            fmpz_mod_add(sqrts + g, sqrts + g, sqrts + g, ctx);
+            g++;
+        }
+        if (g != d->g)
+        {
+            flint_printf("FAIL: g mismatch for D = %wd\n", d->D);
+            flint_abort();
+        }
+
+        fmpz_mod_poly_init(F, ctx);
+        fmpz_mod_poly_init(H, ctx);
+        fmpz_mod_poly_init(R, ctx);
+        fmpz_poly_init(HZ);
+
+        if (!ecpp_class_poly_genus(F, d->D, pstar, g, sqrts, ctx))
+        {
+            flint_printf("FAIL: genus factor not found for D = %wd (h = %wd, g = %wd)\n", d->D, d->h, d->g);
+            flint_abort();
+        }
+        acb_modular_hilbert_class_poly(HZ, d->D);
+        fmpz_mod_poly_set_fmpz_poly(H, HZ, ctx);
+        o = d->h;
+        for (i = 1; i < g; i++)
+            o /= 2;
+        if (fmpz_mod_poly_degree(F, ctx) != o)
+        {
+            flint_printf("FAIL: degree %wd, expected %wd (D = %wd)\n", fmpz_mod_poly_degree(F, ctx), o, d->D);
+            flint_abort();
+        }
+        fmpz_mod_poly_rem(R, H, F, ctx);
+        if (!fmpz_mod_poly_is_zero(R, ctx))
+        {
+            flint_printf("FAIL: factor does not divide H_D mod n (D = %wd, h = %wd, g = %wd)\n", d->D, d->h, d->g);
+            flint_printf("n = "); fmpz_print(n); flint_printf("\n");
+            flint_abort();
+        }
+
+        fmpz_mod_poly_clear(F, ctx);
+        fmpz_mod_poly_clear(H, ctx);
+        fmpz_mod_poly_clear(R, ctx);
+        fmpz_poly_clear(HZ);
+        fmpz_mod_ctx_clear(ctx);
+        for (i = 0; i <= ECPP_DISC_MAXFAC; i++)
+            fmpz_clear(sqrts + i);
+        fmpz_clear(n); fmpz_clear(np); fmpz_clear(s);
+        flint_free(discs);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/ecpp/test/t-class_poly_tower.c
+++ b/src/ecpp/test/t-class_poly_tower.c
@@ -19,12 +19,94 @@
 #include "acb_modular.h"
 #include "ecpp.h"
 
+/* a prime of the given size with n = residue mod modulus that splits
+   completely in the Hilbert class field of D (4n = t^2 + |D| v^2), with
+   v of the requested parity (or any, vpar < 0) */
+static void
+_split_prime(fmpz_t n, fmpz_t v, slong D, slong bits, ulong modulus, ulong residue,
+                                                int vpar, flint_rand_t state)
+{
+    fmpz_t t, sq;
+    fmpz_init(t);
+    fmpz_init(sq);
+    for (;;)
+    {
+        fmpz_randprime(n, state, bits, 0);
+        if (modulus > 1 && fmpz_fdiv_ui(n, modulus) != residue)
+            continue;
+        fmpz_set_si(sq, D);
+        fmpz_mod(sq, sq, n);
+        if (fmpz_jacobi(sq, n) != 1)
+            continue;
+        fmpz_sqrtmod(sq, sq, n);
+        if (!ecpp_cornacchia(t, v, n, D, sq))
+            continue;
+        if (vpar < 0 || (int) fmpz_is_even(v) == vpar)
+            break;
+    }
+    fmpz_clear(t);
+    fmpz_clear(sq);
+}
+
+/* checks that ecpp_class_poly_tower with the flags returns a root of H_Dt */
+static void
+_check_tower(slong D, slong Dt, int flags, const fmpz_t n, flint_rand_t state, const char * what)
+{
+    fmpz_mod_ctx_t ctx;
+    fmpz_poly_t HZ;
+    fmpz_mod_poly_t H;
+    fmpz_t j, t;
+
+    fmpz_init(j);
+    fmpz_init(t);
+    fmpz_mod_ctx_init(ctx, n);
+    fmpz_poly_init(HZ);
+    fmpz_mod_poly_init(H, ctx);
+
+    if (!_ecpp_class_poly_tower(j, Dt, flags, state, ctx))
+    {
+        flint_printf("FAIL: no root found (%s), D = %wd, tower on %wd, flags %d\n", what, D, Dt, flags);
+        flint_printf("n = "); fmpz_print(n); flint_printf("\n");
+        flint_abort();
+    }
+    acb_modular_hilbert_class_poly(HZ, Dt);
+    fmpz_mod_poly_set_fmpz_poly(H, HZ, ctx);
+    fmpz_mod_poly_evaluate_fmpz(t, H, j, ctx);
+    if (!fmpz_is_zero(t))
+    {
+        flint_printf("FAIL: not a root (%s), D = %wd, tower on %wd, flags %d\n", what, D, Dt, flags);
+        flint_printf("n = "); fmpz_print(n); flint_printf("\n");
+        flint_abort();
+    }
+
+    fmpz_mod_poly_clear(H, ctx);
+    fmpz_poly_clear(HZ);
+    fmpz_mod_ctx_clear(ctx);
+    fmpz_clear(j);
+    fmpz_clear(t);
+}
+
 TEST_FUNCTION_START(ecpp_class_poly_tower, state)
 {
-    slong iter;
+    slong iter, i;
     ulong primes[64];
-    slong nprimes = 0, i;
+    slong nprimes = 0;
     n_primes_t it;
+    fmpz_t n, v;
+
+    /* discriminants whose class number has a given prime factor p >= 5 at
+       a level above the bottom, for the Kummer descents: h(-119) = 10,
+       h(-215) = 14, h(-591) = 22 (odd D, hence j); h(-296) = 10,
+       h(-404) = 14, h(-1256) = 26 (even D, Weber; -1256 also with j) */
+    static const slong kummer_D[] = {-119, -215, -591, -296, -404, -1256, -1256};
+    static const slong kummer_p[] = {5, 7, 11, 5, 7, 13, 13};
+    /* even discriminants covering every class of m = -D/4 mod 8 in which
+       Weber's function is used: m = 1, 2, 3, 5, 6, 7 */
+    static const slong weber_D[] = {-4 * 33, -4 * 10, -4 * 35, -4 * 21, -4 * 22, -4 * 15,
+                                    -4 * 105, -4 * 130, -4 * 195, -4 * 165, -4 * 462, -4 * 231};
+
+    fmpz_init(n);
+    fmpz_init(v);
 
     n_primes_init(it);
     n_primes_next(it);
@@ -32,14 +114,11 @@ TEST_FUNCTION_START(ecpp_class_poly_tower, state)
         primes[nprimes++] = n_primes_next(it);
     n_primes_clear(it);
 
-    for (iter = 0; iter < 20 * flint_test_multiplier(); iter++)
+    /* random discriminants from the pool, the default flags */
+    for (iter = 0; iter < 10 * flint_test_multiplier(); iter++)
     {
         ecpp_disc_struct * discs;
-        slong ndiscs, k, tries;
-        fmpz_t n, j, t, v, sq;
-        fmpz_mod_ctx_t ctx;
-        fmpz_poly_t HZ;
-        fmpz_mod_poly_t H;
+        slong ndiscs, k;
         const ecpp_disc_struct * d;
 
         ndiscs = ecpp_disc_table(&discs, primes, nprimes, 40000, 48, 48, 0.0);
@@ -48,64 +127,67 @@ TEST_FUNCTION_START(ecpp_class_poly_tower, state)
         while (discs[k].h < 2);
         d = discs + k;
 
-        fmpz_init(n); fmpz_init(j); fmpz_init(t); fmpz_init(v); fmpz_init(sq);
-
-        /* a prime represented by the principal form: 4n = t^2 + |D| v^2 */
-        for (tries = 0; ; tries++)
-        {
-            fmpz_randprime(n, state, 60 + n_randint(state, 100), 0);
-            fmpz_set_si(sq, d->D);
-            fmpz_mod(sq, sq, n);
-            if (fmpz_jacobi(sq, n) != 1)
-                continue;
-            fmpz_sqrtmod(sq, sq, n);
-            if (ecpp_cornacchia(t, v, n, d->D, sq))
-                break;
-        }
-
-        fmpz_mod_ctx_init(ctx, n);
-        fmpz_poly_init(HZ);
-        fmpz_mod_poly_init(H, ctx);
-
-        if (!ecpp_class_poly_tower(j, d->D, state, ctx))
-        {
-            flint_printf("FAIL: no root found for D = %wd (h = %wd)\n", d->D, d->h);
-            flint_abort();
-        }
-        acb_modular_hilbert_class_poly(HZ, d->D);
-        fmpz_mod_poly_set_fmpz_poly(H, HZ, ctx);
-        fmpz_mod_poly_evaluate_fmpz(t, H, j, ctx);
-        if (!fmpz_is_zero(t))
-        {
-            flint_printf("FAIL: not a root of H_D for D = %wd (h = %wd)\n", d->D, d->h);
-            flint_printf("n = "); fmpz_print(n); flint_printf("\n");
-            flint_abort();
-        }
+        _split_prime(n, v, d->D, 60 + n_randint(state, 100), 1, 0, -1, state);
+        _check_tower(d->D, d->D, 0, n, state, "pool, default");
 
         /* odd D with v even: the order of conductor 2 with Weber's f */
         if (d->D % 2 != 0 && fmpz_is_even(v))
-        {
-            if (!ecpp_class_poly_tower(j, 4 * d->D, state, ctx))
-            {
-                flint_printf("FAIL: no root found for 4D, D = %wd (h = %wd)\n", d->D, d->h);
-                flint_abort();
-            }
-            acb_modular_hilbert_class_poly(HZ, 4 * d->D);
-            fmpz_mod_poly_set_fmpz_poly(H, HZ, ctx);
-            fmpz_mod_poly_evaluate_fmpz(t, H, j, ctx);
-            if (!fmpz_is_zero(t))
-            {
-                flint_printf("FAIL: not a root of H_{4D} for D = %wd (h = %wd)\n", d->D, d->h);
-                flint_abort();
-            }
-        }
+            _check_tower(d->D, 4 * d->D, 0, n, state, "conductor 2");
 
-        fmpz_mod_poly_clear(H, ctx);
-        fmpz_poly_clear(HZ);
-        fmpz_mod_ctx_clear(ctx);
-        fmpz_clear(n); fmpz_clear(j); fmpz_clear(t); fmpz_clear(v); fmpz_clear(sq);
         flint_free(discs);
     }
+
+    /* the Kummer descents: n = 1 mod p (in F_n) and n = -1 mod p (in
+       F_{n^2}), and the powering when neither applies */
+    for (i = 0; i < 7; i++)
+    {
+        slong D = kummer_D[i], p = kummer_p[i];
+        int wflags = (D % 4 == 0 && i != 6) ? 0 : ECPP_TOWER_J;
+
+        _split_prime(n, v, D, 100 + n_randint(state, 100), p, 1, -1, state);
+        _check_tower(D, D, ECPP_TOWER_KUMMER | wflags, n, state, "Kummer in F_n");
+        _split_prime(n, v, D, 100 + n_randint(state, 100), p, p - 1, -1, state);
+        _check_tower(D, D, ECPP_TOWER_KUMMER | wflags, n, state, "Kummer in F_(n^2)");
+        _split_prime(n, v, D, 100 + n_randint(state, 100), p, 2, -1, state);
+        _check_tower(D, D, ECPP_TOWER_KUMMER | wflags, n, state, "Kummer data, powering");
+    }
+
+    /* class number one, and a Kummer descent needing the discrete
+       logarithm in the p-Sylow subgroup (p^2 | n - 1) */
+    _split_prime(n, v, -7, 60 + n_randint(state, 60), 1, 0, -1, state);
+    _check_tower(-7, -7, 0, n, state, "h = 1");
+    _split_prime(n, v, -296, 100 + n_randint(state, 60), 25, 1, -1, state);
+    _check_tower(-296, -296, ECPP_TOWER_KUMMER, n, state, "Kummer, 25 | n - 1");
+    _split_prime(n, v, -404, 100 + n_randint(state, 60), 49, 1, -1, state);
+    _check_tower(-404, -404, ECPP_TOWER_KUMMER, n, state, "Kummer, 49 | n - 1");
+
+    /* Weber's function in every residue class of m, against the j path */
+    for (i = 0; i < 12; i++)
+    {
+        slong D = weber_D[i];
+        _split_prime(n, v, D, 60 + n_randint(state, 100), 1, 0, -1, state);
+        _check_tower(D, D, 0, n, state, "Weber");
+        _check_tower(D, D, ECPP_TOWER_J, n, state, "j on an even D");
+    }
+
+    /* odd D of both residue classes mod 8 through the order of conductor
+       2 (v even: always for D = 1 mod 8, half of the time for D = 5 mod
+       8), and with j when v is odd (D = 5 mod 8 only) */
+    for (iter = 0; iter < 4; iter++)
+    {
+        static const slong odd_D[] = {-1147, -455, -615, -1155};
+        slong D = odd_D[iter];
+        _split_prime(n, v, D, 60 + n_randint(state, 100), 1, 0, 1, state);
+        _check_tower(D, 4 * D, 0, n, state, "conductor 2, v even");
+        if ((-D) % 8 == 3)
+        {
+            _split_prime(n, v, D, 60 + n_randint(state, 100), 1, 0, 0, state);
+            _check_tower(D, D, 0, n, state, "j, v odd");
+        }
+    }
+
+    fmpz_clear(n);
+    fmpz_clear(v);
 
     TEST_FUNCTION_END(state);
 }

--- a/src/ecpp/test/t-class_poly_tower.c
+++ b/src/ecpp/test/t-class_poly_tower.c
@@ -1,0 +1,111 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5.1
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "ulong_extras.h"
+#include "fmpz.h"
+#include "fmpz_poly.h"
+#include "fmpz_mod.h"
+#include "fmpz_mod_poly.h"
+#include "acb_modular.h"
+#include "ecpp.h"
+
+TEST_FUNCTION_START(ecpp_class_poly_tower, state)
+{
+    slong iter;
+    ulong primes[64];
+    slong nprimes = 0, i;
+    n_primes_t it;
+
+    n_primes_init(it);
+    n_primes_next(it);
+    for (i = 0; i < 64; i++)
+        primes[nprimes++] = n_primes_next(it);
+    n_primes_clear(it);
+
+    for (iter = 0; iter < 20 * flint_test_multiplier(); iter++)
+    {
+        ecpp_disc_struct * discs;
+        slong ndiscs, k, tries;
+        fmpz_t n, j, t, v, sq;
+        fmpz_mod_ctx_t ctx;
+        fmpz_poly_t HZ;
+        fmpz_mod_poly_t H;
+        const ecpp_disc_struct * d;
+
+        ndiscs = ecpp_disc_table(&discs, primes, nprimes, 40000, 48, 48, 0.0);
+        do
+            k = n_randint(state, ndiscs);
+        while (discs[k].h < 2);
+        d = discs + k;
+
+        fmpz_init(n); fmpz_init(j); fmpz_init(t); fmpz_init(v); fmpz_init(sq);
+
+        /* a prime represented by the principal form: 4n = t^2 + |D| v^2 */
+        for (tries = 0; ; tries++)
+        {
+            fmpz_randprime(n, state, 60 + n_randint(state, 100), 0);
+            fmpz_set_si(sq, d->D);
+            fmpz_mod(sq, sq, n);
+            if (fmpz_jacobi(sq, n) != 1)
+                continue;
+            fmpz_sqrtmod(sq, sq, n);
+            if (ecpp_cornacchia(t, v, n, d->D, sq))
+                break;
+        }
+
+        fmpz_mod_ctx_init(ctx, n);
+        fmpz_poly_init(HZ);
+        fmpz_mod_poly_init(H, ctx);
+
+        if (!ecpp_class_poly_tower(j, d->D, state, ctx))
+        {
+            flint_printf("FAIL: no root found for D = %wd (h = %wd)\n", d->D, d->h);
+            flint_abort();
+        }
+        acb_modular_hilbert_class_poly(HZ, d->D);
+        fmpz_mod_poly_set_fmpz_poly(H, HZ, ctx);
+        fmpz_mod_poly_evaluate_fmpz(t, H, j, ctx);
+        if (!fmpz_is_zero(t))
+        {
+            flint_printf("FAIL: not a root of H_D for D = %wd (h = %wd)\n", d->D, d->h);
+            flint_printf("n = "); fmpz_print(n); flint_printf("\n");
+            flint_abort();
+        }
+
+        /* odd D with v even: the order of conductor 2 with Weber's f */
+        if (d->D % 2 != 0 && fmpz_is_even(v))
+        {
+            if (!ecpp_class_poly_tower(j, 4 * d->D, state, ctx))
+            {
+                flint_printf("FAIL: no root found for 4D, D = %wd (h = %wd)\n", d->D, d->h);
+                flint_abort();
+            }
+            acb_modular_hilbert_class_poly(HZ, 4 * d->D);
+            fmpz_mod_poly_set_fmpz_poly(H, HZ, ctx);
+            fmpz_mod_poly_evaluate_fmpz(t, H, j, ctx);
+            if (!fmpz_is_zero(t))
+            {
+                flint_printf("FAIL: not a root of H_{4D} for D = %wd (h = %wd)\n", d->D, d->h);
+                flint_abort();
+            }
+        }
+
+        fmpz_mod_poly_clear(H, ctx);
+        fmpz_poly_clear(HZ);
+        fmpz_mod_ctx_clear(ctx);
+        fmpz_clear(n); fmpz_clear(j); fmpz_clear(t); fmpz_clear(v); fmpz_clear(sq);
+        flint_free(discs);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/ecpp/test/t-cornacchia.c
+++ b/src/ecpp/test/t-cornacchia.c
@@ -1,0 +1,95 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5.1
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <math.h>
+#include "test_helpers.h"
+#include "fmpz.h"
+#include "ecpp.h"
+
+TEST_FUNCTION_START(ecpp_cornacchia, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 200 * flint_test_multiplier(); iter++)
+    {
+        fmpz_t n, D, sqrtD, t, v, u;
+        slong Dv;
+        int r;
+
+        fmpz_init(n); fmpz_init(D); fmpz_init(sqrtD);
+        fmpz_init(t); fmpz_init(v); fmpz_init(u);
+
+        /* random prime and small discriminant with (D/n) = 1 */
+        fmpz_randprime(n, state, 10 + n_randint(state, 300), 0);
+        do
+        {
+            Dv = -(slong) (3 + n_randint(state, 2000));
+            if ((-Dv) % 4 != 3 && (-Dv) % 4 != 0)
+                continue;
+            fmpz_set_si(D, Dv);
+            fmpz_mod(D, D, n);
+        } while (fmpz_jacobi(D, n) != 1);
+
+        if (!fmpz_sqrtmod(sqrtD, D, n))
+            flint_abort();
+
+        r = ecpp_cornacchia(t, v, n, Dv, sqrtD);
+
+        if (r)
+        {
+            /* t^2 + |D| v^2 = 4n */
+            fmpz_mul(u, t, t);
+            fmpz_mul(v, v, v);
+            fmpz_mul_si(v, v, -Dv);
+            fmpz_add(u, u, v);
+            fmpz_mul_2exp(t, n, 2);
+            if (!fmpz_equal(u, t))
+            {
+                flint_printf("FAIL: t^2 + |D| v^2 != 4n\n");
+                flint_printf("n = "); fmpz_print(n); flint_printf(" D = %wd\n", Dv);
+                fflush(stdout);
+                flint_abort();
+            }
+        }
+        else
+        {
+            /* verify there is really no solution by brute force for small n */
+            if (fmpz_bits(n) <= 20)
+            {
+                slong nn = fmpz_get_si(n), tt, found = 0;
+                for (tt = 0; tt * tt <= 4 * nn; tt++)
+                {
+                    slong rem = 4 * nn - tt * tt;
+                    if (rem % (-Dv) == 0)
+                    {
+                        slong vv = rem / (-Dv), sq = (slong) sqrt((double) vv);
+                        while (sq * sq < vv) sq++;
+                        while (sq * sq > vv) sq--;
+                        if (sq * sq == vv)
+                            found = 1;
+                    }
+                }
+                if (found)
+                {
+                    flint_printf("FAIL: missed a solution, n = %wd D = %wd\n", nn, Dv);
+                    fflush(stdout);
+                    flint_abort();
+                }
+            }
+        }
+
+        fmpz_clear(n); fmpz_clear(D); fmpz_clear(sqrtD);
+        fmpz_clear(t); fmpz_clear(v); fmpz_clear(u);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/ecpp/test/t-point_mul.c
+++ b/src/ecpp/test/t-point_mul.c
@@ -1,0 +1,145 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5.1
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "fmpz.h"
+#include "fmpz_mod.h"
+#include "ecpp.h"
+
+/* affine coordinates of a Jacobian point */
+static void
+_affine(fmpz_t x, fmpz_t y, const ecpp_point_t P, const fmpz_mod_ctx_t ctx)
+{
+    fmpz_t zi, t;
+    fmpz_init(zi);
+    fmpz_init(t);
+    fmpz_mod_inv(zi, P->Z, ctx);
+    fmpz_mod_mul(t, zi, zi, ctx);
+    fmpz_mod_mul(x, P->X, t, ctx);
+    fmpz_mod_mul(t, t, zi, ctx);
+    fmpz_mod_mul(y, P->Y, t, ctx);
+    fmpz_clear(zi);
+    fmpz_clear(t);
+}
+
+TEST_FUNCTION_START(ecpp_point_mul, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 100 * flint_test_multiplier(); iter++)
+    {
+        fmpz_t n, a, b, x, y, k, l, kl, acc, g, x1, y1, x2, y2, t;
+        fmpz_mod_ctx_t ctx;
+        ecpp_point_t P, R1, R2, R3;
+        int ok;
+
+        fmpz_init(n); fmpz_init(a); fmpz_init(b); fmpz_init(x); fmpz_init(y);
+        fmpz_init(k); fmpz_init(l); fmpz_init(kl); fmpz_init(acc); fmpz_init(g);
+        fmpz_init(x1); fmpz_init(y1); fmpz_init(x2); fmpz_init(y2); fmpz_init(t);
+
+        fmpz_randprime(n, state, 20 + n_randint(state, 200), 0);
+        fmpz_mod_ctx_init(ctx, n);
+        ecpp_point_init(P); ecpp_point_init(R1); ecpp_point_init(R2); ecpp_point_init(R3);
+
+        /* random curve through a random point: b = y^2 - x^3 - a x */
+        fmpz_randm(a, state, n);
+        fmpz_randm(x, state, n);
+        fmpz_randm(y, state, n);
+        fmpz_mod_mul(b, y, y, ctx);
+        fmpz_mod_mul(t, x, x, ctx);
+        fmpz_mod_add(t, t, a, ctx);
+        fmpz_mod_mul(t, t, x, ctx);
+        fmpz_mod_sub(b, b, t, ctx);
+
+        ecpp_point_set_affine(P, x, y);
+        fmpz_randtest_unsigned(k, state, 100);
+        fmpz_randtest_unsigned(l, state, 100);
+        fmpz_add(kl, k, l);
+
+        /* (k + l) P == k P + l P, checked in affine coordinates */
+        fmpz_one(acc);
+        ecpp_point_mul(R1, P, k, a, acc, ctx);
+        ecpp_point_mul(R2, P, l, a, acc, ctx);
+        ecpp_point_mul(R3, P, kl, a, acc, ctx);
+        fmpz_gcd(g, acc, n);
+        if (!fmpz_is_one(g))
+        {
+            flint_printf("FAIL: acc not a unit for prime n\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        ok = 1;
+
+        /* compare (k + l) P with k P + l P added in affine coordinates */
+        {
+            if (!ecpp_point_is_zero(R1) && !ecpp_point_is_zero(R2) && !ecpp_point_is_zero(R3))
+            {
+                /* add R1 and R2 in affine coordinates */
+                fmpz_t lam, x3, y3;
+                fmpz_init(lam); fmpz_init(x3); fmpz_init(y3);
+                _affine(x1, y1, R1, ctx);
+                _affine(x2, y2, R2, ctx);
+                if (fmpz_equal(x1, x2))
+                {
+                    if (!fmpz_equal(y1, y2))
+                        ok = ecpp_point_is_zero(R3);   /* R1 = -R2 */
+                    else
+                    {
+                        /* doubling: lam = (3 x^2 + a) / (2 y) */
+                        fmpz_mod_mul(lam, x1, x1, ctx);
+                        fmpz_mod_mul_ui(lam, lam, 3, ctx);
+                        fmpz_mod_add(lam, lam, a, ctx);
+                        fmpz_mod_add(t, y1, y1, ctx);
+                        fmpz_mod_inv(t, t, ctx);
+                        fmpz_mod_mul(lam, lam, t, ctx);
+                    }
+                }
+                else
+                {
+                    fmpz_mod_sub(lam, y2, y1, ctx);
+                    fmpz_mod_sub(t, x2, x1, ctx);
+                    fmpz_mod_inv(t, t, ctx);
+                    fmpz_mod_mul(lam, lam, t, ctx);
+                }
+                if (ok && !ecpp_point_is_zero(R3) && !(fmpz_equal(x1, x2) && !fmpz_equal(y1, y2)))
+                {
+                    fmpz_mod_mul(x3, lam, lam, ctx);
+                    fmpz_mod_sub(x3, x3, x1, ctx);
+                    fmpz_mod_sub(x3, x3, x2, ctx);
+                    fmpz_mod_sub(y3, x1, x3, ctx);
+                    fmpz_mod_mul(y3, y3, lam, ctx);
+                    fmpz_mod_sub(y3, y3, y1, ctx);
+                    _affine(x1, y1, R3, ctx);
+                    ok = fmpz_equal(x1, x3) && fmpz_equal(y1, y3);
+                }
+                fmpz_clear(lam); fmpz_clear(x3); fmpz_clear(y3);
+            }
+        }
+
+        if (!ok)
+        {
+            flint_printf("FAIL: (k + l) P != k P + l P\n");
+            flint_printf("n = "); fmpz_print(n); flint_printf("\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        ecpp_point_clear(P); ecpp_point_clear(R1); ecpp_point_clear(R2); ecpp_point_clear(R3);
+        fmpz_mod_ctx_clear(ctx);
+        fmpz_clear(n); fmpz_clear(a); fmpz_clear(b); fmpz_clear(x); fmpz_clear(y);
+        fmpz_clear(k); fmpz_clear(l); fmpz_clear(kl); fmpz_clear(acc); fmpz_clear(g);
+        fmpz_clear(x1); fmpz_clear(y1); fmpz_clear(x2); fmpz_clear(y2); fmpz_clear(t);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/ecpp/test/t-prove.c
+++ b/src/ecpp/test/t-prove.c
@@ -82,6 +82,38 @@ TEST_FUNCTION_START(ecpp_prove, state)
         fmpz_clear(b);
     }
 
+    /*
+        The threaded paths (parallel square roots, Cornacchia, tests and
+        primorial reduction, the realisation of a step pipelined with the
+        search for the next) are only used from 1000 bits: one proof each
+        with two and four threads, verified.
+    */
+    {
+        fmpz_t n;
+        ecpp_cert_t cert;
+        int t;
+        fmpz_init(n);
+        ecpp_cert_init(cert);
+        for (t = 2; t <= 4; t += 2)
+        {
+            flint_set_num_threads(t);
+            fmpz_randprime(n, state, 1040, 0);
+            if (ecpp_prove(cert, n) != 1 || !ecpp_verify(cert, n))
+            {
+                flint_printf("FAIL: threaded proof (%d threads)\n", t);
+                flint_abort();
+            }
+        }
+        flint_set_num_threads(1);
+        if (ecpp_is_prime(n) != 1)
+        {
+            flint_printf("FAIL: ecpp_is_prime\n");
+            flint_abort();
+        }
+        ecpp_cert_clear(cert);
+        fmpz_clear(n);
+    }
+
     /* an n = 7 mod 8 with few usable discriminants and, by chance, no
        prime cofactor among them at the default pool: the prover must
        enlarge the pool rather than give up (about 10 s, so only with a

--- a/src/ecpp/test/t-prove.c
+++ b/src/ecpp/test/t-prove.c
@@ -1,0 +1,106 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5.1
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "thread_support.h"
+#include "fmpz.h"
+#include "ecpp.h"
+
+TEST_FUNCTION_START(ecpp_prove, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 20 * flint_test_multiplier(); iter++)
+    {
+        fmpz_t n, a, b;
+        ecpp_cert_t cert;
+        int r, v;
+        ulong bits = 40 + n_randint(state, 260);
+
+        fmpz_init(n);
+        fmpz_init(a);
+        fmpz_init(b);
+        ecpp_cert_init(cert);
+
+        /* primes are proved and the certificate verifies */
+        flint_set_num_threads(1 + n_randint(state, 4));
+        fmpz_randprime(n, state, bits, 0);
+        r = ecpp_prove(cert, n);
+        v = ecpp_verify(cert, n);
+        if (r != 1 || v != 1)
+        {
+            flint_printf("FAIL: prime not proved (r = %d, v = %d)\n", r, v);
+            flint_printf("n = "); fmpz_print(n); flint_printf("\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        /* a tampered certificate does not verify */
+        if (cert->num > 0)
+        {
+            slong i = n_randint(state, cert->num);
+            ecpp_step_struct * s = cert->steps + i;
+            switch (n_randint(state, 3))
+            {
+                case 0: fmpz_add_ui(s->x, s->x, 1); break;
+                case 1: fmpz_add_ui(s->m, s->m, 1); break;
+                default: fmpz_mul_ui(s->q, s->q, 3); fmpz_mul_ui(s->m, s->m, 3); break;
+            }
+            if (ecpp_verify(cert, n))
+            {
+                flint_printf("FAIL: tampered certificate verified (step %wd)\n", i);
+                fflush(stdout);
+                flint_abort();
+            }
+        }
+
+        /* composites are not proved prime */
+        fmpz_randprime(a, state, bits / 2 + 1, 0);
+        fmpz_randprime(b, state, bits / 2 + 1, 0);
+        fmpz_mul(n, a, b);
+        r = ecpp_prove(cert, n);
+        if (r == 1)
+        {
+            flint_printf("FAIL: composite proved prime\n");
+            flint_printf("n = "); fmpz_print(n); flint_printf("\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        ecpp_cert_clear(cert);
+        fmpz_clear(n);
+        fmpz_clear(a);
+        fmpz_clear(b);
+    }
+
+    /* an n = 7 mod 8 with few usable discriminants and, by chance, no
+       prime cofactor among them at the default pool: the prover must
+       enlarge the pool rather than give up (about 10 s, so only with a
+       larger test multiplier) */
+    if (flint_test_multiplier() >= 10)
+    {
+        fmpz_t n;
+        ecpp_cert_t cert;
+        fmpz_init(n);
+        fmpz_set_str(n, "88363814595325262951445720094930589777897145434462564937225488250994905022645222622725601396515582699063218221298025377608393118898106025205715037109591592612870685613877007100075133857203704904169022111933792777110350644611870624711587786863084348383335529279048305428172521478762017194976755312496362372974683031007992968097665280297619129559210622475419066399613556576823984180069109344036197352261142667486746457452339168941999567662039924945596078213579199882014901965117705901630993160274997938406439568014705038962747091037015881295787311820800467719372094876330311922693956283303", 10);
+        ecpp_cert_init(cert);
+        if (ecpp_prove(cert, n) != 1 || !ecpp_verify(cert, n))
+        {
+            flint_printf("FAIL: the n = 7 mod 8 regression case\n");
+            flint_abort();
+        }
+        ecpp_cert_clear(cert);
+        fmpz_clear(n);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/ecpp/test/t-root_radicals.c
+++ b/src/ecpp/test/t-root_radicals.c
@@ -69,5 +69,70 @@ TEST_FUNCTION_START(ecpp_root_radicals, state)
         fmpz_clear(n); fmpz_clear(r); fmpz_clear(x);
     }
 
+    /* the special shapes: a depressed cubic x^3 - c (three roots when
+       n = 1 mod 3) and a biquadratic x^4 + p x^2 + r with roots +-r1, +-r2 */
+    for (iter = 0; iter < 20 * flint_test_multiplier(); iter++)
+    {
+        fmpz_t n, r, x, w;
+        fmpz_mod_ctx_t ctx;
+        fmpz_mod_poly_t f, lin;
+        int biquad = iter % 2, ok;
+
+        fmpz_init(n); fmpz_init(r); fmpz_init(x); fmpz_init(w);
+        do
+            fmpz_randprime(n, state, 20 + n_randint(state, 200), 0);
+        while (fmpz_fdiv_ui(n, 3) != 1);
+        fmpz_mod_ctx_init(ctx, n);
+        fmpz_mod_poly_init(f, ctx);
+        fmpz_mod_poly_init(lin, ctx);
+        fmpz_mod_poly_one(f, ctx);
+        if (!biquad)
+        {
+            /* (x - r)(x - w r)(x - w^2 r) = x^3 - r^3, w a cube root of unity */
+            fmpz_t e;
+            fmpz_init(e);
+            fmpz_sub_ui(e, n, 1);
+            fmpz_divexact_ui(e, e, 3);
+            do
+            {
+                fmpz_randm(w, state, n);
+                fmpz_powm(w, w, e, n);
+            }
+            while (fmpz_is_one(w) || fmpz_is_zero(w));
+            fmpz_randm(r, state, n);
+            fmpz_mod_poly_set_coeff_ui(f, 3, 1, ctx);
+            fmpz_mod_pow_ui(r, r, 3, ctx);
+            fmpz_mod_neg(r, r, ctx);
+            fmpz_mod_poly_set_coeff_fmpz(f, 0, r, ctx);
+            fmpz_clear(e);
+        }
+        else
+        {
+            slong k;
+            for (k = 0; k < 2; k++)
+            {
+                fmpz_randm(r, state, n);
+                fmpz_mod_poly_set_coeff_ui(lin, 2, 1, ctx);
+                fmpz_mod_poly_set_coeff_ui(lin, 1, 0, ctx);
+                fmpz_mod_mul(w, r, r, ctx);
+                fmpz_mod_neg(w, w, ctx);
+                fmpz_mod_poly_set_coeff_fmpz(lin, 0, w, ctx);   /* x^2 - r^2 */
+                fmpz_mod_poly_mul(f, f, lin, ctx);
+            }
+        }
+        ok = ecpp_root_radicals(x, f, state, ctx);
+        if (ok)
+            fmpz_mod_poly_evaluate_fmpz(r, f, x, ctx);
+        if (!ok || !fmpz_is_zero(r))
+        {
+            flint_printf("FAIL: special shape (%s)\n", biquad ? "biquadratic" : "x^3 - c");
+            flint_abort();
+        }
+        fmpz_mod_poly_clear(f, ctx);
+        fmpz_mod_poly_clear(lin, ctx);
+        fmpz_mod_ctx_clear(ctx);
+        fmpz_clear(n); fmpz_clear(r); fmpz_clear(x); fmpz_clear(w);
+    }
+
     TEST_FUNCTION_END(state);
 }

--- a/src/ecpp/test/t-root_radicals.c
+++ b/src/ecpp/test/t-root_radicals.c
@@ -1,0 +1,73 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5.1
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_helpers.h"
+#include "fmpz.h"
+#include "fmpz_mod.h"
+#include "fmpz_mod_poly.h"
+#include "ecpp.h"
+
+TEST_FUNCTION_START(ecpp_root_radicals, state)
+{
+    slong iter;
+
+    for (iter = 0; iter < 200 * flint_test_multiplier(); iter++)
+    {
+        fmpz_t n, r, x;
+        fmpz_mod_ctx_t ctx;
+        fmpz_mod_poly_t f, lin;
+        slong d = 2 + n_randint(state, 3), i;
+        int ok;
+
+        fmpz_init(n); fmpz_init(r); fmpz_init(x);
+        do
+            fmpz_randprime(n, state, 20 + n_randint(state, 200), 0);
+        while (d >= 3 && fmpz_fdiv_ui(n, 9) % 3 != 1 && fmpz_fdiv_ui(n, 9) != 2 && fmpz_fdiv_ui(n, 9) != 5);
+        fmpz_mod_ctx_init(ctx, n);
+        fmpz_mod_poly_init(f, ctx);
+        fmpz_mod_poly_init(lin, ctx);
+
+        fmpz_mod_poly_one(f, ctx);
+        for (i = 0; i < d; i++)
+        {
+            fmpz_randm(r, state, n);
+            if (n_randint(state, 4) == 0)
+                fmpz_set_ui(r, n_randint(state, 3));    /* repeated / small roots */
+            fmpz_mod_poly_set_coeff_ui(lin, 1, 1, ctx);
+            fmpz_mod_neg(r, r, ctx);
+            fmpz_mod_poly_set_coeff_fmpz(lin, 0, r, ctx);
+            fmpz_mod_poly_mul(f, f, lin, ctx);
+        }
+
+        ok = ecpp_root_radicals(x, f, state, ctx);
+        if (!ok)
+        {
+            flint_printf("FAIL: no root found, degree %wd\n", d);
+            flint_printf("n = "); fmpz_print(n); flint_printf("\n");
+            fmpz_mod_poly_print(f, ctx); flint_printf("\n");
+            flint_abort();
+        }
+        fmpz_mod_poly_evaluate_fmpz(r, f, x, ctx);
+        if (!fmpz_is_zero(r))
+        {
+            flint_printf("FAIL: not a root, degree %wd\n", d);
+            flint_abort();
+        }
+
+        fmpz_mod_poly_clear(f, ctx);
+        fmpz_mod_poly_clear(lin, ctx);
+        fmpz_mod_ctx_clear(ctx);
+        fmpz_clear(n); fmpz_clear(r); fmpz_clear(x);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/src/ecpp/tower.c
+++ b/src/ecpp/tower.c
@@ -150,41 +150,60 @@ _classgroup_series(slong * perm, slong * degs, const qfb * forms, slong h, slong
     {
         slong ord, p, cnt;
 
-        /* an element x outside the subgroup, of prime order p modulo it */
-        for (idx = 0; idx < h && in[idx]; idx++) ;
-        qfb_set(x, (qfb *) forms + idx);
-        /* order of x modulo the subgroup: smallest k with x^k in it */
-        qfb_set(t, x);
-        ord = 1;
-        while (_form_index(table, h, t) < 0 || !in[_form_index(table, h, t)])
+        /*
+            An element x outside the subgroup of prime order p modulo it,
+            with p the largest prime factor of the order of x modulo the
+            subgroup, among the first few candidates: the large primes are
+            then the top levels of the tower (where the Kummer descent
+            applies) and 2 and 3 the bottom (radicals).
+        */
         {
-            qfb_nucomp(t, t, x, Df, L);
-            qfb_reduce(t, t, Df);
-            ord++;
-            if (ord > h)
+            slong cand, ncand = 0, best_p = 0, best_idx = -1, best_ord = 0;
+            for (cand = 0; cand < h && ncand < 16 && ok; cand++)
+            {
+                slong q, rest, pc;
+                if (in[cand])
+                    continue;
+                ncand++;
+                qfb_set(x, (qfb *) forms + cand);
+                qfb_set(t, x);
+                ord = 1;
+                while (_form_index(table, h, t) < 0 || !in[_form_index(table, h, t)])
+                {
+                    qfb_nucomp(t, t, x, Df, L);
+                    qfb_reduce(t, t, Df);
+                    ord++;
+                    if (ord > h)
+                    {
+                        ok = 0;
+                        break;
+                    }
+                }
+                if (!ok)
+                    break;
+                for (q = 2, rest = ord, pc = 1; rest > 1; q++)
+                    if (rest % q == 0)
+                    {
+                        pc = q;
+                        while (rest % q == 0)
+                            rest /= q;
+                    }
+                if (pc > best_p)
+                {
+                    best_p = pc;
+                    best_idx = cand;
+                    best_ord = ord;
+                }
+            }
+            if (!ok || best_idx < 0)
             {
                 ok = 0;
                 break;
             }
-        }
-        if (!ok)
-            break;
-        {
-            /* largest prime factor of ord: the large primes are then the
-               top levels of the tower (where the Kummer descent applies)
-               and 2 and 3 the bottom (radicals) */
-            slong q = 2, rest = ord;
-            p = 1;
-            while (rest > 1)
-            {
-                if (rest % q == 0)
-                {
-                    p = q;
-                    while (rest % q == 0)
-                        rest /= q;
-                }
-                q++;
-            }
+            idx = best_idx;
+            p = best_p;
+            ord = best_ord;
+            qfb_set(x, (qfb *) forms + idx);
         }
         if (ord != p)
         {
@@ -1066,6 +1085,16 @@ _weber_to_j(fmpz_t j, const fmpz_t g, slong D, const fmpz_mod_ctx_t ctx)
 int
 ecpp_class_poly_tower(fmpz_t j, slong D, flint_rand_t state, const fmpz_mod_ctx_t ctx)
 {
+    int flags = 0;
+    if (fmpz_bits(fmpz_mod_ctx_modulus(ctx)) >= ECPP_KUMMER_BITS)
+        flags |= ECPP_TOWER_KUMMER;
+    return _ecpp_class_poly_tower(j, D, flags, state, ctx);
+}
+
+int
+_ecpp_class_poly_tower(fmpz_t j, slong D, int flags, flint_rand_t state,
+                                                        const fmpz_mod_ctx_t ctx)
+{
     qfb * forms;
     slong h, levels, i, k, lev, prec;
     slong * perm, * degs;
@@ -1076,11 +1105,11 @@ ecpp_class_poly_tower(fmpz_t j, slong D, flint_rand_t state, const fmpz_mod_ctx_
     acb_t z;
     double lgh;
     int success = 0, kummer_retries = 0;
-    int weber = _weber_ok(D);
+    int weber = _weber_ok(D) && !(flags & ECPP_TOWER_J);
     /* the Kummer data (and its retries) only pay when a powering of a
        degree-p polynomial is expensive, i.e. for large n; the cost model
        in disc.c prices the descents accordingly */
-    int want_kummer = fmpz_bits(fmpz_mod_ctx_modulus(ctx)) >= ECPP_KUMMER_BITS;
+    int want_kummer = (flags & ECPP_TOWER_KUMMER) != 0;
 
     h = qfb_reduced_forms(&forms, D);
     if (h <= 0)

--- a/src/ecpp/tower.c
+++ b/src/ecpp/tower.c
@@ -886,22 +886,31 @@ _acb_poly_get_fmpz_poly(fmpz_poly_t r, const acb_poly_t p)
     (k = 3 if 3 | D, else 1), and j = (F - 16)^3 / F for m odd,
     j = (F + 16)^3 / F for m even (F = f^24 resp. f1^24).
 */
+
+/*
+    The residue class computations on D below use |D| = -D (a positive
+    number) and shifts and masks rather than the division and remainder of
+    a negative slong: the 32-bit build with gcc 15.2 on Alpine took the
+    Weber path for D = -4047 with the latter (D % 4 != 0 being false),
+    which no sanitizer or other compiler reproduces.
+*/
 static int
 _weber_ok(slong D)
 {
-    slong m;
-    if (D % 4 != 0)
+    ulong m;
+    if (D >= 0 || (((ulong) (-D)) & 3) != 0)
         return 0;
-    m = -D / 4;
-    return (m % 8 == 1 || m % 8 == 2 || m % 8 == 3 || m % 8 == 5 || m % 8 == 6 || m % 8 == 7);
+    m = (((ulong) (-D)) >> 2) & 7;
+    return (m == 1 || m == 2 || m == 3 || m == 5 || m == 6 || m == 7);
 }
 
 /* the height factor 72 / e */
 static double
 _weber_factor(slong D)
 {
-    slong m = -D / 4, e = (m % 8 == 5) ? 4 : (m % 8 == 3 || m % 8 == 7) ? 1 : 2;
-    if (D % 3 == 0)
+    ulong m8 = (((ulong) (-D)) >> 2) & 7;
+    slong e = (m8 == 5) ? 4 : (m8 == 3 || m8 == 7) ? 1 : 2;
+    if (((ulong) (-D)) % 3 == 0)
         e *= 3;
     return 72.0 / e;
 }
@@ -975,7 +984,7 @@ _nsystem_entry(slong * a, slong * b, slong N, slong b0, slong D)
 static void
 _weber_value(acb_t g, slong a0, slong b0, slong D, slong prec)
 {
-    slong a = a0, b = b0, m = -D / 4;
+    slong a = a0, b = b0, m = (slong) (((ulong) (-D)) >> 2);
     acb_t tau, t, e1, e2;
     arb_t s2;
 
@@ -1038,7 +1047,7 @@ _weber_value(acb_t g, slong a0, slong b0, slong D, slong prec)
             acb_mul_2exp_si(g, g, -1);
         }
     }
-    if (D % 3 == 0)
+    if (((ulong) (-D)) % 3 == 0)
     {
         acb_mul(t, g, g, prec);
         acb_mul(g, g, t, prec);
@@ -1054,10 +1063,10 @@ _weber_value(acb_t g, slong a0, slong b0, slong D, slong prec)
 static void
 _weber_to_j(fmpz_t j, const fmpz_t g, slong D, const fmpz_mod_ctx_t ctx)
 {
-    slong m = -D / 4;
+    slong m = (slong) (((ulong) (-D)) >> 2);
     fmpz_t F, t;
     fmpz_init(F); fmpz_init(t);
-    fmpz_mod_pow_ui(F, g, (D % 3 == 0) ? 2 : 6, ctx);
+    fmpz_mod_pow_ui(F, g, ((((ulong) (-D)) % 3) == 0) ? 2 : 6, ctx);
     if (m % 8 == 5)
         fmpz_mod_mul_ui(F, F, 64, ctx);
     else if (m % 8 == 3)
@@ -1106,6 +1115,9 @@ _ecpp_class_poly_tower(fmpz_t j, slong D, int flags, flint_rand_t state,
     double lgh;
     int success = 0, kummer_retries = 0;
     int weber = _weber_ok(D) && !(flags & ECPP_TOWER_J);
+    /* the invariant is only a class invariant for D = 0 mod 4 */
+    if (weber && (((ulong) (-D)) & 3) != 0)
+        weber = 0;
     /* the Kummer data (and its retries) only pay when a powering of a
        degree-p polynomial is expensive, i.e. for large n; the cost model
        in disc.c prices the descents accordingly */

--- a/src/ecpp/tower.c
+++ b/src/ecpp/tower.c
@@ -1,0 +1,1445 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5.1
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdlib.h>
+#include <math.h>
+#include "ulong_extras.h"
+#include "fmpz.h"
+#include "fmpz_poly.h"
+#include "fmpz_mod.h"
+#include "fmpz_mod_poly.h"
+#include "qfb.h"
+#include "fmpq.h"
+#include "arb.h"
+#include "acb.h"
+#include "acb_poly.h"
+#include "acb_mat.h"
+#include "acb_modular.h"
+#include "ecpp.h"
+
+extern int ecpp_verbose;
+#ifdef ECPP_PROFILE
+#include <time.h>
+static double _tnow(void)
+{
+    struct timespec t;
+    timespec_get(&t, TIME_UTC);
+    return t.tv_sec + 1e-9 * t.tv_nsec;
+}
+#endif
+#ifdef ECPP_PROFILE
+/* accumulated over a proof: class group series, values (arb), decomposition (arb), descent (mod n) */
+double ecpp_tower_prof[4];
+slong ecpp_tower_count, ecpp_tower_hsum, ecpp_tower_retries;
+#endif
+
+/*
+    A root of the Hilbert class polynomial H_D modulo a prime n that splits
+    completely in the Hilbert class field H, through the class field tower
+    (Enge, Morain: fast decomposition of polynomials with known Galois
+    group; the representation follows Enge's mpfrcx and CM libraries).
+
+    The Galois group of H/K is the class group Cl. A composition series
+    1 = S_0 < S_1 < ... < S_L = Cl with prime quotients p_i = |S_i / S_{i-1}|
+    gives a tower K = L_L < ... < L_1 < L_0 = H of fields L_i = fixed field
+    of S_i, with [L_{i-1} : L_i] = p_i. The j-values are ordered so that
+    consecutive blocks of size |S_i| are cosets of S_i. From the top: the
+    relative minimal polynomial U over L_1 of j has degree p_1 and
+    coefficients in L_1; one of them, y, generates L_1 over K, with minimal
+    polynomial V of degree h / p_1 and integer coefficients (V is fixed by
+    complex conjugation). The other coefficients c of U are written in
+    Hecke form c V'(y) = W_c(y) with W_c the Lagrange numerator
+    sum_k c_k prod_{l != k} (X - y_l), which has integer coefficients as
+    well: no denominators appear. Then the conjugates of y take the role of
+    the roots at the next level down, until the bottom polynomial over K of
+    degree p_L. Modulo n every polynomial splits completely, so a root of
+    the bottom polynomial gives an embedding of L_{L-1}, the Hecke forms
+    evaluated at it give the next relative polynomial, and so on up to a
+    root of U, which is a root of H_D. Every root finding is in a prime
+    degree p_i instead of h.
+
+    Returns 1 and sets j on success, 0 on failure (a generator could not
+    be found or the coefficients not identified; the caller falls back).
+*/
+
+/* reduced form index lookup: forms sorted by (a, b) into a table of
+   (a, b, index), binary search */
+typedef struct { slong a, b, idx; } _form_key;
+
+static int
+_form_key_cmp(const void * x, const void * y)
+{
+    const _form_key * p = (const _form_key *) x, * q = (const _form_key *) y;
+    if (p->a != q->a) return (p->a < q->a) ? -1 : 1;
+    if (p->b != q->b) return (p->b < q->b) ? -1 : 1;
+    return 0;
+}
+
+static _form_key *
+_form_table(const qfb * forms, slong h)
+{
+    _form_key * t = flint_malloc(h * sizeof(_form_key));
+    slong i;
+    for (i = 0; i < h; i++)
+    {
+        t[i].a = fmpz_get_si(forms[i].a);
+        t[i].b = fmpz_get_si(forms[i].b);
+        t[i].idx = i;
+    }
+    qsort(t, h, sizeof(_form_key), _form_key_cmp);
+    return t;
+}
+
+static slong
+_form_index(const _form_key * t, slong h, const qfb_t f)
+{
+    _form_key key, * r;
+    key.a = fmpz_get_si(f->a);
+    key.b = fmpz_get_si(f->b);
+    r = bsearch(&key, t, h, sizeof(_form_key), _form_key_cmp);
+    return (r == NULL) ? -1 : r->idx;
+}
+
+/*
+    Orders the classes as described: perm[k] is the index of the k-th
+    class, degs[0..levels-1] the relative degrees from the bottom
+    (degs[levels-1] = |S_1|). Returns levels, or 0 on failure.
+*/
+static slong
+_classgroup_series(slong * perm, slong * degs, const qfb * forms, slong h, slong D)
+{
+    fmpz_t Df, L;
+    qfb_t x, y, t;
+    slong * cur;        /* elements of the current subgroup, in order */
+    slong size = 1, levels = 0, i, k, idx;
+    char * in;
+    int ok = 1;
+
+    _form_key * table = _form_table(forms, h);
+
+    fmpz_init_set_si(Df, D);
+    fmpz_init(L);
+    fmpz_set_si(L, -D);
+    fmpz_root(L, L, 4);
+    qfb_init(x); qfb_init(y); qfb_init(t);
+
+    /* the principal form */
+    for (i = 0; i < h; i++)
+        if (fmpz_is_one(forms[i].a))
+            break;
+    if (i == h)
+    {
+        ok = 0;
+        goto cleanup;
+    }
+    cur = perm;
+    cur[0] = i;
+    in = flint_calloc(h, sizeof(char));
+    in[i] = 1;
+
+    while (size < h && ok)
+    {
+        slong ord, p, cnt;
+
+        /* an element x outside the subgroup, of prime order p modulo it */
+        for (idx = 0; idx < h && in[idx]; idx++) ;
+        qfb_set(x, (qfb *) forms + idx);
+        /* order of x modulo the subgroup: smallest k with x^k in it */
+        qfb_set(t, x);
+        ord = 1;
+        while (_form_index(table, h, t) < 0 || !in[_form_index(table, h, t)])
+        {
+            qfb_nucomp(t, t, x, Df, L);
+            qfb_reduce(t, t, Df);
+            ord++;
+            if (ord > h)
+            {
+                ok = 0;
+                break;
+            }
+        }
+        if (!ok)
+            break;
+        {
+            /* largest prime factor of ord: the large primes are then the
+               top levels of the tower (where the Kummer descent applies)
+               and 2 and 3 the bottom (radicals) */
+            slong q = 2, rest = ord;
+            p = 1;
+            while (rest > 1)
+            {
+                if (rest % q == 0)
+                {
+                    p = q;
+                    while (rest % q == 0)
+                        rest /= q;
+                }
+                q++;
+            }
+        }
+        if (ord != p)
+        {
+            /* x^(ord/p) has order p modulo the subgroup */
+            qfb_pow_ui(x, x, Df, ord / p);
+            qfb_reduce(x, x, Df);
+        }
+
+        /* new subgroup: S, xS, x^2 S, ..., x^(p-1) S */
+        for (k = 1; k < p; k++)
+        {
+            for (i = 0; i < size; i++)
+            {
+                slong pos;
+                qfb_nucomp(t, x, (qfb *) forms + cur[(k - 1) * size + i], Df, L);
+                qfb_reduce(t, t, Df);
+                pos = _form_index(table, h, t);
+                if (pos < 0 || in[pos])
+                {
+                    ok = 0;
+                    break;
+                }
+                cur[k * size + i] = pos;
+                in[pos] = 1;
+            }
+            if (!ok)
+                break;
+        }
+        cnt = size * p;
+        degs[levels++] = p;
+        size = cnt;
+    }
+    flint_free(in);
+
+    /* degs were filled from the top (S_1 first): reverse to bottom-first */
+    for (i = 0; i < levels / 2; i++)
+    {
+        slong tmp = degs[i];
+        degs[i] = degs[levels - 1 - i];
+        degs[levels - 1 - i] = tmp;
+    }
+
+cleanup:
+    flint_free(table);
+    fmpz_clear(Df);
+    fmpz_clear(L);
+    qfb_clear(x); qfb_clear(y); qfb_clear(t);
+    return ok ? levels : 0;
+}
+
+/*
+    Subproduct tree for P = prod_k (X - y_k) and the Lagrange numerators
+    W_j = sum_k c_{j,k} prod_{l != k} (X - y_l), j < m: for a split
+    S = S1 u S2, P = P1 P2 and W = W1 P2 + W2 P1. Products only, so the
+    error bounds stay tight (synthetic division by X - y_k loses a number
+    of bits proportional to the height at each step).
+*/
+static void
+_hecke_tree(acb_poly_t P, acb_poly_struct * W, slong m, acb_srcptr ys,
+                        const acb_struct * const * cs, slong lo, slong hi, slong prec)
+{
+    slong j;
+
+    if (hi - lo == 1)
+    {
+        acb_t t;
+        acb_init(t);
+        acb_poly_zero(P);
+        acb_poly_set_coeff_si(P, 1, 1);
+        acb_neg(t, ys + lo);
+        acb_poly_set_coeff_acb(P, 0, t);
+        for (j = 0; j < m; j++)
+        {
+            acb_poly_zero(W + j);
+            acb_poly_set_coeff_acb(W + j, 0, cs[j] + lo);
+        }
+        acb_clear(t);
+    }
+    else
+    {
+        slong mid = lo + (hi - lo) / 2;
+        acb_poly_t P1, P2, T;
+        acb_poly_struct * W1 = flint_malloc(m * sizeof(acb_poly_struct));
+        acb_poly_struct * W2 = flint_malloc(m * sizeof(acb_poly_struct));
+        acb_poly_init(P1); acb_poly_init(P2); acb_poly_init(T);
+        for (j = 0; j < m; j++)
+        {
+            acb_poly_init(W1 + j);
+            acb_poly_init(W2 + j);
+        }
+        _hecke_tree(P1, W1, m, ys, cs, lo, mid, prec);
+        _hecke_tree(P2, W2, m, ys, cs, mid, hi, prec);
+        acb_poly_mul(P, P1, P2, prec);
+        for (j = 0; j < m; j++)
+        {
+            acb_poly_mul(W + j, W1 + j, P2, prec);
+            acb_poly_mul(T, W2 + j, P1, prec);
+            acb_poly_add(W + j, W + j, T, prec);
+        }
+        for (j = 0; j < m; j++)
+        {
+            acb_poly_clear(W1 + j);
+            acb_poly_clear(W2 + j);
+        }
+        flint_free(W1); flint_free(W2);
+        acb_poly_clear(P1); acb_poly_clear(P2); acb_poly_clear(T);
+    }
+}
+
+/*
+    Kummer data for a level of prime degree p >= 5. The extension
+    L_{i-1} = L_i(x) is cyclic, generated by sigma (the class group element
+    of order p), with conjugates x_k = sigma^k(x). For a primitive p-th
+    root of unity zeta the Lagrange resolvent theta_zeta = sum_k zeta^k x_k
+    satisfies sigma(theta_zeta) = zeta^{-1} theta_zeta, so
+    A = theta_zeta^p and, for 2 <= s <= p-1, beta_s = theta_{zeta^s}
+    theta_zeta^{p-s} are algebraic integers in L_i(zeta) = L_i + L_i zeta
+    + ... + L_i zeta^{p-2}. Their coordinates (times p^{p-1}, to clear the
+    denominators of the power basis of zeta) are algebraic integers of
+    L_i, hence have Hecke forms like the coefficients of the relative
+    polynomial; they are recovered from the values at the p-1 primitive
+    roots by solving a small linear system. Modulo n with p | n-1 the
+    level is then descended with one p-th root: theta = A^{1/p},
+    theta_s = beta_s theta^s / A, and x = (tr + sum_s theta_s)/p where
+    tr = theta_1 is the trace, instead of a root of a degree-p polynomial.
+    The polynomial is kept for the other n.
+
+    Layout of W[lev]: [0, p) coefficients of the relative polynomial,
+    [p] V', then p-1 coordinates of A, then (p-2)(p-1) coordinates of
+    b_2, ..., b_{p-1}.
+*/
+static slong
+_level_size(slong p)
+{
+    if (p < 5)
+        return p + 1;
+    return p + 1 + 2 * ((p - 1) + (p - 2) * (p - 1));
+}
+
+/* the Kummer numerators have coefficients in K = Q(sqrt D), stored as two
+   integer polynomials: coefficient = (u + v sqrt D) / 2 */
+#define KUMMER_A(p, j) ((p) + 1 + 2 * (j))
+#define KUMMER_B(p, s, j) ((p) + 1 + 2 * (((p) - 1) + ((s) - 2) * ((p) - 1) + (j)))
+
+/*
+    Given the p roots x_0..x_{p-1} of a block, the values, at the coset,
+    of the p-1 coordinates of A and of the b_s (s = 2..p-1): out has
+    (p-1) + (p-2)(p-1) entries. Minv is the inverse of the (p-1) x (p-1)
+    matrix [zeta^{s j}], s = 1..p-1, j = 0..p-2.
+*/
+static void
+_kummer_values(acb_ptr out, acb_srcptr x, slong p, const acb_mat_t Minv, slong prec)
+{
+    acb_ptr theta = _acb_vec_init(p), vals = _acb_vec_init(p - 1), zeta = _acb_vec_init(p);
+    acb_t t;
+    slong u, k, s, j;
+
+    acb_init(t);
+    /* zeta[u] = exp(2 pi i u / p) */
+    _acb_vec_unit_roots(zeta, p, p, prec);
+    /* theta_u = sum_k zeta^{u k} x_k */
+    for (u = 0; u < p; u++)
+    {
+        acb_zero(theta + u);
+        for (k = 0; k < p; k++)
+            acb_addmul(theta + u, zeta + (u * k) % p, x + k, prec);
+    }
+    /* A at the primitive roots: theta_u^p, u = 1..p-1 -> coordinates */
+    for (u = 1; u < p; u++)
+        acb_pow_ui(vals + u - 1, theta + u, p, prec);
+    for (j = 0; j < p - 1; j++)
+    {
+        acb_zero(out + j);
+        for (u = 1; u < p; u++)
+            acb_addmul(out + j, acb_mat_entry(Minv, j, u - 1), vals + u - 1, prec);
+    }
+    /* scaled by p^{p-1}: the coordinates in the power basis of zeta have
+       denominators dividing a power of p */
+    acb_set_si(t, p);
+    acb_pow_ui(t, t, p - 1, prec);
+    for (j = 0; j < p - 1; j++)
+        acb_mul(out + j, out + j, t, prec);
+    /* beta_s = theta_{zeta^s} theta_zeta^{p-s} (an algebraic integer, unlike
+       theta_{zeta^s} / theta_zeta^s) at the primitive root zeta^u */
+    for (s = 2; s < p; s++)
+    {
+        for (u = 1; u < p; u++)
+        {
+            acb_pow_ui(vals + u - 1, theta + u, p - s, prec);
+            acb_mul(vals + u - 1, vals + u - 1, theta + ((u * s) % p), prec);
+        }
+        for (j = 0; j < p - 1; j++)
+        {
+            acb_ptr o = out + (p - 1) + (s - 2) * (p - 1) + j;
+            acb_zero(o);
+            for (u = 1; u < p; u++)
+                acb_addmul(o, acb_mat_entry(Minv, j, u - 1), vals + u - 1, prec);
+            acb_mul(o, o, t, prec);
+        }
+    }
+    acb_clear(t);
+    _acb_vec_clear(theta, p);
+    _acb_vec_clear(vals, p - 1);
+    _acb_vec_clear(zeta, p);
+}
+
+/* w^p = z modulo n = 1 mod p (Adleman-Manders-Miller), z a p-th power */
+static int
+_rootmod_p(fmpz_t w, const fmpz_t z, slong p, flint_rand_t state, const fmpz_mod_ctx_t ctx)
+{
+    const fmpz * n = fmpz_mod_ctx_modulus(ctx);
+    fmpz_t t, e, y, g, G, tmp, pw, m, Gi, cur, pw1;
+    slong sv = 0, k, j, tries, digit;
+    int result = 0;
+
+    if (fmpz_is_zero(z))
+    {
+        fmpz_zero(w);
+        return 1;
+    }
+    fmpz_init(t); fmpz_init(e); fmpz_init(y); fmpz_init(g); fmpz_init(G);
+    fmpz_init(tmp); fmpz_init(pw); fmpz_init(m); fmpz_init(Gi); fmpz_init(cur); fmpz_init(pw1);
+
+    fmpz_sub_ui(t, n, 1);
+    while (fmpz_divisible_si(t, p))
+    {
+        fmpz_divexact_si(t, t, p);
+        sv++;
+    }
+    if (sv == 0)
+        goto cleanup;
+    fmpz_set_ui(e, p);
+    fmpz_invmod(e, e, t);
+    fmpz_powm(w, z, e, n);
+    fmpz_powm(y, z, t, n);
+    if (fmpz_is_one(y))
+    {
+        result = 1;
+        goto cleanup;
+    }
+    fmpz_mul_ui(tmp, e, p);
+    fmpz_sub_ui(tmp, tmp, 1);
+    fmpz_divexact(tmp, tmp, t);
+    fmpz_powm(y, y, tmp, n);            /* y^k in the p-Sylow subgroup, a p-th power there */
+
+    for (tries = 0; tries < 100; tries++)
+    {
+        fmpz_randm(g, state, n);
+        fmpz_powm(G, g, t, n);
+        fmpz_set(pw, G);
+        for (j = 0; j < sv - 1; j++)
+            fmpz_mod_pow_ui(pw, pw, p, ctx);
+        if (!fmpz_is_one(pw) && !fmpz_is_zero(pw))
+            break;
+    }
+    if (tries == 100)
+        goto cleanup;
+    /* pw1 = G^{p^{sv-1}}: an element of order p */
+    fmpz_set(pw1, pw);
+    fmpz_mod_inv(Gi, G, ctx);
+    fmpz_zero(m);
+    for (k = 0; k < sv; k++)
+    {
+        fmpz_powm(cur, Gi, m, n);
+        fmpz_mod_mul(cur, cur, y, ctx);
+        for (j = 0; j < sv - 1 - k; j++)
+            fmpz_mod_pow_ui(cur, cur, p, ctx);
+        /* cur = pw1^digit */
+        fmpz_one(tmp);
+        for (digit = 0; digit < p; digit++)
+        {
+            if (fmpz_equal(cur, tmp))
+                break;
+            fmpz_mod_mul(tmp, tmp, pw1, ctx);
+        }
+        if (digit == p)
+            break;
+        fmpz_set_ui(tmp, 1);
+        for (j = 0; j < k; j++)
+            fmpz_mul_ui(tmp, tmp, p);
+        fmpz_addmul_ui(m, tmp, digit);
+    }
+    if (k == sv && fmpz_divisible_si(m, p))
+    {
+        fmpz_divexact_si(m, m, p);
+        fmpz_powm(cur, Gi, m, n);
+        fmpz_mod_mul(w, w, cur, ctx);
+        fmpz_mod_pow_ui(cur, w, p, ctx);
+        result = fmpz_equal(cur, z);
+    }
+
+cleanup:
+    fmpz_clear(t); fmpz_clear(e); fmpz_clear(y); fmpz_clear(g); fmpz_clear(G);
+    fmpz_clear(tmp); fmpz_clear(pw); fmpz_clear(m); fmpz_clear(Gi); fmpz_clear(cur); fmpz_clear(pw1);
+    return result;
+}
+
+/*
+    Descent through a Kummer level: r the current root (value of the
+    generator y of L_i), deninv = 1 / V'(r); x is set to a root of the
+    relative polynomial U (given for verification). Returns 1 on success.
+*/
+static void _eval_K(fmpz_t c, const fmpz_poly_struct * W, slong idx, const fmpz_t r,
+                        const fmpz_t sqrtD, fmpz_mod_poly_t Wm, const fmpz_mod_ctx_t ctx);
+
+/*
+    Arithmetic in F_{n^2} = F_n[s] / (s^2 - c), c a non-residue, for the
+    Kummer descent when zeta_p lies in F_{n^2} but not in F_n
+    (n = -1 mod p): elements (a, b) = a + b s.
+*/
+static void
+_f2_mul(fmpz_t ra, fmpz_t rb, const fmpz_t a1, const fmpz_t b1,
+        const fmpz_t a2, const fmpz_t b2, const fmpz_t c, const fmpz_mod_ctx_t ctx)
+{
+    fmpz_t t, u;
+    fmpz_init(t); fmpz_init(u);
+    fmpz_mod_mul(t, b1, b2, ctx);
+    fmpz_mod_mul(t, t, c, ctx);
+    fmpz_mod_addmul(t, t, a1, a2, ctx);         /* a1 a2 + c b1 b2 */
+    fmpz_mod_mul(u, a1, b2, ctx);
+    fmpz_mod_addmul(u, u, a2, b1, ctx);         /* a1 b2 + a2 b1 */
+    fmpz_swap(ra, t);
+    fmpz_swap(rb, u);
+    fmpz_clear(t); fmpz_clear(u);
+}
+
+static void
+_f2_pow(fmpz_t ra, fmpz_t rb, const fmpz_t a, const fmpz_t b, const fmpz_t e,
+                                        const fmpz_t c, const fmpz_mod_ctx_t ctx)
+{
+    fmpz_t xa, xb;
+    slong i;
+    fmpz_init(xa); fmpz_init(xb);
+    fmpz_one(xa);
+    fmpz_zero(xb);
+    for (i = fmpz_bits(e) - 1; i >= 0; i--)
+    {
+        _f2_mul(xa, xb, xa, xb, xa, xb, c, ctx);
+        if (fmpz_tstbit(e, i))
+            _f2_mul(xa, xb, xa, xb, a, b, c, ctx);
+    }
+    fmpz_swap(ra, xa);
+    fmpz_swap(rb, xb);
+    fmpz_clear(xa); fmpz_clear(xb);
+}
+
+static void
+_f2_inv(fmpz_t ra, fmpz_t rb, const fmpz_t a, const fmpz_t b, const fmpz_t c,
+                                                        const fmpz_mod_ctx_t ctx)
+{
+    fmpz_t nrm, t;
+    fmpz_init(nrm); fmpz_init(t);
+    fmpz_mod_mul(nrm, b, b, ctx);
+    fmpz_mod_mul(nrm, nrm, c, ctx);
+    fmpz_mod_mul(t, a, a, ctx);
+    fmpz_mod_sub(nrm, t, nrm, ctx);             /* a^2 - c b^2 */
+    fmpz_mod_inv(nrm, nrm, ctx);
+    fmpz_mod_mul(t, a, nrm, ctx);
+    fmpz_mod_mul(rb, b, nrm, ctx);
+    fmpz_mod_neg(rb, rb, ctx);
+    fmpz_swap(ra, t);
+    fmpz_clear(nrm); fmpz_clear(t);
+}
+
+/*
+    The Kummer descent in F_{n^2} for n = -1 mod p, p exactly dividing
+    n + 1: a p-th root of a p-th power A is A^e with p e = 1 mod
+    (n^2 - 1) / p, and the result x = (tr + sum theta_s) / p lies in F_n.
+*/
+static int
+_kummer_descent_f2(fmpz_t x, const fmpz_poly_struct * W, slong p, const fmpz_t r,
+        const fmpz_t deninv, const fmpz_t sqrtD, const fmpz_mod_poly_t U,
+        flint_rand_t state, const fmpz_mod_ctx_t ctx)
+{
+    const fmpz * n = fmpz_mod_ctx_modulus(ctx);
+    fmpz_mod_poly_t Wm;
+    fmpz_t c, e, t, za, zb, pa, pb, Aa, Ab, tha, thb, ta, tb, ba, bb, ia, ib, xa, xb, scale;
+    slong j, tries;
+    int ok = 0;
+
+    fmpz_mod_poly_init(Wm, ctx);
+    fmpz_init(c); fmpz_init(e); fmpz_init(t); fmpz_init(za); fmpz_init(zb);
+    fmpz_init(pa); fmpz_init(pb); fmpz_init(Aa); fmpz_init(Ab); fmpz_init(tha); fmpz_init(thb);
+    fmpz_init(ta); fmpz_init(tb); fmpz_init(ba); fmpz_init(bb); fmpz_init(ia); fmpz_init(ib);
+    fmpz_init(xa); fmpz_init(xb); fmpz_init(scale);
+
+    /* p must divide n + 1 exactly once */
+    fmpz_add_ui(t, n, 1);
+    if (!fmpz_divisible_si(t, p))
+        goto cleanup;
+    fmpz_divexact_si(t, t, p);
+    if (fmpz_divisible_si(t, p))
+        goto cleanup;
+
+    /* a non-residue c and a primitive p-th root of unity zeta = g^((n^2-1)/p) */
+    for (tries = 0; tries < 100; tries++)
+    {
+        fmpz_randm(c, state, n);
+        if (fmpz_jacobi(c, n) == -1)
+            break;
+    }
+    if (tries == 100)
+        goto cleanup;
+    fmpz_mul(e, n, n);
+    fmpz_sub_ui(e, e, 1);
+    fmpz_divexact_si(e, e, p);
+    for (tries = 0; tries < 100; tries++)
+    {
+        fmpz_randm(ta, state, n);
+        fmpz_randm(tb, state, n);
+        _f2_pow(za, zb, ta, tb, e, c, ctx);
+        if (!(fmpz_is_one(za) && fmpz_is_zero(zb)) && !(fmpz_is_zero(za) && fmpz_is_zero(zb)))
+            break;
+    }
+    if (tries == 100)
+        goto cleanup;
+
+    /* 1 / p^{p-1} */
+    fmpz_set_ui(scale, p);
+    fmpz_mod_pow_ui(scale, scale, p - 1, ctx);
+    fmpz_mod_inv(scale, scale, ctx);
+
+    /* A = sum_j A_j zeta^j / p^{p-1} */
+    fmpz_zero(Aa); fmpz_zero(Ab);
+    fmpz_one(pa); fmpz_zero(pb);
+    for (j = 0; j < p - 1; j++)
+    {
+        _eval_K(t, W, KUMMER_A(p, j), r, sqrtD, Wm, ctx);
+        fmpz_mod_mul(t, t, deninv, ctx);
+        fmpz_mod_mul(t, t, scale, ctx);
+        fmpz_mod_addmul(Aa, Aa, t, pa, ctx);
+        fmpz_mod_addmul(Ab, Ab, t, pb, ctx);
+        _f2_mul(pa, pb, pa, pb, za, zb, c, ctx);
+    }
+    if (fmpz_is_zero(Aa) && fmpz_is_zero(Ab))
+        goto cleanup;
+    /* theta = A^e2 with p e2 = 1 mod (n^2-1)/p */
+    fmpz_set_ui(t, p);
+    fmpz_invmod(t, t, e);
+    _f2_pow(tha, thb, Aa, Ab, t, c, ctx);
+    /* check theta^p = A */
+    fmpz_set_ui(t, p);
+    _f2_pow(ta, tb, tha, thb, t, c, ctx);
+    if (!fmpz_equal(ta, Aa) || !fmpz_equal(tb, Ab))
+        goto cleanup;
+    _f2_inv(ia, ib, Aa, Ab, c, ctx);            /* 1 / A */
+
+    /* x = (tr + theta + sum_{s>=2} beta_s theta^s / A) / p */
+    fmpz_mod_poly_set_fmpz_poly(Wm, W + (p - 1), ctx);
+    fmpz_mod_poly_evaluate_fmpz(xa, Wm, r, ctx);
+    fmpz_mod_mul(xa, xa, deninv, ctx);
+    fmpz_mod_neg(xa, xa, ctx);
+    fmpz_zero(xb);
+    fmpz_mod_add(xa, xa, tha, ctx);
+    fmpz_mod_add(xb, xb, thb, ctx);
+    fmpz_set(ta, tha); fmpz_set(tb, thb);       /* theta^s */
+    {
+        slong sidx;
+        for (sidx = 2; sidx < p; sidx++)
+        {
+            _f2_mul(ta, tb, ta, tb, tha, thb, c, ctx);
+            fmpz_zero(ba); fmpz_zero(bb);
+            fmpz_one(pa); fmpz_zero(pb);
+            for (j = 0; j < p - 1; j++)
+            {
+                _eval_K(t, W, KUMMER_B(p, sidx, j), r, sqrtD, Wm, ctx);
+                fmpz_mod_mul(t, t, deninv, ctx);
+                fmpz_mod_mul(t, t, scale, ctx);
+                fmpz_mod_addmul(ba, ba, t, pa, ctx);
+                fmpz_mod_addmul(bb, bb, t, pb, ctx);
+                _f2_mul(pa, pb, pa, pb, za, zb, c, ctx);
+            }
+            _f2_mul(ba, bb, ba, bb, ta, tb, c, ctx);
+            _f2_mul(ba, bb, ba, bb, ia, ib, c, ctx);
+            fmpz_mod_add(xa, xa, ba, ctx);
+            fmpz_mod_add(xb, xb, bb, ctx);
+        }
+    }
+    if (!fmpz_is_zero(xb))
+        goto cleanup;                           /* not in F_n: wrong data */
+    fmpz_set_ui(t, p);
+    fmpz_mod_inv(t, t, ctx);
+    fmpz_mod_mul(x, xa, t, ctx);
+    fmpz_mod_poly_evaluate_fmpz(t, U, x, ctx);
+    ok = fmpz_is_zero(t);
+
+cleanup:
+    fmpz_mod_poly_clear(Wm, ctx);
+    fmpz_clear(c); fmpz_clear(e); fmpz_clear(t); fmpz_clear(za); fmpz_clear(zb);
+    fmpz_clear(pa); fmpz_clear(pb); fmpz_clear(Aa); fmpz_clear(Ab); fmpz_clear(tha); fmpz_clear(thb);
+    fmpz_clear(ta); fmpz_clear(tb); fmpz_clear(ba); fmpz_clear(bb); fmpz_clear(ia); fmpz_clear(ib);
+    fmpz_clear(xa); fmpz_clear(xb); fmpz_clear(scale);
+    return ok;
+}
+
+/* (u(r) + v(r) sqrtD) / 2 for a K-valued Hecke numerator */
+static void
+_eval_K(fmpz_t c, const fmpz_poly_struct * W, slong idx, const fmpz_t r,
+                        const fmpz_t sqrtD, fmpz_mod_poly_t Wm, const fmpz_mod_ctx_t ctx)
+{
+    fmpz_t t, h;
+    fmpz_init(t); fmpz_init(h);
+    fmpz_mod_poly_set_fmpz_poly(Wm, W + idx, ctx);
+    fmpz_mod_poly_evaluate_fmpz(c, Wm, r, ctx);
+    fmpz_mod_poly_set_fmpz_poly(Wm, W + idx + 1, ctx);
+    fmpz_mod_poly_evaluate_fmpz(t, Wm, r, ctx);
+    fmpz_mod_mul(t, t, sqrtD, ctx);
+    fmpz_mod_add(c, c, t, ctx);
+    fmpz_set_ui(h, 2);
+    fmpz_mod_inv(h, h, ctx);
+    fmpz_mod_mul(c, c, h, ctx);
+    fmpz_clear(t); fmpz_clear(h);
+}
+
+static int
+_kummer_descent(fmpz_t x, const fmpz_poly_struct * W, slong p, const fmpz_t r,
+        const fmpz_t deninv, const fmpz_t sqrtD, const fmpz_mod_poly_t U,
+        flint_rand_t state, const fmpz_mod_ctx_t ctx)
+{
+    const fmpz * n = fmpz_mod_ctx_modulus(ctx);
+    fmpz_mod_poly_t Wm;
+    fmpz_t zeta, zpow, A, theta, ths, b, c, t, e, g;
+    slong j, s, tries;
+    int ok = 0;
+
+    fmpz_mod_poly_init(Wm, ctx);
+    fmpz_init(zeta); fmpz_init(zpow); fmpz_init(A); fmpz_init(theta); fmpz_init(ths);
+    fmpz_init(b); fmpz_init(c); fmpz_init(t); fmpz_init(e); fmpz_init(g);
+
+    /* a primitive p-th root of unity */
+    fmpz_sub_ui(e, n, 1);
+    fmpz_divexact_si(e, e, p);
+    for (tries = 0; tries < 100; tries++)
+    {
+        fmpz_randm(g, state, n);
+        fmpz_powm(zeta, g, e, n);
+        if (!fmpz_is_one(zeta) && !fmpz_is_zero(zeta))
+            break;
+    }
+    if (tries == 100)
+        goto cleanup;
+
+    /* A = sum_j A_j zeta^j / p^{p-1} */
+    fmpz_zero(A);
+    fmpz_one(zpow);
+    for (j = 0; j < p - 1; j++)
+    {
+        _eval_K(c, W, KUMMER_A(p, j), r, sqrtD, Wm, ctx);
+        fmpz_mod_mul(c, c, deninv, ctx);
+        fmpz_mod_mul(c, c, zpow, ctx);
+        fmpz_mod_add(A, A, c, ctx);
+        fmpz_mod_mul(zpow, zpow, zeta, ctx);
+    }
+    fmpz_set_ui(t, p);
+    fmpz_mod_pow_ui(t, t, p - 1, ctx);
+    fmpz_mod_inv(t, t, ctx);            /* 1 / p^{p-1} */
+    fmpz_mod_mul(A, A, t, ctx);
+    if (fmpz_is_zero(A) || !_rootmod_p(theta, A, p, state, ctx))
+        goto cleanup;
+    fmpz_mod_inv(g, A, ctx);            /* 1 / A */
+
+    /* x = (tr + theta + sum_{s >= 2} b_s theta^s) / p, tr = -c_{p-1} */
+    fmpz_mod_poly_set_fmpz_poly(Wm, W + (p - 1), ctx);
+    fmpz_mod_poly_evaluate_fmpz(x, Wm, r, ctx);
+    fmpz_mod_mul(x, x, deninv, ctx);
+    fmpz_mod_neg(x, x, ctx);
+    fmpz_mod_add(x, x, theta, ctx);
+    fmpz_set(ths, theta);
+    for (s = 2; s < p; s++)
+    {
+        fmpz_mod_mul(ths, ths, theta, ctx);     /* theta^s */
+        fmpz_zero(b);
+        fmpz_one(zpow);
+        for (j = 0; j < p - 1; j++)
+        {
+            _eval_K(c, W, KUMMER_B(p, s, j), r, sqrtD, Wm, ctx);
+            fmpz_mod_mul(c, c, deninv, ctx);
+            fmpz_mod_mul(c, c, zpow, ctx);
+            fmpz_mod_add(b, b, c, ctx);
+            fmpz_mod_mul(zpow, zpow, zeta, ctx);
+        }
+        fmpz_mod_mul(b, b, t, ctx);         /* / p^{p-1} */
+        fmpz_mod_mul(b, b, ths, ctx);       /* beta_s theta^s */
+        fmpz_mod_mul(b, b, g, ctx);         /* / A */
+        fmpz_mod_add(x, x, b, ctx);
+    }
+    fmpz_set_ui(c, p);
+    fmpz_mod_inv(c, c, ctx);
+    fmpz_mod_mul(x, x, c, ctx);
+
+    fmpz_mod_poly_evaluate_fmpz(t, U, x, ctx);
+    ok = fmpz_is_zero(t);
+
+cleanup:
+    fmpz_mod_poly_clear(Wm, ctx);
+    fmpz_clear(zeta); fmpz_clear(zpow); fmpz_clear(A); fmpz_clear(theta); fmpz_clear(ths);
+    fmpz_clear(b); fmpz_clear(c); fmpz_clear(t); fmpz_clear(e); fmpz_clear(g);
+    return ok;
+}
+
+/* rounds an acb polynomial with coefficients (u + v sqrt D) / 2 in O_K into
+   the integer polynomials u, v; sqrtD = i sqrt|D|; 0 if not identified */
+static int
+_acb_poly_get_K_poly(fmpz_poly_t u, fmpz_poly_t v, const acb_poly_t p, const acb_t sqrtD, slong prec)
+{
+    slong i, len = acb_poly_length(p);
+    fmpz_t c;
+    arb_t t;
+    int ok = 1;
+
+    fmpz_init(c);
+    arb_init(t);
+    fmpz_poly_zero(u);
+    fmpz_poly_zero(v);
+    for (i = 0; i < len && ok; i++)
+    {
+        const acb_struct * z = acb_poly_get_coeff_ptr((acb_poly_struct *) p, i);
+        arb_mul_2exp_si(t, acb_realref(z), 1);
+        if (!arb_get_unique_fmpz(c, t))
+            ok = 0;
+        else
+        {
+            fmpz_poly_set_coeff_fmpz(u, i, c);
+            arb_div(t, acb_imagref(z), acb_imagref(sqrtD), prec);
+            arb_mul_2exp_si(t, t, 1);
+            if (!arb_get_unique_fmpz(c, t))
+                ok = 0;
+            else
+                fmpz_poly_set_coeff_fmpz(v, i, c);
+        }
+    }
+    fmpz_clear(c);
+    arb_clear(t);
+    return ok;
+}
+
+/* rounds an acb polynomial with integer coefficients; 0 if not identified */
+static int
+_acb_poly_get_fmpz_poly(fmpz_poly_t r, const acb_poly_t p)
+{
+    slong i, len = acb_poly_length(p);
+    fmpz_t c;
+    int ok = 1;
+
+    fmpz_init(c);
+    fmpz_poly_zero(r);
+    for (i = 0; i < len && ok; i++)
+    {
+        const acb_struct * z = acb_poly_get_coeff_ptr((acb_poly_struct *) p, i);
+        if (!arb_contains_zero(acb_imagref(z)) || !arb_get_unique_fmpz(c, acb_realref(z)))
+            ok = 0;
+        else
+            fmpz_poly_set_coeff_fmpz(r, i, c);
+    }
+    fmpz_clear(c);
+    return ok;
+}
+
+/*
+    Weber's function f as class invariant, for fundamental D = -4m
+    (m = 1, 2, 3, 5, 6, 7 mod 8). The theorems on which values are class
+    invariants are those of Weber, Yui and Zagier (Math. Comp. 66, 1997)
+    and Schertz (J. Theor. Nombres Bordeaux 14, 2002, whose N-systems fix
+    the form representatives); the normalisations below (the power of f,
+    the factors of sqrt 2, the cube when 3 | D and the sign (2/a)) are the
+    ones of Enge's CM library, used here as the reference for which
+    normalisation yields a polynomial with integer coefficients. The value is taken at tau = (-b + sqrt(D)) / (2a)
+    for a form of the class in a 48-system: gcd(a, 48) = 1 and b = 0 mod
+    96. With f = zeta_48^{-1} eta((tau+1)/2) / eta(tau) and
+    f1 = eta(tau/2) / eta(tau):
+        m = 1 mod 8: g = f^2 / sqrt 2      m = 5 mod 8: g = f^4 / 2
+        m = 3 mod 8: g = f                 m = 7 mod 8: g = f / sqrt 2
+        m = 2, 6 mod 8: g = f1^2 / sqrt 2
+    then g = g^3 if 3 | D, and g = -g if (2/a) = -1 (except m = 3, 5). The
+    class polynomial of g has integer coefficients and height a factor
+    72 / e smaller than that of H_D, e in {1, 2, 4} times 3 if 3 | D.
+    Back from a root g:
+        m = 1, 2, 6: F = (8 g^{6/k})^2,  m = 5: F = 64 g^{6/k},
+        m = 3: F = (g^{6/k})^4,  m = 7: F = (8 g^{6/k})^4
+    (k = 3 if 3 | D, else 1), and j = (F - 16)^3 / F for m odd,
+    j = (F + 16)^3 / F for m even (F = f^24 resp. f1^24).
+*/
+static int
+_weber_ok(slong D)
+{
+    slong m;
+    if (D % 4 != 0)
+        return 0;
+    m = -D / 4;
+    return (m % 8 == 1 || m % 8 == 2 || m % 8 == 3 || m % 8 == 5 || m % 8 == 6 || m % 8 == 7);
+}
+
+/* the height factor 72 / e */
+static double
+_weber_factor(slong D)
+{
+    slong m = -D / 4, e = (m % 8 == 5) ? 4 : (m % 8 == 3 || m % 8 == 7) ? 1 : 2;
+    if (D % 3 == 0)
+        e *= 3;
+    return 72.0 / e;
+}
+
+/*
+    An equivalent form (a', b', c') with gcd(a', N) = 1 and b' = b0 mod 2N
+    (an N-system entry in the sense of Schertz), for a primitive form
+    (a, b, c) of discriminant D with b0 = D mod 2. The first coefficient
+    of the form transformed by [[x, u], [y, v]] in SL_2(Z) is Q(x, y): a
+    pair (x, y) with gcd(Q(x, y), N) = 1 exists among small coprime pairs
+    since the form is primitive, and is completed to a matrix with the
+    extended Euclidean algorithm; a translation by k then moves b to
+    b + 2 a' k = b0 mod 2N, i.e. k = (b0 - b)/2 * a'^{-1} mod N.
+*/
+static void
+_nsystem_entry(slong * a, slong * b, slong N, slong b0, slong D)
+{
+    slong c = (*b * *b - D) / (4 * *a);
+    slong x, y, ap, bp, u, v, k, r, s;
+    ulong g;
+
+    /* Q(x, y) coprime to N, |x|, |y| small: try (1,0), (0,1), then a grid */
+    ap = 0; x = 1; y = 0;
+    for (r = 0; r <= 8 && n_gcd(FLINT_ABS(ap), N) != 1; r++)
+    {
+        for (s = -r; s <= r && (r == 0 || n_gcd(FLINT_ABS(ap), N) != 1); s++)
+        {
+            x = (r == 0) ? 1 : r;
+            y = (r == 0) ? 0 : s;
+            if (n_gcd(FLINT_ABS(x), FLINT_ABS(y)) != 1)
+                continue;
+            ap = *a * x * x + *b * x * y + c * y * y;
+            if (n_gcd(FLINT_ABS(ap), N) == 1)
+                break;
+            x = s; y = r;   /* the pair (s, r) as well */
+            if (n_gcd(FLINT_ABS(x), FLINT_ABS(y)) != 1)
+                continue;
+            ap = *a * x * x + *b * x * y + c * y * y;
+        }
+    }
+    if (n_gcd(FLINT_ABS(ap), N) != 1)
+        return;     /* not reached for primitive forms; leave the form alone */
+
+    /* complete (x, y) to [[x, u], [y, v]] with x v - y u = 1 */
+    {
+        fmpz_t gg, uu, vv, xx, yy;
+        fmpz_init(gg); fmpz_init(uu); fmpz_init(vv);
+        fmpz_init_set_si(xx, x); fmpz_init_set_si(yy, y);
+        fmpz_xgcd(gg, vv, uu, xx, yy);      /* vv x + uu y = 1 */
+        v = fmpz_get_si(vv);
+        u = -fmpz_get_si(uu);               /* x v - y u = x v + y (-u) */
+        fmpz_clear(gg); fmpz_clear(uu); fmpz_clear(vv); fmpz_clear(xx); fmpz_clear(yy);
+    }
+    /* b' = 2 a x u + b (x v + y u) + 2 c y v */
+    bp = 2 * *a * x * u + *b * (x * v + y * u) + 2 * c * y * v;
+
+    /* translate: k = (b0 - b')/2 * a'^{-1} mod N */
+    k = (b0 - bp) / 2;
+    k %= N;
+    if (k < 0)
+        k += N;
+    g = n_invmod(n_mod2_preinv(FLINT_ABS(ap) % N, N, n_preinvert_limb(N)), N);
+    if (ap < 0)
+        g = (N - g) % N;
+    k = (slong) n_mulmod2_preinv((ulong) k, g, N, n_preinvert_limb(N));
+    *a = ap;
+    *b = bp + 2 * ap * k;
+}
+
+/* g at the class of the form (a, b) */
+static void
+_weber_value(acb_t g, slong a0, slong b0, slong D, slong prec)
+{
+    slong a = a0, b = b0, m = -D / 4;
+    acb_t tau, t, e1, e2;
+    arb_t s2;
+
+    _nsystem_entry(&a, &b, 48, 0, D);
+
+    acb_init(tau); acb_init(t); acb_init(e1); acb_init(e2);
+    arb_init(s2);
+    arb_set_si(acb_realref(tau), -b);
+    arb_set_si(acb_imagref(tau), -D);
+    arb_sqrt(acb_imagref(tau), acb_imagref(tau), prec);
+    acb_div_si(tau, tau, 2 * a, prec);
+    arb_sqrt_ui(s2, 2, prec);
+
+    acb_modular_eta(e2, tau, prec);
+    if (m % 8 == 2 || m % 8 == 6)
+    {
+        /* f1 = eta(tau/2) / eta(tau) */
+        acb_mul_2exp_si(t, tau, -1);
+        acb_modular_eta(e1, t, prec);
+        acb_div(g, e1, e2, prec);
+        acb_mul(g, g, g, prec);
+        acb_mul_arb(g, g, s2, prec);
+        acb_mul_2exp_si(g, g, -1);
+    }
+    else
+    {
+        /* f = zeta_48^{-1} eta((tau+1)/2) / eta(tau) */
+        acb_add_ui(t, tau, 1, prec);
+        acb_mul_2exp_si(t, t, -1);
+        acb_modular_eta(e1, t, prec);
+        acb_div(g, e1, e2, prec);
+        {
+            /* zeta_48^{-1} = exp(-2 pi i / 48) = cos(pi/24) - i sin(pi/24) */
+            fmpq_t x;
+            fmpq_init(x);
+            fmpq_set_si(x, -1, 24);
+            arb_sin_cos_pi_fmpq(acb_imagref(t), acb_realref(t), x, prec);
+            fmpq_clear(x);
+        }
+        acb_mul(g, g, t, prec);
+        if (m % 8 == 5)
+        {
+            acb_mul(g, g, g, prec);
+            acb_mul(g, g, g, prec);
+            acb_mul_2exp_si(g, g, -1);
+        }
+        else if (m % 8 == 3)
+        {
+            /* g = f */
+        }
+        else if (m % 8 == 7)
+        {
+            acb_mul_arb(g, g, s2, prec);
+            acb_mul_2exp_si(g, g, -1);
+        }
+        else
+        {
+            acb_mul(g, g, g, prec);
+            acb_mul_arb(g, g, s2, prec);
+            acb_mul_2exp_si(g, g, -1);
+        }
+    }
+    if (D % 3 == 0)
+    {
+        acb_mul(t, g, g, prec);
+        acb_mul(g, g, t, prec);
+    }
+    if (m % 8 != 3 && m % 8 != 5 && n_jacobi_unsigned(2, FLINT_ABS(a)) == -1)
+        acb_neg(g, g);
+
+    acb_clear(tau); acb_clear(t); acb_clear(e1); acb_clear(e2);
+    arb_clear(s2);
+}
+
+/* j from a root g of the class polynomial of the Weber invariant, mod n */
+static void
+_weber_to_j(fmpz_t j, const fmpz_t g, slong D, const fmpz_mod_ctx_t ctx)
+{
+    slong m = -D / 4;
+    fmpz_t F, t;
+    fmpz_init(F); fmpz_init(t);
+    fmpz_mod_pow_ui(F, g, (D % 3 == 0) ? 2 : 6, ctx);
+    if (m % 8 == 5)
+        fmpz_mod_mul_ui(F, F, 64, ctx);
+    else if (m % 8 == 3)
+        fmpz_mod_pow_ui(F, F, 4, ctx);
+    else if (m % 8 == 7)
+    {
+        fmpz_mod_mul_ui(F, F, 8, ctx);
+        fmpz_mod_pow_ui(F, F, 4, ctx);
+    }
+    else
+    {
+        fmpz_mod_mul_ui(F, F, 8, ctx);
+        fmpz_mod_mul(F, F, F, ctx);
+    }
+    if (m % 2 == 1)
+        fmpz_mod_sub_ui(t, F, 16, ctx);
+    else
+        fmpz_mod_add_ui(t, F, 16, ctx);
+    fmpz_mod_pow_ui(t, t, 3, ctx);
+    fmpz_mod_inv(F, F, ctx);
+    fmpz_mod_mul(j, t, F, ctx);
+    fmpz_clear(F); fmpz_clear(t);
+}
+
+int
+ecpp_class_poly_tower(fmpz_t j, slong D, flint_rand_t state, const fmpz_mod_ctx_t ctx)
+{
+    qfb * forms;
+    slong h, levels, i, k, lev, prec;
+    slong * perm, * degs;
+    fmpz_poly_struct ** W;      /* W[lev][0..d] : level lev's Hecke forms, W[0][0] bottom */
+    int * kummer;               /* level has the Kummer data */
+    acb_ptr roots;
+    arb_t sqrtD;
+    acb_t z;
+    double lgh;
+    int success = 0, kummer_retries = 0;
+    int weber = _weber_ok(D);
+    /* the Kummer data (and its retries) only pay when a powering of a
+       degree-p polynomial is expensive, i.e. for large n; the cost model
+       in disc.c prices the descents accordingly */
+    int want_kummer = fmpz_bits(fmpz_mod_ctx_modulus(ctx)) >= ECPP_KUMMER_BITS;
+
+    h = qfb_reduced_forms(&forms, D);
+    if (h <= 0)
+        return 0;
+    if (h == 1)
+    {
+        fmpz_poly_t H;
+        fmpz_poly_init(H);
+        acb_modular_hilbert_class_poly(H, D);
+        fmpz_mod_set_fmpz(j, H->coeffs + 0, ctx);
+        fmpz_mod_neg(j, j, ctx);
+        fmpz_poly_clear(H);
+        qfb_array_clear(&forms, h);
+        return 1;
+    }
+
+    perm = flint_malloc(h * sizeof(slong));
+    degs = flint_malloc((FLINT_BIT_COUNT(h) + 2) * sizeof(slong));
+#ifdef ECPP_PROFILE
+    {
+        double t0 = _tnow();
+        levels = _classgroup_series(perm, degs, forms, h, D);
+        ecpp_tower_prof[0] += _tnow() - t0;
+        ecpp_tower_count++; ecpp_tower_hsum += h;
+    }
+#else
+    levels = _classgroup_series(perm, degs, forms, h, D);
+#endif
+    if (levels == 0)
+        goto cleanup_forms;
+
+    W = flint_malloc(levels * sizeof(fmpz_poly_struct *));
+    kummer = flint_calloc(levels, sizeof(int));
+    for (lev = 0; lev < levels; lev++)
+    {
+        slong nd = (lev == 0) ? 1 : _level_size(degs[lev]);
+        W[lev] = flint_malloc(nd * sizeof(fmpz_poly_struct));
+        for (i = 0; i < nd; i++)
+            fmpz_poly_init(W[lev] + i);
+        if (lev > 0)
+            kummer[lev] = 0;
+    }
+
+    /*
+        Precision. The Lagrange numerators of the Hecke forms are sums of
+        terms of the size of V times the coefficients, with heavy
+        cancellation, and this happens at every level: in practice about
+        six times the height of H_D is needed (with j as the invariant;
+        class invariants of smaller height would reduce this in proportion,
+        which is what makes class numbers in the hundreds affordable in
+        Enge's CM library).
+    */
+    lgh = 0.0;
+    for (i = 0; i < h; i++)
+        lgh += 1.0 / fmpz_get_d(forms[i].a);
+    prec = 3.141593 * sqrt((double) -D) * lgh * 1.442696 * 1.5 / (weber ? _weber_factor(D) : 1.0) + 64 + 4 * h;
+
+    roots = _acb_vec_init(h);
+    arb_init(sqrtD);
+    acb_init(z);
+
+    for (;;)
+    {
+        slong num = h;      /* number of roots at the current level */
+        int kummer_failed = 0;
+        acb_ptr ys = _acb_vec_init(h);
+        acb_poly_t U, V, T, lin;
+        acb_poly_init(U); acb_poly_init(V); acb_poly_init(T); acb_poly_init(lin);
+
+#ifdef ECPP_PROFILE
+        double tj0 = _tnow();
+#endif
+        /* j-values in class group order */
+        arb_set_si(sqrtD, -D);
+        arb_sqrt(sqrtD, sqrtD, prec);
+        for (i = 0; i < h; i++)
+        {
+            const qfb * f = forms + perm[i];
+            if (weber)
+                _weber_value(roots + i, fmpz_get_si(f->a), fmpz_get_si(f->b), D, prec);
+            else
+            {
+                arb_set_fmpz(acb_realref(z), f->b);
+                arb_neg(acb_realref(z), acb_realref(z));
+                arb_set(acb_imagref(z), sqrtD);
+                acb_div_fmpz(z, z, f->a, prec);
+                acb_mul_2exp_si(z, z, -1);
+                acb_modular_j(roots + i, z, prec);
+            }
+        }
+
+        if (ecpp_verbose)
+            flint_printf("ecpp: tower for D = %wd, h = %wd, %wd levels, precision %wd (%s)\n",
+                    D, h, levels, prec, weber ? "Weber" : "j");
+#ifdef ECPP_PROFILE
+        ecpp_tower_prof[1] += _tnow() - tj0;
+        tj0 = _tnow();
+#endif
+        success = 1;
+        for (lev = levels - 1; lev >= 1 && success; lev--)
+        {
+            slong m = degs[lev], nn = num / m, jj, found = -1;
+            acb_poly_struct * Us = flint_malloc(nn * sizeof(acb_poly_struct));
+
+            for (k = 0; k < nn; k++)
+            {
+                acb_poly_init(Us + k);
+                acb_poly_product_roots(Us + k, roots + m * k, m, prec);
+            }
+            /* a generator among the coefficients, the trace first */
+            for (jj = m - 1; jj >= 0 && found < 0; jj--)
+            {
+                int distinct = 1;
+                for (k = 0; k < nn && distinct; k++)
+                    acb_poly_get_coeff_acb(ys + k, Us + k, jj);
+                for (k = 1; k < nn && distinct; k++)
+                {
+                    /* equal up to rounding? compare with a margin */
+                    acb_sub(z, ys + 0, ys + k, prec);
+                    if (acb_contains_zero(z))
+                        distinct = 0;
+                }
+                if (distinct)
+                    found = jj;
+            }
+            if (found < 0)
+            {
+                success = 0;
+            }
+            else
+            {
+                /* V = prod (X - y_k) and the Hecke numerators of the
+                   coefficients c_{jj,k} of the U_k, by a subproduct tree */
+                /* Kummer vectors: their numerators are larger than the
+                   polynomial ones, so only where the numerics are cheap */
+                slong nk = (m >= 5 && (weber || h <= 64) && want_kummer) ? (m - 1) + (m - 2) * (m - 1) : 0;
+                slong nv = m + nk;
+                acb_ptr * cs = flint_malloc(nv * sizeof(acb_ptr));
+                acb_poly_struct * Ws = flint_malloc(nv * sizeof(acb_poly_struct));
+                for (jj = 0; jj < nv; jj++)
+                {
+                    cs[jj] = _acb_vec_init(nn);
+                    acb_poly_init(Ws + jj);
+                }
+                for (jj = 0; jj < m; jj++)
+                    for (k = 0; k < nn; k++)
+                        acb_poly_get_coeff_acb(cs[jj] + k, Us + k, jj);
+                if (nk > 0)
+                {
+                    acb_mat_t Mz, Minv;
+                    acb_ptr vals = _acb_vec_init(nk);
+                    acb_t t;
+                    slong u;
+                    acb_ptr zm = _acb_vec_init(m);
+                    acb_init(t);
+                    acb_mat_init(Mz, m - 1, m - 1);
+                    acb_mat_init(Minv, m - 1, m - 1);
+                    /* zm[k] = exp(2 pi i k / m) */
+                    _acb_vec_unit_roots(zm, m, m, prec);
+                    for (u = 1; u < m; u++)
+                        for (jj = 0; jj < m - 1; jj++)
+                            acb_set(acb_mat_entry(Mz, u - 1, jj), zm + (u * jj) % m);
+                    _acb_vec_clear(zm, m);
+                    acb_mat_inv(Minv, Mz, prec);
+                    for (k = 0; k < nn; k++)
+                    {
+                        _kummer_values(vals, roots + m * k, m, Minv, prec);
+                        for (jj = 0; jj < nk; jj++)
+                            acb_set(cs[m + jj] + k, vals + jj);
+                    }
+                    acb_clear(t);
+                    _acb_vec_clear(vals, nk);
+                    acb_mat_clear(Mz);
+                    acb_mat_clear(Minv);
+                }
+                _hecke_tree(V, Ws, nv, ys, (const acb_struct * const *) cs, 0, nn, prec);
+                if (!_acb_poly_get_fmpz_poly(W[lev] + m, V))   /* temporarily V */
+                    success = 0;
+                for (jj = 0; jj < m && success; jj++)
+                    if (!_acb_poly_get_fmpz_poly(W[lev] + jj, Ws + jj))
+                        success = 0;
+                /* the Kummer data may fail to be integral (e.g. zeta in L_i):
+                   then only the polynomial is kept */
+                kummer[lev] = (nk > 0);
+                if (kummer[lev])
+                {
+                    acb_t sD;
+                    acb_init(sD);
+                    arb_zero(acb_realref(sD));
+                    arb_set(acb_imagref(sD), sqrtD);
+                    for (jj = 0; jj < nk && kummer[lev]; jj++)
+                        if (!_acb_poly_get_K_poly(W[lev] + m + 1 + 2 * jj, W[lev] + m + 2 + 2 * jj,
+                                                    Ws + m + jj, sD, prec))
+                        {
+                            kummer[lev] = 0;
+                            kummer_failed = 1;
+                            if (ecpp_verbose)
+                                flint_printf("ecpp: Kummer data not identified at degree %wd (precision %wd)\n", m, prec);
+                        }
+                    acb_clear(sD);
+                }
+                for (jj = 0; jj < nv; jj++)
+                {
+                    _acb_vec_clear(cs[jj], nn);
+                    acb_poly_clear(Ws + jj);
+                }
+                flint_free(cs);
+                flint_free(Ws);
+                if (success)
+                {
+                    /* W[lev][m] = V' */
+                    fmpz_poly_derivative(W[lev] + m, W[lev] + m);
+                    /* the conjugates of y are the roots of the next level */
+                    for (k = 0; k < nn; k++)
+                        acb_set(roots + k, ys + k);
+                    num = nn;
+                }
+            }
+            for (k = 0; k < nn; k++)
+                acb_poly_clear(Us + k);
+            flint_free(Us);
+        }
+        if (success)
+        {
+            acb_poly_product_roots(V, roots, num, prec);
+            if (!_acb_poly_get_fmpz_poly(W[0] + 0, V))
+                success = 0;
+        }
+
+        acb_poly_clear(U); acb_poly_clear(V); acb_poly_clear(T); acb_poly_clear(lin);
+        _acb_vec_clear(ys, h);
+#ifdef ECPP_PROFILE
+        ecpp_tower_prof[2] += _tnow() - tj0;
+        if (!success || kummer_failed) ecpp_tower_retries++;
+#endif
+
+        /* the Kummer numerators are larger than the polynomial ones: a
+           couple of retries at higher precision before giving them up */
+        if (success && (!kummer_failed || kummer_retries >= 1))
+            break;
+        if (success)
+        {
+            kummer_retries++;
+            prec = 2 * prec + 64;
+            continue;
+        }
+        if (prec > 40 * (3.141593 * sqrt((double) -D) * lgh * 1.442696 + 1000))
+            break;
+        prec = prec * 3 / 2 + 64;
+    }
+
+    /* descent modulo n */
+#ifdef ECPP_PROFILE
+    {
+    double td0 = _tnow();
+#endif
+    if (success)
+    {
+        fmpz_mod_poly_t f;
+        fmpz_t r, den, c, sqrtDn;
+        fmpz_mod_poly_init(f, ctx);
+        fmpz_init(r); fmpz_init(den); fmpz_init(c);
+        fmpz_init(sqrtDn);
+        /* sqrt(D) mod n, needed by the Kummer data (either sign works
+           for one of the two conjugate data sets; both are tried) */
+        {
+            slong lev2;
+            int need = 0;
+            for (lev2 = 1; lev2 < levels; lev2++)
+                need |= kummer[lev2];
+            if (need)
+            {
+                fmpz_set_si(sqrtDn, D);
+                fmpz_mod_set_fmpz(sqrtDn, sqrtDn, ctx);
+                if (!fmpz_sqrtmod(sqrtDn, sqrtDn, fmpz_mod_ctx_modulus(ctx)))
+                    for (lev2 = 1; lev2 < levels; lev2++)
+                        kummer[lev2] = 0;
+            }
+        }
+
+        fmpz_mod_poly_set_fmpz_poly(f, W[0] + 0, ctx);
+        success = ecpp_poly_root(r, f, state, ctx);
+        for (lev = 1; lev < levels && success; lev++)
+        {
+            slong m = degs[lev], jj;
+            ulong nm1;
+            fmpz_mod_poly_t Wm;
+            fmpz_mod_poly_init(Wm, ctx);
+            fmpz_mod_poly_set_fmpz_poly(Wm, W[lev] + m, ctx);
+            fmpz_mod_poly_evaluate_fmpz(den, Wm, r, ctx);
+            if (fmpz_is_zero(den))
+                success = 0;
+            else
+            {
+                fmpz_mod_inv(den, den, ctx);
+                fmpz_mod_poly_zero(f, ctx);
+                fmpz_mod_poly_set_coeff_ui(f, m, 1, ctx);
+                for (jj = 0; jj < m; jj++)
+                {
+                    fmpz_mod_poly_set_fmpz_poly(Wm, W[lev] + jj, ctx);
+                    fmpz_mod_poly_evaluate_fmpz(c, Wm, r, ctx);
+                    fmpz_mod_mul(c, c, den, ctx);
+                    fmpz_mod_poly_set_coeff_fmpz(f, jj, c, ctx);
+                }
+                nm1 = fmpz_fdiv_ui(fmpz_mod_ctx_modulus(ctx), m);
+                if (kummer[lev] && nm1 == 1
+                        && (_kummer_descent(c, W[lev], m, r, den, sqrtDn, f, state, ctx)
+                            || (fmpz_mod_neg(sqrtDn, sqrtDn, ctx),
+                                _kummer_descent(c, W[lev], m, r, den, sqrtDn, f, state, ctx))))
+                {
+                    fmpz_swap(r, c);
+                    if (ecpp_verbose)
+                        flint_printf("ecpp: Kummer descent in degree %wd\n", m);
+                }
+                else if (kummer[lev] && nm1 == (ulong) m - 1
+                        && (_kummer_descent_f2(c, W[lev], m, r, den, sqrtDn, f, state, ctx)
+                            || (fmpz_mod_neg(sqrtDn, sqrtDn, ctx),
+                                _kummer_descent_f2(c, W[lev], m, r, den, sqrtDn, f, state, ctx))))
+                {
+                    fmpz_swap(r, c);
+                    if (ecpp_verbose)
+                        flint_printf("ecpp: Kummer descent in degree %wd through F_(n^2)\n", m);
+                }
+                else
+                    success = ecpp_poly_root(r, f, state, ctx);
+            }
+            fmpz_mod_poly_clear(Wm, ctx);
+        }
+        if (success)
+        {
+            if (weber)
+                _weber_to_j(j, r, D, ctx);
+            else
+                fmpz_set(j, r);
+        }
+        fmpz_mod_poly_clear(f, ctx);
+        fmpz_clear(r); fmpz_clear(den); fmpz_clear(c);
+        fmpz_clear(sqrtDn);
+    }
+#ifdef ECPP_PROFILE
+    ecpp_tower_prof[3] += _tnow() - td0;
+    }
+#endif
+
+    _acb_vec_clear(roots, h);
+    arb_clear(sqrtD);
+    acb_clear(z);
+    for (lev = 0; lev < levels; lev++)
+    {
+        slong nd = (lev == 0) ? 1 : _level_size(degs[lev]);
+        for (i = 0; i < nd; i++)
+            fmpz_poly_clear(W[lev] + i);
+        flint_free(W[lev]);
+    }
+    flint_free(W);
+    flint_free(kummer);
+cleanup_forms:
+    flint_free(perm);
+    flint_free(degs);
+    qfb_array_clear(&forms, h);
+    return success;
+}

--- a/src/ecpp/verify.c
+++ b/src/ecpp/verify.c
@@ -1,0 +1,143 @@
+/*
+    Copyright (C) 2026 Fredrik Johansson
+    Developed using Claude Fable 5.1
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "ulong_extras.h"
+#include "fmpz.h"
+#include "fmpz_mod.h"
+#include "ecpp.h"
+
+/*
+    Checks one step of a certificate. Returns 1 if the step is valid, i.e.
+    n is prime provided q is prime; 0 otherwise.
+*/
+int
+ecpp_verify_step(const ecpp_step_struct * s)
+{
+    int result = 0;
+    fmpz_t t, u, k, acc;
+    fmpz_mod_ctx_t ctx;
+    ecpp_point_t P, R;
+
+    if (fmpz_cmp_ui(s->n, 3) <= 0 || fmpz_is_even(s->n))
+        return 0;
+
+    fmpz_init(t);
+    fmpz_init(u);
+    fmpz_init(k);
+    fmpz_init(acc);
+    fmpz_mod_ctx_init(ctx, s->n);
+    ecpp_point_init(P);
+    ecpp_point_init(R);
+
+    /* q | m, m = k q with k > 1 */
+    if (fmpz_cmp_ui(s->q, 1) <= 0 || !fmpz_divisible(s->m, s->q))
+        goto cleanup;
+    fmpz_divexact(k, s->m, s->q);
+    if (fmpz_cmp_ui(k, 1) <= 0)
+        goto cleanup;
+
+    /* q > (n^{1/4} + 1)^2, i.e. (sqrt(q) - 1)^4 > n; check via floor roots */
+    fmpz_sqrt(t, s->q);                     /* t = floor(sqrt(q)) */
+    fmpz_sub_ui(t, t, 1);
+    if (fmpz_sgn(t) <= 0)
+        goto cleanup;
+    fmpz_pow_ui(u, t, 4);                   /* (floor(sqrt q) - 1)^4 */
+    /* need (sqrt(q) - 1)^4 > n; sqrt(q) - 1 >= floor(sqrt(q)) - 1, so this suffices */
+    if (fmpz_cmp(u, s->n) <= 0)
+        goto cleanup;
+
+    /* gcd(6, n) = 1 and the curve is nonsingular: gcd(4a^3 + 27b^2, n) = 1 */
+    if (fmpz_divisible_si(s->n, 3))
+        goto cleanup;
+    fmpz_mod_mul(t, s->a, s->a, ctx);
+    fmpz_mod_mul(t, t, s->a, ctx);
+    fmpz_mod_mul_ui(t, t, 4, ctx);
+    fmpz_mod_mul(u, s->b, s->b, ctx);
+    fmpz_mod_mul_ui(u, u, 27, ctx);
+    fmpz_mod_add(t, t, u, ctx);
+    fmpz_gcd(t, t, s->n);
+    if (!fmpz_is_one(t))
+        goto cleanup;
+
+    /* P on the curve */
+    fmpz_mod_mul(t, s->x, s->x, ctx);
+    fmpz_mod_add(t, t, s->a, ctx);
+    fmpz_mod_mul(t, t, s->x, ctx);
+    fmpz_mod_add(t, t, s->b, ctx);
+    fmpz_mod_mul(u, s->y, s->y, ctx);
+    if (!fmpz_equal(t, u))
+        goto cleanup;
+
+    ecpp_point_set_affine(P, s->x, s->y);
+    fmpz_one(acc);
+
+    /* m P = O */
+    ecpp_point_mul(R, P, s->m, s->a, acc, ctx);
+    if (!ecpp_point_is_zero(R))
+        goto cleanup;
+
+    /* (m / q) P != O */
+    ecpp_point_mul(R, P, k, s->a, acc, ctx);
+    if (ecpp_point_is_zero(R))
+        goto cleanup;
+
+    /* all case distinctions were legitimate */
+    fmpz_gcd(t, acc, s->n);
+    if (!fmpz_is_one(t))
+        goto cleanup;
+
+    result = 1;
+
+cleanup:
+    ecpp_point_clear(P);
+    ecpp_point_clear(R);
+    fmpz_mod_ctx_clear(ctx);
+    fmpz_clear(t);
+    fmpz_clear(u);
+    fmpz_clear(k);
+    fmpz_clear(acc);
+
+    return result;
+}
+
+/*
+    Returns 1 if the certificate proves that n is prime, 0 otherwise. The
+    chain must start at n and be consecutive (n_{i+1} = q_i), and end with
+    a q < 2^64 which is checked directly. For n < 2^64 the certificate is
+    empty and n is checked directly.
+*/
+int
+ecpp_verify(const ecpp_cert_t cert, const fmpz_t n)
+{
+    slong i;
+    const fmpz * last;
+
+    if (cert->num == 0)
+        return fmpz_sgn(n) > 0 && fmpz_bits(n) <= 64 && fmpz_is_prime(n);
+
+    if (!fmpz_equal(cert->steps[0].n, n))
+        return 0;
+
+    for (i = 0; i < cert->num; i++)
+    {
+        const ecpp_step_struct * s = cert->steps + i;
+
+        if (i > 0 && !fmpz_equal(s->n, cert->steps[i - 1].q))
+            return 0;
+
+        if (!ecpp_verify_step(s))
+            return 0;
+    }
+
+    last = cert->steps[cert->num - 1].q;
+    return fmpz_sgn(last) > 0 && fmpz_bits(last) <= 64 && fmpz_is_prime(last);
+}

--- a/src/fmpz/is_prime.c
+++ b/src/fmpz/is_prime.c
@@ -14,7 +14,41 @@
 #include "ulong_extras.h"
 #include "nmod_vec.h"
 #include "fmpz.h"
+#include "thread_support.h"
 #include "aprcl.h"
+#include "ecpp.h"
+
+/*
+    ECPP versus APRCL for the final proof: single-threaded, ECPP is the
+    faster from about 250 bits on (means over random primes); APRCL parallelises better (its
+    Jacobi sums are independent), ECPP's chain is largely serial, so the
+    crossover moves up with the number of threads (measured on random
+    primes: 250 bits with one thread, 550 with two, 1000 with three, 2000
+    with four).
+*/
+static slong
+_fmpz_is_prime_ecpp_bits(void)
+{
+    slong t = flint_get_num_available_threads();
+    if (t <= 1) return 250;
+    if (t == 2) return 550;
+    if (t == 3) return 1000;
+    if (t == 4) return 2000;
+    if (t <= 8) return 8000;
+    return 12000;   /* heuristic, neither APRCL nor ECPP is currently tuned for larger bit sizes */
+}
+
+static int
+_fmpz_is_prime_proof(const fmpz_t n)
+{
+    if ((slong) fmpz_bits(n) >= _fmpz_is_prime_ecpp_bits())
+    {
+        int r = ecpp_is_prime(n);
+        if (r >= 0)
+            return r;
+    }
+    return aprcl_is_prime(n);
+}
 
 static int _fmpz_is_prime(const fmpz_t n, int proved)
 {
@@ -213,7 +247,7 @@ static int _fmpz_is_prime(const fmpz_t n, int proved)
 
          if (!feasible)
          {
-            res = aprcl_is_prime(n);
+            res = _fmpz_is_prime_proof(n);
             _nmod_vec_clear(pm1);
             _nmod_vec_clear(pp1);
             break;
@@ -354,7 +388,7 @@ static int _fmpz_is_prime(const fmpz_t n, int proved)
                               fmpz_clear(r);
                            } else /* apr-cl primality test */
                            {
-                              res = aprcl_is_prime(n);
+                              res = _fmpz_is_prime_proof(n);
                            }
 
                            fmpz_clear(d);

--- a/src/fmpz_mod_poly/div_newton_n_preinv.c
+++ b/src/fmpz_mod_poly/div_newton_n_preinv.c
@@ -23,14 +23,14 @@ void _fmpz_mod_poly_div_newton_n_preinv (fmpz* Q, const fmpz* A, slong lenA,
 {
     const slong lenQ = lenA - lenB + 1;
     fmpz * Arev;
-
-    Arev = _fmpz_vec_init(lenQ);
-
-    _fmpz_poly_reverse(Arev, A + (lenA - lenQ), lenQ, lenQ);
+    slong i;
+ 
+    Arev = flint_malloc(lenQ * sizeof(fmpz));
+    for (i = 0; i < lenQ; i++)
+        Arev[i] = A[lenA - 1 - i];
     _fmpz_mod_poly_mullow(Q, Arev, lenQ, Binv, FLINT_MIN(lenQ, lenBinv), lenQ, ctx);
     _fmpz_poly_reverse(Q, Q, lenQ, lenQ);
-
-    _fmpz_vec_clear(Arev, lenQ);
+    flint_free(Arev);
 }
 
 

--- a/src/mpn_mod.h
+++ b/src/mpn_mod.h
@@ -132,6 +132,9 @@ int mpn_mod_write(gr_stream_t out, nn_srcptr x, gr_ctx_t ctx);
 
 int mpn_mod_get_fmpz(fmpz_t res, nn_srcptr x, gr_ctx_t ctx);
 
+int mpn_mod_pow_fmpz(nn_ptr res, nn_srcptr x, const fmpz_t e, gr_ctx_t ctx);
+int mpn_mod_pow_ui(nn_ptr res, nn_srcptr x, ulong e, gr_ctx_t ctx);
+
 MPN_MOD_INLINE truth_t
 mpn_mod_is_zero(nn_srcptr x, gr_ctx_t ctx)
 {

--- a/src/mpn_mod/ctx.c
+++ b/src/mpn_mod/ctx.c
@@ -99,10 +99,9 @@ gr_method_tab_input _mpn_mod_methods_input[] =
 
 
     {GR_METHOD_INV,             (gr_funcptr) mpn_mod_inv},
-/*
-    {GR_METHOD_POW_SI,          (gr_funcptr) mpn_mod_pow_si},
     {GR_METHOD_POW_UI,          (gr_funcptr) mpn_mod_pow_ui},
     {GR_METHOD_POW_FMPZ,        (gr_funcptr) mpn_mod_pow_fmpz},
+/*
     {GR_METHOD_SQRT,            (gr_funcptr) mpn_mod_sqrt},
     {GR_METHOD_IS_SQUARE,       (gr_funcptr) mpn_mod_is_square},
 */

--- a/src/mpn_mod/ring.c
+++ b/src/mpn_mod/ring.c
@@ -675,3 +675,64 @@ mpn_mod_div(nn_ptr res, nn_srcptr x, nn_srcptr y, gr_ctx_t ctx)
 
     return status;
 }
+
+/*
+    Powering. For exponents beyond a few bits, mpz_powm (Montgomery
+    representation, sliding windows) is 2-3 times faster than the generic
+    binary powering with mpn_mod multiplications; below that the generic
+    code is used.
+*/
+int
+mpn_mod_pow_fmpz(nn_ptr res, nn_srcptr x, const fmpz_t e, gr_ctx_t ctx)
+{
+    slong nlimbs = MPN_MOD_CTX_NLIMBS(ctx);
+    mpz_t xz, nz, rz, ez;
+    slong xn, rn;
+
+    if (fmpz_sgn(e) < 0 || fmpz_bits(e) <= 6)
+        return gr_generic_pow_fmpz(res, x, e, ctx);
+
+    xn = nlimbs;
+    while (xn > 0 && x[xn - 1] == 0)
+        xn--;
+    if (xn == 0)
+    {
+        /* 0^e = 0 for e > 0 */
+        flint_mpn_zero(res, nlimbs);
+        return GR_SUCCESS;
+    }
+
+    mpz_roinit_n(xz, (mp_srcptr) x, xn);
+    mpz_roinit_n(nz, (mp_srcptr) MPN_MOD_CTX_MODULUS(ctx), nlimbs);
+    if (COEFF_IS_MPZ(*e))
+        mpz_roinit_n(ez, COEFF_TO_PTR(*e)->_mp_d, COEFF_TO_PTR(*e)->_mp_size);
+    else
+    {
+        ulong ev = *e;
+        mpz_roinit_n(ez, &ev, 1);
+        mpz_init(rz);
+        mpz_powm(rz, xz, ez, nz);
+        goto done;
+    }
+    mpz_init(rz);
+    mpz_powm(rz, xz, ez, nz);
+done:
+    rn = rz->_mp_size;
+    flint_mpn_copyi(res, rz->_mp_d, rn);
+    flint_mpn_zero(res + rn, nlimbs - rn);
+    mpz_clear(rz);
+    return GR_SUCCESS;
+}
+
+int
+mpn_mod_pow_ui(nn_ptr res, nn_srcptr x, ulong e, gr_ctx_t ctx)
+{
+    fmpz_t t;
+    int status;
+    if (e <= 64)
+        return gr_generic_pow_ui(res, x, e, ctx);
+    fmpz_init_set_ui(t, e);
+    status = mpn_mod_pow_fmpz(res, x, t, ctx);
+    fmpz_clear(t);
+    return status;
+}


### PR DESCRIPTION
New module `ecpp` for Atkin-Morain elliptic curve primality proving. Implemented using Claude Fable 5.1. Borrows ideas from Pari/GP's `primecert` by Jared Asuncion and from the fastECPP implementation by Andreas Enge in CM. Timings from Pari/GP and CM on the same inputs were used for tuning.

* Adds `ecpp_prove` (certificate), `ecpp_verify`, `ecpp_is_prime`, certificates as text in FLINT and PARI/GP `primecert` formats. Also adds options to `examples/factor_integer.c` to print or verify ECPP certificates for the factors.

* `fmpz_is_prime` uses ECPP instead of APRCL from a size depending on the number of available threads (250 bits with one thread, 550 with two, 1000 with three, 2000 with four, 8000 with up to eight). Single-threaded `fmpz_is_prime` becomes about 2-4x faster for input about 100 digits and up.

Claude reports the following single-threaded timings in a VM (Intel Xeon @ 2.10 GHz):

| bits | FLINT ECPP | FLINT APRCL | PARI/GP `primecert` | CM `ecpp` |
|---|---|---|---|---|
| 500 | **0.07** | 0.11 | 0.28 | 2.01 |
| 1000 | **0.64** | 1.51 | 1.14 | 0.71 |
| 2000 | **6.23** | 24.3 | 12.3 | 8.50 |
| 3000 | **36.2** | 87.3 | 75.7 | 45.1 |
| 4000 | 114.0 | 263.2 | 233.7 | **98.9** |

Here are detailed timings vs APRCL on my Zen3 machine (random primes with `bits` bits):

```
                  1 thread                     2 threads                 4 threads                 8 threads
    bits      aprcl    ecpp  speedup       aprcl    ecpp  speedup    aprcl    ecpp  speedup     aprcl    ecpp  speedup

     100     0.0004    0.0016 (0.25)      0.0002   0.0017 (0.13)     0.0001   0.0017 (0.08)     0.0001   0.0018 (0.07)   
     200     0.0037    0.0045 (0.82)      0.0019   0.0044 (0.42)     0.0011   0.0043 (0.25)     0.0007   0.0044 (0.17)   
     300     0.0121    0.0070 (1.72)      0.0068   0.0075 (0.91)     0.0038   0.0076 (0.50)     0.0023   0.0074 (0.31)   
     400     0.0325    0.0168 (1.93)      0.0163   0.0160 (1.02)     0.0089   0.0163 (0.55)     0.0058   0.0161 (0.36)   
     500     0.0658    0.0383 (1.72)      0.0329   0.0379 (0.87)     0.0177   0.0381 (0.46)     0.0105   0.0380 (0.28)   
     600     0.1380    0.1040 (1.33)      0.0700   0.1030 (0.68)     0.0410   0.1030 (0.40)     0.0220   0.1020 (0.22)   
     700     0.2340    0.0937 (2.50)      0.1220   0.0950 (1.28)     0.0650   0.0950 (0.68)     0.0380   0.0950 (0.40)   
     800     0.4270    0.1690 (2.53)      0.2210   0.1610 (1.37)     0.1140   0.1610 (0.71)     0.0800   0.1640 (0.49)   
     900     0.6460    0.2400 (2.69)      0.3330   0.2370 (1.41)     0.1740   0.2340 (0.74)     0.1040   0.2370 (0.44)   
    1000     0.9120    0.3540 (2.58)      0.4670   0.3570 (1.31)     0.2420   0.2940 (0.82)     0.1440   0.2790 (0.52)   
    1100     1.3140    0.3920 (3.35)      0.6890   0.3430 (2.01)     0.3600   0.3080 (1.17)     0.2160   0.4690 (0.46)   
    1200     1.7800    0.8060 (2.21)      0.9370   0.7350 (1.27)     0.4870   0.6210 (0.78)     0.2890   0.6290 (0.46)   
    1300     2.4080    0.8520 (2.83)      1.2260   0.7320 (1.67)     0.6450   0.6320 (1.02)     0.3790   0.5710 (0.66)   
    1400     2.8910    1.2040 (2.40)      1.5260   1.0970 (1.39)     0.7780   0.9010 (0.86)     0.4980   0.9020 (0.55)   
    1500     3.9780    1.7830 (2.23)      2.0120   1.3730 (1.47)     1.0690   1.4970 (0.71)     0.6050   1.4360 (0.42)   
    2000    15.4090    3.8990 (3.95)      7.9690   2.9330 (2.72)     4.2980   3.0030 (1.43)     2.6890   3.0270 (0.89)   
    2500    37.2730   10.8840 (3.42)     19.1120   8.9400 (2.14)    10.3560   8.7360 (1.19)     6.1080   7.4700 (0.82)   
    3000    55.2050   21.3930 (2.58)     28.7450  17.1670 (1.67)    15.8000  15.6250 (1.01)     8.9670  16.9760 (0.53)   
    3500    95.5900   36.3290 (2.63)     51.9580  26.6160 (1.95)    28.0640  22.7720 (1.23)    16.3210  21.7420 (0.75)   
    4000   165.6480   66.4350 (2.49)     87.4880  49.9550 (1.75)    49.6570  44.3640 (1.12)    29.2930  38.1230 (0.77)   
    4500   257.1760   91.5000 (2.81)    138.4610  64.6440 (2.14)    77.9340  53.7010 (1.45)    48.4780  85.8440 (0.56)   
    5000   374.4350  182.8220 (2.05)    194.5660 128.8150 (1.51)   122.0300 112.2310 (1.09)    66.8760  98.8810 (0.68)   
    5500   552.6620  278.0850 (1.99)    297.6330 184.1870 (1.62)   172.1070 145.3820 (1.18)   105.2790 118.3240 (0.89)   
    6000   676.8140  276.5470 (2.45)    370.4520 188.7670 (1.96)   217.5610 160.7520 (1.35)   131.1760 136.1430 (0.96)   
    6500  1043.5760  491.4420 (2.12)    546.0200 343.8370 (1.59)   315.7610 272.1290 (1.16)   192.5480 246.2680 (0.78)   
    7000  1799.4440 1064.9540 (1.69)    979.5600 841.4490 (1.16)   582.0120 775.6200 (0.75)   354.2400 590.5690 (0.60)   
    7500  2106.8120 1031.6540 (2.04)   1150.8750 654.3700 (1.76)   682.9590 489.7000 (1.39)   414.7600 384.3690 (1.08)   
    8000  2522.7980 1193.6630 (2.11)   1356.8650 774.7820 (1.75)   799.4510 577.5340 (1.38)   489.4370 482.3410 (1.01)   
    8500  2993.4040 1477.8630 (2.03)   1623.7150 952.3770 (1.70)   953.2920 708.6560 (1.35)   594.4260 711.1680 (0.84)   
```

Note that our APRCL remains superior if you have a lot of cores since it's embarrassingly parallel while ECPP has scalar bottlenecks.

It looks like CM's implementation is asymptotically faster, and the ratios versus APRCL beyond the crossover point look flat rather than improving, so there are definitely things left to tune.

Implementation details per Claude:

* pool of fundamental discriminants smooth over a small set of primes, ordered by the cost of realising a step; per n only discriminants with all genus characters 1 are used, sqrt(D) is the product of the square roots of the p* computed once per n with shared Tonelli data;
* rounds extending the prime set until a few prime cofactors are expected; orders factored in one remainder tree of a primorial (precomputed inverse); cofactors sorted and tested, candidate chosen by cost per bit gained; dead ends backtrack;
* class field tower (Enge-Morain) with the Weber invariant for even D and for odd D through the order of conductor 2, Hecke representation computed with subproduct trees (1.5x the height of the class polynomial suffices), descent by radicals (degrees 2-4, in F_n or F_(n^2)) and by Kummer theory (prime degrees >= 5 when n = +-1 mod p), else powering; genus-field factor of H_D as fallback;
* point arithmetic over gr (mpn_mod up to 16 limbs), width-4 NAF;
* Threads: scan phases in parallel, realisation of a step pipelined with the search for the next.

Minor optimizations included: `fmpz_mod_poly` Newton division with a shallow reversal; `mpn_mod` powering through `mpz_powm`.
