### PR TITLE
Remove file handling from qsieve

### DIFF
--- a/doc/source/qsieve.rst
+++ b/doc/source/qsieve.rst
@@ -91,18 +91,28 @@
     Call for initialization of polynomial, sieving, and scanning of sieve
     for all the possible polynomials for particular hypercube i.e. `A`.
 
-.. function:: void qsieve_write_to_file(qs_t qs_inf, ulong prime, const fmpz_t Y, const qs_poly_t poly)
+.. function:: void qsieve_relations_init(qs_t qs_inf)
 
-    Write a relation to the file in a binary format as follows. First, write
-    large prime of size ``sizeof(ulong)``, in case of full relation it is 1.
-    After this, write the number of small primes with size ``sizeof(slong)``.
-    Then, write the small primes, with a total size of
-    ``number_of_small_primes * sizeof(slong)``. Then, write the number of
-    factors with a size of ``sizeof(slong)``. After that, write the factors and
-    their exponents in the format ``factor_1, exponent_1, factor_2, ...``, all
-    with a total size of ``2 * number_of_factors * sizeof(slong)``. Then write
-    ``Y`` with the size of ``Y`` first (size ``sizeof(slong)``, that may be
-    negative), and then its limbs (size ``Y_size * sizeof(ulong)``).
+    Initialise the store which holds the relations found by sieving. Called by
+    :func:`qsieve_init_with_tune`.
+
+.. function:: void qsieve_relations_clear(qs_t qs_inf)
+
+    Free the relation store. Called by :func:`qsieve_clear`.
+
+.. function:: void qsieve_relations_reset(qs_t qs_inf)
+
+    Discard all the relations found so far, retaining the allocations made for
+    them. Used when the linear algebra fails to split `n` and sieving has to
+    start again with a larger factor base.
+
+.. function:: void qsieve_add_relation(qs_t qs_inf, ulong prime, const fmpz_t Y, const qs_poly_t poly)
+
+    Append a relation to the store, where *prime* is its large prime, or 1 if
+    the relation is full, and *poly* supplies the small prime exponents and the
+    remaining factors. The relations are held in memory for the duration of the
+    run. As this is called from the sieving threads, the caller must hold
+    ``qs_inf->mutex``.
 
 .. function:: hash_t * qsieve_get_table_entry(qs_t qs_inf, ulong prime)
 
@@ -113,10 +123,10 @@
     
     Add 'prime' to the hast table.
 
-.. function:: relation_t qsieve_parse_relation(qs_t qs_inf)
+.. function:: relation_t qsieve_get_relation(qs_t qs_inf, slong i)
 
-    Read a relation from the file associated with *qs_inf* and parse it to
-    obtain all the parameters of the relation.
+    Return a copy of the *i*-th relation in the store. The store retains its
+    own copy; the caller owns, and must free, the one returned.
 
 .. function:: relation_t qsieve_merge_relation(qs_t qs_inf, relation_t  a, relation_t  b)
 
@@ -139,9 +149,9 @@
 
 .. function:: int qsieve_process_relation(qs_t qs_inf)
 
-    After we have accumulated required number of relations, first process the file by
-    reading all the relations, removes singleton. Then merge all the possible partial
-    to obtain full relations.
+    After we have accumulated required number of relations, first process the
+    relations found so far, removing singletons. Then merge all the possible
+    partials to obtain full relations.
 
 .. function:: void qsieve_factor(fmpz_factor_t factors, const fmpz_t n)
 

--- a/src/qsieve.h
+++ b/src/qsieve.h
@@ -87,6 +87,14 @@ typedef struct             /* format for relation */
    fmpz_t Y;              /* square root of sieve value for relation */
 } relation_t;
 
