### PR TITLE
Speed up `fmpz_mpoly_gcd` when one input is univariate

### DIFF
--- a/src/fmpz_mpoly/profile/p-gcd_univar.c
+++ b/src/fmpz_mpoly/profile/p-gcd_univar.c
@@ -1,0 +1,233 @@
+/*
+    Copyright (C) 2026 Max Horn
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+/* usage
+make profile MOD=fmpz_mpoly && ./build/fmpz_mpoly/profile/p-gcd_univar [univar|control]
+
+Times fmpz_mpoly_gcd on pairs where one input is a monomial times a univariate
+polynomial ("univar"), and on general pairs as a control ("control"). Run the
+two separately when comparing against another build, so that the long univar
+section cannot skew the control through thermal throttling.
+*/
+
+#include <string.h>
+#include "profiler.h"
+#include "ulong_extras.h"
+#include "fmpz.h"
+#include "fmpz_mpoly.h"
+
+/*
+    A polynomial with `terms` terms, of degree less than 3 in the first variable
+    and total degree 3 in `used` further ones, in a ring that has more variables
+    than that. This is the shape a numerator has when fractions over a multivariate
+    ring are kept in lowest terms and the ring carries more variables than any
+    one element uses.
+*/
+static void _make_numerator(
+    fmpz_mpoly_t A,
+    slong terms,
+    slong used,
+    const fmpz_mpoly_ctx_t ctx)
+{
+    slong i;
+    ulong * e = FLINT_ARRAY_ALLOC(ctx->minfo->nvars, ulong);
+
+    FLINT_ASSERT(used + 1 <= ctx->minfo->nvars);
+
+    for (i = 0; i < ctx->minfo->nvars; i++)
+        e[i] = 0;
+
+    fmpz_mpoly_zero(A, ctx);
+    for (i = 0; i < terms; i++)
+    {
+        slong u = 1 + (i % used);
+        slong v = 1 + ((i/used) % used);
+        slong w = 1 + ((i/(used*used)) % used);
+
+        e[0] = i % 3;
+        e[u] += 1;
+        e[v] += 1;
+        e[w] += 1;
+        fmpz_mpoly_push_term_si_ui(A, (i & 1) ? 1 + (i % 7) : -1 - (i % 5), e, ctx);
+        e[0] = 0;
+        e[u] = 0;
+        e[v] = 0;
+        e[w] = 0;
+    }
+    fmpz_mpoly_sort_terms(A, ctx);
+    fmpz_mpoly_combine_like_terms(A, ctx);
+
+    flint_free(e);
+}
+
+/* x1^deg - 1, the shape of the denominators such fractions have */
+static void _make_denominator(
+    fmpz_mpoly_t B,
+    slong deg,
+    const fmpz_mpoly_ctx_t ctx)
+{
+    ulong * e = FLINT_ARRAY_ALLOC(ctx->minfo->nvars, ulong);
+    slong i;
+
+    for (i = 0; i < ctx->minfo->nvars; i++)
+        e[i] = 0;
+
+    fmpz_mpoly_zero(B, ctx);
+    e[0] = deg;
+    fmpz_mpoly_push_term_si_ui(B, 1, e, ctx);
+    e[0] = 0;
+    fmpz_mpoly_push_term_si_ui(B, -1, e, ctx);
+    fmpz_mpoly_sort_terms(B, ctx);
+
+    flint_free(e);
+}
+
+/* microseconds per gcd */
+static double _time_gcd(
+    const fmpz_mpoly_t A,
+    const fmpz_mpoly_t B,
+    const fmpz_mpoly_ctx_t ctx)
+{
+    fmpz_mpoly_t G;
+    timeit_t timer;
+    slong reps = 1;
+
+    fmpz_mpoly_init(G, ctx);
+
+    /* aim for at least 50ms of work */
+    do {
+        slong i;
+        reps *= 2;
+        timeit_start(timer);
+        for (i = 0; i < reps; i++)
+            fmpz_mpoly_gcd(G, A, B, ctx);
+        timeit_stop(timer);
+    } while (timer->wall < 50 && reps < WORD(1) << 24);
+
+    fmpz_mpoly_clear(G, ctx);
+
+    return 1000.0*timer->wall/reps;
+}
+
+int main(int argc, char ** argv)
+{
+    static const slong nvars_set[] = {13, 52};
+    static const slong terms_set[] = {28, 500};
+    static const slong deg_set[] = {2, 12};
+    slong nvars, terms, deg, i, in, it, id;
+    int do_univar = (argc < 2) || (strcmp(argv[1], "univar") == 0);
+    int do_control = (argc < 2) || (strcmp(argv[1], "control") == 0);
+
+    if (do_univar)
+    {
+
+    flint_printf("--- one input a monomial times a univariate polynomial ---\n");
+    flint_printf("A: `terms` terms, degree < 3 in x1, cubic in 12 further variables\n");
+    flint_printf("B: x1^deg - 1\n");
+    flint_printf("cofactor: the same, with the factor x1 - 1 forced into A too\n\n");
+    flint_printf("%5s %6s %5s %9s %10s  %s\n",
+                            "nvars", "terms", "deg", "coprime", "cofactor", "gcd");
+
+    for (in = 0; in < 2; in++)
+    for (it = 0; it < 2; it++)
+    for (id = 0; id < 2; id++)
+    {
+        nvars = nvars_set[in];
+        terms = terms_set[it];
+        deg = deg_set[id];
+        {
+            fmpz_mpoly_ctx_t ctx;
+            fmpz_mpoly_t A, B, G, f;
+            double t1, t2;
+            slong alen;
+
+            fmpz_mpoly_ctx_init(ctx, nvars, ORD_LEX);
+            fmpz_mpoly_init(A, ctx);
+            fmpz_mpoly_init(B, ctx);
+            fmpz_mpoly_init(G, ctx);
+            fmpz_mpoly_init(f, ctx);
+
+            _make_numerator(A, terms, 12, ctx);
+            _make_denominator(B, deg, ctx);
+            alen = A->length;
+            t1 = _time_gcd(A, B, ctx);
+
+            /* now force x_0 - 1, a factor of B, into A as well */
+            _make_denominator(f, 1, ctx);
+            fmpz_mpoly_mul(A, A, f, ctx);
+            t2 = _time_gcd(A, B, ctx);
+            fmpz_mpoly_gcd(G, A, B, ctx);
+
+            flint_printf("%5wd %6wd %5wd %9.2f %10.2f  ",
+                                              nvars, alen, deg, t1, t2);
+            fmpz_mpoly_print_pretty(G, NULL, ctx);
+            flint_printf("\n");
+
+            fmpz_mpoly_clear(f, ctx);
+            fmpz_mpoly_clear(G, ctx);
+            fmpz_mpoly_clear(B, ctx);
+            fmpz_mpoly_clear(A, ctx);
+            fmpz_mpoly_ctx_clear(ctx);
+        }
+    }
+
+    }
+
+    if (!do_control)
+    {
+        flint_cleanup_master();
+        return 0;
+    }
+
+    flint_printf("--- control: general pairs sharing a factor ---\n");
+    flint_printf("%5s %6s %10s  %s\n", "nvars", "terms", "us", "gcd terms");
+
+    for (nvars = 2; nvars <= 6; nvars++)
+    for (terms = 5; terms <= 20; terms += 15)
+    {
+        flint_rand_t state;
+        fmpz_mpoly_ctx_t ctx;
+        fmpz_mpoly_t A, B, G, a, b, t;
+        double total = 0;
+
+        flint_rand_init(state);
+        flint_rand_set_seed(state, 12345, 6789);
+
+        fmpz_mpoly_ctx_init(ctx, nvars, ORD_LEX);
+        fmpz_mpoly_init(A, ctx); fmpz_mpoly_init(B, ctx); fmpz_mpoly_init(G, ctx);
+        fmpz_mpoly_init(a, ctx); fmpz_mpoly_init(b, ctx); fmpz_mpoly_init(t, ctx);
+
+        for (i = 0; i < 5; i++)
+        {
+            do {
+                fmpz_mpoly_randtest_bound(t, state, 1 + terms/4, 40, 3, ctx);
+            } while (fmpz_mpoly_is_zero(t, ctx));
+            fmpz_mpoly_randtest_bound(a, state, terms, 40, 3, ctx);
+            fmpz_mpoly_randtest_bound(b, state, terms, 40, 3, ctx);
+            fmpz_mpoly_mul(A, a, t, ctx);
+            fmpz_mpoly_mul(B, b, t, ctx);
+            if (fmpz_mpoly_is_zero(A, ctx) || fmpz_mpoly_is_zero(B, ctx))
+                continue;
+            total += _time_gcd(A, B, ctx);
+        }
+
+        fmpz_mpoly_gcd(G, A, B, ctx);
+        flint_printf("%5wd %6wd %10.2f  %wd\n", nvars, terms, total, G->length);
+
+        fmpz_mpoly_clear(t, ctx); fmpz_mpoly_clear(b, ctx); fmpz_mpoly_clear(a, ctx);
+        fmpz_mpoly_clear(G, ctx); fmpz_mpoly_clear(B, ctx); fmpz_mpoly_clear(A, ctx);
+        fmpz_mpoly_ctx_clear(ctx);
+        flint_rand_clear(state);
+    }
+
+    flint_cleanup_master();
+    return 0;
+}

