### PR TITLE
Improve transformed_mpn staging scratch handling

### DIFF
--- a/doc/source/fft_small.rst
+++ b/doc/source/fft_small.rst
@@ -34,6 +34,38 @@ Integer multiplication
     for multiplications. Calling :func:`flint_cleanup` or :func:`flint_cleanup_master`
     frees the cache.
 
+.. function:: void * mpn_ctx_fit_buffer(mpn_ctx_t R, ulong n)
+
+    Returns at least *n* bytes of scratch from the context's buffer,
+    growing it geometrically when needed. The buffer is a single
+    region: a request may reallocate it and invalidate every pointer
+    handed out before, so at most one request is outstanding at a time
+    and the returned pointer is valid only until the next request.
+    Callers never free what they are given; the buffer persists with
+    the context, so a warm thread pays no allocation.
+
+.. function:: void * mpn_ctx_fit_buffer_reserve(mpn_ctx_t R, ulong head, ulong tail)
+              void mpn_ctx_fit_buffer_release(mpn_ctx_t R)
+
+    Pins the scratch buffer: it is grown once to hold *head* + *tail*
+    bytes and the returned tail region keeps its address until the
+    release. While the reservation is live the buffer can neither grow
+    nor move, so :func:`mpn_ctx_fit_buffer` serves requests of up to
+    *head* bytes from it and anything larger from a secondary buffer
+    kept in the context under the same contract. Reserving, like any
+    growth, invalidates a scratch pointer still outstanding.
+
+    A reservation is intended for a caller that is the only user of
+    fft_small on its thread while it holds one; the transformed-mpn
+    ring (:func:`gr_ctx_init_transformed_mpn`) reserves at
+    construction, performs only ring operations and releases at
+    destruction, so in normal use the secondary buffer is never
+    touched. It guarantees that an interleaved multiplication -- test
+    code checking results with ``fmpz`` arithmetic, or an external
+    holder of a ring context -- is served correctly rather than
+    aborted. One reservation exists at a time: a second call returns
+    ``NULL`` and the caller provides its own storage.
+
 .. function:: void mpn_ctx_mpn_mul(mpn_ctx_t R, ulong * r1, const ulong * i1, ulong n1, const ulong * i2, ulong n2)
               void mpn_mul_default_mpn_ctx(nn_ptr r1, nn_srcptr i1, slong n1, nn_srcptr i2, slong n2)
 

--- a/doc/source/gr.rst
+++ b/doc/source/gr.rst
@@ -1060,14 +1060,34 @@ middle products) run substantially faster in such a representation.
     *num_live* element slabs, from which ``gr_init`` draws and to
     which ``gr_clear`` returns; initializations beyond *num_live*
     simultaneously live elements fall back to separate allocation.
-    The reservation makes repeated context creation cheap (the
-    region persists in the thread's scratch buffer across contexts)
-    and requires that ring operations request no scratch from the
-    fft_small context while it is live: a violating request is a
-    hard error. If another reservation is already live, for
-    instance from an enclosing context, the context degrades to
-    separate allocation. Elements should be initialized with
-    ``gr_init`` or ``GR_TMP_INIT_VEC`` in every strategy.
+    The reservation makes repeated context creation cheap, since the
+    region persists in the thread's scratch buffer across contexts. It
+    is designed for a context that is the only user of fft_small on its
+    thread while it lives -- construct, perform ring operations,
+    destroy -- and every use in the library follows that pattern. It is
+    an assumption rather than a requirement: while a reservation is
+    live the thread's scratch buffer can neither grow nor move, and an
+    interleaved fft_small operation, such as an integer multiplication
+    large enough to reach it, is served from a secondary buffer instead
+    (see :func:`mpn_ctx_fit_buffer`). A context held across unrelated
+    work, or test code that checks ring results against ``fmpz``
+    arithmetic, therefore stays correct; the secondary buffer is a
+    guarantee, not a fast path. One reservation exists per thread, so a
+    context constructed while another holds it degrades to separate
+    allocation. Elements should be initialized with ``gr_init`` or
+    ``GR_TMP_INIT_VEC`` in every strategy.
+
+    Conversions out whose destination window is too short to hold the
+    reconstruction are staged inside the ring, and that staging is
+    provisioned with the reservation: a region of well under one
+    element's storage, reserved past the slabs. A caller that will
+    always have an element dead by the time it converts may add the bit
+    flag ``GR_TRANSFORMED_MPN_SCRATCH_FROM_SLAB`` to *alloc_strategy*,
+    and the ring then takes a free slab for the staging rather than
+    reserving anything. The flag declares a footprint; it is not a correctness
+    contract, and if no slab happens to be free the ring falls back to
+    an allocation cached for the context's lifetime. One conversion may
+    be in flight at a time.
 
 .. function:: int gr_transformed_mpn_use_fit_buffer(gr_ctx_t ctx, slong num_live)
 
@@ -1087,7 +1107,17 @@ middle products) run substantially faster in such a representation.
 
     Conversions by limb arrays with an explicit sign. The *destructive*
     get may consume the element, skipping a copy of the transform;
-    *get_limbs* returns the number of limbs the conversion needs.
+    *get_limbs* returns the number of limbs the reconstruction needs,
+    which exceeds the length of the value itself by the top CRT
+    coefficient's length.
+
+    A window of *get_limbs* limbs or more takes the reconstruction
+    directly, with no staging and no copy. A shorter window is also
+    accepted: the ring stages the conversion in its own scratch and
+    copies the result out, succeeding whenever the value fits in *zn*
+    limbs and returning ``GR_DOMAIN`` otherwise. For the destructive
+    forms that refusal arrives with the element already consumed, so it
+    cannot be retried. Limbs of *z* above ``*zn_out`` are zeroed.
 
 .. function:: int gr_transformed_mpn_get_trunc(nn_ptr z, slong zn, slong * zn_out, int * sign, slong lo, gr_srcptr x, gr_ctx_t ctx)
               int gr_transformed_mpn_get_trunc_destructive(nn_ptr z, slong zn, slong * zn_out, int * sign, slong lo, gr_ptr x, gr_ctx_t ctx)
@@ -1102,10 +1132,23 @@ middle products) run substantially faster in such a representation.
     1 ulp) plus the wholly dropped slots' total mass, under half an ulp
     either way.
 
+.. function:: int gr_transformed_mpn_get_fmpz_destructive(fmpz_t f, slong lo_limbs, gr_ptr x, gr_ctx_t ctx)
+
+    Converts *x* out into *f*, consuming it. The width the
+    reconstruction needs is taken from the element and *f* is grown to
+    match, so the conversion writes straight into *f*'s own limbs:
+    neither staging nor a copy of the result. A nonzero *lo_limbs*
+    selects the truncated conversion, with the error described above.
+    This is the conversion to use whenever the destination is an
+    ``fmpz``; the caller needs neither *get_limbs* nor a scratch buffer
+    of its own.
+
 .. function:: ulong gr_transformed_mpn_sizeof_data(gr_ctx_t ctx)
 
     Size in bytes of one element's transform storage in this
-    context.
+    context. A reserved-slab context occupies *num_live* times this,
+    plus the conversion staging region described above when it is not
+    taken from a slab.
 
     The transformed-mpn context constructor takes a *num_live*
     declaration of the elements expected alive simultaneously, and
@@ -1123,6 +1166,9 @@ middle products) run substantially faster in such a representation.
     *is_signed* itself, so callers must not add either to the bound.
     ``gr_transformed_mpn_get_limbs_bound(ctx)`` returns an upper bound,
     over every element of the context, on what
-    ``gr_transformed_mpn_get_limbs`` can return -- conversion staging
-    should be sized from it rather than from a reconstruction of the
-    representation's limb requirements.
+    ``gr_transformed_mpn_get_limbs`` can return. The ring sizes its own
+    conversion staging from it, so callers converting into an ``fmpz``
+    or into a window of *get_limbs* limbs need not consult it; a caller
+    that does want a buffer of its own should size it from this bound
+    rather than from a reconstruction of the representation's limb
+    requirements.

--- a/doc/source/mpn_extras.rst
+++ b/doc/source/mpn_extras.rst
@@ -1171,8 +1171,8 @@ between output and input arrays.
     `ar + ai i`). Each part takes an independent length, at least 1 limb
     and not necessarily normalized. A *signed length* is written for each
     output: the magnitude occupies ``|*zr_len|`` limbs and a negative
-    value means the result is negative; nothing above ``|*zr_len|`` limbs
-    is written. The outputs must have room for
+    value means the result is negative. Limbs above ``|*zr_len|`` are
+    not significant, though the transformed path may zero them. The outputs must have room for
     ``max(arn, ain) + max(brn, bin) + 1`` limbs (``2 max(arn, ain) + 1``
     for the square). The algorithm is selected from the shape: schoolbook
     when a part is much shorter than its partner, Karatsuba when the