+typedef struct          /* a relation as held in the relation store */
+{
+   ulong lp;           /* large prime, is 1, if relation is full */
+   slong num_factors;  /* number of factors, excluding small factors */
+   slong factor_offset; /* offset of the factors in qs_inf->rel_factor */
+   fmpz Y;             /* square root of sieve value for relation */
+} qs_rel_s;
+
 typedef struct
 {
    fmpz_t B;          /* current B coeff of poly */
@@ -191,8 +199,20 @@ typedef struct
                        RELATION DATA
    ***************************************************************************/
 
-   FLINT_FILE * siqs;           /* pointer to file for storing relations */
-   char * fname;          /* name of file used for relations */
+   /* Relations are kept in memory, in the order they were found. Every
+      relation has exactly qs_inf->small_primes small prime exponents, so
+      those live at a fixed stride in rel_small. The number of remaining
+      factors varies, so each relation records the offset of its own block of
+      the shared rel_factor array. */
+   qs_rel_s * relations;   /* relations found so far */
+   slong rel_num;          /* number of relations found so far */
+   slong rel_alloc;        /* number of relations we have space for */
+
+   slong * rel_small;      /* small prime exponents, small_primes per relation */
+
+   fac_t * rel_factor;     /* factors of all relations, concatenated */
+   slong rel_factor_num;   /* entries of rel_factor in use */
+   slong rel_factor_alloc; /* entries of rel_factor allocated */
 
    slong full_relation;   /* number of full relations */
    slong num_cycles;      /* number of possible full relations from partials */
@@ -358,14 +378,20 @@ int qsieve_relations_cmp(const void * a, const void * b);
 
 slong qsieve_merge_relations(qs_t qs_inf);
 
-void qsieve_write_to_file(qs_t qs_inf, ulong prime,
+void qsieve_relations_init(qs_t qs_inf);
+
+void qsieve_relations_clear(qs_t qs_inf);
+
+void qsieve_relations_reset(qs_t qs_inf);
+
+void qsieve_add_relation(qs_t qs_inf, ulong prime,
                                                      const fmpz_t Y, const qs_poly_t poly);
 
 hash_t * qsieve_get_table_entry(qs_t qs_inf, ulong prime);
 
 void qsieve_add_to_hashtable(qs_t qs_inf, ulong prime);
 
-relation_t qsieve_parse_relation(qs_t qs_inf);
+relation_t qsieve_get_relation(qs_t qs_inf, slong i);
 
 relation_t qsieve_merge_relation(qs_t qs_inf, relation_t  a, relation_t  b);
 

--- a/src/qsieve/clear.c
+++ b/src/qsieve/clear.c
@@ -24,5 +24,5 @@ void qsieve_clear(qs_t qs_inf)
     qs_inf->factor_base = NULL;
     qs_inf->sqrts       = NULL;
 
-    flint_free(qs_inf->fname);
+    qsieve_relations_clear(qs_inf);
 }

--- a/src/qsieve/collect_relations.c
+++ b/src/qsieve/collect_relations.c
@@ -543,7 +543,7 @@ slong qsieve_evaluate_candidate(qs_t qs_inf, ulong i, unsigned char * sieve, qs_
 #if FLINT_USES_PTHREAD
          pthread_mutex_lock(&qs_inf->mutex);
 #endif
-	 qsieve_write_to_file(qs_inf, 1, Y, poly);
+         qsieve_add_relation(qs_inf, 1, Y, poly);
 
          qs_inf->full_relation++;
 
@@ -590,9 +590,8 @@ slong qsieve_evaluate_candidate(qs_t qs_inf, ulong i, unsigned char * sieve, qs_
 #if FLINT_USES_PTHREAD
                   pthread_mutex_lock(&qs_inf->mutex);
 #endif
-                  /* store this partial in file */
-
-                  qsieve_write_to_file(qs_inf, prime, Y, poly);
+                  /* store this partial */
+                  qsieve_add_relation(qs_inf, prime, Y, poly);
 
                   qs_inf->edges++;
 

--- a/src/qsieve/factor.c
+++ b/src/qsieve/factor.c
@@ -11,32 +11,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define _STDC_FORMAT_MACROS
-
-/* try to get fdopen, mkstemp declared */
-#if defined(__STRICT_ANSI__)
-# undef __STRICT_ANSI__
-#endif
-
-#if defined(__CYGWIN__)
-# define ulong ulongxx
-# include <sys/param.h>
-# undef ulong
-#endif
-
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include "thread_support.h"
 #include "fmpz.h"
 #include "fmpz_factor.h"
 #include "fmpz_vec.h"
 #include "qsieve.h"
-
-/* Use Windows API for temporary files under MSVC and MinGW */
-#if (defined(__WIN32) && !defined(__CYGWIN__)) || defined(_MSC_VER)
-# include <windows.h>
-#endif
 
 /*
    Refine n by the factors found so far, so that every entry of the result is a
@@ -130,11 +109,6 @@ void qsieve_factor_with_tune(fmpz_factor_t factors, const fmpz_t n,
     fmpz_t temp, temp2, X, Y;
     slong num_facs;
     fmpz * facs;
-#if (defined(__WIN32) && !defined(__CYGWIN__)) || defined(_MSC_VER)
-    char temp_path[MAX_PATH];
-#else
-    int fd;
-#endif
 
     if (fmpz_sgn(n) < 0)
     {
@@ -283,40 +257,6 @@ void qsieve_factor_with_tune(fmpz_factor_t factors, const fmpz_t n,
     pthread_mutex_init(&qs_inf->mutex, NULL);
 #endif
 
-#if (defined(__WIN32) && !defined(__CYGWIN__)) || defined(_MSC_VER)
-    if (GetTempPathA(MAX_PATH, temp_path) == 0)
-    {
-        flint_throw(FLINT_ERROR, "Exception (qsieve_factor). GetTempPathA() failed.\n");
-    }
-    /* uUnique = 0 means the we *do* want a unique filename (obviously!). */
-    if (GetTempFileNameA(temp_path, "siq", /*uUnique*/ 0, qs_inf->fname) == 0)
-    {
-        flint_throw(FLINT_ERROR, "Exception (qsieve_factor). GetTempFileNameA() failed.\n");
-    }
-    qs_inf->siqs = (FLINT_FILE *) fopen(qs_inf->fname, "wb");
-    if (qs_inf->siqs == NULL)
-        flint_throw(FLINT_ERROR, "fopen failed\n");
-#else
-    strcpy(qs_inf->fname, "/tmp/siqsXXXXXX"); /* must be shorter than fname_alloc_size in init.c */
-    fd = mkstemp(qs_inf->fname);
-    if (fd == -1)
-        flint_throw(FLINT_ERROR, "mkstemp failed\n");
-
-    qs_inf->siqs = (FLINT_FILE *) fdopen(fd, "wb");
-    if (qs_inf->siqs == NULL)
-        flint_throw(FLINT_ERROR, "fdopen failed\n");
-#endif
-    /*
-     * The code here and in large_prime_variant.c opens and closes the file
-     * qs_inf->fname in several different places. On Windows all file handles
-     * need to be closed before the file can be removed in cleanup at function
-     * exit. The invariant that needs to be preserved at each open/close is
-     * that either
-     *    qs_inf->siqs is NULL and there are no open handles to the file,
-     * or
-     *    qs_inf->siqs is not NULL and is the *only* open handle to the file.
-     */
-
     for (j = qs_inf->small_primes; j < qs_inf->num_primes; j++)
     {
         if (qs_inf->factor_base[j].p > BLOCK_SIZE)
@@ -355,13 +295,7 @@ void qsieve_factor_with_tune(fmpz_factor_t factors, const fmpz_t n,
             if (qs_inf->full_relation + qs_inf->num_cycles >=
                 ((slong) (1.10*qs_inf->num_primes) + qs_inf->ks_primes + qs_inf->extra_rels))
             {
-                int ok;
-
-                if (fclose((FILE *) qs_inf->siqs))
-                    flint_throw(FLINT_ERROR, "fclose fail\n");
-                qs_inf->siqs = NULL;
-
-                ok = qsieve_process_relation(qs_inf);
+                int ok = qsieve_process_relation(qs_inf);
 
                 if (ok == -1)
                 {
@@ -470,9 +404,7 @@ void qsieve_factor_with_tune(fmpz_factor_t factors, const fmpz_t n,
 
                     _fmpz_vec_clear(facs, 100);
 
-                    qs_inf->siqs = (FLINT_FILE *) fopen(qs_inf->fname, "wb");
-                    if (qs_inf->siqs == NULL)
-                        flint_throw(FLINT_ERROR, "fopen fail\n");
+                    qsieve_relations_reset(qs_inf); /* start the relations over */
                     qs_inf->num_primes = num_primes; /* linear algebra adjusts this */
                     goto more_primes; /* factoring failed, may need more primes */
                 }
@@ -550,11 +482,6 @@ cleanup:
     flint_give_back_threads(qs_inf->handles, qs_inf->num_handles);
 
     flint_free(sieve);
-    if (qs_inf->siqs != NULL && fclose((FILE *) qs_inf->siqs))
-        flint_throw(FLINT_ERROR, "fclose fail\n");
-    if (remove(qs_inf->fname)) {
-        flint_throw(FLINT_ERROR, "remove fail\n");
-    }
     qsieve_clear(qs_inf);
     qsieve_linalg_clear(qs_inf);
     qsieve_poly_clear(qs_inf);

--- a/src/qsieve/init.c
+++ b/src/qsieve/init.c
@@ -13,22 +13,9 @@
 #include "fmpz.h"
 #include "qsieve.h"
 
-#if (defined(__WIN32) && !defined(__CYGWIN__)) || defined(_MSC_VER)
-#include <windows.h>
-#endif
-
 void qsieve_init_with_tune(qs_t qs_inf, const fmpz_t n, ulong ks_primes,
         slong fb_primes, slong small_primes, slong sieve_size, ulong sieve_bits)
 {
-    size_t fname_alloc_size;
-
-#if (defined(__WIN32) && !defined(__CYGWIN__)) || defined(_MSC_VER)
-    fname_alloc_size = MAX_PATH;
-#else
-    fname_alloc_size = 20;
-#endif
-    qs_inf->fname = (char *) flint_malloc(fname_alloc_size); /* space for filename */
-
     /* store n in struct */
     fmpz_init_set(qs_inf->n, n);
 
@@ -74,6 +61,8 @@ void qsieve_init_with_tune(qs_t qs_inf, const fmpz_t n, ulong ks_primes,
     qs_inf->s = 0;
     qs_inf->low = 0;
     qs_inf->high = 0;
+
+    qsieve_relations_init(qs_inf); /* space to hold the relations we find */
 }
 
 void qsieve_init(qs_t qs_inf, const fmpz_t n)

--- a/src/qsieve/large_prime_variant.c
+++ b/src/qsieve/large_prime_variant.c
@@ -10,100 +10,114 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include <stdio.h>
 #include <stdlib.h>
-#include <ctype.h>
 #include <string.h>
-#include <gmp.h>
 #include "fmpz.h"
 #include "qsieve.h"
 
 #define HASH_MULT (2654435761U)       /* hash function, taken from 'msieve' */
 #define HASH(a) ((ulong)((((unsigned int) a) * HASH_MULT) >> qs_inf->hash_shift))
 
-static void
-_qsieve_read(void * data, size_t size, size_t count, FILE * file)
-{
-    if (fread(data, size, count, file) != count)
-        flint_throw(FLINT_ERROR, "Failed to read relation data\n");
-}
-
 /******************************************************************************
  *
- *  Some helper function, used for debugging
+ *  Relation store
  *
  *****************************************************************************/
 
 /*
-    Write partial or full relation to file
+   The relations found by sieving are kept in memory until the linear algebra
+   consumes them.  See the comment on the store in qsieve.h for the layout.
+*/
 
-    The layout is as follows:
-    total write size of relation (including this write size)
-    large prime             (1 * ulong)
-    number of small primes  (1 * slong)
-    small primes            (number of small primes * slong)
-    number of factors       (1 * slong)
-    (factor, exponent)      (number of factors * fac_t)
-    Y->_mp_size             (1 * slong)
-    Y->_mp_d                (Y->_mp_size * ulong)
- */
-void qsieve_write_to_file(qs_t qs_inf, ulong prime, const fmpz_t Y, const qs_poly_t poly)
+#define QS_REL_ALLOC_MIN 256          /* initial number of relations */
+#define QS_REL_FACTOR_ALLOC_MIN 4096  /* initial number of factor entries */
+
+void qsieve_relations_init(qs_t qs_inf)
+{
+    qs_inf->rel_num = 0;
+    qs_inf->rel_alloc = QS_REL_ALLOC_MIN;
+    qs_inf->relations = flint_malloc(qs_inf->rel_alloc*sizeof(qs_rel_s));
+    qs_inf->rel_small = flint_malloc(qs_inf->rel_alloc*
+                                     qs_inf->small_primes*sizeof(slong));
+
+    qs_inf->rel_factor_num = 0;
+    qs_inf->rel_factor_alloc = QS_REL_FACTOR_ALLOC_MIN;
+    qs_inf->rel_factor = flint_malloc(qs_inf->rel_factor_alloc*sizeof(fac_t));
+}
+
+/* discard all relations found so far, keeping the allocations */
+void qsieve_relations_reset(qs_t qs_inf)
+{
+    slong i;
+
+    for (i = 0; i < qs_inf->rel_num; i++)
+        fmpz_clear(&qs_inf->relations[i].Y);
+
+    qs_inf->rel_num = 0;
+    qs_inf->rel_factor_num = 0;
+}
+
+void qsieve_relations_clear(qs_t qs_inf)
+{
+    qsieve_relations_reset(qs_inf);
+
+    flint_free(qs_inf->relations);
+    flint_free(qs_inf->rel_small);
+    flint_free(qs_inf->rel_factor);
+
+    qs_inf->relations = NULL;
+    qs_inf->rel_small = NULL;
+    qs_inf->rel_factor = NULL;
+    qs_inf->rel_alloc = 0;
+    qs_inf->rel_factor_alloc = 0;
+}
+
+/*
+   Add a full (prime == 1) or partial relation to the store.
+
+   Called from the sieving threads, so the caller must hold qs_inf->mutex.
+*/
+void qsieve_add_relation(qs_t qs_inf, ulong prime, const fmpz_t Y, const qs_poly_t poly)
 {
     slong num_factors = poly->num_factors;
-    slong * small = poly->small;
-    fac_t * factor = poly->factor;
-    slong Ysz;
-    slong write_size;
+    slong small_primes = qs_inf->small_primes;
+    qs_rel_s * rel;
 
-    /* Get size of Y */
-    Ysz = COEFF_IS_MPZ(*Y) ? COEFF_TO_PTR(*Y)->_mp_size : FLINT_SGN(*Y);
-
-    /* Write size of relation */
-    write_size =
-        sizeof(slong)                           /* total write size */
-        + sizeof(ulong)                     /* large prime */
-        + sizeof(slong)                         /* number of small primes */
-        + sizeof(slong) * qs_inf->small_primes  /* small primes */
-        + sizeof(slong)                         /* number of factors */
-        + sizeof(fac_t) * num_factors           /* factors */
-        + sizeof(slong)                         /* Y->_mp_size */
-        + sizeof(ulong) * (Ysz != 0 ? FLINT_ABS(Ysz) : 1); /* Y->_mp_d */
-    fwrite(&write_size, sizeof(slong), 1, (FILE *) qs_inf->siqs);
-
-    /* Write large prime */
-    fwrite(&prime, sizeof(ulong), 1, (FILE *) qs_inf->siqs);
-
-    /* NOTE: We do not have to write small primes. */
-    /* Write number of small primes */
-    fwrite(&qs_inf->small_primes, sizeof(slong), 1, (FILE *) qs_inf->siqs);
-
-    /* Write small primes */
-    fwrite(small, sizeof(slong), qs_inf->small_primes, (FILE *) qs_inf->siqs);
-
-    /* Write number of factors */
-    fwrite(&num_factors, sizeof(slong), 1, (FILE *) qs_inf->siqs);
-
-    /* Write factors and exponents */
-    fwrite(factor, sizeof(fac_t), num_factors, (FILE *) qs_inf->siqs);
-
-    /* Write Y->_mp_size (or mock it) */
-    fwrite(&Ysz, sizeof(slong), 1, (FILE *) qs_inf->siqs);
-
-    /* Write Y->_mp_d (or mock it) */
-    if (!COEFF_IS_MPZ(*Y))
+    if (qs_inf->rel_num == qs_inf->rel_alloc)
     {
-        slong abslimb = FLINT_ABS(*Y);
+        slong alloc = 2*qs_inf->rel_alloc;
 
-        /* Write mock Y->_mp_d */
-        fwrite(&abslimb, sizeof(ulong), 1, (FILE *) qs_inf->siqs);
+        qs_inf->relations = flint_realloc(qs_inf->relations,
+                                          alloc*sizeof(qs_rel_s));
+        qs_inf->rel_small = flint_realloc(qs_inf->rel_small,
+                                          alloc*small_primes*sizeof(slong));
+        qs_inf->rel_alloc = alloc;
     }
-    else
+
+    if (qs_inf->rel_factor_num + num_factors > qs_inf->rel_factor_alloc)
     {
-        nn_srcptr Yd = COEFF_TO_PTR(*Y)->_mp_d;
+        slong alloc = FLINT_MAX(2*qs_inf->rel_factor_alloc,
+                                qs_inf->rel_factor_num + num_factors);
 
-        /* Write Y->_mp_d */
-        fwrite(Yd, sizeof(ulong), FLINT_ABS(Ysz), (FILE *) qs_inf->siqs);
+        qs_inf->rel_factor = flint_realloc(qs_inf->rel_factor,
+                                           alloc*sizeof(fac_t));
+        qs_inf->rel_factor_alloc = alloc;
     }
+
+    rel = qs_inf->relations + qs_inf->rel_num;
+
+    rel->lp = prime;
+    rel->num_factors = num_factors;
+    rel->factor_offset = qs_inf->rel_factor_num;
+    fmpz_init_set(&rel->Y, Y);
+
+    memcpy(qs_inf->rel_small + qs_inf->rel_num*small_primes, poly->small,
+           small_primes*sizeof(slong));
+    memcpy(qs_inf->rel_factor + qs_inf->rel_factor_num, poly->factor,
+           num_factors*sizeof(fac_t));
+
+    qs_inf->rel_factor_num += num_factors;
+    qs_inf->rel_num++;
 }
 
 /******************************************************************************
@@ -185,65 +199,29 @@ void qsieve_add_to_hashtable(qs_t qs_inf, ulong prime)
  *****************************************************************************/
 
 /*
-   given a string representing a relation, parse it to
-   obtain relation
+   take a copy of the i-th relation in the store
+
+   The store keeps ownership of its own copy: the relation returned here is
+   handed to the merging and filtering code below, which consumes and frees it.
 */
-relation_t qsieve_parse_relation(qs_t qs_inf)
+relation_t qsieve_get_relation(qs_t qs_inf, slong i)
 {
+    qs_rel_s * stored = qs_inf->relations + i;
     relation_t rel;
-    slong Ysz;
 
-    /* NOTE: write_size and large prime is already read in
-     * qsieve_process_relation. */
+    rel.lp = stored->lp;
+    rel.small_primes = qs_inf->small_primes;
+    rel.num_factors = stored->num_factors;
 
-    /* Get large prime (is always one) */
-    rel.lp = UWORD(1);
-
-    /* NOTE: We can use qs_inf->small_primes here instead of reading. */
-    /* Get number of small primes */
-    _qsieve_read(&rel.small_primes, sizeof(slong), 1, (FILE *) qs_inf->siqs);
-
-    /* Get small primes */
     rel.small = flint_malloc(rel.small_primes * sizeof(slong));
-    _qsieve_read(rel.small, sizeof(slong), rel.small_primes, (FILE *) qs_inf->siqs);
+    memcpy(rel.small, qs_inf->rel_small + i*qs_inf->small_primes,
+           rel.small_primes * sizeof(slong));
 
-    /* Get number of factors */
-    _qsieve_read(&rel.num_factors, sizeof(slong), 1, (FILE *) qs_inf->siqs);
-
-    /* Get factors */
     rel.factor = flint_malloc(rel.num_factors * sizeof(fac_t));
-    _qsieve_read(rel.factor, sizeof(fac_t), rel.num_factors, (FILE *) qs_inf->siqs);
+    memcpy(rel.factor, qs_inf->rel_factor + stored->factor_offset,
+           rel.num_factors * sizeof(fac_t));
 
-    /* Get Ysz */
-    Ysz = 0;
-    _qsieve_read(&Ysz, sizeof(slong), 1, (FILE *) qs_inf->siqs);
-
-    /* Get Y */
-    fmpz_init(rel.Y);
-    if (FLINT_ABS(Ysz) <= 1)
-    {
-        ulong abslimb = 0;
-
-        _qsieve_read(&abslimb, sizeof(ulong), 1, (FILE *) qs_inf->siqs);
-
-#if COEFF_MAX != -COEFF_MIN
-# error
-#endif
-        fmpz_set_ui(rel.Y, abslimb);
-        if (Ysz < 0)
-            fmpz_neg(rel.Y, rel.Y);
-    }
-    else
-    {
-        mpz_ptr mY = _fmpz_new_mpz();
-        mp_ptr ptr;
-
-        mY->_mp_size = Ysz;
-        ptr = FLINT_MPZ_REALLOC(mY, FLINT_ABS(Ysz));
-
-        _qsieve_read(ptr, sizeof(ulong), FLINT_ABS(Ysz), (FILE *) qs_inf->siqs);
-        *rel.Y = PTR_TO_COEFF(mY);
-    }
+    fmpz_init_set(rel.Y, &stored->Y);
 
     return rel;
 }
@@ -474,7 +452,7 @@ void qsieve_insert_relation(qs_t qs_inf, relation_t * rel_list, slong num_relati
 }
 
 /*
-   process relations from the file
+   process the relations found so far
 */
 int qsieve_process_relation(qs_t qs_inf)
 {
@@ -489,27 +467,13 @@ int qsieve_process_relation(qs_t qs_inf)
     relation_t * rlist;
     int done = 0;
 
-    if (qs_inf->siqs != NULL && fclose((FILE *) qs_inf->siqs))
-        flint_throw(FLINT_ERROR, "fclose fail\n");
-    qs_inf->siqs = (FLINT_FILE *) fopen(qs_inf->fname, "rb");
-    if (qs_inf->siqs == NULL)
-        flint_throw(FLINT_ERROR, "fopen fail\n");
-
 #if QS_DEBUG & 64
     flint_printf("Getting relations\n");
 #endif
 
-    while (1)
+    for (i = 0; i < qs_inf->rel_num; i++)
     {
-        int siqs_eof;
-        slong write_size = 0;
-
-        siqs_eof = !fread(&write_size, sizeof(slong), 1, (FILE *) qs_inf->siqs);
-
-        if (siqs_eof)
-            break;
-
-        _qsieve_read(&prime, sizeof(ulong), 1, (FILE *) qs_inf->siqs);
+        prime = qs_inf->relations[i].lp;
         entry = qsieve_get_table_entry(qs_inf, prime);
 
         if (num_relations == rel_size)
@@ -518,23 +482,13 @@ int qsieve_process_relation(qs_t qs_inf)
            rel_size *= 2;
         }
 
+        /* skip partials whose large prime was not seen at least twice */
         if (prime == 1 || entry->count >= 2)
         {
-            rel_list[num_relations] = qsieve_parse_relation(qs_inf);
-            rel_list[num_relations].lp = prime;
+            rel_list[num_relations] = qsieve_get_relation(qs_inf, i);
             num_relations++;
         }
-        else
-        {
-            /* We have to get to the next relation in the file. We have already
-             * read write_size (is a slong) and large prime (is an ulong).*/
-            fseek((FILE *) qs_inf->siqs, write_size - sizeof(slong) - sizeof(ulong), SEEK_CUR);
-        }
     }
-
-    if(fclose((FILE *) qs_inf->siqs))
-        flint_throw(FLINT_ERROR, "fclose fail\n");
-    qs_inf->siqs = NULL;
 
 #if QS_DEBUG & 64
     flint_printf("Removing duplicates\n");
@@ -595,13 +549,9 @@ int qsieve_process_relation(qs_t qs_inf)
 
     if (rlist_length < qs_inf->num_primes + qs_inf->ks_primes + qs_inf->extra_rels)
     {
+       /* not enough: keep the relations we have and go back to sieving */
        qs_inf->edges -= 100;
        done = 0;
-       if (qs_inf->siqs != NULL && fclose((FILE *) qs_inf->siqs))
-           flint_throw(FLINT_ERROR, "fclose fail\n");
-       qs_inf->siqs = (FLINT_FILE *) fopen(qs_inf->fname, "ab");
-       if (qs_inf->siqs == NULL)
-           flint_throw(FLINT_ERROR, "fopen fail\n");
     } else
     {
        done = 1;


### PR DESCRIPTION
There is no reason for the relation data to be kept in a file; keep it in memory. This doesn't really affect performance, but it is simpler. Fixes #708, #2828, replaces #1625 (use a proper data structure rather than emulating files).

Done with Claude Opus 5.