--- a/src/fmpz_mpoly/profile/p-gcd_univar.c
+++ b/src/fmpz_mpoly/profile/p-gcd_univar.c
@@ -121,7 +121,8 @@ int main(int argc, char ** argv)
 {
     static const slong nvars_set[] = {13, 52};
     static const slong terms_set[] = {28, 500};
-    static const slong deg_set[] = {2, 12};
+    /* the last degree is past UNIVAR_DIVISOR_MAX_DEG, so it falls back */
+    static const slong deg_set[] = {2, 12, 1024};
     slong nvars, terms, deg, i, in, it, id;
     int do_univar = (argc < 2) || (strcmp(argv[1], "univar") == 0);
     int do_control = (argc < 2) || (strcmp(argv[1], "control") == 0);
@@ -138,7 +139,7 @@ int main(int argc, char ** argv)
 
     for (in = 0; in < 2; in++)
     for (it = 0; it < 2; it++)
-    for (id = 0; id < 2; id++)
+    for (id = 0; id < 3; id++)
     {
         nvars = nvars_set[in];
         terms = terms_set[it];

--- a/src/fmpz_mpoly/test/t-gcd.c
+++ b/src/fmpz_mpoly/test/t-gcd.c
@@ -11,6 +11,7 @@
 
 #include "test_helpers.h"
 #include "ulong_extras.h"
+#include "fmpz_poly.h"
 #include "fmpz_mpoly.h"
 
 /* Defined in t-gcd.c, t-gcd_brown.c, t-gcd_cofactors.c, t-gcd_hensel.c,
@@ -875,6 +876,108 @@ TEST_FUNCTION_START(fmpz_mpoly_gcd, state)
         fmpz_mpoly_clear(a, ctx);
         fmpz_mpoly_clear(b, ctx);
         fmpz_mpoly_clear(t, ctx);
+        fmpz_mpoly_ctx_clear(ctx);
+    }
+
+    /*
+        One input a monomial times a univariate polynomial. Such pairs turn up
+        whenever fractions over a multivariate ring are kept in lowest terms
+        and the denominators are univariate.
+    */
+    {
+        fmpz_mpoly_ctx_t ctx;
+        fmpz_mpoly_t g, a, b, t;
+        const char * vars[] = {"q", "x", "y", "z"};
+
+        fmpz_mpoly_ctx_init(ctx, 4, ORD_LEX);
+        fmpz_mpoly_init(a, ctx);
+        fmpz_mpoly_init(b, ctx);
+        fmpz_mpoly_init(g, ctx);
+        fmpz_mpoly_init(t, ctx);
+
+        fmpz_mpoly_set_str_pretty(a, "q^2*x + 2*q*x*y - q*y*z + x - y*z", vars, ctx);
+        fmpz_mpoly_set_str_pretty(b, "q^2 - 1", vars, ctx);
+        fmpz_mpoly_one(t, ctx);
+        gcd_check(g, a, b, t, ctx, 0, 0, "univariate, coprime");
+
+        fmpz_mpoly_set_str_pretty(t, "q - 1", vars, ctx);
+        fmpz_mpoly_mul(a, a, t, ctx);
+        gcd_check(g, a, b, t, ctx, 0, 1, "univariate, common factor");
+        gcd_check(g, b, a, t, ctx, 0, 2, "univariate, common factor, swapped");
+
+        fmpz_mpoly_set_str_pretty(t, "y^3*z", vars, ctx);
+        fmpz_mpoly_mul(a, a, t, ctx);
+        fmpz_mpoly_mul(b, b, t, ctx);
+        fmpz_mpoly_set_str_pretty(t, "y^3*z*q - y^3*z", vars, ctx);
+        gcd_check(g, a, b, t, ctx, 0, 3, "univariate times a monomial");
+
+        fmpz_mpoly_clear(a, ctx);
+        fmpz_mpoly_clear(b, ctx);
+        fmpz_mpoly_clear(g, ctx);
+        fmpz_mpoly_clear(t, ctx);
+        fmpz_mpoly_ctx_clear(ctx);
+    }
+
+    /* random b = monomial * univariate, a arbitrary */
+    for (i = 0; i < 50 * flint_test_multiplier(); i++)
+    {
+        fmpz_mpoly_ctx_t ctx;
+        fmpz_mpoly_t g, a, b, t, u;
+        fmpz_poly_t p;
+        slong v, nvars;
+        ulong * exps;
+
+        fmpz_mpoly_ctx_init(ctx, 1 + n_randint(state, 6),
+                                              (ordering_t) n_randint(state, 3));
+        nvars = ctx->minfo->nvars;
+
+        fmpz_mpoly_init(a, ctx);
+        fmpz_mpoly_init(b, ctx);
+        fmpz_mpoly_init(g, ctx);
+        fmpz_mpoly_init(t, ctx);
+        fmpz_mpoly_init(u, ctx);
+        fmpz_poly_init(p);
+        exps = FLINT_ARRAY_ALLOC(nvars, ulong);
+
+        v = n_randint(state, nvars);
+
+        /* t = monomial * p(x_v) is forced into both inputs */
+        do {
+            fmpz_poly_randtest(p, state, 1 + n_randint(state, 4),
+                                                     1 + n_randint(state, 20));
+        } while (fmpz_poly_is_zero(p));
+        fmpz_mpoly_set_fmpz_poly(t, p, v, ctx);
+        for (k = 0; k < nvars; k++)
+            exps[k] = n_randint(state, 3);
+        fmpz_mpoly_one(u, ctx);
+        fmpz_mpoly_set_term_exp_ui(u, 0, exps, ctx);
+        fmpz_mpoly_mul(t, t, u, ctx);
+
+        /* b stays a monomial times a univariate polynomial in x_v */
+        do {
+            fmpz_poly_randtest(p, state, 1 + n_randint(state, 5),
+                                                     1 + n_randint(state, 20));
+        } while (fmpz_poly_is_zero(p));
+        fmpz_mpoly_set_fmpz_poly(b, p, v, ctx);
+        fmpz_mpoly_mul(b, b, t, ctx);
+
+        do {
+            fmpz_mpoly_randtest_bound(a, state, 1 + n_randint(state, 20),
+                                      1 + n_randint(state, 30), 4, ctx);
+        } while (fmpz_mpoly_is_zero(a, ctx));
+        fmpz_mpoly_mul(a, a, t, ctx);
+
+        flint_set_num_threads(n_randint(state, max_threads) + 1);
+        gcd_check(g, a, b, t, ctx, i, 0, "random univariate input");
+        gcd_check(g, b, a, t, ctx, i, 1, "random univariate input, swapped");
+
+        flint_free(exps);
+        fmpz_poly_clear(p);
+        fmpz_mpoly_clear(u, ctx);
+        fmpz_mpoly_clear(t, ctx);
+        fmpz_mpoly_clear(g, ctx);
+        fmpz_mpoly_clear(b, ctx);
+        fmpz_mpoly_clear(a, ctx);
         fmpz_mpoly_ctx_clear(ctx);
     }
 

--- a/src/fmpz_mpoly/test/t-gcd.c
+++ b/src/fmpz_mpoly/test/t-gcd.c
@@ -911,6 +911,16 @@ TEST_FUNCTION_START(fmpz_mpoly_gcd, state)
         fmpz_mpoly_set_str_pretty(t, "y^3*z*q - y^3*z", vars, ctx);
         gcd_check(g, a, b, t, ctx, 0, 3, "univariate times a monomial");
 
+        /* past UNIVAR_DIVISOR_MAX_DEG, so this one takes the general route */
+        fmpz_mpoly_set_str_pretty(a, "q^2*x + 2*q*x*y - q*y*z + x - y*z", vars, ctx);
+        fmpz_mpoly_set_str_pretty(b, "q^500 - 1", vars, ctx);
+        fmpz_mpoly_one(t, ctx);
+        gcd_check(g, a, b, t, ctx, 0, 4, "univariate of high degree, coprime");
+
+        fmpz_mpoly_set_str_pretty(t, "q - 1", vars, ctx);
+        fmpz_mpoly_mul(a, a, t, ctx);
+        gcd_check(g, a, b, t, ctx, 0, 5, "univariate of high degree, common factor");
+
         fmpz_mpoly_clear(a, ctx);
         fmpz_mpoly_clear(b, ctx);
         fmpz_mpoly_clear(g, ctx);
@@ -958,6 +968,12 @@ TEST_FUNCTION_START(fmpz_mpoly_gcd, state)
             fmpz_poly_randtest(p, state, 1 + n_randint(state, 5),
                                                      1 + n_randint(state, 20));
         } while (fmpz_poly_is_zero(p));
+
+        /* sometimes reach past UNIVAR_DIVISOR_MAX_DEG, so the fallback runs */
+        if (n_randint(state, 4) == 0)
+            fmpz_poly_set_coeff_si(p, 100 + n_randint(state, 400),
+                                                     1 + n_randint(state, 5));
+
         fmpz_mpoly_set_fmpz_poly(b, p, v, ctx);
         fmpz_mpoly_mul(b, b, t, ctx);
 

--- a/src/fmpz_mpoly/test/t-gcd_cofactors.c
+++ b/src/fmpz_mpoly/test/t-gcd_cofactors.c
@@ -11,6 +11,7 @@
 
 #include "test_helpers.h"
 #include "ulong_extras.h"
+#include "fmpz_poly.h"
 #include "fmpz_mpoly.h"
 
 /* Defined in t-gcd.c, t-gcd_brown.c, t-gcd_cofactors.c, t-gcd_hensel.c,
@@ -1043,6 +1044,78 @@ TEST_FUNCTION_START(fmpz_mpoly_gcd_cofactors, state)
         fmpz_mpoly_clear(a, ctx);
         fmpz_mpoly_clear(b, ctx);
         fmpz_mpoly_clear(t, ctx);
+        fmpz_mpoly_ctx_clear(ctx);
+    }
+
+    /*
+        One input a monomial times a univariate polynomial, the shape handled
+        by _try_univar_divisor. The cofactors are computed by division there,
+        so the aliasing of G and the cofactors with the inputs matters.
+    */
+    for (i = 0; i < 50 * flint_test_multiplier(); i++)
+    {
+        fmpz_mpoly_ctx_t ctx;
+        fmpz_mpoly_t g, abar, bbar, a, b, t, u;
+        fmpz_poly_t p;
+        slong v, nvars;
+        ulong * exps;
+
+        fmpz_mpoly_ctx_init(ctx, 1 + n_randint(state, 6),
+                                              (ordering_t) n_randint(state, 3));
+        nvars = ctx->minfo->nvars;
+
+        fmpz_mpoly_init(a, ctx);
+        fmpz_mpoly_init(b, ctx);
+        fmpz_mpoly_init(g, ctx);
+        fmpz_mpoly_init(abar, ctx);
+        fmpz_mpoly_init(bbar, ctx);
+        fmpz_mpoly_init(t, ctx);
+        fmpz_mpoly_init(u, ctx);
+        fmpz_poly_init(p);
+        exps = FLINT_ARRAY_ALLOC(nvars, ulong);
+
+        v = n_randint(state, nvars);
+
+        /* t = monomial * p(x_v) is forced into both inputs */
+        do {
+            fmpz_poly_randtest(p, state, 1 + n_randint(state, 4),
+                                                     1 + n_randint(state, 20));
+        } while (fmpz_poly_is_zero(p));
+        fmpz_mpoly_set_fmpz_poly(t, p, v, ctx);
+        for (k = 0; k < nvars; k++)
+            exps[k] = n_randint(state, 3);
+        fmpz_mpoly_one(u, ctx);
+        fmpz_mpoly_set_term_exp_ui(u, 0, exps, ctx);
+        fmpz_mpoly_mul(t, t, u, ctx);
+
+        /* b stays a monomial times a univariate polynomial in x_v */
+        do {
+            fmpz_poly_randtest(p, state, 1 + n_randint(state, 5),
+                                                     1 + n_randint(state, 20));
+        } while (fmpz_poly_is_zero(p));
+        fmpz_mpoly_set_fmpz_poly(b, p, v, ctx);
+        fmpz_mpoly_mul(b, b, t, ctx);
+
+        do {
+            fmpz_mpoly_randtest_bound(a, state, 1 + n_randint(state, 20),
+                                      1 + n_randint(state, 30), 4, ctx);
+        } while (fmpz_mpoly_is_zero(a, ctx));
+        fmpz_mpoly_mul(a, a, t, ctx);
+
+        flint_set_num_threads(n_randint(state, max_threads) + 1);
+        gcd_check(g, abar, bbar, a, b, t, ctx, i, 0, "random univariate input");
+        gcd_check(g, abar, bbar, b, a, t, ctx, i, 1,
+                                          "random univariate input, swapped");
+
+        flint_free(exps);
+        fmpz_poly_clear(p);
+        fmpz_mpoly_clear(u, ctx);
+        fmpz_mpoly_clear(t, ctx);
+        fmpz_mpoly_clear(bbar, ctx);
+        fmpz_mpoly_clear(abar, ctx);
+        fmpz_mpoly_clear(g, ctx);
+        fmpz_mpoly_clear(b, ctx);
+        fmpz_mpoly_clear(a, ctx);
         fmpz_mpoly_ctx_clear(ctx);
     }
 

--- a/src/fmpz_mpoly/test/t-gcd_cofactors.c
+++ b/src/fmpz_mpoly/test/t-gcd_cofactors.c
@@ -1093,6 +1093,12 @@ TEST_FUNCTION_START(fmpz_mpoly_gcd_cofactors, state)
             fmpz_poly_randtest(p, state, 1 + n_randint(state, 5),
                                                      1 + n_randint(state, 20));
         } while (fmpz_poly_is_zero(p));
