### PR TITLE
Fix unsigned clock_t issue in timeit_start on Mac

### DIFF
--- a/src/profiler.h
+++ b/src/profiler.h
@@ -63,7 +63,7 @@ static inline void timeit_start(timeit_t t)
     struct timeval tv;
     gettimeofday(&tv, 0);
     t->wall = - tv.tv_sec * 1000 - tv.tv_usec / 1000;
-    t->cpu = - clock() * 1000 / CLOCKS_PER_SEC;
+    t->cpu = - (slong)(clock() * 1000 / CLOCKS_PER_SEC);
 }
 
 static inline slong timeit_query_wall(timeit_t t)


### PR DESCRIPTION
The changed line somehow assumes `clock_t` is signed, but on Darwin it is actually `unsigned long`. Encountered while running profiles on an Apple M4, where this made the `TIMEIT_START / TIMEIT_STOP` machinery give nonsensical results (it stopped at the first iteration since `t->cpu` was immediately positive and very large due to wrapping mod `2**64`).

This provides a simple fix by casting to `slong`.