### PR TITLE
Improve documentation on geometric progression

### DIFF
--- a/doc/source/nmod_poly.rst
+++ b/doc/source/nmod_poly.rst
@@ -1507,8 +1507,7 @@ Multipoint evaluation
     Evaluates (``coeffs``, ``ilen``) at the first ``olen`` powers
     of the square of ``r``, writing the output values to ``ys``.
     The value of ``r`` should be reduced modulo the modulus ``mod``
-    and of sufficient multiplicative order such that none of
-    the first ``olen`` powers of `r^2` is one.
+    and coprime with ``mod``.
 
     Uses fast geometric multipoint evaluation, building a temporary geometric progression precomputation.
 
@@ -1517,8 +1516,7 @@ Multipoint evaluation
     Evaluates ``poly``  at the first ``olen`` powers
     of the square of ``r``, writing the output values to ``ys``.
     The value of ``r`` should be reduced modulo the modulus of the polynomial
-    and of sufficient multiplicative order such that none of
-    the first ``olen`` powers of `r^2` is one.
+    and coprime with this modulus.
 
     Uses fast geometric multipoint evaluation, building a temporary geometric progression precomputation.
 
@@ -2651,24 +2649,27 @@ Geometric progression
     Builds a geometric progression multipoint evaluation / interpolation structure.
 
     The variant with ``function`` variant builds precomputation for specific
-    functionalities: currently, one should set ``function`` to `1` for
-    evaluation only, to `2` for interpolation only, and to `3` for both
-    evaluation and interpolation. The variant without ``function`` precomputes
-    for both.
+    functionalities. The lowest 3 bits of ``function`` act as a mask for the
+    three functionalities: bit 0 for evaluation, bit 1 for interpolation, and
+    bit 2 for extrapolation. For example, setting ``function`` to `1` prepares
+    precomputation for evaluation only, setting it to `3` prepares for both
+    evaluation and interpolation, and setting it to `5` prepares for evaluation
+    and extrapolation. The variant without ``function`` precomputes for all
+    three functionalities.
 
     The set of points used will be `1, r^2, r^4, \ldots, r^{2(len-1)}`.
 
-    The value of ``r`` should be reduced modulo the modulus ``mod``
-    and of sufficient multiplicative order such that none of
-    the powers `r^2, r^4, \ldots, r^{2(len-1)}` is one.
+    The value of ``r`` should be reduced modulo the modulus ``mod`` and should
+    be coprime with ``mod``. If ``function`` is `1` (evaluation only), there is
+    no other constraint. For any value of ``function`` other than `1`, this `r`
+    should also have sufficient multiplicative order such that none of the
+    powers `r^2, r^4, \ldots, r^{2(len-1)}` is one; additionally, if ``mod`` is
+    not prime then `r` should be such that the auxiliary values `r^{2k} - 1`
+    are invertible modulo ``mod``.
 
     The value of ``len`` should be both greater than or equal to the number of evaluation points to be
     considered, and greater than or equal to the length of the polynomials to be evaluated / interpolated.
-    This allocates vectors and polynomials for a total space of `6 len - 1` coefficients.
-
-    If the modulus is not prime, this function will work under the additional
-    assumption that all the used points `r^{2k}` as well as the auxiliary
-    values `r^{2k} - 1` are invertible.
+    This allocates vectors and polynomials for a total space of ``11*len`` coefficients at most (evaluation alone takes ``3*len``; interpolation takes ``3*len``; extrapolation takes ``6*len`` but with ``1*len`` shared with interpolation).
 
 .. function:: void nmod_geometric_progression_clear(nmod_geometric_progression_t G)
 

--- a/src/nmod_poly/test/t-evaluate_geometric_nmod_vec_fast.c
+++ b/src/nmod_poly/test/t-evaluate_geometric_nmod_vec_fast.c
@@ -14,6 +14,7 @@
 #include "nmod_vec.h"
 #include "nmod_poly.h"
 #include "nmod.h"
+#include "ulong_extras.h"
 
 TEST_FUNCTION_START(nmod_poly_evaluate_geometric_nmod_vec_fast, state)
 {
@@ -24,19 +25,38 @@ TEST_FUNCTION_START(nmod_poly_evaluate_geometric_nmod_vec_fast, state)
         nmod_poly_t P;
         nn_ptr y, z;
         ulong mod, r;
-        slong n, npoints;
+        ulong n, npoints;
 
-        npoints = (i < 10) ? i : n_randint(state, 500);
+        /* will do a few tests with repeated points */
+        int repeated_points = (i % 10 == 5);
+
+        /* number of points */
+        npoints = (i < 20) ? i : n_randint(state, 500);
+
+        /* poly length */
         n = n_randint(state, 1000);
-        do 
-        { 
-            mod = n_randtest_prime(state, 1); 
-        }
-        while (mod <= 2*FLINT_MAX(npoints, n) + 1); // minimum limit for maximum order r
 
+        /* modulus and geometric progression */
+        if (repeated_points) 
+        {
+            mod = 2 + n_randint(state, 5);
+            do
+            {
+                r = n_randint(state, mod);
+            }
+            while (n_gcd(r, mod) != 1);
+        }
+        else
+        {
+            do 
+            { 
+                mod = n_randtest_prime(state, 1); 
+            }
+            while (mod <= 2*FLINT_MAX(npoints, n) + 1);
+            r = n_primitive_root_prime(mod);
+        }
 
         nmod_poly_init(P, mod);
-        r = n_primitive_root_prime(mod);
         y = _nmod_vec_init(npoints);
         z = _nmod_vec_init(npoints);
 


### PR DESCRIPTION
This concerns geometric progressions in `nmod_poly`:

- adds explanations about precomputations for extrapolation (which should have been added in an earlier PR)
- clarifies the fact that when precomputations are done for evaluation as the single target operation, then there is no issue with having repeated points, this works perfectly fine both for precomputations and for the multipoint evaluation itself
- add case in the corresponding test, choosing a very small modulus, not necessarily prime, and picking a geometric progression that is very likely to contain repeated points.