+
+        /* sometimes reach past UNIVAR_DIVISOR_MAX_DEG, so the fallback runs */
+        if (n_randint(state, 4) == 0)
+            fmpz_poly_set_coeff_si(p, 100 + n_randint(state, 400),
+                                                     1 + n_randint(state, 5));
+
         fmpz_mpoly_set_fmpz_poly(b, p, v, ctx);
         fmpz_mpoly_mul(b, b, t, ctx);
 

--- a/src/fmpz_mpoly_factor/gcd_algo.c
+++ b/src/fmpz_mpoly_factor/gcd_algo.c
@@ -782,6 +782,22 @@ static void _set_coeff(
     fmpz_poly_set_coeff_fmpz(c, e == 0 ? 0 : e/var_stride, A->coeffs + k);
 }
 
+/*
+    The route below stores one coefficient per exponent, so it must not be
+    taken for a sparse input of high degree: gcd(x^(10^7) - 1, ...) would build
+    a polynomial of 10^7 coefficients out of two terms. Measured against the
+    general recursion on the shapes in p-gcd_univar, it wins throughout up to a
+    deflated degree of about 100 and breaks even near 128, whether or not the
+    univariate input is dense.
+*/
+#define UNIVAR_DIVISOR_MAX_DEG 100
+
+static int _univar_divisor_is_cheap(slong v, const mpoly_gcd_info_t I)
+{
+    return I->Adeflate_deg[v] <= UNIVAR_DIVISOR_MAX_DEG &&
+           I->Bdeflate_deg[v] <= UNIVAR_DIVISOR_MAX_DEG;
+}
+
 static int _try_univar_divisor(
     fmpz_mpoly_t G,
     fmpz_mpoly_t Abar,          /* cofactor of A, could be NULL */
@@ -1783,14 +1799,14 @@ skip_monomial_cofactors:
         B_ess_nvars += (I->Bmax_exp[j] > I->Bmin_exp[j]);
     }
 