--- a/src/fft_small.h
+++ b/src/fft_small.h
@@ -394,12 +394,17 @@ typedef struct {
 
     profile_entry_struct profiles[MAX_NPROFILES];
     ulong profiles_size;
+    /* scratch buffer and its reservation state; the contract is with
+       the mpn_ctx_fit_buffer declarations below. reserved_head and
+       reserved_tail are zero when no reservation is live. */
     void* buffer;
-    /* reservation of a stable tail of the scratch buffer (see
-       mpn_ctx_fit_buffer_reserve); zero when none is live */
     ulong reserved_head;
     ulong reserved_tail;
     ulong buffer_alloc;
+    /* secondary scratch, serving requests that exceed the reserved head
+       while a reservation is live; unused otherwise */
+    void* spill;
+    ulong spill_alloc;
 
     /* constants of the two-prime pipeline: inv(p1) mod p2 with 2^-d
        folded in per depth, 2^-d mod p1, and the exact bit size of
@@ -421,13 +426,40 @@ unsigned char flint_mpn_add_inplace_c(ulong* z, ulong zn, ulong* a, ulong an, un
 
 void mpn_ctx_init(mpn_ctx_t R, ulong p);
 void mpn_ctx_clear(mpn_ctx_t R);
+/* The context's scratch buffer.
+
+   mpn_ctx_fit_buffer(R, n) returns at least n bytes of scratch, growing
+   the buffer geometrically when needed. It is one region: a request may
+   reallocate it, invalidating every pointer handed out before, so at
+   most one request is outstanding at a time and a returned pointer is
+   valid only until the next request. Callers never free what they are
+   given. The buffer persists with the context, which is thread-local
+   under get_default_mpn_ctx, so a warm thread pays no allocation.
+
+   mpn_ctx_fit_buffer_reserve(R, head, tail) pins the buffer: it is
+   grown once to hold head + tail bytes, and the returned tail region
+   keeps its address until mpn_ctx_fit_buffer_release. While the
+   reservation is live the buffer can neither grow nor move, so
+   mpn_ctx_fit_buffer serves requests of up to head bytes from the
+   buffer itself and anything larger from a secondary buffer kept in
+   the context under the same contract. Like any growth, reserving
+   invalidates a fit_buffer pointer still outstanding.
+
+   A reservation is meant for a caller that is the only user of
+   fft_small on its thread while it holds one. The gr transformed-mpn
+   ring is such a caller: it reserves at construction, performs only
+   ring operations, and releases at destruction, so in normal use the
+   secondary buffer is never touched. It exists so that an interleaved
+   multiplication -- reference arithmetic in a test, or an external
+   holder of a ring context across unrelated work -- is served
+   correctly rather than aborted; that is a guarantee, not a fast path.
+
+   One reservation at a time: a second requester receives NULL and
+   provides its own storage. A stack of regions would be possible --
+   release would have to be last-in-first-out or carry an ownership
+   token, and no region could grow while any is live -- but no current
+   caller needs it. */
 void* mpn_ctx_fit_buffer(mpn_ctx_t R, ulong n);
-/* Reserve a stable tail region of the scratch buffer: the buffer is
-   grown once to hold head + tail bytes and the returned tail region
-   then stays at a fixed address for as long as the reservation is
-   live, provided every interleaved mpn_ctx_fit_buffer request stays
-   within head bytes - the caller's exclusivity contract, asserted in
-   debug builds. One reservation at a time. */
 void * mpn_ctx_fit_buffer_reserve(mpn_ctx_t R, ulong head, ulong tail);
 void mpn_ctx_fit_buffer_release(mpn_ctx_t R);
 void mpn_ctx_mpn_mul(mpn_ctx_t R, ulong* z, const ulong* a, ulong an, const ulong* b, ulong bn);
@@ -646,6 +678,12 @@ void fft_small_op_addmul(fft_small_op_t Z, const fft_small_op_t A,
                     const fft_small_op_t B, const fft_small_plan_t P);
 void fft_small_op_submul(fft_small_op_t Z, const fft_small_op_t A,
                     const fft_small_op_t B, const fft_small_plan_t P);
+/* Z +/-= A*A: the B = A cases of the two above, reading one operand
+   stream instead of two */
+void fft_small_op_addsqr(fft_small_op_t Z, const fft_small_op_t A,
+                    const fft_small_plan_t P);
+void fft_small_op_subsqr(fft_small_op_t Z, const fft_small_op_t A,
+                    const fft_small_plan_t P);
 void fft_small_op_add(fft_small_op_t Z, const fft_small_op_t A,
                     const fft_small_op_t B, const fft_small_plan_t P);
 void fft_small_op_sub(fft_small_op_t Z, const fft_small_op_t A,

--- a/src/fft_small/mpn_mul.c
+++ b/src/fft_small/mpn_mul.c
@@ -1081,6 +1081,8 @@ void mpn_ctx_init(mpn_ctx_t R, ulong p)
 
     R->buffer = NULL;
     R->buffer_alloc = 0;
+    R->spill = NULL;
+    R->spill_alloc = 0;
 
     for (i = 0; i < MPN_CTX_NCRTS; i++)
     {
@@ -1233,6 +1235,7 @@ void mpn_ctx_clear(mpn_ctx_t R)
     flint_aligned_free(R->vec_two_pow_buffer);
 
     flint_aligned_free(R->buffer);
+    flint_aligned_free(R->spill);
 }
 
 
@@ -1341,16 +1344,22 @@ find_next:
 
 void* mpn_ctx_fit_buffer(mpn_ctx_t R, ulong n)
 {
-    /* while a reservation is live, every scratch request must fit
-       the reserved head: growing here would move the reserved tail.
-       The reserving caller is responsible for bounding all scratch
-       used during the reservation's lifetime, so exceeding the head
-       is a hard error, which also serves as the audit that the
-       bound is right. */
+    /* contract in fft_small.h. Under a live reservation the main buffer
+       is pinned, so a request beyond the reserved head goes to the
+       secondary buffer: same no-free contract, same geometric growth,
+       and the same one-outstanding-request rule -- a larger request
+       here reallocates it just as one would the main buffer. */
     if (R->reserved_tail != 0 && n > R->reserved_head)
-        flint_throw(FLINT_ERROR, "mpn_ctx_fit_buffer: request of %wu "
-            "bytes exceeds the reserved head of %wu bytes\n",
-            n, R->reserved_head);
+    {
+        if (n > R->spill_alloc)
+        {
+            flint_aligned_free(R->spill);
+            n = n_round_up(n_max(n, R->spill_alloc*17/16), 4096);
+            R->spill = flint_aligned_alloc(4096, n);
+            R->spill_alloc = n;
+        }
+        return R->spill;
+    }
     if (n > R->buffer_alloc)
     {
         flint_aligned_free(R->buffer);
@@ -1366,8 +1375,10 @@ void * mpn_ctx_fit_buffer_reserve(mpn_ctx_t R, ulong head, ulong tail)
     ulong total = n_round_up(head, FLINT_FFT_SMALL_ALIGNMENT)
                   + n_round_up(tail, FLINT_FFT_SMALL_ALIGNMENT);
 
-    /* one reservation at a time: a second requester (a nested ring
-       context) gets NULL and falls back to plain allocation */
+    /* one reservation at a time: a second requester, such as a ring
+       context constructed while another is live, receives NULL and
+       provides its own storage. The growth below invalidates any
+       fit_buffer pointer still outstanding, as any growth does. */
     if (R->reserved_tail != 0)
         return NULL;
     if (total > R->buffer_alloc)

--- a/src/fft_small/op.c
+++ b/src/fft_small/op.c
@@ -262,6 +262,67 @@ static void _point_addmul(const sd_fft_ctx_struct* Q,
         _point_addmul_impl(Q, z, a, b, m_, subtract, depth, 0);
 }
 
+/* z = z +/- a*a*m: _point_addmul over a single load stream, with the
+   by-m-first ordering of _point_sqr for the same range containment */
+FLINT_FORCE_INLINE void _point_addsqr_impl(const sd_fft_ctx_struct* Q,
+    double* z, const double* a, ulong m_, int subtract,
+    ulong depth, int m_is_one)
+{
+    vec8d m = vec8d_set_d(vec1d_reduce_0n_to_pmhn((slong)m_, Q->p));
+    vec8d n    = vec8d_set_d(Q->p);
+    vec8d ninv = vec8d_set_d(Q->pinv);
+    /* flat over the whole transform: below one block the
+       data is simply shorter, the addressing is unchanged */
+    FLINT_ASSERT(depth >= 4);
+    {
+    double* zx = z;
+    const double* ax = a;
+    ulong npts = n_pow2(depth);
+    ulong j = 0; do {
+            vec8d x0, x1, t0, t1, z0, z1;
+            x0 = vec8d_load(ax+j+0);
+            x1 = vec8d_load(ax+j+8);
+            z0 = vec8d_load(zx+j+0);
+            z1 = vec8d_load(zx+j+8);
+            if (m_is_one)
+            {
+                t0 = vec8d_reduce_to_pm1n(x0, n, ninv);
+                t1 = vec8d_reduce_to_pm1n(x1, n, ninv);
+            }
+            else
+            {
+                t0 = vec8d_mulmod(x0, m, n, ninv);
+                t1 = vec8d_mulmod(x1, m, n, ninv);
+            }
+            x0 = vec8d_mulmod(t0, x0, n, ninv);
+            x1 = vec8d_mulmod(t1, x1, n, ninv);
+            if (subtract)
+            {
+                z0 = vec8d_sub(z0, x0);
+                z1 = vec8d_sub(z1, x1);
+            }
+            else
+            {
+                z0 = vec8d_add(z0, x0);
+                z1 = vec8d_add(z1, x1);
+            }
+            z0 = vec8d_reduce_to_pm1n(z0, n, ninv);
+            z1 = vec8d_reduce_to_pm1n(z1, n, ninv);
+            vec8d_store(zx+j+0, z0);
+            vec8d_store(zx+j+8, z1);
+        } while (j += 16, j < npts);
+    }
+}
+
+static void _point_addsqr(const sd_fft_ctx_struct* Q,
+    double* z, const double* a, ulong m_, int subtract, ulong depth)
+{
+    if (m_ == 1)
+        _point_addsqr_impl(Q, z, a, m_, subtract, depth, 1);
+    else
+        _point_addsqr_impl(Q, z, a, m_, subtract, depth, 0);
+}
+
 /* z = a +/- b, or z = -a for b == NULL */
 static void _point_add(const sd_fft_ctx_struct* Q,
     double* z, const double* a, const double* b, int subtract, ulong depth)
@@ -370,6 +431,37 @@ void fft_small_op_submul(fft_small_op_t Z, const fft_small_op_t A,
         _point_addmul(P->ffts + P->offset + i, Z->data + P->stride*i,
                 A->data + P->stride*i, B->data + P->stride*i,
                 P->m[i], 1, P->depth);
+}
+
+/* Z +/-= A*A. Equivalent to fft_small_op_addmul/submul with B = A and
+   preferable to it: the pointwise pass reads one operand stream instead
+   of two, which matters where it is memory bound. */
+void fft_small_op_addsqr(fft_small_op_t Z, const fft_small_op_t A,
+                    const fft_small_plan_t P)
+{
+    ulong i;
+
+    FLINT_ASSERT(_op_compatible(A, P) && _op_compatible(Z, P));
+    FLINT_ASSERT(A->domain == FFT_SMALL_OP_PRIMAL);
+    FLINT_ASSERT(Z->domain == FFT_SMALL_OP_PRODUCT);
+
+    for (i = 0; i < P->np; i++)
+        _point_addsqr(P->ffts + P->offset + i, Z->data + P->stride*i,
+                A->data + P->stride*i, P->m[i], 0, P->depth);
+}
+
+void fft_small_op_subsqr(fft_small_op_t Z, const fft_small_op_t A,
+                    const fft_small_plan_t P)
+{
+    ulong i;
+
+    FLINT_ASSERT(_op_compatible(A, P) && _op_compatible(Z, P));
+    FLINT_ASSERT(A->domain == FFT_SMALL_OP_PRIMAL);
+    FLINT_ASSERT(Z->domain == FFT_SMALL_OP_PRODUCT);
+
+    for (i = 0; i < P->np; i++)
+        _point_addsqr(P->ffts + P->offset + i, Z->data + P->stride*i,
+                A->data + P->stride*i, P->m[i], 1, P->depth);
 }
 
 void fft_small_op_add(fft_small_op_t Z, const fft_small_op_t A,

--- a/src/fft_small/test/t-transformed_mpn.c
+++ b/src/fft_small/test/t-transformed_mpn.c
@@ -182,6 +182,32 @@ TEST_FUNCTION_START(gr_transformed_mpn, state)
                     "need = %wd, given = %wd\n", need, small);
         }
 
+        /* a window holding the value but not the reconstruction is
+           staged inside the ring and must convert exactly */
+        {
+            slong vn = fmpz_size(ref);
+
+            if (vn > 0 && vn < need)
+            {
+                nn_ptr zs = flint_malloc(vn * sizeof(ulong));
+
+                if (gr_transformed_mpn_get(zs, vn, &zn_out, &sign, acc, ctx)
+                        != GR_SUCCESS)
+                    TEST_FUNCTION_FAIL("staged conversion refused\n"
+                        "need = %wd, value = %wd limbs\n", need, vn);
+
+                _get_fmpz(got, zs, zn_out, sign);
+                if (!fmpz_equal(got, ref))
+                    TEST_FUNCTION_FAIL(
+                        "staged conversion wrong\n"
+                        "is_signed = %d, terms_bound = %wd, bits_bound = %wd\n"
+                        "need = %wd, value = %wd limbs\n",
+                        is_signed, terms_bound, bits_bound, need, vn);
+
+                flint_free(zs);
+            }
+        }
+
         if (gr_transformed_mpn_get(z, need, &zn_out, &sign, acc, ctx)
                 != GR_SUCCESS)
             TEST_FUNCTION_FAIL("exact conversion failed\n"
@@ -224,6 +250,56 @@ TEST_FUNCTION_START(gr_transformed_mpn, state)
                         "zn = %wd, sign = %d\n", zn2, sg2);
                 flint_free(z2);
             }
+            gr_heap_clear(c, ctx);
+        }
+
+        /* coinciding operands take the pointwise squaring kernels, in
+           the plain multiply and in both accumulations */
+        {
+            gr_ptr c = gr_heap_init(ctx);
+            fmpz_t fr;
+            slong zn2;
+            int sg2, st2;
+
+            fmpz_init(fr);
+            st2 = gr_sqr(c, x, ctx);
+            fmpz_mul(fr, fx, fx);
+
+            if (st2 == GR_SUCCESS && terms_bound >= 2)
+            {
+                st2 = gr_addmul(c, x, x, ctx);
+                fmpz_addmul(fr, fx, fx);
+            }
+            if (st2 == GR_SUCCESS && is_signed && terms_bound >= 3)
+            {
+                st2 = gr_submul(c, x, x, ctx);
+                fmpz_submul(fr, fx, fx);
+            }
+
+            if (st2 == GR_SUCCESS)
+            {
+                slong nd2 = gr_transformed_mpn_get_limbs(ctx, c);
+                nn_ptr z2 = flint_malloc(FLINT_MAX(nd2, 1) * sizeof(ulong));
+
+                if (gr_transformed_mpn_get(z2, nd2, &zn2, &sg2, c, ctx)
+                        != GR_SUCCESS)
+                    TEST_FUNCTION_FAIL("squaring conversion failed\n"
+                        "is_signed = %d, terms_bound = %wd\n",
+                        is_signed, terms_bound);
+
+                _get_fmpz(got, z2, zn2, sg2);
+                if (!fmpz_equal(got, fr))
+                    TEST_FUNCTION_FAIL("squaring wrong\n"
+                        "is_signed = %d, terms_bound = %wd, bits_bound = %wd\n"
+                        "want bits = %wd, got bits = %wd\n",
+                        is_signed, terms_bound, bits_bound,
+                        (slong) fmpz_bits(fr), (slong) fmpz_bits(got));
+                flint_free(z2);
+            }
+            else if (st2 != GR_UNABLE && st2 != GR_DOMAIN)
+                TEST_FUNCTION_FAIL("unexpected squaring status %d\n", st2);
+
+            fmpz_clear(fr);
             gr_heap_clear(c, ctx);
         }
 
@@ -306,7 +382,10 @@ cleanup:
         slong j, need, zn_out;
         int sign;
 
-        if (gr_ctx_init_transformed_mpn(ctx, bits_bound, terms_bound, 1, 16,
+        /* three elements are live here (acc, x, y); declaring more
+           reserves slabs that are never used, which at the top of this
+           sweep is tens of megabytes */
+        if (gr_ctx_init_transformed_mpn(ctx, bits_bound, terms_bound, 1, 4,
                 GR_TRANSFORMED_MPN_ALLOC_FIT_BUFFER)
                 != GR_SUCCESS)
             continue;

--- a/src/fmpz_mat/mul_fft_small.c
+++ b/src/fmpz_mat/mul_fft_small.c
@@ -90,50 +90,23 @@ _set_entry(gr_ptr elem, const fmpz * e, gr_ctx_t tctx)
    acc, which the caller re-initializes */
 static int
 _export_entry(fmpz * e, gr_ptr acc, slong lo_limbs, int add_into,
-              nn_ptr t, slong tn_max, gr_ctx_t tctx)
+              gr_ctx_t tctx)
 {
-    slong need, zn;
-    int sg, ok;
-
-    need = (lo_limbs == 0)
-            ? gr_transformed_mpn_get_limbs(tctx, acc)
-            : gr_transformed_mpn_get_limbs_trunc(tctx, acc, lo_limbs);
-    /* the buffer was sized from gr_transformed_mpn_get_limbs_bound, of
-       which need is a per-element instance */
-    FLINT_ASSERT(need <= tn_max);
-    (void) tn_max;
-    if (lo_limbs == 0)
-        ok = gr_transformed_mpn_get_destructive(t, need, &zn, &sg, acc,
-                tctx) == GR_SUCCESS;
-    else
-        ok = gr_transformed_mpn_get_trunc_destructive(t, need, &zn, &sg,
-                lo_limbs, acc, tctx) == GR_SUCCESS;
-    if (!ok)
-        return 0;
-
     if (!add_into)
-    {
-        if (zn == 0)
-            fmpz_zero(e);
-        else
-        {
-            fmpz_set_ui_array(e, t, zn);
-            if (sg)
-                fmpz_neg(e, e);
-        }
-    }
-    else if (zn != 0)
+        return gr_transformed_mpn_get_fmpz_destructive(e, lo_limbs, acc, tctx)
+               == GR_SUCCESS;
+
     {
         fmpz_t p;
+        int ok;
         fmpz_init(p);
-        fmpz_set_ui_array(p, t, zn);
-        if (sg)
-            fmpz_sub(e, e, p);
-        else
+        ok = gr_transformed_mpn_get_fmpz_destructive(p, lo_limbs, acc, tctx)
+             == GR_SUCCESS;
+        if (ok)
             fmpz_add(e, e, p);
         fmpz_clear(p);
+        return ok;
     }
-    return 1;
 }
 
 #endif
@@ -151,8 +124,7 @@ _fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B,
     slong i, j, l, I, J, L;
     gr_ctx_t tctx;
     gr_ptr EA, EB, acc;
-    nn_ptr t;
-    slong tn_max, budget, mb, nb, kb;
+    slong budget, mb, nb, kb;
     int ok = 1;
 #define EA_(i) GR_ENTRY(EA, i, tctx->sizeof_elem)
 #define EB_(i) GR_ENTRY(EB, i, tctx->sizeof_elem)
@@ -276,8 +248,6 @@ _fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B,
 
     /* conversion staging sized by the ring's own bound rather than a
        reconstruction of its limb requirements here */
-    tn_max = gr_transformed_mpn_get_limbs_bound(tctx);
-    t = flint_malloc(tn_max * sizeof(ulong));
 
     for (L = 0; ok && L < k; L += kb)
     {
@@ -329,7 +299,7 @@ _fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B,
 
                         if (ok)
                             ok = _export_entry(fmpz_mat_entry(C, I + i, J + j),
-                                    acc, lo_limbs, L > 0, t, tn_max, tctx);
+                                    acc, lo_limbs, L > 0, tctx);
 
                         gr_clear(acc, tctx);
                         gr_init(acc, tctx);
@@ -349,7 +319,6 @@ _fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B,
     }
     gr_clear(acc, tctx);
     flint_free(acc);
-    flint_free(t);
     gr_ctx_clear(tctx);
 #undef EA_
 #undef EB_

--- a/src/fmpz_mat/mul_fft_small.c
+++ b/src/fmpz_mat/mul_fft_small.c
@@ -58,58 +58,7 @@
       this multiplies the conversions out and is unavailable for the
       truncated variant, whose one-ulp contract does not survive summing
       truncated pieces.
-
-    Whether the transformed representation is worth using at all (entry
-    sizes, dimensions) is the caller's tuning decision; the driver
-    accepts any input it can compute.
 */
-
-#if FLINT_HAVE_FFT_SMALL
-
-static int
-_set_entry(gr_ptr elem, const fmpz * e, gr_ctx_t tctx)
-{
-    fmpz c = *e;
-
-    if (!COEFF_IS_MPZ(c))
-    {
-        ulong v = FLINT_ABS(c);
-        return gr_transformed_mpn_set(elem, &v, c != 0, c < 0, tctx)
-                == GR_SUCCESS;
-    }
-    else
-    {
-        mpz_srcptr m = COEFF_TO_PTR(c);
-        return gr_transformed_mpn_set(elem, m->_mp_d,
-                FLINT_ABS(m->_mp_size), m->_mp_size < 0, tctx)
-                == GR_SUCCESS;
-    }
-}
-
-/* convert the accumulator out into e (add_into: accumulate); consumes
-   acc, which the caller re-initializes */
-static int
-_export_entry(fmpz * e, gr_ptr acc, slong lo_limbs, int add_into,
-              gr_ctx_t tctx)
-{
-    if (!add_into)
-        return gr_transformed_mpn_get_fmpz_destructive(e, lo_limbs, acc, tctx)
-               == GR_SUCCESS;
-
-    {
-        fmpz_t p;
-        int ok;
-        fmpz_init(p);
-        ok = gr_transformed_mpn_get_fmpz_destructive(p, lo_limbs, acc, tctx)
-             == GR_SUCCESS;
-        if (ok)
-            fmpz_add(e, e, p);
-        fmpz_clear(p);
-        return ok;
-    }
-}
-
-#endif
 
 static int
 _fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B,
@@ -124,8 +73,9 @@ _fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B,
     slong i, j, l, I, J, L;
     gr_ctx_t tctx;
     gr_ptr EA, EB, acc;
+    fmpz_t p;
     slong budget, mb, nb, kb;
-    int ok = 1;
+    int status = GR_SUCCESS;
 #define EA_(i) GR_ENTRY(EA, i, tctx->sizeof_elem)
 #define EB_(i) GR_ENTRY(EB, i, tctx->sizeof_elem)
 
@@ -232,38 +182,28 @@ _fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B,
     (void) gr_transformed_mpn_use_fit_buffer(tctx,
         mb * kb + (share ? 0 : kb * nb) + 1);
 
-    EA = flint_malloc((mb * kb) * tctx->sizeof_elem);
-    for (i = 0; i < mb * kb; i++)
-        gr_init(EA_(i), tctx);
+    GR_TMP_INIT_VEC(EA, mb * kb, tctx);
     if (share)
         EB = EA;
     else
-    {
-        EB = flint_malloc((kb * nb) * tctx->sizeof_elem);
-        for (i = 0; i < kb * nb; i++)
-            gr_init(EB_(i), tctx);
-    }
-    acc = flint_malloc(tctx->sizeof_elem);
-    gr_init(acc, tctx);
+        GR_TMP_INIT_VEC(EB, kb * nb, tctx);
+    GR_TMP_INIT(acc, tctx);
+    fmpz_init(p);
 
-    /* conversion staging sized by the ring's own bound rather than a
-       reconstruction of its limb requirements here */
-
-    for (L = 0; ok && L < k; L += kb)
+    for (L = 0; L < k; L += kb)
     {
         slong kl = FLINT_MIN(kb, k - L);
 
-        for (I = 0; ok && I < ar; I += mb)
+        for (I = 0; I < ar; I += mb)
         {
             slong ml = FLINT_MIN(mb, ar - I);
 
             /* the A block, transformed once per (L, I) */
-            for (i = 0; ok && i < ml; i++)
-                for (l = 0; ok && l < kl; l++)
-                    ok = _set_entry(EA_(i * kb + l),
-                            fmpz_mat_entry(A, I + i, L + l), tctx);
+            for (i = 0; i < ml; i++)
+                for (l = 0; l < kl; l++)
+                    status |= gr_set_fmpz(EA_(i * kb + l), fmpz_mat_entry(A, I + i, L + l), tctx);
 
-            for (J = 0; ok && J < bc; J += nb)
+            for (J = 0; J < bc; J += nb)
             {
                 slong nl = FLINT_MIN(nb, bc - J);
 
@@ -274,55 +214,56 @@ _fmpz_mat_mul_fft_small(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B,
                    resident in the column direction and I has advanced;
                    otherwise the J (or J and I) traversal overwrote it */
                 if (!share && (I == 0 || nb < bc))
-                    for (l = 0; ok && l < kl; l++)
-                        for (j = 0; ok && j < nl; j++)
-                            ok = _set_entry(EB_(l * nb + j),
-                                    fmpz_mat_entry(B, L + l, J + j), tctx);
+                    for (l = 0; l < kl; l++)
+                        for (j = 0; j < nl; j++)
+                            status |= gr_set_fmpz(EB_(l * nb + j), fmpz_mat_entry(B, L + l, J + j), tctx);
 
-                for (i = 0; ok && i < ml; i++)
-                    for (j = 0; ok && j < nl; j++)
+                for (i = 0; i < ml; i++)
+                {
+                    for (j = 0; j < nl; j++)
                     {
                         gr_srcptr b0 = share
                             ? EA_((L + 0) * kb + (J + j))
                             : EB_(0 * nb + j);
 
-                        ok = gr_mul(acc, EA_(i * kb + 0), b0, tctx)
-                                == GR_SUCCESS;
-                        for (l = 1; ok && l < kl; l++)
+                        status |= gr_mul(acc, EA_(i * kb + 0), b0, tctx);
+
+                        for (l = 1; l < kl; l++)
                         {
                             gr_srcptr bl = share
                                 ? EA_((L + l) * kb + (J + j))
                                 : EB_(l * nb + j);
-                            ok = gr_addmul(acc, EA_(i * kb + l), bl, tctx)
-                                    == GR_SUCCESS;
+                            status |= gr_addmul(acc, EA_(i * kb + l), bl, tctx);
                         }
 
-                        if (ok)
-                            ok = _export_entry(fmpz_mat_entry(C, I + i, J + j),
-                                    acc, lo_limbs, L > 0, tctx);
+                        if (L == 0)
+                            status |= gr_transformed_mpn_get_fmpz_destructive(
+                                fmpz_mat_entry(C, I + i, J + j), lo_limbs, acc, tctx);
+                        else
+                        {
+                            status |= gr_transformed_mpn_get_fmpz_destructive(p,
+                                lo_limbs, acc, tctx);
+                            fmpz_add(fmpz_mat_entry(C, I + i, J + j),
+                                    fmpz_mat_entry(C, I + i, J + j), p);
+                        }
 
                         gr_clear(acc, tctx);
                         gr_init(acc, tctx);
                     }
+                }
             }
         }
     }
 
-    for (i = 0; i < mb * kb; i++)
-        gr_clear(EA_(i), tctx);
-    flint_free(EA);
+    GR_TMP_CLEAR_VEC(EA, mb * kb, tctx);
     if (!share)
-    {
-        for (i = 0; i < kb * nb; i++)
-            gr_clear(EB_(i), tctx);
-        flint_free(EB);
-    }
-    gr_clear(acc, tctx);
-    flint_free(acc);
+        GR_TMP_CLEAR_VEC(EB, kb * nb, tctx);
+    GR_TMP_CLEAR(acc, tctx);
     gr_ctx_clear(tctx);
+    fmpz_clear(p);
 #undef EA_
 #undef EB_
-    return ok;
+    return status == GR_SUCCESS;
 #else
     (void) C; (void) A; (void) B; (void) lo_limbs;
     return 0;

--- a/src/fmpz_poly/mulmid_classical_fft_small.c
+++ b/src/fmpz_poly/mulmid_classical_fft_small.c
@@ -59,27 +59,7 @@ _set_coeff(gr_ptr elem, const fmpz * f, gr_ctx_t ctx)
 static int
 _get_coeff(fmpz * f, gr_ptr elem, gr_ctx_t ctx)
 {
-    slong w = gr_transformed_mpn_get_limbs(ctx, elem);
-    slong zl;
-    int sg, status;
-    mpz_ptr m;
-
-    if (w <= 0)
-        w = 1;
-
-    m = _fmpz_promote(f);
-    status = gr_transformed_mpn_get_destructive(FLINT_MPZ_REALLOC(m, w), w,
-                                                &zl, &sg, elem, ctx);
-    if (status != GR_SUCCESS)
-    {
-        _fmpz_demote(f);
-        fmpz_zero(f);
-        return status;
-    }
-
-    m->_mp_size = sg ? -zl : zl;
-    _fmpz_demote_val(f);
-    return GR_SUCCESS;
+    return gr_transformed_mpn_get_fmpz_destructive(f, 0, elem, ctx);
 }
 
 #endif

--- a/src/fmpz_poly/mulmid_classical_fft_small.c
+++ b/src/fmpz_poly/mulmid_classical_fft_small.c
@@ -18,52 +18,6 @@
 #include "fft_small.h"
 #include "gr.h"
 
-#if FLINT_HAVE_FFT_SMALL
-
-static nn_srcptr
-_coeff_limbs(const fmpz * f, ulong * scratch, slong * n, int * sgn)
-{
-    fmpz c = *f;
-
-    if (!COEFF_IS_MPZ(c))
-    {
-        *scratch = FLINT_ABS(c);
-        *n = 1;
-        *sgn = c < 0;
-        return scratch;
-    }
-    else
-    {
-        mpz_srcptr m = COEFF_TO_PTR(c);
-
-        *n = FLINT_ABS(m->_mp_size);
-        *sgn = m->_mp_size < 0;
-        return m->_mp_d;
-    }
-}
-
-static int
-_set_coeff(gr_ptr elem, const fmpz * f, gr_ctx_t ctx)
-{
-    ulong scratch;
-    slong n;
-    int sgn;
-    nn_srcptr p = _coeff_limbs(f, &scratch, &n, &sgn);
-
-    return gr_transformed_mpn_set(elem, p, n, sgn, ctx);
-}
-
-/* the accumulated element, converted out directly into an fmpz */
-/* converts the accumulator out destructively -- the caller re-initializes
-   it (borrowed storage, so that is free) before the next output */
-static int
-_get_coeff(fmpz * f, gr_ptr elem, gr_ctx_t ctx)
-{
-    return gr_transformed_mpn_get_fmpz_destructive(f, 0, elem, ctx);
-}
-
-#endif
-
 int
 _fmpz_poly_mulmid_classical_fft_small(fmpz * res,
     const fmpz * poly1, slong len1, const fmpz * poly2, slong len2,
@@ -154,7 +108,7 @@ _fmpz_poly_mulmid_classical_fft_small(fmpz * res,
 
     /* the kept transforms; when sharing they serve both roles */
     for (j = 0; j < k && status == GR_SUCCESS; j++)
-        status |= _set_coeff(GR_ENTRY(B, j, sz),
+        status |= gr_set_fmpz(GR_ENTRY(B, j, sz),
                              (share ? poly1 : poly2) + j, ctx);
 
 #define A_ELEM(t, out) \
@@ -167,7 +121,7 @@ _fmpz_poly_mulmid_classical_fft_small(fmpz * res,
             gr_ptr _e = GR_ENTRY(X, _s, sz); \
             if (xidx[_s] != (t)) \
             { \
-                status |= _set_coeff(_e, poly1 + (t), ctx); \
+                status |= gr_set_fmpz(_e, poly1 + (t), ctx); \
                 xidx[_s] = (t); \
             } \
             (out) = _e; \
@@ -230,7 +184,7 @@ _fmpz_poly_mulmid_classical_fft_small(fmpz * res,
         if (status != GR_SUCCESS)
             break;
 
-        status |= _get_coeff(res + (i - nlo), acc, ctx);
+        status |= gr_transformed_mpn_get_fmpz_destructive(res + (i - nlo), 0, acc, ctx);
             /* the destructive get consumed acc: bring it back for the
                next output; under the fit_buffer strategy this is a
                slab-pool round trip */

--- a/src/fmpzi/mulmid_classical_fft_small.c
+++ b/src/fmpzi/mulmid_classical_fft_small.c
@@ -33,49 +33,6 @@
 
 #if FLINT_HAVE_FFT_SMALL
 
-static nn_srcptr
-_coeff_limbs(const fmpz * f, ulong * scratch, slong * n, int * sgn)
-{
-    fmpz c = *f;
-
-    if (!COEFF_IS_MPZ(c))
-    {
-        *scratch = FLINT_ABS(c);
-        *n = 1;
-        *sgn = c < 0;
-        return scratch;
-    }
-    else
-    {
-        mpz_srcptr m = COEFF_TO_PTR(c);
-
-        *n = FLINT_ABS(m->_mp_size);
-        *sgn = m->_mp_size < 0;
-        return m->_mp_d;
-    }
-}
-
-static int
-_set_coeff(gr_ptr elem, const fmpz * f, gr_ctx_t ctx)
-{
-    ulong scratch;
-    slong n;
-    int sgn;
-    nn_srcptr p = _coeff_limbs(f, &scratch, &n, &sgn);
-
-    return gr_transformed_mpn_set(elem, p, n, sgn, ctx);
-}
-
-/* the accumulated element, converted out directly into an fmpz */
-/* converts the accumulator out destructively -- the caller re-initializes
-   it (borrowed storage, so that is free) before the next output */
-static int
-_get_coeff(fmpz * f, gr_ptr elem, gr_ctx_t ctx)
-{
-    return gr_transformed_mpn_get_fmpz_destructive(f, 0, elem, ctx);
-}
-
-
 int
 _fmpzi_poly_mulmid_classical_fft_small(fmpzi_struct * res,
     const fmpzi_struct * poly1, slong len1,
@@ -182,9 +139,9 @@ _fmpzi_poly_mulmid_classical_fft_small(fmpzi_struct * res,
     for (j = 0; j < k && status == GR_SUCCESS; j++)
     {
         const fmpzi_struct * c = (share ? poly1 : poly2) + j;
-        status |= _set_coeff(GR_ENTRY(B, 2 * j, sz),
+        status |= gr_set_fmpz(GR_ENTRY(B, 2 * j, sz),
                              fmpzi_realref(c), ctx);
-        status |= _set_coeff(GR_ENTRY(B, 2 * j + 1, sz),
+        status |= gr_set_fmpz(GR_ENTRY(B, 2 * j + 1, sz),
                              fmpzi_imagref(c), ctx);
     }
 
@@ -202,9 +159,9 @@ _fmpzi_poly_mulmid_classical_fft_small(fmpzi_struct * res,
             gr_ptr _ei = GR_ENTRY(X, 2 * _s + 1, sz); \
             if (xidx[_s] != (t)) \
             { \
-                status |= _set_coeff(_er, \
+                status |= gr_set_fmpz(_er, \
                     fmpzi_realref(poly1 + (t)), ctx); \
-                status |= _set_coeff(_ei, \
+                status |= gr_set_fmpz(_ei, \
                     fmpzi_imagref(poly1 + (t)), ctx); \
                 xidx[_s] = (t); \
             } \
@@ -284,10 +241,8 @@ _fmpzi_poly_mulmid_classical_fft_small(fmpzi_struct * res,
 
         if (status == GR_SUCCESS)
         {
-            status |= _get_coeff(fmpzi_realref(res + i - nlo),
-                                 accR, ctx);
-            status |= _get_coeff(fmpzi_imagref(res + i - nlo),
-                                 accI, ctx);
+            status |= gr_transformed_mpn_get_fmpz_destructive(fmpzi_realref(res + i - nlo), 0, accR, ctx);
+            status |= gr_transformed_mpn_get_fmpz_destructive(fmpzi_imagref(res + i - nlo), 0, accI, ctx);
             /* the destructive gets consumed the accumulators: bring
                them back for the next output; under the fit_buffer
                strategy this is a slab-pool round trip */

--- a/src/fmpzi/mulmid_classical_fft_small.c
+++ b/src/fmpzi/mulmid_classical_fft_small.c
@@ -72,27 +72,7 @@ _set_coeff(gr_ptr elem, const fmpz * f, gr_ctx_t ctx)
 static int
 _get_coeff(fmpz * f, gr_ptr elem, gr_ctx_t ctx)
 {
-    slong w = gr_transformed_mpn_get_limbs(ctx, elem);
-    slong zl;
-    int sg, status;
-    mpz_ptr m;
-
-    if (w <= 0)
-        w = 1;
-
-    m = _fmpz_promote(f);
-    status = gr_transformed_mpn_get_destructive(FLINT_MPZ_REALLOC(m, w), w,
-                                                &zl, &sg, elem, ctx);
-    if (status != GR_SUCCESS)
-    {
-        _fmpz_demote(f);
-        fmpz_zero(f);
-        return status;
-    }
-
-    m->_mp_size = sg ? -zl : zl;
-    _fmpz_demote_val(f);
-    return GR_SUCCESS;
+    return gr_transformed_mpn_get_fmpz_destructive(f, 0, elem, ctx);
 }
 
 

--- a/src/gr.h
+++ b/src/gr.h
@@ -1510,6 +1510,15 @@ void _gr_ctx_init_fmpz_mod_from_ref(gr_ctx_t ctx, const void * fmod_ctx);
    sign bit; mixed-sign accumulations switch the pointwise additions and
    subtractions, and the sign of a mixed result is resolved at conversion
    out. Conversions in and out are by limb arrays with an explicit sign;
+   A conversion out needs gr_transformed_mpn_get_limbs limbs of window
+   to reconstruct into, a few more than the value itself occupies; a
+   caller supplying at least that many gets the reconstruction written
+   straight into its own buffer. A shorter window is accepted and the
+   ring stages the conversion internally, at the cost of a copy of the
+   result, succeeding whenever the value fits and returning GR_DOMAIN
+   otherwise, as an undersized window always has -- but for the
+   destructive forms that refusal arrives with the element already
+   consumed, so it cannot be retried.
    gr_transformed_mpn_get_trunc returns the limbs of the value starting
    at a given position, with an error against the exact value within
    (-1.5, +0.5) ulp of the lowest returned limb -- equivalently, at most
@@ -1520,15 +1529,34 @@ void _gr_ctx_init_fmpz_mod_from_ref(gr_ctx_t ctx, const void * fmod_ctx);
    (under half an ulp either way). */
 /* Operand allocation strategies for the transformed ring: plain
    aligned allocation per element, or a pool of num_live slabs in a
-   stable reserved tail of the thread's fft_small scratch buffer.
-   The latter costs no allocation once the thread's buffer is warm
-   and shares its memory with the fft scratch, but requires the
-   caller to be the exclusive user of the thread's fft_small context
-   until the ring context is destroyed (no interleaved fft_small
-   operations outside this ring); elements past num_live fall back
-   to plain allocation. */
+   reserved tail of the thread's fft_small scratch buffer, which costs
+   no allocation once the thread's buffer is warm. Elements past
+   num_live fall back to plain allocation.
+
+   The reservation is designed for a context that is the only user of
+   fft_small on its thread while it lives -- reserve, do ring
+   operations, release -- which is how every library caller uses it.
+   It is a design assumption, not a requirement: fft_small serves an
+   interleaved multiplication from a secondary buffer while a
+   reservation is live (see mpn_ctx_fit_buffer in fft_small.h), so a
+   context held across unrelated work, or test code checking ring
+   results against fmpz arithmetic, stays correct at the cost of that
+   buffer. One reservation exists per thread; a context constructed
+   while another holds it silently uses plain allocation instead. */
+/* Conversions out whose window is too short to hold the reconstruction
+   (which exceeds the value by the top CRT coefficient's length) are
+   staged inside the ring rather than by the caller. The staging is a
+   fraction of one element and rides in the slab reservation; a caller
+   that will always have an element dead by conversion time can pass
+   GR_TRANSFORMED_MPN_SCRATCH_FROM_SLAB, OR-ed into alloc_strategy, and
+   the ring takes a free slab instead of reserving anything. The flag
+   is a footprint declaration, not a correctness contract: if no slab
+   is free the ring falls back to an allocation cached for the
+   context's lifetime. One conversion may be in flight at a time. */
 #define GR_TRANSFORMED_MPN_ALLOC_MALLOC 0
 #define GR_TRANSFORMED_MPN_ALLOC_FIT_BUFFER 1
+#define GR_TRANSFORMED_MPN_ALLOC_STRATEGY_MASK 1
+#define GR_TRANSFORMED_MPN_SCRATCH_FROM_SLAB 2
 
 int gr_ctx_init_transformed_mpn(gr_ctx_t ctx, slong bits_bound,
                     slong terms_bound, int is_signed, slong num_live,
@@ -1537,6 +1565,8 @@ int gr_transformed_mpn_set(gr_ptr res, nn_srcptr a, slong an, int sign,
                     gr_ctx_t ctx);
 int gr_transformed_mpn_get(nn_ptr z, slong zn, slong * zn_out, int * sign,
                     gr_srcptr x, gr_ctx_t ctx);
+int gr_transformed_mpn_get_fmpz_destructive(fmpz_t f, slong lo_limbs,
+                                        gr_ptr x, gr_ctx_t ctx);
 int gr_transformed_mpn_get_destructive(nn_ptr z, slong zn, slong * zn_out,
                     int * sign, gr_ptr x, gr_ctx_t ctx);
 int gr_transformed_mpn_get_trunc_destructive(nn_ptr z, slong zn,

--- a/src/gr/transformed_mpn.c
+++ b/src/gr/transformed_mpn.c
@@ -457,6 +457,23 @@ gr_transformed_mpn_set(gr_ptr res, nn_srcptr a, slong an, int sign,
     return GR_SUCCESS;
 }
 
+static int
+tmpn_set_fmpz(gr_ptr elem, const fmpz_t a, gr_ctx_t tctx)
+{
+    fmpz c = *a;
+
+    if (!COEFF_IS_MPZ(c))
+    {
+        ulong v = FLINT_ABS(c);
+        return gr_transformed_mpn_set(elem, &v, c != 0, c < 0, tctx);
+    }
+    else
+    {
+        mpz_srcptr m = COEFF_TO_PTR(c);
+        return gr_transformed_mpn_set(elem, m->_mp_d, FLINT_ABS(m->_mp_size), m->_mp_size < 0, tctx);
+    }
+}
+
 /* number of limbs certainly sufficient for the biased reconstruction of
    an element with m chunks */
 static slong
@@ -1186,6 +1203,7 @@ static gr_method_tab_input __tmpn_methods_input[] =
     {GR_METHOD_ZERO,            (gr_funcptr) (void (*)(void)) tmpn_zero},
     {GR_METHOD_WRITE,           (gr_funcptr) (void (*)(void)) tmpn_write},
     {GR_METHOD_ONE,             (gr_funcptr) (void (*)(void)) tmpn_one},
+    {GR_METHOD_SET_FMPZ,        (gr_funcptr) (void (*)(void)) tmpn_set_fmpz},
     {GR_METHOD_RANDTEST,        (gr_funcptr) (void (*)(void)) tmpn_randtest},
     {GR_METHOD_IS_ZERO,         (gr_funcptr) (void (*)(void)) tmpn_is_zero},
     {GR_METHOD_EQUAL,           (gr_funcptr) (void (*)(void)) tmpn_equal},

--- a/src/gr/transformed_mpn.c
+++ b/src/gr/transformed_mpn.c
@@ -11,6 +11,7 @@
 */
 
 #include <string.h>
+#include "gmpcompat.h"
 #include "fmpz.h"
 #include "mpn_extras.h"
 #include "ulong_extras.h"
@@ -77,6 +78,16 @@ typedef struct
     slong slab_count;
     slong * slab_free;
     slong slab_navail;
+    /* conversion staging, for output windows too short to hold the
+       reconstruction: a region reserved past the slabs, or a free
+       operand slab when the caller has promised one will be dead by
+       conversion time, or a plain allocation cached for the context's
+       lifetime. One conversion may be in flight at a time. */
+    int scratch_from_slab;
+    char * stage_base;              /* inside the reservation, or NULL */
+    ulong stage_size;               /* usable bytes at stage_base */
+    nn_ptr stage_owned;             /* cached fallback, or NULL */
+    ulong stage_owned_size;
 } tmpn_ctx_struct;
 
 typedef struct
@@ -149,20 +160,80 @@ tmpn_ctx_clear(gr_ctx_t ctx)
         mpn_ctx_fit_buffer_release(get_default_mpn_ctx());
         flint_free(T->slab_free);
     }
+    flint_free(T->stage_owned);
     flint_free(T);
+}
+
+/* pop a slab off the pool, or NULL when none is free */
+static char *
+_tmpn_slab_take(tmpn_ctx_struct * T)
+{
+    if (T->slab_navail > 0)
+    {
+        slong slot = T->slab_free[--T->slab_navail];
+        return T->slab_base + (ulong) slot * T->slab_size;
+    }
+    return NULL;
+}
+
+static int
+_tmpn_in_slab_pool(const tmpn_ctx_struct * T, const char * d)
+{
+    return T->slab_base != NULL && d >= T->slab_base
+        && d < T->slab_base + (ulong) T->slab_count * T->slab_size;
+}
+
+static void
+_tmpn_slab_give(tmpn_ctx_struct * T, char * d)
+{
+    FLINT_ASSERT(_tmpn_in_slab_pool(T, d));
+    T->slab_free[T->slab_navail++] =
+        (slong) ((ulong) (d - T->slab_base) / T->slab_size);
+}
+
+/* limb scratch for one conversion, 'need' limbs, never NULL */
+static nn_ptr
+_tmpn_scratch_take(tmpn_ctx_struct * T, slong need)
+{
+    ulong bytes = (ulong) need * sizeof(ulong);
+
+    if (T->stage_base != NULL && bytes <= T->stage_size)
+        return (nn_ptr) T->stage_base;
+
+    if (T->scratch_from_slab && bytes <= T->slab_size)
+    {
+        char * d = _tmpn_slab_take(T);
+        if (d != NULL)
+            return (nn_ptr) d;
+        /* the promise did not hold: fall through to the cached
+           allocation rather than failing the conversion */
+    }
+
+    if (T->stage_owned_size < bytes)
+    {
+        flint_free(T->stage_owned);
+        T->stage_owned = flint_malloc(bytes);
+        T->stage_owned_size = bytes;
+    }
+    return T->stage_owned;
+}
+
+static void
+_tmpn_scratch_give(tmpn_ctx_struct * T, nn_ptr t)
+{
+    /* the reserved region and the cached allocation both persist */
+    if (_tmpn_in_slab_pool(T, (char *) t))
+        _tmpn_slab_give(T, (char *) t);
 }
 
 static void
 tmpn_init(gr_ptr x, gr_ctx_t ctx)
 {
     tmpn_ctx_struct * T = TMPN_CTX(ctx);
+    char * d = _tmpn_slab_take(T);
 
-    if (T->slab_navail > 0)
-    {
-        slong slot = T->slab_free[--T->slab_navail];
-        fft_small_op_init_borrowed(&TMPN(x)->op, T->P,
-            (double *) (T->slab_base + (ulong) slot * T->slab_size));
-    }
+    if (d != NULL)
+        fft_small_op_init_borrowed(&TMPN(x)->op, T->P, (double *) d);
     else
         fft_small_op_init(&TMPN(x)->op, T->P);
     TMPN(x)->nchunks = 0;
@@ -190,14 +261,22 @@ tmpn_clear(gr_ptr x, gr_ctx_t ctx)
     tmpn_ctx_struct * T = TMPN_CTX(ctx);
     char * d = (char *) TMPN(x)->op.data;
 
-    if (T->slab_base != NULL && d >= T->slab_base
-        && d < T->slab_base + (ulong) T->slab_count * T->slab_size)
+    /* a repeat clear is inert. Callers that release elements early,
+       to free a slab for conversion scratch, clear them again through
+       the vector clear at the end; returning a slab twice would hand
+       the same storage to two later elements. */
+    if (d == NULL)
+        return;
+
+    if (_tmpn_in_slab_pool(T, d))
     {
-        T->slab_free[T->slab_navail++] =
-            (slong) ((ulong) (d - T->slab_base) / T->slab_size);
+        _tmpn_slab_give(T, d);
+        TMPN(x)->op.data = NULL;
         return;
     }
     fft_small_op_clear(&TMPN(x)->op);
+    TMPN(x)->op.data = NULL;
+    TMPN(x)->op.owns_data = 0;
 }
 
 static void
@@ -428,6 +507,9 @@ _tmpn_get(nn_ptr z, slong zn, slong * zn_out, int * sign,
     slong need = _tmpn_export_limbs(T, m, negs);
     fft_small_op_struct tmp;
     double * sdata;
+    nn_ptr scratch = NULL;
+    nn_ptr zout = z;
+    slong zoutn = zn;
     ulong itr;
     slong i;
 
@@ -449,7 +531,15 @@ _tmpn_get(nn_ptr z, slong zn, slong * zn_out, int * sign,
     }
 
     if (zn < need)
-        return GR_DOMAIN;
+    {
+        /* the window holds the value but not the reconstruction: stage
+           in the context's own scratch and copy the normalized result
+           out below. A window of get_limbs(ctx, x) limbs or more skips
+           both the staging and the copy. */
+        scratch = _tmpn_scratch_take(T, need);
+        zout = scratch;
+        zoutn = need;
+    }
 
     if (destroy)
     {
@@ -493,23 +583,23 @@ _tmpn_get(nn_ptr z, slong zn, slong * zn_out, int * sign,
         /* per-slot centered lifts: signed chunk values convert directly,
            with no bias operand and no precomputation */
         int esign;
-        fft_small_export_mpn_signed(z, (ulong) need, &esign, &tmp,
+        fft_small_export_mpn_signed(zout, (ulong) need, &esign, &tmp,
                                     (ulong) m, P);
         *sign = TMPN(x)->sign ^ esign;
     }
     else
     {
-        fft_small_export_mpn(z, (ulong) need, &tmp, P);
+        fft_small_export_mpn(zout, (ulong) need, &tmp, P);
         *sign = TMPN(x)->sign;
     }
     if (sdata != NULL)
         flint_aligned_free(sdata);
 
-    if (need < zn)
-        flint_mpn_zero(z + need, zn - need);
+    if (need < zoutn)
+        flint_mpn_zero(zout + need, zoutn - need);
 
     i = need;
-    while (i > 0 && z[i - 1] == 0)
+    while (i > 0 && zout[i - 1] == 0)
         i--;
 
     /* fold the small side value in: the element represents
@@ -522,7 +612,7 @@ _tmpn_get(nn_ptr z, slong zn, slong * zn_out, int * sign,
 
         if (i == 0)
         {
-            z[0] = av;
+            zout[0] = av;
             i = 1;
             *sign = ssign;
         }
@@ -530,26 +620,42 @@ _tmpn_get(nn_ptr z, slong zn, slong * zn_out, int * sign,
         {
             /* the export bound's terms headroom guarantees room:
                |T| + terms_bound < 2^(64 need) */
-            ulong cy = mpn_add_1(z, z, i, av);
+            ulong cy = mpn_add_1(zout, zout, i, av);
             if (cy != 0)
             {
                 FLINT_ASSERT(i < need);
-                z[i++] = cy;
+                zout[i++] = cy;
             }
         }
-        else if (i > 1 || z[0] > av)
+        else if (i > 1 || zout[0] > av)
         {
-            mpn_sub_1(z, z, i, av);
-            while (i > 0 && z[i - 1] == 0)
+            mpn_sub_1(zout, zout, i, av);
+            while (i > 0 && zout[i - 1] == 0)
                 i--;
         }
         else
         {
             /* |T| <= |small|: the sign crosses */
-            z[0] = av - z[0];
-            i = (z[0] != 0);
+            zout[0] = av - zout[0];
+            i = (zout[0] != 0);
             *sign = ssign;
         }
+    }
+
+    if (scratch != NULL)
+    {
+        if (i > zn)
+        {
+            /* undersized for the value itself: the same refusal an
+               undersized window has always given, except that for the
+               destructive forms the element is gone by now */
+            _tmpn_scratch_give(T, scratch);
+            return GR_DOMAIN;
+        }
+        if (i > 0)
+            flint_mpn_copyi(z, scratch, i);
+        flint_mpn_zero(z + i, zn - i);
+        _tmpn_scratch_give(T, scratch);
     }
 
     *zn_out = i;
@@ -598,6 +704,9 @@ _tmpn_get_trunc(nn_ptr z, slong zn, slong * zn_out, int * sign,
     slong needf = _tmpn_export_limbs(T, m, 1);
     fft_small_op_struct tmp;
     double * sdata;
+    nn_ptr scratch = NULL;
+    nn_ptr zout = z;
+    slong zoutn = zn;
     ulong itr;
     slong i;
     int esign;
@@ -611,7 +720,13 @@ _tmpn_get_trunc(nn_ptr z, slong zn, slong * zn_out, int * sign,
     }
 
     if (lo + zn < needf)
-        return GR_DOMAIN;
+    {
+        /* the window does not reach the top of the reconstruction:
+           stage the whole of it and copy the value out below */
+        scratch = _tmpn_scratch_take(T, needf - lo);
+        zout = scratch;
+        zoutn = needf - lo;
+    }
 
     itr = _op_trunc((ulong) m, P);
 
@@ -639,15 +754,15 @@ _tmpn_get_trunc(nn_ptr z, slong zn, slong * zn_out, int * sign,
         _tmpn_scale(Q, d, T->m_orig[i], itr);
     }
     tmp.domain = FFT_SMALL_OP_PRODUCT;
-    fft_small_export_mpn_signed_trunc(z, (ulong) zn, &esign, &tmp,
+    fft_small_export_mpn_signed_trunc(zout, (ulong) zoutn, &esign, &tmp,
                                       (ulong) m, (ulong) lo, P);
     if (sdata != NULL)
         flint_aligned_free(sdata);
 
     *sign = TMPN(x)->sign ^ esign;
 
-    i = zn;
-    while (i > 0 && z[i - 1] == 0)
+    i = zoutn;
+    while (i > 0 && zout[i - 1] == 0)
         i--;
         /* fold the small side value in: the element represents
        (-1)^sign * T + small, and the export just produced a window
@@ -665,7 +780,7 @@ _tmpn_get_trunc(nn_ptr z, slong zn, slong * zn_out, int * sign,
 
         if (i == 0)
         {
-            z[0] = av;
+            zout[0] = av;
             i = 1;
             *sign = ssign;
         }
@@ -673,27 +788,44 @@ _tmpn_get_trunc(nn_ptr z, slong zn, slong * zn_out, int * sign,
         {
             /* the export bound's terms headroom guarantees room:
                |T| + terms_bound < 2^(FLINT_BITS need) */
-            ulong cy = mpn_add_1(z, z, i, av);
+            ulong cy = mpn_add_1(zout, zout, i, av);
             if (cy != 0)
             {
-                FLINT_ASSERT(i < zn);
-                z[i++] = cy;
+                FLINT_ASSERT(i < zoutn);
+                zout[i++] = cy;
             }
         }
-        else if (i > 1 || z[0] > av)
+        else if (i > 1 || zout[0] > av)
         {
-            mpn_sub_1(z, z, i, av);
-            while (i > 0 && z[i - 1] == 0)
+            mpn_sub_1(zout, zout, i, av);
+            while (i > 0 && zout[i - 1] == 0)
                 i--;
         }
         else
         {
             /* |T| <= |small|: the sign crosses */
-            z[0] = av - z[0];
-            i = (z[0] != 0);
+            zout[0] = av - zout[0];
+            i = (zout[0] != 0);
             *sign = ssign;
         }
     }
+
+    if (scratch != NULL)
+    {
+        if (i > zn)
+        {
+            /* undersized for the value itself: the same refusal an
+               undersized window has always given, except that for the
+               destructive forms the element is gone by now */
+            _tmpn_scratch_give(T, scratch);
+            return GR_DOMAIN;
+        }
+        if (i > 0)
+            flint_mpn_copyi(z, scratch, i);
+        flint_mpn_zero(z + i, zn - i);
+        _tmpn_scratch_give(T, scratch);
+    }
+
     *zn_out = i;
     if (i == 0)
         *sign = 0;
@@ -861,7 +993,13 @@ tmpn_mul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
         return GR_UNABLE;
 
     TMPN(x)->op.domain = TMPN(y)->op.domain = FFT_SMALL_OP_PRIMAL;
-    fft_small_op_mul(&TMPN(res)->op, &TMPN(x)->op, &TMPN(y)->op, T->P);
+    /* a square is the same pointwise pass over one operand stream
+       instead of two; the bookkeeping below is unchanged, since every
+       field it derives from x and y coincides */
+    if (x == y)
+        fft_small_op_sqr(&TMPN(res)->op, &TMPN(x)->op, T->P);
+    else
+        fft_small_op_mul(&TMPN(res)->op, &TMPN(x)->op, &TMPN(y)->op, T->P);
     TMPN(res)->op.domain = FFT_SMALL_OP_PRIMAL;
     TMPN(res)->nchunks = m;
     TMPN(res)->terms = terms;
@@ -985,7 +1123,11 @@ _tmpn_addsubmul(gr_ptr res, gr_srcptr x, gr_srcptr y, int subflip,
     {
         /* accumulated product has the accumulator's sign: pointwise
            addmul */
-        fft_small_op_addmul(&TMPN(res)->op, &TMPN(x)->op, &TMPN(y)->op, T->P);
+        if (x == y)
+            fft_small_op_addsqr(&TMPN(res)->op, &TMPN(x)->op, T->P);
+        else
+            fft_small_op_addmul(&TMPN(res)->op, &TMPN(x)->op, &TMPN(y)->op,
+                                T->P);
         TMPN(res)->negs |= TMPN(x)->negs | TMPN(y)->negs;
     }
     else
@@ -994,7 +1136,11 @@ _tmpn_addsubmul(gr_ptr res, gr_srcptr x, gr_srcptr y, int subflip,
            chunk values may go negative */
         if (!T->is_signed)
             return GR_UNABLE;
-        fft_small_op_submul(&TMPN(res)->op, &TMPN(x)->op, &TMPN(y)->op, T->P);
+        if (x == y)
+            fft_small_op_subsqr(&TMPN(res)->op, &TMPN(x)->op, T->P);
+        else
+            fft_small_op_submul(&TMPN(res)->op, &TMPN(x)->op, &TMPN(y)->op,
+                                T->P);
         TMPN(res)->negs = 1;
     }
     TMPN(res)->op.domain = FFT_SMALL_OP_PRIMAL;
@@ -1015,6 +1161,15 @@ static int
 tmpn_submul(gr_ptr res, gr_srcptr x, gr_srcptr y, gr_ctx_t ctx)
 {
     return _tmpn_addsubmul(res, x, y, 1, ctx);
+}
+
+/* the generic square routes through gr_mul(res, x, x), which the
+   coinciding-operand dispatch inside tmpn_mul already handles; this
+   only removes the indirection and states the intent */
+static int
+tmpn_sqr(gr_ptr res, gr_srcptr x, gr_ctx_t ctx)
+{
+    return tmpn_mul(res, x, x, ctx);
 }
 
 static gr_funcptr __tmpn_methods[GR_METHOD_TAB_SIZE];
@@ -1038,6 +1193,7 @@ static gr_method_tab_input __tmpn_methods_input[] =
     {GR_METHOD_ADD,             (gr_funcptr) (void (*)(void)) tmpn_add},
     {GR_METHOD_SUB,             (gr_funcptr) (void (*)(void)) tmpn_sub},
     {GR_METHOD_MUL,             (gr_funcptr) (void (*)(void)) tmpn_mul},
+    {GR_METHOD_SQR,             (gr_funcptr) (void (*)(void)) tmpn_sqr},
     {GR_METHOD_ADDMUL,          (gr_funcptr) (void (*)(void)) tmpn_addmul},
     {GR_METHOD_SUBMUL,          (gr_funcptr) (void (*)(void)) tmpn_submul},
     {0,                         (gr_funcptr) (void (*)(void)) NULL},
@@ -1050,23 +1206,51 @@ gr_transformed_mpn_use_fit_buffer(gr_ctx_t ctx, slong num_live)
     tmpn_ctx_struct * T = TMPN_CTX(ctx);
     slong i;
 
-    if (T->alloc_strategy == GR_TRANSFORMED_MPN_ALLOC_FIT_BUFFER)
+    /* one reservation per context. The test is on the reservation
+       itself, not on alloc_strategy: gr_ctx_init_transformed_mpn sets
+       the strategy from its argument before calling this, so keying
+       off the strategy made an init-time FIT_BUFFER request return
+       here without ever reserving, leaving every element to fall back
+       to a plain per-element allocation. */
+    if (T->slab_base != NULL)
         return GR_SUCCESS;
     if (num_live < 1)
         return GR_UNABLE;
 
     T->slab_size = fft_small_op_sizeof_data(T->P);
 
-    /* The reserved head bounds every scratch request the ring's
-       operations may make from the context while the reservation is
-       live. Since the two-prime exports run their reconstruction
-       through stack blocks, no ring operation requests any: the head
-       is zero, and any request at all is a hard error in
-       mpn_ctx_fit_buffer, which is the standing audit of this claim. */
+    /* Conversion staging rides along in the same reservation, past the
+       slabs. It is a fraction of one of them -- the reconstruction
+       needs get_limbs_bound limbs against a slab's np * stride doubles
+       -- so the memory cost of covering the ring's own conversions is
+       well under the extra element it would take to do the same from
+       the pool. A caller that has promised a dead element instead (see
+       GR_TRANSFORMED_MPN_SCRATCH_FROM_SLAB) pays nothing here. */
+    if (T->scratch_from_slab)
+        T->stage_size = 0;
+    else
+        T->stage_size = n_round_up(
+            (ulong) gr_transformed_mpn_get_limbs_bound(ctx) * sizeof(ulong),
+            FLINT_FFT_SMALL_ALIGNMENT);
+
+    /* The reserved head bounds only the scratch the ring's own
+       operations request from the context, and they request none: the
+       two-prime exports run their reconstruction through stack blocks,
+       so the head is zero. Interleaved requests from unrelated code on
+       this thread -- any integer multiplication large enough to reach
+       fft_small, at any point in this context's lifetime -- are served
+       from the context's secondary buffer instead, so a zero head does
+       not constrain them. */
     T->slab_base = (char *) mpn_ctx_fit_buffer_reserve(
-        get_default_mpn_ctx(), 0, (ulong) num_live * T->slab_size);
+        get_default_mpn_ctx(), 0,
+        (ulong) num_live * T->slab_size + T->stage_size);
     if (T->slab_base == NULL)
+    {
+        T->stage_size = 0;
         return GR_UNABLE;
+    }
+    T->stage_base = (T->stage_size != 0)
+        ? T->slab_base + (ulong) num_live * T->slab_size : NULL;
 
     T->alloc_strategy = GR_TRANSFORMED_MPN_ALLOC_FIT_BUFFER;
     T->slab_count = num_live;
@@ -1157,12 +1341,18 @@ gr_ctx_init_transformed_mpn(gr_ctx_t ctx, slong bits_bound,
         __tmpn_methods_initialized = 1;
     }
 
-    T->alloc_strategy = alloc_strategy;
+    T->alloc_strategy = alloc_strategy & GR_TRANSFORMED_MPN_ALLOC_STRATEGY_MASK;
+    T->scratch_from_slab =
+        (alloc_strategy & GR_TRANSFORMED_MPN_SCRATCH_FROM_SLAB) != 0;
     T->slab_base = NULL;
     T->slab_free = NULL;
     T->slab_navail = 0;
     T->slab_count = 0;
-    if (alloc_strategy == GR_TRANSFORMED_MPN_ALLOC_FIT_BUFFER)
+    T->stage_base = NULL;
+    T->stage_size = 0;
+    T->stage_owned = NULL;
+    T->stage_owned_size = 0;
+    if (T->alloc_strategy == GR_TRANSFORMED_MPN_ALLOC_FIT_BUFFER)
     {
         /* ops scratch at the head, the operand slabs in the stable
            reserved tail; ring operations request no scratch from
@@ -1187,6 +1377,44 @@ gr_transformed_mpn_get(nn_ptr z, slong zn, slong * zn_out, int * sign,
 }
 
 /* as above but consumes x: only gr_clear may follow */
+/* Convert x out into an fmpz, destructively. The width the
+   reconstruction needs is the ring's own business, so it is taken from
+   the element here and the destination grown to match: the conversion
+   then writes straight into f's limbs, with no staging and no copy of
+   the result. lo_limbs > 0 selects the truncated conversion. */
+int
+gr_transformed_mpn_get_fmpz_destructive(fmpz_t f, slong lo_limbs,
+                                        gr_ptr x, gr_ctx_t ctx)
+{
+    slong w, zn;
+    int sg, status;
+    mpz_ptr m;
+
+    w = (lo_limbs == 0) ? gr_transformed_mpn_get_limbs(ctx, x)
+                        : gr_transformed_mpn_get_limbs_trunc(ctx, x, lo_limbs);
+    if (w <= 0)
+        w = 1;
+
+    m = _fmpz_promote(f);
+    if (lo_limbs == 0)
+        status = gr_transformed_mpn_get_destructive(FLINT_MPZ_REALLOC(m, w),
+                     w, &zn, &sg, x, ctx);
+    else
+        status = gr_transformed_mpn_get_trunc_destructive(
+                     FLINT_MPZ_REALLOC(m, w), w, &zn, &sg, lo_limbs, x, ctx);
+
+    if (status != GR_SUCCESS)
+    {
+        _fmpz_demote(f);
+        fmpz_zero(f);
+        return status;
+    }
+
+    m->_mp_size = sg ? -zn : zn;
+    _fmpz_demote_val(f);
+    return GR_SUCCESS;
+}
+
 int
 gr_transformed_mpn_get_destructive(nn_ptr z, slong zn, slong * zn_out,
                                    int * sign, gr_ptr x, gr_ctx_t ctx)

--- a/src/mpn_extras.h
+++ b/src/mpn_extras.h
@@ -1702,8 +1702,9 @@ FLINT_DLL extern slong flint_mpn_sqr_complex_fft_cutoff;
    The full products take an independent length (>= 1 limb) for every
    part, which need not be normalized, and report a *signed length* for
    each output: the magnitude occupies |len| limbs and len < 0 means
-   negative. Nothing above |len| is written, so an fmpz caller can use
-   the value as an mpz size directly. zr and zi must each have room for
+   negative. Limbs above |len| are not significant, though the
+   transformed path may zero them, so an fmpz caller can use the value
+   as an mpz size directly. zr and zi must each have room for
    max(arn, ain) + max(brn, bin) + 1 limbs (2 max(arn, ain) + 1 for the
    square) -- one bound for both, covering either product plus the carry
    of the sum. The algorithm is chosen per shape: schoolbook when any

--- a/src/mpn_extras/mul_complex.c
+++ b/src/mpn_extras/mul_complex.c
@@ -55,8 +55,8 @@
 
     */
 
-slong flint_mpn_mul_complex_fft_cutoff = 700;
-slong flint_mpn_sqr_complex_fft_cutoff = 3000000;
+slong flint_mpn_mul_complex_fft_cutoff = 230;
+slong flint_mpn_sqr_complex_fft_cutoff = 270;
 
 /* Defined here rather than in the fft_small module, which unsupported
    platforms exclude from the build entirely: the budget must be
@@ -81,45 +81,29 @@ ulong flint_fft_small_max_transformed_ring_size = UWORD(1) << 30;
    lowest returned limb, the mulhigh contract); shift = 0 is exact. */
 static int
 _tmpn_out(nn_ptr z, mp_size_t zlimbs, slong * zlen, gr_ptr acc,
-          mp_size_t shift, nn_ptr t, ulong tmax, gr_ctx_t tctx)
+          mp_size_t shift, gr_ctx_t tctx)
 {
-    slong need, tn;
+    slong tn;
     int sg, status;
 
-    /* the accumulators are dead after this, so the conversion may
-       consume them and skip copying the transform; t is a slice of a
-       dead operand's storage, large enough by construction (an element
-       holds np * stride doubles against need ~ zlimbs + a few limbs) */
+    /* The accumulators are dead after this, so the conversion consumes
+       them and skips copying the transform. The window is the caller's
+       result window, which is short of the reconstruction by the top
+       CRT coefficient's length; the ring stages that itself, out of a
+       slab freed by the clears above, and refuses if the value does
+       not fit. */
     if (shift > 0)
-    {
-        need = gr_transformed_mpn_get_limbs_trunc(tctx, acc, shift);
-        if ((ulong) need > tmax)
-            return 0;
-        status = gr_transformed_mpn_get_trunc_destructive(t, need, &tn, &sg,
-                                                          shift, acc, tctx);
-    }
+        status = gr_transformed_mpn_get_trunc_destructive(z, zlimbs, &tn,
+                                                          &sg, shift, acc,
+                                                          tctx);
     else
-    {
-        need = gr_transformed_mpn_get_limbs(tctx, acc);
-        if ((ulong) need > tmax)
-            return 0;
-        status = gr_transformed_mpn_get_destructive(t, need, &tn, &sg, acc,
-                                                    tctx);
-    }
+        status = gr_transformed_mpn_get_destructive(z, zlimbs, &tn, &sg,
+                                                    acc, tctx);
 
-    if (status == GR_SUCCESS)
-    {
-        /* the true value must fit the caller's window */
-        if (tn > zlimbs)
-            status = GR_UNABLE;
-        else
-        {
-            if (tn > 0)
-                flint_mpn_copyi(z, t, tn);
-            *zlen = (tn == 0 || !sg) ? tn : -(slong) tn;
-        }
-    }
-    return status == GR_SUCCESS;
+    if (status != GR_SUCCESS)
+        return 0;
+    *zlen = (tn == 0 || !sg) ? tn : -(slong) tn;
+    return 1;
 }
 
 /* fft path shared by mul and mulhigh: shift = 0 writes 2n+1 limbs,
@@ -138,44 +122,49 @@ _mul_complex_fft(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len,
 #define E_(i) GR_ENTRY(E, i, tctx->sizeof_elem)
 
     /* the bound is one product's magnitude; the two-term accumulation
-       and the sign are the context's own provisioning */
+       and the sign are the context's own provisioning. Five elements
+       suffice (see the schedule below), and the conversions take their
+       staging from a slab the clears release rather than from a
+       reservation of their own */
     if (gr_ctx_init_transformed_mpn(tctx,
             FLINT_BITS * (slong) (FLINT_MAX(arn, ain) + FLINT_MAX(brn, bin)),
-            2, 1, 6, GR_TRANSFORMED_MPN_ALLOC_FIT_BUFFER)
+            2, 1, 5, GR_TRANSFORMED_MPN_ALLOC_FIT_BUFFER
+                     | GR_TRANSFORMED_MPN_SCRATCH_FROM_SLAB)
             != GR_SUCCESS)
         return 0;
 
-    /* elements come from the slab cache through plain gr_init: the
-       previous carving from the context fit_buffer, which every
-       two-prime export reuses mid-operation, was correct only
-       because the exports run after the last operand use and their
-       scratch stayed below the output elements' offsets */
-    GR_TMP_INIT_VEC(E, 6, tctx);
+    GR_TMP_INIT_VEC(E, 5, tctx);
 
     ok = ok && gr_transformed_mpn_set(E_(0), ar, arn, ar_sgn, tctx) == GR_SUCCESS;
     ok = ok && gr_transformed_mpn_set(E_(1), ai, ain, ai_sgn, tctx) == GR_SUCCESS;
     ok = ok && gr_transformed_mpn_set(E_(2), br, brn, br_sgn, tctx) == GR_SUCCESS;
     ok = ok && gr_transformed_mpn_set(E_(3), bi, bin, bi_sgn, tctx) == GR_SUCCESS;
 
-    /* zr = ar br - ai bi, zi = ar bi + ai br */
+    /*
+        zr = ar br - ai bi, zi = ar bi + ai br. Every input enters both
+        outputs, so nothing is dead until the second is formed and the
+        first output needs a slot of its own -- but only the first: the
+        second is accumulated over ar in place, which dies at its own
+        last use. Hence five elements, and the same two product pairs
+        as a six-element schedule, so the depth agreement the
+        accumulations require is unchanged.
+    */
     ok = ok && gr_mul(E_(4), E_(0), E_(2), tctx) == GR_SUCCESS;
-    ok = ok && gr_submul(E_(4), E_(1), E_(3), tctx) == GR_SUCCESS;
-    ok = ok && gr_mul(E_(5), E_(0), E_(3), tctx) == GR_SUCCESS;
-    ok = ok && gr_addmul(E_(5), E_(1), E_(2), tctx) == GR_SUCCESS;
+    ok = ok && gr_submul(E_(4), E_(1), E_(3), tctx) == GR_SUCCESS;   /* zr */
+    ok = ok && gr_mul(E_(0), E_(0), E_(3), tctx) == GR_SUCCESS;
+    ok = ok && gr_addmul(E_(0), E_(1), E_(2), tctx) == GR_SUCCESS;   /* zi */
 
-    {
-        ulong tmax = gr_transformed_mpn_sizeof_data(tctx)
-                     / sizeof(ulong);
-        nn_ptr tstage = flint_malloc(tmax * sizeof(ulong));
+    /* ai, br and bi are dead; releasing them now returns their slabs,
+       and the conversions below take their staging from one. A repeat
+       clear is inert, so the vector clear at the end stays correct. */
+    gr_clear(E_(1), tctx);
+    gr_clear(E_(2), tctx);
+    gr_clear(E_(3), tctx);
 
-        ok = ok && _tmpn_out(zr, zlimbs, zr_len, E_(4), shift,
-                             tstage, tmax, tctx);
-        ok = ok && _tmpn_out(zi, zlimbs, zi_len, E_(5), shift,
-                             tstage, tmax, tctx);
-        flint_free(tstage);
-    }
+    ok = ok && _tmpn_out(zr, zlimbs, zr_len, E_(4), shift, tctx);
+    ok = ok && _tmpn_out(zi, zlimbs, zi_len, E_(0), shift, tctx);
 
-    GR_TMP_CLEAR_VEC(E, 6, tctx);
+    GR_TMP_CLEAR_VEC(E, 5, tctx);
     gr_ctx_clear(tctx);
 #undef E_
     return ok;
@@ -204,11 +193,13 @@ _sqr_complex_fft(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len,
         ar * ar - ai * ai keeps the same geometry as the complex product.
     */
     if (gr_ctx_init_transformed_mpn(tctx,
-            FLINT_BITS * (slong) (2 * FLINT_MAX(arn, ain)), 2, 1, 4, GR_TRANSFORMED_MPN_ALLOC_FIT_BUFFER)
+            FLINT_BITS * (slong) (2 * FLINT_MAX(arn, ain)), 2, 1, 3,
+            GR_TRANSFORMED_MPN_ALLOC_FIT_BUFFER
+            | GR_TRANSFORMED_MPN_SCRATCH_FROM_SLAB)
             != GR_SUCCESS)
         return 0;
 
-    GR_TMP_INIT_VEC(E, 4, tctx);
+    GR_TMP_INIT_VEC(E, 3, tctx);
 
     /* the operands enter as magnitudes: the squares are sign free and
        2 ar ai has the known sign ar_sgn ^ ai_sgn, applied below -- so
@@ -220,31 +211,31 @@ _sqr_complex_fft(nn_ptr zr, slong * zr_len, nn_ptr zi, slong * zi_len,
     ok = ok && gr_transformed_mpn_set(E_(0), ar, arn, 0, tctx) == GR_SUCCESS;
     ok = ok && gr_transformed_mpn_set(E_(1), ai, ain, 0, tctx) == GR_SUCCESS;
 
-    /* zr = ar ar - ai ai; zi = ar ai doubled by a pointwise addition,
-       which costs a pass over the evaluations against a full pointwise
-       multiplication */
-    ok = ok && gr_mul(E_(2), E_(0), E_(0), tctx) == GR_SUCCESS;
-    ok = ok && gr_submul(E_(2), E_(1), E_(1), tctx) == GR_SUCCESS;
-    ok = ok && gr_mul(E_(3), E_(0), E_(1), tctx) == GR_SUCCESS;
-    ok = ok && gr_add(E_(3), E_(3), E_(3), tctx) == GR_SUCCESS;
+    /*
+        zr = ar ar - ai ai; zi = ar ai doubled by a pointwise addition,
+        which costs a pass over the evaluations against a full pointwise
+        multiplication. Three elements, by the same argument as the
+        product: zr takes the one slot the inputs cannot supply, and zi
+        is accumulated over ar in place at its last use. The two
+        squarings go through the pointwise square, reading one operand
+        stream where a multiply would read two.
+    */
+    ok = ok && gr_sqr(E_(2), E_(0), tctx) == GR_SUCCESS;
+    ok = ok && gr_submul(E_(2), E_(1), E_(1), tctx) == GR_SUCCESS;    /* zr */
+    ok = ok && gr_mul(E_(0), E_(0), E_(1), tctx) == GR_SUCCESS;
+    ok = ok && gr_add(E_(0), E_(0), E_(0), tctx) == GR_SUCCESS;       /* zi */
 
-    {
-        ulong tmax = gr_transformed_mpn_sizeof_data(tctx)
-                     / sizeof(ulong);
-        nn_ptr tstage = flint_malloc(tmax * sizeof(ulong));
+    /* ai is dead; its slab is the conversions' staging */
+    gr_clear(E_(1), tctx);
 
-        ok = ok && _tmpn_out(zr, zlimbs, zr_len, E_(2), shift,
-                             tstage, tmax, tctx);
-        ok = ok && _tmpn_out(zi, zlimbs, zi_len, E_(3), shift,
-                             tstage, tmax, tctx);
-        flint_free(tstage);
+    ok = ok && _tmpn_out(zr, zlimbs, zr_len, E_(2), shift, tctx);
+    ok = ok && _tmpn_out(zi, zlimbs, zi_len, E_(0), shift, tctx);
 
-        /* attach the known sign of 2 ar ai */
-        if (ok && (ar_sgn ^ ai_sgn))
-            *zi_len = -*zi_len;
-    }
+    /* attach the known sign of 2 ar ai */
+    if (ok && (ar_sgn ^ ai_sgn))
+        *zi_len = -*zi_len;
 
-    GR_TMP_CLEAR_VEC(E, 4, tctx);
+    GR_TMP_CLEAR_VEC(E, 3, tctx);
     gr_ctx_clear(tctx);
 #undef E_
     return ok;


### PR DESCRIPTION
In the transformed_mpn ring, allocate the staging scratch along with the operand slabs instead of requiring callers to malloc it. It would be better if the staging scratch was not required, but that's more intricate to fix.

Along with two other changes (optimizing pointwise squarings, removing one temporary operand), this fixes the performance of `flint_mpn_mul_complex` et al.: both multiplication and squaring cutoffs drop to ~230 limbs which is much more reasonable than the previous values.

Unfortunately, FFT complex squaring is still slower than Karatsuba between around 80,000 and 10^6 limbs, ostensibly because of the signed output conversion, so `flint_mpn_sqr_complex` might want to exceptionally switch to Karatsuba for that range. This doesn't affect mul, mulhigh or sqrhigh. There are also isolated small n where FFT performs worse than Karatsuba due landing on a doubled transform length; those *could* be fixed, but that's hardly high priority.

This patch also simplifies the polynomial and matrix multiplication code by adding `gr_transformed_mpn_get_fmpz_destructive`, allowing standard `gr_set_fmpz` to be use for input conversions, plus some other cleanups.

Also a fix: expressly allow fft_small fit_buffer to return a temporary buffer when the main one is in use, and add documentation about how the memory management works. Normally fft_small users are supposed to have exclusive access, but it is useful to make an exception e.g. in test code to allow comparisons with fmpz arithmetic while a transformed ring using the main fft_small buffer is already in use. In the future we may want to redesign the memory management here for use with gr_poly transformed rings where having more than one transformed ring live at the same time is normal and expected, and where allowing use of the main fft_small buffer would help performance (right now, page faults are a significant performance bottleneck working with transformed nmod polys).

Part of this patch done using Claude Opus 5 and Claude Fable 5.1.