-    if (B_ess_nvars == 1)
+    if (B_ess_nvars == 1 && _univar_divisor_is_cheap(v_in_both, I))
     {
         success = _try_univar_divisor(G, Abar, Bbar, A, I->Amin_exp,
                                       B, I->Bmin_exp, v_in_both, I, ctx);
         goto cleanup;
     }
 
-    if (A_ess_nvars == 1)
+    if (A_ess_nvars == 1 && _univar_divisor_is_cheap(v_in_both, I))
     {
         success = _try_univar_divisor(G, Bbar, Abar, B, I->Bmin_exp,
                                       A, I->Amin_exp, v_in_both, I, ctx);

--- a/src/fmpz_mpoly_factor/gcd_algo.c
+++ b/src/fmpz_mpoly_factor/gcd_algo.c
@@ -718,6 +718,206 @@ static int _do_univar(
 
 
 
+/**** ess(B) depends on one variable only, ess(A) on more ********************/
+/*
+    Every term of B then has the same exponent in every variable other than v,
+    that is, B = m*b(x_v) for a monomial m and a b in Z[x_v]. Every divisor of
+    B is therefore a monomial times a divisor of b, and a d in Z[x_v] divides A
+    exactly when it divides each coefficient of A viewed as a polynomial in the
+    variables other than v. So
+
+        gcd(A, B) = xbar^Gmin_exp * gcd(b, coefficients of A),
+
+    all of which is univariate arithmetic. Without this the gcd is found by
+    _try_missing_var, which splits off one variable of A at a time and recurses
+    on the multivariate coefficients, paying for a full mpoly_gcd_info per
+    level.
+*/
+/* sort perm by the corresponding keys, using tmp as scratch */
+static void _sort_by_key(
+    slong * perm,
+    slong * tmp,
+    slong len,
+    const ulong * keys,
+    slong N)
+{
+    slong width;
+
+    for (width = 1; width < len; width *= 2)
+    {
+        slong i;
+
+        for (i = 0; i < len; i += 2*width)
+        {
+            slong a = i;
+            slong b = FLINT_MIN(i + width, len);
+            slong mid = b, right = FLINT_MIN(i + 2*width, len);
+            slong k = i;
+
+            while (a < mid && b < right)
+                tmp[k++] = mpoly_monomial_lt_nomask(keys + N*perm[b],
+                                     keys + N*perm[a], N) ? perm[b++] : perm[a++];
+
+            while (a < mid)
+                tmp[k++] = perm[a++];
+
+            while (b < right)
+                tmp[k++] = perm[b++];
+        }
+
+        for (i = 0; i < len; i++)
+            perm[i] = tmp[i];
+    }
+}
+
+/* set the coefficient of term k of A in the deflated variable x_v */
+static void _set_coeff(
+    fmpz_poly_t c,
+    const fmpz_mpoly_t A,
+    slong k,
+    slong N, slong off, slong shift, ulong mask,
+    ulong var_shift, ulong var_stride)
+{
+    ulong e = ((A->exps[N*k + off] >> shift) & mask) - var_shift;
+    fmpz_poly_set_coeff_fmpz(c, e == 0 ? 0 : e/var_stride, A->coeffs + k);
+}
+
+static int _try_univar_divisor(
+    fmpz_mpoly_t G,
+    fmpz_mpoly_t Abar,          /* cofactor of A, could be NULL */
+    fmpz_mpoly_t Bbar,          /* cofactor of B, could be NULL */
+    const fmpz_mpoly_t A, const ulong * Amin_exp,
+    const fmpz_mpoly_t B, const ulong * Bmin_exp,
+    slong v,
+    const mpoly_gcd_info_t I,
+    const fmpz_mpoly_ctx_t ctx)
+{
+    int success = 1;
+    slong i, j;
+    slong Alen = A->length;
+    slong N = mpoly_words_per_exp_sp(A->bits, ctx->minfo);
+    slong off, shift;
+    ulong mask = (-UWORD(1)) >> (FLINT_BITS - A->bits);
+    ulong var_shift = Amin_exp[v];
+    ulong var_stride = I->Gstride[v];
+    ulong * oneexp;
+    ulong * keys;
+    slong * perm;
+    slong * scratch;
+    fmpz_poly_t g, c, t;
+    TMP_INIT;
+
+    FLINT_ASSERT(A->bits <= FLINT_BITS);
+    FLINT_ASSERT(var_stride > 0);
+
+    TMP_START;
+    oneexp = (ulong *) TMP_ALLOC(N*sizeof(ulong));
+    mpoly_gen_monomial_sp(oneexp, v, A->bits, ctx->minfo);
+    mpoly_gen_offset_shift_sp(&off, &shift, v, A->bits, ctx->minfo);
+
+    fmpz_poly_init(g);
+    fmpz_poly_init(c);
+    fmpz_poly_init(t);
+
+    _fmpz_mpoly_to_fmpz_poly_deflate(g, B, v, Bmin_exp, I->Gstride, ctx);
+
+    /*
+        The coefficients of A as a polynomial in the variables other than x_v
+        are the groups of terms of A sharing a monomial once x_v is divided
+        out. Sorting by that monomial brings each group together, but the
+        running gcd is usually already one after the first group, so do that
+        group by itself first and only sort when it is not.
+    */
+    keys = FLINT_ARRAY_ALLOC(N*Alen, ulong);
+    perm = FLINT_ARRAY_ALLOC(2*Alen, slong);
+    scratch = perm + Alen;
+
+    for (i = 0; i < Alen; i++)
+    {
+        ulong e = (A->exps[N*i + off] >> shift) & mask;
+        mpoly_monomial_msub(keys + N*i, A->exps + N*i, e, oneexp, N);
+        perm[i] = i;
+    }
+
+    fmpz_poly_zero(c);
+    for (i = 0; i < Alen; i++)
+    {
+        if (mpoly_monomial_equal(keys, keys + N*i, N))
+            _set_coeff(c, A, i, N, off, shift, mask, var_shift, var_stride);
+    }
+    fmpz_poly_gcd(t, g, c);
+    fmpz_poly_swap(g, t);
+
+    if (!fmpz_poly_is_one(g))
+    {
+        _sort_by_key(perm, scratch, Alen, keys, N);
+
+        for (i = 0; i < Alen && !fmpz_poly_is_one(g); i = j)
+        {
+            fmpz_poly_zero(c);
+            for (j = i; j < Alen && mpoly_monomial_equal(keys + N*perm[i],
+                                                    keys + N*perm[j], N); j++)
+            {
+                _set_coeff(c, A, perm[j], N, off, shift, mask,
+                                                       var_shift, var_stride);
+            }
+
+            fmpz_poly_gcd(t, g, c);
+            fmpz_poly_swap(g, t);
+        }
+    }
+
+    if (Abar == NULL && Bbar == NULL)
+    {
+        _fmpz_mpoly_from_fmpz_poly_inflate(G, I->Gbits, g, v, I->Gmin_exp,
+                                                             I->Gstride, ctx);
+    }
+    else
+    {
+        /* G and the cofactors may alias A or B, so finish reading both first */
+        fmpz_mpoly_t tG, tAbar, tBbar;
+
+        fmpz_mpoly_init(tG, ctx);
+        fmpz_mpoly_init(tAbar, ctx);
+        fmpz_mpoly_init(tBbar, ctx);
+
+        _fmpz_mpoly_from_fmpz_poly_inflate(tG, I->Gbits, g, v, I->Gmin_exp,
+                                                             I->Gstride, ctx);
+
+        if (Abar != NULL)
+            success = success && fmpz_mpoly_divides(tAbar, A, tG, ctx);
+
+        if (Bbar != NULL)
+            success = success && fmpz_mpoly_divides(tBbar, B, tG, ctx);
+
+        if (success)
+        {
+            if (Abar != NULL)
+                fmpz_mpoly_swap(Abar, tAbar, ctx);
+
+            if (Bbar != NULL)
+                fmpz_mpoly_swap(Bbar, tBbar, ctx);
+
+            fmpz_mpoly_swap(G, tG, ctx);
+        }
+
+        fmpz_mpoly_clear(tG, ctx);
+        fmpz_mpoly_clear(tAbar, ctx);
+        fmpz_mpoly_clear(tBbar, ctx);
+    }
+
+    flint_free(keys);
+    flint_free(perm);
+    fmpz_poly_clear(g);
+    fmpz_poly_clear(c);
+    fmpz_poly_clear(t);
+
+    TMP_END;
+
+    return success;
+}
+
+
 /********* Assume B has length one when converted to univar format ***********/
 static int _try_missing_var(
     fmpz_mpoly_t G, flint_bitcnt_t Gbits,
@@ -1437,6 +1637,8 @@ static int _fmpz_mpoly_gcd_algo_small(
     slong v_in_either;
     slong v_in_A_only;
     slong v_in_B_only;
+    slong A_ess_nvars;
+    slong B_ess_nvars;
     slong j;
     slong nvars = ctx->minfo->nvars;
     mpoly_gcd_info_t I;
@@ -1566,6 +1768,33 @@ skip_monomial_cofactors:
     {
         _do_univar(G, Abar, Bbar, A, B, v_in_both, I, ctx);
         goto successful;
+    }
+
+    /*
+        If one of ess(A), ess(B) depends on v_in_both only, then it is a
+        monomial times a univariate polynomial and the gcd follows from
+        univariate arithmetic.
+    */
+    A_ess_nvars = 0;
+    B_ess_nvars = 0;
+    for (j = 0; j < nvars; j++)
+    {
+        A_ess_nvars += (I->Amax_exp[j] > I->Amin_exp[j]);
+        B_ess_nvars += (I->Bmax_exp[j] > I->Bmin_exp[j]);
+    }
+
+    if (B_ess_nvars == 1)
+    {
+        success = _try_univar_divisor(G, Abar, Bbar, A, I->Amin_exp,
+                                      B, I->Bmin_exp, v_in_both, I, ctx);
+        goto cleanup;
+    }
+
+    if (A_ess_nvars == 1)
+    {
+        success = _try_univar_divisor(G, Bbar, Abar, B, I->Bmin_exp,
+                                      A, I->Amin_exp, v_in_both, I, ctx);
+        goto cleanup;
     }
 
     /* check if there is a variable in ess(A) that is not in ess(B) */


### PR DESCRIPTION
Let `A` and `B` be two `fmpz_mpoly` whose `gcd` we would like to compute. Write `ess(B)` for `B` divided by its term content, that is `B` with the monomial common to all of its terms taken out. Suppose `ess(B)` involves a single variable `x_v`, so that

    B = m * b(x_v)

for a monomial `m` and a `b` in `Z[x_v]`. Every divisor of `B` is then a monomial times a divisor of `b`, and a `d` in `Z[x_v]` divides `A` exactly when it divides every coefficient of `A` viewed as a polynomial in the variables other than `x_v`. So

    gcd(A, B) = xbar^Gmin_exp * gcd(b, coefficients of A)

which is `fmpz_poly` work throughout. The coefficients of `A` are the groups of its terms that share a monomial once `x_v` is divided out; sorting the packed exponents brings each group together, but the running gcd is usually one after the first group already, so that group is done on its own first and the sort only happens when it is not enough.

Until now such a pair went to `_try_missing_var`, which splits off one variable of `A` at a time and calls the general gcd on each of the resulting multivariate coefficients, allocating and filling an `mpoly_gcd_info` over every variable of the ring at each level.

The new profile program `p-gcd_univar` measures this. `A` has `terms` terms, degree less than 3 in `x1` and total degree 3 in twelve further variables, inside a ring with `nvars` variables; `B` is `x1^deg - 1`; the cofactor column repeats the measurement with the factor `x1 - 1` multiplied into `A` as well, so that the gcd is not one. Medians of five interleaved runs, microseconds per gcd, on an M1 Max:

                       coprime               cofactor
    nvars terms deg   before  after       before   after
       13    28   2     5.62   1.74       130.86    8.18
       13    28  12     5.62   2.50       132.81    9.03
       13   364   2    24.90  18.07      1218.75   94.73
       13   364  12    24.41  18.31      1218.75   99.61
       52    28   2     9.16   5.37       226.56   14.16
       52    28  12     9.16   6.10       226.56   15.38
       52   364   2    67.38  61.52      2000.00  158.20
       52   364  12    67.38  61.52      2000.00  169.92

The control section of the same program times general pairs sharing a factor, which the new branch never sees, to check that the added test for it costs nothing: over the same five interleaved runs the worst of its ten rows is 0.7% slower and the rest are level or slightly faster.

Such inputs show up whenever fractions over a multivariate polynomial ring are kept in lowest terms and the denominators are univariate, for instance in Oscar's generic character tables.

The tests cover the new path with a deterministic example and with random pairs where one side is a monomial times a univariate polynomial, in both argument orders and with a forced common factor. Doing the same in `t-gcd_cofactors.c` pins down the aliasing of `G` and the cofactors with the inputs, which the new path has to handle itself.

This pull request was written with the assistance of generative AI (Claude Code).